### PR TITLE
docs(deployment): clarify push main = DEV preprod, tag v* = PROD

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -1,33 +1,65 @@
-# Production Deployment
+# Deployment (DEV preprod + PROD)
+
+## Deploy triggers (CRITIQUE — ne pas confondre DEV et PROD)
+
+| Trigger git | Workflow | Image produite | Environnement | VPS |
+|-------------|----------|----------------|---------------|-----|
+| `push origin main` (ou `dev`) | `.github/workflows/ci.yml` (job `deploy`) | `massdoc/nestjs-remix-monorepo:preprod` | **DEV pré-prod** | 46.224.118.55 |
+| `push origin v*` (tag) | `.github/workflows/deploy-prod.yml` | promote `preprod` → `production` | **PROD** | 49.12.233.2 |
+| `workflow_dispatch` manuel sur `deploy-prod.yml` | idem | idem | **PROD** | idem |
+
+**Règle mnémonique** :
+- `git push main` = **DEV** pré-prod (pas prod)
+- `git tag v... && git push --tags` = **PROD**
+
+Jamais annoncer "déployé en prod" après un simple merge sur main.
 
 ## Docker
 
-Port 3001 interne, Caddy reverse proxy, Redis sessions, Supabase prod. Image : `massdoc/nestjs-remix-monorepo:production`
+Port 3001 interne, Caddy reverse proxy, Redis sessions, Supabase prod.
+- Image DEV : `massdoc/nestjs-remix-monorepo:preprod`
+- Image PROD : `massdoc/nestjs-remix-monorepo:production` (promote preprod sur tag push)
 
-## CI/CD (GitHub Actions)
+## Promote DEV → PROD (workflow nominal)
 
-Fichier : `.github/workflows/ci.yml`. Self-hosted runner Linux X64.
-`git push main` → Lint → TypeCheck → Build Docker → Deploy (~5-10 min).
+```bash
+# 1. Merger sur main (déclenche deploy DEV automatique)
+gh pr merge {PR} --repo ak125/nestjs-remix-monorepo --squash
 
-Pipeline auto : pull image → stop/rm containers → `docker compose up -d`
+# 2. Valider en DEV sur 46.224.118.55
+
+# 3. Créer un tag semver + push pour déclencher deploy PROD
+git checkout main && git pull
+git tag v2.1.0
+git push origin v2.1.0
+```
+
+Ou via UI GitHub : Actions → "Deploy PROD (via tag)" → Run workflow.
 
 ## Rollback
 
 ```bash
-git revert HEAD && git push origin main  # Redeclenche avec ancien code
-# OU : docker pull image@sha256:xxx && docker compose up -d
+# DEV : revert + push main
+git revert HEAD && git push origin main
+
+# PROD : pull une image production précédente + redeploy
+docker pull massdoc/nestjs-remix-monorepo:v2.0.9 && docker compose up -d
 ```
 
 ## Monitoring
 
 - GitHub Actions : `github.com/ak125/nestjs-remix-monorepo/actions`
-- Serveur : `docker compose logs -f`, `docker ps | grep nestjs-remix`, `curl localhost:3000/health`
+- DEV : `ssh 46.224.118.55 docker compose logs -f`
+- PROD : `ssh 49.12.233.2 docker compose logs -f`
+- Health : `curl localhost:3000/health`
 
 ## Secrets GitHub
 
-`DOCKERHUB_USERNAME/TOKEN`, `DATABASE_URL`, `TURBO_TOKEN/TEAM` (optionnel)
+`DOCKERHUB_USERNAME/TOKEN`, `DATABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `TURBO_TOKEN/TEAM` (optionnel)
 
 ## Regles
 
-- `main` = prod uniquement, `develop` = code + docs
+- `main` → DEV pré-prod uniquement (JAMAIS prod directement)
+- `v*` tag → PROD
+- `dev` → DEV pré-prod (branche de développement équivalente à main pour les deploys)
 - **No Paid Render** — Docker + Caddy self-hosted uniquement


### PR DESCRIPTION
## Problème

\`.claude/rules/deployment.md\` disait \"\`git push main\` → Deploy (~5-10 min)\" sans préciser DEV vs PROD. J'ai annoncé \"prod dans 10 min\" après merge PR #86 sur main — faux, c'était DEV pré-prod.

## Réalité (source : workflow files)

| Trigger | Workflow | Environnement |
|---------|----------|---------------|
| \`push main\` | \`ci.yml:679\` job \`deploy\` | **DEV pré-prod** (46.224.118.55) |
| \`push tag v*\` | \`deploy-prod.yml:3-5\` | **PROD** (49.12.233.2) |

## Fix

\`deployment.md\` rewrite 70% :
- Tableau triggers DEV/PROD explicites
- Workflow nominal promote DEV → PROD via tag semver
- Règles : \`main\` = DEV, \`v*\` = PROD
- Rollback prod via image tag versionnée
- Mnémonique \"push main = DEV / tag = PROD\"

## Test plan

- [x] Vérification sur \`.github/workflows/ci.yml\` + \`deploy-prod.yml\`
- [x] Commit signé Deploy Bot
- [ ] Review humaine pour valider exhaustivité

🤖 Generated with [Claude Code](https://claude.com/claude-code)