### PR TITLE
fix(ci): add RAG_SERVICE_URL + RAG_API_KEY to perf-gates.yml (follow-up #123)

### DIFF
--- a/.github/workflows/perf-gates.yml
+++ b/.github/workflows/perf-gates.yml
@@ -67,6 +67,13 @@ jobs:
           # mocks + NODE_ENV=production but no APP_URL matches the CI crash
           # exactly. Incident: INC-2026-009.
           APP_URL: http://localhost:3000
+          # RAG_SERVICE_URL / RAG_API_KEY : requis par RagKnowledgeService,
+          # RagChatService, RagPipelineService, RagIngestionService via getOrThrow.
+          # Sans ces vars, Nest crash au boot avec:
+          #   TypeError: Configuration key "RAG_SERVICE_URL" does not exist
+          # Valeurs mock CI : le service RAG n'est pas requis pour Lighthouse/CWV.
+          RAG_SERVICE_URL: http://disabled:8000
+          RAG_API_KEY: ci-mock-rag-api-key-not-for-production-use
           REDIS_URL: redis://localhost:6379
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_KEY }}


### PR DESCRIPTION
## Context

Follow-up to merged PR #123 (APP_URL fix). After APP_URL was resolved, the CI revealed a second missing env var:

\`\`\`
TypeError: Configuration key \"RAG_SERVICE_URL\" does not exist
  at ConfigService.getOrThrow (config.service.js:132:19)
  at new RagKnowledgeService (rag-knowledge.service.js:65:42)
\`\`\`

4 services call \`configService.getOrThrow<string>('RAG_SERVICE_URL')\` at instantiation, so the backend crashes during Nest module init even though RAG is never contacted during Lighthouse runs.

## Fix

Add both vars to the \`Start server\` step env:
\`\`\`yaml
RAG_SERVICE_URL: http://disabled:8000
RAG_API_KEY: ci-mock-rag-api-key-not-for-production-use
\`\`\`

Plus a multi-line comment explaining why both vars are needed in CI. Zero backend/prod impact.

## Test plan
- [x] Local reproduction (Node 20, NODE_ENV=production, exact CI mocks) reproduces the crash without these vars and succeeds with them
- [ ] Merge → PR #116 CWV check should finally pass

Ref: INC-2026-009 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)