### PR TITLE
fix(rag): vehicle-rag-generator type_relfollow -> type_display (ADR-022 P1)

### DIFF
--- a/backend/src/modules/admin/services/vehicle-rag-generator.service.ts
+++ b/backend/src/modules/admin/services/vehicle-rag-generator.service.ts
@@ -289,13 +289,17 @@ export class VehicleRagGeneratorService extends SupabaseBaseService {
   }
 
   private async fetchMotorisations(modeleId: number): Promise<Motorisation[]> {
+    // Filter on type_display='1' (canonical active flag). Previous filter
+    // type_relfollow='1' was excluding 2250/3434 models (65% of catalog) —
+    // notably TecDoc remapped types (type_id >= 60000) have relfollow='0'
+    // but display='1'. ADR-022 Pilier 1 unblock.
     const { data, error } = await this.client
       .from('auto_type')
       .select(
         'type_id, type_fuel, type_name, type_power_ps, type_liter, type_year_from, type_year_to, type_body',
       )
       .eq('type_modele_id', String(modeleId))
-      .eq('type_relfollow', '1')
+      .eq('type_display', '1')
       .order('type_fuel')
       .order('type_power_ps');
 
@@ -354,12 +358,13 @@ export class VehicleRagGeneratorService extends SupabaseBaseService {
   }
 
   private async fetchTopGammes(modeleId: number): Promise<TopGamme[]> {
-    // Get all type_ids for this model
+    // Get all type_ids for this model — same filter rationale as
+    // fetchMotorisations (type_display='1' canonical active flag, ADR-022 P1).
     const { data: types } = await this.client
       .from('auto_type')
       .select('type_id')
       .eq('type_modele_id', String(modeleId))
-      .eq('type_relfollow', '1');
+      .eq('type_display', '1');
 
     if (!types?.length) return [];
 


### PR DESCRIPTION
## Summary

Fixes 2 SQL filters in \`VehicleRagGeneratorService\` using legacy \`type_relfollow='1'\` filter that excluded **2250 / 3434 models (65% of catalog)** — notably ALL TecDoc remapped types (\`type_id >= 60000\`).

## Root cause (discovered during SMART canary)

During ADR-022 per-constructor rollout test on SMART (13 models), 3 out of 13 generated empty RAG files with warning \`no motorisations found\` :
- \`smart-forfour-ii\` (modele_id 151015)
- \`smart-fortwo-cabrio-iii\` (modele_id 151017)
- \`smart-fortwo-coupe-iii\` (modele_id 151016)

These are 2014+ TecDoc-remapped models with \`type_display='1'\` (active) but \`type_relfollow='0'\` (excluded by legacy filter).

### Impact measured on DB

| Metric | Count |
|--------|-------|
| Models with active types (\`display='1'\`) | 3 434 |
| Models passing OLD filter (\`relfollow='1'\`) | 1 184 |
| **Models invisible to RAG generator (BUG)** | **2 250 (65%)** |

## Fix

Swap the filter in both affected methods :

- \`fetchMotorisations\` (line 298) : \`type_relfollow='1'\` → \`type_display='1'\`
- \`fetchTopGammes\` (line 362) : same

\`type_display='1'\` is the canonical active flag already used throughout the codebase for sitemap inclusion, RPC filters, etc.

## Risk

**Zero** on existing 10 complete SMART models — their types have both \`display=1\` AND \`relfollow=1\`, so they pass both old and new filter unchanged.

## Test plan

- [x] Lint + TypeScript checks locally
- [ ] Re-generate the 3 SMART incomplets post-merge :
  \`\`\`bash
  curl -b /tmp/cookies.txt -X POST http://localhost:3000/api/admin/vehicle-rag/generate-batch \
    -d '{\"modeleIds\": [151015, 151016, 151017]}'
  \`\`\`
  Expected : 4 motorisations each, pieces_usure + problemes_connus populated.
- [ ] Diff verify 10 complete SMART files remain unchanged
- [ ] CI green

## Refs

- ADR-022 : R8 RAG Control Plane, Pilier 1 (débloquer 65% catalogue)
- Plan vault : \`ledger/knowledge/r8-rag-control-plane-implementation-plan-20260423.md\`
- Related PRs : #141 migration, #142 CI skeleton, #143 RagProposalService

🤖 Generated with [Claude Code](https://claude.com/claude-code)