### PR TITLE
fix(ci): 3 structural gates — SHA consistency + RPC allowlist coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,20 @@ jobs:
         with:
           context: .
           push: true
-          tags: massdoc/nestjs-remix-monorepo:${{ inputs.tag || 'production' }}
+          # Double-tag : le tag logique (preprod|production) ET le sha court pour
+          # traçabilité irrévocable. deploy-prod.yml utilise le sha pour vérifier
+          # que l'image promue correspond bien au commit du tag git (évite la
+          # classe de bug "tag v* promote une image preprod obsolète").
+          tags: |
+            massdoc/nestjs-remix-monorepo:${{ inputs.tag || 'production' }}
+            massdoc/nestjs-remix-monorepo:sha-${{ github.sha }}
+          # Labels OCI pour introspection via `docker inspect`. deploy-prod.yml
+          # lit org.opencontainers.image.revision pour comparer avec le commit
+          # du tag git.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,13 @@ jobs:
             echo "✅ All RPC calls go through callRpc()"
           fi
 
+      - name: 🛡️ Check RPC allowlist coverage (source=api)
+        # Empêche la classe de bug INC-2026-006 (2026-04-21) :
+        # un callRpc(..., { source: 'api' }) vers un nom absent de l'allowlist
+        # → RpcBlockedError runtime → 503 prod.
+        run: |
+          bash scripts/ci/check-rpc-allowlist-coverage.sh
+
   # ============================================
   # ADR-010 - Governance Validation (2026-02-04)
   # CI as Final Authority for Agent Governance

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,10 +24,52 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: 🏷️ Promote preprod → production
+      - name: 🔒 Safety gate — SHA consistency (preprod image ↔ tag commit)
         run: |
+          # Le tag git pointe sur un commit précis. L'image :preprod est un alias
+          # flottant qui peut encore contenir un build antérieur (cas typique :
+          # push main → tag v* avant que le build preprod post-merge ait terminé).
+          # Cette étape fail-fast si mismatch, pour empêcher la classe de bug
+          # "promote une image obsolète" (incident 2026-04-21 INC-2026-006).
+          set -euo pipefail
+
           echo "📦 Pulling preprod image..."
           docker pull massdoc/nestjs-remix-monorepo:preprod
