### PR TITLE
fix(security): convert v_tecdoc_activation_candidates to security invoker (vague 3e)

### DIFF
--- a/backend/supabase/migrations/20260422_views_invoker_tecdoc_candidates.sql
+++ b/backend/supabase/migrations/20260422_views_invoker_tecdoc_candidates.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- Migration : Convert v_tecdoc_activation_candidates to SECURITY INVOKER (Vague 3e)
+-- Date      : 2026-04-22
+-- Severity  : MEDIUM (Supabase advisor — security_definer_view)
+-- Scope     : Vague 3e / 7 — 1 view (tecdoc activation candidates, public-only deps)
+-- =============================================================================
+--
+-- View covered
+--   v_tecdoc_activation_candidates
+--
+-- Why this is in vague 3e (separate from vague 3f tecdoc views)
+-- -------------------------------------------------------------
+-- The other v_tecdoc_* views (v_tecdoc_dlnr_reconciliation,
+-- v_tecdoc_unlinked_pieces_reason, __tecdoc_losch_log) read from the
+-- `tecdoc_map` and/or `tecdoc_raw` schemas — service_role does NOT have
+-- USAGE on those schemas (verified 2026-04-22), so they MUST stay DEFINER.
+--
+-- This view (v_tecdoc_activation_candidates) reads ONLY from public.* tables
+-- (pieces, pieces_marque, pieces_gamme, gamme_aggregates, pieces_relation_type,
+-- auto_type, pieces_media_img) — confirmed via pg_get_viewdef inspection.
+-- Hence it can safely be converted to SECURITY INVOKER like other public-only
+-- views.
+--
+-- Backend impact
+-- --------------
+-- Zero. Admin tooling only (service_role). No frontend supabase-js calls.
+--
+-- Smoke-tested in transaction on prod DB 2026-04-22:
+--   options=security_invoker=true, public_grants=0.
+-- =============================================================================
+
+BEGIN;
+
+ALTER VIEW public.v_tecdoc_activation_candidates SET (security_invoker = true);
+REVOKE ALL ON public.v_tecdoc_activation_candidates FROM anon, authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Vague 3e. Closes **1** `security_definer_view` ERROR.

| View | Sources |
|---|---|
| `v_tecdoc_activation_candidates` | `pieces`, `pieces_marque`, `pieces_gamme`, `gamme_aggregates`, `pieces_relation_type`, `auto_type`, `pieces_media_img` |

### Why this view is in vague 3e (separated from vague 3f tecdoc views)
The other 3 `v_tecdoc_*` views (`v_tecdoc_dlnr_reconciliation`, `v_tecdoc_unlinked_pieces_reason`, `__tecdoc_losch_log`) read from the `tecdoc_map` and/or `tecdoc_raw` schemas — service_role does NOT have USAGE on those schemas (verified 2026-04-22), so they MUST stay DEFINER (vague 3f).

This view reads ONLY from `public.*` tables (confirmed via `pg_get_viewdef` inspection), so it can safely be converted to INVOKER like other public-only views.

### Backend impact
Zero. Admin tooling only (service_role). No frontend supabase-js calls.

### Verification
- Smoke test in transaction (BEGIN/ROLLBACK): `security_invoker=true`, `public_grants=0`
- Local Migration Safety gate: PASS

### Apply status
**NOT applied to prod**. Awaiting explicit per-PR approval.

### Note on branch naming
The first attempt at this PR (`security/views-invoker-tecdoc-cand-vague3e-20260422`) ended up containing an unrelated commit due to a parallel-agent branch switch. This `-v2` branch is the canonical clean version. The `-v1` branch can be deleted.

## Vague 3 progress
- ✅ Vague 3a (#111) — KG (10)
- ✅ Vague 3b (#112) — SEO (11)
- ✅ Vague 3c (#113) — Pipeline+monitoring (9)
- ✅ Vague 3d (#114) — Gamme/KW/R5 + matview (8)
- ✅ Vague 3e (this PR) — `v_tecdoc_activation_candidates` (1)
- ⏳ Vague 3f — KEEP DEFINER + REVOKE (7 cross-schema/special)

Cumulative: **39/43 CONVERT-INVOKER + 1 matview ready**, 0 applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)