### PR TITLE
spec(arch): AUT-271 — 3 ADRs + 44 manifests + 69 invariants + DoD

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,119 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences max. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (no behavior change)
+- [ ] Performance improvement
+- [ ] Database migration
+- [ ] Spec / manifest update
+- [ ] CI / tooling
+
+---
+
+## Spec & Manifest (required by gate)
+
+<!-- Fill both fields. The manifest-check gate validates these. -->
+<!-- "N/A" is only valid for docs, CI, and root config changes. -->
+
+**Spec:** `.spec/modules/<module>/manifest.yaml` — _status: [stub|draft|certified]_  
+**Manifest covered tables:** `<!-- list tables touched, or N/A -->`
+
+---
+
+## Definition of Done (DoD checklist)
+
+Check all that apply. The Code-Analyst nightly sweep will re-open `done` tasks missing required checks.
+
+### For all PRs
+
+- [ ] Lint passes (`npm run lint`)
+- [ ] TypeCheck passes (`npm run typecheck`)
+- [ ] Build succeeds (`npm run build`)
+- [ ] `manifest-check` gate passes (or violations documented below)
+- [ ] No new `owned_tables` conflict (table owned by exactly one module)
+- [ ] CODEOWNERS updated if a new module directory was created
+
+### For PRs touching backend modules
+
+- [ ] Module manifest exists at `.spec/modules/<module>/manifest.yaml`
+- [ ] All new HTTP routes are listed in the manifest's `http_routes`
+- [ ] All new tables written are listed in `owned_tables` (or `read_tables` for reads)
+- [ ] New RPC calls are listed in `owned_rpcs`
+- [ ] `depends_on` is up to date (new module imports reflected)
+- [ ] `change_surface.review_checklist` is up to date
+
+### For PRs touching database (migrations)
+
+- [ ] Data-Ops (0bd1fd16) approval added as reviewer
+- [ ] Migration is additive (no DROP without retirement + backup plan)
+- [ ] `sql-migration-checklist.md` followed
+- [ ] Relevant invariants in `.spec/00-canon/invariants/sql/INV-*.sql` still return 0 rows
+- [ ] `invariants_ref` in manifest updated if new invariants apply
+
+### For PRs touching SEO / sitemap
+
+- [ ] IA-SEO Master / CEO (993a4a02) notified via Paperclip comment
+- [ ] No unintended `noindex` added to indexed pages
+- [ ] Sitemap output verified if routes change
+- [ ] `seo_contracts` in manifest updated
+
+### For PRs touching payments
+
+- [ ] `timingSafeEqual` used for all HMAC comparisons (never `===`)
+- [ ] `normalizeOrderId()` called before DB lookup in callbacks
+- [ ] Test endpoints confirmed not reachable in PROD
+- [ ] Error code verified before marking order paid
+
+### For PRs certified module scope (blocking gate)
+
+- [ ] `manifest-check` gate is GREEN (no violations)
+- [ ] All invariants in `invariants_ref` pass locally
+- [ ] Gate battery listed in `change_surface.gate_battery` is green
+
+---
+
+## Manifest violations (if any)
+
+<!-- If the manifest-check gate reports violations, explain them here. -->
+<!-- In ADVISORY mode this is informational. In BLOCKING mode, violations must be fixed. -->
+
+```
+# Paste gate output here if violations exist, or write "None"
+None
+```
+
+---
+
+## Testing
+
+<!-- How was this tested? -->
+
+- [ ] Manual test on DEV (`46.224.118.55`)
+- [ ] Unit tests added/updated
+- [ ] Integration test verified
+- [ ] No test (explain why):
+
+---
+
+## Rollback plan
+
+<!-- How to revert if this breaks PROD? -->
+
+```bash
+git revert HEAD && git push origin main
+# or: describe specific steps
+```
+
+---
+
+## Related
+
+<!-- Link Paperclip tasks and related issues -->
+
+- Paperclip: `AUT-NNN`
+- Blocks: 
+- Required by:

--- a/.spec/00-canon/invariants/feature-invariants.json
+++ b/.spec/00-canon/invariants/feature-invariants.json
@@ -1,0 +1,638 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "created": "2026-04-13",
+    "total": 69,
+    "description": "Invariants exécutables pour AutoMecanik — chaque SQL doit retourner 0 ligne. Non-respect = régression ou incident potentiel.",
+    "source": "AUT-274 / AUT-271 epic. Fondé sur full-structural-audit.md v1.5.0, domain-map.md v1.4.2, incident pg_alias 2026-03, sql-governance-rules.md v1.0.0",
+    "domains": ["D1-catalog", "D2-vehicle", "D3-seo", "D4-orders", "D5-structural", "D6-consistency"]
+  },
+  "invariants": [
+    {
+      "id": "INV-001",
+      "name": "pg-alias-unique",
+      "domain": "D1-catalog",
+      "severity": "critical",
+      "description": "pieces_gamme.pg_alias doit être unique (non-null). Violation = incident pg_alias 2026-03 reproduit.",
+      "incident_ref": "20260329_dedup_pg_alias_unique.sql",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-001-pg-alias-unique.sql"
+    },
+    {
+      "id": "INV-002",
+      "name": "pg-alias-no-dup-suffix",
+      "domain": "D1-catalog",
+      "severity": "critical",
+      "description": "Aucun pg_alias ne doit contenir le suffixe '-dup' (résidu de la migration de dédup 2026-03).",
+      "incident_ref": "20260329_dedup_pg_alias_unique.sql",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-002-pg-alias-no-dup-suffix.sql"
+    },
+    {
+      "id": "INV-003",
+      "name": "pieces-gamme-pg-id-unique",
+      "domain": "D1-catalog",
+      "severity": "critical",
+      "description": "pieces_gamme.pg_id (PK) doit être unique. Doublons = corruption du catalogue.",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-003-pieces-gamme-pg-id-unique.sql"
+    },
+    {
+      "id": "INV-004",
+      "name": "pieces-price-non-negative",
+      "domain": "D1-catalog",
+      "severity": "critical",
+      "description": "Tous les prix dans pieces_price doivent être >= 0 (colonnes shadow _n migrées en V4b/V5a).",
+      "tables": ["pieces_price"],
+      "sql_file": "INV-004-pieces-price-non-negative.sql"
+    },
+    {
+      "id": "INV-005",
+      "name": "order-amount-non-negative",
+      "domain": "D4-orders",
+      "severity": "critical",
+      "description": "Tout montant commande ___xtr_order doit être >= 0.",
+      "tables": ["___xtr_order"],
+      "sql_file": "INV-005-order-amount-non-negative.sql"
+    },
+    {
+      "id": "INV-006",
+      "name": "pieces-relation-type-fk-piece",
+      "domain": "D1-catalog",
+      "severity": "high",
+      "description": "pieces_relation_type.rtp_piece_id doit référencer une pièce existante dans pieces.",
+      "tables": ["pieces_relation_type", "pieces"],
+      "sql_file": "INV-006-pieces-relation-type-fk-piece.sql"
+    },
+    {
+      "id": "INV-007",
+      "name": "pieces-media-img-fk-piece",
+      "domain": "D1-catalog",
+      "severity": "high",
+      "description": "pieces_media_img.pmi_piece_id doit référencer une pièce existante dans pieces.",
+      "tables": ["pieces_media_img", "pieces"],
+      "sql_file": "INV-007-pieces-media-img-fk-piece.sql"
+    },
+    {
+      "id": "INV-008",
+      "name": "pieces-ref-ean-fk-piece",
+      "domain": "D1-catalog",
+      "severity": "high",
+      "description": "pieces_ref_ean.pre_piece_id doit référencer une pièce existante dans pieces.",
+      "tables": ["pieces_ref_ean", "pieces"],
+      "sql_file": "INV-008-pieces-ref-ean-fk-piece.sql"
+    },
+    {
+      "id": "INV-009",
+      "name": "pieces-price-fk-piece",
+      "domain": "D1-catalog",
+      "severity": "high",
+      "description": "pieces_price.pp_piece_id doit référencer une pièce existante dans pieces.",
+      "tables": ["pieces_price", "pieces"],
+      "sql_file": "INV-009-pieces-price-fk-piece.sql"
+    },
+    {
+      "id": "INV-010",
+      "name": "pieces-list-fk-piece",
+      "domain": "D1-catalog",
+      "severity": "high",
+      "description": "pieces_list.pl_piece_id doit référencer une pièce existante dans pieces.",
+      "tables": ["pieces_list", "pieces"],
+      "sql_file": "INV-010-pieces-list-fk-piece.sql"
+    },
+    {
+      "id": "INV-011",
+      "name": "pieces-relation-criteria-fk-auto-type",
+      "domain": "D1-catalog",
+      "severity": "high",
+      "description": "pieces_relation_criteria.rcp_type_id doit référencer un véhicule existant dans auto_type.",
+      "tables": ["pieces_relation_criteria", "auto_type"],
+      "sql_file": "INV-011-pieces-relation-criteria-fk-auto-type.sql"
+    },
+    {
+      "id": "INV-012",
+      "name": "pieces-gamme-parent-no-self-ref",
+      "domain": "D1-catalog",
+      "severity": "high",
+      "description": "pieces_gamme ne doit pas avoir de gamme dont pg_parent_gamme_id pointe vers elle-même.",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-012-pieces-gamme-parent-no-self-ref.sql"
+    },
+    {
+      "id": "INV-013",
+      "name": "pieces-gamme-parent-fk-valid",
+      "domain": "D1-catalog",
+      "severity": "high",
+      "description": "pieces_gamme.pg_parent_gamme_id doit référencer un pg_id existant dans pieces_gamme (quand non null).",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-013-pieces-gamme-parent-fk-valid.sql"
+    },
+    {
+      "id": "INV-014",
+      "name": "pieces-gamme-active-has-name",
+      "domain": "D1-catalog",
+      "severity": "medium",
+      "description": "Une gamme avec pg_status='active' doit avoir pg_name non null et non vide.",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-014-pieces-gamme-active-has-name.sql"
+    },
+    {
+      "id": "INV-015",
+      "name": "pieces-gamme-active-has-alias",
+      "domain": "D1-catalog",
+      "severity": "high",
+      "description": "Une gamme avec pg_status='active' doit avoir pg_alias non null et non vide.",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-015-pieces-gamme-active-has-alias.sql"
+    },
+    {
+      "id": "INV-016",
+      "name": "pieces-ref-ean-not-empty",
+      "domain": "D1-catalog",
+      "severity": "medium",
+      "description": "pieces_ref_ean ne doit pas contenir de codes EAN vides ou NULL.",
+      "tables": ["pieces_ref_ean"],
+      "sql_file": "INV-016-pieces-ref-ean-not-empty.sql"
+    },
+    {
+      "id": "INV-017",
+      "name": "pieces-media-img-name-not-empty",
+      "domain": "D1-catalog",
+      "severity": "medium",
+      "description": "pieces_media_img.pmi_name ne doit pas être vide (colonne obligatoire du PK composite).",
+      "tables": ["pieces_media_img"],
+      "sql_file": "INV-017-pieces-media-img-name-not-empty.sql"
+    },
+    {
+      "id": "INV-018",
+      "name": "pieces-criteria-link-fk-piece",
+      "domain": "D1-catalog",
+      "severity": "medium",
+      "description": "pieces_criteria_link doit référencer des pièces existantes dans pieces.",
+      "tables": ["pieces_criteria_link", "pieces"],
+      "sql_file": "INV-018-pieces-criteria-link-fk-piece.sql"
+    },
+    {
+      "id": "INV-019",
+      "name": "pieces-ref-search-fk-piece",
+      "domain": "D1-catalog",
+      "severity": "medium",
+      "description": "pieces_ref_search ne doit pas contenir de références orphelines vers pieces.",
+      "tables": ["pieces_ref_search", "pieces"],
+      "sql_file": "INV-019-pieces-ref-search-fk-piece.sql"
+    },
+    {
+      "id": "INV-020",
+      "name": "pieces-gamme-pg-alias-url-safe",
+      "domain": "D1-catalog",
+      "severity": "medium",
+      "description": "pieces_gamme.pg_alias doit correspondre au pattern URL-safe [a-z0-9-]+ (minuscules, chiffres, tirets uniquement).",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-020-pieces-gamme-pg-alias-url-safe.sql"
+    },
+    {
+      "id": "INV-021",
+      "name": "auto-type-type-id-unique",
+      "domain": "D2-vehicle",
+      "severity": "critical",
+      "description": "auto_type.type_id doit être unique. Doublons = ambiguïté véhicule sur le catalogue.",
+      "tables": ["auto_type"],
+      "sql_file": "INV-021-auto-type-type-id-unique.sql"
+    },
+    {
+      "id": "INV-022",
+      "name": "auto-type-type-id-i-unique",
+      "domain": "D2-vehicle",
+      "severity": "high",
+      "description": "auto_type.type_id_i (shadow column INTEGER) doit être unique où non null.",
+      "tables": ["auto_type"],
+      "sql_file": "INV-022-auto-type-type-id-i-unique.sql"
+    },
+    {
+      "id": "INV-023",
+      "name": "auto-type-year-range-valid",
+      "domain": "D2-vehicle",
+      "severity": "high",
+      "description": "auto_type: year_from <= year_to quand les deux sont définis et non null.",
+      "tables": ["auto_type"],
+      "sql_file": "INV-023-auto-type-year-range-valid.sql"
+    },
+    {
+      "id": "INV-024",
+      "name": "auto-type-number-code-fk",
+      "domain": "D2-vehicle",
+      "severity": "medium",
+      "description": "auto_type_number_code doit référencer des type_id existants dans auto_type.",
+      "tables": ["auto_type_number_code", "auto_type"],
+      "sql_file": "INV-024-auto-type-number-code-fk.sql"
+    },
+    {
+      "id": "INV-025",
+      "name": "cross-gamme-car-fk-auto-type",
+      "domain": "D2-vehicle",
+      "severity": "high",
+      "description": "__cross_gamme_car_new doit référencer des type_id existants dans auto_type.",
+      "tables": ["__cross_gamme_car_new", "auto_type"],
+      "sql_file": "INV-025-cross-gamme-car-fk-auto-type.sql"
+    },
+    {
+      "id": "INV-026",
+      "name": "cross-gamme-car-fk-gamme",
+      "domain": "D2-vehicle",
+      "severity": "high",
+      "description": "__cross_gamme_car_new doit référencer des pg_alias existants dans pieces_gamme.",
+      "tables": ["__cross_gamme_car_new", "pieces_gamme"],
+      "sql_file": "INV-026-cross-gamme-car-fk-gamme.sql"
+    },
+    {
+      "id": "INV-027",
+      "name": "cross-gamme-car-no-duplicate-pair",
+      "domain": "D2-vehicle",
+      "severity": "medium",
+      "description": "__cross_gamme_car_new: chaque paire (gamme, vehicle) doit être unique.",
+      "tables": ["__cross_gamme_car_new"],
+      "sql_file": "INV-027-cross-gamme-car-no-duplicate-pair.sql"
+    },
+    {
+      "id": "INV-028",
+      "name": "auto-type-type-id-positive",
+      "domain": "D2-vehicle",
+      "severity": "medium",
+      "description": "auto_type.type_id doit être > 0 (valeur TecDoc positive attendue).",
+      "tables": ["auto_type"],
+      "sql_file": "INV-028-auto-type-type-id-positive.sql"
+    },
+    {
+      "id": "INV-029",
+      "name": "cars-engine-fk-auto-type",
+      "domain": "D2-vehicle",
+      "severity": "medium",
+      "description": "cars_engine doit référencer des type_id existants dans auto_type.",
+      "tables": ["cars_engine", "auto_type"],
+      "sql_file": "INV-029-cars-engine-fk-auto-type.sql"
+    },
+    {
+      "id": "INV-030",
+      "name": "auto-type-not-all-null-identity",
+      "domain": "D2-vehicle",
+      "severity": "medium",
+      "description": "auto_type: au moins une des colonnes d'identité (marque, modèle, type) ne doit pas être null.",
+      "tables": ["auto_type"],
+      "sql_file": "INV-030-auto-type-not-all-null-identity.sql"
+    },
+    {
+      "id": "INV-031",
+      "name": "seo-page-slug-unique-per-role",
+      "domain": "D3-seo",
+      "severity": "critical",
+      "description": "__seo_page: slug doit être unique par role (pas de doublons de pages canoniques).",
+      "tables": ["__seo_page"],
+      "sql_file": "INV-031-seo-page-slug-unique-per-role.sql"
+    },
+    {
+      "id": "INV-032",
+      "name": "seo-page-published-has-slug",
+      "domain": "D3-seo",
+      "severity": "critical",
+      "description": "__seo_page: les pages publiées (status='published') doivent avoir un slug non null et non vide.",
+      "tables": ["__seo_page"],
+      "sql_file": "INV-032-seo-page-published-has-slug.sql"
+    },
+    {
+      "id": "INV-033",
+      "name": "seo-page-published-has-title",
+      "domain": "D3-seo",
+      "severity": "high",
+      "description": "__seo_page: les pages publiées doivent avoir un titre non null et non vide.",
+      "tables": ["__seo_page"],
+      "sql_file": "INV-033-seo-page-published-has-title.sql"
+    },
+    {
+      "id": "INV-034",
+      "name": "seo-page-role-valid",
+      "domain": "D3-seo",
+      "severity": "high",
+      "description": "__seo_page.role doit être dans l'ensemble autorisé {R1,R2,R3,R4,R5,R6,R7,R8,R0}.",
+      "tables": ["__seo_page"],
+      "sql_file": "INV-034-seo-page-role-valid.sql"
+    },
+    {
+      "id": "INV-035",
+      "name": "seo-page-status-valid",
+      "domain": "D3-seo",
+      "severity": "high",
+      "description": "__seo_page.status doit être dans l'ensemble autorisé {draft,published,archived,review}.",
+      "tables": ["__seo_page"],
+      "sql_file": "INV-035-seo-page-status-valid.sql"
+    },
+    {
+      "id": "INV-036",
+      "name": "seo-gamme-conseil-fk-pieces-gamme",
+      "domain": "D3-seo",
+      "severity": "high",
+      "description": "__seo_gamme_conseil.pg_alias doit référencer un pg_alias existant dans pieces_gamme.",
+      "incident_ref": "20260329_dedup_pg_alias_unique.sql — .single() cassé sur R3/R6",
+      "tables": ["__seo_gamme_conseil", "pieces_gamme"],
+      "sql_file": "INV-036-seo-gamme-conseil-fk-pieces-gamme.sql"
+    },
+    {
+      "id": "INV-037",
+      "name": "seo-gamme-conseil-no-duplicate-section",
+      "domain": "D3-seo",
+      "severity": "high",
+      "description": "__seo_gamme_conseil: pas de doublons (pg_alias, section_key). Cause directe de .single() error R3/R6.",
+      "incident_ref": "20260329_dedup_pg_alias_unique.sql",
+      "tables": ["__seo_gamme_conseil"],
+      "sql_file": "INV-037-seo-gamme-conseil-no-duplicate-section.sql"
+    },
+    {
+      "id": "INV-038",
+      "name": "seo-gamme-conseil-published-not-empty",
+      "domain": "D3-seo",
+      "severity": "medium",
+      "description": "__seo_gamme_conseil: contenu non vide pour les sections avec status='published'.",
+      "tables": ["__seo_gamme_conseil"],
+      "sql_file": "INV-038-seo-gamme-conseil-published-not-empty.sql"
+    },
+    {
+      "id": "INV-039",
+      "name": "seo-page-brief-pg-alias-unique-per-role",
+      "domain": "D3-seo",
+      "severity": "high",
+      "description": "__seo_page_brief: pg_alias doit être unique par role (pas de doublons de briefs).",
+      "tables": ["__seo_page_brief"],
+      "sql_file": "INV-039-seo-page-brief-pg-alias-unique-per-role.sql"
+    },
+    {
+      "id": "INV-040",
+      "name": "seo-keywords-no-duplicate",
+      "domain": "D3-seo",
+      "severity": "medium",
+      "description": "__seo_keywords: pas de keyword identique pour le même (pg_alias, role).",
+      "tables": ["__seo_keywords"],
+      "sql_file": "INV-040-seo-keywords-no-duplicate.sql"
+    },
+    {
+      "id": "INV-041",
+      "name": "sitemap-link-url-unique",
+      "domain": "D3-seo",
+      "severity": "medium",
+      "description": "__sitemap_p_link: pas de doublon d'URL dans le sitemap.",
+      "tables": ["__sitemap_p_link"],
+      "sql_file": "INV-041-sitemap-link-url-unique.sql"
+    },
+    {
+      "id": "INV-042",
+      "name": "seo-link-impressions-non-negative",
+      "domain": "D3-seo",
+      "severity": "medium",
+      "description": "seo_link_impressions.impressions doit être >= 0.",
+      "tables": ["seo_link_impressions"],
+      "sql_file": "INV-042-seo-link-impressions-non-negative.sql"
+    },
+    {
+      "id": "INV-043",
+      "name": "seo-keywords-search-volume-non-negative",
+      "domain": "D3-seo",
+      "severity": "low",
+      "description": "__seo_keywords.search_volume doit être >= 0 où défini.",
+      "tables": ["__seo_keywords"],
+      "sql_file": "INV-043-seo-keywords-search-volume-non-negative.sql"
+    },
+    {
+      "id": "INV-044",
+      "name": "seo-page-entity-fk-brief",
+      "domain": "D3-seo",
+      "severity": "medium",
+      "description": "__seo_page.entity_id doit référencer une entrée existante dans __seo_page_brief où non null.",
+      "tables": ["__seo_page", "__seo_page_brief"],
+      "sql_file": "INV-044-seo-page-entity-fk-brief.sql"
+    },
+    {
+      "id": "INV-045",
+      "name": "seo-keyword-type-mapping-fk",
+      "domain": "D3-seo",
+      "severity": "low",
+      "description": "__seo_keyword_type_mapping doit référencer des keyword_type valides (si données présentes).",
+      "tables": ["__seo_keyword_type_mapping"],
+      "sql_file": "INV-045-seo-keyword-type-mapping-fk.sql"
+    },
+    {
+      "id": "INV-046",
+      "name": "customer-email-not-null",
+      "domain": "D4-orders",
+      "severity": "critical",
+      "description": "___xtr_customer.email ne doit pas être null ou vide.",
+      "tables": ["___xtr_customer"],
+      "sql_file": "INV-046-customer-email-not-null.sql"
+    },
+    {
+      "id": "INV-047",
+      "name": "customer-email-unique",
+      "domain": "D4-orders",
+      "severity": "high",
+      "description": "___xtr_customer: pas de doublons d'email (identifiant unique client).",
+      "tables": ["___xtr_customer"],
+      "sql_file": "INV-047-customer-email-unique.sql"
+    },
+    {
+      "id": "INV-048",
+      "name": "order-fk-customer",
+      "domain": "D4-orders",
+      "severity": "critical",
+      "description": "___xtr_order doit référencer un client existant dans ___xtr_customer.",
+      "tables": ["___xtr_order", "___xtr_customer"],
+      "sql_file": "INV-048-order-fk-customer.sql"
+    },
+    {
+      "id": "INV-049",
+      "name": "order-line-fk-order",
+      "domain": "D4-orders",
+      "severity": "critical",
+      "description": "___xtr_order_line doit référencer une commande existante dans ___xtr_order.",
+      "tables": ["___xtr_order_line", "___xtr_order"],
+      "sql_file": "INV-049-order-line-fk-order.sql"
+    },
+    {
+      "id": "INV-050",
+      "name": "order-line-quantity-positive",
+      "domain": "D4-orders",
+      "severity": "high",
+      "description": "___xtr_order_line.quantity doit être > 0.",
+      "tables": ["___xtr_order_line"],
+      "sql_file": "INV-050-order-line-quantity-positive.sql"
+    },
+    {
+      "id": "INV-051",
+      "name": "order-line-unit-price-non-negative",
+      "domain": "D4-orders",
+      "severity": "high",
+      "description": "___xtr_order_line.unit_price doit être >= 0.",
+      "tables": ["___xtr_order_line"],
+      "sql_file": "INV-051-order-line-unit-price-non-negative.sql"
+    },
+    {
+      "id": "INV-052",
+      "name": "order-status-valid",
+      "domain": "D4-orders",
+      "severity": "high",
+      "description": "___xtr_order.status doit être dans l'ensemble autorisé (pending, confirmed, shipped, delivered, cancelled, refunded).",
+      "tables": ["___xtr_order"],
+      "sql_file": "INV-052-order-status-valid.sql"
+    },
+    {
+      "id": "INV-053",
+      "name": "invoice-line-fk-invoice",
+      "domain": "D4-orders",
+      "severity": "high",
+      "description": "___xtr_invoice_line doit référencer une facture existante dans ___xtr_invoice.",
+      "tables": ["___xtr_invoice_line", "___xtr_invoice"],
+      "sql_file": "INV-053-invoice-line-fk-invoice.sql"
+    },
+    {
+      "id": "INV-054",
+      "name": "invoice-fk-order",
+      "domain": "D4-orders",
+      "severity": "high",
+      "description": "___xtr_invoice doit référencer une commande existante dans ___xtr_order (où FK est défini).",
+      "tables": ["___xtr_invoice", "___xtr_order"],
+      "sql_file": "INV-054-invoice-fk-order.sql"
+    },
+    {
+      "id": "INV-055",
+      "name": "order-line-status-valid",
+      "domain": "D4-orders",
+      "severity": "medium",
+      "description": "___xtr_order_line_status: statut dans l'ensemble autorisé.",
+      "tables": ["___xtr_order_line_status"],
+      "sql_file": "INV-055-order-line-status-valid.sql"
+    },
+    {
+      "id": "INV-056",
+      "name": "pieces-price-shadow-cols-sync",
+      "domain": "D5-structural",
+      "severity": "high",
+      "description": "pieces_price: les shadow columns _n (numériques) ne doivent pas être null où la colonne TEXT originale est non-null (cohérence migration V4b/V5a).",
+      "tables": ["pieces_price"],
+      "sql_file": "INV-056-pieces-price-shadow-cols-sync.sql"
+    },
+    {
+      "id": "INV-057",
+      "name": "auto-type-shadow-col-sync",
+      "domain": "D5-structural",
+      "severity": "high",
+      "description": "auto_type: type_id_i (shadow col INTEGER) ne doit pas être null où type_id TEXT est non-null.",
+      "tables": ["auto_type"],
+      "sql_file": "INV-057-auto-type-shadow-col-sync.sql"
+    },
+    {
+      "id": "INV-058",
+      "name": "no-public-table-without-pk",
+      "domain": "D5-structural",
+      "severity": "critical",
+      "description": "Aucune table du schéma public ne doit être sans PK (régression sur fix V4a).",
+      "tables": ["information_schema.table_constraints", "information_schema.tables"],
+      "sql_file": "INV-058-no-public-table-without-pk.sql"
+    },
+    {
+      "id": "INV-059",
+      "name": "no-price-text-column-unpopulated",
+      "domain": "D5-structural",
+      "severity": "medium",
+      "description": "pieces_price: les colonnes shadow _n doivent être cohérentes — aucune valeur TEXT non convertible en numérique.",
+      "tables": ["pieces_price"],
+      "sql_file": "INV-059-no-price-text-column-unpopulated.sql"
+    },
+    {
+      "id": "INV-060",
+      "name": "pieces-gamme-pg-level-valid",
+      "domain": "D5-structural",
+      "severity": "medium",
+      "description": "pieces_gamme.pg_level doit être dans l'ensemble autorisé (top, mid, leaf, null) où défini.",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-060-pieces-gamme-pg-level-valid.sql"
+    },
+    {
+      "id": "INV-061",
+      "name": "pieces-gamme-no-circular-parent",
+      "domain": "D5-structural",
+      "severity": "medium",
+      "description": "pieces_gamme: pas de cycle dans la hiérarchie parent (pg_parent_gamme_id). Profondeur max 5 niveaux.",
+      "tables": ["pieces_gamme"],
+      "sql_file": "INV-061-pieces-gamme-no-circular-parent.sql"
+    },
+    {
+      "id": "INV-062",
+      "name": "no-orphan-seo-published-pages",
+      "domain": "D5-structural",
+      "severity": "high",
+      "description": "__seo_page: pages publiées sans entity_id correspondant dans __seo_page_brief = pages orphelines.",
+      "tables": ["__seo_page", "__seo_page_brief"],
+      "sql_file": "INV-062-no-orphan-seo-published-pages.sql"
+    },
+    {
+      "id": "INV-063",
+      "name": "seo-page-brief-has-pg-alias",
+      "domain": "D5-structural",
+      "severity": "high",
+      "description": "__seo_page_brief: pg_alias ne doit pas être null ou vide (clé de jointure critique).",
+      "tables": ["__seo_page_brief"],
+      "sql_file": "INV-063-seo-page-brief-has-pg-alias.sql"
+    },
+    {
+      "id": "INV-064",
+      "name": "pieces-gamme-active-count-seo-brief",
+      "domain": "D6-consistency",
+      "severity": "medium",
+      "description": "Les gammes actives avec pg_alias doivent avoir au moins un brief SEO (R3 ou R6) dans __seo_page_brief.",
+      "tables": ["pieces_gamme", "__seo_page_brief"],
+      "sql_file": "INV-064-pieces-gamme-active-count-seo-brief.sql"
+    },
+    {
+      "id": "INV-065",
+      "name": "pieces-active-has-price",
+      "domain": "D6-consistency",
+      "severity": "medium",
+      "description": "Les pièces actives (pg_status implicite ou explicite) devraient avoir au moins un enregistrement de prix dans pieces_price.",
+      "tables": ["pieces", "pieces_price"],
+      "sql_file": "INV-065-pieces-active-has-price.sql"
+    },
+    {
+      "id": "INV-066",
+      "name": "seo-r3-page-has-conseil",
+      "domain": "D6-consistency",
+      "severity": "medium",
+      "description": "Les pages R3 publiées doivent avoir au moins une section dans __seo_gamme_conseil pour le même pg_alias.",
+      "tables": ["__seo_page", "__seo_gamme_conseil"],
+      "sql_file": "INV-066-seo-r3-page-has-conseil.sql"
+    },
+    {
+      "id": "INV-067",
+      "name": "pieces-criteria-link-fk-criteria",
+      "domain": "D6-consistency",
+      "severity": "medium",
+      "description": "pieces_criteria_link doit référencer des critères existants dans pieces_criteria.",
+      "tables": ["pieces_criteria_link", "pieces_criteria"],
+      "sql_file": "INV-067-pieces-criteria-link-fk-criteria.sql"
+    },
+    {
+      "id": "INV-068",
+      "name": "pieces-ref-search-no-duplicate",
+      "domain": "D6-consistency",
+      "severity": "medium",
+      "description": "pieces_ref_search: pas de doublon sur la clé de recherche primaire (si PK composite défini).",
+      "tables": ["pieces_ref_search"],
+      "sql_file": "INV-068-pieces-ref-search-no-duplicate.sql"
+    },
+    {
+      "id": "INV-069",
+      "name": "seo-gamme-conseil-pg-alias-matches-active-gamme",
+      "domain": "D6-consistency",
+      "severity": "high",
+      "description": "__seo_gamme_conseil.pg_alias doit correspondre à une gamme active dans pieces_gamme (pas de conseil orphelin post-dédup).",
+      "incident_ref": "20260329_dedup_pg_alias_unique.sql — conseillers R3/R6 sur alias -dup cassés",
+      "tables": ["__seo_gamme_conseil", "pieces_gamme"],
+      "sql_file": "INV-069-seo-gamme-conseil-pg-alias-matches-active-gamme.sql"
+    }
+  ]
+}

