### PR TITLE
fix(ci): perf-gates env + spec-validation find guards

### DIFF
--- a/.github/workflows/perf-gates.yml
+++ b/.github/workflows/perf-gates.yml
@@ -66,6 +66,8 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SESSION_SECRET: ci-perf-test-session-secret-not-for-production-use
           SYSTEMPAY_SITE_ID: "00000000"
+          SYSTEMPAY_CERTIFICATE_PROD: "ci-mock-systempay-certificate-prod-not-for-production-use"
+          SYSTEMPAY_CERTIFICATE_TEST: "ci-mock-systempay-certificate-test-not-for-production-use"
           PAYBOX_SITE: "0000000"
           PAYBOX_HMAC_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
 

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -219,12 +219,13 @@ jobs:
           echo "# 📊 Spec Coverage Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
-          # Count specs by type
-          FEATURE_COUNT=$(find .spec/features -name "*.md" | wc -l)
-          ARCH_COUNT=$(find .spec/architecture -name "*.md" | wc -l)
-          API_COUNT=$(find .spec/api -name "*.yaml" -o -name "*.yml" | wc -l)
-          TYPE_COUNT=$(find .spec/types -name "*.ts" | wc -l)
-          WORKFLOW_COUNT=$(find .spec/workflows -name "*.md" | wc -l)
+          # Count specs by type — guard each find against missing subdir.
+          # `set -e` crashes the whole step otherwise (observed on .spec/api).
+          FEATURE_COUNT=$(find .spec/features -name "*.md" 2>/dev/null | wc -l)
+          ARCH_COUNT=$(find .spec/architecture -name "*.md" 2>/dev/null | wc -l)
+          API_COUNT=$(find .spec/api \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null | wc -l)
+          TYPE_COUNT=$(find .spec/types -name "*.ts" 2>/dev/null | wc -l)
+          WORKFLOW_COUNT=$(find .spec/workflows -name "*.md" 2>/dev/null | wc -l)
           
           echo "| Type | Count |" >> $GITHUB_STEP_SUMMARY
           echo "|------|-------|" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fix deux bugs infra CI qui bloquaient les PRs #97 / #98 (et tous les PRs récents qui modifient backend / frontend).

### 1. `perf-gates.yml` — SystemPay cert manquant

Le step **Start server** lance `npm run start` qui démarre le backend NestJS. Le backend crash au boot :

```
[ExceptionHandler] Missing required environment variable: SYSTEMPAY_CERTIFICATE_PROD
```

→ timeout 60s sur `curl /health` → exit code 124 → CWV check fail.

**Fix** : mock value pour `SYSTEMPAY_CERTIFICATE_PROD` + `SYSTEMPAY_CERTIFICATE_TEST`, pattern identique aux secrets déjà présents (`SYSTEMPAY_SITE_ID`, `PAYBOX_*`). Aucune valeur réelle — juste démarrer le backend pour Lighthouse.

### 2. `spec-validation.yml` — `find` crash sur sous-dossier absent

Le step **Generate spec coverage report** appelle `find .spec/api …` sans garde :

```
find: '.spec/api': No such file or directory
```

Avec `set -e`, exit 1 → crash du step pour un simple count de fichiers.

**Fix** : redirige `stderr` vers `/dev/null` pour les 5 sous-dossiers (cohérence). Ajoute les parenthèses explicites sur le `-o` de `.spec/api` pour la précédence.

## Diff

```diff
# perf-gates.yml
           SYSTEMPAY_SITE_ID: "00000000"
+          SYSTEMPAY_CERTIFICATE_PROD: "ci-mock-systempay-certificate-prod-not-for-production-use"
+          SYSTEMPAY_CERTIFICATE_TEST: "ci-mock-systempay-certificate-test-not-for-production-use"
           PAYBOX_SITE: "0000000"

# spec-validation.yml
-          FEATURE_COUNT=$(find .spec/features -name "*.md" | wc -l)
-          ARCH_COUNT=$(find .spec/architecture -name "*.md" | wc -l)
-          API_COUNT=$(find .spec/api -name "*.yaml" -o -name "*.yml" | wc -l)
-          TYPE_COUNT=$(find .spec/types -name "*.ts" | wc -l)
-          WORKFLOW_COUNT=$(find .spec/workflows -name "*.md" | wc -l)
+          FEATURE_COUNT=$(find .spec/features -name "*.md" 2>/dev/null | wc -l)
+          ARCH_COUNT=$(find .spec/architecture -name "*.md" 2>/dev/null | wc -l)
+          API_COUNT=$(find .spec/api \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null | wc -l)
+          TYPE_COUNT=$(find .spec/types -name "*.ts" 2>/dev/null | wc -l)
+          WORKFLOW_COUNT=$(find .spec/workflows -name "*.md" 2>/dev/null | wc -l)
```

## Scope

2 fichiers `.github/workflows/*.yml` uniquement. Zero touch sur code applicatif. Branche dédiée depuis main.

## Impact

- PR #97 : unblock ❌ `Validate Specifications` + ❌ `Performance Gates`
- PR #98 : unblock ❌ `Performance Gates`
- Prévient le même flake sur PRs futures qui modifient backend/frontend

## Test plan

- [ ] CI runs green sur cette PR elle-même (meta-test : les workflows corrigés doivent passer avec leurs propres corrections)
- [ ] Rerun CI sur #97 / #98 après merge pour confirmer unblock

## Refs

- Comments infra : [#97#issuecomment-4290096842](https://github.com/ak125/nestjs-remix-monorepo/pull/97#issuecomment-4290096842) · [#98#issuecomment-4290097756](https://github.com/ak125/nestjs-remix-monorepo/pull/98#issuecomment-4290097756)

🤖 Generated with [Claude Code](https://claude.com/claude-code)