### PR TITLE
fix(frontend): restore brand-colors.css on R8 vehicle .html route (F5)

### DIFF
--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -240,7 +240,7 @@ function transformRpcToLoaderData(
   const modele_id = parseInt(modelParts[modelParts.length - 1]) || 0;
   const modele_alias = modelParts.slice(0, -1).join("-");
 
-  const typeWithoutHtml = params.type.replace(".html", "");
+  const typeWithoutHtml = params.type.replace(/\.html$/, "");
   const typeParts = typeWithoutHtml.split("-");
   const type_id = parseInt(typeParts[typeParts.length - 1]) || 0;
 
@@ -501,8 +501,8 @@ export async function loader({ params }: LoaderFunctionArgs) {
     });
   }
 
-  // Parsing du type_id
-  const typeWithoutHtml = type.replace(".html", "");
+  // Parsing du type_id (suffixe .html optionnel, ancré fin de chaîne)
+  const typeWithoutHtml = type.replace(/\.html$/, "");
   const typeParts = typeWithoutHtml.split("-");
   const type_id = parseInt(typeParts[typeParts.length - 1]) || 0;
 

--- a/frontend/app/routes/constructeurs.$brand.$model.$type[.].tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type[.].tsx
@@ -1,6 +1,10 @@
-// Redirection pour les anciennes URLs sans .html vers les nouvelles avec .html
-// Format ancien: /constructeurs/{marque}-{id}/{modele}-{id}/{type}-{id}
-// Format nouveau: /constructeurs/{marque}-{id}/{modele}-{id}/{type}-{id}.html
+// Route 301 pour les URLs véhicule se terminant par un point littéral.
+// Convention remix-flat-routes : `$type[.]` + `.tsx` = segment `:type.`
+// (trailing dot), pas un segment sans extension.
+// Utilité : artefacts legacy / liens cassés (ex. mail client qui ajoute un `.`
+// en fin d'URL) → redirige vers la variante canonique `.html`.
+// Les URLs sans extension sont servies par ./constructeurs.$brand.$model.$type
+// (tolérance 200, pas de 301 — confirmé 2026-04-22 comme intentionnel).
 import { redirect, type LoaderFunctionArgs } from "@remix-run/node";
 import { useRouteError, isRouteErrorResponse } from "@remix-run/react";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";

--- a/frontend/app/routes/constructeurs.$brand.$model.$type[.]html.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type[.]html.tsx
@@ -1,12 +1,26 @@
-// 🚗 Route avec extension .html pour les pages véhicules constructeurs
+// Route véhicule R8 — variante canonique avec extension .html.
 // Format: /constructeurs/{marque}-{id}/{modele}-{id}/{type}-{id}.html
-// Réexporte le contenu de la route sans .html pour éviter la duplication de code
+//
+// Délègue toute l'implémentation à ./constructeurs.$brand.$model.$type
+// (même loader, même composant — pas de duplication).
+//
+// INVARIANT : la liste ci-dessous doit refléter TOUS les exports Remix
+// du fichier source, sinon la route .html perd la fonctionnalité associée.
+// Bug historique 2026-04-22 : `links` oublié → perte de brand-colors.css
+// sur la route canonique .html (vérifié avec curl | grep brand-colors).
+//
+// Avant d'ajouter un nouvel export au fichier source, répercuter ici :
+//   grep -n "^export " frontend/app/routes/constructeurs.\$brand.\$model.\$type.tsx
+// Aucun `export * from` : le compilateur Remix Vite fait du static analysis
+// route-module (split server/client) et le codebase n'utilise jamais ce pattern
+// sur les routes (6 précédents nominatifs vérifiés).
 
 export {
+  handle, // Phase 10: Propager pageRole au root Layout
+  links, // Phase F5 (2026-04-22): brand-colors.css stylesheet
+  shouldRevalidate,
   loader,
   meta,
-  shouldRevalidate,
   default,
   ErrorBoundary,
-  handle, // Phase 10: Propager pageRole au root Layout
 } from "./constructeurs.$brand.$model.$type";


### PR DESCRIPTION
## Summary

Three targeted fixes on the R8 vehicle route triplet (`/constructeurs/:brand/:model/:type[.html]`), all live-verified on DEV.

### F5 (bug, MEDIUM) — silent loss of `brand-colors.css` on canonical `.html` route
The canonical `.html` route re-exports its implementation from `constructeurs.\$brand.\$model.\$type.tsx` via a nominal list. The list had **6 entries** while the source file exports **7** — `links` was missing since the file's creation. Consequence: `brandColorsStyles` (`brand-colors.css`) was **NOT loaded** on the canonical `.html` URL, so `data-brand=...` / `text-brand` / `bg-brand` classes had no effect (silent visual regression depending on the brand).

**Empirical proof before fix** (`curl localhost:3000`):
| URL | `brand-colors.css` |
|---|---|
| `.../type-40000.html` | ❌ ABSENT |
| `.../type-40000` (no ext) | ✅ present |

After fix: both variants load the stylesheet. Trailing-dot variant (301 → `.html`) unchanged.

Added an **invariant comment** documenting the parity rule (7 source exports ↔ 7 re-exports) and the grep command to verify when adding future Remix exports. **No `export * from`** — codebase uses nominal re-exports on all routes (6 precedents, 0 wildcard) because the Remix Vite plugin does static analysis on route-module exports for the server/client bundle split.

### F2 (polish, LOW) — anchor `.html` strip to suffix
`.replace(".html", "")` → `.replace(/\.html$/, "")` (2 occurrences in `\$type.tsx`). Avoids theoretical mid-string matches.

### F6 (doc, LOW) — fix misleading header comment in `\$type[.].tsx`
The comment claimed to redirect "anciennes URLs sans .html", but the `remix-flat-routes` convention makes `\$type[.]` + `.tsx` = `:type.` (literal trailing dot). URLs without extension are served by the main `\$type.tsx` (tolerance 200, intentional — confirmed 2026-04-22). Comment rewritten to match actual routing behavior.

### Out of scope
- **F1** (force 301 from non-`.html` to `.html`): retired — previously attempted, confirmed to break indexed URLs. Dual-200 is intentional; Google dedupes via the canonical meta link.
- **F4** (extract 2000-line monolith to `frontend/app/features/vehicle/`): separate ticket.

## Test plan
- [x] `npm run typecheck` passes (no errors).
- [x] `curl localhost:3000/constructeurs/.../*.html | grep brand-colors` → present (after fix).
- [x] `curl localhost:3000/constructeurs/.../*` (no ext) → still present (non-regression).
- [x] `curl -I localhost:3000/constructeurs/.../*.` (trailing dot) → 301 (non-regression).
- [ ] Visual smoke on 3 contrasting brands (BMW blue, Mercedes gray, Renault yellow) — to confirm `data-brand` resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)