### PR TITLE
feat: automatiser génération sitemaps au déploiement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,12 @@ jobs:
       #       docker compose -f docker-compose.staging.yaml up -d
       #       docker system prune --all --volumes --force
 
+      - name: Setup Node.js for sitemap generation
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: 🚀 Run Docker Compose on Production
         if: ${{ github.ref == 'refs/heads/main' }}
         env:
@@ -122,32 +128,76 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           docker pull massdoc/nestjs-remix-monorepo:production
-          
+
           # Dossier de production sur le serveur
           PROD_DIR="/home/deploy/app"
-          
+
           # Synchroniser les fichiers docker-compose depuis Git
           cp $GITHUB_WORKSPACE/docker-compose.prod.yml $PROD_DIR/
           cp $GITHUB_WORKSPACE/docker-compose.caddy.yml $PROD_DIR/
-          
+          mkdir -p $PROD_DIR/config
+          cp -r $GITHUB_WORKSPACE/config/caddy $PROD_DIR/config/
+
+          # Créer le dossier pour les sitemaps
+          mkdir -p $PROD_DIR/public/sitemaps
+
           cd $PROD_DIR
-          
+
           # Créer le réseau externe s'il n'existe pas
           docker network create automecanik-prod 2>/dev/null || true
-          
+
           # Arrêter et supprimer les anciens conteneurs s'ils existent
           docker stop nestjs-remix-caddy nestjs-remix-monorepo-prod 2>/dev/null || true
           docker rm nestjs-remix-caddy nestjs-remix-monorepo-prod 2>/dev/null || true
-          
+
           # Démarrer avec la nouvelle config (avec USE_UNIFIED_RPC=true)
           docker compose -f docker-compose.prod.yml -f docker-compose.caddy.yml up -d
-          
+
           # Attendre le démarrage
           sleep 15
-          
+
           # Vérifier que USE_UNIFIED_RPC est bien passé
           echo "🔍 Vérification des variables d'environnement:"
           docker exec nestjs-remix-monorepo-prod env | grep -E "UNIFIED|RPC" || echo "⚠️ Variables RPC non trouvées"
-          
+
           # Nettoyer les images (sans --volumes pour préserver les données)
           docker image prune -f
+
+      - name: 🗺️ Generate static sitemaps (si nécessaire)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          NODE_ENV: production
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          PROD_DIR="/home/deploy/app"
+          SITEMAP_FILE="$PROD_DIR/public/sitemaps/sitemap.xml"
+          MAX_AGE_DAYS=7
+
+          # Vérifier si les sitemaps existent et sont récents
+          if [ -f "$SITEMAP_FILE" ]; then
+            FILE_AGE=$(( ($(date +%s) - $(stat -c %Y "$SITEMAP_FILE")) / 86400 ))
+            if [ $FILE_AGE -lt $MAX_AGE_DAYS ]; then
+              echo "✅ Sitemaps récents ($FILE_AGE jours) - génération ignorée"
+              ls -la $PROD_DIR/public/sitemaps/
+              exit 0
+            fi
+            echo "⚠️ Sitemaps anciens ($FILE_AGE jours) - régénération nécessaire..."
+          else
+            echo "📝 Sitemaps absents - génération initiale..."
+          fi
+
+          echo "📦 Installation des dépendances backend..."
+          cd $GITHUB_WORKSPACE/backend
+          npm install --include=dev
+
+          echo "🗺️ Génération des sitemaps statiques (714k URLs)..."
+          mkdir -p $PROD_DIR/public/sitemaps
+          export OUTPUT_DIR="$PROD_DIR/public/sitemaps"
+          npx ts-node scripts/generate-sitemaps.ts
+
+          echo "✅ Sitemaps générés dans $PROD_DIR/public/sitemaps/"
+          ls -la $PROD_DIR/public/sitemaps/
+
+          echo "🔄 Rechargement de Caddy..."
+          docker exec nestjs-remix-caddy caddy reload --config /etc/caddy/Caddyfile || docker restart nestjs-remix-caddy

--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -49,17 +49,14 @@ automecanik.com, www.automecanik.com {
     redir @upload_images https://cxpojprgwgubzjyqzmoq.supabase.co/storage/v1/object/public/uploads/{re.upload_path.1} 301
     
     # ===== SITEMAPS STATIQUES (714k URLs) =====
+    # Servis directement depuis le filesystem (générés automatiquement au déploiement)
     @sitemaps path /sitemap*.xml
     handle @sitemaps {
+        root * /srv/sitemaps
         header Content-Type "application/xml; charset=utf-8"
         header Cache-Control "public, max-age=86400"
         header X-Robots-Tag "noindex"
-        reverse_proxy monorepo_prod:3000 {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto {scheme}
-        }
+        file_server
     }
 
     # ===== ASSETS STATIQUES AVEC CACHE =====

--- a/docker-compose.caddy.yml
+++ b/docker-compose.caddy.yml
@@ -10,14 +10,17 @@ services:
     volumes:
       # Configuration
       - ./config/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
-      
+
       # Données persistantes (certificats SSL)
       - caddy_data:/data
       - caddy_config:/config
-      
+
       # Logs
       - ./logs/caddy:/var/log/caddy
-      
+
+      # Sitemaps statiques (714k URLs générés automatiquement)
+      - ./public/sitemaps:/srv/sitemaps:ro
+
       # Configuration générée pour redirections (optionnel)
       - ./config/caddy/caddy-pieces-redirects.conf:/etc/caddy/redirects.conf:ro
     


### PR DESCRIPTION
## Summary
- Automatise la génération des 714k URLs sitemaps lors de chaque déploiement
- Configure Caddy pour servir les fichiers XML statiques directement depuis le filesystem
- Plus besoin de manipulation manuelle sur le serveur de production

## Changements
1. **CI/CD** (.github/workflows/ci.yml):
   - Ajoute étape "Generate static sitemaps" après le déploiement Docker
   - Utilise les secrets SUPABASE_URL et SUPABASE_SERVICE_ROLE_KEY
   - Génère les fichiers dans `/home/deploy/app/public/sitemaps/`
   - Recharge Caddy automatiquement

2. **Caddy** (config/caddy/Caddyfile):
   - Remplace le reverse_proxy par file_server pour /sitemap*.xml
   - Sert les fichiers depuis `/srv/sitemaps` (volume monté)

3. **Docker** (docker-compose.caddy.yml):
   - Monte `./public/sitemaps:/srv/sitemaps:ro` dans le conteneur Caddy

4. **Script** (backend/scripts/generate-sitemaps.ts):
   - Supporte variable d'environnement OUTPUT_DIR pour production
   - Ne crée plus de symlinks en mode production

## Test plan
- [ ] Vérifier que les checks CI passent (lint, typecheck, build)
- [ ] Merger et vérifier les logs du déploiement
- [ ] Tester https://www.automecanik.com/sitemap.xml
- [ ] Soumettre à Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)