### PR TITLE
fix(rpc-gate): allowlist ADR-016 new RPCs — stop 503 on /constructeurs/*

### DIFF
--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -500,9 +500,24 @@
       "reason": "SELECT only"
     },
     {
-      "name": "get_vehicle_page_data_optimized",
+      "name": "get_vehicle_page_data_cached",
+      "volatility": "STABLE",
+      "reason": "ADR-016 Phase 2 cache-first RPC, reads from __vehicle_page_cache"
+    },
+    {
+      "name": "rebuild_vehicle_page_cache",
       "volatility": "VOLATILE",
-      "reason": "Read-only optimization (migrated from P2)"
+      "reason": "ADR-016 UPSERT into __vehicle_page_cache (idempotent via source_hash)"
+    },
+    {
+      "name": "refresh_stale_vehicle_cache",
+      "volatility": "VOLATILE",
+      "reason": "ADR-016 cron helper, refresh N stale rows"
+    },
+    {
+      "name": "build_vehicle_page_payload",
+      "volatility": "STABLE",
+      "reason": "ADR-016 payload builder (called internally by rebuild)"
     },
     {
       "name": "get_vlevel_champions",

--- a/governance/rpc/rpc_allowlist.json
+++ b/governance/rpc/rpc_allowlist.json
@@ -470,9 +470,24 @@
       "reason": "SELECT only"
     },
     {
-      "name": "get_vehicle_page_data_optimized",
+      "name": "get_vehicle_page_data_cached",
+      "volatility": "STABLE",
+      "reason": "ADR-016 Phase 2 cache-first RPC, reads from __vehicle_page_cache"
+    },
+    {
+      "name": "rebuild_vehicle_page_cache",
       "volatility": "VOLATILE",
-      "reason": "Read-only optimization (migrated from P2)"
+      "reason": "ADR-016 UPSERT into __vehicle_page_cache (idempotent via source_hash)"
+    },
+    {
+      "name": "refresh_stale_vehicle_cache",
+      "volatility": "VOLATILE",
+      "reason": "ADR-016 cron helper, refresh N stale rows"
+    },
+    {
+      "name": "build_vehicle_page_payload",
+      "volatility": "STABLE",
+      "reason": "ADR-016 payload builder (called internally by rebuild)"
     },
     {
       "name": "get_vlevel_champions",


### PR DESCRIPTION
## 🚨 Hotfix prod

**Symptom :** 503 systémique sur toutes les pages `/constructeurs/{brand}/{model}/{type}.html` (~90ms), rendering Remix error boundary.

## Root cause

Après deploy tag \`v2026.04.21-adr-017-rpc-cleanup\`, le backend prod tourne sur le code Phase 2 qui appelle \`get_vehicle_page_data_cached\`. Le RPC Gate a son allowlist dans \`governance/rpc/rpc_allowlist.json\` avec \`get_vehicle_page_data_optimized\` (legacy) uniquement.

Conséquence : chaque appel backend est BLOCK → \`RpcBlockedError\` → \`ServiceUnavailableException\` → 503.

DB confirmed OK : \`SELECT get_vehicle_page_data_cached(62290)\` retourne success=true en 2ms.

## Fix

Ajout des 4 RPCs ADR-016 à l'allowlist (les 2 fichiers governance) :

- \`get_vehicle_page_data_cached\` — STABLE, lecture cache-first
- \`rebuild_vehicle_page_cache\` — VOLATILE, UPSERT idempotent
- \`refresh_stale_vehicle_cache\` — VOLATILE, cron helper
- \`build_vehicle_page_payload\` — STABLE, called internally

Entrée legacy \`get_vehicle_page_data_optimized\` retirée (fonction droppée en Phase 2).

## Urgence

**Priority P0**. Toutes pages véhicule R8 down en prod depuis ~14h UTC.

## Merge + tag

Une fois mergée, créer immédiatement un tag pour deploy prod :
\`\`\`bash
git tag v2026.04.21-hotfix-rpc-allowlist
git push origin v2026.04.21-hotfix-rpc-allowlist
\`\`\`

## Test plan

- [x] File JSON valid
- [x] Diff isolé (4 ajouts, 1 suppression)
- [ ] Post-merge : re-test \`/constructeurs/bmw-33/x2-f39-33104/18-d-sdrive-62290.html\` → doit retourner HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)