### PR TITLE
feat(tooling): claude knowledge base + deterministic cleanup gates

### DIFF
--- a/.ast-grep/rules/backend-no-console-log.yml
+++ b/.ast-grep/rules/backend-no-console-log.yml
@@ -3,11 +3,19 @@ language: typescript
 severity: warning
 message: |
   Use NestJS Logger (this.logger.log / debug / error) instead of console.*
-  in backend modules, so logs honour log levels and structured output.
+  in backend runtime code, so logs honour log levels and structured output.
+  CLI / validation / tooling scripts are exempt (see `ignores` below).
 files:
   - backend/src/modules/**/*.ts
   - backend/src/services/**/*.ts
   - backend/src/controllers/**/*.ts
+ignores:
+  - backend/src/**/validate-*.ts
+  - backend/src/**/cli/*.ts
+  - backend/src/**/scripts/*.ts
+  - backend/src/**/*.spec.ts
+  - backend/src/**/*.e2e-spec.ts
+  - backend/src/**/test-*.ts
 rule:
   any:
     - pattern: console.log($$$)

--- a/.ast-grep/rules/backend-no-console-log.yml
+++ b/.ast-grep/rules/backend-no-console-log.yml
@@ -1,0 +1,16 @@
+id: backend-no-console-log
+language: typescript
+severity: warning
+message: |
+  Use NestJS Logger (this.logger.log / debug / error) instead of console.*
+  in backend modules, so logs honour log levels and structured output.
+files:
+  - backend/src/modules/**/*.ts
+  - backend/src/services/**/*.ts
+  - backend/src/controllers/**/*.ts
+rule:
+  any:
+    - pattern: console.log($$$)
+    - pattern: console.error($$$)
+    - pattern: console.warn($$$)
+    - pattern: console.debug($$$)

--- a/.ast-grep/rules/payments-no-raw-equality.yml
+++ b/.ast-grep/rules/payments-no-raw-equality.yml
@@ -20,3 +20,11 @@ rule:
     - has:
         regex: '(?i)signature|hmac|mac|digest|hash'
         stopBy: end
+    - not:
+        has:
+          kind: string
+          stopBy: end
+    - not:
+        has:
+          kind: template_string
+          stopBy: end

--- a/.ast-grep/rules/payments-no-raw-equality.yml
+++ b/.ast-grep/rules/payments-no-raw-equality.yml
@@ -1,0 +1,22 @@
+id: payments-no-raw-equality
+language: typescript
+severity: warning
+message: |
+  Signature/HMAC comparison in payments/* must use crypto.timingSafeEqual,
+  not === or !==. Plain string equality is vulnerable to timing attacks.
+  See .claude/rules/payments.md.
+note: |
+  Replace  if (a === b)  with:
+    const aBuf = Buffer.from(a, 'hex');
+    const bBuf = Buffer.from(b, 'hex');
+    if (aBuf.length === bBuf.length && crypto.timingSafeEqual(aBuf, bBuf)) { ... }
+files:
+  - backend/src/modules/payments/**/*.ts
+rule:
+  all:
+    - any:
+        - pattern: $SIG === $REF
+        - pattern: $SIG !== $REF
+    - has:
+        regex: '(?i)signature|hmac|mac|digest|hash'
+        stopBy: end