--- a/.spec/00-canon/invariants/sql/INV-001-pg-alias-unique.sql
+++ b/.spec/00-canon/invariants/sql/INV-001-pg-alias-unique.sql
@@ -1,0 +1,8 @@
+-- INV-001: pg-alias-unique
+-- Domain: D1-catalog
+-- Severity: critical
+-- Description: pg_alias must be unique and non-null in pieces_gamme
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_alias, COUNT(*) FROM pieces_gamme WHERE pg_alias IS NOT NULL GROUP BY pg_alias HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-002-pg-alias-no-dup-suffix.sql
+++ b/.spec/00-canon/invariants/sql/INV-002-pg-alias-no-dup-suffix.sql
@@ -1,0 +1,8 @@
+-- INV-002: pg-alias-no-dup-suffix
+-- Domain: D1-catalog
+-- Severity: critical
+-- Description: No pg_alias may contain '-dup' suffix
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_id, pg_alias FROM pieces_gamme WHERE pg_alias LIKE '%-dup';

--- a/.spec/00-canon/invariants/sql/INV-003-pieces-gamme-pg-id-unique.sql
+++ b/.spec/00-canon/invariants/sql/INV-003-pieces-gamme-pg-id-unique.sql
@@ -1,0 +1,8 @@
+-- INV-003: pieces-gamme-pg-id-unique
+-- Domain: D1-catalog
+-- Severity: critical
+-- Description: pieces_gamme.pg_id (PK) must be unique
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_id, COUNT(*) FROM pieces_gamme GROUP BY pg_id HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-004-pieces-price-non-negative.sql
+++ b/.spec/00-canon/invariants/sql/INV-004-pieces-price-non-negative.sql
@@ -1,0 +1,8 @@
+-- INV-004: pieces-price-non-negative
+-- Domain: D1-catalog
+-- Severity: critical
+-- Description: All numeric price columns in pieces_price must be >= 0. Shadow columns are named with _n suffix
+-- Tables: pieces_price
+-- Returns 0 rows when invariant holds.
+
+SELECT pp_id FROM pieces_price WHERE pp_prix_public_n < 0 OR pp_prix_brut_n < 0 OR pp_remise_n < 0;

--- a/.spec/00-canon/invariants/sql/INV-005-order-amount-non-negative.sql
+++ b/.spec/00-canon/invariants/sql/INV-005-order-amount-non-negative.sql
@@ -1,0 +1,8 @@
+-- INV-005: order-amount-non-negative
+-- Domain: D4-orders
+-- Severity: critical
+-- Description: All order amounts must be >= 0
+-- Tables: ___xtr_order
+-- Returns 0 rows when invariant holds.
+
+SELECT id FROM ___xtr_order WHERE total_amount < 0 OR subtotal < 0;

--- a/.spec/00-canon/invariants/sql/INV-006-pieces-relation-type-fk-piece.sql
+++ b/.spec/00-canon/invariants/sql/INV-006-pieces-relation-type-fk-piece.sql
@@ -1,0 +1,8 @@
+-- INV-006: pieces-relation-type-fk-piece
+-- Domain: D1-catalog
+-- Severity: high
+-- Description: pieces_relation_type.rtp_piece_id must reference existing piece in pieces
+-- Tables: pieces_relation_type, pieces
+-- Returns 0 rows when invariant holds.
+
+SELECT prt.rtp_id FROM pieces_relation_type prt LEFT JOIN pieces p ON prt.rtp_piece_id = p.p_id WHERE prt.rtp_piece_id IS NOT NULL AND p.p_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-007-pieces-media-img-fk-piece.sql
+++ b/.spec/00-canon/invariants/sql/INV-007-pieces-media-img-fk-piece.sql
@@ -1,0 +1,8 @@
+-- INV-007: pieces-media-img-fk-piece
+-- Domain: D1-catalog
+-- Severity: high
+-- Description: pieces_media_img.pmi_piece_id must reference existing piece
+-- Tables: pieces_media_img, pieces
+-- Returns 0 rows when invariant holds.
+
+SELECT pmi.pmi_id FROM pieces_media_img pmi LEFT JOIN pieces p ON pmi.pmi_piece_id = p.p_id WHERE pmi.pmi_piece_id IS NOT NULL AND p.p_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-008-pieces-ref-ean-fk-piece.sql
+++ b/.spec/00-canon/invariants/sql/INV-008-pieces-ref-ean-fk-piece.sql
@@ -1,0 +1,8 @@
+-- INV-008: pieces-ref-ean-fk-piece
+-- Domain: D1-catalog
+-- Severity: high
+-- Description: pieces_ref_ean.pre_piece_id must reference existing piece
+-- Tables: pieces_ref_ean, pieces
+-- Returns 0 rows when invariant holds.
+
+SELECT pre.pre_id FROM pieces_ref_ean pre LEFT JOIN pieces p ON pre.pre_piece_id = p.p_id WHERE pre.pre_piece_id IS NOT NULL AND p.p_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-009-pieces-price-fk-piece.sql
+++ b/.spec/00-canon/invariants/sql/INV-009-pieces-price-fk-piece.sql
@@ -1,0 +1,8 @@
+-- INV-009: pieces-price-fk-piece
+-- Domain: D1-catalog
+-- Severity: high
+-- Description: pieces_price.pp_piece_id must reference existing piece
+-- Tables: pieces_price, pieces
+-- Returns 0 rows when invariant holds.
+
+SELECT pp.pp_id FROM pieces_price pp LEFT JOIN pieces p ON pp.pp_piece_id = p.p_id WHERE pp.pp_piece_id IS NOT NULL AND p.p_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-010-pieces-list-fk-piece.sql
+++ b/.spec/00-canon/invariants/sql/INV-010-pieces-list-fk-piece.sql
@@ -1,0 +1,8 @@
+-- INV-010: pieces-list-fk-piece
+-- Domain: D1-catalog
+-- Severity: high
+-- Description: pieces_list.pl_piece_id must reference existing piece
+-- Tables: pieces_list, pieces
+-- Returns 0 rows when invariant holds.
+
+SELECT pl.pl_id FROM pieces_list pl LEFT JOIN pieces p ON pl.pl_piece_id = p.p_id WHERE pl.pl_piece_id IS NOT NULL AND p.p_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-011-pieces-relation-criteria-fk-auto-type.sql
+++ b/.spec/00-canon/invariants/sql/INV-011-pieces-relation-criteria-fk-auto-type.sql
@@ -1,0 +1,8 @@
+-- INV-011: pieces-relation-criteria-fk-auto-type
+-- Domain: D1-catalog
+-- Severity: high
+-- Description: pieces_relation_criteria.rcp_type_id must reference existing vehicle in auto_type
+-- Tables: pieces_relation_criteria, auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT prc.rcp_id FROM pieces_relation_criteria prc LEFT JOIN auto_type at ON prc.rcp_type_id::text = at.type_id WHERE prc.rcp_type_id IS NOT NULL AND at.type_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-012-pieces-gamme-parent-no-self-ref.sql
+++ b/.spec/00-canon/invariants/sql/INV-012-pieces-gamme-parent-no-self-ref.sql
@@ -1,0 +1,8 @@
+-- INV-012: pieces-gamme-parent-no-self-ref
+-- Domain: D1-catalog
+-- Severity: high
+-- Description: No gamme may have pg_parent_gamme_id pointing to itself
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_id, pg_alias, pg_parent_gamme_id FROM pieces_gamme WHERE pg_parent_gamme_id = pg_id;

