### PR TITLE
feat(seo): wire R6 sgpg_gatekeeper_* persistence symmetric to R1

### DIFF
--- a/backend/src/config/field-catalog.constants.ts
+++ b/backend/src/config/field-catalog.constants.ts
@@ -453,6 +453,35 @@ export const FIELD_CATALOG: FieldOwnership[] = [
     resourceGroup: 'purchase_guide_main',
   },
 
+  // ── R6 gatekeeper verdict (mirrors r1s_gatekeeper_* on R1_ROUTER) ──
+  {
+    table: '__seo_gamme_purchase_guide',
+    field: 'sgpg_gatekeeper_score',
+    ownerRole: RoleId.R6_GUIDE_ACHAT,
+    writeClass: 'metadata',
+    writeStrategy: 'replace',
+    conflictPolicy: 'hold',
+    resourceGroup: 'purchase_guide_main',
+  },
+  {
+    table: '__seo_gamme_purchase_guide',
+    field: 'sgpg_gatekeeper_flags',
+    ownerRole: RoleId.R6_GUIDE_ACHAT,
+    writeClass: 'metadata',
+    writeStrategy: 'replace',
+    conflictPolicy: 'hold',
+    resourceGroup: 'purchase_guide_main',
+  },
+  {
+    table: '__seo_gamme_purchase_guide',
+    field: 'sgpg_gatekeeper_checks',
+    ownerRole: RoleId.R6_GUIDE_ACHAT,
+    writeClass: 'metadata',
+    writeStrategy: 'replace',
+    conflictPolicy: 'hold',
+    resourceGroup: 'purchase_guide_main',
+  },
+
   // ── R6 state slot ──
   {
     table: '__seo_gamme_purchase_guide',

--- a/backend/src/modules/admin/services/buying-guide-enricher.service.ts
+++ b/backend/src/modules/admin/services/buying-guide-enricher.service.ts
@@ -252,6 +252,20 @@ export class BuyingGuideEnricherService {
       qualityScore,
     );
 
+    // Gatekeeper verdict — mirrors R1EnricherService (r1s_gatekeeper_{score,flags})
+    // Persisted in the same UPDATE as content columns so the BEFORE UPDATE
+    // trigger `trg_invalidate_sgpg_gatekeeper` keeps our fresh values instead
+    // of nulling them out.
+    const gatekeeper = this.qualityGates.computeGatekeeperScore({
+      sectionResults,
+      qualityFlags: uniqueFlags,
+      qualityScore,
+      antiWikiGate,
+    });
+    updatePayload.sgpg_gatekeeper_score = gatekeeper.score;
+    updatePayload.sgpg_gatekeeper_flags = gatekeeper.flags;
+    updatePayload.sgpg_gatekeeper_checks = gatekeeper.checks;
+
     // Guard: skip intro_role write if content describes a different piece
     if (
       typeof updatePayload.sgpg_intro_role === 'string' &&

--- a/backend/src/modules/admin/services/buying-guide/buying-guide-quality-gates.service.ts
+++ b/backend/src/modules/admin/services/buying-guide/buying-guide-quality-gates.service.ts
@@ -12,8 +12,15 @@ import {
   MIN_FAQS,
   MIN_SYMPTOMS,
   MIN_FAQ_ANSWER_LENGTH,
+  MIN_QUALITY_SCORE,
 } from '../../../../config/buying-guide-quality.constants';
 import type { SectionValidationResult } from './buying-guide.types';
+
+export interface GatekeeperComputation {
+  score: number;
+  flags: string[];
+  checks: Record<string, unknown>;
+}
 
 /**
  * Quality validation gates for buying guide enrichment.
@@ -271,5 +278,47 @@ export class BuyingGuideQualityGatesService {
     }
 
     return { ok: reasons.length === 0, reasons };
+  }
+
+  /**
+   * Build the R6 gatekeeper verdict persisted to
+   * `__seo_gamme_purchase_guide.sgpg_gatekeeper_{score,flags,checks}`.
+   *
+   * Mirrors the R1EnricherService persistence pattern (see r1-enricher.service.ts
+   * lines 192-193) but carries the richer R6 signal — per-section OK + anti-wiki
+   * gate — into the JSONB `checks` column.
+   *
+   * Pure sync: never reads/writes DB. The caller merges the returned fields
+   * into the enricher payload passed to BuyingGuideDbService.upsertBuyingGuide.
+   */
+  computeGatekeeperScore(input: {
+    sectionResults: Record<string, SectionValidationResult>;
+    qualityFlags: GammeContentQualityFlag[];
+    qualityScore: number;
+    antiWikiGate: { ok: boolean; reasons: string[] };
+  }): GatekeeperComputation {
+    const { sectionResults, qualityFlags, qualityScore, antiWikiGate } = input;
+
+    const score = Math.max(0, Math.min(100, Math.round(qualityScore)));
+
+    const flags = Array.from(
+      new Set<string>([...qualityFlags, ...antiWikiGate.reasons]),
+    );
+
+    const sectionsOk: Record<string, boolean> = {};
+    for (const [key, result] of Object.entries(sectionResults)) {
+      sectionsOk[key] = result.ok;
+    }
+
+    const checks: Record<string, unknown> = {
+      quality_score: score,
+      min_threshold: MIN_QUALITY_SCORE,
+      passed: score >= MIN_QUALITY_SCORE && antiWikiGate.ok,
+      anti_wiki: antiWikiGate,
+      sections_ok: sectionsOk,
+      computed_at: new Date().toISOString(),
+    };
+
+    return { score, flags, checks };
   }
 }

--- a/backend/src/modules/admin/services/buying-guide/index.ts
+++ b/backend/src/modules/admin/services/buying-guide/index.ts
@@ -1,6 +1,9 @@
 export { BuyingGuideRagFetcherService } from './buying-guide-rag-fetcher.service';
 export { BuyingGuideSectionExtractor } from './buying-guide-section-extractor.service';
-export { BuyingGuideQualityGatesService } from './buying-guide-quality-gates.service';
+export {
+  BuyingGuideQualityGatesService,
+  type GatekeeperComputation,
+} from './buying-guide-quality-gates.service';
 export { BuyingGuideDbService } from './buying-guide-db.service';
 export { BuyingGuideSeoDraftService } from './buying-guide-seo-draft.service';
 export { ClaimExtractor } from './claim-extractor.util';


### PR DESCRIPTION
## Summary

Wires `BuyingGuideQualityGatesService.computeGatekeeperScore()` + enricher persistence to populate `__seo_gamme_purchase_guide.sgpg_gatekeeper_{score,flags,checks}`, mirroring [R1EnricherService:192-193](https://github.com/ak125/nestjs-remix-monorepo/blob/main/backend/src/modules/admin/services/r1-enricher.service.ts#L192-L193).

- Before: 235/241 rows had `sgpg_gatekeeper_score IS NULL` (column + invalidation trigger existed, no writer).
- After: every `/api/internal/buying-guides/enrich` run persists the gate verdict in the same UPDATE as content columns.

## Changes

- `buying-guide-quality-gates.service.ts` — pure sync method `computeGatekeeperScore({sectionResults, qualityFlags, qualityScore, antiWikiGate})` → `{score, flags, checks}`. Exports `GatekeeperComputation` via the barrel.
- `buying-guide-enricher.service.ts` — merges `sgpg_gatekeeper_{score,flags,checks}` into the UPDATE payload. The BEFORE-UPDATE trigger `fn_invalidate_sgpg_gatekeeper` uses `IS NOT DISTINCT FROM OLD` on score+flags, so fresh values survive.
- `field-catalog.constants.ts` — 3 new R6_GUIDE_ACHAT × `purchase_guide_main` entries (`writeClass: metadata`, `writeStrategy: replace`) symmetric to `r1s_gatekeeper_*`. Prevents WriteGuard stripping in enforce mode.
- `buying-guide/index.ts` — re-export `GatekeeperComputation` type.

## Test plan

- [x] `tsc --noEmit -p tsconfig.json` → `EXIT=0`
- [x] E2E on pg_id=124 (DEV): `POST /api/internal/buying-guides/enrich {pgIds:["124"]}` → HTTP 201, 4 sections updated.
  - DB after: `sgpg_gatekeeper_score=84`, `sgpg_gatekeeper_flags=[ANTI_MISTAKES_NO_ACTION, MISSING_REQUIRED_TERMS, MISSING_ANTI_MISTAKES (got 0, need 4), GUIDANCE_COPIES_LABEL (6/7), USE_CASES_NOT_PROFILES]`
  - `sgpg_gatekeeper_checks` JSON : `{passed:false, quality_score:84, min_threshold:70, anti_wiki:{ok:false,reasons:[…]}, sections_ok:{faq:true,use_cases:true,anti_mistakes:false,decision_tree:true,how_to_choose:false,selection_criteria:true}, computed_at:"2026-04-23T15:01:22.544Z"}`
- [ ] Post-merge backfill — run a batch POST `/enrich` over the 233 remaining NULL rows (rate-limited, 1 gamme / 2 s).

## Canon

- Follow-up to audit trail [`governance-vault/ledger/audit-trail/2026-04-23-seo-kw-pipeline-cable-frein-main.md §4`](https://github.com/ak125/governance-vault/blob/main/ledger/audit-trail/2026-04-23-seo-kw-pipeline-cable-frein-main.md#L82-L114) ("R6 enricher — gap systémique identifié").
- DB trigger + invalidation: [`2026-04-21-pipeline-content-hardening.md §P1.3`](https://github.com/ak125/governance-vault/blob/main/ledger/audit-trail/2026-04-21-pipeline-content-hardening.md#L140-L144).

🤖 Generated with [Claude Code](https://claude.com/claude-code)