### PR TITLE
fix(seo): alias enrichment repartiteur-de-frein (R-SEO-KW-06 applied)

### DIFF
--- a/config/rag-alias-expansions.yaml
+++ b/config/rag-alias-expansions.yaml
@@ -207,6 +207,19 @@ pompe-a-vide-de-freinage:
   - pompe a vide      # catch toutes les formes "pompe a vide + vehicule/motorisation"
   - pompe de frein    # forme courte FR
 
+repartiteur-de-frein:
+  # Added 2026-04-24 (R1_ROUTER batch) — R-SEO-KW-01 review 28.6% vol → ~0%
+  # Canon R-SEO-KW-06 : pg=73 seule active, siblings pg=167/782/1341/2734/3666
+  # tous inactifs (level≥4, display=0, 0 KW). Répartiteur = régulateur =
+  # compensateur = limiteur de freinage (synonymes techniques exacts).
+  - repartiteur freinage          # forme sans "de"
+  - regulateur de frein           # synonyme technique
+  - regulateur de freinage
+  - compensateur de freinage      # synonyme technique auto
+  - compensateur freinage
+  - limiteur de freinage          # synonyme technique
+  - limiteur frein
+
 # ── Distribution ────────────────────────────────────────────────────────
 
 courroie-de-distribution:


### PR DESCRIPTION
## Summary

R-SEO-KW-01 triggered : 28.6% vol rejeté sur CSV `Keyword Stats 2026-04-24 at 17_02_03.csv`. Arbitrage canon [R-SEO-KW-06](https://github.com/ak125/governance-vault/blob/main/ledger/rules/rules-seo-kw-import.md) appliqué.

### Taxonomie siblings (SQL verified)

| pg_id | pg_alias | level | display | État |
|---|---|---|---|---|
| **73** | `repartiteur-de-frein` | 2 | 1 | ✅ **ACTIVE** |
| 167 | `regulateur-de-la-pression-de-freinage` | 5 | 0 | Inactive |
| 782 | `kit-de-reparation-regulateur-de-freinage` | 4 | 0 | Kit (distinct) |
| 1341 | `regulateur-alb-*` | 4 | 0 | Inactive |
| 2734 | `tampon-regulateur-de-freinage` | 4 | 0 | Tampon (distinct) |
| 3666 | `regulateur-de-pression-alimentation-air-*` | 4 | 0 | Air (distinct) |

→ Option 1 R-SEO-KW-06 : alias large légitime.

### 7 aliases ajoutés

```yaml
repartiteur-de-frein:
  - repartiteur freinage
  - regulateur de frein
  - regulateur de freinage
  - compensateur de freinage
  - compensateur freinage
  - limiteur de freinage
  - limiteur frein
```

Synonymes techniques auto documentés : **répartiteur = régulateur = compensateur = limiteur de freinage** (même pièce, terminologies concurrentes en FR).

### Evidence

```
Before : 62 raw → 52 pertinents, rejets 1400/4900 (28.6%)
After  : 62 raw → 61 pertinents, rejets 50/4900 (1.6%)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)