--- a/.spec/00-canon/invariants/sql/INV-013-pieces-gamme-parent-fk-valid.sql
+++ b/.spec/00-canon/invariants/sql/INV-013-pieces-gamme-parent-fk-valid.sql
@@ -1,0 +1,8 @@
+-- INV-013: pieces-gamme-parent-fk-valid
+-- Domain: D1-catalog
+-- Severity: high
+-- Description: pieces_gamme.pg_parent_gamme_id must reference a valid pg_id (when not null)
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT pg.pg_id, pg.pg_alias, pg.pg_parent_gamme_id FROM pieces_gamme pg LEFT JOIN pieces_gamme parent ON pg.pg_parent_gamme_id = parent.pg_id WHERE pg.pg_parent_gamme_id IS NOT NULL AND parent.pg_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-014-pieces-gamme-active-has-name.sql
+++ b/.spec/00-canon/invariants/sql/INV-014-pieces-gamme-active-has-name.sql
@@ -1,0 +1,8 @@
+-- INV-014: pieces-gamme-active-has-name
+-- Domain: D1-catalog
+-- Severity: medium
+-- Description: Active gamme must have non-null non-empty pg_name
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_id, pg_alias FROM pieces_gamme WHERE pg_status = 'active' AND (pg_name IS NULL OR pg_name = '');

--- a/.spec/00-canon/invariants/sql/INV-015-pieces-gamme-active-has-alias.sql
+++ b/.spec/00-canon/invariants/sql/INV-015-pieces-gamme-active-has-alias.sql
@@ -1,0 +1,8 @@
+-- INV-015: pieces-gamme-active-has-alias
+-- Domain: D1-catalog
+-- Severity: high
+-- Description: Active gamme must have non-null non-empty pg_alias
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_id FROM pieces_gamme WHERE pg_status = 'active' AND (pg_alias IS NULL OR pg_alias = '');

--- a/.spec/00-canon/invariants/sql/INV-016-pieces-ref-ean-not-empty.sql
+++ b/.spec/00-canon/invariants/sql/INV-016-pieces-ref-ean-not-empty.sql
@@ -1,0 +1,8 @@
+-- INV-016: pieces-ref-ean-not-empty
+-- Domain: D1-catalog
+-- Severity: medium
+-- Description: pieces_ref_ean must not contain empty or null EAN codes
+-- Tables: pieces_ref_ean
+-- Returns 0 rows when invariant holds.
+
+SELECT pre_id FROM pieces_ref_ean WHERE pre_ean IS NULL OR pre_ean = '';

--- a/.spec/00-canon/invariants/sql/INV-017-pieces-media-img-name-not-empty.sql
+++ b/.spec/00-canon/invariants/sql/INV-017-pieces-media-img-name-not-empty.sql
@@ -1,0 +1,8 @@
+-- INV-017: pieces-media-img-name-not-empty
+-- Domain: D1-catalog
+-- Severity: medium
+-- Description: pieces_media_img.pmi_name must not be empty (part of composite PK)
+-- Tables: pieces_media_img
+-- Returns 0 rows when invariant holds.
+
+SELECT pmi_id FROM pieces_media_img WHERE pmi_name IS NULL OR pmi_name = '';

--- a/.spec/00-canon/invariants/sql/INV-018-pieces-criteria-link-fk-piece.sql
+++ b/.spec/00-canon/invariants/sql/INV-018-pieces-criteria-link-fk-piece.sql
@@ -1,0 +1,8 @@
+-- INV-018: pieces-criteria-link-fk-piece
+-- Domain: D1-catalog
+-- Severity: medium
+-- Description: pieces_criteria_link must reference existing pieces
+-- Tables: pieces_criteria_link, pieces
+-- Returns 0 rows when invariant holds.
+
+SELECT pcl.id FROM pieces_criteria_link pcl LEFT JOIN pieces p ON pcl.piece_id = p.p_id WHERE pcl.piece_id IS NOT NULL AND p.p_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-019-pieces-ref-search-fk-piece.sql
+++ b/.spec/00-canon/invariants/sql/INV-019-pieces-ref-search-fk-piece.sql
@@ -1,0 +1,8 @@
+-- INV-019: pieces-ref-search-fk-piece
+-- Domain: D1-catalog
+-- Severity: medium
+-- Description: pieces_ref_search must not have orphaned references to pieces
+-- Tables: pieces_ref_search, pieces
+-- Returns 0 rows when invariant holds.
+
+SELECT prs.id FROM pieces_ref_search prs LEFT JOIN pieces p ON prs.piece_id = p.p_id WHERE prs.piece_id IS NOT NULL AND p.p_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-020-pieces-gamme-pg-alias-url-safe.sql
+++ b/.spec/00-canon/invariants/sql/INV-020-pieces-gamme-pg-alias-url-safe.sql
@@ -1,0 +1,8 @@
+-- INV-020: pieces-gamme-pg-alias-url-safe
+-- Domain: D1-catalog
+-- Severity: medium
+-- Description: pieces_gamme.pg_alias must match pattern [a-z0-9-]+ (lowercase, digits, hyphens only)
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_id, pg_alias FROM pieces_gamme WHERE pg_alias IS NOT NULL AND pg_alias !~ '^[a-z0-9-]+$';

--- a/.spec/00-canon/invariants/sql/INV-021-auto-type-type-id-unique.sql
+++ b/.spec/00-canon/invariants/sql/INV-021-auto-type-type-id-unique.sql
@@ -1,0 +1,8 @@
+-- INV-021: auto-type-type-id-unique
+-- Domain: D2-vehicle
+-- Severity: critical
+-- Description: auto_type.type_id must be unique
+-- Tables: auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT type_id, COUNT(*) FROM auto_type GROUP BY type_id HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-022-auto-type-type-id-i-unique.sql
+++ b/.spec/00-canon/invariants/sql/INV-022-auto-type-type-id-i-unique.sql
@@ -1,0 +1,8 @@
+-- INV-022: auto-type-type-id-i-unique
+-- Domain: D2-vehicle
+-- Severity: high
+-- Description: auto_type.type_id_i (shadow INTEGER column) must be unique where not null
+-- Tables: auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT type_id_i, COUNT(*) FROM auto_type WHERE type_id_i IS NOT NULL GROUP BY type_id_i HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-023-auto-type-year-range-valid.sql
+++ b/.spec/00-canon/invariants/sql/INV-023-auto-type-year-range-valid.sql
@@ -1,0 +1,8 @@
+-- INV-023: auto-type-year-range-valid
+-- Domain: D2-vehicle
+-- Severity: high
+-- Description: auto_type: year_from <= year_to when both defined
+-- Tables: auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT type_id, year_from, year_to FROM auto_type WHERE year_from IS NOT NULL AND year_to IS NOT NULL AND year_from > year_to;

--- a/.spec/00-canon/invariants/sql/INV-024-auto-type-number-code-fk.sql
+++ b/.spec/00-canon/invariants/sql/INV-024-auto-type-number-code-fk.sql
@@ -1,0 +1,8 @@
+-- INV-024: auto-type-number-code-fk
+-- Domain: D2-vehicle
+-- Severity: medium
+-- Description: auto_type_number_code must reference existing type_id in auto_type
+-- Tables: auto_type_number_code, auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT atnc.id FROM auto_type_number_code atnc LEFT JOIN auto_type at ON atnc.type_id = at.type_id WHERE atnc.type_id IS NOT NULL AND at.type_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-025-cross-gamme-car-fk-auto-type.sql
+++ b/.spec/00-canon/invariants/sql/INV-025-cross-gamme-car-fk-auto-type.sql
@@ -1,0 +1,8 @@
+-- INV-025: cross-gamme-car-fk-auto-type
+-- Domain: D2-vehicle
+-- Severity: high
+-- Description: __cross_gamme_car_new must reference existing type_id in auto_type
+-- Tables: __cross_gamme_car_new, auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT cgc.id FROM __cross_gamme_car_new cgc LEFT JOIN auto_type at ON cgc.type_id::text = at.type_id WHERE cgc.type_id IS NOT NULL AND at.type_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-026-cross-gamme-car-fk-gamme.sql
+++ b/.spec/00-canon/invariants/sql/INV-026-cross-gamme-car-fk-gamme.sql
@@ -1,0 +1,8 @@
+-- INV-026: cross-gamme-car-fk-gamme
+-- Domain: D2-vehicle
+-- Severity: high
+-- Description: __cross_gamme_car_new must reference existing pg_alias in pieces_gamme
+-- Tables: __cross_gamme_car_new, pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT cgc.id FROM __cross_gamme_car_new cgc LEFT JOIN pieces_gamme pg ON cgc.pg_alias = pg.pg_alias WHERE cgc.pg_alias IS NOT NULL AND pg.pg_alias IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-027-cross-gamme-car-no-duplicate-pair.sql
+++ b/.spec/00-canon/invariants/sql/INV-027-cross-gamme-car-no-duplicate-pair.sql
@@ -1,0 +1,8 @@
+-- INV-027: cross-gamme-car-no-duplicate-pair
+-- Domain: D2-vehicle
+-- Severity: medium
+-- Description: __cross_gamme_car_new: each (gamme, vehicle) pair must be unique
+-- Tables: __cross_gamme_car_new
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_alias, type_id, COUNT(*) FROM __cross_gamme_car_new GROUP BY pg_alias, type_id HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-028-auto-type-type-id-positive.sql
+++ b/.spec/00-canon/invariants/sql/INV-028-auto-type-type-id-positive.sql
@@ -1,0 +1,8 @@
+-- INV-028: auto-type-type-id-positive
+-- Domain: D2-vehicle
+-- Severity: medium
+-- Description: auto_type.type_id must be > 0 (positive TecDoc value)
+-- Tables: auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT type_id FROM auto_type WHERE type_id::bigint <= 0;

--- a/.spec/00-canon/invariants/sql/INV-029-cars-engine-fk-auto-type.sql
+++ b/.spec/00-canon/invariants/sql/INV-029-cars-engine-fk-auto-type.sql
@@ -1,0 +1,8 @@
+-- INV-029: cars-engine-fk-auto-type
+-- Domain: D2-vehicle
+-- Severity: medium
+-- Description: cars_engine must reference existing type_id in auto_type
+-- Tables: cars_engine, auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT ce.id FROM cars_engine ce LEFT JOIN auto_type at ON ce.type_id = at.type_id WHERE ce.type_id IS NOT NULL AND at.type_id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-030-auto-type-not-all-null-identity.sql
+++ b/.spec/00-canon/invariants/sql/INV-030-auto-type-not-all-null-identity.sql
@@ -1,0 +1,8 @@
+-- INV-030: auto-type-not-all-null-identity
+-- Domain: D2-vehicle
+-- Severity: medium
+-- Description: auto_type: at least one identity column (brand, model, type_label) must not be null
+-- Tables: auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT type_id FROM auto_type WHERE marque IS NULL AND modele IS NULL AND type_label IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-031-seo-page-slug-unique-per-role.sql
+++ b/.spec/00-canon/invariants/sql/INV-031-seo-page-slug-unique-per-role.sql
@@ -1,0 +1,8 @@
+-- INV-031: seo-page-slug-unique-per-role
+-- Domain: D3-seo
+-- Severity: critical
+-- Description: __seo_page: slug must be unique per role
+-- Tables: __seo_page
+-- Returns 0 rows when invariant holds.
+
+SELECT slug, role, COUNT(*) FROM __seo_page WHERE slug IS NOT NULL GROUP BY slug, role HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-032-seo-page-published-has-slug.sql
+++ b/.spec/00-canon/invariants/sql/INV-032-seo-page-published-has-slug.sql
@@ -1,0 +1,8 @@
+-- INV-032: seo-page-published-has-slug
+-- Domain: D3-seo
+-- Severity: critical
+-- Description: Published __seo_page rows must have non-null non-empty slug
+-- Tables: __seo_page
+-- Returns 0 rows when invariant holds.
+
+SELECT id FROM __seo_page WHERE status = 'published' AND (slug IS NULL OR slug = '');

--- a/.spec/00-canon/invariants/sql/INV-033-seo-page-published-has-title.sql
+++ b/.spec/00-canon/invariants/sql/INV-033-seo-page-published-has-title.sql
@@ -1,0 +1,8 @@
+-- INV-033: seo-page-published-has-title
+-- Domain: D3-seo
+-- Severity: high
+-- Description: Published __seo_page rows must have non-null non-empty title
+-- Tables: __seo_page
+-- Returns 0 rows when invariant holds.
+
+SELECT id, slug FROM __seo_page WHERE status = 'published' AND (title IS NULL OR title = '');

--- a/.spec/00-canon/invariants/sql/INV-034-seo-page-role-valid.sql
+++ b/.spec/00-canon/invariants/sql/INV-034-seo-page-role-valid.sql
@@ -1,0 +1,8 @@
+-- INV-034: seo-page-role-valid
+-- Domain: D3-seo
+-- Severity: high
+-- Description: __seo_page.role must be in allowed set {R0,R1,R2,R3,R4,R5,R6,R7,R8}
+-- Tables: __seo_page
+-- Returns 0 rows when invariant holds.
+
+SELECT id, slug, role FROM __seo_page WHERE role NOT IN ('R0','R1','R2','R3','R4','R5','R6','R7','R8');

--- a/.spec/00-canon/invariants/sql/INV-035-seo-page-status-valid.sql
+++ b/.spec/00-canon/invariants/sql/INV-035-seo-page-status-valid.sql
@@ -1,0 +1,8 @@
+-- INV-035: seo-page-status-valid
+-- Domain: D3-seo
+-- Severity: high
+-- Description: __seo_page.status must be in allowed set {draft,published,archived,review}
+-- Tables: __seo_page
+-- Returns 0 rows when invariant holds.
+
+SELECT id, slug, status FROM __seo_page WHERE status NOT IN ('draft','published','archived','review');

--- a/.spec/00-canon/invariants/sql/INV-036-seo-gamme-conseil-fk-pieces-gamme.sql
+++ b/.spec/00-canon/invariants/sql/INV-036-seo-gamme-conseil-fk-pieces-gamme.sql
@@ -1,0 +1,8 @@
+-- INV-036: seo-gamme-conseil-fk-pieces-gamme
+-- Domain: D3-seo
+-- Severity: high
+-- Description: __seo_gamme_conseil.pg_alias must reference existing pg_alias in pieces_gamme
+-- Tables: __seo_gamme_conseil, pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT sgc.id, sgc.pg_alias FROM __seo_gamme_conseil sgc LEFT JOIN pieces_gamme pg ON sgc.pg_alias = pg.pg_alias WHERE sgc.pg_alias IS NOT NULL AND pg.pg_alias IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-037-seo-gamme-conseil-no-duplicate-section.sql
+++ b/.spec/00-canon/invariants/sql/INV-037-seo-gamme-conseil-no-duplicate-section.sql
@@ -1,0 +1,8 @@
+-- INV-037: seo-gamme-conseil-no-duplicate-section
+-- Domain: D3-seo
+-- Severity: high
+-- Description: __seo_gamme_conseil: no duplicate (pg_alias, section_key) pairs
+-- Tables: __seo_gamme_conseil
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_alias, section_key, COUNT(*) FROM __seo_gamme_conseil GROUP BY pg_alias, section_key HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-038-seo-gamme-conseil-published-not-empty.sql
+++ b/.spec/00-canon/invariants/sql/INV-038-seo-gamme-conseil-published-not-empty.sql
@@ -1,0 +1,8 @@
+-- INV-038: seo-gamme-conseil-published-not-empty
+-- Domain: D3-seo
+-- Severity: medium
+-- Description: Published conseil sections must have non-empty content
+-- Tables: __seo_gamme_conseil
+-- Returns 0 rows when invariant holds.
+
+SELECT id, pg_alias, section_key FROM __seo_gamme_conseil WHERE status = 'published' AND (content IS NULL OR content = '');

--- a/.spec/00-canon/invariants/sql/INV-039-seo-page-brief-pg-alias-unique-per-role.sql
+++ b/.spec/00-canon/invariants/sql/INV-039-seo-page-brief-pg-alias-unique-per-role.sql
@@ -1,0 +1,8 @@
+-- INV-039: seo-page-brief-pg-alias-unique-per-role
+-- Domain: D3-seo
+-- Severity: high
+-- Description: __seo_page_brief: pg_alias must be unique per role
+-- Tables: __seo_page_brief
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_alias, role, COUNT(*) FROM __seo_page_brief WHERE pg_alias IS NOT NULL GROUP BY pg_alias, role HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-040-seo-keywords-no-duplicate.sql
+++ b/.spec/00-canon/invariants/sql/INV-040-seo-keywords-no-duplicate.sql
@@ -1,0 +1,8 @@
+-- INV-040: seo-keywords-no-duplicate
+-- Domain: D3-seo
+-- Severity: medium
+-- Description: __seo_keywords: no duplicate keyword for same (pg_alias, role)
+-- Tables: __seo_keywords
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_alias, role, keyword, COUNT(*) FROM __seo_keywords GROUP BY pg_alias, role, keyword HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-041-sitemap-link-url-unique.sql
+++ b/.spec/00-canon/invariants/sql/INV-041-sitemap-link-url-unique.sql
@@ -1,0 +1,8 @@
+-- INV-041: sitemap-link-url-unique
+-- Domain: D3-seo
+-- Severity: medium
+-- Description: __sitemap_p_link: no duplicate URL
+-- Tables: __sitemap_p_link
+-- Returns 0 rows when invariant holds.
+
+SELECT url, COUNT(*) FROM __sitemap_p_link GROUP BY url HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-042-seo-link-impressions-non-negative.sql
+++ b/.spec/00-canon/invariants/sql/INV-042-seo-link-impressions-non-negative.sql
@@ -1,0 +1,8 @@
+-- INV-042: seo-link-impressions-non-negative
+-- Domain: D3-seo
+-- Severity: medium
+-- Description: seo_link_impressions.impressions must be >= 0
+-- Tables: seo_link_impressions
+-- Returns 0 rows when invariant holds.
+
+SELECT id FROM seo_link_impressions WHERE impressions < 0;

--- a/.spec/00-canon/invariants/sql/INV-043-seo-keywords-search-volume-non-negative.sql
+++ b/.spec/00-canon/invariants/sql/INV-043-seo-keywords-search-volume-non-negative.sql
@@ -1,0 +1,8 @@
+-- INV-043: seo-keywords-search-volume-non-negative
+-- Domain: D3-seo
+-- Severity: low
+-- Description: __seo_keywords.search_volume must be >= 0 where defined
+-- Tables: __seo_keywords
+-- Returns 0 rows when invariant holds.
+
+SELECT id, keyword FROM __seo_keywords WHERE search_volume IS NOT NULL AND search_volume < 0;

--- a/.spec/00-canon/invariants/sql/INV-044-seo-page-entity-fk-brief.sql
+++ b/.spec/00-canon/invariants/sql/INV-044-seo-page-entity-fk-brief.sql
@@ -1,0 +1,8 @@
+-- INV-044: seo-page-entity-fk-brief
+-- Domain: D3-seo
+-- Severity: medium
+-- Description: __seo_page.entity_id must reference existing entry in __seo_page_brief where not null
+-- Tables: __seo_page, __seo_page_brief
+-- Returns 0 rows when invariant holds.
+
+SELECT sp.id, sp.slug, sp.entity_id FROM __seo_page sp LEFT JOIN __seo_page_brief spb ON sp.entity_id = spb.id WHERE sp.entity_id IS NOT NULL AND spb.id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-045-seo-keyword-type-mapping-fk.sql
+++ b/.spec/00-canon/invariants/sql/INV-045-seo-keyword-type-mapping-fk.sql
@@ -1,0 +1,8 @@
+-- INV-045: seo-keyword-type-mapping-fk
+-- Domain: D3-seo
+-- Severity: low
+-- Description: __seo_keyword_type_mapping must reference valid keyword types (if data present)
+-- Tables: __seo_keyword_type_mapping, __seo_keywords
+-- Returns 0 rows when invariant holds.
+
+SELECT sktm.id FROM __seo_keyword_type_mapping sktm LEFT JOIN __seo_keywords sk ON sktm.keyword_id = sk.id WHERE sktm.keyword_id IS NOT NULL AND sk.id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-046-customer-email-not-null.sql
+++ b/.spec/00-canon/invariants/sql/INV-046-customer-email-not-null.sql
@@ -1,0 +1,8 @@
+-- INV-046: customer-email-not-null
+-- Domain: D4-orders
+-- Severity: critical
+-- Description: ___xtr_customer.email must not be null or empty
+-- Tables: ___xtr_customer
+-- Returns 0 rows when invariant holds.
+
+SELECT id FROM ___xtr_customer WHERE email IS NULL OR email = '';

