### PR TITLE
feat(seo): delegate vehicle extraction to SQL RPC (dynamic, no hardcoded regex)

### DIFF
--- a/backend/supabase/migrations/20260423_match_keyword_text_to_vehicle.sql
+++ b/backend/supabase/migrations/20260423_match_keyword_text_to_vehicle.sql
@@ -1,0 +1,147 @@
+-- 2026-04-23: match_keyword_text_to_vehicle + _batch
+-- ----------------------------------------------------------------------------
+-- Pure-function (STABLE, no DB write) qui extrait model+energy depuis un texte
+-- brut, sans necessiter de row __seo_keywords prealable.
+--
+-- Contexte :
+--   scripts/insert-missing-keywords.ts embarquait des regex hardcodees
+--   (clio/megane/scenic/c3/c4/etc) lignes 302-350 qui rataient TOUS les
+--   modeles anciens (2cv, c15, c25, espace, xantia, saxo, yaris, etc).
+--   Sur pg_id=258 (maitre-cylindre-de-frein) le script TS matchait 0 KW
+--   vehicule alors que extract_vehicle_keywords(258) en matchait 59.
+--
+-- Fix canon :
+--   Meme logique que extract_vehicle_keywords (CTE base_modeles avec 3 formes :
+--   original, arabic from roman, digit-letter collapsed) mais sans UPDATE DB.
+--   Le script TS appelle cette RPC via match_keyword_text_to_vehicle_batch
+--   (accepte text[]) pour resoudre model+energy en un seul round-trip.
+--
+-- Normalisation input :
+--   - lowercase + translate accents/apostrophes/hyphens → espaces
+--   - collapse whitespace
+--
+-- 3 match_forms par modele dans auto_modele :
+--   1. original : "clio iii", "2 cv", "c15"
+--   2. arabic from roman : "clio 3", "espace 4" (si le modele contient i-x)
+--   3. digit-letter collapsed : "2cv" pour "2 cv" (si le modele a pattern "\d \w")
+--
+-- Resultat sur sanity tests :
+--   2cv        → "2 cv"       ✅
+--   c15        → "c15"        ✅ (inchange)
+--   clio 3     → "clio iii"   ✅
+--   306 hdi    → "306"/diesel ✅
+--   twingo 1   → "twingo i"   ✅
+--   espace 4   → "espace iv"  ✅
+--   xantia     → "xantia"     ✅
+--   saxo       → "saxo"       ✅
+--
+-- Impact script insert-missing-keywords.ts sur pg_id=258 :
+--   AVANT : 0 vehicles detected → V2=0 V3=0 V4=0 V5=0 (v_level=NULL pour 313 KW)
+--   APRES : 66 vehicles detected → V2=8 V3=23 V4=15 V5=0 (46 type_ids classifies)
+--
+-- Idempotent : aucune ecriture DB.
+
+CREATE OR REPLACE FUNCTION public.match_keyword_text_to_vehicle(p_text text)
+ RETURNS TABLE(matched_model text, matched_energy text)
+ LANGUAGE plpgsql STABLE
+AS $function$
+DECLARE
+  v_norm text;
+BEGIN
+  v_norm := lower(p_text);
+  v_norm := translate(v_norm,
+    'àâäéèêëîïôöùûüç''-_',
+    'aaaeeeeiioouuuc   '
+  );
+  v_norm := regexp_replace(v_norm, '\s+', ' ', 'g');
+  v_norm := trim(v_norm);
+
+  RETURN QUERY
+  WITH
+  base_modeles AS (
+    SELECT DISTINCT lower(m.modele_name) AS original_name
+    FROM auto_modele m
+    WHERE EXISTS (
+      SELECT 1 FROM auto_type t
+      WHERE t.type_modele_id::text = m.modele_id::text AND t.type_display='1'
+    )
+    AND length(m.modele_name) >= 2
+  ),
+  active_modeles AS (
+    -- Form 1 : original
+    SELECT original_name AS canonical, original_name AS match_form, length(original_name) AS len
+    FROM base_modeles
+    UNION
+    -- Form 2 : arabic from roman (clio iii → clio 3)
+    SELECT b.original_name,
+      regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(
+        b.original_name,
+        '\yx\y', '10', 'g'), '\yix\y', '9', 'g'), '\yviii\y', '8', 'g'),
+        '\yvii\y', '7', 'g'), '\yvi\y', '6', 'g'), '\yiv\y', '4', 'g'),
+        '\yv\y', '5', 'g'), '\yiii\y', '3', 'g'), '\yii\y', '2', 'g'),
+        '\yi\y', '1', 'g'),
+      length(b.original_name)
+    FROM base_modeles b
+    WHERE b.original_name ~ '\y(i{1,3}|iv|v|vi{0,3}|ix|x)\y'
+      AND b.original_name <> regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(regexp_replace(
+          b.original_name,
+          '\yx\y', '10', 'g'), '\yix\y', '9', 'g'), '\yviii\y', '8', 'g'),
+          '\yvii\y', '7', 'g'), '\yvi\y', '6', 'g'), '\yiv\y', '4', 'g'),
+          '\yv\y', '5', 'g'), '\yiii\y', '3', 'g'), '\yii\y', '2', 'g'),
+          '\yi\y', '1', 'g')
+    UNION
+    -- Form 3 : digit-letter collapsed (2 cv → 2cv)
+    SELECT b.original_name,
+      regexp_replace(b.original_name, '(\d)\s+([a-z])', '\1\2', 'g'),
+      length(b.original_name)
+    FROM base_modeles b
+    WHERE b.original_name ~ '\d\s+[a-z]'
+  ),
+  candidates AS (
+    SELECT am.canonical AS name_lower, am.match_form, am.len
+    FROM active_modeles am
+    WHERE v_norm LIKE '%' || am.match_form || '%'
+  ),
+  picked AS (
+    SELECT c.name_lower AS model_matched
+    FROM candidates c
+    WHERE v_norm ~ ('\y' || c.match_form || '\y')
+    ORDER BY c.len DESC
+    LIMIT 1
+  )
+  SELECT
+    (SELECT model_matched FROM picked),
+    CASE
+      WHEN v_norm ~ '\y(hdi|tdi|multijet|jtd|cdi|dci|diesel)\y' THEN 'diesel'
+      WHEN v_norm ~ '\y(tce|thp|gti|essence|vti)\y' THEN 'essence'
+      WHEN v_norm ~ '\y(phev|hybrid|hybride)\y' THEN 'hybride'
+      WHEN v_norm ~ '\y(electrique|electric|bev|ev)\y' THEN 'electrique'
+      WHEN v_norm ~ '\y(gpl|lpg|bifuel)\y' THEN 'gpl'
+      ELSE NULL
+    END;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.match_keyword_text_to_vehicle(text) IS
+  'Pure-function (STABLE, no DB write) variant of extract_vehicle_keywords. Returns (model, energy) from auto_modele catalog with roman/arabic/collapsed aliases. Canon for scripts/insert-missing-keywords.ts — replaces hardcoded regex.';
+
+
+-- Batch variant pour appel depuis un script qui a un array de KW
+CREATE OR REPLACE FUNCTION public.match_keyword_text_to_vehicle_batch(p_texts text[])
+ RETURNS TABLE(input text, matched_model text, matched_energy text)
+ LANGUAGE plpgsql STABLE
+AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT t.input, mk.matched_model, mk.matched_energy
+  FROM unnest(p_texts) AS t(input),
+       LATERAL public.match_keyword_text_to_vehicle(t.input) mk;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.match_keyword_text_to_vehicle_batch(text[]) IS
+  'Batch wrapper around match_keyword_text_to_vehicle for TS scripts. Returns (input, model, energy) per input text.';
+
+
+GRANT EXECUTE ON FUNCTION public.match_keyword_text_to_vehicle(text) TO authenticated, service_role, anon;
+GRANT EXECUTE ON FUNCTION public.match_keyword_text_to_vehicle_batch(text[]) TO authenticated, service_role, anon;

