### PR TITLE
fix(ci): Dockerfile npm ci --ignore-scripts (unblock deploy after @ast-grep crash)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,13 @@ WORKDIR /app
 # First install the dependencies (as they change less often)
 COPY --chown=node:node --from=builder /app/out/json/ .
 COPY --chown=node:node --from=builder /app/out/package-lock.json ./package-lock.json
-RUN --mount=type=cache,target=/root/.npm npm ci
+# --ignore-scripts skips postinstall hooks. Required because @ast-grep/cli
+# (devDep used by audit:ast) crashes its postinstall on Alpine musl
+# ("Failed to move @ast-grep/cli binary into place"). ast-grep is only
+# used in CI audit.yml on Ubuntu (where its binary works), not in Docker
+# build. No other package in this monorepo needs a postinstall step at
+# build time (husky `prepare` is a npm script, not postinstall hook).
+RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts
 
 # Build the project
 COPY --from=builder /app/out/full/ .


### PR DESCRIPTION
## Summary

**P1 BLOCKER** : Deploy CI cassé depuis 2026-04-25 09:29 UTC (4 échecs consécutifs).

```
npm error path /app/node_modules/@ast-grep/cli
npm error Failed to move @ast-grep/cli binary into place
RUN /bin/sh -c npm ci did not complete successfully: exit code: 1
```

`@ast-grep/cli` (devDep, audit:ast script) ship une binary native qui crash son postinstall sur Alpine musl. Le binary n'a pas de variant musl-compat.

## Fix

`npm ci --ignore-scripts` dans le Dockerfile uniquement.

### Justifications

- ast-grep n'est **pas** utilisé au build Docker (juste `audit:ast` script + audit.yml CI Ubuntu)
- audit.yml continue d'utiliser `npm ci` sans flag → ast-grep s'install correctement sur Ubuntu où la binary fonctionne
- Aucun autre package du monorepo n'a de postinstall hook critique au build (husky `prepare` est un npm script, pas postinstall)

## Impact

Débloque les déploiements DEV pré-prod après :
- PR #154 (3 INC DB fix) merged 2026-04-24 17:05 UTC
- PR #161 (view RAG_ONLY_ENRICHED) merged 2026-04-25 09:41 UTC

Les 2 sont sur main mais pas déployés à cause du blocker.

## Test plan

- [x] Identification root cause (postinstall ast-grep + Alpine musl)
- [x] Vérif `--ignore-scripts` ne casse pas autres deps (grep postinstall = 0)
- [ ] CI : Docker build doit passer

🤖 Generated with [Claude Code](https://claude.com/claude-code)