--- a/.claude/knowledge/README.md
+++ b/.claude/knowledge/README.md
@@ -1,0 +1,102 @@
+# Knowledge — Mémoire codebase AutoMecanik
+
+> **But** : permettre à Claude Code de répondre aux questions sur le codebase
+> **sans relire tous les fichiers**. Cette mémoire est lue en premier, avant
+> tout `Grep` ou `Glob` en rafale.
+
+## Hiérarchie de lecture
+
+1. `README.md` (ce fichier) — index + règles de navigation
+2. `modules/<name>.md` — pour toute question portant sur un module backend NestJS
+3. `db/*.md` — pour les questions sur les tables, RPCs, migrations Supabase
+4. `integrations/*.md` — pour Paybox, SystemPay, Supabase, catalogue fournisseur (parts-feed)
+5. `routes/*.md` — pour les routes Remix critiques
+
+Si la question n'est pas couverte ici, lire `.claude/rules/*` puis grepper.
+
+## Modules backend (auto-détectés, `backend/src/modules/*`)
+
+Les fichiers `modules/*.md` ont tous une section `Rôle` / `Pourquoi` /
+`Gotchas` / `Références` à compléter humainement. Le bloc `AUTO-GENERATED`
+(exports, providers, fichiers primaires) est mis à jour par
+`scripts/knowledge/refresh-knowledge.py`.
+
+### Modules critiques (lire en priorité)
+
+| Module | Rôle principal | Criticité |
+|---|---|---|
+| [payments](modules/payments.md) | Passerelles Paybox + SystemPay (HMAC, callbacks, RSA) | **HIGH** — sécurité |
+| [rag-proxy](modules/rag-proxy.md) | Pipeline RAG, ingestion, search, circuit breaker | **HIGH** — coeur IA |
+| [seo](modules/seo.md) | SEO V4 Ultimate, DynamicSeo, sitemap, JSON-LD | **HIGH** — trafic |
+| [admin](modules/admin.md) | Dashboard, SEO tooling, gammes, content-refresh | **HIGH** — outillage interne |
+| [auth](modules/../../rules/backend.md) | Sessions Redis, bcrypt+MD5, JWT admin (voir rules/) | **HIGH** — sécurité |
+| [catalog](modules/catalog.md) | Catalogue pièces, V-Level, filtres véhicule | MEDIUM |
+| [products](modules/products.md) | Produits, cross-selling, gammes | MEDIUM |
+| [orders](modules/orders.md) | Commandes, items, statuts | MEDIUM |
+| [cart](modules/cart.md) | Panier, merge anonymous→user | MEDIUM |
+| [diagnostic-engine](modules/diagnostic-engine.md) | Diagnostic véhicule, symptômes, opérations | MEDIUM |
+| [knowledge-graph](modules/knowledge-graph.md) | KG sync, RAG bridge | MEDIUM |
+| [substitution](modules/substitution.md) | Équivalences pièces, refs croisées | MEDIUM |
+| [search](modules/search.md) | Recherche unifiée, RPC Postgres | MEDIUM |
+| [vehicles](modules/vehicles.md) | V-Level, compatibility, cache | MEDIUM |
+| [users](modules/users.md) | Users, profils, roles | MEDIUM |
+
+### Autres modules (stub auto-généré, à enrichir à la demande)
+
+analytics, ai-content, agentic-engine, blog, blog-metadata, bot-guard,
+commercial, config, dashboard, errors, gamme-rest, health, invoices, layout,
+marketing, mcp-validation, messages, metadata, navigation, promo, rm,
+seo-logs, shipping, staff, suppliers, support, system, upload
+
+## Base de données
+
+| Fichier | Couvre |
+|---|---|
+| [db/tables-seo.md](db/tables-seo.md) | `__seo_*`, `__blog_*`, vues `__pg_*` |
+| [db/tables-pieces.md](db/tables-pieces.md) | `pieces_*`, `pieces_media_img*`, dédoublonnage `_i` |
+| [db/tables-rag.md](db/tables-rag.md) | `rag_documents`, `__rag_*`, `kg_rag_sync_log` |
+| [db/rpcs-critical.md](db/rpcs-critical.md) | RPCs SEO, vehicle-compat, pieces-detail |
+
+## Intégrations externes
+
+| Fichier | Couvre |
+|---|---|
+| [integrations/paybox.md](integrations/paybox.md) | HMAC-SHA512, callback flow, RSA mode |
+| [integrations/systempay.md](integrations/systempay.md) | HMAC-SHA256, vads_* ordering |
+| [integrations/supabase.md](integrations/supabase.md) | Projet `cxpojprgwgubzjyqzmoq`, MCP, RLS |
+| [integrations/parts-feed.md](integrations/parts-feed.md) | Pipeline V2 catalogue fournisseur, remap, noindex legacy |
+
+## Routes Remix critiques
+
+| Fichier | Couvre |
+|---|---|
+| [routes/pieces.md](routes/pieces.md) | Catalogue pièces (pieces.*) |
+| [routes/admin.md](routes/admin.md) | Dashboard interne (admin.*) |
+| [routes/panier.md](routes/panier.md) | Panier + checkout (panier.*) |
+
+## Règles adjacentes (NE PAS dupliquer ici)
+
+Ces règles vivent dans `.claude/rules/*` — `knowledge/` les référence, jamais ne les recopie :
+
+- [rules/backend.md](../rules/backend.md) — stack NestJS, three-tier, session, Redis
+- [rules/frontend.md](../rules/frontend.md) — Remix, shadcn/ui + Tailwind, conventions
+- [rules/deployment.md](../rules/deployment.md) — DEV preprod / PROD (tag), Docker, Caddy
+- [rules/payments.md](../rules/payments.md) — règles HMAC critiques, timingSafeEqual, security
+- [rules/context7.md](../rules/context7.md) — Context7 MCP usage (frugal)
+- [rules/agent-exit-contract.md](../rules/agent-exit-contract.md) — anti-overclaim pour agents
+
+## Gouvernance
+
+La gouvernance (ADRs, incidents, policies) vit dans
+`/opt/automecanik/governance-vault/` — voir [CLAUDE.md](../../CLAUDE.md).
+Ce dossier `knowledge/` est le miroir *code applicatif*, pas le vault.
+
+## Maintenance
+
+- Auto-refresh du bloc `<!-- AUTO-GENERATED -->` + frontmatter à chaque commit via `.husky/pre-commit`
+- Audit manuel : `python3 scripts/knowledge/refresh-knowledge.py refresh`
+- Audit complet : `python3 scripts/knowledge/refresh-knowledge.py bootstrap` (recrée les manquants, ne touche pas l'humain)
+
+---
+
+_Dernière révision index : 2026-04-24 — `feat/claude-knowledge-base`_

--- a/.claude/knowledge/db/rpcs-critical.md
+++ b/.claude/knowledge/db/rpcs-critical.md
@@ -1,0 +1,51 @@
+---
+scope: RPCs critiques
+last_scan: 2026-04-24
+---
+
+# RPCs Supabase critiques
+
+## ADR-017 RPC cleanup (LIVE depuis 2026-04-21)
+
+Phase 1 terminée : RPC #1 gain -96% (395ms vs 10.5s baseline). Index 2.6 GB.
+8 RPCs restantes à valider J+1 via `pg_stat_statements` avant RPC #2.
+
+**Règle canon** : pour `CREATE INDEX CONCURRENTLY` ou queries > 60s,
+utiliser `scripts/db/adr017-create-index-concurrently.py` (Python psycopg2,
+port 5432, autocommit, `statement_timeout=0`). MCP Supabase ne le supporte pas.
+
+## RPCs SEO
+
+| RPC | Rôle | Notes |
+|---|---|---|
+| `match_keyword_text_to_vehicle(p_text)` | Extrait véhicules d'un keyword texte (cas anciens : 2cv, 4L, C15, Espace, Xantia, Saxo...) | PR #132. Remplace regex hardcodé du script `insert-missing-keywords.ts`. |
+| `extract_vehicle_keywords(pg_id)` / `_batch(text[])` | Batch : keyword → vehicles + type_ids | STABLE, cache-friendly. |
+| `sgpg_gatekeeper_*` | Gate R6 (symétrie R1) | PR #130. Protège Purchase Guide gamme contre insertion sans gate. |
+
+## RPCs Véhicule & compatibilité
+
+| RPC | Rôle | Notes |
+|---|---|---|
+| `get_piece_detail(piece_id_i)` | Détail pièce + média + compat | Cache Redis 10 min. |
+| `compat_vehicle_piece(type_id, piece_id)` | Test compat bool | Pas de FK (design imposé par le flux fournisseur). |
+| V-Level classification | SQL port depuis Python archivé | Script `scripts/seo/rebuild-type-vlevel.py` (canon, PR #131). |
+
+## RPCs Recherche
+
+| RPC | Rôle | Notes |
+|---|---|---|
+| `search_unaccent_*` | Recherche texte sans accents | Utilisé par diagnostic-engine |
+| `diagnostic_search(q)` | Branche sur `__diag_*` (13 systèmes, 62 symptômes, 30 ops entretien) | 97 sessions, unaccent. |
+
+## Gotchas RPC
+
+- **Jamais `DROP FUNCTION` sans validation** (voir MEMORY.md, DB protection)
+- **RPC batch KP DROPPED** — remplacées par NestJS. Moteur agentique déprécié pour KP
+- **type_display filter** : utiliser `type_display` (pas `type_relfollow`) dans vehicle-rag-generator (fix commit 729ff632)
+- **Cache invalidation** : après update via RPC, flush Redis pattern approprié
+
+## Règles associées
+
+- MEMORY.md : `adr-017-rpc-cleanup.md`, `adr-016-vehicle-page-cache.md`
+- Vault knowledge `mcp-vs-python-direct-pg.md` : limitations MCP pour DDL + queries > 60s
+- Scripts canon : `scripts/db/adr017-*.py`, `scripts/seo/rebuild-type-vlevel.py`

--- a/.claude/knowledge/db/tables-pieces.md
+++ b/.claude/knowledge/db/tables-pieces.md
@@ -1,0 +1,54 @@
+---
+scope: Pieces tables
+sources:
+  - backend/supabase/migrations/**/20260*_pieces_*.sql
+last_scan: 2026-04-24
+---
+
+# Tables Pieces (catalogue pièces)
+
+## Tables principales
+
+| Table | Rôle | Remarques |
+|---|---|---|
+| `pieces` | Catalogue pièces maître | PK `id`. Colonnes dédoublées TEXT + `_i` INTEGER (voir Gotchas). |
+| `pieces_media_img` | Images produits TEXT (legacy) | ~80K images actives. Recovery post-incident 2026-04-11. |
+| `pieces_media_img_i` | Index entier des images | Recréé 2026-04-12 via RPC `get_piece_detail`. Cache Redis actif. |
+| `pieces_relation_type` | Relations pièces (cross-refs flux fournisseur) | Pollution flux fournisseur scannée 2026-04-13. |
+| `pieces_compatibility` | Compatibilité pièce ↔ véhicule | Jointure avec `types` véhicule via V-Level. |
+
+## Duplication colonnes TEXT + `_i`
+
+**Pattern récurrent** dans les tables issues du flux fournisseur (`pieces`, etc.) :
+- Colonne `foo TEXT` (ancienne, données brutes du flux)
+- Colonne `foo_i INTEGER` (internal ID, celle à utiliser)
+
+**Règle** : toujours utiliser les IDs internes (`*_i`), jamais les colonnes brutes préfixées par le namespace fournisseur.
+Voir MEMORY.md `feedback_internal_ids.md` (règle émergente post-incident pieces_media_img).
+Règle ast-grep d'enforcement non activée pour l'instant (voir parts-feed.md).
+
+## Incident 2026-04-11 — pagination bug
+
+- Bug de pagination dans script d'import → 80K images actives supprimées
+- Recovery via Supabase backups (MEMORY.md `incident-images-2026-04-11.md`)
+- Post-mortem : pagination offset + validation de bornes
+
+## RPC critiques
+
+| RPC | Rôle |
+|---|---|
+| `get_piece_detail(piece_id_i)` | Détail pièce avec média + compat. Cache Redis 10 min. |
+| `match_keyword_text_to_vehicle(p_text)` | Extrait vehicles d'un keyword texte. Remplace regex hardcodé (PR #132). |
+| `extract_vehicle_keywords(pg_id)` | Batch variant. Utilise RPC SQL STABLE. |
+
+## Gotchas
+
+- Ne JAMAIS utiliser les colonnes brutes préfixées par le namespace fournisseur en code applicatif
+- Cache Redis : invalider après update via `pieces:detail:*` pattern
+- `pieces_media_img` vs `pieces_media_img_i` : utiliser `_i` pour lookups, legacy TEXT pour affichage
+- PAS de FK sur `types` (design imposé par le flux fournisseur, voir memory `vehicle-ops`)
+
+## Règles associées
+
+- MEMORY.md : `feedback_internal_ids.md`, `incident-images-2026-04-11.md`, `db-pieces-indexes.md`
+- MEMORY.md : `tecdoc-integration.md` — pipeline V2, 78K actives, SEO protection 301+noindex

--- a/.claude/knowledge/db/tables-rag.md
+++ b/.claude/knowledge/db/tables-rag.md
@@ -1,0 +1,52 @@
+---
+scope: RAG tables & sync
+sources:
+  - backend/supabase/migrations/**/20260313_rag_documents_v2.sql
+  - backend/supabase/migrations/**/20260125_kg_v3_rag_sync.sql
+last_scan: 2026-04-24
+---
+
+# Tables RAG (Supabase projection)
+
+Le RAG canonique vit dans Weaviate (`/opt/automecanik/rag/`). Ces tables Supabase sont
+la projection structurée (métadonnées, audit, lifecycle) avec tsvector français.
+
+## Tables
+
+| Table | Rôle |
+|---|---|
+| `rag_documents` | Documents RAG : truth_level, domain, lifecycle_status, hashes MD5/SHA, frontmatter JSONB. Fulltext tsvector FR. |
+| `rag_document_versions` | Historique immutable de toute version (append-only). |
+| `rag_job_history` | Log des ingestions (par job, par source). |
+| `kg_rag_sync_log` | Sync KG ↔ RAG (depuis 20260125). |
+| `__rag_knowledge` | Miroir hash des `.md` dans `/opt/automecanik/rag/knowledge/`. Script `sync-rag-knowledge.ts`. |
+| `__rag_proposals` | **Stage 0 ADR-022 (2026-04-23)** — propose-before-write pour éviter écritures hallucinées RAG. RLS actif. |
+
+## Pipeline d'ingestion
+
+```
+Markdown/PDF  →  Python ingestor  →  Weaviate (embeddings all-MiniLM-L6-v2)
+               + hash MD5/SHA       ↓
+                                 rag_documents (Supabase projection)
+                                    ↓
+                                 trg_rag_content_changed → poll 60s → ContentMerger (merge-only)
+```
+
+## Feature flags actifs
+
+- **Stage 1 A10 propose-before-write** : `RagProposalService` + flag (MEMORY : `adr-022-vehicle-page-cache` trail)
+- **Stage 0 migration** : `__rag_proposals` + tests + RLS audit (commit 598d4b63)
+
+## Gotchas
+
+- Les embeddings Weaviate sont `all-MiniLM-L6-v2` (384 dims), pas OpenAI
+- `rag_documents` ne stocke PAS les embeddings, uniquement métadonnées
+- Le RAG **n'indexe PAS le code** (contenu métier uniquement). Pour le code → `.claude/knowledge/`
+- Sync `knowledge/` → `__rag_knowledge` par hash MD5 (pas par mtime — git-safe)
+- Transforms Supabase **désactivées** (voir MEMORY.md `supabase-cleanup-2026-03.md`)
+
+## Règles associées
+
+- MEMORY.md : `rag.md`, `rag-foundation-baseline.md`, `rag-enrichment-pipeline.md`, `rag-pipeline-strategy.md`
+- ADR-022 : propose-before-write (vault)
+- Circuit breaker : `RagProxyModule.services.CircuitBreaker`

--- a/.claude/knowledge/db/tables-seo.md
+++ b/.claude/knowledge/db/tables-seo.md
@@ -1,0 +1,55 @@
+---
+scope: SEO tables
+sources:
+  - backend/supabase/migrations/**/20260*_seo_*.sql
+  - backend/supabase/migrations/**/20260*_kp_*.sql
+last_scan: 2026-04-24
+---
+
+# Tables SEO & Blog
+
+## Tables principales
+
+| Table | Rôle | Remarques |
+|---|---|---|
+| `__seo_gamme_conseil` | Contenu sections conseils (S1–S8) par gamme | RLS active. Pollution OEM scannée par `pollution-scanner`. Jamais caster `sgc_id` → timestamptz. `sg_updated_at` = horodatage. |
+| `__seo_keyword_plan_r1` à `r8` | Keyword plans par rôle R1–R8 | 1 plan par `pg_id` et par rôle. Format JSONB. |
+| `__seo_keyword_results` | Résultats classification Google Ads | Écrit par `/kw-classify`, contient `vol_percentile`. |
+| `__seo_keywords` | Keywords bruts Google Ads KP | Import via `import-gads-kp.py`. |
+| `__seo_research_brief` | Briefs recherche Stage 1 pipeline v2 | Écrit par `research-agent`. |
+| `__seo_page_brief` | Briefs de page enrichis Stage 2 | Écrit par `brief-enricher`. |
+| `__seo_r2_keyword_plan` | R2 Product V3 audit-first | 6 phases (P0–P5), 11 quality gates. |
+| `__seo_r4_keyword_plan` / `__seo_reference` | R4 Reference V2 + V4 audit-first | Pass A discover, Pass B compile. |
+| `__seo_r5_keyword_plan` | R5 Diagnostic | 6 sections, safety gate. |
+| `__seo_r6_keyword_plan` / `__seo_gamme_purchase_guide` | R6 Guide d'achat V2 | 7 prompts, compliance score. |
+| `__seo_r7_keyword_plan` / `__seo_brand_*` | R7 Brand V3 | Section bundle JSON V3. |
+| `__seo_r8_*` (7 tables) | R8 Vehicle V5 | Blocks, diversity scoring, fingerprinting, governance. |
+| `__blog_advice`, `__blog_advice_h2`, `__blog_advice_h3` | Legacy blog (CMS hérité) | Source pour `legacy-recycler`. |
+| `gamme_aggregates` | 241 gammes agrégées | RLS active. 243 – 2 (merge 3942→817, deprecate 3333). |
+
+## Vues
+
+| Vue | Rôle |
+|---|---|
+| `__pg_gammes` | 232 gammes G1/G2 publiables, exclut pg_level=0 + G3/G4 orphelines. Corrigée 2026-04-08. 100% avec alias. |
+
+## Gotchas DB SEO
+
+- **pg_level=0 = gamme parent agrégée** → exclure des pages catalogue
+- **G3/G4 orphelines** → filtrées par `__pg_gammes`
+- **Rate limit KP** : burst max 2 agents parallèles (sinon API 429)
+- **R3 S5 threshold** : ≥ 70 pour être publiable
+- **pg_id=3942** merged vers 817 (doublon historique) ; pg_id=3333 deprecated
+- **pg_id=258** : cas TypeScript regex insuffisant → utiliser RPC `match_keyword_text_to_vehicle` (PR #132)
+
+## Règles associées
+
+- `.claude/rules/backend.md` — SupabaseBaseService, pas de Prisma
+- `.claude/rules/agent-exit-contract.md` — anti-overclaim agents SEO
+- MEMORY.md : `qa-seo.md`, `kw-pipeline-gads.md`, `kw-pipeline-status.md`, `r4-batch-progress.md`
+
+## Accès
+
+- Via NestJS : `SupabaseBaseService` → `.from('__seo_...')` ou `.rpc('...')`
+- Via MCP Supabase (diagnostic + queries read-only)
+- PAS de DROP/TRUNCATE sans validation humaine explicite (voir MEMORY)

--- a/.claude/knowledge/integrations/parts-feed.md
+++ b/.claude/knowledge/integrations/parts-feed.md
@@ -1,0 +1,48 @@
+---
+integration: parts-feed
+pipeline: V2
+last_scan: 2026-04-24
+---
+
+# Intégration parts-feed (catalogue fournisseur pièces)
+
+## Pipeline V2 (actif)
+
+- **78K types actifs** (véhicules)
+- **Remap 23K types legacy** (IDs `60000` à `83456`) avec protection SEO :
+  - `noindex` sur les pages remap (évite duplicate content)
+  - redirection `301` vers types canoniques
+- **Legacy 30 502 types** (IDs `< 60000`) conservée intacte
+
+## Règle IDs internes
+
+**CRITIQUE** : toujours utiliser les IDs internes, jamais les colonnes brutes du flux fournisseur.
+
+- Pattern des colonnes : `foo TEXT` (brut, issu du flux) + `foo_i INTEGER` (ID interne canonique)
+- Règle ast-grep d'enforcement non activée pour l'instant (en attente décision sur le pattern à matcher)
+- Incident racine : pollution `pieces_media_img` détectée 2026-04-13
+
+## Root cause ingestion (2026-04-13)
+
+- Rapport de fix : [.spec/reports/tecdoc-ingestion-rootcause-2026-04-13.md](../../../.spec/reports/tecdoc-ingestion-rootcause-2026-04-13.md) (nom historique conservé côté reports)
+- Symptôme : `pieces_relation_type` pollué par des relations fournisseur non filtrées en amont
+
+## Fichiers applicatifs
+
+- `backend/src/modules/substitution/` — équivalences pièces (cross-refs flux fournisseur)
+- `backend/src/modules/vehicles/` — mapping types + V-Level (utilise `type_display`, pas `type_relfollow` — voir commit 729ff632)
+- `backend/src/modules/catalog/` — V-Level classification T/V
+
+## Gotchas
+
+- **V-Level v5.0** : T=keywords, V=vehicles. V3=champion, V4=rest, V5=sibling, V2=top10
+- **type_display** obligatoire dans le vehicle-rag-generator (pas `type_relfollow` qui pollue)
+- `types < 60000` : legacy intacte, pas de noindex
+- `types 60000-83456` : remap, `noindex` + `301` obligatoires
+- PAS de FK sur la table `types` (design imposé par le flux fournisseur — ne pas forcer)
+
+## Règles associées
+
+- MEMORY.md — entrées historiques sur ce pipeline (nom historique conservé côté memory) et `feedback_internal_ids.md`, `vehicle-ops.md`
+- Rapport racine : `.spec/reports/tecdoc-ingestion-rootcause-2026-04-13.md`
+- Mapping canon : `.spec/00-canon/db-governance/tecdoc-apply-mapping.md`

--- a/.claude/knowledge/integrations/paybox.md
+++ b/.claude/knowledge/integrations/paybox.md
@@ -1,0 +1,62 @@
+---
+integration: Paybox
+mode: production
+sources:
+  - backend/src/modules/payments/services/paybox.service.ts
+  - backend/src/modules/payments/services/paybox-callback-gate.service.ts
+  - backend/src/modules/payments/controllers/paybox-callback.controller.ts
+last_scan: 2026-04-24
+---
+
+# Intégration Paybox (production)
+
+## Mode actuel
+
+**Paybox RSA STRICT mode actif en production** (voir MEMORY.md `paybox-rsa.md`).
+La vérification RSA remplace progressivement HMAC pour les nouveaux paiements.
+
+## Flow
+
+```
+Order → redirect Paybox → user paie → Paybox POST callback
+     → /api/payments/paybox/callback → PayboxCallbackGateService.verify()
+     → signature RSA/HMAC vérifiée (timingSafeEqual obligatoire)
+     → error code check → order.status = paid
+     → redirect user success
+```
+
+## Config environnement
+
+- `PAYBOX_SITE`
+- `PAYBOX_RANG`
+- `PAYBOX_IDENTIFIANT`
+- `PAYBOX_HMAC_KEY` (legacy, strict mode = RSA)
+- `PAYBOX_RSA_PUBKEY` (strict mode)
+
+## Règles CRITIQUES (bloquantes)
+
+1. **`timingSafeEqual` obligatoire** — JAMAIS `===` (timing attack). Enforcé par ast-grep rule `payments-no-raw-equality`.
+2. **`normalizeOrderId()`** obligatoire avant DB lookup (référence clé).
+3. **Vérifier error code AVANT** de confirmer `paid`.
+4. **Jamais de HMAC keys hardcodées** dans le code.
+5. **Jamais de test endpoints en prod**.
+
+## Fichiers clés
+
+- [paybox-callback-gate.service.ts](../../../backend/src/modules/payments/services/paybox-callback-gate.service.ts) — vérif signature
+- [paybox.service.ts](../../../backend/src/modules/payments/services/paybox.service.ts) — génération payload
+- [paybox-callback.controller.ts](../../../backend/src/modules/payments/controllers/paybox-callback.controller.ts) — endpoint HTTP
+- [paybox-redirect.controller.ts](../../../backend/src/modules/payments/controllers/paybox-redirect.controller.ts) — retour user
+- [paybox-monitoring.controller.ts](../../../backend/src/modules/payments/controllers/paybox-monitoring.controller.ts) — health probes
+
+## Gotchas vécus
+
+- Callback peut arriver en GET OU POST selon config Paybox → gérer les 2 côtés controller
+- `vads_*` est SystemPay, pas Paybox — ne pas mélanger
+- En mode RSA strict, HMAC est ignoré ; prévoir fallback si Paybox downgrade signature
+
+## Règles associées
+
+- `.claude/rules/payments.md` — règles sécurité (bloquantes)
+- MEMORY.md : `paybox-rsa.md` — RSA strict mode 2026-04
+- Incidents vault : `governance-vault/ledger/incidents/2026/paybox-*`

--- a/.claude/knowledge/integrations/supabase.md
+++ b/.claude/knowledge/integrations/supabase.md
@@ -1,0 +1,57 @@
+---
+integration: Supabase
+project_id: cxpojprgwgubzjyqzmoq
+last_scan: 2026-04-24
+---
+
+# Intégration Supabase
+
+## Projet
+
+- **Project ID** : `cxpojprgwgubzjyqzmoq`
+- **DB size** : 221 GB
+- **Storage** : ~101 GB (Transforms DÉSACTIVÉES)
+
+## Accès côté app
+
+- `SupabaseBaseService` (base NestJS)
+- `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (backend)
+- `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` (frontend SSR)
+
+**PAS de Prisma.** Tout passe par `supabase.from().select().eq()` ou `supabase.rpc()`.
+
+## RLS & sécurité
+
+- **ADR-021 RLS Hardening MERGED** (PR #42, 2026-04-23) : 204 objets DB hardenisés sur 2 jours + INC-2026-011 (admin password hashes leak via anon key).
+- Weekly-lint post-merge : 0 new findings (ADR-020, cron Mon 02:00 UTC).
+- Collision ID INC-2026-009 résolue via règle FIFO (PR #36 garde 009, PR #42 → 011, PR #40 Paybox = 010).
+
+## Accès MCP
+
+- MCP Supabase connecté (`mcp__supabase__*` outils)
+- **Règle** : PAS de DROP/TRUNCATE sans validation humaine explicite
+- **Limitation MCP** : pas de `CREATE INDEX CONCURRENTLY`, pas de queries > 60s → utiliser Python psycopg2 direct (port 5432, autocommit, `statement_timeout=0`). Voir vault knowledge `mcp-vs-python-direct-pg.md`.
+
+## Migrations
+
+- Path : `backend/supabase/migrations/*.sql`
+- Nommage : `YYYYMMDD_<verbe>_<feature>.sql`
+- Appliquer via `mcp__supabase__apply_migration` OU script direct psycopg2 pour DDL lourd
+
+## Storage
+
+- Buckets organisés (voir MEMORY.md `supabase-cleanup-2026-03.md`)
+- Cleanup 2026-03 : -77 GB DB, -105 GB Storage
+- Transforms **DÉSACTIVÉES** (ne pas réactiver sans ADR)
+
+## Gotchas
+
+- Service role key JAMAIS dans le code frontend (anon key only côté client)
+- RLS activée sur toutes les tables métier récentes (si ajout nouvelle table, prévoir RLS dans la migration)
+- Cleanup historique : 38 tables + 44 RPC supprimées vers schema `_archive` (MEMORY.md `db-cleanup.md`)
+
+## Règles associées
+
+- MEMORY.md : `db-governance.md`, `supabase-cleanup-2026-03.md`, `db-cleanup.md`, `adr-017-rpc-cleanup.md`, `adr-021-db-rls-hardening.md`
+- ADR-015 : Vault is SoT
+- `.claude/rules/backend.md` — pas de Prisma

--- a/.claude/knowledge/integrations/systempay.md
+++ b/.claude/knowledge/integrations/systempay.md
@@ -1,0 +1,53 @@
+---
+integration: SystemPay
+mode: test
+sources:
+  - backend/src/modules/payments/services/systempay.service.ts
+last_scan: 2026-04-24
+---
+
+# Intégration SystemPay (test)
+
+## Mode actuel
+
+**SystemPay utilisé en test uniquement**. Paybox est la passerelle production.
+
+## Flow
+
+```
+Order → SystemPay form fields (vads_*) → user paie → SystemPay callback
+     → /api/payments/systempay/callback → signature HMAC-SHA256 vérifiée
+     → order.status = paid
+```
+
+## Config environnement
+
+- `SYSTEMPAY_SITE_ID`
+- `SYSTEMPAY_CERTIFICATE_TEST`
+- `SYSTEMPAY_CERTIFICATE_PROD`
+
+## Règles CRITIQUES
+
+1. **`vads_*` params TRIÉS alphabétiquement** avant signature (règle SystemPay).
+2. **HMAC-SHA256** (différent de Paybox qui est SHA512). Ne pas mélanger.
+3. **`timingSafeEqual`** obligatoire (même règle que Paybox).
+4. **Certificate key rotation** : doit être hot-swappable sans redeploy.
+
+## Fichiers clés
+
+- [systempay.service.ts](../../../backend/src/modules/payments/services/systempay.service.ts) — génération form + vérification
+
+## Gotchas
+
+- Ordre alphabétique des `vads_*` NON négociable — un bug connu si on tri sur un subset
+- Certificate test vs prod : JAMAIS endpoint test sur certif prod
+- Le callback URL doit matcher exactement celui déclaré côté SystemPay (sinon signature invalide)
+
+## CI gate connu
+
+`perf-gates SystemPay cert` — CI flake récurrent, fix dans PR monorepo #100 (voir MEMORY.md `ci-flakes-known-infra.md`).
+
+## Règles associées
+
+- `.claude/rules/payments.md`
+- MEMORY.md : `ci-flakes-known-infra.md`

--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -1,0 +1,103 @@
+---
+module: admin
+sources:
+- backend/src/modules/admin
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/admin/admin.module.ts
+- backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts
+- backend/src/modules/admin/controllers/admin-buying-guide.controller.ts
+- backend/src/modules/admin/controllers/admin-conseil.controller.ts
+- backend/src/modules/admin/controllers/admin-db-governance.controller.ts
+- backend/src/modules/admin/controllers/admin-feature-flags.controller.ts
+- backend/src/modules/admin/controllers/admin-gammes-seo-aggregates.controller.ts
+- backend/src/modules/admin/controllers/admin-gammes-seo-list.controller.ts
+depends_on:
+- DatabaseModule
+- OrdersModule
+- StaffModule
+- ProductsModule
+- WorkerModule
+- SeoModule
+- RagProxyModule
+- SystemModule
+- AiContentModule
+---
+
+# Module Admin
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `ConfigurationService`
+- `StockManagementService`
+- `ReportingService`
+- `UserManagementService`
+- `AdminProductsService`
+- `GammeDetailEnricherService`
+- `GammeVLevelService`
+- `StockMovementService`
+- `StockReportService`
+- `PageBriefService`
+- `Export`
+- `WorkerModule`
+- `BriefGatesService`
+- `HardGatesService`
+- `ImageGatesService`
+- `AdminJobHealthService`
+- `RagSafeDistillService`
+- `RAG`
+- `KeywordPlanGatesService`
+- `R1KeywordPlanGatesService`
+- `R1`
+- `R8VehicleEnricherService`
+- `R7BrandEnricherService`
+- `R7`
+- `VehicleRagGeneratorService`
+- `R8`
+- `RagGammeReaderService`
+
+### Providers (top 15)
+- `ConfigurationService`
+- `StockManagementService`
+- `Service`
+- `WorkingStockService`
+- `RealStockService`
+- `ReportingService`
+- `UserManagementService`
+- `AdminProductsService`
+- `StaffService`
+- `StaffModule`
+- `AdminGammesSeoService`
+- `Gammes`
+- `SEO`
+- `GammeSeoThresholdsService`
+- `Seuils`
+
+### Fichiers primaires
+- [backend/src/modules/admin/admin.module.ts](../../../backend/src/modules/admin/admin.module.ts)
+- [backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts](../../../backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts)
+- [backend/src/modules/admin/controllers/admin-buying-guide.controller.ts](../../../backend/src/modules/admin/controllers/admin-buying-guide.controller.ts)
+- [backend/src/modules/admin/controllers/admin-conseil.controller.ts](../../../backend/src/modules/admin/controllers/admin-conseil.controller.ts)
+- [backend/src/modules/admin/controllers/admin-db-governance.controller.ts](../../../backend/src/modules/admin/controllers/admin-db-governance.controller.ts)
+- [backend/src/modules/admin/controllers/admin-feature-flags.controller.ts](../../../backend/src/modules/admin/controllers/admin-feature-flags.controller.ts)
+- [backend/src/modules/admin/controllers/admin-gammes-seo-aggregates.controller.ts](../../../backend/src/modules/admin/controllers/admin-gammes-seo-aggregates.controller.ts)
+- [backend/src/modules/admin/controllers/admin-gammes-seo-list.controller.ts](../../../backend/src/modules/admin/controllers/admin-gammes-seo-list.controller.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -37,46 +37,39 @@ _Section à rédiger._
 - `StockManagementService`
 - `ReportingService`
 - `UserManagementService`
-- `AdminProductsService`
 - `GammeDetailEnricherService`
 - `GammeVLevelService`
 - `StockMovementService`
 - `StockReportService`
 - `PageBriefService`
-- `Export`
-- `WorkerModule`
 - `BriefGatesService`
 - `HardGatesService`
 - `ImageGatesService`
 - `AdminJobHealthService`
 - `RagSafeDistillService`
-- `RAG`
 - `KeywordPlanGatesService`
 - `R1KeywordPlanGatesService`
-- `R1`
 - `R8VehicleEnricherService`
 - `R7BrandEnricherService`
-- `R7`
 - `VehicleRagGeneratorService`
-- `R8`
 - `RagGammeReaderService`
 
 ### Providers (top 15)
 - `ConfigurationService`
 - `StockManagementService`
-- `Service`
 - `WorkingStockService`
-- `RealStockService`
 - `ReportingService`
 - `UserManagementService`
-- `AdminProductsService`
-- `StaffService`
-- `StaffModule`
 - `AdminGammesSeoService`
-- `Gammes`
-- `SEO`
 - `GammeSeoThresholdsService`
-- `Seuils`
+- `GammeSeoAuditService`
+- `GammeSeoBadgesService`
+- `SeoCockpitService`
+- `GammeDetailEnricherService`
+- `GammeVLevelService`
+- `StockMovementService`
+- `StockReportService`
+- `BuyingGuideEnricherService`
 
 ### Fichiers primaires
 - [backend/src/modules/admin/admin.module.ts](../../../backend/src/modules/admin/admin.module.ts)

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -1,0 +1,68 @@
+---
+module: agentic-engine
+sources:
+- backend/src/modules/agentic-engine
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/agentic-engine/agentic-engine.controller.ts
+- backend/src/modules/agentic-engine/agentic-engine.module.ts
+- backend/src/modules/agentic-engine/constants/agentic.constants.ts
+- backend/src/modules/agentic-engine/events/agentic.events.ts
+- backend/src/modules/agentic-engine/services/agentic-data.service.ts
+- backend/src/modules/agentic-engine/services/arbiter.service.ts
+- backend/src/modules/agentic-engine/services/critic.service.ts
+- backend/src/modules/agentic-engine/services/evidence-ledger.service.ts
+depends_on:
+- DatabaseModule
+- FeatureFlagsModule
+- BullModule
+---
+
+# Module Agentic Engine
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `RunManagerService`
+- `AgenticDataService`
+- `PlannerService`
+- `SolverService`
+- `CriticService`
+
+### Providers (top 15)
+- `AgenticDataService`
+- `EvidenceLedgerService`
+- `RunManagerService`
+- `PlannerService`
+- `SolverService`
+- `CriticService`
+- `VerifierService`
+- `ArbiterService`
+
+### Fichiers primaires
+- [backend/src/modules/agentic-engine/agentic-engine.controller.ts](../../../backend/src/modules/agentic-engine/agentic-engine.controller.ts)
+- [backend/src/modules/agentic-engine/agentic-engine.module.ts](../../../backend/src/modules/agentic-engine/agentic-engine.module.ts)
+- [backend/src/modules/agentic-engine/constants/agentic.constants.ts](../../../backend/src/modules/agentic-engine/constants/agentic.constants.ts)
+- [backend/src/modules/agentic-engine/events/agentic.events.ts](../../../backend/src/modules/agentic-engine/events/agentic.events.ts)
+- [backend/src/modules/agentic-engine/services/agentic-data.service.ts](../../../backend/src/modules/agentic-engine/services/agentic-data.service.ts)
+- [backend/src/modules/agentic-engine/services/arbiter.service.ts](../../../backend/src/modules/agentic-engine/services/arbiter.service.ts)
+- [backend/src/modules/agentic-engine/services/critic.service.ts](../../../backend/src/modules/agentic-engine/services/critic.service.ts)
+- [backend/src/modules/agentic-engine/services/evidence-ledger.service.ts](../../../backend/src/modules/agentic-engine/services/evidence-ledger.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -1,0 +1,60 @@
+---
+module: ai-content
+sources:
+- backend/src/modules/ai-content
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/ai-content/ai-content-cache.service.ts
+- backend/src/modules/ai-content/ai-content.controller.ts
+- backend/src/modules/ai-content/ai-content.module.ts
+- backend/src/modules/ai-content/ai-content.service.ts
+- backend/src/modules/ai-content/config/models.constants.ts
+- backend/src/modules/ai-content/dto/generate-content.dto.ts
+- backend/src/modules/ai-content/dto/prompt-template.dto.ts
+- backend/src/modules/ai-content/prompt-template.controller.ts
+depends_on:
+- ConfigModule
+---
+
+# Module Ai Content
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `AiContentService`
+- `PromptTemplateService`
+- `CircuitBreakerService`
+
+### Providers (top 15)
+- `AiContentService`
+- `AiContentCacheService`
+- `PromptTemplateService`
+- `CircuitBreakerService`
+
+### Fichiers primaires
+- [backend/src/modules/ai-content/ai-content-cache.service.ts](../../../backend/src/modules/ai-content/ai-content-cache.service.ts)
+- [backend/src/modules/ai-content/ai-content.controller.ts](../../../backend/src/modules/ai-content/ai-content.controller.ts)
+- [backend/src/modules/ai-content/ai-content.module.ts](../../../backend/src/modules/ai-content/ai-content.module.ts)
+- [backend/src/modules/ai-content/ai-content.service.ts](../../../backend/src/modules/ai-content/ai-content.service.ts)
+- [backend/src/modules/ai-content/config/models.constants.ts](../../../backend/src/modules/ai-content/config/models.constants.ts)
+- [backend/src/modules/ai-content/dto/generate-content.dto.ts](../../../backend/src/modules/ai-content/dto/generate-content.dto.ts)
+- [backend/src/modules/ai-content/dto/prompt-template.dto.ts](../../../backend/src/modules/ai-content/dto/prompt-template.dto.ts)
+- [backend/src/modules/ai-content/prompt-template.controller.ts](../../../backend/src/modules/ai-content/prompt-template.controller.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -1,0 +1,46 @@
+---
+module: analytics
+sources:
+- backend/src/modules/analytics
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/analytics/analytics.module.ts
+- backend/src/modules/analytics/controllers/simple-analytics.controller.ts
+- backend/src/modules/analytics/services/simple-analytics.service.ts
+depends_on:
+- ConfigModule
+- DatabaseModule
+---
+
+# Module Analytics
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `SimpleAnalyticsService`
+
+### Providers (top 15)
+- `SimpleAnalyticsService`
+
+### Fichiers primaires
+- [backend/src/modules/analytics/analytics.module.ts](../../../backend/src/modules/analytics/analytics.module.ts)
+- [backend/src/modules/analytics/controllers/simple-analytics.controller.ts](../../../backend/src/modules/analytics/controllers/simple-analytics.controller.ts)
+- [backend/src/modules/analytics/services/simple-analytics.service.ts](../../../backend/src/modules/analytics/services/simple-analytics.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -1,0 +1,44 @@
+---
+module: blog-metadata
+sources:
+- backend/src/modules/blog-metadata
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/blog-metadata/blog-metadata.controller.ts
+- backend/src/modules/blog-metadata/blog-metadata.module.ts
+- backend/src/modules/blog-metadata/blog-metadata.service.ts
+depends_on: []
+---
+
+# Module Blog Metadata
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `BlogMetadataService`
+
+### Providers (top 15)
+- `BlogMetadataService`
+
+### Fichiers primaires
+- [backend/src/modules/blog-metadata/blog-metadata.controller.ts](../../../backend/src/modules/blog-metadata/blog-metadata.controller.ts)
+- [backend/src/modules/blog-metadata/blog-metadata.module.ts](../../../backend/src/modules/blog-metadata/blog-metadata.module.ts)
+- [backend/src/modules/blog-metadata/blog-metadata.service.ts](../../../backend/src/modules/blog-metadata/blog-metadata.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -29,8 +29,6 @@ _Section à rédiger._
 ### Exports publics du module
 - `BlogService`
 - `BlogCacheService`
-- `Cache`
-- `HTML`
 - `AdviceService`
 - `GuideService`
 - `ConstructeurService`
@@ -41,21 +39,21 @@ _Section à rédiger._
 - `AdviceEnrichmentService`
 
 ### Providers (top 15)
-- `Services`
 - `BlogService`
 - `BlogCacheService`
 - `HtmlContentSanitizerService`
-- `Nettoyage`
-- `HTML`
-- `Extraction`
-- `SRP`
-- `Single`
-- `Responsibility`
-- `Principle`
 - `BlogArticleTransformService`
-- `Transformations`
 - `BlogArticleDataService`
-- `CRUD`
+- `BlogStatisticsService`
+- `BlogSeoService`
+- `BlogArticleRelationService`
+- `AdviceService`
+- `GuideService`
+- `ConstructeurService`
+- `GlossaryService`
+- `ConstructeurSearchService`
+- `ConstructeurTransformService`
+- `AdviceTransformService`
 
 ### Fichiers primaires
 - [backend/src/modules/blog/blog.module.ts](../../../backend/src/modules/blog/blog.module.ts)

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -1,0 +1,82 @@
+---
+module: blog
+sources:
+- backend/src/modules/blog
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/blog/blog.module.ts
+- backend/src/modules/blog/controllers/advice-hierarchy.controller.ts
+- backend/src/modules/blog/controllers/advice.controller.ts
+- backend/src/modules/blog/controllers/blog.controller.ts
+- backend/src/modules/blog/controllers/content.controller.ts
+- backend/src/modules/blog/controllers/r3-guide.controller.ts
+- backend/src/modules/blog/controllers/r6-guide.controller.ts
+- backend/src/modules/blog/interfaces/blog.interfaces.ts
+depends_on:
+- CacheModule
+- SearchModule
+- SeoModule
+---
+
+# Module Blog
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `BlogService`
+- `BlogCacheService`
+- `Cache`
+- `HTML`
+- `AdviceService`
+- `GuideService`
+- `ConstructeurService`
+- `GlossaryService`
+- `ConstructeurSearchService`
+- `ConstructeurTransformService`
+- `AdviceTransformService`
+- `AdviceEnrichmentService`
+
+### Providers (top 15)
+- `Services`
+- `BlogService`
+- `BlogCacheService`
+- `HtmlContentSanitizerService`
+- `Nettoyage`
+- `HTML`
+- `Extraction`
+- `SRP`
+- `Single`
+- `Responsibility`
+- `Principle`
+- `BlogArticleTransformService`
+- `Transformations`
+- `BlogArticleDataService`
+- `CRUD`
+
+### Fichiers primaires
+- [backend/src/modules/blog/blog.module.ts](../../../backend/src/modules/blog/blog.module.ts)
+- [backend/src/modules/blog/controllers/advice-hierarchy.controller.ts](../../../backend/src/modules/blog/controllers/advice-hierarchy.controller.ts)
+- [backend/src/modules/blog/controllers/advice.controller.ts](../../../backend/src/modules/blog/controllers/advice.controller.ts)
+- [backend/src/modules/blog/controllers/blog.controller.ts](../../../backend/src/modules/blog/controllers/blog.controller.ts)
+- [backend/src/modules/blog/controllers/content.controller.ts](../../../backend/src/modules/blog/controllers/content.controller.ts)
+- [backend/src/modules/blog/controllers/r3-guide.controller.ts](../../../backend/src/modules/blog/controllers/r3-guide.controller.ts)
+- [backend/src/modules/blog/controllers/r6-guide.controller.ts](../../../backend/src/modules/blog/controllers/r6-guide.controller.ts)
+- [backend/src/modules/blog/interfaces/blog.interfaces.ts](../../../backend/src/modules/blog/interfaces/blog.interfaces.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -1,0 +1,46 @@
+---
+module: bot-guard
+sources:
+- backend/src/modules/bot-guard
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/bot-guard/bot-guard.controller.ts
+- backend/src/modules/bot-guard/bot-guard.middleware.ts
+- backend/src/modules/bot-guard/bot-guard.module.ts
+- backend/src/modules/bot-guard/bot-guard.service.ts
+depends_on: []
+---
+
+# Module Bot Guard
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `BotGuardService`
+
+### Providers (top 15)
+- `BotGuardService`
+
+### Fichiers primaires
+- [backend/src/modules/bot-guard/bot-guard.controller.ts](../../../backend/src/modules/bot-guard/bot-guard.controller.ts)
+- [backend/src/modules/bot-guard/bot-guard.middleware.ts](../../../backend/src/modules/bot-guard/bot-guard.middleware.ts)
+- [backend/src/modules/bot-guard/bot-guard.module.ts](../../../backend/src/modules/bot-guard/bot-guard.module.ts)
+- [backend/src/modules/bot-guard/bot-guard.service.ts](../../../backend/src/modules/bot-guard/bot-guard.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -1,0 +1,72 @@
+---
+module: cart
+sources:
+- backend/src/modules/cart
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/cart/cart.module.ts
+- backend/src/modules/cart/controllers/cart-analytics.controller.ts
+- backend/src/modules/cart/controllers/cart-controller.utils.ts
+- backend/src/modules/cart/controllers/cart-core.controller.ts
+- backend/src/modules/cart/controllers/cart-items.controller.ts
+- backend/src/modules/cart/controllers/cart-promo.controller.ts
+- backend/src/modules/cart/controllers/cart-recovery.controller.ts
+- backend/src/modules/cart/controllers/cart-shipping.controller.ts
+depends_on:
+- DatabaseModule
+- ProductsModule
+- PromoModule
+- FeatureFlagsModule
+- BullModule
+---
+
+# Module Cart
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `CartService`
+- `CartValidationService`
+- `CartAnalyticsService`
+- `ShippingCalculatorService`
+- `AbandonedCartService`
+- `CartDataService`
+
+### Providers (top 15)
+- `CartService`
+- `CartValidationService`
+- `CartAnalyticsService`
+- `ShippingCalculatorService`
+- `AbandonedCartService`
+- `AbandonedCartDataService`
+- `CartDataService`
+- `PromoDataService`
+- `ShippingDataService`
+
+### Fichiers primaires
+- [backend/src/modules/cart/cart.module.ts](../../../backend/src/modules/cart/cart.module.ts)
+- [backend/src/modules/cart/controllers/cart-analytics.controller.ts](../../../backend/src/modules/cart/controllers/cart-analytics.controller.ts)
+- [backend/src/modules/cart/controllers/cart-controller.utils.ts](../../../backend/src/modules/cart/controllers/cart-controller.utils.ts)
+- [backend/src/modules/cart/controllers/cart-core.controller.ts](../../../backend/src/modules/cart/controllers/cart-core.controller.ts)
+- [backend/src/modules/cart/controllers/cart-items.controller.ts](../../../backend/src/modules/cart/controllers/cart-items.controller.ts)
+- [backend/src/modules/cart/controllers/cart-promo.controller.ts](../../../backend/src/modules/cart/controllers/cart-promo.controller.ts)
+- [backend/src/modules/cart/controllers/cart-recovery.controller.ts](../../../backend/src/modules/cart/controllers/cart-recovery.controller.ts)
+- [backend/src/modules/cart/controllers/cart-shipping.controller.ts](../../../backend/src/modules/cart/controllers/cart-shipping.controller.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -1,0 +1,92 @@
+---
+module: catalog
+sources:
+- backend/src/modules/catalog
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/catalog/catalog.controller.ts
+- backend/src/modules/catalog/catalog.module.ts
+- backend/src/modules/catalog/catalog.service.ts
+- backend/src/modules/catalog/controllers/catalog-integrity.controller.ts
+- backend/src/modules/catalog/controllers/compatibility.controller.ts
+- backend/src/modules/catalog/controllers/enhanced-vehicle-catalog.controller.ts
+- backend/src/modules/catalog/controllers/equipementiers.controller.ts
+- backend/src/modules/catalog/controllers/gamme-unified.controller.ts
+depends_on:
+- DatabaseModule
+- NestCacheModule
+---
+
+# Module Catalog
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `CatalogService`
+- `EnhancedVehicleCatalogService`
+- `VehicleFilteredCatalogV4HybridService`
+- `CatalogDataIntegrityService`
+- `GammeUnifiedService`
+- `GammeRestModule`
+- `VehiclePiecesCompatibilityService`
+- `OemPlatformMappingService`
+- `OEM`
+- `SEO`
+- `SeoTemplateService`
+- `UnifiedPageDataService`
+- `RPC`
+- `V4`
+- `HomepageRpcService`
+- `CatalogHierarchyService`
+- `Single`
+- `CompatibilityService`
+- `Pack`
+- `Confiance`
+- `V2`
+- `PopularGammesService`
+- `VehiclesModule`
+
+### Providers (top 15)
+- `Services`
+- `CatalogService`
+- `EnhancedVehicleCatalogService`
+- `GammeUnifiedService`
+- `EquipementiersService`
+- `VehicleFilteredCatalogV4HybridService`
+- `VehiclePiecesCompatibilityService`
+- `CatalogDataIntegrityService`
+- `Service`
+- `PRICING`
+- `SERVICE`
+- `PricingService`
+- `OEM`
+- `PLATFORM`
+- `MAPPING`
+
+### Fichiers primaires
+- [backend/src/modules/catalog/catalog.controller.ts](../../../backend/src/modules/catalog/catalog.controller.ts)
+- [backend/src/modules/catalog/catalog.module.ts](../../../backend/src/modules/catalog/catalog.module.ts)
+- [backend/src/modules/catalog/catalog.service.ts](../../../backend/src/modules/catalog/catalog.service.ts)
+- [backend/src/modules/catalog/controllers/catalog-integrity.controller.ts](../../../backend/src/modules/catalog/controllers/catalog-integrity.controller.ts)
+- [backend/src/modules/catalog/controllers/compatibility.controller.ts](../../../backend/src/modules/catalog/controllers/compatibility.controller.ts)
+- [backend/src/modules/catalog/controllers/enhanced-vehicle-catalog.controller.ts](../../../backend/src/modules/catalog/controllers/enhanced-vehicle-catalog.controller.ts)
+- [backend/src/modules/catalog/controllers/equipementiers.controller.ts](../../../backend/src/modules/catalog/controllers/equipementiers.controller.ts)
+- [backend/src/modules/catalog/controllers/gamme-unified.controller.ts](../../../backend/src/modules/catalog/controllers/gamme-unified.controller.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -31,27 +31,16 @@ _Section à rédiger._
 - `VehicleFilteredCatalogV4HybridService`
 - `CatalogDataIntegrityService`
 - `GammeUnifiedService`
-- `GammeRestModule`
 - `VehiclePiecesCompatibilityService`
 - `OemPlatformMappingService`
-- `OEM`
-- `SEO`
 - `SeoTemplateService`
 - `UnifiedPageDataService`
-- `RPC`
-- `V4`
 - `HomepageRpcService`
 - `CatalogHierarchyService`
-- `Single`
 - `CompatibilityService`
-- `Pack`
-- `Confiance`
-- `V2`
 - `PopularGammesService`
-- `VehiclesModule`
 
 ### Providers (top 15)
-- `Services`
 - `CatalogService`
 - `EnhancedVehicleCatalogService`
 - `GammeUnifiedService`
@@ -59,13 +48,14 @@ _Section à rédiger._
 - `VehicleFilteredCatalogV4HybridService`
 - `VehiclePiecesCompatibilityService`
 - `CatalogDataIntegrityService`
-- `Service`
-- `PRICING`
-- `SERVICE`
 - `PricingService`
-- `OEM`
-- `PLATFORM`
-- `MAPPING`
+- `OemPlatformMappingService`
+- `SeoTemplateService`
+- `UnifiedPageDataService`
+- `HomepageRpcService`
+- `CatalogHierarchyService`
+- `CacheWarmingService`
+- `CompatibilityService`
 
 ### Fichiers primaires
 - [backend/src/modules/catalog/catalog.controller.ts](../../../backend/src/modules/catalog/catalog.controller.ts)

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -1,0 +1,49 @@
+---
+module: commercial
+sources:
+- backend/src/modules/commercial
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/commercial/archives/archives.controller.ts
+- backend/src/modules/commercial/archives/archives.service.ts
+- backend/src/modules/commercial/commercial.module.ts
+depends_on:
+- DatabaseModule
+- ScheduleModule
+---
+
+# Module Commercial
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `CommercialArchivesService`
+- `Service`
+
+### Providers (top 15)
+- `CommercialArchivesService`
+- `Service`
+- `CRON`
+
+### Fichiers primaires
+- [backend/src/modules/commercial/archives/archives.controller.ts](../../../backend/src/modules/commercial/archives/archives.controller.ts)
+- [backend/src/modules/commercial/archives/archives.service.ts](../../../backend/src/modules/commercial/archives/archives.service.ts)
+- [backend/src/modules/commercial/commercial.module.ts](../../../backend/src/modules/commercial/commercial.module.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -9,7 +9,6 @@ primary_files:
 - backend/src/modules/commercial/commercial.module.ts
 depends_on:
 - DatabaseModule
-- ScheduleModule
 ---
 
 # Module Commercial
@@ -22,12 +21,9 @@ _Section à rédiger._
 
 ### Exports publics du module
 - `CommercialArchivesService`
-- `Service`
 
 ### Providers (top 15)
 - `CommercialArchivesService`
-- `Service`
-- `CRON`
 
 ### Fichiers primaires
 - [backend/src/modules/commercial/archives/archives.controller.ts](../../../backend/src/modules/commercial/archives/archives.controller.ts)

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -1,0 +1,61 @@
+---
+module: config
+sources:
+- backend/src/modules/config
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/config/config.module.ts
+- backend/src/modules/config/controllers/simple-database-config.controller.ts
+- backend/src/modules/config/dto/config.dto.ts
+- backend/src/modules/config/interfaces/config.interfaces.ts
+- backend/src/modules/config/schemas/config.schemas.ts
+- backend/src/modules/config/services/database-config.service.ts
+- backend/src/modules/config/services/simple-database-config.service.ts
+- backend/src/modules/config/validators/config.validator.ts
+depends_on:
+- NestConfigModule
+---
+
+# Module Config
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `DatabaseConfigService`
+- `SimpleDatabaseConfigService`
+
+### Providers (top 15)
+- `DatabaseConfigService`
+- `SimpleDatabaseConfigService`
+- `Providers`
+- `ANALYTICS_ENABLED`
+- `NODE_ENV`
+- `CONFIG_OPTIONS`
+
+### Fichiers primaires
+- [backend/src/modules/config/config.module.ts](../../../backend/src/modules/config/config.module.ts)
+- [backend/src/modules/config/controllers/simple-database-config.controller.ts](../../../backend/src/modules/config/controllers/simple-database-config.controller.ts)
+- [backend/src/modules/config/dto/config.dto.ts](../../../backend/src/modules/config/dto/config.dto.ts)
+- [backend/src/modules/config/interfaces/config.interfaces.ts](../../../backend/src/modules/config/interfaces/config.interfaces.ts)
+- [backend/src/modules/config/schemas/config.schemas.ts](../../../backend/src/modules/config/schemas/config.schemas.ts)
+- [backend/src/modules/config/services/database-config.service.ts](../../../backend/src/modules/config/services/database-config.service.ts)
+- [backend/src/modules/config/services/simple-database-config.service.ts](../../../backend/src/modules/config/services/simple-database-config.service.ts)
+- [backend/src/modules/config/validators/config.validator.ts](../../../backend/src/modules/config/validators/config.validator.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -31,10 +31,6 @@ _Section à rédiger._
 ### Providers (top 15)
 - `DatabaseConfigService`
 - `SimpleDatabaseConfigService`
-- `Providers`
-- `ANALYTICS_ENABLED`
-- `NODE_ENV`
-- `CONFIG_OPTIONS`
 
 ### Fichiers primaires
 - [backend/src/modules/config/config.module.ts](../../../backend/src/modules/config/config.module.ts)

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -1,0 +1,48 @@
+---
+module: dashboard
+sources:
+- backend/src/modules/dashboard
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/dashboard/dashboard.controller.ts
+- backend/src/modules/dashboard/dashboard.module.ts
+- backend/src/modules/dashboard/dashboard.service.ts
+depends_on:
+- DatabaseModule
+- AuthModule
+- ConfigModule
+- NestCacheModule
+---
+
+# Module Dashboard
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `DashboardService`
+
+### Providers (top 15)
+- `DashboardService`
+
+### Fichiers primaires
+- [backend/src/modules/dashboard/dashboard.controller.ts](../../../backend/src/modules/dashboard/dashboard.controller.ts)
+- [backend/src/modules/dashboard/dashboard.module.ts](../../../backend/src/modules/dashboard/dashboard.module.ts)
+- [backend/src/modules/dashboard/dashboard.service.ts](../../../backend/src/modules/dashboard/dashboard.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -26,18 +26,10 @@ _Section à rédiger._
 <!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
 
 ### Exports publics du module
-- `DiagnosticEngineOrchestrator`
 - `DiagnosticEngineDataService`
 
 ### Providers (top 15)
-- `DiagnosticEngineOrchestrator`
 - `DiagnosticEngineDataService`
-- `SignalInterpretationEngine`
-- `HypothesisScoringEngine`
-- `RiskSafetyEngine`
-- `CatalogOrientationEngine`
-- `MaintenanceIntelligenceEngine`
-- `RagEnrichmentEngine`
 
 ### Fichiers primaires
 - [backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts](../../../backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts)

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -1,0 +1,64 @@
+---
+module: diagnostic-engine
+sources:
+- backend/src/modules/diagnostic-engine
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
+- backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
+- backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts
+- backend/src/modules/diagnostic-engine/diagnostic-engine.module.ts
+- backend/src/modules/diagnostic-engine/diagnostic-engine.orchestrator.ts
+- backend/src/modules/diagnostic-engine/engines/catalog-orientation.engine.ts
+- backend/src/modules/diagnostic-engine/engines/hypothesis-scoring.engine.ts
+- backend/src/modules/diagnostic-engine/engines/maintenance-intelligence.engine.ts
+depends_on:
+- DatabaseModule
+- RagProxyModule
+---
+
+# Module Diagnostic Engine
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `DiagnosticEngineOrchestrator`
+- `DiagnosticEngineDataService`
+
+### Providers (top 15)
+- `DiagnosticEngineOrchestrator`
+- `DiagnosticEngineDataService`
+- `SignalInterpretationEngine`
+- `HypothesisScoringEngine`
+- `RiskSafetyEngine`
+- `CatalogOrientationEngine`
+- `MaintenanceIntelligenceEngine`
+- `RagEnrichmentEngine`
+
+### Fichiers primaires
+- [backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts](../../../backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts)
+- [backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts](../../../backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts)
+- [backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts](../../../backend/src/modules/diagnostic-engine/diagnostic-engine.data-service.ts)
+- [backend/src/modules/diagnostic-engine/diagnostic-engine.module.ts](../../../backend/src/modules/diagnostic-engine/diagnostic-engine.module.ts)
+- [backend/src/modules/diagnostic-engine/diagnostic-engine.orchestrator.ts](../../../backend/src/modules/diagnostic-engine/diagnostic-engine.orchestrator.ts)
+- [backend/src/modules/diagnostic-engine/engines/catalog-orientation.engine.ts](../../../backend/src/modules/diagnostic-engine/engines/catalog-orientation.engine.ts)
+- [backend/src/modules/diagnostic-engine/engines/hypothesis-scoring.engine.ts](../../../backend/src/modules/diagnostic-engine/engines/hypothesis-scoring.engine.ts)
+- [backend/src/modules/diagnostic-engine/engines/maintenance-intelligence.engine.ts](../../../backend/src/modules/diagnostic-engine/engines/maintenance-intelligence.engine.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -31,7 +31,6 @@ _Section à rédiger._
 - `ErrorService`
 - `ErrorLogService`
 - `RedirectService`
-- `APP_FILTER`
 - `GlobalErrorFilter`
 
 ### Fichiers primaires

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -1,0 +1,58 @@
+---
+module: errors
+sources:
+- backend/src/modules/errors
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/errors/controllers/error.controller.ts
+- backend/src/modules/errors/entities/error-log.entity.ts
+- backend/src/modules/errors/errors.module.ts
+- backend/src/modules/errors/filters/global-error.filter.ts
+- backend/src/modules/errors/services/error-log.service.ts
+- backend/src/modules/errors/services/error.service.ts
+- backend/src/modules/errors/services/redirect.service.ts
+depends_on: []
+---
+
+# Module Errors
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `ErrorService`
+- `ErrorLogService`
+- `RedirectService`
+
+### Providers (top 15)
+- `ErrorService`
+- `ErrorLogService`
+- `RedirectService`
+- `APP_FILTER`
+- `GlobalErrorFilter`
+
+### Fichiers primaires
+- [backend/src/modules/errors/controllers/error.controller.ts](../../../backend/src/modules/errors/controllers/error.controller.ts)
+- [backend/src/modules/errors/entities/error-log.entity.ts](../../../backend/src/modules/errors/entities/error-log.entity.ts)
+- [backend/src/modules/errors/errors.module.ts](../../../backend/src/modules/errors/errors.module.ts)
+- [backend/src/modules/errors/filters/global-error.filter.ts](../../../backend/src/modules/errors/filters/global-error.filter.ts)
+- [backend/src/modules/errors/services/error-log.service.ts](../../../backend/src/modules/errors/services/error-log.service.ts)
+- [backend/src/modules/errors/services/error.service.ts](../../../backend/src/modules/errors/services/error.service.ts)
+- [backend/src/modules/errors/services/redirect.service.ts](../../../backend/src/modules/errors/services/redirect.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -1,0 +1,63 @@
+---
+module: gamme-rest
+sources:
+- backend/src/modules/gamme-rest
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/gamme-rest/gamme-rest-optimized.controller.ts
+- backend/src/modules/gamme-rest/gamme-rest-rpc-v2.controller.ts
+- backend/src/modules/gamme-rest/gamme-rest.module.ts
+- backend/src/modules/gamme-rest/services/buying-guide-data.service.ts
+- backend/src/modules/gamme-rest/services/gamme-data-transformer.service.ts
+- backend/src/modules/gamme-rest/services/gamme-page-data.service.ts
+- backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
+- backend/src/modules/gamme-rest/services/gamme-rpc.schema.ts
+depends_on:
+- CatalogModule
+- DatabaseModule
+- SeoModule
+- AdminModule
+---
+
+# Module Gamme Rest
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- _(aucun export dans le `@Module({exports: [...]})`)_
+
+### Providers (top 15)
+- `GammeDataTransformerService`
+- `GammeRpcService`
+- `GammeResponseBuilderService`
+- `GammePageDataService`
+- `BuyingGuideDataService`
+- `R1RelatedResourcesService`
+
+### Fichiers primaires
+- [backend/src/modules/gamme-rest/gamme-rest-optimized.controller.ts](../../../backend/src/modules/gamme-rest/gamme-rest-optimized.controller.ts)
+- [backend/src/modules/gamme-rest/gamme-rest-rpc-v2.controller.ts](../../../backend/src/modules/gamme-rest/gamme-rest-rpc-v2.controller.ts)
+- [backend/src/modules/gamme-rest/gamme-rest.module.ts](../../../backend/src/modules/gamme-rest/gamme-rest.module.ts)
+- [backend/src/modules/gamme-rest/services/buying-guide-data.service.ts](../../../backend/src/modules/gamme-rest/services/buying-guide-data.service.ts)
+- [backend/src/modules/gamme-rest/services/gamme-data-transformer.service.ts](../../../backend/src/modules/gamme-rest/services/gamme-data-transformer.service.ts)
+- [backend/src/modules/gamme-rest/services/gamme-page-data.service.ts](../../../backend/src/modules/gamme-rest/services/gamme-page-data.service.ts)
+- [backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts](../../../backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts)
+- [backend/src/modules/gamme-rest/services/gamme-rpc.schema.ts](../../../backend/src/modules/gamme-rest/services/gamme-rpc.schema.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -1,0 +1,40 @@
+---
+module: health
+sources:
+- backend/src/modules/health
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/health/health.module.ts
+depends_on: []
+---
+
+# Module Health
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `HealthService`
+
+### Providers (top 15)
+- `HealthService`
+
+### Fichiers primaires
+- [backend/src/modules/health/health.module.ts](../../../backend/src/modules/health/health.module.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -1,0 +1,45 @@
+---
+module: invoices
+sources:
+- backend/src/modules/invoices
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/invoices/invoices.controller.ts
+- backend/src/modules/invoices/invoices.module.ts
+- backend/src/modules/invoices/invoices.service.ts
+depends_on:
+- CacheModule
+---
+
+# Module Invoices
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `InvoicesService`
+
+### Providers (top 15)
+- `InvoicesService`
+
+### Fichiers primaires
+- [backend/src/modules/invoices/invoices.controller.ts](../../../backend/src/modules/invoices/invoices.controller.ts)
+- [backend/src/modules/invoices/invoices.module.ts](../../../backend/src/modules/invoices/invoices.module.ts)
+- [backend/src/modules/invoices/invoices.service.ts](../../../backend/src/modules/invoices/invoices.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -1,0 +1,53 @@
+---
+module: knowledge-graph
+sources:
+- backend/src/modules/knowledge-graph
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/knowledge-graph/index.ts
+- backend/src/modules/knowledge-graph/kg-data.service.ts
+- backend/src/modules/knowledge-graph/kg.controller.ts
+- backend/src/modules/knowledge-graph/kg.service.ts
+- backend/src/modules/knowledge-graph/kg.types.ts
+- backend/src/modules/knowledge-graph/knowledge-graph.module.ts
+depends_on:
+- ConfigModule
+---
+
+# Module Knowledge Graph
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `KgService`
+- `KgDataService`
+
+### Providers (top 15)
+- `KgService`
+- `KgDataService`
+
+### Fichiers primaires
+- [backend/src/modules/knowledge-graph/index.ts](../../../backend/src/modules/knowledge-graph/index.ts)
+- [backend/src/modules/knowledge-graph/kg-data.service.ts](../../../backend/src/modules/knowledge-graph/kg-data.service.ts)
+- [backend/src/modules/knowledge-graph/kg.controller.ts](../../../backend/src/modules/knowledge-graph/kg.controller.ts)
+- [backend/src/modules/knowledge-graph/kg.service.ts](../../../backend/src/modules/knowledge-graph/kg.service.ts)
+- [backend/src/modules/knowledge-graph/kg.types.ts](../../../backend/src/modules/knowledge-graph/kg.types.ts)
+- [backend/src/modules/knowledge-graph/knowledge-graph.module.ts](../../../backend/src/modules/knowledge-graph/knowledge-graph.module.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -1,0 +1,64 @@
+---
+module: layout
+sources:
+- backend/src/modules/layout
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/layout/controllers/layout.controller.ts
+- backend/src/modules/layout/controllers/section.controller.ts
+- backend/src/modules/layout/layout.module.ts
+- backend/src/modules/layout/services/footer.service.ts
+- backend/src/modules/layout/services/header.service.ts
+- backend/src/modules/layout/services/index.ts
+- backend/src/modules/layout/services/layout.service.ts
+- backend/src/modules/layout/services/meta-tags.service.ts
+depends_on: []
+---
+
+# Module Layout
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `LayoutService`
+- `HeaderService`
+- `FooterService`
+- `QuickSearchService`
+- `SocialShareService`
+- `MetaTagsService`
+
+### Providers (top 15)
+- `LayoutService`
+- `HeaderService`
+- `FooterService`
+- `QuickSearchService`
+- `SocialShareService`
+- `MetaTagsService`
+
+### Fichiers primaires
+- [backend/src/modules/layout/controllers/layout.controller.ts](../../../backend/src/modules/layout/controllers/layout.controller.ts)
+- [backend/src/modules/layout/controllers/section.controller.ts](../../../backend/src/modules/layout/controllers/section.controller.ts)
+- [backend/src/modules/layout/layout.module.ts](../../../backend/src/modules/layout/layout.module.ts)
+- [backend/src/modules/layout/services/footer.service.ts](../../../backend/src/modules/layout/services/footer.service.ts)
+- [backend/src/modules/layout/services/header.service.ts](../../../backend/src/modules/layout/services/header.service.ts)
+- [backend/src/modules/layout/services/index.ts](../../../backend/src/modules/layout/services/index.ts)
+- [backend/src/modules/layout/services/layout.service.ts](../../../backend/src/modules/layout/services/layout.service.ts)
+- [backend/src/modules/layout/services/meta-tags.service.ts](../../../backend/src/modules/layout/services/meta-tags.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -1,0 +1,69 @@
+---
+module: marketing
+sources:
+- backend/src/modules/marketing
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
+- backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts
+- backend/src/modules/marketing/controllers/marketing-dashboard.controller.ts
+- backend/src/modules/marketing/controllers/marketing-pipeline.controller.ts
+- backend/src/modules/marketing/controllers/marketing-social-posts.controller.ts
+- backend/src/modules/marketing/interfaces/marketing-hub.interfaces.ts
+- backend/src/modules/marketing/interfaces/marketing.interfaces.ts
+- backend/src/modules/marketing/marketing.module.ts
+depends_on:
+- DatabaseModule
+- AiContentModule
+---
+
+# Module Marketing
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `MarketingDataService`
+- `MarketingHubDataService`
+- `UTMBuilderService`
+
+### Providers (top 15)
+- `Existing`
+- `MarketingDataService`
+- `MarketingDashboardService`
+- `MarketingBacklinksService`
+- `MarketingContentRoadmapService`
+- `Hub`
+- `MarketingHubDataService`
+- `UTMBuilderService`
+- `WeeklyPlanGeneratorService`
+- `MultiChannelCopywriterService`
+- `BrandComplianceGateService`
+- `PublishQueueService`
+
+### Fichiers primaires
+- [backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts](../../../backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts)
+- [backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts](../../../backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts)
+- [backend/src/modules/marketing/controllers/marketing-dashboard.controller.ts](../../../backend/src/modules/marketing/controllers/marketing-dashboard.controller.ts)
+- [backend/src/modules/marketing/controllers/marketing-pipeline.controller.ts](../../../backend/src/modules/marketing/controllers/marketing-pipeline.controller.ts)
+- [backend/src/modules/marketing/controllers/marketing-social-posts.controller.ts](../../../backend/src/modules/marketing/controllers/marketing-social-posts.controller.ts)
+- [backend/src/modules/marketing/interfaces/marketing-hub.interfaces.ts](../../../backend/src/modules/marketing/interfaces/marketing-hub.interfaces.ts)
+- [backend/src/modules/marketing/interfaces/marketing.interfaces.ts](../../../backend/src/modules/marketing/interfaces/marketing.interfaces.ts)
+- [backend/src/modules/marketing/marketing.module.ts](../../../backend/src/modules/marketing/marketing.module.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -31,12 +31,10 @@ _Section à rédiger._
 - `UTMBuilderService`
 
 ### Providers (top 15)
-- `Existing`
 - `MarketingDataService`
 - `MarketingDashboardService`
 - `MarketingBacklinksService`
 - `MarketingContentRoadmapService`
-- `Hub`
 - `MarketingHubDataService`
 - `UTMBuilderService`
 - `WeeklyPlanGeneratorService`

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -1,0 +1,76 @@
+---
+module: mcp-validation
+sources:
+- backend/src/modules/mcp-validation
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
+- backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts
+- backend/src/modules/mcp-validation/index.ts
+- backend/src/modules/mcp-validation/interceptors/mcp-shadow.interceptor.ts
+- backend/src/modules/mcp-validation/interceptors/mcp-verify.interceptor.ts
+- backend/src/modules/mcp-validation/mcp-validation.module.ts
+- backend/src/modules/mcp-validation/mcp-validation.service.ts
+- backend/src/modules/mcp-validation/mcp-validation.types.ts
+depends_on:
+- ConfigModule
+---
+
+# Module Mcp Validation
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `Services`
+- `McpValidationService`
+- `McpQueryService`
+- `McpAlertingService`
+- `Phase`
+- `External`
+- `ChromeDevToolsClientService`
+- `ExternalCompatibilityService`
+
+### Providers (top 15)
+- `Core`
+- `McpValidationService`
+- `Phase`
+- `Query`
+- `Alerting`
+- `McpQueryService`
+- `McpAlertingService`
+- `External`
+- `Compatibility`
+- `Chrome`
+- `DevTools`
+- `ChromeDevToolsClientService`
+- `ExternalCompatibilityScrapingService`
+- `ExternalCompatibilityConsensusService`
+- `ExternalCompatibilityCacheService`
+
+### Fichiers primaires
+- [backend/src/modules/mcp-validation/config/mcp-route-map.config.ts](../../../backend/src/modules/mcp-validation/config/mcp-route-map.config.ts)
+- [backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts](../../../backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts)
+- [backend/src/modules/mcp-validation/index.ts](../../../backend/src/modules/mcp-validation/index.ts)
+- [backend/src/modules/mcp-validation/interceptors/mcp-shadow.interceptor.ts](../../../backend/src/modules/mcp-validation/interceptors/mcp-shadow.interceptor.ts)
+- [backend/src/modules/mcp-validation/interceptors/mcp-verify.interceptor.ts](../../../backend/src/modules/mcp-validation/interceptors/mcp-verify.interceptor.ts)
+- [backend/src/modules/mcp-validation/mcp-validation.module.ts](../../../backend/src/modules/mcp-validation/mcp-validation.module.ts)
+- [backend/src/modules/mcp-validation/mcp-validation.service.ts](../../../backend/src/modules/mcp-validation/mcp-validation.service.ts)
+- [backend/src/modules/mcp-validation/mcp-validation.types.ts](../../../backend/src/modules/mcp-validation/mcp-validation.types.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -25,31 +25,24 @@ _Section à rédiger._
 <!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
 
 ### Exports publics du module
-- `Services`
 - `McpValidationService`
 - `McpQueryService`
 - `McpAlertingService`
-- `Phase`
-- `External`
 - `ChromeDevToolsClientService`
 - `ExternalCompatibilityService`
 
 ### Providers (top 15)
-- `Core`
 - `McpValidationService`
-- `Phase`
-- `Query`
-- `Alerting`
 - `McpQueryService`
 - `McpAlertingService`
-- `External`
-- `Compatibility`
-- `Chrome`
-- `DevTools`
 - `ChromeDevToolsClientService`
 - `ExternalCompatibilityScrapingService`
 - `ExternalCompatibilityConsensusService`
 - `ExternalCompatibilityCacheService`
+- `ExternalCompatibilityPartsLink24Service`
+- `ExternalCompatibilityService`
+- `McpShadowInterceptor`
+- `McpVerifyInterceptor`
 
 ### Fichiers primaires
 - [backend/src/modules/mcp-validation/config/mcp-route-map.config.ts](../../../backend/src/modules/mcp-validation/config/mcp-route-map.config.ts)

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -26,20 +26,13 @@ _Section à rédiger._
 <!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
 
 ### Exports publics du module
-- `Export`
 - `MessagesService`
 - `MessageDataService`
 - `MessagingGateway`
 
 ### Providers (top 15)
-- `Services`
 - `MessagesService`
-- `Data`
-- `Repository`
-- `Pattern`
 - `MessageDataService`
-- `WebSocket`
-- `Gateway`
 - `MessagingGateway`
 
 ### Fichiers primaires

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -1,0 +1,67 @@
+---
+module: messages
+sources:
+- backend/src/modules/messages
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/messages/dto/index.ts
+- backend/src/modules/messages/dto/message.schemas.ts
+- backend/src/modules/messages/index.ts
+- backend/src/modules/messages/messages.controller.ts
+- backend/src/modules/messages/messages.module.ts
+- backend/src/modules/messages/messages.service.ts
+- backend/src/modules/messages/messaging.gateway.ts
+- backend/src/modules/messages/repositories/message-data.service.ts
+depends_on:
+- DatabaseModule
+- JwtModule
+---
+
+# Module Messages
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `Export`
+- `MessagesService`
+- `MessageDataService`
+- `MessagingGateway`
+
+### Providers (top 15)
+- `Services`
+- `MessagesService`
+- `Data`
+- `Repository`
+- `Pattern`
+- `MessageDataService`
+- `WebSocket`
+- `Gateway`
+- `MessagingGateway`
+
+### Fichiers primaires
+- [backend/src/modules/messages/dto/index.ts](../../../backend/src/modules/messages/dto/index.ts)
+- [backend/src/modules/messages/dto/message.schemas.ts](../../../backend/src/modules/messages/dto/message.schemas.ts)
+- [backend/src/modules/messages/index.ts](../../../backend/src/modules/messages/index.ts)
+- [backend/src/modules/messages/messages.controller.ts](../../../backend/src/modules/messages/messages.controller.ts)
+- [backend/src/modules/messages/messages.module.ts](../../../backend/src/modules/messages/messages.module.ts)
+- [backend/src/modules/messages/messages.service.ts](../../../backend/src/modules/messages/messages.service.ts)
+- [backend/src/modules/messages/messaging.gateway.ts](../../../backend/src/modules/messages/messaging.gateway.ts)
+- [backend/src/modules/messages/repositories/message-data.service.ts](../../../backend/src/modules/messages/repositories/message-data.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -1,0 +1,54 @@
+---
+module: metadata
+sources:
+- backend/src/modules/metadata
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
+- backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts
+- backend/src/modules/metadata/controllers/optimized-metadata.controller.ts
+- backend/src/modules/metadata/metadata.module.ts
+- backend/src/modules/metadata/services/optimized-breadcrumb.service.ts
+- backend/src/modules/metadata/services/optimized-metadata.service.ts
+depends_on:
+- CacheModule
+- DatabaseModule
+---
+
+# Module Metadata
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `OptimizedMetadataService`
+- `OptimizedBreadcrumbService`
+
+### Providers (top 15)
+- `OptimizedMetadataService`
+- `OptimizedBreadcrumbService`
+
+### Fichiers primaires
+- [backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts](../../../backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts)
+- [backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts](../../../backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts)
+- [backend/src/modules/metadata/controllers/optimized-metadata.controller.ts](../../../backend/src/modules/metadata/controllers/optimized-metadata.controller.ts)
+- [backend/src/modules/metadata/metadata.module.ts](../../../backend/src/modules/metadata/metadata.module.ts)
+- [backend/src/modules/metadata/services/optimized-breadcrumb.service.ts](../../../backend/src/modules/metadata/services/optimized-breadcrumb.service.ts)
+- [backend/src/modules/metadata/services/optimized-metadata.service.ts](../../../backend/src/modules/metadata/services/optimized-metadata.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -1,0 +1,55 @@
+---
+module: navigation
+sources:
+- backend/src/modules/navigation
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/navigation/navigation.controller.ts
+- backend/src/modules/navigation/navigation.module.ts
+- backend/src/modules/navigation/navigation.service.ts
+- backend/src/modules/navigation/services/commercial-menu.service.ts
+- backend/src/modules/navigation/services/expedition-menu.service.ts
+- backend/src/modules/navigation/services/seo-menu.service.ts
+depends_on:
+- DatabaseModule
+- NestCacheModule
+---
+
+# Module Navigation
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `NavigationService`
+
+### Providers (top 15)
+- `NavigationService`
+- `CommercialMenuService`
+- `ExpeditionMenuService`
+- `SeoMenuService`
+
+### Fichiers primaires
+- [backend/src/modules/navigation/navigation.controller.ts](../../../backend/src/modules/navigation/navigation.controller.ts)
+- [backend/src/modules/navigation/navigation.module.ts](../../../backend/src/modules/navigation/navigation.module.ts)
+- [backend/src/modules/navigation/navigation.service.ts](../../../backend/src/modules/navigation/navigation.service.ts)
+- [backend/src/modules/navigation/services/commercial-menu.service.ts](../../../backend/src/modules/navigation/services/commercial-menu.service.ts)
+- [backend/src/modules/navigation/services/expedition-menu.service.ts](../../../backend/src/modules/navigation/services/expedition-menu.service.ts)
+- [backend/src/modules/navigation/services/seo-menu.service.ts](../../../backend/src/modules/navigation/services/seo-menu.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -1,0 +1,80 @@
+---
+module: orders
+sources:
+- backend/src/modules/orders
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/orders/controllers/order-actions.controller.ts
+- backend/src/modules/orders/controllers/order-archive.controller.ts
+- backend/src/modules/orders/controllers/order-status.controller.ts
+- backend/src/modules/orders/controllers/orders.controller.ts
+- backend/src/modules/orders/controllers/tickets.controller.ts
+- backend/src/modules/orders/dto/automotive-orders.dto.ts
+- backend/src/modules/orders/dto/index.ts
+- backend/src/modules/orders/dto/orders-enhanced.dto.ts
+depends_on:
+- DatabaseModule
+- ShippingModule
+- CartModule
+- ApiModule
+- AuthModule
+- ConfigModule
+---
+
+# Module Orders
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `Export`
+- `OrdersService`
+- `OrderCalculationService`
+- `OrderStatusService`
+- `OrderArchiveService`
+- `TicketsService`
+- `OrderActionsService`
+
+### Providers (top 15)
+- `Services`
+- `Phase`
+- `OrdersService`
+- `Service`
+- `CRUD`
+- `OrderCalculationService`
+- `Calculs`
+- `OrderStatusService`
+- `Workflow`
+- `OrderArchiveService`
+- `Archivage`
+- `TicketsService`
+- `SAV`
+- `OrderActionsService`
+- `Actions`
+
+### Fichiers primaires
+- [backend/src/modules/orders/controllers/order-actions.controller.ts](../../../backend/src/modules/orders/controllers/order-actions.controller.ts)
+- [backend/src/modules/orders/controllers/order-archive.controller.ts](../../../backend/src/modules/orders/controllers/order-archive.controller.ts)
+- [backend/src/modules/orders/controllers/order-status.controller.ts](../../../backend/src/modules/orders/controllers/order-status.controller.ts)
+- [backend/src/modules/orders/controllers/orders.controller.ts](../../../backend/src/modules/orders/controllers/orders.controller.ts)
+- [backend/src/modules/orders/controllers/tickets.controller.ts](../../../backend/src/modules/orders/controllers/tickets.controller.ts)
+- [backend/src/modules/orders/dto/automotive-orders.dto.ts](../../../backend/src/modules/orders/dto/automotive-orders.dto.ts)
+- [backend/src/modules/orders/dto/index.ts](../../../backend/src/modules/orders/dto/index.ts)
+- [backend/src/modules/orders/dto/orders-enhanced.dto.ts](../../../backend/src/modules/orders/dto/orders-enhanced.dto.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -30,7 +30,6 @@ _Section à rédiger._
 <!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
 
 ### Exports publics du module
-- `Export`
 - `OrdersService`
 - `OrderCalculationService`
 - `OrderStatusService`
@@ -39,21 +38,13 @@ _Section à rédiger._
 - `OrderActionsService`
 
 ### Providers (top 15)
-- `Services`
-- `Phase`
 - `OrdersService`
-- `Service`
-- `CRUD`
 - `OrderCalculationService`
-- `Calculs`
 - `OrderStatusService`
-- `Workflow`
 - `OrderArchiveService`
-- `Archivage`
 - `TicketsService`
-- `SAV`
 - `OrderActionsService`
-- `Actions`
+- `OrderCleanupService`
 
 ### Fichiers primaires
 - [backend/src/modules/orders/controllers/order-actions.controller.ts](../../../backend/src/modules/orders/controllers/order-actions.controller.ts)

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -1,0 +1,69 @@
+---
+module: payments
+sources:
+- backend/src/modules/payments
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/payments/controllers/paybox-callback.controller.ts
+- backend/src/modules/payments/controllers/paybox-monitoring.controller.ts
+- backend/src/modules/payments/controllers/paybox-redirect.controller.ts
+- backend/src/modules/payments/controllers/payment-admin.controller.ts
+- backend/src/modules/payments/controllers/payment-callback.controller.ts
+- backend/src/modules/payments/controllers/payment-controller.utils.ts
+- backend/src/modules/payments/controllers/payment-core.controller.ts
+- backend/src/modules/payments/controllers/payment-methods.controller.ts
+depends_on:
+- DatabaseModule
+- ConfigModule
+---
+
+# Module Payments
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `PaymentService`
+- `CyberplusService`
+- `PaymentDataService`
+
+### Providers (top 15)
+- `Services`
+- `PaymentService`
+- `CyberplusService`
+- `PayboxService`
+- `PaymentValidationService`
+- `PayboxCallbackGateService`
+- `SAFE`
+- `CHANGE`
+- `Callback`
+- `Gate`
+- `Data`
+- `PaymentDataService`
+
+### Fichiers primaires
+- [backend/src/modules/payments/controllers/paybox-callback.controller.ts](../../../backend/src/modules/payments/controllers/paybox-callback.controller.ts)
+- [backend/src/modules/payments/controllers/paybox-monitoring.controller.ts](../../../backend/src/modules/payments/controllers/paybox-monitoring.controller.ts)
+- [backend/src/modules/payments/controllers/paybox-redirect.controller.ts](../../../backend/src/modules/payments/controllers/paybox-redirect.controller.ts)
+- [backend/src/modules/payments/controllers/payment-admin.controller.ts](../../../backend/src/modules/payments/controllers/payment-admin.controller.ts)
+- [backend/src/modules/payments/controllers/payment-callback.controller.ts](../../../backend/src/modules/payments/controllers/payment-callback.controller.ts)
+- [backend/src/modules/payments/controllers/payment-controller.utils.ts](../../../backend/src/modules/payments/controllers/payment-controller.utils.ts)
+- [backend/src/modules/payments/controllers/payment-core.controller.ts](../../../backend/src/modules/payments/controllers/payment-core.controller.ts)
+- [backend/src/modules/payments/controllers/payment-methods.controller.ts](../../../backend/src/modules/payments/controllers/payment-methods.controller.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -31,17 +31,11 @@ _Section à rédiger._
 - `PaymentDataService`
 
 ### Providers (top 15)
-- `Services`
 - `PaymentService`
 - `CyberplusService`
 - `PayboxService`
 - `PaymentValidationService`
 - `PayboxCallbackGateService`
-- `SAFE`
-- `CHANGE`
-- `Callback`
-- `Gate`
-- `Data`
 - `PaymentDataService`
 
 ### Fichiers primaires

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -1,0 +1,80 @@
+---
+module: products
+sources:
+- backend/src/modules/products
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/products/controllers/products-admin.controller.ts
+- backend/src/modules/products/controllers/products-catalog.controller.ts
+- backend/src/modules/products/controllers/products-controller.utils.ts
+- backend/src/modules/products/controllers/products-core.controller.ts
+- backend/src/modules/products/controllers/products-inventory.controller.ts
+- backend/src/modules/products/controllers/products-search.controller.ts
+- backend/src/modules/products/cross-selling.controller.ts
+- backend/src/modules/products/dto/additional-product.dto.ts
+depends_on:
+- DatabaseModule
+- CacheModule
+---
+
+# Module Products
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `ProductsService`
+- `ProductsCatalogService`
+- `ProductsAdminService`
+- `ProductsTechnicalService`
+- `ProductEnhancementService`
+- `ProductFilteringService`
+- `PricingService`
+- `CrossSellingService`
+- `StockService`
+- `CrossSellingSeoService`
+- `CrossSellingSourceService`
+
+### Providers (top 15)
+- `Services`
+- `Split`
+- `Phase`
+- `ProductsService`
+- `CRUD`
+- `Search`
+- `ProductsCatalogService`
+- `Gammes`
+- `Marques`
+- `Stats`
+- `Debug`
+- `ProductsAdminService`
+- `Commercial`
+- `Filtres`
+- `Toggle`
+
+### Fichiers primaires
+- [backend/src/modules/products/controllers/products-admin.controller.ts](../../../backend/src/modules/products/controllers/products-admin.controller.ts)
+- [backend/src/modules/products/controllers/products-catalog.controller.ts](../../../backend/src/modules/products/controllers/products-catalog.controller.ts)
+- [backend/src/modules/products/controllers/products-controller.utils.ts](../../../backend/src/modules/products/controllers/products-controller.utils.ts)
+- [backend/src/modules/products/controllers/products-core.controller.ts](../../../backend/src/modules/products/controllers/products-core.controller.ts)
+- [backend/src/modules/products/controllers/products-inventory.controller.ts](../../../backend/src/modules/products/controllers/products-inventory.controller.ts)
+- [backend/src/modules/products/controllers/products-search.controller.ts](../../../backend/src/modules/products/controllers/products-search.controller.ts)
+- [backend/src/modules/products/cross-selling.controller.ts](../../../backend/src/modules/products/cross-selling.controller.ts)
+- [backend/src/modules/products/dto/additional-product.dto.ts](../../../backend/src/modules/products/dto/additional-product.dto.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -39,21 +39,17 @@ _Section à rédiger._
 - `CrossSellingSourceService`
 
 ### Providers (top 15)
-- `Services`
-- `Split`
-- `Phase`
 - `ProductsService`
-- `CRUD`
-- `Search`
 - `ProductsCatalogService`
-- `Gammes`
-- `Marques`
-- `Stats`
-- `Debug`
 - `ProductsAdminService`
-- `Commercial`
-- `Filtres`
-- `Toggle`
+- `ProductsTechnicalService`
+- `ProductEnhancementService`
+- `ProductFilteringService`
+- `PricingService`
+- `CrossSellingService`
+- `StockService`
+- `CrossSellingSeoService`
+- `CrossSellingSourceService`
 
 ### Fichiers primaires
 - [backend/src/modules/products/controllers/products-admin.controller.ts](../../../backend/src/modules/products/controllers/products-admin.controller.ts)

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -1,0 +1,45 @@
+---
+module: promo
+sources:
+- backend/src/modules/promo
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/promo/promo.controller.ts
+- backend/src/modules/promo/promo.module.ts
+- backend/src/modules/promo/promo.service.ts
+depends_on:
+- DatabaseModule
+---
+
+# Module Promo
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `PromoService`
+
+### Providers (top 15)
+- `PromoService`
+
+### Fichiers primaires
+- [backend/src/modules/promo/promo.controller.ts](../../../backend/src/modules/promo/promo.controller.ts)
+- [backend/src/modules/promo/promo.module.ts](../../../backend/src/modules/promo/promo.module.ts)
+- [backend/src/modules/promo/promo.service.ts](../../../backend/src/modules/promo/promo.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -25,12 +25,10 @@ _Section à rédiger._
 <!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
 
 ### Exports publics du module
-- `Backward`
 - `RagProxyService`
 - `FrontmatterValidatorService`
 - `RagCleanupService`
 - `WebhookAuditService`
-- `New`
 - `RagKnowledgeService`
 - `RagChatService`
 - `RagGammeDetectionService`
@@ -42,40 +40,29 @@ _Section à rédiger._
 - `RagMdMergerService`
 - `RagImageManagementService`
 - `RagVideoManagementService`
-- `Phase`
-- `Ingestion`
-- `Foundation`
 - `RagFingerprintService`
 - `RagValidationService`
 - `RagFoundationGateService`
-- `Normalization`
 - `RagNormalizationService`
-- `Business`
-- `Admissibility`
-- `Gate`
 - `RagAdmissibilityGateService`
-- `Legacy`
-- `Adapted`
-- `Shadow`
-- `Audit`
 - `RagPhase2aShadowAuditService`
 
 ### Providers (top 15)
-- `Phase`
-- `Ingestion`
-- `Foundation`
 - `RagFingerprintService`
 - `RagValidationService`
 - `RagFoundationGateService`
-- `Normalization`
-- `Identity`
-- `Resolution`
 - `RagNormalizationService`
-- `Business`
-- `Admissibility`
-- `Gate`
 - `RagAdmissibilityGateService`
-- `Legacy`
+- `RagPhase2aShadowAuditService`
+- `FrontmatterValidatorService`
+- `RagCleanupService`
+- `WebhookAuditService`
+- `RagCircuitBreakerService`
+- `RagRedisJobService`
+- `RagKnowledgeService`
+- `RagChatService`
+- `RagGammeDetectionService`
+- `RagIngestionService`
 
 ### Fichiers primaires
 - [backend/src/modules/rag-proxy/dto/chat.dto.ts](../../../backend/src/modules/rag-proxy/dto/chat.dto.ts)

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -1,0 +1,102 @@
+---
+module: rag-proxy
+sources:
+- backend/src/modules/rag-proxy
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/rag-proxy/dto/chat.dto.ts
+- backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts
+- backend/src/modules/rag-proxy/dto/pdf-ingest.dto.ts
+- backend/src/modules/rag-proxy/dto/pipeline.dto.ts
+- backend/src/modules/rag-proxy/dto/search.dto.ts
+- backend/src/modules/rag-proxy/dto/web-ingest.dto.ts
+- backend/src/modules/rag-proxy/dto/webhook-ingest.dto.ts
+- backend/src/modules/rag-proxy/events/rag-ingestion.events.ts
+depends_on:
+- ConfigModule
+---
+
+# Module Rag Proxy
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `Backward`
+- `RagProxyService`
+- `FrontmatterValidatorService`
+- `RagCleanupService`
+- `WebhookAuditService`
+- `New`
+- `RagKnowledgeService`
+- `RagChatService`
+- `RagGammeDetectionService`
+- `RagIngestionService`
+- `RagWebhookCompletionService`
+- `RagWebIngestDbService`
+- `PdfTextExtractorService`
+- `PdfRagClassifierService`
+- `RagMdMergerService`
+- `RagImageManagementService`
+- `RagVideoManagementService`
+- `Phase`
+- `Ingestion`
+- `Foundation`
+- `RagFingerprintService`
+- `RagValidationService`
+- `RagFoundationGateService`
+- `Normalization`
+- `RagNormalizationService`
+- `Business`
+- `Admissibility`
+- `Gate`
+- `RagAdmissibilityGateService`
+- `Legacy`
+- `Adapted`
+- `Shadow`
+- `Audit`
+- `RagPhase2aShadowAuditService`
+
+### Providers (top 15)
+- `Phase`
+- `Ingestion`
+- `Foundation`
+- `RagFingerprintService`
+- `RagValidationService`
+- `RagFoundationGateService`
+- `Normalization`
+- `Identity`
+- `Resolution`
+- `RagNormalizationService`
+- `Business`
+- `Admissibility`
+- `Gate`
+- `RagAdmissibilityGateService`
+- `Legacy`
+
+### Fichiers primaires
+- [backend/src/modules/rag-proxy/dto/chat.dto.ts](../../../backend/src/modules/rag-proxy/dto/chat.dto.ts)
+- [backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts](../../../backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts)
+- [backend/src/modules/rag-proxy/dto/pdf-ingest.dto.ts](../../../backend/src/modules/rag-proxy/dto/pdf-ingest.dto.ts)
+- [backend/src/modules/rag-proxy/dto/pipeline.dto.ts](../../../backend/src/modules/rag-proxy/dto/pipeline.dto.ts)
+- [backend/src/modules/rag-proxy/dto/search.dto.ts](../../../backend/src/modules/rag-proxy/dto/search.dto.ts)
+- [backend/src/modules/rag-proxy/dto/web-ingest.dto.ts](../../../backend/src/modules/rag-proxy/dto/web-ingest.dto.ts)
+- [backend/src/modules/rag-proxy/dto/webhook-ingest.dto.ts](../../../backend/src/modules/rag-proxy/dto/webhook-ingest.dto.ts)
+- [backend/src/modules/rag-proxy/events/rag-ingestion.events.ts](../../../backend/src/modules/rag-proxy/events/rag-ingestion.events.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -1,0 +1,48 @@
+---
+module: rm
+sources:
+- backend/src/modules/rm
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/rm/controllers/rm.controller.ts
+- backend/src/modules/rm/rm.module.ts
+- backend/src/modules/rm/rm.types.ts
+- backend/src/modules/rm/services/rm-builder.service.ts
+depends_on:
+- DatabaseModule
+- CatalogModule
+---
+
+# Module Rm
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `RmBuilderService`
+
+### Providers (top 15)
+- `RmBuilderService`
+
+### Fichiers primaires
+- [backend/src/modules/rm/controllers/rm.controller.ts](../../../backend/src/modules/rm/controllers/rm.controller.ts)
+- [backend/src/modules/rm/rm.module.ts](../../../backend/src/modules/rm/rm.module.ts)
+- [backend/src/modules/rm/rm.types.ts](../../../backend/src/modules/rm/rm.types.ts)
+- [backend/src/modules/rm/services/rm-builder.service.ts](../../../backend/src/modules/rm/services/rm-builder.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -1,0 +1,74 @@
+---
+module: search
+sources:
+- backend/src/modules/search
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/search/controllers/pieces.controller.ts
+- backend/src/modules/search/controllers/search-debug.controller.ts
+- backend/src/modules/search/controllers/search-enhanced-existing.controller.ts
+- backend/src/modules/search/controllers/search.controller.ts
+- backend/src/modules/search/search.module.ts
+- backend/src/modules/search/services/database-analysis.service.ts
+- backend/src/modules/search/services/indexation.service.ts
+- backend/src/modules/search/services/meilisearch.service.ts
+depends_on:
+- ConfigModule
+- DatabaseModule
+---
+
+# Module Search
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `MeilisearchService`
+- `SearchMonitoringService`
+- `SearchCacheService`
+- `SearchEnhancedExistingService`
+- `SupabaseIndexationService`
+
+### Providers (top 15)
+- `Core`
+- `Services`
+- `MeilisearchService`
+- `SearchMonitoringService`
+- `Specialized`
+- `SearchCacheService`
+- `DatabaseAnalysisService`
+- `VehicleNamingService`
+- `PiecesAnalysisService`
+- `SearchSuggestionService`
+- `SearchFilterService`
+- `IndexationService`
+- `SupabaseIndexationService`
+- `SearchEnhancedExistingService`
+- `SearchSimpleService`
+
+### Fichiers primaires
+- [backend/src/modules/search/controllers/pieces.controller.ts](../../../backend/src/modules/search/controllers/pieces.controller.ts)
+- [backend/src/modules/search/controllers/search-debug.controller.ts](../../../backend/src/modules/search/controllers/search-debug.controller.ts)
+- [backend/src/modules/search/controllers/search-enhanced-existing.controller.ts](../../../backend/src/modules/search/controllers/search-enhanced-existing.controller.ts)
+- [backend/src/modules/search/controllers/search.controller.ts](../../../backend/src/modules/search/controllers/search.controller.ts)
+- [backend/src/modules/search/search.module.ts](../../../backend/src/modules/search/search.module.ts)
+- [backend/src/modules/search/services/database-analysis.service.ts](../../../backend/src/modules/search/services/database-analysis.service.ts)
+- [backend/src/modules/search/services/indexation.service.ts](../../../backend/src/modules/search/services/indexation.service.ts)
+- [backend/src/modules/search/services/meilisearch.service.ts](../../../backend/src/modules/search/services/meilisearch.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -33,11 +33,8 @@ _Section à rédiger._
 - `SupabaseIndexationService`
 
 ### Providers (top 15)
-- `Core`
-- `Services`
 - `MeilisearchService`
 - `SearchMonitoringService`
-- `Specialized`
 - `SearchCacheService`
 - `DatabaseAnalysisService`
 - `VehicleNamingService`

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -28,11 +28,7 @@ _Section à rédiger._
 - `CrawlBudgetOrchestratorService`
 
 ### Providers (top 15)
-- `Audit`
 - `SeoAuditSchedulerService`
-- `A`
-- `B`
-- `Testing`
 - `CrawlBudgetSupabaseService`
 - `GoogleSearchConsoleService`
 - `GoogleAnalyticsService`

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -1,0 +1,65 @@
+---
+module: seo-logs
+sources:
+- backend/src/modules/seo-logs
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
+- backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts
+- backend/src/modules/seo-logs/controllers/seo-audit.controller.ts
+- backend/src/modules/seo-logs/controllers/seo-kpi.controller.ts
+- backend/src/modules/seo-logs/dto/crawl-budget-experiment.dto.ts
+- backend/src/modules/seo-logs/seo-logs.module.ts
+- backend/src/modules/seo-logs/services/crawl-budget-audit.service.ts
+- backend/src/modules/seo-logs/services/crawl-budget-experiment.service.ts
+depends_on: []
+---
+
+# Module Seo Logs
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `SeoAuditSchedulerService`
+- `CrawlBudgetOrchestratorService`
+
+### Providers (top 15)
+- `Audit`
+- `SeoAuditSchedulerService`
+- `A`
+- `B`
+- `Testing`
+- `CrawlBudgetSupabaseService`
+- `GoogleSearchConsoleService`
+- `GoogleAnalyticsService`
+- `SitemapGeneratorService`
+- `CrawlBudgetOrchestratorService`
+- `CrawlBudgetAuditService`
+
+### Fichiers primaires
+- [backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts](../../../backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts)
+- [backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts](../../../backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts)
+- [backend/src/modules/seo-logs/controllers/seo-audit.controller.ts](../../../backend/src/modules/seo-logs/controllers/seo-audit.controller.ts)
+- [backend/src/modules/seo-logs/controllers/seo-kpi.controller.ts](../../../backend/src/modules/seo-logs/controllers/seo-kpi.controller.ts)
+- [backend/src/modules/seo-logs/dto/crawl-budget-experiment.dto.ts](../../../backend/src/modules/seo-logs/dto/crawl-budget-experiment.dto.ts)
+- [backend/src/modules/seo-logs/seo-logs.module.ts](../../../backend/src/modules/seo-logs/seo-logs.module.ts)
+- [backend/src/modules/seo-logs/services/crawl-budget-audit.service.ts](../../../backend/src/modules/seo-logs/services/crawl-budget-audit.service.ts)
+- [backend/src/modules/seo-logs/services/crawl-budget-experiment.service.ts](../../../backend/src/modules/seo-logs/services/crawl-budget-experiment.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -1,0 +1,109 @@
+---
+module: seo
+sources:
+- backend/src/modules/seo
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/seo/config/hreflang.config.ts
+- backend/src/modules/seo/config/sitemap.config.ts
+- backend/src/modules/seo/constants/seo-templates.constants.ts
+- backend/src/modules/seo/controllers/diagnostic.controller.ts
+- backend/src/modules/seo/controllers/keywords-dashboard.controller.ts
+- backend/src/modules/seo/controllers/r2-page.controller.ts
+- backend/src/modules/seo/controllers/reference.controller.ts
+- backend/src/modules/seo/controllers/robots-txt.controller.ts
+depends_on:
+- ConfigModule
+- DatabaseModule
+- WorkerModule
+- CatalogModule
+- AiContentModule
+- NestCacheModule
+---
+
+# Module Seo
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `Core`
+- `SeoService`
+- `DynamicSeoV4UltimateService`
+- `HreflangService`
+- `ProductImageService`
+- `RobotsTxtService`
+- `SeoHeadersService`
+- `UrlCompatibilityService`
+- `Validation`
+- `PageRoleValidatorService`
+- `QualityValidatorService`
+- `PurchaseGuideValidatorService`
+- `Linking`
+- `InternalLinkingService`
+- `SeoLinkTrackingService`
+- `Monitoring`
+- `SeoMonitoringService`
+- `SeoPilotageService`
+- `SeoKpisService`
+- `RiskFlagsEngineService`
+- `GooglebotDetectorService`
+- `KeywordsDashboardService`
+- `LogIngestionService`
+- `Sitemap`
+- `SitemapV10Service`
+- `SitemapV10HubsService`
+- `SitemapV10ScoringService`
+- `SitemapDeltaService`
+- `SitemapStreamingService`
+- `SitemapHygieneService`
+- `SitemapVehiclePiecesValidator`
+- `Content`
+- `ReferenceService`
+- `DiagnosticService`
+- `SeoGeneratorService`
+- `SeoTitleEngineService`
+
+### Providers (top 15)
+- `Core`
+- `SeoService`
+- `SeoV4SwitchEngineService`
+- `SeoV4MonitoringService`
+- `DynamicSeoV4UltimateService`
+- `HreflangService`
+- `ProductImageService`
+- `RobotsTxtService`
+- `SeoHeadersService`
+- `UrlCompatibilityService`
+- `Validation`
+- `PageRoleValidatorService`
+- `QualityValidatorService`
+- `PurchaseGuideValidatorService`
+- `Linking`
+
+### Fichiers primaires
+- [backend/src/modules/seo/config/hreflang.config.ts](../../../backend/src/modules/seo/config/hreflang.config.ts)
+- [backend/src/modules/seo/config/sitemap.config.ts](../../../backend/src/modules/seo/config/sitemap.config.ts)
+- [backend/src/modules/seo/constants/seo-templates.constants.ts](../../../backend/src/modules/seo/constants/seo-templates.constants.ts)
+- [backend/src/modules/seo/controllers/diagnostic.controller.ts](../../../backend/src/modules/seo/controllers/diagnostic.controller.ts)
+- [backend/src/modules/seo/controllers/keywords-dashboard.controller.ts](../../../backend/src/modules/seo/controllers/keywords-dashboard.controller.ts)
+- [backend/src/modules/seo/controllers/r2-page.controller.ts](../../../backend/src/modules/seo/controllers/r2-page.controller.ts)
+- [backend/src/modules/seo/controllers/reference.controller.ts](../../../backend/src/modules/seo/controllers/reference.controller.ts)
+- [backend/src/modules/seo/controllers/robots-txt.controller.ts](../../../backend/src/modules/seo/controllers/robots-txt.controller.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -30,7 +30,6 @@ _Section à rédiger._
 <!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
 
 ### Exports publics du module
-- `Core`
 - `SeoService`
 - `DynamicSeoV4UltimateService`
 - `HreflangService`
@@ -38,14 +37,11 @@ _Section à rédiger._
 - `RobotsTxtService`
 - `SeoHeadersService`
 - `UrlCompatibilityService`
-- `Validation`
 - `PageRoleValidatorService`
 - `QualityValidatorService`
 - `PurchaseGuideValidatorService`
-- `Linking`
 - `InternalLinkingService`
 - `SeoLinkTrackingService`
-- `Monitoring`
 - `SeoMonitoringService`
 - `SeoPilotageService`
 - `SeoKpisService`
@@ -53,22 +49,18 @@ _Section à rédiger._
 - `GooglebotDetectorService`
 - `KeywordsDashboardService`
 - `LogIngestionService`
-- `Sitemap`
 - `SitemapV10Service`
 - `SitemapV10HubsService`
 - `SitemapV10ScoringService`
 - `SitemapDeltaService`
 - `SitemapStreamingService`
 - `SitemapHygieneService`
-- `SitemapVehiclePiecesValidator`
-- `Content`
 - `ReferenceService`
 - `DiagnosticService`
 - `SeoGeneratorService`
 - `SeoTitleEngineService`
 
 ### Providers (top 15)
-- `Core`
 - `SeoService`
 - `SeoV4SwitchEngineService`
 - `SeoV4MonitoringService`
@@ -78,11 +70,12 @@ _Section à rédiger._
 - `RobotsTxtService`
 - `SeoHeadersService`
 - `UrlCompatibilityService`
-- `Validation`
 - `PageRoleValidatorService`
 - `QualityValidatorService`
 - `PurchaseGuideValidatorService`
-- `Linking`
+- `InternalLinkingService`
+- `SeoLinkTrackingService`
+- `SeoMonitoringService`
 
 ### Fichiers primaires
 - [backend/src/modules/seo/config/hreflang.config.ts](../../../backend/src/modules/seo/config/hreflang.config.ts)

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -1,0 +1,47 @@
+---
+module: shipping
+sources:
+- backend/src/modules/shipping
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/shipping/shipping-new.module.ts
+- backend/src/modules/shipping/shipping.controller.ts
+- backend/src/modules/shipping/shipping.module.ts
+- backend/src/modules/shipping/shipping.service.ts
+depends_on:
+- CartModule
+---
+
+# Module Shipping
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `ShippingService`
+
+### Providers (top 15)
+- `ShippingService`
+
+### Fichiers primaires
+- [backend/src/modules/shipping/shipping-new.module.ts](../../../backend/src/modules/shipping/shipping-new.module.ts)
+- [backend/src/modules/shipping/shipping.controller.ts](../../../backend/src/modules/shipping/shipping.controller.ts)
+- [backend/src/modules/shipping/shipping.module.ts](../../../backend/src/modules/shipping/shipping.module.ts)
+- [backend/src/modules/shipping/shipping.service.ts](../../../backend/src/modules/shipping/shipping.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -1,0 +1,50 @@
+---
+module: staff
+sources:
+- backend/src/modules/staff
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/staff/dto/staff.dto.ts
+- backend/src/modules/staff/services/staff-data.service.ts
+- backend/src/modules/staff/staff.controller.ts
+- backend/src/modules/staff/staff.module.ts
+- backend/src/modules/staff/staff.service.ts
+depends_on:
+- ConfigModule
+---
+
+# Module Staff
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `StaffService`
+
+### Providers (top 15)
+- `StaffDataService`
+- `StaffService`
+
+### Fichiers primaires
+- [backend/src/modules/staff/dto/staff.dto.ts](../../../backend/src/modules/staff/dto/staff.dto.ts)
+- [backend/src/modules/staff/services/staff-data.service.ts](../../../backend/src/modules/staff/services/staff-data.service.ts)
+- [backend/src/modules/staff/staff.controller.ts](../../../backend/src/modules/staff/staff.controller.ts)
+- [backend/src/modules/staff/staff.module.ts](../../../backend/src/modules/staff/staff.module.ts)
+- [backend/src/modules/staff/staff.service.ts](../../../backend/src/modules/staff/staff.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -1,0 +1,54 @@
+---
+module: substitution
+sources:
+- backend/src/modules/substitution
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/substitution/controllers/substitution.controller.ts
+- backend/src/modules/substitution/services/intent-extractor.service.ts
+- backend/src/modules/substitution/services/substitution-logger.service.ts
+- backend/src/modules/substitution/services/substitution.service.ts
+- backend/src/modules/substitution/substitution.module.ts
+- backend/src/modules/substitution/types/substitution.types.ts
+depends_on:
+- ConfigModule
+---
+
+# Module Substitution
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `SubstitutionService`
+- `IntentExtractorService`
+
+### Providers (top 15)
+- `IntentExtractorService`
+- `SubstitutionService`
+- `SubstitutionLoggerService`
+
+### Fichiers primaires
+- [backend/src/modules/substitution/controllers/substitution.controller.ts](../../../backend/src/modules/substitution/controllers/substitution.controller.ts)
+- [backend/src/modules/substitution/services/intent-extractor.service.ts](../../../backend/src/modules/substitution/services/intent-extractor.service.ts)
+- [backend/src/modules/substitution/services/substitution-logger.service.ts](../../../backend/src/modules/substitution/services/substitution-logger.service.ts)
+- [backend/src/modules/substitution/services/substitution.service.ts](../../../backend/src/modules/substitution/services/substitution.service.ts)
+- [backend/src/modules/substitution/substitution.module.ts](../../../backend/src/modules/substitution/substitution.module.ts)
+- [backend/src/modules/substitution/types/substitution.types.ts](../../../backend/src/modules/substitution/types/substitution.types.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -1,0 +1,53 @@
+---
+module: suppliers
+sources:
+- backend/src/modules/suppliers
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/suppliers/dto/index.ts
+- backend/src/modules/suppliers/dto/supplier.dto.ts
+- backend/src/modules/suppliers/dto/supplier.schemas.ts
+- backend/src/modules/suppliers/suppliers-modern.controller.ts
+- backend/src/modules/suppliers/suppliers.controller.ts
+- backend/src/modules/suppliers/suppliers.module.ts
+- backend/src/modules/suppliers/suppliers.service.ts
+depends_on:
+- DatabaseModule
+---
+
+# Module Suppliers
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `SuppliersService`
+
+### Providers (top 15)
+- `SuppliersService`
+
+### Fichiers primaires
+- [backend/src/modules/suppliers/dto/index.ts](../../../backend/src/modules/suppliers/dto/index.ts)
+- [backend/src/modules/suppliers/dto/supplier.dto.ts](../../../backend/src/modules/suppliers/dto/supplier.dto.ts)
+- [backend/src/modules/suppliers/dto/supplier.schemas.ts](../../../backend/src/modules/suppliers/dto/supplier.schemas.ts)
+- [backend/src/modules/suppliers/suppliers-modern.controller.ts](../../../backend/src/modules/suppliers/suppliers-modern.controller.ts)
+- [backend/src/modules/suppliers/suppliers.controller.ts](../../../backend/src/modules/suppliers/suppliers.controller.ts)
+- [backend/src/modules/suppliers/suppliers.module.ts](../../../backend/src/modules/suppliers/suppliers.module.ts)
+- [backend/src/modules/suppliers/suppliers.service.ts](../../../backend/src/modules/suppliers/suppliers.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -31,8 +31,6 @@ _Section à rédiger._
 - `NotificationService`
 - `SupportAnalyticsService`
 - `SupportConfigService`
-- `Export`
-- `IA`
 - `AISentimentService`
 - `AICategorizationService`
 - `AISmartResponseService`
@@ -41,7 +39,6 @@ _Section à rédiger._
 - `LegalPageService`
 
 ### Providers (top 15)
-- `Services`
 - `ReviewService`
 - `ContactService`
 - `QuoteService`
@@ -51,11 +48,12 @@ _Section à rédiger._
 - `NotificationService`
 - `SupportAnalyticsService`
 - `SupportConfigService`
-- `Intelligence`
-- `Artificielle`
 - `AISentimentService`
 - `AICategorizationService`
 - `AISmartResponseService`
+- `AIPredictiveService`
+- `LegalVersionService`
+- `LegalPageService`
 
 ### Fichiers primaires
 - [backend/src/modules/support/controllers/ai-support.controller.ts](../../../backend/src/modules/support/controllers/ai-support.controller.ts)

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -1,0 +1,82 @@
+---
+module: support
+sources:
+- backend/src/modules/support
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/support/controllers/ai-support.controller.ts
+- backend/src/modules/support/controllers/claim.controller.ts
+- backend/src/modules/support/controllers/contact.controller.ts
+- backend/src/modules/support/controllers/faq.controller.ts
+- backend/src/modules/support/controllers/legal.controller.ts
+- backend/src/modules/support/controllers/quote.controller.ts
+- backend/src/modules/support/controllers/review.controller.ts
+- backend/src/modules/support/controllers/support-analytics.controller.ts
+depends_on:
+- ConfigModule
+- DatabaseModule
+- NotificationsModule
+---
+
+# Module Support
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `ContactService`
+- `NotificationService`
+- `SupportAnalyticsService`
+- `SupportConfigService`
+- `Export`
+- `IA`
+- `AISentimentService`
+- `AICategorizationService`
+- `AISmartResponseService`
+- `AIPredictiveService`
+- `LegalVersionService`
+- `LegalPageService`
+
+### Providers (top 15)
+- `Services`
+- `ReviewService`
+- `ContactService`
+- `QuoteService`
+- `FaqService`
+- `LegalService`
+- `ClaimService`
+- `NotificationService`
+- `SupportAnalyticsService`
+- `SupportConfigService`
+- `Intelligence`
+- `Artificielle`
+- `AISentimentService`
+- `AICategorizationService`
+- `AISmartResponseService`
+
+### Fichiers primaires
+- [backend/src/modules/support/controllers/ai-support.controller.ts](../../../backend/src/modules/support/controllers/ai-support.controller.ts)
+- [backend/src/modules/support/controllers/claim.controller.ts](../../../backend/src/modules/support/controllers/claim.controller.ts)
+- [backend/src/modules/support/controllers/contact.controller.ts](../../../backend/src/modules/support/controllers/contact.controller.ts)
+- [backend/src/modules/support/controllers/faq.controller.ts](../../../backend/src/modules/support/controllers/faq.controller.ts)
+- [backend/src/modules/support/controllers/legal.controller.ts](../../../backend/src/modules/support/controllers/legal.controller.ts)
+- [backend/src/modules/support/controllers/quote.controller.ts](../../../backend/src/modules/support/controllers/quote.controller.ts)
+- [backend/src/modules/support/controllers/review.controller.ts](../../../backend/src/modules/support/controllers/review.controller.ts)
+- [backend/src/modules/support/controllers/support-analytics.controller.ts](../../../backend/src/modules/support/controllers/support-analytics.controller.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -34,17 +34,10 @@ _Section à rédiger._
 
 ### Providers (top 15)
 - `SystemHealthService`
-- `Simple`
 - `SystemService`
 - `MetricsService`
-- `Enterprise`
 - `DatabaseMonitorService`
-- `Database`
 - `DbGovernanceService`
-- `DB`
-- `Phase`
-- `M1`
-- `M6`
 
 ### Fichiers primaires
 - [backend/src/modules/system/processors/metrics.processor.ts](../../../backend/src/modules/system/processors/metrics.processor.ts)

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -1,0 +1,71 @@
+---
+module: system
+sources:
+- backend/src/modules/system
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/system/processors/metrics.processor.ts
+- backend/src/modules/system/services/database-monitor.service.ts
+- backend/src/modules/system/services/db-governance.service.ts
+- backend/src/modules/system/services/health-check.service.ts
+- backend/src/modules/system/services/metrics.service.ts
+- backend/src/modules/system/services/system.service.ts
+- backend/src/modules/system/simple.service.ts
+- backend/src/modules/system/system-health.controller.ts
+depends_on:
+- ConfigModule
+- DatabaseModule
+---
+
+# Module System
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `SystemHealthService`
+- `SystemService`
+- `MetricsService`
+- `DatabaseMonitorService`
+- `DbGovernanceService`
+
+### Providers (top 15)
+- `SystemHealthService`
+- `Simple`
+- `SystemService`
+- `MetricsService`
+- `Enterprise`
+- `DatabaseMonitorService`
+- `Database`
+- `DbGovernanceService`
+- `DB`
+- `Phase`
+- `M1`
+- `M6`
+
+### Fichiers primaires
+- [backend/src/modules/system/processors/metrics.processor.ts](../../../backend/src/modules/system/processors/metrics.processor.ts)
+- [backend/src/modules/system/services/database-monitor.service.ts](../../../backend/src/modules/system/services/database-monitor.service.ts)
+- [backend/src/modules/system/services/db-governance.service.ts](../../../backend/src/modules/system/services/db-governance.service.ts)
+- [backend/src/modules/system/services/health-check.service.ts](../../../backend/src/modules/system/services/health-check.service.ts)
+- [backend/src/modules/system/services/metrics.service.ts](../../../backend/src/modules/system/services/metrics.service.ts)
+- [backend/src/modules/system/services/system.service.ts](../../../backend/src/modules/system/services/system.service.ts)
+- [backend/src/modules/system/simple.service.ts](../../../backend/src/modules/system/simple.service.ts)
+- [backend/src/modules/system/system-health.controller.ts](../../../backend/src/modules/system/system-health.controller.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -1,0 +1,63 @@
+---
+module: upload
+sources:
+- backend/src/modules/upload
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/upload/dto/index.ts
+- backend/src/modules/upload/dto/upload.dto.ts
+- backend/src/modules/upload/services/file-validation.service.ts
+- backend/src/modules/upload/services/image-processing.service.ts
+- backend/src/modules/upload/services/supabase-storage.service.ts
+- backend/src/modules/upload/services/upload-analytics.service.ts
+- backend/src/modules/upload/services/upload-optimization.service.ts
+- backend/src/modules/upload/services/upload.service.ts
+depends_on:
+- ConfigModule
+- MulterModule
+---
+
+# Module Upload
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `UploadService`
+- `ImageProcessingService`
+- `SupabaseStorageService`
+
+### Providers (top 15)
+- `UploadService`
+- `ImageProcessingService`
+- `SupabaseStorageService`
+- `FileValidationService`
+- `UploadAnalyticsService`
+- `UploadOptimizationService`
+
+### Fichiers primaires
+- [backend/src/modules/upload/dto/index.ts](../../../backend/src/modules/upload/dto/index.ts)
+- [backend/src/modules/upload/dto/upload.dto.ts](../../../backend/src/modules/upload/dto/upload.dto.ts)
+- [backend/src/modules/upload/services/file-validation.service.ts](../../../backend/src/modules/upload/services/file-validation.service.ts)
+- [backend/src/modules/upload/services/image-processing.service.ts](../../../backend/src/modules/upload/services/image-processing.service.ts)
+- [backend/src/modules/upload/services/supabase-storage.service.ts](../../../backend/src/modules/upload/services/supabase-storage.service.ts)
+- [backend/src/modules/upload/services/upload-analytics.service.ts](../../../backend/src/modules/upload/services/upload-analytics.service.ts)
+- [backend/src/modules/upload/services/upload-optimization.service.ts](../../../backend/src/modules/upload/services/upload-optimization.service.ts)
+- [backend/src/modules/upload/services/upload.service.ts](../../../backend/src/modules/upload/services/upload.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -1,0 +1,81 @@
+---
+module: users
+sources:
+- backend/src/modules/users
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/users/controllers/addresses.controller.ts
+- backend/src/modules/users/controllers/password.controller.ts
+- backend/src/modules/users/controllers/user-shipment.controller.ts
+- backend/src/modules/users/dto/addresses.dto.ts
+- backend/src/modules/users/dto/change-password.dto.ts
+- backend/src/modules/users/dto/create-user.dto.ts
+- backend/src/modules/users/dto/index.ts
+- backend/src/modules/users/dto/login.dto.ts
+depends_on:
+- ConfigModule
+- DatabaseModule
+- AuthModule
+- MessagesModule
+- JwtModule
+---
+
+# Module Users
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `SERVICES`
+- `PRINCIPAUX`
+- `UsersFinalService`
+- `Service`
+- `UserDataConsolidatedService`
+- `Services`
+- `ProfileService`
+- `UsersAdminService`
+- `PasswordService`
+- `AddressesService`
+- `UserShipmentService`
+
+### Providers (top 15)
+- `SERVICES`
+- `PRINCIPAUX`
+- `UsersFinalService`
+- `Service`
+- `Redis`
+- `UserDataConsolidatedService`
+- `Supabase`
+- `Services`
+- `ProfileService`
+- `UsersAdminService`
+- `PasswordService`
+- `AddressesService`
+- `UserShipmentService`
+
+### Fichiers primaires
+- [backend/src/modules/users/controllers/addresses.controller.ts](../../../backend/src/modules/users/controllers/addresses.controller.ts)
+- [backend/src/modules/users/controllers/password.controller.ts](../../../backend/src/modules/users/controllers/password.controller.ts)
+- [backend/src/modules/users/controllers/user-shipment.controller.ts](../../../backend/src/modules/users/controllers/user-shipment.controller.ts)
+- [backend/src/modules/users/dto/addresses.dto.ts](../../../backend/src/modules/users/dto/addresses.dto.ts)
+- [backend/src/modules/users/dto/change-password.dto.ts](../../../backend/src/modules/users/dto/change-password.dto.ts)
+- [backend/src/modules/users/dto/create-user.dto.ts](../../../backend/src/modules/users/dto/create-user.dto.ts)
+- [backend/src/modules/users/dto/index.ts](../../../backend/src/modules/users/dto/index.ts)
+- [backend/src/modules/users/dto/login.dto.ts](../../../backend/src/modules/users/dto/login.dto.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -29,12 +29,8 @@ _Section à rédiger._
 <!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
 
 ### Exports publics du module
-- `SERVICES`
-- `PRINCIPAUX`
 - `UsersFinalService`
-- `Service`
 - `UserDataConsolidatedService`
-- `Services`
 - `ProfileService`
 - `UsersAdminService`
 - `PasswordService`
@@ -42,14 +38,8 @@ _Section à rédiger._
 - `UserShipmentService`
 
 ### Providers (top 15)
-- `SERVICES`
-- `PRINCIPAUX`
 - `UsersFinalService`
-- `Service`
-- `Redis`
 - `UserDataConsolidatedService`
-- `Supabase`
-- `Services`
 - `ProfileService`
 - `UsersAdminService`
 - `PasswordService`

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -44,21 +44,21 @@ _Section à rédiger._
 - `VehicleProfileService`
 
 ### Providers (top 15)
-- `Services`
 - `VehiclesService`
 - `EnhancedVehicleService`
-- `Core`
 - `VehicleCacheService`
 - `VehicleEnrichmentService`
-- `Data`
 - `VehicleBrandsService`
 - `VehicleModelsService`
 - `VehicleTypesService`
-- `Search`
 - `VehicleSearchService`
 - `VehicleMineService`
-- `SEO`
 - `BrandSeoService`
+- `VehicleMetaService`
+- `BrandBestsellersService`
+- `VehicleMotorCodesService`
+- `VehicleProfileService`
+- `VehicleRpcService`
 
 ### Fichiers primaires
 - [backend/src/modules/vehicles/brands.controller.ts](../../../backend/src/modules/vehicles/brands.controller.ts)

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -1,0 +1,85 @@
+---
+module: vehicles
+sources:
+- backend/src/modules/vehicles
+last_scan: '2026-04-24'
+primary_files:
+- backend/src/modules/vehicles/brands.controller.ts
+- backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts
+- backend/src/modules/vehicles/decorators/performance-monitoring.decorator.ts
+- backend/src/modules/vehicles/dto/vehicles-simple-zod.dto.ts
+- backend/src/modules/vehicles/dto/vehicles-zod.dto.ts
+- backend/src/modules/vehicles/dto/vehicles.dto.ts
+- backend/src/modules/vehicles/pipes/vehicle-validation.pipe.ts
+- backend/src/modules/vehicles/services/brand-bestsellers.service.ts
+depends_on:
+- ConfigModule
+- DatabaseModule
+- CatalogModule
+- CacheModule
+---
+
+# Module Vehicles
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `VehiclesService`
+- `EnhancedVehicleService`
+- `VehicleBrandsService`
+- `VehicleModelsService`
+- `VehicleTypesService`
+- `VehicleSearchService`
+- `VehicleMineService`
+- `VehicleCacheService`
+- `VehicleRpcService`
+- `BrandRpcService`
+- `VehicleMetaService`
+- `BrandBestsellersService`
+- `VehicleMotorCodesService`
+- `VehicleProfileService`
+
+### Providers (top 15)
+- `Services`
+- `VehiclesService`
+- `EnhancedVehicleService`
+- `Core`
+- `VehicleCacheService`
+- `VehicleEnrichmentService`
+- `Data`
+- `VehicleBrandsService`
+- `VehicleModelsService`
+- `VehicleTypesService`
+- `Search`
+- `VehicleSearchService`
+- `VehicleMineService`
+- `SEO`
+- `BrandSeoService`
+
+### Fichiers primaires
+- [backend/src/modules/vehicles/brands.controller.ts](../../../backend/src/modules/vehicles/brands.controller.ts)
+- [backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts](../../../backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts)
+- [backend/src/modules/vehicles/decorators/performance-monitoring.decorator.ts](../../../backend/src/modules/vehicles/decorators/performance-monitoring.decorator.ts)
+- [backend/src/modules/vehicles/dto/vehicles-simple-zod.dto.ts](../../../backend/src/modules/vehicles/dto/vehicles-simple-zod.dto.ts)
+- [backend/src/modules/vehicles/dto/vehicles-zod.dto.ts](../../../backend/src/modules/vehicles/dto/vehicles-zod.dto.ts)
+- [backend/src/modules/vehicles/dto/vehicles.dto.ts](../../../backend/src/modules/vehicles/dto/vehicles.dto.ts)
+- [backend/src/modules/vehicles/pipes/vehicle-validation.pipe.ts](../../../backend/src/modules/vehicles/pipes/vehicle-validation.pipe.ts)
+- [backend/src/modules/vehicles/services/brand-bestsellers.service.ts](../../../backend/src/modules/vehicles/services/brand-bestsellers.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,0 +1,143 @@
+/**
+ * dependency-cruiser config for AutoMecanik monorepo
+ * Starts permissive: hard errors on obvious wrongs, warnings on architectural
+ * concerns so the pre-commit hook never blocks day 1.
+ * Tighten severity as cleanup Phase 1 progresses.
+ */
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  forbidden: [
+    {
+      name: 'no-circular',
+      severity: 'warn',
+      comment:
+        'Circular dependencies make code hard to reason about and break tree-shaking.',
+      from: {},
+      to: { circular: true },
+    },
+    {
+      name: 'no-orphans',
+      severity: 'warn',
+      comment:
+        'Files without dependents are either dead code or missing an entry point.',
+      from: {
+        orphan: true,
+        pathNot: [
+          '(^|/)\\.[^/]+\\.(js|cjs|mjs|ts|json)$',
+          '\\.d\\.ts$',
+          '(^|/)tsconfig\\.json$',
+          '(^|/)(babel|webpack)\\.config\\.(js|cjs|mjs|ts|json)$',
+        ],
+      },
+      to: {},
+    },
+    {
+      name: 'not-to-deprecated',
+      severity: 'warn',
+      comment: 'Imported module is deprecated.',
+      from: {},
+      to: { dependencyTypes: ['deprecated'] },
+    },
+    {
+      name: 'frontend-not-to-backend-src',
+      severity: 'warn',
+      comment:
+        'Frontend must go through HTTP/API, never reach into backend source directly. Promote to error after Phase 1 cleanup.',
+      from: { path: '^frontend/app/' },
+      to: { path: '^backend/src/' },
+    },
+    {
+      name: 'backend-not-to-frontend',
+      severity: 'warn',
+      comment:
+        'Backend must not reach into frontend source (coupling + bundling disaster). Promote to error after Phase 1 cleanup.',
+      from: { path: '^backend/src/' },
+      to: { path: '^frontend/app/' },
+    },
+    {
+      name: 'no-deep-module-access',
+      severity: 'warn',
+      comment:
+        'Modules should depend on each other via public barrels, not reach inside. Tighten to error after Phase 1.',
+      from: {
+        path: '^backend/src/modules/([^/]+)/',
+        pathNot: '^backend/src/modules/([^/]+)/.*\\.spec\\.ts$',
+      },
+      to: {
+        path: '^backend/src/modules/([^/]+)/.+',
+        pathNot: [
+          '^backend/src/modules/$1/',
+          '^backend/src/modules/[^/]+/index\\.ts$',
+          '^backend/src/modules/[^/]+/[^/]+\\.module\\.ts$',
+        ],
+      },
+    },
+    {
+      name: 'not-to-test',
+      severity: 'warn',
+      comment: 'Production code should not import tests. Promote to error after Phase 1 cleanup.',
+      from: {
+        pathNot: [
+          '\\.(spec|test|e2e-spec)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$',
+        ],
+      },
+      to: {
+        path: '\\.(spec|test|e2e-spec)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$',
+      },
+    },
+    {
+      name: 'not-to-spec',
+      severity: 'warn',
+      comment: 'No imports from documentation folder. Promote to error after Phase 1 cleanup.',
+      from: {},
+      to: { path: '^\\.spec/' },
+    },
+    {
+      name: 'no-non-package-json',
+      severity: 'warn',
+      comment:
+        'Only allow deps declared in package.json (prevents phantom deps). Promote to error after Phase 1 cleanup.',
+      from: {},
+      to: { dependencyTypes: ['npm-no-pkg', 'npm-unknown'] },
+    },
+  ],
+  options: {
+    doNotFollow: {
+      path: [
+        'node_modules',
+        'dist',
+        'build',
+        '\\.cache',
+        '\\.turbo',
+        'coverage',
+        '\\.next',
+        'public/build',
+      ],
+    },
+    exclude: {
+      path: [
+        '\\.spec/',
+        'audit-monorepo/',
+        '99-meta/',
+        'output/',
+        'gates/',
+        '\\.local/',
+        '\\.codex',
+        'rm/',
+        '\\.spec\\.ts$',
+        '\\.e2e-spec\\.ts$',
+      ],
+    },
+    tsPreCompilationDeps: true,
+    enhancedResolveOptions: {
+      exportsFields: ['exports'],
+      conditionNames: ['import', 'require', 'node', 'default', 'types'],
+      mainFields: ['module', 'main', 'types', 'typings'],
+    },
+    reporterOptions: {
+      text: {
+        highlightFocused: true,
+      },
+    },
+  },
+};

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -16,3 +16,36 @@ if [ -n "$BLOCKED" ]; then
 fi
 
 npx lint-staged
+
+# Refresh auto-generated YAML frontmatter + AUTO-GENERATED blocks in
+# .claude/knowledge/modules/*.md so last_scan + primary_files stay honest.
+# Only touches files when the module .ts changed; otherwise no-op.
+# Soft-fail: a missing python3/pyyaml must NOT block a commit.
+if command -v python3 >/dev/null 2>&1 \
+   && python3 -c "import yaml" >/dev/null 2>&1 \
+   && [ -f scripts/knowledge/refresh-knowledge.py ]; then
+  # Headers-only: fast path for commit time. Full refresh remains manual.
+  python3 scripts/knowledge/refresh-knowledge.py refresh --headers-only >/dev/null 2>&1 || true
+  # If any knowledge/ files were changed, stage them so they ride along.
+  CHANGED=$(git diff --name-only -- '.claude/knowledge/' || true)
+  if [ -n "$CHANGED" ]; then
+    git add $CHANGED 2>/dev/null || true
+  fi
+fi
+
+# Fast deterministic gate: ast-grep rules in .ast-grep/rules/
+# Warnings do not block commits; only `severity: error` rules fail here.
+# For full audit run: npm run audit:all (see package.json scripts)
+if command -v npx >/dev/null 2>&1; then
+  npx --no-install ast-grep scan --config sgconfig.yml || {
+    code=$?
+    # ast-grep returns non-zero when it finds *errors* (not warnings).
+    # We keep Phase 0 permissive so only explicit `severity: error` rules block.
+    if [ "$code" != "0" ] && [ "$code" != "10" ]; then
+      echo ""
+      echo "ast-grep: blocking errors detected. Commit refused."
+      echo "Run 'npm run audit:ast' to inspect, or fix the flagged files."
+      exit 1
+    fi
+  }
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,28 @@
 
 ---
 
+## Mémoire codebase — lire `.claude/knowledge/` avant exploration
+
+**Avant** tout `Grep` / `Glob` / lecture en rafale pour répondre à une question
+sur le code applicatif (modules NestJS, tables DB, intégrations externes,
+routes Remix critiques), **lire d'abord** :
+
+1. [`.claude/knowledge/README.md`](.claude/knowledge/README.md) — index racine + règles de navigation
+2. Le ou les fichiers pertinents sous `.claude/knowledge/{modules,db,integrations,routes}/`
+
+Ce dossier est le **miroir structuré du codebase** — il remplace le grep pour
+l'orientation. Le bloc `<!-- AUTO-GENERATED -->` est rafraîchi par
+`scripts/knowledge/refresh-knowledge.py` au pre-commit. Les sections prose
+("Pourquoi", "Gotchas", "Références") sont éditées à la main par les humains.
+
+**Grep reste légitime pour** : debugging ciblé (pattern précis), strings
+dans le code, cas non couverts par le knowledge, cross-refs larges.
+
+La gouvernance canon vit au vault (voir ci-dessous) — `.claude/knowledge/`
+ne la duplique pas, il la référence.
+
+---
+
 ## Source de vérité (SoT)
 
 **La gouvernance AutoMecanik vit ici et nulle part ailleurs :**

--- a/audit-reports/.gitignore
+++ b/audit-reports/.gitignore
@@ -1,0 +1,6 @@
+# Raw tool outputs are regeneratable via `npm run audit:all`.
+# Only the curated baseline.md is versioned.
+phase0-knip.txt
+phase0-madge.txt
+phase0-depcruise.txt
+phase0-astgrep.txt

--- a/audit-reports/phase0-baseline.md
+++ b/audit-reports/phase0-baseline.md
@@ -1,10 +1,23 @@
 # Phase 0 — Cleanup Gate Baseline
 
 Generated: 2026-04-24 — branch `feat/claude-knowledge-base`
+Updated: 2026-04-24 — tier-1 refinements applied.
 
 Deterministic tools ran on the full monorepo with all rules at `severity: warning`
 (Phase 0 is non-blocking by design). This file is the baseline we promote to
 `error` severity after each Phase 1 cleanup pass.
+
+## Tier-1 refinements applied
+
+- `backend-no-console-log` rule: added `ignores` for validation/CLI/test files.
+  Eliminated 13 false positives (console.log in validate-*.ts tooling).
+- `payments-no-raw-equality` rule: added `not has kind: string | template_string`
+  constraint. Eliminated 2 false positives on config-value equality checks.
+- `knip.json`: added entry patterns for workers, scripts, Remix routes config.
+  Dropped unused types count from 338 to 310.
+- `refresh-knowledge.py`: now strips JS/TS comments + filters providers by
+  NestJS-class suffix (Service / Controller / Module / Guard / …). Cleaned
+  ~117 lines of noise across 20 module .md files.
 
 ## Raw outputs (same directory)
 
@@ -17,21 +30,26 @@ Deterministic tools ran on the full monorepo with all rules at `severity: warnin
 
 ### knip (unused code + deps)
 
-| Category                | Count |
-|-------------------------|-------|
-| Unused files            | 362   |
-| Unused dependencies     | 4     |
-| Unused devDependencies  | 4     |
-| Unlisted dependencies   | 10    |
-| Unlisted binaries       | 4     |
-| Unused exports          | 219   |
-| Unused exported types   | 338   |
-| Duplicate exports       | 41    |
+| Category                | Count (initial) | Count (tier-1) |
+|-------------------------|-----------------|----------------|
+| Unused files            | 362             | 362            |
+| Unused dependencies     | 4               | 4              |
+| Unused devDependencies  | 4               | 4              |
+| Unlisted dependencies   | 10              | 9              |
+| Unlisted binaries       | 4               | 3              |
+| Unused exports          | 219             | 218            |
+| Unused exported types   | 338             | **310** (-28)  |
+| Duplicate exports       | 41              | 41             |
 
-**Interpretation.** 362 files with no detected consumer is the largest lever.
-Some may be false positives (route files loaded by Remix's flat-router, dynamic
-imports, CLI scripts not listed as entry points). A sampling pass before bulk
-delete is non-negotiable.
+**Interpretation.** 362 files with no detected consumer is the largest lever,
+unchanged after tier-1 because knip does not track NestJS decorator-based DI
+registration. Classes annotated with `@Injectable`, `@Controller`, `@Module`
+are loaded via metadata reflection, not imports — knip sees them as unused.
+Fixing this would require a knip NestJS plugin config or explicit per-file
+entries; out of Phase 0 scope.
+
+A sampling pass before any bulk delete remains non-negotiable — expect that
+a significant fraction of the 362 are NestJS-DI false positives.
 
 ### madge (circular dependencies)
 
@@ -58,16 +76,14 @@ likely require breaking out a shared-types file.
 
 ### ast-grep (pattern rules from `.ast-grep/rules/`)
 
-14 warnings across the 2 initial rules:
+**After tier-1 refinement: 0 warnings, 0 errors.** Both initial false-positive
+clusters have been resolved by tightening the rules, so the baseline is clean.
 
-1. `payments-no-raw-equality` — 1 hit in
-   `backend/src/modules/payments/controllers/paybox-monitoring.controller.ts:159`
-   (`config.hmacKey === 'CONFIGURED'`). Not a real HMAC comparison — it's a
-   status probe. Either whitelist this file, or tighten the rule's AST pattern
-   to match only `crypto`-involved comparisons.
-2. `backend-no-console-log` — 13 hits, all in dev utility scripts
-   (`validate-phase0.ts` etc). Legit in validation CLIs; rule needs a
-   `pathNot: scripts|validators` filter.
+Previously (before tier-1): 14 warnings :
+1. `payments-no-raw-equality` — 1 false positive (`config.hmacKey === 'CONFIGURED'`,
+   status probe not HMAC compare). Fixed by adding `not has kind: string`.
+2. `backend-no-console-log` — 13 hits all in dev utility CLIs (`validate-phase0.ts`).
+   Fixed by adding `ignores: backend/src/**/validate-*.ts` + cli/scripts/test patterns.
 
 **Pending rule** : a guard against raw supplier-prefixed columns (the ones
 suffixed `_i` should always be used instead) is **not yet wired**. The literal

--- a/audit-reports/phase0-baseline.md
+++ b/audit-reports/phase0-baseline.md
@@ -1,0 +1,112 @@
+# Phase 0 — Cleanup Gate Baseline
+
+Generated: 2026-04-24 — branch `feat/claude-knowledge-base`
+
+Deterministic tools ran on the full monorepo with all rules at `severity: warning`
+(Phase 0 is non-blocking by design). This file is the baseline we promote to
+`error` severity after each Phase 1 cleanup pass.
+
+## Raw outputs (same directory)
+
+- `phase0-knip.txt` — unused files / exports / deps
+- `phase0-madge.txt` — circular dependencies
+- `phase0-depcruise.txt` — architectural dependency violations
+- `phase0-astgrep.txt` — rule-pattern violations from `.ast-grep/rules/`
+
+## Summary
+
+### knip (unused code + deps)
+
+| Category                | Count |
+|-------------------------|-------|
+| Unused files            | 362   |
+| Unused dependencies     | 4     |
+| Unused devDependencies  | 4     |
+| Unlisted dependencies   | 10    |
+| Unlisted binaries       | 4     |
+| Unused exports          | 219   |
+| Unused exported types   | 338   |
+| Duplicate exports       | 41    |
+
+**Interpretation.** 362 files with no detected consumer is the largest lever.
+Some may be false positives (route files loaded by Remix's flat-router, dynamic
+imports, CLI scripts not listed as entry points). A sampling pass before bulk
+delete is non-negotiable.
+
+### madge (circular dependencies)
+
+- **Backend**: 16 cycles across `config/role-ids.ts`, `workers/types/`,
+  `modules/admin/services/brief-gates`, `modules/rag-proxy/*`, `modules/products`,
+  `modules/blog`, `modules/support`, `auth ↔ users`.
+- **Frontend**: 1 cycle `root.tsx → hooks/useRootData.ts`.
+
+**Interpretation.** All cycles are local (within a module or between
+directly-coupled modules), none cross the backend/frontend boundary. The
+`rag-proxy/*` cluster (3 cycles) is the densest; refactoring it would most
+likely require breaking out a shared-types file.
+
+### dependency-cruiser (architectural violations)
+
+- 148 warnings on 2101 modules, 8425 dependencies
+- 0 errors (Phase 0 severity = `warn` across the board)
+- 1 flagged phantom dep: `file-type` imported by
+  `backend/src/modules/upload/services/file-validation.service.ts` but not in
+  `package.json` — promote to error after a quick `npm i -D file-type`.
+- Cross-module service imports (`no-deep-module-access`) flagged but left as
+  warning — typical NestJS setup where shared services get imported across
+  module boundaries.
+
+### ast-grep (pattern rules from `.ast-grep/rules/`)
+
+14 warnings across the 2 initial rules:
+
+1. `payments-no-raw-equality` — 1 hit in
+   `backend/src/modules/payments/controllers/paybox-monitoring.controller.ts:159`
+   (`config.hmacKey === 'CONFIGURED'`). Not a real HMAC comparison — it's a
+   status probe. Either whitelist this file, or tighten the rule's AST pattern
+   to match only `crypto`-involved comparisons.
+2. `backend-no-console-log` — 13 hits, all in dev utility scripts
+   (`validate-phase0.ts` etc). Legit in validation CLIs; rule needs a
+   `pathNot: scripts|validators` filter.
+
+**Pending rule** : a guard against raw supplier-prefixed columns (the ones
+suffixed `_i` should always be used instead) is **not yet wired**. The literal
+column prefix in the DB clashes with a project naming constraint; decide on
+the matcher before enabling.
+
+## Gate posture after Phase 0
+
+| Tool                   | Phase 0 posture            | Run via                   |
+|------------------------|----------------------------|---------------------------|
+| ast-grep               | pre-commit, soft-fail      | `npm run audit:ast`       |
+| knip                   | on-demand / CI             | `npm run audit:knip`      |
+| madge                  | on-demand / CI             | `npm run audit:madge`     |
+| dependency-cruiser     | on-demand / CI             | `npm run audit:depcruise` |
+| Full audit             | on-demand                  | `npm run audit:all`       |
+
+**Rationale.** knip / madge / depcruise scan the full monorepo and take
+several seconds to ~1 min each — running them on every commit punishes fast
+iteration. ast-grep is Rust-fast and narrow, so it stays in the pre-commit
+hook as the "symbolic rule" guard.
+
+## Promotion path (after Phase 1 cleanup)
+
+1. Delete or justify each of the 362 unused files (knip review).
+2. Break the 17 cycles (extract shared types, invert one dependency).
+3. Add `file-type` to `package.json`, then promote `no-non-package-json` to
+   `error` in `.dependency-cruiser.cjs`.
+4. Tighten ast-grep `payments-no-raw-equality` (match `crypto.*` contexts only),
+   then promote to `error`.
+5. Add a CI job running `npm run audit:all` on every PR with
+   `--no-exit-code` replaced by strict mode.
+
+## Non-objectives of Phase 0
+
+- Not deleting any code. Only collecting evidence.
+- Not refactoring cycles. Only identifying them.
+- Not failing commits. Only surfacing signals.
+- Not making Phase 1 decisions. Human-in-the-loop for every deletion.
+
+---
+
+_Run `npm run audit:all` to regenerate this data end-to-end._

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "workspaces": {
+    ".": {
+      "entry": ["scripts/**/*.{js,ts,mjs,cjs}"],
+      "project": ["scripts/**/*.{js,ts,mjs,cjs}"],
+      "ignore": [
+        "audit-monorepo/**",
+        "99-meta/**",
+        "output/**",
+        "gates/**",
+        ".spec/**",
+        ".codex",
+        ".local/**"
+      ]
+    },
+    "backend": {
+      "entry": [
+        "src/main.ts",
+        "src/main.server.ts",
+        "src/app.module.ts",
+        "src/workers/**/*.ts",
+        "supabase/migrations/**"
+      ],
+      "project": ["src/**/*.ts", "test/**/*.ts"],
+      "ignore": [
+        "dist/**",
+        "rm/**",
+        "**/*.spec.ts",
+        "**/*.e2e-spec.ts"
+      ],
+      "ignoreDependencies": [
+        "reflect-metadata",
+        "@nestjs/.*"
+      ]
+    },
+    "frontend": {
+      "entry": [
+        "server.js",
+        "app/entry.client.tsx",
+        "app/entry.server.tsx",
+        "app/root.tsx",
+        "app/routes/**/*.{ts,tsx}"
+      ],
+      "project": ["app/**/*.{ts,tsx}"],
+      "ignore": [
+        "build/**",
+        "public/build/**",
+        ".cache/**"
+      ]
+    },
+    "packages/*": {
+      "entry": ["src/index.ts", "src/index.tsx"],
+      "project": ["src/**/*.{ts,tsx}"]
+    }
+  },
+  "ignoreBinaries": ["turbo", "husky"],
+  "rules": {
+    "files": "warn",
+    "dependencies": "warn",
+    "devDependencies": "warn",
+    "unlisted": "warn",
+    "exports": "warn",
+    "types": "warn",
+    "duplicates": "warn"
+  }
+}

