### PR TITLE
fix(db): 3 incidents DB découverts sur QA pg=3859 (trigger polyglot + r6_kp backfill + executor upsert)

### DIFF
--- a/backend/src/config/content-write-executor.service.ts
+++ b/backend/src/config/content-write-executor.service.ts
@@ -184,22 +184,55 @@ export class ContentWriteExecutor {
         }
       }
 
-      // ── Step H: Write ──
-      const { error } = await this.supabase
+      // ── Step H: Write (UPDATE-then-INSERT fallback) ──
+      //
+      // Strategy: UPDATE then check rowCount. If 0 rows affected, the row
+      // doesn't exist yet — fall back to INSERT. This handles the "fresh
+      // seed" case where a new gamme has no pre-existing row (discovered
+      // 2026-04-24 on pg=3859 kit-de-freins-arriere: R1 enricher reported
+      // slotsWritten but content was silently dropped because .update().eq()
+      // no-ops when row is absent).
+      const { error: updateError, count: updatedCount } = await this.supabase
         .from(writeTarget.table)
-        .update(mergedPayload)
+        .update(mergedPayload, { count: 'exact' })
         .eq(writeTarget.pkField, pkValue);
 
-      if (error) {
+      if (updateError) {
         this.logger.error(
-          `ContentWriteExecutor: write failed for ${target}:${pkValue} — ${error.message}`,
+          `ContentWriteExecutor: update failed for ${target}:${pkValue} — ${updateError.message}`,
         );
         return {
           written: false,
-          reason: `db_error: ${error.message}`,
+          reason: `db_error: ${updateError.message}`,
           fieldsWritten: [],
           mergeDetails,
         };
+      }
+
+      // Fallback INSERT if no row was updated
+      if ((updatedCount ?? 0) === 0) {
+        const insertPayload = {
+          ...mergedPayload,
+          [writeTarget.pkField]: pkValue,
+        };
+        const { error: insertError } = await this.supabase
+          .from(writeTarget.table)
+          .insert(insertPayload);
+
+        if (insertError) {
+          this.logger.error(
+            `ContentWriteExecutor: insert fallback failed for ${target}:${pkValue} — ${insertError.message}`,
+          );
+          return {
+            written: false,
+            reason: `db_error_insert: ${insertError.message}`,
+            fieldsWritten: [],
+            mergeDetails,
+          };
+        }
+        this.logger.log(
+          `ContentWriteExecutor: inserted new row for ${target}:${pkValue} (row was absent)`,
+        );
       }
 
       const fieldsWritten = Object.keys(mergedPayload);

--- a/backend/supabase/migrations/20260424_fix_fn_warn_orphan_pg_id_polyglot.sql
+++ b/backend/supabase/migrations/20260424_fix_fn_warn_orphan_pg_id_polyglot.sql
@@ -1,0 +1,63 @@
+-- 2026-04-24: fn_warn_orphan_pg_id — fix plpgsql polyglot field access
+-- ----------------------------------------------------------------------------
+-- INCIDENT : la fonction déclenchée par 4 triggers (r1_gamme_slots,
+-- gamme_purchase_guide, gamme_conseil, gamme) utilisait un CASE statique
+-- sur NEW.xxx_pg_id. En plpgsql, les branches CASE non atteintes sont
+-- validées au compile-time contre le type du NEW record (qui est typé
+-- selon la table d'invocation). Résultat : INSERT sur __seo_r1_gamme_slots
+-- échouait avec :
+--
+--   ERROR: record "new" has no field "sgpg_pg_id"
+--
+-- Symptôme observé : aucun R1 slot créé pour les nouvelles gammes depuis
+-- l'activation du trigger. Bloquait pg=3859 kit-de-freins-arriere (session
+-- 2026-04-24) et probablement toute gamme après le backfill initial.
+--
+-- FIX : remplacer le CASE static par to_jsonb(NEW) + COALESCE sur les 4
+-- colonnes candidates. Accès dynamique → pas de type check compile-time.
+--
+-- Comportement inchangé :
+--   - 4 triggers BEFORE INSERT sur les mêmes 4 tables
+--   - warn (pas BLOCK) si pg_id n'existe pas dans pieces_gamme
+--   - RETURN NEW toujours (observationnel, pas enforce)
+--
+-- Idempotent : CREATE OR REPLACE.
+
+CREATE OR REPLACE FUNCTION public.fn_warn_orphan_pg_id()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  pgid_str text;
+  exists_in_pg boolean;
+  rec_json jsonb;
+BEGIN
+  rec_json := to_jsonb(NEW);
+  pgid_str := COALESCE(
+    rec_json->>'r1s_pg_id',
+    rec_json->>'sgpg_pg_id',
+    rec_json->>'sgc_pg_id',
+    rec_json->>'sg_pg_id'
+  );
+  IF pgid_str IS NULL THEN RETURN NEW; END IF;
+  SELECT EXISTS (SELECT 1 FROM pieces_gamme pg WHERE pg.pg_id::text = pgid_str) INTO exists_in_pg;
+  IF NOT exists_in_pg THEN
+    RAISE WARNING 'orphan_pg_id: table=% pg_id=% has no matching pieces_gamme row', TG_TABLE_NAME, pgid_str;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_warn_orphan_pg_id() IS
+  'Trigger function (BEFORE INSERT) that warns if pg_id has no matching pieces_gamme row. Uses to_jsonb(NEW) for dynamic field access — avoids plpgsql polyglot type-check errors when the same function is attached to multiple tables with different pg_id column names. Fix 2026-04-24.';
+
+
+-- ─── INC-2 backfill : resync 61 rows __seo_r6_keyword_plan ──────────────
+-- Contexte : certaines rows ont r6kp_pg_id désynchronisé de r6kp_pg_alias
+-- (conséquence des merges gammes historiques — ex: 3942→817, deprecate 3333).
+-- Canon : r6kp_pg_id doit toujours être cohérent avec pieces_gamme.pg_id
+-- pour le r6kp_pg_alias donné.
+
+UPDATE __seo_r6_keyword_plan r6
+SET r6kp_pg_id = pg.pg_id::text
+FROM pieces_gamme pg
+WHERE pg.pg_alias = r6.r6kp_pg_alias
+  AND r6.r6kp_pg_id::text IS DISTINCT FROM pg.pg_id::text;

--- a/backend/supabase/migrations/20260424_fix_fn_warn_orphan_pg_id_polyglot.sql
+++ b/backend/supabase/migrations/20260424_fix_fn_warn_orphan_pg_id_polyglot.sql
@@ -55,7 +55,25 @@ COMMENT ON FUNCTION public.fn_warn_orphan_pg_id() IS
 -- (conséquence des merges gammes historiques — ex: 3942→817, deprecate 3333).
 -- Canon : r6kp_pg_id doit toujours être cohérent avec pieces_gamme.pg_id
 -- pour le r6kp_pg_alias donné.
+--
+-- Ordre impératif :
+--   1. Supprimer les rows duplicata legacy (pg_id orphelin + row canon existe)
+--   2. UPDATE resync sur les rows restantes
+--
+-- Sans step 1, UPDATE échoue avec unique constraint violation
+-- (r6kp_pg_id_key) car 2 rows ont le même pg_alias avec pg_ids différents.
 
+-- Step 1 : DELETE rows duplicata legacy (2 rows sur pg_ids 1562, 1643)
+DELETE FROM __seo_r6_keyword_plan r6
+WHERE NOT EXISTS (SELECT 1 FROM pieces_gamme pg WHERE pg.pg_id::text = r6.r6kp_pg_id::text)
+  AND EXISTS (
+    SELECT 1 FROM __seo_r6_keyword_plan r6_canon
+    JOIN pieces_gamme pg ON pg.pg_alias = r6_canon.r6kp_pg_alias
+    WHERE r6_canon.r6kp_pg_alias = r6.r6kp_pg_alias
+      AND pg.pg_id::text = r6_canon.r6kp_pg_id::text
+  );
+
+-- Step 2 : UPDATE resync pour les ~61 rows restantes
 UPDATE __seo_r6_keyword_plan r6
 SET r6kp_pg_id = pg.pg_id::text
 FROM pieces_gamme pg


### PR DESCRIPTION
## Summary

Session QA 2026-04-24 sur pg=3859 `kit-de-freins-arriere` a révélé **3 incidents DB systémiques** bloquant l'enrichissement canonique de toute nouvelle gamme. Fix combiné car interdépendants (tests pg=3859 ne passent qu'après les 3).

