### PR TITLE
feat(monitoring): PREV-2 generic 5xx alerting via __error_logs

### DIFF
--- a/backend/supabase/migrations/20260421_add_check_error_logs_5xx_threshold_rpc.sql
+++ b/backend/supabase/migrations/20260421_add_check_error_logs_5xx_threshold_rpc.sql
@@ -1,0 +1,123 @@
+-- =============================================================================
+-- PREV-2 — RPC d'agrégation 5xx pour alerting générique
+-- =============================================================================
+-- Post-incident INC-2026-006 (2026-04-21, 67 min 503 /constructeurs/*).
+--
+-- Le problème actuel : aucune alerte ne se déclenche quand une classe d'URLs
+-- tombe en 5xx en prod. L'incident du 21/04 a été détecté manuellement par
+-- un smoke test, pas par une sonde. Durée avant détection : 25 min.
+--
+-- Cette RPC alimente scripts/monitoring/check-error-logs-5xx.sh, un cron
+-- toutes les 5 min qui alerte par email si le seuil est dépassé.
+--
+-- ARCHITECTURE : identique à check_payment_tunnel_health (PREV-1).
+--   - Appelée via PostgREST + service_role_key
+--   - SECURITY DEFINER pour bypass RLS sur __error_logs
+--   - Retour : compteurs globaux + breach flag + top 5 URLs affectées
+--
+-- COUVERTURE : toutes les routes qui passent par ErrorLogsInterceptor NestJS
+-- (ie. toutes les routes HTTP). Contrairement aux smoke tests par URL
+-- hardcodée (bricolage), cette alerte est générique et future-proof.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.check_error_logs_5xx_threshold(
+  p_window_minutes integer DEFAULT 5,
+  p_min_count integer DEFAULT 5
+)
+RETURNS TABLE(
+  total_5xx bigint,
+  distinct_urls bigint,
+  threshold_breached boolean,
+  top_urls jsonb,
+  window_start timestamptz,
+  window_end timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+  WITH window_bounds AS (
+    SELECT
+      NOW() - make_interval(mins => p_window_minutes) AS win_start,
+      NOW() AS win_end
+  ),
+  errors AS (
+    SELECT
+      -- Normaliser l'URL au path (enlever query string) pour le regroupement
+      SPLIT_PART(COALESCE(err_url, ''), '?', 1) AS url_path,
+      err_status,
+      err_code,
+      err_message,
+      err_created_at
+    FROM __error_logs, window_bounds
+    WHERE err_created_at >= window_bounds.win_start
+      AND (
+        -- HTTP status explicite 5xx
+        COALESCE(err_status, 0) >= 500
+        -- OU exception NestJS avec statut 5xx implicite (err_status=NULL pour
+        -- les Exception NestJS — le buffer __error_logs ne matérialise pas le
+        -- HTTP status quand l'erreur vient d'un throw d'Exception).
+        OR err_code IN (
+          'ServiceUnavailableException',
+          'InternalServerErrorException',
+          'OperationFailedException',
+          'GatewayTimeoutException',
+          'BadGatewayException',
+          'NotImplementedException'
+        )
+      )
+      -- Exclure bruit d'health checks / bots qui échouent par design
+      AND COALESCE(err_url, '') NOT LIKE '/.well-known/%'
+      AND COALESCE(err_url, '') NOT LIKE '/robots.txt%'
+      AND COALESCE(err_url, '') NOT LIKE '/favicon.ico%'
+  ),
+  aggregated AS (
+    SELECT
+      url_path,
+      COUNT(*) AS url_count,
+      -- Sample du dernier message/code pour diagnostic rapide
+      (ARRAY_AGG(err_message ORDER BY err_created_at DESC))[1] AS last_message,
+      (ARRAY_AGG(err_code    ORDER BY err_created_at DESC))[1] AS last_code,
+      MAX(err_created_at)::text AS last_seen
+    FROM errors
+    GROUP BY url_path
+  ),
+  top AS (
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'url',          url_path,
+        'count',        url_count,
+        'last_message', last_message,
+        'last_code',    last_code,
+        'last_seen',    last_seen
+      )
+      ORDER BY url_count DESC
+    ) FILTER (WHERE url_path IS NOT NULL) AS urls_json
+    FROM (
+      SELECT * FROM aggregated
+      ORDER BY url_count DESC
+      LIMIT 5
+    ) AS limited
+  ),
+  totals AS (
+    SELECT
+      COUNT(*)::bigint              AS tot,
+      COUNT(DISTINCT url_path)::bigint AS nb_urls
+    FROM errors
+  )
+  SELECT
+    totals.tot,
+    totals.nb_urls,
+    (totals.tot >= p_min_count)   AS breached,
+    COALESCE(top.urls_json, '[]'::jsonb) AS urls,
+    window_bounds.win_start,
+    window_bounds.win_end
+  FROM totals, top, window_bounds;
+$fn$;
+
+COMMENT ON FUNCTION public.check_error_logs_5xx_threshold(integer,integer) IS
+  'PREV-2 — Agrégation 5xx sur fenêtre glissante pour alerting externe. '
+  'Retourne total/distinct_urls/breach + top 5 URLs avec sample message. '
+  'Consommé par scripts/monitoring/check-error-logs-5xx.sh. '
+  'Added 2026-04-21 post-incident INC-2026-006.';

--- a/scripts/monitoring/README.md
+++ b/scripts/monitoring/README.md
@@ -154,9 +154,113 @@ Le #2 est idéal mais requiert un endpoint backend dédié. À inclure dans PREV
 
 ---
 
-## RPC Supabase associée
+## `check-error-logs-5xx.sh` (PREV-2)
 
-Le script consomme [`check_payment_tunnel_health(p_window_hours int)`](../../backend/supabase/migrations/20260417_add_check_payment_tunnel_health_rpc.sql).
+Alerte générique sur les 5xx backend. Complément structurel à PREV-1 (Paybox-specific).
+
+### Contexte
+
+Incident INC-2026-006 (2026-04-21, 67 min 503 sur `/constructeurs/*` sans alerte). Détection manuelle via smoke test ad-hoc. PREV-2 sonne l'alarme en ≤ 5 min sur **toute classe d'URLs** qui tombe en 5xx, sans liste hardcodée.
+
+Détails : [`governance-vault/ledger/incidents/2026/2026-04-21-503-vehicle-pages-rpc-allowlist-stale-image.md`](https://github.com/ak125/governance-vault/blob/main/ledger/incidents/2026/2026-04-21-503-vehicle-pages-rpc-allowlist-stale-image.md).
+
+### Architecture
+
+Identique à PREV-1 (même pattern → maintenable) :
+
+```
+cron (5min)
+   │
+   ▼
+check-error-logs-5xx.sh
+   │
+   ├── curl POST ──► Supabase PostgREST /rpc/check_error_logs_5xx_threshold
+   │                 Retourne {total_5xx, distinct_urls, breached, top_urls[]}
+   │
+   ├── règle : threshold_breached == true → alerte
+   │
+   └── alerte → python3 stdlib → Gmail SMTP OAuth2
+```
+
+### Couverture
+
+Toutes les routes qui passent par `ErrorLogsInterceptor` NestJS (= toutes les routes HTTP). La RPC matche :
+- `err_status >= 500` (HTTP status explicite)
+- `err_code IN ('ServiceUnavailableException', 'InternalServerErrorException', 'OperationFailedException', 'GatewayTimeoutException', 'BadGatewayException', 'NotImplementedException')` (Exceptions NestJS avec err_status=NULL)
+
+Exclut `/robots.txt`, `/.well-known/*`, `/favicon.ico` (bruit connu).
+
+### Règle d'alerte
+
+```
+alerte si (total_5xx >= MIN_COUNT_THRESHOLD sur WINDOW_MINUTES)
+       ET (pas d'alerte envoyée depuis DEDUP_WINDOW_MIN)
+```
+
+Défauts :
+- `WINDOW_MINUTES=5`
+- `MIN_COUNT_THRESHOLD=5` (évite faux positifs sur traffic léger)
+- `DEDUP_WINDOW_MIN=30`
+
+### Env vars
+
+Identiques à PREV-1 (les secrets Gmail sont partagés). Seuls les seuils changent :
+
+| Variable | Défaut | Usage |
+|---|---|---|
+| `WINDOW_MINUTES` | `5` | Fenêtre glissante (minutes) |
+| `MIN_COUNT_THRESHOLD` | `5` | Nb min 5xx pour déclencher |
+| `DEDUP_WINDOW_MIN` | `30` | Minutes avant ré-alerte |
+| `DEDUP_CACHE` | `/var/tmp/check-error-logs-5xx.last-alert` | Fichier dedup |
+
+### Installation prod (host `49.12.233.2`)
+
+```bash
+RUNNER_REPO=/home/deploy/actions-runner/_work/nestjs-remix-monorepo/nestjs-remix-monorepo
+sudo install -m 755 "$RUNNER_REPO/scripts/monitoring/check-error-logs-5xx.sh" /usr/local/bin/
+
+# Réutilise le fichier env de PREV-1 (mêmes secrets Gmail + Supabase)
+sudo ln -sf /etc/default/check-payment-tunnel /etc/default/check-error-logs-5xx
+
+# Test manuel
+sudo -E bash -c 'set -a; . /etc/default/check-error-logs-5xx; set +a; /usr/local/bin/check-error-logs-5xx.sh'
+# Exit code 0 = pas de breach, 2 = alerte envoyée, 1 = erreur technique
+
+# Activer le cron (toutes les 5 min)
+sudo tee /etc/cron.d/check-error-logs-5xx >/dev/null <<'EOF'
+MAILTO=automecanik.seo@gmail.com
+*/5 * * * * root set -a; . /etc/default/check-error-logs-5xx; set +a; /usr/local/bin/check-error-logs-5xx.sh >> /var/log/check-error-logs-5xx.log 2>&1
+EOF
+sudo chmod 644 /etc/cron.d/check-error-logs-5xx
+```
+
+### Test manuel (force alerte)
+
+```bash
+sudo -E bash -c '
+  set -a; . /etc/default/check-error-logs-5xx; set +a
+  DEDUP_CACHE=/tmp/test-alert-5xx.cache MIN_COUNT_THRESHOLD=1 WINDOW_MINUTES=60 \
+  /usr/local/bin/check-error-logs-5xx.sh
+'
+```
+
+### Exit codes
+
+Identiques à PREV-1 : `0`=OK, `1`=erreur technique, `2`=alerte envoyée.
+
+---
+
+## RPC Supabase associées
+
+**PREV-1** : [`check_payment_tunnel_health(p_window_hours int)`](../../backend/supabase/migrations/20260417_add_check_payment_tunnel_health_rpc.sql)
+
+**PREV-2** : [`check_error_logs_5xx_threshold(p_window_minutes int, p_min_count int)`](../../backend/supabase/migrations/20260421_add_check_error_logs_5xx_threshold_rpc.sql)
+
+Test direct en SQL :
+```sql
+SELECT total_5xx, distinct_urls, threshold_breached FROM check_error_logs_5xx_threshold();
+SELECT jsonb_pretty(top_urls) FROM check_error_logs_5xx_threshold(60, 5);  -- 60min, seuil 5
+```
 
 Test direct en SQL :
 ```sql

--- a/scripts/monitoring/check-error-logs-5xx.sh
+++ b/scripts/monitoring/check-error-logs-5xx.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# check-error-logs-5xx.sh — PREV-2 alerting générique sur les 5xx backend.
+#
+# Contexte : incident INC-2026-006 (2026-04-21, 67 min 503 sur /constructeurs/*).
+# Détection actuelle : manuelle par smoke test ad-hoc. Ce script sonne l'alarme
+# en ≤ 5 min sur toute classe d'URLs qui passe en 5xx, sans liste hardcodée.
+#
+# Architecture : identique à check-payment-tunnel.sh (PREV-1). Zéro dépendance
+# système hors python3 + curl. Voir scripts/monitoring/README.md pour l'install.
+#   - Supabase PostgREST : RPC check_error_logs_5xx_threshold
+#   - Gmail SMTP OAuth2  : envoi alerte (python3 stdlib)
+#
+# Règle : alerte si total_5xx >= MIN_COUNT_THRESHOLD sur fenêtre glissante
+# WINDOW_MINUTES. Anti-spam DEDUP_WINDOW_MIN.
+#
+# Env requis (identiques à PREV-1, partagés via /etc/default/check-error-logs-5xx) :
+#   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+#   GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN, GMAIL_USER_EMAIL
+#   ALERT_EMAIL_TO, EMAIL_FROM
+#
+# Env optionnel :
+#   WINDOW_MINUTES=5     (fenêtre glissante)
+#   MIN_COUNT_THRESHOLD=5 (seuil total 5xx déclenchant alerte)
+#   DEDUP_WINDOW_MIN=30   (minutes avant ré-alerte)
+#
+# Exit codes :
+#   0 = OK (pas de breach ou signal insuffisant)
+#   1 = erreur technique (API down, creds manquants, parsing)
+#   2 = alerte envoyée (dedup activé)
+
+set -euo pipefail
+
+SCRIPT_NAME="check-error-logs-5xx"
+log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [${SCRIPT_NAME}] $*" >&2; }
+
+# --- Validation env --------------------------------------------------------
+: "${SUPABASE_URL:?SUPABASE_URL manquant}"
+: "${SUPABASE_SERVICE_ROLE_KEY:?SUPABASE_SERVICE_ROLE_KEY manquant}"
+: "${GMAIL_CLIENT_ID:?GMAIL_CLIENT_ID manquant}"
+: "${GMAIL_CLIENT_SECRET:?GMAIL_CLIENT_SECRET manquant}"
+: "${GMAIL_REFRESH_TOKEN:?GMAIL_REFRESH_TOKEN manquant}"
+: "${GMAIL_USER_EMAIL:?GMAIL_USER_EMAIL manquant (ex: contact@automecanik.com)}"
+: "${ALERT_EMAIL_TO:?ALERT_EMAIL_TO manquant}"
+: "${EMAIL_FROM:?EMAIL_FROM manquant}"
+
+WINDOW_MINUTES="${WINDOW_MINUTES:-5}"
+MIN_COUNT_THRESHOLD="${MIN_COUNT_THRESHOLD:-5}"
+DEDUP_CACHE="${DEDUP_CACHE:-/var/tmp/check-error-logs-5xx.last-alert}"
+DEDUP_WINDOW_MIN="${DEDUP_WINDOW_MIN:-30}"
+
+# --- Appel RPC Supabase via PostgREST --------------------------------------
+RPC_URL="${SUPABASE_URL}/rest/v1/rpc/check_error_logs_5xx_threshold"
+RPC_PAYLOAD="{\"p_window_minutes\": ${WINDOW_MINUTES}, \"p_min_count\": ${MIN_COUNT_THRESHOLD}}"
+
+RESP=$(curl -sS -w $'\n%{http_code}' \
+  -X POST "$RPC_URL" \
+  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H 'Content-Type: application/json' \
+  -d "$RPC_PAYLOAD" 2>&1) || {
+    log "ERROR: curl vers $RPC_URL a échoué"
+    exit 1
+  }
+
+HTTP_CODE=$(printf '%s\n' "$RESP" | tail -n1)
+BODY=$(printf '%s\n' "$RESP" | sed '$d')
+
+if [ "$HTTP_CODE" != "200" ]; then
+  log "ERROR: RPC HTTP ${HTTP_CODE} — body: ${BODY}"
+  exit 1
+fi
+
+# --- Parse JSON ------------------------------------------------------------
+# RPC retourne array PostgREST : [{"total_5xx":N, "threshold_breached":bool, ...}]
+METRICS=$(printf '%s' "$BODY" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception as e:
+    print("ERROR_PARSE:" + str(e), end="")
+    sys.exit(1)
+if isinstance(data, list) and data:
+    d = data[0]
+elif isinstance(data, dict):
+    d = data
+else:
+    print("ERROR_SHAPE", end="")
+    sys.exit(1)
+total = d.get("total_5xx", 0)
+nb = d.get("distinct_urls", 0)
+breached = 1 if d.get("threshold_breached") else 0
+# Serialiser top_urls en TSV compact pour le shell
+top = d.get("top_urls") or []
+if isinstance(top, str):
+    try: top = json.loads(top)
+    except: top = []
+top_encoded = "\n".join(
+    f"{u.get(\"count\",0)}\t{u.get(\"url\",\"?\")}\t{(u.get(\"last_code\") or \"?\")[:50]}\t{(u.get(\"last_message\") or \"\")[:200]}"
+    for u in top
+)
+# Fin avec |||END||| pour séparer les champs multiligne
+print(f"{total}|||{nb}|||{breached}|||{top_encoded}", end="")
+') || {
+    log "ERROR: parsing JSON échoué — body: ${BODY}"
+    exit 1
+  }
+
+total_5xx=$(printf '%s' "$METRICS" | awk -F '[|][|][|]' '{print $1}')
+distinct_urls=$(printf '%s' "$METRICS" | awk -F '[|][|][|]' '{print $2}')
+breached=$(printf '%s' "$METRICS" | awk -F '[|][|][|]' '{print $3}')
+top_urls_raw=$(printf '%s' "$METRICS" | awk -F '[|][|][|]' '{for (i=4; i<=NF; i++) printf "%s%s", $i, (i<NF ? "|||" : "")}')
+
+case "$total_5xx"      in ''|*[!0-9]*) log "ERROR: total_5xx non numerique: $total_5xx"; exit 1;; esac
+case "$distinct_urls"  in ''|*[!0-9]*) log "ERROR: distinct_urls non numerique";          exit 1;; esac
+
+log "INFO: window=${WINDOW_MINUTES}min total_5xx=${total_5xx} distinct_urls=${distinct_urls} breached=${breached}"
+
+# --- Règle d'alerte --------------------------------------------------------
+if [ "$breached" != "1" ]; then
+  log "OK: pas de breach (${total_5xx} < ${MIN_COUNT_THRESHOLD} sur ${WINDOW_MINUTES}min)"
+  exit 0
+fi
+
+# --- Anti-spam -------------------------------------------------------------
+if [ -f "$DEDUP_CACHE" ]; then
+  last_alert_ts=$(cat "$DEDUP_CACHE" 2>/dev/null || echo 0)
+  now_ts=$(date +%s)
+  dedup_seconds=$((DEDUP_WINDOW_MIN * 60))
+  if [ $((now_ts - last_alert_ts)) -lt "$dedup_seconds" ]; then
+    log "OK: alerte deja envoyee < ${DEDUP_WINDOW_MIN}min, skip"
+    exit 0
+  fi
+fi
+
+# --- Construction du corps d'email -----------------------------------------
+SUBJECT="[PREV-2] ${total_5xx} erreurs 5xx sur ${WINDOW_MINUTES}min — ${distinct_urls} URLs distinctes"
+HOST_SAFE=$(hostname 2>/dev/null || echo "?")
+
+# Top URLs formatées en tableau texte
+TOP_TABLE=""
+if [ -n "$top_urls_raw" ]; then
+  TOP_TABLE=$(printf '%s' "$top_urls_raw" \
+    | tr '\n' '\001' \
+    | sed 's/|||/\n/g' \
+    | tr '\001' '\n' \
+    | awk -F '\t' 'NF>=3 { printf "  - [%s×] %s\n      code: %s\n      msg : %s\n\n", $1, $2, $3, $4 }')
+fi
+
+TXT_BODY=$(cat <<EOF
+[PREV-2] Alerte 5xx — seuil dépassé.
+
+Fenêtre         : ${WINDOW_MINUTES} minutes
+Total 5xx       : ${total_5xx}   (seuil: ${MIN_COUNT_THRESHOLD})
+URLs distinctes : ${distinct_urls}
+Host (sonde)    : ${HOST_SAFE}
+
+=== Top URLs affectées ===
+
+${TOP_TABLE:-  (aucune — check l'agrégation RPC)}
+
+=== Diagnostic immédiat ===
+
+1. Supabase MCP — inspection directe :
+   SELECT err_created_at, err_status, err_url, err_message, err_code
+   FROM __error_logs
+   WHERE err_created_at > NOW() - INTERVAL '${WINDOW_MINUTES} minutes'
+     AND err_status >= 500
+   ORDER BY err_created_at DESC
+   LIMIT 50;
+
+2. Backend logs prod :
+   docker logs nestjs-remix-monorepo-prod --since ${WINDOW_MINUTES}m 2>&1 \\
+     | grep -iE 'error|exception' | tail -30
+
+3. GitHub Actions récents :
+   https://github.com/ak125/nestjs-remix-monorepo/actions
+
+=== Références ===
+
+- INC-2026-006 — post-mortem 503 /constructeurs/* (governance-vault)
+- Runbook PREV-2 : scripts/monitoring/README.md
+
+-- Auto-generated by scripts/monitoring/check-error-logs-5xx.sh
+EOF
+)
+
+# --- Envoi Gmail SMTP OAuth2 (identique à PREV-1) --------------------------
+SEND_RESULT=$(SUBJECT="$SUBJECT" EMAIL_FROM="$EMAIL_FROM" \
+  ALERT_EMAIL_TO="$ALERT_EMAIL_TO" \
+  BODY_TEXT="$TXT_BODY" \
+  GMAIL_CLIENT_ID="$GMAIL_CLIENT_ID" \
+  GMAIL_CLIENT_SECRET="$GMAIL_CLIENT_SECRET" \
+  GMAIL_REFRESH_TOKEN="$GMAIL_REFRESH_TOKEN" \
+  GMAIL_USER_EMAIL="$GMAIL_USER_EMAIL" \
+python3 <<'PYEOF' 2>&1
+import os, sys, json, base64, smtplib, urllib.request, urllib.parse
+from email.message import EmailMessage
+
+body_text = os.environ["BODY_TEXT"]
+
+try:
+    token_req = urllib.request.Request(
+        "https://oauth2.googleapis.com/token",
+        data=urllib.parse.urlencode({
+            "client_id": os.environ["GMAIL_CLIENT_ID"],
+            "client_secret": os.environ["GMAIL_CLIENT_SECRET"],
+            "refresh_token": os.environ["GMAIL_REFRESH_TOKEN"],
+            "grant_type": "refresh_token",
+        }).encode(),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    with urllib.request.urlopen(token_req, timeout=10) as r:
+        token_data = json.loads(r.read())
+    access_token = token_data["access_token"]
+except urllib.error.HTTPError as e:
+    err_body = e.read().decode("utf-8", errors="replace")[:300]
+    print(f"ERROR_OAUTH:HTTP{e.code}:{err_body}")
+    sys.exit(1)
+except Exception as e:
+    print(f"ERROR_OAUTH:{type(e).__name__}:{e}")
+    sys.exit(1)
+
+msg = EmailMessage()
+msg["From"] = os.environ["EMAIL_FROM"]
+msg["To"] = os.environ["ALERT_EMAIL_TO"]
+msg["Subject"] = os.environ["SUBJECT"]
+msg.set_content(body_text)
+
+try:
+    user = os.environ["GMAIL_USER_EMAIL"]
+    auth_str = f"user={user}\x01auth=Bearer {access_token}\x01\x01"
+    auth_b64 = base64.b64encode(auth_str.encode()).decode()
+
+    with smtplib.SMTP("smtp.gmail.com", 587, timeout=20) as s:
+        s.ehlo()
+        s.starttls()
+        s.ehlo()
+        code, resp = s.docmd("AUTH", f"XOAUTH2 {auth_b64}")
+        if code != 235:
+            print(f"ERROR_SMTP_AUTH:{code}:{resp.decode('utf-8', errors='replace')[:200]}")
+            sys.exit(1)
+        s.send_message(msg)
+    print("OK")
+except smtplib.SMTPException as e:
+    print(f"ERROR_SMTP:{type(e).__name__}:{e}")
+    sys.exit(1)
+except Exception as e:
+    print(f"ERROR_SEND:{type(e).__name__}:{e}")
+    sys.exit(1)
+PYEOF
+) || {
+    log "ERROR: envoi email Gmail échoué — ${SEND_RESULT}"
+    exit 1
+  }
+
+if [ "$SEND_RESULT" != "OK" ]; then
+  log "ERROR: envoi email Gmail inattendu — ${SEND_RESULT}"
+  exit 1
+fi
+
+log "ALERT: email Gmail envoyé à ${ALERT_EMAIL_TO} (total=${total_5xx}, nb_urls=${distinct_urls})"
+date +%s > "$DEDUP_CACHE"
+exit 2


### PR DESCRIPTION
## Summary

Structural detection layer pour la classe de bug "prod 5xx silent" révélée par INC-2026-006 (67 min 503 sur `/constructeurs/*` sans aucune alerte).

## Pourquoi générique plutôt que hardcodé

Post-mortem proposait "ajouter smoke test /constructeurs/*". C'était du bricolage : chaque nouvelle route exigerait maintenance de la liste.

Solution générique : cron toutes les 5 min sur `__error_logs` avec seuil paramétrable. Couvre **toutes** les routes actuelles et futures, zéro liste à maintenir.

## Architecture (calquée sur PREV-1)

```
cron (5min) → check-error-logs-5xx.sh
  → RPC check_error_logs_5xx_threshold (Supabase)
  → si breached → python3 stdlib → Gmail SMTP OAuth2
```

## Matching robuste

La RPC matche :
- `err_status >= 500` (HTTP explicite)
- `err_code` dans liste NestJS 5xx : `ServiceUnavailableException`, `InternalServerErrorException`, `OperationFailedException`, `GatewayTimeoutException`, `BadGatewayException`, `NotImplementedException`

Ce double critère gère le cas `err_status=NULL` quand un throw d'Exception bypass le status mapping.

## Test en prod (RPC déjà applied via MCP)

Sur les 60 dernières minutes (incident 2026-04-21 inclus) :
- **44 erreurs 5xx détectées**, 14 URLs distinctes, breach=true
- Top 5 extrait correctement avec last_message + last_code
- **Blindspot bonus révélé** : `/api/rm/page-v2` a 26 `OperationFailedException` non liées à l'incident du jour — bug latent à investiguer séparément

## Files

- `backend/supabase/migrations/20260421_add_check_error_logs_5xx_threshold_rpc.sql` — RPC SECURITY DEFINER
- `scripts/monitoring/check-error-logs-5xx.sh` — script cron (263 lignes, template PREV-1)
- `scripts/monitoring/README.md` — section PREV-2 + install cron */5min

## Installation prod

Réutilise le `/etc/default/check-payment-tunnel` existant (mêmes secrets Gmail + Supabase). Juste un symlink + ajout du cron.

## Defaults

- Fenêtre : **5 min**
- Seuil : **5 erreurs 5xx** (évite faux positifs trafic léger)
- Dedup : **30 min** avant ré-alerte

## Test plan

- [x] Migration applied via MCP
- [x] RPC teste sur données réelles (44 erreurs → top 5 correct)
- [x] Script bash syntax check
- [ ] Post-merge : copier le script sur VPS prod + activer cron */5min

## Refs

- INC-2026-006 (post-mortem)
- PR #95 (3 gates structurels)
- PREV-1 = pattern de référence réutilisé