### PR TITLE
fix(perf): resolve robots.txt recursive loop causing 5s TTFB

### DIFF
--- a/backend/src/modules/seo/controllers/robots-txt.controller.ts
+++ b/backend/src/modules/seo/controllers/robots-txt.controller.ts
@@ -1,5 +1,9 @@
 /**
  * 🤖 CONTRÔLEUR ROBOTS.TXT
+ *
+ * IMPORTANT: Deux endpoints disponibles:
+ * - /api/seo/robots.txt → Utilisé par Remix (évite la boucle récursive)
+ * - /robots.txt → Route directe (interceptée par Remix, donc non utilisée)
  */
 
 import { Controller, Get, Header } from '@nestjs/common';
@@ -10,8 +14,20 @@ export class RobotsTxtController {
   constructor(private readonly robotsTxtService: RobotsTxtService) {}
 
   /**
+   * GET /api/seo/robots.txt
+   * Endpoint API pour Remix - Évite la boucle récursive localhost:3000/robots.txt
+   */
+  @Get('api/seo/robots.txt')
+  @Header('Content-Type', 'text/plain')
+  @Header('Cache-Control', 'public, max-age=86400') // 24h
+  getRobotsTxtApi(): string {
+    return this.robotsTxtService.generate();
+  }
+
+  /**
    * GET /robots.txt
-   * Générer robots.txt dynamique
+   * Route directe (NOTE: interceptée par Remix en production)
+   * Conservée pour compatibilité si NestJS est exposé directement
    */
   @Get('robots.txt')
   @Header('Content-Type', 'text/plain')

--- a/frontend/app/routes/robots[.]txt.tsx
+++ b/frontend/app/routes/robots[.]txt.tsx
@@ -59,16 +59,18 @@ Sitemap: ${SITEMAP_CONFIG.BASE_URL}/sitemap-blog.xml`;
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const startTime = Date.now();
-  
+
   try {
-    // ✅ Robots.txt depuis backend
+    // ✅ Robots.txt depuis backend via API (évite boucle récursive /robots.txt)
+    // IMPORTANT: On utilise /api/seo/robots.txt au lieu de /robots.txt
+    // car /robots.txt serait intercepté par Remix lui-même (boucle infinie)
     const response = await fetchWithRetry(
-      `${SITEMAP_CONFIG.BACKEND_URL}/robots.txt`
+      `${SITEMAP_CONFIG.BACKEND_URL}/api/seo/robots.txt`
     );
-    
+
     const robotsTxt = await response.text();
     const duration = Date.now() - startTime;
-    
+
     return new Response(robotsTxt, {
       headers: {
         "Content-Type": "text/plain; charset=utf-8",
@@ -80,7 +82,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   } catch (error) {
     const duration = Date.now() - startTime;
     logSitemapError('Robots.txt', error, duration);
-    
+
     return new Response(generateFallbackRobots(), {
       headers: {
         "Content-Type": "text/plain; charset=utf-8",


### PR DESCRIPTION
## Summary
- Fix critical performance issue: robots.txt route was causing 5s TTFB due to recursive self-call
- Add `/api/seo/robots.txt` backend endpoint to bypass Remix interception
- Update Remix to fetch from new API endpoint

## Problem
- Remix `robots[.]txt.tsx` fetched `http://localhost:3000/robots.txt`
- This URL was intercepted by Remix itself → infinite loop
- Every robots.txt request took 5s (timeout) + caused 250% CPU

## Solution
| File | Change |
|------|--------|
| `backend/.../robots-txt.controller.ts` | Add `/api/seo/robots.txt` endpoint |
| `frontend/.../robots[.]txt.tsx` | Fetch from `/api/seo/robots.txt` |

## Expected Impact
| Metric | Before | After |
|--------|--------|-------|
| TTFB | 5-6s | <500ms |
| CPU | 250% | <50% |

## Test plan
- [ ] Verify `/robots.txt` responds quickly (<500ms)
- [ ] Verify robots.txt content is complete (not fallback)
- [ ] Check CPU usage drops on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)