--- a/scripts/insert-missing-keywords.ts
+++ b/scripts/insert-missing-keywords.ts
@@ -255,22 +255,49 @@ function normalizeKeyword(keyword: string): string {
     .trim();
 }
 
-/**
- * Extract model and variant from keyword
- */
-/**
- * Convert Arabic generation number to Roman numeral for DB matching
- * "clio 4" → "clio iv", "golf 7" → "golf vii", "polo 6" → "polo vi"
- * Converts trailing number (1-10) after a model name
- */
-function generationToRoman(model: string): string {
-  const map: Record<string, string> = {
-    '1': 'i', '2': 'ii', '3': 'iii', '4': 'iv', '5': 'v',
-    '6': 'vi', '7': 'vii', '8': 'viii', '9': 'ix', '10': 'x',
-  };
-  return model.replace(/\s+(\d+)\s*$/, (_, num) => {
-    return map[num] ? ` ${map[num]}` : ` ${num}`;
-  });
+// ── Vehicle extraction — DB-driven via RPC match_keyword_text_to_vehicle_batch ─
+//
+// Design : au lieu de regex hardcodées (qui rataient 2cv, 4l, c15, c25,
+// espace, xantia, saxo, yaris, twingo i, etc.), on délègue l'extraction
+// model+energy à une RPC SQL qui lit auto_modele FULL catalog avec aliases
+// romain/arabe + digit-letter collapsed. Couvre 1482+ modèles dynamiquement.
+//
+// Flow :
+//   1. Avant triage T3, appeler buildVehicleExtractionCache(csvKeywords)
+//      — 1 round-trip DB par chunk de 500 KW
+//   2. extractVehicleInfo() lit depuis la Map, pas de regex
+//
+// Cf. migration 20260423_match_keyword_text_to_vehicle.sql
+
+interface VehicleExtraction {
+  model: string | null;
+  energy: string | null;
+}
+
+const vehicleExtractionCache = new Map<string, VehicleExtraction>();
+
+async function buildVehicleExtractionCache(keywords: string[]): Promise<void> {
+  if (keywords.length === 0) return;
+  const unique = Array.from(new Set(keywords));
+  const BATCH = 500;
+
+  for (let i = 0; i < unique.length; i += BATCH) {
+    const chunk = unique.slice(i, i + BATCH);
+    const { data, error } = await supabase.rpc(
+      'match_keyword_text_to_vehicle_batch',
+      { p_texts: chunk }
+    );
+    if (error) {
+      console.error(`⚠️ RPC match_keyword_text_to_vehicle_batch (batch ${i}): ${error.message}`);
+      continue;
+    }
+    for (const row of (data || []) as Array<{ input: string; matched_model: string | null; matched_energy: string | null }>) {
+      vehicleExtractionCache.set(row.input, {
+        model: row.matched_model,
+        energy: row.matched_energy,
+      });
+    }
+  }
 }
 
 function extractVehicleInfo(
@@ -280,10 +307,10 @@ function extractVehicleInfo(
   const normalized = normalizeKeyword(keyword);
   const gammeNorm = normalizeKeyword(gamme);
 
-  // Remove gamme from keyword
+  // Remove gamme from keyword for variant extraction
   let remaining = normalized.replace(gammeNorm, '').trim();
 
-  // STEP 1: Extract displacement FIRST
+  // STEP 1: Extract displacement (1.6, 2.0, ...)
   let displacement: string | null = null;
   const dispMatch = remaining.match(/\b(\d)[.,](\d)\b/);
   if (dispMatch) {
@@ -291,7 +318,7 @@ function extractVehicleInfo(
     remaining = remaining.replace(dispMatch[0], ' __DISP__ ').trim();
   }
 
-  // STEP 2: Extract power (CV)
+  // STEP 2: Extract power (CV/CH)
   let power: number | null = null;
   const powerMatch = remaining.match(/\b(6[05]|7[05]|8[056]|9[05]|1[0-4][05]|1[56]0)\s*(ch|cv)?\b/i);
   if (powerMatch) {
@@ -299,82 +326,19 @@ function extractVehicleInfo(
     remaining = remaining.replace(powerMatch[0], ' ').trim();
   }
 
-  // STEP 3: Model patterns
-  const modelsWithGeneration = [
-    /\b(clio)\s+(\d+|[ivx]+)\b/i,
-    /\b(megane)\s+(\d+|[ivx]+)\b/i,
-    /\b(scenic)\s+(\d+|[ivx]+)\b/i,
-    /\b(twingo)\s+(\d+|[ivx]+)\b/i,
-    /\b(golf)\s+(\d+|[ivx]+)\b/i,
-  ];
+  // STEP 3: Model from DB-driven cache (canon via auto_modele + roman/arabic/collapsed aliases)
+  const cached = vehicleExtractionCache.get(keyword);
+  const model = cached?.model ?? null;
 
-  const modelsOptionalGeneration = [
-    /\b(captur)\s*(\d+|[ivx]+)?\b/i,
-    /\b(kangoo)\s*(\d+|[ivx]+)?\b/i,
-    /\b(polo)\s*(\d+|[ivx]+)?\b/i,
-    /\b(focus)\s*(\d+|[ivx]+)?\b/i,
-    /\b(fiesta)\s*(\d+|[ivx]+)?\b/i,
-    /\b(mondeo)\s*(\d+|[ivx]+)?\b/i,
-    /\b(corsa)\s*(\d+|[ivx]+)?\b/i,
-    /\b(astra)\s*(\d+|[ivx]+)?\b/i,
-  ];
-
-  // Compound models (must match BEFORE base models to avoid splitting)
-  const modelsCompound = [
-    /\b(c3\s+picasso)\b/i,
-    /\b(c3\s+aircross)\b/i,
-    /\b(c3\s+pluriel)\b/i,
-    /\b(c4\s+grand\s+picasso)\b/i,
-    /\b(c4\s+picasso)\b/i,
-    /\b(c4\s+cactus)\b/i,
-    /\b(c4\s+aircross)\b/i,
-    /\b(c4\s+spacetourer)\b/i,
-    /\b(c5\s+aircross)\b/i,
-    /\b(xsara\s+picasso)\b/i,
-    /\b(grand\s+scenic)\s*(\d+|[ivx]+)?\b/i,
-    /\b(308\s+sw)\b/i,
-    /\b(508\s+sw)\b/i,
-  ];
-
-  const modelsNoGeneration = [
-    /\b(c3|c4|c5)\b/i,
-    /\b(c3 i|c3 ii|c3 iii)\b/i,
-    /\b(c4 i|c4 ii)\b/i,
-    /\b(berlingo)\s*(\d+|[ivx]+)?\b/i,
-    /\b(207|208|2008)\b/i,
-    /\b(307|308|3008)\b/i,
-    /\b(407|408|4008)\b/i,
-    /\b(508|5008)\b/i,
-    /\b(a3|a4|a6|a1|a5|a7|a8)\b/i,
-    /\b(q3|q5|q7|q2|q8)\b/i,
-  ];
-
-  const allPatterns = [
-    ...modelsCompound,         // Compound first (c4 picasso before c4)
-    ...modelsWithGeneration,
-    ...modelsNoGeneration,
-    ...modelsOptionalGeneration,
-  ];
-
-  let model: string | null = null;
+  // STEP 4: Variant = what's left after stripping the matched model + gamme + displacement
   let variant: string | null = null;
-
-  for (const pattern of allPatterns) {
-    const match = remaining.match(pattern);
-    if (match) {
-      model = generationToRoman(match[0].toLowerCase().replace(/\s+/g, ' ').trim());
-
-      const modelEnd = remaining.indexOf(match[0]) + match[0].length;
-      let afterModel = remaining.slice(modelEnd).trim();
-
-      afterModel = afterModel.replace('__DISP__', displacement || '').trim();
-
-      if (afterModel) {
-        variant = afterModel
-          .replace(/\s+/g, ' ')
-          .replace(/^\s*,\s*/, '')
-          .trim() || null;
-      }
+  if (model) {
+    const escapedModel = model.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const modelPattern = new RegExp(`\\b${escapedModel}\\b`, 'i');
+    let afterModel = remaining.replace(modelPattern, ' ').trim();
+    afterModel = afterModel.replace('__DISP__', displacement || '').trim();
+    if (afterModel) {
+      variant = afterModel.replace(/\s+/g, ' ').replace(/^\s*,\s*/, '').trim() || null;
 
       // Strip non-variant noise words
       if (variant) {
@@ -388,12 +352,8 @@ function extractVehicleInfo(
           variant = null;
         }
       }
-
-      break;
     }
-  }
-
-  if (!model && displacement) {
+  } else if (displacement) {
     const cleanRemaining = remaining.replace('__DISP__', '').trim();
     if (cleanRemaining) {
       variant = `${displacement} ${cleanRemaining}`.replace(/\s+/g, ' ').trim();
@@ -562,6 +522,14 @@ Examples:
   const csvKeywordsRaw = parseGoogleAdsCSV(csvPath);
   console.log(`📊 CSV: ${csvKeywordsRaw.length} keywords parsed`);
 
+  // ── Pre-fetch vehicle extraction (DB-driven via RPC) ───────────────────────
+  // Remplace les regex hardcodées par un lookup dans auto_modele (1482+ modèles).
+  // Couvre tous les modèles anciens (2cv/c15/c25/xantia/saxo/espace/twingo i/etc).
+  console.log(`\n⚙️  Pré-fetch extraction véhicule (RPC match_keyword_text_to_vehicle_batch)...`);
+  await buildVehicleExtractionCache(csvKeywordsRaw.map(k => k.keyword));
+  const cachedModelCount = Array.from(vehicleExtractionCache.values()).filter(v => v.model).length;
+  console.log(`   → ${cachedModelCount}/${vehicleExtractionCache.size} KW ont un modèle véhicule détecté`);
+
   // ── Phase T: Triage ─────────────────────────────────────────────────────────
   console.log(`\n⚙️  Phase T: Triage...`);
   const triage = runTriagePipeline(csvKeywordsRaw, gammeName);
@@ -626,24 +594,37 @@ Examples:
 
   // Add existing keywords (for recalc mode) — skip V5 (DB siblings, not from CSV)
   if (recalc) {
+    // Extend vehicle cache with existing KW that aren't in the CSV (e.g. from previous imports).
+    // Ensures V-Level recalculation uses fresh RPC-based model detection even for legacy rows.
+    const existingKwTexts = (existingKeywords || []).map(k => k.keyword).filter(Boolean);
+    const uncached = existingKwTexts.filter(t => !vehicleExtractionCache.has(t));
+    if (uncached.length > 0) {
+      await buildVehicleExtractionCache(uncached);
+    }
+
     for (const kw of (existingKeywords || []).filter(k => k.v_level !== 'V5')) {
       // Find volume from CSV if available
       const csvMatch = csvKeywords.find(
         (c) => normalizeKeyword(c.keyword) === normalizeKeyword(kw.keyword)
       );
 
+      // Refresh model/energy from canonical RPC cache (overrides potentially stale DB values)
+      const cached = vehicleExtractionCache.get(kw.keyword);
+      const refreshedModel = cached?.model ?? kw.model;
+      const refreshedEnergy = cached?.energy ?? kw.energy ?? detectEnergy(kw.keyword);
+
       allKeywords.push({
         id: kw.id,
         keyword: kw.keyword,
         keyword_normalized: normalizeKeyword(kw.keyword),
         gamme: gammeName,
-        model: kw.model,
+        model: refreshedModel,
         variant: kw.variant,
-        energy: kw.energy || detectEnergy(kw.keyword),
+        energy: refreshedEnergy,
         v_level: kw.v_level,
         volume: csvMatch?.volume ?? kw.volume ?? 0,
         score_seo: null, // Will be recalculated
-        type: kw.model ? 'vehicle' : 'generic',
+        type: refreshedModel ? 'vehicle' : 'generic',
         type_id: kw.type_id,
         power: null,
         displacement: null,


### PR DESCRIPTION
## Summary

Replace ~100 lines of hardcoded regex in `scripts/insert-missing-keywords.ts` with a call to a new SQL RPC that reads from the full `auto_modele` catalog (1482+ models) with roman/arabic/collapsed aliases.

## Problem

The hardcoded regex patterns in `extractVehicleInfo()` (lines 302-350) only covered ~40 modern models. On pg_id=258 (`maitre-cylindre-de-frein`), the TS script matched **0 vehicles** while the SQL RPC `extract_vehicle_keywords(258)` matched **59**. The TS script then wrote `v_level=NULL` to 313 rows, **erasing** pre-existing V-Level data.

Models missing from the hardcoded regex: `2cv`, `4l`, `c15`, `c25`, `espace`, `xantia`, `saxo`, `yaris`, `twingo i`, `laguna` (sans "2"), `fiat 500`, `ford s max`, `bmw e46`, etc.

## Solution

### New migration `20260423_match_keyword_text_to_vehicle.sql`

Adds two `STABLE` RPCs (no DB write) :

- `match_keyword_text_to_vehicle(p_text text)` → `(matched_model, matched_energy)`
- `match_keyword_text_to_vehicle_batch(p_texts text[])` → batch variant

Both read from `auto_modele` with **3 match_forms** per model :
1. **original** : `clio iii`, `2 cv`, `c15`
2. **arabic from roman** : `clio 3` (for stored `clio iii`)
3. **digit-letter collapsed** : `2cv` (for stored `2 cv`)

Energy detection : `hdi/tdi/dci` → diesel, `tce/thp/gti` → essence, `phev/hybrid` → hybride, etc.

### Script refactor

- New `buildVehicleExtractionCache(keywords)` — 1 round-trip DB per 500 KW
- Called **before** T3 triage + **before** recalc mode existing KW processing
- `extractVehicleInfo()` now reads `model` from the cache (no regex)
- Variant extraction preserved (strips matched model from remaining text)
- Removed `generationToRoman()` helper (RPC returns canonical form already)

## Evidence on pg_id=258 (Maître cylindre de frein)

```
BEFORE refactor :
  Phase T: T3/T4 véhicule: 45 (but 0 models extracted)
  Phase V: V2=0 V3=0 V4=0 V5=0
  Phase V-PROPAGATE: 0 keywords réalignés
  → 313 KW with v_level=NULL

AFTER refactor :
  Pre-fetch RPC: 66/314 KW with vehicle model detected
  Phase T: T3/T4 véhicule: 66
  Phase V: V2=8 V3=23 V4=15 V5=0 (46 type_ids classifiés)
  Phase V1: xantia détecté comme candidat V1 inter-gammes (absent avant)
```

## Test plan

- [x] Sanity tests SQL : `2cv`, `c15`, `clio 3`, `xantia`, `espace 4`, `twingo 1`, `306 hdi` all match
- [x] Runtime test script on pg_id=258 → 66 vehicles detected (vs 0 avant)
- [x] TypeScript compile OK (`tsc --noEmit`)
- [ ] CI : TypeScript / ESLint / Backend Tests / Frontend Tests / Migration Safety / CodeQL

## Canon refs

- Existing RPC `extract_vehicle_keywords(p_pg_id)` — batch mode on DB rows
- This PR adds the **per-text variant** for the TS script (no DB row prerequisite)
- Evidence session 2026-04-23 : vault `2026-04-23-seo-kw-pipeline-maitre-cylindre.md` (PR vault #44)

## Follow-up

- Build `scripts/seo/rebuild-type-vlevel.py` combining this RPC + __seo_type_vlevel UPSERT (noted in both vault evidences 2026-04-23).
- Consider table `auto_modele_aliases` for commercial nicknames (4L → R4, etc.) — currently unhandled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)