### PR TITLE
fix(security): convert 11 seo views to security invoker (vague 3b)

### DIFF
--- a/backend/supabase/migrations/20260422_views_invoker_seo.sql
+++ b/backend/supabase/migrations/20260422_views_invoker_seo.sql
@@ -1,0 +1,88 @@
+-- =============================================================================
+-- Migration : Convert SEO views from SECURITY DEFINER to SECURITY INVOKER (Vague 3b)
+-- Date      : 2026-04-22
+-- Severity  : MEDIUM (Supabase advisor — security_definer_view)
+-- Scope     : Vague 3b / 7 — 11 SEO views (analytics + monitoring)
+-- =============================================================================
+--
+-- Problem
+-- -------
+-- These 11 views are currently `SECURITY DEFINER`, bypassing the RLS we put
+-- on `seo_link_*`, `__seo_*` tables in vagues 1-2e. Anyone with the anon key
+-- could read SEO link analytics or scraping data via PostgREST through these
+-- views.
+--
+-- Views covered (cf. .spec/reports/security/vague3-security-definer-views-audit-20260422.md)
+--
+-- A) SEO analytics & A/B testing (5)
+--   - seo_link_ctr               (seo_link_clicks aggregate)
+--   - seo_ab_testing_formula_ctr (seo_link_clicks aggregate)
+--   - seo_ab_testing_top_formulas(seo_link_clicks + impressions aggregate)
+--   - seo_ab_testing_verbs       (seo_link_clicks aggregate)
+--   - seo_ab_testing_nouns       (seo_link_clicks aggregate)
+--
+-- B) SEO monitoring (6)
+--   - v_seo_internal_link_stats        (__seo_internal_link aggregate)
+--   - v_seo_crawl_stats_7d             (__seo_crawl_log aggregate)
+--   - v_seo_last_googlebot_crawl       (__seo_crawl_log aggregate)
+--   - v_seo_keywords_unmatched         (__seo_keywords filter)
+--   - v_seo_interpolation_alerts_24h   (__seo_interpolation_alerts aggregate)
+--   - v_seo_interpolation_alerts_weekly(__seo_interpolation_alerts + pieces_gamme)
+--
+-- Backend impact
+-- --------------
+-- Zero. All consumers are backend service_role (BYPASSRLS). Frontend has NO
+-- direct supabase-js calls to these views.
+--
+-- Strategy : same as vague 3a.
+--   1. ALTER VIEW … SET (security_invoker = true)
+--   2. REVOKE ALL on anon, authenticated (defense in depth)
+--   3. service_role keeps access via BYPASSRLS
+--
+-- Smoke-tested in transaction (BEGIN/ROLLBACK) on prod DB 2026-04-22:
+--   options=security_invoker=true on all 11 views, public_grants=0.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- A) SEO analytics & A/B testing
+-- -----------------------------------------------------------------------------
+
+ALTER VIEW public.seo_link_ctr                  SET (security_invoker = true);
+ALTER VIEW public.seo_ab_testing_formula_ctr    SET (security_invoker = true);
+ALTER VIEW public.seo_ab_testing_top_formulas   SET (security_invoker = true);
+ALTER VIEW public.seo_ab_testing_verbs          SET (security_invoker = true);
+ALTER VIEW public.seo_ab_testing_nouns          SET (security_invoker = true);
+
+REVOKE ALL ON public.seo_link_ctr                  FROM anon, authenticated;
+REVOKE ALL ON public.seo_ab_testing_formula_ctr    FROM anon, authenticated;
+REVOKE ALL ON public.seo_ab_testing_top_formulas   FROM anon, authenticated;
+REVOKE ALL ON public.seo_ab_testing_verbs          FROM anon, authenticated;
+REVOKE ALL ON public.seo_ab_testing_nouns          FROM anon, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- B) SEO monitoring
+-- -----------------------------------------------------------------------------
+
+ALTER VIEW public.v_seo_internal_link_stats         SET (security_invoker = true);
+ALTER VIEW public.v_seo_crawl_stats_7d              SET (security_invoker = true);
+ALTER VIEW public.v_seo_last_googlebot_crawl        SET (security_invoker = true);
+ALTER VIEW public.v_seo_keywords_unmatched          SET (security_invoker = true);
+ALTER VIEW public.v_seo_interpolation_alerts_24h    SET (security_invoker = true);
+ALTER VIEW public.v_seo_interpolation_alerts_weekly SET (security_invoker = true);
+
+REVOKE ALL ON public.v_seo_internal_link_stats         FROM anon, authenticated;
+REVOKE ALL ON public.v_seo_crawl_stats_7d              FROM anon, authenticated;
+REVOKE ALL ON public.v_seo_last_googlebot_crawl        FROM anon, authenticated;
+REVOKE ALL ON public.v_seo_keywords_unmatched          FROM anon, authenticated;
+REVOKE ALL ON public.v_seo_interpolation_alerts_24h    FROM anon, authenticated;
+REVOKE ALL ON public.v_seo_interpolation_alerts_weekly FROM anon, authenticated;
+
+COMMIT;
+
+-- =============================================================================
+-- Verification
+--   SELECT relname, array_to_string(reloptions, ',') FROM pg_class
+--   WHERE relname IN (...above 11...) AND relkind = 'v';
+-- =============================================================================


