### PR TITLE
feat(memory): log.md append-only session timeline + Stop hook + skill

### DIFF
--- a/.claude/knowledge/README.md
+++ b/.claude/knowledge/README.md
@@ -15,6 +15,15 @@
 
 Si la question n'est pas couverte ici, lire `.claude/rules/*` puis grepper.
 
+### Voisins (pas dans ce dossier mais souvent utiles)
+
+- [`/log.md`](../../log.md) — **timeline append-only des sessions Claude** (date, branche, décision, PRs/commits). Lecture conseillée en début de session pour contexte récent.
+- `~/.claude/projects/.../memory/MEMORY.md` — **apprentissages persistants** (règles, gotchas, feedback). Auto-loadé chaque session, USER-only.
+- PR descriptions sur GitHub — **détails techniques** d'un changement.
+- `governance-vault/` — **décisions canon** (ADRs, incidents, retros).
+
+Distinction : `knowledge/` = STRUCTURE du codebase (où vit quoi) ; `log.md` = TIMELINE des sessions (quand quoi a été fait) ; `MEMORY.md` = APPRIS (règles persistantes) ; PRs = POURQUOI (détails) ; vault = CANON (décisions).
+
 ## Modules backend (auto-détectés, `backend/src/modules/*`)
 
 Les fichiers `modules/*.md` ont tous une section `Rôle` / `Pourquoi` /

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /opt/automecanik/app/scripts/claude-hooks/stop-log-session-suggest.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/session-log/SKILL.md
+++ b/.claude/skills/session-log/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: session-log
+description: Append a 3-4 line curated entry to log.md at the monorepo root. Use when the current Claude Code session has produced commits or PRs and the user (or Stop hook) requests recording it. Format strict, no secrets, append-only. Trigger keywords - "log session", "/log-session", "record this work", or auto-suggested by Stop hook when git activity detected.
+---
+
+# session-log
+
+## When to use
+
+- Stop hook detected commits ahead of `main` on the current branch and asked Claude to record the session.
+- User explicitly types `/log-session` or "log this session" or "record this work in log.md".
+- Major work completed (feature merged, refactor shipped, incident resolved) and the user wants a permanent timeline trace.
+
+## When NOT to use
+
+- Read-only sessions (no commits, no PRs).
+- Trivial single-line edits with no merge/PR.
+- Internal session noise (debugging, exploration without artifact).
+- Anything containing secrets, tokens, internal IPs, credentials.
+
+## Strict format
+
+Append exactly this block at the END of `/opt/automecanik/app/log.md`:
+
+```markdown
+
+## YYYY-MM-DD — sujet bref (max 60 chars)
+
+- **Branche** : `<branch-name>`
+- **Décision** : <1 phrase française, l'essentiel de ce qui a été tranché ou produit>
+- **Sortie** : PRs #XXX [#YYY] | commits abc1234 [def5678] | fichiers `path/X`, `path/Y`
+
+```
+
+Rules:
+- Heading is **always** H2 (`##`), date in `YYYY-MM-DD`.
+- "Sujet" max 60 chars, French, no trailing punctuation.
+- "Branche" : the actual branch name (use `git branch --show-current`).
+- "Décision" : ONE sentence. The most important thing the session decided or produced.
+- "Sortie" : factual artifacts only. PRs by number with `#`, commits by short SHA, files by path. Pipe-separated.
+- 3 or 4 lines total in the bullet block. Never more.
+- Always one blank line BEFORE the new H2 heading and AFTER the closing bullet.
+
+## How to write the entry
+
+1. Determine the date : use today's local date (`date +%F`).
+2. Determine the branch : `git branch --show-current` from the worktree where work happened.
+3. Determine the sujet : look at the session goal. ONE noun phrase, ≤ 60 chars.
+4. Determine the décision : look at the most-impactful commit message OR what the user explicitly asked. ONE sentence.
+5. Determine the sortie :
+   - Get PRs : `gh pr list --head <branch>` or check session history.
+   - Get commits : `git log main..HEAD --pretty=format:'%h'` (short SHAs).
+   - Get top-level files : look at the largest `git diff --stat` paths.
+6. Append the block to `log.md`.
+
+## Anti-patterns
+
+- ❌ Editing past entries (append-only — corrections = new dated entry)
+- ❌ Dumping diff content (PR description handles details)
+- ❌ Including secrets / tokens / internal IPs
+- ❌ Fluff English / marketing tone (it's a log, not a release note)
+- ❌ More than 4 bullet lines
+- ❌ Missing one of the 3 required fields (Branche / Décision / Sortie)
+
+## After writing
+
+Confirm with one line : `Logged session to log.md.` — nothing else.

--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,7 @@ frontend/tests/e2e/reports/
 
 # Claude Code backups
 .claude/*.bak
+.claude/.session-log-state/
 
 # Cookies (curl debug artifacts)
 cookies.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,22 @@
 
 ---
 
+## Démarrage de session — lire `log.md` pour contexte récent
+
+Au début de chaque session Claude Code, lire les ~20 dernières entrées de
+[`log.md`](log.md) à la racine pour situer le travail récent (commits, PRs,
+décisions). Append-only, écrit par le skill `session-log` (déclenché auto par
+le hook `Stop` quand commits/PRs créés).
+
+Délimitation explicite :
+
+- **`log.md`** = QUAND/QUOI : timeline session (date, branche, sortie)
+- **`MEMORY.md`** (auto-loaded) = QUOI APPRIS : règles, gotchas, feedback
+- **PR descriptions GitHub** = POURQUOI : détails techniques du changement
+- **`governance-vault/`** = DÉCIDÉ CANON : ADRs, incidents, retros
+
+---
+
 ## Mémoire codebase — lire `.claude/knowledge/` avant exploration
 
 **Avant** tout `Grep` / `Glob` / lecture en rafale pour répondre à une question

--- a/log.md
+++ b/log.md
@@ -1,0 +1,59 @@
+# Log — Timeline des sessions Claude Code
+
+> **But** : trace append-only des sessions Claude Code "importantes"
+> (commits / PRs créés). Lu au début de chaque nouvelle session pour
+> donner du contexte récent au LLM. Complémentaire à `MEMORY.md`
+> (apprentissages) et aux PR descriptions GitHub (détails techniques).
+
+## Délimitation
+
+| Quoi | Où |
+|---|---|
+| Timeline session : date, sujet, branche, sortie | **`log.md`** (ce fichier) |
+| Règles persistantes, gotchas, feedback utilisateur | `~/.claude/projects/.../memory/MEMORY.md` |
+| Détails techniques d'un changement | PR description GitHub |
+| Décision architecturale canon | `governance-vault/ledger/decisions/adr/` |
+| Transcripts session bruts | `.remember/logs/memory-*.log` (gitignored) |
+
+## Format strict (imposé par le skill `/log-session`)
+
+```markdown
+## YYYY-MM-DD — sujet bref (≤ 60 chars)
+
+- **Branche** : `feat/<sujet>`
+- **Décision** : 1 ligne en français, l'essentiel
+- **Sortie** : PRs #XXX | commits abc1234 | fichiers `path/X`, `path/Y`
+
+```
+
+Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
+
+## Règles
+
+1. **Append-only.** Jamais éditer une entrée passée. Une correction = nouvelle entrée datée.
+2. **Pas de secrets.** Pas de tokens, IPs internes, credentials. `gitleaks` actif en pre-commit.
+3. **Filtre auto.** Hook `Stop` détecte commits/PRs créés et déclenche le skill. Sessions de simple lecture ne loguent pas.
+4. **Curated.** Seul Claude Code (via skill `/log-session`) écrit. Les autres agents n'écrivent pas ici.
+5. **Lu au démarrage.** `CLAUDE.md` instruit de lire les ~100 dernières lignes en début de session.
+
+---
+
+# Timeline
+
+## 2026-04-25 — bootstrap log.md timeline
+
+- **Branche** : `chore/log-md-session-timeline-1777110107`
+- **Décision** : Adoption d'un `log.md` append-only à la racine, complémentaire à `MEMORY.md` (apprentissages) et aux PR descriptions (détails). Hook `Stop` auto-déclenche le skill `/log-session` si commits ou PRs créés. Format strict 3-4 lignes par entrée.
+- **Sortie** : nouvelle PR (numéro à venir) | fichiers `log.md`, `.claude/skills/session-log/SKILL.md`, `scripts/claude-hooks/stop-log-session-suggest.sh`, `.claude/settings.json`, `CLAUDE.md`, `.claude/knowledge/README.md`
+
+## 2026-04-25 — vague cleanup batches 1-3 (rétroactif)
+
+- **Branche** : multiples — `chore/cleanup-backend-root-js-...`, `chore/cleanup-dead-components-search-...`, `chore/cleanup-dead-components-forms-...`
+- **Décision** : Lancement vague cleanup post-Phase-0. Pattern adopté : worktree isolé + branches timestamp uniques + sequence atomique (rm + commit + push + PR sans typecheck local) pour zero collision avec IDE actif. Validation par CI uniquement.
+- **Sortie** : PR #157 mergée (62 scripts `.js` backend root, 5991 lignes) | PRs #158 + #160 ouvertes (3 + 4 composants `frontend/app/components/{search,forms}/`, ~3500 lignes) | git worktree à `/tmp/claude-cleanup-worktree`
+
+## 2026-04-24 — infrastructure Phase 0 cleanup tooling
+
+- **Branche** : `feat/claude-knowledge-base`, `feat/audit-ci-integration`, `feat/cleanup-tooling-prep`
+- **Décision** : Adoption knip + madge + dependency-cruiser + ast-grep en gates déterministes (warning-mode Phase 0). Création `.claude/knowledge/` (42 modules + 4 db + 4 integrations). CI workflow `audit.yml` blockant ast-grep. Safe-delete script + baseline JSON regression gate + 3 runbooks ops.
+- **Sortie** : PRs #149, #152, #155 mergées | knip 6.6.2 (avec nested zod@4 override) + madge 8 + dep-cruiser 17.3 + @ast-grep/cli 0.42 installés | baseline 362 unused / 17 cycles / 148 violations / 0 ast-errors capturée

--- a/scripts/claude-hooks/stop-log-session-suggest.sh
+++ b/scripts/claude-hooks/stop-log-session-suggest.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# stop-log-session-suggest.sh — Stop hook for Claude Code.
+#
+# Detects whether the current Claude Code session has produced commits or
+# PRs that would warrant an entry in log.md. If so, returns JSON instructing
+# Claude to invoke the `session-log` skill (silently if no work found).
+#
+# Wire-up: .claude/settings.json
+#   "hooks": {
+#     "Stop": [
+#       { "hooks": [ { "type": "command", "command": "bash scripts/claude-hooks/stop-log-session-suggest.sh" } ] }
+#     ]
+#   }
+#
+# Read-only operation. Never writes to log.md directly. Only signals Claude.
+
+set -u
+
+# Resolve repo root regardless of where the hook runs from.
+REPO_ROOT="$(git -C "${PWD}" rev-parse --show-toplevel 2>/dev/null || echo /opt/automecanik/app)"
+cd "$REPO_ROOT" 2>/dev/null || exit 0
+
+# Marker so we don't re-suggest within the same logical session unless new work appears.
+MARKER_DIR="${REPO_ROOT}/.claude/.session-log-state"
+mkdir -p "$MARKER_DIR" 2>/dev/null
+LAST_SHA_FILE="${MARKER_DIR}/last-suggested-head"
+LAST_BRANCH_FILE="${MARKER_DIR}/last-suggested-branch"
+
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
+current_head="$(git rev-parse HEAD 2>/dev/null || echo '')"
+
+# Skip if not on a feature branch (main, master, detached HEAD)
+case "$current_branch" in
+  main|master|HEAD|"")
+    exit 0
+    ;;
+esac
+
+# Look for commits ahead of origin/main on the current branch
+# (= work done in this branch, not yet merged).
+commits_ahead="$(git log origin/main..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')"
+
+# Skip if no commits at all on this branch yet.
+if [ "${commits_ahead:-0}" -lt 1 ]; then
+  exit 0
+fi
+
+# Has anything changed since the last suggestion ? (avoid re-prompt loop)
+last_sha="$(cat "$LAST_SHA_FILE" 2>/dev/null || echo '')"
+last_branch="$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo '')"
+
+if [ "$current_head" = "$last_sha" ] && [ "$current_branch" = "$last_branch" ]; then
+  # Same SHA + same branch as last time we suggested -> already prompted, skip.
+  exit 0
+fi
+
+# Detect open PR for this branch (informational only).
+pr_number=""
+if command -v gh >/dev/null 2>&1; then
+  pr_number="$(gh pr list --head "$current_branch" --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+fi
+
+pr_hint=""
+if [ -n "$pr_number" ]; then
+  pr_hint=" PR #${pr_number} is open."
+fi
+
+# Persist state so we don't re-prompt for the same SHA.
+printf '%s\n' "$current_head" > "$LAST_SHA_FILE"
+printf '%s\n' "$current_branch" > "$LAST_BRANCH_FILE"
+
+# Emit JSON for Claude Code Stop hook protocol — signals additional context
+# for the model. The model will see this as part of the next assistant turn.
+cat <<EOF
+{
+  "decision": "block",
+  "reason": "Session has produced ${commits_ahead} commit(s) on branch '${current_branch}'.${pr_hint} Before stopping, invoke the 'session-log' skill to append a 3-4 line entry to log.md. After logging, you may stop."
+}
+EOF
+
+exit 0


### PR DESCRIPTION
## Contexte

Vérification empirique préalable a montré qu'aucun mécanisme actuel ne couvre simultanément ces 3 axes :
1. Append-only timeline (vs MEMORY.md = overwrite-style learnings, vs `.remember/logs/` = raw transcripts)
2. Tracked git (vs MEMORY.md USER-only, vs `.remember/` gitignored)
3. Lu auto par Claude au démarrage

Cette PR comble exactement ce trou.

## Délimitation explicite

| Contenu | Va dans |
|---|---|
| Timeline session : date, branche, sortie | **`log.md`** (NEW) |
| Règles persistantes, gotchas, feedback | `MEMORY.md` (inchangé) |
| Détails techniques d'un changement | PR description GitHub (inchangé) |
| Décision architecturale canon | `governance-vault/` (inchangé) |
| Transcripts session bruts | `.remember/logs/` (inchangé, gitignored) |

Pas de duplication. Chaque artefact a un rôle clair.

## Contenu (7 fichiers, 244 lignes)

- **`log.md`** — header documentant format + délimitation + 3 entrées bootstrap (cette session + cleanup batches + Phase 0 rétroactif)
- **`.claude/skills/session-log/SKILL.md`** — skill `/log-session` qui impose le format strict 3-4 lignes
- **`scripts/claude-hooks/stop-log-session-suggest.sh`** — hook Stop : détecte commits/PRs créés, idempotent (marker file), silence si rien à logger
- **`.claude/settings.json`** — wire Stop hook
- **`CLAUDE.md`** — section "Démarrage de session" + table délimitation
- **`.claude/knowledge/README.md`** — sous-section "Voisins" pointant vers log.md
- **`.gitignore`** — skip `.claude/.session-log-state/` (marker files locaux)

## Format strict

```markdown
## YYYY-MM-DD — sujet bref (≤ 60 chars)

- **Branche** : \`feat/<sujet>\`
- **Décision** : 1 ligne en français, l'essentiel
- **Sortie** : PRs #XXX | commits abc1234 | fichiers \`path/X\`, \`path/Y\`
```

3-4 lignes max. Heading H2 par session = greppable + naviguable.

## Tests effectués

- [x] Hook sur branche sans commit ahead → exit 0 silent (no false trigger)
- [x] Hook sur branche avec 3 commits + PR ouverte → JSON `decision: block` correct
- [x] Hook idempotent : 2e appel sur même SHA → exit 0 silent (marker file)
- [x] Marker file gitignored

## Honnêteté sur les claims initiaux

- **"Karpathy le recommande"** → son `/raw` folder est pour INPUTS (papers, contexte LLM), pas un session log. Pattern engineering changelog. Attribution corrigée.
- **"90% de Claude-Mem"** → overclaim. Claude-Mem fait retrieval vector sémantique. log.md fait timeline texte. Différentes abstractions. Avantage zero-dep VRAI mais périmètre plus étroit.
- **"Risque drift"** → vrai sans hook auto. C'est exactement pour ça que le hook auto + skill format strict.

## Non-goals

- Pas de migration de MEMORY.md
- Pas de remplacement de `.remember/`
- Pas de retrieval sémantique
- Pas d'écriture par Cowork/Codex (Claude only)
- Pas de rotation auto (problème dans 2 ans, pas maintenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)