### PR TITLE
fix(seo): alias enrichment cable-de-frein-a-main (R1_ROUTER batch)

### DIFF
--- a/config/rag-alias-expansions.yaml
+++ b/config/rag-alias-expansions.yaml
@@ -129,6 +129,12 @@ cable-de-frein-a-main:
   - cable frein main
   - cable frein de parking
   - frein stationnement cable
+  # Added 2026-04-23 (R1_ROUTER batch) — R-SEO-KW-01 review 12.56% vol → 0.47%
+  - cable de frein
+  - cables de frein a main
+  - cable frein de stationnement
+  - cable frein parking
+  - cable frein voiture
 
 maitre-cylindre-de-frein:
   - maitre-cylindre


### PR DESCRIPTION
## Summary

- R-SEO-KW-01 triggered : 12.56% vol rejected on CSV `Keyword Stats 2026-04-23 at 13_40_13.csv` for pg_id=124 (`cable-de-frein-a-main`).
- Added 5 aliases to `config/rag-alias-expansions.yaml`.
- Post-fix rejection rate : **0.47%** (1 KW, intentional out-of-scope for cross-gamme risk).

## Aliases added

| Alias | Rationale | Catches |
|---|---|---|
| `cable de frein` | Generic brake cable (catalog context = handbrake) | 3 KW incl. generic vol=500 |
| `cables de frein a main` | Morphological plural | vol=500 |
| `cable frein de stationnement` | FR synonym direct | vol=50 |
| `cable frein parking` | Short anglicism syn | vol=50 (scenic 2) |
| `cable frein voiture` | Common search form | vol=50 |

## Intentionally NOT added

- `cable frein tambour` (vol=50) — cross-gamme risk, `tambour` = drum brake distinct gamme `frein-tambour`.

## Evidence

```
--- Before ---
152 raw → 134 relevant, rejets vol 1350/10750 (12.56%)

--- After (dry-run) ---
152 raw → 142 relevant, rejets vol 50/10750 (0.47%)
```

## Canon refs

- `ledger/rules/rules-seo-kw-import.md` (governance-vault)
- R-SEO-KW-01 : ≥ 5% vol rejected → review required
- R-SEO-KW-03 : batch YAML per session `fix/seo-kw-aliases-{role}-{YYYYMMDD}`
- R-SEO-KW-05 : `--suggest-aliases` used (merged via #124)

## Test plan

- [x] Dry-run before/after measured (12.56% → 0.47%)
- [x] Threshold 5% (R-SEO-KW-01) respected
- [ ] CI green (config YAML only, minimal scope)
- [ ] Post-merge : live import + `/kw-classify` for pg_id=124 on DEV

🤖 Generated with [Claude Code](https://claude.com/claude-code)