### PR TITLE
spec: add RAG enrichment pipeline schemas (v2.1)

### DIFF
--- a/.spec/00-canon/conflict.schema.yaml
+++ b/.spec/00-canon/conflict.schema.yaml
@@ -1,0 +1,135 @@
+# Schema _conflicts[] — Pipeline RAG Enrichissement
+# Ref: docs/pipeline-rag-enrichissement.md (ai-cos-system), D4
+#
+# Ce schema definit la structure de chaque entree dans le champ _conflicts[]
+# du frontmatter des fichiers gamme .md.
+#
+# Chaque conflit est cree pendant l'enrichissement (Etape 2) quand deux sources
+# fournissent des valeurs divergentes pour le meme champ.
+
+conflict_entry:
+  type: object
+  required:
+    - block
+    - field
+    - conflict_type
+    - run_id
+    - existing_value
+    - new_value
+    - existing_sources
+    - new_sources
+    - resolution_status
+    - human_review_required
+    - created_at
+  properties:
+
+    block:
+      type: string
+      description: Bloc du frontmatter concerne
+      enum: [domain, selection, diagnostic, maintenance, installation, rendering]
+
+    field:
+      type: string
+      description: Chemin du champ en notation dot (ex. interval.value, symptoms[0].label)
+
+    conflict_type:
+      type: string
+      description: |
+        minor_variation — formulation differente, meme sens metier. Ne bloque PAS L1.
+        technical_conflict — valeur technique divergente. BLOQUE L1.
+        safety_conflict — contradiction sur procedure/securite. BLOQUE L1 + priorite revue.
+      enum:
+        - minor_variation
+        - technical_conflict
+        - safety_conflict
+
+    run_id:
+      type: string
+      format: uuid
+      description: UUID v4 du run qui a detecte le conflit (E4b)
+
+    existing_value:
+      type: string
+      description: Valeur actuellement dans le fichier gamme
+
+    new_value:
+      type: string
+      description: Valeur trouvee par le pipeline d'enrichissement
+
+    existing_sources:
+      type: array
+      items:
+        $ref: '#/source_ref'
+      description: Sources de la valeur existante
+
+    new_sources:
+      type: array
+      items:
+        $ref: '#/source_ref'
+      description: Sources de la nouvelle valeur
+
+    resolution_status:
+      type: string
+      enum:
+        - open        # Non resolu, en attente de revue
+        - resolved    # Resolu par un humain
+        - dismissed   # Ecarte (faux positif ou minor_variation normalisee)
+
+    human_review_required:
+      type: boolean
+      description: |
+        true si technical_conflict ou safety_conflict.
+        false uniquement pour minor_variation.
+
+    created_at:
+      type: string
+      format: date
+      description: Date de detection (YYYY-MM-DD)
+
+    resolved_by:
+      type: [string, 'null']
+      description: Identifiant du reviewer humain (null si non resolu)
+
+    resolution:
+      type: [string, 'null']
+      description: Decision prise par le reviewer
+      enum:
+        - accept_existing   # Conserver la valeur actuelle
+        - accept_new        # Remplacer par la nouvelle valeur
+        - merge             # Combiner les deux valeurs
+        - rewrite           # Reecriture manuelle (ni l'un ni l'autre)
+        - null              # Non resolu
+
+    resolved_at:
+      type: [string, 'null']
+      format: date
+      description: Date de resolution (null si non resolu)
+
+source_ref:
+  type: object
+  required:
+    - url
+    - tier
+  properties:
+    url:
+      type: string
+      format: uri
+      description: URL de la source
+    tier:
+      type: string
+      enum: [A, B, C]
+      description: |
+        A = constructeur/norme (Valeo, Bosch, ISO)
+        B = revendeur/guide expert (Oscaro, Mister Auto)
+        C = generaliste (Wikipedia, blogs, forums)
+
+# ── Regles metier (D4) ──
+#
+# - minor_variation ne bloque pas L1, peut etre resolu par normalisation
+# - technical_conflict bloque L1 tant que resolution_status != resolved
+# - safety_conflict bloque L1 + _review_required: true + priorite revue humaine
+#
+# ── Owner de revue (E6) ──
+#
+# - technical_conflict → Tech Lead ou Expert Metier
+# - safety_conflict → Tech Lead (obligatoire, pas delegable)

