### PR TITLE
feat(diagnostic): exposer moteur __diag_* + delegation RAG (plan breezy-eagle propre)

### DIFF
--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.0.1",
-  "generated_at": "2026-04-18T16:30:00Z",
+  "version": "1.0.2",
+  "generated_at": "2026-04-20T13:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 166,
+  "total": 164,
   "functions": [
     {
       "name": "__gov_m1_table_sizes",
@@ -758,16 +758,6 @@
       "name": "search_seo_observable_by_dtc",
       "volatility": "STABLE",
       "reason": "SELECT only"
-    },
-    {
-      "name": "search_diag_symptoms",
-      "volatility": "STABLE",
-      "reason": "SELECT only - breezy-eagle public search (unaccent+substring on __diag_symptom)"
-    },
-    {
-      "name": "search_diag_maintenance",
-      "volatility": "STABLE",
-      "reason": "SELECT only - breezy-eagle public search (unaccent+substring on __diag_maintenance_operation)"
     },
     {
       "name": "show_limit",

--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.0.0",
-  "generated_at": "2026-02-03T14:00:00Z",
+  "version": "1.0.1",
+  "generated_at": "2026-04-18T16:30:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 164,
+  "total": 166,
   "functions": [
     {
       "name": "__gov_m1_table_sizes",
@@ -758,6 +758,16 @@
       "name": "search_seo_observable_by_dtc",
       "volatility": "STABLE",
       "reason": "SELECT only"
+    },
+    {
+      "name": "search_diag_symptoms",
+      "volatility": "STABLE",
+      "reason": "SELECT only - breezy-eagle public search (unaccent+substring on __diag_symptom)"
+    },
+    {
+      "name": "search_diag_maintenance",
+      "volatility": "STABLE",
+      "reason": "SELECT only - breezy-eagle public search (unaccent+substring on __diag_maintenance_operation)"
     },
     {
       "name": "show_limit",

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
@@ -190,7 +190,8 @@ export class DiagnosticEngineController {
         error: 'Format DTC invalide (ex: P0300, C0035)',
       };
     }
-    const result = await this.dataService.lookupDtc(parsed.data.code);
+    // Delegue au RAG via searchService (pivot 2026-04-18)
+    const result = await this.searchService.lookupDtc(parsed.data.code);
     return { success: true, ...result };
   }
 

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
@@ -14,10 +14,19 @@ import {
   Body,
   Query,
   Param,
+  Header,
   Logger,
 } from '@nestjs/common';
 import { DiagnosticEngineOrchestrator } from './diagnostic-engine.orchestrator';
 import { DiagnosticEngineDataService } from './diagnostic-engine.data-service';
+import { DiagnosticEngineSearchService } from './diagnostic-engine.search.service';
+import {
+  SearchQuerySchema,
+  DtcCodeSchema,
+  MaintenanceListQuerySchema,
+  SlugParamSchema,
+  PopularQuerySchema,
+} from './types/public-endpoints.schema';
 
 @Controller('api/diagnostic-engine')
 export class DiagnosticEngineController {
@@ -26,6 +35,7 @@ export class DiagnosticEngineController {
   constructor(
     private readonly orchestrator: DiagnosticEngineOrchestrator,
     private readonly dataService: DiagnosticEngineDataService,
+    private readonly searchService: DiagnosticEngineSearchService,
   ) {}
 
   /**
@@ -60,6 +70,7 @@ export class DiagnosticEngineController {
    * List active diagnostic systems
    */
   @Get('systems')
+  @Header('Cache-Control', 'public, max-age=3600')
   async getSystems() {
     const systems = await this.dataService.getActiveSystems();
     return {
@@ -69,6 +80,8 @@ export class DiagnosticEngineController {
         slug: s.slug,
         label: s.label,
         description: s.description,
+        icon_slug: s.icon_slug,
+        color_token: s.color_token,
       })),
     };
   }
@@ -134,6 +147,204 @@ export class DiagnosticEngineController {
         created_at: s.created_at,
       })),
     };
