### PR TITLE
fix(security): convert 7 gamme/kw/r5 views + lock 1 matview to security invoker (vague 3d)

### DIFF
--- a/backend/supabase/migrations/20260422_views_invoker_gamme_kw_r5.sql
+++ b/backend/supabase/migrations/20260422_views_invoker_gamme_kw_r5.sql
@@ -1,0 +1,72 @@
+-- =============================================================================
+-- Migration : Convert gamme dashboards + KW + R5 views to SECURITY INVOKER (Vague 3d)
+-- Date      : 2026-04-22
+-- Severity  : MEDIUM (Supabase advisor — security_definer_view)
+-- Scope     : Vague 3d / 7 — 7 views + 1 matview
+-- =============================================================================
+--
+-- Views covered (cf. .spec/reports/security/vague3-security-definer-views-audit-20260422.md)
+--
+-- A) Standard views (7) — ALTER VIEW + REVOKE
+--   - v_conseil_pack_coverage    (__seo_gamme_conseil + pieces_gamme aggregate)
+--   - v_gamme_content_orphans    (cross __seo_gamme* tables orphan check)
+--   - v_gamme_readiness          (cross __seo_* + gamme_aggregates dashboard)
+--   - v_kw_pipeline_status       (cross 21+ tables pipeline status snapshot)
+--   - v_r5_consolidation_status  (__seo_gamme_conseil + __seo_observable)
+--   - v_thresholds_by_family     (gate_thresholds aggregate)
+--   - v_thresholds_comparison    (gate_thresholds aggregate)
+--
+-- B) Materialized view (1) — REVOKE only
+--   - v_gamme_seo_dashboard      (snapshot of gamme_aggregates + pieces_gamme + __seo_*)
+--
+-- Why matview is REVOKE-only
+-- --------------------------
+-- Postgres does NOT support `security_invoker` reloption on materialized
+-- views (only on regular views). The matview is a stored snapshot, accessed
+-- like a table — the SECURITY DEFINER concept doesn't apply to SELECT on it
+-- (that's just a normal table read). The advisor flag is technically a false
+-- positive for matviews, but the public-grant exposure is real and needs
+-- REVOKE to lock down anon/authenticated PostgREST access.
+--
+-- The REFRESH MATERIALIZED VIEW continues to work normally (executed by
+-- service_role with BYPASSRLS, no DEFINER attribute needed).
+--
+-- Backend impact
+-- --------------
+-- Zero. All consumers are admin tooling / RPC backend (service_role).
+-- Frontend has no direct supabase-js calls.
+--
+-- Smoke-tested in transaction on prod DB 2026-04-22:
+--   7 views: options=security_invoker=true, public_grants=0
+--   1 matview: public_grants=0
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- A) Standard views — ALTER + REVOKE
+-- -----------------------------------------------------------------------------
+
+ALTER VIEW public.v_conseil_pack_coverage      SET (security_invoker = true);
+ALTER VIEW public.v_gamme_content_orphans      SET (security_invoker = true);
+ALTER VIEW public.v_gamme_readiness            SET (security_invoker = true);
+ALTER VIEW public.v_kw_pipeline_status         SET (security_invoker = true);
+ALTER VIEW public.v_r5_consolidation_status    SET (security_invoker = true);
+ALTER VIEW public.v_thresholds_by_family       SET (security_invoker = true);
+ALTER VIEW public.v_thresholds_comparison      SET (security_invoker = true);
+
+REVOKE ALL ON public.v_conseil_pack_coverage    FROM anon, authenticated;
+REVOKE ALL ON public.v_gamme_content_orphans    FROM anon, authenticated;
+REVOKE ALL ON public.v_gamme_readiness          FROM anon, authenticated;
+REVOKE ALL ON public.v_kw_pipeline_status       FROM anon, authenticated;
+REVOKE ALL ON public.v_r5_consolidation_status  FROM anon, authenticated;
+REVOKE ALL ON public.v_thresholds_by_family     FROM anon, authenticated;
+REVOKE ALL ON public.v_thresholds_comparison    FROM anon, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- B) Materialized view — REVOKE only (security_invoker not supported on matview)
+-- -----------------------------------------------------------------------------
+
+REVOKE ALL ON public.v_gamme_seo_dashboard FROM anon, authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Vague 3d. Closes **8** `security_definer_view` ERRORs.

| Cluster | Views |
|---|---|
| Standard views (7) — ALTER + REVOKE | `v_conseil_pack_coverage`, `v_gamme_content_orphans`, `v_gamme_readiness`, `v_kw_pipeline_status`, `v_r5_consolidation_status`, `v_thresholds_by_family`, `v_thresholds_comparison` |
| Materialized view (1) — REVOKE only | `v_gamme_seo_dashboard` |

### Why matview is REVOKE-only
Postgres does NOT support `security_invoker` reloption on materialized views. The matview is a stored snapshot accessed like a table — the SECURITY DEFINER concept doesn't apply to SELECT on it. The advisor flag is technically a false positive on matviews, but the public-grant exposure is real and needs REVOKE to lock down anon/authenticated PostgREST access. REFRESH continues normally via service_role.

### Backend impact
Zero. All admin tooling (service_role). Frontend has no direct supabase-js calls.

### Verification
- Smoke test in transaction (BEGIN/ROLLBACK):
  - 7 views: `security_invoker=true`, `public_grants=0`
  - 1 matview: `public_grants=0`
- Local Migration Safety gate: PASS

### Apply status
**NOT applied to prod**. Awaiting explicit per-PR approval.

## Vague 3 progress
- ✅ Vague 3a (#111) — KG views (10)
- ✅ Vague 3b (#112) — SEO analytics + monitoring (11)
- ✅ Vague 3c (#113) — Pipeline + DB monitoring (9)
- ✅ Vague 3d (this PR) — Gamme + KW + R5 views (7) + matview (1)
- ⏳ Vague 3e — `v_tecdoc_activation_candidates` (1) — awaiting your GO
- ⏳ Vague 3f — KEEP DEFINER + REVOKE (3 cross-schema tecdoc + `__pg_gammes` + 2 sitemaps + `v_pieces_seo_safe`)

Cumulative: **38/43 CONVERT-INVOKER + 1/1 matview-REVOKE ready**, 0 applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)