+
+          # Le commit pointé par le tag git
+          TAG_SHA="${GITHUB_SHA}"
+          echo "🏷️ Tag commit SHA      : $TAG_SHA"
+
+          # Le SHA inscrit par build.yml dans le label OCI de l'image :preprod
+          IMAGE_SHA=$(docker inspect massdoc/nestjs-remix-monorepo:preprod \
+            --format='{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+            2>/dev/null || echo "")
+          echo "🐳 Preprod image SHA    : ${IMAGE_SHA:-<unset>}"
+
+          if [ -z "$IMAGE_SHA" ]; then
+            echo "⚠️  Preprod image has no OCI revision label."
+            echo "    Cette image a été buildée avant build.yml labeling (pré 2026-04-21)."
+            echo "    On laisse passer cette fois mais prochain build sera validé."
+            echo "    Si ce message apparaît après le 2026-05-01, c'est un bug à investiguer."
+          elif [ "$IMAGE_SHA" != "$TAG_SHA" ]; then
+            echo ""
+            echo "❌ FATAL: l'image :preprod ne correspond PAS au commit du tag."
+            echo ""
+            echo "  Tag $GITHUB_REF_NAME pointe sur $TAG_SHA"
+            echo "  Mais :preprod contient $IMAGE_SHA"
+            echo ""
+            echo "Cause probable :"
+            echo "  - Le build preprod déclenché par le merge de ce commit n'a pas encore terminé."
+            echo "  - OU un build préprod a échoué sans re-publier :preprod."
+            echo ""
+            echo "Remède :"
+            echo "  1. Attendre que le workflow 'Deploy PREPROD' pour le commit $TAG_SHA soit ✅"
+            echo "  2. OU supprimer ce tag et le re-créer après : git tag -d X && git push --delete origin X"
+            echo "  3. OU utiliser l'image explicite :sha-$TAG_SHA (prochaine étape de ce job)"
+            exit 1
+          else
+            echo "✅ SHA match — safe to promote"
+          fi
 
           echo "🏷️ Tagging as production..."
           docker tag massdoc/nestjs-remix-monorepo:preprod massdoc/nestjs-remix-monorepo:production

--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -520,6 +520,21 @@
       "reason": "ADR-016 payload builder (called internally by rebuild)"
     },
     {
+      "name": "check_piece_vehicle_compatibility",
+      "volatility": "STABLE",
+      "reason": "Piece↔vehicle compatibility check (caller: pieces service)"
+    },
+    {
+      "name": "get_seo_observable_featured",
+      "volatility": "STABLE",
+      "reason": "SELECT only — featured observable for SEO diag"
+    },
+    {
+      "name": "increment_cache_hit",
+      "volatility": "VOLATILE",
+      "reason": "UPDATE cache hit counter (write but minimal)"
+    },
+    {
       "name": "get_vlevel_champions",
       "volatility": "VOLATILE",
       "reason": "SELECT only"

--- a/governance/rpc/rpc_allowlist.json
+++ b/governance/rpc/rpc_allowlist.json
@@ -490,6 +490,21 @@
       "reason": "ADR-016 payload builder (called internally by rebuild)"
     },
     {
+      "name": "check_piece_vehicle_compatibility",
+      "volatility": "STABLE",
+      "reason": "Piece↔vehicle compatibility check (caller: pieces service)"
+    },
+    {
+      "name": "get_seo_observable_featured",
+      "volatility": "STABLE",
+      "reason": "SELECT only — featured observable for SEO diag"
+    },
+    {
+      "name": "increment_cache_hit",
+      "volatility": "VOLATILE",
+      "reason": "UPDATE cache hit counter (write but minimal)"
+    },
+    {
       "name": "get_vlevel_champions",
       "volatility": "VOLATILE",
       "reason": "SELECT only"

--- a/scripts/ci/check-rpc-allowlist-coverage.sh
+++ b/scripts/ci/check-rpc-allowlist-coverage.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-rpc-allowlist-coverage.sh
+# =============================================================================
+# Gate CI : empêche un appel `callRpc('foo')` backend qui ne serait pas dans
+# `backend/governance/rpc/rpc_allowlist.json`. Déclenche sinon une erreur
+# RpcBlockedError au runtime (cause incident 2026-04-21 INC-2026-006, où
+# ADR-016 Phase 2 a renommé get_vehicle_page_data_optimized →
+# get_vehicle_page_data_cached sans mettre à jour l'allowlist).
+#
+# Scope : détecte uniquement les littéraux string simples. N'attrape PAS les
+# noms RPC calculés dynamiquement (variable, concat, template litéral). Ces
+# cas sont rares et généralement repérables en code review.
+#
+# Usage :
+#   bash scripts/ci/check-rpc-allowlist-coverage.sh
+#
+# Exit codes :
+#   0  — tous les callRpc('*') littéraux sont dans l'allowlist
+#   1  — au moins un RPC manquant
+#   2  — erreur setup (fichier allowlist introuvable, jq manquant, etc.)
+# =============================================================================
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ALLOWLIST="$ROOT/backend/governance/rpc/rpc_allowlist.json"
+BACKEND_SRC="$ROOT/backend/src"
+
+if [ ! -f "$ALLOWLIST" ]; then
+  echo "[FATAL] Allowlist introuvable : $ALLOWLIST" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[FATAL] jq est requis (apt install jq)" >&2
+  exit 2
+fi
+
+# ── Étape 1 : extraire les noms RPC de l'allowlist ──────────────────────────
+ALLOWED=$(jq -r '.functions[].name' "$ALLOWLIST" | sort -u)
+
+# ── Étape 2 : extraire les callRpc(...) avec source: 'api' ────────────────
+# Seules les RPC appelées avec `source: 'api'` DOIVENT être dans l'allowlist
+# (cf. rpc-gate.service.ts : UNKNOWN_SERVICE_ROLE=ALLOW, UNKNOWN_BLOCKED_PROD
+# quand source=api). Les autres contextes (service-role, internal) passent
+# par défaut et n'ont pas besoin d'allowlist.
+#
+# Pattern cible :
+#   this.callRpc<T>('rpc_name', { params }, { source: 'api' })
+# On extrait le nom RPC SI le bloc d'appel contient `source: 'api'`.
+CALLED=$(python3 - "$BACKEND_SRC" <<'PYEOF' | sort -u
+import os, re, sys
+root = sys.argv[1]
+
+# On capture TOUT l'appel callRpc(...) pour inspecter son context.
+# Pattern robuste : callRpc, optionnel <Type>, puis ( jusqu'à la ) qui ferme
+# au bon niveau de parenthèses.
+def extract_calls(src: str):
+    """Yield (rpc_name, has_api_source) per callRpc(...) invocation."""
+    # Trouver toutes les positions de "callRpc"
+    for m in re.finditer(r"callRpc(?:<[^>]*>)?\s*\(", src):
+        start = m.end()
+        # Parcourir pour trouver la ) qui ferme, en comptant les (
+        depth = 1
+        i = start
+        while i < len(src) and depth > 0:
+            c = src[i]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+            elif c in "'\"`":
+                # Skip string literals proprement
+                quote = c
+                i += 1
+                while i < len(src) and src[i] != quote:
+                    if src[i] == "\\":
+                        i += 2
+                        continue
+                    i += 1
+            i += 1
+        call_body = src[start:i]
+        # Extraire le nom RPC (1er string literal)
+        name_m = re.search(r"^\s*['\"]([a-zA-Z_][a-zA-Z0-9_]*)['\"]", call_body)
+        if not name_m:
+            continue
+        has_api = bool(re.search(r"source\s*:\s*['\"]api['\"]", call_body))
+        yield name_m.group(1), has_api
+
+found = set()
+for dirpath, dirs, files in os.walk(root):
+    if any(skip in dirpath for skip in ("/node_modules", "/dist", "/build", "/.nest")):
+        continue
+    for f in files:
+        if not f.endswith(".ts"):
+            continue
+        path = os.path.join(dirpath, f)
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                src = fh.read()
+        except Exception:
+            continue
+        for name, has_api in extract_calls(src):
+            if has_api:  # ← le filtre clé
+                found.add(name)
+
+for name in sorted(found):
+    print(name)
+PYEOF
+)
+
+# ── Étape 3 : diff ──────────────────────────────────────────────────────────
+MISSING=$(comm -23 <(echo "$CALLED") <(echo "$ALLOWED"))
+
+if [ -z "$MISSING" ]; then
+  COUNT=$(echo "$CALLED" | grep -c . || echo 0)
+  echo "✅ RPC allowlist coverage OK ($COUNT appels callRpc, tous couverts)"
+  exit 0
+fi
+
+echo "❌ RPC allowlist coverage FAILED" >&2
+echo "" >&2
+echo "Les RPC suivantes sont appelées par le backend mais absentes de l'allowlist :" >&2
+echo "$MISSING" | sed 's/^/  - /' >&2
+echo "" >&2
+echo "Fix : ajouter chaque RPC dans $ALLOWLIST" >&2
+echo "      (format : {\"name\": \"<rpc>\", \"volatility\": \"STABLE|VOLATILE\", \"reason\": \"...\"})" >&2
+echo "" >&2
+echo "Pourquoi ce gate existe :" >&2
+echo "  Incident 2026-04-21 — ADR-016 Phase 2 a renommé get_vehicle_page_data_optimized" >&2
+echo "  en get_vehicle_page_data_cached sans MAJ de l'allowlist → 503 systémique en prod" >&2
+echo "  pendant 67 min. Ce gate empêche la classe de bug." >&2
+exit 1


### PR DESCRIPTION
Post-mortem **INC-2026-006** (2026-04-21) — 503 sur `/constructeurs/*` pendant 67 min.

## Root cause (double bug)

1. **ADR-016 Phase 2** a renommé `get_vehicle_page_data_optimized` en `get_vehicle_page_data_cached` mais l'allowlist RPC Gate n'a pas été mise à jour → `RpcBlockedError` → 503.
2. `deploy-prod.yml` promote l'image `:preprod` **sans vérifier** que son SHA correspond au commit du tag git → premier hotfix a promu une ancienne image sans fix.

## 3 gates structurels (fix la classe entière de bug)

### 1. Labels OCI + tag SHA sur chaque image Docker (`build.yml`)
- Ajout tag `sha-<github.sha>` en plus de `:preprod`
- Labels OCI : `org.opencontainers.image.revision`, `source`, `created`

### 2. SHA consistency gate (`deploy-prod.yml`)
- `docker inspect :preprod` lit le label revision
- **Fail fast** si ≠ `github.sha` du tag
- Message d'erreur explicite avec 3 remèdes

### 3. RPC allowlist coverage gate (`scripts/ci/check-rpc-allowlist-coverage.sh`)
- Parse multiline tous les `callRpc(..., { source: 'api' })` en Python
- Compare avec `backend/governance/rpc/rpc_allowlist.json`
- **Fail CI** si un nom RPC manque
- Wired dans le job `rpc-gate-check` (ci.yml)

## Allowlist mise à jour

- 4 RPC ADR-016 (déjà fait en hotfix #93)
- 3 RPC manquantes détectées par le nouveau gate (`check_piece_vehicle_compatibility`, `get_seo_observable_featured`, `increment_cache_hit`)

## Vérification locale

```
✅ RPC allowlist coverage OK (28 appels callRpc, tous couverts)
```

## Test plan

- [x] Script gate passe en local (28/28)
- [ ] CI doit passer tous les gates existants + le nouveau
- [ ] Post-merge → build preprod labeled SHA
- [ ] Tag test v* (dry-run) → vérifier SHA consistency step

## Refs

- INC-2026-006 — post-mortem dans vault (PR suivante)
- ADR-016 Phase 2 (fc9b94af)
- PR #93 (allowlist hotfix) — déjà mergée

🤖 Generated with [Claude Code](https://claude.com/claude-code)