### PR TITLE
fix(vehicles): root-cause INC-2026-007 — optimize build_vehicle_page_payload + steady-state cache guarantees + observability

### DIFF
--- a/.github/workflows/prod-smoke-tests.yml
+++ b/.github/workflows/prod-smoke-tests.yml
@@ -41,7 +41,7 @@ jobs:
           fi
           echo "✅ Homepage: title='$TITLE'"
 
-      - name: 📦 Pages multi-rôles (8 URLs)
+      - name: 📦 Pages multi-rôles (11 URLs)
         id: pages-check
         run: |
           FAILED=0
@@ -54,6 +54,9 @@ jobs:
             "/blog-pieces-auto/conseils/amortisseur"
             "/blog-pieces-auto/guide-achat/roulement-de-roue"
             "/sitemap.xml"
+            "/constructeurs/renault-140/clio-iii-140004/1-5-dci-34746.html"
+            "/constructeurs/audi-22/r8-422-32058/4-2-fsi-quattro-v8-32058.html"
+            "/constructeurs/peugeot-105/308-105058/1-6-hdi-21090.html"
           )
           for URL in "${URLS[@]}"; do
             STATUS=$(docker exec $CONTAINER wget --spider -qS "http://localhost:3000$URL" 2>&1 | grep "HTTP/" | tail -1 | awk '{print $2}')
@@ -68,6 +71,32 @@ jobs:
             exit 1
           fi
           echo "✅ All 8 pages OK"
+
+      - name: 🚨 INC-2026-007 — __error_logs 5xx /constructeurs/* (1h window)
+        id: vehicle-5xx-check
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+            echo "⚠️ Supabase credentials missing — skipping vehicle 5xx alert check"
+            exit 0
+          fi
+          # Count 5xx on /constructeurs/* in last hour. Threshold: 5 events.
+          ONE_HOUR_AGO=$(date -u -d '1 hour ago' '+%Y-%m-%dT%H:%M:%S')
+          COUNT=$(curl -sk \
+            "${SUPABASE_URL}/rest/v1/__error_logs?select=err_id&err_status=gte.500&err_url=like.%2Fconstructeurs%2F%25&err_created_at=gte.${ONE_HOUR_AGO}" \
+            -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Prefer: count=exact" \
+            -H "Range: 0-0" \
+            -D - 2>/dev/null | grep -i "content-range" | sed -n 's/.*\/\([0-9]*\).*/\1/p')
+          COUNT=${COUNT:-0}
+          if [ "$COUNT" -gt 5 ]; then
+            echo "❌ INC-2026-007 ALERT: $COUNT × 5xx on /constructeurs/* in last 1h (threshold 5)"
+            exit 1
+          fi
+          echo "✅ INC-2026-007 OK: $COUNT × 5xx on /constructeurs/* in last 1h (threshold 5)"
 
       - name: 🔍 SEO Meta tags
         id: seo-meta-check
