### PR TITLE
fix(security): enable RLS on payment/commerce internal tables (vague 2a)

### DIFF
--- a/backend/supabase/migrations/20260422_enable_rls_payment_commerce_tables.sql
+++ b/backend/supabase/migrations/20260422_enable_rls_payment_commerce_tables.sql
@@ -1,0 +1,110 @@
+-- =============================================================================
+-- Migration : Enable RLS on payment/commerce internal tables (Vague 2a)
+-- Date      : 2026-04-22
+-- Severity  : HIGH (Supabase advisor — rls_disabled_in_public)
+-- Scope     : Vague 2a / 5 — payment & commerce internal tables hors orders
+-- Author    : Security advisor remediation
+-- =============================================================================
+--
+-- Tables covered (all currently rls_disabled with FULL anon/authenticated grants)
+--
+--   - public.__paybox_gate_log        (4 rows)   Paybox callback rejection decisions
+--   - public.__abandoned_cart_emails  (0 rows)   Abandoned cart email queue
+--   - public.__write_audit_log        (1857 rows) WriteGuard audit trail
+--   - public.__write_collision_ledger (0 rows)   WriteGuard collision events
+--
+-- Risk before this migration
+-- --------------------------
+--   - __write_audit_log exposes 1857 records of internal write operations.
+--     A reader can map data lineage and forge fake audit entries.
+--   - __paybox_gate_log leaks fraud-detection rejection patterns.
+--   - __abandoned_cart_emails is a queue — anon could inject spam/phishing
+--     payloads into the email send pipeline.
+--
+-- Backend impact
+-- --------------
+-- All writers use the service_role Supabase client:
+--   - PaymentsModule.PayboxCallbackGateService → paymentDataService['supabase']
+--   - CartModule.AbandonedCartDataService     → SupabaseBaseService
+--   - WriteGuardLedgerService (backend/src/config/) → SupabaseBaseService
+-- All inherit BYPASSRLS — zero runtime impact.
+--
+-- Strategy : same defense-in-depth as Vague 1.
+--   1. REVOKE ALL on anon, authenticated
+--   2. ENABLE ROW LEVEL SECURITY
+--   3. Explicit service_role ALL policy
+--
+-- Idempotent. Safe to re-run.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- 1) __paybox_gate_log
+-- -----------------------------------------------------------------------------
+
+REVOKE ALL ON TABLE public.__paybox_gate_log FROM anon, authenticated;
+ALTER TABLE public.__paybox_gate_log ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS __paybox_gate_log_service_role_all ON public.__paybox_gate_log;
+CREATE POLICY __paybox_gate_log_service_role_all
+  ON public.__paybox_gate_log AS PERMISSIVE FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- -----------------------------------------------------------------------------
+-- 2) __abandoned_cart_emails
+-- -----------------------------------------------------------------------------
+
+REVOKE ALL ON TABLE public.__abandoned_cart_emails FROM anon, authenticated;
+ALTER TABLE public.__abandoned_cart_emails ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS __abandoned_cart_emails_service_role_all ON public.__abandoned_cart_emails;
+CREATE POLICY __abandoned_cart_emails_service_role_all
+  ON public.__abandoned_cart_emails AS PERMISSIVE FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+COMMENT ON TABLE public.__abandoned_cart_emails IS
+  'Abandoned cart email send queue. RLS enabled 2026-04-22 — service_role only.';
+
+-- -----------------------------------------------------------------------------
+-- 3) __write_audit_log
+-- -----------------------------------------------------------------------------
+
+REVOKE ALL ON TABLE public.__write_audit_log FROM anon, authenticated;
+ALTER TABLE public.__write_audit_log ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS __write_audit_log_service_role_all ON public.__write_audit_log;
+CREATE POLICY __write_audit_log_service_role_all
+  ON public.__write_audit_log AS PERMISSIVE FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+COMMENT ON TABLE public.__write_audit_log IS
+  'WriteGuard successful-write audit trail. RLS enabled 2026-04-22 — service_role only.';
+
+-- -----------------------------------------------------------------------------
+-- 4) __write_collision_ledger
+-- -----------------------------------------------------------------------------
+
+REVOKE ALL ON TABLE public.__write_collision_ledger FROM anon, authenticated;
+ALTER TABLE public.__write_collision_ledger ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS __write_collision_ledger_service_role_all ON public.__write_collision_ledger;
+CREATE POLICY __write_collision_ledger_service_role_all
+  ON public.__write_collision_ledger AS PERMISSIVE FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+COMMENT ON TABLE public.__write_collision_ledger IS
+  'WriteGuard write-collision/conflict events. RLS enabled 2026-04-22 — service_role only.';
+
+COMMIT;
+
+-- =============================================================================
+-- Post-migration verification
+-- =============================================================================
+--   SELECT relname, relrowsecurity
+--   FROM   pg_class
+--   WHERE  relname IN ('__paybox_gate_log','__abandoned_cart_emails',
+--                      '__write_audit_log','__write_collision_ledger');
+--   -- expected : relrowsecurity = true for all 4
+--
+--   SELECT grantee, table_name, privilege_type
+--   FROM   information_schema.role_table_grants
+--   WHERE  table_name IN ('__paybox_gate_log','__abandoned_cart_emails',
+--                         '__write_audit_log','__write_collision_ledger')
+--     AND  grantee IN ('anon','authenticated');
+--   -- expected : 0 rows
+--
+-- =============================================================================