--- a/.spec/00-canon/enrichment-report.schema.json
+++ b/.spec/00-canon/enrichment-report.schema.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "enrichment-report.schema.json",
+  "title": "Enrichment Report",
+  "description": "Schema for the enrichment_report.json artifact produced by each pipeline run. Ref: docs/pipeline-rag-enrichissement.md (ai-cos-system)",
+  "type": "object",
+  "required": [
+    "run_id",
+    "alias",
+    "run_date",
+    "execution_mode",
+    "state_before",
+    "state_after",
+    "truth_level_before",
+    "truth_level_after",
+    "blocks",
+    "conflicts",
+    "pending_manual_sources",
+    "seo_regression_checks",
+    "validators_invoked",
+    "validator_verdicts",
+    "decision",
+    "reason"
+  ],
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "UUID v4 unique per execution, propagated to _archive, _conflicts, QA logs, and lifecycle.last_enriched_run_id"
+    },
+    "alias": {
+      "type": "string",
+      "description": "Gamme slug (pg_alias)"
+    },
+    "run_date": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO 8601 date (YYYY-MM-DD)"
+    },
+    "execution_mode": {
+      "type": "string",
+      "enum": ["audit_only", "enrich_dry_run", "enrich_write", "qa_only", "qa_write", "index_ready_check"]
+    },
+    "state_before": {
+      "$ref": "#/$defs/lifecycle_stage"
+    },
+    "state_after": {
+      "$ref": "#/$defs/lifecycle_stage"
+    },
+    "truth_level_before": {
+      "$ref": "#/$defs/truth_level"
+    },
+    "truth_level_after": {
+      "$ref": "#/$defs/truth_level"
+    },
+    "blocks": {
+      "type": "object",
+      "description": "Per-block results. Keys: domain, selection, maintenance, diagnostic, installation",
+      "properties": {
+        "domain": { "$ref": "#/$defs/block_result" },
+        "selection": { "$ref": "#/$defs/block_result" },
+        "maintenance": { "$ref": "#/$defs/block_result" },
+        "diagnostic": { "$ref": "#/$defs/block_result" },
+        "installation": { "$ref": "#/$defs/block_result" }
+      },
+      "additionalProperties": false
+    },
+    "conflicts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/conflict_summary" },
+      "description": "Conflicts detected during this run"
+    },
+    "pending_manual_sources": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Fields requiring manual Tier A sourcing (format: block.field)"
+    },
+    "seo_regression_checks": {
+      "type": "object",
+      "required": ["passed", "failed", "details"],
+      "properties": {
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["check_id", "status"],
+            "properties": {
+              "check_id": { "type": "integer", "minimum": 1, "maximum": 8 },
+              "status": { "type": "string", "enum": ["pass", "fail"] },
+              "detail": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "validators_invoked": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["R0", "R1", "R3", "R4", "R5", "R6", "R7", "R8"]
+      }
+    },
+    "validator_verdicts": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["PASS", "PARTIAL", "FAIL", "SKIPPED"]
+      }
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["PROMOTE_L1", "KEEP_L2", "BLOCKED", "PENDING_REVIEW"],
+      "description": "Final pipeline decision for this gamme"
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable explanation of the decision"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "lifecycle_stage": {
+      "type": "string",
+      "enum": [
+        "v5_ssot",
+        "v5_audited",
+        "v5_enriched",
+        "v5_qa_passed",
+        "v5_indexed",
+        "v5_blocked",
+        "v5_pending_review"
+      ]
+    },
+    "truth_level": {
+      "type": "string",
+      "enum": ["L1", "L2"]
+    },
+    "block_result": {
+      "type": "object",
+      "required": ["action", "qa_score", "evidence_score", "structural_complete"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": ["unchanged", "modified", "added", "removed"]
+        },
+        "qa_score": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 100
+        },
+        "evidence_score": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "maximum": 100
+        },
+        "structural_complete": {
+          "type": ["boolean", "null"],
+          "description": "Whether the block meets D5 minimal schema requirements"
+        }
+      },
+      "additionalProperties": false
+    },
+    "conflict_summary": {
+      "type": "object",
+      "required": ["block", "field", "conflict_type"],
+      "properties": {
+        "block": { "type": "string" },
+        "field": { "type": "string" },
+        "conflict_type": {
+          "type": "string",
+          "enum": ["minor_variation", "technical_conflict", "safety_conflict"]
+        }
+      },
+      "description": "Summary of conflict — full detail in gamme _conflicts[]. See conflict.schema.yaml"
+    }
+  }
+}

