### PR TITLE
feat(seo): consolidate Gamme SEO & V-Level system

### DIFF
--- a/backend/src/modules/admin/controllers/admin-gammes-seo.controller.ts
+++ b/backend/src/modules/admin/controllers/admin-gammes-seo.controller.ts
@@ -16,6 +16,8 @@
  * - POST /api/admin/gammes-seo/thresholds/reset → Réinitialiser seuils
  * - GET  /api/admin/gammes-seo/audit            → Historique des actions
  * - GET  /api/admin/gammes-seo/audit/stats      → Stats audit
+ * - PUT  /api/admin/gammes-seo/:pgId/seo        → Sauvegarder SEO depuis formulaire
+ * - POST /api/admin/gammes-seo/:pgId/generate-seo → Générer SEO automatiquement
  */
 
 import {
@@ -24,6 +26,7 @@ import {
   Put,
   Patch,
   Post,
+  Delete,
   Query,
   Body,
   Param,
@@ -717,6 +720,779 @@ export class AdminGammesSeoController {
         {
           success: false,
           message: 'Erreur lors de la récupération des stats V-Level',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  // ============== SEO MANAGEMENT ENDPOINTS ==============
+
+  /**
+   * 💾 PUT /api/admin/gammes-seo/:pgId/seo
+   * Met à jour les données SEO d'une gamme (depuis le formulaire admin)
+   */
+  @Put(':pgId/seo')
+  async updateGammeSeo(
+    @Param('pgId', ParseIntPipe) pgId: number,
+    @Body()
+    seoData: {
+      sg_title: string;
+      sg_descrip: string;
+      sg_keywords: string;
+      sg_h1: string;
+      sg_content: string;
+    },
+  ) {
+    try {
+      this.logger.log(`💾 PUT /api/admin/gammes-seo/${pgId}/seo`);
+
+      const result = await this.gammesSeoService.updateGammeSeo(pgId, seoData);
+
+      return {
+        success: true,
+        message: result.message,
+        data: result,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error(`❌ Error updating SEO for gamme ${pgId}:`, error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la mise à jour SEO',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  // ============== PURCHASE GUIDE ENDPOINTS ==============
+
+  /**
+   * 📖 GET /api/admin/gammes-seo/:pgId/purchase-guide
+   * Récupère le guide d'achat d'une gamme
+   */
+  @Get(':pgId/purchase-guide')
+  async getPurchaseGuide(@Param('pgId', ParseIntPipe) pgId: number) {
+    try {
+      this.logger.log(`📖 GET /api/admin/gammes-seo/${pgId}/purchase-guide`);
+
+      const guide = await this.gammesSeoService.getPurchaseGuide(pgId);
+
+      return {
+        success: true,
+        data: guide,
+        message: guide ? 'Guide récupéré' : 'Aucun guide pour cette gamme',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error(
+        `❌ Error fetching purchase guide for gamme ${pgId}:`,
+        error,
+      );
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la récupération du guide',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 💾 PUT /api/admin/gammes-seo/:pgId/purchase-guide
+   * Met à jour ou crée le guide d'achat d'une gamme
+   */
+  @Put(':pgId/purchase-guide')
+  async updatePurchaseGuide(
+    @Param('pgId', ParseIntPipe) pgId: number,
+    @Body()
+    guideData: {
+      step1: {
+        title: string;
+        content: string;
+        highlight: string;
+        bullets?: string[];
+      };
+      step2: {
+        economique: {
+          subtitle: string;
+          description: string;
+          specs: string[];
+          priceRange: string;
+        };
+        qualitePlus: {
+          subtitle: string;
+          description: string;
+          specs: string[];
+          priceRange: string;
+          badge?: string;
+        };
+        premium: {
+          subtitle: string;
+          description: string;
+          specs: string[];
+          priceRange: string;
+        };
+      };
+      step3: {
+        title: string;
+        content: string;
+        alerts: Array<{ type: 'danger' | 'warning' | 'info'; text: string }>;
+        relatedGammes?: Array<{
+          pgId: number;
+          pgName: string;
+          pgAlias: string;
+        }>;
+      };
+    },
+  ) {
+    try {
+      this.logger.log(`💾 PUT /api/admin/gammes-seo/${pgId}/purchase-guide`);
+
+      const result = await this.gammesSeoService.updatePurchaseGuide(
+        pgId,
+        guideData,
+      );
+
+      return {
+        success: result.success,
+        message: result.message,
+        data: result.guide,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error(
+        `❌ Error updating purchase guide for gamme ${pgId}:`,
+        error,
+      );
+      throw new HttpException(
+        {
+          success: false,
+          message: "Erreur lors de la mise à jour du guide d'achat",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 🗑️ DELETE /api/admin/gammes-seo/:pgId/purchase-guide
+   * Supprime le guide d'achat d'une gamme
+   */
+  @Delete(':pgId/purchase-guide')
+  async deletePurchaseGuide(@Param('pgId', ParseIntPipe) pgId: number) {
+    try {
+      this.logger.log(`🗑️ DELETE /api/admin/gammes-seo/${pgId}/purchase-guide`);
+
+      const result = await this.gammesSeoService.deletePurchaseGuide(pgId);
+
+      return {
+        success: result.success,
+        message: result.message,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error(
+        `❌ Error deleting purchase guide for gamme ${pgId}:`,
+        error,
+      );
+      throw new HttpException(
+        {
+          success: false,
+          message: "Erreur lors de la suppression du guide d'achat",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  // ============== SEO GENERATION ENDPOINTS ==============
+
+  /**
+   * 🎯 POST /api/admin/gammes-seo/:pgId/generate-seo
+   * Génère le contenu SEO pour une gamme spécifique
+   */
+  @Post(':pgId/generate-seo')
+  async generateGammeSeo(@Param('pgId', ParseIntPipe) pgId: number) {
+    try {
+      this.logger.log(`🎯 POST /api/admin/gammes-seo/${pgId}/generate-seo`);
+
+      const result = await this.gammesSeoService.generateGammeSeo(pgId);
+
+      return {
+        success: true,
+        message: result.message,
+        data: result,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error(`❌ Error generating SEO for gamme ${pgId}:`, error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la génération SEO',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 🚀 POST /api/admin/gammes-seo/generate-all
+   * Génère le SEO pour toutes les gammes (batch)
+   */
+  @Post('generate-all')
+  async generateAllGammesSeo(
+    @Body()
+    body: {
+      onlyEmpty?: boolean;
+      gLevels?: string[];
+      limit?: number;
+    },
+  ) {
+    try {
+      this.logger.log('🚀 POST /api/admin/gammes-seo/generate-all');
+
+      const result = await this.gammesSeoService.generateAllGammesSeo({
+        onlyEmpty: body.onlyEmpty ?? true,
+        gLevels: body.gLevels,
+        limit: body.limit,
+      });
+
+      return {
+        success: result.success,
+        message: result.message,
+        data: result,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error('❌ Error in batch SEO generation:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la génération SEO batch',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 📊 GET /api/admin/gammes-seo/seo-stats
+   * Statistiques de couverture SEO
+   */
+  @Get('seo-stats')
+  async getSeoGenerationStats() {
+    try {
+      this.logger.log('📊 GET /api/admin/gammes-seo/seo-stats');
+
+      const stats = await this.gammesSeoService.getSeoGenerationStats();
+
+      return {
+        success: true,
+        data: stats,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error('❌ Error getting SEO stats:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la récupération des stats SEO',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  // =========================================================================
+  // CRUD Family Switches
+  // =========================================================================
+
+  /**
+   * ➕ POST /api/admin/gammes-seo/:pgId/switches
+   * Créer un Family Switch
+   */
+  @Post(':pgId/switches')
+  async createFamilySwitch(
+    @Param('pgId') pgId: string,
+    @Body() body: { alias: number; content: string },
+  ) {
+    try {
+      this.logger.log(`➕ POST /api/admin/gammes-seo/${pgId}/switches`);
+
+      const result = await this.gammesSeoService.createFamilySwitch(
+        parseInt(pgId, 10),
+        body.alias,
+        body.content,
+      );
+
+      if (!result.success) {
+        throw new HttpException(
+          { success: false, message: result.error },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return {
+        success: true,
+        id: result.id,
+        message: `Switch alias ${body.alias} créé`,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.error('❌ Error creating family switch:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la création du switch',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * ✏️ PUT /api/admin/gammes-seo/:pgId/switches/:id
+   * Modifier un Family Switch
+   */
+  @Put(':pgId/switches/:id')
+  async updateFamilySwitch(
+    @Param('pgId') pgId: string,
+    @Param('id') id: string,
+    @Body() body: { content: string },
+  ) {
+    try {
+      this.logger.log(`✏️ PUT /api/admin/gammes-seo/${pgId}/switches/${id}`);
+
+      const result = await this.gammesSeoService.updateFamilySwitch(
+        parseInt(id, 10),
+        body.content,
+      );
+
+      if (!result.success) {
+        throw new HttpException(
+          { success: false, message: result.error },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return {
+        success: true,
+        message: 'Switch mis à jour',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.error('❌ Error updating family switch:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la mise à jour du switch',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 🗑️ DELETE /api/admin/gammes-seo/:pgId/switches/:id
+   * Supprimer un Family Switch
+   */
+  @Delete(':pgId/switches/:id')
+  async deleteFamilySwitch(
+    @Param('pgId') pgId: string,
+    @Param('id') id: string,
+  ) {
+    try {
+      this.logger.log(`🗑️ DELETE /api/admin/gammes-seo/${pgId}/switches/${id}`);
+
+      const result = await this.gammesSeoService.deleteFamilySwitch(
+        parseInt(id, 10),
+      );
+
+      if (!result.success) {
+        throw new HttpException(
+          { success: false, message: result.error },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return {
+        success: true,
+        message: 'Switch supprimé',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.error('❌ Error deleting family switch:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la suppression du switch',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  // ============== INFORMATIONS TECHNIQUES ENDPOINTS ==============
+
+  /**
+   * 📚 GET /api/admin/gammes-seo/:pgId/informations
+   * Récupère toutes les informations techniques d'une gamme
+   */
+  @Get(':pgId/informations')
+  async getInformations(@Param('pgId', ParseIntPipe) pgId: number) {
+    try {
+      this.logger.log(`📚 GET /api/admin/gammes-seo/${pgId}/informations`);
+      const data = await this.gammesSeoService.getInformations(pgId);
+      return {
+        success: true,
+        data,
+        count: data.length,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error('❌ Error getting informations:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la récupération des informations',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * ➕ POST /api/admin/gammes-seo/:pgId/informations
+   * Ajoute une nouvelle information technique
+   */
+  @Post(':pgId/informations')
+  async addInformation(
+    @Param('pgId', ParseIntPipe) pgId: number,
+    @Body('content') content: string,
+  ) {
+    try {
+      this.logger.log(`➕ POST /api/admin/gammes-seo/${pgId}/informations`);
+
+      if (!content || content.trim().length === 0) {
+        throw new HttpException(
+          { success: false, message: 'Le contenu est requis' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const result = await this.gammesSeoService.addInformation(pgId, content);
+
+      if (!result.success) {
+        throw new HttpException(
+          { success: false, message: result.message },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return {
+        success: true,
+        data: result.item,
+        message: 'Information ajoutée',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.error('❌ Error adding information:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: "Erreur lors de l'ajout de l'information",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * ✏️ PUT /api/admin/gammes-seo/informations/:sgiId
+   * Met à jour une information technique
+   */
+  @Put('informations/:sgiId')
+  async updateInformation(
+    @Param('sgiId', ParseIntPipe) sgiId: number,
+    @Body('content') content: string,
+  ) {
+    try {
+      this.logger.log(`✏️ PUT /api/admin/gammes-seo/informations/${sgiId}`);
+
+      if (!content || content.trim().length === 0) {
+        throw new HttpException(
+          { success: false, message: 'Le contenu est requis' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const result = await this.gammesSeoService.updateInformation(sgiId, content);
+
+      if (!result.success) {
+        throw new HttpException(
+          { success: false, message: result.message },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return {
+        success: true,
+        message: 'Information mise à jour',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.error('❌ Error updating information:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: "Erreur lors de la mise à jour de l'information",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 🗑️ DELETE /api/admin/gammes-seo/informations/:sgiId
+   * Supprime une information technique
+   */
+  @Delete('informations/:sgiId')
+  async deleteInformation(@Param('sgiId', ParseIntPipe) sgiId: number) {
+    try {
+      this.logger.log(`🗑️ DELETE /api/admin/gammes-seo/informations/${sgiId}`);
+
+      const result = await this.gammesSeoService.deleteInformation(sgiId);
+
+      if (!result.success) {
+        throw new HttpException(
+          { success: false, message: result.message },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return {
+        success: true,
+        message: 'Information supprimée',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.error('❌ Error deleting information:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: "Erreur lors de la suppression de l'information",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  // ============== ÉQUIPEMENTIERS ENDPOINTS ==============
+
+  /**
+   * 🏭 GET /api/admin/gammes-seo/:pgId/equipementiers
+   * Récupère tous les équipementiers d'une gamme
+   */
+  @Get(':pgId/equipementiers')
+  async getEquipementiers(@Param('pgId', ParseIntPipe) pgId: number) {
+    try {
+      this.logger.log(`🏭 GET /api/admin/gammes-seo/${pgId}/equipementiers`);
+      const data = await this.gammesSeoService.getEquipementiers(pgId);
+      return {
+        success: true,
+        data,
+        count: data.length,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error('❌ Error getting equipementiers:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la récupération des équipementiers',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 📋 GET /api/admin/gammes-seo/marques/available
+   * Liste des marques disponibles pour le dropdown
+   */
+  @Get('marques/available')
+  async getAvailableMarques() {
+    try {
+      this.logger.log('📋 GET /api/admin/gammes-seo/marques/available');
+      const data = await this.gammesSeoService.getAvailableMarques();
+      return {
+        success: true,
+        data,
+        count: data.length,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      this.logger.error('❌ Error getting available marques:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: 'Erreur lors de la récupération des marques',
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * ➕ POST /api/admin/gammes-seo/:pgId/equipementiers
+   * Ajoute un équipementier à une gamme
+   */
+  @Post(':pgId/equipementiers')
+  async addEquipementier(
+    @Param('pgId', ParseIntPipe) pgId: number,
+    @Body() body: { pmId: number; content: string },
+  ) {
+    try {
+      this.logger.log(`➕ POST /api/admin/gammes-seo/${pgId}/equipementiers`);
+
+      if (!body.pmId) {
+        throw new HttpException(
+          { success: false, message: 'La marque est requise' },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const result = await this.gammesSeoService.addEquipementier(
+        pgId,
+        body.pmId,
+        body.content || '',
+      );
+
+      if (!result.success) {
+        throw new HttpException(
+          { success: false, message: result.message },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return {
+        success: true,
+        data: result.item,
+        message: 'Équipementier ajouté',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.error('❌ Error adding equipementier:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: "Erreur lors de l'ajout de l'équipementier",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * ✏️ PUT /api/admin/gammes-seo/equipementiers/:segId
+   * Met à jour la description d'un équipementier
+   */
+  @Put('equipementiers/:segId')
+  async updateEquipementier(
+    @Param('segId', ParseIntPipe) segId: number,
+    @Body('content') content: string,
+  ) {
+    try {
+      this.logger.log(`✏️ PUT /api/admin/gammes-seo/equipementiers/${segId}`);
+
+      const result = await this.gammesSeoService.updateEquipementier(segId, content || '');
+
+      if (!result.success) {
+        throw new HttpException(
+          { success: false, message: result.message },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return {
+        success: true,
+        message: 'Équipementier mis à jour',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.error('❌ Error updating equipementier:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: "Erreur lors de la mise à jour de l'équipementier",
+          error: error instanceof Error ? error.message : 'Erreur inconnue',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 🗑️ DELETE /api/admin/gammes-seo/equipementiers/:segId
+   * Supprime un équipementier d'une gamme
+   */
+  @Delete('equipementiers/:segId')
+  async deleteEquipementier(@Param('segId', ParseIntPipe) segId: number) {
+    try {
+      this.logger.log(`🗑️ DELETE /api/admin/gammes-seo/equipementiers/${segId}`);
+
+      const result = await this.gammesSeoService.deleteEquipementier(segId);
+
+      if (!result.success) {
+        throw new HttpException(
+          { success: false, message: result.message },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      return {
+        success: true,
+        message: 'Équipementier supprimé',
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpException) throw error;
+      this.logger.error('❌ Error deleting equipementier:', error);
+      throw new HttpException(
+        {
+          success: false,
+          message: "Erreur lors de la suppression de l'équipementier",
           error: error instanceof Error ? error.message : 'Erreur inconnue',
         },
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/backend/src/modules/support/services/legal.service.ts
+++ b/backend/src/modules/support/services/legal.service.ts
@@ -1,4 +1,3 @@
-import { TABLES } from '@repo/database-types';
 import {
   Injectable,
   Logger,
@@ -7,17 +6,25 @@ import {
 } from '@nestjs/common';
 import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
 
+/**
+ * ✅ MIGRÉ: Utilise maintenant les tables dédiées (migration 20260108)
+ *    - `legal_documents` - Documents légaux avec colonnes indexées
+ *    - `legal_document_versions` - Historique des versions
+ *    - `legal_acceptances` - Acceptations par les utilisateurs
+ *    au lieu de `___xtr_msg` (12.8M rows, LIKE queries = timeouts)
+ */
 export interface LegalDocument {
+  // Champs legacy (conservés pour compatibilité)
   msg_id: string;
-  msg_cst_id: string; // Staff ID qui a créé le document
-  msg_cnfa_id?: string; // Staff ID qui a modifié
+  msg_cst_id: string;
+  msg_cnfa_id?: string;
   msg_date: string;
-  msg_subject: string; // Titre du document
-  msg_content: string; // Contenu JSON avec le document légal
-  msg_open: '0' | '1'; // 1 = draft, 0 = publié
-  msg_close: '0' | '1'; // 1 = archivé, 0 = actif
+  msg_subject: string;
+  msg_content: string;
+  msg_open: '0' | '1';
+  msg_close: '0' | '1';
 
-  // Données dérivées du JSON dans msg_content
+  // Données du document
   id: string;
   type:
     | 'terms'
@@ -88,6 +95,7 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Créer un nouveau document légal
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_documents`
    */
   async createDocument(
     documentData: CreateLegalDocumentRequest,
@@ -97,31 +105,24 @@ export class LegalService extends SupabaseBaseService {
 
       const version = 'v1.0';
       const effectiveDate = documentData.effectiveDate || new Date();
+      const slug = this.generateSlug(documentData.title);
 
-      // Préparer le contenu JSON
-      const contentData = {
-        type: 'legal_document',
-        documentType: documentData.type,
-        content: documentData.content,
-        version,
-        effectiveDate: effectiveDate.toISOString(),
-        published: false,
-        language: documentData.language || 'fr',
-        slug: this.generateSlug(documentData.title),
-        metadata: documentData.metadata || {},
-        createdAt: new Date().toISOString(),
-      };
-
-      // Créer le document dans ___xtr_msg
-      const { data: legalMessage, error } = await this.supabase
-        .from(TABLES.xtr_msg)
+      // Créer le document dans la nouvelle table legal_documents
+      const { data: newDoc, error } = await this.supabase
+        .from('legal_documents')
         .insert({
-          msg_cst_id: documentData.createdBy || '1', // Utiliser ID par défaut si null
-          msg_date: new Date().toISOString(),
-          msg_subject: documentData.title,
-          msg_content: JSON.stringify(contentData),
-          msg_open: '1', // Draft
-          msg_close: '0', // Actif
+          document_type: documentData.type,
+          title: documentData.title,
+          content: documentData.content,
+          slug,
+          version,
+          effective_date: effectiveDate.toISOString(),
+          published: false,
+          is_draft: true,
+          is_archived: false,
+          language: documentData.language || 'fr',
+          metadata: documentData.metadata || {},
+          created_by: documentData.createdBy || 'system',
         })
         .select('*')
         .single();
@@ -133,9 +134,9 @@ export class LegalService extends SupabaseBaseService {
       }
 
       this.logger.log(
-        `Document légal créé: ${legalMessage.msg_id} - Type: ${documentData.type}`,
+        `Document légal créé: ${newDoc.id} - Type: ${documentData.type}`,
       );
-      return await this.enrichDocumentData(legalMessage);
+      return this.mapToLegalDocument(newDoc);
     } catch (error) {
       this.logger.error(
         `Échec de création du document: ${(error as Error).message}`,
@@ -147,41 +148,45 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Récupérer un document par ID ou slug
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_documents`
    */
   async getDocument(identifier: string): Promise<LegalDocument | null> {
     try {
-      let message = null;
+      // Essayer d'abord par ID numérique
+      const numericId = parseInt(identifier, 10);
 
-      // Essayer par ID de message d'abord
-      const { data: messageById } = await this.supabase
-        .from(TABLES.xtr_msg)
-        .select('*')
-        .eq('msg_id', identifier)
-        .like('msg_content', '%"type":"legal_document"%')
-        .single();
+      let doc = null;
 
-      if (messageById) {
-        message = messageById;
-      } else {
-        // Essayer par slug dans le contenu JSON
-        const { data: messages } = await this.supabase
-          .from(TABLES.xtr_msg)
+      if (!isNaN(numericId)) {
+        const { data } = await this.supabase
+          .from('legal_documents')
           .select('*')
-          .like('msg_content', '%"type":"legal_document"%');
-
-        if (messages) {
-          message = messages.find((msg) => {
-            try {
-              const content = JSON.parse(msg.msg_content || '{}');
-              return content.slug === identifier;
-            } catch {
-              return false;
-            }
-          });
-        }
+          .eq('id', numericId)
+          .single();
+        doc = data;
       }
 
-      return message ? await this.enrichDocumentData(message) : null;
+      // Sinon essayer par slug
+      if (!doc) {
+        const { data } = await this.supabase
+          .from('legal_documents')
+          .select('*')
+          .eq('slug', identifier)
+          .single();
+        doc = data;
+      }
+
+      // Essayer par legacy_msg_id
+      if (!doc) {
+        const { data } = await this.supabase
+          .from('legal_documents')
+          .select('*')
+          .eq('legacy_msg_id', identifier)
+          .single();
+        doc = data;
+      }
+
+      return doc ? this.mapToLegalDocument(doc) : null;
     } catch (error) {
       this.logger.error(
         `Erreur lors de la récupération du document ${identifier}: ${(error as Error).message}`,
@@ -192,30 +197,24 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Récupérer un document par type
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_documents`
    */
   async getDocumentByType(
     type: LegalDocument['type'],
   ): Promise<LegalDocument | null> {
     try {
-      const { data: messages } = await this.supabase
-        .from(TABLES.xtr_msg)
+      const { data: doc, error } = await this.supabase
+        .from('legal_documents')
         .select('*')
-        .like('msg_content', '%"type":"legal_document"%')
-        .eq('msg_open', '0') // Seulement les documents publiés
-        .order('msg_date', { ascending: false });
+        .eq('document_type', type)
+        .eq('published', true)
+        .order('updated_at', { ascending: false })
+        .limit(1)
+        .single();
 
-      if (!messages) return null;
+      if (error || !doc) return null;
 
-      const message = messages.find((msg) => {
-        try {
-          const content = JSON.parse(msg.msg_content || '{}');
-          return content.documentType === type;
-        } catch {
-          return false;
-        }
-      });
-
-      return message ? await this.enrichDocumentData(message) : null;
+      return this.mapToLegalDocument(doc);
     } catch (error) {
       this.logger.error(
         `Erreur lors de la récupération du document de type ${type}: ${(error as Error).message}`,
@@ -226,6 +225,7 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Récupérer tous les documents avec filtres
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_documents`
    */
   async getAllDocuments(filters?: {
     type?: LegalDocument['type'];
@@ -234,17 +234,26 @@ export class LegalService extends SupabaseBaseService {
   }): Promise<LegalDocument[]> {
     try {
       let query = this.supabase
-        .from(TABLES.xtr_msg)
+        .from('legal_documents')
         .select('*')
-        .like('msg_content', '%"type":"legal_document"%')
-        .order('msg_date', { ascending: false });
+        .order('updated_at', { ascending: false });
+
+      // Filtrer par type
+      if (filters?.type) {
+        query = query.eq('document_type', filters.type);
+      }
 
       // Filtrer par statut de publication
       if (filters?.published !== undefined) {
-        query = query.eq('msg_open', filters.published ? '0' : '1');
+        query = query.eq('published', filters.published);
       }
 
-      const { data: messages, error } = await query;
+      // Filtrer par langue
+      if (filters?.language) {
+        query = query.eq('language', filters.language);
+      }
+
+      const { data: docs, error } = await query;
 
       if (error) {
         throw new Error(
@@ -252,12 +261,7 @@ export class LegalService extends SupabaseBaseService {
         );
       }
 
-      // Enrichir et filtrer par contenu JSON
-      const documents = await Promise.all(
-        messages.map((message) => this.enrichDocumentData(message)),
-      );
-
-      return this.applyContentFilters(documents, filters);
+      return (docs || []).map((doc) => this.mapToLegalDocument(doc));
     } catch (error) {
       this.logger.error(
         `Erreur lors de la récupération des documents: ${(error as Error).message}`,
@@ -268,6 +272,7 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Mettre à jour un document
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_documents`
    */
   async updateDocument(
     documentId: string,
@@ -281,29 +286,33 @@ export class LegalService extends SupabaseBaseService {
         throw new NotFoundException(`Document ${documentId} introuvable`);
       }
 
-      // Sauvegarder la version actuelle
+      // Sauvegarder la version actuelle si des changements sont indiqués
       if (changes) {
         await this.saveVersion(documentId, document, changes, updatedBy);
       }
 
-      // Préparer le contenu mis à jour
-      const currentContent = JSON.parse(document.msg_content || '{}');
-      const updatedContent = {
-        ...currentContent,
-        ...updates,
-        lastUpdated: new Date().toISOString(),
-        updatedBy,
+      // Préparer les données de mise à jour
+      const updateData: Record<string, any> = {
+        updated_by: updatedBy,
       };
 
+      if (updates.title) updateData.title = updates.title;
+      if (updates.content) updateData.content = updates.content;
+      if (updates.type) updateData.document_type = updates.type;
+      if (updates.language) updateData.language = updates.language;
+      if (updates.slug) updateData.slug = updates.slug;
+      if (updates.metadata) updateData.metadata = updates.metadata;
+      if (updates.effectiveDate)
+        updateData.effective_date = updates.effectiveDate;
+
+      // Extraire l'ID numérique
+      const numericId = parseInt(document.id, 10);
+
       // Mettre à jour le document
-      const { data: updatedMessage, error } = await this.supabase
-        .from(TABLES.xtr_msg)
-        .update({
-          msg_subject: updates.title || document.msg_subject,
-          msg_content: JSON.stringify(updatedContent),
-          msg_cnfa_id: updatedBy,
-        })
-        .eq('msg_id', documentId)
+      const { data: updatedDoc, error } = await this.supabase
+        .from('legal_documents')
+        .update(updateData)
+        .eq('id', numericId)
         .select('*')
         .single();
 
@@ -312,7 +321,7 @@ export class LegalService extends SupabaseBaseService {
       }
 
       this.logger.log(`Document ${documentId} mis à jour par ${updatedBy}`);
-      return await this.enrichDocumentData(updatedMessage);
+      return this.mapToLegalDocument(updatedDoc);
     } catch (error) {
       this.logger.error(
         `Erreur lors de la mise à jour du document ${documentId}: ${(error as Error).message}`,
@@ -323,6 +332,7 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Publier ou dépublier un document
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_documents`
    */
   async publishDocument(
     documentId: string,
@@ -334,19 +344,16 @@ export class LegalService extends SupabaseBaseService {
         throw new NotFoundException(`Document ${documentId} introuvable`);
       }
 
-      // Mettre à jour le contenu JSON
-      const content = JSON.parse(document.msg_content || '{}');
-      content.published = published;
-      content.lastUpdated = new Date().toISOString();
+      const numericId = parseInt(document.id, 10);
 
       // Mettre à jour le statut
-      const { data: updatedMessage, error } = await this.supabase
-        .from(TABLES.xtr_msg)
+      const { data: updatedDoc, error } = await this.supabase
+        .from('legal_documents')
         .update({
-          msg_content: JSON.stringify(content),
-          msg_open: published ? '0' : '1', // 0 = publié, 1 = draft
+          published,
+          is_draft: !published,
         })
-        .eq('msg_id', documentId)
+        .eq('id', numericId)
         .select('*')
         .single();
 
@@ -357,7 +364,7 @@ export class LegalService extends SupabaseBaseService {
       this.logger.log(
         `Document ${documentId} ${published ? 'publié' : 'dépublié'}`,
       );
-      return await this.enrichDocumentData(updatedMessage);
+      return this.mapToLegalDocument(updatedDoc);
     } catch (error) {
       this.logger.error(
         `Erreur lors de la publication du document ${documentId}: ${(error as Error).message}`,
@@ -368,6 +375,7 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Supprimer un document
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_documents`
    */
   async deleteDocument(documentId: string): Promise<void> {
     try {
@@ -376,10 +384,12 @@ export class LegalService extends SupabaseBaseService {
         throw new NotFoundException(`Document ${documentId} introuvable`);
       }
 
+      const numericId = parseInt(document.id, 10);
+
       const { error } = await this.supabase
-        .from(TABLES.xtr_msg)
+        .from('legal_documents')
         .delete()
-        .eq('msg_id', documentId);
+        .eq('id', numericId);
 
       if (error) {
         throw new Error(`Erreur lors de la suppression: ${error.message}`);
@@ -396,6 +406,7 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Enregistrer l'acceptation d'un document légal
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_acceptances`
    */
   async acceptDocument(
     documentType: LegalDocument['type'],
@@ -411,26 +422,23 @@ export class LegalService extends SupabaseBaseService {
         );
       }
 
-      // Créer un enregistrement d'acceptation dans ___xtr_msg
-      const acceptanceData = {
-        type: 'legal_acceptance',
-        userId,
-        documentId: document.id,
-        documentType: document.type,
-        version: document.version,
-        ipAddress,
-        userAgent,
-        acceptedAt: new Date().toISOString(),
-      };
+      const numericDocId = parseInt(document.id, 10);
 
-      const { error } = await this.supabase.from(TABLES.xtr_msg).insert({
-        msg_cst_id: userId,
-        msg_date: new Date().toISOString(),
-        msg_subject: `Acceptation ${documentType}`,
-        msg_content: JSON.stringify(acceptanceData),
-        msg_open: '0', // Fermé
-        msg_close: '0', // Actif
-      });
+      // Créer un enregistrement d'acceptation dans legal_acceptances
+      const { error } = await this.supabase.from('legal_acceptances').upsert(
+        {
+          user_id: userId,
+          document_id: isNaN(numericDocId) ? null : numericDocId,
+          document_type: documentType,
+          document_version: document.version,
+          ip_address: ipAddress || null,
+          user_agent: userAgent || null,
+          accepted_at: new Date().toISOString(),
+        },
+        {
+          onConflict: 'user_id,document_type,document_version',
+        },
+      );
 
       if (error) {
         throw new Error(`Erreur lors de l'enregistrement: ${error.message}`);
@@ -449,6 +457,7 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Récupérer les acceptations d'un utilisateur
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_acceptances`
    */
   async getUserAcceptances(userId: string): Promise<
     Array<{
@@ -458,33 +467,19 @@ export class LegalService extends SupabaseBaseService {
     }>
   > {
     try {
-      const { data: messages } = await this.supabase
-        .from(TABLES.xtr_msg)
-        .select('*')
-        .eq('msg_cst_id', userId)
-        .like('msg_content', '%"type":"legal_acceptance"%')
-        .order('msg_date', { ascending: false });
+      const { data: acceptances, error } = await this.supabase
+        .from('legal_acceptances')
+        .select('document_type, document_version, accepted_at')
+        .eq('user_id', userId)
+        .order('accepted_at', { ascending: false });
 
-      if (!messages) return [];
+      if (error || !acceptances) return [];
 
-      return messages
-        .map((msg) => {
-          try {
-            const content = JSON.parse(msg.msg_content || '{}');
-            return {
-              documentType: content.documentType,
-              version: content.version,
-              acceptedAt: new Date(content.acceptedAt),
-            };
-          } catch {
-            return null;
-          }
-        })
-        .filter(Boolean) as Array<{
-        documentType: LegalDocument['type'];
-        version: string;
-        acceptedAt: Date;
-      }>;
+      return acceptances.map((acc) => ({
+        documentType: acc.document_type as LegalDocument['type'],
+        version: acc.document_version,
+        acceptedAt: new Date(acc.accepted_at),
+      }));
     } catch (error) {
       this.logger.error(
         `Erreur lors de la récupération des acceptations de ${userId}: ${(error as Error).message}`,
@@ -513,39 +508,32 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Récupérer les versions d'un document
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_document_versions`
    */
   async getDocumentVersions(
     documentId: string,
   ): Promise<LegalDocumentVersion[]> {
     try {
-      const { data: messages } = await this.supabase
-        .from(TABLES.xtr_msg)
+      const numericId = parseInt(documentId, 10);
+
+      const { data: versions, error } = await this.supabase
+        .from('legal_document_versions')
         .select('*')
-        .like('msg_content', `%"documentId":"${documentId}"%`)
-        .like('msg_content', '%"type":"legal_version"%')
-        .order('msg_date', { ascending: false });
+        .eq('document_id', numericId)
+        .order('created_at', { ascending: false });
 
-      if (!messages) return [];
+      if (error || !versions) return [];
 
-      return messages
-        .map((msg) => {
-          try {
-            const content = JSON.parse(msg.msg_content || '{}');
-            return {
-              id: msg.msg_id,
-              documentId: content.documentId,
-              version: content.version,
-              content: content.content,
-              changes: content.changes,
-              effectiveDate: new Date(content.effectiveDate),
-              createdAt: new Date(msg.msg_date),
-              createdBy: msg.msg_cst_id,
-            };
-          } catch {
-            return null;
-          }
-        })
-        .filter(Boolean) as LegalDocumentVersion[];
+      return versions.map((v) => ({
+        id: v.id.toString(),
+        documentId: v.document_id.toString(),
+        version: v.version,
+        content: v.content,
+        changes: v.changes || '',
+        effectiveDate: new Date(v.effective_date),
+        createdAt: new Date(v.created_at),
+        createdBy: v.created_by,
+      }));
     } catch (error) {
       this.logger.error(
         `Erreur lors de la récupération des versions: ${(error as Error).message}`,
@@ -556,31 +544,34 @@ export class LegalService extends SupabaseBaseService {
 
   /**
    * Récupérer une version spécifique
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_document_versions`
    */
   async getDocumentVersion(
     documentId: string,
     versionId: string,
   ): Promise<LegalDocumentVersion | null> {
     try {
-      const { data: message } = await this.supabase
-        .from(TABLES.xtr_msg)
+      const numericDocId = parseInt(documentId, 10);
+      const numericVersionId = parseInt(versionId, 10);
+
+      const { data: version, error } = await this.supabase
+        .from('legal_document_versions')
         .select('*')
-        .eq('msg_id', versionId)
-        .like('msg_content', `%"documentId":"${documentId}"%`)
+        .eq('id', numericVersionId)
+        .eq('document_id', numericDocId)
         .single();
 
-      if (!message) return null;
+      if (error || !version) return null;
 
-      const content = JSON.parse(message.msg_content || '{}');
       return {
-        id: message.msg_id,
-        documentId: content.documentId,
-        version: content.version,
-        content: content.content,
-        changes: content.changes,
-        effectiveDate: new Date(content.effectiveDate),
-        createdAt: new Date(message.msg_date),
-        createdBy: message.msg_cst_id,
+        id: version.id.toString(),
+        documentId: version.document_id.toString(),
+        version: version.version,
+        content: version.content,
+        changes: version.changes || '',
+        effectiveDate: new Date(version.effective_date),
+        createdAt: new Date(version.created_at),
+        createdBy: version.created_by,
       };
     } catch (error) {
       this.logger.error(
@@ -621,6 +612,47 @@ export class LegalService extends SupabaseBaseService {
   }
 
   // ==================== MÉTHODES UTILITAIRES ====================
+
+  /**
+   * Convertir une row de la table legal_documents vers l'interface LegalDocument
+   * ✅ Nouvelle méthode pour la migration vers les tables dédiées
+   */
+  private mapToLegalDocument(row: any): LegalDocument {
+    return {
+      // Champs legacy (compatibilité - simulés depuis les nouvelles colonnes)
+      msg_id: row.legacy_msg_id || row.id?.toString() || '',
+      msg_cst_id: row.created_by || '',
+      msg_cnfa_id: row.updated_by || undefined,
+      msg_date: row.created_at || new Date().toISOString(),
+      msg_subject: row.title || '',
+      msg_content: JSON.stringify({
+        type: 'legal_document',
+        documentType: row.document_type,
+        content: row.content,
+        version: row.version,
+        slug: row.slug,
+        language: row.language,
+        metadata: row.metadata,
+      }),
+      msg_open: row.is_draft ? '1' : '0',
+      msg_close: row.is_archived ? '1' : '0',
+
+      // Données du document (nouvelles colonnes)
+      id: row.id?.toString() || '',
+      type: row.document_type || 'custom',
+      title: row.title || '',
+      content: row.content || '',
+      version: row.version || 'v1.0',
+      effectiveDate: new Date(row.effective_date || row.created_at),
+      lastUpdated: new Date(row.updated_at || row.created_at),
+      published: row.published ?? false,
+      language: row.language || 'fr',
+      slug: row.slug || '',
+      metadata: row.metadata || {},
+      createdBy: row.created_by || 'system',
+      updatedBy: row.updated_by || undefined,
+    };
+  }
 
   /**
    * Initialiser les documents par défaut
@@ -679,47 +711,8 @@ export class LegalService extends SupabaseBaseService {
   }
 
   /**
-   * Enrichir les données de document avec les informations dérivées
-   */
-  private async enrichDocumentData(message: any): Promise<LegalDocument> {
-    try {
-      const content = JSON.parse(message.msg_content || '{}');
-
-      return {
-        msg_id: message.msg_id,
-        msg_cst_id: message.msg_cst_id,
-        msg_cnfa_id: message.msg_cnfa_id,
-        msg_date: message.msg_date,
-        msg_subject: message.msg_subject,
-        msg_content: message.msg_content,
-        msg_open: message.msg_open,
-        msg_close: message.msg_close,
-
-        // Données dérivées du JSON
-        id: message.msg_id,
-        type: content.documentType || 'custom',
-        title: message.msg_subject || '',
-        content: content.content || '',
-        version: content.version || 'v1.0',
-        effectiveDate: new Date(content.effectiveDate || message.msg_date),
-        lastUpdated: new Date(content.lastUpdated || message.msg_date),
-        published: content.published || message.msg_open === '0',
-        language: content.language || 'fr',
-        slug: content.slug || this.generateSlug(message.msg_subject),
-        metadata: content.metadata || {},
-        createdBy: message.msg_cst_id,
-        updatedBy: content.updatedBy || message.msg_cnfa_id,
-      };
-    } catch (error) {
-      this.logger.error(
-        `Erreur dans enrichDocumentData: ${(error as Error).message}`,
-      );
-      throw error;
-    }
-  }
-
-  /**
    * Sauvegarder une version du document
+   * ✅ MIGRÉ: Utilise maintenant la table `legal_document_versions`
    */
   private async saveVersion(
     documentId: string,
@@ -728,65 +721,21 @@ export class LegalService extends SupabaseBaseService {
     createdBy: string,
   ): Promise<void> {
     try {
-      const versionData = {
-        type: 'legal_version',
-        documentId,
+      const numericDocId = parseInt(documentId, 10);
+
+      await this.supabase.from('legal_document_versions').insert({
+        document_id: numericDocId,
         version: document.version,
         content: document.content,
         changes,
-        effectiveDate: document.effectiveDate.toISOString(),
-      };
-
-      await this.supabase.from(TABLES.xtr_msg).insert({
-        msg_cst_id: createdBy,
-        msg_date: new Date().toISOString(),
-        msg_subject: `Version ${document.version} - ${document.title}`,
-        msg_content: JSON.stringify(versionData),
-        msg_open: '0',
-        msg_close: '0',
+        effective_date: document.effectiveDate.toISOString(),
+        created_by: createdBy,
       });
     } catch (error) {
       this.logger.error(
         `Erreur lors de la sauvegarde de version: ${(error as Error).message}`,
       );
     }
-  }
-
-  /**
-   * Appliquer les filtres basés sur le contenu JSON
-   */
-  private applyContentFilters(
-    documents: LegalDocument[],
-    filters?: {
-      type?: LegalDocument['type'];
-      published?: boolean;
-      language?: string;
-    },
-  ): LegalDocument[] {
-    if (!filters) {
-      return documents;
-    }
-
-    return documents
-      .filter((doc) => {
-        if (filters.type && doc.type !== filters.type) {
-          return false;
-        }
-        if (
-          filters.published !== undefined &&
-          doc.published !== filters.published
-        ) {
-          return false;
-        }
-        if (filters.language && doc.language !== filters.language) {
-          return false;
-        }
-        return true;
-      })
-      .sort(
-        (a, b) =>
-          new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime(),
-      );
   }
 
   /**

--- a/backend/src/modules/support/services/review.service.ts
+++ b/backend/src/modules/support/services/review.service.ts
@@ -207,48 +207,18 @@ export class ReviewService extends SupabaseBaseService {
 
   /**
    * Récupérer les avis avec filtres
+   *
+   * ⚠️ DÉSACTIVÉ TEMPORAIREMENT (2026-01-03)
+   * Cause: LIKE query sur ___xtr_msg (12.8M rows) = timeout 15s
+   * Solution: Migrer vers table dédiée `reviews`
+   * @see 20260104_create_reviews_table.sql (migration en attente)
    */
-  async getReviews(filters?: ReviewFilters): Promise<ReviewData[]> {
-    try {
-      let query = this.supabase
-        .from(TABLES.xtr_msg)
-        .select('*')
-        .like('msg_content', '%"type":"review"%')
-        .order('msg_date', { ascending: false });
-
-      // Appliquer les filtres
-      if (filters) {
-        if (filters.customer_id) {
-          query = query.eq('msg_cst_id', filters.customer_id);
-        }
-        if (filters.startDate) {
-          query = query.gte('msg_date', filters.startDate.toISOString());
-        }
-        if (filters.endDate) {
-          query = query.lte('msg_date', filters.endDate.toISOString());
-        }
-      }
-
-      const { data: messages, error } = await query;
-
-      if (error) {
-        throw new Error(
-          `Erreur lors de la récupération des avis: ${error.message}`,
-        );
-      }
-
-      // Enrichir les données et appliquer les filtres JSON
-      const reviews = await Promise.all(
-        messages.map((message) => this.enrichReviewData(message)),
-      );
-
-      return this.applyContentFilters(reviews, filters);
-    } catch (error) {
-      this.logger.error(
-        `Erreur lors de la récupération des avis: ${(error as Error).message}`,
-      );
-      throw error;
-    }
+  async getReviews(_filters?: ReviewFilters): Promise<ReviewData[]> {
+    this.logger.warn(
+      '⚠️ getReviews() désactivé: LIKE sur ___xtr_msg cause timeout (12.8M rows). ' +
+        'Retourne [] en attendant migration vers table `reviews`.',
+    );
+    return [];
   }
 
   /**

--- a/backend/supabase/migrations/20260103_consolidate_seo_vlevel.sql
+++ b/backend/supabase/migrations/20260103_consolidate_seo_vlevel.sql
@@ -1,0 +1,198 @@
+-- ============================================================================
+-- MIGRATION: Consolidation SEO & V-Level (Version Complète)
+-- ============================================================================
+-- Basé sur la documentation G/V Classification
+-- Date: 2026-01-03
+-- Cible: 235 gammes principales (pg_level > 0)
+-- ============================================================================
+
+-- ============================================================================
+-- PARTIE 1: Table gamme_seo_audit (remplace l'usage incorrect de ___xtr_msg)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS gamme_seo_audit (
+  id SERIAL PRIMARY KEY,
+  admin_id INTEGER,
+  admin_email TEXT,
+  action_type TEXT NOT NULL,  -- 'UPDATE_G_LEVEL', 'UPDATE_V_LEVEL', 'BULK_UPDATE', etc.
+  entity_type TEXT DEFAULT 'gamme',  -- 'gamme', 'vehicle', 'model'
+  entity_ids INTEGER[],
+  old_values JSONB,
+  new_values JSONB,
+  metadata JSONB,  -- Informations supplémentaires (IP, user-agent, etc.)
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gamme_seo_audit_date ON gamme_seo_audit(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_gamme_seo_audit_admin ON gamme_seo_audit(admin_email);
+CREATE INDEX IF NOT EXISTS idx_gamme_seo_audit_action ON gamme_seo_audit(action_type);
+
+COMMENT ON TABLE gamme_seo_audit IS 'Audit trail pour les modifications SEO (G-Level, V-Level)';
+
+-- ============================================================================
+-- PARTIE 2: Ajouter G-Level à pieces_gamme
+-- ============================================================================
+
+DO $$
+BEGIN
+  -- Colonne pg_g_level pour classification G1/G2/G3/G4
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'pieces_gamme' AND column_name = 'pg_g_level') THEN
+    ALTER TABLE pieces_gamme ADD COLUMN pg_g_level VARCHAR(5);
+    RAISE NOTICE 'Colonne pg_g_level ajoutée';
+  END IF;
+
+  -- Colonne pour parent (G3 = enfant d'une G1/G2)
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'pieces_gamme' AND column_name = 'pg_parent_gamme_id') THEN
+    ALTER TABLE pieces_gamme ADD COLUMN pg_parent_gamme_id INTEGER;
+    RAISE NOTICE 'Colonne pg_parent_gamme_id ajoutée';
+  END IF;
+END $$;
+
+-- Index pour requêtes SEO
+CREATE INDEX IF NOT EXISTS idx_pg_g_level ON pieces_gamme(pg_g_level);
+CREATE INDEX IF NOT EXISTS idx_pg_display_level ON pieces_gamme(pg_display, pg_level);
+CREATE INDEX IF NOT EXISTS idx_pg_parent ON pieces_gamme(pg_parent_gamme_id);
+
+-- Mapper pg_level existant vers pg_g_level (UNIQUEMENT pour les 235 gammes principales)
+UPDATE pieces_gamme SET pg_g_level = CASE
+  WHEN pg_level = '1' THEN 'G1'  -- Prioritaires (114 gammes)
+  WHEN pg_level = '2' THEN 'G2'  -- Secondaires (118 gammes)
+  WHEN pg_level IN ('3', '4') THEN 'G3'  -- Enfants (1 gamme)
+  WHEN pg_level = '5' THEN 'G4'  -- Catalogue-only (2 gammes)
+  ELSE NULL  -- Ne pas toucher aux gammes level=0
+END
+WHERE pg_g_level IS NULL
+  AND pg_display = '1'
+  AND pg_level::INTEGER > 0;  -- Seulement les 235 gammes principales
+
+-- ============================================================================
+-- PARTIE 3: Ajouter colonnes manquantes à gamme_seo_metrics
+-- ============================================================================
+
+DO $$
+BEGIN
+  -- Colonne bloc pour distinguer Bloc A (gamme→véhicule) et Bloc B (véhicule→pièce)
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'gamme_seo_metrics' AND column_name = 'bloc') THEN
+    ALTER TABLE gamme_seo_metrics ADD COLUMN bloc VARCHAR(5) DEFAULT 'A';
+    RAISE NOTICE 'Colonne bloc ajoutée';
+  END IF;
+
+  -- Colonne model_id pour lien avec auto_modele
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'gamme_seo_metrics' AND column_name = 'model_id') THEN
+    ALTER TABLE gamme_seo_metrics ADD COLUMN model_id INTEGER;
+    RAISE NOTICE 'Colonne model_id ajoutée';
+  END IF;
+
+  -- Colonne variant_id pour lien avec auto_type
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'gamme_seo_metrics' AND column_name = 'variant_id') THEN
+    ALTER TABLE gamme_seo_metrics ADD COLUMN variant_id INTEGER;
+    RAISE NOTICE 'Colonne variant_id ajoutée';
+  END IF;
+
+  -- Colonne is_v1 pour marquer le V1 global du modèle
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'gamme_seo_metrics' AND column_name = 'is_v1') THEN
+    ALTER TABLE gamme_seo_metrics ADD COLUMN is_v1 BOOLEAN DEFAULT FALSE;
+    RAISE NOTICE 'Colonne is_v1 ajoutée';
+  END IF;
+
+  -- Colonne v2_count pour calcul V1 (nombre de fois V2)
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'gamme_seo_metrics' AND column_name = 'v2_count') THEN
+    ALTER TABLE gamme_seo_metrics ADD COLUMN v2_count INTEGER DEFAULT 0;
+    RAISE NOTICE 'Colonne v2_count ajoutée';
+  END IF;
+END $$;
+
+-- Index pour requêtes V-Level
+CREATE INDEX IF NOT EXISTS idx_gsm_bloc ON gamme_seo_metrics(bloc);
+CREATE INDEX IF NOT EXISTS idx_gsm_model ON gamme_seo_metrics(model_id);
+CREATE INDEX IF NOT EXISTS idx_gsm_is_v1 ON gamme_seo_metrics(is_v1) WHERE is_v1 = TRUE;
+
+-- ============================================================================
+-- PARTIE 4: Insérer les 17 gammes manquantes (parmi les 235 principales)
+-- ============================================================================
+
+INSERT INTO gamme_seo_metrics (pg_id, gamme_name, v_level, rank, score, search_volume, bloc, updated_at)
+SELECT
+  pg.pg_id::INTEGER,
+  pg.pg_name,
+  'V5' AS v_level,  -- Défaut: Bloc B
+  999 AS rank,
+  0 AS score,
+  0 AS search_volume,
+  'B' AS bloc,  -- Bloc B par défaut pour les nouvelles
+  NOW() AS updated_at
+FROM pieces_gamme pg
+WHERE pg.pg_display = '1'
+  AND pg.pg_level::INTEGER > 0  -- Seulement les 235 gammes principales
+  AND NOT EXISTS (
+    SELECT 1 FROM gamme_seo_metrics gsm WHERE gsm.pg_id = pg.pg_id::INTEGER
+  )
+ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- PARTIE 5: Supprimer tables vides inutilisées
+-- ============================================================================
+
+DO $$
+DECLARE
+  tbl TEXT;
+  cnt INTEGER;
+  tables_to_check TEXT[] := ARRAY[
+    'v_level', 'vlevel', 'v_level_status', 'vlevel_status',
+    'pieces_gamme_vlevel', 'gamme_vlevel', 'gamme_seo_config',
+    'seo_config', 'seo_settings', 'admin_seo_config'
+  ];
+BEGIN
+  FOREACH tbl IN ARRAY tables_to_check
+  LOOP
+    BEGIN
+      EXECUTE format('SELECT COUNT(*) FROM %I', tbl) INTO cnt;
+      IF cnt = 0 THEN
+        EXECUTE format('DROP TABLE IF EXISTS %I CASCADE', tbl);
+        RAISE NOTICE 'Table % supprimée (était vide)', tbl;
+      ELSE
+        RAISE NOTICE 'Table % conservée (% rows)', tbl, cnt;
+      END IF;
+    EXCEPTION WHEN undefined_table THEN
+      RAISE NOTICE 'Table % n''existe pas (OK)', tbl;
+    END;
+  END LOOP;
+END $$;
+
+-- ============================================================================
+-- PARTIE 6: Statistiques finales
+-- ============================================================================
+
+DO $$
+DECLARE
+  gammes_principales INTEGER;
+  gammes_seo INTEGER;
+  v2_count INTEGER;
+  v5_count INTEGER;
+  g1_count INTEGER;
+  g2_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO gammes_principales FROM pieces_gamme WHERE pg_display = '1' AND pg_level::INTEGER > 0;
+  SELECT COUNT(DISTINCT pg_id) INTO gammes_seo FROM gamme_seo_metrics;
+  SELECT COUNT(*) INTO v2_count FROM gamme_seo_metrics WHERE v_level = 'V2';
+  SELECT COUNT(*) INTO v5_count FROM gamme_seo_metrics WHERE v_level = 'V5';
+  SELECT COUNT(*) INTO g1_count FROM pieces_gamme WHERE pg_g_level = 'G1';
+  SELECT COUNT(*) INTO g2_count FROM pieces_gamme WHERE pg_g_level = 'G2';
+
+  RAISE NOTICE '========================================';
+  RAISE NOTICE 'Consolidation SEO & V-Level terminée:';
+  RAISE NOTICE '  Gammes principales (level>0): %', gammes_principales;
+  RAISE NOTICE '  Gammes avec métriques SEO: %', gammes_seo;
+  RAISE NOTICE '  G1 (prioritaires): %', g1_count;
+  RAISE NOTICE '  G2 (secondaires): %', g2_count;
+  RAISE NOTICE '  V2 (champions): %', v2_count;
+  RAISE NOTICE '  V5 (bloc B): %', v5_count;
+  RAISE NOTICE '========================================';
+END $$;

--- a/backend/supabase/migrations/20260108_create_legal_documents_table.sql
+++ b/backend/supabase/migrations/20260108_create_legal_documents_table.sql
@@ -1,0 +1,298 @@
+-- ============================================================================
+-- MIGRATION: Tables legal_documents dédiées (Décomposition ___xtr_msg)
+-- ============================================================================
+-- Date: 2026-01-08
+-- Objectif: Remplacer les LIKE queries sur ___xtr_msg pour les documents légaux
+-- Impact: Performance + Séparation claire des données légales
+-- ============================================================================
+
+-- ============================================================================
+-- PARTIE 1: Table legal_documents (remplace les entrées "type":"legal_document")
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS legal_documents (
+  id SERIAL PRIMARY KEY,
+
+  -- Type de document
+  document_type TEXT NOT NULL CHECK (document_type IN (
+    'terms', 'privacy', 'cookies', 'gdpr', 'returns', 'shipping', 'warranty', 'custom'
+  )),
+
+  -- Contenu
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  slug TEXT NOT NULL,
+
+  -- Versioning
+  version TEXT DEFAULT 'v1.0',
+  effective_date TIMESTAMPTZ DEFAULT NOW(),
+
+  -- Statut
+  published BOOLEAN DEFAULT FALSE,
+  is_draft BOOLEAN DEFAULT TRUE,
+  is_archived BOOLEAN DEFAULT FALSE,
+
+  -- Langue
+  language TEXT DEFAULT 'fr',
+
+  -- Métadonnées
+  metadata JSONB DEFAULT '{}',
+
+  -- Audit
+  created_by TEXT NOT NULL,
+  updated_by TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+  -- Référence legacy
+  legacy_msg_id TEXT UNIQUE
+);
+
+-- Index pour requêtes fréquentes
+CREATE INDEX IF NOT EXISTS idx_legal_docs_type ON legal_documents(document_type);
+CREATE INDEX IF NOT EXISTS idx_legal_docs_published ON legal_documents(published) WHERE published = TRUE;
+CREATE INDEX IF NOT EXISTS idx_legal_docs_slug ON legal_documents(slug);
+CREATE INDEX IF NOT EXISTS idx_legal_docs_language ON legal_documents(language);
+
+-- ============================================================================
+-- PARTIE 2: Table legal_document_versions (historique des versions)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS legal_document_versions (
+  id SERIAL PRIMARY KEY,
+
+  -- Référence au document parent
+  document_id INTEGER NOT NULL REFERENCES legal_documents(id) ON DELETE CASCADE,
+
+  -- Version
+  version TEXT NOT NULL,
+  content TEXT NOT NULL,
+  changes TEXT,  -- Description des modifications
+
+  -- Dates
+  effective_date TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+
+  -- Audit
+  created_by TEXT NOT NULL,
+
+  -- Référence legacy
+  legacy_msg_id TEXT UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_legal_versions_doc ON legal_document_versions(document_id);
+CREATE INDEX IF NOT EXISTS idx_legal_versions_date ON legal_document_versions(created_at DESC);
+
+-- ============================================================================
+-- PARTIE 3: Table legal_acceptances (acceptations par les utilisateurs)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS legal_acceptances (
+  id SERIAL PRIMARY KEY,
+
+  -- Utilisateur
+  user_id TEXT NOT NULL,
+
+  -- Document accepté
+  document_id INTEGER REFERENCES legal_documents(id) ON DELETE SET NULL,
+  document_type TEXT NOT NULL,
+  document_version TEXT NOT NULL,
+
+  -- Contexte
+  ip_address INET,
+  user_agent TEXT,
+
+  -- Date d'acceptation
+  accepted_at TIMESTAMPTZ DEFAULT NOW(),
+
+  -- Référence legacy
+  legacy_msg_id TEXT UNIQUE,
+
+  -- Contrainte: un utilisateur ne peut accepter une version qu'une fois
+  UNIQUE(user_id, document_type, document_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_legal_accept_user ON legal_acceptances(user_id);
+CREATE INDEX IF NOT EXISTS idx_legal_accept_doc ON legal_acceptances(document_id);
+CREATE INDEX IF NOT EXISTS idx_legal_accept_type ON legal_acceptances(document_type);
+
+-- ============================================================================
+-- PARTIE 4: Trigger pour updated_at automatique
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION update_legal_documents_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_legal_documents_updated_at ON legal_documents;
+CREATE TRIGGER trigger_legal_documents_updated_at
+  BEFORE UPDATE ON legal_documents
+  FOR EACH ROW
+  EXECUTE FUNCTION update_legal_documents_updated_at();
+
+-- ============================================================================
+-- PARTIE 5: Migration des données existantes (si présentes dans ___xtr_msg)
+-- ============================================================================
+
+DO $$
+DECLARE
+  migrated_docs INTEGER := 0;
+  migrated_accept INTEGER := 0;
+  migrated_versions INTEGER := 0;
+  row_data RECORD;
+  content_json JSONB;
+BEGIN
+  RAISE NOTICE 'Début migration des documents légaux depuis ___xtr_msg...';
+
+  -- 5.1 Migrer les documents légaux
+  FOR row_data IN
+    SELECT msg_id, msg_cst_id, msg_cnfa_id, msg_date, msg_subject, msg_content, msg_open, msg_close
+    FROM ___xtr_msg
+    WHERE msg_content IS NOT NULL
+      AND msg_content LIKE '%"type":"legal_document"%'
+    LIMIT 1000
+  LOOP
+    BEGIN
+      content_json := row_data.msg_content::JSONB;
+
+      INSERT INTO legal_documents (
+        document_type, title, content, slug, version, effective_date,
+        published, is_draft, is_archived, language, metadata,
+        created_by, updated_by, created_at, updated_at, legacy_msg_id
+      ) VALUES (
+        COALESCE(content_json->>'documentType', 'custom'),
+        row_data.msg_subject,
+        COALESCE(content_json->>'content', ''),
+        COALESCE(content_json->>'slug', ''),
+        COALESCE(content_json->>'version', 'v1.0'),
+        COALESCE((content_json->>'effectiveDate')::TIMESTAMPTZ, row_data.msg_date::TIMESTAMPTZ),
+        COALESCE((content_json->>'published')::BOOLEAN, row_data.msg_open = '0'),
+        row_data.msg_open = '1',
+        row_data.msg_close = '1',
+        COALESCE(content_json->>'language', 'fr'),
+        COALESCE(content_json->'metadata', '{}'::JSONB),
+        row_data.msg_cst_id,
+        COALESCE(content_json->>'updatedBy', row_data.msg_cnfa_id),
+        row_data.msg_date::TIMESTAMPTZ,
+        COALESCE((content_json->>'lastUpdated')::TIMESTAMPTZ, row_data.msg_date::TIMESTAMPTZ),
+        row_data.msg_id
+      )
+      ON CONFLICT (legacy_msg_id) DO NOTHING;
+
+      migrated_docs := migrated_docs + 1;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Erreur migration doc msg_id=%: %', row_data.msg_id, SQLERRM;
+    END;
+  END LOOP;
+
+  -- 5.2 Migrer les acceptations
+  FOR row_data IN
+    SELECT msg_id, msg_cst_id, msg_date, msg_content
+    FROM ___xtr_msg
+    WHERE msg_content IS NOT NULL
+      AND msg_content LIKE '%"type":"legal_acceptance"%'
+    LIMIT 10000
+  LOOP
+    BEGIN
+      content_json := row_data.msg_content::JSONB;
+
+      INSERT INTO legal_acceptances (
+        user_id, document_type, document_version, ip_address, user_agent,
+        accepted_at, legacy_msg_id
+      ) VALUES (
+        COALESCE(content_json->>'userId', row_data.msg_cst_id),
+        COALESCE(content_json->>'documentType', 'terms'),
+        COALESCE(content_json->>'version', 'v1.0'),
+        CASE WHEN content_json->>'ipAddress' IS NOT NULL
+             THEN (content_json->>'ipAddress')::INET ELSE NULL END,
+        content_json->>'userAgent',
+        COALESCE((content_json->>'acceptedAt')::TIMESTAMPTZ, row_data.msg_date::TIMESTAMPTZ),
+        row_data.msg_id
+      )
+      ON CONFLICT (legacy_msg_id) DO NOTHING;
+
+      migrated_accept := migrated_accept + 1;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Erreur migration accept msg_id=%: %', row_data.msg_id, SQLERRM;
+    END;
+  END LOOP;
+
+  -- 5.3 Migrer les versions
+  FOR row_data IN
+    SELECT msg_id, msg_cst_id, msg_date, msg_content
+    FROM ___xtr_msg
+    WHERE msg_content IS NOT NULL
+      AND msg_content LIKE '%"type":"legal_version"%'
+    LIMIT 5000
+  LOOP
+    BEGIN
+      content_json := row_data.msg_content::JSONB;
+
+      -- Trouver le document parent
+      INSERT INTO legal_document_versions (
+        document_id, version, content, changes, effective_date,
+        created_at, created_by, legacy_msg_id
+      )
+      SELECT
+        ld.id,
+        COALESCE(content_json->>'version', 'v1.0'),
+        COALESCE(content_json->>'content', ''),
+        content_json->>'changes',
+        COALESCE((content_json->>'effectiveDate')::TIMESTAMPTZ, row_data.msg_date::TIMESTAMPTZ),
+        row_data.msg_date::TIMESTAMPTZ,
+        row_data.msg_cst_id,
+        row_data.msg_id
+      FROM legal_documents ld
+      WHERE ld.legacy_msg_id = content_json->>'documentId'
+        OR ld.id::TEXT = content_json->>'documentId'
+      ON CONFLICT (legacy_msg_id) DO NOTHING;
+
+      migrated_versions := migrated_versions + 1;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Erreur migration version msg_id=%: %', row_data.msg_id, SQLERRM;
+    END;
+  END LOOP;
+
+  RAISE NOTICE '========================================';
+  RAISE NOTICE 'Migration documents légaux terminée:';
+  RAISE NOTICE '  Documents migrés: %', migrated_docs;
+  RAISE NOTICE '  Acceptations migrées: %', migrated_accept;
+  RAISE NOTICE '  Versions migrées: %', migrated_versions;
+  RAISE NOTICE '========================================';
+END $$;
+
+-- ============================================================================
+-- PARTIE 6: Statistiques
+-- ============================================================================
+
+DO $$
+DECLARE
+  total_docs INTEGER;
+  published_docs INTEGER;
+  total_accept INTEGER;
+  total_versions INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO total_docs FROM legal_documents;
+  SELECT COUNT(*) INTO published_docs FROM legal_documents WHERE published = TRUE;
+  SELECT COUNT(*) INTO total_accept FROM legal_acceptances;
+  SELECT COUNT(*) INTO total_versions FROM legal_document_versions;
+
+  RAISE NOTICE '========================================';
+  RAISE NOTICE 'Statistiques tables légales:';
+  RAISE NOTICE '  Documents: % (publiés: %)', total_docs, published_docs;
+  RAISE NOTICE '  Acceptations: %', total_accept;
+  RAISE NOTICE '  Versions: %', total_versions;
+  RAISE NOTICE '========================================';
+END $$;
+
+-- ============================================================================
+-- PARTIE 7: Commentaires
+-- ============================================================================
+
+COMMENT ON TABLE legal_documents IS 'Documents légaux (CGV, RGPD, etc.) - Migré depuis ___xtr_msg';
+COMMENT ON TABLE legal_document_versions IS 'Historique des versions des documents légaux';
+COMMENT ON TABLE legal_acceptances IS 'Acceptations des documents légaux par les utilisateurs';

--- a/frontend/app/components/layout/Container.tsx
+++ b/frontend/app/components/layout/Container.tsx
@@ -1,0 +1,97 @@
+import { cn } from '~/lib/utils';
+
+export type ContainerSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full';
+
+export interface ContainerProps {
+	children: React.ReactNode;
+	/** Max width constraint. Default: 'xl' (1280px) */
+	size?: ContainerSize;
+	/** Add horizontal padding. Default: true */
+	padding?: boolean;
+	/** Center content horizontally. Default: true */
+	centered?: boolean;
+	/** HTML element to render. Default: 'div' */
+	as?: 'div' | 'section' | 'article' | 'main' | 'aside';
+	className?: string;
+}
+
+const maxWidthClasses: Record<ContainerSize, string> = {
+	sm: 'max-w-screen-sm', // 640px
+	md: 'max-w-screen-md', // 768px
+	lg: 'max-w-screen-lg', // 1024px
+	xl: 'max-w-screen-xl', // 1280px
+	'2xl': 'max-w-screen-2xl', // 1536px
+	full: 'max-w-full',
+};
+
+/**
+ * Container - Responsive wrapper with consistent max-width and padding
+ *
+ * @example
+ * // Standard usage
+ * <Container>
+ *   <h1>Page Title</h1>
+ * </Container>
+ *
+ * @example
+ * // Full width section
+ * <Container size="full" padding={false}>
+ *   <Hero />
+ * </Container>
+ *
+ * @example
+ * // Narrow content
+ * <Container size="md">
+ *   <ArticleContent />
+ * </Container>
+ */
+export function Container({
+	children,
+	size = 'xl',
+	padding = true,
+	centered = true,
+	as: Component = 'div',
+	className,
+}: ContainerProps) {
+	return (
+		<Component
+			className={cn(
+				'w-full',
+				maxWidthClasses[size],
+				centered && 'mx-auto',
+				// Responsive padding: 16px mobile → 24px tablet → 32px desktop
+				padding && 'px-4 sm:px-6 lg:px-8',
+				className
+			)}
+		>
+			{children}
+		</Component>
+	);
+}
+
+/**
+ * Section - Container variant for page sections with vertical spacing
+ */
+export function Section({
+	children,
+	size = 'xl',
+	padding = true,
+	className,
+	...props
+}: ContainerProps & { spacing?: 'sm' | 'md' | 'lg' | 'xl' }) {
+	return (
+		<Container
+			as="section"
+			size={size}
+			padding={padding}
+			className={cn(
+				// Fluid vertical spacing
+				'py-8 sm:py-12 lg:py-16',
+				className
+			)}
+			{...props}
+		>
+			{children}
+		</Container>
+	);
+}

--- a/frontend/app/components/layout/MobileBottomBar.tsx
+++ b/frontend/app/components/layout/MobileBottomBar.tsx
@@ -1,0 +1,125 @@
+import { cn } from '~/lib/utils';
+
+export interface MobileBottomBarProps {
+	children: React.ReactNode;
+	/**
+	 * Show on tablet too (up to lg breakpoint)
+	 * Default: false (hidden at md+)
+	 */
+	showOnTablet?: boolean;
+	/**
+	 * Add shadow above the bar
+	 * Default: true
+	 */
+	shadow?: boolean;
+	/**
+	 * Background style
+	 * Default: 'solid'
+	 */
+	background?: 'solid' | 'blur' | 'transparent';
+	className?: string;
+}
+
+const backgroundClasses = {
+	solid: 'bg-white dark:bg-gray-900',
+	blur: 'bg-white/80 dark:bg-gray-900/80 backdrop-blur-lg',
+	transparent: 'bg-transparent',
+};
+
+/**
+ * MobileBottomBar - Sticky bottom action bar for mobile
+ *
+ * Critical e-commerce pattern: CTA always visible for +15-25% conversion.
+ * Automatically handles iPhone safe area (notch/Dynamic Island).
+ *
+ * @example
+ * // Product page - Add to cart button
+ * <MobileBottomBar>
+ *   <Button className="w-full touch-target-lg">
+ *     Ajouter au panier - 49,99 €
+ *   </Button>
+ * </MobileBottomBar>
+ *
+ * @example
+ * // Cart page - Checkout with price
+ * <MobileBottomBar>
+ *   <div className="flex items-center justify-between gap-4">
+ *     <div>
+ *       <div className="text-sm text-gray-500">Total</div>
+ *       <div className="text-lg font-bold">149,99 €</div>
+ *     </div>
+ *     <Button className="flex-1 touch-target-lg">
+ *       Commander
+ *     </Button>
+ *   </div>
+ * </MobileBottomBar>
+ *
+ * @example
+ * // With blur effect
+ * <MobileBottomBar background="blur" shadow={false}>
+ *   <FilterButtons />
+ * </MobileBottomBar>
+ */
+export function MobileBottomBar({
+	children,
+	showOnTablet = false,
+	shadow = true,
+	background = 'solid',
+	className,
+}: MobileBottomBarProps) {
+	return (
+		<div
+			className={cn(
+				// Positioning
+				'fixed bottom-0 left-0 right-0 z-50',
+				// Border
+				'border-t border-gray-200 dark:border-gray-800',
+				// Background
+				backgroundClasses[background],
+				// Shadow
+				shadow && 'shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]',
+				// Padding with safe area for iPhone
+				'p-4 pb-safe',
+				// Responsive visibility
+				showOnTablet ? 'lg:hidden' : 'md:hidden',
+				className
+			)}
+		>
+			{children}
+		</div>
+	);
+}
+
+/**
+ * MobileBottomBarSpacer - Adds padding at the bottom of the page
+ * to prevent content from being hidden behind the MobileBottomBar
+ *
+ * @example
+ * <main>
+ *   <ProductContent />
+ *   <MobileBottomBarSpacer />
+ * </main>
+ * <MobileBottomBar>
+ *   <CTAButton />
+ * </MobileBottomBar>
+ */
+export function MobileBottomBarSpacer({
+	showOnTablet = false,
+	className,
+}: {
+	showOnTablet?: boolean;
+	className?: string;
+}) {
+	return (
+		<div
+			className={cn(
+				// Height to match MobileBottomBar (padding + button height + safe area)
+				'h-20 pb-safe',
+				// Match visibility with MobileBottomBar
+				showOnTablet ? 'lg:hidden' : 'md:hidden',
+				className
+			)}
+			aria-hidden="true"
+		/>
+	);
+}

--- a/frontend/app/components/layout/ResponsiveGrid.tsx
+++ b/frontend/app/components/layout/ResponsiveGrid.tsx
@@ -1,0 +1,169 @@
+import { cn } from '~/lib/utils';
+
+export type GridGap = 'none' | 'sm' | 'md' | 'lg';
+
+export interface ResponsiveGridProps {
+	children: React.ReactNode;
+	/**
+	 * Number of columns at each breakpoint
+	 * Default: { base: 1, sm: 2, lg: 3, xl: 4 } - E-commerce product grid
+	 */
+	cols?: {
+		base?: 1 | 2 | 3 | 4 | 5 | 6;
+		sm?: 1 | 2 | 3 | 4 | 5 | 6;
+		md?: 1 | 2 | 3 | 4 | 5 | 6;
+		lg?: 1 | 2 | 3 | 4 | 5 | 6;
+		xl?: 1 | 2 | 3 | 4 | 5 | 6;
+	};
+	/** Gap size between items. Default: 'md' */
+	gap?: GridGap;
+	className?: string;
+}
+
+// Gap classes with responsive scaling
+const gapClasses: Record<GridGap, string> = {
+	none: 'gap-0',
+	sm: 'gap-2 sm:gap-3', // 8px → 12px
+	md: 'gap-3 sm:gap-4 lg:gap-6', // 12px → 16px → 24px
+	lg: 'gap-4 sm:gap-6 lg:gap-8', // 16px → 24px → 32px
+};
+
+// Column classes mapping
+const colClassMap = {
+	1: 'grid-cols-1',
+	2: 'grid-cols-2',
+	3: 'grid-cols-3',
+	4: 'grid-cols-4',
+	5: 'grid-cols-5',
+	6: 'grid-cols-6',
+};
+
+const smColClassMap = {
+	1: 'sm:grid-cols-1',
+	2: 'sm:grid-cols-2',
+	3: 'sm:grid-cols-3',
+	4: 'sm:grid-cols-4',
+	5: 'sm:grid-cols-5',
+	6: 'sm:grid-cols-6',
+};
+
+const mdColClassMap = {
+	1: 'md:grid-cols-1',
+	2: 'md:grid-cols-2',
+	3: 'md:grid-cols-3',
+	4: 'md:grid-cols-4',
+	5: 'md:grid-cols-5',
+	6: 'md:grid-cols-6',
+};
+
+const lgColClassMap = {
+	1: 'lg:grid-cols-1',
+	2: 'lg:grid-cols-2',
+	3: 'lg:grid-cols-3',
+	4: 'lg:grid-cols-4',
+	5: 'lg:grid-cols-5',
+	6: 'lg:grid-cols-6',
+};
+
+const xlColClassMap = {
+	1: 'xl:grid-cols-1',
+	2: 'xl:grid-cols-2',
+	3: 'xl:grid-cols-3',
+	4: 'xl:grid-cols-4',
+	5: 'xl:grid-cols-5',
+	6: 'xl:grid-cols-6',
+};
+
+/**
+ * ResponsiveGrid - CSS Grid with responsive column configuration
+ *
+ * Optimized for e-commerce product listings with sensible defaults.
+ *
+ * @example
+ * // Default product grid (1 → 2 → 3 → 4 columns)
+ * <ResponsiveGrid>
+ *   {products.map(p => <ProductCard key={p.id} product={p} />)}
+ * </ResponsiveGrid>
+ *
+ * @example
+ * // Custom configuration
+ * <ResponsiveGrid cols={{ base: 2, md: 3, xl: 5 }} gap="lg">
+ *   {items.map(item => <ItemCard key={item.id} item={item} />)}
+ * </ResponsiveGrid>
+ *
+ * @example
+ * // Two-column layout
+ * <ResponsiveGrid cols={{ base: 1, md: 2 }} gap="lg">
+ *   <MainContent />
+ *   <Sidebar />
+ * </ResponsiveGrid>
+ */
+export function ResponsiveGrid({
+	children,
+	cols = { base: 1, sm: 2, lg: 3, xl: 4 },
+	gap = 'md',
+	className,
+}: ResponsiveGridProps) {
+	const colClasses = [
+		cols.base && colClassMap[cols.base],
+		cols.sm && smColClassMap[cols.sm],
+		cols.md && mdColClassMap[cols.md],
+		cols.lg && lgColClassMap[cols.lg],
+		cols.xl && xlColClassMap[cols.xl],
+	]
+		.filter(Boolean)
+		.join(' ');
+
+	return (
+		<div className={cn('grid', colClasses, gapClasses[gap], className)}>
+			{children}
+		</div>
+	);
+}
+
+/**
+ * ProductGrid - Pre-configured grid for product listings
+ * 1 col mobile → 2 col tablet → 3 col laptop → 4 col desktop
+ */
+export function ProductGrid({
+	children,
+	className,
+}: {
+	children: React.ReactNode;
+	className?: string;
+}) {
+	return (
+		<ResponsiveGrid
+			cols={{ base: 1, sm: 2, lg: 3, xl: 4 }}
+			gap="md"
+			className={className}
+		>
+			{children}
+		</ResponsiveGrid>
+	);
+}
+
+/**
+ * TwoColumnLayout - Common two-column responsive layout
+ * Stacked on mobile, side-by-side on tablet+
+ */
+export function TwoColumnLayout({
+	children,
+	className,
+	reversed = false,
+}: {
+	children: React.ReactNode;
+	className?: string;
+	/** Reverse order on desktop (sidebar first) */
+	reversed?: boolean;
+}) {
+	return (
+		<ResponsiveGrid
+			cols={{ base: 1, md: 2 }}
+			gap="lg"
+			className={cn(reversed && 'md:[&>*:first-child]:order-2', className)}
+		>
+			{children}
+		</ResponsiveGrid>
+	);
+}

--- a/frontend/app/components/layout/Stack.tsx
+++ b/frontend/app/components/layout/Stack.tsx
@@ -1,0 +1,160 @@
+import { cn } from '~/lib/utils';
+
+export type StackDirection = 'vertical' | 'horizontal' | 'responsive';
+export type StackGap = 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+export type StackAlign = 'start' | 'center' | 'end' | 'stretch' | 'baseline';
+export type StackJustify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';
+
+export interface StackProps {
+	children: React.ReactNode;
+	/**
+	 * Direction of the stack
+	 * - 'vertical': Column layout (default)
+	 * - 'horizontal': Row layout
+	 * - 'responsive': Column on mobile, row on sm+ breakpoint
+	 */
+	direction?: StackDirection;
+	/** Gap between children */
+	gap?: StackGap;
+	/** Cross-axis alignment (align-items) */
+	align?: StackAlign;
+	/** Main-axis distribution (justify-content) */
+	justify?: StackJustify;
+	/** Allow wrapping for horizontal stacks */
+	wrap?: boolean;
+	/** HTML element to render */
+	as?: 'div' | 'section' | 'article' | 'nav' | 'ul' | 'ol';
+	className?: string;
+}
+
+const directionClasses: Record<StackDirection, string> = {
+	vertical: 'flex-col',
+	horizontal: 'flex-row',
+	responsive: 'flex-col sm:flex-row',
+};
+
+const gapClasses: Record<StackGap, string> = {
+	none: 'gap-0',
+	xs: 'gap-1', // 4px
+	sm: 'gap-2', // 8px
+	md: 'gap-4', // 16px
+	lg: 'gap-6', // 24px
+	xl: 'gap-8', // 32px
+	'2xl': 'gap-12', // 48px
+};
+
+const alignClasses: Record<StackAlign, string> = {
+	start: 'items-start',
+	center: 'items-center',
+	end: 'items-end',
+	stretch: 'items-stretch',
+	baseline: 'items-baseline',
+};
+
+const justifyClasses: Record<StackJustify, string> = {
+	start: 'justify-start',
+	center: 'justify-center',
+	end: 'justify-end',
+	between: 'justify-between',
+	around: 'justify-around',
+	evenly: 'justify-evenly',
+};
+
+/**
+ * Stack - Flexbox layout component for consistent spacing
+ *
+ * @example
+ * // Vertical stack (default)
+ * <Stack gap="md">
+ *   <Card />
+ *   <Card />
+ * </Stack>
+ *
+ * @example
+ * // Horizontal with alignment
+ * <Stack direction="horizontal" align="center" justify="between">
+ *   <Logo />
+ *   <Navigation />
+ * </Stack>
+ *
+ * @example
+ * // Responsive: column on mobile, row on tablet+
+ * <Stack direction="responsive" gap="lg">
+ *   <ProductImage />
+ *   <ProductDetails />
+ * </Stack>
+ */
+export function Stack({
+	children,
+	direction = 'vertical',
+	gap = 'md',
+	align = 'stretch',
+	justify = 'start',
+	wrap = false,
+	as: Component = 'div',
+	className,
+}: StackProps) {
+	return (
+		<Component
+			className={cn(
+				'flex',
+				directionClasses[direction],
+				gapClasses[gap],
+				alignClasses[align],
+				justifyClasses[justify],
+				wrap && 'flex-wrap',
+				className
+			)}
+		>
+			{children}
+		</Component>
+	);
+}
+
+/**
+ * HStack - Horizontal stack shortcut
+ */
+export function HStack({
+	children,
+	gap = 'md',
+	align = 'center',
+	justify = 'start',
+	wrap = false,
+	className,
+}: Omit<StackProps, 'direction'>) {
+	return (
+		<Stack
+			direction="horizontal"
+			gap={gap}
+			align={align}
+			justify={justify}
+			wrap={wrap}
+			className={className}
+		>
+			{children}
+		</Stack>
+	);
+}
+
+/**
+ * VStack - Vertical stack shortcut
+ */
+export function VStack({
+	children,
+	gap = 'md',
+	align = 'stretch',
+	justify = 'start',
+	className,
+}: Omit<StackProps, 'direction' | 'wrap'>) {
+	return (
+		<Stack
+			direction="vertical"
+			gap={gap}
+			align={align}
+			justify={justify}
+			className={className}
+		>
+			{children}
+		</Stack>
+	);
+}

--- a/frontend/app/components/ui/FilterDrawer.tsx
+++ b/frontend/app/components/ui/FilterDrawer.tsx
@@ -1,0 +1,223 @@
+import { Filter, X } from 'lucide-react';
+import { useIsMobile } from '~/hooks/useMediaQuery';
+import { cn } from '~/lib/utils';
+import { Button } from './button';
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetClose,
+} from './sheet';
+
+export interface FilterDrawerProps {
+	children: React.ReactNode;
+	/** Controlled open state */
+	isOpen: boolean;
+	/** Callback when open state changes */
+	onOpenChange: (open: boolean) => void;
+	/** Title shown in the header. Default: 'Filtres' */
+	title?: string;
+	/** Show active filter count badge */
+	activeCount?: number;
+	/** Footer content (e.g., Apply/Reset buttons) */
+	footer?: React.ReactNode;
+	/** Desktop sidebar width. Default: 'w-64' */
+	sidebarWidth?: string;
+	className?: string;
+}
+
+/**
+ * FilterDrawer - Responsive filter panel
+ *
+ * Pattern: Sidebar on desktop → Bottom sheet on mobile
+ * Bottom sheet is the optimal mobile pattern for filters (thumb zone).
+ *
+ * @example
+ * // Basic usage
+ * const [isOpen, setIsOpen] = useState(false);
+ *
+ * <FilterDrawer isOpen={isOpen} onOpenChange={setIsOpen}>
+ *   <FilterSection title="Marque">
+ *     <Checkbox label="Valeo" />
+ *     <Checkbox label="Bosch" />
+ *   </FilterSection>
+ * </FilterDrawer>
+ *
+ * @example
+ * // With footer actions
+ * <FilterDrawer
+ *   isOpen={isOpen}
+ *   onOpenChange={setIsOpen}
+ *   activeCount={3}
+ *   footer={
+ *     <div className="flex gap-2">
+ *       <Button variant="outline" onClick={handleReset}>Réinitialiser</Button>
+ *       <Button onClick={handleApply}>Appliquer</Button>
+ *     </div>
+ *   }
+ * >
+ *   {filterContent}
+ * </FilterDrawer>
+ */
+export function FilterDrawer({
+	children,
+	isOpen,
+	onOpenChange,
+	title = 'Filtres',
+	activeCount,
+	footer,
+	sidebarWidth = 'w-64',
+	className,
+}: FilterDrawerProps) {
+	const isMobile = useIsMobile();
+
+	// Mobile: Bottom sheet
+	if (isMobile) {
+		return (
+			<Sheet open={isOpen} onOpenChange={onOpenChange}>
+				<SheetContent
+					side="bottom"
+					className={cn(
+						// Height with max to prevent full screen
+						'h-[85vh] max-h-[85vh]',
+						// Rounded top corners for modern look
+						'rounded-t-xl',
+						// Safe area padding for iPhone
+						'pb-safe',
+						// Remove default padding, we'll add our own
+						'p-0',
+						className
+					)}
+				>
+					{/* Header */}
+					<SheetHeader className="sticky top-0 z-10 bg-white dark:bg-gray-900 border-b p-4">
+						<div className="flex items-center justify-between">
+							<SheetTitle className="flex items-center gap-2">
+								<Filter className="h-5 w-5" />
+								{title}
+								{activeCount !== undefined && activeCount > 0 && (
+									<span className="inline-flex items-center justify-center h-5 min-w-[20px] px-1.5 text-xs font-medium bg-primary text-primary-foreground rounded-full">
+										{activeCount}
+									</span>
+								)}
+							</SheetTitle>
+							<SheetClose asChild>
+								<Button variant="ghost" size="icon" className="touch-target">
+									<X className="h-5 w-5" />
+									<span className="sr-only">Fermer</span>
+								</Button>
+							</SheetClose>
+						</div>
+					</SheetHeader>
+
+					{/* Scrollable content */}
+					<div className="flex-1 overflow-y-auto overscroll-contain p-4">
+						{children}
+					</div>
+
+					{/* Footer */}
+					{footer && (
+						<div className="sticky bottom-0 z-10 bg-white dark:bg-gray-900 border-t p-4 pb-safe">
+							{footer}
+						</div>
+					)}
+				</SheetContent>
+			</Sheet>
+		);
+	}
+
+	// Desktop: Static sidebar
+	return (
+		<aside
+			className={cn(
+				'hidden lg:block flex-shrink-0',
+				sidebarWidth,
+				className
+			)}
+		>
+			{/* Header */}
+			<div className="flex items-center justify-between mb-4">
+				<h2 className="text-lg font-semibold flex items-center gap-2">
+					<Filter className="h-5 w-5" />
+					{title}
+					{activeCount !== undefined && activeCount > 0 && (
+						<span className="inline-flex items-center justify-center h-5 min-w-[20px] px-1.5 text-xs font-medium bg-primary text-primary-foreground rounded-full">
+							{activeCount}
+						</span>
+					)}
+				</h2>
+			</div>
+
+			{/* Content */}
+			<div className="space-y-6">{children}</div>
+
+			{/* Footer */}
+			{footer && <div className="mt-6 pt-4 border-t">{footer}</div>}
+		</aside>
+	);
+}
+
+/**
+ * FilterTrigger - Button to open the filter drawer on mobile
+ *
+ * @example
+ * <FilterTrigger onClick={() => setIsOpen(true)} activeCount={3} />
+ */
+export function FilterTrigger({
+	onClick,
+	activeCount,
+	className,
+}: {
+	onClick: () => void;
+	activeCount?: number;
+	className?: string;
+}) {
+	return (
+		<Button
+			variant="outline"
+			onClick={onClick}
+			className={cn('lg:hidden touch-target gap-2', className)}
+		>
+			<Filter className="h-4 w-4" />
+			Filtres
+			{activeCount !== undefined && activeCount > 0 && (
+				<span className="inline-flex items-center justify-center h-5 min-w-[20px] px-1.5 text-xs font-medium bg-primary text-primary-foreground rounded-full">
+					{activeCount}
+				</span>
+			)}
+		</Button>
+	);
+}
+
+/**
+ * FilterSection - Group related filters together
+ *
+ * @example
+ * <FilterSection title="Prix" defaultOpen>
+ *   <PriceRangeSlider />
+ * </FilterSection>
+ */
+export function FilterSection({
+	title,
+	children,
+	defaultOpen = true,
+	className,
+}: {
+	title: string;
+	children: React.ReactNode;
+	defaultOpen?: boolean;
+	className?: string;
+}) {
+	return (
+		<details open={defaultOpen} className={cn('group', className)}>
+			<summary className="flex items-center justify-between cursor-pointer list-none py-2 font-medium text-sm hover:text-primary transition-colors">
+				{title}
+				<span className="text-gray-400 group-open:rotate-180 transition-transform">
+					▼
+				</span>
+			</summary>
+			<div className="pt-2 pb-4 space-y-2">{children}</div>
+		</details>
+	);
+}

--- a/frontend/app/components/ui/ResponsiveTable.tsx
+++ b/frontend/app/components/ui/ResponsiveTable.tsx
@@ -1,0 +1,238 @@
+import { useIsMobile } from '~/hooks/useMediaQuery';
+import { cn } from '~/lib/utils';
+
+export interface Column<T> {
+	/** Unique key for the column */
+	key: string;
+	/** Column header text */
+	header: string;
+	/** Render function for cell content */
+	render: (item: T, index: number) => React.ReactNode;
+	/** Column alignment. Default: 'left' */
+	align?: 'left' | 'center' | 'right';
+	/** Hide column on mobile (still visible in card view) */
+	hideOnMobile?: boolean;
+	/** Width class (e.g., 'w-24', 'w-1/4') */
+	width?: string;
+}
+
+export interface ResponsiveTableProps<T> {
+	/** Data array to display */
+	data: T[];
+	/** Column definitions */
+	columns: Column<T>[];
+	/**
+	 * Custom mobile card renderer
+	 * If not provided, columns will be stacked vertically
+	 */
+	mobileCard?: (item: T, index: number) => React.ReactNode;
+	/** Unique key extractor for each row */
+	keyExtractor: (item: T, index: number) => string | number;
+	/** Empty state message */
+	emptyMessage?: string;
+	/** Loading state */
+	isLoading?: boolean;
+	/** Table caption for accessibility */
+	caption?: string;
+	className?: string;
+}
+
+/**
+ * ResponsiveTable - Adaptive table that switches to cards on mobile
+ *
+ * Pattern: Table on desktop → Cards on mobile
+ * Eliminates horizontal scroll that causes mobile abandonment.
+ *
+ * @example
+ * // Basic usage with auto-generated mobile cards
+ * <ResponsiveTable
+ *   data={orders}
+ *   columns={[
+ *     { key: 'id', header: 'N° Commande', render: (o) => o.id },
+ *     { key: 'date', header: 'Date', render: (o) => formatDate(o.date) },
+ *     { key: 'total', header: 'Total', render: (o) => formatPrice(o.total), align: 'right' },
+ *   ]}
+ *   keyExtractor={(o) => o.id}
+ * />
+ *
+ * @example
+ * // Custom mobile card design
+ * <ResponsiveTable
+ *   data={orders}
+ *   columns={orderColumns}
+ *   keyExtractor={(o) => o.id}
+ *   mobileCard={(order) => (
+ *     <OrderCard order={order} />
+ *   )}
+ * />
+ */
+export function ResponsiveTable<T>({
+	data,
+	columns,
+	mobileCard,
+	keyExtractor,
+	emptyMessage = 'Aucun élément à afficher',
+	isLoading = false,
+	caption,
+	className,
+}: ResponsiveTableProps<T>) {
+	const isMobile = useIsMobile();
+
+	// Loading state
+	if (isLoading) {
+		return (
+			<div className="space-y-3">
+				{[1, 2, 3].map((i) => (
+					<div
+						key={i}
+						className="h-20 bg-gray-100 dark:bg-gray-800 rounded-lg animate-pulse"
+					/>
+				))}
+			</div>
+		);
+	}
+
+	// Empty state
+	if (data.length === 0) {
+		return (
+			<div className="text-center py-12 text-gray-500 dark:text-gray-400">
+				{emptyMessage}
+			</div>
+		);
+	}
+
+	// Mobile: Card view
+	if (isMobile) {
+		return (
+			<div className={cn('space-y-3', className)}>
+				{data.map((item, index) => {
+					const key = keyExtractor(item, index);
+
+					// Custom card renderer
+					if (mobileCard) {
+						return (
+							<div key={key} className="animate-fadeIn">
+								{mobileCard(item, index)}
+							</div>
+						);
+					}
+
+					// Default card layout (stacked columns)
+					return (
+						<div
+							key={key}
+							className={cn(
+								'bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800',
+								'p-4 space-y-2 shadow-sm'
+							)}
+						>
+							{columns.map((col) => (
+								<div
+									key={col.key}
+									className="flex justify-between items-start gap-2"
+								>
+									<span className="text-sm text-gray-500 dark:text-gray-400 flex-shrink-0">
+										{col.header}
+									</span>
+									<span
+										className={cn(
+											'text-sm font-medium text-right',
+											col.align === 'right' && 'tabular-nums'
+										)}
+									>
+										{col.render(item, index)}
+									</span>
+								</div>
+							))}
+						</div>
+					);
+				})}
+			</div>
+		);
+	}
+
+	// Desktop: Standard table
+	return (
+		<div className={cn('overflow-x-auto', className)}>
+			<table className="w-full border-collapse">
+				{caption && (
+					<caption className="sr-only">{caption}</caption>
+				)}
+				<thead>
+					<tr className="border-b border-gray-200 dark:border-gray-800">
+						{columns
+							.filter((col) => !col.hideOnMobile)
+							.map((col) => (
+								<th
+									key={col.key}
+									className={cn(
+										'px-4 py-3 text-sm font-semibold text-gray-600 dark:text-gray-400',
+										'text-left',
+										col.align === 'center' && 'text-center',
+										col.align === 'right' && 'text-right',
+										col.width
+									)}
+								>
+									{col.header}
+								</th>
+							))}
+					</tr>
+				</thead>
+				<tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+					{data.map((item, index) => (
+						<tr
+							key={keyExtractor(item, index)}
+							className="hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+						>
+							{columns
+								.filter((col) => !col.hideOnMobile)
+								.map((col) => (
+									<td
+										key={col.key}
+										className={cn(
+											'px-4 py-3 text-sm',
+											col.align === 'center' && 'text-center',
+											col.align === 'right' && 'text-right tabular-nums',
+											col.width
+										)}
+									>
+										{col.render(item, index)}
+									</td>
+								))}
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+/**
+ * MobileCard - Pre-styled card for custom mobile table rows
+ */
+export function MobileCard({
+	children,
+	onClick,
+	className,
+}: {
+	children: React.ReactNode;
+	onClick?: () => void;
+	className?: string;
+}) {
+	const Component = onClick ? 'button' : 'div';
+
+	return (
+		<Component
+			onClick={onClick}
+			className={cn(
+				'w-full text-left',
+				'bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800',
+				'p-4 shadow-sm',
+				onClick && 'touch-target hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors',
+				className
+			)}
+		>
+			{children}
+		</Component>
+	);
+}

--- a/frontend/app/global.css
+++ b/frontend/app/global.css
@@ -140,4 +140,85 @@
   .scrollbar-thin::-webkit-scrollbar-thumb:hover {
     @apply bg-gray-400;
   }
+
+  /* === MOBILE-FIRST RESPONSIVE UTILITIES === */
+
+  /* Safe area (iPhone notch/Dynamic Island) */
+  .pb-safe {
+    padding-bottom: env(safe-area-inset-bottom, 0);
+  }
+  .pt-safe {
+    padding-top: env(safe-area-inset-top, 0);
+  }
+  .pl-safe {
+    padding-left: env(safe-area-inset-left, 0);
+  }
+  .pr-safe {
+    padding-right: env(safe-area-inset-right, 0);
+  }
+  .p-safe {
+    padding: env(safe-area-inset-top, 0) env(safe-area-inset-right, 0) env(safe-area-inset-bottom, 0) env(safe-area-inset-left, 0);
+  }
+
+  /* Touch targets - WCAG AA minimum 44px, Google recommends 48px for e-commerce */
+  .touch-target {
+    @apply min-h-[44px] min-w-[44px];
+  }
+  .touch-target-lg {
+    @apply min-h-[48px] min-w-[48px];
+  }
+
+  /* Mobile-only / Desktop-only shortcuts */
+  .mobile-only {
+    @apply md:hidden;
+  }
+  .desktop-only {
+    @apply hidden md:block;
+  }
+  .tablet-up {
+    @apply hidden sm:block;
+  }
+  .desktop-up {
+    @apply hidden lg:block;
+  }
+
+  /* Responsive text that doesn't break layout */
+  .text-balance {
+    text-wrap: balance;
+  }
+  .text-pretty {
+    text-wrap: pretty;
+  }
+
+  /* Hide scrollbar but allow scrolling (for horizontal scroll containers) */
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Touch manipulation - disable double-tap zoom for faster click response */
+  .touch-manipulation {
+    touch-action: manipulation;
+  }
+
+  /* Prevent iOS zoom on input focus (requires font-size >= 16px) */
+  .no-zoom-input {
+    @apply text-base;
+    font-size: max(16px, 1rem);
+  }
+
+  /* Snap scrolling for carousels */
+  .snap-x-mandatory {
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+  }
+  .snap-start {
+    scroll-snap-align: start;
+  }
+  .snap-center {
+    scroll-snap-align: center;
+  }
 }

--- a/frontend/app/hooks/useBreakpoint.ts
+++ b/frontend/app/hooks/useBreakpoint.ts
@@ -1,0 +1,89 @@
+import { useState, useEffect } from 'react';
+import { breakpoints, type BreakpointKey } from './useMediaQuery';
+
+export type Breakpoint = 'xs' | BreakpointKey;
+
+/**
+ * Hook pour obtenir le breakpoint actuel
+ * @returns Breakpoint - 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
+ *
+ * @example
+ * const bp = useBreakpoint();
+ * if (bp === 'xs' || bp === 'sm') {
+ *   // Mobile layout
+ * }
+ */
+export function useBreakpoint(): Breakpoint {
+	const [bp, setBp] = useState<Breakpoint>('xs');
+
+	useEffect(() => {
+		// SSR safety
+		if (typeof window === 'undefined') return;
+
+		const update = () => {
+			const w = window.innerWidth;
+
+			if (w >= breakpoints['2xl']) setBp('2xl');
+			else if (w >= breakpoints.xl) setBp('xl');
+			else if (w >= breakpoints.lg) setBp('lg');
+			else if (w >= breakpoints.md) setBp('md');
+			else if (w >= breakpoints.sm) setBp('sm');
+			else setBp('xs');
+		};
+
+		// Initial check
+		update();
+
+		// Throttled resize listener for performance
+		let timeoutId: NodeJS.Timeout;
+		const throttledUpdate = () => {
+			if (timeoutId) return;
+			timeoutId = setTimeout(() => {
+				update();
+				timeoutId = undefined as unknown as NodeJS.Timeout;
+			}, 100);
+		};
+
+		window.addEventListener('resize', throttledUpdate);
+		return () => {
+			window.removeEventListener('resize', throttledUpdate);
+			if (timeoutId) clearTimeout(timeoutId);
+		};
+	}, []);
+
+	return bp;
+}
+
+/**
+ * Hook pour vérifier si le viewport est >= un breakpoint donné
+ * @param minBreakpoint - Le breakpoint minimum requis
+ * @returns boolean
+ *
+ * @example
+ * const isLgOrAbove = useMinBreakpoint('lg');
+ */
+export function useMinBreakpoint(minBreakpoint: Breakpoint): boolean {
+	const current = useBreakpoint();
+	const order: Breakpoint[] = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'];
+	return order.indexOf(current) >= order.indexOf(minBreakpoint);
+}
+
+/**
+ * Hook pour vérifier si le viewport est <= un breakpoint donné
+ * @param maxBreakpoint - Le breakpoint maximum
+ * @returns boolean
+ *
+ * @example
+ * const isMdOrBelow = useMaxBreakpoint('md');
+ */
+export function useMaxBreakpoint(maxBreakpoint: Breakpoint): boolean {
+	const current = useBreakpoint();
+	const order: Breakpoint[] = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'];
+	return order.indexOf(current) <= order.indexOf(maxBreakpoint);
+}
+
+/**
+ * Export des breakpoints pour usage en JS
+ * Permet de garder la cohérence avec Tailwind
+ */
+export { breakpoints } from './useMediaQuery';

--- a/frontend/app/hooks/useMediaQuery.ts
+++ b/frontend/app/hooks/useMediaQuery.ts
@@ -1,0 +1,125 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Breakpoints standard Tailwind (en pixels)
+ * Utilisés pour la cohérence avec les classes CSS
+ */
+export const breakpoints = {
+	sm: 640,
+	md: 768,
+	lg: 1024,
+	xl: 1280,
+	'2xl': 1536,
+} as const;
+
+export type BreakpointKey = keyof typeof breakpoints;
+
+/**
+ * Hook universel pour les media queries
+ * @param query - Media query string (ex: "(min-width: 768px)")
+ * @returns boolean - true si la query match
+ *
+ * @example
+ * const isWide = useMediaQuery('(min-width: 1024px)');
+ */
+export function useMediaQuery(query: string): boolean {
+	const [matches, setMatches] = useState(false);
+
+	useEffect(() => {
+		// SSR safety
+		if (typeof window === 'undefined') return;
+
+		const media = window.matchMedia(query);
+		setMatches(media.matches);
+
+		const listener = (e: MediaQueryListEvent) => setMatches(e.matches);
+		media.addEventListener('change', listener);
+
+		return () => media.removeEventListener('change', listener);
+	}, [query]);
+
+	return matches;
+}
+
+/**
+ * Hook pour détecter si on est sur mobile (<768px)
+ * @returns boolean - true si viewport < md breakpoint
+ */
+export function useIsMobile(): boolean {
+	return useMediaQuery(`(max-width: ${breakpoints.md - 1}px)`);
+}
+
+/**
+ * Hook pour détecter si on est sur tablette (768px - 1023px)
+ * @returns boolean - true si viewport entre md et lg breakpoints
+ */
+export function useIsTablet(): boolean {
+	return useMediaQuery(
+		`(min-width: ${breakpoints.md}px) and (max-width: ${breakpoints.lg - 1}px)`
+	);
+}
+
+/**
+ * Hook pour détecter si on est sur desktop (≥1024px)
+ * @returns boolean - true si viewport >= lg breakpoint
+ */
+export function useIsDesktop(): boolean {
+	return useMediaQuery(`(min-width: ${breakpoints.lg}px)`);
+}
+
+/**
+ * Hook pour détecter si l'écran est tactile
+ * @returns boolean - true si touch device
+ */
+export function useIsTouchDevice(): boolean {
+	const [isTouch, setIsTouch] = useState(false);
+
+	useEffect(() => {
+		if (typeof window === 'undefined') return;
+
+		const checkTouch = () => {
+			setIsTouch(
+				'ontouchstart' in window ||
+					navigator.maxTouchPoints > 0 ||
+					window.matchMedia('(pointer: coarse)').matches
+			);
+		};
+
+		checkTouch();
+	}, []);
+
+	return isTouch;
+}
+
+/**
+ * Hook pour détecter l'orientation de l'écran
+ * @returns 'portrait' | 'landscape'
+ */
+export function useOrientation(): 'portrait' | 'landscape' {
+	const isPortrait = useMediaQuery('(orientation: portrait)');
+	return isPortrait ? 'portrait' : 'landscape';
+}
+
+/**
+ * Hook combiné pour obtenir toutes les infos device en une fois
+ * Utile pour éviter multiple re-renders
+ */
+export function useDeviceInfo() {
+	const isMobile = useIsMobile();
+	const isTablet = useIsTablet();
+	const isDesktop = useIsDesktop();
+	const isTouch = useIsTouchDevice();
+	const orientation = useOrientation();
+
+	return {
+		isMobile,
+		isTablet,
+		isDesktop,
+		isTouch,
+		orientation,
+		// Helpers
+		isMobileOrTablet: isMobile || isTablet,
+		isPortrait: orientation === 'portrait',
+		isLandscape: orientation === 'landscape',
+	};
+}

--- a/frontend/app/routes/admin.gammes-seo.tsx
+++ b/frontend/app/routes/admin.gammes-seo.tsx
@@ -16,7 +16,9 @@ import {
 import { useLoaderData, useNavigation, useSearchParams, Link } from "@remix-run/react";
 import {
   AlertTriangle,
+  ArrowRight,
   ArrowUpDown,
+  BarChart3,
   CheckCircle,
   ChevronLeft,
   ChevronRight,
@@ -937,6 +939,13 @@ export default function AdminGammesSeo() {
               Export CSV
             </Button>
           </a>
+          <Link to="/admin/v-level-status">
+            <Button variant="outline" className="bg-blue-50 border-blue-200 text-blue-700 hover:bg-blue-100">
+              <BarChart3 className="h-4 w-4 mr-2" />
+              V-Level Status
+              <ArrowRight className="h-4 w-4 ml-2" />
+            </Button>
+          </Link>
         </div>
       </div>
 

--- a/frontend/app/routes/admin.v-level-status.tsx
+++ b/frontend/app/routes/admin.v-level-status.tsx
@@ -13,7 +13,7 @@ import {
   type LoaderFunctionArgs,
   type MetaFunction,
 } from "@remix-run/node";
-import { useLoaderData, useRevalidator } from "@remix-run/react";
+import { useLoaderData, useRevalidator, Link } from "@remix-run/react";
 import {
   BarChart3,
   RefreshCw,
@@ -23,6 +23,8 @@ import {
   Database,
   TrendingUp,
   Layers,
+  ArrowRight,
+  Tag,
 } from "lucide-react";
 import { useState } from "react";
 
@@ -160,6 +162,13 @@ export default function VLevelStatusPage() {
           </p>
         </div>
         <div className="flex gap-2">
+          <Link to="/admin/gammes-seo">
+            <Button variant="outline" className="bg-green-50 border-green-200 text-green-700 hover:bg-green-100">
+              <Tag className="h-4 w-4 mr-2" />
+              Gammes SEO
+              <ArrowRight className="h-4 w-4 ml-2" />
+            </Button>
+          </Link>
           <Button
             variant="outline"
             onClick={() => revalidator.revalidate()}

--- a/scripts/audit-responsive.sh
+++ b/scripts/audit-responsive.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# =============================================================================
+# AUDIT RESPONSIVE - Mobile-First E-commerce
+# =============================================================================
+# Détecte automatiquement les problèmes responsive sans vérifier page par page
+# Usage: ./scripts/audit-responsive.sh [--fix]
+# =============================================================================
+
+set -e
+
+FRONTEND_DIR="frontend/app"
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}       📱 AUDIT RESPONSIVE - Mobile-First E-commerce       ${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+echo ""
+
+# -----------------------------------------------------------------------------
+# 1. Fichiers sans classes responsive
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}📱 Fichiers SANS classes responsive (sm:|md:|lg:|xl:)${NC}"
+echo -e "${YELLOW}   Ces fichiers peuvent avoir des problèmes mobile${NC}"
+echo ""
+
+FILES_WITHOUT_RESPONSIVE=$(find "$FRONTEND_DIR" -name "*.tsx" -type f \
+  ! -path "*/node_modules/*" \
+  ! -name "*.test.tsx" \
+  ! -name "*.spec.tsx" \
+  -exec grep -L "sm:\|md:\|lg:\|xl:" {} \; 2>/dev/null | head -20)
+
+if [ -n "$FILES_WITHOUT_RESPONSIVE" ]; then
+  echo "$FILES_WITHOUT_RESPONSIVE" | while read -r file; do
+    echo -e "   ${RED}⚠${NC}  $file"
+  done
+  COUNT_NO_RESPONSIVE=$(echo "$FILES_WITHOUT_RESPONSIVE" | wc -l | tr -d ' ')
+  echo ""
+  echo -e "   ${RED}Total: $COUNT_NO_RESPONSIVE fichiers sans responsive${NC}"
+else
+  echo -e "   ${GREEN}✓ Tous les fichiers ont des classes responsive${NC}"
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
+# 2. Touch targets insuffisants
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}👆 Boutons potentiellement trop petits pour touch (<44px)${NC}"
+echo -e "${YELLOW}   Recommandation: min-h-[44px] ou touch-target${NC}"
+echo ""
+
+SMALL_BUTTONS=$(grep -rn "className.*<Button\|<button" "$FRONTEND_DIR" --include="*.tsx" 2>/dev/null \
+  | grep -v "min-h-\[44\|min-h-\[48\|touch-target\|h-10\|h-11\|h-12\|size=\"lg\"" \
+  | head -10)
+
+if [ -n "$SMALL_BUTTONS" ]; then
+  echo "$SMALL_BUTTONS" | while read -r line; do
+    FILE=$(echo "$line" | cut -d':' -f1)
+    LINE_NUM=$(echo "$line" | cut -d':' -f2)
+    echo -e "   ${YELLOW}⚠${NC}  $FILE:$LINE_NUM"
+  done
+else
+  echo -e "   ${GREEN}✓ Tous les boutons ont une taille touch adéquate${NC}"
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
+# 3. Inputs sans text-base (zoom iOS)
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}🔍 Inputs risquant le zoom iOS (font-size < 16px)${NC}"
+echo -e "${YELLOW}   Recommandation: text-base ou no-zoom-input${NC}"
+echo ""
+
+ZOOM_INPUTS=$(grep -rn "<input\|<Input\|<textarea\|<Textarea" "$FRONTEND_DIR" --include="*.tsx" 2>/dev/null \
+  | grep -v "text-base\|text-lg\|no-zoom-input\|type=\"hidden\"\|type=\"checkbox\"\|type=\"radio\"" \
+  | head -10)
+
+if [ -n "$ZOOM_INPUTS" ]; then
+  echo "$ZOOM_INPUTS" | while read -r line; do
+    FILE=$(echo "$line" | cut -d':' -f1)
+    LINE_NUM=$(echo "$line" | cut -d':' -f2)
+    echo -e "   ${YELLOW}⚠${NC}  $FILE:$LINE_NUM"
+  done
+else
+  echo -e "   ${GREEN}✓ Tous les inputs ont une taille de police adéquate${NC}"
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
+# 4. Tables sans responsive
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}📊 Tables sans gestion mobile${NC}"
+echo -e "${YELLOW}   Recommandation: ResponsiveTable ou overflow-x-auto${NC}"
+echo ""
+
+NON_RESPONSIVE_TABLES=$(grep -rn "<table" "$FRONTEND_DIR" --include="*.tsx" 2>/dev/null \
+  | grep -v "overflow-x-auto\|ResponsiveTable\|hidden\|mobile" \
+  | head -10)
+
+if [ -n "$NON_RESPONSIVE_TABLES" ]; then
+  echo "$NON_RESPONSIVE_TABLES" | while read -r line; do
+    FILE=$(echo "$line" | cut -d':' -f1)
+    LINE_NUM=$(echo "$line" | cut -d':' -f2)
+    echo -e "   ${YELLOW}⚠${NC}  $FILE:$LINE_NUM"
+  done
+else
+  echo -e "   ${GREEN}✓ Toutes les tables sont responsive${NC}"
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
+# 5. Grids sans colonnes mobile
+# -----------------------------------------------------------------------------
+echo -e "${YELLOW}📐 Grids potentiellement cassées sur mobile${NC}"
+echo -e "${YELLOW}   Pattern attendu: grid-cols-1 sm:grid-cols-2 ...${NC}"
+echo ""
+
+BAD_GRIDS=$(grep -rn "grid-cols-[2-6]" "$FRONTEND_DIR" --include="*.tsx" 2>/dev/null \
+  | grep -v "grid-cols-1\|sm:grid-cols\|md:grid-cols" \
+  | head -10)
+
+if [ -n "$BAD_GRIDS" ]; then
+  echo "$BAD_GRIDS" | while read -r line; do
+    FILE=$(echo "$line" | cut -d':' -f1)
+    LINE_NUM=$(echo "$line" | cut -d':' -f2)
+    echo -e "   ${YELLOW}⚠${NC}  $FILE:$LINE_NUM"
+  done
+else
+  echo -e "   ${GREEN}✓ Toutes les grilles sont mobile-first${NC}"
+fi
+echo ""
+
+# -----------------------------------------------------------------------------
+# 6. Statistiques globales
+# -----------------------------------------------------------------------------
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}                      📊 STATISTIQUES                       ${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+echo ""
+
+TOTAL_TSX=$(find "$FRONTEND_DIR" -name "*.tsx" -type f ! -path "*/node_modules/*" | wc -l | tr -d ' ')
+WITH_RESPONSIVE=$(grep -rl "sm:\|md:\|lg:\|xl:" "$FRONTEND_DIR" --include="*.tsx" 2>/dev/null | wc -l | tr -d ' ')
+WITHOUT_RESPONSIVE=$((TOTAL_TSX - WITH_RESPONSIVE))
+PERCENTAGE=$((WITH_RESPONSIVE * 100 / TOTAL_TSX))
+
+echo -e "   📁 Total fichiers TSX:        ${BLUE}$TOTAL_TSX${NC}"
+echo -e "   ✓  Avec classes responsive:   ${GREEN}$WITH_RESPONSIVE${NC}"
+echo -e "   ⚠  Sans classes responsive:   ${YELLOW}$WITHOUT_RESPONSIVE${NC}"
+echo -e "   📈 Couverture responsive:     ${GREEN}${PERCENTAGE}%${NC}"
+echo ""
+
+# Nouveaux composants disponibles
+echo -e "${BLUE}🆕 Composants Mobile-First disponibles:${NC}"
+echo -e "   • Container, Section       - Wrapper responsive"
+echo -e "   • Stack, HStack, VStack    - Flexbox simplifié"
+echo -e "   • ResponsiveGrid           - Grille e-commerce"
+echo -e "   • MobileBottomBar          - CTA sticky mobile"
+echo -e "   • ResponsiveTable          - Table → Cards"
+echo -e "   • FilterDrawer             - Bottom sheet filtres"
+echo ""
+
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}                    ✓ Audit terminé                        ${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════════════${NC}"


### PR DESCRIPTION
## Summary

- **Migration SQL complète** pour G-Level et V-Level consolidation
- **Table `gamme_seo_audit`** dédiée (remplace ___xtr_msg pour audit)
- **Colonnes G-Level** (`pg_g_level`, `pg_parent_gamme_id`) dans `pieces_gamme`
- **Colonnes V-Level** (`bloc`, `is_v1`, `v2_count`) dans `gamme_seo_metrics`
- **50+ endpoints admin** pour gestion G/V-Level
- **Dashboard frontend** complet avec métriques temps réel

### Classification G-Level (235 gammes)
| Niveau | Gammes | Description |
|--------|--------|-------------|
| G1 | 114 | Prioritaires (≥5000 rech/mois) |
| G2 | 118 | Secondaires (200-5000 rech/mois) |
| G3 | 1 | Enfants (parent requis) |
| G4 | 2 | Catalogue-only (0 recherche) |

### Classification V-Level (2 blocs)
- **Bloc A** (gamme→véhicule): V1/V2/V3/V4
- **Bloc B** (véhicule→pièce): V5

## Commits inclus
- `feat(seo): consolidate Gamme SEO & V-Level system`
- `fix(___xtr_msg): migrate gamme-seo-audit + disable review queries`
- `feat(legal): migrate legal.service.ts from ___xtr_msg to dedicated tables`

## Test plan
- [ ] Vérifier que la migration SQL s'exécute sans erreur
- [ ] Tester les endpoints admin `/api/admin/gammes-seo/*`
- [ ] Vérifier le dashboard frontend `/admin/gammes-seo`
- [ ] Confirmer que l'audit fonctionne avec la nouvelle table

🤖 Generated with [Claude Code](https://claude.com/claude-code)