@@ -640,7 +669,8 @@ jobs:
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Health | ${{ steps.health-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Homepage | ${{ steps.homepage-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Pages (8 URLs) | ${{ steps.pages-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pages (11 URLs) | ${{ steps.pages-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| INC-2026-007 vehicle 5xx | ${{ steps.vehicle-5xx-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| SEO Meta | ${{ steps.seo-meta-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| API catalog | ${{ steps.api-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| imgproxy | ${{ steps.imgproxy-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prod-smoke-tests.yml
+++ b/.github/workflows/prod-smoke-tests.yml
@@ -41,7 +41,7 @@ jobs:
           fi
           echo "✅ Homepage: title='$TITLE'"
 
-      - name: 📦 Pages multi-rôles (11 URLs)
+      - name: 📦 Pages multi-rôles (12 URLs)
         id: pages-check
         run: |
           FAILED=0
@@ -55,8 +55,9 @@ jobs:
             "/blog-pieces-auto/guide-achat/roulement-de-roue"
             "/sitemap.xml"
             "/constructeurs/renault-140/clio-iii-140004/1-5-dci-34746.html"
-            "/constructeurs/audi-22/r8-422-32058/4-2-fsi-quattro-v8-32058.html"
-            "/constructeurs/peugeot-105/308-105058/1-6-hdi-21090.html"
+            "/constructeurs/chevrolet-44/aveo-ii-44011/1-2-1623.html"
+            "/constructeurs/fiat-58/bravo-ii-58011/1-4-16v-1630.html"
+            "/constructeurs/volkswagen-173/passat-iii-173086/1-6-1709.html"
           )
           for URL in "${URLS[@]}"; do
             STATUS=$(docker exec $CONTAINER wget --spider -qS "http://localhost:3000$URL" 2>&1 | grep "HTTP/" | tail -1 | awk '{print $2}')
@@ -669,7 +670,7 @@ jobs:
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Health | ${{ steps.health-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Homepage | ${{ steps.homepage-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Pages (11 URLs) | ${{ steps.pages-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pages (12 URLs) | ${{ steps.pages-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| INC-2026-007 vehicle 5xx | ${{ steps.vehicle-5xx-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| SEO Meta | ${{ steps.seo-meta-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| API catalog | ${{ steps.api-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -98,6 +98,8 @@ import { BrandEditorialService } from './services/brand-editorial.service'; // �
 import { VehicleRagGeneratorService } from './services/vehicle-rag-generator.service'; // 🚗 Vehicle RAG .md generator (0 LLM)
 import { RagProposalService } from './services/rag-proposal.service'; // 📝 ADR-022 L1 propose-before-write
 import { AdminVehicleRagController } from './controllers/admin-vehicle-rag.controller'; // 🚗 Vehicle RAG generation endpoints
+import { AdminVehicleCacheController } from './controllers/admin-vehicle-cache.controller'; // 🚗 INC-2026-007 — Vehicle cache rebuild/invalidate/stats
+import { VehiclesModule } from '../vehicles/vehicles.module'; // 🚗 INC-2026-007 — pour VehicleRpcService
 
 // Services - Stock services pour le controller consolidé
 import { ConfigurationService } from './services/configuration.service';
@@ -139,6 +141,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     RagProxyModule, // 📖 Import pour accès à RagProxyService (enrichissement buying guide)
     SystemModule, // DB governance Phase 2 (DbGovernanceService)
     AiContentModule, // 🤖 Pour ConseilEnricher + BuyingGuideSEODraft (optional LLM polish)
+    VehiclesModule, // 🚗 INC-2026-007 — pour AdminVehicleCacheController (VehicleRpcService)
   ],
   controllers: [
     ConfigurationController,
@@ -176,6 +179,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     AdminR8VehicleController, // 🚗 R8 Vehicle enrichment - /api/admin/r8/enrich/:typeId
     AdminR7BrandController, // 🏭 R7 Brand enrichment - /api/admin/r7/enrich/:marqueId
     AdminVehicleRagController, // 🚗 Vehicle RAG generation - /api/admin/vehicle-rag/*
+    AdminVehicleCacheController, // 🚗 INC-2026-007 - /api/admin/vehicle-cache/* (rebuild, invalidate, stats)
     // AdminSupplierStatsController — not ready for prod
     AdminDbGovernanceController, // 📊 DB Governance Phase 2 - /api/admin/db-governance/*
     AdminPipelineController, // 🚀 Unified pipeline execution - /api/admin/pipeline/*

--- a/backend/src/modules/admin/controllers/admin-vehicle-cache.controller.ts
+++ b/backend/src/modules/admin/controllers/admin-vehicle-cache.controller.ts
@@ -1,0 +1,77 @@
+/**
+ * AdminVehicleCacheController
+ *
+ * INC-2026-007 — Étape 5 du plan
+ *
+ * Endpoints admin pour piloter manuellement le cache `__vehicle_page_cache`
+ * (force rebuild, invalidate Redis, stats). Complète :
+ *   - le trigger auto_type (Étape 3, rebuild auto à INSERT/activation)
+ *   - le wrapper SQL mark_stale_with_followup_rebuild (Étape 4, garde-fou pour scripts)
+ *   - le cron one-shot backfill (Étape 2, rattrapage des stale existants)
+ *
+ * Réutilise les méthodes déjà présentes dans VehicleRpcService :
+ *   - rebuildDbCache(typeId) : ligne 233 vehicle-rpc.service.ts
+ *   - invalidateCache(typeId) : ligne 184
+ *   - getDbCacheStats() : ligne 260
+ */
+
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  UseGuards,
+  Logger,
+  ParseIntPipe,
+  BadRequestException,
+} from '@nestjs/common';
+import { AuthenticatedGuard } from '../../../auth/authenticated.guard';
+import { IsAdminGuard } from '../../../auth/is-admin.guard';
+import { VehicleRpcService } from '../../vehicles/services/vehicle-rpc.service';
+
+@Controller('api/admin/vehicle-cache')
+@UseGuards(AuthenticatedGuard, IsAdminGuard)
+export class AdminVehicleCacheController {
+  private readonly logger = new Logger(AdminVehicleCacheController.name);
+
+  constructor(private readonly vehicleRpc: VehicleRpcService) {}
+
+  /**
+   * GET /api/admin/vehicle-cache/stats
+   * Retourne total / stale / oldest_built_at / newest_built_at.
+   */
+  @Get('stats')
+  async getStats() {
+    this.logger.log('GET /api/admin/vehicle-cache/stats');
+    return await this.vehicleRpc.getDbCacheStats();
+  }
+
+  /**
+   * POST /api/admin/vehicle-cache/:typeId/rebuild
+   * Force le rebuild DB d'un type_id + invalide Redis L1.
+   * Idempotent.
+   */
+  @Post(':typeId/rebuild')
+  async rebuild(@Param('typeId', ParseIntPipe) typeId: number) {
+    if (typeId <= 0) {
+      throw new BadRequestException('typeId must be a positive integer');
+    }
+    this.logger.log(`POST /api/admin/vehicle-cache/${typeId}/rebuild`);
+    const rebuilt = await this.vehicleRpc.rebuildDbCache(typeId);
+    return { typeId, rebuilt, success: rebuilt };
+  }
+
+  /**
+   * POST /api/admin/vehicle-cache/:typeId/invalidate
+   * Invalide uniquement Redis L1 pour un type_id (la table DB reste).
+   */
+  @Post(':typeId/invalidate')
+  async invalidate(@Param('typeId', ParseIntPipe) typeId: number) {
+    if (typeId <= 0) {
+      throw new BadRequestException('typeId must be a positive integer');
+    }
+    this.logger.log(`POST /api/admin/vehicle-cache/${typeId}/invalidate`);
+    await this.vehicleRpc.invalidateCache(typeId);
+    return { typeId, invalidated: true };
+  }
+}

--- a/backend/src/modules/errors/controllers/internal-error-log.controller.ts
+++ b/backend/src/modules/errors/controllers/internal-error-log.controller.ts
@@ -1,0 +1,74 @@
+/**
+ * InternalErrorLogController
+ *
+ * INC-2026-007 — Étape 7 du plan
+ *
+ * Comble le blindspot d'instrumentation : les `throw new Response(503)` côté
+ * loader Remix ne s'écrivent pas dans `__error_logs` puisque c'est NestJS qui
+ * détient la connexion DB. Cet endpoint permet au loader Remix de logger les
+ * 5xx qu'il génère, en réutilisant le service centralisé `ErrorLogService`
+ * (buffer, dedup 60s, circuit breaker, bot filter).
+ *
+ * Sécurité : protégé par `InternalApiKeyGuard` (header `X-Internal-Key` validé
+ * en `timingSafeEqual` contre `INTERNAL_API_KEY` env var).
+ *
+ * NOT exposed via Caddy en prod (localhost only).
+ */
+
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { InternalApiKeyGuard } from '../../../auth/internal-api-key.guard';
+import { ErrorLogService } from '../services/error-log.service';
+
+interface LoaderErrorLogBody {
+  status: number;
+  url: string;
+  subject?: string;
+  message?: string;
+  userAgent?: string;
+  metadata?: Record<string, unknown>;
+}
+
+@Controller('api/internal/error-log')
+@UseGuards(InternalApiKeyGuard)
+export class InternalErrorLogController {
+  private readonly logger = new Logger(InternalErrorLogController.name);
+
+  constructor(private readonly errorLogService: ErrorLogService) {}
+
+  /**
+   * POST /api/internal/error-log
+   * Body: { status, url, subject?, message?, userAgent?, metadata? }
+   *
+   * Le loader Remix appelle ce endpoint en fire-and-forget AVANT de throw 503,
+   * pour que le 503 soit visible dans `__error_logs` (sinon blindspot total).
+   */
+  @Post()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async logFromLoader(@Body() body: LoaderErrorLogBody): Promise<void> {
+    if (!body || typeof body.status !== 'number' || !body.url) {
+      this.logger.warn(
+        `Invalid loader error-log payload: ${JSON.stringify(body)}`,
+      );
+      return;
+    }
+
+    await this.errorLogService.logError({
+      code: body.status,
+      url: body.url,
+      userAgent: body.userAgent,
+      metadata: {
+        loader_subject: body.subject ?? `LOADER_${body.status}`,
+        loader_message: body.message,
+        ...(body.metadata ?? {}),
+      },
+    });
+  }
+}

--- a/backend/src/modules/errors/errors.module.ts
+++ b/backend/src/modules/errors/errors.module.ts
@@ -1,18 +1,21 @@
 import { Global, Module } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import { ErrorController } from './controllers/error.controller';
+import { InternalErrorLogController } from './controllers/internal-error-log.controller'; // INC-2026-007 Étape 7
 import { ErrorService } from './services/error.service';
 import { ErrorLogService } from './services/error-log.service';
 import { RedirectService } from './services/redirect.service';
 import { GlobalErrorFilter } from './filters/global-error.filter';
+import { InternalApiKeyGuard } from '../../auth/internal-api-key.guard';
 
 @Global()
 @Module({
-  controllers: [ErrorController],
+  controllers: [ErrorController, InternalErrorLogController],
   providers: [
     ErrorService,
     ErrorLogService,
     RedirectService,
+    InternalApiKeyGuard, // INC-2026-007 Étape 7 : guard pour /api/internal/error-log
     {
       provide: APP_FILTER,
       useClass: GlobalErrorFilter,

--- a/backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql
+++ b/backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql
@@ -1,0 +1,63 @@
+-- Migration : wrapper canon mark_stale_with_followup_rebuild
+--
+-- INC-2026-007 — Étape 4 du plan
+--
+-- Cause secondaire du 503 (cf. INC-2026-007 root cause) :
+--   Le 23/04, un script `catalog_gamme_dedup_20260423` a fait
+--   `UPDATE __vehicle_page_cache SET stale=true WHERE ...` sur 28 252 rows
+--   sans rien déclencher d'autre. Aucun cron ne rebuild les stale → état dégradé permanent
+--   jusqu'à ce qu'un hit utilisateur force un rebuild on-miss synchrone (~2s = 503).
+--
+-- Solution canon : ce wrapper marque stale ET déclenche immédiatement le rebuild.
+-- Tout script SEO/admin DOIT l'utiliser au lieu d'un UPDATE direct.
+--
+-- Mode async : si on doit invalider beaucoup (ex. 28k rows), p_rebuild_immediately=false
+-- laisse le cron Étape 2 faire le rebuild en background, mais le marquage stale est tracé.
+
+CREATE OR REPLACE FUNCTION public.mark_stale_with_followup_rebuild(
+  p_type_ids INTEGER[],
+  p_reason TEXT,
+  p_rebuild_immediately BOOLEAN DEFAULT TRUE
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_marked  INTEGER;
+  v_rebuilt INTEGER := 0;
+  v_id      INTEGER;
+BEGIN
+  IF p_type_ids IS NULL OR array_length(p_type_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  IF COALESCE(trim(p_reason), '') = '' THEN
+    RAISE EXCEPTION 'INC-2026-007: p_reason must be a non-empty string explaining why the cache is invalidated';
+  END IF;
+
+  UPDATE public.__vehicle_page_cache
+  SET stale = TRUE, stale_reason = p_reason
+  WHERE type_id = ANY(p_type_ids);
+  GET DIAGNOSTICS v_marked = ROW_COUNT;
+
+  IF p_rebuild_immediately THEN
+    FOREACH v_id IN ARRAY p_type_ids LOOP
+      BEGIN
+        PERFORM public.rebuild_vehicle_page_cache(v_id);
+        v_rebuilt := v_rebuilt + 1;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'INC-2026-007: rebuild_vehicle_page_cache(%) failed in mark_stale: %',
+          v_id, SQLERRM;
+      END;
+    END LOOP;
+  END IF;
+
+  RAISE NOTICE 'INC-2026-007: marked % rows stale (reason: %), rebuilt % synchronously',
+    v_marked, p_reason, v_rebuilt;
+
+  RETURN v_marked;
+END;
+$$;
+
+COMMENT ON FUNCTION public.mark_stale_with_followup_rebuild(INTEGER[], TEXT, BOOLEAN) IS
+  'INC-2026-007 Etape 4 CANONIQUE: tout script qui invalide des rows __vehicle_page_cache DOIT utiliser cette fonction au lieu d''un UPDATE direct. p_rebuild_immediately=false delegue au cron de l''Etape 2. Reason obligatoire pour la traceability.';

--- a/backend/supabase/migrations/20260425_oneshot_backfill_stale_vehicle_cache.sql
+++ b/backend/supabase/migrations/20260425_oneshot_backfill_stale_vehicle_cache.sql
@@ -1,0 +1,52 @@
+-- Migration : backfill one-shot des rows stale dans __vehicle_page_cache
+--
+-- INC-2026-007 — Étape 2 du plan
+--
+-- Contexte : 28 252 rows sur 28 505 sont marquées stale=true depuis le 23/04
+-- (script catalog_gamme_dedup_20260423) sans qu'aucun cron de refresh ne soit schedulé.
+-- Ce backfill rattrape la dette en deux jobs auto-déprogrammés :
+--   - vehicle_cache_oneshot_backfill : rebuild 200 rows par minute via refresh_stale_vehicle_cache
+--   - vehicle_cache_oneshot_watcher : surveille stale_count et unschedule les deux jobs à 0
+--
+-- Estimation durée : avec p50=405ms par rebuild post-Étape 1 (mesuré stress test 50 types),
+--   200 rows × 0.4s = 80s par batch. Schedule chaque minute → batch ne déborde pas.
+--   28252 / 200 = 141 ticks de 60s = ~2h20 total.
+--
+-- Ce job est éphémère : auto-déprogrammé dès que stale_count = 0. Pas un cron permanent
+-- (qui serait du bricolage). Le pattern long-terme = trigger auto_type Étape 3 + garde-fou
+-- mark_stale_with_followup_rebuild Étape 4.
+
+-- 1. Job principal : rebuild incremental
+SELECT cron.schedule(
+  'vehicle_cache_oneshot_backfill',
+  '* * * * *',
+  $$SELECT public.refresh_stale_vehicle_cache(200)$$
+);
+
+-- 2. Watcher : auto-unschedule des deux jobs quand stale_count = 0
+SELECT cron.schedule(
+  'vehicle_cache_oneshot_watcher',
+  '*/2 * * * *',
+  $watcher$
+  DO $$
+  BEGIN
+    IF (SELECT COUNT(*) FROM public.__vehicle_page_cache WHERE stale=true) = 0 THEN
+      PERFORM cron.unschedule('vehicle_cache_oneshot_backfill');
+      PERFORM cron.unschedule('vehicle_cache_oneshot_watcher');
+      RAISE NOTICE 'INC-2026-007: vehicle cache backfill complete, jobs unscheduled';
+    END IF;
+  END $$;
+  $watcher$
+);
+
+-- Vérification : les 2 jobs sont bien créés
+DO $$
+DECLARE
+  n INT;
+BEGIN
+  SELECT COUNT(*) INTO n FROM cron.job WHERE jobname IN ('vehicle_cache_oneshot_backfill', 'vehicle_cache_oneshot_watcher');
+  IF n != 2 THEN
+    RAISE EXCEPTION 'Expected 2 cron jobs created, got %', n;
+  END IF;
+  RAISE NOTICE 'INC-2026-007: 2 cron jobs scheduled, will auto-unschedule on stale_count=0';
+END $$;

--- a/backend/supabase/migrations/20260425_optimize_build_vehicle_page_payload_catalog.sql
+++ b/backend/supabase/migrations/20260425_optimize_build_vehicle_page_payload_catalog.sql
@@ -1,0 +1,269 @@
+-- Migration : optimisation de la sous-requête `catalog` dans build_vehicle_page_payload
+--
+-- INC-2026-007 — Pages véhicule R8 503 transitoires
+--
+-- Diagnostic root-cause :
+--   Phase 1 ADR-016 (commit fc9b94af, 21/04) a créé build_vehicle_page_payload avec une
+--   sous-requête `catalog` qui force le planner sur pieces_relation_type_v2_pkey
+--   (rtp_type_id, rtp_piece_id) 12 GB au lieu de l'index covering existant
+--   idx_pieces_relation_type_type_id_composite (rtp_type_id, rtp_pg_id) 4 GB.
+--
+--   Cause : la jointure forcée sur pieces.piece_id (pour filtrer piece_display=true)
+--   indique au planner qu'il a besoin de rtp_piece_id → choisit le PK 12 GB qui contient
+--   les deux colonnes, scanne 18 384 rows pour produire 116 résultats (≈ 692 ms warm,
+--   ≈ 2 s cold I/O).
+--
+-- Fix : décomposer la requête en deux phases.
+--   Phase 1 : index-only scan sur idx_..._composite (4 GB), récupère les rtp_pg_id
+--     distincts uniquement (skip totalement la jointure pieces).
+--   Phase 2 : pour chaque candidat, EXISTS sur (1) pieces_gamme display+level,
+--     (2) au moins une piece visible — chacun via index lookup ciblé.
+--
+-- Sémantique préservée : validé sur 10 types stale random (rtp_pg_id et piece_pg_id
+-- produisent les mêmes ensembles dans 100% des cas testés).
+--
+-- Mesures (warm cache, type_id=18110) :
+--   Avant : 692 ms / 18 384 row scans / Buffers hit=72 622 read=2 165
+--   Après : 27.6 ms / 113 rows / Buffers hit=11 868 read=0
+--
+-- Cold path : reste lent (~2 s) à cause de l'I/O brut sur pieces_relation_type 47 GB.
+-- Le 503 est évité structurellement par les Étapes 2+3+4 du plan (cron + trigger + garde-fou)
+-- qui garantissent steady state stale=0 → aucun rebuild on-miss en prod.
+
+CREATE OR REPLACE FUNCTION public.build_vehicle_page_payload(p_type_id integer)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+AS $function$
+DECLARE
+  v_result    JSONB;
+  v_marque_id INTEGER;
+BEGIN
+  SELECT jsonb_build_object(
+    'vehicle', (
+      SELECT jsonb_build_object(
+        'type_id', at.type_id,
+        'type_name', at.type_name,
+        'type_name_meta', at.type_name_meta,
+        'type_alias', at.type_alias,
+        'type_power_ps', at.type_power_ps,
+        'type_power_kw', at.type_power_kw,
+        'type_fuel', at.type_fuel,
+        'type_body', at.type_body,
+        'type_engine', at.type_engine,
+        'type_liter', at.type_liter,
+        'type_month_from', at.type_month_from,
+        'type_year_from', at.type_year_from,
+        'type_month_to', at.type_month_to,
+        'type_year_to', at.type_year_to,
+        'type_relfollow', at.type_relfollow,
+        'modele_id', am.modele_id,
+        'modele_name', am.modele_name,
+        'modele_name_meta', am.modele_name_meta,
+        'modele_alias', am.modele_alias,
+        'modele_pic', am.modele_pic,
+        'modele_ful_name', am.modele_ful_name,
+        'modele_body', am.modele_body,
+        'modele_relfollow', am.modele_relfollow,
+        'modele_year_from', am.modele_year_from,
+        'modele_year_to', am.modele_year_to,
+        'marque_id', amarq.marque_id,
+        'marque_name', amarq.marque_name,
+        'marque_name_meta', amarq.marque_name_meta,
+        'marque_name_meta_title', amarq.marque_name_meta_title,
+        'marque_alias', amarq.marque_alias,
+        'marque_logo', amarq.marque_logo,
+        'marque_relfollow', amarq.marque_relfollow,
+        'marque_top', amarq.marque_top
+      )
+      FROM auto_type at
+      INNER JOIN auto_modele am ON am.modele_id::TEXT = at.type_modele_id
+      INNER JOIN auto_marque amarq ON amarq.marque_id::SMALLINT = am.modele_marque_id
+      WHERE at.type_id = p_type_id::TEXT
+        AND at.type_display = '1'
+      LIMIT 1
+    ),
+    'motor_codes', (
+      SELECT COALESCE(jsonb_agg(tmc_code), '[]'::jsonb)
+      FROM auto_type_motor_code
+      WHERE tmc_type_id = p_type_id::TEXT
+    ),
+    'mine_codes', (
+      SELECT COALESCE(jsonb_agg(DISTINCT tnc_code), '[]'::jsonb)
+      FROM auto_type_number_code
+      WHERE tnc_type_id = p_type_id::TEXT
+        AND tnc_code IS NOT NULL
+        AND tnc_code != ''
+    ),
+    'cnit_codes', (
+      SELECT COALESCE(jsonb_agg(DISTINCT tnc_cnit), '[]'::jsonb)
+      FROM auto_type_number_code
+      WHERE tnc_type_id = p_type_id::TEXT
+        AND tnc_cnit IS NOT NULL
+        AND tnc_cnit != ''
+    ),
+    'seo_custom', (
+      SELECT jsonb_build_object(
+        'mta_title', mta_title,
+        'mta_descrip', mta_descrip,
+        'mta_keywords', mta_keywords,
+        'mta_h1', mta_h1,
+        'mta_content', mta_content,
+        'mta_relfollow', mta_relfollow
+      )
+      FROM ___meta_tags_ariane
+      WHERE mta_alias LIKE '%-' || p_type_id::TEXT
+      LIMIT 1
+    )
+  ) INTO v_result;
+
+  IF v_result IS NULL
+     OR jsonb_typeof(v_result->'vehicle') = 'null'
+     OR v_result->'vehicle' IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  v_marque_id := (v_result->'vehicle'->>'marque_id')::INTEGER;
+
+  v_result := v_result || jsonb_build_object(
+    'blog_content', (
+      SELECT jsonb_build_object(
+        'bsm_id', bsm_id,
+        'bsm_h1', bsm_h1,
+        'bsm_content', bsm_content,
+        'bsm_descrip', bsm_descrip
+      )
+      FROM __blog_seo_marque
+      WHERE bsm_marque_id = v_marque_id::TEXT
+      LIMIT 1
+    )
+  );
+
+  -- ============================================================================
+  -- OPTIMISATION INC-2026-007 : sous-requête `catalog` réécrite en deux phases
+  -- ============================================================================
+  -- Phase 1 (gamme_candidates) : index-only scan sur idx_pieces_relation_type_type_id_composite
+  --   pour récupérer les rtp_pg_id distincts SANS toucher la table pieces.
+  -- Phase 2 (visible_gammes) : EXISTS check ciblé pour vérifier la visibilité réelle
+  --   d'au moins une pièce par gamme.
+  -- Sémantique : équivalente à l'ancienne version (validé sur 10 types stale random).
+  v_result := v_result || jsonb_build_object(
+    'catalog', (
+      WITH gamme_candidates AS (
+        SELECT DISTINCT prt.rtp_pg_id AS pg_id
+        FROM pieces_relation_type prt
+        WHERE prt.rtp_type_id = p_type_id
+      ),
+      visible_gammes AS (
+        SELECT gc.pg_id
+        FROM gamme_candidates gc
+        INNER JOIN pieces_gamme pg ON pg.pg_id = gc.pg_id
+        WHERE pg.pg_display = '1'
+          AND pg.pg_level IN ('1', '2')
+          AND EXISTS (
+            SELECT 1
+            FROM pieces_relation_type prt2
+            INNER JOIN pieces p ON p.piece_id = prt2.rtp_piece_id
+            WHERE prt2.rtp_type_id = p_type_id
+              AND prt2.rtp_pg_id = gc.pg_id
+              AND p.piece_display = true
+            LIMIT 1
+          )
+        LIMIT 500
+      ),
+      gamme_data AS (
+        SELECT pg.pg_id, pg.pg_alias, pg.pg_name, pg.pg_name_meta, pg.pg_img, cg.mc_mf_id, cg.mc_sort
+        FROM visible_gammes vg
+        INNER JOIN pieces_gamme pg ON pg.pg_id = vg.pg_id
+        INNER JOIN catalog_gamme cg ON cg.mc_pg_id = pg.pg_id::TEXT
+      ),
+      families_with_gammes AS (
+        SELECT cf.mf_id, cf.mf_name, COALESCE(cf.mf_name_system, cf.mf_name) AS mf_name_display,
+          cf.mf_description, cf.mf_pic, cf.mf_sort,
+          jsonb_agg(
+            jsonb_build_object(
+              'pg_id', gd.pg_id,
+              'pg_alias', gd.pg_alias,
+              'pg_name', gd.pg_name,
+              'pg_name_meta', gd.pg_name_meta,
+              'pg_img', gd.pg_img,
+              'mc_sort', gd.mc_sort
+            ) ORDER BY gd.mc_sort::INTEGER NULLS LAST
+          ) AS gammes
+        FROM gamme_data gd
+        INNER JOIN catalog_family cf ON cf.mf_id = gd.mc_mf_id
+        WHERE cf.mf_display = '1'
+        GROUP BY cf.mf_id, cf.mf_name, cf.mf_name_system, cf.mf_description, cf.mf_pic, cf.mf_sort
+      )
+      SELECT jsonb_build_object(
+        'families', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'mf_id', mf_id,
+              'mf_name', mf_name_display,
+              'mf_description', mf_description,
+              'mf_pic', mf_pic,
+              'gammes', gammes,
+              'gammes_count', jsonb_array_length(gammes)
+            ) ORDER BY mf_sort::INTEGER NULLS LAST
+          ) FROM families_with_gammes),
+          '[]'::jsonb
+        ),
+        'total_families', (SELECT COUNT(*) FROM families_with_gammes),
+        'total_gammes', (SELECT COALESCE(SUM(jsonb_array_length(gammes)), 0) FROM families_with_gammes)
+      )
+    )
+  );
+  -- ============================================================================
+  -- FIN OPTIMISATION INC-2026-007
+  -- ============================================================================
+
+  v_result := v_result || jsonb_build_object(
+    'popular_parts', (
+      SELECT COALESCE(jsonb_agg(sub), '[]'::jsonb)
+      FROM (
+        SELECT DISTINCT ON (cgc.cgc_pg_id)
+          cgc.cgc_pg_id::INTEGER AS pg_id,
+          pg.pg_alias,
+          pg.pg_name,
+          pg.pg_name_meta,
+          pg.pg_img
+        FROM __cross_gamme_car_new cgc
+        INNER JOIN pieces_gamme pg ON pg.pg_id::TEXT = cgc.cgc_pg_id
+        WHERE cgc.cgc_type_id = p_type_id::TEXT
+          AND cgc.cgc_level IN ('1', '2')
+          AND pg.pg_display = '1'
+        ORDER BY cgc.cgc_pg_id, cgc.cgc_level ASC
+        LIMIT 8
+      ) sub
+    )
+  );
+
+  v_result := v_result || jsonb_build_object(
+    'seo_validation', jsonb_build_object(
+      'family_count', (v_result->'catalog'->>'total_families')::INTEGER,
+      'gamme_count', (v_result->'catalog'->>'total_gammes')::INTEGER,
+      'marque_relfollow', (v_result->'vehicle'->>'marque_relfollow')::INTEGER,
+      'modele_relfollow', (v_result->'vehicle'->>'modele_relfollow')::INTEGER,
+      'type_relfollow', (v_result->'vehicle'->>'type_relfollow')::INTEGER,
+      'is_indexable', (
+        (v_result->'catalog'->>'total_families')::INTEGER >= 3 AND
+        (v_result->'catalog'->>'total_gammes')::INTEGER >= 5 AND
+        COALESCE((v_result->'vehicle'->>'marque_relfollow')::INTEGER, 0) = 1 AND
+        COALESCE((v_result->'vehicle'->>'modele_relfollow')::INTEGER, 0) = 1 AND
+        COALESCE((v_result->'vehicle'->>'type_relfollow')::INTEGER, 0) = 1
+      )
+    )
+  );
+
+  v_result := v_result || jsonb_build_object(
+    'success', TRUE,
+    'type_id', p_type_id
+  );
+
+  RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.build_vehicle_page_payload(integer) IS
+  'INC-2026-007: sous-requete catalog optimisee (warm 27ms vs 692ms ancien). Cold path reste limite par I/O sur pieces_relation_type 47GB - protection structurelle assuree par cron + trigger auto_type + mark_stale_with_followup_rebuild garantissant steady state stale=0.';

--- a/backend/supabase/migrations/20260425_trigger_auto_type_rebuild_vehicle_cache.sql
+++ b/backend/supabase/migrations/20260425_trigger_auto_type_rebuild_vehicle_cache.sql
@@ -1,0 +1,60 @@
+-- Migration : trigger sur auto_type pour rebuild auto du cache véhicule
+--
+-- INC-2026-007 — Étape 3 du plan
+--
+-- Garantit que toute insertion/activation d'un type véhicule déclenche immédiatement
+-- le rebuild de sa ligne `__vehicle_page_cache`. Élimine le rebuild on-miss synchrone
+-- côté hit utilisateur, qui est la cause du 503 (cf. INC-2026-007).
+--
+-- Cas couverts :
+--   1. INSERT auto_type avec type_display=1 → rebuild immédiat
+--   2. UPDATE type_display 0→1 (activation d'un type existant) → rebuild immédiat
+--
+-- Cas NON couverts par ce trigger (gérés par les Étapes 2+4) :
+--   - Données sources (pieces, pieces_relation_type) modifiées : marquage stale via
+--     mark_stale_with_followup_rebuild() côté script de sync (Étape 4)
+--   - Stale rows existantes : cron de l'Étape 2 les rattrape
+--
+-- Conforme ADR-016 ligne 224 : pas de trigger sur pieces_relation_type (368M rows,
+-- dégraderait sync catalogue fournisseur).
+
+CREATE OR REPLACE FUNCTION public.trg_auto_type_rebuild_cache()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_type_id_int INTEGER;
+BEGIN
+  -- auto_type.type_id est TEXT, on cast en INT pour rebuild_vehicle_page_cache
+  v_type_id_int := NEW.type_id::INTEGER;
+
+  -- Cas 1 : INSERT avec type_display=1
+  -- Cas 2 : UPDATE type_display 0→1
+  IF (TG_OP = 'INSERT' AND NEW.type_display::INT = 1)
+     OR (TG_OP = 'UPDATE' AND COALESCE(OLD.type_display, '0')::INT = 0 AND NEW.type_display::INT = 1)
+  THEN
+    -- Best-effort : si rebuild échoue (vehicle pas trouvé, etc.), ne pas bloquer le INSERT
+    BEGIN
+      PERFORM public.rebuild_vehicle_page_cache(v_type_id_int);
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'INC-2026-007: rebuild_vehicle_page_cache(%) failed in trigger: %',
+        v_type_id_int, SQLERRM;
+    END;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_auto_type_rebuild_cache ON public.auto_type;
+
+CREATE TRIGGER trg_auto_type_rebuild_cache
+AFTER INSERT OR UPDATE OF type_display ON public.auto_type
+FOR EACH ROW EXECUTE FUNCTION public.trg_auto_type_rebuild_cache();
+
+COMMENT ON FUNCTION public.trg_auto_type_rebuild_cache() IS
+  'INC-2026-007 Etape 3: pre-rebuild __vehicle_page_cache des qu''un type est insere ou active. Garantit zero rebuild on-miss en steady state.';
+
+COMMENT ON TRIGGER trg_auto_type_rebuild_cache ON public.auto_type IS
+  'INC-2026-007: appelle rebuild_vehicle_page_cache(NEW.type_id) sur INSERT type_display=1 ou UPDATE display 0->1.';

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -79,6 +79,38 @@ export const links: LinksFunction = () => [
 const loaderCache = new Map<string, { data: LoaderData; timestamp: number }>();
 const CACHE_TTL = 60000; // 1 minute
 
+// 📡 INC-2026-007 — Comble le blindspot __error_logs : notifie le backend
+// avant chaque throw 503 du loader. Fire-and-forget, jamais bloquant.
+async function notify503ToErrorLog(
+  url: string,
+  subject: string,
+  message: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  const internalKey = process.env.INTERNAL_API_KEY;
+  if (!internalKey) return;
+
+  try {
+    await fetch(`${getInternalApiUrl("")}/api/internal/error-log`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Internal-Key": internalKey,
+      },
+      body: JSON.stringify({
+        status: 503,
+        url,
+        subject,
+        message,
+        metadata,
+      }),
+      signal: AbortSignal.timeout(500), // ne jamais bloquer le loader
+    }).catch(() => {});
+  } catch {
+    // best-effort, jamais bloquant
+  }
+}
+
 // Types, transform, schema, constants moved to components/vehicle/r8/
 // - r8.types.ts        : VehicleData, CatalogFamily, PopularPart, SEOData, R8Block, R8Content, LoaderData
 // - r8-transform.ts    : transformRpcToLoaderData (RPC → LoaderData, pure)
@@ -212,6 +244,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
         throw new Response("Véhicule supprimé du catalogue", { status: 410 });
       }
       // Vrais erreurs serveur → 503 (Google réessaye) au lieu de 500
+      await notify503ToErrorLog(
+        `/constructeurs/${brand}/${model}/${type}`,
+        "LOADER_503_BACKEND_RPC_ERROR",
+        `Backend page-data-rpc returned HTTP ${rpcResponse.status} for type_id=${type_id}`,
+        { type_id, backend_status: rpcResponse.status },
+      );
       throw new Response("Service temporairement indisponible", {
         status: 503,
       });
@@ -225,6 +263,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
       (error.name === "AbortError" || error.name === "TimeoutError")
     ) {
       logger.error(`⏱️ [RPC] Timeout 10s pour type_id=${type_id}`);
+      await notify503ToErrorLog(
+        `/constructeurs/${brand}/${model}/${type}`,
+        "LOADER_503_RPC_TIMEOUT",
+        `Backend page-data-rpc timeout (10s) for type_id=${type_id}`,
+        { type_id, timeout_ms: 10000 },
+      );
       throw new Response("Service temporairement indisponible", {
         status: 503,
       });
@@ -235,6 +279,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
     }
     // Autres erreurs → 503 (Google réessaye) au lieu de 500
     logger.error(`❌ [RPC] Erreur fetch pour type_id=${type_id}:`, error);
+    await notify503ToErrorLog(
+      `/constructeurs/${brand}/${model}/${type}`,
+      "LOADER_503_RPC_FETCH_ERROR",
+      `Backend page-data-rpc fetch failed for type_id=${type_id}: ${error instanceof Error ? error.message : String(error)}`,
+      { type_id, error_name: error instanceof Error ? error.name : "unknown" },
+    );
     throw new Response("Service temporairement indisponible", { status: 503 });
   }
 
@@ -242,6 +292,16 @@ export async function loader({ params }: LoaderFunctionArgs) {
     logger.error("❌ [RPC] Données invalides:", rpcResult);
     // 503 et non 410 : le véhicule peut exister mais le service a échoué.
     // 410 causerait une désindexation Google permanente.
+    await notify503ToErrorLog(
+      `/constructeurs/${brand}/${model}/${type}`,
+      "LOADER_503_RPC_INVALID_PAYLOAD",
+      `Backend returned 200 but payload invalid for type_id=${type_id}`,
+      {
+        type_id,
+        payload_success: rpcResult.success,
+        has_vehicle: !!rpcResult.data?.vehicle,
+      },
+    );
     throw new Response("Service temporairement indisponible", { status: 503 });
   }
 

--- a/log.md
+++ b/log.md
@@ -40,6 +40,12 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 
 # Timeline
 
+## 2026-04-27 — INC-2026-010 fix root-cause 503 R8 + steady state J+2
+
+- **Branche** : `fix/inc-2026-007-build-vehicle-page-payload-optim` (monorepo) + `incident/inc-2026-007-503-vehicle-build-payload-slow` (vault) — note : nom branches garde `007` historique, ID incident vault renumerote `INC-2026-010` post collision detectee par CI vault
+- **Décision** : Root-cause 503 R8 vehicle pages = `build_vehicle_page_payload` cree par Phase 1 ADR-016 (21/04) avec sous-requete `catalog` qui force le PK 12 GB au lieu de l'index covering 4 GB existant (~2 s rebuild vs timeout 2 s = 503). Fix structurel : reecriture en deux phases (CTE) -> warm 27 ms (-96 %) + steady-state guarantees (cron one-shot backfill + trigger auto_type + wrapper canon mark_stale_with_followup_rebuild + check CI guard). Validation J+2 : stale=0/28 505, watcher auto-unschedule, page 34746 = 200, stress 100 hits = 100/100 = 200.
+- **Sortie** : PR monorepo #167 OPEN (4 commits, 4 migrations DB + 2 controllers NestJS + instrumentation loader Remix + smoke 12 URLs + check CI) | PR vault #65 OPEN (post-mortem INC-2026-010 + steady state J+2 + fix CI G2/wikilinks) | DB deja patchee en prod via MCP (idempotent) | Reste : merge user PR #167 + tag semver pour deploy PROD, Etape 6 RPC_TIMEOUT_MS=500 (post-merge), Etape 10 ADR-016 accepted (J+7 = 2026-05-02), J+14 verif __error_logs + GSC
+
 ## 2026-04-25 — bootstrap log.md timeline
 
 - **Branche** : `chore/log-md-session-timeline-1777110107`

--- a/log.md
+++ b/log.md
@@ -82,6 +82,12 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Décision** : feat(seo-department): phase 2a - audit findings table + canonical auditor
 - **Sortie** : PR #174 | commits 9581f6c2
 
+## 2026-04-25 — fix/inc-2026-007-build-vehicle-page-payload-optim (auto)
+
+- **Branche** : `fix/inc-2026-007-build-vehicle-page-payload-optim`
+- **Décision** : fix(ci): smoke /constructeurs/* — replace inactive type + redirect URL with valid ones (+3 other commits)
+- **Sortie** : PR #167 | commits 84aa9655 9dc8f71b 26d3cea0 26812832
+
 ## 2026-04-27 — feat/r1-gamme-page-cache-phase1 (auto)
 
 - **Branche** : `feat/r1-gamme-page-cache-phase1`

--- a/scripts/ci/check-no-direct-vehicle-cache-stale.sh
+++ b/scripts/ci/check-no-direct-vehicle-cache-stale.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# INC-2026-007 — Check CI : interdire UPDATE __vehicle_page_cache SET stale=... direct
+#
+# Tout script qui invalide doit utiliser mark_stale_with_followup_rebuild()
+# (cf. backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql).
+#
+# Exit 0 si propre, 1 si violation détectée.
+
+set -euo pipefail
+
+SCAN_DIRS=(
+  "backend/supabase/migrations"
+  "scripts/seo"
+  "scripts/db"
+)
+
+EXEMPT_FILES=(
+  "backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql"
+  "backend/supabase/migrations/20260425_oneshot_backfill_stale_vehicle_cache.sql"
+)
+
+VIOLATIONS=0
+TMPFILE="$(mktemp)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+for dir in "${SCAN_DIRS[@]}"; do
+  if [[ ! -d "$dir" ]]; then
+    continue
+  fi
+  # Cherche pattern : UPDATE ... __vehicle_page_cache ... SET stale
+  grep -rEln "UPDATE[[:space:]]+(public\.)?__vehicle_page_cache[[:space:]]+SET[[:space:]]+stale" "$dir" 2>/dev/null > "$TMPFILE" || true
+
+  while IFS= read -r match_file; do
+    [[ -z "$match_file" ]] && continue
+
+    # Skip exempt files
+    skip=0
+    for exempt in "${EXEMPT_FILES[@]}"; do
+      if [[ "$match_file" == "$exempt" ]] || [[ "$match_file" == */"$exempt" ]]; then
+        skip=1
+        break
+      fi
+    done
+    [[ $skip -eq 1 ]] && continue
+
+    echo "❌ INC-2026-007 violation: $match_file uses UPDATE __vehicle_page_cache SET stale directly"
+    echo "   → use SELECT mark_stale_with_followup_rebuild(ARRAY[...], 'reason') instead"
+    VIOLATIONS=$((VIOLATIONS + 1))
+  done < "$TMPFILE"
+done
+
+if [[ $VIOLATIONS -gt 0 ]]; then
+  echo ""
+  echo "FAIL: $VIOLATIONS violation(s) detected. Use mark_stale_with_followup_rebuild() canon."
+  exit 1
+fi
+
+echo "✅ INC-2026-007 check passed: no direct UPDATE __vehicle_page_cache SET stale found"
+exit 0


### PR DESCRIPTION
## Summary

Root-cause fix pour **INC-2026-007** (503 transitoires sur `/constructeurs/*` rapportés par utilisateur le 25/04 sur `clio-iii-140004/1-5-dci-34746.html`).

Trois enchaînements ont créé le bug :

| Date | Modif | Effet |
|------|-------|-------|
| 21/04 (`fc9b94af`) | Phase 1 ADR-016 crée `build_vehicle_page_payload` avec sous-requête `catalog` mal optimisée | 692 ms warm sur `catalog` seul, ~2 s cumulé pour les 8 sections (mesure EXPLAIN ANALYZE 25/04) |
| 21/04 (idem) | Phase 2 baisse `RPC_TIMEOUT_MS` 9000 → 2000 ms sans valider que la fonction tient le budget | Tout rebuild ≥ 2 s renvoie 503 |
| 23/04 | Script `catalog_gamme_dedup_20260423` marque 28 252 / 28 505 rows `stale=true` sans déclencher rebuild ; cron Phase 3 ADR-016 jamais schedulé | 99 % du cache stale, hits cold expose la lenteur structurelle |

## Fix structurel (Étapes 1-9 du plan)

### DB (4 migrations Supabase)

1. **`20260425_optimize_build_vehicle_page_payload_catalog.sql`** — réécrit la sous-requête `catalog` en deux phases (CTE) pour utiliser l'index covering existant `idx_pieces_relation_type_type_id_composite` (4 GB) au lieu du PK 12 GB. Sémantique préservée (validé 10/10 types stale random). **Mesure : warm 27 ms vs 692 ms (-96 %), p50 cold 405 ms vs ~2 s (-80 %).**

2. **`20260425_oneshot_backfill_stale_vehicle_cache.sql`** — cron `* * * * *` rebuild 200 rows par minute + watcher `*/2 * * * *` qui auto-`unschedule` les 2 jobs quand `stale_count = 0`. Pas un cron permanent (éphémère par design).

3. **`20260425_trigger_auto_type_rebuild_vehicle_cache.sql`** — trigger AFTER INSERT OR UPDATE OF `type_display` qui appelle `rebuild_vehicle_page_cache(NEW.type_id)` immédiatement. Garantit zéro rebuild on-miss en steady state.

4. **`20260425_mark_stale_with_followup_rebuild.sql`** — wrapper canonique `mark_stale_with_followup_rebuild(type_ids[], reason, immediate=true)` à utiliser au lieu d'`UPDATE __vehicle_page_cache SET stale=true` direct. `p_reason` obligatoire pour traceability.

### Backend NestJS (2 nouveaux controllers)

5. **`AdminVehicleCacheController`** (`/api/admin/vehicle-cache/`) — endpoints rebuild/invalidate/stats pour debug/hot-fix manuel. Réutilise les méthodes existantes du `VehicleRpcService` (lignes 184/233/260, déjà présentes mais non exposées HTTP).

6. **`InternalErrorLogController`** (`POST /api/internal/error-log`, X-Internal-Key auth) — comble le blindspot historique : les `throw new Response(503)` du loader Remix n'écrivaient rien dans `__error_logs` (vérifié : 0 row depuis 21/04 alors qu'un 503 est observé le 25/04). Réutilise `ErrorLogService` (buffer + dedup + circuit breaker).

### Frontend Remix (loader R8)

7. **`constructeurs.$brand.$model.$type.tsx`** — helper `notify503ToErrorLog` fire-and-forget (timeout 500 ms, jamais bloquant) appelé avant chacun des 4 chemins `throw 503`, avec subjects distincts pour debug : `LOADER_503_BACKEND_RPC_ERROR`, `LOADER_503_RPC_TIMEOUT`, `LOADER_503_RPC_FETCH_ERROR`, `LOADER_503_RPC_INVALID_PAYLOAD`.

### CI / Observabilité

8. **`prod-smoke-tests.yml`** — ajoute 3 URLs `/constructeurs/*` (Renault Clio III, Audi R8, Peugeot 308) au step `pages-check` (hors top-10 historique pour tester long-tail). Nouveau step `vehicle-5xx-check` qui interroge Supabase REST `__error_logs` pour 5xx sur `/constructeurs/*` dans la dernière heure, fail si > 5. **MTTD ramené de "découverte par utilisateur" à ≤ 6h.**

9. **`scripts/ci/check-no-direct-vehicle-cache-stale.sh`** — garde-fou CI : grep tout `UPDATE __vehicle_page_cache SET stale` dans `scripts/` et `backend/supabase/migrations/`, fail si match non-exempté. À wirer dans `ci.yml` en suivi.

## Hors scope (à suivre)

- **Étape 6** : passer `RPC_TIMEOUT_MS` de 2000 à 500 ms dans `vehicle-rpc.service.ts` (alignement ADR-016 critère #5). PR séparée après J+1 validation steady state stale=0 effective en prod.
- **Étape 10** : mettre `ADR-016` status `proposed` → `accepted` dans le vault (PR `ak125/governance-vault`) après J+7 observation.
- **Étape 11** : créer `INC-2026-007` dans le vault (helper `_scripts/new-incident.sh`).

## État prod au moment du push

```sql
SELECT
  (SELECT COUNT(*) FROM __vehicle_page_cache WHERE stale=true) AS stale,
  (SELECT COUNT(*) FROM __vehicle_page_cache WHERE stale=false) AS fresh,
  (SELECT COUNT(*) FROM cron.job WHERE jobname LIKE 'vehicle_cache%') AS jobs_active;
-- stale ~27 000 (en cours de rattrapage, ETA ~2h), fresh ~1 500, jobs_active=2
```

## Test plan

- [ ] CI : `prod-smoke-tests.yml` doit passer (11 URLs, dont 3 `/constructeurs/*`)
- [ ] CI : nouveau step `vehicle-5xx-check` doit retourner 0 (post-merge)
- [ ] DB : `SELECT COUNT(*) FROM __vehicle_page_cache WHERE stale=true` → 0 sous 2-3h post-merge
- [ ] DB : `SELECT jobname FROM cron.job WHERE jobname LIKE 'vehicle_cache_oneshot%'` → vide après watcher unschedule
- [ ] Stress test : `seq 1 100 | xargs -P 100 -I% curl ... 34746.html` → 100 × 200, zéro 503
- [ ] À J+7 : valider 0 entrée `__error_logs` 5xx sur `/constructeurs/*` sur 7 jours

🤖 Generated with [Claude Code](https://claude.com/claude-code)