### PR TITLE
feat(ci): audit.yml — deterministic gates on PRs (stacked on #149)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,82 @@
+name: 🛡️ Audit gates (Phase 0)
+
+# Deterministic codebase audits : knip + madge + dependency-cruiser + ast-grep.
+# Phase 0 posture : warning-mode, ast-grep is the only gate that blocks the PR
+# (and only on `severity: error` rules). knip / madge / depcruise print signals
+# but never fail the run — they are informational until Phase 1 cleanup ships.
+# Promote individual steps to `--strict` / `continue-on-error: false` once the
+# baseline in `audit-reports/phase0-baseline.md` is cleared.
+
+on:
+  pull_request:
+    paths:
+      - "backend/src/**"
+      - "frontend/app/**"
+      - "packages/**"
+      - "scripts/**"
+      - ".ast-grep/**"
+      - "knip.json"
+      - ".dependency-cruiser.cjs"
+      - "sgconfig.yml"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/audit.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: 🛡️ Deterministic gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      NODE_OPTIONS: "--max-old-space-size=4096"
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: 🎯 ast-grep scan (rule-pattern guard — blocks on severity:error)
+        run: npm run audit:ast
+
+      - name: 🔁 madge — circular dependencies (informational)
+        if: always()
+        continue-on-error: true
+        run: npm run audit:madge
+
+      - name: 🏛️ dependency-cruiser — architectural rules (informational)
+        if: always()
+        continue-on-error: true
+        run: npm run audit:depcruise
+
+      - name: 🧹 knip — unused files / exports / deps (informational)
+        if: always()
+        continue-on-error: true
+        run: npm run audit:knip
+
+      - name: 📋 Baseline reminder
+        if: always()
+        run: |
+          echo ""
+          echo "=================================================="
+          echo "Phase 0 baseline : audit-reports/phase0-baseline.md"
+          echo ""
+          echo "ast-grep runs BLOCKING on rules with severity: error."
+          echo "knip / madge / depcruise are warning-only for now."
+          echo "Promote to blocking after Phase 1 cleanup lands."
+          echo "=================================================="


### PR DESCRIPTION
## Contexte

PR **stackée sur #149** (`feat/claude-knowledge-base`). Auto-retargetera vers `main` après merge de #149.

PR #149 a installé knip + madge + dep-cruiser + ast-grep en local avec wiring pre-commit. Ça manque de protection CI : une PR pourrait silencieusement faire régresser la baseline (nouveaux fichiers morts, cycles, phantom deps) sans que personne le voie.

## Ce que cette PR ajoute

**1 seul fichier** : [.github/workflows/audit.yml](.github/workflows/audit.yml)

### Comportement du workflow

| Étape | Posture | Bloque la PR ? |
|---|---|---|
| `ast-grep` scan | Blocking sur `severity: error` | ✅ oui (cohérent avec pre-commit local) |
| `madge --circular` | Informational | ❌ non (`continue-on-error: true`) |
| `dependency-cruiser` | Informational | ❌ non |
| `knip` | Informational | ❌ non |

### Path filter

Le workflow trigger uniquement si la PR touche :
- `backend/src/**`, `frontend/app/**`, `packages/**`, `scripts/**`
- `.ast-grep/**`, `knip.json`, `.dependency-cruiser.cjs`, `sgconfig.yml`
- `package.json`, `package-lock.json`
- Le workflow lui-même

Les PRs doc-only ou vault-only ne déclenchent rien → pas de spam CI.

### Concurrency

`cancel-in-progress: true` → chaque push nouveau annule la run précédente.

## Non-goals (explicitement)

- **Pas de seuil de régression** (pas de bot diff baseline yet)
- **Pas de promotion à blocking** pour depcruise/knip — ça viendra quand Phase 1 cleanup aura sorti les 362 unused files / 17 cycles / 148 violations. Ce sera une PR dédiée après.

## Test plan

- [ ] PR ouverte sur cette branche → workflow `🛡️ Audit gates (Phase 0)` s'exécute
- [ ] `ast-grep` job passe (0 warnings actuel → exit 0)
- [ ] Les 3 autres jobs impriment leurs findings mais `continue-on-error` les empêche de fail
- [ ] PR doc-only (ex: README.md seul) → workflow NE se déclenche PAS (path filter)
- [ ] Après merge #149 + cette PR, une PR future ajoutant un fichier `.ts` fait apparaître le job

🤖 Generated with [Claude Code](https://claude.com/claude-code)