### PR TITLE
refactor(r8): extract BreadcrumbSection + HeroSection (Phase 2a)

### DIFF
--- a/frontend/app/components/vehicle/r8/index.ts
+++ b/frontend/app/components/vehicle/r8/index.ts
@@ -14,3 +14,7 @@ export type {
 export { FAMILY_MICRO_DESCRIPTIONS } from "./r8-constants";
 export { generateVehicleSchema } from "./r8-schema";
 export { transformRpcToLoaderData } from "./r8-transform";
+
+// Sections
+export { BreadcrumbSection } from "./sections/BreadcrumbSection";
+export { HeroSection } from "./sections/HeroSection";

--- a/frontend/app/components/vehicle/r8/sections/BreadcrumbSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/BreadcrumbSection.tsx
@@ -1,0 +1,98 @@
+// 🍞 R8 Vehicle — S_BREADCRUMB
+// Schema.org BreadcrumbList microdata (for Google rich snippets).
+
+import { type LoaderData } from "../r8.types";
+
+interface Props {
+  vehicle: LoaderData["vehicle"];
+  breadcrumb: LoaderData["breadcrumb"];
+}
+
+export function BreadcrumbSection({ vehicle, breadcrumb }: Props) {
+  return (
+    <nav
+      className="bg-white border-b border-gray-200 py-3"
+      aria-label="Breadcrumb"
+      data-section="S_BREADCRUMB"
+    >
+      <div className="container mx-auto px-4">
+        <ol
+          className="flex items-center gap-2 text-sm"
+          itemScope
+          itemType="https://schema.org/BreadcrumbList"
+        >
+          <li
+            itemProp="itemListElement"
+            itemScope
+            itemType="https://schema.org/ListItem"
+          >
+            <a href="/" itemProp="item" className="hover:underline text-brand">
+              <span itemProp="name">Accueil</span>
+            </a>
+            <meta itemProp="position" content="1" />
+          </li>
+          <li>
+            <span className="text-gray-400">→</span>
+          </li>
+          <li
+            itemProp="itemListElement"
+            itemScope
+            itemType="https://schema.org/ListItem"
+          >
+            <a
+              href="/constructeurs"
+              itemProp="item"
+              className="hover:underline text-brand"
+            >
+              <span itemProp="name">Constructeurs</span>
+            </a>
+            <meta itemProp="position" content="2" />
+          </li>
+          <li>
+            <span className="text-gray-400">→</span>
+          </li>
+          <li
+            itemProp="itemListElement"
+            itemScope
+            itemType="https://schema.org/ListItem"
+          >
+            <a
+              href={`/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}.html`}
+              itemProp="item"
+              className="hover:underline text-brand"
+            >
+              <span itemProp="name">{breadcrumb.brand}</span>
+            </a>
+            <meta itemProp="position" content="3" />
+          </li>
+          <li>
+            <span className="text-gray-400">→</span>
+          </li>
+          <li
+            itemProp="itemListElement"
+            itemScope
+            itemType="https://schema.org/ListItem"
+          >
+            <span itemProp="name" className="text-gray-600">
+              {breadcrumb.model}
+            </span>
+            <meta itemProp="position" content="4" />
+          </li>
+          <li>
+            <span className="text-gray-400">→</span>
+          </li>
+          <li
+            itemProp="itemListElement"
+            itemScope
+            itemType="https://schema.org/ListItem"
+          >
+            <span itemProp="name" className="font-semibold text-gray-900">
+              {vehicle.type_name} {vehicle.type_power_ps} ch
+            </span>
+            <meta itemProp="position" content="5" />
+          </li>
+        </ol>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/app/components/vehicle/r8/sections/HeroSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/HeroSection.tsx
@@ -1,0 +1,22 @@
+// 🎯 R8 Vehicle — S_HERO
+// H1 unique (image-matrix-v1 §7, gradient-only)
+
+import { resolveSlogan } from "~/config/visual-intent";
+import { HeroSelection } from "../../../heroes";
+import { type LoaderData } from "../r8.types";
+
+interface Props {
+  vehicle: LoaderData["vehicle"];
+}
+
+export function HeroSection({ vehicle }: Props) {
+  return (
+    <div data-section="S_HERO">
+      <HeroSelection
+        title={`${vehicle.marque_name} ${vehicle.modele_name} ${vehicle.type_name} ${vehicle.type_power_ps} ch de ${vehicle.type_year_from} à ${vehicle.type_year_to || "aujourd'hui"}`}
+        subtitle={`${vehicle.type_fuel} · ${vehicle.type_body} · ${vehicle.type_year_from}–${vehicle.type_year_to || "Auj."}`}
+        slogan={resolveSlogan("selection")}
+      />
+    </div>
+  );
+}

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -39,18 +39,18 @@ import {
   Wrench,
 } from "lucide-react";
 import { useState, useEffect } from "react";
-import { resolveSlogan } from "~/config/visual-intent";
 import brandColorsStyles from "~/styles/brand-colors.css?url";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
 import { ErrorGeneric } from "../components/errors";
-import { HeroSelection } from "../components/heroes";
 import { ModelContentV1Display } from "../components/model";
 import { HtmlContent } from "../components/seo/HtmlContent";
 import {
+  BreadcrumbSection,
   FAMILY_MICRO_DESCRIPTIONS,
   generateVehicleSchema,
+  HeroSection,
   transformRpcToLoaderData,
   type LoaderData,
 } from "../components/vehicle/r8";
@@ -442,104 +442,9 @@ export default function VehicleDetailPage() {
       className="min-h-screen bg-gray-50"
       data-brand={vehicle.marque_alias?.toLowerCase()}
     >
-      {/* 🍞 Fil d'Ariane - Au-dessus du hero */}
-      <nav
-        className="bg-white border-b border-gray-200 py-3"
-        aria-label="Breadcrumb"
-        data-section="S_BREADCRUMB"
-      >
-        <div className="container mx-auto px-4">
-          <ol
-            className="flex items-center gap-2 text-sm"
-            itemScope
-            itemType="https://schema.org/BreadcrumbList"
-          >
-            <li
-              itemProp="itemListElement"
-              itemScope
-              itemType="https://schema.org/ListItem"
-            >
-              <a
-                href="/"
-                itemProp="item"
-                className="hover:underline text-brand"
-              >
-                <span itemProp="name">Accueil</span>
-              </a>
-              <meta itemProp="position" content="1" />
-            </li>
-            <li>
-              <span className="text-gray-400">→</span>
-            </li>
-            <li
-              itemProp="itemListElement"
-              itemScope
-              itemType="https://schema.org/ListItem"
-            >
-              <a
-                href="/constructeurs"
-                itemProp="item"
-                className="hover:underline text-brand"
-              >
-                <span itemProp="name">Constructeurs</span>
-              </a>
-              <meta itemProp="position" content="2" />
-            </li>
-            <li>
-              <span className="text-gray-400">→</span>
-            </li>
-            <li
-              itemProp="itemListElement"
-              itemScope
-              itemType="https://schema.org/ListItem"
-            >
-              <a
-                href={`/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}.html`}
-                itemProp="item"
-                className="hover:underline text-brand"
-              >
-                <span itemProp="name">{breadcrumb.brand}</span>
-              </a>
-              <meta itemProp="position" content="3" />
-            </li>
-            <li>
-              <span className="text-gray-400">→</span>
-            </li>
-            <li
-              itemProp="itemListElement"
-              itemScope
-              itemType="https://schema.org/ListItem"
-            >
-              <span itemProp="name" className="text-gray-600">
-                {breadcrumb.model}
-              </span>
-              <meta itemProp="position" content="4" />
-            </li>
-            <li>
-              <span className="text-gray-400">→</span>
-            </li>
-            <li
-              itemProp="itemListElement"
-              itemScope
-              itemType="https://schema.org/ListItem"
-            >
-              <span itemProp="name" className="font-semibold text-gray-900">
-                {vehicle.type_name} {vehicle.type_power_ps} ch
-              </span>
-              <meta itemProp="position" content="5" />
-            </li>
-          </ol>
-        </div>
-      </nav>
+      <BreadcrumbSection vehicle={vehicle} breadcrumb={breadcrumb} />
 
-      {/* Hero Selection — H1 unique (image-matrix-v1 §7, gradient-only) */}
-      <div data-section="S_HERO">
-        <HeroSelection
-          title={`${vehicle.marque_name} ${vehicle.modele_name} ${vehicle.type_name} ${vehicle.type_power_ps} ch de ${vehicle.type_year_from} à ${vehicle.type_year_to || "aujourd'hui"}`}
-          subtitle={`${vehicle.type_fuel} · ${vehicle.type_body} · ${vehicle.type_year_from}–${vehicle.type_year_to || "Auj."}`}
-          slogan={resolveSlogan("selection")}
-        />
-      </div>
+      <HeroSection vehicle={vehicle} />
 
       {/* Vehicle image + specs (hors hero — SELECTION = gradient-only) */}
       <section className="bg-white border-b" data-section="S_IDENTITY">


### PR DESCRIPTION
## Summary

Phase 2a of the R8 vehicle page refactor. Extracts the first 2 of 13 section sub-components from the monolithic \`VehicleDetailPage\`.

**Pure mechanical JSX extraction — zero behavior change.**

| Section | Component | Lines |
|---|---|---|
| \`S_BREADCRUMB\` | [BreadcrumbSection.tsx](frontend/app/components/vehicle/r8/sections/BreadcrumbSection.tsx) | 102 |
| \`S_HERO\` | [HeroSection.tsx](frontend/app/components/vehicle/r8/sections/HeroSection.tsx) | 22 |

Route shrinks **1559 → 1464 lines (−95)**. Phase 1 (#126) brought the file down from 2020 lines — cumulative reduction is **2020 → 1464 = −28%**.

## Phase 1 dependency

This PR stacks on top of #126 (Phase 1). Merge #126 first, then rebase this onto main.

## Gates

- [x] \`npx tsc --noEmit -p frontend/tsconfig.json\` → 0 errors
- [x] \`npx eslint frontend/app/routes/... frontend/app/components/vehicle/r8/sections/\` → 0 warnings
- [x] Hooks lint-staged + prettier passed
- [ ] DEV smoke-test post-merge (3 vehicles) — verify identical HTML output

## Untouched on purpose

Critical SEO path unchanged : 301/410/503 loader, canonicalization, TecDoc remap ≥100K, noindex 60000-83456, ADR-016.

## Next (Phase 2b/c...)

11 remaining sections to extract : S_IDENTITY, S_FAST_ACCESS, S_SEO_INTRO, S_CATALOG, S_BESTSELLERS, S_SAFE_TABLE, S_R8_ENRICHED, S_ANTI_ERRORS, S_HOWTO, S_FAQ, S_TRUST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)