### PR TITLE
fix(ci): bump perf-gates health-wait timeout 60s → 180s (INC-2026-009 follow-up)

### DIFF
--- a/.github/workflows/perf-gates.yml
+++ b/.github/workflows/perf-gates.yml
@@ -55,7 +55,11 @@ jobs:
         run: |
           npm run start &
           echo "⏳ Waiting for server to start..."
-          timeout 60 bash -c 'until curl -s http://localhost:3000/health > /dev/null 2>&1; do sleep 2; done'
+          # 180s needed because backend does cache warming (176 gammes + hierarchy + homepage)
+          # at onApplicationBootstrap. In local dev this takes ~5s; in CI runners with
+          # remote Supabase, cold RPCs, and slow network it can take 60-120s.
+          # Previous timeout=60 caused exit 124 even though backend would eventually start.
+          timeout 180 bash -c 'until curl -s http://localhost:3000/health > /dev/null 2>&1; do sleep 2; done'
           echo "✅ Server is ready"
         env:
           NODE_ENV: production


### PR DESCRIPTION
After PR #123 (APP_URL) and PR #127 (RAG vars), backend boots cleanly in CI. But `until curl /health` still times out at 60s because `app.listen()` is blocked by `onApplicationBootstrap`:

- CatalogService preloads 176 gammes + hierarchy + homepage
- Multiple cold RPC round-trips to remote Supabase

In local dev this takes ~5s, in CI runners 60-120s cold. Bump timeout to **180s** with explanatory comment. Zero runtime impact.

Ref: INC-2026-009 follow-up #2. Unblocks PR #116 CWV gate definitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)