### PR TITLE
fix(ci): add APP_URL to perf-gates.yml to unblock CWV (INC-2026-009)

### DIFF
--- a/.github/workflows/perf-gates.yml
+++ b/.github/workflows/perf-gates.yml
@@ -60,6 +60,13 @@ jobs:
         env:
           NODE_ENV: production
           PORT: 3000
+          # APP_URL: required by PaymentsModule boot (payment.config.ts:48-62).
+          # Without it, backend crashes silently with ConfigurationException
+          # after DiagnosticEngineModule init, and the 60s /health wait times
+          # out (exit 124). Reproducing this fault locally with these exact
+          # mocks + NODE_ENV=production but no APP_URL matches the CI crash
+          # exactly. Incident: INC-2026-009.
+          APP_URL: http://localhost:3000
           REDIS_URL: redis://localhost:6379
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_KEY }}


### PR DESCRIPTION
## Root cause (INC-2026-009, empirically reproduced)

\`backend/src/config/payment.config.ts:48-62\` validates 4 env vars required for PaymentsModule initialization, including \`APP_URL\`. The \`perf-gates.yml\` workflow was missing it, causing the backend to crash silently with \`ConfigurationException\` after \`DiagnosticEngineModule\` init. Because \`main.ts\` uses \`bufferLogs: true\`, the stack trace was hidden — only \`[ExceptionHandler] Missing required environment variable\` showed in the CI log.

## Reproduction (local, Node 20, exact CI mocks + NODE_ENV=production)

| Config | Result |
|---|---|
| With \`APP_URL=...\` set | ✅ Nest starts, HTTP 200 on /health within 1s |
| Without \`APP_URL\` | ❌ \`npm start\` exit 1 → 60s /health wait → exit 124 |

Same failure signature as both run [24791159333](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/24791159333/job/72548690575) and [24830539178](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/24830539178/job/72677611190).

## Fix

One line added to \`Start server\` step env, matching the \`PORT\` value already there. Zero effect on prod — prod has APP_URL set correctly (\`curl https://www.automecanik.com/health\` returns HTTP/2 200).

## Effect

Once merged, the Performance Gates workflow will re-run on PR #116 (and any frontend/backend PR) with the backend successfully booting. CWV Lighthouse audits will run for the first time since 2+ days.

## Separate incident revealed

Investigation of this CI failure revealed **INC-2026-010** — a separate **SEV1** incident (Paybox payment tunnel client regression post-clôture INC-2026-002, 0 paiement vrai client depuis 2026-03-20, 34+ jours). That is tracked in governance-vault PR #40 and is **NOT** addressed here.

## Test plan
- [x] Local reproduction with exact CI env vars confirmed the bug and the fix
- [ ] Merge → PR #116 CWV check should pass on rerun
- [ ] Update INC-2026-009 status: investigating → resolved once PR #116 CWV turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)