--- a/.spec/00-canon/invariants/sql/INV-047-customer-email-unique.sql
+++ b/.spec/00-canon/invariants/sql/INV-047-customer-email-unique.sql
@@ -1,0 +1,8 @@
+-- INV-047: customer-email-unique
+-- Domain: D4-orders
+-- Severity: high
+-- Description: ___xtr_customer: no duplicate emails
+-- Tables: ___xtr_customer
+-- Returns 0 rows when invariant holds.
+
+SELECT email, COUNT(*) FROM ___xtr_customer WHERE email IS NOT NULL GROUP BY email HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-048-order-fk-customer.sql
+++ b/.spec/00-canon/invariants/sql/INV-048-order-fk-customer.sql
@@ -1,0 +1,8 @@
+-- INV-048: order-fk-customer
+-- Domain: D4-orders
+-- Severity: critical
+-- Description: ___xtr_order must reference existing customer in ___xtr_customer
+-- Tables: ___xtr_order, ___xtr_customer
+-- Returns 0 rows when invariant holds.
+
+SELECT o.id FROM ___xtr_order o LEFT JOIN ___xtr_customer c ON o.customer_id = c.id WHERE o.customer_id IS NOT NULL AND c.id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-049-order-line-fk-order.sql
+++ b/.spec/00-canon/invariants/sql/INV-049-order-line-fk-order.sql
@@ -1,0 +1,8 @@
+-- INV-049: order-line-fk-order
+-- Domain: D4-orders
+-- Severity: critical
+-- Description: ___xtr_order_line must reference existing order in ___xtr_order
+-- Tables: ___xtr_order_line, ___xtr_order
+-- Returns 0 rows when invariant holds.
+
+SELECT ol.id FROM ___xtr_order_line ol LEFT JOIN ___xtr_order o ON ol.order_id = o.id WHERE ol.order_id IS NOT NULL AND o.id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-050-order-line-quantity-positive.sql
+++ b/.spec/00-canon/invariants/sql/INV-050-order-line-quantity-positive.sql
@@ -1,0 +1,8 @@
+-- INV-050: order-line-quantity-positive
+-- Domain: D4-orders
+-- Severity: high
+-- Description: ___xtr_order_line.quantity must be > 0
+-- Tables: ___xtr_order_line
+-- Returns 0 rows when invariant holds.
+
+SELECT id, order_id FROM ___xtr_order_line WHERE quantity IS NULL OR quantity <= 0;

--- a/.spec/00-canon/invariants/sql/INV-051-order-line-unit-price-non-negative.sql
+++ b/.spec/00-canon/invariants/sql/INV-051-order-line-unit-price-non-negative.sql
@@ -1,0 +1,8 @@
+-- INV-051: order-line-unit-price-non-negative
+-- Domain: D4-orders
+-- Severity: high
+-- Description: ___xtr_order_line.unit_price must be >= 0
+-- Tables: ___xtr_order_line
+-- Returns 0 rows when invariant holds.
+
+SELECT id, order_id FROM ___xtr_order_line WHERE unit_price IS NOT NULL AND unit_price < 0;

--- a/.spec/00-canon/invariants/sql/INV-052-order-status-valid.sql
+++ b/.spec/00-canon/invariants/sql/INV-052-order-status-valid.sql
@@ -1,0 +1,8 @@
+-- INV-052: order-status-valid
+-- Domain: D4-orders
+-- Severity: high
+-- Description: ___xtr_order.status must be in allowed set
+-- Tables: ___xtr_order
+-- Returns 0 rows when invariant holds.
+
+SELECT id, status FROM ___xtr_order WHERE status NOT IN ('pending','confirmed','shipped','delivered','cancelled','refunded');

--- a/.spec/00-canon/invariants/sql/INV-053-invoice-line-fk-invoice.sql
+++ b/.spec/00-canon/invariants/sql/INV-053-invoice-line-fk-invoice.sql
@@ -1,0 +1,8 @@
+-- INV-053: invoice-line-fk-invoice
+-- Domain: D4-orders
+-- Severity: high
+-- Description: ___xtr_invoice_line must reference existing invoice in ___xtr_invoice
+-- Tables: ___xtr_invoice_line, ___xtr_invoice
+-- Returns 0 rows when invariant holds.
+
+SELECT il.id FROM ___xtr_invoice_line il LEFT JOIN ___xtr_invoice i ON il.invoice_id = i.id WHERE il.invoice_id IS NOT NULL AND i.id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-054-invoice-fk-order.sql
+++ b/.spec/00-canon/invariants/sql/INV-054-invoice-fk-order.sql
@@ -1,0 +1,8 @@
+-- INV-054: invoice-fk-order
+-- Domain: D4-orders
+-- Severity: high
+-- Description: ___xtr_invoice must reference existing order in ___xtr_order (where FK is defined)
+-- Tables: ___xtr_invoice, ___xtr_order
+-- Returns 0 rows when invariant holds.
+
+SELECT i.id FROM ___xtr_invoice i LEFT JOIN ___xtr_order o ON i.order_id = o.id WHERE i.order_id IS NOT NULL AND o.id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-055-order-line-status-valid.sql
+++ b/.spec/00-canon/invariants/sql/INV-055-order-line-status-valid.sql
@@ -1,0 +1,8 @@
+-- INV-055: order-line-status-valid
+-- Domain: D4-orders
+-- Severity: medium
+-- Description: ___xtr_order_line_status: status must be in allowed set
+-- Tables: ___xtr_order_line_status
+-- Returns 0 rows when invariant holds.
+
+SELECT id, status FROM ___xtr_order_line_status WHERE status NOT IN ('pending','processing','shipped','delivered','cancelled','returned','refunded');

--- a/.spec/00-canon/invariants/sql/INV-056-pieces-price-shadow-cols-sync.sql
+++ b/.spec/00-canon/invariants/sql/INV-056-pieces-price-shadow-cols-sync.sql
@@ -1,0 +1,8 @@
+-- INV-056: pieces-price-shadow-cols-sync
+-- Domain: D5-structural
+-- Severity: high
+-- Description: pieces_price: shadow _n columns must not be null where TEXT original is non-null
+-- Tables: pieces_price
+-- Returns 0 rows when invariant holds.
+
+SELECT pp_id FROM pieces_price WHERE (pp_prix_public IS NOT NULL AND pp_prix_public_n IS NULL) OR (pp_prix_brut IS NOT NULL AND pp_prix_brut_n IS NULL) OR (pp_remise IS NOT NULL AND pp_remise_n IS NULL);

--- a/.spec/00-canon/invariants/sql/INV-057-auto-type-shadow-col-sync.sql
+++ b/.spec/00-canon/invariants/sql/INV-057-auto-type-shadow-col-sync.sql
@@ -1,0 +1,8 @@
+-- INV-057: auto-type-shadow-col-sync
+-- Domain: D5-structural
+-- Severity: high
+-- Description: auto_type: type_id_i (INTEGER shadow) must not be null where type_id TEXT is non-null
+-- Tables: auto_type
+-- Returns 0 rows when invariant holds.
+
+SELECT type_id FROM auto_type WHERE type_id IS NOT NULL AND type_id_i IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-058-no-public-table-without-pk.sql
+++ b/.spec/00-canon/invariants/sql/INV-058-no-public-table-without-pk.sql
@@ -1,0 +1,8 @@
+-- INV-058: no-public-table-without-pk
+-- Domain: D5-structural
+-- Severity: critical
+-- Description: No table in public schema may lack a primary key
+-- Tables: information_schema.tables, information_schema.table_constraints
+-- Returns 0 rows when invariant holds.
+
+SELECT t.table_name FROM information_schema.tables t WHERE t.table_schema = 'public' AND t.table_type = 'BASE TABLE' AND NOT EXISTS ( SELECT 1 FROM information_schema.table_constraints tc WHERE tc.table_schema = 'public' AND tc.table_name = t.table_name AND tc.constraint_type = 'PRIMARY KEY' );

--- a/.spec/00-canon/invariants/sql/INV-059-no-price-text-column-unpopulated.sql
+++ b/.spec/00-canon/invariants/sql/INV-059-no-price-text-column-unpopulated.sql
@@ -1,0 +1,8 @@
+-- INV-059: no-price-text-column-unpopulated
+-- Domain: D5-structural
+-- Severity: medium
+-- Description: pieces_price: TEXT price columns should be castable to numeric (no unconvertible values)
+-- Tables: pieces_price
+-- Returns 0 rows when invariant holds.
+
+SELECT pp_id, pp_prix_public FROM pieces_price WHERE pp_prix_public IS NOT NULL AND pp_prix_public !~ '^-?[0-9]+(\.[0-9]+)?$';

--- a/.spec/00-canon/invariants/sql/INV-060-pieces-gamme-pg-level-valid.sql
+++ b/.spec/00-canon/invariants/sql/INV-060-pieces-gamme-pg-level-valid.sql
@@ -1,0 +1,8 @@
+-- INV-060: pieces-gamme-pg-level-valid
+-- Domain: D5-structural
+-- Severity: medium
+-- Description: pieces_gamme.pg_level must be in allowed set (top, mid, leaf, or null)
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT pg_id, pg_alias, pg_level FROM pieces_gamme WHERE pg_level IS NOT NULL AND pg_level NOT IN ('top','mid','leaf');

--- a/.spec/00-canon/invariants/sql/INV-061-pieces-gamme-no-circular-parent.sql
+++ b/.spec/00-canon/invariants/sql/INV-061-pieces-gamme-no-circular-parent.sql
@@ -1,0 +1,16 @@
+-- INV-061: pieces-gamme-no-circular-parent
+-- Domain: D5-structural
+-- Severity: medium
+-- Description: pieces_gamme: no cycle in parent hierarchy (max 5 levels deep)
+-- Tables: pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+WITH RECURSIVE hierarchy AS (
+  SELECT pg_id, pg_parent_gamme_id, 1 AS depth, ARRAY[pg_id] AS path
+  FROM pieces_gamme WHERE pg_parent_gamme_id IS NOT NULL
+  UNION ALL
+  SELECT pg.pg_id, pg.pg_parent_gamme_id, h.depth + 1, h.path || pg.pg_id
+  FROM pieces_gamme pg JOIN hierarchy h ON pg.pg_id = h.pg_parent_gamme_id
+  WHERE pg.pg_id <> ALL(h.path) AND h.depth < 6
+)
+SELECT pg_id FROM hierarchy WHERE depth >= 6 OR pg_id = ANY(path[1:array_length(path,1)-1]);

--- a/.spec/00-canon/invariants/sql/INV-062-no-orphan-seo-published-pages.sql
+++ b/.spec/00-canon/invariants/sql/INV-062-no-orphan-seo-published-pages.sql
@@ -1,0 +1,8 @@
+-- INV-062: no-orphan-seo-published-pages
+-- Domain: D5-structural
+-- Severity: high
+-- Description: Published __seo_page without corresponding entity_id in __seo_page_brief = orphan
+-- Tables: __seo_page, __seo_page_brief
+-- Returns 0 rows when invariant holds.
+
+SELECT sp.id, sp.slug FROM __seo_page sp WHERE sp.status = 'published' AND sp.entity_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM __seo_page_brief spb WHERE spb.id = sp.entity_id);

--- a/.spec/00-canon/invariants/sql/INV-063-seo-page-brief-has-pg-alias.sql
+++ b/.spec/00-canon/invariants/sql/INV-063-seo-page-brief-has-pg-alias.sql
@@ -1,0 +1,8 @@
+-- INV-063: seo-page-brief-has-pg-alias
+-- Domain: D5-structural
+-- Severity: high
+-- Description: __seo_page_brief: pg_alias must not be null or empty
+-- Tables: __seo_page_brief
+-- Returns 0 rows when invariant holds.
+
+SELECT id, role FROM __seo_page_brief WHERE pg_alias IS NULL OR pg_alias = '';

--- a/.spec/00-canon/invariants/sql/INV-064-pieces-gamme-active-count-seo-brief.sql
+++ b/.spec/00-canon/invariants/sql/INV-064-pieces-gamme-active-count-seo-brief.sql
@@ -1,0 +1,8 @@
+-- INV-064: pieces-gamme-active-count-seo-brief
+-- Domain: D6-consistency
+-- Severity: medium
+-- Description: Active gammes with pg_alias must have at least one SEO brief (R3 or R6) in __seo_page_brief
+-- Tables: pieces_gamme, __seo_page_brief
+-- Returns 0 rows when invariant holds.
+
+SELECT pg.pg_id, pg.pg_alias FROM pieces_gamme pg WHERE pg.pg_status = 'active' AND pg.pg_alias IS NOT NULL AND NOT EXISTS ( SELECT 1 FROM __seo_page_brief spb WHERE spb.pg_alias = pg.pg_alias AND spb.role IN ('R3','R6') );

--- a/.spec/00-canon/invariants/sql/INV-065-pieces-active-has-price.sql
+++ b/.spec/00-canon/invariants/sql/INV-065-pieces-active-has-price.sql
@@ -1,0 +1,8 @@
+-- INV-065: pieces-active-has-price
+-- Domain: D6-consistency
+-- Severity: medium
+-- Description: Active pieces should have at least one price record
+-- Tables: pieces, pieces_price
+-- Returns 0 rows when invariant holds.
+
+SELECT p.p_id FROM pieces p WHERE p.p_status = 'active' AND NOT EXISTS (SELECT 1 FROM pieces_price pp WHERE pp.pp_piece_id = p.p_id);

--- a/.spec/00-canon/invariants/sql/INV-066-seo-r3-page-has-conseil.sql
+++ b/.spec/00-canon/invariants/sql/INV-066-seo-r3-page-has-conseil.sql
@@ -1,0 +1,8 @@
+-- INV-066: seo-r3-page-has-conseil
+-- Domain: D6-consistency
+-- Severity: medium
+-- Description: Published R3 pages must have at least one conseil section for same pg_alias
+-- Tables: __seo_page, __seo_page_brief, __seo_gamme_conseil
+-- Returns 0 rows when invariant holds.
+
+SELECT sp.id, sp.slug FROM __seo_page sp JOIN __seo_page_brief spb ON sp.entity_id = spb.id WHERE sp.status = 'published' AND sp.role = 'R3' AND NOT EXISTS ( SELECT 1 FROM __seo_gamme_conseil sgc WHERE sgc.pg_alias = spb.pg_alias );

--- a/.spec/00-canon/invariants/sql/INV-067-pieces-criteria-link-fk-criteria.sql
+++ b/.spec/00-canon/invariants/sql/INV-067-pieces-criteria-link-fk-criteria.sql
@@ -1,0 +1,8 @@
+-- INV-067: pieces-criteria-link-fk-criteria
+-- Domain: D6-consistency
+-- Severity: medium
+-- Description: pieces_criteria_link must reference existing criteria in pieces_criteria
+-- Tables: pieces_criteria_link, pieces_criteria
+-- Returns 0 rows when invariant holds.
+
+SELECT pcl.id FROM pieces_criteria_link pcl LEFT JOIN pieces_criteria pc ON pcl.criteria_id = pc.id WHERE pcl.criteria_id IS NOT NULL AND pc.id IS NULL;

--- a/.spec/00-canon/invariants/sql/INV-068-pieces-ref-search-no-duplicate.sql
+++ b/.spec/00-canon/invariants/sql/INV-068-pieces-ref-search-no-duplicate.sql
@@ -1,0 +1,8 @@
+-- INV-068: pieces-ref-search-no-duplicate
+-- Domain: D6-consistency
+-- Severity: medium
+-- Description: pieces_ref_search: no duplicate on primary search key
+-- Tables: pieces_ref_search
+-- Returns 0 rows when invariant holds.
+
+SELECT search_key, piece_id, COUNT(*) FROM pieces_ref_search WHERE search_key IS NOT NULL GROUP BY search_key, piece_id HAVING COUNT(*) > 1;

--- a/.spec/00-canon/invariants/sql/INV-069-seo-gamme-conseil-pg-alias-matches-active-gamme.sql
+++ b/.spec/00-canon/invariants/sql/INV-069-seo-gamme-conseil-pg-alias-matches-active-gamme.sql
@@ -1,0 +1,8 @@
+-- INV-069: seo-gamme-conseil-pg-alias-matches-active-gamme
+-- Domain: D6-consistency
+-- Severity: high
+-- Description: __seo_gamme_conseil.pg_alias must match an active gamme in pieces_gamme
+-- Tables: __seo_gamme_conseil, pieces_gamme
+-- Returns 0 rows when invariant holds.
+
+SELECT sgc.id, sgc.pg_alias FROM __seo_gamme_conseil sgc LEFT JOIN pieces_gamme pg ON sgc.pg_alias = pg.pg_alias AND pg.pg_status = 'active' WHERE pg.pg_alias IS NULL;

