### PR TITLE
feat(ai-content): advisor escalation infra (Pattern A, documented)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -71,6 +71,12 @@ PAYBOX_CALLBACK_MODE=strict
 # ANTHROPIC_API_KEY=
 # ANTHROPIC_MODEL=claude-sonnet-4-6
 
+# Advisor escalation (Pattern A — documented subagent fallback).
+# Executor produces a draft; if the caller's gate decides the draft is
+# insufficient, the advisor model produces an improved version.
+# Only consumed by callers that opt into generateContentWithAdvisor().
+# ANTHROPIC_ADVISOR_MODEL=claude-opus-4-6
+
 # RAG PDF Classifier (PdfRagClassifierService) — Groq direct, independant de AiContentService
 # GROQ_API_KEY=
 # GROQ_MODEL=llama-3.3-70b-versatile

--- a/backend/src/modules/ai-content/providers/anthropic.provider.ts
+++ b/backend/src/modules/ai-content/providers/anthropic.provider.ts
@@ -7,7 +7,10 @@ import {
   ErrorCodes,
 } from '../../../common/exceptions';
 import { getErrorMessage } from '../../../common/utils/error.utils';
-import { DEFAULT_EXECUTOR_MODEL } from '../config/models.constants';
+import {
+  DEFAULT_ADVISOR_MODEL,
+  DEFAULT_EXECUTOR_MODEL,
+} from '../config/models.constants';
 
 export interface AiTokenUsage {
   input: number;
@@ -20,6 +23,41 @@ export interface AiProviderOptions {
   temperature?: number;
   maxTokens?: number;
   model?: string;
+}
+
+/**
+ * Configuration for the advisor-escalation strategy (Pattern A).
+ * A fast/cheap executor model produces a draft. The caller's gate decides
+ * whether to escalate to a stronger advisor model for a second pass.
+ */
+export interface AdvisorConfig {
+  /** Advisor model ID. Defaults to ANTHROPIC_ADVISOR_MODEL env or DEFAULT_ADVISOR_MODEL. */
+  model?: string;
+  /**
+   * Gate invoked on the executor draft. Return true to escalate to the advisor,
+   * false to keep the executor draft. Errors thrown here skip escalation.
+   */
+  shouldEscalate: (
+    draft: string,
+    usage: AiTokenUsage,
+  ) => boolean | Promise<boolean>;
+  /**
+   * Optional custom advisor prompt builder. If omitted, a default "review and
+   * improve this draft" wrapper is used.
+   */
+  buildAdvisorPrompt?: (originalUserPrompt: string, draft: string) => string;
+  /** Max tokens for the advisor call. Defaults to the executor options.maxTokens. */
+  advisorMaxTokens?: number;
+}
+
+export interface AdvisorResult {
+  /** Final content — advisor output if escalated, executor draft otherwise. */
+  content: string;
+  executorUsage: AiTokenUsage;
+  advisorUsage: AiTokenUsage | null;
+  escalated: boolean;
+  /** Non-null when escalation was requested but did not run. */
+  escalationSkipped: 'not_requested' | 'advisor_failed' | null;
 }
 
 export interface AIProvider {
@@ -132,6 +170,132 @@ export class AnthropicProvider implements AIProvider {
       );
       throw error;
     }
+  }
+
+  /**
+   * Advisor-escalation strategy (Pattern A — documented subagent escalation).
+   *
+   * Flow:
+   *   1. Executor model (e.g. Sonnet) produces a draft.
+   *   2. `advisor.shouldEscalate(draft, usage)` decides if the draft is
+   *      good enough. Keep the draft on false, escalate on true.
+   *   3. On escalation, a stronger advisor model (e.g. Opus) receives the
+   *      SAME system prompt (prompt-cache preserving) plus a wrapper prompt
+   *      that exposes the original request and the executor draft.
+   *   4. Advisor output replaces the draft. Advisor errors fall back to the
+   *      executor draft so the caller never sees a total failure due to the
+   *      advisor path.
+   *
+   * No beta APIs, no server-side tools — two independent Messages API calls.
+   */
+  async generateContentWithAdvisor(
+    systemPrompt: string,
+    userPrompt: string,
+    options: AiProviderOptions,
+    advisor: AdvisorConfig,
+  ): Promise<AdvisorResult> {
+    // Step 1: executor draft
+    const executor = await this.generateContentWithUsage(
+      systemPrompt,
+      userPrompt,
+      options,
+    );
+
+    // Step 2: gate
+    let shouldEscalate: boolean;
+    try {
+      shouldEscalate = await advisor.shouldEscalate(
+        executor.content,
+        executor.usage,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Advisor gate threw, keeping executor draft: ${getErrorMessage(err)}`,
+      );
+      return {
+        content: executor.content,
+        executorUsage: executor.usage,
+        advisorUsage: null,
+        escalated: false,
+        escalationSkipped: 'advisor_failed',
+      };
+    }
+
+    if (!shouldEscalate) {
+      return {
+        content: executor.content,
+        executorUsage: executor.usage,
+        advisorUsage: null,
+        escalated: false,
+        escalationSkipped: 'not_requested',
+      };
+    }
+
+    // Step 3: advisor call
+    const advisorModel =
+      advisor.model ??
+      this.configService.get<string>(
+        'ANTHROPIC_ADVISOR_MODEL',
+        DEFAULT_ADVISOR_MODEL,
+      );
+
+    const advisorPrompt = advisor.buildAdvisorPrompt
+      ? advisor.buildAdvisorPrompt(userPrompt, executor.content)
+      : this.defaultAdvisorPrompt(userPrompt, executor.content);
+
+    try {
+      const advisorOutput = await this.generateContentWithUsage(
+        systemPrompt, // identical — preserves any system-prompt cache entry
+        advisorPrompt,
+        {
+          ...options,
+          model: advisorModel,
+          maxTokens: advisor.advisorMaxTokens ?? options.maxTokens,
+        },
+      );
+      this.logger.log(
+        `Advisor escalation success: executor_out=${executor.usage.output} advisor_out=${advisorOutput.usage.output}`,
+      );
+      return {
+        content: advisorOutput.content,
+        executorUsage: executor.usage,
+        advisorUsage: advisorOutput.usage,
+        escalated: true,
+        escalationSkipped: null,
+      };
+    } catch (err) {
+      this.logger.warn(
+        `Advisor call failed, keeping executor draft: ${getErrorMessage(err)}`,
+      );
+      return {
+        content: executor.content,
+        executorUsage: executor.usage,
+        advisorUsage: null,
+        escalated: false,
+        escalationSkipped: 'advisor_failed',
+      };
+    }
+  }
+
+  private defaultAdvisorPrompt(
+    originalUserPrompt: string,
+    draft: string,
+  ): string {
+    return [
+      'You are reviewing a draft produced by a smaller model.',
+      '',
+      '---ORIGINAL REQUEST---',
+      originalUserPrompt,
+      '---END ORIGINAL REQUEST---',
+      '',
+      '---DRAFT---',
+      draft,
+      '---END DRAFT---',
+      '',
+      'If the draft correctly and fully addresses the request, return it unchanged.',
+      'If the draft has issues (wrong format, missing info, factual errors, style problems),',
+      'return an improved version. Return ONLY the final response content, no commentary.',
+    ].join('\n');
   }
 
   /**


### PR DESCRIPTION
## Summary

Stacked on top of #87. Adds \`generateContentWithAdvisor()\` to \`AnthropicProvider\` — two-call subagent escalation pattern documented in \`shared/agent-design.md\`. A fast executor model (Sonnet) produces a draft; if the caller's gate decides the draft is insufficient, a stronger advisor model (Opus) produces an improved version using the same system prompt (preserving the prompt-cache entry).

Zero beta APIs, zero server-side tools — two independent Messages API calls. The blog-post \"Advisor tool\" (\`advisor_20260301\` / \`advisor-tool-2026-03-01\`) is **not** documented in platform.claude.com/docs or the \`claude-api\` skill (cached 2026-04-15); this implementation deliberately does not rely on it.

## Key properties

- **Opt-in** — callers must pass an \`AdvisorConfig\`; the default path is unchanged
- **Resilient** — advisor-call failures fall back to the executor draft; callers never see a total failure caused by the advisor path
- **Observable** — returns executor + advisor usage separately so billing can be tracked per tier (\`escalated\` flag + \`escalationSkipped\` reason)
- **Cache-preserving** — both calls share the exact system prompt
- **No service-layer wiring** — this PR is infrastructure only, so there is no risk surface for existing callers

## Why no service-layer wiring yet

Audit of active callers showed the two natural candidates (\`conseil-enricher\`, \`buying-guide-seo-draft\`) both hard-code \`llmPolishEnabled = false\` under the current skills-first architecture. Wiring advisor escalation into a dead path would be dead code. Phase 1b will wire in when a validated active caller is identified.

## Test plan

- [x] \`tsc --noEmit\` passes on changed files
- [x] \`eslint\` clean on changed files
- [x] Pre-commit hooks passed
- [x] No caller uses the new method, so no behavior change in any shipping flow

## Merge order

- [ ] Merge #87 first
- [ ] This PR's base will auto-update from \`chore/ai-content-phase0-hygiene\` to \`main\` after #87 merges
- [ ] Then merge this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)