--- a/knip.json
+++ b/knip.json
@@ -19,13 +19,17 @@
         "src/main.ts",
         "src/main.server.ts",
         "src/app.module.ts",
+        "src/workers/main.ts",
+        "src/workers/worker.module.ts",
         "src/workers/**/*.ts",
+        "scripts/**/*.{js,ts,mjs,cjs}",
         "supabase/migrations/**"
       ],
       "project": ["src/**/*.ts", "test/**/*.ts"],
       "ignore": [
         "dist/**",
         "rm/**",
+        "scripts/**",
         "**/*.spec.ts",
         "**/*.e2e-spec.ts"
       ],
@@ -40,14 +44,19 @@
         "app/entry.client.tsx",
         "app/entry.server.tsx",
         "app/root.tsx",
-        "app/routes/**/*.{ts,tsx}"
+        "app/routes/**/*.{ts,tsx}",
+        "app/routes.ts"
       ],
       "project": ["app/**/*.{ts,tsx}"],
       "ignore": [
         "build/**",
         "public/build/**",
         ".cache/**"
-      ]
+      ],
+      "remix": {
+        "config": "remix.config.js",
+        "entry": ["app/root.tsx", "app/entry.client.tsx", "app/entry.server.tsx"]
+      }
     },
     "packages/*": {
       "entry": ["src/index.ts", "src/index.tsx"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@ast-grep/cli": "0.42.1",
         "@changesets/cli": "^2.29.7",
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
@@ -49,11 +50,13 @@
         "@types/bcrypt": "^6.0.0",
         "@types/file-type": "^10.9.3",
         "@types/multer": "^2.0.0",
-        "depcheck": "^1.4.7",
+        "dependency-cruiser": "17.3.10",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
+        "knip": "5.60.0",
         "lint-staged": "^16.2.7",
+        "madge": "8.0.0",
         "prettier": "^3.4.1",
         "reflect-metadata": "^0.1.14",
         "rxjs": "^7.8.2",
@@ -1173,6 +1176,152 @@
       "version": "2.3.9",
       "license": "MIT"
     },
+    "node_modules/@ast-grep/cli": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli/-/cli-0.42.1.tgz",
+      "integrity": "sha512-L1D7JX7p/RohtvE4IViKelWCtEYjQDvmlZ85aP4LmJVoQth/iC/+z/fCXmg6qSK8zr9IjC9okpxDZX7x1arKbQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "ast-grep": "ast-grep",
+        "sg": "sg"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "optionalDependencies": {
+        "@ast-grep/cli-darwin-arm64": "0.42.1",
+        "@ast-grep/cli-darwin-x64": "0.42.1",
+        "@ast-grep/cli-linux-arm64-gnu": "0.42.1",
+        "@ast-grep/cli-linux-x64-gnu": "0.42.1",
+        "@ast-grep/cli-win32-arm64-msvc": "0.42.1",
+        "@ast-grep/cli-win32-ia32-msvc": "0.42.1",
+        "@ast-grep/cli-win32-x64-msvc": "0.42.1"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-arm64": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-arm64/-/cli-darwin-arm64-0.42.1.tgz",
+      "integrity": "sha512-G9rk0NAN10mybxi611CVNqwPtPO+yF0rFqPzpdgHBa4roeCq5FYsg2q/WqxM95st3jilNS9UIfZFD0i3BDfKEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-darwin-x64": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-darwin-x64/-/cli-darwin-x64-0.42.1.tgz",
+      "integrity": "sha512-IZ1HY69zj6sj4QnHKPR71FjtuCDImhLW5v5QhTGq6Fl0T9fjhQP/g9aEk7PrJB1puOk4HhTw/J/u0wZOPmp4bA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-arm64-gnu": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-0.42.1.tgz",
+      "integrity": "sha512-eirVmtAciL1cXwvODYkqKEFtWgxxYyhNLTTNchdKynktFixuAmAvn0OUX0bcQnhXH5DgsdT4+1+CtvjuPc5uGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-linux-x64-gnu": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-linux-x64-gnu/-/cli-linux-x64-gnu-0.42.1.tgz",
+      "integrity": "sha512-DrsV3+LkzwcaCw2AkLqM5o9ISaS4ZfJIL96RIdFRD+ydp5Mirsdw3aZdDmBqpa6nxt2NjMsFWgOivvzPiKzGAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-arm64-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-0.42.1.tgz",
+      "integrity": "sha512-9DabeCAtOQEUTiCVB6fpoJ0mI21brEAa5oY2jjOzaz1SBwYuh9TPLnKBn8F+PYbUU/4Umyy26YwVg+xw4+J/Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-ia32-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-0.42.1.tgz",
+      "integrity": "sha512-xQlxTwaqiCzOUZc5lB6rp/glS0DmQd67ID6MliRZ3TH1PvX+a3oiP+QEdSgcvfcArObuKxtRGNKlOfgwMe+J8Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/cli-win32-x64-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/cli-win32-x64-msvc/-/cli-win32-x64-msvc-0.42.1.tgz",
+      "integrity": "sha512-bOMSGeTKGfYBB1m+S0WLiA2GUkNVBaHOy+mKw27mf/kd6W2KNG3DJwAWry35qargLL0WP9PBcCaOkdnzeNyZ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@axe-core/playwright": {
       "version": "4.11.1",
       "dev": true,
@@ -1476,7 +1625,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2711,6 +2862,57 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dependents/detective-less": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-5.0.2.tgz",
+      "integrity": "sha512-QPKO4ao2+iniYAYnPZwHKK67EgDG2GAdye9OCy11xsmApHGwzpH3AcSdPjGyPO3tC2/K8mF7JjWX3A/FTRnskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/hash": {
@@ -4000,6 +4202,25 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@neoconfetti/react": {
       "version": "1.0.0",
       "dev": true,
@@ -4805,6 +5026,289 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
+      "integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
+      "integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz",
+      "integrity": "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
+      "integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
+      "integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
+      "integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
+      "integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
+      "integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
+      "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
+      "integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
+      "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
+      "integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
+      "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
+      "integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
+      "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
+      "integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
+      "integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
+      "integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
+      "integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
+      "integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
@@ -7175,6 +7679,96 @@
       "version": "0.3.0",
       "license": "MIT"
     },
+    "node_modules/@ts-graphviz/adapter": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/adapter/-/adapter-2.0.6.tgz",
+      "integrity": "sha512-kJ10lIMSWMJkLkkCG5gt927SnGZcBuG0s0HHswGzcHTgvtUe7yk5/3zTEr0bafzsodsOq5Gi6FhQeV775nC35Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-graphviz/ast": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/ast/-/ast-2.0.7.tgz",
+      "integrity": "sha512-e6+2qtNV99UT6DJSoLbHfkzfyqY84aIuoV8Xlb9+hZAjgpum8iVHprGeAMQ4rF6sKUAxrmY8rfF/vgAwoPc3gw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-graphviz/common": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/common/-/common-2.1.5.tgz",
+      "integrity": "sha512-S6/9+T6x8j6cr/gNhp+U2olwo1n0jKj/682QVqsh7yXWV6ednHYqxFw0ZsY3LyzT0N8jaZ6jQY9YD99le3cmvg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-graphviz/core": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/core/-/core-2.0.7.tgz",
+      "integrity": "sha512-w071DSzP94YfN6XiWhOxnLpYT3uqtxJBDYdh6Jdjzt+Ce6DNspJsPQgpC7rbts/B8tEkq0LHoYuIF/O5Jh5rPg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/ast": "^2.0.7",
+        "@ts-graphviz/common": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "devOptional": true,
@@ -7194,6 +7788,17 @@
       "version": "1.0.4",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
@@ -7563,11 +8168,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "license": "MIT"
@@ -7601,11 +8201,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/passport": {
       "version": "1.0.17",
@@ -8910,44 +9505,52 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.27",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
+      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@vue/shared": "3.5.27",
-        "entities": "^7.0.0",
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.33",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-core/node_modules/estree-walker": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.27",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
+      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.27",
-        "@vue/shared": "3.5.27"
+        "@vue/compiler-core": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.27",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
+      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@vue/compiler-core": "3.5.27",
-        "@vue/compiler-dom": "3.5.27",
-        "@vue/compiler-ssr": "3.5.27",
-        "@vue/shared": "3.5.27",
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.33",
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/compiler-ssr": "3.5.33",
+        "@vue/shared": "3.5.33",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.10",
         "source-map-js": "^1.2.1"
       }
     },
@@ -8965,16 +9568,20 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.27",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
+      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.27",
-        "@vue/shared": "3.5.27"
+        "@vue/compiler-dom": "3.5.33",
+        "@vue/shared": "3.5.33"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.27",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
+      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -9157,7 +9764,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -9187,8 +9796,30 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -9357,6 +9988,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "license": "MIT"
@@ -9400,14 +10038,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-differ": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/array-flatten": {
@@ -9563,14 +10193,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/arrify": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/asap": {
       "version": "2.0.6",
       "dev": true,
@@ -9582,6 +10204,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-module-types": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.1.tgz",
+      "integrity": "sha512-WHw67kLXYbZuHTmcdbIrVArCq5wxo6NEuj3hiYAWr8mwJeC+C2mMCIBIWCiDoCye/OF/xelc+teJ1ERoWmnEIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ast-types": {
@@ -10285,13 +10917,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/callsite": {
-      "version": "1.0.0",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "dev": true,
@@ -10621,27 +11246,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/cliui": {
-      "version": "7.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/clone": {
       "version": "1.0.4",
       "dev": true,
@@ -10750,6 +11354,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -10943,21 +11554,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/create-jest": {
@@ -11261,6 +11857,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -11342,76 +11948,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/depcheck": {
-      "version": "1.4.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.23.0",
-        "@babel/traverse": "^7.23.2",
-        "@vue/compiler-sfc": "^3.3.4",
-        "callsite": "^1.0.0",
-        "camelcase": "^6.3.0",
-        "cosmiconfig": "^7.1.0",
-        "debug": "^4.3.4",
-        "deps-regex": "^0.2.0",
-        "findup-sync": "^5.0.0",
-        "ignore": "^5.2.4",
-        "is-core-module": "^2.12.0",
-        "js-yaml": "^3.14.1",
-        "json5": "^2.2.3",
-        "lodash": "^4.17.21",
-        "minimatch": "^7.4.6",
-        "multimatch": "^5.0.0",
-        "please-upgrade-node": "^3.2.0",
-        "readdirp": "^3.6.0",
-        "require-package-name": "^2.0.1",
-        "resolve": "^1.22.3",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "depcheck": "bin/depcheck.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/depcheck/node_modules/argparse": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/depcheck/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/depcheck/node_modules/minimatch": {
-      "version": "7.4.9",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "license": "MIT",
@@ -11419,10 +11955,105 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/deps-regex": {
-      "version": "0.2.0",
+    "node_modules/dependency-cruiser": {
+      "version": "17.3.10",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.3.10.tgz",
+      "integrity": "sha512-jF5WaIb+O+wLabXrQE7iBY2zYBEW8VlnuuL0+iZPvZHGhTaAYdLk31DI0zkwhcGE8CiHcDwGhMnn3PfOAYnVdQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "8.16.0",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.5.2",
+        "acorn-walk": "8.3.5",
+        "commander": "14.0.3",
+        "enhanced-resolve": "5.20.1",
+        "ignore": "7.0.5",
+        "interpret": "3.1.1",
+        "is-installed-globally": "1.0.0",
+        "json5": "2.2.3",
+        "picomatch": "4.0.4",
+        "prompts": "2.4.2",
+        "rechoir": "0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "7.7.4",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
+        "watskeburt": "5.0.3"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.mjs",
+        "depcruise-baseline": "bin/depcruise-baseline.mjs",
+        "depcruise-fmt": "bin/depcruise-fmt.mjs",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+        "dependency-cruise": "bin/dependency-cruise.mjs",
+        "dependency-cruiser": "bin/dependency-cruise.mjs"
+      },
+      "engines": {
+        "node": "^20.12||^22||>=24"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/dependency-tree": {
+      "version": "11.4.3",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.4.3.tgz",
+      "integrity": "sha512-Y2gzOJ2Rb2X7MN6pT9llWpXxl5J5s5/11CBpJ5b85DjEqZH7jv3T9RO6HRV/PI/3MDmaKn/g7uoYdYmSb9vLlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "filing-cabinet": "^5.3.0",
+        "precinct": "^12.3.1",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "dependency-tree": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -11438,14 +12069,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/detect-file": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/detect-indent": {
@@ -11474,6 +12097,272 @@
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "license": "MIT"
+    },
+    "node_modules/detective-amd": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-6.0.2.tgz",
+      "integrity": "sha512-qX4zkNVcufOoo7pKlRnLHEzUwDcqIY5N9FEuNJN+rDUjct3gikNdVJXRfpI6sG/Y9pfIMjcXeNdHV1oYulxjmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "escodegen": "^2.1.0",
+        "get-amd-module-type": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "bin": {
+        "detective-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-cjs": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-6.1.1.tgz",
+      "integrity": "sha512-pSh7mkCKEtLlmANqLu3KDFS3NV8Hx41jy/JF1/gAWOgU+Uo5QTkeI1tWNP4dWGo4L0E9j18Ez9EPsTleautKqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-es6": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-5.0.2.tgz",
+      "integrity": "sha512-+qHHGYhjupiVs4rnIpI9nZ5B130A4AmE35ZX1w33hb46vcZ7T3jfDbvmPw0FhWtMHn5BS5HHu7ZtnZ53bMcXZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-postcss": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-7.0.1.tgz",
+      "integrity": "sha512-bEOVpHU9picRZux5XnwGsmCN4+8oZo7vSW0O0/Enq/TO5R2pIAP2279NsszpJR7ocnQt4WXU0+nnh/0JuK4KHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-url": "^1.2.4",
+        "postcss-values-parser": "^6.0.2"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.47"
+      }
+    },
+    "node_modules/detective-sass": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-6.0.1.tgz",
+      "integrity": "sha512-jSGPO8QDy7K7pztUmGC6aiHkexBQT4GIH+mBAL9ZyBmnUIOFbkfZnO8wPRRJFP/QP83irObgsZHCoDHZ173tRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-scss": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-5.0.1.tgz",
+      "integrity": "sha512-MAyPYRgS6DCiS6n6AoSBJXLGVOydsr9huwXORUlJ37K3YLyiN0vYHpzs3AdJOgHobBfispokoqrEon9rbmKacg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-stylus": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-5.0.1.tgz",
+      "integrity": "sha512-Dgn0bUqdGbE3oZJ+WCKf8Dmu7VWLcmRJGc6RCzBgG31DLIyai9WAoEhYRgIHpt/BCRMrnXLbGWGPQuBUrnF0TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-typescript": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-14.1.2.tgz",
+      "integrity": "sha512-bIeEn0eVi/JRsE1YizBR2ilnMlWRAIBJJ6kXCKNFxEEWhUcEY3R6I3KYIAy48ieURbD1hcb3Ebvl8AqeoPMSzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^8.58.2",
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4 || ^6.0.2"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/detective-typescript/node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/detective-vue2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/detective-vue2/-/detective-vue2-2.3.0.tgz",
+      "integrity": "sha512-3gwbZPqVTm9sL9XdZsgEJ7x4x99O853VVZHapQAiEkGuMJMpFPjHDrecSgfqnS5JW3FJfYXesLZGvUOibjn49g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dependents/detective-less": "^5.0.1",
+        "@vue/compiler-sfc": "^3.5.32",
+        "detective-es6": "^5.0.1",
+        "detective-sass": "^6.0.1",
+        "detective-scss": "^5.0.1",
+        "detective-stylus": "^5.0.1",
+        "detective-typescript": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4 || ^6.0.2"
+      }
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -11784,7 +12673,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12125,6 +13016,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -13385,17 +14309,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/expand-tilde": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "homedir-polyfill": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/expect": {
       "version": "29.7.0",
       "dev": true,
@@ -13643,6 +14556,16 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "license": "MIT",
@@ -13740,6 +14663,42 @@
         "node": ">= 10.4.0"
       }
     },
+    "node_modules/filing-cabinet": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.3.0.tgz",
+      "integrity": "sha512-2EwtzdQkC37FJxDOrKuEOplTFzzaToCqzT008DrIWW27RQ6psxitfUi6hct5mUhMHO7C6xopOhxubyjyPCapbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-module-path": "^2.2.0",
+        "commander": "^12.1.0",
+        "enhanced-resolve": "^5.20.1",
+        "module-definition": "^6.0.1",
+        "module-lookup-amd": "^9.1.1",
+        "resolve": "^1.22.12",
+        "resolve-dependency-path": "^4.0.1",
+        "sass-lookup": "^6.1.1",
+        "stylus-lookup": "^6.1.1",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "filing-cabinet": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "license": "MIT",
@@ -13787,20 +14746,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/findup-sync": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.4",
-        "resolve-dir": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
       }
     },
     "node_modules/fix-dts-default-cjs-exports": {
@@ -13992,6 +14937,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/formatly": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.2.4.tgz",
+      "integrity": "sha512-lIN7GpcvX/l/i24r/L9bnJ0I8Qn01qijWpQpDDvTLL29nKqSaJJu4h20+7VJ6m2CAhQ2/En/GbxDiHCzq/0MyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^2.0.0"
+      },
+      "bin": {
+        "formatly": "bin/index.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0"
       }
     },
     "node_modules/formdata-node": {
@@ -14219,6 +15180,20 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-amd-module-type": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-6.0.2.tgz",
+      "integrity": "sha512-7zShVYAYtMnj9S65CfN+hvpBCByfuB1OY8xID01nZEzXTZbx4YyysAfi+nMl95JSR6odt4q8TCj2W63KAoyVLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "license": "ISC",
@@ -14265,6 +15240,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
@@ -14323,7 +15305,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.6",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14422,45 +15406,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/global-modules": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/global-prefix": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/global-prefix/node_modules/which": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/globals": {
       "version": "13.24.0",
       "dev": true,
@@ -14513,6 +15458,22 @@
       "version": "0.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "gonzales": "bin/gonzales.js"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/google-auth-library": {
       "version": "10.5.0",
@@ -14845,17 +15806,6 @@
     "node_modules/help-me": {
       "version": "5.0.0",
       "license": "MIT"
-    },
-    "node_modules/homedir-polyfill": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse-passwd": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/hosted-git-info": {
       "version": "6.1.3",
@@ -15245,6 +16195,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/ioredis": {
       "version": "5.9.2",
       "license": "MIT",
@@ -15594,6 +16554,36 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-installed-globally/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "dev": true,
@@ -15710,6 +16700,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-set": {
       "version": "2.0.3",
       "dev": true,
@@ -15803,6 +16803,26 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-url-superb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17236,6 +18256,89 @@
         "node": ">=6"
       }
     },
+    "node_modules/knip": {
+      "version": "5.60.0",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-5.60.0.tgz",
+      "integrity": "sha512-r6oIbaV0Ztz/7DKe1voxg2O5IRhLi9Q0GjhplfRqUZ1gvTChew6ywmLzehuaXIHVKkPs8LF5UKOxFlc93RKzow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        },
+        {
+          "type": "polar",
+          "url": "https://polar.sh/webpro-nl"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "@nodelib/fs.walk": "^1.2.3",
+        "fast-glob": "^3.3.3",
+        "formatly": "^0.2.4",
+        "jiti": "^2.4.2",
+        "js-yaml": "^4.1.0",
+        "minimist": "^1.2.8",
+        "oxc-resolver": "^11.1.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.1",
+        "smol-toml": "^1.3.4",
+        "strip-json-comments": "5.0.2",
+        "zod": "^3.22.4",
+        "zod-validation-error": "^3.0.3"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18",
+        "typescript": ">=5.0.4"
+      }
+    },
+    "node_modules/knip/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/knip/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/knip/node_modules/strip-json-comments": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.2.tgz",
+      "integrity": "sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "dev": true,
@@ -17796,6 +18899,55 @@
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/madge": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-8.0.0.tgz",
+      "integrity": "sha512-9sSsi3TBPhmkTCIpVQF0SPiChj1L7Rq9kU2KDG1o6v2XH9cCw086MopjVCD+vuoL5v8S77DTbVopTO8OUiQpIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^7.2.0",
+        "commondir": "^1.0.1",
+        "debug": "^4.3.4",
+        "dependency-tree": "^11.0.0",
+        "ora": "^5.4.1",
+        "pluralize": "^8.0.0",
+        "pretty-ms": "^7.0.1",
+        "rc": "^1.2.8",
+        "stream-to-array": "^2.3.0",
+        "ts-graphviz": "^2.1.2",
+        "walkdir": "^0.4.1"
+      },
+      "bin": {
+        "madge": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/pahen"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/madge/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/magic-string": {
@@ -19028,6 +20180,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/module-definition": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.2.tgz",
+      "integrity": "sha512-SvAU3lB0+Yjbq55yHY3wkRZBOh+fhU1SnIF3IFbTewv6mtAh7yUT8ACHAJ2mGIJ7tCes2QuCL/cl6m0JSZ/ArA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "bin": {
+        "module-definition": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/module-lookup-amd": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.1.2.tgz",
+      "integrity": "sha512-HFEiUNm8/woZFJZcd42wrovEHjHN6nwfNjf2CjiVLbVFRbj+sEmEJn0mrx8JY4/qJP8wSZTtmguikAJBqEuRRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "requirejs": "^2.3.8",
+        "requirejs-config-file": "^4.0.0"
+      },
+      "bin": {
+        "lookup-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/module-lookup-amd/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/morgan": {
       "version": "1.10.1",
       "license": "MIT",
@@ -19247,44 +20444,6 @@
         "node": ">= 10.16.0"
       }
     },
-    "node_modules/multimatch": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "array-differ": "^3.0.0",
-        "array-union": "^2.1.0",
-        "arrify": "^2.0.1",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/multimatch/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/multimatch/node_modules/minimatch": {
-      "version": "3.1.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "dev": true,
@@ -19501,6 +20660,19 @@
     "node_modules/node-releases": {
       "version": "2.0.27",
       "license": "MIT"
+    },
+    "node_modules/node-source-walk": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-7.0.1.tgz",
+      "integrity": "sha512-3VW/8JpPqPvnJvseXowjZcirPisssnBuDikk6JIZ8jQzF7KJQX52iPFX4RYYxLycYH7IbMRSPUOga/esVjy5Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.26.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nodemailer": {
       "version": "8.0.1",
@@ -20054,6 +21226,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oxc-resolver": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
+      "integrity": "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.19.1",
+        "@oxc-resolver/binding-android-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-x64": "11.19.1",
+        "@oxc-resolver/binding-freebsd-x64": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-musl": "11.19.1",
+        "@oxc-resolver/binding-openharmony-arm64": "11.19.1",
+        "@oxc-resolver/binding-wasm32-wasi": "11.19.1",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
+      }
+    },
     "node_modules/p-filter": {
       "version": "2.1.0",
       "dev": true,
@@ -20194,14 +21398,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parse-passwd": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/parse5": {
@@ -20602,14 +21798,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/please-upgrade-node": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver-compare": "^1.0.0"
-      }
-    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "dev": true,
@@ -20634,7 +21822,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -20878,6 +22068,64 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "license": "MIT"
+    },
+    "node_modules/postcss-values-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+      "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "is-url-superb": "^4.0.0",
+        "quote-unquote": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.9"
+      }
+    },
+    "node_modules/precinct": {
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-12.3.1.tgz",
+      "integrity": "sha512-wGyTIvtxh2S2NAHxTJj0YymxWOIcEDotu17yHoQUd2Bz2C07LrS28L1nvXDMxrCHvHmV6KTlaIQy5PzRm7Y8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dependents/detective-less": "^5.0.1",
+        "commander": "^12.1.0",
+        "detective-amd": "^6.0.1",
+        "detective-cjs": "^6.1.0",
+        "detective-es6": "^5.0.1",
+        "detective-postcss": "^7.0.1",
+        "detective-sass": "^6.0.1",
+        "detective-scss": "^5.0.1",
+        "detective-stylus": "^5.0.1",
+        "detective-typescript": "^14.1.1",
+        "detective-vue2": "^2.3.0",
+        "module-definition": "^6.0.1",
+        "node-source-walk": "^7.0.1",
+        "postcss": "^8.5.10",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "precinct": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/precinct/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -21400,6 +22648,13 @@
       "version": "4.0.4",
       "license": "MIT"
     },
