### PR TITLE
fix(seo): route legacy /pieces-{supplier}.html via 3-layer error pipeline

### DIFF
--- a/backend/src/remix/remix.controller.ts
+++ b/backend/src/remix/remix.controller.ts
@@ -40,15 +40,6 @@ export class RemixController {
       return next();
     }
 
-    // 🛑 410 Gone - Legacy supplier URLs
-    // URLs format: /pieces-{supplier}.html (ex: /pieces-al-ko.html, /pieces-bosch.html)
-    const supplierUrlRegex = /^\/pieces-[a-z0-9-]+\.html$/i;
-    if (supplierUrlRegex.test(request.url)) {
-      this.logger.log(`[410] Legacy supplier URL: ${request.url}`);
-      response.status(HttpStatus.GONE).send('Gone');
-      return;
-    }
-
     try {
       const build = await getServerBuild();
       return createRequestHandler({

--- a/frontend/app/routes/$.tsx
+++ b/frontend/app/routes/$.tsx
@@ -366,7 +366,13 @@ function resolveKnownPattern(pathname: string): string | null {
   }
 
   // Trailing .html sur des URLs non-pièces → retirer le .html
-  if (pathname.endsWith(".html") && !pathname.startsWith("/pieces/")) {
+  // Exclusion : /pieces-{supplier}.html (legacy équipementier) reste tel quel
+  // pour être capté directement en 410 par checkIfOldLink (évite un 301 intermédiaire)
+  if (
+    pathname.endsWith(".html") &&
+    !pathname.startsWith("/pieces/") &&
+    !/^\/pieces-[a-z0-9-]+\.html$/i.test(pathname)
+  ) {
     return pathname.slice(0, -5);
   }
 
@@ -411,6 +417,7 @@ async function checkIfOldLink(pathname: string): Promise<boolean> {
       /\/[0-9]{4}\/old\//, // Patterns avec année et "old"
       /^\/piece\//, // URLs legacy /piece/* (~90K URLs à désindexer)
       /^\/pieces\/[^/]+\/[^/]+\/[^/]+\/[^/]+\.html\//, // Extra segments après .html (legacy pagination)
+      /^\/pieces-[a-z0-9-]+\.html$/i, // URLs legacy équipementier /pieces-{supplier}.html (ex: /pieces-purflux.html)
       /^\/reference-auto\//, // Anciennes pages référence
     ];
 


### PR DESCRIPTION
## Summary

Removes a hardcoded 410 shortcut in `RemixController` that bypassed the existing 3-layer error-handling architecture (frontend catchall → API bridge → `RedirectService` / `ErrorLogService`).

Legacy equipementier URLs (`/pieces-purflux.html`, `/pieces-bosch.html`, `/pieces-mann-filter.html`, …) now flow through the normal pipeline and benefit from:

- **Telemetry** — requests logged in `__error_logs` (currently silent: 0 hits traced on 30d because the backend shortcut bypassed the logger)
- **DB override** — admin can add a 301 in `___xtr_msg` (REDIRECT_RULE) without redeploy via `RedirectService.createRedirect()`
- **Proper UX** — 410 rendered as `<ErrorGeneric>` HTML page with `Cache-Control: max-age=86400` + `X-Robots-Tag: noindex`, instead of the bare plain-text `'Gone'` body

## Changes

| File | Change |
|------|--------|
| `backend/src/remix/remix.controller.ts` | Drop `/^\/pieces-[a-z0-9-]+\.html$/i` regex + 410 shortcut (8 lines) |
| `frontend/app/routes/$.tsx` (`resolveKnownPattern`) | Preserve `.html` on `/pieces-{supplier}.html` to avoid an intermediate 301 hop |
| `frontend/app/routes/$.tsx` (`checkIfOldLink`) | Match the new pattern → emit proper HTML 410 |

## Flow (1 HTTP hop)

```
Remix controller → Remix router → $.tsx catchall
 ├─ isGarbageUrl? NO
 ├─ resolveKnownPattern? NO (explicit exclusion)
 ├─ POST /api/errors/log → 410 traced in __error_logs ✅
 ├─ GET /api/redirects/check → RedirectService DB → no rule → continue
 ├─ /api/redirects/resolve-legacy → skip (not /pieces-auto/)
 ├─ /api/errors/suggestions → smart suggestions
 └─ checkIfOldLink match /^\/pieces-[a-z0-9-]+\.html$/i → 410 HTML <ErrorGeneric>
```

## Context

- 0 `REDIRECT_RULE` rows in `___xtr_msg` today → no conflict, safe no-op if no traffic
- 0 distinct `/pieces-*.html` URLs in last 30d `__error_logs` → confirms the shortcut was bypassing the logger (telemetry gap)
- Purflux / Bosch / Valeo / AL-KO absent from `___xtr_supplier` (historical displayed suppliers) → these URLs were never site-generated; likely external backlinks/scrapers
- No R7 coverage for equipementiers (R7 = car constructors only, 36 brands in `__seo_r7_pages`) → 410 remains semantically correct; pipeline-aware 410 is the improvement

## Test plan

- [ ] After DEV preprod deploy (push to `main`), `curl -sI https://dev.automecanik.com/pieces-purflux.html` returns 410 with `Cache-Control` + `X-Robots-Tag` headers and HTML body
- [ ] One row inserted in `__error_logs` per request (verify: `SELECT COUNT(*) FROM __error_logs WHERE err_url LIKE '/pieces-%.html' AND err_created_at > NOW() - INTERVAL '5 minutes'`)
- [ ] `/pieces-purflux` (without `.html`) still returns 404 (not a pattern match)
- [ ] `/pieces/filtre-a-huile-7.html` (real gamme URL) still returns 200
- [ ] No regression on `/api/*`, `/sitemap-v2/*`, `/admin/breadcrumbs/*`, `/auth/*` passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)