### PR TITLE
docs(spec): sync SEO Squad with 4 sub-leads (ADR-013)

### DIFF
--- a/.spec/workflows/ai-cos-business-squad.md
+++ b/.spec/workflows/ai-cos-business-squad.md
@@ -41,15 +41,17 @@ Le **Business Squad** comprend **17 agents** avec un budget total de **€262K**
                                          │
     ┌─────────────────┬──────────────────┼──────────────────┬─────────────────┐
     │                 │                  │                  │                 │
-┌───┴─────────┐  ┌────┴────────┐   ┌────┴────────┐   ┌────┴────────┐   ┌────┴────────┐
-│ SEO Squad   │  │ Marketing   │   │ E-Commerce  │   │ Intelligence│   │ Customer    │
-│ [NOUVEAU]   │  │ Squad [NEW] │   │             │   │             │   │             │
-├─────────────┤  ├─────────────┤   ├─────────────┤   ├─────────────┤   ├─────────────┤
-│ IA-SEO      │  │ IA-Marketing│   │ Growth IA   │   │ VoC Miner   │   │ IA-CRM      │
-│ Master      │  │ Director    │   │ IA-Merch    │   │ Analytics   │   │ IA-Sales    │
-│ SEO Sentinel│  │ Content Bot │   │ Pricing Intel│  │ Agent       │   │             │
-│ Schema Bot  │  │ Social Media│   │             │   │             │   │             │
-└─────────────┘  └─────────────┘   └─────────────┘   └─────────────┘   └─────────────┘
+┌──────────────────┐  ┌────┴────────┐   ┌────┴────────┐   ┌────┴────────┐   ┌────┴────────┐
+│ SEO Squad        │  │ Marketing   │   │ E-Commerce  │   │ Intelligence│   │ Customer    │
+│ [v3.9.0+ADR-013] │  │ Squad [NEW] │   │             │   │             │   │             │
+├──────────────────┤  ├─────────────┤   ├─────────────┤   ├─────────────┤   ├─────────────┤
+│ IA-SEO Master    │  │ IA-Marketing│   │ Growth IA   │   │ VoC Miner   │   │ IA-CRM      │
+│ ├─ KP Lead (7)   │  │ Director    │   │ IA-Merch    │   │ Analytics   │   │ IA-Sales    │
+│ ├─ Content Lead(11)│ │ Content Bot │   │ Pricing Intel│  │ Agent       │   │             │
+│ ├─ QA Lead (7)   │  │ Social Media│   │             │   │             │   │             │
+│ └─ Exec Lead (6) │  │             │   │             │   │             │   │             │
+│ SEO Sentinel     │  │             │   │             │   │             │   │             │
+└──────────────────┘  └─────────────┘   └─────────────┘   └─────────────┘   └─────────────┘
 
      ⚠️ RÈGLE CARDINALE: SEO et Marketing NE SE MÉLANGENT JAMAIS
      En cas de conflit: Escalade IA-CEO → HUMAIN décide
@@ -607,7 +609,16 @@ L'**IA-SEO Master** est le **Lead du SEO Squad**, responsable de la **Structure 
 
 ### Coordination
 
-- **SEO Sentinel** : Agent exécution sous IA-SEO Master
+**4 sous-leads (ADR-013, Level 2.5)** — span of control ~30 → 4 :
+
+| Sous-lead | Agents | Périmètre |
+|-----------|--------|-----------|
+| **KP Lead** (`agent.seo.kp.lead`) | 7 | keyword-planner (r1/r4/r6), research-agent, brief-enricher, seo-keyword-expert, serp-analyzer |
+| **Content Lead** (`agent.seo.content.lead`) | 11 | content-batch (r1/r4/r6), conseil-batch, image-prompt (r3/r6), seo-content-architect, content-refresh, video-execution |
+| **QA Lead** (`agent.seo.qa.lead`) | 7 | seo-monitor-*, seo-audit-scheduler, interpolation-monitor, qa.seo-tech, SEO Sentinel |
+| **Exec Lead** (`agent.seo.exec.lead`) | 6 | seo-vlevel, seo-sitemap, seo-canonical, sitemap-delta, pipeline-chain-poller, a9_seo |
+
+**Autres coordinateurs** :
 - **Schema Bot** : Structured data
 - **IA-Marketing Director** : Escalade conflits → HUMAIN
 


### PR DESCRIPTION
## Contexte\n\nSync de ai-cos-business-squad.md avec la restructuration SEO Master (governance-vault PR #1, mergée).\n\nIA-SEO Master passe de ~30 reports directs à 4 sous-leads (ADR-013 G1).\n\n## Changements\n\n- Diagramme ASCII SEO Squad mis à jour (4 sous-leads visibles)\n- Section Coordination : tableau détaillé des 4 sous-leads + agents managés\n- Aucun changement de code\n\n## Note\n\nCette PR ne touche que `.spec/workflows/` — aucun impact sur le pipeline SEO en cours (KP/Content). Les sous-leads sont `NOT_APPROVED` (design organisationnel).\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)