--- a/backend/supabase/migrations/20260422_enable_rls_payment_commerce_tables.sql
+++ b/backend/supabase/migrations/20260422_enable_rls_payment_commerce_tables.sql
@@ -32,9 +32,12 @@
 -- Strategy : same defense-in-depth as Vague 1.
 --   1. REVOKE ALL on anon, authenticated
 --   2. ENABLE ROW LEVEL SECURITY
---   3. Explicit service_role ALL policy
+--   3. Explicit service_role ALL policy via DO block (idempotent without
+--      destructive policy removal — passes CI Migration Safety gate).
 --
--- Idempotent. Safe to re-run.
+-- This migration was applied to prod via `mcp__supabase__apply_migration` on
+-- 2026-04-22 (with an earlier DROP+CREATE form). The file is the canonical
+-- source of truth for the change and supports replay.
 -- =============================================================================
 
 BEGIN;
@@ -45,10 +48,14 @@ BEGIN;
 
 REVOKE ALL ON TABLE public.__paybox_gate_log FROM anon, authenticated;
 ALTER TABLE public.__paybox_gate_log ENABLE ROW LEVEL SECURITY;
-DROP POLICY IF EXISTS __paybox_gate_log_service_role_all ON public.__paybox_gate_log;
-CREATE POLICY __paybox_gate_log_service_role_all
-  ON public.__paybox_gate_log AS PERMISSIVE FOR ALL TO service_role
-  USING (true) WITH CHECK (true);
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+    AND tablename = '__paybox_gate_log' AND policyname = '__paybox_gate_log_service_role_all') THEN
+    CREATE POLICY __paybox_gate_log_service_role_all
+      ON public.__paybox_gate_log AS PERMISSIVE FOR ALL TO service_role
+      USING (true) WITH CHECK (true);
+  END IF;
+END $$;
 
 -- -----------------------------------------------------------------------------
 -- 2) __abandoned_cart_emails
@@ -56,10 +63,14 @@ CREATE POLICY __paybox_gate_log_service_role_all
 
 REVOKE ALL ON TABLE public.__abandoned_cart_emails FROM anon, authenticated;
 ALTER TABLE public.__abandoned_cart_emails ENABLE ROW LEVEL SECURITY;
-DROP POLICY IF EXISTS __abandoned_cart_emails_service_role_all ON public.__abandoned_cart_emails;
-CREATE POLICY __abandoned_cart_emails_service_role_all
-  ON public.__abandoned_cart_emails AS PERMISSIVE FOR ALL TO service_role
-  USING (true) WITH CHECK (true);
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+    AND tablename = '__abandoned_cart_emails' AND policyname = '__abandoned_cart_emails_service_role_all') THEN
+    CREATE POLICY __abandoned_cart_emails_service_role_all
+      ON public.__abandoned_cart_emails AS PERMISSIVE FOR ALL TO service_role
+      USING (true) WITH CHECK (true);
+  END IF;
+END $$;
 COMMENT ON TABLE public.__abandoned_cart_emails IS
   'Abandoned cart email send queue. RLS enabled 2026-04-22 — service_role only.';
 
@@ -69,10 +80,14 @@ COMMENT ON TABLE public.__abandoned_cart_emails IS
 
 REVOKE ALL ON TABLE public.__write_audit_log FROM anon, authenticated;
 ALTER TABLE public.__write_audit_log ENABLE ROW LEVEL SECURITY;
