### PR TITLE
fix(seo): alias enrichment kit-de-freins-arriere (R-SEO-KW-06 Option 2 strict)

### DIFF
--- a/config/rag-alias-expansions.yaml
+++ b/config/rag-alias-expansions.yaml
@@ -220,6 +220,21 @@ repartiteur-de-frein:
   - limiteur de freinage          # synonyme technique
   - limiteur frein
 
+kit-de-freins-arriere:
+  # Added 2026-04-24 (R1_ROUTER batch) — R-SEO-KW-06 Option conservative.
+  # Canon : ≥4 gammes actives dans le scope CSV (pg=82 disque, pg=402 plaquette,
+  # pg=123 tambour, pg=70 machoires). Alias large INTERDIT. Aliases kit-only
+  # strictement : head term "kit" + contexte frein arrière/tambour.
+  # Les KW disque/plaquette/tambour/machoires seuls appartiennent aux autres
+  # gammes (leurs CSV respectifs déjà importés ou à venir).
+  - kit frein arriere       # forme courte
+  - kit de frein arriere    # singulier avec "de"
+  - kit freins arriere      # pluriel sans "de"
+  - kit arriere frein       # ordre inversé
+  - kit frein a tambour     # variante tambour dans kit
+  - kit frein tambour       # variante courte (tambours = arrière en majorité)
+  - kit machoire frein      # mâchoires + accessoires dans kit
+
 # ── Distribution ────────────────────────────────────────────────────────
 
 courroie-de-distribution:


### PR DESCRIPTION
## Summary

R-SEO-KW-01 triggered : **95 %** vol rejeté (CSV mélange 4+ gammes actives). R-SEO-KW-06 appliquée :

### Taxonomie SQL verified

| pg_id | gamme active | KW dans CSV | Verdict |
|---|---|---|---|
| **3859** | `kit-de-freins-arriere` | "kit..." | ✅ scope légitime |
| 82 | `disque-de-frein` | `disque de frein arriere` (5000 vol) | ❌ autre gamme |
| 402 | `plaquette-de-frein` | `plaquette frein arriere` | ❌ autre gamme |
| 123 | `tambour-de-frein` | `garniture frein tambour` | ❌ autre gamme |
| 70 | `machoires-de-frein` | `garniture de frein arriere` | ❌ autre gamme |

→ **Option 2** R-SEO-KW-06 : ≥ 2 gammes actives → alias large INTERDIT.

### Solution canon conservative

Aliases **kit-only strict** — head term "kit" + contexte arrière/tambour :

```yaml
kit-de-freins-arriere:
  - kit frein arriere
  - kit de frein arriere    # singulier avec "de"
  - kit freins arriere      # pluriel sans "de"
  - kit arriere frein       # ordre inversé
  - kit frein a tambour
  - kit frein tambour
  - kit machoire frein
```

### Evidence

```
Before : 160 raw → 5 pertinents (95% rejets)
After  : 160 raw → 106 pertinents (32% rejets, résiduels = autres gammes)
```

Rejets restants (~50 KW) appartiennent à pg=82/402/123/70 qui ont leurs propres CSV. C'est **la bonne chose canon** (anti-cannibalisation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)