+  }
+
+  // ==========================================================================
+  // Public discovery endpoints (breezy-eagle plan Phase A4)
+  // Pour la surface /diagnostic-auto refactored + /entretien + typeahead
+  // ==========================================================================
+
+  /**
+   * GET /api/diagnostic-engine/search?q=...&limit=10
+   * Typeahead unifie symptomes + entretien + DTC
+   */
+  @Get('search')
+  @Header('Cache-Control', 'public, max-age=60')
+  async search(@Query() query: Record<string, string>) {
+    const parsed = SearchQuerySchema.safeParse(query);
+    if (!parsed.success) {
+      return {
+        success: false,
+        error: 'Parametres invalides',
+        details: parsed.error.issues.map((i) => i.message),
+      };
+    }
+    const results = await this.searchService.search(
+      parsed.data.q,
+      parsed.data.limit,
+    );
+    return { success: true, q: parsed.data.q, count: results.length, results };
+  }
+
+  /**
+   * GET /api/diagnostic-engine/dtc/:code
+   * Lookup DTC OBD-II → symptomes + causes probables
+   */
+  @Get('dtc/:code')
+  @Header('Cache-Control', 'public, max-age=86400')
+  async lookupDtc(@Param() params: Record<string, string>) {
+    const parsed = DtcCodeSchema.safeParse(params);
+    if (!parsed.success) {
+      return {
+        success: false,
+        error: 'Format DTC invalide (ex: P0300, C0035)',
+      };
+    }
+    const result = await this.dataService.lookupDtc(parsed.data.code);
+    return { success: true, ...result };
+  }
+
+  /**
+   * GET /api/diagnostic-engine/maintenance?system=&popular=&limit=
+   * Liste des operations d'entretien
+   */
+  @Get('maintenance')
+  @Header('Cache-Control', 'public, max-age=3600')
+  async listMaintenance(@Query() query: Record<string, string>) {
+    const parsed = MaintenanceListQuerySchema.safeParse(query);
+    if (!parsed.success) {
+      return {
+        success: false,
+        error: 'Parametres invalides',
+        details: parsed.error.issues.map((i) => i.message),
+      };
+    }
+
+    if (parsed.data.popular) {
+      const items = await this.dataService.popularMaintenance(
+        parsed.data.limit,
+      );
+      return { success: true, count: items.length, items };
+    }
+
+    const items = await this.dataService.listMaintenanceOps({
+      system: parsed.data.system,
+      limit: parsed.data.limit,
+    });
+    return { success: true, count: items.length, items };
+  }
+
+  /**
+   * GET /api/diagnostic-engine/maintenance/:slug
+   * Detail d'une operation d'entretien + symptomes lies
+   */
+  @Get('maintenance/:slug')
+  @Header('Cache-Control', 'public, max-age=3600')
+  async getMaintenance(@Param() params: Record<string, string>) {
+    const parsed = SlugParamSchema.safeParse(params);
+    if (!parsed.success) {
+      return { success: false, error: 'Slug invalide' };
+    }
+    const result = await this.dataService.getMaintenanceBySlug(
+      parsed.data.slug,
+    );
+    if (!result) {
+      return {
+        success: false,
+        error: `Operation d'entretien non trouvee: ${parsed.data.slug}`,
+      };
+    }
+    return { success: true, ...result };
+  }
+
+  /**
+   * GET /api/diagnostic-engine/popular?kind=symptom|maintenance&limit=6
+   * Top-N depuis __diag_session (signal agrege)
+   */
+  @Get('popular')
+  @Header('Cache-Control', 'public, max-age=600')
+  async popular(@Query() query: Record<string, string>) {
+    const parsed = PopularQuerySchema.safeParse(query);
+    if (!parsed.success) {
+      return { success: false, error: 'Parametres invalides' };
+    }
+    const items =
+      parsed.data.kind === 'symptom'
+        ? await this.dataService.popularSymptoms(parsed.data.limit)
+        : await this.dataService.popularMaintenance(parsed.data.limit);
+    return {
+      success: true,
+      kind: parsed.data.kind,
+      count: items.length,
+      items,
+    };
+  }
+
+  /**
+   * GET /api/diagnostic-engine/symptoms/:slug
+   * Detail symptome + causes probables scorees + regles securite du systeme parent
+   */
+  @Get('symptoms/:slug')
+  @Header('Cache-Control', 'public, max-age=3600')
+  async getSymptomBySlug(@Param() params: Record<string, string>) {
+    const parsed = SlugParamSchema.safeParse(params);
+    if (!parsed.success) {
+      return { success: false, error: 'Slug invalide' };
+    }
+    const symptom = await this.dataService.getSymptomBySlug(parsed.data.slug);
+    if (!symptom) {
+      return {
+        success: false,
+        error: `Symptome non trouve: ${parsed.data.slug}`,
+      };
+    }
+    const [causesLinks, system, maintenanceOps] = await Promise.all([
+      this.dataService.getScoredCausesForSymptom(parsed.data.slug),
+      this.dataService.getSystemById(symptom.system_id),
+      this.dataService.getMaintenanceForSymptom(parsed.data.slug),
+    ]);
+    const safety_rules = system?.slug
+      ? await this.dataService.getSafetyRules(system.slug)
+      : [];
+
+    return {
+      success: true,
+      symptom,
+      system,
+      causes: causesLinks.map((l) => ({
+        slug: l.cause?.slug || `cause-${l.cause_id}`,
+        label: l.cause?.label || '',
+        cause_type: l.cause?.cause_type || '',
+        description: l.cause?.description || null,
+        verification_method: l.cause?.verification_method || null,
+        urgency: l.cause?.urgency || null,
+        relative_score: l.relative_score,
+        evidence_for: l.evidence_for || [],
+        evidence_against: l.evidence_against || [],
+        requires_verification: l.requires_verification,
+      })),
+      safety_rules,
+      maintenance_ops: maintenanceOps.map((m) => ({
+        slug: m.slug,
+        label: m.label,
+        severity_if_overdue: m.severity_if_overdue,
+        interval_km_min: m.interval_km_min,
+        interval_km_max: m.interval_km_max,
+      })),
+    };
+  }
+
+  /**
+   * GET /api/diagnostic-engine/systems/:slug
+   * Systeme + symptomes + regles securite
+   */
+  @Get('systems/:slug')
+  @Header('Cache-Control', 'public, max-age=3600')
+  async getSystemBySlug(@Param() params: Record<string, string>) {
+    const parsed = SlugParamSchema.safeParse(params);
+    if (!parsed.success) {
+      return { success: false, error: 'Slug invalide' };
+    }
+    const result = await this.dataService.getSystemBySlugWithSymptoms(
+      parsed.data.slug,
+    );
+    if (!result) {
+      return {
+        success: false,
+        error: `Systeme non trouve: ${parsed.data.slug}`,
+      };
+    }
+    return { success: true, ...result };
   }
 
   /**

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts
@@ -29,8 +29,6 @@ export interface DiagSymptom {
   signal_mode: string;
   urgency: string;
   active: boolean;
-  synonyms: string[];
-  dtc_codes: string[];
 }
 
 export interface DiagMaintenanceOperation {
@@ -410,9 +408,6 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
     causes_count: number;
     safety_rules_count: number;
     maintenance_ops_count: number;
-    symptoms_with_synonyms: number;
-    symptoms_with_dtc: number;
-    maintenance_with_synonyms: number;
   }> {
     // Run counts in parallel
     const [
@@ -422,9 +417,6 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
       causesRes,
       rulesRes,
       maintRes,
-      symptomsSynRes,
-      symptomsDtcRes,
-      maintSynRes,
     ] = await Promise.all([
       this.supabase
         .from('__diag_session')
@@ -446,18 +438,6 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
         .from('__diag_maintenance_operation')
         .select('id', { count: 'exact', head: true })
         .eq('active', true),
-      this.supabase
-        .from('__diag_symptom')
-        .select('id', { count: 'exact', head: true })
-        .not('synonyms', 'eq', '{}'),
-      this.supabase
-        .from('__diag_symptom')
-        .select('id', { count: 'exact', head: true })
-        .not('dtc_codes', 'eq', '{}'),
-      this.supabase
-        .from('__diag_maintenance_operation')
-        .select('id', { count: 'exact', head: true })
-        .not('synonyms', 'eq', '{}'),
     ]);
 
     // Sessions by system (manual grouping from recent 500)
@@ -482,9 +462,6 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
       causes_count: causesRes.count || 0,
       safety_rules_count: rulesRes.count || 0,
       maintenance_ops_count: maintRes.count || 0,
-      symptoms_with_synonyms: symptomsSynRes.count || 0,
-      symptoms_with_dtc: symptomsDtcRes.count || 0,
-      maintenance_with_synonyms: maintSynRes.count || 0,
     };
   }
 
@@ -556,8 +533,17 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
   }
 
   /**
-   * DTC code lookup: returns symptoms that reference the code + their
-   * top scored causes. Normalizes code to uppercase.
+   * DTC code lookup : delegue au RAG (strategy pivot 2026-04-18).
+   *
+   * Le RAG est interroge avec le code DTC comme query. Les chunks R5_DIAGNOSTIC
+   * qui citent le code (dans leur texte ou frontmatter) sont retournes, puis
+   * on tente de resoudre le slug DB via match exact h3 titre -> label.
+   *
+   * La resolution finale et l'agregation RAG/DB sont faites par SearchService.
+   * Cette methode retourne juste le code normalise + symptomes resolus (si le
+   * caller passe en DB par match exact via getSymptomBySlug).
+   *
+   * Fallback : si aucun RAG disponible, retourne vide.
    */
   async lookupDtc(code: string): Promise<{
     code: string;
@@ -565,34 +551,10 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
     likely_causes: DiagSymptomCauseLink[];
   }> {
     const normalized = code.trim().toUpperCase();
-
-    const { data: symptoms, error } = await this.supabase
-      .from('__diag_symptom')
-      .select('*')
-      .eq('active', true)
-      .contains('dtc_codes', [normalized])
-      .limit(20);
-
-    if (error) {
-      this.logger.warn(`lookupDtc failed for ${normalized}`, error.message);
-      return { code: normalized, symptoms: [], likely_causes: [] };
-    }
-
-    const foundSymptoms: DiagSymptom[] = symptoms || [];
-    if (!foundSymptoms.length) {
-      return { code: normalized, symptoms: [], likely_causes: [] };
-    }
-
-    // Fetch top causes for each symptom, merged
-    const allLinks = await this.getScoredCausesForSymptoms(
-      foundSymptoms.map((s) => s.slug),
-    );
-
-    return {
-      code: normalized,
-      symptoms: foundSymptoms,
-      likely_causes: allLinks.slice(0, 8),
-    };
+    // La resolution complete passe par SearchService (qui injecte RagProxyService).
+    // Ici on retourne la forme canonique ; le controller passe par searchService.search(code)
+    // qui gere deja les cas DTC + delegation RAG.
+    return { code: normalized, symptoms: [], likely_causes: [] };
   }
 
   /**

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts
@@ -16,6 +16,8 @@ export interface DiagSystem {
   description: string | null;
   display_order: number;
   active: boolean;
+  icon_slug: string | null;
+  color_token: string | null;
 }
 
 export interface DiagSymptom {
@@ -27,6 +29,44 @@ export interface DiagSymptom {
   signal_mode: string;
   urgency: string;
   active: boolean;
+  synonyms: string[];
+  dtc_codes: string[];
+}
+
+export interface DiagMaintenanceOperation {
+  id: number;
+  slug: string;
+  system_id: number;
+  label: string;
+  description: string | null;
+  interval_km_min: number | null;
+  interval_km_max: number | null;
+  interval_months_min: number | null;
+  interval_months_max: number | null;
+  severity_if_overdue: string | null;
+  normal_wear_km_min: number | null;
+  normal_wear_km_max: number | null;
+  related_gamme_slug: string | null;
+  related_pg_id: number | null;
+  active: boolean;
+}
+
+export interface PopularSymptom {
+  slug: string;
+  label: string;
+  system_slug: string;
+  system_label: string;
+  urgency: string;
+  session_count: number;
+}
+
+export interface PopularMaintenance {
+  slug: string;
+  label: string;
+  system_slug: string;
+  severity_if_overdue: string | null;
+  related_pg_id: number | null;
+  popularity_score: number;
 }
 
 export interface DiagCause {
@@ -84,6 +124,21 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
       return [];
     }
     return data || [];
+  }
+
+  /**
+   * Get system by numeric ID
+   */
+  async getSystemById(id: number): Promise<DiagSystem | null> {
+    const { data, error } = await this.supabase
+      .from('__diag_system')
+      .select('*')
+      .eq('id', id)
+      .eq('active', true)
+      .single();
+
+    if (error) return null;
+    return data;
   }
 
   /**
@@ -354,27 +409,56 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
     symptoms_count: number;
     causes_count: number;
     safety_rules_count: number;
+    maintenance_ops_count: number;
+    symptoms_with_synonyms: number;
+    symptoms_with_dtc: number;
+    maintenance_with_synonyms: number;
   }> {
     // Run counts in parallel
-    const [sessionsRes, systemsRes, symptomsRes, causesRes, rulesRes] =
-      await Promise.all([
-        this.supabase
-          .from('__diag_session')
-          .select('id', { count: 'exact', head: true }),
-        this.supabase
-          .from('__diag_system')
-          .select('id', { count: 'exact', head: true })
-          .eq('active', true),
-        this.supabase
-          .from('__diag_symptom')
-          .select('id', { count: 'exact', head: true }),
-        this.supabase
-          .from('__diag_cause')
-          .select('id', { count: 'exact', head: true }),
-        this.supabase
-          .from('__diag_safety_rule')
-          .select('id', { count: 'exact', head: true }),
-      ]);
+    const [
+      sessionsRes,
+      systemsRes,
+      symptomsRes,
+      causesRes,
+      rulesRes,
+      maintRes,
+      symptomsSynRes,
+      symptomsDtcRes,
+      maintSynRes,
+    ] = await Promise.all([
+      this.supabase
+        .from('__diag_session')
+        .select('id', { count: 'exact', head: true }),
+      this.supabase
+        .from('__diag_system')
+        .select('id', { count: 'exact', head: true })
+        .eq('active', true),
+      this.supabase
+        .from('__diag_symptom')
+        .select('id', { count: 'exact', head: true }),
+      this.supabase
+        .from('__diag_cause')
+        .select('id', { count: 'exact', head: true }),
+      this.supabase
+        .from('__diag_safety_rule')
+        .select('id', { count: 'exact', head: true }),
+      this.supabase
+        .from('__diag_maintenance_operation')
+        .select('id', { count: 'exact', head: true })
+        .eq('active', true),
+      this.supabase
+        .from('__diag_symptom')
+        .select('id', { count: 'exact', head: true })
+        .not('synonyms', 'eq', '{}'),
+      this.supabase
+        .from('__diag_symptom')
+        .select('id', { count: 'exact', head: true })
+        .not('dtc_codes', 'eq', '{}'),
+      this.supabase
+        .from('__diag_maintenance_operation')
+        .select('id', { count: 'exact', head: true })
+        .not('synonyms', 'eq', '{}'),
+    ]);
 
     // Sessions by system (manual grouping from recent 500)
     const { data: recentSessions } = await this.supabase
@@ -397,6 +481,377 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
       symptoms_count: symptomsRes.count || 0,
       causes_count: causesRes.count || 0,
       safety_rules_count: rulesRes.count || 0,
+      maintenance_ops_count: maintRes.count || 0,
+      symptoms_with_synonyms: symptomsSynRes.count || 0,
+      symptoms_with_dtc: symptomsDtcRes.count || 0,
+      maintenance_with_synonyms: maintSynRes.count || 0,
     };
+  }
+
+  // ==========================================================================
+  // Public surface methods (breezy-eagle plan Phase A2)
+  // Lecture des __diag_* pour /search, /dtc, /maintenance, /popular, /systems/:slug
+  // ==========================================================================
+
+  /**
+   * Search symptoms via RPC search_diag_symptoms : unaccent + substring-in-array.
+   * Matches label, description, synonyms[] (substring), dtc_codes[] (exact).
+   * Graceful fallback : ILIKE sur label si RPC absente.
+   */
+  async searchSymptoms(q: string, limit = 10): Promise<DiagSymptom[]> {
+    const query = q.trim();
+    if (query.length < 2) return [];
+
+    const { data, error } = await this.supabase.rpc('search_diag_symptoms', {
+      p_q: query,
+      p_limit: limit,
+    });
+
+    if (error) {
+      this.logger.warn(
+        `searchSymptoms RPC failed for "${q}" — fallback ILIKE`,
+        error.message,
+      );
+      // Graceful fallback (if RPC missing)
+      const fallback = await this.supabase
+        .from('__diag_symptom')
+        .select('*')
+        .eq('active', true)
+        .ilike('label', `%${query}%`)
+        .limit(limit);
+      return fallback.data || [];
+    }
+    return (data as DiagSymptom[]) || [];
+  }
+
+  /**
+   * Search maintenance operations via RPC search_diag_maintenance : unaccent.
+   * Graceful fallback : ILIKE sur label si RPC absente.
+   */
+  async searchMaintenance(
+    q: string,
+    limit = 10,
+  ): Promise<DiagMaintenanceOperation[]> {
+    const query = q.trim();
+    if (query.length < 2) return [];
+
+    const { data, error } = await this.supabase.rpc('search_diag_maintenance', {
+      p_q: query,
+      p_limit: limit,
+    });
+
+    if (error) {
+      this.logger.warn(
+        `searchMaintenance RPC failed for "${q}" — fallback ILIKE`,
+        error.message,
+      );
+      const fallback = await this.supabase
+        .from('__diag_maintenance_operation')
+        .select('*')
+        .eq('active', true)
+        .ilike('label', `%${query}%`)
+        .limit(limit);
+      return fallback.data || [];
+    }
+    return (data as DiagMaintenanceOperation[]) || [];
+  }
+
+  /**
+   * DTC code lookup: returns symptoms that reference the code + their
+   * top scored causes. Normalizes code to uppercase.
+   */
+  async lookupDtc(code: string): Promise<{
+    code: string;
+    symptoms: DiagSymptom[];
+    likely_causes: DiagSymptomCauseLink[];
+  }> {
+    const normalized = code.trim().toUpperCase();
+
+    const { data: symptoms, error } = await this.supabase
+      .from('__diag_symptom')
+      .select('*')
+      .eq('active', true)
+      .contains('dtc_codes', [normalized])
+      .limit(20);
+
+    if (error) {
+      this.logger.warn(`lookupDtc failed for ${normalized}`, error.message);
+      return { code: normalized, symptoms: [], likely_causes: [] };
+    }
+
+    const foundSymptoms: DiagSymptom[] = symptoms || [];
+    if (!foundSymptoms.length) {
+      return { code: normalized, symptoms: [], likely_causes: [] };
+    }
+
+    // Fetch top causes for each symptom, merged
+    const allLinks = await this.getScoredCausesForSymptoms(
+      foundSymptoms.map((s) => s.slug),
+    );
+
+    return {
+      code: normalized,
+      symptoms: foundSymptoms,
+      likely_causes: allLinks.slice(0, 8),
+    };
+  }
+
+  /**
+   * List maintenance operations with optional filters.
+   */
+  async listMaintenanceOps(opts: {
+    system?: string;
+    limit?: number;
+  }): Promise<DiagMaintenanceOperation[]> {
+    const limit = Math.min(Math.max(opts.limit || 30, 1), 100);
+
+    let systemId: number | null = null;
+    if (opts.system) {
+      const sys = await this.getSystemBySlug(opts.system);
+      if (!sys) return [];
+      systemId = sys.id;
+    }
+
+    let query = this.supabase
+      .from('__diag_maintenance_operation')
+      .select('*')
+      .eq('active', true)
+      .order('slug')
+      .limit(limit);
+
+    if (systemId !== null) query = query.eq('system_id', systemId);
+
+    const { data, error } = await query;
+    if (error) {
+      this.logger.warn('listMaintenanceOps failed', error.message);
+      return [];
+    }
+    return data || [];
+  }
+
+  /**
+   * Get maintenance operation by slug with linked symptoms.
+   */
+  async getMaintenanceBySlug(slug: string): Promise<{
+    operation: DiagMaintenanceOperation;
+    linked_symptoms: DiagSymptom[];
+  } | null> {
+    const { data: op, error } = await this.supabase
+      .from('__diag_maintenance_operation')
+      .select('*')
+      .eq('slug', slug)
+      .eq('active', true)
+      .single();
+
+    if (error || !op) {
+      this.logger.warn(`getMaintenanceBySlug not found: ${slug}`);
+      return null;
+    }
+
+    const { data: links } = await this.supabase
+      .from('__diag_maintenance_symptom_link')
+      .select('symptom_id')
+      .eq('operation_id', op.id)
+      .eq('active', true);
+
+    const symptomIds = (links || []).map((l) => l.symptom_id);
+    let linkedSymptoms: DiagSymptom[] = [];
+    if (symptomIds.length) {
+      const { data: symptoms } = await this.supabase
+        .from('__diag_symptom')
+        .select('*')
+        .in('id', symptomIds)
+        .eq('active', true);
+      linkedSymptoms = symptoms || [];
+    }
+
+    return { operation: op, linked_symptoms: linkedSymptoms };
+  }
+
+  /**
+   * Popular symptoms aggregated from last 500 sessions.
+   * Reads __diag_session.signal_input->symptom_slugs.
+   */
+  async popularSymptoms(limit = 6): Promise<PopularSymptom[]> {
+    const { data: sessions, error } = await this.supabase
+      .from('__diag_session')
+      .select('signal_input')
+      .order('created_at', { ascending: false })
+      .limit(500);
+
+    if (error || !sessions?.length) {
+      this.logger.warn('popularSymptoms: no sessions', error?.message);
+      return [];
+    }
+
+    // __diag_session.signal_input layout observed in prod:
+    //   { signal_mode, primary_signal, secondary_signals: [] }
+    // Some legacy rows may use symptom_slugs: [] — we handle both.
+    const counts = new Map<string, number>();
+    for (const row of sessions) {
+      const input = row.signal_input as Record<string, unknown>;
+      if (!input) continue;
+      if (typeof input.primary_signal === 'string') {
+        counts.set(
+          input.primary_signal,
+          (counts.get(input.primary_signal) || 0) + 2, // weighted
+        );
+      }
+      const secondary = input.secondary_signals;
+      if (Array.isArray(secondary)) {
+        for (const s of secondary) {
+          if (typeof s === 'string') counts.set(s, (counts.get(s) || 0) + 1);
+        }
+      }
+      // Legacy fallback
+      const legacy = input.symptom_slugs;
+      if (Array.isArray(legacy)) {
+        for (const s of legacy) {
+          if (typeof s === 'string') counts.set(s, (counts.get(s) || 0) + 1);
+        }
+      }
+    }
+
+    const topSlugs = Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit * 2) // oversample, some may be inactive
+      .map(([slug]) => slug);
+
+    if (!topSlugs.length) return [];
+
+    const { data: symptoms } = await this.supabase
+      .from('__diag_symptom')
+      .select(
+        'slug, label, urgency, system_id, active, __diag_system!inner(slug, label)',
+      )
+      .in('slug', topSlugs)
+      .eq('active', true);
+
+    const items: PopularSymptom[] = [];
+    for (const sym of symptoms || []) {
+      const sysJoin = (sym as Record<string, unknown>).__diag_system as
+        | { slug: string; label: string }
+        | undefined;
+      const systemSlug = sysJoin?.slug || '';
+      const systemLabel = sysJoin?.label || '';
+      items.push({
+        slug: sym.slug,
+        label: sym.label,
+        system_slug: systemSlug,
+        system_label: systemLabel,
+        urgency: sym.urgency,
+        session_count: counts.get(sym.slug) || 0,
+      });
+    }
+
+    return items
+      .sort((a, b) => b.session_count - a.session_count)
+      .slice(0, limit);
+  }
+
+  /**
+   * Popular maintenance operations — heuristic:
+   * low interval_km_min first (frequent maintenance), then severity.
+   * (We don't yet have a "session recorded maintenance" metric.)
+   */
+  async popularMaintenance(limit = 6): Promise<PopularMaintenance[]> {
+    // DB uses EN values: critical / high / moderate / low
+    const severityRank: Record<string, number> = {
+      critical: 4,
+      high: 3,
+      moderate: 2,
+      low: 1,
+    };
+
+    const { data, error } = await this.supabase
+      .from('__diag_maintenance_operation')
+      .select(
+        'slug, label, severity_if_overdue, related_pg_id, interval_km_min, __diag_system!inner(slug)',
+      )
+      .eq('active', true)
+      .order('interval_km_min', { ascending: true, nullsFirst: false })
+      .limit(limit * 3);
+
+    if (error || !data?.length) {
+      this.logger.warn('popularMaintenance failed', error?.message);
+      return [];
+    }
+
+    const items = data.map((m) => {
+      const sysJoin = (m as Record<string, unknown>).__diag_system as
+        | { slug: string }
+        | undefined;
+      const severity = m.severity_if_overdue || 'low';
+      const score =
+        (severityRank[severity] || 1) * 10 +
+        (m.interval_km_min ? Math.max(0, 40000 - m.interval_km_min) / 1000 : 0);
+      return {
+        slug: m.slug,
+        label: m.label,
+        system_slug: sysJoin?.slug || '',
+        severity_if_overdue: m.severity_if_overdue,
+        related_pg_id: m.related_pg_id,
+        popularity_score: Math.round(score),
+      };
+    });
+
+    return items
+      .sort((a, b) => b.popularity_score - a.popularity_score)
+      .slice(0, limit);
+  }
+
+  /**
+   * Get maintenance operations linked to a symptom slug (reverse of maintenance.linked_symptoms).
+   * Lit __diag_maintenance_symptom_link puis join vers __diag_maintenance_operation.
+   */
+  async getMaintenanceForSymptom(
+    symptomSlug: string,
+  ): Promise<DiagMaintenanceOperation[]> {
+    const symptom = await this.getSymptomBySlug(symptomSlug);
+    if (!symptom) return [];
+
+    const { data: links } = await this.supabase
+      .from('__diag_maintenance_symptom_link')
+      .select('operation_id')
+      .eq('symptom_id', symptom.id)
+      .eq('active', true);
+
+    const operationIds = (links || []).map((l) => l.operation_id);
+    if (!operationIds.length) return [];
+
+    const { data: ops, error } = await this.supabase
+      .from('__diag_maintenance_operation')
+      .select('*')
+      .in('id', operationIds)
+      .eq('active', true)
+      .order('slug');
+
+    if (error) {
+      this.logger.warn(
+        `getMaintenanceForSymptom failed for ${symptomSlug}`,
+        error.message,
+      );
+      return [];
+    }
+    return ops || [];
+  }
+
+  /**
+   * System detail with all its symptoms and safety rules.
+   */
+  async getSystemBySlugWithSymptoms(slug: string): Promise<{
+    system: DiagSystem;
+    symptoms: DiagSymptom[];
+    safety_rules: DiagSafetyRule[];
+  } | null> {
+    const system = await this.getSystemBySlug(slug);
+    if (!system) return null;
+
+    const [symptoms, safety_rules] = await Promise.all([
+      this.getSymptomsBySystem(slug),
+      this.getSafetyRules(slug),
+    ]);
+
+    return { system, symptoms, safety_rules };
   }
 }

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts
@@ -837,21 +837,23 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
   }
 
   /**
-   * System detail with all its symptoms and safety rules.
+   * System detail with all its symptoms, safety rules and maintenance operations.
    */
   async getSystemBySlugWithSymptoms(slug: string): Promise<{
     system: DiagSystem;
     symptoms: DiagSymptom[];
     safety_rules: DiagSafetyRule[];
+    maintenance_ops: DiagMaintenanceOperation[];
   } | null> {
     const system = await this.getSystemBySlug(slug);
     if (!system) return null;
 
-    const [symptoms, safety_rules] = await Promise.all([
+    const [symptoms, safety_rules, maintenance_ops] = await Promise.all([
       this.getSymptomsBySystem(slug),
       this.getSafetyRules(slug),
+      this.listMaintenanceOps({ system: slug, limit: 50 }),
     ]);
 
-    return { system, symptoms, safety_rules };
+    return { system, symptoms, safety_rules, maintenance_ops };
   }
 }

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts
@@ -494,66 +494,65 @@ export class DiagnosticEngineDataService extends SupabaseBaseService {
   // ==========================================================================
 
   /**
-   * Search symptoms via RPC search_diag_symptoms : unaccent + substring-in-array.
-   * Matches label, description, synonyms[] (substring), dtc_codes[] (exact).
-   * Graceful fallback : ILIKE sur label si RPC absente.
+   * Retourne tous les symptomes actifs (utilise par le SearchService RAG
+   * pour resoudre chunk_title -> slug via match exact).
    */
-  async searchSymptoms(q: string, limit = 10): Promise<DiagSymptom[]> {
-    const query = q.trim();
-    if (query.length < 2) return [];
-
-    const { data, error } = await this.supabase.rpc('search_diag_symptoms', {
-      p_q: query,
-      p_limit: limit,
-    });
+  async getAllActiveSymptoms(): Promise<DiagSymptom[]> {
+    const { data, error } = await this.supabase
+      .from('__diag_symptom')
+      .select('*')
+      .eq('active', true);
 
     if (error) {
-      this.logger.warn(
-        `searchSymptoms RPC failed for "${q}" — fallback ILIKE`,
-        error.message,
-      );
-      // Graceful fallback (if RPC missing)
-      const fallback = await this.supabase
-        .from('__diag_symptom')
-        .select('*')
-        .eq('active', true)
-        .ilike('label', `%${query}%`)
-        .limit(limit);
-      return fallback.data || [];
+      this.logger.warn('getAllActiveSymptoms failed', error.message);
+      return [];
     }
-    return (data as DiagSymptom[]) || [];
+    return data || [];
   }
 
   /**
-   * Search maintenance operations via RPC search_diag_maintenance : unaccent.
-   * Graceful fallback : ILIKE sur label si RPC absente.
+   * Fallback ILIKE simple sur __diag_symptom.label (sans synonymes, sans RPC).
+   * Utilise uniquement quand le RAG est indisponible.
    */
-  async searchMaintenance(
+  async searchSymptomsByLabelOnly(
+    q: string,
+    limit = 10,
+  ): Promise<DiagSymptom[]> {
+    const query = q.trim();
+    if (query.length < 2) return [];
+    const { data, error } = await this.supabase
+      .from('__diag_symptom')
+      .select('*')
+      .eq('active', true)
+      .ilike('label', `%${query}%`)
+      .limit(limit);
+    if (error) {
+      this.logger.warn(`searchSymptomsByLabelOnly failed`, error.message);
+      return [];
+    }
+    return data || [];
+  }
+
+  /**
+   * Fallback ILIKE simple sur __diag_maintenance_operation.label.
+   */
+  async searchMaintenanceByLabelOnly(
     q: string,
     limit = 10,
   ): Promise<DiagMaintenanceOperation[]> {
     const query = q.trim();
     if (query.length < 2) return [];
-
-    const { data, error } = await this.supabase.rpc('search_diag_maintenance', {
-      p_q: query,
-      p_limit: limit,
-    });
-
+    const { data, error } = await this.supabase
+      .from('__diag_maintenance_operation')
+      .select('*')
+      .eq('active', true)
+      .ilike('label', `%${query}%`)
+      .limit(limit);
     if (error) {
-      this.logger.warn(
-        `searchMaintenance RPC failed for "${q}" — fallback ILIKE`,
-        error.message,
-      );
-      const fallback = await this.supabase
-        .from('__diag_maintenance_operation')
-        .select('*')
-        .eq('active', true)
-        .ilike('label', `%${query}%`)
-        .limit(limit);
-      return fallback.data || [];
+      this.logger.warn(`searchMaintenanceByLabelOnly failed`, error.message);
+      return [];
     }
-    return (data as DiagMaintenanceOperation[]) || [];
+    return data || [];
   }
 
   /**

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.module.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.module.ts
@@ -14,6 +14,7 @@ import { RagProxyModule } from '../rag-proxy/rag-proxy.module';
 import { DiagnosticEngineController } from './diagnostic-engine.controller';
 import { DiagnosticEngineOrchestrator } from './diagnostic-engine.orchestrator';
 import { DiagnosticEngineDataService } from './diagnostic-engine.data-service';
+import { DiagnosticEngineSearchService } from './diagnostic-engine.search.service';
 import { SignalInterpretationEngine } from './engines/signal-interpretation.engine';
 import { HypothesisScoringEngine } from './engines/hypothesis-scoring.engine';
 import { RiskSafetyEngine } from './engines/risk-safety.engine';
@@ -30,6 +31,7 @@ import { RagEnrichmentEngine } from './engines/rag-enrichment.engine';
   providers: [
     DiagnosticEngineOrchestrator,
     DiagnosticEngineDataService,
+    DiagnosticEngineSearchService,
     SignalInterpretationEngine,
     HypothesisScoringEngine,
     RiskSafetyEngine,
@@ -37,7 +39,11 @@ import { RagEnrichmentEngine } from './engines/rag-enrichment.engine';
     MaintenanceIntelligenceEngine,
     RagEnrichmentEngine,
   ],
-  exports: [DiagnosticEngineOrchestrator, DiagnosticEngineDataService],
+  exports: [
+    DiagnosticEngineOrchestrator,
+    DiagnosticEngineDataService,
+    DiagnosticEngineSearchService,
+  ],
 })
 export class DiagnosticEngineModule {
   private readonly logger = new Logger(DiagnosticEngineModule.name);

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.search.service.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.search.service.ts
@@ -46,32 +46,33 @@ export class DiagnosticEngineSearchService {
     const q = rawQ.trim();
     if (q.length < 2) return [];
 
-    const isDtc = DTC_RE.test(q);
-
-    // DTC : lookup direct via data-service (aucun besoin du RAG)
-    if (isDtc) {
-      const dtcResult = await this.data.lookupDtc(q);
-      if (dtcResult.symptoms.length > 0) {
-        const systemMap = await this.buildSystemMap();
-        return [
-          {
-            type: 'dtc',
-            slug: dtcResult.code,
-            label: `Code OBD ${dtcResult.code} — ${dtcResult.symptoms.length} symptôme(s)`,
-            system_slug: systemMap.get(dtcResult.symptoms[0].system_id) || null,
-            urgency: dtcResult.symptoms[0].urgency,
-            score: 1,
-          },
-        ];
-      }
-    }
-
-    // Recherche semantique via RAG
+    // Tout (free text ET DTC code) passe par le RAG — zero dependance colonnes DB.
+    // Le RAG matche les codes DTC cites dans le texte des chunks R5.
     const ragHits = await this.searchViaRag(q, limit);
     if (ragHits.length > 0) return ragHits;
 
-    // Fallback ILIKE si RAG indisponible ou zero hit
+    // Fallback ILIKE si RAG indisponible (pas applicable aux DTC : pas de match
+    // label->code possible sans source officielle SAE J2012 en DB).
+    if (DTC_RE.test(q)) return [];
     return this.searchViaFallback(q, limit);
+  }
+
+  /**
+   * Lookup DTC code — expose une API structuree au controller /dtc/:code.
+   * Delegue au search() (RAG) puis formate le resultat pour l'endpoint.
+   */
+  async lookupDtc(code: string): Promise<{
+    code: string;
+    symptoms: SearchHit[];
+    rag_hits: SearchHit[];
+  }> {
+    const normalized = code.trim().toUpperCase();
+    const hits = await this.search(normalized, 10);
+    return {
+      code: normalized,
+      symptoms: hits.filter((h) => h.type === 'symptom'),
+      rag_hits: hits.filter((h) => h.type === 'rag'),
+    };
   }
 
   /**

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.search.service.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.search.service.ts
@@ -1,0 +1,149 @@
+/**
+ * DiagnosticEngine SearchService — Ranking unifie (breezy-eagle Phase A3)
+ *
+ * Agrège les resultats /search de type symptom + maintenance + dtc,
+ * score chaque hit, retourne un tableau ordonne pour le typeahead.
+ *
+ * Ranking rules (plan) :
+ *   3 × exact label match
+ *   2 × substring label match
+ *   1.5 × synonym hit
+ *   1 × DTC hit
+ *   0.8 × maintenance label
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  DiagnosticEngineDataService,
+  DiagSymptom,
+  DiagMaintenanceOperation,
+} from './diagnostic-engine.data-service';
+
+export interface SearchHit {
+  type: 'symptom' | 'maintenance' | 'dtc';
+  slug: string;
+  label: string;
+  system_slug: string | null;
+  urgency: string | null;
+  score: number;
+}
+
+const DTC_RE = /^[PCBU]\d{4}$/i;
+
+@Injectable()
+export class DiagnosticEngineSearchService {
+  private readonly logger = new Logger(DiagnosticEngineSearchService.name);
+
+  constructor(private readonly data: DiagnosticEngineDataService) {}
+
+  async search(rawQ: string, limit = 10): Promise<SearchHit[]> {
+    const q = rawQ.trim();
+    if (q.length < 2) return [];
+
+    const qLower = q.toLowerCase();
+    const isDtc = DTC_RE.test(q);
+
+    // Fire the right queries in parallel
+    const [symptoms, maintenance, dtcResult] = await Promise.all([
+      this.data.searchSymptoms(q, limit * 2),
+      this.data.searchMaintenance(q, limit),
+      isDtc
+        ? this.data.lookupDtc(q)
+        : Promise.resolve({
+            code: q.toUpperCase(),
+            symptoms: [] as DiagSymptom[],
+            likely_causes: [],
+          }),
+    ]);
+
+    // Resolve system slugs for symptoms (single batch)
+    const systemMap = await this.buildSystemMap(
+      symptoms.concat(dtcResult.symptoms),
+    );
+
+    const hits: SearchHit[] = [];
+
+    // Symptoms
+    for (const s of symptoms) {
+      hits.push({
+        type: 'symptom',
+        slug: s.slug,
+        label: s.label,
+        system_slug: systemMap.get(s.system_id) || null,
+        urgency: s.urgency,
+        score: this.scoreSymptom(s, qLower),
+      });
+    }
+
+    // DTC hit (one synthetic entry if the query matches a DTC code)
+    if (isDtc && dtcResult.symptoms.length > 0) {
+      hits.push({
+        type: 'dtc',
+        slug: dtcResult.code,
+        label: `Code OBD ${dtcResult.code} — ${dtcResult.symptoms.length} symptôme(s)`,
+        system_slug: systemMap.get(dtcResult.symptoms[0].system_id) || null,
+        urgency: dtcResult.symptoms[0].urgency,
+        score: 100, // DTC exact match ranks highest
+      });
+    }
+
+    // Maintenance
+    for (const m of maintenance) {
+      hits.push({
+        type: 'maintenance',
+        slug: m.slug,
+        label: m.label,
+        system_slug: systemMap.get(m.system_id) || null,
+        urgency: null,
+        score: this.scoreMaintenance(m, qLower),
+      });
+    }
+
+    // Dedup by (type+slug), keep highest score
+    const best = new Map<string, SearchHit>();
+    for (const h of hits) {
+      const key = `${h.type}:${h.slug}`;
+      const prev = best.get(key);
+      if (!prev || h.score > prev.score) best.set(key, h);
+    }
+
+    return Array.from(best.values())
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+  }
+
+  private scoreSymptom(s: DiagSymptom, qLower: string): number {
+    const label = s.label.toLowerCase();
+    let score = 0;
+    if (label === qLower) score += 30;
+    else if (label.includes(qLower)) score += 20;
+    if (s.synonyms.some((syn) => syn.toLowerCase().includes(qLower)))
+      score += 15;
+    if (s.dtc_codes.some((d) => d.toLowerCase() === qLower)) score += 10;
+    // Urgency boost
+    if (s.urgency === 'critique') score += 3;
+    else if (s.urgency === 'haute') score += 2;
+    return score;
+  }
+
+  private scoreMaintenance(
+    m: DiagMaintenanceOperation,
+    qLower: string,
+  ): number {
+    const label = m.label.toLowerCase();
+    let score = 0;
+    if (label === qLower) score += 24;
+    else if (label.includes(qLower)) score += 16;
+    if (m.description?.toLowerCase().includes(qLower)) score += 4;
+    return score * 0.8; // maintenance weight per plan
+  }
+
+  private async buildSystemMap(
+    symptoms: DiagSymptom[],
+  ): Promise<Map<number, string>> {
+    const map = new Map<number, string>();
+    if (!symptoms.length) return map;
+    const systems = await this.data.getActiveSystems();
+    for (const sys of systems) map.set(sys.id, sys.slug);
+    return map;
+  }
+}

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.search.service.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.search.service.ts
@@ -1,30 +1,34 @@
 /**
- * DiagnosticEngine SearchService — Ranking unifie (breezy-eagle Phase A3)
+ * DiagnosticEngine SearchService — delegation RAG (strategy pivot 2026-04-18)
  *
- * Agrège les resultats /search de type symptom + maintenance + dtc,
- * score chaque hit, retourne un tableau ordonne pour le typeahead.
+ * Recherche unifiee pour /api/diagnostic-engine/search :
+ *   1. Delegue la requete au RAG pipeline (embeddings semantiques)
+ *   2. Filtre les chunks R5_DIAGNOSTIC (excl. backups)
+ *   3. Pour chaque chunk, tente un match EXACT titre H3 -> __diag_symptom.label
+ *      (pas de matching fuzzy/synonymes fabriques)
+ *   4. Retourne hits avec slug DB lie si match exact, sinon chunk RAG autonome
+ *   5. Fallback si RAG indisponible : ILIKE simple sur __diag_symptom.label
  *
- * Ranking rules (plan) :
- *   3 × exact label match
- *   2 × substring label match
- *   1.5 × synonym hit
- *   1 × DTC hit
- *   0.8 × maintenance label
+ * ❌ Aucun synonyme en DB (colonnes synonyms/dtc_codes ignorees)
+ * ❌ Aucun mapping pre-calcule en DB (rag_doc_id absent)
+ * ✅ RAG = single source of truth pour la recherche
  */
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { RagProxyService } from '../rag-proxy/rag-proxy.service';
 import {
   DiagnosticEngineDataService,
   DiagSymptom,
-  DiagMaintenanceOperation,
 } from './diagnostic-engine.data-service';
 
 export interface SearchHit {
-  type: 'symptom' | 'maintenance' | 'dtc';
+  type: 'symptom' | 'maintenance' | 'dtc' | 'rag';
   slug: string;
   label: string;
   system_slug: string | null;
   urgency: string | null;
   score: number;
+  rag_source_path?: string;
+  rag_truth_level?: string;
 }
 
 const DTC_RE = /^[PCBU]\d{4}$/i;
@@ -33,36 +37,145 @@ const DTC_RE = /^[PCBU]\d{4}$/i;
 export class DiagnosticEngineSearchService {
   private readonly logger = new Logger(DiagnosticEngineSearchService.name);
 
-  constructor(private readonly data: DiagnosticEngineDataService) {}
+  constructor(
+    private readonly data: DiagnosticEngineDataService,
+    @Optional() private readonly ragService: RagProxyService | null,
+  ) {}
 
   async search(rawQ: string, limit = 10): Promise<SearchHit[]> {
     const q = rawQ.trim();
     if (q.length < 2) return [];
 
-    const qLower = q.toLowerCase();
     const isDtc = DTC_RE.test(q);
 
-    // Fire the right queries in parallel
-    const [symptoms, maintenance, dtcResult] = await Promise.all([
-      this.data.searchSymptoms(q, limit * 2),
-      this.data.searchMaintenance(q, limit),
-      isDtc
-        ? this.data.lookupDtc(q)
-        : Promise.resolve({
-            code: q.toUpperCase(),
-            symptoms: [] as DiagSymptom[],
-            likely_causes: [],
-          }),
+    // DTC : lookup direct via data-service (aucun besoin du RAG)
+    if (isDtc) {
+      const dtcResult = await this.data.lookupDtc(q);
+      if (dtcResult.symptoms.length > 0) {
+        const systemMap = await this.buildSystemMap();
+        return [
+          {
+            type: 'dtc',
+            slug: dtcResult.code,
+            label: `Code OBD ${dtcResult.code} — ${dtcResult.symptoms.length} symptôme(s)`,
+            system_slug: systemMap.get(dtcResult.symptoms[0].system_id) || null,
+            urgency: dtcResult.symptoms[0].urgency,
+            score: 1,
+          },
+        ];
+      }
+    }
+
+    // Recherche semantique via RAG
+    const ragHits = await this.searchViaRag(q, limit);
+    if (ragHits.length > 0) return ragHits;
+
+    // Fallback ILIKE si RAG indisponible ou zero hit
+    return this.searchViaFallback(q, limit);
+  }
+
+  /**
+   * Delegue au RAG pipeline + resolution slug DB par match exact titre -> label.
+   */
+  private async searchViaRag(q: string, limit: number): Promise<SearchHit[]> {
+    if (!this.ragService) {
+      this.logger.debug('RAG service not loaded, skipping semantic search');
+      return [];
+    }
+
+    try {
+      const response = await this.ragService.search({
+        query: q,
+        limit: Math.max(limit * 3, 15),
+        filters: { truth_levels: ['L1', 'L2'] },
+        routing: { target_role: 'R5_DIAGNOSTIC' },
+      });
+      const results = response.results || [];
+
+      // Filtrer chunks R5 diagnostic, exclure backups
+      const filtered = results.filter((r) => {
+        const sp = (r.source_path || r.sourcePath || '').toString();
+        if (sp.includes('.backup-') || sp.includes('/_quarantine/'))
+          return false;
+        return (
+          r.primary_role === 'R5_DIAGNOSTIC' ||
+          r.section_key === 'symptoms' ||
+          r.allowed_roles?.includes('R5_DIAGNOSTIC') ||
+          sp.startsWith('diagnostic/')
+        );
+      });
+
+      if (filtered.length === 0) return [];
+
+      // Preparer map labels -> DiagSymptom pour resolution slug
+      const symptoms = await this.data.getAllActiveSymptoms();
+      const systemMap = await this.buildSystemMap();
+      const byNormalizedLabel = new Map<string, DiagSymptom>();
+      for (const s of symptoms) {
+        byNormalizedLabel.set(this.normalize(s.label), s);
+      }
+
+      // Pour chaque chunk RAG, tenter match exact avec un label DB
+      const hits: SearchHit[] = [];
+      const seenSlugs = new Set<string>();
+      for (const r of filtered) {
+        const h3 = this.extractH3FromContent(r.content || '');
+        const normalizedH3 = this.normalize(h3 || r.title || '');
+        const sym = byNormalizedLabel.get(normalizedH3);
+
+        if (sym && !seenSlugs.has(sym.slug)) {
+          seenSlugs.add(sym.slug);
+          hits.push({
+            type: 'symptom',
+            slug: sym.slug,
+            label: sym.label,
+            system_slug: systemMap.get(sym.system_id) || null,
+            urgency: sym.urgency,
+            score: r.score,
+            rag_source_path: r.source_path || r.sourcePath,
+            rag_truth_level: r.truth_level,
+          });
+        } else if (hits.length < limit) {
+          // Chunk RAG sans slug DB : proposer en resultat autonome
+          hits.push({
+            type: 'rag',
+            slug: r.chunk_id || '',
+            label: h3 || r.title || '(chunk)',
+            system_slug: null,
+            urgency: null,
+            score: r.score,
+            rag_source_path: r.source_path || r.sourcePath,
+            rag_truth_level: r.truth_level,
+          });
+        }
+
+        if (hits.length >= limit) break;
+      }
+
+      return hits;
+    } catch (e) {
+      this.logger.warn(
+        `RAG search failed for "${q}": ${(e as Error).message} — fallback to ILIKE`,
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Fallback ILIKE sur __diag_symptom.label quand le RAG est indisponible.
+   * Pas de synonymes, pas d'unaccent avance — juste un match basique.
+   */
+  private async searchViaFallback(
+    q: string,
+    limit: number,
+  ): Promise<SearchHit[]> {
+    const [symptoms, maintenance, systemMap] = await Promise.all([
+      this.data.searchSymptomsByLabelOnly(q, limit),
+      this.data.searchMaintenanceByLabelOnly(q, limit),
+      this.buildSystemMap(),
     ]);
 
-    // Resolve system slugs for symptoms (single batch)
-    const systemMap = await this.buildSystemMap(
-      symptoms.concat(dtcResult.symptoms),
-    );
-
     const hits: SearchHit[] = [];
-
-    // Symptoms
     for (const s of symptoms) {
       hits.push({
         type: 'symptom',
@@ -70,23 +183,9 @@ export class DiagnosticEngineSearchService {
         label: s.label,
         system_slug: systemMap.get(s.system_id) || null,
         urgency: s.urgency,
-        score: this.scoreSymptom(s, qLower),
+        score: 0.5, // score bas pour signaler fallback
       });
     }
-
-    // DTC hit (one synthetic entry if the query matches a DTC code)
-    if (isDtc && dtcResult.symptoms.length > 0) {
-      hits.push({
-        type: 'dtc',
-        slug: dtcResult.code,
-        label: `Code OBD ${dtcResult.code} — ${dtcResult.symptoms.length} symptôme(s)`,
-        system_slug: systemMap.get(dtcResult.symptoms[0].system_id) || null,
-        urgency: dtcResult.symptoms[0].urgency,
-        score: 100, // DTC exact match ranks highest
-      });
-    }
-
-    // Maintenance
     for (const m of maintenance) {
       hits.push({
         type: 'maintenance',
@@ -94,54 +193,28 @@ export class DiagnosticEngineSearchService {
         label: m.label,
         system_slug: systemMap.get(m.system_id) || null,
         urgency: null,
-        score: this.scoreMaintenance(m, qLower),
+        score: 0.4,
       });
     }
-
-    // Dedup by (type+slug), keep highest score
-    const best = new Map<string, SearchHit>();
-    for (const h of hits) {
-      const key = `${h.type}:${h.slug}`;
-      const prev = best.get(key);
-      if (!prev || h.score > prev.score) best.set(key, h);
-    }
-
-    return Array.from(best.values())
-      .sort((a, b) => b.score - a.score)
-      .slice(0, limit);
+    return hits.slice(0, limit);
   }
 
-  private scoreSymptom(s: DiagSymptom, qLower: string): number {
-    const label = s.label.toLowerCase();
-    let score = 0;
-    if (label === qLower) score += 30;
-    else if (label.includes(qLower)) score += 20;
-    if (s.synonyms.some((syn) => syn.toLowerCase().includes(qLower)))
-      score += 15;
-    if (s.dtc_codes.some((d) => d.toLowerCase() === qLower)) score += 10;
-    // Urgency boost
-    if (s.urgency === 'critique') score += 3;
-    else if (s.urgency === 'haute') score += 2;
-    return score;
+  private normalize(s: string): string {
+    return s
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
   }
 
-  private scoreMaintenance(
-    m: DiagMaintenanceOperation,
-    qLower: string,
-  ): number {
-    const label = m.label.toLowerCase();
-    let score = 0;
-    if (label === qLower) score += 24;
-    else if (label.includes(qLower)) score += 16;
-    if (m.description?.toLowerCase().includes(qLower)) score += 4;
-    return score * 0.8; // maintenance weight per plan
+  private extractH3FromContent(content: string): string {
+    const m = content.match(/^###\s+(.+?)$/m);
+    return m ? m[1].trim() : '';
   }
 
-  private async buildSystemMap(
-    symptoms: DiagSymptom[],
-  ): Promise<Map<number, string>> {
+  private async buildSystemMap(): Promise<Map<number, string>> {
     const map = new Map<number, string>();
-    if (!symptoms.length) return map;
     const systems = await this.data.getActiveSystems();
     for (const sys of systems) map.set(sys.id, sys.slug);
     return map;

--- a/backend/src/modules/diagnostic-engine/types/public-endpoints.schema.ts
+++ b/backend/src/modules/diagnostic-engine/types/public-endpoints.schema.ts
@@ -1,0 +1,63 @@
+/**
+ * Zod schemas pour les endpoints publics du DiagnosticEngine (plan breezy-eagle).
+ * Valident query strings / path params avant de descendre dans data-service.
+ */
+import { z } from 'zod';
+
+export const SearchQuerySchema = z.object({
+  q: z.string().trim().min(2).max(80),
+  limit: z
+    .string()
+    .optional()
+    .transform((v) =>
+      v ? Math.min(Math.max(parseInt(v, 10) || 10, 1), 15) : 10,
+    ),
+});
+
+export const DtcCodeSchema = z.object({
+  code: z
+    .string()
+    .trim()
+    .regex(/^[PCBU]\d{4}$/i, 'Format DTC invalide (ex: P0300, C0035)'),
+});
+
+export const MaintenanceListQuerySchema = z.object({
+  system: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9_-]{2,40}$/)
+    .optional(),
+  popular: z
+    .string()
+    .optional()
+    .transform((v) => v === 'true'),
+  limit: z
+    .string()
+    .optional()
+    .transform((v) =>
+      v ? Math.min(Math.max(parseInt(v, 10) || 20, 1), 100) : 20,
+    ),
+});
+
+export const SlugParamSchema = z.object({
+  slug: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9_-]{2,80}$/),
+});
+
+export const PopularQuerySchema = z.object({
+  kind: z.enum(['symptom', 'maintenance']).default('symptom'),
+  limit: z
+    .string()
+    .optional()
+    .transform((v) =>
+      v ? Math.min(Math.max(parseInt(v, 10) || 6, 1), 20) : 6,
+    ),
+});
+
+export type SearchQuery = z.infer<typeof SearchQuerySchema>;
+export type DtcCode = z.infer<typeof DtcCodeSchema>;
+export type MaintenanceListQuery = z.infer<typeof MaintenanceListQuerySchema>;
+export type SlugParam = z.infer<typeof SlugParamSchema>;
+export type PopularQuery = z.infer<typeof PopularQuerySchema>;

--- a/backend/src/modules/seo/controllers/diagnostic.controller.ts
+++ b/backend/src/modules/seo/controllers/diagnostic.controller.ts
@@ -77,10 +77,18 @@ export class DiagnosticController {
    * Crée les entrées en mode DRAFT (is_published: false)
    * ADMIN ONLY
    */
+  /**
+   * @deprecated since breezy-eagle plan (2026-04-18). Use the DiagnosticEngine
+   * at /api/diagnostic-engine backed by __diag_* tables instead. This legacy
+   * generation path writes to __seo_observable which is no longer the source
+   * of truth for the public diagnostic surface.
+   */
   @Post('generate')
   @UseGuards(IsAdminGuard)
   async generateFromTemplates(): Promise<{ created: number; skipped: number }> {
-    this.logger.log('🏭 POST /api/seo/diagnostic/generate');
+    this.logger.warn(
+      '[DEPRECATED] POST /api/seo/diagnostic/generate — use /api/diagnostic-engine (breezy-eagle plan)',
+    );
     return this.diagnosticService.generateFromTemplates();
   }
 
@@ -193,12 +201,19 @@ export class DiagnosticController {
    * PATCH /api/seo/diagnostic/:slug/publish
    * ADMIN ONLY
    */
+  /**
+   * @deprecated since breezy-eagle plan (2026-04-18). __seo_observable publish
+   * path is frozen — use the DiagnosticEngine at /api/diagnostic-engine for
+   * new authored content.
+   */
   @Patch(':slug/publish')
   @UseGuards(IsAdminGuard)
   async publishDiagnostic(
     @Param('slug') slug: string,
   ): Promise<{ success: boolean; error?: string }> {
-    this.logger.log(`📢 PATCH /api/seo/diagnostic/${slug}/publish`);
+    this.logger.warn(
+      `[DEPRECATED] PATCH /api/seo/diagnostic/${slug}/publish — use /api/diagnostic-engine (breezy-eagle plan)`,
+    );
     return this.diagnosticService.publish(slug);
   }
 

--- a/backend/src/modules/seo/services/sitemap-v10-static.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-static.service.ts
@@ -345,37 +345,61 @@ export class SitemapV10StaticService extends SupabaseBaseService {
   }
 
   /**
-   * 🩺 Génère sitemap-diagnostic.xml (pages R5 Observable Pro)
+   * 🩺 Génère sitemap-diagnostic.xml (pages R5 Observable Pro + moteur breezy-eagle)
+   * Inclut : /diagnostic-auto, /wizard, /systeme/:slug (13), /symptome/:slug (62 actifs).
+   * Les URL legacy /diagnostic-auto/:slug existent toujours (24) mais sont 301 vers /blog-pieces-auto.
    */
   async generateDiagnosticSitemap(): Promise<string | null> {
     try {
-      // 🛡️ RPC Safety Gate
-      const { data: diagnostics, error } = await this.callRpc<
-        Record<string, unknown>[]
-      >('get_all_seo_observables_for_sitemap', {}, { source: 'cron' });
+      const nowIso = new Date().toISOString();
 
-      if (error) {
-        this.logger.error(
-          `❌ Error fetching diagnostics for sitemap: ${error.message}`,
-        );
-        return null;
-      }
-
-      if (!diagnostics || diagnostics.length === 0) {
-        this.logger.warn('⚠️ No diagnostic pages found for sitemap');
-        return null;
-      }
-
-      // R5 consolidation: only include hub, sub-pages redirect to R3
+      // 1. URL statiques
       const urls: SitemapUrl[] = [
         {
           url: '/diagnostic-auto',
           page_type: 'diagnostic',
           changefreq: 'weekly',
           priority: '0.8',
-          last_modified_at: new Date().toISOString(),
+          last_modified_at: nowIso,
+        },
+        {
+          url: '/diagnostic-auto/wizard',
+          page_type: 'diagnostic',
+          changefreq: 'monthly',
+          priority: '0.7',
+          last_modified_at: nowIso,
         },
       ];
+
+      // 2. Hubs systèmes __diag_system (13 actifs)
+      const { data: systems } = await this.supabase
+        .from('__diag_system')
+        .select('slug')
+        .eq('active', true);
+      for (const s of systems || []) {
+        urls.push({
+          url: `/diagnostic-auto/systeme/${s.slug}`,
+          page_type: 'diagnostic',
+          changefreq: 'monthly',
+          priority: '0.7',
+          last_modified_at: nowIso,
+        });
+      }
+
+      // 3. Symptomes canoniques __diag_symptom (62 actifs)
+      const { data: symptoms } = await this.supabase
+        .from('__diag_symptom')
+        .select('slug, created_at')
+        .eq('active', true);
+      for (const sym of symptoms || []) {
+        urls.push({
+          url: `/diagnostic-auto/symptome/${sym.slug}`,
+          page_type: 'diagnostic',
+          changefreq: 'monthly',
+          priority: '0.6',
+          last_modified_at: sym.created_at || nowIso,
+        });
+      }
 
       const filePath = path.join(
         this.xmlService.OUTPUT_DIR,
@@ -386,6 +410,61 @@ export class SitemapV10StaticService extends SupabaseBaseService {
       return filePath;
     } catch (error) {
       this.logger.error(`❌ Failed to generate diagnostic sitemap: ${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * 🔧 Génère sitemap-maintenance.xml (entretien preventif, plan breezy-eagle).
+   * Inclut : /entretien + /entretien/:slug (30 operations).
+   */
+  async generateMaintenanceSitemap(): Promise<string | null> {
+    try {
+      const nowIso = new Date().toISOString();
+
+      const urls: SitemapUrl[] = [
+        {
+          url: '/entretien',
+          page_type: 'maintenance',
+          changefreq: 'weekly',
+          priority: '0.8',
+          last_modified_at: nowIso,
+        },
+      ];
+
+      const { data: ops, error } = await this.supabase
+        .from('__diag_maintenance_operation')
+        .select('slug, created_at')
+        .eq('active', true);
+
+      if (error) {
+        this.logger.error(
+          `❌ Error fetching maintenance ops for sitemap: ${error.message}`,
+        );
+        return null;
+      }
+
+      for (const op of ops || []) {
+        urls.push({
+          url: `/entretien/${op.slug}`,
+          page_type: 'maintenance',
+          changefreq: 'monthly',
+          priority: '0.6',
+          last_modified_at: op.created_at || nowIso,
+        });
+      }
+
+      const filePath = path.join(
+        this.xmlService.OUTPUT_DIR,
+        'sitemap-maintenance.xml',
+      );
+      await this.xmlService.writeStaticSitemapFile(filePath, urls);
+      this.logger.log(
+        `   ✅ sitemap-maintenance.xml: ${urls.length} URLs (entretien)`,
+      );
+      return filePath;
+    } catch (error) {
+      this.logger.error(`❌ Failed to generate maintenance sitemap: ${error}`);
       return null;
     }
   }

--- a/backend/src/modules/seo/services/sitemap-v10.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10.service.ts
@@ -120,10 +120,15 @@ export class SitemapV10Service extends SupabaseBaseService {
       const pages = await this.staticService.generatePagesSitemap();
       if (pages) allFilePaths.push(pages);
 
-      // 6. Diagnostic R5 (Observable Pro)
+      // 6. Diagnostic R5 (Observable Pro + hubs systemes + symptomes canoniques)
       this.logger.log('🩺 [6/9] Generating sitemap-diagnostic.xml...');
       const diagnostic = await this.staticService.generateDiagnosticSitemap();
       if (diagnostic) allFilePaths.push(diagnostic);
+
+      // 6b. Entretien preventif (breezy-eagle)
+      this.logger.log('🔧 [6b/9] Generating sitemap-maintenance.xml...');
+      const maintenance = await this.staticService.generateMaintenanceSitemap();
+      if (maintenance) allFilePaths.push(maintenance);
 
       // 7. Référence R4
       this.logger.log('📖 [7/9] Generating sitemap-reference.xml...');
@@ -542,6 +547,10 @@ export class SitemapV10Service extends SupabaseBaseService {
       this.logger.log('🩺 [6/9] Generating sitemap-diagnostic.xml...');
       const diagnostic = await this.staticService.generateDiagnosticSitemap();
       if (diagnostic) allFilePaths.push(diagnostic);
+
+      this.logger.log('🔧 [6b/9] Generating sitemap-maintenance.xml...');
+      const maintenance = await this.staticService.generateMaintenanceSitemap();
+      if (maintenance) allFilePaths.push(maintenance);
 
       this.logger.log('📖 [7/9] Generating sitemap-reference.xml...');
       const reference = await this.staticService.generateReferenceSitemap();

--- a/backend/supabase/migrations/20260418_diag_public_surface.sql
+++ b/backend/supabase/migrations/20260418_diag_public_surface.sql
@@ -1,0 +1,125 @@
+-- ============================================================================
+-- Migration : 20260418_diag_public_surface
+-- But : Exposer publiquement le moteur diagnostic + entretien (plan breezy-eagle)
+--   - Ajout presentation (icon_slug, color_token) sur __diag_system
+--   - Ajout discoverability (synonyms, dtc_codes) sur __diag_symptom
+--   - Extensions et index pour la recherche plein-texte + DTC lookup
+-- Non destructif : toutes colonnes nullables / DEFAULT vide, rollback possible.
+-- ============================================================================
+
+-- 1. Extensions -----------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- 2. __diag_system : colonnes presentation UI --------------------------------
+ALTER TABLE __diag_system
+  ADD COLUMN IF NOT EXISTS icon_slug text,
+  ADD COLUMN IF NOT EXISTS color_token text;
+
+-- Seed presentation pour les 13 systemes actifs
+-- icon_slug = nom kebab-case d'un lucide-react icon ; color_token = Tailwind base
+UPDATE __diag_system SET icon_slug='snowflake',         color_token='sky'     WHERE slug='climatisation';
+UPDATE __diag_system SET icon_slug='battery-charging',  color_token='amber'   WHERE slug='demarrage_charge';
+UPDATE __diag_system SET icon_slug='move-horizontal',   color_token='indigo'  WHERE slug='direction';
+UPDATE __diag_system SET icon_slug='cog',               color_token='purple'  WHERE slug='distribution';
+UPDATE __diag_system SET icon_slug='wind',              color_token='slate'   WHERE slug='echappement';
+UPDATE __diag_system SET icon_slug='lightbulb',         color_token='yellow'  WHERE slug='eclairage';
+UPDATE __diag_system SET icon_slug='disc-3',            color_token='orange'  WHERE slug='embrayage';
+UPDATE __diag_system SET icon_slug='filter',            color_token='emerald' WHERE slug='filtration';
+UPDATE __diag_system SET icon_slug='shield',            color_token='red'     WHERE slug='freinage';
+UPDATE __diag_system SET icon_slug='fuel',              color_token='teal'    WHERE slug='injection';
+UPDATE __diag_system SET icon_slug='thermometer-sun',   color_token='cyan'    WHERE slug='refroidissement';
+UPDATE __diag_system SET icon_slug='car',               color_token='blue'    WHERE slug='suspension';
+UPDATE __diag_system SET icon_slug='settings-2',        color_token='stone'   WHERE slug='transmission';
+
+-- 3. __diag_symptom : discoverability (synonymes + DTC) ----------------------
+ALTER TABLE __diag_symptom
+  ADD COLUMN IF NOT EXISTS synonyms text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS dtc_codes text[] NOT NULL DEFAULT '{}';
+
+-- Backfill DTC depuis __seo_observable quand slug matche (non destructif)
+UPDATE __diag_symptom s
+SET dtc_codes = obs.dtc_codes
+FROM __seo_observable obs
+WHERE obs.slug = s.slug
+  AND obs.dtc_codes IS NOT NULL
+  AND array_length(obs.dtc_codes, 1) > 0
+  AND array_length(s.dtc_codes, 1) IS NULL;
+
+-- 4. Index pour search + DTC lookup -----------------------------------------
+CREATE INDEX IF NOT EXISTS __diag_symptom_label_trgm
+  ON __diag_symptom USING gin (label gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS __diag_symptom_dtc_gin
+  ON __diag_symptom USING gin (dtc_codes);
+
+CREATE INDEX IF NOT EXISTS __diag_symptom_synonyms_gin
+  ON __diag_symptom USING gin (synonyms);
+
+CREATE INDEX IF NOT EXISTS __diag_maintenance_operation_label_trgm
+  ON __diag_maintenance_operation USING gin (label gin_trgm_ops);
+
+-- 5. __diag_maintenance_operation : synonymes pour recherche publique --------
+ALTER TABLE __diag_maintenance_operation
+  ADD COLUMN IF NOT EXISTS synonyms text[] NOT NULL DEFAULT '{}';
+
+CREATE INDEX IF NOT EXISTS __diag_maintenance_synonyms_gin
+  ON __diag_maintenance_operation USING gin (synonyms);
+
+-- 6. Extension unaccent + RPC de recherche propre ----------------------------
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+CREATE OR REPLACE FUNCTION immutable_unaccent(text)
+RETURNS text AS $$
+  SELECT unaccent('unaccent', $1)
+$$ LANGUAGE sql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION search_diag_symptoms(p_q text, p_limit integer DEFAULT 10)
+RETURNS SETOF __diag_symptom
+LANGUAGE sql STABLE AS $$
+  WITH q AS (SELECT lower(immutable_unaccent($1)) AS needle)
+  SELECT DISTINCT s.*
+  FROM __diag_symptom s, q
+  WHERE s.active = true
+    AND (
+      lower(immutable_unaccent(s.label)) LIKE '%' || q.needle || '%'
+      OR lower(immutable_unaccent(coalesce(s.description, ''))) LIKE '%' || q.needle || '%'
+      OR EXISTS (
+        SELECT 1 FROM unnest(s.synonyms) AS syn
+        WHERE lower(immutable_unaccent(syn)) LIKE '%' || q.needle || '%'
+      )
+      OR EXISTS (
+        SELECT 1 FROM unnest(s.dtc_codes) AS d
+        WHERE lower(d) LIKE '%' || lower($1) || '%'
+      )
+    )
+  ORDER BY s.slug
+  LIMIT $2;
+$$;
+
+CREATE OR REPLACE FUNCTION search_diag_maintenance(p_q text, p_limit integer DEFAULT 10)
+RETURNS SETOF __diag_maintenance_operation
+LANGUAGE sql STABLE AS $$
+  WITH q AS (SELECT lower(immutable_unaccent($1)) AS needle)
+  SELECT DISTINCT m.*
+  FROM __diag_maintenance_operation m, q
+  WHERE m.active = true
+    AND (
+      lower(immutable_unaccent(m.label)) LIKE '%' || q.needle || '%'
+      OR lower(immutable_unaccent(coalesce(m.description, ''))) LIKE '%' || q.needle || '%'
+      OR EXISTS (
+        SELECT 1 FROM unnest(m.synonyms) AS syn
+        WHERE lower(immutable_unaccent(syn)) LIKE '%' || q.needle || '%'
+      )
+    )
+  ORDER BY m.slug
+  LIMIT $2;
+$$;
+
+-- 7. Commentaires (documentation) --------------------------------------------
+COMMENT ON COLUMN __diag_system.icon_slug IS 'lucide-react icon slug (kebab-case), map client-side';
+COMMENT ON COLUMN __diag_system.color_token IS 'Tailwind color base token (ex: red, blue, amber)';
+COMMENT ON COLUMN __diag_symptom.synonyms IS 'Synonymes pour recherche typeahead (plain text, lowercased)';
+COMMENT ON COLUMN __diag_symptom.dtc_codes IS 'Codes OBD-II (P/C/B/U + 4 chiffres) associés au symptôme';
+COMMENT ON COLUMN __diag_maintenance_operation.synonyms IS 'Synonymes pour recherche typeahead (FR + EN courants)';
+COMMENT ON FUNCTION search_diag_symptoms(text, integer) IS 'Recherche symptome multi-champs avec unaccent + substring in array';
+COMMENT ON FUNCTION search_diag_maintenance(text, integer) IS 'Recherche entretien multi-champs avec unaccent + substring in array';

--- a/backend/supabase/migrations/20260420_diag_cleanup_post_pivot.sql
+++ b/backend/supabase/migrations/20260420_diag_cleanup_post_pivot.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- Migration : 20260420_diag_cleanup_post_pivot
+-- But : Nettoyer la dette technique laissee par le pivot delegation RAG
+--   (incident INC-2026-003 — voir ledger/incidents/2026/2026-04-18_*)
+--
+-- Apres le pivot (commit f9d76bd4), le code ne lit plus :
+--   - __diag_symptom.synonyms
+--   - __diag_symptom.dtc_codes
+--   - __diag_maintenance_operation.synonyms
+--   - RPC search_diag_symptoms()
+--   - RPC search_diag_maintenance()
+--
+-- La recherche est deleguee a /api/rag/search (embeddings Weaviate).
+-- Ce fichier supprime les colonnes/RPC orphelines.
+--
+-- PRE-REQUIS :
+--   - Backend en prod execute bien commit f9d76bd4+ (pivot RAG)
+--   - DB Supabase desaturation (actuellement timeouts RPC gamme)
+--   - Smoke test RAG delegation vert en DEV
+--
+-- CONSERVE (utile) :
+--   - __diag_system.icon_slug + color_token (UI)
+--   - Extension pg_trgm (utilisee ailleurs)
+--   - Extension unaccent + immutable_unaccent() (utilisables par autres services)
+-- ============================================================================
+
+BEGIN;
+
+-- 1. Drop RPC obsoletes
+DROP FUNCTION IF EXISTS search_diag_symptoms(text, integer);
+DROP FUNCTION IF EXISTS search_diag_maintenance(text, integer);
+
+-- 2. Drop index specifiques aux colonnes supprimees
+DROP INDEX IF EXISTS __diag_symptom_dtc_gin;
+DROP INDEX IF EXISTS __diag_symptom_synonyms_gin;
+DROP INDEX IF EXISTS __diag_maintenance_synonyms_gin;
+DROP INDEX IF EXISTS __diag_symptom_label_trgm;
+DROP INDEX IF EXISTS __diag_maintenance_operation_label_trgm;
+
+-- 3. Drop colonnes orphelines
+ALTER TABLE __diag_symptom
+  DROP COLUMN IF EXISTS synonyms,
+  DROP COLUMN IF EXISTS dtc_codes;
+
+ALTER TABLE __diag_maintenance_operation
+  DROP COLUMN IF EXISTS synonyms;
+
+-- 4. Update commentaires pour refleter l'etat final
+COMMENT ON TABLE __diag_symptom IS
+  'Symptomes diagnostiques. Recherche deleguee a /api/rag/search (pivot 2026-04-18).';
+COMMENT ON TABLE __diag_maintenance_operation IS
+  'Operations entretien preventif. Recherche deleguee a /api/rag/search (pivot 2026-04-18).';
+
+COMMIT;

--- a/frontend/app/components/diagnostic-public/DiagnosticGuide.tsx
+++ b/frontend/app/components/diagnostic-public/DiagnosticGuide.tsx
@@ -1,0 +1,120 @@
+import { BookOpen, Eye, Gauge, Volume2, Wrench } from "lucide-react";
+import { Card } from "~/components/ui/card";
+
+const SIGNS = [
+  {
+    icon: Volume2,
+    canal: "Auditif",
+    color: "text-blue-600",
+    examples: [
+      {
+        label: "Crissement au freinage",
+        to: "/diagnostic-auto/symptome/brake_noise_metallic",
+      },
+      {
+        label: "Claquement moteur",
+        to: "/diagnostic-auto/symptome/bruit_claquement_moteur",
+      },
+      {
+        label: "Bruit d'échappement fort",
+        to: "/diagnostic-auto/symptome/bruit_echappement_fort",
+      },
+    ],
+  },
+  {
+    icon: Eye,
+    canal: "Visuel",
+    color: "text-amber-600",
+    examples: [
+      {
+        label: "Voyant température",
+        to: "/diagnostic-auto/symptome/temp_warning_light",
+      },
+      { label: "Voyant huile", to: "/diagnostic-auto/symptome/voyant_huile" },
+      {
+        label: "Fumée noire diesel",
+        to: "/diagnostic-auto/symptome/fumee_noire_injection",
+      },
+    ],
+  },
+  {
+    icon: Wrench,
+    canal: "Tactile",
+    color: "text-purple-600",
+    examples: [
+      {
+        label: "Rebonds excessifs",
+        to: "/diagnostic-auto/symptome/rebonds_excessifs",
+      },
+      {
+        label: "Bruits en braquant",
+        to: "/diagnostic-auto/symptome/bruit_direction",
+      },
+      {
+        label: "Bruit au débrayage",
+        to: "/diagnostic-auto/symptome/bruit_debrayage",
+      },
+    ],
+  },
+  {
+    icon: Gauge,
+    canal: "Performance",
+    color: "text-emerald-600",
+    examples: [
+      {
+        label: "Moteur qui broute",
+        to: "/diagnostic-auto/symptome/moteur_broute",
+      },
+      {
+        label: "Ralenti instable",
+        to: "/diagnostic-auto/symptome/ralenti_instable",
+      },
+      {
+        label: "Perte de puissance",
+        to: "/diagnostic-auto/symptome/perte_puissance_injection",
+      },
+    ],
+  },
+];
+
+export function DiagnosticGuide() {
+  return (
+    <section aria-labelledby="guide-heading">
+      <div className="flex items-center gap-2 mb-4">
+        <BookOpen className="h-5 w-5 text-slate-600" />
+        <h2 id="guide-heading" className="text-xl font-bold">
+          Les 4 canaux sensoriels du diagnostic
+        </h2>
+      </div>
+      <p className="text-sm text-muted-foreground mb-5 max-w-3xl">
+        Un diagnostic auto démarre toujours par l'observation d'un signal.
+        Classer ce signal par canal sensoriel oriente vers le bon système.
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {SIGNS.map((s) => {
+          const Icon = s.icon;
+          return (
+            <Card key={s.canal} className="p-5">
+              <div className="flex items-center gap-2 mb-3">
+                <Icon className={`h-5 w-5 ${s.color}`} />
+                <h3 className="font-semibold">{s.canal}</h3>
+              </div>
+              <ul className="space-y-1.5 text-sm">
+                {s.examples.map((ex) => (
+                  <li key={ex.label}>
+                    <a
+                      href={ex.to}
+                      className="text-muted-foreground hover:text-primary hover:underline"
+                    >
+                      {ex.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/components/diagnostic-public/DiagnosticSearchBar.tsx
+++ b/frontend/app/components/diagnostic-public/DiagnosticSearchBar.tsx
@@ -1,0 +1,161 @@
+import { useNavigate } from "@remix-run/react";
+import { Search, AlertTriangle, Wrench, ScanLine, Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Card } from "~/components/ui/card";
+import { type SearchHitPublic } from "./types";
+
+const DEBOUNCE_MS = 220;
+
+function TypeIcon({ type }: { type: SearchHitPublic["type"] }) {
+  if (type === "dtc") return <ScanLine className="h-4 w-4 text-purple-600" />;
+  if (type === "maintenance")
+    return <Wrench className="h-4 w-4 text-emerald-600" />;
+  return <AlertTriangle className="h-4 w-4 text-amber-600" />;
+}
+
+function routeFor(hit: SearchHitPublic): string {
+  if (hit.type === "dtc") return `/diagnostic-auto/dtc/${hit.slug}`;
+  if (hit.type === "maintenance") return `/entretien/${hit.slug}`;
+  return `/diagnostic-auto/symptome/${hit.slug}`;
+}
+
+interface DiagnosticSearchBarProps {
+  placeholder?: string;
+  className?: string;
+}
+
+export function DiagnosticSearchBar({
+  placeholder = "Rechercher un symptôme, un entretien ou un code OBD (ex: P0300)…",
+  className = "",
+}: DiagnosticSearchBarProps) {
+  const navigate = useNavigate();
+  const [q, setQ] = useState("");
+  const [results, setResults] = useState<SearchHitPublic[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const trimmed = q.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      setOpen(false);
+      return;
+    }
+
+    const t = setTimeout(async () => {
+      abortRef.current?.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `/api/diagnostic-engine/search?q=${encodeURIComponent(trimmed)}&limit=8`,
+          { signal: ac.signal },
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        setResults(Array.isArray(data.results) ? data.results : []);
+        setOpen(true);
+        setActiveIdx(0);
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") {
+          setResults([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(t);
+  }, [q]);
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open || !results.length) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const hit = results[activeIdx];
+      if (hit) navigate(routeFor(hit));
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div className={`relative ${className}`}>
+      <div className="relative">
+        <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground" />
+        <input
+          type="text"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          onFocus={() => results.length && setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+          onKeyDown={handleKey}
+          placeholder={placeholder}
+          className="w-full h-14 pl-12 pr-12 rounded-xl border-2 border-border bg-background text-base shadow-sm focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 transition-colors"
+          aria-label="Rechercher dans le moteur diagnostic"
+          aria-autocomplete="list"
+        />
+        {loading && (
+          <Loader2 className="absolute right-4 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground animate-spin" />
+        )}
+      </div>
+
+      {open && results.length > 0 && (
+        <Card className="absolute top-full left-0 right-0 mt-2 z-50 max-h-96 overflow-auto shadow-xl">
+          <ul role="listbox">
+            {results.map((hit, idx) => (
+              <li
+                key={`${hit.type}:${hit.slug}`}
+                role="option"
+                aria-selected={idx === activeIdx}
+              >
+                <button
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => navigate(routeFor(hit))}
+                  onMouseEnter={() => setActiveIdx(idx)}
+                  className={`w-full text-left px-4 py-3 flex items-start gap-3 transition-colors ${
+                    idx === activeIdx ? "bg-accent" : "hover:bg-accent/50"
+                  }`}
+                >
+                  <div className="mt-0.5">
+                    <TypeIcon type={hit.type} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm font-medium truncate">
+                      {hit.label}
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-2">
+                      <span className="uppercase">{hit.type}</span>
+                      {hit.system_slug && (
+                        <>
+                          <span>•</span>
+                          <span>{hit.system_slug}</span>
+                        </>
+                      )}
+                      {hit.urgency && (
+                        <>
+                          <span>•</span>
+                          <span>{hit.urgency}</span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/diagnostic-public/DiagnosticSearchBar.tsx
+++ b/frontend/app/components/diagnostic-public/DiagnosticSearchBar.tsx
@@ -1,16 +1,39 @@
 import { useNavigate } from "@remix-run/react";
-import { Search, AlertTriangle, Wrench, ScanLine, Loader2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import { Card } from "~/components/ui/card";
+import { AlertTriangle, Loader2, ScanLine, Wrench } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "~/components/ui/command";
+import { cn } from "~/lib/utils";
+
 import { type SearchHitPublic } from "./types";
 
 const DEBOUNCE_MS = 220;
+const MIN_CHARS = 2;
+const LIMIT = 10;
 
-function TypeIcon({ type }: { type: SearchHitPublic["type"] }) {
-  if (type === "dtc") return <ScanLine className="h-4 w-4 text-purple-600" />;
-  if (type === "maintenance")
-    return <Wrench className="h-4 w-4 text-emerald-600" />;
-  return <AlertTriangle className="h-4 w-4 text-amber-600" />;
+type HitType = SearchHitPublic["type"];
+
+const TYPE_LABEL: Record<HitType, string> = {
+  symptom: "Symptômes",
+  maintenance: "Entretien",
+  dtc: "Codes OBD-II",
+};
+
+const TYPE_ORDER: HitType[] = ["symptom", "maintenance", "dtc"];
+
+function TypeIcon({ type }: { type: HitType }) {
+  if (type === "dtc") return <ScanLine className="text-purple-600" />;
+  if (type === "maintenance") return <Wrench className="text-emerald-600" />;
+  return <AlertTriangle className="text-amber-600" />;
 }
 
 function routeFor(hit: SearchHitPublic): string {
@@ -19,31 +42,43 @@ function routeFor(hit: SearchHitPublic): string {
   return `/diagnostic-auto/symptome/${hit.slug}`;
 }
 
-interface DiagnosticSearchBarProps {
-  placeholder?: string;
-  className?: string;
+function urgencyClass(urgency: string | null): string {
+  if (!urgency) return "";
+  const u = urgency.toLowerCase();
+  if (u === "critical" || u === "high")
+    return "bg-red-100 text-red-700 border-red-200";
+  if (u === "medium") return "bg-amber-100 text-amber-800 border-amber-200";
+  return "bg-slate-100 text-slate-700 border-slate-200";
 }
 
-export function DiagnosticSearchBar({
-  placeholder = "Rechercher un symptôme, un entretien ou un code OBD (ex: P0300)…",
-  className = "",
-}: DiagnosticSearchBarProps) {
-  const navigate = useNavigate();
-  const [q, setQ] = useState("");
+function highlight(label: string, q: string) {
+  const trimmed = q.trim();
+  if (!trimmed) return label;
+  const i = label.toLowerCase().indexOf(trimmed.toLowerCase());
+  if (i < 0) return label;
+  return (
+    <>
+      {label.slice(0, i)}
+      <mark className="bg-yellow-100 text-inherit rounded-sm px-0.5">
+        {label.slice(i, i + trimmed.length)}
+      </mark>
+      {label.slice(i + trimmed.length)}
+    </>
+  );
+}
+
+function useDebouncedSearch(q: string) {
   const [results, setResults] = useState<SearchHitPublic[]>([]);
   const [loading, setLoading] = useState(false);
-  const [open, setOpen] = useState(false);
-  const [activeIdx, setActiveIdx] = useState(0);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     const trimmed = q.trim();
-    if (trimmed.length < 2) {
+    if (trimmed.length < MIN_CHARS) {
       setResults([]);
-      setOpen(false);
+      setLoading(false);
       return;
     }
-
     const t = setTimeout(async () => {
       abortRef.current?.abort();
       const ac = new AbortController();
@@ -51,111 +86,222 @@ export function DiagnosticSearchBar({
       setLoading(true);
       try {
         const res = await fetch(
-          `/api/diagnostic-engine/search?q=${encodeURIComponent(trimmed)}&limit=8`,
+          `/api/diagnostic-engine/search?q=${encodeURIComponent(trimmed)}&limit=${LIMIT}`,
           { signal: ac.signal },
         );
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         setResults(Array.isArray(data.results) ? data.results : []);
-        setOpen(true);
-        setActiveIdx(0);
       } catch (err) {
-        if ((err as Error).name !== "AbortError") {
-          setResults([]);
-        }
+        if ((err as Error).name !== "AbortError") setResults([]);
       } finally {
         setLoading(false);
       }
     }, DEBOUNCE_MS);
-
     return () => clearTimeout(t);
   }, [q]);
 
-  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!open || !results.length) return;
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setActiveIdx((i) => Math.min(i + 1, results.length - 1));
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setActiveIdx((i) => Math.max(i - 1, 0));
-    } else if (e.key === "Enter") {
-      e.preventDefault();
-      const hit = results[activeIdx];
-      if (hit) navigate(routeFor(hit));
-    } else if (e.key === "Escape") {
-      setOpen(false);
-    }
+  const grouped = useMemo(() => {
+    const map: Record<HitType, SearchHitPublic[]> = {
+      symptom: [],
+      maintenance: [],
+      dtc: [],
+    };
+    for (const hit of results) map[hit.type]?.push(hit);
+    return map;
+  }, [results]);
+
+  return { results, grouped, loading };
+}
+
+function HitRow({
+  hit,
+  q,
+  onSelect,
+}: {
+  hit: SearchHitPublic;
+  q: string;
+  onSelect: () => void;
+}) {
+  return (
+    <CommandItem
+      value={`${hit.type}:${hit.slug}`}
+      onSelect={onSelect}
+      className="min-h-[44px] gap-3 py-2.5"
+    >
+      <TypeIcon type={hit.type} />
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium truncate">
+          {highlight(hit.label, q)}
+        </div>
+        <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+          {hit.system_slug && (
+            <span className="truncate">{hit.system_slug}</span>
+          )}
+          {hit.urgency && (
+            <span
+              className={cn(
+                "rounded-full border px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide",
+                urgencyClass(hit.urgency),
+              )}
+            >
+              {hit.urgency}
+            </span>
+          )}
+        </div>
+      </div>
+    </CommandItem>
+  );
+}
+
+interface SearchBodyProps {
+  q: string;
+  setQ: (v: string) => void;
+  onPick: (hit: SearchHitPublic) => void;
+  placeholder: string;
+  inputClassName?: string;
+  listClassName?: string;
+}
+
+function SearchBody({
+  q,
+  setQ,
+  onPick,
+  placeholder,
+  inputClassName,
+  listClassName,
+}: SearchBodyProps) {
+  const { grouped, loading } = useDebouncedSearch(q);
+  const trimmed = q.trim();
+  const showResults = trimmed.length >= MIN_CHARS;
+
+  return (
+    <>
+      <CommandInput
+        value={q}
+        onValueChange={setQ}
+        placeholder={placeholder}
+        className={inputClassName}
+        aria-label="Rechercher dans le moteur diagnostic"
+      />
+      {showResults && (
+        <CommandList className={listClassName}>
+          {loading && (
+            <div className="flex items-center gap-2 px-4 py-6 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Recherche en cours…
+            </div>
+          )}
+          {!loading && (
+            <CommandEmpty>Aucun résultat pour « {trimmed} ».</CommandEmpty>
+          )}
+          {TYPE_ORDER.map((type, idx) => {
+            const items = grouped[type];
+            if (!items.length) return null;
+            return (
+              <div key={type}>
+                {idx > 0 && <CommandSeparator />}
+                <CommandGroup heading={TYPE_LABEL[type]}>
+                  {items.map((hit) => (
+                    <HitRow
+                      key={`${hit.type}:${hit.slug}`}
+                      hit={hit}
+                      q={q}
+                      onSelect={() => onPick(hit)}
+                    />
+                  ))}
+                </CommandGroup>
+              </div>
+            );
+          })}
+        </CommandList>
+      )}
+    </>
+  );
+}
+
+interface DiagnosticSearchBarProps {
+  placeholder?: string;
+  className?: string;
+  /** Active le raccourci global ⌘K / Ctrl+K (default: true) */
+  enableShortcut?: boolean;
+}
+
+export function DiagnosticSearchBar({
+  placeholder = "Rechercher un symptôme, un entretien ou un code OBD (ex: P0300)…",
+  className = "",
+  enableShortcut = true,
+}: DiagnosticSearchBarProps) {
+  const navigate = useNavigate();
+  const [inlineQ, setInlineQ] = useState("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogQ, setDialogQ] = useState("");
+
+  useEffect(() => {
+    if (!enableShortcut) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setDialogOpen((v) => !v);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [enableShortcut]);
+
+  const pickInline = (hit: SearchHitPublic) => {
+    setInlineQ("");
+    navigate(routeFor(hit));
+  };
+  const pickDialog = (hit: SearchHitPublic) => {
+    setDialogOpen(false);
+    setDialogQ("");
+    navigate(routeFor(hit));
   };
 
   return (
-    <div className={`relative ${className}`}>
-      <div className="relative">
-        <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground" />
-        <input
-          type="text"
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          onFocus={() => results.length && setOpen(true)}
-          onBlur={() => setTimeout(() => setOpen(false), 150)}
-          onKeyDown={handleKey}
+    <div className={cn("relative", className)}>
+      <Command
+        shouldFilter={false}
+        loop
+        className="overflow-visible rounded-xl border-2 border-border bg-background shadow-sm focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/10"
+      >
+        <SearchBody
+          q={inlineQ}
+          setQ={setInlineQ}
+          onPick={pickInline}
           placeholder={placeholder}
-          className="w-full h-14 pl-12 pr-12 rounded-xl border-2 border-border bg-background text-base shadow-sm focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 transition-colors"
-          aria-label="Rechercher dans le moteur diagnostic"
-          aria-autocomplete="list"
+          inputClassName="h-14 text-base"
+          listClassName="absolute top-full left-0 right-0 z-50 mt-2 max-h-96 overflow-auto rounded-xl border bg-popover shadow-xl"
         />
-        {loading && (
-          <Loader2 className="absolute right-4 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground animate-spin" />
-        )}
-      </div>
+      </Command>
 
-      {open && results.length > 0 && (
-        <Card className="absolute top-full left-0 right-0 mt-2 z-50 max-h-96 overflow-auto shadow-xl">
-          <ul role="listbox">
-            {results.map((hit, idx) => (
-              <li
-                key={`${hit.type}:${hit.slug}`}
-                role="option"
-                aria-selected={idx === activeIdx}
-              >
-                <button
-                  type="button"
-                  onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => navigate(routeFor(hit))}
-                  onMouseEnter={() => setActiveIdx(idx)}
-                  className={`w-full text-left px-4 py-3 flex items-start gap-3 transition-colors ${
-                    idx === activeIdx ? "bg-accent" : "hover:bg-accent/50"
-                  }`}
-                >
-                  <div className="mt-0.5">
-                    <TypeIcon type={hit.type} />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium truncate">
-                      {hit.label}
-                    </div>
-                    <div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-2">
-                      <span className="uppercase">{hit.type}</span>
-                      {hit.system_slug && (
-                        <>
-                          <span>•</span>
-                          <span>{hit.system_slug}</span>
-                        </>
-                      )}
-                      {hit.urgency && (
-                        <>
-                          <span>•</span>
-                          <span>{hit.urgency}</span>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                </button>
-              </li>
-            ))}
-          </ul>
-        </Card>
+      {enableShortcut && (
+        <div className="mt-2 text-right">
+          <kbd className="inline-flex items-center gap-1 rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground">
+            <span className="text-xs">⌘</span>K
+          </kbd>
+          <span className="ml-2 text-xs text-muted-foreground">
+            pour ouvrir la recherche
+          </span>
+        </div>
       )}
+
+      <CommandDialog
+        open={dialogOpen}
+        onOpenChange={(o) => {
+          setDialogOpen(o);
+          if (!o) setDialogQ("");
+        }}
+        shouldFilter={false}
+      >
+        <SearchBody
+          q={dialogQ}
+          setQ={setDialogQ}
+          onPick={pickDialog}
+          placeholder={placeholder}
+        />
+      </CommandDialog>
     </div>
   );
 }

--- a/frontend/app/components/diagnostic-public/DiagnosticSearchBar.tsx
+++ b/frontend/app/components/diagnostic-public/DiagnosticSearchBar.tsx
@@ -36,10 +36,14 @@ function TypeIcon({ type }: { type: HitType }) {
   return <AlertTriangle className="text-amber-600" />;
 }
 
-function routeFor(hit: SearchHitPublic): string {
-  if (hit.type === "dtc") return `/diagnostic-auto/dtc/${hit.slug}`;
-  if (hit.type === "maintenance") return `/entretien/${hit.slug}`;
-  return `/diagnostic-auto/symptome/${hit.slug}`;
+function routeFor(hit: SearchHitPublic, vehicleTypeId?: number): string {
+  const base =
+    hit.type === "dtc"
+      ? `/diagnostic-auto/dtc/${hit.slug}`
+      : hit.type === "maintenance"
+        ? `/entretien/${hit.slug}`
+        : `/diagnostic-auto/symptome/${hit.slug}`;
+  return vehicleTypeId ? `${base}?type=${vehicleTypeId}` : base;
 }
 
 function urgencyClass(urgency: string | null): string {
@@ -225,12 +229,15 @@ interface DiagnosticSearchBarProps {
   className?: string;
   /** Active le raccourci global ⌘K / Ctrl+K (default: true) */
   enableShortcut?: boolean;
+  /** type_id véhicule — propagé en query param ?type= sur la navigation */
+  vehicleTypeId?: number;
 }
 
 export function DiagnosticSearchBar({
   placeholder = "Rechercher un symptôme, un entretien ou un code OBD (ex: P0300)…",
   className = "",
   enableShortcut = true,
+  vehicleTypeId,
 }: DiagnosticSearchBarProps) {
   const navigate = useNavigate();
   const [inlineQ, setInlineQ] = useState("");
@@ -251,12 +258,12 @@ export function DiagnosticSearchBar({
 
   const pickInline = (hit: SearchHitPublic) => {
     setInlineQ("");
-    navigate(routeFor(hit));
+    navigate(routeFor(hit, vehicleTypeId));
   };
   const pickDialog = (hit: SearchHitPublic) => {
     setDialogOpen(false);
     setDialogQ("");
-    navigate(routeFor(hit));
+    navigate(routeFor(hit, vehicleTypeId));
   };
 
   return (

--- a/frontend/app/components/diagnostic-public/DtcQuickLookup.tsx
+++ b/frontend/app/components/diagnostic-public/DtcQuickLookup.tsx
@@ -1,0 +1,68 @@
+import { useNavigate } from "@remix-run/react";
+import { ScanLine, ArrowRight } from "lucide-react";
+import { useState } from "react";
+import { Card } from "~/components/ui/card";
+
+const DTC_RE = /^[PCBU]\d{4}$/i;
+
+export function DtcQuickLookup() {
+  const navigate = useNavigate();
+  const [code, setCode] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = code.trim().toUpperCase();
+    if (!DTC_RE.test(trimmed)) {
+      setErr("Format invalide. Exemple : P0300, C0035, B1001");
+      return;
+    }
+    setErr(null);
+    navigate(`/diagnostic-auto/dtc/${trimmed}`);
+  };
+
+  return (
+    <Card className="p-5 border-2 border-purple-200 bg-purple-50/40">
+      <div className="flex items-start gap-3">
+        <div className="h-10 w-10 rounded-lg bg-gradient-to-br from-purple-500 to-pink-600 flex items-center justify-center shrink-0">
+          <ScanLine className="h-5 w-5 text-white" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-purple-900 mb-1">
+            Code OBD-II (valise diagnostic)
+          </h3>
+          <p className="text-xs text-purple-700/80 mb-3">
+            Tapez le code remonté par la valise (ex: P0300, C0035)
+          </p>
+          <form onSubmit={submit} className="flex gap-2">
+            <input
+              type="text"
+              value={code}
+              onChange={(e) => {
+                setCode(e.target.value.toUpperCase());
+                if (err) setErr(null);
+              }}
+              placeholder="P0300"
+              maxLength={5}
+              pattern="[PCBUpcbu]\d{4}"
+              className="flex-1 h-10 px-3 rounded-md border border-purple-300 bg-white text-sm font-mono uppercase focus:outline-none focus:ring-2 focus:ring-purple-500"
+              aria-label="Code OBD-II"
+            />
+            <button
+              type="submit"
+              className="h-10 px-4 rounded-md bg-purple-600 text-white text-sm font-medium hover:bg-purple-700 inline-flex items-center gap-1.5"
+            >
+              Chercher
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          </form>
+          {err && (
+            <p className="mt-2 text-xs text-red-600" role="alert">
+              {err}
+            </p>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/app/components/diagnostic-public/MaintenancePopularGrid.tsx
+++ b/frontend/app/components/diagnostic-public/MaintenancePopularGrid.tsx
@@ -1,0 +1,79 @@
+import { Link } from "@remix-run/react";
+import { Wrench, ArrowRight, Calendar } from "lucide-react";
+import { Badge } from "~/components/ui/badge";
+import { Card } from "~/components/ui/card";
+import { type PopularMaintenancePublic } from "./types";
+
+const SEVERITY_BADGE: Record<string, string> = {
+  critical: "bg-red-100 text-red-800 border-red-200",
+  high: "bg-orange-100 text-orange-800 border-orange-200",
+  moderate: "bg-amber-100 text-amber-800 border-amber-200",
+  low: "bg-emerald-100 text-emerald-800 border-emerald-200",
+};
+
+const SEVERITY_LABEL: Record<string, string> = {
+  critical: "Critique",
+  high: "Haute",
+  moderate: "Modérée",
+  low: "Basse",
+};
+
+interface MaintenancePopularGridProps {
+  items: PopularMaintenancePublic[];
+  title?: string;
+}
+
+export function MaintenancePopularGrid({
+  items,
+  title = "Entretiens populaires",
+}: MaintenancePopularGridProps) {
+  if (!items.length) return null;
+
+  return (
+    <section aria-labelledby="popular-maint-heading">
+      <div className="flex items-center gap-2 mb-4">
+        <Wrench className="h-5 w-5 text-emerald-600" />
+        <h2 id="popular-maint-heading" className="text-xl font-bold">
+          {title}
+        </h2>
+        <Badge variant="outline" className="ml-auto text-xs">
+          <Calendar className="h-3 w-3 mr-1" />À intervalles réguliers
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {items.map((m) => {
+          const sev = m.severity_if_overdue || "low";
+          const badgeClass = SEVERITY_BADGE[sev] || SEVERITY_BADGE.low;
+          return (
+            <Link key={m.slug} to={`/entretien/${m.slug}`} className="group">
+              <Card className="h-full p-4 border transition-all hover:shadow-md hover:border-emerald-400">
+                <div className="flex items-start gap-3">
+                  <div className="h-8 w-8 rounded-lg bg-emerald-100 flex items-center justify-center shrink-0">
+                    <Wrench className="h-4 w-4 text-emerald-700" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-medium text-sm leading-snug group-hover:text-emerald-700 transition-colors">
+                      {m.label}
+                    </h3>
+                    <div className="mt-2 flex items-center gap-2 flex-wrap">
+                      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                        {m.system_slug}
+                      </span>
+                      <span
+                        className={`text-[10px] px-1.5 py-0.5 rounded border ${badgeClass}`}
+                      >
+                        {SEVERITY_LABEL[sev] || sev}
+                      </span>
+                    </div>
+                  </div>
+                  <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 group-hover:text-emerald-600 transition-all" />
+                </div>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/components/diagnostic-public/PopularSymptomsGrid.tsx
+++ b/frontend/app/components/diagnostic-public/PopularSymptomsGrid.tsx
@@ -1,0 +1,78 @@
+import { Link } from "@remix-run/react";
+import { AlertTriangle, ArrowRight, TrendingUp } from "lucide-react";
+import { Badge } from "~/components/ui/badge";
+import { Card } from "~/components/ui/card";
+import { type PopularSymptomPublic } from "./types";
+
+const URGENCY_BADGE: Record<string, string> = {
+  critique: "bg-red-100 text-red-800 border-red-200",
+  haute: "bg-orange-100 text-orange-800 border-orange-200",
+  moyenne: "bg-amber-100 text-amber-800 border-amber-200",
+  basse: "bg-emerald-100 text-emerald-800 border-emerald-200",
+};
+
+interface PopularSymptomsGridProps {
+  items: PopularSymptomPublic[];
+  title?: string;
+}
+
+export function PopularSymptomsGrid({
+  items,
+  title = "Diagnostics fréquents",
+}: PopularSymptomsGridProps) {
+  if (!items.length) return null;
+
+  return (
+    <section aria-labelledby="popular-symptoms-heading">
+      <div className="flex items-center gap-2 mb-4">
+        <TrendingUp className="h-5 w-5 text-orange-600" />
+        <h2 id="popular-symptoms-heading" className="text-xl font-bold">
+          {title}
+        </h2>
+        <Badge variant="outline" className="ml-auto text-xs">
+          D'après les analyses récentes
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {items.map((s) => {
+          const badgeClass = URGENCY_BADGE[s.urgency] || URGENCY_BADGE.moyenne;
+          return (
+            <Link
+              key={s.slug}
+              to={`/diagnostic-auto/symptome/${s.slug}`}
+              className="group"
+            >
+              <Card className="h-full p-4 border transition-all hover:shadow-md hover:border-primary/40">
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5">
+                    <AlertTriangle className="h-4 w-4 text-amber-600" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-medium text-sm leading-snug group-hover:text-primary transition-colors">
+                      {s.label}
+                    </h3>
+                    <div className="mt-2 flex items-center gap-2 flex-wrap">
+                      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                        {s.system_label}
+                      </span>
+                      <span
+                        className={`text-[10px] px-1.5 py-0.5 rounded border ${badgeClass}`}
+                      >
+                        {s.urgency}
+                      </span>
+                      <span className="text-[10px] text-muted-foreground ml-auto">
+                        {s.session_count} analyses
+                      </span>
+                    </div>
+                  </div>
+                  <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 group-hover:text-primary transition-all" />
+                </div>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/components/diagnostic-public/SystemCardsGrid.tsx
+++ b/frontend/app/components/diagnostic-public/SystemCardsGrid.tsx
@@ -1,0 +1,58 @@
+import { Link } from "@remix-run/react";
+import { ChevronRight } from "lucide-react";
+import { Card } from "~/components/ui/card";
+import { getDiagnosticIcon, getDiagnosticColor } from "~/lib/diagnostic-icons";
+import { type DiagSystemPublic } from "./types";
+
+interface SystemCardsGridProps {
+  systems: DiagSystemPublic[];
+}
+
+export function SystemCardsGrid({ systems }: SystemCardsGridProps) {
+  if (!systems.length) {
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+        Aucun système disponible. Vérifiez la configuration DB.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+      {systems.map((s) => {
+        const Icon = getDiagnosticIcon(s.icon_slug);
+        const color = getDiagnosticColor(s.color_token);
+        return (
+          <Link
+            key={s.slug}
+            to={`/diagnostic-auto/systeme/${s.slug}`}
+            className="group block"
+            aria-label={`Diagnostic ${s.label}`}
+          >
+            <Card
+              className={`h-full p-5 border-2 transition-all hover:shadow-lg ${color.border}`}
+            >
+              <div
+                className={`h-11 w-11 rounded-lg bg-gradient-to-br ${color.from} ${color.to} flex items-center justify-center mb-3`}
+              >
+                <Icon className="h-6 w-6 text-white" />
+              </div>
+              <h3 className={`font-semibold text-base mb-1 ${color.text}`}>
+                {s.label}
+              </h3>
+              <p className="text-xs text-muted-foreground line-clamp-2">
+                {s.description || "Diagnostic système automobile"}
+              </p>
+              <div
+                className={`mt-3 flex items-center text-xs font-medium ${color.text} group-hover:translate-x-1 transition-transform`}
+              >
+                Voir symptômes
+                <ChevronRight className="h-3.5 w-3.5 ml-1" />
+              </div>
+            </Card>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/app/components/diagnostic-public/types.ts
+++ b/frontend/app/components/diagnostic-public/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Types publics partages pour les composants diagnostic-public.
+ * Aligne sur les reponses du backend /api/diagnostic-engine/*.
+ */
+
+export interface DiagSystemPublic {
+  slug: string;
+  label: string;
+  description: string | null;
+  icon_slug: string | null;
+  color_token: string | null;
+}
+
+export interface PopularSymptomPublic {
+  slug: string;
+  label: string;
+  system_slug: string;
+  system_label: string;
+  urgency: string;
+  session_count: number;
+}
+
+export interface PopularMaintenancePublic {
+  slug: string;
+  label: string;
+  system_slug: string;
+  severity_if_overdue: string | null;
+  related_pg_id: number | null;
+  popularity_score: number;
+}
+
+export interface SearchHitPublic {
+  type: "symptom" | "maintenance" | "dtc";
+  slug: string;
+  label: string;
+  system_slug: string | null;
+  urgency: string | null;
+  score: number;
+}
+
+export interface MaintenanceOpPublic {
+  slug: string;
+  label: string;
+  description: string | null;
+  system_id: number;
+  interval_km_min: number | null;
+  interval_km_max: number | null;
+  interval_months_min: number | null;
+  interval_months_max: number | null;
+  severity_if_overdue: string | null;
+  normal_wear_km_min: number | null;
+  normal_wear_km_max: number | null;
+  related_gamme_slug: string | null;
+  related_pg_id: number | null;
+}

--- a/frontend/app/components/ui/command.tsx
+++ b/frontend/app/components/ui/command.tsx
@@ -1,10 +1,10 @@
-import { type DialogProps } from "@radix-ui/react-dialog"
-import { Command as CommandPrimitive } from "cmdk"
-import { Search } from "lucide-react"
-import * as React from "react"
+import { type DialogProps } from "@radix-ui/react-dialog";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+import * as React from "react";
 
-import { Dialog, DialogContent } from "~/components/ui/dialog"
-import { cn } from "~/lib/utils"
+import { Dialog, DialogContent } from "~/components/ui/dialog";
+import { cn } from "~/lib/utils";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -14,24 +14,42 @@ const Command = React.forwardRef<
     ref={ref}
     className={cn(
       "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
-      className
+      className,
     )}
     {...props}
   />
-))
-Command.displayName = CommandPrimitive.displayName
+));
+Command.displayName = CommandPrimitive.displayName;
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+type CommandDialogProps = DialogProps & {
+  shouldFilter?: React.ComponentProps<typeof CommandPrimitive>["shouldFilter"];
+  filter?: React.ComponentProps<typeof CommandPrimitive>["filter"];
+  loop?: React.ComponentProps<typeof CommandPrimitive>["loop"];
+};
+
+const CommandDialog = ({
+  children,
+  shouldFilter,
+  filter,
+  loop,
+  ...dialogProps
+}: CommandDialogProps) => {
   return (
-    <Dialog {...props}>
+    <Dialog {...dialogProps}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          shouldFilter={shouldFilter}
+          filter={filter}
+          loop={loop}
+          // eslint-disable-next-line no-restricted-syntax -- `[hidden]` is a cmdk CSS attribute selector, not a Tailwind hidden class
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+        >
           {children}
         </Command>
       </DialogContent>
     </Dialog>
-  )
-}
+  );
+};
 
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
@@ -43,14 +61,14 @@ const CommandInput = React.forwardRef<
       ref={ref}
       className={cn(
         "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     />
   </div>
-))
+));
 
-CommandInput.displayName = CommandPrimitive.Input.displayName
+CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 const CommandList = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.List>,
@@ -61,9 +79,9 @@ const CommandList = React.forwardRef<
     className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
     {...props}
   />
-))
+));
 
-CommandList.displayName = CommandPrimitive.List.displayName
+CommandList.displayName = CommandPrimitive.List.displayName;
 
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
@@ -74,9 +92,9 @@ const CommandEmpty = React.forwardRef<
     className="py-6 text-center text-sm"
     {...props}
   />
-))
+));
 
-CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
 const CommandGroup = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Group>,
@@ -86,13 +104,13 @@ const CommandGroup = React.forwardRef<
     ref={ref}
     className={cn(
       "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
-      className
+      className,
     )}
     {...props}
   />
-))
+));
 
-CommandGroup.displayName = CommandPrimitive.Group.displayName
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
 
 const CommandSeparator = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Separator>,
@@ -103,8 +121,8 @@ const CommandSeparator = React.forwardRef<
     className={cn("-mx-1 h-px bg-border", className)}
     {...props}
   />
-))
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
 const CommandItem = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Item>,
@@ -114,13 +132,13 @@ const CommandItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      className
+      className,
     )}
     {...props}
   />
-))
+));
 
-CommandItem.displayName = CommandPrimitive.Item.displayName
+CommandItem.displayName = CommandPrimitive.Item.displayName;
 
 const CommandShortcut = ({
   className,
@@ -130,13 +148,13 @@ const CommandShortcut = ({
     <span
       className={cn(
         "ml-auto text-xs tracking-widest text-muted-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
-}
-CommandShortcut.displayName = "CommandShortcut"
+  );
+};
+CommandShortcut.displayName = "CommandShortcut";
 
 export {
   Command,
@@ -148,4 +166,4 @@ export {
   CommandItem,
   CommandShortcut,
   CommandSeparator,
-}
+};

--- a/frontend/app/lib/diagnostic-icons.ts
+++ b/frontend/app/lib/diagnostic-icons.ts
@@ -1,0 +1,147 @@
+/**
+ * Mapping slug (snake/kebab) -> LucideIcon + Tailwind color tokens.
+ * Source de verite cote DB : __diag_system.icon_slug + color_token.
+ * Cette lib est uniquement presentational : aucune donnee metier.
+ */
+import {
+  Snowflake,
+  BatteryCharging,
+  MoveHorizontal,
+  Cog,
+  Wind,
+  Lightbulb,
+  Disc3,
+  Filter,
+  Shield,
+  Fuel,
+  ThermometerSun,
+  Car,
+  Settings2,
+  HelpCircle,
+  type LucideIcon,
+} from "lucide-react";
+
+const ICONS: Record<string, LucideIcon> = {
+  snowflake: Snowflake,
+  "battery-charging": BatteryCharging,
+  "move-horizontal": MoveHorizontal,
+  cog: Cog,
+  wind: Wind,
+  lightbulb: Lightbulb,
+  "disc-3": Disc3,
+  filter: Filter,
+  shield: Shield,
+  fuel: Fuel,
+  "thermometer-sun": ThermometerSun,
+  car: Car,
+  "settings-2": Settings2,
+};
+
+export function getDiagnosticIcon(slug: string | null | undefined): LucideIcon {
+  if (!slug) return HelpCircle;
+  return ICONS[slug] || HelpCircle;
+}
+
+const COLOR_CLASSES: Record<
+  string,
+  { bg: string; text: string; border: string; from: string; to: string }
+> = {
+  red: {
+    bg: "bg-red-50",
+    text: "text-red-700",
+    border: "border-red-200",
+    from: "from-red-500",
+    to: "to-rose-600",
+  },
+  amber: {
+    bg: "bg-amber-50",
+    text: "text-amber-700",
+    border: "border-amber-200",
+    from: "from-amber-500",
+    to: "to-orange-600",
+  },
+  orange: {
+    bg: "bg-orange-50",
+    text: "text-orange-700",
+    border: "border-orange-200",
+    from: "from-orange-500",
+    to: "to-amber-600",
+  },
+  yellow: {
+    bg: "bg-yellow-50",
+    text: "text-yellow-700",
+    border: "border-yellow-200",
+    from: "from-yellow-500",
+    to: "to-amber-600",
+  },
+  emerald: {
+    bg: "bg-emerald-50",
+    text: "text-emerald-700",
+    border: "border-emerald-200",
+    from: "from-emerald-500",
+    to: "to-teal-600",
+  },
+  teal: {
+    bg: "bg-teal-50",
+    text: "text-teal-700",
+    border: "border-teal-200",
+    from: "from-teal-500",
+    to: "to-cyan-600",
+  },
+  cyan: {
+    bg: "bg-cyan-50",
+    text: "text-cyan-700",
+    border: "border-cyan-200",
+    from: "from-cyan-500",
+    to: "to-teal-600",
+  },
+  sky: {
+    bg: "bg-sky-50",
+    text: "text-sky-700",
+    border: "border-sky-200",
+    from: "from-sky-500",
+    to: "to-blue-600",
+  },
+  blue: {
+    bg: "bg-blue-50",
+    text: "text-blue-700",
+    border: "border-blue-200",
+    from: "from-blue-500",
+    to: "to-indigo-600",
+  },
+  indigo: {
+    bg: "bg-indigo-50",
+    text: "text-indigo-700",
+    border: "border-indigo-200",
+    from: "from-indigo-500",
+    to: "to-purple-600",
+  },
+  purple: {
+    bg: "bg-purple-50",
+    text: "text-purple-700",
+    border: "border-purple-200",
+    from: "from-purple-500",
+    to: "to-pink-600",
+  },
+  slate: {
+    bg: "bg-slate-50",
+    text: "text-slate-700",
+    border: "border-slate-200",
+    from: "from-slate-500",
+    to: "to-slate-700",
+  },
+  stone: {
+    bg: "bg-stone-50",
+    text: "text-stone-700",
+    border: "border-stone-200",
+    from: "from-stone-500",
+    to: "to-stone-700",
+  },
+};
+
+export function getDiagnosticColor(
+  token: string | null | undefined,
+): (typeof COLOR_CLASSES)[string] {
+  if (!token) return COLOR_CLASSES.slate;
+  return COLOR_CLASSES[token] || COLOR_CLASSES.slate;
+}

--- a/frontend/app/routes/diagnostic-auto.$slug.tsx
+++ b/frontend/app/routes/diagnostic-auto.$slug.tsx
@@ -305,6 +305,25 @@ export default function DiagnosticAutoDetail() {
         />
       )}
 
+      {/* Banniere legacy -> nouveau moteur (breezy-eagle plan) */}
+      <div className="bg-gradient-to-r from-emerald-600 to-teal-600 text-white">
+        <Container className="py-2.5">
+          <div className="flex items-center justify-between gap-4 text-sm">
+            <p className="flex-1">
+              <span className="font-semibold">Nouveau :</span> un moteur de
+              diagnostic interactif est disponible (13 systèmes, scoring
+              hypothèses, alertes sécurité).
+            </p>
+            <Link
+              to="/diagnostic-auto/wizard"
+              className="inline-flex items-center gap-1 font-medium underline underline-offset-2 hover:no-underline whitespace-nowrap"
+            >
+              Essayer →
+            </Link>
+          </div>
+        </Container>
+      </div>
+
       {/* Breadcrumbs */}
       <div className="bg-white border-b">
         <Container className="py-3">

--- a/frontend/app/routes/diagnostic-auto._index.tsx
+++ b/frontend/app/routes/diagnostic-auto._index.tsx
@@ -1,47 +1,37 @@
 /**
  * Route : /diagnostic-auto
- * Index des pages Diagnostic (R5 - DIAGNOSTIC)
+ * Landing du moteur diagnostic + entretien (R5 DIAGNOSTIC).
+ * Source unique : /api/diagnostic-engine/* (tables __diag_*).
  *
- * Rôle SEO : R5 - DIAGNOSTIC
- * Intention : Identifier un symptôme automobile
+ * Contient :
+ *   - Hero + CTA wizard
+ *   - DiagnosticSearchBar (typeahead /search)
+ *   - DtcQuickLookup (OBD-II)
+ *   - SystemCardsGrid (13 systemes depuis /systems)
+ *   - PopularSymptomsGrid (top from /popular?kind=symptom)
+ *   - MaintenancePopularGrid (top from /maintenance?popular=true)
+ *   - DiagnosticGuide (4 canaux sensoriels)
+ *   - FAQ statique
  */
-
 import {
   json,
   type LoaderFunctionArgs,
   type MetaFunction,
 } from "@remix-run/node";
-import {
-  Link,
-  useLoaderData,
-  useRouteError,
-  isRouteErrorResponse,
-} from "@remix-run/react";
-import {
-  AlertTriangle,
-  ArrowRight,
-  Car,
-  CheckCircle2,
-  ChevronRight,
-  Disc3,
-  Eye,
-  Gauge,
-  HelpCircle,
-  Phone,
-  ScanLine,
-  Search,
-  Shield,
-  ThermometerSun,
-  Volume2,
-  Wrench,
-  Zap,
-  BookOpen,
-} from "lucide-react";
-import { useState } from "react";
+import { Link, useLoaderData } from "@remix-run/react";
+import { ArrowRight, Phone, Wrench } from "lucide-react";
 
-import { DiagnosticWizard } from "~/components/diagnostic-wizard/DiagnosticWizard";
-import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
-import { HeroDiagnostic } from "~/components/heroes";
+import { DiagnosticGuide } from "~/components/diagnostic-public/DiagnosticGuide";
+import { DiagnosticSearchBar } from "~/components/diagnostic-public/DiagnosticSearchBar";
+import { DtcQuickLookup } from "~/components/diagnostic-public/DtcQuickLookup";
+import { MaintenancePopularGrid } from "~/components/diagnostic-public/MaintenancePopularGrid";
+import { PopularSymptomsGrid } from "~/components/diagnostic-public/PopularSymptomsGrid";
+import { SystemCardsGrid } from "~/components/diagnostic-public/SystemCardsGrid";
+import {
+  type DiagSystemPublic,
+  type PopularMaintenancePublic,
+  type PopularSymptomPublic,
+} from "~/components/diagnostic-public/types";
 import Container from "~/components/layout/Container";
 import {
   Accordion,
@@ -49,10 +39,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "~/components/ui/accordion";
-import { Badge } from "~/components/ui/badge";
-import { Input } from "~/components/ui/input";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
-import { Separator } from "~/components/ui/separator";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
 
@@ -63,361 +50,123 @@ export const handle = {
   }),
 };
 
-// Types
-interface DiagnosticItem {
-  slug: string;
-  title: string;
-  meta_description: string;
-  observable_type: "symptom" | "sign" | "dtc";
-  perception_channel: string;
-  risk_level: "confort" | "securite" | "critique";
-  safety_gate: "none" | "warning" | "stop_soon" | "stop_immediate";
-  cluster_id: string;
+interface Stats {
+  total_sessions: number;
+  systems_count: number;
+  symptoms_count: number;
 }
 
-interface ClusterInfo {
-  id: string;
-  label: string;
-  icon: React.ComponentType<{ className?: string }>;
-  description: string;
-  color: string;
+interface LoaderData {
+  systems: DiagSystemPublic[];
+  popularSymptoms: PopularSymptomPublic[];
+  popularMaintenance: PopularMaintenancePublic[];
+  stats: Stats | null;
 }
 
-const CLUSTERS: ClusterInfo[] = [
-  {
-    id: "embrayage",
-    label: "Embrayage",
-    icon: Disc3,
-    description: "Patinage, bruits, vibrations pédale",
-    color: "from-amber-500 to-orange-600",
-  },
-  {
-    id: "freinage",
-    label: "Freinage",
-    icon: Shield,
-    description: "Sifflements, vibrations, efficacité réduite",
-    color: "from-red-500 to-rose-600",
-  },
-  {
-    id: "moteur",
-    label: "Moteur",
-    icon: Gauge,
-    description: "Claquements, fumées, perte de puissance",
-    color: "from-slate-600 to-slate-800",
-  },
-  {
-    id: "suspension",
-    label: "Suspension",
-    icon: Car,
-    description: "Cognements, tenue de route dégradée",
-    color: "from-blue-500 to-indigo-600",
-  },
-  {
-    id: "electricite",
-    label: "Électricité",
-    icon: Zap,
-    description: "Voyants allumés, démarrage difficile",
-    color: "from-yellow-500 to-amber-600",
-  },
-  {
-    id: "refroidissement",
-    label: "Refroidissement",
-    icon: ThermometerSun,
-    description: "Surchauffe, fuites liquide, ventilateur",
-    color: "from-cyan-500 to-teal-600",
-  },
-];
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch (error) {
+    logger.error("[diagnostic-auto] fetch error", { url, error });
+    return null;
+  }
+}
 
-const PERCEPTION_ICONS: Record<
-  string,
-  React.ComponentType<{ className?: string }>
-> = {
-  auditory: Volume2,
-  visual: Eye,
-  tactile: Wrench,
-  performance: Gauge,
-  electronic: Zap,
-  olfactory: ThermometerSun,
-};
+export async function loader(_args: LoaderFunctionArgs) {
+  const API_URL = process.env.VITE_API_URL || "http://127.0.0.1:3000";
 
-const RISK_CONFIG = {
-  critique: {
-    label: "Critique",
-    dot: "bg-red-500",
-    text: "text-red-700",
-    bg: "bg-red-50",
-  },
-  securite: {
-    label: "Sécurité",
-    dot: "bg-amber-500",
-    text: "text-amber-700",
-    bg: "bg-amber-50",
-  },
-  confort: {
-    label: "Confort",
-    dot: "bg-blue-500",
-    text: "text-blue-700",
-    bg: "bg-blue-50",
-  },
-} as const;
+  const [systemsRes, popSympRes, popMaintRes, statsRes] = await Promise.all([
+    fetchJson<{ systems?: DiagSystemPublic[] }>(
+      `${API_URL}/api/diagnostic-engine/systems`,
+    ),
+    fetchJson<{ items?: PopularSymptomPublic[] }>(
+      `${API_URL}/api/diagnostic-engine/popular?kind=symptom&limit=6`,
+    ),
+    fetchJson<{ items?: PopularMaintenancePublic[] }>(
+      `${API_URL}/api/diagnostic-engine/maintenance?popular=true&limit=6`,
+    ),
+    fetchJson<Stats>(`${API_URL}/api/diagnostic-engine/stats`),
+  ]);
+
+  return json<LoaderData>({
+    systems: systemsRes?.systems || [],
+    popularSymptoms: popSympRes?.items || [],
+    popularMaintenance: popMaintRes?.items || [],
+    stats: statsRes,
+  });
+}
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const d = data as LoaderData | undefined;
   const canonicalUrl = "https://www.automecanik.com/diagnostic-auto";
-
-  // Unified FAQPage: static items + dynamic featured items
-  const staticEntities = FAQ_DATA.map((item) => ({
-    "@type": "Question" as const,
-    name: item.question,
-    acceptedAnswer: { "@type": "Answer" as const, text: item.answer },
-  }));
-
-  const dynamicEntities =
-    data?.featured && data.featured.length > 0
-      ? data.featured.slice(0, 5).map((d: DiagnosticItem) => ({
-          "@type": "Question" as const,
-          name: `Qu'est-ce qu'un ${d.title.split(":")[0].trim()} ?`,
-          acceptedAnswer: {
-            "@type": "Answer" as const,
-            text:
-              d.meta_description ||
-              `Le ${d.title.split(":")[0].trim().toLowerCase()} est un symptôme automobile.`,
-          },
-        }))
-      : [];
+  const symptomsCount = d?.stats?.symptoms_count ?? 0;
+  const title = `Diagnostic auto : moteur d'analyse des pannes — ${symptomsCount} symptômes catalogués | AutoMecanik`;
+  const description = `Identifier une panne auto : recherche par symptôme, code OBD ou système. ${symptomsCount} symptômes + ${d?.stats?.systems_count ?? 0} systèmes + entretien préventif.`;
 
   return [
-    {
-      title:
-        "Identifier une panne auto : diagnostic gratuit, signes et codes OBD | AutoMecanik",
-    },
-    {
-      name: "description",
-      content:
-        "Comment identifier une panne voiture ? Lisez les signes avant-coureurs, décodez les voyants et codes OBD. 193 diagnostics gratuits avec causes probables par nos experts.",
-    },
-    { name: "robots", content: "index, follow" },
+    { title },
+    { name: "description", content: description },
+    { name: "robots", content: "index,follow" },
     { tagName: "link", rel: "canonical", href: canonicalUrl },
-    {
-      property: "og:title",
-      content:
-        "Identifier une panne auto : diagnostic gratuit, signes et codes OBD",
-    },
-    {
-      property: "og:description",
-      content:
-        "Comment identifier une panne voiture ? Signes avant-coureurs, voyants, codes OBD. 193 diagnostics gratuits avec causes et solutions.",
-    },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
     { property: "og:type", content: "website" },
     { property: "og:url", content: canonicalUrl },
     {
       property: "og:image",
       content: "https://www.automecanik.com/images/og/diagnostic.webp",
     },
-    { property: "og:image:width", content: "1200" },
-    { property: "og:image:height", content: "630" },
     { name: "twitter:card", content: "summary_large_image" },
-    {
-      name: "twitter:image",
-      content: "https://www.automecanik.com/images/og/diagnostic.webp",
-    },
     {
       "script:ld+json": {
         "@context": "https://schema.org",
         "@type": "FAQPage",
-        mainEntity: [...staticEntities, ...dynamicEntities],
-      },
-    },
-    {
-      "script:ld+json": {
-        "@context": "https://schema.org",
-        "@type": "HowTo",
-        name: "Comment identifier une panne auto",
-        description:
-          "3 méthodes pour diagnostiquer une panne voiture : observation sensorielle, lecture des voyants, scanner OBD.",
-        step: [
-          {
-            "@type": "HowToStep",
-            position: 1,
-            name: "Observer les symptômes sensoriels",
-            text: "Identifiez le canal sensoriel : auditif (bruits), visuel (fumée, voyants), tactile (vibrations), olfactif (odeurs brûlées). Chaque canal pointe vers un système spécifique du véhicule.",
-          },
-          {
-            "@type": "HowToStep",
-            position: 2,
-            name: "Lire les voyants du tableau de bord",
-            text: "Voyant rouge = arrêt immédiat. Voyant orange = attention requise. Voyant jaune = information. Un voyant moteur orange nécessite la lecture d'un code OBD dans les 48h.",
-          },
-          {
-            "@type": "HowToStep",
-            position: 3,
-            name: "Scanner le code OBD",
-            text: "Branchez un scanner OBD2 sur le port sous le tableau de bord. Les codes Pxxxx concernent le moteur, Cxxxx le châssis, Bxxxx la carrosserie. Entrez le code dans notre outil pour un diagnostic ciblé.",
-          },
-        ],
+        mainEntity: FAQ_DATA.map((f) => ({
+          "@type": "Question",
+          name: f.question,
+          acceptedAnswer: { "@type": "Answer", text: f.answer },
+        })),
       },
     },
   ];
 };
 
-const SIGNS_DATA = [
-  {
-    title: "Bruit inhabituel au freinage",
-    detail:
-      "Sifflement aigu = plaquettes usées. Grincement métallique = disques atteints ou étrier. Organe de sécurité : à traiter en priorité.",
-    cluster: "freinage",
-    clusterLabel: "Freinage",
-  },
-  {
-    title: "Voyant moteur allumé (check engine)",
-    detail:
-      "Un code OBD est enregistré dans le calculateur. Lisez-le dans les 48h avec un scanner OBD ou entrez-le dans notre outil ci-dessus.",
-    cluster: "electricite",
-    clusterLabel: "Électricité",
-  },
-  {
-    title: "Vibration au volant",
-    detail:
-      "À vitesse constante : pneumatiques ou géométrie. Au freinage : disques voilés. Basse vitesse : rotule ou biellette de suspension.",
-    cluster: "suspension",
-    clusterLabel: "Suspension",
-  },
-  {
-    title: "Démarrage difficile ou raté",
-    detail:
-      "Lent = batterie faible. Clic unique = relais de démarrage. Silence total = démarreur ou sécurité moteur. Vérifiez aussi les bougies.",
-    cluster: "electricite",
-    clusterLabel: "Électricité",
-  },
-  {
-    title: "Surconsommation soudaine",
-    detail:
-      "Augmentation > 15% sans changement de conduite. Causes : injecteurs, bougie défaillante, thermostat bloqué ouvert, fuite circuit d'air.",
-    cluster: "moteur",
-    clusterLabel: "Moteur",
-  },
-  {
-    title: "Fumée à l'échappement",
-    detail:
-      "Blanche dense = liquide de refroidissement (joint de culasse). Noire = mélange trop riche. Bleue = huile brûlée (segments, joints spi).",
-    cluster: "moteur",
-    clusterLabel: "Moteur",
-  },
-  {
-    title: "Perte de puissance",
-    detail:
-      "FAP obstrué (diesel, trajets courts), turbo défaillant, injecteurs encrassés ou problème de gestion moteur. Scanner OBD recommandé.",
-    cluster: "moteur",
-    clusterLabel: "Moteur",
-  },
-  {
-    title: "Odeur de brûlé",
-    detail:
-      "Caoutchouc : courroie en contact. Plastique : fusible ou faisceau. Œuf pourri : catalyseur. Âcre : embrayage en patinage.",
-    cluster: "embrayage",
-    clusterLabel: "Embrayage",
-  },
-  {
-    title: "Pédale de frein molle ou spongieuse",
-    detail:
-      "Air dans le circuit ou fuite de liquide de frein. Perte de freinage possible. Arrêt immédiat si la pédale touche le plancher.",
-    cluster: "freinage",
-    clusterLabel: "Freinage",
-  },
-  {
-    title: "Voyant ABS ou ESP allumé",
-    detail:
-      "ABS orange = capteur de roue défaillant dans 60% des cas. Le freinage reste actif mais sans assistance. Contrôle sous 7 jours.",
-    cluster: "electricite",
-    clusterLabel: "Électricité",
-  },
-];
-
 const FAQ_DATA = [
   {
     question: "Comment savoir quel est le problème de ma voiture ?",
     answer:
-      "Commencez par observer les symptômes sensoriels : voyants allumés, bruits inhabituels, vibrations, odeurs. Si un voyant moteur est allumé, lisez le code OBD avec un scanner ou entrez-le directement dans notre outil ci-dessus. Pour les pannes sans voyant, décrivez le symptôme dans le champ de recherche (ex : « bruit au freinage », « vibration volant »).",
-    link: null as { href: string; label: string } | null,
-  },
-  {
-    question: "Comment identifier une panne de démarreur ?",
-    answer:
-      "Un démarreur défaillant se manifeste par : un clic unique sans démarrage du moteur (relais ou solénoïde), un grincement bref lors de la mise en route, ou une absence totale de réaction alors que la batterie est chargée (tension > 12.4V). Pour confirmer, mesurez la tension aux bornes du démarreur lors de la sollicitation.",
-    link: {
-      href: "/diagnostic-auto?cluster=electricite",
-      label: "Voir les diagnostics électricité",
-    },
-  },
-  {
-    question: "Qu'est-ce qu'une panne voyant ABS ?",
-    answer:
-      "Le voyant ABS orange indique que le système antiblocage est désactivé. Le freinage normal reste fonctionnel. Cause la plus fréquente : capteur ABS de roue défaillant (50 à 80 EUR la pièce). La lecture d'un code OBD Cxxxx confirme le capteur concerné. Rouler sans ABS est dangereux en freinage d'urgence.",
-    link: null,
+      "Observez les symptômes sensoriels (voyants, bruits, vibrations, odeurs). Si un voyant moteur est allumé, lisez le code OBD et entrez-le dans le lookup ci-dessus. Pour les pannes sans voyant, utilisez la recherche de symptômes.",
   },
   {
     question: "Comment lire un code panne OBD ?",
     answer:
-      "Branchez un scanner OBD2 sur le port situé sous le tableau de bord côté conducteur (sous la colonne de direction). Le scanner lit les codes du type P0300 (raté d'allumage), C0031 (capteur ABS), etc. Vous pouvez également entrer le code dans notre outil Scanner en haut de page. N'effacez un code qu'après réparation.",
-    link: null,
+      "Branchez un scanner OBD-II sous le tableau de bord (côté conducteur). Les codes Pxxxx concernent le moteur, Cxxxx le châssis, Bxxxx la carrosserie, Uxxxx le réseau. Entrez le code dans le lookup ci-dessus.",
   },
   {
     question: "Voiture en panne qui ne démarre pas : par où commencer ?",
     answer:
-      "Vérifiez dans cet ordre : 1) Batterie — tension > 12.4V au repos, bornes non oxydées. 2) Démarreur — clic = relais OK, silence = démarreur ou sécurité. 3) Allumage — bougies, bobines si le moteur tourne mais cale. 4) Alimentation — pompe à carburant (bruit 2 sec au contact). Un code OBD précise souvent la piste.",
-    link: null,
+      "Vérifiez dans cet ordre : 1) Batterie (tension > 12.4V), 2) Démarreur (clic = relais OK), 3) Allumage (bougies, bobines), 4) Alimentation (pompe à carburant). Lancez un diagnostic guidé pour une analyse pas-à-pas.",
   },
   {
     question: "Panne mécanique ou électrique : comment savoir ?",
     answer:
-      "Une panne mécanique est progressive : bruits, vibrations, odeurs, aggravée par la température. Une panne électronique est souvent soudaine avec voyant allumé et sans symptôme sonore. Le scanner OBD identifie les défauts électroniques ; une inspection physique révèle les pannes mécaniques.",
-    link: null,
+      "Une panne mécanique est progressive : bruits, vibrations, odeurs. Une panne électronique est soudaine, avec voyant allumé. Le scanner OBD identifie les défauts électroniques.",
   },
   {
     question: "Que faire si un voyant rouge s'allume en conduisant ?",
     answer:
-      "Un voyant rouge impose l'arrêt immédiat sécurisé du véhicule (huile, température, frein). Garez-vous dès que possible, coupez le moteur. Relancer un moteur surchauffé ou en manque de pression d'huile cause des dommages irréversibles. Appelez de l'assistance.",
-    link: {
-      href: "/diagnostic-auto?cluster=moteur",
-      label: "Diagnostics moteur urgents",
-    },
+      "Arrêtez-vous en sécurité immédiatement (huile, température, frein). Relancer un moteur surchauffé cause des dommages irréversibles. Appelez de l'assistance.",
   },
 ];
 
-export async function loader({ request }: LoaderFunctionArgs) {
-  const API_URL = process.env.VITE_API_URL || "http://127.0.0.1:3000";
-
-  try {
-    const response = await fetch(`${API_URL}/api/seo/diagnostic/featured`, {
-      headers: { Accept: "application/json" },
-    });
-
-    let featured: DiagnosticItem[] = [];
-    if (response.ok) {
-      const data = await response.json();
-      featured = data?.data || [];
-    }
-
-    return json({ featured });
-  } catch (error) {
-    logger.error("[diagnostic-auto._index] Loader error:", error);
-    return json({ featured: [] as DiagnosticItem[] });
-  }
-}
-
 export default function DiagnosticAutoIndex() {
-  const { featured } = useLoaderData<typeof loader>();
-  const [searchQuery, setSearchQuery] = useState("");
-  const [dtcCode, setDtcCode] = useState("");
-
-  const filteredClusters = CLUSTERS.filter(
-    (c) =>
-      c.label.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      c.description.toLowerCase().includes(searchQuery.toLowerCase()),
-  );
+  const { systems, popularSymptoms, popularMaintenance, stats } =
+    useLoaderData<typeof loader>();
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Breadcrumbs */}
       <div className="bg-white border-b">
         <Container className="py-3">
           <PublicBreadcrumb
@@ -429,680 +178,147 @@ export default function DiagnosticAutoIndex() {
         </Container>
       </div>
 
-      {/* ═══ HERO ═══ */}
-      <HeroDiagnostic
-        title="Identifiez votre panne auto"
-        description="Décrivez le symptôme, notre outil identifie les causes probables et vous oriente vers la bonne pièce. Gratuit, sans inscription."
-        severity="warning"
-      />
-
-      {/* ═══ WIZARD DIAGNOSTIC INTELLIGENT ═══ */}
-      <section className="bg-white border-b py-8">
+      {/* Hero */}
+      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white py-12 md:py-16">
         <Container>
-          <div className="max-w-2xl mx-auto">
-            <DiagnosticWizard />
-          </div>
-        </Container>
-      </section>
+          <div className="max-w-4xl">
+            <h1 className="text-3xl md:text-5xl font-bold mb-4">
+              Diagnostic auto — Identifier une panne
+            </h1>
+            <p className="text-lg text-slate-200 mb-8 max-w-2xl">
+              {stats
+                ? `${stats.symptoms_count} symptômes catalogués, ${stats.systems_count} systèmes, ${stats.total_sessions.toLocaleString()} diagnostics réalisés.`
+                : "Recherchez un symptôme, un code OBD ou lancez un diagnostic guidé."}
+            </p>
 
-      {/* ═══ RECHERCHE + OBD ═══ */}
-      <section className="bg-white border-b py-4">
-        <Container>
-          <div className="flex flex-col sm:flex-row gap-3 max-w-2xl">
-            <div className="relative flex-1">
-              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
-              <Input
-                type="search"
-                placeholder="Décrivez votre problème (ex: bruit au freinage...)"
-                className="pl-11 h-11 rounded-xl text-base"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
-            </div>
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                const code = dtcCode.trim().toUpperCase();
-                if (code) {
-                  window.location.href = `/diagnostic-auto?dtc=${encodeURIComponent(code)}`;
-                }
-              }}
-              className="flex gap-2"
-            >
-              <Input
-                type="text"
-                placeholder="Code OBD (P0300...)"
-                className="h-11 w-40 bg-gray-100 border-gray-200 font-mono rounded-xl text-center"
-                value={dtcCode}
-                onChange={(e) => setDtcCode(e.target.value)}
-              />
-              <button
-                type="submit"
-                className="h-11 px-5 bg-cta hover:bg-cta-hover text-white font-semibold rounded-xl transition-colors whitespace-nowrap"
-              >
-                Scanner
-              </button>
-            </form>
-          </div>
-        </Container>
-      </section>
+            <DiagnosticSearchBar className="mb-6" />
 
-      {/* ═══ CLUSTERS ═══ */}
-      <Container as="section" className="py-12">
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Par catégorie</h2>
-        <p className="text-gray-500 mb-8">
-          Sélectionnez la zone concernée pour affiner le diagnostic
-        </p>
-
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
-          {filteredClusters.map((cluster) => {
-            const Icon = cluster.icon;
-            return (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <DtcQuickLookup />
               <Link
-                key={cluster.id}
-                to={`/diagnostic-auto?cluster=${cluster.id}`}
+                to="/diagnostic-auto/wizard"
                 className="group block"
+                aria-label="Lancer le diagnostic guidé"
               >
-                <div
-                  className={`relative rounded-2xl p-5 bg-gradient-to-br ${cluster.color} text-white overflow-hidden transition-all duration-300 hover:-translate-y-1 hover:shadow-xl`}
-                >
-                  <div
-                    className="absolute top-0 right-0 w-20 h-20 bg-white/10 rounded-full -translate-x-4 -translate-y-4"
-                    aria-hidden="true"
-                  />
-                  <Icon className="h-8 w-8 mb-3 relative z-10" />
-                  <p className="font-bold text-sm relative z-10">
-                    {cluster.label}
-                  </p>
-                  <p className="text-[11px] text-white/70 mt-1 leading-tight relative z-10">
-                    {cluster.description}
-                  </p>
-                </div>
-              </Link>
-            );
-          })}
-        </div>
-
-        {filteredClusters.length === 0 && searchQuery && (
-          <p className="text-center text-gray-500 py-8">
-            Aucune catégorie ne correspond à « {searchQuery} »
-          </p>
-        )}
-      </Container>
-
-      {/* ═══ GUIDE : COMMENT IDENTIFIER SA PANNE ═══ */}
-      <Container as="section" className="py-14">
-        <div className="grid lg:grid-cols-3 gap-10">
-          <div className="lg:col-span-2">
-            <Badge className="mb-4 bg-cta-50 text-cta-800 border-cta-200">
-              Guide expert
-            </Badge>
-            <h2 className="text-3xl font-extrabold text-gray-900 mb-4 leading-tight">
-              Comment identifier une panne auto : le guide complet
-            </h2>
-            <p className="text-gray-600 mb-6 leading-relaxed">
-              80 % des pannes automobiles présentent des signes avant-coureurs
-              pendant plusieurs semaines avant l'immobilisation. Savoir les
-              reconnaître vous permet d'agir avant la panne totale et d'arriver
-              chez le garagiste avec une hypothèse claire — ce qui réduit le
-              coût de réparation.
-            </p>
-
-            {/* Methode 1 */}
-            <div className="mb-6">
-              <h3 className="text-lg font-bold text-gray-900 mb-2 flex items-center gap-2">
-                <span className="w-7 h-7 rounded-full bg-cta text-white text-sm flex items-center justify-center font-bold shrink-0">
-                  1
-                </span>
-                Observer les symptômes sensoriels (sans outil)
-              </h3>
-              <p className="text-gray-600 mb-3">
-                Chaque système du véhicule s'exprime par un canal sensoriel
-                distinct. Identifier le canal affine le diagnostic avant tout
-                démontage.
-              </p>
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                {[
-                  {
-                    icon: Volume2,
-                    label: "Auditif",
-                    examples: "Sifflement, claquement, grincement",
-                    zone: "Freinage, suspension, moteur",
-                    iconColor: "text-blue-500",
-                  },
-                  {
-                    icon: Eye,
-                    label: "Visuel",
-                    examples: "Fumée, voyant, fuite visible",
-                    zone: "Moteur, refroidissement, freins",
-                    iconColor: "text-amber-500",
-                  },
-                  {
-                    icon: Wrench,
-                    label: "Tactile",
-                    examples: "Vibration, à-coup, pédale molle",
-                    zone: "Suspension, embrayage, freinage",
-                    iconColor: "text-slate-500",
-                  },
-                  {
-                    icon: ThermometerSun,
-                    label: "Olfactif",
-                    examples: "Odeur de brûlé, caoutchouc",
-                    zone: "Embrayage, freins, électrique",
-                    iconColor: "text-red-500",
-                  },
-                ].map(({ icon: Icon, label, examples, zone, iconColor }) => (
-                  <div
-                    key={label}
-                    className="p-3 bg-gray-50 rounded-xl border border-gray-100"
-                  >
-                    <Icon className={`h-5 w-5 ${iconColor} mb-2`} />
-                    <p className="font-semibold text-gray-900 text-sm">
-                      {label}
-                    </p>
-                    <p className="text-xs text-gray-500 mt-0.5">{examples}</p>
-                    <p className="text-xs text-gray-400 mt-1 italic">{zone}</p>
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Methode 2 */}
-            <div className="mb-6">
-              <h3 className="text-lg font-bold text-gray-900 mb-2 flex items-center gap-2">
-                <span className="w-7 h-7 rounded-full bg-cta text-white text-sm flex items-center justify-center font-bold shrink-0">
-                  2
-                </span>
-                Lire les voyants du tableau de bord
-              </h3>
-              <p className="text-gray-600 mb-3">
-                Les voyants sont le premier niveau de diagnostic embarqué. La
-                couleur indique l'urgence :{" "}
-                <span className="text-red-600 font-semibold">
-                  rouge = arrêt immédiat
-                </span>
-                ,{" "}
-                <span className="text-amber-600 font-semibold">
-                  orange = attention rapide
-                </span>
-                ,{" "}
-                <span className="text-yellow-600 font-semibold">
-                  jaune = information
-                </span>
-                .
-              </p>
-              <Link
-                to="/diagnostic-auto?cluster=electricite"
-                className="inline-flex items-center gap-1.5 text-sm text-cta hover:text-cta-hover font-medium transition-colors"
-              >
-                Voir tous les diagnostics voyants{" "}
-                <ChevronRight className="h-4 w-4" />
-              </Link>
-            </div>
-
-            {/* Methode 3 */}
-            <div>
-              <h3 className="text-lg font-bold text-gray-900 mb-2 flex items-center gap-2">
-                <span className="w-7 h-7 rounded-full bg-cta text-white text-sm flex items-center justify-center font-bold shrink-0">
-                  3
-                </span>
-                Scanner le code OBD (P, C, B, U)
-              </h3>
-              <p className="text-gray-600">
-                Depuis 2001, tous les véhicules ont un port OBD2 sous le tableau
-                de bord. Un scanner OBD (à partir de 30 EUR) lit les codes
-                défaut enregistrés par le calculateur. Les codes Pxxxx
-                concernent le moteur, Cxxxx le châssis (ABS, ESP), Bxxxx la
-                carrosserie, Uxxxx le réseau de communication. Entrez votre code
-                dans l'outil en haut de page pour un diagnostic ciblé.
-              </p>
-            </div>
-          </div>
-
-          {/* Sidebar stats */}
-          <div className="space-y-4">
-            <div className="rounded-2xl bg-navy text-white p-6">
-              <p className="text-4xl font-extrabold text-cta-light mb-1">80%</p>
-              <p className="text-sm text-white/70">
-                des pannes présentent des signes avant-coureurs avant
-                l'immobilisation
-              </p>
-            </div>
-            <div className="rounded-2xl border p-6 bg-white">
-              <p className="text-4xl font-extrabold text-gray-900 mb-1">193</p>
-              <p className="text-sm text-gray-500">
-                diagnostics disponibles avec causes et solutions
-              </p>
-              <Link
-                to="/diagnostic-auto?cluster=moteur"
-                className="mt-3 inline-flex items-center gap-1.5 text-sm text-cta font-medium hover:text-cta-hover transition-colors"
-              >
-                Explorer <ChevronRight className="h-4 w-4" />
-              </Link>
-            </div>
-            <div className="rounded-2xl border p-6 bg-amber-50 border-amber-200">
-              <Zap className="h-5 w-5 text-amber-600 mb-2" />
-              <p className="text-sm font-semibold text-amber-900 mb-1">
-                Diagnostics électroniques
-              </p>
-              <p className="text-xs text-amber-700">
-                Entrez votre code OBD (P0300...) dans l'outil ci-dessus pour
-                identifier la panne avec 95% de fiabilité.
-              </p>
-            </div>
-          </div>
-        </div>
-      </Container>
-
-      {/* ═══ SIGNES AVANT-COUREURS ═══ */}
-      <section className="bg-gray-50 border-y py-14">
-        <Container>
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">
-            Les 10 signes avant-coureurs d'une panne auto
-          </h2>
-          <p className="text-gray-500 mb-8 max-w-2xl">
-            Reconnaître ces signaux tôt évite l'immobilisation et réduit le coût
-            de réparation. Classés par fréquence d'apparition.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {SIGNS_DATA.map((sign, index) => (
-              <div
-                key={index}
-                className="flex items-start gap-4 bg-white rounded-xl p-4 border border-gray-100"
-              >
-                <span className="text-2xl font-extrabold text-gray-200 w-8 shrink-0 leading-none mt-0.5">
-                  {String(index + 1).padStart(2, "0")}
-                </span>
-                <div>
-                  <p className="font-semibold text-gray-900 text-sm mb-0.5">
-                    {sign.title}
-                  </p>
-                  <p className="text-xs text-gray-500 leading-relaxed">
-                    {sign.detail}
-                  </p>
-                  {sign.cluster && (
-                    <Link
-                      to={`/diagnostic-auto?cluster=${sign.cluster}`}
-                      className="mt-1.5 inline-flex items-center gap-1 text-xs text-cta hover:text-cta-hover font-medium transition-colors"
-                    >
-                      Diagnostics {sign.clusterLabel}{" "}
-                      <ChevronRight className="h-3 w-3" />
-                    </Link>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </Container>
-      </section>
-
-      {/* ═══ MÉCANIQUE VS ÉLECTRIQUE ═══ */}
-      <Container as="section" className="py-14">
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">
-          Panne mécanique ou électrique : comment les distinguer ?
-        </h2>
-        <p className="text-gray-500 mb-8 max-w-2xl">
-          Le type de panne conditionne la méthode de diagnostic et le
-          professionnel à contacter. Voici les critères clés.
-        </p>
-        <div className="grid md:grid-cols-2 gap-6">
-          {/* Mecanique */}
-          <div className="rounded-2xl border-2 border-slate-200 p-6 bg-white">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="p-2 bg-slate-100 rounded-xl">
-                <Wrench className="h-6 w-6 text-slate-600" />
-              </div>
-              <h3 className="text-lg font-bold text-gray-900">
-                Panne mécanique
-              </h3>
-            </div>
-            <ul className="space-y-3 text-sm text-gray-700">
-              <li className="flex gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
-                <span>Apparition progressive sur plusieurs semaines</span>
-              </li>
-              <li className="flex gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
-                <span>S'accompagne de bruits, vibrations ou odeurs</span>
-              </li>
-              <li className="flex gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
-                <span>Souvent aggravée par la montée en température</span>
-              </li>
-              <li className="flex gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
-                <span>Diagnostic : inspection visuelle et écoute</span>
-              </li>
-            </ul>
-            <Separator className="my-4" />
-            <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-2">
-              Exemples fréquents
-            </p>
-            <div className="flex flex-wrap gap-1.5">
-              {[
-                "Usure plaquettes",
-                "Joint de culasse",
-                "Courroie de distribution",
-                "Amortisseur",
-                "Embrayage",
-              ].map((ex) => (
-                <span
-                  key={ex}
-                  className="text-xs bg-slate-100 text-slate-700 rounded-full px-2.5 py-0.5"
-                >
-                  {ex}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          {/* Electrique */}
-          <div className="rounded-2xl border-2 border-yellow-200 p-6 bg-white">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="p-2 bg-yellow-100 rounded-xl">
-                <Zap className="h-6 w-6 text-yellow-600" />
-              </div>
-              <h3 className="text-lg font-bold text-gray-900">
-                Panne électrique / électronique
-              </h3>
-            </div>
-            <ul className="space-y-3 text-sm text-gray-700">
-              <li className="flex gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
-                <span>Apparition souvent soudaine avec voyant allumé</span>
-              </li>
-              <li className="flex gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
-                <span>Indépendante de la température ou des vibrations</span>
-              </li>
-              <li className="flex gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
-                <span>Scanner OBD indispensable pour lire le code défaut</span>
-              </li>
-              <li className="flex gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
-                <span>Peut masquer une cause mécanique sous-jacente</span>
-              </li>
-            </ul>
-            <Separator className="my-4" />
-            <p className="text-xs text-gray-500 font-medium uppercase tracking-wider mb-2">
-              Exemples fréquents
-            </p>
-            <div className="flex flex-wrap gap-1.5">
-              {[
-                "Capteur ABS",
-                "Capteur O2",
-                "Calculateur moteur",
-                "Alternateur",
-                "FAP obstrué",
-              ].map((ex) => (
-                <span
-                  key={ex}
-                  className="text-xs bg-yellow-100 text-yellow-700 rounded-full px-2.5 py-0.5"
-                >
-                  {ex}
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </Container>
-
-      {/* ═══ DIAGNOSTICS POPULAIRES ═══ */}
-      <section className="bg-white border-y">
-        <Container className="py-12">
-          <div className="flex items-center justify-between mb-8">
-            <div>
-              <h2 className="text-2xl font-bold text-gray-900">
-                Diagnostics fréquents
-              </h2>
-              <p className="text-gray-500 mt-1">
-                Les pannes les plus recherchées par nos utilisateurs
-              </p>
-            </div>
-          </div>
-
-          {featured.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {featured.map((item) => {
-                const PerceptionIcon =
-                  PERCEPTION_ICONS[item.perception_channel] || Volume2;
-                const risk =
-                  RISK_CONFIG[item.risk_level as keyof typeof RISK_CONFIG] ||
-                  RISK_CONFIG.confort;
-
-                return (
-                  <Link
-                    key={item.slug}
-                    to={`/diagnostic-auto/${item.slug}`}
-                    className="group"
-                  >
-                    <div className="h-full rounded-xl border bg-white p-5 transition-all duration-200 hover:shadow-lg hover:border-gray-300 group-hover:-translate-y-0.5">
-                      <div className="flex items-start gap-3 mb-3">
-                        <div className="p-2 bg-gray-100 rounded-lg shrink-0 group-hover:bg-cta-50 transition-colors">
-                          <PerceptionIcon className="h-5 w-5 text-gray-500 group-hover:text-cta transition-colors" />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <h3 className="font-semibold text-gray-900 text-sm leading-tight group-hover:text-cta-hover transition-colors">
-                            {item.title}
-                          </h3>
-                        </div>
-                        <ArrowRight className="h-4 w-4 text-gray-300 shrink-0 group-hover:text-cta group-hover:translate-x-0.5 transition-all" />
-                      </div>
-                      <p className="text-sm text-gray-500 line-clamp-2 mb-3">
-                        {item.meta_description}
-                      </p>
-                      <div className="flex items-center gap-2">
-                        <span
-                          className={`inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full ${risk.bg} ${risk.text}`}
-                        >
-                          <span
-                            className={`w-1.5 h-1.5 rounded-full ${risk.dot}`}
-                          />
-                          {risk.label}
-                        </span>
-                        <span className="text-xs text-gray-400 capitalize">
-                          {item.cluster_id?.replace(/-/g, " ")}
-                        </span>
-                      </div>
+                <div className="h-full p-5 rounded-xl border-2 border-emerald-400/60 bg-emerald-500/10 hover:bg-emerald-500/20 transition-colors">
+                  <div className="flex items-start gap-3">
+                    <div className="h-10 w-10 rounded-lg bg-gradient-to-br from-emerald-400 to-teal-500 flex items-center justify-center shrink-0">
+                      <Wrench className="h-5 w-5 text-white" />
                     </div>
-                  </Link>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="py-12 text-center">
-              <ScanLine className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-              <p className="font-semibold text-gray-900 mb-1">
-                Diagnostics en cours de préparation
-              </p>
-              <p className="text-sm text-gray-500">
-                Explorez les catégories ci-dessus en attendant.
-              </p>
-            </div>
-          )}
-        </Container>
-      </section>
-
-      {/* ═══ URGENCE : PANNE SUR AUTOROUTE ═══ */}
-      <section className="bg-gradient-to-br from-red-950 to-red-900 text-white py-12">
-        <Container>
-          <div className="flex items-center gap-3 mb-6">
-            <div className="p-2 bg-red-800/60 rounded-xl border border-red-700/50">
-              <AlertTriangle className="h-6 w-6 text-red-300" />
-            </div>
-            <div>
-              <p className="text-xs text-red-400 uppercase tracking-widest font-semibold">
-                Urgence
-              </p>
-              <h2 className="text-2xl font-bold">
-                Que faire en cas de panne sur autoroute ?
-              </h2>
-            </div>
-          </div>
-          <p className="text-red-200 mb-8 max-w-2xl text-sm">
-            Sur autoroute, la priorité absolue est la sécurité des occupants —
-            avant tout diagnostic. Ne tentez jamais de réparer sur la bande
-            d'arrêt d'urgence.
-          </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-            {[
-              {
-                step: "1",
-                icon: AlertTriangle,
-                text: "Allumer les feux de détresse immédiatement",
-              },
-              {
-                step: "2",
-                icon: Car,
-                text: "Se garer sur la BAU, le plus à droite possible",
-              },
-              {
-                step: "3",
-                icon: Shield,
-                text: "Sortir par la droite, s'éloigner, revêtir le gilet",
-              },
-              {
-                step: "4",
-                icon: Phone,
-                text: "Appeler le 3477 (société d'autoroute) ou le 112",
-              },
-            ].map(({ step, icon: Icon, text }) => (
-              <div
-                key={step}
-                className="flex gap-3 bg-red-800/40 rounded-xl p-4 border border-red-700/30"
-              >
-                <span className="w-8 h-8 rounded-full bg-red-500/30 text-red-200 text-sm font-bold flex items-center justify-center shrink-0">
-                  {step}
-                </span>
-                <div>
-                  <Icon className="h-4 w-4 text-red-300 mb-1.5" />
-                  <p className="text-sm text-red-100 leading-snug">{text}</p>
+                    <div className="flex-1">
+                      <h3 className="font-semibold mb-1 text-white">
+                        Diagnostic guidé pas-à-pas
+                      </h3>
+                      <p className="text-xs text-emerald-100/90 mb-3">
+                        Véhicule + symptômes → hypothèses scorées + alertes
+                        sécurité
+                      </p>
+                      <span className="inline-flex items-center gap-1 text-sm font-medium text-emerald-200 group-hover:translate-x-1 transition-transform">
+                        Lancer
+                        <ArrowRight className="h-4 w-4" />
+                      </span>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
-          <div className="flex flex-wrap gap-3">
-            <Link
-              to="/diagnostic-auto?cluster=moteur"
-              className="inline-flex items-center gap-2 bg-white/10 hover:bg-white/20 text-white text-sm font-medium px-4 py-2 rounded-xl transition-colors border border-white/20"
-            >
-              Diagnostics moteur <ChevronRight className="h-4 w-4" />
-            </Link>
-            <Link
-              to="/diagnostic-auto?cluster=electricite"
-              className="inline-flex items-center gap-2 bg-white/10 hover:bg-white/20 text-white text-sm font-medium px-4 py-2 rounded-xl transition-colors border border-white/20"
-            >
-              Diagnostics électricité <ChevronRight className="h-4 w-4" />
-            </Link>
+              </Link>
+            </div>
           </div>
         </Container>
       </section>
 
-      {/* ═══ FAQ ═══ */}
-      <Container as="section" className="py-14">
-        <div className="flex items-center gap-3 mb-8">
-          <HelpCircle className="h-6 w-6 text-cta" />
-          <h2 className="text-2xl font-bold text-gray-900">
-            Questions fréquentes sur les pannes auto
-          </h2>
-        </div>
-        <div className="max-w-3xl">
-          <Accordion type="single" collapsible className="space-y-2">
-            {FAQ_DATA.map((item, index) => (
-              <AccordionItem
-                key={index}
-                value={`faq-${index}`}
-                className="border rounded-xl px-4 bg-white"
+      <Container className="py-10 space-y-10">
+        {/* 13 systemes */}
+        <section aria-labelledby="systems-heading">
+          <div className="flex items-center gap-3 mb-4">
+            <h2 id="systems-heading" className="text-xl font-bold">
+              Choisir par système
+            </h2>
+            <span className="text-sm text-muted-foreground">
+              {systems.length} systèmes analysés
+            </span>
+          </div>
+          <SystemCardsGrid systems={systems} />
+        </section>
+
+        {/* Diagnostics frequents (popular symptoms) */}
+        {popularSymptoms.length > 0 && (
+          <PopularSymptomsGrid items={popularSymptoms} />
+        )}
+
+        {/* Entretiens populaires */}
+        {popularMaintenance.length > 0 && (
+          <section>
+            <MaintenancePopularGrid items={popularMaintenance} />
+            <div className="mt-3 text-right">
+              <Link
+                to="/entretien"
+                className="inline-flex items-center gap-1 text-sm text-emerald-700 hover:underline font-medium"
               >
-                <AccordionTrigger className="text-left text-sm font-semibold text-gray-900 py-4 hover:no-underline">
-                  {item.question}
+                Voir tous les entretiens
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </div>
+          </section>
+        )}
+
+        {/* 4 canaux sensoriels */}
+        <DiagnosticGuide />
+
+        {/* FAQ */}
+        <section aria-labelledby="faq-heading">
+          <h2 id="faq-heading" className="text-xl font-bold mb-4">
+            Questions fréquentes
+          </h2>
+          <Accordion
+            type="single"
+            collapsible
+            className="bg-white rounded-lg border"
+          >
+            {FAQ_DATA.map((f, i) => (
+              <AccordionItem key={i} value={`faq-${i}`}>
+                <AccordionTrigger className="px-5 text-left">
+                  {f.question}
                 </AccordionTrigger>
-                <AccordionContent className="text-sm text-gray-600 leading-relaxed pb-4">
-                  {item.answer}
-                  {item.link && (
-                    <Link
-                      to={item.link.href}
-                      className="mt-2 inline-flex items-center gap-1 text-cta hover:text-cta-hover font-medium transition-colors"
-                    >
-                      {item.link.label} <ChevronRight className="h-3.5 w-3.5" />
-                    </Link>
-                  )}
+                <AccordionContent className="px-5 text-sm text-muted-foreground">
+                  {f.answer}
                 </AccordionContent>
               </AccordionItem>
             ))}
           </Accordion>
-        </div>
+        </section>
       </Container>
 
-      {/* ═══ CTA BOTTOM ═══ */}
-      <Container as="section" className="py-12">
-        <div className="rounded-2xl bg-navy text-white p-8 md:p-12 flex flex-col md:flex-row items-center gap-8">
-          <div className="flex-1">
-            <div className="flex items-center gap-2 mb-3">
-              <AlertTriangle className="h-5 w-5 text-yellow-400" />
-              <span className="text-sm font-medium text-yellow-400 uppercase tracking-wider">
-                Code erreur
-              </span>
-            </div>
-            <h3 className="text-2xl font-bold mb-2">
-              Votre tableau de bord affiche un voyant ?
-            </h3>
-            <p className="text-white/60">
-              Entrez le code OBD (P0XXX, C1XXX...) pour un diagnostic précis à
-              95% de fiabilité.
+      {/* Footer urgence */}
+      <section className="bg-gradient-to-br from-red-950 to-red-900 text-white py-10">
+        <Container>
+          <div className="max-w-3xl">
+            <h2 className="text-xl font-bold mb-2 flex items-center gap-2">
+              <Phone className="h-5 w-5" />
+              Voyant rouge ou panne bloquante ?
+            </h2>
+            <p className="text-red-100/90 text-sm mb-4">
+              Un voyant rouge impose un arrêt immédiat du véhicule. N'essayez
+              pas de continuer à rouler : les dommages peuvent devenir
+              irréversibles. Contactez un dépannage ou un garage de confiance.
             </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                to="/diagnostic-auto/wizard"
+                className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md bg-white text-red-800 text-sm font-medium hover:bg-red-50"
+              >
+                <Wrench className="h-4 w-4" />
+                Diagnostic guidé
+              </Link>
+              <Link
+                to="/entretien"
+                className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md border border-white/40 text-sm font-medium hover:bg-white/10"
+              >
+                Voir l'entretien préventif
+              </Link>
+            </div>
           </div>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              const code = dtcCode.trim().toUpperCase();
-              if (code) {
-                window.location.href = `/diagnostic-auto?dtc=${encodeURIComponent(code)}`;
-              }
-            }}
-            className="flex gap-2 shrink-0"
-          >
-            <Input
-              type="text"
-              placeholder="P0300"
-              className="h-12 w-36 bg-white/10 border-white/20 text-white placeholder:text-white/40 font-mono text-center rounded-xl text-lg"
-              value={dtcCode}
-              onChange={(e) => setDtcCode(e.target.value)}
-            />
-            <button
-              type="submit"
-              className="h-12 px-6 bg-cta hover:bg-cta-hover text-white font-bold rounded-xl transition-colors flex items-center gap-2"
-            >
-              Scanner
-              <ChevronRight className="w-4 h-4" />
-            </button>
-          </form>
-        </div>
-      </Container>
-
-      {/* Cross-link glossaire */}
-      <Container className="pb-12 flex items-center justify-center gap-2 text-sm text-gray-500">
-        <BookOpen className="w-4 h-4 text-indigo-500" />
-        <span>Comprendre les pièces mentionnées ?</span>
-        <Link
-          to="/reference-auto"
-          className="text-indigo-600 hover:text-indigo-800 font-medium transition-colors"
-        >
-          Consulter le glossaire
-        </Link>
-      </Container>
+        </Container>
+      </section>
     </div>
   );
-}
-
-export function ErrorBoundary() {
-  const error = useRouteError();
-
-  if (isRouteErrorResponse(error)) {
-    if (error.status === 404) return <ErrorGeneric />;
-    return <ErrorGeneric status={error.status} message={error.statusText} />;
-  }
-
-  return <ErrorGeneric />;
 }

--- a/frontend/app/routes/diagnostic-auto._index.tsx
+++ b/frontend/app/routes/diagnostic-auto._index.tsx
@@ -19,7 +19,8 @@ import {
   type MetaFunction,
 } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
-import { ArrowRight, Phone, Wrench } from "lucide-react";
+import { ArrowRight, Car, Phone, Wrench, X } from "lucide-react";
+import { useState } from "react";
 
 import { DiagnosticGuide } from "~/components/diagnostic-public/DiagnosticGuide";
 import { DiagnosticSearchBar } from "~/components/diagnostic-public/DiagnosticSearchBar";
@@ -39,9 +40,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "~/components/ui/accordion";
+import { Button } from "~/components/ui/button";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import VehicleSelector from "~/components/vehicle/VehicleSelector";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
+
+interface SelectedVehicle {
+  brandName: string;
+  modelName: string;
+  typeName: string;
+  year: number;
+  typeId: number;
+}
 
 export const handle = {
   pageRole: createPageRoleMeta(PageRole.R5_DIAGNOSTIC, {
@@ -165,6 +176,8 @@ export default function DiagnosticAutoIndex() {
   const { systems, popularSymptoms, popularMaintenance, stats } =
     useLoaderData<typeof loader>();
 
+  const [vehicle, setVehicle] = useState<SelectedVehicle | null>(null);
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="bg-white border-b">
@@ -190,6 +203,47 @@ export default function DiagnosticAutoIndex() {
                 ? `${stats.symptoms_count} symptômes catalogués, ${stats.systems_count} systèmes, ${stats.total_sessions.toLocaleString()} diagnostics réalisés.`
                 : "Recherchez un symptôme, un code OBD ou lancez un diagnostic guidé."}
             </p>
+
+            <div className="mb-6 space-y-4">
+              {vehicle ? (
+                <div className="flex items-center justify-between gap-3 rounded-xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-50">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Car className="h-4 w-4 shrink-0 text-emerald-300" />
+                    <span className="font-semibold">Véhicule :</span>
+                    <span className="truncate">
+                      {vehicle.brandName} {vehicle.modelName} {vehicle.year}
+                      {" • "}
+                      {vehicle.typeName}
+                    </span>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setVehicle(null)}
+                    className="h-8 px-2 text-emerald-100 hover:bg-emerald-400/20 hover:text-white"
+                    aria-label="Retirer le véhicule sélectionné"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : (
+                <VehicleSelector
+                  mode="full"
+                  context="search"
+                  redirectOnSelect={false}
+                  onVehicleSelect={(v) =>
+                    setVehicle({
+                      brandName: v.brand.marque_name,
+                      modelName: v.model.modele_name,
+                      typeName: v.type.type_name,
+                      year: v.year,
+                      typeId: v.type.type_id,
+                    })
+                  }
+                />
+              )}
+            </div>
 
             <DiagnosticSearchBar className="mb-6" />
 

--- a/frontend/app/routes/diagnostic-auto._index.tsx
+++ b/frontend/app/routes/diagnostic-auto._index.tsx
@@ -245,7 +245,10 @@ export default function DiagnosticAutoIndex() {
               )}
             </div>
 
-            <DiagnosticSearchBar className="mb-6" />
+            <DiagnosticSearchBar
+              className="mb-6"
+              vehicleTypeId={vehicle?.typeId}
+            />
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <DtcQuickLookup />

--- a/frontend/app/routes/diagnostic-auto.dtc.$code.tsx
+++ b/frontend/app/routes/diagnostic-auto.dtc.$code.tsx
@@ -1,0 +1,304 @@
+/**
+ * Route : /diagnostic-auto/dtc/$code
+ * Lookup DTC OBD-II → symptomes correspondants + causes probables.
+ * Source : GET /api/diagnostic-engine/dtc/:code
+ */
+import {
+  json,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  ScanLine,
+  Wrench,
+} from "lucide-react";
+
+import Container from "~/components/layout/Container";
+import { Badge } from "~/components/ui/badge";
+import { Card } from "~/components/ui/card";
+import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { logger } from "~/utils/logger";
+import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
+
+export const handle = {
+  pageRole: createPageRoleMeta(PageRole.R5_DIAGNOSTIC, {
+    clusterId: "diagnostic",
+    canonicalEntity: "diagnostic-dtc",
+  }),
+};
+
+const DTC_RE = /^[PCBU]\d{4}$/i;
+
+interface SymptomRow {
+  slug: string;
+  label: string;
+  description: string | null;
+  urgency: string;
+  dtc_codes: string[];
+}
+
+interface CauseLink {
+  cause_id: number;
+  relative_score: number;
+  evidence_for: string[];
+  evidence_against: string[];
+  cause?: {
+    slug: string;
+    label: string;
+    cause_type: string;
+    description: string | null;
+    urgency: string | null;
+  };
+}
+
+interface LoaderData {
+  code: string;
+  symptoms: SymptomRow[];
+  likely_causes: CauseLink[];
+  error?: string;
+}
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const API_URL = process.env.VITE_API_URL || "http://127.0.0.1:3000";
+  const code = (params.code || "").toUpperCase();
+
+  if (!DTC_RE.test(code)) {
+    return json<LoaderData>(
+      {
+        code,
+        symptoms: [],
+        likely_causes: [],
+        error: "Format DTC invalide. Exemple : P0300, C0035, B1001.",
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const res = await fetch(
+      `${API_URL}/api/diagnostic-engine/dtc/${encodeURIComponent(code)}`,
+      { headers: { Accept: "application/json" } },
+    );
+    const payload = await res.json();
+    if (!payload.success) {
+      return json<LoaderData>(
+        {
+          code,
+          symptoms: [],
+          likely_causes: [],
+          error: payload.error || "Code introuvable",
+        },
+        { status: 404 },
+      );
+    }
+    return json<LoaderData>({
+      code: payload.code || code,
+      symptoms: payload.symptoms || [],
+      likely_causes: payload.likely_causes || [],
+    });
+  } catch (error) {
+    logger.error("[diagnostic-auto.dtc] loader error", error);
+    return json<LoaderData>(
+      {
+        code,
+        symptoms: [],
+        likely_causes: [],
+        error: "Erreur lors du lookup",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const d = data as LoaderData | undefined;
+  const code = d?.code || "DTC";
+  return [
+    { title: `Code OBD ${code} — Diagnostic Auto` },
+    {
+      name: "description",
+      content: `Signification du code défaut ${code} : symptômes associés et causes probables.`,
+    },
+    { name: "robots", content: "index,follow" },
+  ];
+};
+
+export default function DiagnosticDtc() {
+  const { code, symptoms, likely_causes, error } =
+    useLoaderData<typeof loader>();
+
+  const notFound = !symptoms.length && !likely_causes.length;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white border-b">
+        <Container className="py-3">
+          <PublicBreadcrumb
+            items={[
+              { label: "Accueil", href: "/" },
+              { label: "Diagnostic Auto", href: "/diagnostic-auto" },
+              {
+                label: `Code OBD ${code}`,
+                href: `/diagnostic-auto/dtc/${code}`,
+              },
+            ]}
+          />
+        </Container>
+      </div>
+
+      <Container className="py-8">
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-purple-500 to-pink-600 flex items-center justify-center">
+              <ScanLine className="h-6 w-6 text-white" />
+            </div>
+            <div>
+              <div className="text-xs uppercase font-medium text-purple-700">
+                Code OBD-II
+              </div>
+              <h1 className="text-3xl font-bold font-mono">{code}</h1>
+            </div>
+          </div>
+          {error && (
+            <Card className="p-4 border-amber-300 bg-amber-50">
+              <div className="flex items-start gap-2 text-sm text-amber-900">
+                <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                <span>{error}</span>
+              </div>
+            </Card>
+          )}
+        </div>
+
+        {notFound ? (
+          <Card className="p-8 text-center">
+            <p className="text-muted-foreground mb-6">
+              Aucune correspondance catalogée pour le code{" "}
+              <strong>{code}</strong>. Lancez le diagnostic guidé pour une
+              analyse contextuelle.
+            </p>
+            <div className="flex justify-center gap-3">
+              <Link
+                to="/diagnostic-auto/wizard"
+                className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90"
+              >
+                <Wrench className="h-4 w-4" />
+                Diagnostic guidé
+              </Link>
+              <Link
+                to="/diagnostic-auto"
+                className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md border text-sm font-medium hover:bg-accent"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Retour
+              </Link>
+            </div>
+          </Card>
+        ) : (
+          <>
+            {symptoms.length > 0 && (
+              <section className="mb-8">
+                <h2 className="text-xl font-bold mb-4">
+                  Symptômes associés ({symptoms.length})
+                </h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {symptoms.map((s) => (
+                    <Link
+                      key={s.slug}
+                      to={`/diagnostic-auto/symptome/${s.slug}`}
+                      className="group"
+                    >
+                      <Card className="h-full p-4 border transition-all hover:shadow-md hover:border-primary/40">
+                        <div className="flex items-start gap-3">
+                          <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5" />
+                          <div className="flex-1 min-w-0">
+                            <h3 className="font-medium text-sm leading-snug group-hover:text-primary">
+                              {s.label}
+                            </h3>
+                            {s.description && (
+                              <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                                {s.description}
+                              </p>
+                            )}
+                            <div className="mt-2 flex items-center gap-2">
+                              <Badge variant="outline" className="text-[10px]">
+                                {s.urgency}
+                              </Badge>
+                            </div>
+                          </div>
+                          <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 group-hover:text-primary transition-all" />
+                        </div>
+                      </Card>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {likely_causes.length > 0 && (
+              <section>
+                <h2 className="text-xl font-bold mb-4">
+                  Causes probables scorées ({likely_causes.length})
+                </h2>
+                <div className="space-y-3">
+                  {likely_causes.map((c, i) => (
+                    <Card key={i} className="p-4">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex-1 min-w-0">
+                          <h3 className="font-semibold text-sm mb-1">
+                            {c.cause?.label || `Cause #${c.cause_id}`}
+                          </h3>
+                          {c.cause?.description && (
+                            <p className="text-xs text-muted-foreground">
+                              {c.cause.description}
+                            </p>
+                          )}
+                          {c.cause?.cause_type && (
+                            <Badge
+                              variant="secondary"
+                              className="mt-2 text-[10px]"
+                            >
+                              {c.cause.cause_type}
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="text-right shrink-0">
+                          <div className="text-xs text-muted-foreground">
+                            Score
+                          </div>
+                          <div className="text-lg font-bold">
+                            {c.relative_score}
+                          </div>
+                        </div>
+                      </div>
+                    </Card>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                to="/diagnostic-auto/wizard"
+                className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90"
+              >
+                <Wrench className="h-4 w-4" />
+                Diagnostic guidé contextuel
+              </Link>
+              <Link
+                to="/diagnostic-auto"
+                className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md border text-sm font-medium hover:bg-accent"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Retour au diagnostic
+              </Link>
+            </div>
+          </>
+        )}
+      </Container>
+    </div>
+  );
+}

--- a/frontend/app/routes/diagnostic-auto.symptome.$slug.tsx
+++ b/frontend/app/routes/diagnostic-auto.symptome.$slug.tsx
@@ -1,0 +1,456 @@
+/**
+ * Route : /diagnostic-auto/symptome/$slug
+ * Page canonical d'un symptome (R5 DIAGNOSTIC) : causes scorees + regles securite.
+ * Source : GET /api/diagnostic-engine/symptoms/:slug
+ */
+import {
+  json,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  ShieldAlert,
+  Target,
+  Wrench,
+  XCircle,
+} from "lucide-react";
+
+import Container from "~/components/layout/Container";
+import { Badge } from "~/components/ui/badge";
+import { Card } from "~/components/ui/card";
+import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { getDiagnosticColor, getDiagnosticIcon } from "~/lib/diagnostic-icons";
+import { logger } from "~/utils/logger";
+import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
+
+export const handle = {
+  pageRole: createPageRoleMeta(PageRole.R5_DIAGNOSTIC, {
+    clusterId: "diagnostic",
+    canonicalEntity: "diagnostic-symptome",
+  }),
+};
+
+interface SymptomRow {
+  slug: string;
+  label: string;
+  description: string | null;
+  urgency: string;
+  signal_mode: string;
+  synonyms: string[];
+  dtc_codes: string[];
+}
+
+interface SystemRow {
+  slug: string;
+  label: string;
+  icon_slug: string | null;
+  color_token: string | null;
+}
+
+interface CauseRow {
+  slug: string;
+  label: string;
+  cause_type: string;
+  description: string | null;
+  verification_method: string | null;
+  urgency: string | null;
+  relative_score: number;
+  evidence_for: string[];
+  evidence_against: string[];
+  requires_verification: boolean;
+}
+
+interface SafetyRuleRow {
+  rule_slug: string;
+  condition_description: string;
+  risk_flag: string;
+  urgency: string | null;
+}
+
+interface MaintenanceOpRow {
+  slug: string;
+  label: string;
+  severity_if_overdue: string | null;
+  interval_km_min: number | null;
+  interval_km_max: number | null;
+}
+
+interface LoaderData {
+  symptom: SymptomRow | null;
+  system: SystemRow | null;
+  causes: CauseRow[];
+  safety_rules: SafetyRuleRow[];
+  maintenance_ops: MaintenanceOpRow[];
+  error?: string;
+}
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const API_URL = process.env.VITE_API_URL || "http://127.0.0.1:3000";
+  const slug = params.slug || "";
+
+  try {
+    const res = await fetch(
+      `${API_URL}/api/diagnostic-engine/symptoms/${encodeURIComponent(slug)}`,
+      { headers: { Accept: "application/json" } },
+    );
+    const payload = await res.json();
+    if (!payload.success) {
+      return json<LoaderData>(
+        {
+          symptom: null,
+          system: null,
+          causes: [],
+          safety_rules: [],
+          maintenance_ops: [],
+          error: payload.error || "Symptôme introuvable",
+        },
+        { status: 404 },
+      );
+    }
+    return json<LoaderData>({
+      symptom: payload.symptom,
+      system: payload.system,
+      causes: payload.causes || [],
+      safety_rules: payload.safety_rules || [],
+      maintenance_ops: payload.maintenance_ops || [],
+    });
+  } catch (error) {
+    logger.error("[diagnostic-auto.symptome] loader error", error);
+    return json<LoaderData>(
+      {
+        symptom: null,
+        system: null,
+        causes: [],
+        safety_rules: [],
+        maintenance_ops: [],
+        error: "Erreur chargement",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const d = data as LoaderData | undefined;
+  const label = d?.symptom?.label || "Symptôme";
+  return [
+    { title: `${label} — Diagnostic Auto` },
+    {
+      name: "description",
+      content:
+        d?.symptom?.description ||
+        `Causes possibles et vérifications pour le symptôme : ${label}.`,
+    },
+    { name: "robots", content: "index,follow" },
+  ];
+};
+
+const CAUSE_TYPE_LABEL: Record<string, string> = {
+  part_failure: "Panne pièce",
+  wear: "Usure normale",
+  maintenance: "Entretien requis",
+  electrical: "Défaut électrique",
+};
+
+function scoreBarColor(score: number) {
+  if (score >= 70) return "bg-red-500";
+  if (score >= 50) return "bg-orange-500";
+  if (score >= 30) return "bg-amber-500";
+  return "bg-slate-400";
+}
+
+export default function DiagnosticSymptome() {
+  const { symptom, system, causes, safety_rules, maintenance_ops, error } =
+    useLoaderData<typeof loader>();
+
+  if (!symptom) {
+    return (
+      <Container className="py-16 text-center">
+        <h1 className="text-2xl font-bold mb-4">Symptôme introuvable</h1>
+        <p className="text-muted-foreground mb-6">{error}</p>
+        <Link
+          to="/diagnostic-auto"
+          className="text-primary hover:underline inline-flex items-center gap-1.5"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Retour au diagnostic
+        </Link>
+      </Container>
+    );
+  }
+
+  const SystemIcon = getDiagnosticIcon(system?.icon_slug);
+  const color = getDiagnosticColor(system?.color_token);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white border-b">
+        <Container className="py-3">
+          <PublicBreadcrumb
+            items={[
+              { label: "Accueil", href: "/" },
+              { label: "Diagnostic Auto", href: "/diagnostic-auto" },
+              system
+                ? {
+                    label: system.label,
+                    href: `/diagnostic-auto/systeme/${system.slug}`,
+                  }
+                : null,
+              {
+                label: symptom.label,
+                href: `/diagnostic-auto/symptome/${symptom.slug}`,
+              },
+            ].filter((x): x is { label: string; href: string } => x !== null)}
+          />
+        </Container>
+      </div>
+
+      <Container className="py-8">
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-3">
+            {system && (
+              <Link
+                to={`/diagnostic-auto/systeme/${system.slug}`}
+                className={`inline-flex items-center gap-1.5 text-xs font-medium uppercase ${color.text} hover:underline`}
+              >
+                <SystemIcon className="h-3.5 w-3.5" />
+                {system.label}
+              </Link>
+            )}
+            <Badge variant="outline" className="text-xs">
+              Urgence : {symptom.urgency}
+            </Badge>
+          </div>
+          <h1 className="text-3xl font-bold mb-3">{symptom.label}</h1>
+          {symptom.description && (
+            <p className="text-muted-foreground max-w-3xl">
+              {symptom.description}
+            </p>
+          )}
+          {symptom.dtc_codes?.length > 0 && (
+            <div className="mt-4 flex items-center gap-2 flex-wrap">
+              <span className="text-xs text-muted-foreground">
+                Codes OBD associés :
+              </span>
+              {symptom.dtc_codes.map((c) => (
+                <Link
+                  key={c}
+                  to={`/diagnostic-auto/dtc/${c}`}
+                  className="font-mono text-xs px-2 py-0.5 rounded bg-purple-100 text-purple-800 border border-purple-200 hover:bg-purple-200"
+                >
+                  {c}
+                </Link>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              to="/diagnostic-auto/wizard"
+              className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90"
+            >
+              <Wrench className="h-4 w-4" />
+              Lancer un diagnostic guidé
+            </Link>
+            <Link
+              to="/diagnostic-auto"
+              className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md border text-sm font-medium hover:bg-accent"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Retour
+            </Link>
+          </div>
+        </div>
+
+        {safety_rules.length > 0 && (
+          <Card className="p-4 mb-8 border-red-200 bg-red-50/60">
+            <div className="flex items-start gap-3">
+              <ShieldAlert className="h-5 w-5 text-red-600 shrink-0 mt-0.5" />
+              <div>
+                <h2 className="text-sm font-bold text-red-900 mb-2">
+                  Sécurité — attention
+                </h2>
+                <ul className="space-y-1 text-sm text-red-800">
+                  {safety_rules.slice(0, 4).map((r) => (
+                    <li key={r.rule_slug} className="flex gap-2">
+                      <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                      <span>{r.condition_description}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        <section>
+          <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
+            <Target className="h-5 w-5 text-primary" />
+            Causes probables ({causes.length})
+          </h2>
+          {causes.length === 0 ? (
+            <p className="text-muted-foreground">
+              Aucune cause cataloguée pour ce symptôme. Lancez le diagnostic
+              guidé pour une analyse personnalisée.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {causes.map((c) => (
+                <Card key={c.slug} className="p-5">
+                  <div className="flex items-start justify-between gap-4 mb-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <Badge variant="secondary" className="text-xs">
+                          {CAUSE_TYPE_LABEL[c.cause_type] || c.cause_type}
+                        </Badge>
+                        {c.urgency && (
+                          <Badge variant="outline" className="text-xs">
+                            Urgence : {c.urgency}
+                          </Badge>
+                        )}
+                        {c.requires_verification && (
+                          <Badge className="text-xs bg-amber-100 text-amber-900 border-amber-200">
+                            Vérification requise
+                          </Badge>
+                        )}
+                      </div>
+                      <h3 className="font-semibold text-base">{c.label}</h3>
+                      {c.description && (
+                        <p className="text-sm text-muted-foreground mt-1">
+                          {c.description}
+                        </p>
+                      )}
+                    </div>
+                    <div className="shrink-0 w-32 text-right">
+                      <div className="text-xs text-muted-foreground mb-1">
+                        Score
+                      </div>
+                      <div className="text-xl font-bold">
+                        {c.relative_score}
+                      </div>
+                      <div className="mt-1 h-1.5 rounded-full bg-slate-200 overflow-hidden">
+                        <div
+                          className={`h-full rounded-full ${scoreBarColor(c.relative_score)}`}
+                          style={{
+                            width: `${Math.min(100, Math.max(0, c.relative_score))}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  {c.verification_method && (
+                    <div className="mt-3 text-sm">
+                      <span className="font-medium">Vérification : </span>
+                      <span className="text-muted-foreground">
+                        {c.verification_method}
+                      </span>
+                    </div>
+                  )}
+
+                  {(c.evidence_for?.length > 0 ||
+                    c.evidence_against?.length > 0) && (
+                    <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3">
+                      {c.evidence_for?.length > 0 && (
+                        <div>
+                          <div className="text-xs font-semibold text-emerald-700 mb-1.5 flex items-center gap-1">
+                            <CheckCircle2 className="h-3.5 w-3.5" />
+                            Éléments en faveur
+                          </div>
+                          <ul className="space-y-1 text-xs text-muted-foreground">
+                            {c.evidence_for.map((e, i) => (
+                              <li key={i} className="flex gap-1.5">
+                                <span>•</span>
+                                <span>{e}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                      {c.evidence_against?.length > 0 && (
+                        <div>
+                          <div className="text-xs font-semibold text-slate-700 mb-1.5 flex items-center gap-1">
+                            <XCircle className="h-3.5 w-3.5" />
+                            Éléments contre
+                          </div>
+                          <ul className="space-y-1 text-xs text-muted-foreground">
+                            {c.evidence_against.map((e, i) => (
+                              <li key={i} className="flex gap-1.5">
+                                <span>•</span>
+                                <span>{e}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {maintenance_ops.length > 0 && (
+          <section className="mt-10" aria-labelledby="maint-heading">
+            <h2
+              id="maint-heading"
+              className="text-xl font-bold mb-4 flex items-center gap-2"
+            >
+              <Wrench className="h-5 w-5 text-emerald-600" />
+              Entretien préventif lié ({maintenance_ops.length})
+            </h2>
+            <p className="text-sm text-muted-foreground mb-4 max-w-3xl">
+              Ces opérations d'entretien préviennent ou traitent souvent ce
+              symptôme. À vérifier en priorité si elles sont en retard.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {maintenance_ops.map((m) => (
+                <Link
+                  key={m.slug}
+                  to={`/entretien/${m.slug}`}
+                  className="group"
+                >
+                  <Card className="h-full p-4 border transition-all hover:shadow-md hover:border-emerald-400">
+                    <div className="flex items-start gap-3">
+                      <div className="h-8 w-8 rounded-lg bg-emerald-100 flex items-center justify-center shrink-0">
+                        <Wrench className="h-4 w-4 text-emerald-700" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h3 className="font-medium text-sm group-hover:text-emerald-700">
+                          {m.label}
+                        </h3>
+                        <div className="mt-1.5 flex items-center gap-2 text-[11px] text-muted-foreground">
+                          {m.interval_km_min && (
+                            <span>
+                              Tous les {m.interval_km_min.toLocaleString()}
+                              {m.interval_km_max
+                                ? `–${m.interval_km_max.toLocaleString()}`
+                                : ""}{" "}
+                              km
+                            </span>
+                          )}
+                          {m.severity_if_overdue && (
+                            <Badge variant="outline" className="text-[10px]">
+                              {m.severity_if_overdue}
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                      <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 group-hover:text-emerald-600 transition-all" />
+                    </div>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+      </Container>
+    </div>
+  );
+}

--- a/frontend/app/routes/diagnostic-auto.systeme.$slug.tsx
+++ b/frontend/app/routes/diagnostic-auto.systeme.$slug.tsx
@@ -1,0 +1,301 @@
+/**
+ * Route : /diagnostic-auto/systeme/$slug
+ * Liste des symptomes d'un systeme + regles de securite (R5 DIAGNOSTIC).
+ * Source : GET /api/diagnostic-engine/systems/:slug
+ */
+import {
+  json,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  Shield,
+  Wrench,
+} from "lucide-react";
+
+import Container from "~/components/layout/Container";
+import { Badge } from "~/components/ui/badge";
+import { Card } from "~/components/ui/card";
+import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { getDiagnosticColor, getDiagnosticIcon } from "~/lib/diagnostic-icons";
+import { logger } from "~/utils/logger";
+import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
+
+export const handle = {
+  pageRole: createPageRoleMeta(PageRole.R5_DIAGNOSTIC, {
+    clusterId: "diagnostic",
+    canonicalEntity: "diagnostic-systeme",
+  }),
+};
+
+interface SystemDetail {
+  slug: string;
+  label: string;
+  description: string | null;
+  icon_slug: string | null;
+  color_token: string | null;
+}
+
+interface SymptomRow {
+  slug: string;
+  label: string;
+  description: string | null;
+  urgency: string;
+}
+
+interface SafetyRuleRow {
+  rule_slug: string;
+  condition_description: string;
+  risk_flag: string;
+  urgency: string | null;
+}
+
+interface LoaderData {
+  system: SystemDetail | null;
+  symptoms: SymptomRow[];
+  safety_rules: SafetyRuleRow[];
+  error?: string;
+}
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const API_URL = process.env.VITE_API_URL || "http://127.0.0.1:3000";
+  const slug = params.slug || "";
+
+  try {
+    const res = await fetch(
+      `${API_URL}/api/diagnostic-engine/systems/${encodeURIComponent(slug)}`,
+      { headers: { Accept: "application/json" } },
+    );
+    if (!res.ok) {
+      return json<LoaderData>(
+        {
+          system: null,
+          symptoms: [],
+          safety_rules: [],
+          error: `Système non trouvé (${res.status})`,
+        },
+        { status: res.status },
+      );
+    }
+    const payload = await res.json();
+    if (!payload.success) {
+      return json<LoaderData>(
+        {
+          system: null,
+          symptoms: [],
+          safety_rules: [],
+          error: payload.error || "Erreur",
+        },
+        { status: 404 },
+      );
+    }
+    return json<LoaderData>({
+      system: payload.system,
+      symptoms: payload.symptoms || [],
+      safety_rules: payload.safety_rules || [],
+    });
+  } catch (error) {
+    logger.error("[diagnostic-auto.systeme] loader error", error);
+    return json<LoaderData>(
+      {
+        system: null,
+        symptoms: [],
+        safety_rules: [],
+        error: "Erreur chargement",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const d = data as LoaderData | undefined;
+  const label = d?.system?.label || "Système";
+  return [
+    { title: `${label} — Diagnostic Auto` },
+    {
+      name: "description",
+      content:
+        d?.system?.description ||
+        `Symptômes et diagnostics du système ${label}.`,
+    },
+    { name: "robots", content: "index,follow" },
+  ];
+};
+
+const URGENCY_COLOR: Record<string, string> = {
+  critique: "bg-red-100 text-red-800 border-red-200",
+  haute: "bg-orange-100 text-orange-800 border-orange-200",
+  moyenne: "bg-amber-100 text-amber-800 border-amber-200",
+  basse: "bg-emerald-100 text-emerald-800 border-emerald-200",
+};
+
+export default function DiagnosticSysteme() {
+  const { system, symptoms, safety_rules, error } =
+    useLoaderData<typeof loader>();
+
+  if (!system) {
+    return (
+      <Container className="py-16 text-center">
+        <h1 className="text-2xl font-bold mb-4">Système introuvable</h1>
+        <p className="text-muted-foreground mb-6">{error}</p>
+        <Link
+          to="/diagnostic-auto"
+          className="text-primary hover:underline inline-flex items-center gap-1.5"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Retour au diagnostic
+        </Link>
+      </Container>
+    );
+  }
+
+  const Icon = getDiagnosticIcon(system.icon_slug);
+  const color = getDiagnosticColor(system.color_token);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white border-b">
+        <Container className="py-3">
+          <PublicBreadcrumb
+            items={[
+              { label: "Accueil", href: "/" },
+              { label: "Diagnostic Auto", href: "/diagnostic-auto" },
+              {
+                label: system.label,
+                href: `/diagnostic-auto/systeme/${system.slug}`,
+              },
+            ]}
+          />
+        </Container>
+      </div>
+
+      <Container className="py-8">
+        <div className="mb-8">
+          <div className="flex items-center gap-4 mb-4">
+            <div
+              className={`h-14 w-14 rounded-xl bg-gradient-to-br ${color.from} ${color.to} flex items-center justify-center`}
+            >
+              <Icon className="h-7 w-7 text-white" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-bold">{system.label}</h1>
+              {system.description && (
+                <p className="text-muted-foreground mt-1 max-w-2xl">
+                  {system.description}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              to="/diagnostic-auto/wizard"
+              className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90"
+            >
+              <Wrench className="h-4 w-4" />
+              Diagnostic guidé
+            </Link>
+            <Link
+              to="/diagnostic-auto"
+              className="inline-flex items-center gap-1.5 h-9 px-4 rounded-md border text-sm font-medium hover:bg-accent"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Retour
+            </Link>
+          </div>
+        </div>
+
+        {safety_rules.length > 0 && (
+          <section className="mb-8">
+            <div className="flex items-center gap-2 mb-3">
+              <Shield className="h-5 w-5 text-red-600" />
+              <h2 className="text-lg font-bold">Règles de sécurité</h2>
+              <Badge variant="outline" className="ml-auto text-xs">
+                {safety_rules.length} règle(s)
+              </Badge>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {safety_rules.map((r) => (
+                <Card
+                  key={r.rule_slug}
+                  className="p-4 border-red-200 bg-red-50/40"
+                >
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle className="h-4 w-4 text-red-600 mt-0.5" />
+                    <div className="flex-1">
+                      <p className="text-sm text-red-900">
+                        {r.condition_description}
+                      </p>
+                      <div className="mt-2 flex items-center gap-2 text-xs">
+                        <Badge variant="outline" className="text-red-700">
+                          {r.risk_flag}
+                        </Badge>
+                        {r.urgency && (
+                          <span className="text-red-600">
+                            Urgence : {r.urgency}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section>
+          <h2 className="text-lg font-bold mb-4">
+            Symptômes identifiables ({symptoms.length})
+          </h2>
+          {symptoms.length === 0 ? (
+            <p className="text-muted-foreground">
+              Aucun symptôme enregistré pour ce système.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {symptoms.map((s) => {
+                const badge = URGENCY_COLOR[s.urgency] || URGENCY_COLOR.moyenne;
+                return (
+                  <Link
+                    key={s.slug}
+                    to={`/diagnostic-auto/symptome/${s.slug}`}
+                    className="group"
+                  >
+                    <Card className="h-full p-4 border transition-all hover:shadow-md hover:border-primary/40">
+                      <div className="flex items-start gap-3">
+                        <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5" />
+                        <div className="flex-1 min-w-0">
+                          <h3 className="font-medium text-sm leading-snug group-hover:text-primary">
+                            {s.label}
+                          </h3>
+                          {s.description && (
+                            <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                              {s.description}
+                            </p>
+                          )}
+                          <div className="mt-2">
+                            <span
+                              className={`text-[10px] px-1.5 py-0.5 rounded border ${badge}`}
+                            >
+                              {s.urgency}
+                            </span>
+                          </div>
+                        </div>
+                        <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 group-hover:text-primary transition-all" />
+                      </div>
+                    </Card>
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      </Container>
+    </div>
+  );
+}

--- a/frontend/app/routes/diagnostic-auto.systeme.$slug.tsx
+++ b/frontend/app/routes/diagnostic-auto.systeme.$slug.tsx
@@ -54,10 +54,20 @@ interface SafetyRuleRow {
   urgency: string | null;
 }
 
+interface MaintenanceOpRow {
+  slug: string;
+  label: string;
+  description: string | null;
+  severity_if_overdue: string | null;
+  interval_km_min: number | null;
+  interval_km_max: number | null;
+}
+
 interface LoaderData {
   system: SystemDetail | null;
   symptoms: SymptomRow[];
   safety_rules: SafetyRuleRow[];
+  maintenance_ops: MaintenanceOpRow[];
   error?: string;
 }
 
@@ -76,6 +86,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
           system: null,
           symptoms: [],
           safety_rules: [],
+          maintenance_ops: [],
           error: `Système non trouvé (${res.status})`,
         },
         { status: res.status },
@@ -88,6 +99,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
           system: null,
           symptoms: [],
           safety_rules: [],
+          maintenance_ops: [],
           error: payload.error || "Erreur",
         },
         { status: 404 },
@@ -97,6 +109,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
       system: payload.system,
       symptoms: payload.symptoms || [],
       safety_rules: payload.safety_rules || [],
+      maintenance_ops: payload.maintenance_ops || [],
     });
   } catch (error) {
     logger.error("[diagnostic-auto.systeme] loader error", error);
@@ -105,6 +118,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
         system: null,
         symptoms: [],
         safety_rules: [],
+        maintenance_ops: [],
         error: "Erreur chargement",
       },
       { status: 500 },
@@ -135,7 +149,7 @@ const URGENCY_COLOR: Record<string, string> = {
 };
 
 export default function DiagnosticSysteme() {
-  const { system, symptoms, safety_rules, error } =
+  const { system, symptoms, safety_rules, maintenance_ops, error } =
     useLoaderData<typeof loader>();
 
   if (!system) {
@@ -295,6 +309,62 @@ export default function DiagnosticSysteme() {
             </div>
           )}
         </section>
+
+        {maintenance_ops.length > 0 && (
+          <section className="mt-10" aria-labelledby="maint-heading">
+            <div className="flex items-center gap-2 mb-4">
+              <Wrench className="h-5 w-5 text-emerald-600" />
+              <h2 id="maint-heading" className="text-lg font-bold">
+                Entretien préventif du système
+              </h2>
+              <Badge variant="outline" className="ml-auto text-xs">
+                {maintenance_ops.length} opération(s)
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground mb-4 max-w-3xl">
+              Opérations à respecter pour prévenir les pannes sur ce système.
+            </p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {maintenance_ops.map((m) => (
+                <Link
+                  key={m.slug}
+                  to={`/entretien/${m.slug}`}
+                  className="group"
+                >
+                  <Card className="h-full p-4 border transition-all hover:shadow-md hover:border-emerald-400">
+                    <div className="flex items-start gap-3">
+                      <div className="h-8 w-8 rounded-lg bg-emerald-100 flex items-center justify-center shrink-0">
+                        <Wrench className="h-4 w-4 text-emerald-700" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h3 className="font-medium text-sm group-hover:text-emerald-700">
+                          {m.label}
+                        </h3>
+                        <div className="mt-1.5 flex items-center gap-2 text-[11px] text-muted-foreground flex-wrap">
+                          {m.interval_km_min && (
+                            <span>
+                              Tous les {m.interval_km_min.toLocaleString()}
+                              {m.interval_km_max
+                                ? `–${m.interval_km_max.toLocaleString()}`
+                                : ""}{" "}
+                              km
+                            </span>
+                          )}
+                          {m.severity_if_overdue && (
+                            <Badge variant="outline" className="text-[10px]">
+                              {m.severity_if_overdue}
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                      <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 group-hover:text-emerald-600 transition-all" />
+                    </div>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
       </Container>
     </div>
   );

--- a/frontend/app/routes/diagnostic-auto.wizard.tsx
+++ b/frontend/app/routes/diagnostic-auto.wizard.tsx
@@ -1,0 +1,72 @@
+/**
+ * Route : /diagnostic-auto/wizard
+ * Route dediee au DiagnosticWizard (contrat API inchange).
+ *
+ * Role SEO : R5 - DIAGNOSTIC (sous-surface interactive)
+ */
+import { type MetaFunction } from "@remix-run/node";
+import { Link } from "@remix-run/react";
+import { ArrowLeft } from "lucide-react";
+
+import { DiagnosticWizard } from "~/components/diagnostic-wizard/DiagnosticWizard";
+import Container from "~/components/layout/Container";
+import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
+
+export const handle = {
+  pageRole: createPageRoleMeta(PageRole.R5_DIAGNOSTIC, {
+    clusterId: "diagnostic",
+    canonicalEntity: "diagnostic-auto-wizard",
+  }),
+};
+
+export const meta: MetaFunction = () => [
+  { title: "Diagnostic guidé — AutoMecanik" },
+  {
+    name: "description",
+    content:
+      "Outil interactif pour identifier une panne automobile. Renseignez votre véhicule et vos symptômes, obtenez hypothèses scorées, alertes sécurité et recommandations.",
+  },
+  { name: "robots", content: "index,follow" },
+];
+
+export default function DiagnosticAutoWizard() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white border-b">
+        <Container className="py-3">
+          <PublicBreadcrumb
+            items={[
+              { label: "Accueil", href: "/" },
+              { label: "Diagnostic Auto", href: "/diagnostic-auto" },
+              { label: "Diagnostic guidé", href: "/diagnostic-auto/wizard" },
+            ]}
+          />
+        </Container>
+      </div>
+
+      <Container className="py-8">
+        <div className="mb-6">
+          <Link
+            to="/diagnostic-auto"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Retour au diagnostic
+          </Link>
+        </div>
+
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold mb-2">Diagnostic guidé</h1>
+          <p className="text-muted-foreground max-w-2xl">
+            Renseignez votre véhicule et les symptômes observés : notre moteur
+            analyse les indices, score les hypothèses et vous oriente vers les
+            vérifications à mener.
+          </p>
+        </div>
+
+        <DiagnosticWizard />
+      </Container>
+    </div>
+  );
+}

--- a/frontend/app/routes/entretien.$slug.tsx
+++ b/frontend/app/routes/entretien.$slug.tsx
@@ -1,0 +1,294 @@
+/**
+ * Route : /entretien/$slug
+ * Detail d'une operation d'entretien (R3 CONSEILS preventif).
+ * Source : GET /api/diagnostic-engine/maintenance/:slug
+ */
+import {
+  json,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  Calendar,
+  Gauge,
+  ShoppingCart,
+  Wrench,
+} from "lucide-react";
+
+import Container from "~/components/layout/Container";
+import { Badge } from "~/components/ui/badge";
+import { Card } from "~/components/ui/card";
+import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { logger } from "~/utils/logger";
+
+interface MaintenanceOp {
+  slug: string;
+  label: string;
+  description: string | null;
+  system_id: number;
+  interval_km_min: number | null;
+  interval_km_max: number | null;
+  interval_months_min: number | null;
+  interval_months_max: number | null;
+  severity_if_overdue: string | null;
+  normal_wear_km_min: number | null;
+  normal_wear_km_max: number | null;
+  related_gamme_slug: string | null;
+  related_pg_id: number | null;
+}
+
+interface LinkedSymptom {
+  slug: string;
+  label: string;
+  urgency: string;
+}
+
+interface LoaderData {
+  operation: MaintenanceOp | null;
+  linked_symptoms: LinkedSymptom[];
+  error?: string;
+}
+
+const SEVERITY_BADGE: Record<string, string> = {
+  critical: "bg-red-100 text-red-800 border-red-200",
+  high: "bg-orange-100 text-orange-800 border-orange-200",
+  moderate: "bg-amber-100 text-amber-800 border-amber-200",
+  low: "bg-emerald-100 text-emerald-800 border-emerald-200",
+};
+
+const SEVERITY_LABEL: Record<string, string> = {
+  critical: "Critique",
+  high: "Haute",
+  moderate: "Modérée",
+  low: "Basse",
+};
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const API_URL = process.env.VITE_API_URL || "http://127.0.0.1:3000";
+  const slug = params.slug || "";
+
+  try {
+    const res = await fetch(
+      `${API_URL}/api/diagnostic-engine/maintenance/${encodeURIComponent(slug)}`,
+      { headers: { Accept: "application/json" } },
+    );
+    const payload = await res.json();
+    if (!payload.success) {
+      return json<LoaderData>(
+        {
+          operation: null,
+          linked_symptoms: [],
+          error: payload.error || "Opération introuvable",
+        },
+        { status: 404 },
+      );
+    }
+    return json<LoaderData>({
+      operation: payload.operation,
+      linked_symptoms: payload.linked_symptoms || [],
+    });
+  } catch (error) {
+    logger.error("[entretien.$slug] loader error", error);
+    return json<LoaderData>(
+      {
+        operation: null,
+        linked_symptoms: [],
+        error: "Erreur chargement",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  const d = data as LoaderData | undefined;
+  const label = d?.operation?.label || "Entretien";
+  return [
+    { title: `${label} — Guide d'entretien auto` },
+    {
+      name: "description",
+      content:
+        d?.operation?.description ||
+        `Guide complet : ${label}. Intervalle conseillé, signes d'usure, gravité en cas de retard.`,
+    },
+    { name: "robots", content: "index,follow" },
+  ];
+};
+
+export default function EntretienDetail() {
+  const { operation, linked_symptoms, error } = useLoaderData<typeof loader>();
+
+  if (!operation) {
+    return (
+      <Container className="py-16 text-center">
+        <h1 className="text-2xl font-bold mb-4">Opération introuvable</h1>
+        <p className="text-muted-foreground mb-6">{error}</p>
+        <Link
+          to="/entretien"
+          className="text-primary hover:underline inline-flex items-center gap-1.5"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Retour aux entretiens
+        </Link>
+      </Container>
+    );
+  }
+
+  const severity = operation.severity_if_overdue || "low";
+  const badgeClass = SEVERITY_BADGE[severity] || SEVERITY_BADGE.low;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white border-b">
+        <Container className="py-3">
+          <PublicBreadcrumb
+            items={[
+              { label: "Accueil", href: "/" },
+              { label: "Entretien", href: "/entretien" },
+              { label: operation.label, href: `/entretien/${operation.slug}` },
+            ]}
+          />
+        </Container>
+      </div>
+
+      <Container className="py-8">
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="h-12 w-12 rounded-xl bg-gradient-to-br from-emerald-500 to-teal-600 flex items-center justify-center">
+              <Wrench className="h-6 w-6 text-white" />
+            </div>
+            <div>
+              <div className="text-xs uppercase font-medium text-emerald-700">
+                Entretien préventif
+              </div>
+              <h1 className="text-3xl font-bold">{operation.label}</h1>
+            </div>
+          </div>
+          {operation.description && (
+            <p className="text-muted-foreground max-w-3xl">
+              {operation.description}
+            </p>
+          )}
+          <div className="mt-4">
+            <span
+              className={`text-xs px-2 py-1 rounded border ${badgeClass} font-medium`}
+            >
+              Gravité si retard : {SEVERITY_LABEL[severity] || severity}
+            </span>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+          {(operation.interval_km_min || operation.interval_km_max) && (
+            <Card className="p-5">
+              <div className="flex items-center gap-2 mb-2">
+                <Gauge className="h-4 w-4 text-emerald-600" />
+                <h2 className="font-semibold text-sm">
+                  Intervalle kilométrique
+                </h2>
+              </div>
+              <p className="text-2xl font-bold">
+                {operation.interval_km_min?.toLocaleString() || "?"}
+                {operation.interval_km_max
+                  ? `–${operation.interval_km_max.toLocaleString()}`
+                  : ""}{" "}
+                km
+              </p>
+              {operation.normal_wear_km_min && (
+                <p className="text-xs text-muted-foreground mt-2">
+                  Usure normale observée :{" "}
+                  {operation.normal_wear_km_min.toLocaleString()}
+                  {operation.normal_wear_km_max
+                    ? `–${operation.normal_wear_km_max.toLocaleString()}`
+                    : ""}{" "}
+                  km
+                </p>
+              )}
+            </Card>
+          )}
+
+          {(operation.interval_months_min || operation.interval_months_max) && (
+            <Card className="p-5">
+              <div className="flex items-center gap-2 mb-2">
+                <Calendar className="h-4 w-4 text-emerald-600" />
+                <h2 className="font-semibold text-sm">Intervalle temporel</h2>
+              </div>
+              <p className="text-2xl font-bold">
+                {operation.interval_months_min || "?"}
+                {operation.interval_months_max
+                  ? `–${operation.interval_months_max}`
+                  : ""}{" "}
+                mois
+              </p>
+              <p className="text-xs text-muted-foreground mt-2">
+                Applicable au premier des deux seuils atteint.
+              </p>
+            </Card>
+          )}
+        </div>
+
+        {linked_symptoms.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-amber-600" />
+              Symptômes qui déclenchent cet entretien
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {linked_symptoms.map((s) => (
+                <Link
+                  key={s.slug}
+                  to={`/diagnostic-auto/symptome/${s.slug}`}
+                  className="group"
+                >
+                  <Card className="h-full p-4 border transition-all hover:shadow-md hover:border-amber-400">
+                    <div className="flex items-start gap-3">
+                      <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5" />
+                      <div className="flex-1 min-w-0">
+                        <h3 className="font-medium text-sm group-hover:text-amber-700">
+                          {s.label}
+                        </h3>
+                        <Badge variant="outline" className="mt-1.5 text-[10px]">
+                          {s.urgency}
+                        </Badge>
+                      </div>
+                      <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 transition-all" />
+                    </div>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <div className="flex flex-wrap gap-3">
+          {operation.related_gamme_slug && (
+            <Link
+              to={`/pieces/${operation.related_gamme_slug}`}
+              className="inline-flex items-center gap-1.5 h-10 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90"
+            >
+              <ShoppingCart className="h-4 w-4" />
+              Voir les pièces
+            </Link>
+          )}
+          <Link
+            to="/entretien"
+            className="inline-flex items-center gap-1.5 h-10 px-4 rounded-md border text-sm font-medium hover:bg-accent"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Retour aux entretiens
+          </Link>
+          <Link
+            to="/diagnostic-auto"
+            className="inline-flex items-center gap-1.5 h-10 px-4 rounded-md border text-sm font-medium hover:bg-accent"
+          >
+            Diagnostic auto
+          </Link>
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/frontend/app/routes/entretien._index.tsx
+++ b/frontend/app/routes/entretien._index.tsx
@@ -1,0 +1,218 @@
+/**
+ * Route : /entretien
+ * Liste publique des operations d'entretien (preventif).
+ * Complement de /diagnostic-auto : focus sur l'entretien planifie.
+ *
+ * Role SEO : R3 - CONSEILS (maintenance preventive)
+ */
+import {
+  json,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from "@remix-run/node";
+import { Link, useLoaderData } from "@remix-run/react";
+import { ArrowRight, Calendar, Gauge, Wrench, TrendingUp } from "lucide-react";
+
+import { type MaintenanceOpPublic } from "~/components/diagnostic-public/types";
+import Container from "~/components/layout/Container";
+import { Badge } from "~/components/ui/badge";
+import { Card } from "~/components/ui/card";
+import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { logger } from "~/utils/logger";
+
+interface LoaderData {
+  items: MaintenanceOpPublic[];
+  error?: string;
+}
+
+const SEVERITY_BADGE: Record<string, string> = {
+  critical: "bg-red-100 text-red-800 border-red-200",
+  high: "bg-orange-100 text-orange-800 border-orange-200",
+  moderate: "bg-amber-100 text-amber-800 border-amber-200",
+  low: "bg-emerald-100 text-emerald-800 border-emerald-200",
+};
+
+const SEVERITY_LABEL: Record<string, string> = {
+  critical: "Critique",
+  high: "Haute",
+  moderate: "Modérée",
+  low: "Basse",
+};
+
+export async function loader(_args: LoaderFunctionArgs) {
+  const API_URL = process.env.VITE_API_URL || "http://127.0.0.1:3000";
+
+  try {
+    const res = await fetch(
+      `${API_URL}/api/diagnostic-engine/maintenance?limit=100`,
+      { headers: { Accept: "application/json" } },
+    );
+    if (!res.ok)
+      return json<LoaderData>({ items: [], error: `HTTP ${res.status}` });
+    const payload = await res.json();
+    return json<LoaderData>({ items: payload.items || [] });
+  } catch (error) {
+    logger.error("[entretien._index] loader error", error);
+    return json<LoaderData>({ items: [], error: "Erreur chargement" });
+  }
+}
+
+export const meta: MetaFunction = () => [
+  { title: "Entretien automobile — Guide par opération" },
+  {
+    name: "description",
+    content:
+      "Calendrier d'entretien automobile : vidange, filtres, plaquettes, courroie. Intervalles, signes d'usure et gravité en cas de retard.",
+  },
+  { name: "robots", content: "index,follow" },
+];
+
+function kmLabel(min: number | null, max: number | null): string {
+  if (min && max)
+    return `Tous les ${min.toLocaleString()}–${max.toLocaleString()} km`;
+  if (min) return `À partir de ${min.toLocaleString()} km`;
+  return "";
+}
+
+function monthsLabel(min: number | null, max: number | null): string {
+  if (min && max) return `ou ${min}–${max} mois`;
+  if (min) return `ou ${min} mois`;
+  return "";
+}
+
+export default function EntretienIndex() {
+  const { items, error } = useLoaderData<typeof loader>();
+
+  // Group by severity for quick scanning
+  const bySeverity = new Map<string, MaintenanceOpPublic[]>();
+  for (const m of items) {
+    const key = m.severity_if_overdue || "low";
+    if (!bySeverity.has(key)) bySeverity.set(key, []);
+    bySeverity.get(key)!.push(m);
+  }
+  const severityOrder = ["critical", "high", "moderate", "low"];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white border-b">
+        <Container className="py-3">
+          <PublicBreadcrumb
+            items={[
+              { label: "Accueil", href: "/" },
+              { label: "Entretien", href: "/entretien" },
+            ]}
+          />
+        </Container>
+      </div>
+
+      <section className="bg-gradient-to-br from-emerald-600 to-teal-700 text-white py-12">
+        <Container>
+          <div className="flex items-center gap-3 mb-3">
+            <Wrench className="h-8 w-8" />
+            <h1 className="text-3xl md:text-4xl font-bold">
+              Entretien automobile
+            </h1>
+          </div>
+          <p className="text-emerald-50 max-w-2xl">
+            Les {items.length} opérations d'entretien qui rallongent la durée de
+            vie de votre véhicule. Intervalles constructeur, signes d'usure
+            normale et gravité en cas de retard.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Link
+              to="/diagnostic-auto"
+              className="inline-flex items-center gap-1.5 h-10 px-4 rounded-md bg-white text-emerald-700 text-sm font-medium hover:bg-emerald-50"
+            >
+              <TrendingUp className="h-4 w-4" />
+              Plutôt un diagnostic ?
+            </Link>
+          </div>
+        </Container>
+      </section>
+
+      <Container className="py-8">
+        {error && (
+          <Card className="p-4 mb-6 border-red-200 bg-red-50 text-sm text-red-900">
+            Impossible de charger la liste : {error}
+          </Card>
+        )}
+
+        {severityOrder.map((sev) => {
+          const rows = bySeverity.get(sev);
+          if (!rows?.length) return null;
+          const badgeClass = SEVERITY_BADGE[sev] || SEVERITY_BADGE.low;
+          return (
+            <section key={sev} className="mb-10">
+              <div className="flex items-center gap-2 mb-4">
+                <h2 className="text-xl font-bold">
+                  Gravité si négligé : {SEVERITY_LABEL[sev] || sev}
+                </h2>
+                <span
+                  className={`text-[10px] px-1.5 py-0.5 rounded border ${badgeClass}`}
+                >
+                  {rows.length}
+                </span>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {rows.map((m) => (
+                  <Link
+                    key={m.slug}
+                    to={`/entretien/${m.slug}`}
+                    className="group"
+                  >
+                    <Card className="h-full p-4 border transition-all hover:shadow-md hover:border-emerald-400">
+                      <div className="flex items-start gap-3">
+                        <div className="h-9 w-9 rounded-lg bg-emerald-100 flex items-center justify-center shrink-0">
+                          <Wrench className="h-4 w-4 text-emerald-700" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <h3 className="font-medium text-sm leading-snug group-hover:text-emerald-700">
+                            {m.label}
+                          </h3>
+                          {m.description && (
+                            <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                              {m.description}
+                            </p>
+                          )}
+                          <div className="mt-2 flex items-center gap-2 flex-wrap text-[11px] text-muted-foreground">
+                            {m.interval_km_min && (
+                              <span className="inline-flex items-center gap-1">
+                                <Gauge className="h-3 w-3" />
+                                {kmLabel(m.interval_km_min, m.interval_km_max)}
+                              </span>
+                            )}
+                            {m.interval_months_min && (
+                              <span className="inline-flex items-center gap-1">
+                                <Calendar className="h-3 w-3" />
+                                {monthsLabel(
+                                  m.interval_months_min,
+                                  m.interval_months_max,
+                                )}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <ArrowRight className="h-4 w-4 text-muted-foreground group-hover:translate-x-0.5 group-hover:text-emerald-600 transition-all" />
+                      </div>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+
+        {items.length === 0 && !error && (
+          <Card className="p-8 text-center">
+            <Badge variant="outline" className="mb-3">
+              Aucune opération
+            </Badge>
+            <p className="text-muted-foreground">
+              Aucune opération d'entretien disponible pour l'instant.
+            </p>
+          </Card>
+        )}
+      </Container>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé

Expose publiquement le moteur diagnostic+entretien déjà développé (`__diag_*` : 13 systèmes, 62 symptômes, 58 causes, 30 opérations, **100+ sessions enregistrées**) via 6 nouvelles routes Remix + 8 endpoints backend. Refactor la landing `/diagnostic-auto` qui dupliquait un bloc CLUSTERS hardcodé cassé (4/6 liens 404).

**Architecture** : la recherche est déléguée au **RAG pipeline existant** (embeddings Weaviate, `truth_level: L1/L2`). Zéro synonyme fabriqué, zéro contenu LLM persisté en DB.

## 5 commits — branche propre depuis `main`

| SHA | Rôle |
|---|---|
| `8a6c2418` | Plan breezy-eagle : migration DB + 8 endpoints + 6 routes + refactor index (1108→319 LoC) + bannière legacy |
| `408845f1` | Cross-link inverse système → entretiens préventifs |
| `933c9b05` | **Pivot RAG delegation** : search via `ragProxyService.search({target_role: R5_DIAGNOSTIC})` + match exact h3→label |
| `9850ccd6` | Cleanup migration : DROP colonnes/RPC/index orphelins post-pivot |
| `79ac2073` | Finalise : `lookupDtc` aussi via RAG, zéro dépendance `dtc_codes` DB |

## Nouvelles surfaces publiques (8 endpoints backend + 6 routes Remix)

### Backend `/api/diagnostic-engine`
- `POST /analyze` — wizard diagnostic (orchestrator 6 engines)
- `GET /systems` — 13 systèmes avec icon/color
- `GET /systems/:slug` — détail + symptômes + safety + entretiens
- `GET /symptoms/:slug` — causes scorées + safety + entretiens liés (cross-link)
- `GET /search?q=` — **délègue au RAG** (embeddings sémantiques, truth_level gated)
- `GET /dtc/:code` — lookup OBD-II **via RAG** (zéro seed fabriqué)
- `GET /maintenance?system=&popular=&limit=` + `/maintenance/:slug`
- `GET /popular?kind=symptom|maintenance`

### Frontend Remix
- `/diagnostic-auto` (319 LoC, 13 cartes système SSR)
- `/diagnostic-auto/wizard` (DiagnosticWizard isolé)
- `/diagnostic-auto/systeme/:slug`
- `/diagnostic-auto/symptome/:slug` (causes + safety + entretiens)
- `/diagnostic-auto/dtc/:code`
- `/entretien` + `/entretien/:slug`
- `/diagnostic-auto/:slug` (legacy 24 URL, bannière "Nouveau diagnostic interactif")

## Smoke test live (2026-04-20, DB saine post-saturation)

```
systems          HTTP 200 — 13/13 systèmes
stats            HTTP 200 — 100 sessions, 62 symptômes, 30 entretiens
search "grincement freinage"  → 9 hits, top match slug DB résolu (score 0.94)
search "direction lourde"     → 10 hits, match exact slug DB (score 0.86)
dtc/P0300        HTTP 200 — 8 chunks RAG (plus de fabrication DB)
Frontend 7/7 routes HTTP 200
```

## Incident associé

Cette PR inclut le pivot post-incident **INC-2026-003**. Post-mortem complet : [governance-vault#9](https://github.com/ak125/governance-vault/pull/9).

L'agent avait initialement seedé ~350 entrées synonymes/DTC depuis LLM au lieu du RAG. Rollback data + pivot code appliqués. Cette PR contient uniquement le résultat final propre.

## Checklist pré-merge

- [x] Typecheck backend : EXIT=0
- [x] Typecheck frontend : EXIT=0
- [x] Lint : 0 warning
- [x] Jest diagnostic : 6/6 pass
- [x] Build backend : OK
- [x] Smoke test live DB saine : 8/8 HTTP 200
- [x] RAG delegation testée FR+EN (grincement, direction lourde, fumée noire, vidange)
- [x] Migration `20260418_diag_public_surface.sql` **appliquée en DB** (2026-04-18)
- [x] Migration `20260420_diag_cleanup_post_pivot.sql` **appliquée en DB** (2026-04-20, post-refactor)
- [x] RPC allowlist cohérent (164/164)

## Impact déploiement

Post-merge vers `main` :
- CI/CD auto-deploy prod (~5-10 min)
- `/diagnostic-auto` bascule sur nouvelle version SSR (1108 → 319 LoC)
- `/diagnostic-auto/:slug` legacy 301 inchangé (24 URL préservées)
- Cron sitemap régénère → +108 URL crawlables
- `RagProxyModule` déjà chargé en prod si `RAG_ENABLED=true` (sinon fallback ILIKE sur label)

## Fichiers clés

- `backend/src/modules/diagnostic-engine/` : 8 endpoints + orchestrator + search service RAG-delegated
- `frontend/app/routes/` : +6 routes (`diagnostic-auto.*`, `entretien.*`)
- `frontend/app/components/diagnostic-public/` : 7 composants publics
- `frontend/app/lib/diagnostic-icons.ts` : map icon/color
- `backend/supabase/migrations/` : 2 migrations déjà appliquées en DB

---

⚠️ PR #79 (`docs/inc-2026-002-paybox-tunnel`) mélangeait ce travail avec le sujet initial paybox. Cette PR-ci est **l'extraction propre** dédiée breezy-eagle uniquement.