### PR TITLE
fix(r7): show vehicle name on popular parts + remove misleading 'Universel' badge

### DIFF
--- a/frontend/app/routes/constructeurs.$brand[.]html.tsx
+++ b/frontend/app/routes/constructeurs.$brand[.]html.tsx
@@ -1176,23 +1176,26 @@ function ApiPartCard({
           />
         </div>
 
-        {/* Titre */}
+        {/* Titre gamme */}
         <h4 className="font-semibold text-sm text-gray-900 mb-1 group-hover:text-blue-600 transition-colors line-clamp-2">
           {part.pg_name}
         </h4>
 
-        {/* Description SEO dynamique */}
-        {part.seo_switch_content ? (
-          <p className="text-xs text-gray-600 mb-2 line-clamp-2 leading-relaxed">
-            {part.seo_switch_content}
-          </p>
-        ) : (
-          <p className="text-xs text-gray-500 mb-2 line-clamp-1">
-            {part.modele_name} • {part.type_name}
+        {/* Véhicule compatible (toujours affiché si dispo) */}
+        {(part.modele_name || part.type_name) && (
+          <p className="text-xs font-medium text-gray-700 mb-1 line-clamp-1">
+            {[part.modele_name, part.type_name].filter(Boolean).join(" · ")}
           </p>
         )}
 
-        {/* Footer avec CTA */}
+        {/* Description SEO (bonus, si présente) */}
+        {part.seo_switch_content && (
+          <p className="text-xs text-gray-500 mb-2 line-clamp-2 leading-relaxed italic">
+            {part.seo_switch_content}
+          </p>
+        )}
+
+        {/* Footer avec CTA + année/puissance */}
         <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-100">
           <span className="text-xs font-medium text-blue-600 group-hover:underline">
             Voir les pièces →
@@ -1201,11 +1204,13 @@ function ApiPartCard({
             <span className="text-[10px] font-medium text-white px-2 py-0.5 rounded-full bg-blue-600">
               {part.type_power_ps} ch
             </span>
-          ) : (
-            <span className="text-[10px] font-medium text-gray-500 px-2 py-0.5 rounded-full bg-gray-100">
-              Universel
+          ) : part.type_year_from ? (
+            <span className="text-[10px] font-medium text-gray-600 px-2 py-0.5 rounded-full bg-gray-100">
+              {part.type_year_to
+                ? `${part.type_year_from}-${part.type_year_to}`
+                : `≥${part.type_year_from}`}
             </span>
-          )}
+          ) : null}
         </div>
       </div>
     </Link>


### PR DESCRIPTION
## Problème signalé

Section \"Pièces BMW populaires\" sur la page R7 :
- Chaque card montre \`pg_name\` (ex: \"Démarreur\") + un switch SEO (\"vérifier si grippé\")
- **Aucune info véhicule** : pas de \`modele_name\`, pas de \`type_name\`
- Badge \"Universel\" systématique quand \`type_power_ps\` absent → trompeur (la pièce EST pour un type_id spécifique)

## Cause

Le rendering fait un \`if/else\` : soit \`seo_switch_content\`, soit \`modele_name + type_name\`. Si le switch SEO existe (presque toujours), le véhicule disparaît.

## Fix

1. Ligne modèle+type **toujours** visible si dispo : \`Série 3 · 320d\`
2. Switch SEO en italique gris comme **bonus**
3. Badge : \`184 ch\` si \`type_power_ps\`, sinon \`2015-2019\` (année), sinon rien. Plus de \"Universel\" trompeur.

## Diff

\`frontend/app/routes/constructeurs.\$brand[.]html.tsx\` : +18 / -13 dans \`ApiPartCard\` seulement.

## Avant / après visuel

**Avant** :
\`\`\`
[img]
Démarreur
vérifier si grippé
[Voir les pièces →] [Universel]
\`\`\`

**Après** :
\`\`\`
[img]
Démarreur
Série 3 · 320d            <- nouveau, toujours
(vérifier si grippé)       <- italique gris, optionnel
[Voir les pièces →] [184 ch ou 2015-2019]
\`\`\`

## Test plan

- [x] TypeScript clean
- [ ] Manual test DEV : \`/constructeurs/bmw-33.html\` section pièces populaires montre le modèle+type
- [ ] Manual test marque sans seo_switch_content : fallback lisible
- [ ] Manual test type ancien (\`type_year_to\` renseigné) : affiche range \"2015-2019\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)