### PR TITLE
feat(rag): wire selectVariation into 5 R8 enricher blocks (ADR-022 P2d)

### DIFF
--- a/backend/src/config/seo-variations.config.ts
+++ b/backend/src/config/seo-variations.config.ts
@@ -38,6 +38,122 @@ export const SEO_PROPOSE_VARIATIONS = [
 export type PriceVariation = (typeof SEO_PRICE_VARIATIONS)[number];
 export type ProposeVariation = (typeof SEO_PROPOSE_VARIATIONS)[number];
 
+// ─────────────────────────────────────────────────────────────────────────────
+// ADR-022 Pilier 2b — R8 Vehicle/Motorisation variation pools
+//
+// Sizing rationale : pool sizes chosen as PRIMES (7, 11, 13) or coprime-safe
+// values so that `typeId % N` yields maximum distinct residues across sibling
+// motorisations of a given model. Avoided N=8, 9, 10, 12 which share factors
+// with common sibling counts (Clio III = 18 types, Renault brand = ~100 types
+// per generation). See audit report: Phase B.1 baseline.
+//
+// Per-slot OFFSET provides salting to keep slots independent : slot_1 offset 0,
+// slot_2 offset 100, slot_3 offset 200, etc. — ensures same type_id gets
+// different picks per slot.
+//
+// Editorial ownership : modifications via PR signed commits (G3). Pattern
+// aligned with R1-R6 existing SEO_PRICE_VARIATIONS / SEO_PROPOSE_VARIATIONS.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Variations pour l'intro motorisation (bloc S_IDENTITY + S_SEO_INTRO).
+ * Size = 7 (prime, max distribution sur 18 siblings Clio III).
+ * Placeholders : {brand} {model} {type} {power} {fuel} {year_from} {year_to}
+ */
+export const SEO_R8_INTRO_VARIATIONS = [
+  "La {brand} {model} {type} {power} ch {fuel} a été produite de {year_from} à {year_to}. Cette fiche regroupe l'ensemble des pièces compatibles.",
+  "Moteur {type} équipe la {brand} {model} avec {power} ch {fuel}. Sélectionnez parmi notre catalogue les pièces d'origine et équivalentes homologuées.",
+  'Équipée du bloc {type} ({power} ch {fuel}), votre {brand} {model} dispose de nombreuses familles de pièces référencées et garanties.',
+  'Retrouvez dans cette fiche la liste complète des pièces compatibles avec votre {brand} {model} {type} {power} ch, produite à partir de {year_from}.',
+  'Votre {brand} {model} {type} {power} ch {fuel} mérite des pièces de qualité. Consultez notre sélection spécifique pour cette motorisation.',
+  "Cette {brand} {model} motorisation {type} de {power} ch ({fuel}) bénéficie d'un catalogue pièces d'origine et compatibles auprès d'équipementiers reconnus.",
+  'Fiche technique et pièces compatibles pour la {brand} {model} {type} ({power} ch {fuel}), années {year_from}-{year_to}.',
+] as const;
+
+/**
+ * Variations pour différenciation motorisation vs sœurs (bloc S_VARIANT_DIFFERENCE).
+ * Size = 11 (prime, meilleure distribution sur grands modèles >50 types).
+ * Placeholders : {brand} {model} {type} {power} {fuel} {engine_code} {families_count}
+ */
+export const SEO_R8_VARIANT_HIGHLIGHT_VARIATIONS = [
+  'Cette motorisation {type} {power} ch se distingue des autres versions par sa puissance et son catalogue spécifique.',
+  'La version {type} {power} ch {fuel} possède certaines pièces propres à cette motorisation (turbo, injecteurs, calculateur).',
+  'Attention : les pièces de la {type} {power} ch ne sont pas toujours interchangeables avec les autres motorisations du même modèle.',
+  'Les {families_count} familles de pièces référencées pour cette {type} {power} ch incluent des composants spécifiques à la version {fuel}.',
+  'Dans la gamme {brand} {model}, la {type} {power} ch se reconnaît à ses caractéristiques moteur distinctes.',
+  "Cette déclinaison {type} {power} ch {fuel} adresse un profil d'usage spécifique — adaptez votre choix de pièces en conséquence.",
+  "La motorisation {type} ({power} ch) bénéficie d'un catalogue pièces auto segmenté par famille technique, distinct des autres versions.",
+  'Certains composants (courroie, embrayage, distribution) diffèrent pour la {type} {power} ch — vérifiez la compatibilité avant commande.',
+  'Parmi les versions {brand} {model}, la {type} {power} ch présente des besoins entretien et pièces propres à cette motorisation {fuel}.',
+  'Fiabilité et entretien spécifiques à la {type} {power} ch : ce bloc regroupe les pièces et conseils adaptés à votre motorisation.',
+  'La {type} de {power} ch ({fuel}) partage certaines pièces avec les autres motorisations, mais comporte aussi des éléments dédiés.',
+] as const;
+
+/**
+ * Variations pour l'accès au catalogue familles pièces (bloc S_CATALOG_ACCESS).
+ * Size = 7 (prime).
+ * Placeholders : {brand} {model} {type} {families_count}
+ */
+export const SEO_R8_CATALOG_ACCESS_VARIATIONS = [
+  'Parcourez les {families_count} familles de pièces compatibles avec votre {brand} {model} {type} classées par usage.',
+  '{families_count} familles de pièces référencées pour cette motorisation — naviguez par catégorie ci-dessous.',
+  'Catalogue complet {brand} {model} {type} organisé en {families_count} familles : freinage, moteur, filtration, transmission, etc.',
+  'Choisissez parmi {families_count} familles de pièces détachées pour votre {brand} {model} {type}, chacune accompagnée de références compatibles.',
+  'Toutes les familles de pièces pour {brand} {model} {type} regroupées ci-dessous — {families_count} catégories techniques distinctes.',
+  'Votre {brand} {model} {type} est couverte par {families_count} familles de pièces, du freinage à la carrosserie.',
+  'Explorez les {families_count} catégories de pièces compatibles {brand} {model} {type} — sélectionnez celle correspondant à votre besoin.',
+] as const;
+
+/**
+ * Variations d'amorce FAQ (bloc S_FAQ_DEDICATED).
+ * Size = 7 (prime).
+ * Placeholders : {brand} {model} {type}
+ */
+export const SEO_R8_FAQ_OPENING_VARIATIONS = [
+  'Questions fréquentes sur les pièces {brand} {model} {type} — compatibilité, entretien, référencement.',
+  'Les interrogations les plus courantes concernant votre {brand} {model} {type} sont traitées ci-dessous.',
+  "FAQ dédiée à la motorisation {brand} {model} {type} : compatibilité pièces, conseils entretien, signes d'usure.",
+  'Voici les réponses aux questions les plus posées par les propriétaires de {brand} {model} {type}.',
+  "Conseils pratiques et questions fréquentes pour l'entretien de votre {brand} {model} {type}.",
+  "Aide à l'achat et FAQ motorisation {brand} {model} {type} — retrouvez les réponses aux questions essentielles.",
+  'Section dédiée aux questions fréquentes autour de votre {brand} {model} {type} : pièces, entretien, garanties.',
+] as const;
+
+/**
+ * Variations trust signals (bloc S_TRUST — atténue boilerplate).
+ * Size = 5 (stable, bloc moins différenciant par nature).
+ * Placeholders : {brand} {model}
+ */
+export const SEO_R8_TRUST_SIGNAL_VARIATIONS = [
+  'AutoMecanik garantit la conformité des pièces {brand} {model} avec les standards constructeur, livrées sous 24-48h.',
+  'Toutes les pièces {brand} {model} sont vérifiées, référencées par équipementier reconnu, expédiées rapidement partout en France.',
+  'Commandez vos pièces {brand} {model} en toute confiance : garantie constructeur, paiement sécurisé, retours acceptés 30 jours.',
+  "Notre équipe sélectionne pour {brand} {model} des pièces d'origine et compatibles validées, avec livraison express.",
+  'Qualité OEM et compatibles pour {brand} {model} — stock professionnel, assistance téléphonique, expédition 24h ouvrées.',
+] as const;
+
+export type R8IntroVariation = (typeof SEO_R8_INTRO_VARIATIONS)[number];
+export type R8VariantHighlight =
+  (typeof SEO_R8_VARIANT_HIGHLIGHT_VARIATIONS)[number];
+export type R8CatalogAccessVariation =
+  (typeof SEO_R8_CATALOG_ACCESS_VARIATIONS)[number];
+export type R8FaqOpeningVariation =
+  (typeof SEO_R8_FAQ_OPENING_VARIATIONS)[number];
+export type R8TrustSignalVariation =
+  (typeof SEO_R8_TRUST_SIGNAL_VARIATIONS)[number];
+
+/**
+ * Slot offsets for R8 variation rotation. Different offset per slot ensures
+ * that the same type_id picks independent variants across slots (salting).
+ */
+export const R8_SLOT_OFFSETS = {
+  INTRO: 0,
+  VARIANT_HIGHLIGHT: 100,
+  CATALOG_ACCESS: 200,
+  FAQ_OPENING: 300,
+  TRUST_SIGNAL: 400,
+} as const;
+
 /**
  * Sélectionne une variation par rotation déterministe
  *

--- a/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
+++ b/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
@@ -24,6 +24,15 @@ import {
   type R8SeoDecision,
   type R8ReasonCode,
 } from '../../../config/r8-keyword-plan.constants';
+import {
+  selectVariation,
+  SEO_R8_INTRO_VARIATIONS,
+  SEO_R8_VARIANT_HIGHLIGHT_VARIATIONS,
+  SEO_R8_CATALOG_ACCESS_VARIATIONS,
+  SEO_R8_FAQ_OPENING_VARIATIONS,
+  SEO_R8_TRUST_SIGNAL_VARIATIONS,
+  R8_SLOT_OFFSETS,
+} from '../../../config/seo-variations.config';
 
 // ── Result ──
 
@@ -497,15 +506,42 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
     const fuel = v.fuel || '';
     const yearFrom = v.year_from || '';
     const yearTo = v.year_to || '';
+    const typeIdInt = parseInt(String(v.type_id || 0), 10);
+    const placeholderCtx = {
+      brand,
+      model,
+      type,
+      power: String(power),
+      fuel,
+      year_from: String(yearFrom),
+      year_to: yearTo ? String(yearTo) : "aujourd'hui",
+      families_count: String(families.length),
+      engine_code:
+        Array.isArray(v.engine_codes) && v.engine_codes.length
+          ? v.engine_codes[0]
+          : '',
+    };
+    const renderTemplate = (template: string): string =>
+      template.replace(/\{(\w+)\}/g, (_, key) =>
+        Object.prototype.hasOwnProperty.call(placeholderCtx, key)
+          ? (placeholderCtx as Record<string, string>)[key]
+          : `{${key}}`,
+      );
 
-    // S_IDENTITY
+    // S_IDENTITY (ADR-022 P2d : rotation déterministe pool 7)
+    const introTemplate = selectVariation(
+      SEO_R8_INTRO_VARIATIONS,
+      typeIdInt,
+      0,
+      R8_SLOT_OFFSETS.INTRO,
+    );
     blocks.push({
       id: 'S_IDENTITY',
       type: 'vehicle_identity',
       title: `${brand} ${model} ${type}`,
-      renderedText: `La ${brand} ${model} ${type} ${power} ch${fuel ? ` (${fuel})` : ''} est produite de ${yearFrom}${yearTo ? ` à ${yearTo}` : " à aujourd'hui"}. Cette fiche regroupe l'ensemble des pièces compatibles avec votre motorisation.`,
-      specificityWeight: 0.7,
-      boilerplateRisk: 0.2,
+      renderedText: renderTemplate(introTemplate),
+      specificityWeight: 0.75,
+      boilerplateRisk: 0.15,
       semanticPayload: [brand, model, type, fuel, power].filter(Boolean),
     });
 
@@ -596,29 +632,30 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
       });
     }
 
-    // S_VARIANT_DIFFERENCE
-    if (neighbors.length > 0) {
-      const variantText = `Cette motorisation ${type} ${power} ch se distingue par sa puissance et son catalogue de pièces. Certaines familles (turbo, injecteurs, calculateur) sont spécifiques à cette version.`;
-      blocks.push({
-        id: 'S_VARIANT_DIFFERENCE',
-        type: 'variant_difference',
-        title: `Ce qui distingue la ${type} ${power} ch`,
-        renderedText: variantText,
-        specificityWeight: 0.95,
-        boilerplateRisk: 0.05,
-        semanticPayload: [type, power, 'variant', 'différence'],
-      });
-    } else {
-      blocks.push({
-        id: 'S_VARIANT_DIFFERENCE',
-        type: 'variant_difference',
-        title: `Spécificités de la ${type} ${power} ch`,
-        renderedText: `La ${brand} ${model} ${type} ${power} ch possède un catalogue de ${families.length} familles de pièces. Les pièces de freinage, filtration et distribution sont les plus demandées pour cette motorisation.`,
-        specificityWeight: 0.8,
-        boilerplateRisk: 0.15,
-        semanticPayload: [type, power, String(families.length)],
-      });
-    }
+    // S_VARIANT_DIFFERENCE (ADR-022 P2d : rotation pool 11 avec salt)
+    const variantTemplate = selectVariation(
+      SEO_R8_VARIANT_HIGHLIGHT_VARIATIONS,
+      typeIdInt,
+      0,
+      R8_SLOT_OFFSETS.VARIANT_HIGHLIGHT,
+    );
+    blocks.push({
+      id: 'S_VARIANT_DIFFERENCE',
+      type: 'variant_difference',
+      title:
+        neighbors.length > 0
+          ? `Ce qui distingue la ${type} ${power} ch`
+          : `Spécificités de la ${type} ${power} ch`,
+      renderedText: renderTemplate(variantTemplate),
+      specificityWeight: neighbors.length > 0 ? 0.95 : 0.85,
+      boilerplateRisk: neighbors.length > 0 ? 0.05 : 0.1,
+      semanticPayload: [
+        type,
+        power,
+        neighbors.length > 0 ? 'variant' : String(families.length),
+        'différence',
+      ],
+    });
 
     // S_SELECTION_GUIDE
     const usurePieces = vehicleRag.pieces_usure || [];
@@ -648,9 +685,17 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
       });
     }
 
-    // S_CATALOG_ACCESS (dynamic ranking)
+    // S_CATALOG_ACCESS (dynamic ranking + ADR-022 P2d variation opener)
     const topFamilies = families.slice(0, 10);
     if (topFamilies.length >= 3) {
+      const catalogOpener = renderTemplate(
+        selectVariation(
+          SEO_R8_CATALOG_ACCESS_VARIATIONS,
+          typeIdInt,
+          0,
+          R8_SLOT_OFFSETS.CATALOG_ACCESS,
+        ),
+      );
       const catalogLines = topFamilies.map(
         (f, i) => `${i + 1}. **${f.pg_name}** — ${f.product_count} références`,
       );
@@ -658,37 +703,51 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
         id: 'S_CATALOG_ACCESS',
         type: 'dynamic_category_ranking',
         title: `Top familles de pièces`,
-        renderedText: catalogLines.join('\n'),
+        renderedText: `${catalogOpener}\n\n${catalogLines.join('\n')}`,
         specificityWeight: 0.75,
         boilerplateRisk: 0.15,
         semanticPayload: topFamilies.map((f) => f.pg_alias),
       });
     }
 
-    // S_FAQ_DEDICATED (merge from gamme RAGs)
+    // S_FAQ_DEDICATED (merge from gamme RAGs + ADR-022 P2d variation opener)
     const allFaqs = gammeRags.flatMap((g) => g.faq);
     const uniqueFaqs = this.deduplicateFaqs(allFaqs).slice(0, 6);
     if (uniqueFaqs.length >= 2) {
+      const faqOpener = renderTemplate(
+        selectVariation(
+          SEO_R8_FAQ_OPENING_VARIATIONS,
+          typeIdInt,
+          0,
+          R8_SLOT_OFFSETS.FAQ_OPENING,
+        ),
+      );
       blocks.push({
         id: 'S_FAQ_DEDICATED',
         type: 'dedicated_faq',
         title: `Questions fréquentes`,
-        renderedText: uniqueFaqs.map((f) => `**${f.q}**\n${f.a}`).join('\n\n'),
-        specificityWeight: 0.65,
-        boilerplateRisk: 0.25,
+        renderedText: `${faqOpener}\n\n${uniqueFaqs.map((f) => `**${f.q}**\n${f.a}`).join('\n\n')}`,
+        specificityWeight: 0.7,
+        boilerplateRisk: 0.2,
         semanticPayload: uniqueFaqs.map((f) => f.q.slice(0, 30)),
       });
     }
 
-    // S_TRUST (static boilerplate)
+    // S_TRUST (ADR-022 P2d : atténue boilerplate via rotation pool 5)
+    const trustTemplate = selectVariation(
+      SEO_R8_TRUST_SIGNAL_VARIATIONS,
+      typeIdInt,
+      0,
+      R8_SLOT_OFFSETS.TRUST_SIGNAL,
+    );
     blocks.push({
       id: 'S_TRUST',
       type: 'trust_and_support',
       title: `Garantie et livraison`,
-      renderedText: `Toutes les pièces sont garanties et expédiées sous 24-48h. Retours gratuits sous 30 jours. Notre service client est disponible du lundi au vendredi.`,
-      specificityWeight: 0.3,
-      boilerplateRisk: 0.8,
-      semanticPayload: ['garantie', 'livraison'],
+      renderedText: renderTemplate(trustTemplate),
+      specificityWeight: 0.4,
+      boilerplateRisk: 0.65,
+      semanticPayload: ['garantie', 'livraison', brand, model].filter(Boolean),
     });
 
     return blocks;


### PR DESCRIPTION
## Summary

Wires the 5 R8 variation pools (introduced by **#145**) into the R8 enricher blocks. **Depends on #145** (base branch set accordingly — will be re-targeted to main after #145 merge).

Prevents duplicate content between sibling motorisations via deterministic rotation with per-slot salting.

## Blocks wired

| Block                | Pool                                      | N  |
|---------------------|-------------------------------------------|----|
| S_IDENTITY           | SEO_R8_INTRO_VARIATIONS                  | 7  |
| S_VARIANT_DIFFERENCE | SEO_R8_VARIANT_HIGHLIGHT_VARIATIONS      | 11 |
| S_CATALOG_ACCESS     | SEO_R8_CATALOG_ACCESS_VARIATIONS (opener)| 7  |
| S_FAQ_DEDICATED      | SEO_R8_FAQ_OPENING_VARIATIONS (opener)   | 7  |
| S_TRUST              | SEO_R8_TRUST_SIGNAL_VARIATIONS           | 5  |

## Helper `renderTemplate()`

Substitutes 9 placeholders in the template strings :

- `{brand}` `{model}` `{type}` `{power}` `{fuel}`
- `{year_from}` `{year_to}` (with fallback 'aujourd'hui')
- `{families_count}` `{engine_code}` (first of array)

## Structural changes

- **S_VARIANT_DIFFERENCE** : 2 branches (neighbors vs none) fusionnées — même pool partagé, l'index de rotation unique par type_id assure la différenciation
- **S_TRUST** : `boilerplateRisk` 0.8 → 0.65 (atténué par rotation)
- **S_IDENTITY** : `specificityWeight` 0.7 → 0.75
- **Fingerprinting inchangé** : les 6 hashes R8 absorbent naturellement le rendered text

## Impact SEO attendu

Sur 18 motorisations Clio III :
- **Avant** : 1 texte unique par bloc → 18 pages avec intros/FAQ/catalog quasi-identiques
- **Après** : 7-11 textes distincts par bloc, distribués par hash → intro_hash, catalog_hash, faq_hash, trust_hash distincts siblings
- Fingerprint diversity attendue : 7/18 minimum (slot S_IDENTITY), jusqu'à 11/18 (S_VARIANT_DIFFERENCE)

## Test plan

- [x] ESLint clean (0 errors, 2 pre-existing `any` warnings non liés)
- [ ] CI green
- [ ] Post-merge : smoke test Clio III 18 type_ids via `enrichSingle` et vérif hashes distincts

## Refs

- ADR-022 Pilier 2d
- Base PR : #145 (variation pools)
- Legacy pattern : `SeoTemplateService` R1-R6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
