### PR TITLE
feat(rag): stage 1 A10 — RagProposalService + RAG_PROPOSAL_MODE flag (ADR-022)

### DIFF
--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -96,6 +96,7 @@ import { R8VehicleEnricherService } from './services/r8-vehicle-enricher.service
 import { R7BrandEnricherService } from './services/r7-brand-enricher.service'; // 🏭 R7 Brand page enricher (RAG + diversity scoring)
 import { BrandEditorialService } from './services/brand-editorial.service'; // 🏭 R7 Brand editorial content (FAQ/issues/maintenance)
 import { VehicleRagGeneratorService } from './services/vehicle-rag-generator.service'; // 🚗 Vehicle RAG .md generator (0 LLM)
+import { RagProposalService } from './services/rag-proposal.service'; // 📝 ADR-022 L1 propose-before-write
 import { AdminVehicleRagController } from './controllers/admin-vehicle-rag.controller'; // 🚗 Vehicle RAG generation endpoints
 
 // Services - Stock services pour le controller consolidé
@@ -232,6 +233,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     R7BrandEnricherService, // 🏭 R7 Brand page enricher (RAG + diversity scoring, 0-LLM)
     BrandEditorialService, // 🏭 R7 Brand editorial content CRUD
     VehicleRagGeneratorService, // 🚗 Vehicle RAG .md generator (DB + gamme RAGs, 0-LLM)
+    RagProposalService, // 📝 ADR-022 L1 propose-before-write staging (__rag_proposals)
     // AdminSupplierStatsService — not ready for prod
     ExecutionRouterService, // 🚀 Unified enricher dispatch router (ExecutionRegistry-based)
     R2EnricherService, // 🏗️ R2 Product enricher (WriteGate-native, 0-LLM)

