### PR TITLE
fix(gate-1): exclude .github/workflows/prod-*.yml from PROD ref scan

### DIFF
--- a/tools/validator-gates/gate-1-no-prod-supabase.sh
+++ b/tools/validator-gates/gate-1-no-prod-supabase.sh
@@ -28,6 +28,7 @@ EXCLUDE_GLOBS=(
   "backend/*.sh"
   ".vscode/**"
   "docker-compose.imgproxy.yml" # CDN URL whitelist, pas connexion DB
+  ".github/workflows/prod-*.yml" # PROD smoke tests / deploy workflows (CI, pas DEV)
 )
 
 # Cibles: seulement fichiers trackes pertinents


### PR DESCRIPTION
## Problem

GATE-1 (\`tools/validator-gates/gate-1-no-prod-supabase.sh\`) scannait tous les workflows GitHub, y compris \`.github/workflows/prod-smoke-tests.yml\` qui référence légitimement le project_ref PROD Supabase pour les smoke tests anti-régression.

Résultat : faux positifs bloquant toute PR récente sur \`🔒 DEV Safety (Blocking)\` — vu sur PR #80 et #81.

## Fix

Ajout \`.github/workflows/prod-*.yml\` à \`EXCLUDE_GLOBS\` — aligné avec la convention existante pour \`docker-compose.imgproxy.yml\` (CDN URL whitelist).

## Test plan

- [x] Test local : \`bash tools/validator-gates/gate-1-no-prod-supabase.sh\` → \`✅ GATE-1 PASSED\`
- [ ] CI verte sur cette PR
- [ ] Après merge : PR #80 et PR #81 DEV Safety passent automatiquement

## Unblocks

- #80 docs(claude-md): pointer unique vers governance-vault (ADR-015)
- #81 chore(governance): rm .local/governance-vault + pre-commit anti-regression