+    "node_modules/quote-unquote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+      "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/random-bytes": {
       "version": "1.0.0",
       "license": "MIT",
@@ -21433,6 +22688,32 @@
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21779,6 +23060,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "dev": true,
@@ -21842,6 +23136,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -22016,11 +23320,6 @@
         "node": "*"
       }
     },
-    "node_modules/require-package-name": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/requireindex": {
       "version": "1.2.0",
       "dev": true,
@@ -22029,10 +23328,41 @@
         "node": ">=0.10.5"
       }
     },
-    "node_modules/resolve": {
-      "version": "1.22.11",
+    "node_modules/requirejs": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.8.tgz",
+      "integrity": "sha512-7/cTSLOdYkNBNJcDMWf+luFvMriVm7eYxp4BcFCsAX0wF421Vyce5SXP17c+Jd5otXKGNehIonFlyQXSowL6Mw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "r_js": "bin/r.js",
+        "r.js": "bin/r.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/requirejs-config-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/requirejs-config-file/-/requirejs-config-file-4.0.0.tgz",
+      "integrity": "sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
+        "esprima": "^4.0.0",
+        "stringify-object": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -22058,16 +23388,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-dir": {
-      "version": "1.0.1",
+    "node_modules/resolve-dependency-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-4.0.1.tgz",
+      "integrity": "sha512-YQftIIC4vzO9UMhO/sCgXukNyiwVRCVaxiWskCBy7Zpqkplm8kTAISZ8O1MoKW1ca6xzgLUBjZTcDgypXvXxiQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
-      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=18"
       }
     },
     "node_modules/resolve-from": {
@@ -22423,6 +23751,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
+    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "license": "MIT",
@@ -22448,6 +23786,33 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/sass-lookup": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-6.1.1.tgz",
+      "integrity": "sha512-12dvZdQYTeKZ1ypjuiijZYuMZ1m0F+4+BkRX5yJi2WA9W3DBUrcdCt7bVuKlagHl11n8eYtalWDle+m98Ol2DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "enhanced-resolve": "^5.20.0"
+      },
+      "bin": {
+        "sass-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sass-lookup/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -22545,11 +23910,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -22860,6 +24220,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/socket.io": {
@@ -23220,6 +24593,16 @@
       "version": "0.1.2",
       "license": "MIT"
     },
+    "node_modules/stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.1.0"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "engines": {
@@ -23474,6 +24857,31 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/stringify-object/node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.2",
       "license": "MIT",
@@ -23595,6 +25003,32 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.1.1"
+      }
+    },
+    "node_modules/stylus-lookup": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-6.1.1.tgz",
+      "integrity": "sha512-0+xmFLaqWksv5/pMiZtONG6gP82YNGVWgKiQXvw8cdKVFEJ++X9dySGR0hG+A+78PBtbHPqiJzXi2ZKoWr/7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "stylus-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/stylus-lookup/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/sucrase": {
@@ -24186,11 +25620,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -24386,6 +25822,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.10"
+      }
+    },
+    "node_modules/ts-graphviz": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-2.1.6.tgz",
+      "integrity": "sha512-XyLVuhBVvdJTJr2FJJV2L1pc4MwSjMhcunRVgDE9k4wbb2ee7ORYnPewxMWUav12vxyfUM686MSGsqnVRIInuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/adapter": "^2.0.6",
+        "@ts-graphviz/ast": "^2.0.7",
+        "@ts-graphviz/common": "^2.1.5",
+        "@ts-graphviz/core": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -26071,6 +27533,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "dev": true,
@@ -26089,6 +27571,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/watskeburt": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.3.tgz",
+      "integrity": "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "watskeburt": "dist/run-cli.js"
+      },
+      "engines": {
+        "node": "^20.12||^22.13||>=24.0"
       }
     },
     "node_modules/wcwidth": {
@@ -26492,44 +27987,11 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "16.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/yn": {
@@ -26577,6 +28039,19 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
+      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.24.4"
       }
     },
     "node_modules/zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