--- a/.spec/00-canon/policies/change-protocol.md
+++ b/.spec/00-canon/policies/change-protocol.md
@@ -1,0 +1,154 @@
+# Change Protocol — AutoMecanik Architecture
+
+**Version:** 1.0.0  
+**Status:** CANON  
+**Date:** 2026-04-14  
+**Owner:** Software-Architect (d2e89803)  
+**Approver:** CTO (7fa3c971)  
+**Source:** [AUT-277](/AUT/issues/AUT-277) / [AUT-271](/AUT/issues/AUT-271)
+
+---
+
+## Purpose
+
+This document defines the levels of governance required for architectural changes in the AutoMecanik monorepo. It is authoritative — every agent, engineer, and automated gate must respect these rules.
+
+Any change that is not covered by a lower level **must** escalate to the next level. When in doubt: escalate, do not assume.
+
+---
+
+## Change Levels
+
+### R0 — No-approval (autonomous)
+
+**Scope:** Changes that carry zero architectural risk.
+
+Examples:
+- Fix a typo in a comment
+- Update a log message
+- Add a `console.log` for debugging (removed before merge)
+- Update `package.json` version numbers (patch bumps, not deps)
+
+**Gate required:** Lint + TypeCheck only.  
+**Approver:** None.
+
+---
+
+### R1 — Manifest drift (advisory)
+
+**Scope:** Changes that touch a module covered by a `stub` or `draft` manifest.
+
+Triggered when:
+- A file in `backend/src/modules/<module>/` is modified
+- The module's manifest has `status: stub` or `status: draft`
+
+**Gate:** `manifest-check` in ADVISORY mode — reports violations, does not block.  
+**Action required:** Update the manifest to reflect the change (add to `http_routes`, `owned_tables`, etc.).  
+**Approver:** None (self-serve), but violations must be documented in the PR.
+
+**manifest_version_read:** Before any R1 or higher change, the agent/engineer MUST read the current manifest version:
+```bash
+cat .spec/modules/<module>/manifest.yaml
+```
+This prevents stale-manifest drift where the manifest describes a prior state of the module.
+
+**manifest_drift_clean:** If the manifest is out of date (reality diverged from manifest), a manifest-only PR must be opened to sync the manifest before or alongside the feature PR.
+
+---
+
+### R2 — Certified module change (blocking)
+
+**Scope:** Changes that touch a module with `status: certified` in its manifest.
+
+Triggered when:
+- A file in `backend/src/modules/<module>/` is modified
+- The module's manifest has `status: certified`
+
+**Gate:** `manifest-check` in BLOCKING mode — must pass before merge.  
+**Approver:** PR author self-review is sufficient IF the gate is green.  
+**If gate is red:** Gate-override requires CTO approval + Data-Ops (for DB-touching modules) or IA-SEO Master (for SEO-touching modules).
+
+**Additional requirements:**
+- All `invariants_ref` SQL gates must return 0 rows
+- `change_surface.review_checklist` must be addressed in PR body
+
+---
+
+### R3 — Database migration (write)
+
+**Scope:** Any migration that adds, modifies, or removes a table, column, index, or constraint.
+
+**Gate:** `manifest-check` + migration checklist (`sql-migration-checklist.md`) + invariant gates.  
+**Approver:** Data-Ops (0bd1fd16) — mandatory reviewer.  
+**Rule:** No `DROP TABLE` without a prior `retirement` entry in `.spec/retired/`. No `DROP COLUMN` without evidence that 0 consumers exist (code search + 30-day DB stats).
+
+**Tool restriction (Paperclip):**
+- `mcp__claude_ai_Supabase__apply_migration` — reserved for Data-Ops agent and the `migration-gate` worker only.
+- `mcp__claude_ai_Supabase__execute_sql` — reserved for Data-Ops agent only (production writes).
+- Software-Architect, Code-Fixer, and Code-Analyst must NEVER invoke these tools directly on production.
+
+---
+
+### R4 — Cross-domain dependency change
+
+**Scope:** A change that adds or removes a dependency between two modules (changes `depends_on` in a manifest), introduces a new cross-domain table read, or modifies a public export contract.
+
+**Gate:** All R2 requirements + cross-domain dependency review.  
+**Approver:** CTO (7fa3c971) — mandatory.  
+**ADR required if:** The change introduces a new circular dependency, removes a previously public export, or changes the ownership of a table between modules.
+
+---
+
+## Manifest Lifecycle (mandatory_version_read + manifest_drift_clean)
+
+Every agent working on a module MUST:
+
+1. **`manifest_version_read`** — Read `.spec/modules/<module>/manifest.yaml` at the start of any work session on that module.
+
+2. **`manifest_drift_clean`** — If the manifest is out of date (e.g., new routes exist that aren't listed, or a table is used but not in `owned_tables`/`read_tables`), open a manifest-sync PR before or alongside the feature work.
+
+3. **Never work from memory** — The manifest is the source of truth for the module's contract, not the agent's prior knowledge.
+
+### Promoting a manifest
+
+| Transition | Who approves | Gate required |
+|------------|-------------|---------------|
+| `stub` → `draft` | PR author self-review | None (advisory only) |
+| `draft` → `certified` | CTO review + comment | All invariants green, gate battery green |
+| `certified` → `retired` | CTO + Data-Ops | Full retirement audit + `.spec/retired/` entry |
+
+---
+
+## Tooling Restrictions
+
+| Tool | Allowed agents | Notes |
+|------|----------------|-------|
+| `mcp__claude_ai_Supabase__apply_migration` | Data-Ops (0bd1fd16), migration-gate worker | Production DB writes only |
+| `mcp__claude_ai_Supabase__execute_sql` | Data-Ops (0bd1fd16) | Production SELECT allowed; writes are R3 |
+| `mcp__claude_ai_Supabase__create_branch` | Any agent | Safe (creates isolated branch) |
+| `mcp__claude_ai_Supabase__delete_branch` | Data-Ops only | Gate required |
+| `gates/manifest-check.ts` | All agents (read) | Mandatory pre-commit for R2+ |
+
+---
+
+## Agent Ownership Rules
+
+| Agent | Write scope | Cannot write to |
+|-------|-------------|-----------------|
+| Software-Architect (d2e89803) | `.spec/**`, `docs/adr/**`, `gates/**`, `.github/workflows/` (gates only) | `backend/**`, `frontend/**`, `scripts/**`, `packages/**` |
+| Code-Fixer (b0df5075) | Modules where it is listed as `owner_agent` in manifest | Modules not listed in its ownership |
+| Code-Analyst (77fbb90a) | Read + report only | Cannot write application code |
+| Data-Ops (0bd1fd16) | `backend/supabase/migrations/**` | Application code |
+
+---
+
+## Violation Handling
+
+If an agent takes an action that violates this protocol:
+
+1. The gate blocks the PR (for R2+ violations).
+2. The agent must NOT retry with `--no-verify` or equivalent bypass flags.
+3. The agent posts a Paperclip comment on the task explaining the violation and requesting the appropriate approval.
+4. If the agent is unsure of the correct level: escalate to CTO immediately — do not proceed.
+
+Repeated violations (>2 in a sprint) trigger a governance review by CTO.

--- a/.spec/modules/_schema.yaml
+++ b/.spec/modules/_schema.yaml
@@ -1,0 +1,213 @@
+# .spec/modules/_schema.yaml
+# Module Manifest Schema — AutoMecanik Monorepo
+# Version: 1.0.0 | Status: CANON | Owner: Software-Architect (d2e89803)
+# ADR reference: docs/adr/0001-module-manifest-schema.md
+# Source epic: AUT-271 / AUT-272
+
+$schema: "https://json-schema.org/draft/2020-12"
+$id: "spec://modules/manifest-schema/v1"
+title: "Module Manifest"
+description: >
+  Machine-verified contract for every NestJS backend module and every Remix
+  route cluster. The gate gates/manifest-check.ts enforces this schema on every
+  PR. Phase 0–1: advisory (report-only). Phase 2+: blocking on certified modules.
+
+type: object
+required:
+  - module
+  - status
+  - owned_tables
+  - http_routes
+  - depends_on
+  - change_surface
+
+properties:
+  # ── Identity ──────────────────────────────────────────────────────────────
+  module:
+    type: string
+    description: >
+      Module identifier, matching the directory name under
+      backend/src/modules/<module>. Snake-case, lowercase.
+    pattern: "^[a-z][a-z0-9_-]*$"
+    examples: ["vehicles", "payments", "catalog", "seo"]
+
+  title:
+    type: string
+    description: Human-readable module title.
+
+  description:
+    type: string
+    description: One-sentence purpose of the module.
+
+  domain:
+    type: string
+    description: Domain code from domain-map.md (D1-D8 or multi).
+    pattern: "^D[1-8](-[A-Za-z]+)?(,D[1-8](-[A-Za-z]+)?)*$"
+    examples: ["D1-catalog", "D4-vehicle", "D3-seo", "D1-catalog,D3-seo"]
+
+  status:
+    type: string
+    description: >
+      Lifecycle status of this manifest.
+      - stub: auto-generated skeleton, not yet reviewed
+      - draft: human-authored, not yet gate-enforced
+      - certified: gate-enforced, auto-merge eligible with full green battery
+      - retired: module removed, archived in .spec/retired/
+    enum: [stub, draft, certified, retired]
+
+  certification_date:
+    type: string
+    format: date
+    description: ISO date when status was set to certified.
+
+  # ── Database Surface ───────────────────────────────────────────────────────
+  owned_tables:
+    type: array
+    description: >
+      Tables this module is the sole authorized writer of. A table must appear
+      in exactly ONE manifest as owned. The gate rejects PRs where a file
+      writes to a table not owned by its enclosing module.
+    items:
+      type: string
+    uniqueItems: true
+    examples:
+      - ["auto_type", "auto_modele", "auto_marque"]
+
+  read_tables:
+    type: array
+    description: >
+      Tables this module reads but does not own (cross-domain reads).
+      Informational only — not gate-enforced in Phase 1.
+    items:
+      type: string
+    uniqueItems: true
+
+  owned_rpcs:
+    type: array
+    description: >
+      RPC/function names in Supabase this module is the sole caller of
+      (or the owner of if defined in a migration it owns).
+    items:
+      type: string
+    uniqueItems: true
+
+  # ── HTTP Surface ───────────────────────────────────────────────────────────
+  http_routes:
+    type: array
+    description: HTTP routes exposed by this module. Method + path pattern.
+    items:
+      type: object
+      required: [method, path]
+      properties:
+        method:
+          type: string
+          enum: [GET, POST, PUT, PATCH, DELETE, WS]
+        path:
+          type: string
+          description: Express-style path, e.g. /api/vehicles/brands/:id
+        auth:
+          type: string
+          enum: [public, session, admin, service_role]
+          default: session
+        notes:
+          type: string
+
+  # ── Exports & Dependencies ─────────────────────────────────────────────────
+  public_exports:
+    type: array
+    description: >
+      Symbols (types, DTOs, services) exported by this module for use by
+      other modules. Everything else is treated as private.
+    items:
+      type: object
+      required: [symbol, kind]
+      properties:
+        symbol:
+          type: string
+        kind:
+          type: string
+          enum: [service, dto, type, interface, enum, constant, guard]
+        notes:
+          type: string
+
+  depends_on:
+    type: array
+    description: >
+      Modules this module imports from (NestJS module imports or
+      shared package imports). Gate will flag circular dependencies.
+    items:
+      type: string
+    uniqueItems: true
+
+  # ── Invariants & SEO ──────────────────────────────────────────────────────
+  invariants_ref:
+    type: array
+    description: >
+      Invariant IDs from .spec/00-canon/invariants/feature-invariants.json
+      that this module must not violate. Gate checks all referenced invariants
+      against .spec/00-canon/invariants/sql/*.sql before certifying.
+    items:
+      type: string
+      pattern: "^INV-[0-9]{3}$"
+    uniqueItems: true
+    examples:
+      - ["INV-001", "INV-002", "INV-003"]
+
+  seo_contracts:
+    type: object
+    description: >
+      SEO obligations for modules that produce or consume SEO data.
+      Only required when domain contains D3-seo.
+    properties:
+      canonical_table:
+        type: string
+        description: Primary SEO table owned by this module.
+      sitemap_feeds:
+        type: array
+        items:
+          type: string
+      noindex_rules:
+        type: array
+        items:
+          type: string
+      robots_policy:
+        type: string
+        enum: [index_follow, noindex_follow, noindex_nofollow]
+
+  # ── Change Surface ─────────────────────────────────────────────────────────
+  change_surface:
+    type: object
+    description: >
+      What to verify when a PR touches files in this module.
+      Used by the manifest gate and Code-Review agent.
+    required: [review_checklist]
+    properties:
+      risk_level:
+        type: string
+        enum: [low, medium, high, critical]
+      review_checklist:
+        type: array
+        description: Ordered list of checks for reviewers.
+        items:
+          type: string
+        minItems: 1
+      requires_data_ops_approval:
+        type: boolean
+        default: false
+        description: >
+          True if any migration or schema change requires Data-Ops sign-off
+          (modules with owned_tables in D1 or D4 always true).
+      requires_seo_approval:
+        type: boolean
+        default: false
+        description: >
+          True if changes could affect SEO indexation or sitemap output.
+      gate_battery:
+        type: array
+        description: >
+          Gate IDs that must pass green before auto-merge is allowed
+          (only applies when status=certified).
+        items:
+          type: string
+
+additionalProperties: false

--- a/.spec/modules/admin/manifest.yaml
+++ b/.spec/modules/admin/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/admin/manifest.yaml
+# Module Manifest — admin
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: admin
+title: "Admin Module"
+description: "Administration dashboard and back-office operations."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/agentic-engine/manifest.yaml
+++ b/.spec/modules/agentic-engine/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/agentic-engine/manifest.yaml
+# Module Manifest — agentic-engine
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: agentic-engine
+title: "Agentic Engine Module"
+description: "Agentic AI pipeline (runs, branches, steps, evidence, checkpoints)."
+domain: D6-rag
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/ai-content/manifest.yaml
+++ b/.spec/modules/ai-content/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/ai-content/manifest.yaml
+# Module Manifest — ai-content
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: ai-content
+title: "Ai Content Module"
+description: "AI-assisted content generation for SEO sections."
+domain: D3-seo
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/analytics/manifest.yaml
+++ b/.spec/modules/analytics/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/analytics/manifest.yaml
+# Module Manifest — analytics
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: analytics
+title: "Analytics Module"
+description: "Analytics tracking and reporting."
+domain: D3-seo
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/auth/manifest.yaml
+++ b/.spec/modules/auth/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/auth/manifest.yaml
+# Module Manifest — auth
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: auth
+title: "Auth Module"
+description: "Authentication, sessions (Redis), Passport.js strategies."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/blog-metadata/manifest.yaml
+++ b/.spec/modules/blog-metadata/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/blog-metadata/manifest.yaml
+# Module Manifest — blog-metadata
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: blog-metadata
+title: "Blog Metadata Module"
+description: "Blog SEO metadata, breadcrumbs, meta-tags."
+domain: D5-blog
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/blog/manifest.yaml
+++ b/.spec/modules/blog/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/blog/manifest.yaml
+# Module Manifest — blog
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: blog
+title: "Blog Module"
+description: "Blog articles, guides, and editorial content."
+domain: D5-blog
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/bot-guard/manifest.yaml
+++ b/.spec/modules/bot-guard/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/bot-guard/manifest.yaml
+# Module Manifest — bot-guard
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: bot-guard
+title: "Bot Guard Module"
+description: "Bot detection and rate limiting middleware."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/cart/manifest.yaml
+++ b/.spec/modules/cart/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/cart/manifest.yaml
+# Module Manifest — cart
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: cart
+title: "Cart Module"
+description: "Shopping cart state management."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/catalog/manifest.yaml
+++ b/.spec/modules/catalog/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/catalog/manifest.yaml
+# Module Manifest — catalog
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: catalog
+title: "Catalog Module"
+description: "Core product catalogue — pieces, prices, media, criteria."
+domain: D1-catalog
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/commercial/manifest.yaml
+++ b/.spec/modules/commercial/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/commercial/manifest.yaml
+# Module Manifest — commercial
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: commercial
+title: "Commercial Module"
+description: "Commercial operations, B2B, price lists."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/config/manifest.yaml
+++ b/.spec/modules/config/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/config/manifest.yaml
+# Module Manifest — config
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: config
+title: "Config Module"
+description: "Application configuration and environment variable injection."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/customers/manifest.yaml
+++ b/.spec/modules/customers/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/customers/manifest.yaml
+# Module Manifest — customers
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: customers
+title: "Customers Module"
+description: "Customer profiles, addresses, account management."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/dashboard/manifest.yaml
+++ b/.spec/modules/dashboard/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/dashboard/manifest.yaml
+# Module Manifest — dashboard
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: dashboard
+title: "Dashboard Module"
+description: "User-facing dashboard for order history, account overview."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/diagnostic-engine/manifest.yaml
+++ b/.spec/modules/diagnostic-engine/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/diagnostic-engine/manifest.yaml
+# Module Manifest — diagnostic-engine
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: diagnostic-engine
+title: "Diagnostic Engine Module"
+description: "Vehicle diagnostic symptom-cause engine."
+domain: D7-kg
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/errors/manifest.yaml
+++ b/.spec/modules/errors/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/errors/manifest.yaml
+# Module Manifest — errors
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: errors
+title: "Errors Module"
+description: "Global error filters and error response normalisation."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/gamme-rest/manifest.yaml
+++ b/.spec/modules/gamme-rest/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/gamme-rest/manifest.yaml
+# Module Manifest — gamme-rest
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: gamme-rest
+title: "Gamme Rest Module"
+description: "REST endpoints for pieces gamme (product family pages)."
+domain: D1-catalog
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/health/manifest.yaml
+++ b/.spec/modules/health/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/health/manifest.yaml
+# Module Manifest — health
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: health
+title: "Health Module"
+description: "Health check endpoints for Docker/Caddy monitoring."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/invoices/manifest.yaml
+++ b/.spec/modules/invoices/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/invoices/manifest.yaml
+# Module Manifest — invoices
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: invoices
+title: "Invoices Module"
+description: "Invoice generation and download."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/knowledge-graph/manifest.yaml
+++ b/.spec/modules/knowledge-graph/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/knowledge-graph/manifest.yaml
+# Module Manifest — knowledge-graph
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: knowledge-graph
+title: "Knowledge Graph Module"
+description: "Mechanical knowledge graph (kg_nodes, kg_edges)."
+domain: D7-kg
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/layout/manifest.yaml
+++ b/.spec/modules/layout/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/layout/manifest.yaml
+# Module Manifest — layout
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: layout
+title: "Layout Module"
+description: "Layout and navigation data for SSR."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/marketing/manifest.yaml
+++ b/.spec/modules/marketing/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/marketing/manifest.yaml
+# Module Manifest — marketing
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: marketing
+title: "Marketing Module"
+description: "Marketing campaigns, promotions meta."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/mcp-validation/manifest.yaml
+++ b/.spec/modules/mcp-validation/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/mcp-validation/manifest.yaml
+# Module Manifest — mcp-validation
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: mcp-validation
+title: "Mcp Validation Module"
+description: "MCP (Model-Context-Protocol) request validation layer."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/messages/manifest.yaml
+++ b/.spec/modules/messages/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/messages/manifest.yaml
+# Module Manifest — messages
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: messages
+title: "Messages Module"
+description: "Legacy PrestaShop messaging history (___xtr_msg)."
+domain: D2-legacy
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/metadata/manifest.yaml
+++ b/.spec/modules/metadata/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/metadata/manifest.yaml
+# Module Manifest — metadata
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: metadata
+title: "Metadata Module"
+description: "Dynamic meta-tags and JSON-LD generation."
+domain: D3-seo
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/navigation/manifest.yaml
+++ b/.spec/modules/navigation/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/navigation/manifest.yaml
+# Module Manifest — navigation
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: navigation
+title: "Navigation Module"
+description: "Navigation menus, category trees, breadcrumbs."
+domain: D1-catalog
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/orders/manifest.yaml
+++ b/.spec/modules/orders/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/orders/manifest.yaml
+# Module Manifest — orders
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: orders
+title: "Orders Module"
+description: "Order lifecycle — creation, tracking, status transitions."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/payments/manifest.yaml
+++ b/.spec/modules/payments/manifest.yaml
@@ -1,0 +1,184 @@
+# .spec/modules/payments/manifest.yaml
+# Module Manifest — payments
+# Version: 1.0.0 | Status: draft | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271
+# References: .claude/rules/payments.md, domain-map.md v1.4.2, full-structural-audit.md v1.5.0
+
+module: payments
+title: "Payments Module (Paybox + SystemPay)"
+description: >
+  Handles payment initialization, gateway callbacks (Paybox CyberPlus, SystemPay),
+  HMAC signature verification (SHA512/SHA256), order status updates, refunds,
+  and payment method management. Critical security surface — timing-safe compare mandatory.
+domain: D4-orders
+status: draft
+
+# ── Database Surface ────────────────────────────────────────────────────────
+owned_tables:
+  # No dedicated payment tables in current schema — payments write to orders tables
+  # owned by orders module. See read_tables + change_surface note.
+  []
+
+read_tables:
+  # Orders domain — payments read and update order state
+  - ___xtr_order
+  - ___xtr_order_line
+  - ___xtr_order_line_status
+  - ___xtr_customer
+  - ___xtr_invoice
+  - ___xtr_invoice_line
+  # Cart tables (written by cart module, read for payment initialization)
+  - cart
+  - cart_items
+
+owned_rpcs:
+  # Payment-related RPCs
+  - get_payment_by_reference
+  - get_payments_by_order
+  - get_payments_by_user
+  - update_order_payment_status
+  - create_payment_record
+
+# ── HTTP Surface ────────────────────────────────────────────────────────────
+http_routes:
+  # Core payment endpoints
+  - method: POST
+    path: /api/payments
+    auth: session
+    notes: Initialize payment (Paybox or SystemPay), returns redirect URL
+  - method: GET
+    path: /api/payments/:id
+    auth: session
+    notes: Get payment by ID
+  - method: GET
+    path: /api/payments/user/:userId
+    auth: session
+    notes: List payments for a user
+  - method: GET
+    path: /api/payments/order/:orderId
+    auth: session
+  - method: GET
+    path: /api/payments/reference/:reference
+    auth: session
+  - method: POST
+    path: /api/payments/:id/cancel
+    auth: session
+  - method: POST
+    path: /api/payments/proceed-supplement
+    auth: session
+    notes: Pay supplement for an existing order
+  # Payment methods
+  - method: GET
+    path: /api/payments/methods/available
+    auth: session
+    notes: Available payment methods for current cart
+  - method: POST
+    path: /api/payments/test/create-with-consignes
+    auth: session
+    notes: Test endpoint — DEV only, must not be accessible in PROD
+  - method: GET
+    path: /api/payments/:id/transactions
+    auth: session
+  # Admin
+  - method: GET
+    path: /api/payments/stats
+    auth: admin
+  - method: GET
+    path: /api/payments/stats/global
+    auth: admin
+  - method: GET
+    path: /api/payments
+    auth: admin
+    notes: List all payments
+  # Paybox callback (public — signed by Paybox HMAC)
+  - method: POST
+    path: /api/paybox/callback
+    auth: public
+    notes: "CRITICAL: HMAC-SHA512 verification required. timingSafeEqual mandatory."
+  - method: GET
+    path: /api/paybox/callback
+    auth: public
+    notes: Paybox GET callback (some scenarios)
+  - method: GET
+    path: /api/paybox/redirect
+    auth: public
+    notes: Post-payment redirect
+  # SystemPay callback (public — signed by SystemPay HMAC)
+  - method: GET
+    path: /api/systempay/redirect
+    auth: public
+    notes: "CRITICAL: HMAC-SHA256 verification. vads_* params sorted alphabetically."
+  # CyberPlus / unified callback
+  - method: POST
+    path: /api/payments/callback/cyberplus
+    auth: public
+    notes: "CRITICAL: Verify signature before any state change."
+  - method: POST
+    path: /api/payments/callback/success
+    auth: public
+  - method: POST
+    path: /api/payments/callback/error
+    auth: public
+  # Admin monitoring
+  - method: GET
+    path: /api/admin/paybox-monitoring
+    auth: admin
+  - method: GET
+    path: /api/admin/paybox-health
+    auth: admin
+
+# ── Exports & Dependencies ───────────────────────────────────────────────────
+public_exports:
+  - symbol: PaymentsModule
+    kind: service
+  - symbol: PaymentsService
+    kind: service
+    notes: Used by orders module for payment status lookup
+  - symbol: PayboxCallbackGateService
+    kind: service
+    notes: Security gate — HMAC verification. Never bypass.
+
+depends_on:
+  - orders     # Order state updates after payment
+  - cart       # Cart data for payment initialization
+  - customers  # Customer data for billing
+  - config     # Gateway credentials (PAYBOX_*, SYSTEMPAY_*)
+
+# ── Invariants ───────────────────────────────────────────────────────────────
+invariants_ref:
+  # Orders/payments integrity (D4-orders)
+  - INV-046    # customer-email-not-null
+  - INV-047    # customer-email-unique
+  - INV-048    # order-fk-customer
+  - INV-049    # order-line-fk-order
+  - INV-050    # order-line-quantity-positive
+  - INV-051    # order-line-unit-price-non-negative
+  - INV-052    # order-status-valid
+  - INV-053    # invoice-line-fk-invoice
+  - INV-054    # invoice-fk-order
+  - INV-055    # order-line-status-valid
+
+# ── Change Surface ────────────────────────────────────────────────────────────
+change_surface:
+  risk_level: critical
+  requires_data_ops_approval: false
+  requires_seo_approval: false
+  review_checklist:
+    # Security checks (non-negotiable)
+    - "timingSafeEqual must be used for ALL HMAC comparisons — never === for signatures"
+    - "normalizeOrderId() must be called before any DB lookup in callback handlers"
+    - "Verify error code before marking order as paid"
+    - "No HMAC keys hardcoded — must come from config module only"
+    - "Test endpoints (/test/*) must not be reachable in production (Docker env check)"
+    - "vads_* params for SystemPay must remain sorted alphabetically before HMAC"
+    # Order integrity checks
+    - "Run INV-046 through INV-055 to confirm order/customer FK integrity"
+    - "Verify payment status transitions are idempotent (duplicate Paybox callbacks)"
+    - "Check that refund flow does not double-refund (reference idempotency key)"
+    # Dependency checks
+    - "Confirm PayboxCallbackGateService is not bypassed in any new route"
+    - "Verify OrdersModule dependency injection is not broken after changes"
+  gate_battery:
+    - manifest-check
+    - invariant-check-D4-orders
+    - security-payment-hmac

--- a/.spec/modules/products/manifest.yaml
+++ b/.spec/modules/products/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/products/manifest.yaml
+# Module Manifest — products
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: products
+title: "Products Module"
+description: "Product detail pages REST layer (thin wrapper over catalog)."
+domain: D1-catalog
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/promo/manifest.yaml
+++ b/.spec/modules/promo/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/promo/manifest.yaml
+# Module Manifest — promo
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: promo
+title: "Promo Module"
+description: "Promotional codes and discount logic."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/rag-proxy/manifest.yaml
+++ b/.spec/modules/rag-proxy/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/rag-proxy/manifest.yaml
+# Module Manifest — rag-proxy
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: rag-proxy
+title: "Rag Proxy Module"
+description: "RAG knowledge base ingestion, web ingest jobs, refresh logs."
+domain: D6-rag
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/rm/manifest.yaml
+++ b/.spec/modules/rm/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/rm/manifest.yaml
+# Module Manifest — rm
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: rm
+title: "Rm Module"
+description: "CQRS read model — pre-computed catalogue listings."
+domain: D8-readmodel
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/search/manifest.yaml
+++ b/.spec/modules/search/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/search/manifest.yaml
+# Module Manifest — search
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: search
+title: "Search Module"
+description: "Full-text and reference search across pieces."
+domain: D1-catalog
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/seo-logs/manifest.yaml
+++ b/.spec/modules/seo-logs/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/seo-logs/manifest.yaml
+# Module Manifest — seo-logs
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: seo-logs
+title: "Seo Logs Module"
+description: "SEO generation logs and quality scoring."
+domain: D3-seo
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/seo/manifest.yaml
+++ b/.spec/modules/seo/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/seo/manifest.yaml
+# Module Manifest — seo
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: seo
+title: "Seo Module"
+description: "SEO page generation V4 — meta, OG, JSON-LD, sitemap."
+domain: D3-seo
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/shipping/manifest.yaml
+++ b/.spec/modules/shipping/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/shipping/manifest.yaml
+# Module Manifest — shipping
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: shipping
+title: "Shipping Module"
+description: "Shipping methods, carrier rates, delivery zones."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/staff/manifest.yaml
+++ b/.spec/modules/staff/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/staff/manifest.yaml
+# Module Manifest — staff
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: staff
+title: "Staff Module"
+description: "Internal staff accounts and roles."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/substitution/manifest.yaml
+++ b/.spec/modules/substitution/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/substitution/manifest.yaml
+# Module Manifest — substitution
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: substitution
+title: "Substitution Module"
+description: "Cross-reference and piece substitution lookup."
+domain: D1-catalog
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/suppliers/manifest.yaml
+++ b/.spec/modules/suppliers/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/suppliers/manifest.yaml
+# Module Manifest — suppliers
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: suppliers
+title: "Suppliers Module"
+description: "Supplier catalogue links and data (___xtr_supplier)."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/support/manifest.yaml
+++ b/.spec/modules/support/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/support/manifest.yaml
+# Module Manifest — support
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: support
+title: "Support Module"
+description: "Customer support messaging and ticket handling."
+domain: D2-legacy
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/system/manifest.yaml
+++ b/.spec/modules/system/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/system/manifest.yaml
+# Module Manifest — system
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: system
+title: "System Module"
+description: "System-level operations, cache flush, admin utils."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/upload/manifest.yaml
+++ b/.spec/modules/upload/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/upload/manifest.yaml
+# Module Manifest — upload
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: upload
+title: "Upload Module"
+description: "File upload handling (images, documents)."
+domain: D5-structural
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/users/manifest.yaml
+++ b/.spec/modules/users/manifest.yaml
@@ -1,0 +1,25 @@
+# .spec/modules/users/manifest.yaml
+# Module Manifest — users
+# Version: 1.0.0 | Status: stub | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271 — AUTO-GENERATED STUB
+# TODO: human review required before promoting to draft/certified
+
+module: users
+title: "Users Module"
+description: "User accounts, registration, profile management."
+domain: D4-orders
+status: stub
+
+owned_tables: []
+read_tables: []
+owned_rpcs: []
+http_routes: []
+public_exports: []
+depends_on: []
+invariants_ref: []
+
+change_surface:
+  risk_level: medium
+  review_checklist:
+    - "Stub not yet reviewed — fill owned_tables, http_routes, depends_on"
+    - "Promote status to draft after human review"

--- a/.spec/modules/vehicles/manifest.yaml
+++ b/.spec/modules/vehicles/manifest.yaml
@@ -1,0 +1,185 @@
+# .spec/modules/vehicles/manifest.yaml
+# Module Manifest — vehicles
+# Version: 1.0.0 | Status: draft | Owner: Software-Architect (d2e89803)
+# Source: AUT-272 / AUT-271
+# References: tecdoc-integration-roadmap-v3.md v3.19, domain-map.md v1.4.2
+
+module: vehicles
+title: "Vehicle & Compatibility Module"
+description: >
+  Manages vehicle catalogue (brands, models, types), TecDoc integration,
+  compatibility matching (piece ↔ vehicle), mine codes, motor codes, and
+  brand SEO pages. Owns the D4 domain tables.
+domain: D4-vehicle
+status: draft
+
+# ── Database Surface ────────────────────────────────────────────────────────
+owned_tables:
+  - auto_type
+  - auto_modele
+  - auto_marque
+  - auto_modele_group
+  - auto_type_number_code
+  - auto_type_motor_fuel
+  - auto_type_motor_code
+  - auto_modele_robot
+  - cars_engine
+  - vehicule_v1_dominant
+  # Cross-gamme-car tables: owned by vehicles, produced by TecDoc pipeline
+  - __cross_gamme_car
+  - __cross_gamme_car_new
+  - __cross_gamme_car_new2
+
+read_tables:
+  # D1: catalog compatibility joins
+  - pieces_gamme
+  - pieces_relation_type
+  - pieces_relation_criteria
+  # D3: SEO type/vlevel lookup
+  - __seo_type_vlevel
+  - __seo_type_switch
+  - __seo_gamme_car
+  - __seo_marque
+
+owned_rpcs:
+  # Vehicle-compatibility RPCs (from phase-2b-rpc-audit-results.md, VehicleModule)
+  - get_vehicle_compatible_pieces
+  - get_vehicle_profile
+  - get_brand_bestsellers
+  - get_vehicle_maillage
+  - search_vehicles_advanced
+  - get_vehicle_motor_codes
+  - get_vehicle_mine_codes
+  - get_top_brands
+
+# ── HTTP Surface ────────────────────────────────────────────────────────────
+http_routes:
+  - method: GET
+    path: /api/vehicles/brands
+    auth: public
+    notes: List all vehicle brands
+  - method: GET
+    path: /api/vehicles/brands/:brandId
+    auth: public
+    notes: Brand detail
+  - method: GET
+    path: /api/vehicles/brands/:brandId/models
+    auth: public
+    notes: Models for a brand
+  - method: GET
+    path: /api/vehicles/brands/:brandId/years
+    auth: public
+  - method: GET
+    path: /api/vehicles/models/:modelId/types
+    auth: public
+    notes: Types (motorizations) for a model
+  - method: GET
+    path: /api/vehicles/types/:typeId
+    auth: public
+    notes: Full type detail
+  - method: GET
+    path: /api/vehicles/types/:typeId/motor-codes
+    auth: public
+  - method: GET
+    path: /api/vehicles/types/:typeId/mine-codes
+    auth: public
+  - method: GET
+    path: /api/vehicles/stats
+    auth: admin
+  - method: GET
+    path: /api/vehicles/search/advanced
+    auth: public
+  - method: GET
+    path: /api/vehicles/search/mine/:code
+    auth: public
+    notes: Search by mine code (French homologation code)
+  - method: GET
+    path: /api/vehicles/search/cnit/:code
+    auth: public
+  - method: GET
+    path: /api/vehicles/search/motor-code/:code
+    auth: public
+  - method: GET
+    path: /api/vehicles/mines/model/:id
+    auth: public
+  - method: GET
+    path: /api/vehicles/meta-tags/:typeId
+    auth: public
+    notes: SEO meta tags for a vehicle type page
+  - method: GET
+    path: /api/vehicles/brand/:brandAlias/bestsellers
+    auth: public
+    notes: Top pieces for a brand (SEO maillage)
+  - method: GET
+    path: /api/vehicles/brand/:brandId/maillage
+    auth: public
+    notes: Internal link maillage for brand
+  - method: GET
+    path: /api/vehicles/top-brands
+    auth: public
+  # Brand controller routes
+  - method: GET
+    path: /api/vehicles/brands/:brandAlias/forms
+    auth: public
+    notes: Vehicle selection forms (brands.controller.ts)
+
+# ── Exports & Dependencies ───────────────────────────────────────────────────
+public_exports:
+  - symbol: VehiclesModule
+    kind: service
+  - symbol: VehiclesService
+    kind: service
+  - symbol: VehicleRpcService
+    kind: service
+    notes: Used by catalog/seo for compatibility joins
+  - symbol: BrandRpcService
+    kind: service
+  - symbol: EnhancedVehicleService
+    kind: service
+  - symbol: VehicleProfileService
+    kind: service
+
+depends_on:
+  - seo        # SEO meta-tag generation
+  - catalog    # Piece compatibility reads
+
+# ── Invariants ───────────────────────────────────────────────────────────────
+invariants_ref:
+  # D2-vehicle invariants (from feature-invariants.json)
+  - INV-021    # auto-type-ktypnr-unique
+  - INV-022    # auto-modele-fk-marque
+  - INV-023    # auto-type-fk-modele
+  - INV-024    # auto-type-year-valid
+  - INV-025    # cross-gamme-car-fk-auto-type
+  - INV-026    # cross-gamme-car-fk-pg
+  - INV-027    # auto-type-number-code-fk-type
+  - INV-028    # auto-type-sequential-range
+
+# ── SEO Contracts ────────────────────────────────────────────────────────────
+seo_contracts:
+  canonical_table: __seo_type_vlevel
+  sitemap_feeds:
+    - __sitemap_motorisation
+    - __seo_marque
+  noindex_rules:
+    - "auto_type.type_id in range [60000..83456] → noindex (TecDoc sequential remap 2026-03-27)"
+    - "auto_type.type_id >= 100000 → 301 redirect (orphan protection)"
+  robots_policy: index_follow
+
+# ── Change Surface ────────────────────────────────────────────────────────────
+change_surface:
+  risk_level: critical
+  requires_data_ops_approval: true
+  requires_seo_approval: true
+  review_checklist:
+    - "Verify no auto_type rows are deleted (retirement only via SEO-protection flag)"
+    - "Check that type_id sequential range [60000..83456] noindex is preserved"
+    - "Confirm __cross_gamme_car_new remains the primary consumer (not _new2 orphan)"
+    - "Run INV-021 through INV-028 SQL gates before merge"
+    - "Verify VehicleRpcService is not broken — used by catalog and seo modules"
+    - "Check sitemap __sitemap_motorisation regeneration is not triggered unintentionally"
+    - "SEO approval required if routes /api/vehicles/brand/:brandAlias/* change"
+    - "Data-Ops approval required for any migration touching D4 tables"
+  gate_battery:
+    - manifest-check
+    - invariant-check-D2-vehicle

--- a/docs/adr/0001-module-manifest-schema.md
+++ b/docs/adr/0001-module-manifest-schema.md
@@ -1,0 +1,106 @@
+# ADR-001 — Module Manifest Schema
+
+**Status:** Accepted  
+**Date:** 2026-04-13  
+**Author:** Software-Architect (d2e89803)  
+**Parent issue:** [AUT-281](/AUT/issues/AUT-281) · [AUT-271](/AUT/issues/AUT-271)  
+**Supersedes:** —  
+**Superseded by:** —
+
+---
+
+## Context
+
+AutoMecanik's monorepo has grown to ~40+ backend modules without a formal ownership contract. The result:
+
+- No machine-readable declaration of which module owns which tables → cross-module writes proliferate silently
+- No invariants_ref → regression gates can't be automatically scoped to a module's test suite
+- No forbidden_imports enforcement → circular dependencies accumulate
+- No risk_level signal → CTO can't prioritise review budget
+
+The TecDoc post-migration epic ([AUT-271](/AUT/issues/AUT-271)) requires a contractual baseline before adding new modules (`vehicles`, `payments`, and 43 others). Without a schema, the manifests would be prose documents with no machine enforcement.
+
+Prior to this ADR there was no `.spec/modules/` directory and no schema artifact.
+
+---
+
+## Decision
+
+We adopt a **YAML module manifest** for every backend/frontend module, validated against a JSON Schema declared at `.spec/modules/_schema.yaml`.
+
+Each manifest lives at `.spec/modules/<name>/manifest.yaml`.
+
+### Required fields (gate-blocking if absent)
+
+| Field | Purpose |
+|---|---|
+| `name` | Kebab-case identifier, matches directory name |
+| `version` | SemVer; gates compare against last merged version |
+| `owner_agent` | Paperclip agent UUID — who is accountable for code changes |
+| `risk_level` | `low / medium / high / critical` — gates enforce review quorum |
+| `change_surface` | `isolated / cross-module / cross-domain / infra` |
+| `owned_tables.write` | Tables this module exclusively writes; violations trigger `db-ownership-gate` |
+| `owned_tables.read` | Cross-module reads (informational, for dep graph) |
+| `owned_rpcs` | Supabase RPC functions owned; needed for RPC Gate allowlist generation |
+| `forbidden_imports` | dep-cruiser enforces these at lint time |
+| `invariants_ref` | INV-NNN IDs from `feature-invariants.json`; invariants-nightly CI runs these |
+
+### Optional but recommended fields
+
+`http_routes`, `public_exports`, `depends_on_modules`, `seo_contracts`, `canonical_tests`, `description`, `status`
+
+### Status lifecycle
+
+```
+draft → certified → deprecated → retired
+```
+
+- **draft**: manifest written, gates advisory only
+- **certified**: gate battery green for 5 consecutive runs; auto-merge unlocked
+- **deprecated**: retirement announced; freeze window begins (72h per ADR-003)
+- **retired**: archived to `.spec/retired/`, no new imports allowed
+
+### Ownership rule
+
+Software-Architect (`d2e89803`) is **never** `owner_agent` on any module manifest. Software-Architect owns only `.spec/**` artifacts. Module code ownership belongs to Code-Fixer or the assigned backend agent.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Gate automation**: `manifest-check` CI gate can validate schema conformance on every PR touching `.spec/modules/`.
+- **Invariant scoping**: `invariants-nightly` CI maps `INV-NNN` refs to modules, reports drift by domain.
+- **Dep-cruiser integration**: `forbidden_imports` feeds the dep-cruiser allowlist without manual config files.
+- **Risk-based review quorum**: `risk_level: critical` PRs require CTO approval before merge.
+- **Retirement traceability**: nothing is deleted; `.spec/retired/` holds all retired manifests.
+
+### Negative / trade-offs
+
+- **Maintenance overhead**: every new module requires a manifest PR through Software-Architect.
+- **Bootstrapping cost**: 43 existing modules need manifests written (scope of [AUT-272](/AUT/issues/AUT-272)).
+- **Schema evolution risk**: adding required fields to `_schema.yaml` invalidates all existing manifests until updated. Mitigation: required fields may only be added via a new ADR.
+
+### Neutral
+
+- The schema is intentionally permissive on optional fields to minimise initial adoption friction. Fields become required only via explicit ADR.
+
+---
+
+## Validation Criterion
+
+The schema is considered valid when it successfully validates the first two module manifests:
+
+1. `.spec/modules/vehicles/manifest.yaml` (deliverable of [AUT-272](/AUT/issues/AUT-272))
+2. `.spec/modules/payments/manifest.yaml` (deliverable of [AUT-272](/AUT/issues/AUT-272))
+
+If either fails schema validation, this ADR is reopened for revision before [AUT-272](/AUT/issues/AUT-272) proceeds to mass scaffolding.
+
+---
+
+## Artefacts
+
+- Schema: [`.spec/modules/_schema.yaml`](../../.spec/modules/_schema.yaml)
+- Gate design: `gates/manifest-check.ts` (to be implemented by CI-CD-Watch)
+- Nightly drift sweep: `gates/manifest-drift.ts` (to be consumed by Code-Analyst, [AUT-272](/AUT/issues/AUT-272))

--- a/docs/adr/0002-dev-only-db-write-enforcement.md
+++ b/docs/adr/0002-dev-only-db-write-enforcement.md
@@ -1,0 +1,113 @@
+# ADR-002 — Dev-only DB Write Enforcement
+
+**Status:** Accepted — Hardening ticket opened (see §Consequences)  
+**Date:** 2026-04-13  
+**Author:** Software-Architect (d2e89803)  
+**Parent issue:** [AUT-282](/AUT/issues/AUT-282) · [AUT-271](/AUT/issues/AUT-271)  
+**Supersedes:** —
+
+---
+
+## Context
+
+[AUT-271](/AUT/issues/AUT-271) assumes that write access to the Supabase production DB is restricted to the backend application server. This ADR investigates and documents the enforcement mechanism.
+
+Three enforcement modes were evaluated:
+
+1. **Network-level** (VPC/SG/firewall): Supabase project configured to only accept connections from the prod server IP.
+2. **IAM/RLS**: service_role key scoped; Row Level Security policies block writes from certain roles/contexts.
+3. **Convention only**: any holder of `SUPABASE_SERVICE_ROLE_KEY` can write to prod with no technical barrier.
+
+---
+
+## Investigation
+
+### Credential surface — where the key exists
+
+| Location | Key type | Purpose |
+|---|---|---|
+| `backend/.env.example` | placeholder `your-service-role-key` | Developer bootstrap template |
+| `backend/.env` (prod server, not in git) | real key | Runtime — injected via docker-compose env |
+| `docker-compose.prod.yml` | env passthrough (`${SUPABASE_SERVICE_ROLE_KEY}`) | Passes host `.env` into container |
+| `docker-compose.preprod.yml` | same pattern | Preprod environment |
+| `docker-compose.ci-deploy.yml` | same pattern | CI deploy step |
+| GitHub Secret: `SUPABASE_SERVICE_ROLE_KEY` | real key | Injected during CI deploy job via `sed -i` into `.env` on prod host |
+| CI test matrix | `mock-key-for-ci` (fake) | Unit/integration tests use a mock — ✅ never touches prod DB |
+
+The real key exists in **two places**: the prod host `.env` and the GitHub repository secret.
+
+### Network-level enforcement
+
+Supabase Cloud projects support an **IP allowlist** feature (Settings → Database → Network Restrictions). Investigation of the codebase, docker-compose files, and `.spec/` reveals **no evidence** of IP allowlist configuration in scripts or documentation.
+
+**Verdict: No verified network-level enforcement.**
+
+### RLS enforcement
+
+`SUPABASE_SERVICE_ROLE_KEY` is the service role key. By design in Supabase, the service role **bypasses all Row Level Security policies**. RLS is not a barrier when using this key.
+
+**Verdict: RLS does not protect against writes using the service_role key.**
+
+### IAM scoping
+
+Supabase does not currently support fine-grained IAM scoping of the service_role key (e.g., read-only service roles). The anon key exists separately but is not used for backend writes.
+
+**Verdict: No IAM enforcement available with current Supabase tier.**
+
+### Conclusion
+
+**Enforcement mode: Convention only (Mode 3).**
+
+The current model relies entirely on the convention that developers do not run code that writes to prod using the service role key outside of the deployed backend application. There is no technical barrier preventing anyone who possesses the key from executing arbitrary writes against the production Supabase database.
+
+---
+
+## Decision
+
+We **accept the current convention-based model as a documented baseline** while simultaneously opening a hardening workstream. The architecture plan (AUT-271) may proceed under this baseline, but the following hardening tasks are opened as P0 follow-up:
+
+### Hardening recommendations (see §Consequences for ticket)
+
+**H1 — Enable Supabase IP Allowlist (P0 Critical)**  
+Configure the Supabase production project to only accept connections from the production server IP (`49.12.233.2`) and the dev server IP (`46.224.118.55`). This is the single highest-leverage control.
+
+**H2 — GitHub Secret rotation policy**  
+`SUPABASE_SERVICE_ROLE_KEY` in GitHub Secrets should be rotated every 90 days. Rotation procedure: generate new key in Supabase dashboard → update GitHub Secret → trigger prod re-deploy. No downtime required.
+
+**H3 — Audit log alert**  
+Enable Supabase Audit Logs. Set an alert for writes originating from unexpected source IPs (future: once H1 is in place, any non-allowlisted write is already blocked).
+
+**H4 — CI: verify mock key is used in tests**  
+The CI pipeline already uses `mock-key-for-ci` — document and gate this (assert that `SUPABASE_URL` in CI points to `mock.supabase.co` and never to `*.supabase.co` with a real project ID).
+
+---
+
+## Consequences
+
+### Positive
+
+- Convention documented: all agents and developers now have explicit awareness that write access is not technically enforced.
+- Hardening path is clear and prioritized (H1 first).
+- CI/CD proof: tests demonstrably use a mock key — no prod data at risk from automated test runs.
+
+### Negative
+
+- **Risk exposure**: until H1 is implemented, any leaked `SUPABASE_SERVICE_ROLE_KEY` allows arbitrary writes to production. This risk pre-existed this ADR; it is now explicit.
+- **Hardening debt**: H1 requires Supabase dashboard access by a human operator (not automatable by agents).
+
+### Hardening ticket opened
+
+> **[AUT-282-H1] Activer l'IP allowlist Supabase prod** — Priority: Critical  
+> Scope: Supabase dashboard → Settings → Network Restrictions → add `49.12.233.2` (prod) + `46.224.118.55` (dev)  
+> Owner: CTO or human operator  
+> Unblocks: Full enforcement of "dev-only DB write" assumption in AUT-271
+
+This ADR is considered `Accepted` with the hardening ticket open. If H1 is never implemented, this ADR must be revisited before Phase 2 of AUT-271 (P2 firewall enforcement) is declared complete.
+
+---
+
+## Artefacts
+
+- This document: `docs/adr/0002-dev-only-db-write-enforcement.md`
+- Related: [AUT-271](/AUT/issues/AUT-271), [AUT-273](/AUT/issues/AUT-273) (DB firewall design)
+- Key locations: see §Investigation table above

--- a/docs/adr/0002-dev-only-db-write-enforcement.md
+++ b/docs/adr/0002-dev-only-db-write-enforcement.md
@@ -1,7 +1,7 @@
 # ADR-002 — Dev-only DB Write Enforcement
 
-**Status:** Accepted — Hardening ticket opened (see §Consequences)  
-**Date:** 2026-04-13  
+**Status:** Accepted — Mode 1 (Network enforcement active); H1 done, H2-H4 retained as P1  
+**Date:** 2026-04-13 · **Revised:** 2026-04-14  
 **Author:** Software-Architect (d2e89803)  
 **Parent issue:** [AUT-282](/AUT/issues/AUT-282) · [AUT-271](/AUT/issues/AUT-271)  
 **Supersedes:** —
@@ -38,9 +38,11 @@ The real key exists in **two places**: the prod host `.env` and the GitHub repos
 
 ### Network-level enforcement
 
-Supabase Cloud projects support an **IP allowlist** feature (Settings → Database → Network Restrictions). Investigation of the codebase, docker-compose files, and `.spec/` reveals **no evidence** of IP allowlist configuration in scripts or documentation.
+Supabase Cloud projects support an **IP allowlist** feature (Settings → Database → Network Restrictions). Initial investigation of the codebase, docker-compose files, and `.spec/` found no evidence of IP allowlist configuration in scripts or documentation.
 
-**Verdict: No verified network-level enforcement.**
+**Board correction (2026-04-14):** The IP allowlist is already active in the Supabase production project. The initial investigation was a false negative caused by the Architect container lacking dashboard access. ✅ **Confirmed by board.**
+
+**Verdict: ✅ IP allowlist active — Network-level enforcement confirmed.**
 
 ### RLS enforcement
 
@@ -56,28 +58,28 @@ Supabase does not currently support fine-grained IAM scoping of the service_role
 
 ### Conclusion
 
-**Enforcement mode: Convention only (Mode 3).**
+**Enforcement mode: Network enforcement active (Mode 1).** *(Revised 2026-04-14 after board correction — see Network-level enforcement above.)*
 
-The current model relies entirely on the convention that developers do not run code that writes to prod using the service role key outside of the deployed backend application. There is no technical barrier preventing anyone who possesses the key from executing arbitrary writes against the production Supabase database.
+The IP allowlist restricts Supabase production connections to known server IPs, providing a technical barrier beyond convention. Anyone holding the `SUPABASE_SERVICE_ROLE_KEY` who is not originating from an allowlisted IP cannot write to the production database. The credential surface concern documented above (key in GitHub Secrets + prod host `.env`) remains valid and is addressed by H2-H4.
 
 ---
 
 ## Decision
 
-We **accept the current convention-based model as a documented baseline** while simultaneously opening a hardening workstream. The architecture plan (AUT-271) may proceed under this baseline, but the following hardening tasks are opened as P0 follow-up:
+We **accept the network-enforced model (Mode 1) as the confirmed baseline**. The architecture plan ([AUT-271](/AUT/issues/AUT-271)) may proceed under this enforcement. Remaining hardening tasks are retained as P1 follow-up:
 
 ### Hardening recommendations (see §Consequences for ticket)
 
-**H1 — Enable Supabase IP Allowlist (P0 Critical)**  
-Configure the Supabase production project to only accept connections from the production server IP (`49.12.233.2`) and the dev server IP (`46.224.118.55`). This is the single highest-leverage control.
+**H1 — Enable Supabase IP Allowlist** ✅ **DONE** *(confirmed by board 2026-04-14)*  
+IP allowlist already active: production server (`49.12.233.2`) and dev server (`46.224.118.55`) are the allowlisted sources. See [AUT-302](/AUT/issues/AUT-302) — H1 closed.
 
-**H2 — GitHub Secret rotation policy**  
+**H2 — GitHub Secret rotation policy (P1)**  
 `SUPABASE_SERVICE_ROLE_KEY` in GitHub Secrets should be rotated every 90 days. Rotation procedure: generate new key in Supabase dashboard → update GitHub Secret → trigger prod re-deploy. No downtime required.
 
-**H3 — Audit log alert**  
-Enable Supabase Audit Logs. Set an alert for writes originating from unexpected source IPs (future: once H1 is in place, any non-allowlisted write is already blocked).
+**H3 — Audit log alert (P1)**  
+Enable Supabase Audit Logs. Set an alert for writes originating from unexpected source IPs (with H1 active, any non-allowlisted write is already blocked at network level).
 
-**H4 — CI: verify mock key is used in tests**  
+**H4 — CI: verify mock key is used in tests (P1)**  
 The CI pipeline already uses `mock-key-for-ci` — document and gate this (assert that `SUPABASE_URL` in CI points to `mock.supabase.co` and never to `*.supabase.co` with a real project ID).
 
 ---
@@ -86,28 +88,32 @@ The CI pipeline already uses `mock-key-for-ci` — document and gate this (asser
 
 ### Positive
 
-- Convention documented: all agents and developers now have explicit awareness that write access is not technically enforced.
-- Hardening path is clear and prioritized (H1 first).
+- Network enforcement (Mode 1) confirmed active: IP allowlist blocks connections from non-allowlisted sources.
+- H1 complete: the single highest-leverage control is already in production.
 - CI/CD proof: tests demonstrably use a mock key — no prod data at risk from automated test runs.
+- Credential surface is fully documented; remaining H2-H4 controls address the residual risk.
 
 ### Negative
 
-- **Risk exposure**: until H1 is implemented, any leaked `SUPABASE_SERVICE_ROLE_KEY` allows arbitrary writes to production. This risk pre-existed this ADR; it is now explicit.
-- **Hardening debt**: H1 requires Supabase dashboard access by a human operator (not automatable by agents).
+- **Residual risk**: a leaked `SUPABASE_SERVICE_ROLE_KEY` used from an allowlisted IP would still reach prod — mitigated by H2 (rotation) and H3 (audit alerts).
+- **Hardening debt**: H2-H4 remain open as P1; H3 requires Supabase dashboard access by a human operator.
 
-### Hardening ticket opened
+### Hardening ticket status
 
-> **[AUT-282-H1] Activer l'IP allowlist Supabase prod** — Priority: Critical  
-> Scope: Supabase dashboard → Settings → Network Restrictions → add `49.12.233.2` (prod) + `46.224.118.55` (dev)  
-> Owner: CTO or human operator  
-> Unblocks: Full enforcement of "dev-only DB write" assumption in AUT-271
+> **[AUT-302](/AUT/issues/AUT-302) — Supabase hardening**  
+> H1: ✅ **DONE** — IP allowlist confirmed active by board (2026-04-14)  
+> H2-H4: Open — Priority **P1** (downgraded from P0 now that H1 is confirmed active)
 
-This ADR is considered `Accepted` with the hardening ticket open. If H1 is never implemented, this ADR must be revisited before Phase 2 of AUT-271 (P2 firewall enforcement) is declared complete.
+This ADR is considered `Accepted` with Mode 1 enforcement in place. H2-H4 are P1 and must be completed before Phase 2 of [AUT-271](/AUT/issues/AUT-271) (P2 firewall enforcement) is declared complete.
 
 ---
 
 ## Artefacts
 
 - This document: `docs/adr/0002-dev-only-db-write-enforcement.md`
-- Related: [AUT-271](/AUT/issues/AUT-271), [AUT-273](/AUT/issues/AUT-273) (DB firewall design)
+- Related: [AUT-271](/AUT/issues/AUT-271), [AUT-273](/AUT/issues/AUT-273) (DB firewall design), [AUT-302](/AUT/issues/AUT-302) (hardening H1-H4)
 - Key locations: see §Investigation table above
+
+---
+
+*Revised 2026-04-14 after board correction — initial Mode 3 verdict was a false negative (Architect container lacked Supabase dashboard access). Board confirmed IP allowlist already active. Verdict updated to Mode 1 (Network enforcement active). Task: [AUT-303](/AUT/issues/AUT-303).*

--- a/docs/adr/0003-grandfathering-gate-flip.md
+++ b/docs/adr/0003-grandfathering-gate-flip.md
@@ -1,0 +1,126 @@
+# ADR-003 — Grandfathering advisory→blocking flip
+
+**Status:** proposed  
+**Date:** 2026-04-14  
+**Author:** Software-Architect (d2e89803)  
+**Approver (required):** CTO (7fa3c971)  
+**Source:** [AUT-283](/AUT/issues/AUT-283) / [AUT-271](/AUT/issues/AUT-271)  
+**Depends on:** ADR-001 (module manifest schema), [AUT-276](/AUT/issues/AUT-276)
+
+---
+
+## Context
+
+Phase 1 of the architectural hardening plan (AUT-271) ends with the first batch of modules reaching `status: certified` in their manifest. At that point, the `manifest-check` gate — currently running in ADVISORY mode (exit 0 always) — must flip to **BLOCKING** for certified modules.
+
+PRs that are already open at the moment of the flip will fail their CI if they touch certified modules and haven't already satisfied the gate battery. Without a grandfathering protocol, the flip will cause cascading failures, block the team, and risk being reverted entirely.
+
+This ADR defines the controlled transition: a 72-hour freeze window, a label-based grace period for in-flight PRs, a drain strategy, and a rollback plan.
+
+---
+
+## Decision
+
+### 1. Freeze window — 72h before the flip
+
+- The CTO announces the flip date (`T-day`) at least **72 hours in advance** via a Paperclip comment on [AUT-276](/AUT/issues/AUT-276) and a message in `#eng` channel.
+- During the 72h window, no new module may be promoted to `certified`. The set of certified modules at `T-72h` is the **baseline set** for the flip.
+- A GitHub Actions workflow (`pre-gate-baseline-label.yml`, see below) runs at `T-72h` and automatically labels all currently open PRs that touch certified modules with `pre-gate-baseline`.
+
+### 2. Label `pre-gate-baseline` — grace period
+
+PRs labeled `pre-gate-baseline` receive the following treatment:
+
+| Window | Gate behavior |
+|--------|---------------|
+| `T` to `T+72h` | Gate remains ADVISORY — CI reports but does not block merge |
+| After `T+72h` | Gate is BLOCKING — PR must pass before merge or be closed |
+
+The label is applied automatically by the workflow and **must not be applied manually** except by Software-Architect or CTO.
+
+The label expires semantically at `T+72h`. The enforcement workflow removes it and switches the gate to blocking for that PR.
+
+### 3. Drain strategy
+
+At `T-day`, the following responsibilities apply:
+
+| Actor | Responsibility |
+|-------|----------------|
+| **PR author** | Primary responsibility: rebase on `main`, fix manifest violations before `T+72h` |
+| **Code-Analyst (77fbb90a)** | Nightly sweep: identify all open `pre-gate-baseline` PRs; comment on each with remaining time |
+| **Code-Fixer (b0df5075)** | If a PR is assigned to Code-Fixer and touches a certified module, it must be rebased and gate-compliant within 48h |
+| **CTO** | The only agent authorized to grant a `gate-override` extension beyond `T+72h`. Requires 2-agent approval (CTO + Data-Ops for DB-touching modules) |
+| **Software-Architect** | Does NOT apply `gate-override` unilaterally. Escalates via [AUT-271](/AUT/issues/AUT-271) comment |
+
+**Close vs rebase decision tree:**
+
+```
+PR has pre-gate-baseline label?
+├── YES → is it stale (no commits in 7d)?
+│   ├── YES → close with comment "stale at gate flip, please reopen when gate-compliant"
+│   └── NO → author must rebase by T+72h
+└── NO → gate is already blocking, PR must comply
+```
+
+### 4. Rollback plan
+
+If **>10% of non-stale open PRs** are blocked by the gate at `T+24h` and unable to drain:
+
+1. Software-Architect posts a Paperclip comment on [AUT-276](/AUT/issues/AUT-276) declaring rollback intent.
+2. CTO approves (explicit comment required — no silent auto-rollback).
+3. The gate is reverted to ADVISORY for all modules by setting `GATE_MODE=advisory` in the workflow environment variable.
+4. A post-mortem issue is opened (child of AUT-271) within 48h.
+5. The flip is retried at `S+1` (next sprint start) with lessons applied.
+
+**Rollback is NOT automatic.** A human CTO approval is required at step 2.
+
+---
+
+## Schema change to `.spec/modules/_schema.yaml`
+
+No schema change required. The `status: certified` field already triggers blocking behavior in `gates/manifest-check.ts`.
+
+The gate reads `status` at runtime — promoting a module to `certified` is the activation mechanism.
+
+---
+
+## Implementation
+
+### Files produced by this ADR
+
+| File | Description |
+|------|-------------|
+| `.github/workflows/pre-gate-baseline-label.yml` | Workflow that labels open PRs and manages grace period |
+| `docs/runbooks/gate-flip-day.md` | Step-by-step runbook for the operator executing the flip |
+| `docs/adr/0003-grandfathering-gate-flip.md` | This ADR |
+
+### What this ADR does NOT decide
+
+- Which modules are first to reach `certified` — that is decided by the CTO during review of individual `draft` manifests.
+- The exact `T-day` date — CTO decides based on sprint progress.
+- The `prevent-regression` gate ([AUT-276](/AUT/issues/AUT-276)) — that gate has its own ADR. This ADR covers the flip of `manifest-check` only.
+
+---
+
+## Consequences
+
+**Positive:**
+- Teams have 72h advance notice — no surprise failures.
+- The `pre-gate-baseline` label makes the grace period explicit and auditable.
+- Rollback is defined and bounded — prevents the flip from being permanently reverted.
+
+**Negative:**
+- Adds operational complexity during the flip week.
+- Requires Code-Analyst to actively monitor PRs during `[T, T+72h]`.
+
+**Neutral:**
+- This ADR becomes irrelevant once all modules have reached `certified` status — at that point the gate is permanently blocking.
+
+---
+
+## Approval
+
+| Approver | Status | Date |
+|----------|--------|------|
+| CTO (7fa3c971) | **pending** | — |
+| Software-Architect (d2e89803) | proposed | 2026-04-14 |

--- a/docs/runbooks/gate-flip-day.md
+++ b/docs/runbooks/gate-flip-day.md
@@ -1,0 +1,145 @@
+# Runbook — Gate Flip Day (advisory → blocking)
+
+**Version:** 1.0.0  
+**Owner:** Software-Architect (d2e89803)  
+**Source:** ADR-003 / [AUT-283](/AUT/issues/AUT-283)  
+**Audience:** CTO, Software-Architect, Code-Analyst  
+**Last updated:** 2026-04-14
+
+---
+
+## Overview
+
+This runbook covers the controlled transition of the `manifest-check` gate from ADVISORY to BLOCKING mode for certified modules. Follow the steps in order. Do not skip steps without recording the reason.
+
+---
+
+## Pre-conditions (check all before starting)
+
+- [ ] CTO has approved ADR-003 (comment on [AUT-283](/AUT/issues/AUT-283))
+- [ ] At least 1 module has `status: certified` in its manifest
+- [ ] `T-day` announced in `#eng` at least 72h in advance
+- [ ] Pre-gate-baseline workflow (`pre-gate-baseline-label.yml`) is deployed and tested
+
+---
+
+## T-72h — Announce and label
+
+**Actor: CTO**
+
+1. Post in `#eng`: "Gate flip scheduled for [DATE+72h]. PRs touching certified modules must be gate-compliant by then or receive the `pre-gate-baseline` grace label."
+
+2. Post on [AUT-276](/AUT/issues/AUT-276): "@Software-Architect confirming T-day as [DATE+72h]. Proceed with baseline label run."
+
+**Actor: Software-Architect**
+
+3. Manually trigger `pre-gate-baseline-label.yml` via GitHub Actions > Run workflow, input `mode=label`.
+
+4. Verify the workflow run succeeds. Check labeled PRs list in the workflow summary.
+
+5. Post on [AUT-276](/AUT/issues/AUT-276): "Baseline label applied. N PRs labeled. Grace window closes at [DATE+72h]."
+
+---
+
+## T-0 — The flip
+
+**Actor: CTO**
+
+1. Merge the PR that sets `status: certified` for the first module (if not already merged).
+
+2. Verify `manifest-check.yml` gate runs in blocking mode on a test PR against the certified module:
+   ```bash
+   # Create a test branch touching a certified module
+   git checkout -b test/gate-flip-verification
+   touch backend/src/modules/<certified-module>/test-gate-flip.ts
+   git add -A && git commit -m "chore: gate flip verification test"
+   git push origin test/gate-flip-verification
+   # Open PR, verify CI blocks on manifest violation
+   # Then close the test PR without merging
+   ```
+
+3. If the gate blocks correctly: announce flip complete in `#eng`.
+
+4. If the gate does NOT block: do not announce. Investigate `gates/manifest-check.ts` — the `continue-on-error: true` in the workflow may need to be removed for certified-module PRs.
+
+---
+
+## T to T+72h — Grace period monitoring
+
+**Actor: Code-Analyst (77fbb90a)** — nightly sweep
+
+For each PR with `pre-gate-baseline` label:
+1. Check if the PR passes the `manifest-check` gate.
+2. If it passes: remove the `pre-gate-baseline` label (gate is already satisfied).
+3. If it fails: post a comment on the PR with remaining time and specific violations.
+
+**Actor: Software-Architect** — daily check
+
+1. Query open `pre-gate-baseline` PRs:
+   ```
+   GET /api/companies/{companyId}/issues?q=pre-gate-baseline&status=in_progress
+   ```
+   (or via GitHub: `gh pr list --label pre-gate-baseline`)
+
+2. If drain is proceeding normally (PRs closing or being fixed): no action.
+
+3. If >10% are blocked with no progress: escalate to CTO via [AUT-271](/AUT/issues/AUT-271) comment.
+
+---
+
+## T+72h — Grace period ends
+
+**Actor: GitHub Actions (automated)**
+
+The `pre-gate-baseline-label.yml` workflow runs again (scheduled at T+72h) with `mode=expire`:
+- Removes `pre-gate-baseline` label from all PRs
+- The gate is now BLOCKING for all PRs touching certified modules
+
+**Actor: Software-Architect**
+
+1. Verify the expiry run succeeded.
+2. Post on [AUT-276](/AUT/issues/AUT-276): "Grace period closed. Gate is now fully blocking for certified modules."
+
+---
+
+## Rollback procedure (if >10% PRs blocked at T+24h)
+
+**Decision gate: CTO must approve**
+
+1. Software-Architect posts on [AUT-276](/AUT/issues/AUT-276):
+   > "Rollback intent: [N] PRs blocked at T+24h ([%] of active PRs). Requesting CTO approval to revert gate to advisory."
+
+2. CTO approves via explicit comment (no silent approval).
+
+3. Software-Architect edits `.github/workflows/manifest-check.yml`:
+   - Change `continue-on-error: false` back to `continue-on-error: true`
+   - OR set `GATE_MODE: advisory` in env block
+   - Commit, push, merge to main immediately.
+
+4. Post in `#eng`: "Gate reverted to advisory. Post-mortem scheduled within 48h."
+
+5. Open post-mortem issue (child of [AUT-271](/AUT/issues/AUT-271)) within 48h.
+
+6. Plan retry at S+1 (next sprint start).
+
+---
+
+## Gate-override (emergency bypass)
+
+`gate-override` label requires **2-agent approval**:
+- Modules touching DB: CTO + Data-Ops (0bd1fd16)
+- Modules touching SEO: CTO + IA-SEO Master / CEO (993a4a02)
+
+Software-Architect **cannot** apply `gate-override` unilaterally. Attempting to do so is a governance violation.
+
+---
+
+## Contacts and escalation
+
+| Role | Agent ID | Responsibility |
+|------|----------|----------------|
+| Software-Architect | d2e89803 | Gate design, runbook owner |
+| CTO | 7fa3c971 | Final approver, rollback decision |
+| Code-Analyst | 77fbb90a | Nightly sweep, PR tracking |
+| Data-Ops | 0bd1fd16 | DB gate-override co-approval |
+| IA-SEO Master / CEO | 993a4a02 | SEO gate-override co-approval |

--- a/gates/manifest-check.ts
+++ b/gates/manifest-check.ts
@@ -1,0 +1,368 @@
+/**
+ * gates/manifest-check.ts
+ *
+ * Module Manifest Gate — AutoMecanik
+ * Version: 1.0.0 | Mode: ADVISORY (report-only)
+ * Source: AUT-272 / AUT-271 | ADR: docs/adr/0001-module-manifest-schema.md
+ *
+ * This gate:
+ *   1. Discovers changed files in the PR diff
+ *   2. Resolves which module each file belongs to
+ *   3. Verifies a manifest exists and is valid for that module
+ *   4. In ADVISORY mode: reports violations but exits 0
+ *   5. In BLOCKING mode (status=certified modules): exits non-zero
+ *
+ * Phase 0-1 (current): ADVISORY globally
+ * Phase 2+: BLOCKING for modules with status=certified
+ *
+ * Usage:
+ *   npx ts-node gates/manifest-check.ts [--changed-files <file>] [--mode advisory|blocking]
+ *   CHANGED_FILES=file1,file2 npx ts-node gates/manifest-check.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface ManifestHttpRoute {
+  method: string;
+  path: string;
+  auth?: string;
+  notes?: string;
+}
+
+interface ManifestPublicExport {
+  symbol: string;
+  kind: string;
+  notes?: string;
+}
+
+interface ManifestChangeSurface {
+  risk_level?: string;
+  review_checklist: string[];
+  requires_data_ops_approval?: boolean;
+  requires_seo_approval?: boolean;
+  gate_battery?: string[];
+}
+
+interface ModuleManifest {
+  module: string;
+  title?: string;
+  description?: string;
+  domain?: string;
+  status: 'stub' | 'draft' | 'certified' | 'retired';
+  certification_date?: string;
+  owned_tables: string[];
+  read_tables?: string[];
+  owned_rpcs?: string[];
+  http_routes: ManifestHttpRoute[];
+  public_exports?: ManifestPublicExport[];
+  depends_on: string[];
+  invariants_ref?: string[];
+  seo_contracts?: Record<string, unknown>;
+  change_surface: ManifestChangeSurface;
+}
+
+interface GateResult {
+  file: string;
+  module: string | null;
+  manifestFound: boolean;
+  manifestValid: boolean;
+  manifestStatus: string;
+  violations: string[];
+  warnings: string[];
+}
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SPEC_MODULES_DIR = path.join(REPO_ROOT, '.spec', 'modules');
+const BACKEND_MODULES_DIR = path.join(REPO_ROOT, 'backend', 'src', 'modules');
+
+// File → module mapping rules (ordered, first match wins)
+const MODULE_PATH_PATTERNS: Array<{pattern: RegExp; module: string | null}> = [
+  // Backend modules
+  { pattern: /^backend\/src\/modules\/([^/]+)\//, module: null }, // capture group 1
+  // Frontend route clusters (future)
+  { pattern: /^frontend\/app\/routes\/vehicles/, module: 'vehicles' },
+  { pattern: /^frontend\/app\/routes\/panier/, module: 'cart' },
+  { pattern: /^frontend\/app\/routes\/pieces/, module: 'catalog' },
+  { pattern: /^frontend\/app\/routes\/admin/, module: 'admin' },
+  // Spec files are always allowed
+  { pattern: /^\.spec\//, module: '__spec__' },
+  // Gate files themselves
+  { pattern: /^gates\//, module: '__gates__' },
+  // Workflows
+  { pattern: /^\.github\/workflows\//, module: '__ci__' },
+  // Root config files — not module-specific
+  { pattern: /^(package\.json|turbo\.json|\.env|docker-compose|CLAUDE\.md|AGENTS\.md)/, module: '__root__' },
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function resolveModuleFromPath(filePath: string): string | null {
+  // Normalize to repo-relative path
+  const rel = filePath.replace(/^\//, '');
+
+  for (const rule of MODULE_PATH_PATTERNS) {
+    const match = rel.match(rule.pattern);
+    if (match) {
+      if (rule.module === null) {
+        // Use capture group 1 (backend module name)
+        return match[1] ?? null;
+      }
+      return rule.module;
+    }
+  }
+  return null;
+}
+
+function loadManifest(moduleName: string): ModuleManifest | null {
+  const manifestPath = path.join(SPEC_MODULES_DIR, moduleName, 'manifest.yaml');
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+  try {
+    const content = fs.readFileSync(manifestPath, 'utf-8');
+    return yaml.load(content) as ModuleManifest;
+  } catch (e) {
+    return null;
+  }
+}
+
+function validateManifest(manifest: ModuleManifest, moduleName: string): string[] {
+  const violations: string[] = [];
+
+  // Required fields
+  if (!manifest.module) {
+    violations.push('manifest.module is required');
+  } else if (manifest.module !== moduleName) {
+    violations.push(
+      `manifest.module="${manifest.module}" does not match directory name "${moduleName}"`,
+    );
+  }
+
+  if (!manifest.status) {
+    violations.push('manifest.status is required');
+  } else if (!['stub', 'draft', 'certified', 'retired'].includes(manifest.status)) {
+    violations.push(`manifest.status="${manifest.status}" is not a valid status`);
+  }
+
+  if (!Array.isArray(manifest.owned_tables)) {
+    violations.push('manifest.owned_tables must be an array');
+  }
+
+  if (!Array.isArray(manifest.http_routes)) {
+    violations.push('manifest.http_routes must be an array');
+  }
+
+  if (!Array.isArray(manifest.depends_on)) {
+    violations.push('manifest.depends_on must be an array');
+  }
+
+  if (!manifest.change_surface || !Array.isArray(manifest.change_surface.review_checklist)) {
+    violations.push('manifest.change_surface.review_checklist is required and must be an array');
+  }
+
+  return violations;
+}
+
+function checkTableOwnership(
+  manifest: ModuleManifest,
+  moduleName: string,
+  allManifests: Map<string, ModuleManifest>,
+): string[] {
+  const violations: string[] = [];
+
+  // Check that each owned_table is not also claimed by another module
+  for (const table of manifest.owned_tables || []) {
+    for (const [otherModule, otherManifest] of allManifests) {
+      if (otherModule === moduleName) continue;
+      if ((otherManifest.owned_tables || []).includes(table)) {
+        violations.push(
+          `Table "${table}" is claimed by both "${moduleName}" and "${otherModule}" — a table must have exactly one owner`,
+        );
+      }
+    }
+  }
+
+  return violations;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const modeArg = args.find((a) => a === '--mode');
+  const modeIdx = args.indexOf('--mode');
+  const forceMode = modeIdx !== -1 ? args[modeIdx + 1] : null;
+
+  // Collect changed files from env or --changed-files arg
+  let changedFiles: string[] = [];
+  const changedFilesEnv = process.env.CHANGED_FILES;
+  const changedFilesArgIdx = args.indexOf('--changed-files');
+
+  if (changedFilesArgIdx !== -1 && args[changedFilesArgIdx + 1]) {
+    const filePath = args[changedFilesArgIdx + 1];
+    if (fs.existsSync(filePath)) {
+      changedFiles = fs
+        .readFileSync(filePath, 'utf-8')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+    }
+  } else if (changedFilesEnv) {
+    changedFiles = changedFilesEnv.split(',').map((f) => f.trim()).filter(Boolean);
+  } else {
+    // Fall back to git diff against main
+    const { execSync } = require('child_process');
+    try {
+      const out = execSync('git diff --name-only origin/main...HEAD 2>/dev/null || git diff --name-only HEAD~1 HEAD', {
+        encoding: 'utf-8',
+        cwd: REPO_ROOT,
+      });
+      changedFiles = out.split('\n').map((l: string) => l.trim()).filter(Boolean);
+    } catch {
+      changedFiles = [];
+    }
+  }
+
+  if (changedFiles.length === 0) {
+    console.log('manifest-check: no changed files detected, skipping.');
+    process.exit(0);
+  }
+
+  // Load all manifests for cross-ownership checks
+  const allManifests = new Map<string, ModuleManifest>();
+  if (fs.existsSync(SPEC_MODULES_DIR)) {
+    for (const entry of fs.readdirSync(SPEC_MODULES_DIR, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const m = loadManifest(entry.name);
+      if (m) allManifests.set(entry.name, m);
+    }
+  }
+
+  const results: GateResult[] = [];
+  const processedModules = new Set<string>();
+
+  for (const file of changedFiles) {
+    const moduleName = resolveModuleFromPath(file);
+
+    // Skip spec/gate/root files — they don't need module manifests
+    if (
+      moduleName === '__spec__' ||
+      moduleName === '__gates__' ||
+      moduleName === '__ci__' ||
+      moduleName === '__root__'
+    ) {
+      continue;
+    }
+
+    if (!moduleName) {
+      results.push({
+        file,
+        module: null,
+        manifestFound: false,
+        manifestValid: false,
+        manifestStatus: 'unknown',
+        violations: [`File "${file}" could not be mapped to any module`],
+        warnings: [],
+      });
+      continue;
+    }
+
+    // Only process each module once (multiple files in same module)
+    if (processedModules.has(moduleName)) continue;
+    processedModules.add(moduleName);
+
+    const manifest = loadManifest(moduleName);
+
+    if (!manifest) {
+      results.push({
+        file,
+        module: moduleName,
+        manifestFound: false,
+        manifestValid: false,
+        manifestStatus: 'missing',
+        violations: [`No manifest found at .spec/modules/${moduleName}/manifest.yaml`],
+        warnings: [],
+      });
+      continue;
+    }
+
+    const schemaViolations = validateManifest(manifest, moduleName);
+    const ownershipViolations = checkTableOwnership(manifest, moduleName, allManifests);
+    const allViolations = [...schemaViolations, ...ownershipViolations];
+
+    const warnings: string[] = [];
+    if (manifest.status === 'stub') {
+      warnings.push(`Module "${moduleName}" has status=stub — manifest not yet reviewed`);
+    }
+    if (manifest.status === 'draft') {
+      warnings.push(`Module "${moduleName}" has status=draft — not yet gate-enforced`);
+    }
+
+    results.push({
+      file,
+      module: moduleName,
+      manifestFound: true,
+      manifestValid: allViolations.length === 0,
+      manifestStatus: manifest.status,
+      violations: allViolations,
+      warnings,
+    });
+  }
+
+  // ── Report ──────────────────────────────────────────────────────────────────
+
+  console.log('\n╔══════════════════════════════════════════════════════════╗');
+  console.log('║         manifest-check gate — AutoMecanik                ║');
+  console.log('╚══════════════════════════════════════════════════════════╝');
+  console.log(`\nMode: ADVISORY (Phase 0-1 — report only)\n`);
+  console.log(`Changed files analyzed: ${changedFiles.length}`);
+  console.log(`Modules touched: ${processedModules.size}\n`);
+
+  let blockingViolations = 0;
+  let advisoryViolations = 0;
+
+  for (const result of results) {
+    const icon = result.manifestFound && result.manifestValid ? '✓' : '✗';
+    const statusLabel = result.manifestStatus;
+
+    console.log(`${icon} [${statusLabel.toUpperCase()}] ${result.module ?? result.file}`);
+
+    for (const v of result.violations) {
+      console.log(`    VIOLATION: ${v}`);
+      // In BLOCKING mode, only certified modules fail the gate
+      if (result.manifestStatus === 'certified' || forceMode === 'blocking') {
+        blockingViolations++;
+      } else {
+        advisoryViolations++;
+      }
+    }
+
+    for (const w of result.warnings) {
+      console.log(`    WARNING:   ${w}`);
+    }
+  }
+
+  console.log('\n──────────────────────────────────────────────────────────');
+  console.log(`Blocking violations: ${blockingViolations}`);
+  console.log(`Advisory violations: ${advisoryViolations} (report only — not failing gate)`);
+
+  if (blockingViolations > 0) {
+    console.log('\n✗ GATE FAILED — certified module(s) have manifest violations.');
+    console.log('  Fix: update the manifest at .spec/modules/<module>/manifest.yaml');
+    process.exit(1);
+  } else {
+    console.log('\n✓ GATE PASSED (advisory mode — no certified modules blocked)');
+    process.exit(0);
+  }
+}
+
+main().catch((err) => {
+  console.error('manifest-check: unexpected error', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Consolidated spec deliverable for AUT-271 — post-TecDoc contractual baseline.

**Contents:**
- `docs/adr/` — ADR-001 (manifest schema), ADR-002 (DB write enforcement), ADR-003 (gate flip protocol)
- `.spec/modules/_schema.yaml` + 44 `manifest.yaml` files (AUT-272)
- `.spec/00-canon/invariants/sql/` — 69 executable SQL invariants (AUT-274)
- `.github/pull_request_template.md` — DoD checklist (AUT-277)
- `gates/manifest-check.ts` — advisory gate checker (AUT-272)
- `docs/runbooks/gate-flip-day.md` — ADR-003 runbook

**Not included** (require workflow token scope, push separately):
- `.github/workflows/manifest-check.yml`
- `.github/workflows/pre-gate-baseline-label.yml`

**Gate mode:** ADVISORY — no PRs blocked. Gate becomes blocking via ADR-003 when modules reach certified status.

**Hardening:** ADR-002 verdict = convention-based only. AUT-302 (P0) assigned to CTO for IP allowlist.

CTO review required. Do not auto-merge.

Co-Authored-By: Paperclip <noreply@paperclip.ing>