### PR TITLE
fix(ci): spec-validation cherche .spec/apis (pluriel) pas .spec/api

### DIFF
--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -56,7 +56,8 @@ jobs:
           echo "Checking .spec directory structure..."
           
           # Check required directories exist
-          for dir in features architecture api types workflows templates; do
+          # Note: 'apis' (plural) is the actual directory in this repo, not 'api'.
+          for dir in features architecture apis types workflows templates; do
             if [ ! -d ".spec/$dir" ]; then
               echo "❌ Missing required directory: .spec/$dir"
               exit 1


### PR DESCRIPTION
## Summary

Fix CI infra : le step \"Validate spec structure\" du workflow [spec-validation.yml](.github/workflows/spec-validation.yml) listait `.spec/api` (singulier) parmi les répertoires requis, alors que le repo contient `.spec/apis` (pluriel) depuis longtemps.

**Conséquence** : 100% des PRs récentes en failure sur \"Validate Specifications\" (ex: PR #159 et 9 autres branches sur les dernières runs du workflow 208083594). PR #100 avait fix le `find .spec/api …` mais oublié la liste de check de structure.

**Fix** : aligner la liste sur l'arborescence réelle du repo (`api` → `apis`).

## Evidence

- `ls .spec/` → `apis` présent, `api` absent
- `gh run list` workflow 208083594 → 10/10 dernières runs en failure même cause
- `git log -- .github/workflows/spec-validation.yml` → PR #100 (4fa0a0f4) a fix le find mais pas la liste

## Test plan

- [x] `for d in features architecture apis types workflows templates; do [ -d \".spec/\$d\" ] && echo OK; done` → 6/6 OK localement
- [ ] CI Validate Specifications green sur cette PR
- [ ] PR #159 (et autres en attente) débloquées une fois mergé

🤖 Generated with [Claude Code](https://claude.com/claude-code)