-        "knip": "5.60.0",
+        "knip": "6.6.2",
         "lint-staged": "^16.2.7",
         "madge": "8.0.0",
         "prettier": "^3.4.1",
@@ -2885,7 +2885,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -2898,7 +2897,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2910,7 +2908,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -5026,6 +5023,358 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
       "version": "11.19.1",
@@ -9300,22 +9649,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vitest/browser/node_modules/yaml": {
-      "version": "2.8.2",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -14940,9 +15273,9 @@
       }
     },
     "node_modules/formatly": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.2.4.tgz",
-      "integrity": "sha512-lIN7GpcvX/l/i24r/L9bnJ0I8Qn01qijWpQpDDvTLL29nKqSaJJu4h20+7VJ6m2CAhQ2/En/GbxDiHCzq/0MyA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18257,9 +18590,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "5.60.0",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-5.60.0.tgz",
-      "integrity": "sha512-r6oIbaV0Ztz/7DKe1voxg2O5IRhLi9Q0GjhplfRqUZ1gvTChew6ywmLzehuaXIHVKkPs8LF5UKOxFlc93RKzow==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.6.2.tgz",
+      "integrity": "sha512-ma2p+SvgIs1GZZLUV9QJrLkb9gGNBQHk7fcrtt3aVhiW2XEXH/yfMOU88F7ZdriYuBYkB53djPNYMWb2pKVl/g==",
       "dev": true,
       "funding": [
         {
@@ -18269,38 +18602,31 @@
         {
           "type": "opencollective",
           "url": "https://opencollective.com/knip"
-        },
-        {
-          "type": "polar",
-          "url": "https://polar.sh/webpro-nl"
         }
       ],
       "license": "ISC",
       "dependencies": {
-        "@nodelib/fs.walk": "^1.2.3",
-        "fast-glob": "^3.3.3",
-        "formatly": "^0.2.4",
-        "jiti": "^2.4.2",
-        "js-yaml": "^4.1.0",
+        "fdir": "^6.5.0",
+        "formatly": "^0.3.0",
+        "get-tsconfig": "4.14.0",
+        "jiti": "^2.6.0",
         "minimist": "^1.2.8",
-        "oxc-resolver": "^11.1.0",
-        "picocolors": "^1.1.1",
-        "picomatch": "^4.0.1",
-        "smol-toml": "^1.3.4",
-        "strip-json-comments": "5.0.2",
-        "zod": "^3.22.4",
-        "zod-validation-error": "^3.0.3"
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
+        "picomatch": "^4.0.4",
+        "smol-toml": "^1.6.1",
+        "strip-json-comments": "5.0.3",
+        "tinyglobby": "^0.2.16",
+        "unbash": "^3.0.0",
+        "yaml": "^2.8.2",
+        "zod": "^4.1.11"
       },
       "bin": {
         "knip": "bin/knip.js",
         "knip-bun": "bin/knip-bun.js"
       },
       "engines": {
-        "node": ">=18.18.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18",
-        "typescript": ">=5.0.4"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/knip/node_modules/jiti": {
@@ -18327,9 +18653,9 @@
       }
     },
     "node_modules/knip/node_modules/strip-json-comments": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.2.tgz",
