### PR TITLE
fix(seo): cleanup duplicate sitemaps - unify to single index

### DIFF
--- a/backend/src/modules/seo/services/robots-txt.service.ts
+++ b/backend/src/modules/seo/services/robots-txt.service.ts
@@ -275,13 +275,9 @@ Disallow: /
 # ===========================================
 # 📍 SITEMAPS
 # ===========================================
-# Index principal (tous les sitemaps)
+# Index principal unique (contient tous les sitemaps thématiques)
+# V6: sitemap-vehicules.xml inclut marques + modèles + types
 Sitemap: ${this.baseUrl}/sitemap.xml
-
-# Sitemaps individuels
-Sitemap: ${this.baseUrl}/sitemap-constructeurs.xml
-Sitemap: ${this.baseUrl}/sitemap-types.xml
-Sitemap: ${this.baseUrl}/sitemap-blog.xml
 
 # ===========================================
 # ℹ️ INFORMATIONS

--- a/backend/src/modules/seo/services/sitemap-unified.service.ts
+++ b/backend/src/modules/seo/services/sitemap-unified.service.ts
@@ -119,6 +119,9 @@ export class SitemapUnifiedService {
     // Créer le répertoire si nécessaire
     this.ensureDirectory(outputDir);
 
+    // 🧹 Nettoyer les fichiers obsolètes (anciens sitemaps remplacés par V6)
+    this.cleanupObsoleteFiles(outputDir);
+
     try {
       // 1. Racine/Homepage (1 URL)
       this.logger.log('🏠 [1/7] Generating sitemap-racine.xml...');
@@ -627,6 +630,29 @@ ${urlEntries}
     if (bytes < 1024) return `${bytes} B`;
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  /**
+   * 🧹 Supprime les fichiers sitemap obsolètes
+   * Ces fichiers ont été remplacés par sitemap-vehicules.xml qui contient tout
+   */
+  private cleanupObsoleteFiles(dir: string): void {
+    const obsoleteFiles = [
+      'sitemap-constructeurs.xml', // Remplacé par sitemap-vehicules.xml
+      'sitemap-types.xml', // Remplacé par sitemap-vehicules.xml
+    ];
+
+    for (const filename of obsoleteFiles) {
+      const filepath = path.join(dir, filename);
+      if (fs.existsSync(filepath)) {
+        try {
+          fs.unlinkSync(filepath);
+          this.logger.log(`🗑️ Deleted obsolete file: ${filename}`);
+        } catch (error: any) {
+          this.logger.warn(`⚠️ Could not delete ${filename}: ${error.message}`);
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Suppression des références aux anciens sitemaps dans robots.txt
- `sitemap.xml` (index unique) contient maintenant `sitemap-vehicules.xml` avec 13 764 URLs (marques + modèles + types)
- Ajout de `cleanupObsoleteFiles()` pour supprimer automatiquement `sitemap-constructeurs.xml` et `sitemap-types.xml` lors de la régénération
- Nettoyage du code mort dans `generate-sitemaps.ts`

## Problème résolu
Google recevait des signaux mixtes de plusieurs sitemaps en doublon, causant des pages "Détectées, non indexées".

## Test plan
- [ ] Vérifier robots.txt ne référence plus que `sitemap.xml`
- [ ] Régénérer sitemaps : `curl -X POST http://localhost:3000/api/sitemap/generate-all`
- [ ] Vérifier suppression des fichiers obsolètes
- [ ] Soumettre `sitemap.xml` dans Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)