--- a/.spec/00-canon/gamme-md-schema.md
+++ b/.spec/00-canon/gamme-md-schema.md
@@ -421,6 +421,8 @@ Chaque section est **absente** si le bloc source n'est pas present ou est vide.
 
 ## Lifecycle stages
 
+### Stages de creation (historique)
+
 ```
 auto_generated → v4_converted → skill_enriched → expert_reviewed → published
 ```
@@ -432,3 +434,47 @@ auto_generated → v4_converted → skill_enriched → expert_reviewed → publi
 | `skill_enriched` | Contenu genere par skill | `/seo-content-architect` |
 | `expert_reviewed` | Valide par admin | Manuel |
 | `published` | Publie en production | Pipeline auto-publish |
+
+### Stages v5 — Pipeline enrichissement RAG
+
+> Ref: `docs/pipeline-rag-enrichissement.md` (ai-cos-system)
+
+```
+v5_ssot ──────────→ v5_audited ────────→ v5_enriched ───────→ v5_qa_passed ──────→ v5_indexed
+                        ↓                     ↓                    ↓
+                    v5_blocked            v5_blocked           v5_pending_review
+                                         v5_pending_review
+```
+
+| Stage | cycle_terminal | reopenable | indexable | enrichissable | promouvable L1 | revue humaine |
+|-------|----------------|------------|-----------|---------------|----------------|---------------|
+| `v5_ssot` | non | — | oui | oui | non | non |
+| `v5_audited` | non | — | oui | oui | non | non |
+| `v5_enriched` | non | — | non | oui | non | non |
+| `v5_qa_passed` | non | — | oui | oui | **oui** | non |
+| `v5_indexed` | **oui** | **oui** (→ v5_ssot) | oui | oui (nouveau cycle) | non | non |
+| `v5_blocked` | non | non | non | non | non | **oui** |
+| `v5_pending_review` | non | non | non | limite | non | **oui** |
+
+### Contraintes truth_level × lifecycle.stage
+
+| truth_level | stages autorises |
+|-------------|-----------------|
+| L2 | `v5_ssot`, `v5_audited`, `v5_enriched`, `v5_qa_passed`, `v5_blocked`, `v5_pending_review` |
+| L1 | `v5_qa_passed`, `v5_indexed` uniquement |
+
+**Regle canonique** : La promotion L2 → L1 n'est autorisee qu'au moment de la transition `v5_enriched → v5_qa_passed`, exclusivement via le mode `qa_write`.
+
+### Champs lifecycle supplementaires (pipeline enrichissement)
+
+```yaml
+lifecycle:
+  # ── Champs existants ──
+  stage: string
+  last_enriched_by: string
+  last_enriched_at: date
+
+  # ── Ajouts pipeline enrichissement ──
+  last_enriched_run_id: string|null   # UUID v4 du dernier run
+  v5_migrated_at: date|null           # date migration v5
+```


### PR DESCRIPTION
## Summary
- `enrichment-report.schema.json` — JSON Schema for pipeline run reports (D9)
- `conflict.schema.yaml` — schema for `_conflicts[]` in gamme frontmatter (D4)
- `gamme-md-schema.md` — add `lifecycle.stage` v5 pipeline values + `truth_level` constraints (E1-E3)

Ref: ai-cos-system `docs/pipeline-rag-enrichissement.md` (spec v2.1)

## Test plan
- [ ] Validate enrichment-report.schema.json with a JSON Schema validator
- [ ] Verify gamme-md-schema.md lifecycle stages match spec v2.1
- [ ] Phase 0 dry-run completed successfully (AUT-45)

🤖 Generated with [Claude Code](https://claude.com/claude-code)