### PR DESCRIPTION
## Summary

Vague 3b. Closes **11** `security_definer_view` ERRORs on SEO views (analytics + monitoring).

| Cluster | Views | Source tables |
|---|---|---|
| **Analytics + A/B** (5) | `seo_link_ctr`, `seo_ab_testing_formula_ctr`, `seo_ab_testing_top_formulas`, `seo_ab_testing_verbs`, `seo_ab_testing_nouns` | `seo_link_clicks`, `seo_link_impressions` |
| **Monitoring** (6) | `v_seo_internal_link_stats`, `v_seo_crawl_stats_7d`, `v_seo_last_googlebot_crawl`, `v_seo_keywords_unmatched`, `v_seo_interpolation_alerts_24h`, `v_seo_interpolation_alerts_weekly` | `__seo_internal_link`, `__seo_crawl_log`, `__seo_keywords`, `__seo_interpolation_alerts`, `pieces_gamme` |

### Risk before
Views ran as `postgres` (DEFINER), bypassing RLS we just added on `seo_link_*` (vague 2e) and `__seo_*` (vagues 2d/2e). Anon key holders could read SEO link analytics or crawl data via PostgREST.

### Fix
1. `ALTER VIEW … SET (security_invoker = true)`
2. `REVOKE ALL on anon, authenticated`
3. service_role keeps access via BYPASSRLS

### Verification
- Smoke test in transaction (BEGIN/ROLLBACK): 11 views `security_invoker=true`, `public_grants=0`
- Local Migration Safety gate: PASS
- Backend service_role bypass confirmed; no frontend supabase-js calls

### Apply status
**NOT applied to prod**. Awaiting explicit per-PR approval (per session feedback memory).

## Vague 3 progress
- ✅ Vague 3a (#111) — KG views (10)
- ✅ Vague 3b (this PR) — SEO analytics + monitoring (11)
- ⏳ Vague 3c — Pipeline + DB monitoring (9) — awaiting your GO
- ⏳ Vague 3d — Gamme dashboards + KW + R5 (8)
- ⏳ Vague 3e — Tecdoc INVOKER candidates (1: `v_tecdoc_activation_candidates`)
- ⏳ Vague 3f — KEEP DEFINER + REVOKE (3 cross-schema tecdoc + `__pg_gammes` + sitemaps + `v_pieces_seo_safe`)

Cumulative after this PR: 21/43 CONVERT-INVOKER candidates ready.

## Test plan

- [x] Smoke test in transaction (rollback)
- [x] Local CI gate check passes
- [ ] Reviewer: approve apply via `mcp__supabase__apply_migration`
- [ ] Post-apply: re-run advisor, confirm 11 entries gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)