-      "integrity": "sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18337,6 +18663,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/knip/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -18429,20 +18765,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/lint-staged/node_modules/yaml": {
-      "version": "2.8.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/listr2": {
@@ -21226,6 +21548,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+      }
+    },
     "node_modules/oxc-resolver": {
       "version": "11.19.1",
       "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
@@ -21929,21 +22289,6 @@
         "ts-node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/postcss-load-config/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/postcss-modules": {
@@ -26243,22 +26588,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/tsup/node_modules/yaml": {
-      "version": "2.8.2",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tsutils": {
       "version": "3.21.0",
       "dev": true,
@@ -26560,6 +26889,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unbash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
+      "integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/unbox-primitive": {
@@ -27503,22 +27842,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "license": "MIT"
@@ -27987,6 +28310,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "license": "ISC",
@@ -28039,19 +28377,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
-      }
-    },
-    "node_modules/zod-validation-error": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.5.4.tgz",
-      "integrity": "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.24.4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
     "docs:build": "cd .spec/docs && npm run build",
     "dev:full": "echo '⚠️ Lancer dans 2 terminaux: 1) npm run dev (backend+frontend port 3000), 2) npm run docs:dev (portail port 3002)'",
     "prepare": "husky",
-    "check:no-client-localhost": "bash scripts/check-no-client-localhost.sh"
+    "check:no-client-localhost": "bash scripts/check-no-client-localhost.sh",
+    "audit:knip": "knip --no-exit-code --reporter compact",
+    "audit:madge": "madge --circular --extensions ts,tsx backend/src frontend/app",
+    "audit:depcruise": "depcruise --config .dependency-cruiser.cjs --output-type err-long backend/src frontend/app",
+    "audit:ast": "ast-grep scan",
+    "audit:all": "npm run audit:ast && npm run audit:madge && npm run audit:depcruise && npm run audit:knip"
   },
   "keywords": [],
   "author": "",
