### PR TITLE
fix(pipeline): RAG-as-Optional-Overlay — missing RAG no longer fails jobs

### DIFF
--- a/backend/src/workers/processors/__tests__/content-refresh.processor.test.ts
+++ b/backend/src/workers/processors/__tests__/content-refresh.processor.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Unit tests for ContentRefreshProcessor — RAG-as-Optional-Overlay
+ *
+ * Validates that missing RAG data produces 'skipped' (neutral),
+ * NOT 'failed'. Only genuine quality issues or exceptions produce 'failed'.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// ── Module mocks (must be before imports) ──
+
+jest.mock('@nestjs/bull', () => ({
+  Processor: () => () => undefined,
+  Process: () => () => undefined,
+  InjectQueue: () => () => undefined,
+}));
+
+jest.mock('@nestjs/common', () => ({
+  Injectable: () => () => undefined,
+  Logger: jest.fn().mockImplementation(() => ({
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+jest.mock('@nestjs/config', () => ({
+  ConfigService: jest.fn(),
+}));
+
+jest.mock('../../../database/services/supabase-base.service', () => ({
+  SupabaseBaseService: class {
+    protected client: any;
+    protected configService: any;
+    protected logger: any = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    constructor(..._args: any[]) {}
+  },
+}));
+
+jest.mock(
+  '../../../modules/admin/services/buying-guide-enricher.service',
+  () => ({
+    BuyingGuideEnricherService: jest.fn(),
+  }),
+);
+
+jest.mock('../../../modules/admin/services/conseil-enricher.service', () => ({
+  ConseilEnricherService: jest.fn(),
+}));
+
+jest.mock('../../../modules/seo/services/reference.service', () => ({
+  ReferenceService: jest.fn(),
+}));
+
+// ── Now import the processor ──
+
+import { ContentRefreshProcessor } from '../content-refresh.processor';
+import type { ContentRefreshResult } from '../../types/content-refresh.types';
+
+// ── Test helpers ──
+
+const mockSupabaseUpdate = jest.fn().mockReturnValue({
+  eq: jest.fn().mockResolvedValue({ error: null }),
+});
+
+const mockSupabaseFrom = jest.fn().mockReturnValue({
+  update: mockSupabaseUpdate,
+  select: jest.fn().mockReturnValue({
+    eq: jest.fn().mockReturnValue({
+      neq: jest.fn().mockReturnValue({
+        neq: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue({ data: [] }),
+        }),
+      }),
+    }),
+    single: jest.fn().mockResolvedValue({ data: null }),
+  }),
+});
+
+const mockBuyingGuideEnricher = { enrich: jest.fn() };
+const mockConseilEnricher = { enrichSingle: jest.fn() };
+const mockReferenceService = { refreshSingleGamme: jest.fn() };
+const mockConfigService = {
+  get: jest.fn((key: string, defaultVal?: string) => {
+    if (key === 'CONTENT_AUTO_PUBLISH_THRESHOLD') return '101';
+    return defaultVal ?? '';
+  }),
+};
+
+let processor: any;
+
+beforeAll(() => {
+  processor = Object.create(ContentRefreshProcessor.prototype);
+  processor.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  processor.client = { from: mockSupabaseFrom };
+  processor.configService = mockConfigService;
+  processor.buyingGuideEnricher = mockBuyingGuideEnricher;
+  processor.conseilEnricher = mockConseilEnricher;
+  processor.referenceService = mockReferenceService;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSupabaseUpdate.mockReturnValue({
+    eq: jest.fn().mockResolvedValue({ error: null }),
+  });
+  mockConfigService.get.mockImplementation(
+    (key: string, defaultVal?: string) => {
+      if (key === 'CONTENT_AUTO_PUBLISH_THRESHOLD') return '101';
+      return defaultVal ?? '';
+    },
+  );
+});
+
+function makeJob(
+  overrides: Partial<{
+    refreshLogId: number;
+    pgId: number;
+    pgAlias: string;
+    pageType: string;
+  }>,
+) {
+  return {
+    data: {
+      refreshLogId: 1,
+      pgId: 100,
+      pgAlias: 'filtre-a-huile',
+      pageType: 'R4_reference',
+      ...overrides,
+    },
+  } as any;
+}
+
+// ── Tests ──
+
+describe('ContentRefreshProcessor — RAG-as-Optional-Overlay', () => {
+  // Test 1: R4 sans RAG → skipped
+  it('should set status=skipped when R4 reference has no RAG file', async () => {
+    mockReferenceService.refreshSingleGamme.mockResolvedValue({
+      created: false,
+      updated: false,
+      skipped: true,
+    });
+
+    const result: ContentRefreshResult = await processor.handleContentRefresh(
+      makeJob({ pageType: 'R4_reference', pgAlias: 'filtre-a-huile' }),
+    );
+
+    expect(result.status).toBe('skipped');
+    expect(result.qualityScore).toBeNull();
+    expect(result.qualityFlags).toContain('NO_RAG_DATA_AVAILABLE');
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  // Test 2: R4 avec RAG (created) → draft
+  it('should set status=draft when R4 reference creates new entry', async () => {
+    mockReferenceService.refreshSingleGamme.mockResolvedValue({
+      created: true,
+      updated: false,
+      skipped: false,
+    });
+
+    const result: ContentRefreshResult = await processor.handleContentRefresh(
+      makeJob({ pageType: 'R4_reference', pgAlias: 'disque-de-frein' }),
+    );
+
+    expect(result.status).toBe('draft');
+    expect(result.qualityScore).toBe(80);
+    expect(result.qualityFlags).toContain('NEW_ENTRY_CREATED');
+  });
+
+  // Test 3: R3_conseils sans RAG (NO_RAG_DOC) → skipped
+  it('should set status=skipped when R3 conseils has no RAG doc', async () => {
+    mockConseilEnricher.enrichSingle.mockResolvedValue({
+      status: 'skipped',
+      score: 0,
+      flags: [],
+      sectionsCreated: 0,
+      sectionsUpdated: 0,
+      reason: 'NO_RAG_DOC',
+    });
+
+    const result: ContentRefreshResult = await processor.handleContentRefresh(
+      makeJob({ pageType: 'R3_conseils', pgAlias: 'filtre-a-huile' }),
+    );
+
+    expect(result.status).toBe('skipped');
+    expect(result.qualityScore).toBeNull();
+  });
+
+  // Test 4: R3_conseils avec RAG mais qualité < 70 → failed (vrai échec)
+  it('should set status=failed when R3 conseils has RAG but quality is low', async () => {
+    mockConseilEnricher.enrichSingle.mockResolvedValue({
+      status: 'failed',
+      score: 45,
+      flags: ['MISSING_PROCEDURE', 'FAQ_TOO_SMALL'],
+      sectionsCreated: 0,
+      sectionsUpdated: 0,
+      reason: 'QUALITY_BELOW_THRESHOLD',
+    });
+
+    const result: ContentRefreshResult = await processor.handleContentRefresh(
+      makeJob({ pageType: 'R3_conseils', pgAlias: 'disque-de-frein' }),
+    );
+
+    expect(result.status).toBe('failed');
+    expect(result.qualityScore).toBe(45);
+  });
+
+  // Test 5: R1 toutes sections skippées → skipped
+  it('should set status=skipped when R1 buying guide has all sections skipped', async () => {
+    mockBuyingGuideEnricher.enrich.mockResolvedValue([
+      {
+        pgId: '100',
+        sections: {},
+        averageConfidence: 0,
+        updated: false,
+        sectionsUpdated: 0,
+        skippedSections: [
+          'anti_mistakes',
+          'selection_criteria',
+          'decision_tree',
+          'use_cases',
+        ],
+      },
+    ]);
+
+    const result: ContentRefreshResult = await processor.handleContentRefresh(
+      makeJob({ pageType: 'R1_pieces', pgAlias: 'filtre-a-huile' }),
+    );
+
+    expect(result.status).toBe('skipped');
+    expect(result.qualityScore).toBeNull();
+    expect(result.qualityFlags).toEqual(
+      expect.arrayContaining([
+        'SKIPPED_ANTI_MISTAKES',
+        'SKIPPED_SELECTION_CRITERIA',
+      ]),
+    );
+  });
+
+  // Test 6: R1 avec RAG partiel (avgConf 0.65) → failed (genuine low quality)
+  it('should set status=failed when R1 has partial RAG overlay with low confidence', async () => {
+    mockBuyingGuideEnricher.enrich.mockResolvedValue([
+      {
+        pgId: '100',
+        sections: { anti_mistakes: {}, selection_criteria: {} },
+        averageConfidence: 0.65,
+        updated: true,
+        sectionsUpdated: 2,
+        skippedSections: ['decision_tree'],
+      },
+    ]);
+
+    const result: ContentRefreshResult = await processor.handleContentRefresh(
+      makeJob({
+        pageType: 'R3_guide_achat',
+        pgAlias: 'disque-de-frein',
+      }),
+    );
+
+    // avgConf 0.65 < 0.8 → score 60, 60 < 70 → genuine failed
+    expect(result.status).toBe('failed');
+    expect(result.qualityScore).toBe(60);
+  });
+
+  // Test 7: skipped → PAS d'updates secondaires
+  it('should NOT update dependent tables when status is skipped', async () => {
+    mockReferenceService.refreshSingleGamme.mockResolvedValue({
+      created: false,
+      updated: false,
+      skipped: true,
+    });
+
+    await processor.handleContentRefresh(
+      makeJob({ pageType: 'R4_reference', pgAlias: 'filtre-a-huile' }),
+    );
+
+    // Only __rag_content_refresh_log should be touched, never __seo_reference
+    const fromCalls = mockSupabaseFrom.mock.calls.map((c: unknown[]) => c[0]);
+    expect(fromCalls).not.toContain('__seo_reference');
+    expect(fromCalls).not.toContain('__seo_gamme_purchase_guide');
+  });
+
+  // Test 8: Exception runtime → failed avec EXCEPTION flag
+  it('should set status=failed with EXCEPTION flag on runtime error', async () => {
+    mockReferenceService.refreshSingleGamme.mockRejectedValue(
+      new Error('Connection timeout'),
+    );
+
+    const result: ContentRefreshResult = await processor.handleContentRefresh(
+      makeJob({ pageType: 'R4_reference', pgAlias: 'disque-de-frein' }),
+    );
+
+    expect(result.status).toBe('failed');
+    expect(result.qualityScore).toBe(0);
+    expect(result.qualityFlags).toContain('EXCEPTION');
+    expect(result.errorMessage).toContain('Connection timeout');
+  });
+});

--- a/backend/src/workers/types/content-refresh.types.ts
+++ b/backend/src/workers/types/content-refresh.types.ts
@@ -7,7 +7,26 @@ export interface ContentRefreshJobData {
 
 export interface ContentRefreshResult {
   status: 'draft' | 'failed' | 'skipped' | 'auto_published';
-  qualityScore: number;
+  qualityScore: number | null;
   qualityFlags: string[];
   errorMessage?: string;
+}
+
+// ── RAG Overlay Contract ──
+
+/** Outcome of attempting to load RAG data for an enrichment job */
+export type RagPatchStatus =
+  | 'SUCCESS' // RAG file found, parsed, valid data extracted
+  | 'SKIPPED_NO_RAG' // No RAG file exists for this gamme (NORMAL)
+  | 'SKIPPED_INVALID_RAG' // RAG file exists but content is unparseable/too short
+  | 'ERROR'; // Unexpected error during RAG loading
+
+export interface RagPatchResult {
+  status: RagPatchStatus;
+  /** Raw content if status=SUCCESS */
+  content?: string;
+  /** Human-readable reason for non-SUCCESS statuses */
+  reason?: string;
+  /** Source path for provenance tracking */
+  sourcePath?: string;
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `ContentRefreshProcessor` had a binary decision (`score >= 70 ? draft : failed`) — the `skipped` status existed in TypeScript types and admin UI but was **never assigned**
- **Impact**: ~190/191 "failed" entries in `__rag_content_refresh_log` are false positives (gammes without RAG files, i.e. 97.7% of catalog)
- **Fix**: Introduces `ragSkipped` flag so absent RAG data produces `status='skipped'` (neutral), while genuine quality issues still produce `status='failed'`

### Changes (3 files)

| File | Change |
|------|--------|
| `content-refresh.processor.ts` | 6 changes (A–F): ragSkipped pathway for R1/R3/R4, skip link markers + dependent tables when skipped |
| `content-refresh.types.ts` | `qualityScore: number \| null`, added `RagPatchStatus`/`RagPatchResult` types |
| `content-refresh.processor.test.ts` | 8 unit tests covering all R-type skip/fail/exception scenarios |

### What stays unchanged

- **0 enricher changes** — ConseilEnricher, BuyingGuideEnricher, ReferenceService already signal "no RAG" correctly
- **0 frontend changes** — all routes are already DB-first
- **Admin UI** — already has `skipped: "NEUTRAL"` badge mapping

## Test plan

- [x] 8 unit tests pass (R4 no RAG→skipped, R4 with RAG→draft, R3 no RAG→skipped, R3 low quality→failed, R1 all skipped→skipped, R1 partial RAG→failed, skipped→no dependent table updates, exception→EXCEPTION flag)
- [x] TypeScript typecheck passes
- [x] ESLint + Prettier pass
- [ ] Post-deploy: 4 smoke tests (trigger refresh sans/avec RAG, dashboard counts, frontend pages 200)
- [ ] Post-deploy: SQL migration to reclassify ~190 false-positive "failed" entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)