--- a/backend/src/modules/admin/services/rag-proposal.service.ts
+++ b/backend/src/modules/admin/services/rag-proposal.service.ts
@@ -1,0 +1,208 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'node:crypto';
+import { execSync } from 'node:child_process';
+import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
+import {
+  RagProposalCreateInput,
+  RagProposalMode,
+  RagProposalResult,
+  RagProposalRiskLevel,
+  RagProposalRow,
+} from './rag-proposal.types';
+
+const RAG_REPO_PATH = '/opt/automecanik/rag';
+const LEGACY_MODE_DEFAULT: RagProposalMode = 'off';
+
+/**
+ * RagProposalService — ADR-022 R8 RAG Control Plane (L1).
+ *
+ * Writes RAG file change proposals to `__rag_proposals` instead of direct
+ * disk writes. CI validates, approves (low-risk auto or human), then opens
+ * a signed PR against the RAG repo.
+ *
+ * Feature flag `RAG_PROPOSAL_MODE` controls the behavior of upstream callers
+ * (VehicleRagGeneratorService) :
+ *   - off           : legacy direct-write (default)
+ *   - shadow        : write file AND insert proposal (dual-track)
+ *   - propose-only  : insert proposal only, no disk write
+ *
+ * This service is idempotent via `input_fingerprint` — re-proposing the
+ * exact same input returns the existing active proposal instead of inserting
+ * a duplicate (PostgreSQL unique partial index enforces this).
+ */
+@Injectable()
+export class RagProposalService extends SupabaseBaseService {
+  protected readonly logger = new Logger(RagProposalService.name);
+
+  constructor(configService: ConfigService) {
+    super(configService);
+  }
+
+  /**
+   * Returns the current feature flag value from env.
+   * Defaults to 'off' if unset or unknown.
+   */
+  getMode(): RagProposalMode {
+    const raw = this.configService?.get<string>('RAG_PROPOSAL_MODE');
+    if (raw === 'shadow' || raw === 'propose-only' || raw === 'off') {
+      return raw;
+    }
+    return LEGACY_MODE_DEFAULT;
+  }
+
+  /**
+   * Insert a new proposal or return existing active one for same fingerprint.
+   *
+   * Idempotence guarantee : unique partial index on
+   * `(input_fingerprint) WHERE status IN ('pending','validating','approved')`
+   * prevents duplicates. We query first and short-circuit to return the
+   * existing row without an INSERT attempt — cleaner than catching 23505.
+   */
+  async propose(input: RagProposalCreateInput): Promise<RagProposalResult> {
+    try {
+      // 1. Dedup check : return existing active proposal if fingerprint already used
+      const existing = await this.findByFingerprint(input.input_fingerprint);
+      if (existing) {
+        this.logger.log(
+          `Proposal deduped for fingerprint ${input.input_fingerprint} → existing ${existing.proposal_uuid} (status=${existing.status})`,
+        );
+        return { status: 'deduped', proposal: existing };
+      }
+
+      // 2. Resolve base_commit_sha of RAG repo (what HEAD looked like at propose time)
+      const baseCommitSha = input.base_commit_sha || this.getRagRepoHead();
+
+      // 3. Compute content hash
+      const proposedContentHash = this.sha256(input.proposed_content);
+
+      // 4. Classify risk level (if not explicitly provided)
+      const riskLevel = input.risk_level ?? this.classifyRisk(input);
+
+      // 5. INSERT
+      const { data, error } = await this.supabase
+        .from('__rag_proposals')
+        .insert({
+          target_path: input.target_path,
+          target_slug: input.target_slug,
+          target_kind: input.target_kind,
+          base_commit_sha: baseCommitSha,
+          base_content_hash: input.base_content_hash ?? null,
+          proposed_content: input.proposed_content,
+          proposed_content_hash: proposedContentHash,
+          input_fingerprint: input.input_fingerprint,
+          created_by: input.created_by,
+          risk_level: riskLevel,
+          depends_on: input.depends_on ?? null,
+        })
+        .select('*')
+        .single();
+
+      if (error) {
+        this.logger.error(
+          `Propose failed for ${input.target_slug} (${input.target_kind}): ${error.message}`,
+        );
+        return { status: 'failed', message: error.message };
+      }
+
+      this.logger.log(
+        `Proposal created ${data.proposal_uuid} target=${input.target_path} risk=${riskLevel}`,
+      );
+      return { status: 'created', proposal: data as RagProposalRow };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.logger.error(`Propose threw: ${msg}`);
+      return { status: 'failed', message: msg };
+    }
+  }
+
+  async findByFingerprint(fingerprint: string): Promise<RagProposalRow | null> {
+    const { data, error } = await this.supabase
+      .from('__rag_proposals')
+      .select('*')
+      .eq('input_fingerprint', fingerprint)
+      .in('status', ['pending', 'validating', 'approved'])
+      .maybeSingle();
+
+    if (error) {
+      this.logger.warn(`findByFingerprint error: ${error.message}`);
+      return null;
+    }
+    return (data as RagProposalRow | null) ?? null;
+  }
+
+  async findByUuid(uuid: string): Promise<RagProposalRow | null> {
+    const { data, error } = await this.supabase
+      .from('__rag_proposals')
+      .select('*')
+      .eq('proposal_uuid', uuid)
+      .maybeSingle();
+
+    if (error) {
+      this.logger.warn(`findByUuid error: ${error.message}`);
+      return null;
+    }
+    return (data as RagProposalRow | null) ?? null;
+  }
+
+  /**
+   * Classifies risk level based on input characteristics.
+   *
+   * Rules (from design spec § 5.2) :
+   *   - new file (base_content_hash null)                     → medium
+   *   - proposed_content > 8KB                                → medium
+   *   - proposed_content > 40KB                               → high
+   *   - otherwise                                             → low
+   *
+   * NOTE : diff-lines based classification happens in CI validation step
+   * when CI computes the actual unified diff. At propose time, we give a
+   * conservative estimate — CI can bump later.
+   */
+  private classifyRisk(input: RagProposalCreateInput): RagProposalRiskLevel {
+    const size = input.proposed_content.length;
+    if (!input.base_content_hash) {
+      return 'medium'; // new file is never low-risk (needs editorial eye)
+    }
+    if (size > 40000) return 'high';
+    if (size > 8000) return 'medium';
+    return 'low';
+  }
+
+  private sha256(s: string): string {
+    return 'sha256:' + createHash('sha256').update(s).digest('hex');
+  }
+
+  /**
+   * Returns current HEAD of the RAG repo (ak125/automecanik-rag). Used as
+   * base_commit_sha to detect upstream drift between propose time and merge
+   * time (if HEAD moves, proposal should be superseded and re-computed).
+   *
+   * Falls back to 'unknown' if repo not accessible (CI may not have it).
+   */
+  private getRagRepoHead(): string {
+    try {
+      return execSync('git rev-parse HEAD', {
+        cwd: RAG_REPO_PATH,
+        encoding: 'utf-8',
+      })
+        .trim()
+        .slice(0, 40);
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  /**
+   * Compute a stable fingerprint for generator inputs.
+   * Regen with same inputs → same fingerprint → dedup hit → no-op.
+   */
+  static computeInputFingerprint(
+    parts: Record<string, string | number>,
+  ): string {
+    const sorted = Object.keys(parts)
+      .sort()
+      .map((k) => `${k}=${parts[k]}`)
+      .join('|');
+    return createHash('sha256').update(sorted).digest('hex').slice(0, 32);
+  }
+}

--- a/backend/src/modules/admin/services/rag-proposal.types.ts
+++ b/backend/src/modules/admin/services/rag-proposal.types.ts
@@ -1,0 +1,87 @@
+/**
+ * Types for RagProposalService — ADR-022 R8 RAG Control Plane (Stage 1 L1).
+ *
+ * A proposal represents a pending/validating change to a RAG vehicle file
+ * stored in ak125/automecanik-rag. Instead of writing directly to disk,
+ * VehicleRagGeneratorService inserts a proposal row into __rag_proposals.
+ * CI validates, approves (low-risk auto or human), then opens a signed PR.
+ */
+
+export type RagProposalTargetKind = 'vehicle_model' | 'variations' | 'role_map';
+
+export type RagProposalStatus =
+  | 'pending'
+  | 'validating'
+  | 'approved'
+  | 'rejected'
+  | 'merged'
+  | 'expired'
+  | 'superseded';
+
+export type RagProposalRiskLevel = 'low' | 'medium' | 'high';
+
+/**
+ * Feature flag values.
+ * - off           : legacy direct-write (default, no behavior change)
+ * - shadow        : write file AND insert proposal (dual-track validation)
+ * - propose-only  : insert proposal only, no disk write
+ */
+export type RagProposalMode = 'off' | 'shadow' | 'propose-only';
+
+export interface RagProposalCreateInput {
+  target_path: string; // ex: 'knowledge/vehicles/renault-clio-3.md'
+  target_slug: string; // ex: 'renault-clio-3'
+  target_kind: RagProposalTargetKind;
+  base_commit_sha: string; // git HEAD of target repo at generation time
+  base_content_hash?: string | null; // null if new file
+  proposed_content: string; // full file content (not diff)
+  input_fingerprint: string; // stable hash of generator inputs (for dedup)
+  created_by: string; // 'service@version' or 'user@email'
+  risk_level?: RagProposalRiskLevel; // default computed from diff size
+  depends_on?: string | null; // parent proposal_uuid
+}
+
+export interface RagProposalRow {
+  id: number;
+  proposal_uuid: string;
+  target_path: string;
+  target_slug: string;
+  target_kind: RagProposalTargetKind;
+  base_commit_sha: string;
+  base_content_hash: string | null;
+  proposed_content: string;
+  proposed_content_hash: string;
+  diff_unified: string | null;
+  input_fingerprint: string;
+  status: RagProposalStatus;
+  created_at: string;
+  created_by: string;
+  validated_at: string | null;
+  approved_at: string | null;
+  approved_by: string | null;
+  rejected_at: string | null;
+  rejection_reason: string | null;
+  merged_at: string | null;
+  merged_commit_sha: string | null;
+  expires_at: string;
+  risk_level: RagProposalRiskLevel;
+  risk_flags: string[];
+  diff_lines_added: number;
+  diff_lines_removed: number;
+  schema_valid: boolean | null;
+  forbidden_terms_found: string[] | null;
+  placeholders_unresolved: string[] | null;
+  validation_report: Record<string, unknown> | null;
+  depends_on: string | null;
+  superseded_by: string | null;
+}
+
+export interface RagProposalResult {
+  status:
+    | 'created' // new row inserted
+    | 'deduped' // existing active proposal for same fingerprint — returned as-is
+    | 'skipped' // mode=off, no action
+    | 'failed';
+  proposal?: RagProposalRow;
+  message?: string;
+}

--- a/backend/src/modules/admin/services/vehicle-rag-generator.service.ts
+++ b/backend/src/modules/admin/services/vehicle-rag-generator.service.ts
@@ -11,6 +11,8 @@ import { join } from 'node:path';
 import * as yaml from 'js-yaml';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
 import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
+import { createHash } from 'node:crypto';
+import { RagProposalService } from './rag-proposal.service';
 
 // ── Result ──
 
@@ -91,7 +93,10 @@ export class VehicleRagGeneratorService extends SupabaseBaseService {
   private readonly RAG_VEHICLES_DIR = `${RAG_KNOWLEDGE_PATH}/vehicles`;
   private readonly RAG_GAMMES_DIR = `${RAG_KNOWLEDGE_PATH}/gammes`;
 
-  constructor(configService: ConfigService) {
+  constructor(
+    configService: ConfigService,
+    private readonly ragProposal: RagProposalService,
+  ) {
     super(configService);
   }
 
@@ -175,16 +180,73 @@ export class VehicleRagGeneratorService extends SupabaseBaseService {
       webSpecs,
     );
 
-    // 8. Write file
-    mkdirSync(this.RAG_VEHICLES_DIR, { recursive: true });
-    writeFileSync(filePath, md, 'utf-8');
+    // 8. Write (branched on RAG_PROPOSAL_MODE — ADR-022 L1 propose-before-write)
+    const mode = this.ragProposal.getMode();
+    const existedBefore = existsSync(filePath);
 
-    const status = existsSync(filePath) ? 'updated' : 'created';
+    if (mode === 'off' || mode === 'shadow') {
+      // Legacy path — direct fs write
+      mkdirSync(this.RAG_VEHICLES_DIR, { recursive: true });
+      writeFileSync(filePath, md, 'utf-8');
+    }
+
+    if (mode === 'shadow' || mode === 'propose-only') {
+      // L1 propose — insert into __rag_proposals
+      const fingerprint = RagProposalService.computeInputFingerprint({
+        modele_id: modelData.modeleId,
+        motorisations_count: motorisations.length,
+        gammes_count: topGammes.length,
+        content_sha256: this.shortHash(md),
+      });
+
+      // target_path is relative to the RAG repo root (ak125/automecanik-rag)
+      const ragTargetPath = `knowledge/vehicles/${slug}.md`;
+
+      const existingHash = existedBefore
+        ? 'sha256:' + this.shortHash(readFileSync(filePath, 'utf-8'))
+        : null;
+
+      const proposal = await this.ragProposal.propose({
+        target_path: ragTargetPath,
+        target_slug: slug,
+        target_kind: 'vehicle_model',
+        base_commit_sha: '',
+        base_content_hash: existingHash,
+        proposed_content: md,
+        input_fingerprint: fingerprint,
+        created_by: `VehicleRagGeneratorService@${mode}`,
+      });
+
+      if (proposal.status === 'failed') {
+        warnings.push(
+          `rag_proposal_failed: ${proposal.message ?? 'unknown error'}`,
+        );
+      } else {
+        warnings.push(
+          `rag_proposal_${proposal.status}: ${proposal.proposal?.proposal_uuid ?? '-'}`,
+        );
+      }
+    }
+
+    const status = existedBefore ? 'updated' : 'created';
     this.logger.log(
-      `RAG vehicle ${status}: ${slug} (${sections.length} sections, ${warnings.length} warnings)`,
+      `RAG vehicle ${status} (mode=${mode}): ${slug} (${sections.length} sections, ${warnings.length} warnings)`,
     );
 
-    return { status: 'created', slug, filePath, sections, warnings };
+    return {
+      status: mode === 'propose-only' ? 'created' : 'created',
+      slug,
+      filePath,
+      sections,
+      warnings,
+    };
+  }
+
+  /**
+   * Short content hash for fingerprint stability (not cryptographic).
+   */
+  private shortHash(content: string): string {
+    return createHash('sha256').update(content).digest('hex').slice(0, 16);
   }
 
   /**


### PR DESCRIPTION
## Summary

Stage 1 A10 of ADR-022 (R8 RAG Control Plane). Introduces the **L1 propose-before-write** mechanism. `VehicleRagGeneratorService.generateForModel()` now branches on `RAG_PROPOSAL_MODE` env flag :

| Mode | Behavior |
|------|----------|
| `off` (default) | Legacy direct fs write — **zero behavior change** |
| `shadow` | Write file AND insert into `__rag_proposals` (dual-track validation) |
| `propose-only` | Insert proposal only, no disk write |

## Artefacts

### NEW `rag-proposal.types.ts`
- `RagProposalMode | Status | RiskLevel` enums
- `CreateInput | Row | Result` interfaces matching `__rag_proposals` schema

### NEW `rag-proposal.service.ts` (~180 LOC)
- `propose()` — idempotent INSERT with dedup via `findByFingerprint()` short-circuit (leverages unique partial index on active proposals)
- `findByUuid()` / `findByFingerprint()` lookups
- `getMode()` reads env flag with `off` fallback
- `classifyRisk()` — `low|medium|high` heuristic based on content size + new-file flag
- `computeInputFingerprint()` static helper (SHA-256 of sorted k=v)
- `getRagRepoHead()` — graceful `execSync` git HEAD on `/opt/automecanik/rag`

### REFACTOR `vehicle-rag-generator.service.ts`
- Inject `RagProposalService` via constructor
- `generateForModel()` branches on `ragProposal.getMode()` after content compile
- Legacy logic intact (flag=off path identical to pre-PR)

### UPDATE `admin.module.ts`
- Register `RagProposalService` as provider

## Non-goals

- **No flag activation** : default `off` in env, nothing changes in prod until Stage 2 canary
- **No consumer** of proposals yet : CI validation workflow is skeleton (A08, PR #142 merged)
- **No cross-repo PR creation** : A09 (merge-approved workflow) is Stage 2 scope

## Test plan

- [x] TypeScript typecheck on new files (clean)
- [x] ESLint clean on new + modified files (0 errors, 2 pre-existing `any` warnings at lines 507/509)
- [x] Default mode = off → `generateForModel()` writes file as before, no DB insert
- [ ] CI green on PR
- [ ] Manual shadow test in DEV (requires explicit flag set, part of Stage 2 pre-launch)

## Rollback

- Flag `RAG_PROPOSAL_MODE` unset/off → zero effect
- `git revert` removes the flag code path
- `RagProposalService` injected but never called if flag=off

## Stage 2 requires separate GO

- Activate `RAG_PROPOSAL_MODE=shadow` on 10 low-profile canary models
- **Clio 3 explicitly NOT canary** (18 motorisations, high traffic — Stage 5)
- Editorial review of first 10 proposals before auto-approve activation

## Refs

- ADR-022 : R8 RAG Control Plane
- Design spec § 5 : propose-before-write detail
- Impl plan A10
- DB : PR #141 merged (`__rag_proposals` migration)
- CI skeleton : PR #142 merged (rag-proposals-validate.yml)
- Schemas : vault PR #53 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)