### PR TITLE
fix: corriger syntaxe health_checks Caddy 2

### DIFF
--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -142,23 +142,16 @@ automecanik.com, www.automecanik.com {
     reverse_proxy monorepo_prod:3000 {
         header_up Host {host}
         header_up X-Real-IP {remote_host}
-        header_up X-Forwarded-For {remote_host}
-        header_up X-Forwarded-Proto {scheme}
-        header_up X-Forwarded-Host {host}
-        
-        health_checks {
-            active {
-                path /health
-                interval 30s
-                timeout 5s
-                expect_status 2xx
-            }
-        }
-        
+
+        # Health checks Caddy 2
+        health_uri /health
+        health_interval 30s
+        health_timeout 5s
+        health_status 2xx
+
         transport http {
             dial_timeout 10s
             response_header_timeout 60s
-            read_buffer_size 4096
         }
     }
     


### PR DESCRIPTION
## Summary
- Corriger la syntaxe `health_checks { active {...} }` vers `health_uri`, `health_interval`, `health_timeout`, `health_status` (syntaxe Caddy 2)
- Supprimer les `header_up X-Forwarded-*` redondants (Caddy les ajoute automatiquement)
- Supprimer `read_buffer_size` non supporté dans transport

## Contexte
Le Caddyfile précédent utilisait une syntaxe invalide pour les health checks, causant l'erreur :
```
Error: adapting config using caddyfile: parsing caddyfile tokens for 'reverse_proxy': unrecognized subdirective health_checks
```

## Test plan
- [x] Testé en production - Caddy démarre correctement avec `serving initial configuration`
- [x] Les warnings `Unnecessary header_up X-Forwarded-*` sont supprimés

🤖 Generated with [Claude Code](https://claude.com/claude-code)