@@ -44,6 +49,7 @@
     "packages/*"
   ],
   "devDependencies": {
+    "@ast-grep/cli": "0.42.1",
     "@changesets/cli": "^2.29.7",
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
@@ -53,11 +59,13 @@
     "@types/bcrypt": "^6.0.0",
     "@types/file-type": "^10.9.3",
     "@types/multer": "^2.0.0",
-    "depcheck": "^1.4.7",
+    "dependency-cruiser": "17.3.10",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "knip": "5.60.0",
     "lint-staged": "^16.2.7",
+    "madge": "8.0.0",
     "prettier": "^3.4.1",
     "reflect-metadata": "^0.1.14",
     "rxjs": "^7.8.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "knip": "5.60.0",
+    "knip": "6.6.2",
     "lint-staged": "^16.2.7",
     "madge": "8.0.0",
     "prettier": "^3.4.1",
@@ -102,7 +102,10 @@
     "path-to-regexp": "3.3.0",
     "zod": "^3.25.76",
     "typescript": "^5.9.3",
-    "handlebars": "4.7.9"
+    "handlebars": "4.7.9",
+    "knip": {
+      "zod": "^4.0.0"
+    }
   },
   "lint-staged": {
     "frontend/app/**/*.{ts,tsx}": [

--- a/scripts/knowledge/refresh-knowledge.py
+++ b/scripts/knowledge/refresh-knowledge.py
@@ -43,6 +43,41 @@ EXPORTS_ARRAY_RE = re.compile(r"exports\s*:\s*\[([^\]]*)\]", re.DOTALL)
 PROVIDERS_ARRAY_RE = re.compile(r"providers\s*:\s*\[([^\]]*)\]", re.DOTALL)
 CLASS_ID_RE = re.compile(r"\b([A-Z][A-Za-z0-9_]*)\b")
 
+# JS/TS comment strippers — apply to source before regex extraction so that
+# words inside // or /* */ don't leak into the detected identifiers list.
+LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+# Heuristic suffix filter: NestJS providers/exports/imports almost always end
+# with one of these. Words without a recognised suffix are likely comment
+# fragments, not real class identifiers. Keeps `Module` for imports matching,
+# and domain suffixes for providers/exports.
+NEST_CLASS_SUFFIXES = (
+    "Module",
+    "Service",
+    "Controller",
+    "Repository",
+    "Guard",
+    "Interceptor",
+    "Pipe",
+    "Filter",
+    "Strategy",
+    "Provider",
+    "Gateway",
+    "Middleware",
+    "Factory",
+    "Handler",
+    "Resolver",
+)
+
+
+def _strip_comments(src: str) -> str:
+    return BLOCK_COMMENT_RE.sub("", LINE_COMMENT_RE.sub("", src))
+
+
+def _looks_like_nest_class(ident: str) -> bool:
+    return ident.endswith(NEST_CLASS_SUFFIXES)
+
 
 @dataclass
 class ModuleInfo:
@@ -75,7 +110,12 @@ def detect_modules(only: str | None = None) -> list[ModuleInfo]:
 
 
 def analyze_module(mod_dir: Path, module_file: Path) -> ModuleInfo:
-    content = module_file.read_text(encoding="utf-8", errors="replace")
+    raw = module_file.read_text(encoding="utf-8", errors="replace")
+    # Strip comments before regex-matching @Module arrays — otherwise fragments
+    # like `// SAFE changes`, `// Data services`, `/* Callback Gate */` leak
+    # into the detected identifiers list and pollute the knowledge .md.
+    content = _strip_comments(raw)
+
     imports_match = IMPORTS_ARRAY_RE.search(content)
     exports_match = EXPORTS_ARRAY_RE.search(content)
     providers_match = PROVIDERS_ARRAY_RE.search(content)
@@ -92,13 +132,13 @@ def analyze_module(mod_dir: Path, module_file: Path) -> ModuleInfo:
     exports: list[str] = []
     if exports_match:
         for ident in CLASS_ID_RE.findall(exports_match.group(1)):
-            if ident not in exports:
+            if _looks_like_nest_class(ident) and ident not in exports:
                 exports.append(ident)
 
     providers: list[str] = []
     if providers_match:
         for ident in CLASS_ID_RE.findall(providers_match.group(1)):
-            if ident not in providers:
+            if _looks_like_nest_class(ident) and ident not in providers:
                 providers.append(ident)
 
     primary_files = sorted(

--- a/scripts/knowledge/refresh-knowledge.py
+++ b/scripts/knowledge/refresh-knowledge.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Refresh .claude/knowledge/ files from the codebase.
+
+Modes
+-----
+    bootstrap              Create missing .md files, never overwrite human edits.
+    refresh                Rewrite only the `<!-- AUTO-GENERATED -->` block in
+                           existing .md files. Idempotent.
+    --headers-only         Update the YAML frontmatter only. Fast; designed for
+                           the pre-commit hook.
+    --module NAME          Limit to a single module.
+
+Non-goals
+---------
+    * No deletion of .md files even if the underlying module disappears.
+    * No touch to prose sections ("Rôle", "Pourquoi", "Gotchas", "Références")
+      — those are human-owned.
+    * No network, no LLM, no embeddings. pyyaml + stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+APP_ROOT = Path(__file__).resolve().parents[2]
+KNOWLEDGE_DIR = APP_ROOT / ".claude" / "knowledge"
+MODULES_DIR = KNOWLEDGE_DIR / "modules"
+BACKEND_MODULES_DIR = APP_ROOT / "backend" / "src" / "modules"
+
+AUTO_GEN_BEGIN = "<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->"
+AUTO_GEN_END = "<!-- END AUTO-GENERATED -->"
+
+MODULE_CLASS_RE = re.compile(r"class\s+(\w+Module)\b")
+IMPORTS_ARRAY_RE = re.compile(r"imports\s*:\s*\[([^\]]*)\]", re.DOTALL)
+EXPORTS_ARRAY_RE = re.compile(r"exports\s*:\s*\[([^\]]*)\]", re.DOTALL)
+PROVIDERS_ARRAY_RE = re.compile(r"providers\s*:\s*\[([^\]]*)\]", re.DOTALL)
+CLASS_ID_RE = re.compile(r"\b([A-Z][A-Za-z0-9_]*)\b")
+
+
+@dataclass
+class ModuleInfo:
+    name: str
+    module_file: Path
+    primary_files: list[Path] = field(default_factory=list)
+    exports: list[str] = field(default_factory=list)
+    providers: list[str] = field(default_factory=list)
+    depends_on: list[str] = field(default_factory=list)
+
+
+def detect_modules(only: str | None = None) -> list[ModuleInfo]:
+    if not BACKEND_MODULES_DIR.exists():
+        return []
+    modules: list[ModuleInfo] = []
+    for mod_dir in sorted(BACKEND_MODULES_DIR.iterdir()):
+        if not mod_dir.is_dir():
+            continue
+        if only and mod_dir.name != only:
+            continue
+        module_file = mod_dir / f"{mod_dir.name}.module.ts"
+        if not module_file.exists():
+            # some folders use a different naming convention
+            candidates = list(mod_dir.glob("*.module.ts"))
+            if not candidates:
+                continue
+            module_file = candidates[0]
+        modules.append(analyze_module(mod_dir, module_file))
+    return modules
+
+
+def analyze_module(mod_dir: Path, module_file: Path) -> ModuleInfo:
+    content = module_file.read_text(encoding="utf-8", errors="replace")
+    imports_match = IMPORTS_ARRAY_RE.search(content)
+    exports_match = EXPORTS_ARRAY_RE.search(content)
+    providers_match = PROVIDERS_ARRAY_RE.search(content)
+
+    this_module_class_names = {m.group(1) for m in MODULE_CLASS_RE.finditer(content)}
+
+    depends_on: list[str] = []
+    if imports_match:
+        for ident in CLASS_ID_RE.findall(imports_match.group(1)):
+            if ident.endswith("Module") and ident not in this_module_class_names:
+                if ident not in depends_on:
+                    depends_on.append(ident)
+
+    exports: list[str] = []
+    if exports_match:
+        for ident in CLASS_ID_RE.findall(exports_match.group(1)):
+            if ident not in exports:
+                exports.append(ident)
+
+    providers: list[str] = []
+    if providers_match:
+        for ident in CLASS_ID_RE.findall(providers_match.group(1)):
+            if ident not in providers:
+                providers.append(ident)
+
+    primary_files = sorted(
+        p for p in mod_dir.rglob("*.ts")
+        if not p.name.endswith(".spec.ts")
+        and not p.name.endswith(".e2e-spec.ts")
+        and not p.name.endswith(".d.ts")
+    )[:8]
+
+    return ModuleInfo(
+        name=mod_dir.name,
+        module_file=module_file,
+        primary_files=primary_files,
+        exports=exports,
+        providers=providers,
+        depends_on=depends_on,
+    )
+
+
+def _rel(p: Path) -> str:
+    return str(p.relative_to(APP_ROOT))
+
+
+def build_frontmatter(mod: ModuleInfo) -> str:
+    fm: dict = {
+        "module": mod.name,
+        "sources": [_rel(mod.module_file.parent)],
+        "last_scan": str(date.today()),
+        "primary_files": [_rel(p) for p in mod.primary_files],
+        "depends_on": mod.depends_on,
+    }
+    return yaml.safe_dump(fm, default_flow_style=False, allow_unicode=True, sort_keys=False).strip()
+
+
+def build_auto_block(mod: ModuleInfo) -> str:
+    exports_list = "\n".join(f"- `{e}`" for e in mod.exports) or "- _(aucun export dans le `@Module({exports: [...]})`)_"
+    providers_list = "\n".join(f"- `{p}`" for p in mod.providers[:15]) or "- _(aucun provider détecté)_"
+    files_list = "\n".join(f"- [{_rel(p)}](../../../{_rel(p)})" for p in mod.primary_files)
+
+    return f"""{AUTO_GEN_BEGIN}
+
+### Exports publics du module
+{exports_list}
+
+### Providers (top 15)
+{providers_list}
+
+### Fichiers primaires
+{files_list}
+
+{AUTO_GEN_END}"""
+
+
+def build_full_md(mod: ModuleInfo) -> str:
+    title = mod.name.replace("-", " ").title()
+    return f"""---
+{build_frontmatter(mod)}
+---
+
+# Module {title}
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+{build_auto_block(mod)}
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._
+"""
+
+
+def replace_auto_block(existing: str, mod: ModuleInfo) -> str:
+    new_block = build_auto_block(mod)
+    pattern = re.compile(
+        rf"{re.escape(AUTO_GEN_BEGIN)}.*?{re.escape(AUTO_GEN_END)}",
+        re.DOTALL,
+    )
+    if pattern.search(existing):
+        return pattern.sub(new_block, existing, count=1)
+    # delimiters missing: append block at end (conservative — no prose overwrite)
+    return existing.rstrip() + "\n\n" + new_block + "\n"
+
+
+def replace_frontmatter(existing: str, mod: ModuleInfo) -> str:
+    new_fm = f"---\n{build_frontmatter(mod)}\n---\n"
+    if existing.startswith("---\n"):
+        return re.sub(r"^---\n.*?\n---\n", new_fm, existing, count=1, flags=re.DOTALL)
+    return new_fm + existing
+
+
+def process(mode: str, mods: Iterable[ModuleInfo], headers_only: bool) -> tuple[int, int]:
+    MODULES_DIR.mkdir(parents=True, exist_ok=True)
+    created = updated = 0
+    for mod in mods:
+        md_path = MODULES_DIR / f"{mod.name}.md"
+        if not md_path.exists():
+            if mode == "bootstrap":
+                md_path.write_text(build_full_md(mod), encoding="utf-8")
+                print(f"CREATED  {_rel(md_path)}")
+                created += 1
+            else:
+                print(f"SKIP     {mod.name} (no .md, use `bootstrap` mode to create)")
+            continue
+        existing = md_path.read_text(encoding="utf-8")
+        new = replace_frontmatter(existing, mod) if headers_only else replace_auto_block(existing, mod)
+        if headers_only is False and not headers_only:
+            # Always refresh frontmatter too in non-headers-only modes (keeps last_scan current)
+            new = replace_frontmatter(new, mod)
+        if new != existing:
+            md_path.write_text(new, encoding="utf-8")
+            print(f"UPDATED  {_rel(md_path)}")
+            updated += 1
+    return created, updated
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("mode", choices=["bootstrap", "refresh"], help="bootstrap: create missing. refresh: only update AUTO blocks.")
+    ap.add_argument("--module", help="Limit to one module name (directory name under backend/src/modules).")
+    ap.add_argument("--headers-only", action="store_true", help="Only refresh the YAML frontmatter. Fast path for pre-commit.")
+    args = ap.parse_args()
+
+    modules = detect_modules(only=args.module)
+    if not modules:
+        print("No modules found under backend/src/modules/.", file=sys.stderr)
+        return 1
+
+    created, updated = process(args.mode, modules, headers_only=args.headers_only)
+    print(f"Done. {len(modules)} modules scanned, {created} created, {updated} updated.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,5 @@
+# ast-grep scan config — turns rules in .claude/rules/ into mechanical guards.
+# Severity starts at "warning" for new rules; promote to "error" once the codebase is clean.
+# Run via:   npx ast-grep scan
+ruleDirs:
+  - .ast-grep/rules


### PR DESCRIPTION
## Contexte

Claude Code relisait tous les fichiers pour chaque question sur le codebase — gaspillage de tokens et de temps. Le `governance-vault` couvre la gouvernance, pas le code applicatif. Cette PR installe deux couches orthogonales :

1. Une **mémoire codebase** en markdown lue en premier par Claude (lecture directe, pas de MCP round-trip).
2. Des **garde-fous déterministes** pour gérer le cleanup sans tokens LLM.

Alternatives écartées (plan complet `/home/deploy/.claude/plans/`) : Graphify (pre-1.0, bugs data-loss), Serena LSP (nouvelle brique infra pas justifiée day 1), extension RAG Weaviate (bricolage infra métier), GoodMem MCP (sur-dimensionné).

## Contenu

### 1. `.claude/knowledge/` — mémoire codebase

- `README.md` — index + règles de navigation, pointé depuis `CLAUDE.md`
- `modules/` — 42 stubs auto-générés (1 par module NestJS)
- `db/` — 4 fichiers humains : `tables-seo.md`, `tables-pieces.md`, `tables-rag.md`, `rpcs-critical.md`
- `integrations/` — 4 fichiers humains : `paybox.md`, `systempay.md`, `supabase.md`, `parts-feed.md`
- Sections `Pourquoi`/`Gotchas`/`Références` laissées `_À compléter_` : remplissage organique (Pareto).

### 2. `scripts/knowledge/refresh-knowledge.py`

Python stdlib + pyyaml, 3 modes (`bootstrap`, `refresh`, `--headers-only`). Zéro LLM.

### 3. Gates déterministes

| Outil | Version | Rôle |
|---|---|---|
| `knip` | `5.60.0` | unused files/exports/deps |
| `madge` | `8.0.0` | circular deps |
| `dependency-cruiser` | `17.3.10` | architectural rules |
| `@ast-grep/cli` | `0.42.1` | pattern rules |

Tous `severity: warning` Phase 0. `depcheck` zombie retiré. `npm run audit:{knip,madge,depcruise,ast,all}`.

### 4. Baseline `audit-reports/phase0-baseline.md`

- knip : 362 unused files, 4 unused deps, 219 unused exports, 338 unused types, 41 duplicate exports
- madge : 17 cycles (aucun cross-boundary)
- depcruise : 148 warnings, 0 errors
- ast-grep : 14 warnings

Raw `.txt` outputs gitignorés (régénérables).

### 5. Pre-commit + `CLAUDE.md`

Hook : refresh knowledge headers + ast-grep scan, tous en soft-fail.
`CLAUDE.md` : règle "lire `.claude/knowledge/README.md` avant grep".

## Non-objectifs (deferred)

- Pourquoi/Gotchas humains par module : enrichissement organique au fil des cas.
- Promote `severity: error` sur depcruise/ast-grep : après Phase 1 cleanup.
- Cleanup actif des 362 fichiers / 17 cycles : Phase 1, humain-in-the-loop.

## Test plan

- [ ] `npm run audit:ast` → 14 warnings, exit 0
- [ ] `npm run audit:madge` → 17 cycles listés
- [ ] `npm run audit:knip` → rapport cohérent baseline
- [ ] `npm run audit:depcruise` → 148 warnings, 0 errors
- [ ] `python3 scripts/knowledge/refresh-knowledge.py refresh` → idempotent (pas de diff au 2e run)
- [ ] Pre-commit hook passe sur commit trivial
- [ ] Nouvelle session Claude : "où est géré le callback Paybox ?" → Claude lit `.claude/knowledge/modules/payments.md` au lieu de grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)