## INC-1 — Trigger `fn_warn_orphan_pg_id` casse tous les INSERTs

Fonction attachée à 4 triggers (`r1_gamme_slots`, `gamme_purchase_guide`, `gamme_conseil`, `gamme`) utilisait un CASE statique sur `NEW.xxx_pg_id`. En plpgsql, les branches CASE non-atteintes sont validées au compile-time contre le type du NEW record → échec :

```
ERROR: record "new" has no field "sgpg_pg_id"
```

**Fix** : `to_jsonb(NEW)` + COALESCE sur les 4 colonnes candidates. Accès dynamique → pas de type check compile-time.

## INC-2 — 61 rows `__seo_r6_keyword_plan` avec pg_id désynchronisé

Rows ont `r6kp_pg_id` différent de `pieces_gamme.pg_id` pour le `r6kp_pg_alias` correspondant (conséquence merges gammes historiques : 3942→817, deprecate 3333).

Exemple : `kit-de-freins-arriere` avait `r6kp_pg_id='1683'` (gamme disparue) alors que `pieces_gamme.pg_id='3859'`.

**Fix** : DELETE 2 rows duplicata legacy (pg_ids 1562, 1643 qui n'existent plus) + UPDATE resync des 61 rows. Appliqué en live DB, 0 remaining.

## INC-3 — `ContentWriteExecutor` no-op silencieux sur rows absentes

Step H faisait `.update().eq(pk, pkValue)` seul. Quand la row n'existe pas, l'UPDATE ne renvoie pas d'erreur mais ne fait rien. Résultat : R1 enricher reportait `status=enriched slotsWritten=6` mais les content fields restaient NULL en DB.

**Fix** : UPDATE-then-INSERT fallback. Si `updatedCount=0`, INSERT avec pk injecté dans le payload.

## Impact combiné

- Toute gamme sans row pré-existante dans `__seo_r1_gamme_slots` (ou autres tables sous WriteGuard) était invisible pour l'enrichissement canon depuis l'activation des 3 composants
- Bloquait pg=3859 + toutes futures nouvelles gammes

## Test plan

- [x] INC-1 : INSERT `__seo_r1_gamme_slots (r1s_pg_id)` → succès (avant fix = échec polyglot)
- [x] INC-2 : backfill live DB, 0 row misaligned remaining
- [x] INC-3 : code compile OK, logique testée manuellement
- [ ] CI : TypeScript / ESLint / Backend Tests / Migration Safety / CodeQL
- [ ] Post-merge : re-run R1 enricher sur pg=3859 → content fields peuplés

## Canon refs

- Discovery session 2026-04-24 : `kit-de-freins-arriere` batch R1_ROUTER 19/232
- Vault PR à suivre : evidence-pack 3 INC + pg=3859 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)