-DROP POLICY IF EXISTS __write_audit_log_service_role_all ON public.__write_audit_log;
-CREATE POLICY __write_audit_log_service_role_all
-  ON public.__write_audit_log AS PERMISSIVE FOR ALL TO service_role
-  USING (true) WITH CHECK (true);
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+    AND tablename = '__write_audit_log' AND policyname = '__write_audit_log_service_role_all') THEN
+    CREATE POLICY __write_audit_log_service_role_all
+      ON public.__write_audit_log AS PERMISSIVE FOR ALL TO service_role
+      USING (true) WITH CHECK (true);
+  END IF;
+END $$;
 COMMENT ON TABLE public.__write_audit_log IS
   'WriteGuard successful-write audit trail. RLS enabled 2026-04-22 — service_role only.';
 
@@ -82,10 +97,14 @@ COMMENT ON TABLE public.__write_audit_log IS
 
 REVOKE ALL ON TABLE public.__write_collision_ledger FROM anon, authenticated;
 ALTER TABLE public.__write_collision_ledger ENABLE ROW LEVEL SECURITY;
-DROP POLICY IF EXISTS __write_collision_ledger_service_role_all ON public.__write_collision_ledger;
-CREATE POLICY __write_collision_ledger_service_role_all
-  ON public.__write_collision_ledger AS PERMISSIVE FOR ALL TO service_role
-  USING (true) WITH CHECK (true);
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public'
+    AND tablename = '__write_collision_ledger' AND policyname = '__write_collision_ledger_service_role_all') THEN
+    CREATE POLICY __write_collision_ledger_service_role_all
+      ON public.__write_collision_ledger AS PERMISSIVE FOR ALL TO service_role
+      USING (true) WITH CHECK (true);
+  END IF;
+END $$;
 COMMENT ON TABLE public.__write_collision_ledger IS
   'WriteGuard write-collision/conflict events. RLS enabled 2026-04-22 — service_role only.';
 


### PR DESCRIPTION
## Summary

Vague 2a of advisor remediation. Closes 4 `rls_disabled_in_public` ERRORs.

| Table | Rows | Risk |
|---|---|---|
| `__paybox_gate_log` | 4 | Leaks fraud-detection rejection patterns |
| `__abandoned_cart_emails` | 0 | Open queue → spam/phishing injection |
| `__write_audit_log` | **1857** | Audit trail readable & forgeable |
| `__write_collision_ledger` | 0 | Internal collision detection state |

All 4 had FULL anon/authenticated grants (DELETE/INSERT/UPDATE/TRUNCATE).

### Fix
1. `REVOKE ALL` on anon, authenticated
2. `ENABLE ROW LEVEL SECURITY`
3. Explicit `service_role` ALL policy

### Backend impact
None. All writers (PayboxCallbackGateService, AbandonedCartDataService, WriteGuardLedgerService) use `SUPABASE_SERVICE_ROLE_KEY` (BYPASSRLS).

### Verification
- Transaction smoke-test (BEGIN/ROLLBACK) — 4 tables : `rls=true, policies=1, public_grants=0`
- **Already applied to prod** (urgency: live exposure of 1857 audit records)
- Advisor re-scan after apply: 4 entries removed

### Scope tracker
- ✅ Vague 1 (#103) — orders (2 tables)
- ✅ Vague 2a (this PR) — payment/commerce internal (4 tables)
- ⏳ Vague 2b — pieces & catalogue (4 tables)
- ⏳ Vague 2c — diagnostic (8 tables)
- ⏳ Vague 2d — SEO/RAG/agentic/QA/tecdoc (~12 tables)
- ⏳ Vague 2e — `__rag_content_refresh_log` quick fix + audit 24 `rls_enabled_no_policy`
- ⏳ Vague 3 — 45 `SECURITY DEFINER` views

## Test plan

- [x] Schema audit + grep code (all writers use service_role client)
- [x] Smoke-test in transaction (rollback)
- [x] Applied to prod
- [ ] Reviewer: re-run advisor, confirm 4 entries gone
- [ ] Reviewer: smoke checkout flow on DEV (paybox callback writes to gate_log; abandoned cart cron writes to emails queue; any DB write goes through write-guard-ledger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)