### PR TITLE
fix(security): remove public Redis port exposure (BSI CB-Report#20260422-10008190)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,12 +14,19 @@ services:
     ports:
       - 3000:3000
   redis_dev:
-    image: redis:latest
+    image: redis:7-alpine
     restart: always
-    ports:
-      - '6379:6379'
-    command: ["redis-server"] 
-    # --save 20 1 --loglevel warning --requirepass eYVX7EwVmmxKPCDmwMtyKVge8oLd2t81
-    volumes: 
+    # SECURITY: Never expose Redis publicly - internal network only
+    # BSI CB-Report#20260422-10008190 — ports retirés volontairement
+    # Accès via réseau Docker uniquement (monorepo_dev via hostname redis_dev)
+    # Pour debug local : docker exec redis-dev redis-cli
+    # ports:
+    #   - '6379:6379'
+    command: >
+      redis-server
+      --appendonly yes
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+    volumes:
       - ./cache:/data
       # - /dev/volumes/nestjs-remix/dev/sessions/:/data

--- a/docker-compose.meilisearch.yml
+++ b/docker-compose.meilisearch.yml
@@ -22,9 +22,18 @@ services:
   redis:
     image: redis:7-alpine
     container_name: fafa_redis
-    command: redis-server --appendonly yes
-    ports:
-      - "6379:6379"
+    # SECURITY: Never expose Redis publicly - internal network only
+    # BSI CB-Report#20260422-10008190 — ports retirés volontairement
+    # Accès via réseau Docker uniquement (meilisearch et autres services
+    # joignent `redis` via le DNS Docker interne sur fafa_network)
+    # Pour debug local : docker exec fafa_redis redis-cli
+    # ports:
+    #   - "6379:6379"
+    command: >
+      redis-server
+      --appendonly yes
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
     volumes:
       - redis_data:/data
     restart: unless-stopped

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -1,10 +1,18 @@
 services:
   redis_standalone:
-    image: redis:latest
+    image: redis:7-alpine
     restart: always
-    ports:
-      - '6379:6379'
-    command: ["redis-server", "--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru"]
+    # SECURITY: Never expose Redis publicly - internal network only
+    # BSI CB-Report#20260422-10008190 — ports retirés volontairement
+    # Accès via réseau Docker uniquement (autres containers du même network)
+    # Pour debug local : docker exec <container> redis-cli
+    # ports:
+    #   - '6379:6379'
+    command: >
+      redis-server
+      --appendonly yes
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
     deploy:
       resources:
         limits:
@@ -12,4 +20,3 @@ services:
     volumes:
       - ./cache:/data
       # - /dev/volumes/nestjs-remix/dev/sessions/:/data
-


### PR DESCRIPTION
## Summary
- 3 compose files (`dev`, `redis` standalone, `meilisearch`) exposaient `6379:6379` sur `0.0.0.0` sans `requirepass`
- Alignement sur le pattern éprouvé `docker-compose.prod.yml` — ports commentés, accès via réseau Docker uniquement
- Défense en profondeur par-dessus le Hetzner Cloud Firewall déjà en place (niveau réseau)

## Contexte incident
- **BSI** : `CB-Report#20260422-10008190` — Open Redis server in AS24940
- **Hetzner** : `AbuseID:118DAFD:19`
- **IP concernée** : DEV VPS `46.224.118.55`
- **Redis version** : 7.4.7
- **Détection** : 2026-04-21 13:12:07 UTC

## Remédiation en place

| # | Couche | Action | Statut |
|---|--------|--------|--------|
| 1 | **Réseau** | Hetzner Cloud Firewall `dev-vps-redis-block` — inbound DROP tcp/6379 | ✅ **Appliqué** |
| 2 | **Config** | Cette PR — `ports: 6379:6379` retirés des 3 compose files | 🟡 **En review** |

## Pourquoi pas de `--requirepass` dans cette PR

Historique des tentatives précédentes :

| Commit | Action | Résultat |
|--------|--------|----------|
| `2c4c24aa` (2025-12-17) | Ajout `--requirepass` + ports retirés sur prod | OK |
| `16410088` (2026-01-17) | Retrait auth preprod (\"no password needed\") | Préparait la régression |
| `71ac9791` (2026-03-05) | **Retrait `--requirepass` de prod** | `REDIS_PASSWORD was never set, caused crash-loop` |

Leçon : le secret `REDIS_PASSWORD` n'est pas propagé de façon fiable dans l'env de déploiement. Chaque tentative `--requirepass` provoque un crash-loop qui casse les sessions (30j TTL). Cette PR évite délibérément ce chemin — la protection repose sur l'isolation réseau, pas sur l'auth applicative.

## Audit post-exposition (READ-ONLY)

Scan depuis DEV sur `redis-dev` avant remédiation :

| Check | Résultat |
|-------|----------|
| `CONFIG GET dir` | `/data` ✅ (pas de pivot vers `/root/.ssh` ou `/var/spool/cron`) |
| `CONFIG GET dbfilename` | `dump.rdb` ✅ |
| `DBSIZE` | 400 clés (cohérent BullMQ + cache app) |
| Scan `crackit*` | 0 match |
| Scan `xmrig*` / `mining*` / `pwn*` | 0 match |
| Scan `*ssh*` / `*cron*` / `*.py` / `*.sh` | 0 match |
| Scan `backup*` | 4 clés (97-99 bytes, strings — données applicatives, pas d'exploit payload) |

**Verdict : zero compromission détectée.**

## Changements par fichier

### [docker-compose.redis.yml](docker-compose.redis.yml)
- Image : `redis:latest` → `redis:7-alpine` (pinned)
- `ports: '6379:6379'` → commenté avec référence BSI
- `command` aligné sur pattern prod (`--appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru`)

### [docker-compose.dev.yml](docker-compose.dev.yml)
- Image `redis_dev` : `redis:latest` → `redis:7-alpine`
- `ports: '6379:6379'` → commenté
- `command` aligné sur pattern prod
- Monorepo `ports: 3000:3000` conservé (dev local uniquement)

### [docker-compose.meilisearch.yml](docker-compose.meilisearch.yml)
- `ports: \"6379:6379\"` → commenté
- `command` enrichi (maxmemory + eviction policy)

## Impact

- **Zero régression cache/sessions** : cette PR ne redémarre aucun container en soi (elle sera active au prochain `docker compose up`)
- **Zero impact production** : `docker-compose.prod.yml` est déjà aligné sur ce pattern depuis 2025-12-17 (commit `2c4c24aa`)
- **Accès inter-containers préservé** : les services du même réseau Docker joignent Redis via DNS interne (`redis_dev`, `fafa_redis`, `redis_standalone`)
- **Accès debug local préservé** : via `docker exec <container> redis-cli`

## Test plan
- [ ] Merge → deploy DEV preprod automatique (push main = DEV, pas PROD)
- [ ] Vérifier `docker ps` sur DEV : Redis containers actifs, ports internes uniquement (`6379/tcp` sans mapping `0.0.0.0`)
- [ ] Vérifier BullMQ queues fonctionnelles (`/api/queues/health` ou équivalent)
- [ ] Laisser le firewall Hetzner actif (filet de sécurité permanent)
- [ ] Répondre au ticket BSI/Hetzner avec référence à ce PR

## Refs
- BSI `CB-Report#20260422-10008190`
- Hetzner `AbuseID:118DAFD:19`
- ADR monorepo — pas de gouvernance ici, pointer vers `/opt/automecanik/governance-vault/` si ADR requis