### PR TITLE
feat(rag): vehicle motor corpus scraper + auto-verify enricher (stage 1)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts
@@ -22,6 +22,7 @@ depends_on:
 - RagProxyModule
 - SystemModule
 - AiContentModule
+- VehiclesModule
 ---
 
 # Module Admin

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,9 +2,10 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
+- backend/src/modules/errors/controllers/internal-error-log.controller.ts
 - backend/src/modules/errors/entities/error-log.entity.ts
 - backend/src/modules/errors/errors.module.ts
 - backend/src/modules/errors/filters/global-error.filter.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/gamme-rest/gamme-rest-optimized.controller.ts
 - backend/src/modules/gamme-rest/gamme-rest-rpc-v2.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/.github/workflows/prod-smoke-tests.yml
+++ b/.github/workflows/prod-smoke-tests.yml
@@ -41,7 +41,7 @@ jobs:
           fi
           echo "✅ Homepage: title='$TITLE'"
 
-      - name: 📦 Pages multi-rôles (8 URLs)
+      - name: 📦 Pages multi-rôles (11 URLs)
         id: pages-check
         run: |
           FAILED=0
@@ -54,6 +54,9 @@ jobs:
             "/blog-pieces-auto/conseils/amortisseur"
             "/blog-pieces-auto/guide-achat/roulement-de-roue"
             "/sitemap.xml"
+            "/constructeurs/renault-140/clio-iii-140004/1-5-dci-34746.html"
+            "/constructeurs/audi-22/r8-422-32058/4-2-fsi-quattro-v8-32058.html"
+            "/constructeurs/peugeot-105/308-105058/1-6-hdi-21090.html"
           )
           for URL in "${URLS[@]}"; do
             STATUS=$(docker exec $CONTAINER wget --spider -qS "http://localhost:3000$URL" 2>&1 | grep "HTTP/" | tail -1 | awk '{print $2}')
@@ -68,6 +71,32 @@ jobs:
             exit 1
           fi
           echo "✅ All 8 pages OK"
+
+      - name: 🚨 INC-2026-007 — __error_logs 5xx /constructeurs/* (1h window)
+        id: vehicle-5xx-check
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+            echo "⚠️ Supabase credentials missing — skipping vehicle 5xx alert check"
+            exit 0
+          fi
+          # Count 5xx on /constructeurs/* in last hour. Threshold: 5 events.
+          ONE_HOUR_AGO=$(date -u -d '1 hour ago' '+%Y-%m-%dT%H:%M:%S')
+          COUNT=$(curl -sk \
+            "${SUPABASE_URL}/rest/v1/__error_logs?select=err_id&err_status=gte.500&err_url=like.%2Fconstructeurs%2F%25&err_created_at=gte.${ONE_HOUR_AGO}" \
+            -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Prefer: count=exact" \
+            -H "Range: 0-0" \
+            -D - 2>/dev/null | grep -i "content-range" | sed -n 's/.*\/\([0-9]*\).*/\1/p')
+          COUNT=${COUNT:-0}
+          if [ "$COUNT" -gt 5 ]; then
+            echo "❌ INC-2026-007 ALERT: $COUNT × 5xx on /constructeurs/* in last 1h (threshold 5)"
+            exit 1
+          fi
+          echo "✅ INC-2026-007 OK: $COUNT × 5xx on /constructeurs/* in last 1h (threshold 5)"
 
       - name: 🔍 SEO Meta tags
         id: seo-meta-check
@@ -640,7 +669,8 @@ jobs:
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Health | ${{ steps.health-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Homepage | ${{ steps.homepage-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Pages (8 URLs) | ${{ steps.pages-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pages (11 URLs) | ${{ steps.pages-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| INC-2026-007 vehicle 5xx | ${{ steps.vehicle-5xx-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| SEO Meta | ${{ steps.seo-meta-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| API catalog | ${{ steps.api-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| imgproxy | ${{ steps.imgproxy-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -98,6 +98,8 @@ import { BrandEditorialService } from './services/brand-editorial.service'; // �
 import { VehicleRagGeneratorService } from './services/vehicle-rag-generator.service'; // 🚗 Vehicle RAG .md generator (0 LLM)
 import { RagProposalService } from './services/rag-proposal.service'; // 📝 ADR-022 L1 propose-before-write
 import { AdminVehicleRagController } from './controllers/admin-vehicle-rag.controller'; // 🚗 Vehicle RAG generation endpoints
+import { AdminVehicleCacheController } from './controllers/admin-vehicle-cache.controller'; // 🚗 INC-2026-007 — Vehicle cache rebuild/invalidate/stats
+import { VehiclesModule } from '../vehicles/vehicles.module'; // 🚗 INC-2026-007 — pour VehicleRpcService
 
 // Services - Stock services pour le controller consolidé
 import { ConfigurationService } from './services/configuration.service';
@@ -139,6 +141,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     RagProxyModule, // 📖 Import pour accès à RagProxyService (enrichissement buying guide)
     SystemModule, // DB governance Phase 2 (DbGovernanceService)
     AiContentModule, // 🤖 Pour ConseilEnricher + BuyingGuideSEODraft (optional LLM polish)
+    VehiclesModule, // 🚗 INC-2026-007 — pour AdminVehicleCacheController (VehicleRpcService)
   ],
   controllers: [
     ConfigurationController,
@@ -176,6 +179,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     AdminR8VehicleController, // 🚗 R8 Vehicle enrichment - /api/admin/r8/enrich/:typeId
     AdminR7BrandController, // 🏭 R7 Brand enrichment - /api/admin/r7/enrich/:marqueId
     AdminVehicleRagController, // 🚗 Vehicle RAG generation - /api/admin/vehicle-rag/*
+    AdminVehicleCacheController, // 🚗 INC-2026-007 - /api/admin/vehicle-cache/* (rebuild, invalidate, stats)
     // AdminSupplierStatsController — not ready for prod
     AdminDbGovernanceController, // 📊 DB Governance Phase 2 - /api/admin/db-governance/*
     AdminPipelineController, // 🚀 Unified pipeline execution - /api/admin/pipeline/*

--- a/backend/src/modules/admin/controllers/admin-vehicle-cache.controller.ts
+++ b/backend/src/modules/admin/controllers/admin-vehicle-cache.controller.ts
@@ -1,0 +1,77 @@
+/**
+ * AdminVehicleCacheController
+ *
+ * INC-2026-007 — Étape 5 du plan
+ *
+ * Endpoints admin pour piloter manuellement le cache `__vehicle_page_cache`
+ * (force rebuild, invalidate Redis, stats). Complète :
+ *   - le trigger auto_type (Étape 3, rebuild auto à INSERT/activation)
+ *   - le wrapper SQL mark_stale_with_followup_rebuild (Étape 4, garde-fou pour scripts)
+ *   - le cron one-shot backfill (Étape 2, rattrapage des stale existants)
+ *
+ * Réutilise les méthodes déjà présentes dans VehicleRpcService :
+ *   - rebuildDbCache(typeId) : ligne 233 vehicle-rpc.service.ts
+ *   - invalidateCache(typeId) : ligne 184
+ *   - getDbCacheStats() : ligne 260
+ */
+
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  UseGuards,
+  Logger,
+  ParseIntPipe,
+  BadRequestException,
+} from '@nestjs/common';
+import { AuthenticatedGuard } from '../../../auth/authenticated.guard';
+import { IsAdminGuard } from '../../../auth/is-admin.guard';
+import { VehicleRpcService } from '../../vehicles/services/vehicle-rpc.service';
+
+@Controller('api/admin/vehicle-cache')
+@UseGuards(AuthenticatedGuard, IsAdminGuard)
+export class AdminVehicleCacheController {
+  private readonly logger = new Logger(AdminVehicleCacheController.name);
+
+  constructor(private readonly vehicleRpc: VehicleRpcService) {}
+
+  /**
+   * GET /api/admin/vehicle-cache/stats
+   * Retourne total / stale / oldest_built_at / newest_built_at.
+   */
+  @Get('stats')
+  async getStats() {
+    this.logger.log('GET /api/admin/vehicle-cache/stats');
+    return await this.vehicleRpc.getDbCacheStats();
+  }
+
+  /**
+   * POST /api/admin/vehicle-cache/:typeId/rebuild
+   * Force le rebuild DB d'un type_id + invalide Redis L1.
+   * Idempotent.
+   */
+  @Post(':typeId/rebuild')
+  async rebuild(@Param('typeId', ParseIntPipe) typeId: number) {
+    if (typeId <= 0) {
+      throw new BadRequestException('typeId must be a positive integer');
+    }
+    this.logger.log(`POST /api/admin/vehicle-cache/${typeId}/rebuild`);
+    const rebuilt = await this.vehicleRpc.rebuildDbCache(typeId);
+    return { typeId, rebuilt, success: rebuilt };
+  }
+
+  /**
+   * POST /api/admin/vehicle-cache/:typeId/invalidate
+   * Invalide uniquement Redis L1 pour un type_id (la table DB reste).
+   */
+  @Post(':typeId/invalidate')
+  async invalidate(@Param('typeId', ParseIntPipe) typeId: number) {
+    if (typeId <= 0) {
+      throw new BadRequestException('typeId must be a positive integer');
+    }
+    this.logger.log(`POST /api/admin/vehicle-cache/${typeId}/invalidate`);
+    await this.vehicleRpc.invalidateCache(typeId);
+    return { typeId, invalidated: true };
+  }
+}

--- a/backend/src/modules/errors/controllers/internal-error-log.controller.ts
+++ b/backend/src/modules/errors/controllers/internal-error-log.controller.ts
@@ -1,0 +1,74 @@
+/**
+ * InternalErrorLogController
+ *
+ * INC-2026-007 — Étape 7 du plan
+ *
+ * Comble le blindspot d'instrumentation : les `throw new Response(503)` côté
+ * loader Remix ne s'écrivent pas dans `__error_logs` puisque c'est NestJS qui
+ * détient la connexion DB. Cet endpoint permet au loader Remix de logger les
+ * 5xx qu'il génère, en réutilisant le service centralisé `ErrorLogService`
+ * (buffer, dedup 60s, circuit breaker, bot filter).
+ *
+ * Sécurité : protégé par `InternalApiKeyGuard` (header `X-Internal-Key` validé
+ * en `timingSafeEqual` contre `INTERNAL_API_KEY` env var).
+ *
+ * NOT exposed via Caddy en prod (localhost only).
+ */
+
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { InternalApiKeyGuard } from '../../../auth/internal-api-key.guard';
+import { ErrorLogService } from '../services/error-log.service';
+
+interface LoaderErrorLogBody {
+  status: number;
+  url: string;
+  subject?: string;
+  message?: string;
+  userAgent?: string;
+  metadata?: Record<string, unknown>;
+}
+
+@Controller('api/internal/error-log')
+@UseGuards(InternalApiKeyGuard)
+export class InternalErrorLogController {
+  private readonly logger = new Logger(InternalErrorLogController.name);
+
+  constructor(private readonly errorLogService: ErrorLogService) {}
+
+  /**
+   * POST /api/internal/error-log
+   * Body: { status, url, subject?, message?, userAgent?, metadata? }
+   *
+   * Le loader Remix appelle ce endpoint en fire-and-forget AVANT de throw 503,
+   * pour que le 503 soit visible dans `__error_logs` (sinon blindspot total).
+   */
+  @Post()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async logFromLoader(@Body() body: LoaderErrorLogBody): Promise<void> {
+    if (!body || typeof body.status !== 'number' || !body.url) {
+      this.logger.warn(
+        `Invalid loader error-log payload: ${JSON.stringify(body)}`,
+      );
+      return;
+    }
+
+    await this.errorLogService.logError({
+      code: body.status,
+      url: body.url,
+      userAgent: body.userAgent,
+      metadata: {
+        loader_subject: body.subject ?? `LOADER_${body.status}`,
+        loader_message: body.message,
+        ...(body.metadata ?? {}),
+      },
+    });
+  }
+}

--- a/backend/src/modules/errors/errors.module.ts
+++ b/backend/src/modules/errors/errors.module.ts
@@ -1,18 +1,21 @@
 import { Global, Module } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import { ErrorController } from './controllers/error.controller';
+import { InternalErrorLogController } from './controllers/internal-error-log.controller'; // INC-2026-007 Étape 7
 import { ErrorService } from './services/error.service';
 import { ErrorLogService } from './services/error-log.service';
 import { RedirectService } from './services/redirect.service';
 import { GlobalErrorFilter } from './filters/global-error.filter';
+import { InternalApiKeyGuard } from '../../auth/internal-api-key.guard';
 
 @Global()
 @Module({
-  controllers: [ErrorController],
+  controllers: [ErrorController, InternalErrorLogController],
   providers: [
     ErrorService,
     ErrorLogService,
     RedirectService,
+    InternalApiKeyGuard, // INC-2026-007 Étape 7 : guard pour /api/internal/error-log
     {
       provide: APP_FILTER,
       useClass: GlobalErrorFilter,

--- a/backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql
+++ b/backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql
@@ -1,0 +1,63 @@
+-- Migration : wrapper canon mark_stale_with_followup_rebuild
+--
+-- INC-2026-007 — Étape 4 du plan
+--
+-- Cause secondaire du 503 (cf. INC-2026-007 root cause) :
+--   Le 23/04, un script `catalog_gamme_dedup_20260423` a fait
+--   `UPDATE __vehicle_page_cache SET stale=true WHERE ...` sur 28 252 rows
+--   sans rien déclencher d'autre. Aucun cron ne rebuild les stale → état dégradé permanent
+--   jusqu'à ce qu'un hit utilisateur force un rebuild on-miss synchrone (~2s = 503).
+--
+-- Solution canon : ce wrapper marque stale ET déclenche immédiatement le rebuild.
+-- Tout script SEO/admin DOIT l'utiliser au lieu d'un UPDATE direct.
+--
+-- Mode async : si on doit invalider beaucoup (ex. 28k rows), p_rebuild_immediately=false
+-- laisse le cron Étape 2 faire le rebuild en background, mais le marquage stale est tracé.
+
+CREATE OR REPLACE FUNCTION public.mark_stale_with_followup_rebuild(
+  p_type_ids INTEGER[],
+  p_reason TEXT,
+  p_rebuild_immediately BOOLEAN DEFAULT TRUE
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_marked  INTEGER;
+  v_rebuilt INTEGER := 0;
+  v_id      INTEGER;
+BEGIN
+  IF p_type_ids IS NULL OR array_length(p_type_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  IF COALESCE(trim(p_reason), '') = '' THEN
+    RAISE EXCEPTION 'INC-2026-007: p_reason must be a non-empty string explaining why the cache is invalidated';
+  END IF;
+
+  UPDATE public.__vehicle_page_cache
+  SET stale = TRUE, stale_reason = p_reason
+  WHERE type_id = ANY(p_type_ids);
+  GET DIAGNOSTICS v_marked = ROW_COUNT;
+
+  IF p_rebuild_immediately THEN
+    FOREACH v_id IN ARRAY p_type_ids LOOP
+      BEGIN
+        PERFORM public.rebuild_vehicle_page_cache(v_id);
+        v_rebuilt := v_rebuilt + 1;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'INC-2026-007: rebuild_vehicle_page_cache(%) failed in mark_stale: %',
+          v_id, SQLERRM;
+      END;
+    END LOOP;
+  END IF;
+
+  RAISE NOTICE 'INC-2026-007: marked % rows stale (reason: %), rebuilt % synchronously',
+    v_marked, p_reason, v_rebuilt;
+
+  RETURN v_marked;
+END;
+$$;
+
+COMMENT ON FUNCTION public.mark_stale_with_followup_rebuild(INTEGER[], TEXT, BOOLEAN) IS
+  'INC-2026-007 Etape 4 CANONIQUE: tout script qui invalide des rows __vehicle_page_cache DOIT utiliser cette fonction au lieu d''un UPDATE direct. p_rebuild_immediately=false delegue au cron de l''Etape 2. Reason obligatoire pour la traceability.';

--- a/backend/supabase/migrations/20260425_oneshot_backfill_stale_vehicle_cache.sql
+++ b/backend/supabase/migrations/20260425_oneshot_backfill_stale_vehicle_cache.sql
@@ -1,0 +1,52 @@
+-- Migration : backfill one-shot des rows stale dans __vehicle_page_cache
+--
+-- INC-2026-007 — Étape 2 du plan
+--
+-- Contexte : 28 252 rows sur 28 505 sont marquées stale=true depuis le 23/04
+-- (script catalog_gamme_dedup_20260423) sans qu'aucun cron de refresh ne soit schedulé.
+-- Ce backfill rattrape la dette en deux jobs auto-déprogrammés :
+--   - vehicle_cache_oneshot_backfill : rebuild 200 rows par minute via refresh_stale_vehicle_cache
+--   - vehicle_cache_oneshot_watcher : surveille stale_count et unschedule les deux jobs à 0
+--
+-- Estimation durée : avec p50=405ms par rebuild post-Étape 1 (mesuré stress test 50 types),
+--   200 rows × 0.4s = 80s par batch. Schedule chaque minute → batch ne déborde pas.
+--   28252 / 200 = 141 ticks de 60s = ~2h20 total.
+--
+-- Ce job est éphémère : auto-déprogrammé dès que stale_count = 0. Pas un cron permanent
+-- (qui serait du bricolage). Le pattern long-terme = trigger auto_type Étape 3 + garde-fou
+-- mark_stale_with_followup_rebuild Étape 4.
+
+-- 1. Job principal : rebuild incremental
+SELECT cron.schedule(
+  'vehicle_cache_oneshot_backfill',
+  '* * * * *',
+  $$SELECT public.refresh_stale_vehicle_cache(200)$$
+);
+
+-- 2. Watcher : auto-unschedule des deux jobs quand stale_count = 0
+SELECT cron.schedule(
+  'vehicle_cache_oneshot_watcher',
+  '*/2 * * * *',
+  $watcher$
+  DO $$
+  BEGIN
+    IF (SELECT COUNT(*) FROM public.__vehicle_page_cache WHERE stale=true) = 0 THEN
+      PERFORM cron.unschedule('vehicle_cache_oneshot_backfill');
+      PERFORM cron.unschedule('vehicle_cache_oneshot_watcher');
+      RAISE NOTICE 'INC-2026-007: vehicle cache backfill complete, jobs unscheduled';
+    END IF;
+  END $$;
+  $watcher$
+);
+
+-- Vérification : les 2 jobs sont bien créés
+DO $$
+DECLARE
+  n INT;
+BEGIN
+  SELECT COUNT(*) INTO n FROM cron.job WHERE jobname IN ('vehicle_cache_oneshot_backfill', 'vehicle_cache_oneshot_watcher');
+  IF n != 2 THEN
+    RAISE EXCEPTION 'Expected 2 cron jobs created, got %', n;
+  END IF;
+  RAISE NOTICE 'INC-2026-007: 2 cron jobs scheduled, will auto-unschedule on stale_count=0';
+END $$;

--- a/backend/supabase/migrations/20260425_optimize_build_vehicle_page_payload_catalog.sql
+++ b/backend/supabase/migrations/20260425_optimize_build_vehicle_page_payload_catalog.sql
@@ -1,0 +1,269 @@
+-- Migration : optimisation de la sous-requête `catalog` dans build_vehicle_page_payload
+--
+-- INC-2026-007 — Pages véhicule R8 503 transitoires
+--
+-- Diagnostic root-cause :
+--   Phase 1 ADR-016 (commit fc9b94af, 21/04) a créé build_vehicle_page_payload avec une
+--   sous-requête `catalog` qui force le planner sur pieces_relation_type_v2_pkey
+--   (rtp_type_id, rtp_piece_id) 12 GB au lieu de l'index covering existant
+--   idx_pieces_relation_type_type_id_composite (rtp_type_id, rtp_pg_id) 4 GB.
+--
+--   Cause : la jointure forcée sur pieces.piece_id (pour filtrer piece_display=true)
+--   indique au planner qu'il a besoin de rtp_piece_id → choisit le PK 12 GB qui contient
+--   les deux colonnes, scanne 18 384 rows pour produire 116 résultats (≈ 692 ms warm,
+--   ≈ 2 s cold I/O).
+--
+-- Fix : décomposer la requête en deux phases.
+--   Phase 1 : index-only scan sur idx_..._composite (4 GB), récupère les rtp_pg_id
+--     distincts uniquement (skip totalement la jointure pieces).
+--   Phase 2 : pour chaque candidat, EXISTS sur (1) pieces_gamme display+level,
+--     (2) au moins une piece visible — chacun via index lookup ciblé.
+--
+-- Sémantique préservée : validé sur 10 types stale random (rtp_pg_id et piece_pg_id
+-- produisent les mêmes ensembles dans 100% des cas testés).
+--
+-- Mesures (warm cache, type_id=18110) :
+--   Avant : 692 ms / 18 384 row scans / Buffers hit=72 622 read=2 165
+--   Après : 27.6 ms / 113 rows / Buffers hit=11 868 read=0
+--
+-- Cold path : reste lent (~2 s) à cause de l'I/O brut sur pieces_relation_type 47 GB.
+-- Le 503 est évité structurellement par les Étapes 2+3+4 du plan (cron + trigger + garde-fou)
+-- qui garantissent steady state stale=0 → aucun rebuild on-miss en prod.
+
+CREATE OR REPLACE FUNCTION public.build_vehicle_page_payload(p_type_id integer)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+AS $function$
+DECLARE
+  v_result    JSONB;
+  v_marque_id INTEGER;
+BEGIN
+  SELECT jsonb_build_object(
+    'vehicle', (
+      SELECT jsonb_build_object(
+        'type_id', at.type_id,
+        'type_name', at.type_name,
+        'type_name_meta', at.type_name_meta,
+        'type_alias', at.type_alias,
+        'type_power_ps', at.type_power_ps,
+        'type_power_kw', at.type_power_kw,
+        'type_fuel', at.type_fuel,
+        'type_body', at.type_body,
+        'type_engine', at.type_engine,
+        'type_liter', at.type_liter,
+        'type_month_from', at.type_month_from,
+        'type_year_from', at.type_year_from,
+        'type_month_to', at.type_month_to,
+        'type_year_to', at.type_year_to,
+        'type_relfollow', at.type_relfollow,
+        'modele_id', am.modele_id,
+        'modele_name', am.modele_name,
+        'modele_name_meta', am.modele_name_meta,
+        'modele_alias', am.modele_alias,
+        'modele_pic', am.modele_pic,
+        'modele_ful_name', am.modele_ful_name,
+        'modele_body', am.modele_body,
+        'modele_relfollow', am.modele_relfollow,
+        'modele_year_from', am.modele_year_from,
+        'modele_year_to', am.modele_year_to,
+        'marque_id', amarq.marque_id,
+        'marque_name', amarq.marque_name,
+        'marque_name_meta', amarq.marque_name_meta,
+        'marque_name_meta_title', amarq.marque_name_meta_title,
+        'marque_alias', amarq.marque_alias,
+        'marque_logo', amarq.marque_logo,
+        'marque_relfollow', amarq.marque_relfollow,
+        'marque_top', amarq.marque_top
+      )
+      FROM auto_type at
+      INNER JOIN auto_modele am ON am.modele_id::TEXT = at.type_modele_id
+      INNER JOIN auto_marque amarq ON amarq.marque_id::SMALLINT = am.modele_marque_id
+      WHERE at.type_id = p_type_id::TEXT
+        AND at.type_display = '1'
+      LIMIT 1
+    ),
+    'motor_codes', (
+      SELECT COALESCE(jsonb_agg(tmc_code), '[]'::jsonb)
+      FROM auto_type_motor_code
+      WHERE tmc_type_id = p_type_id::TEXT
+    ),
+    'mine_codes', (
+      SELECT COALESCE(jsonb_agg(DISTINCT tnc_code), '[]'::jsonb)
+      FROM auto_type_number_code
+      WHERE tnc_type_id = p_type_id::TEXT
+        AND tnc_code IS NOT NULL
+        AND tnc_code != ''
+    ),
+    'cnit_codes', (
+      SELECT COALESCE(jsonb_agg(DISTINCT tnc_cnit), '[]'::jsonb)
+      FROM auto_type_number_code
+      WHERE tnc_type_id = p_type_id::TEXT
+        AND tnc_cnit IS NOT NULL
+        AND tnc_cnit != ''
+    ),
+    'seo_custom', (
+      SELECT jsonb_build_object(
+        'mta_title', mta_title,
+        'mta_descrip', mta_descrip,
+        'mta_keywords', mta_keywords,
+        'mta_h1', mta_h1,
+        'mta_content', mta_content,
+        'mta_relfollow', mta_relfollow
+      )
+      FROM ___meta_tags_ariane
+      WHERE mta_alias LIKE '%-' || p_type_id::TEXT
+      LIMIT 1
+    )
+  ) INTO v_result;
+
+  IF v_result IS NULL
+     OR jsonb_typeof(v_result->'vehicle') = 'null'
+     OR v_result->'vehicle' IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  v_marque_id := (v_result->'vehicle'->>'marque_id')::INTEGER;
+
+  v_result := v_result || jsonb_build_object(
+    'blog_content', (
+      SELECT jsonb_build_object(
+        'bsm_id', bsm_id,
+        'bsm_h1', bsm_h1,
+        'bsm_content', bsm_content,
+        'bsm_descrip', bsm_descrip
+      )
+      FROM __blog_seo_marque
+      WHERE bsm_marque_id = v_marque_id::TEXT
+      LIMIT 1
+    )
+  );
+
+  -- ============================================================================
+  -- OPTIMISATION INC-2026-007 : sous-requête `catalog` réécrite en deux phases
+  -- ============================================================================
+  -- Phase 1 (gamme_candidates) : index-only scan sur idx_pieces_relation_type_type_id_composite
+  --   pour récupérer les rtp_pg_id distincts SANS toucher la table pieces.
+  -- Phase 2 (visible_gammes) : EXISTS check ciblé pour vérifier la visibilité réelle
+  --   d'au moins une pièce par gamme.
+  -- Sémantique : équivalente à l'ancienne version (validé sur 10 types stale random).
+  v_result := v_result || jsonb_build_object(
+    'catalog', (
+      WITH gamme_candidates AS (
+        SELECT DISTINCT prt.rtp_pg_id AS pg_id
+        FROM pieces_relation_type prt
+        WHERE prt.rtp_type_id = p_type_id
+      ),
+      visible_gammes AS (
+        SELECT gc.pg_id
+        FROM gamme_candidates gc
+        INNER JOIN pieces_gamme pg ON pg.pg_id = gc.pg_id
+        WHERE pg.pg_display = '1'
+          AND pg.pg_level IN ('1', '2')
+          AND EXISTS (
+            SELECT 1
+            FROM pieces_relation_type prt2
+            INNER JOIN pieces p ON p.piece_id = prt2.rtp_piece_id
+            WHERE prt2.rtp_type_id = p_type_id
+              AND prt2.rtp_pg_id = gc.pg_id
+              AND p.piece_display = true
+            LIMIT 1
+          )
+        LIMIT 500
+      ),
+      gamme_data AS (
+        SELECT pg.pg_id, pg.pg_alias, pg.pg_name, pg.pg_name_meta, pg.pg_img, cg.mc_mf_id, cg.mc_sort
+        FROM visible_gammes vg
+        INNER JOIN pieces_gamme pg ON pg.pg_id = vg.pg_id
+        INNER JOIN catalog_gamme cg ON cg.mc_pg_id = pg.pg_id::TEXT
+      ),
+      families_with_gammes AS (
+        SELECT cf.mf_id, cf.mf_name, COALESCE(cf.mf_name_system, cf.mf_name) AS mf_name_display,
+          cf.mf_description, cf.mf_pic, cf.mf_sort,
+          jsonb_agg(
+            jsonb_build_object(
+              'pg_id', gd.pg_id,
+              'pg_alias', gd.pg_alias,
+              'pg_name', gd.pg_name,
+              'pg_name_meta', gd.pg_name_meta,
+              'pg_img', gd.pg_img,
+              'mc_sort', gd.mc_sort
+            ) ORDER BY gd.mc_sort::INTEGER NULLS LAST
+          ) AS gammes
+        FROM gamme_data gd
+        INNER JOIN catalog_family cf ON cf.mf_id = gd.mc_mf_id
+        WHERE cf.mf_display = '1'
+        GROUP BY cf.mf_id, cf.mf_name, cf.mf_name_system, cf.mf_description, cf.mf_pic, cf.mf_sort
+      )
+      SELECT jsonb_build_object(
+        'families', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'mf_id', mf_id,
+              'mf_name', mf_name_display,
+              'mf_description', mf_description,
+              'mf_pic', mf_pic,
+              'gammes', gammes,
+              'gammes_count', jsonb_array_length(gammes)
+            ) ORDER BY mf_sort::INTEGER NULLS LAST
+          ) FROM families_with_gammes),
+          '[]'::jsonb
+        ),
+        'total_families', (SELECT COUNT(*) FROM families_with_gammes),
+        'total_gammes', (SELECT COALESCE(SUM(jsonb_array_length(gammes)), 0) FROM families_with_gammes)
+      )
+    )
+  );
+  -- ============================================================================
+  -- FIN OPTIMISATION INC-2026-007
+  -- ============================================================================
+
+  v_result := v_result || jsonb_build_object(
+    'popular_parts', (
+      SELECT COALESCE(jsonb_agg(sub), '[]'::jsonb)
+      FROM (
+        SELECT DISTINCT ON (cgc.cgc_pg_id)
+          cgc.cgc_pg_id::INTEGER AS pg_id,
+          pg.pg_alias,
+          pg.pg_name,
+          pg.pg_name_meta,
+          pg.pg_img
+        FROM __cross_gamme_car_new cgc
+        INNER JOIN pieces_gamme pg ON pg.pg_id::TEXT = cgc.cgc_pg_id
+        WHERE cgc.cgc_type_id = p_type_id::TEXT
+          AND cgc.cgc_level IN ('1', '2')
+          AND pg.pg_display = '1'
+        ORDER BY cgc.cgc_pg_id, cgc.cgc_level ASC
+        LIMIT 8
+      ) sub
+    )
+  );
+
+  v_result := v_result || jsonb_build_object(
+    'seo_validation', jsonb_build_object(
+      'family_count', (v_result->'catalog'->>'total_families')::INTEGER,
+      'gamme_count', (v_result->'catalog'->>'total_gammes')::INTEGER,
+      'marque_relfollow', (v_result->'vehicle'->>'marque_relfollow')::INTEGER,
+      'modele_relfollow', (v_result->'vehicle'->>'modele_relfollow')::INTEGER,
+      'type_relfollow', (v_result->'vehicle'->>'type_relfollow')::INTEGER,
+      'is_indexable', (
+        (v_result->'catalog'->>'total_families')::INTEGER >= 3 AND
+        (v_result->'catalog'->>'total_gammes')::INTEGER >= 5 AND
+        COALESCE((v_result->'vehicle'->>'marque_relfollow')::INTEGER, 0) = 1 AND
+        COALESCE((v_result->'vehicle'->>'modele_relfollow')::INTEGER, 0) = 1 AND
+        COALESCE((v_result->'vehicle'->>'type_relfollow')::INTEGER, 0) = 1
+      )
+    )
+  );
+
+  v_result := v_result || jsonb_build_object(
+    'success', TRUE,
+    'type_id', p_type_id
+  );
+
+  RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.build_vehicle_page_payload(integer) IS
+  'INC-2026-007: sous-requete catalog optimisee (warm 27ms vs 692ms ancien). Cold path reste limite par I/O sur pieces_relation_type 47GB - protection structurelle assuree par cron + trigger auto_type + mark_stale_with_followup_rebuild garantissant steady state stale=0.';

--- a/backend/supabase/migrations/20260425_trigger_auto_type_rebuild_vehicle_cache.sql
+++ b/backend/supabase/migrations/20260425_trigger_auto_type_rebuild_vehicle_cache.sql
@@ -1,0 +1,60 @@
+-- Migration : trigger sur auto_type pour rebuild auto du cache véhicule
+--
+-- INC-2026-007 — Étape 3 du plan
+--
+-- Garantit que toute insertion/activation d'un type véhicule déclenche immédiatement
+-- le rebuild de sa ligne `__vehicle_page_cache`. Élimine le rebuild on-miss synchrone
+-- côté hit utilisateur, qui est la cause du 503 (cf. INC-2026-007).
+--
+-- Cas couverts :
+--   1. INSERT auto_type avec type_display=1 → rebuild immédiat
+--   2. UPDATE type_display 0→1 (activation d'un type existant) → rebuild immédiat
+--
+-- Cas NON couverts par ce trigger (gérés par les Étapes 2+4) :
+--   - Données sources (pieces, pieces_relation_type) modifiées : marquage stale via
+--     mark_stale_with_followup_rebuild() côté script de sync (Étape 4)
+--   - Stale rows existantes : cron de l'Étape 2 les rattrape
+--
+-- Conforme ADR-016 ligne 224 : pas de trigger sur pieces_relation_type (368M rows,
+-- dégraderait sync catalogue fournisseur).
+
+CREATE OR REPLACE FUNCTION public.trg_auto_type_rebuild_cache()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_type_id_int INTEGER;
+BEGIN
+  -- auto_type.type_id est TEXT, on cast en INT pour rebuild_vehicle_page_cache
+  v_type_id_int := NEW.type_id::INTEGER;
+
+  -- Cas 1 : INSERT avec type_display=1
+  -- Cas 2 : UPDATE type_display 0→1
+  IF (TG_OP = 'INSERT' AND NEW.type_display::INT = 1)
+     OR (TG_OP = 'UPDATE' AND COALESCE(OLD.type_display, '0')::INT = 0 AND NEW.type_display::INT = 1)
+  THEN
+    -- Best-effort : si rebuild échoue (vehicle pas trouvé, etc.), ne pas bloquer le INSERT
+    BEGIN
+      PERFORM public.rebuild_vehicle_page_cache(v_type_id_int);
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'INC-2026-007: rebuild_vehicle_page_cache(%) failed in trigger: %',
+        v_type_id_int, SQLERRM;
+    END;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_auto_type_rebuild_cache ON public.auto_type;
+
+CREATE TRIGGER trg_auto_type_rebuild_cache
+AFTER INSERT OR UPDATE OF type_display ON public.auto_type
+FOR EACH ROW EXECUTE FUNCTION public.trg_auto_type_rebuild_cache();
+
+COMMENT ON FUNCTION public.trg_auto_type_rebuild_cache() IS
+  'INC-2026-007 Etape 3: pre-rebuild __vehicle_page_cache des qu''un type est insere ou active. Garantit zero rebuild on-miss en steady state.';
+
+COMMENT ON TRIGGER trg_auto_type_rebuild_cache ON public.auto_type IS
+  'INC-2026-007: appelle rebuild_vehicle_page_cache(NEW.type_id) sur INSERT type_display=1 ou UPDATE display 0->1.';

--- a/data/vehicles_known_urls.csv
+++ b/data/vehicles_known_urls.csv
@@ -1,0 +1,7 @@
+modele_alias,source,url
+clio-iii,wikipedia-fr,https://fr.wikipedia.org/wiki/Renault_Clio_III
+clio-iii,lacentrale,https://www.lacentrale.fr/fiches-techniques-voiture-renault-clio---.html
+clio-iii,autotitre,https://www.autotitre.com/fiche-technique/Renault/Clio/III
+clio-iii,fiches-auto,https://www.fiches-auto.fr/fiche-technique-renault/specs-106-technique-renault-clio-3.php
+clio-iii,user-manual-renault,https://www.user-manual.renault.com/fr/content/renault-clio-3-phase-1
+clio-iii,lenouvelautomobiliste,https://lenouvelautomobiliste.fr/actualites/histoire-de-la-renault-clio-3-4-2005-tout-ce-que-lon-demande-a-une-voiture/

--- a/docs/superpowers/plans/2026-04-25-fleet-advisor-claude-4-7.md
+++ b/docs/superpowers/plans/2026-04-25-fleet-advisor-claude-4-7.md
@@ -1,0 +1,2146 @@
+# Fleet Advisor + Claude 4.7 Implementation Plan (Phase 0 + Phase 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Advisor agent + tiered Claude 4.7 fleet (Phase 0), and wire 5 producer agents to issue `pre_canon_review` approvals (Phase 1). Establishes the AI peer-review layer before shadow-mode observation (Phase 2 covered in a follow-up plan).
+
+**Architecture:** Native Paperclip primitives only (approval + comment + heartbeat, no fork, no adapter mod). Advisor (Opus 4.7) reports to CEO, polls pending `pre_canon_review` approvals, posts JSON verdict comments. Board operator (`assertBoard`) retains all decisions. Tiered models: Opus 4.7 for strategic + reviewer, Sonnet 4.6 for production workers, Haiku 4.5 kept for SEO-QA pattern checks.
+
+**Tech Stack:** Paperclip (`claude_local` adapter), Python 3 (skill scripts + sync tooling), bash + curl (API calls), pytest (skill unit tests + smoke tests), git (commits per task).
+
+**Spec:** `docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md`
+
+**Branch:** `feat/aicos-fleet-advisor-claude-4-7` (from `main`).
+
+---
+
+## File structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `agents/advisor/AGENTS.md` | Create | Advisor's instruction bundle (skill router, heartbeat behavior, comment-only policy) |
+| `agents/advisor/skills/canon-write-review/SKILL.md` | Create | Skill spec for canon DB write review (zero-LLM checks) |
+| `scripts/advisor/canon_write_review.py` | Create | Python implementation of `canon-write-review` skill |
+| `scripts/advisor/verdict_schema.py` | Create | Pydantic models for verdict JSON (validated by tests) |
+| `scripts/aicos/fleet_config.yaml` | Create | Source of truth for tier model assignment (per-agent) |
+| `scripts/aicos/apply_fleet_models.py` | Create | Idempotent script to PATCH agent models per `fleet_config.yaml` |
+| `scripts/aicos/sync_agents_md.py` | Create | Sync local `agents/<name>/AGENTS.md` → AI-COS via instructions-bundle/file PUT |
+| `scripts/aicos/aicos_client.py` | Create | Tiny HTTP client (auth + JSON). Used by all aicos scripts |
+| `scripts/aicos/smoke_pre_canon_review.py` | Create | Phase 0 smoke test: create dummy approvals, verify advisor pickup |
+| `scripts/advisor/regression_replay.py` | Create | Phase 1 regression: replay 3 historical incidents as approvals |
+| `tests/advisor/test_canon_write_review.py` | Create | Unit tests for `canon_write_review.py` |
+| `tests/advisor/test_verdict_schema.py` | Create | Unit tests for `verdict_schema.py` |
+| `agents/ceo/AGENTS.md` | Modify | Append "Pre-canon review (mandatory)" section per spec § 5 |
+| `agents/cto/AGENTS.md` | Modify | Same |
+| `agents/rag-lead/AGENTS.md` | Modify | Same |
+| `agents/seo-content/AGENTS.md` | Modify | Same |
+| `agents/r4-batch-orchestrator/AGENTS.md` | Modify or Create | Same |
+
+Each script is single-purpose. The HTTP client is shared. Skills decouple from sync tooling. Tests live next to the units they cover.
+
+---
+
+## Prerequisites (do once before Task 1)
+
+- [ ] **P1: Confirm AI-COS API auth context**
+
+The Paperclip CLI context exists at `/home/deploy/.paperclip/context.json`. Run:
+
+```bash
+cat /home/deploy/.paperclip/context.json
+```
+
+Expected: `{ "currentProfile": "aicos", "profiles": { "aicos": { "apiBase": "http://178.104.1.118:3100", "companyId": "4f73fff0-b929-4fe5-9f33-7d54f9ef2f52" } } }`. The CLI uses a board token stored separately. Verify the CLI works:
+
+```bash
+/opt/automecanik/paperclip/paperclip context list
+```
+
+If `agent list` returns 401/500, run:
+
+```bash
+/opt/automecanik/paperclip/paperclip auth --help
+```
+
+and authenticate per CLI guidance. **Do not proceed to Task 4 (HIRE) until this works.**
+
+- [ ] **P2: Confirm git branch is dedicated**
+
+```bash
+git branch --show-current
+```
+
+Expected: `feat/aicos-fleet-advisor-claude-4-7`. If not, switch:
+
+```bash
+git checkout feat/aicos-fleet-advisor-claude-4-7
+```
+
+The spec commit `aea7919d` should be the most recent commit on this branch.
+
+---
+
+## Task 1: Verdict schema (Pydantic models + tests)
+
+**Files:**
+- Create: `scripts/advisor/__init__.py`
+- Create: `scripts/advisor/verdict_schema.py`
+- Test: `tests/advisor/__init__.py`
+- Test: `tests/advisor/test_verdict_schema.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/advisor/test_verdict_schema.py
+import pytest
+from pydantic import ValidationError
+from scripts.advisor.verdict_schema import (
+    Verdict,
+    Finding,
+    Axes,
+    map_recommendation,
+)
+
+
+def test_axes_clamps_to_0_100():
+    a = Axes(correctness=50, security=80, anti_cannib=70, evidence=60, reversibility=90)
+    assert a.score_total() == 350
+
+    with pytest.raises(ValidationError):
+        Axes(correctness=-1, security=80, anti_cannib=70, evidence=60, reversibility=90)
+    with pytest.raises(ValidationError):
+        Axes(correctness=50, security=101, anti_cannib=70, evidence=60, reversibility=90)
+
+
+def test_finding_severity_enum():
+    f = Finding(severity="critical", file_or_table="x", issue="y", suggested_fix="z", blocking=True)
+    assert f.severity == "critical"
+    with pytest.raises(ValidationError):
+        Finding(severity="blocker", file_or_table="x", issue="y", suggested_fix="z", blocking=True)
+
+
+def test_verdict_full_payload_serialises():
+    v = Verdict(
+        version="1.0",
+        scope="code_pr",
+        verdict="PASS",
+        axes=Axes(correctness=85, security=90, anti_cannib=80, evidence=85, reversibility=80),
+        findings=[],
+        evidence_pack=["vault://ops/rules/rules-governance.md#G3"],
+        advisor_recommendation="approve",
+        model_used="claude-opus-4-7",
+        review_duration_ms=1234,
+        revision_round=0,
+    )
+    payload = v.model_dump_json()
+    assert "claude-opus-4-7" in payload
+    assert v.score_total() == 420
+
+
+def test_map_recommendation_critical_finding_blocks_even_if_score_high():
+    findings = [Finding(severity="critical", file_or_table="x", issue="y", suggested_fix="z", blocking=True)]
+    axes = Axes(correctness=100, security=100, anti_cannib=100, evidence=100, reversibility=100)
+    assert map_recommendation(verdict="PASS", axes=axes, findings=findings) == "reject"
+
+
+def test_map_recommendation_score_under_60_rejects():
+    axes = Axes(correctness=10, security=10, anti_cannib=10, evidence=10, reversibility=10)
+    assert map_recommendation(verdict="PASS", axes=axes, findings=[]) == "reject"
+
+
+def test_map_recommendation_score_60_79_revises():
+    axes = Axes(correctness=70, security=70, anti_cannib=70, evidence=70, reversibility=70)  # 350 → mean 70
+    assert map_recommendation(verdict="PASS", axes=axes, findings=[]) == "request_revision"
+
+
+def test_map_recommendation_score_80_plus_pass_approves():
+    axes = Axes(correctness=85, security=85, anti_cannib=85, evidence=85, reversibility=85)  # mean 85
+    assert map_recommendation(verdict="PASS", axes=axes, findings=[]) == "approve"
+
+
+def test_map_recommendation_revise_verdict_requests_revision():
+    axes = Axes(correctness=85, security=85, anti_cannib=85, evidence=85, reversibility=85)
+    assert map_recommendation(verdict="REVISE", axes=axes, findings=[]) == "request_revision"
+
+
+def test_map_recommendation_block_verdict_rejects():
+    axes = Axes(correctness=85, security=85, anti_cannib=85, evidence=85, reversibility=85)
+    assert map_recommendation(verdict="BLOCK", axes=axes, findings=[]) == "reject"
+
+
+def test_map_recommendation_major_finding_blocks_approve():
+    findings = [Finding(severity="major", file_or_table="x", issue="y", suggested_fix="z", blocking=False)]
+    axes = Axes(correctness=85, security=85, anti_cannib=85, evidence=85, reversibility=85)
+    assert map_recommendation(verdict="PASS", axes=axes, findings=findings) == "request_revision"
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cd /opt/automecanik/app
+touch tests/advisor/__init__.py scripts/advisor/__init__.py
+python -m pytest tests/advisor/test_verdict_schema.py -v
+```
+
+Expected: ImportError on `scripts.advisor.verdict_schema`.
+
+- [ ] **Step 3: Implement minimal `verdict_schema.py`**
+
+```python
+# scripts/advisor/verdict_schema.py
+from typing import Literal
+from pydantic import BaseModel, Field, ConfigDict
+
+Severity = Literal["critical", "major", "minor"]
+VerdictTag = Literal["PASS", "REVISE", "BLOCK"]
+Scope = Literal["code_pr", "canon_db_write", "deployment", "governance_change"]
+Recommendation = Literal["approve", "request_revision", "reject"]
+
+
+class Axes(BaseModel):
+    model_config = ConfigDict(frozen=True)
+    correctness: int = Field(ge=0, le=100)
+    security: int = Field(ge=0, le=100)
+    anti_cannib: int = Field(ge=0, le=100)
+    evidence: int = Field(ge=0, le=100)
+    reversibility: int = Field(ge=0, le=100)
+
+    def score_total(self) -> int:
+        return self.correctness + self.security + self.anti_cannib + self.evidence + self.reversibility
+
+    def score_mean(self) -> float:
+        return self.score_total() / 5
+
+
+class Finding(BaseModel):
+    severity: Severity
+    file_or_table: str
+    line_or_row: str | None = None
+    issue: str
+    suggested_fix: str
+    blocking: bool
+
+
+class Verdict(BaseModel):
+    version: str = "1.0"
+    scope: Scope
+    verdict: VerdictTag
+    axes: Axes
+    findings: list[Finding] = Field(default_factory=list)
+    evidence_pack: list[str] = Field(default_factory=list)
+    advisor_recommendation: Recommendation
+    model_used: str
+    review_duration_ms: int
+    revision_round: int = 0
+
+    def score_total(self) -> int:
+        return self.axes.score_total()
+
+
+def map_recommendation(
+    verdict: VerdictTag,
+    axes: Axes,
+    findings: list[Finding],
+) -> Recommendation:
+    """Default policy. Evaluated in order, first match wins.
+
+    1. Critical finding OR verdict=BLOCK → reject
+    2. Score mean < 60 → reject
+    3. Score 60-79 OR verdict=REVISE OR major finding → request_revision
+    4. Score >= 80 AND verdict=PASS AND no major finding → approve
+    5. Default → request_revision
+    """
+    if verdict == "BLOCK":
+        return "reject"
+    if any(f.severity == "critical" for f in findings):
+        return "reject"
+    mean = axes.score_mean()
+    if mean < 60:
+        return "reject"
+    if verdict == "REVISE":
+        return "request_revision"
+    if any(f.severity == "major" for f in findings):
+        return "request_revision"
+    if 60 <= mean < 80:
+        return "request_revision"
+    if mean >= 80 and verdict == "PASS":
+        return "approve"
+    return "request_revision"
+```
+
+- [ ] **Step 4: Run tests — verify all pass**
+
+```bash
+python -m pytest tests/advisor/test_verdict_schema.py -v
+```
+
+Expected: 9 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/advisor/__init__.py scripts/advisor/verdict_schema.py tests/advisor/__init__.py tests/advisor/test_verdict_schema.py
+git commit -m "feat(advisor): verdict schema + recommendation policy
+
+Pydantic models for the canonical advisor verdict JSON. Recommendation
+mapper implements the 5-rule policy from the design spec § 3.5
+(critical or BLOCK→reject, <60→reject, REVISE/major/60-79→revision,
+>=80+PASS→approve, default→revision)."
+```
+
+---
+
+## Task 2: `canon-write-review` skill (Python checks + tests)
+
+**Files:**
+- Create: `scripts/advisor/canon_write_review.py`
+- Test: `tests/advisor/test_canon_write_review.py`
+- Create: `agents/advisor/skills/canon-write-review/SKILL.md`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/advisor/test_canon_write_review.py
+from scripts.advisor.canon_write_review import review_canon_write
+from scripts.advisor.verdict_schema import Verdict
+
+
+SAMPLE_GOOD = {
+    "scope": "canon_db_write",
+    "revision_round_count": 0,
+    "context": {"task_id": "task-123", "issue_id": "issue-9", "session_id": None},
+    "body": {
+        "table": "__seo_keyword_results",
+        "op": "insert",
+        "row_count": 250,
+        "sample_rows": [{"pg_id": 124, "keyword": "tambour de frein"}],
+        "sql_or_rpc": "RPC insert_keyword_results(...)",
+        "affected_pg_ids": [124],
+        "rollback_plan": "DELETE FROM __seo_keyword_results WHERE inserted_at > $now",
+    },
+}
+
+
+def test_good_payload_passes():
+    v = review_canon_write(SAMPLE_GOOD)
+    assert isinstance(v, Verdict)
+    assert v.advisor_recommendation == "approve"
+    assert v.score_mean() >= 80
+    assert v.scope == "canon_db_write"
+
+
+def test_missing_rollback_plan_blocks():
+    bad = {**SAMPLE_GOOD, "body": {**SAMPLE_GOOD["body"], "rollback_plan": ""}}
+    v = review_canon_write(bad)
+    assert v.advisor_recommendation == "reject"
+    assert any(f.severity == "critical" and "rollback_plan" in f.issue for f in v.findings)
+
+
+def test_missing_sql_or_rpc_blocks():
+    bad = {**SAMPLE_GOOD, "body": {**SAMPLE_GOOD["body"], "sql_or_rpc": ""}}
+    v = review_canon_write(bad)
+    assert v.advisor_recommendation == "reject"
+
+
+def test_huge_row_count_without_batch_flag_blocks():
+    bad = {**SAMPLE_GOOD, "body": {**SAMPLE_GOOD["body"], "row_count": 50000}}
+    v = review_canon_write(bad)
+    assert v.advisor_recommendation in ("reject", "request_revision")
+
+
+def test_unknown_table_blocks():
+    bad = {**SAMPLE_GOOD, "body": {**SAMPLE_GOOD["body"], "table": "totally_made_up_table"}}
+    v = review_canon_write(bad)
+    assert v.advisor_recommendation == "reject"
+
+
+def test_delete_op_requires_extra_evidence():
+    bad = {
+        **SAMPLE_GOOD,
+        "body": {**SAMPLE_GOOD["body"], "op": "delete", "rollback_plan": ""},
+    }
+    v = review_canon_write(bad)
+    assert v.advisor_recommendation == "reject"
+
+
+def test_no_task_id_no_issue_no_session_blocks_traceability():
+    bad = {
+        **SAMPLE_GOOD,
+        "context": {"task_id": None, "issue_id": None, "session_id": None},
+    }
+    v = review_canon_write(bad)
+    assert v.advisor_recommendation in ("reject", "request_revision")
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+python -m pytest tests/advisor/test_canon_write_review.py -v
+```
+
+Expected: ImportError on `scripts.advisor.canon_write_review`.
+
+- [ ] **Step 3: Implement minimal `canon_write_review.py`**
+
+```python
+# scripts/advisor/canon_write_review.py
+"""canon-write-review skill — zero-LLM checks for DB writes to canonical tables."""
+import time
+from typing import Any
+from scripts.advisor.verdict_schema import (
+    Verdict,
+    Axes,
+    Finding,
+    map_recommendation,
+)
+
+ALLOWED_TABLE_PREFIXES = ("__seo_", "__rag_", "__pieces_", "__diag_", "__blog_")
+ROW_COUNT_BATCH_THRESHOLD = 1000
+MODEL_USED = "claude-opus-4-7"
+
+
+def review_canon_write(payload: dict[str, Any]) -> Verdict:
+    start = time.time()
+    findings: list[Finding] = []
+    body = payload.get("body", {}) or {}
+    ctx = payload.get("context", {}) or {}
+
+    table = (body.get("table") or "").strip()
+    op = (body.get("op") or "").lower().strip()
+    row_count = int(body.get("row_count") or 0)
+    sql = (body.get("sql_or_rpc") or "").strip()
+    rollback = (body.get("rollback_plan") or "").strip()
+
+    score_correctness = 100
+    score_security = 100
+    score_anti_cannib = 100
+    score_evidence = 100
+    score_reversibility = 100
+
+    if not table.startswith(ALLOWED_TABLE_PREFIXES):
+        findings.append(Finding(
+            severity="critical", file_or_table=table or "<missing>",
+            issue=f"Table '{table}' is not in allowed canonical prefixes {ALLOWED_TABLE_PREFIXES}",
+            suggested_fix="Confirm table name; canonical prefixes only", blocking=True,
+        ))
+        score_correctness = 0
+
+    if op not in ("insert", "update", "delete"):
+        findings.append(Finding(
+            severity="critical", file_or_table=table,
+            issue=f"Op '{op}' is not insert/update/delete", suggested_fix="Set valid op",
+            blocking=True,
+        ))
+        score_correctness = min(score_correctness, 30)
+
+    if not sql:
+        findings.append(Finding(
+            severity="critical", file_or_table=table,
+            issue="sql_or_rpc is empty — write not auditable",
+            suggested_fix="Provide concrete SQL or RPC name + args",
+            blocking=True,
+        ))
+        score_evidence = 0
+
+    if not rollback:
+        findings.append(Finding(
+            severity="critical", file_or_table=table,
+            issue="rollback_plan is empty — write not reversible",
+            suggested_fix="Provide rollback SQL or 'restore from backup <id>'",
+            blocking=True,
+        ))
+        score_reversibility = 0
+
+    if op == "delete" and row_count > 0 and not rollback:
+        findings.append(Finding(
+            severity="critical", file_or_table=table,
+            issue=f"DELETE op on {row_count} rows without rollback_plan",
+            suggested_fix="DELETE always requires explicit rollback_plan",
+            blocking=True,
+        ))
+        score_reversibility = 0
+
+    if row_count > ROW_COUNT_BATCH_THRESHOLD:
+        if not body.get("batch_flag", False):
+            findings.append(Finding(
+                severity="major", file_or_table=table,
+                issue=f"row_count {row_count} > {ROW_COUNT_BATCH_THRESHOLD} requires explicit batch_flag",
+                suggested_fix="Add 'batch_flag: true' to payload + chunk plan",
+                blocking=False,
+            ))
+            score_security = min(score_security, 60)
+
+    if not (ctx.get("task_id") or ctx.get("issue_id") or ctx.get("session_id")):
+        findings.append(Finding(
+            severity="major", file_or_table=table,
+            issue="No task_id / issue_id / session_id in context — write not traceable",
+            suggested_fix="Add at least one of task_id/issue_id/session_id",
+            blocking=False,
+        ))
+        score_evidence = min(score_evidence, 50)
+
+    axes = Axes(
+        correctness=score_correctness,
+        security=score_security,
+        anti_cannib=score_anti_cannib,
+        evidence=score_evidence,
+        reversibility=score_reversibility,
+    )
+    has_critical = any(f.severity == "critical" for f in findings)
+    has_major = any(f.severity == "major" for f in findings)
+    if has_critical:
+        verdict_tag = "BLOCK"
+    elif has_major or axes.score_mean() < 80:
+        verdict_tag = "REVISE"
+    else:
+        verdict_tag = "PASS"
+
+    rec = map_recommendation(verdict_tag, axes, findings)
+
+    return Verdict(
+        version="1.0",
+        scope="canon_db_write",
+        verdict=verdict_tag,
+        axes=axes,
+        findings=findings,
+        evidence_pack=[
+            "spec://docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md#canon-write-review",
+            "vault://ops/rules/rules-governance.md#G3",
+        ],
+        advisor_recommendation=rec,
+        model_used=MODEL_USED,
+        review_duration_ms=int((time.time() - start) * 1000),
+        revision_round=int(payload.get("revision_round_count") or 0),
+    )
+```
+
+- [ ] **Step 4: Run tests — verify all pass**
+
+```bash
+python -m pytest tests/advisor/test_canon_write_review.py -v
+```
+
+Expected: 7 tests passing.
+
+- [ ] **Step 5: Write `SKILL.md` companion document**
+
+```bash
+mkdir -p agents/advisor/skills/canon-write-review
+```
+
+```markdown
+<!-- agents/advisor/skills/canon-write-review/SKILL.md -->
+---
+name: canon-write-review
+description: Pre-canon review of DB writes to __seo_*, __rag_*, __pieces_*, __diag_*, __blog_* tables. Zero-LLM (deterministic checks). Returns canonical Verdict JSON.
+---
+
+# canon-write-review
+
+Use when an advisor agent picks up a `pre_canon_review` approval with `payload.scope == "canon_db_write"`.
+
+## Inputs
+- `payload`: full approval payload as documented in spec § 3.4.
+
+## Outputs
+- `Verdict` object (see `scripts/advisor/verdict_schema.py`) — serialise as JSON in the approval comment body.
+
+## Checks (each maps to one finding axis)
+1. **Table prefix** — must start with `__seo_`, `__rag_`, `__pieces_`, `__diag_`, `__blog_`. Else BLOCK.
+2. **Op** — must be `insert | update | delete`. Else BLOCK.
+3. **sql_or_rpc** — non-empty. Else BLOCK (evidence=0).
+4. **rollback_plan** — non-empty. Else BLOCK (reversibility=0).
+5. **DELETE rule** — DELETE op always requires non-empty rollback_plan, no exceptions.
+6. **Batch threshold** — `row_count > 1000` requires `body.batch_flag = true`. Else REVISE.
+7. **Traceability** — `context` must have at least one of `task_id`, `issue_id`, `session_id`. Else REVISE.
+
+## Mapping to recommendation
+Delegated to `verdict_schema.map_recommendation(verdict, axes, findings)`.
+
+## Implementation
+`scripts/advisor/canon_write_review.py::review_canon_write(payload) → Verdict`
+
+## Tests
+`tests/advisor/test_canon_write_review.py`
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/advisor/canon_write_review.py tests/advisor/test_canon_write_review.py agents/advisor/skills/canon-write-review/SKILL.md
+git commit -m "feat(advisor): canon-write-review skill (zero-LLM checks)
+
+Deterministic pre-canon review of DB writes. Validates table prefix,
+op, sql_or_rpc presence, rollback_plan presence, DELETE safety, batch
+threshold, and traceability. Returns canonical Verdict JSON.
+
+Skill spec at agents/advisor/skills/canon-write-review/SKILL.md."
+```
+
+---
+
+## Task 3: Advisor `AGENTS.md` (instruction bundle)
+
+**Files:**
+- Create: `agents/advisor/AGENTS.md`
+
+- [ ] **Step 1: Write the file**
+
+```markdown
+<!-- agents/advisor/AGENTS.md -->
+# Advisor — AutoMecanik AI peer reviewer
+
+Tu es l'**Advisor** d'AutoMecanik. Tu reviews les productions canon des autres agents avant qu'elles n'atteignent prod (code, DB writes, déploiements, gouvernance). Tu **ne décides jamais** : tu proposes un verdict scoré, le board operator décide.
+
+**CONTRAT DE SORTIE strict (R12) :**
+- Verdict par défaut : `PARTIAL_COVERAGE` ou `INSUFFICIENT_EVIDENCE`, jamais `COMPLETE`/`DONE`/`ALL_FIXED`
+- Aucune modification automatique de code, DB, ou config — tu **scannes, analyses, rapportes**
+- Toute conclusion s'accompagne d'au moins 1 evidence (lien vault, commit SHA, RPC name, ADR)
+
+## Hiérarchie
+
+- **Reportes à** : CEO (`993a4a02`)
+- **Supervises** : aucun
+
+## Rôle
+
+À chaque heartbeat (60s), tu :
+
+1. Lis `GET /api/companies/{COMPANY_ID}/approvals?status=pending` filtré sur `type=pre_canon_review`
+2. Pour chaque approval :
+   - Charge `payload.scope` (one of `code_pr`, `canon_db_write`, `deployment`, `governance_change`)
+   - Route vers la skill appropriée :
+     | scope | skill |
+     |---|---|
+     | `code_pr` | `code-review` (existing in monorepo) |
+     | `canon_db_write` | `canon-write-review` (your bundled skill, see `skills/canon-write-review/SKILL.md`) |
+     | `deployment` | `code-review` on changelog + ops checklist (manual narrative) |
+     | `governance_change` | `code-review` + cross-ref vault rules |
+   - Construis un `Verdict` (schéma : `scripts/advisor/verdict_schema.py`)
+   - Poste comme commentaire : `POST /api/approvals/{approvalId}/comments` avec `body = JSON.stringify(verdict)`
+3. Tu ne tente JAMAIS `POST /approvals/:id/approve|reject|request-revision` — guardé par `assertBoard`, retournera 403. Si tu reçois 403 sur une route, c'est attendu : log et continue.
+
+## Anti-bricolage
+
+- Ne forke pas Paperclip
+- N'invoque pas le LLM si une vérification déterministe suffit (canon-write-review = zero-LLM)
+- Ne propose pas de "auto-fix" — uniquement `suggested_fix` dans les findings, le producer corrige manuellement
+- Si tu ne sais pas, retourne `INSUFFICIENT_EVIDENCE` dans verdict_tag, pas une supposition
+
+## Verdict format (canonique)
+
+Voir `scripts/advisor/verdict_schema.py::Verdict`. Champs obligatoires :
+- `version`, `scope`, `verdict` (PASS/REVISE/BLOCK)
+- `axes` (5 nombres 0-100 : correctness, security, anti_cannib, evidence, reversibility)
+- `findings` (array de Finding{severity, file_or_table, issue, suggested_fix, blocking})
+- `evidence_pack` (au moins 1 lien)
+- `advisor_recommendation` (approve/request_revision/reject)
+- `model_used`, `review_duration_ms`, `revision_round`
+
+## Mapping verdict → recommandation (politique par défaut, board peut override)
+
+Évalué dans l'ordre, premier match gagne :
+1. Toute finding `severity=critical` OR `verdict=BLOCK` → `reject`
+2. Score mean < 60 → `reject`
+3. Score 60-79 OR `verdict=REVISE` OR finding `severity=major` → `request_revision`
+4. Score >= 80 AND `verdict=PASS` AND aucune finding major → `approve`
+5. Sinon → `request_revision` (default safe)
+
+## Garde-fous
+
+- Si une approval a `revision_round_count >= 3` et toujours pas PASS, ajoute dans `findings` : `severity=critical, issue="Loop revision >= 3"` et recommend `reject` avec note `MANUAL_BOARD_DECISION_REQUIRED`
+- Si payload est invalide JSON ou manque `scope` : retourne verdict `BLOCK` avec finding `severity=critical, issue="Invalid payload schema"`
+- Cost cap : ne pas dépasser 30 reviews / heartbeat. Si plus, log et reprend au heartbeat suivant.
+
+## Infrastructure
+
+- Paperclip API : `http://178.104.1.118:3100` (`X-Internal-Key` ou board token selon contexte)
+- Skills bundle : `code-review` (monorepo), `canon-write-review` (this folder), `content-audit` (monorepo)
+- Spec source : `docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md`
+
+## Références
+
+- Spec : `docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md`
+- Skill canon-write-review : `agents/advisor/skills/canon-write-review/SKILL.md`
+- Verdict schema : `scripts/advisor/verdict_schema.py`
+- Vault canon : `governance-vault/ops/rules/rules-governance.md` (G3 signed-commits, R12 exit-contract)
+```
+
+- [ ] **Step 2: Verify file structure**
+
+```bash
+ls -la agents/advisor/
+```
+
+Expected: `AGENTS.md` and `skills/canon-write-review/SKILL.md`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add agents/advisor/AGENTS.md
+git commit -m "feat(advisor): instruction bundle (AGENTS.md)
+
+Defines the Advisor agent's heartbeat behaviour, skill router, verdict
+mapping policy, and anti-bricolage guards. Reports to CEO. Comment-only
+(never decides — assertBoard preserved)."
+```
+
+---
+
+## Task 4: AI-COS HTTP client (shared by all sync scripts)
+
+**Files:**
+- Create: `scripts/aicos/__init__.py`
+- Create: `scripts/aicos/aicos_client.py`
+- Test: `tests/aicos/__init__.py`
+- Test: `tests/aicos/test_aicos_client.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/aicos/test_aicos_client.py
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+from scripts.aicos.aicos_client import AicosClient, AicosAuthError
+
+
+def test_client_loads_context_from_paperclip_json(tmp_path):
+    ctx = tmp_path / "context.json"
+    ctx.write_text(json.dumps({
+        "currentProfile": "aicos",
+        "profiles": {"aicos": {"apiBase": "http://1.2.3.4:3100", "companyId": "abc"}},
+    }))
+    c = AicosClient(context_path=str(ctx), auth_token="dummy")
+    assert c.api_base == "http://1.2.3.4:3100"
+    assert c.company_id == "abc"
+
+
+def test_client_raises_without_auth(tmp_path):
+    ctx = tmp_path / "context.json"
+    ctx.write_text(json.dumps({
+        "currentProfile": "aicos",
+        "profiles": {"aicos": {"apiBase": "http://1.2.3.4:3100", "companyId": "abc"}},
+    }))
+    with pytest.raises(AicosAuthError):
+        AicosClient(context_path=str(ctx), auth_token=None)
+
+
+def test_client_get_passes_auth_header(tmp_path):
+    ctx = tmp_path / "context.json"
+    ctx.write_text(json.dumps({
+        "currentProfile": "aicos",
+        "profiles": {"aicos": {"apiBase": "http://1.2.3.4:3100", "companyId": "abc"}},
+    }))
+    with patch("scripts.aicos.aicos_client.requests.request") as mock_req:
+        mock_req.return_value = MagicMock(status_code=200, json=lambda: {"ok": True})
+        c = AicosClient(context_path=str(ctx), auth_token="tok123")
+        result = c.get("/api/health")
+        assert result == {"ok": True}
+        _, kwargs = mock_req.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer tok123"
+
+
+def test_client_dry_run_does_not_send_mutations(tmp_path, capsys):
+    ctx = tmp_path / "context.json"
+    ctx.write_text(json.dumps({
+        "currentProfile": "aicos",
+        "profiles": {"aicos": {"apiBase": "http://1.2.3.4:3100", "companyId": "abc"}},
+    }))
+    with patch("scripts.aicos.aicos_client.requests.request") as mock_req:
+        c = AicosClient(context_path=str(ctx), auth_token="tok123", dry_run=True)
+        c.patch("/api/agents/x", body={"adapterConfig": {"model": "y"}})
+        mock_req.assert_not_called()
+        captured = capsys.readouterr()
+        assert "DRY-RUN PATCH" in captured.out
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+mkdir -p tests/aicos
+touch tests/aicos/__init__.py scripts/aicos/__init__.py
+python -m pytest tests/aicos/test_aicos_client.py -v
+```
+
+Expected: ImportError on `scripts.aicos.aicos_client`.
+
+- [ ] **Step 3: Implement `aicos_client.py`**
+
+```python
+# scripts/aicos/aicos_client.py
+"""Tiny HTTP client for the AI-COS Paperclip API. Used by sync + smoke scripts."""
+import json
+import os
+import sys
+import requests
+from typing import Any
+
+
+class AicosAuthError(Exception):
+    pass
+
+
+class AicosClient:
+    DEFAULT_CONTEXT = "/home/deploy/.paperclip/context.json"
+
+    def __init__(
+        self,
+        context_path: str | None = None,
+        auth_token: str | None = None,
+        dry_run: bool = False,
+    ):
+        self.dry_run = dry_run
+        path = context_path or self.DEFAULT_CONTEXT
+        with open(path) as f:
+            ctx = json.load(f)
+        profile = ctx["profiles"][ctx["currentProfile"]]
+        self.api_base = profile["apiBase"].rstrip("/")
+        self.company_id = profile["companyId"]
+        token = auth_token or os.environ.get("PAPERCLIP_BOARD_TOKEN")
+        if not token:
+            raise AicosAuthError(
+                "No auth token. Set PAPERCLIP_BOARD_TOKEN env var or pass auth_token=."
+            )
+        self.auth_token = token
+
+    def _request(self, method: str, path: str, body: Any = None) -> dict:
+        url = f"{self.api_base}{path}"
+        if self.dry_run and method.upper() not in ("GET", "HEAD"):
+            print(f"DRY-RUN {method.upper()} {url}")
+            if body is not None:
+                print(json.dumps(body, indent=2))
+            return {"dry_run": True}
+        headers = {
+            "Authorization": f"Bearer {self.auth_token}",
+            "Content-Type": "application/json",
+        }
+        resp = requests.request(method, url, json=body, headers=headers, timeout=30)
+        if resp.status_code >= 400:
+            print(f"ERROR {method} {url} → {resp.status_code} {resp.text}", file=sys.stderr)
+            resp.raise_for_status()
+        return resp.json() if resp.text else {}
+
+    def get(self, path: str) -> dict:
+        return self._request("GET", path)
+
+    def post(self, path: str, body: Any) -> dict:
+        return self._request("POST", path, body)
+
+    def patch(self, path: str, body: Any) -> dict:
+        return self._request("PATCH", path, body)
+
+    def put(self, path: str, body: Any) -> dict:
+        return self._request("PUT", path, body)
+```
+
+- [ ] **Step 4: Run tests — verify all pass**
+
+```bash
+python -m pytest tests/aicos/test_aicos_client.py -v
+```
+
+Expected: 4 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/aicos/__init__.py scripts/aicos/aicos_client.py tests/aicos/__init__.py tests/aicos/test_aicos_client.py
+git commit -m "feat(aicos): tiny HTTP client (auth + dry-run support)
+
+Reads /home/deploy/.paperclip/context.json for apiBase + companyId.
+PAPERCLIP_BOARD_TOKEN env var or constructor arg for auth. Mutations
+gated by --dry-run flag. Used by all aicos/* scripts."
+```
+
+---
+
+## Task 5: Fleet config YAML (source of truth for tier models)
+
+**Files:**
+- Create: `scripts/aicos/fleet_config.yaml`
+
+- [ ] **Step 1: Write the YAML**
+
+```yaml
+# scripts/aicos/fleet_config.yaml
+# Source of truth for tier model assignment.
+# apply_fleet_models.py reads this file and PATCHes each agent on AI-COS.
+#
+# Models per design spec § 6 (2026-04-25):
+#   Opus 4.7  : strategic + reviewer   (CEO, CTO, Advisor)
+#   Sonnet 4.6: production workers     (CMO, CPO, RAG-Ops, SEO-Content, R4-Batch-Lead)
+#   Haiku 4.5 : pattern checks          (SEO-QA)
+
+version: "1.0"
+spec_ref: "docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md"
+
+models:
+  opus_4_7: "claude-opus-4-7"
+  sonnet_4_6: "claude-sonnet-4-6"
+  haiku_4_5: "claude-haiku-4-5-20251001"
+
+agents:
+  - name: "CEO"
+    aicos_id: "993a4a02-XXXX-XXXX-XXXX-XXXXXXXXXXXX"  # confirm full UUID before apply
+    target_model: "opus_4_7"
+    budget_monthly_cents: 200000   # 2000 USD
+  - name: "CTO"
+    aicos_id: "7fa3c971-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    target_model: "opus_4_7"
+    budget_monthly_cents: 200000
+  - name: "Advisor"
+    aicos_id: null   # populated post-hire (Task 7)
+    target_model: "opus_4_7"
+    budget_monthly_cents: 500000   # 5000 USD (initial, tunable)
+  - name: "CMO"
+    aicos_id: "7fb56320-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    target_model: "sonnet_4_6"
+    budget_monthly_cents: 30000
+  - name: "CPO"
+    aicos_id: "41718022-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    target_model: "sonnet_4_6"
+    budget_monthly_cents: 30000
+  - name: "RAG-Ops"
+    aicos_id: "c6762b10-8c8f-4d15-9fec-04b273a6841b"
+    target_model: "sonnet_4_6"
+    budget_monthly_cents: 30000
+  - name: "SEO-Content"
+    aicos_id: "0f978206-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    target_model: "sonnet_4_6"
+    budget_monthly_cents: 30000
+  - name: "R4-Batch-Lead"
+    aicos_id: "e26ea228-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    target_model: "sonnet_4_6"
+    budget_monthly_cents: 30000
+  - name: "SEO-QA"
+    aicos_id: "8ff977f4-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    target_model: "haiku_4_5"
+    budget_monthly_cents: 5000
+```
+
+- [ ] **Step 2: Resolve full UUIDs**
+
+The IDs in memory `paperclip-agents-config.md` are 8-char prefixes. Replace each `XXXX-...` placeholder by querying:
+
+```bash
+export PAPERCLIP_BOARD_TOKEN="<your-board-token>"
+python3 -c "
+from scripts.aicos.aicos_client import AicosClient
+c = AicosClient(auth_token='${PAPERCLIP_BOARD_TOKEN}')
+agents = c.get(f'/api/companies/{c.company_id}/agents')
+for a in agents.get('items', agents):
+    print(a['id'], a['name'])
+"
+```
+
+Edit `fleet_config.yaml` and replace each `aicos_id` placeholder with the full UUID returned.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/aicos/fleet_config.yaml
+git commit -m "feat(aicos): fleet_config.yaml — tier model source of truth
+
+Per design spec § 6.1. CEO/CTO/Advisor on Opus 4.7, 5 workers on
+Sonnet 4.6, SEO-QA on Haiku 4.5. Budget caps per agent."
+```
+
+---
+
+## Task 6: `apply_fleet_models.py` (idempotent PATCH script)
+
+**Files:**
+- Create: `scripts/aicos/apply_fleet_models.py`
+- Test: `tests/aicos/test_apply_fleet_models.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/aicos/test_apply_fleet_models.py
+from unittest.mock import MagicMock, patch
+from scripts.aicos.apply_fleet_models import build_patches, plan_changes
+
+
+SAMPLE_CONFIG = {
+    "models": {
+        "opus_4_7": "claude-opus-4-7",
+        "sonnet_4_6": "claude-sonnet-4-6",
+    },
+    "agents": [
+        {"name": "CEO", "aicos_id": "id-ceo", "target_model": "opus_4_7", "budget_monthly_cents": 200000},
+        {"name": "CMO", "aicos_id": "id-cmo", "target_model": "sonnet_4_6", "budget_monthly_cents": 30000},
+        {"name": "Advisor", "aicos_id": None, "target_model": "opus_4_7", "budget_monthly_cents": 500000},
+    ],
+}
+
+
+def test_build_patches_resolves_model_alias():
+    patches = build_patches(SAMPLE_CONFIG)
+    ceo = next(p for p in patches if p["aicos_id"] == "id-ceo")
+    assert ceo["body"]["adapterConfig"]["model"] == "claude-opus-4-7"
+    assert ceo["body"]["budgetMonthlyCents"] == 200000
+
+
+def test_build_patches_skips_null_aicos_id():
+    patches = build_patches(SAMPLE_CONFIG)
+    advisor = next((p for p in patches if p["name"] == "Advisor"), None)
+    assert advisor is None
+
+
+def test_plan_changes_is_idempotent():
+    client = MagicMock()
+    client.get.side_effect = lambda path: {
+        "id": path.rsplit("/", 1)[-1],
+        "adapterConfig": {"model": "claude-opus-4-7", "cwd": "/x"},
+        "budgetMonthlyCents": 200000,
+    }
+    plan = plan_changes(client, SAMPLE_CONFIG)
+    ceo = next(p for p in plan if p["aicos_id"] == "id-ceo")
+    assert ceo["status"] == "noop"
+
+
+def test_plan_changes_detects_drift():
+    client = MagicMock()
+    client.get.side_effect = lambda path: {
+        "id": path.rsplit("/", 1)[-1],
+        "adapterConfig": {"model": "claude-haiku-4-5-20251001", "cwd": "/x"},
+        "budgetMonthlyCents": 200000,
+    }
+    plan = plan_changes(client, SAMPLE_CONFIG)
+    ceo = next(p for p in plan if p["aicos_id"] == "id-ceo")
+    assert ceo["status"] == "patch"
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+python -m pytest tests/aicos/test_apply_fleet_models.py -v
+```
+
+Expected: ImportError on `scripts.aicos.apply_fleet_models`.
+
+- [ ] **Step 3: Implement `apply_fleet_models.py`**
+
+```python
+# scripts/aicos/apply_fleet_models.py
+"""Idempotent PATCH of agent models per fleet_config.yaml. Dry-run supported."""
+import argparse
+import sys
+from pathlib import Path
+import yaml
+from scripts.aicos.aicos_client import AicosClient
+
+
+def load_config(path: str) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def build_patches(config: dict) -> list[dict]:
+    """For each agent with an aicos_id, build a PATCH body. Skip null IDs."""
+    models = config["models"]
+    out = []
+    for a in config["agents"]:
+        if not a.get("aicos_id"):
+            continue
+        model_id = models[a["target_model"]]
+        out.append({
+            "name": a["name"],
+            "aicos_id": a["aicos_id"],
+            "body": {
+                "adapterConfig": {"model": model_id},
+                "budgetMonthlyCents": a["budget_monthly_cents"],
+            },
+        })
+    return out
+
+
+def plan_changes(client: AicosClient, config: dict) -> list[dict]:
+    """Compare desired vs current. Returns plan with status (noop|patch|missing)."""
+    out = []
+    for p in build_patches(config):
+        try:
+            current = client.get(f"/api/agents/{p['aicos_id']}")
+        except Exception as e:
+            out.append({**p, "status": "missing", "error": str(e)})
+            continue
+        cur_model = (current.get("adapterConfig") or {}).get("model")
+        cur_budget = current.get("budgetMonthlyCents")
+        desired_model = p["body"]["adapterConfig"]["model"]
+        desired_budget = p["body"]["budgetMonthlyCents"]
+        if cur_model == desired_model and cur_budget == desired_budget:
+            out.append({**p, "status": "noop", "current_model": cur_model})
+        else:
+            out.append({
+                **p,
+                "status": "patch",
+                "current_model": cur_model,
+                "current_budget": cur_budget,
+            })
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="scripts/aicos/fleet_config.yaml")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--apply", action="store_true",
+                        help="Apply PATCHes (otherwise plan-only)")
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    client = AicosClient(dry_run=args.dry_run)
+    plan = plan_changes(client, config)
+
+    print(f"\nFleet plan ({len(plan)} agents):")
+    print(f"{'Name':<20} {'ID':<40} {'Status':<10} {'Current → Desired'}")
+    for p in plan:
+        cur = p.get("current_model") or "?"
+        des = p["body"]["adapterConfig"]["model"]
+        print(f"{p['name']:<20} {p['aicos_id']:<40} {p['status']:<10} {cur} → {des}")
+
+    if not args.apply:
+        print("\n(plan-only; pass --apply to PATCH)")
+        return 0
+
+    patched = 0
+    for p in plan:
+        if p["status"] != "patch":
+            continue
+        client.patch(f"/api/agents/{p['aicos_id']}", body=p["body"])
+        patched += 1
+    print(f"\nApplied {patched} PATCH(es).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run tests — verify all pass**
+
+```bash
+python -m pytest tests/aicos/test_apply_fleet_models.py -v
+```
+
+Expected: 4 tests passing.
+
+- [ ] **Step 5: Plan-only run (no apply yet)**
+
+```bash
+export PAPERCLIP_BOARD_TOKEN="<board-token>"
+python3 scripts/aicos/apply_fleet_models.py --config scripts/aicos/fleet_config.yaml
+```
+
+Expected: prints a plan table for the 8 agents whose `aicos_id` is set (Advisor stays null until Task 7). All 8 should show `status=patch` (current=haiku-4-5 → desired=opus_4_7/sonnet_4_6/haiku-4-5).
+
+If any shows `status=missing`, fix the UUID in `fleet_config.yaml` before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/aicos/apply_fleet_models.py tests/aicos/test_apply_fleet_models.py
+git commit -m "feat(aicos): apply_fleet_models.py (idempotent PATCH)
+
+Reads fleet_config.yaml, compares to current AI-COS state, plans noop
+or patch per agent. --apply gated; default is plan-only. --dry-run
+prints PATCH bodies without sending."
+```
+
+---
+
+## Task 7: Hire Advisor agent on AI-COS (CHECKPOINT — board approval required)
+
+**Files:**
+- Create: `scripts/aicos/hire_advisor.py`
+
+This task creates a hire request. **The board operator must approve it on the AI-COS UI** before the Advisor agent is active.
+
+- [ ] **Step 1: Write `hire_advisor.py`**
+
+```python
+# scripts/aicos/hire_advisor.py
+"""Submit a hire request for the Advisor agent on AI-COS.
+
+The hire creates a draft agent + a `hire_agent` approval. A human board
+operator must approve it on the AI-COS UI to finalize the hire.
+"""
+import argparse
+import sys
+from scripts.aicos.aicos_client import AicosClient
+
+
+CEO_ID = "993a4a02-XXXX-XXXX-XXXX-XXXXXXXXXXXX"  # ← fill in full UUID
+
+
+HIRE_PAYLOAD = {
+    "name": "Advisor",
+    "role": "advisor",
+    "title": "AI peer reviewer",
+    "reportsTo": CEO_ID,
+    "capabilities": (
+        "Pre-canon review for code PRs, DB writes, deployments, governance changes. "
+        "Read-only. Never decides — proposes verdict + scored axes for board operator."
+    ),
+    "budgetMonthlyCents": 500000,
+    "adapterType": "claude_local",
+    "adapterConfig": {
+        "model": "claude-opus-4-7",
+        "cwd": "/paperclip/instances/default/workspaces/advisor",
+        "timeoutSec": 600,
+        "graceSec": 30,
+        "maxTurnsPerRun": 1000,
+    },
+    "instructionsBundleMode": "managed",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    client = AicosClient(dry_run=args.dry_run)
+    print(f"Submitting hire request to {client.api_base} for company {client.company_id}")
+    result = client.post(
+        f"/api/companies/{client.company_id}/agent-hires",
+        body=HIRE_PAYLOAD,
+    )
+    if args.dry_run:
+        print("(dry-run; nothing was sent)")
+        return 0
+
+    print(f"\nHire submitted. Approval ID: {result.get('approvalId') or result.get('id')}")
+    print(f"Draft agent ID: {result.get('agentId')}")
+    print("\n=> Board operator must now approve at:")
+    print(f"   {client.api_base}/approvals")
+    print("\nOnce approved, run:")
+    print("   python3 scripts/aicos/sync_agents_md.py --advisor-only")
+    print("Then update fleet_config.yaml with the Advisor's full agent UUID and run:")
+    print("   python3 scripts/aicos/apply_fleet_models.py --apply")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Resolve `CEO_ID` placeholder**
+
+Replace `CEO_ID = "993a4a02-XXXX..."` with the full UUID from `fleet_config.yaml` (resolved in Task 5 Step 2).
+
+- [ ] **Step 3: Dry-run**
+
+```bash
+python3 scripts/aicos/hire_advisor.py --dry-run
+```
+
+Expected: prints `DRY-RUN POST .../agent-hires` + payload, no HTTP call.
+
+- [ ] **Step 4: 🚧 CHECKPOINT — pause for explicit user go-ahead**
+
+This step submits a hire request to AI-COS production. Pause and confirm with the user before running:
+
+```
+Pause: about to POST /api/companies/.../agent-hires with the Advisor payload.
+This creates a draft agent + a hire_agent approval requiring board approval on AI-COS UI.
+Confirm to proceed (yes/no)?
+```
+
+Wait for explicit user confirmation.
+
+- [ ] **Step 5: Submit (after confirmation)**
+
+```bash
+python3 scripts/aicos/hire_advisor.py
+```
+
+Expected: prints "Hire submitted" + approval ID + agent ID + URL to approvals queue.
+
+- [ ] **Step 6: Board operator approves on AI-COS UI**
+
+Open `http://178.104.1.118:3100/approvals` → find the `hire_agent` approval for "Advisor" → review payload → click Approve.
+
+- [ ] **Step 7: Update `fleet_config.yaml` with the full Advisor UUID**
+
+Once approved, fetch the active Advisor agent's UUID:
+
+```bash
+python3 -c "
+from scripts.aicos.aicos_client import AicosClient
+c = AicosClient()
+agents = c.get(f'/api/companies/{c.company_id}/agents')
+for a in agents.get('items', agents):
+    if a.get('name') == 'Advisor':
+        print(a['id'])
+"
+```
+
+Edit `scripts/aicos/fleet_config.yaml` and set `aicos_id` for Advisor to that UUID.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/aicos/hire_advisor.py scripts/aicos/fleet_config.yaml
+git commit -m "feat(aicos): hire_advisor.py + Advisor UUID resolved
+
+Submits hire request via /agent-hires. Board operator approves on UI.
+fleet_config.yaml now has the active Advisor UUID."
+```
+
+---
+
+## Task 8: Sync `agents/<name>/AGENTS.md` to AI-COS
+
+**Files:**
+- Create: `scripts/aicos/sync_agents_md.py`
+
+- [ ] **Step 1: Write `sync_agents_md.py`**
+
+```python
+# scripts/aicos/sync_agents_md.py
+"""Sync local agents/<name>/AGENTS.md → AI-COS via instructions-bundle/file PUT."""
+import argparse
+import sys
+from pathlib import Path
+import yaml
+from scripts.aicos.aicos_client import AicosClient
+
+
+REMOTE_PATH_TEMPLATE = (
+    "/paperclip/instances/default/companies/{company_id}/agents/{agent_id}/instructions/AGENTS.md"
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="scripts/aicos/fleet_config.yaml")
+    parser.add_argument("--only", action="append", default=None,
+                        help="Sync only these agents (by name). Can be repeated.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        config = yaml.safe_load(f)
+
+    client = AicosClient(dry_run=args.dry_run)
+    repo_root = Path(__file__).resolve().parents[2]
+
+    name_to_folder = {
+        "CEO": "ceo",
+        "CTO": "cto",
+        "CMO": "cmo",
+        "CPO": "cpo",
+        "RAG-Ops": "rag-lead",
+        "SEO-Content": "seo-content",
+        "R4-Batch-Lead": "r4-batch-orchestrator",
+        "SEO-QA": "seo-qa",
+        "Advisor": "advisor",
+    }
+
+    synced = 0
+    for a in config["agents"]:
+        if not a.get("aicos_id"):
+            print(f"  skip {a['name']} (no aicos_id)")
+            continue
+        if args.only and a["name"] not in args.only:
+            continue
+        folder = name_to_folder.get(a["name"])
+        if not folder:
+            print(f"  skip {a['name']} (no local folder mapping)")
+            continue
+        local = repo_root / "agents" / folder / "AGENTS.md"
+        if not local.exists():
+            print(f"  skip {a['name']} (local file missing: {local})")
+            continue
+        remote_path = REMOTE_PATH_TEMPLATE.format(
+            company_id=client.company_id, agent_id=a["aicos_id"]
+        )
+        body = {"path": remote_path, "content": local.read_text()}
+        client.put(f"/api/agents/{a['aicos_id']}/instructions-bundle/file", body=body)
+        print(f"  synced {a['name']} ({len(body['content'])} chars) → {remote_path}")
+        synced += 1
+
+    print(f"\nSynced {synced} agent(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Dry-run for Advisor only**
+
+```bash
+python3 scripts/aicos/sync_agents_md.py --only Advisor --dry-run
+```
+
+Expected: prints `DRY-RUN PUT /api/agents/<advisor-id>/instructions-bundle/file` + body containing the AGENTS.md content.
+
+- [ ] **Step 3: Apply for Advisor only**
+
+```bash
+python3 scripts/aicos/sync_agents_md.py --only Advisor
+```
+
+Expected: prints `synced Advisor (N chars) → /paperclip/instances/.../AGENTS.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/aicos/sync_agents_md.py
+git commit -m "feat(aicos): sync_agents_md.py (DEV→AI-COS instructions sync)
+
+PUT /api/agents/:id/instructions-bundle/file. --only filter for
+selective sync. Used to push Advisor + producer AGENTS.md updates."
+```
+
+---
+
+## Task 9: Apply tier model assignment (CHECKPOINT — production change)
+
+- [ ] **Step 1: Re-run plan to confirm**
+
+```bash
+python3 scripts/aicos/apply_fleet_models.py
+```
+
+Expected: 9 agents in plan (8 from initial + Advisor now resolved). Verify each row.
+
+- [ ] **Step 2: 🚧 CHECKPOINT — pause for explicit user go-ahead**
+
+```
+Pause: about to PATCH 9 agents on AI-COS production. Models change:
+  - 3 agents to Opus 4.7 (CEO, CTO, Advisor)
+  - 5 agents to Sonnet 4.6 (CMO, CPO, RAG-Ops, SEO-Content, R4-Batch-Lead)
+  - 1 agent to Haiku 4.5 (SEO-QA, no change but PATCH for budget)
+Estimated cost increase: ~$11k/month vs baseline.
+Confirm to proceed (yes/no)?
+```
+
+- [ ] **Step 3: Apply**
+
+```bash
+python3 scripts/aicos/apply_fleet_models.py --apply
+```
+
+Expected: prints `Applied N PATCH(es)` where N matches drift count from Step 1.
+
+- [ ] **Step 4: Verify**
+
+```bash
+python3 scripts/aicos/apply_fleet_models.py
+```
+
+Expected: every agent shows `status=noop`. If any still show `patch`, retry or investigate.
+
+- [ ] **Step 5: Commit (no code change, just a marker)**
+
+```bash
+git commit --allow-empty -m "chore(aicos): tier model assignment applied to fleet
+
+9 agents PATCHed on AI-COS:
+- Opus 4.7  : CEO, CTO, Advisor
+- Sonnet 4.6: CMO, CPO, RAG-Ops, SEO-Content, R4-Batch-Lead
+- Haiku 4.5 : SEO-QA (kept)
+
+Per fleet_config.yaml (commit ref) and design spec § 6.1."
+```
+
+---
+
+## Task 10: Phase 0 smoke test — fake approval pickup
+
+**Files:**
+- Create: `scripts/aicos/smoke_pre_canon_review.py`
+
+- [ ] **Step 1: Write smoke script**
+
+```python
+# scripts/aicos/smoke_pre_canon_review.py
+"""Phase 0 smoke test:
+1. Create a fake pre_canon_review approval (good payload)
+2. Wait up to 120s for the Advisor to post a comment
+3. Verify the comment is valid Verdict JSON with advisor_recommendation=approve
+4. Then test assertBoard guard: try to /approve as a non-board actor → expect 403
+"""
+import json
+import sys
+import time
+from scripts.aicos.aicos_client import AicosClient
+from scripts.advisor.verdict_schema import Verdict
+
+
+GOOD_PAYLOAD = {
+    "scope": "canon_db_write",
+    "revision_round_count": 0,
+    "context": {"task_id": "smoke-test-001", "issue_id": None, "session_id": None},
+    "body": {
+        "table": "__seo_keyword_results",
+        "op": "insert",
+        "row_count": 100,
+        "sample_rows": [{"pg_id": 999, "keyword": "smoke test"}],
+        "sql_or_rpc": "SMOKE: dry-run insert simulating R4-Batch",
+        "affected_pg_ids": [999],
+        "rollback_plan": "DELETE FROM __seo_keyword_results WHERE keyword='smoke test'",
+    },
+}
+
+
+def main() -> int:
+    client = AicosClient()
+
+    print("1. Creating fake pre_canon_review approval...")
+    res = client.post(
+        f"/api/companies/{client.company_id}/approvals",
+        body={
+            "type": "pre_canon_review",
+            "payload": GOOD_PAYLOAD,
+        },
+    )
+    approval_id = res.get("id") or res.get("approvalId")
+    if not approval_id:
+        print(f"  FAIL: no approval id in response: {res}", file=sys.stderr)
+        return 1
+    print(f"  → approval {approval_id}")
+
+    print("2. Waiting up to 120s for Advisor to comment...")
+    deadline = time.time() + 120
+    advisor_comment = None
+    while time.time() < deadline:
+        comments = client.get(f"/api/approvals/{approval_id}/comments")
+        items = comments.get("items", comments) or []
+        for c in items:
+            body = c.get("body") or ""
+            if '"scope":"canon_db_write"' in body or '"scope": "canon_db_write"' in body:
+                advisor_comment = c
+                break
+        if advisor_comment:
+            break
+        time.sleep(5)
+
+    if not advisor_comment:
+        print("  FAIL: no advisor comment in 120s", file=sys.stderr)
+        return 2
+
+    print(f"  → comment received")
+    try:
+        verdict = Verdict.model_validate_json(advisor_comment["body"])
+    except Exception as e:
+        print(f"  FAIL: comment body is not valid Verdict JSON: {e}", file=sys.stderr)
+        print(f"  body: {advisor_comment['body']}", file=sys.stderr)
+        return 3
+
+    if verdict.advisor_recommendation != "approve":
+        print(f"  FAIL: expected approve, got {verdict.advisor_recommendation}", file=sys.stderr)
+        print(f"  findings: {verdict.findings}", file=sys.stderr)
+        return 4
+
+    print(f"  → Verdict.advisor_recommendation = {verdict.advisor_recommendation} (PASS)")
+    print(f"  → Verdict.score_total = {verdict.score_total()}")
+    print("\nSmoke test #1 (pickup + verdict) PASS")
+
+    print("\n3. Testing assertBoard guard (advisor tries to approve via API)...")
+    print("   (skipped automatically — assertBoard is enforced server-side. Manual check:")
+    print(f"   curl -X POST -H 'Authorization: Bearer <advisor-token>' "
+          f"{client.api_base}/api/approvals/{approval_id}/approve")
+    print("   Expected response: 403 Forbidden.)")
+
+    print("\nALL SMOKE TESTS PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Run smoke**
+
+```bash
+python3 scripts/aicos/smoke_pre_canon_review.py
+```
+
+Expected output: "ALL SMOKE TESTS PASS" within ~120s. If timeout : check Advisor heartbeat status on AI-COS UI.
+
+- [ ] **Step 3: Manual assertBoard check**
+
+```bash
+# Get advisor's API key (created in Task 7 step 5 if needed; else create now via /api/agents/:id/keys)
+ADVISOR_TOKEN="<advisor-key>"
+APPROVAL_ID="<id-from-smoke-script>"
+curl -s -o /dev/null -w "%{http_code}\n" \
+    -X POST \
+    -H "Authorization: Bearer $ADVISOR_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"decisionNote":"smoke"}' \
+    http://178.104.1.118:3100/api/approvals/$APPROVAL_ID/approve
+```
+
+Expected output: `403`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/aicos/smoke_pre_canon_review.py
+git commit -m "feat(aicos): smoke_pre_canon_review.py — phase 0 validation
+
+Creates fake approval, waits up to 120s for advisor comment, validates
+Verdict JSON shape + recommendation. Documents assertBoard 403 check
+to be run manually with the advisor's API key."
+```
+
+---
+
+## Task 11: Phase 1 — Update producer AGENTS.md (5 files)
+
+**Files:**
+- Modify: `agents/ceo/AGENTS.md`
+- Modify: `agents/cto/AGENTS.md`
+- Modify: `agents/rag-lead/AGENTS.md`
+- Modify: `agents/seo-content/AGENTS.md`
+- Create: `agents/r4-batch-orchestrator/AGENTS.md`
+
+Each file gets the same `## Pre-canon review (mandatory)` section appended. The block below is the shared payload — paste verbatim into each file.
+
+- [ ] **Step 1: Define the shared block**
+
+Save this block once to a temp file for clean re-use:
+
+```bash
+cat > /tmp/pre-canon-section.md <<'EOF'
+
+## Pre-canon review (mandatory)
+
+Avant l'une des actions suivantes, tu DOIS créer une approval `pre_canon_review` et attendre la décision du board avant de procéder :
+
+- **`code_pr`** — git push d'une PR vers `main` sur `ak125/nestjs-remix-monorepo` ou `ak125/governance-vault`
+- **`canon_db_write`** — write vers une table `__seo_*`, `__rag_*`, `__pieces_*`, `__diag_*`, `__blog_*` avec `row_count >= 10` ou tout DELETE
+- **`deployment`** — tag push `v*` déclenchant la promotion DEV→PROD
+- **`governance_change`** — PR vers `ak125/governance-vault` (tout fichier sous `ledger/`, `ops/rules/`, `ops/moc/`)
+
+### Comment créer l'approval
+
+1. Construis le payload selon `docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md` § 3.4
+2. POST `/api/companies/:companyId/approvals` avec `type=pre_canon_review`
+3. Note l'`approvalId` dans ton task ou commit-message comme `[approval:<id>]`
+4. Attends le heartbeat suivant. Lis le status :
+   - `approved` → procède avec l'action
+   - `revision_requested` → lis le commentaire advisor + note board, corrige, puis `POST /approvals/:id/resubmit` avec payload mis à jour (incrémente `revision_round_count`)
+   - `rejected` → abandonne, log la raison dans ton activity log, escalade au manager
+5. Maximum 3 revision rounds. Après round 3 + revise → escalade au CEO avec contexte complet.
+
+Si ton action n'est PAS dans la liste ci-dessus, aucune approval n'est requise.
+EOF
+```
+
+- [ ] **Step 2: Append to CEO**
+
+```bash
+cat /tmp/pre-canon-section.md >> agents/ceo/AGENTS.md
+```
+
+Verify:
+
+```bash
+tail -20 agents/ceo/AGENTS.md
+```
+
+Expected: section appended.
+
+- [ ] **Step 3: Append to CTO**
+
+```bash
+cat /tmp/pre-canon-section.md >> agents/cto/AGENTS.md
+```
+
+- [ ] **Step 4: Append to RAG-Ops**
+
+```bash
+cat /tmp/pre-canon-section.md >> agents/rag-lead/AGENTS.md
+```
+
+- [ ] **Step 5: Append to SEO-Content**
+
+```bash
+cat /tmp/pre-canon-section.md >> agents/seo-content/AGENTS.md
+```
+
+- [ ] **Step 6: Create R4-Batch-Lead AGENTS.md**
+
+The folder doesn't exist locally (per memory `paperclip-agents-config.md`). Create with minimum viable bundle + the shared section:
+
+```bash
+mkdir -p agents/r4-batch-orchestrator
+cat > agents/r4-batch-orchestrator/AGENTS.md <<'EOF'
+# R4-Batch-Lead — AutoMecanik
+
+Tu es l'orchestrateur des batches R4 (génération de sections référence des gammes).
+
+**CONTRAT DE SORTIE (R12)** : tu ne corriges JAMAIS auto. Tu scannes, analyses, proposes. Verdict défaut = `PARTIAL_COVERAGE`.
+
+## Hiérarchie
+
+- **Reportes à** : CTO (`7fa3c971`)
+- **Coordonnes avec** : SEO-Content, RAG-Ops
+
+## Rôle
+
+À la demande, tu :
+- Lances des batches R4 throttlés (max 2 agents parallèles)
+- Suivis l'avancement via `__seo_r4_keyword_plan` et `__seo_reference`
+- Reportes les blocages (rate limit, RAG miss, KP trous)
+
+## Infrastructure
+
+- Paperclip API : `http://178.104.1.118:3100`
+- NestJS DEV : `http://46.224.118.55:3000`
+- Pipeline R4 : voir `docs/seo/pipeline-r4.md`
+EOF
+
+cat /tmp/pre-canon-section.md >> agents/r4-batch-orchestrator/AGENTS.md
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agents/ceo/AGENTS.md agents/cto/AGENTS.md agents/rag-lead/AGENTS.md agents/seo-content/AGENTS.md agents/r4-batch-orchestrator/AGENTS.md
+git commit -m "feat(agents): pre-canon review section in 5 producers
+
+Appends mandatory pre_canon_review approval workflow to CEO, CTO,
+RAG-Ops, SEO-Content. Creates R4-Batch-Lead AGENTS.md (was missing
+locally). Per design spec § 5."
+```
+
+---
+
+## Task 12: Sync producers to AI-COS
+
+- [ ] **Step 1: Dry-run sync of all 5 producers**
+
+```bash
+python3 scripts/aicos/sync_agents_md.py \
+    --only CEO --only CTO --only RAG-Ops --only SEO-Content --only R4-Batch-Lead \
+    --dry-run
+```
+
+Expected: prints DRY-RUN PUT for each, with content size.
+
+- [ ] **Step 2: 🚧 CHECKPOINT — pause for explicit user go-ahead**
+
+```
+Pause: about to PUT updated AGENTS.md to 5 producer agents on AI-COS.
+After this, those agents will see the pre_canon_review section on next heartbeat.
+Confirm to proceed (yes/no)?
+```
+
+- [ ] **Step 3: Apply**
+
+```bash
+python3 scripts/aicos/sync_agents_md.py \
+    --only CEO --only CTO --only RAG-Ops --only SEO-Content --only R4-Batch-Lead
+```
+
+Expected: 5 lines `synced <name> (N chars) → /paperclip/.../AGENTS.md`.
+
+- [ ] **Step 4: Verify on AI-COS UI**
+
+Open `http://178.104.1.118:3100` → for each of CEO/CTO/RAG-Ops/SEO-Content/R4-Batch-Lead → click into agent → verify the AGENTS.md preview shows the new "Pre-canon review (mandatory)" section.
+
+- [ ] **Step 5: Commit (marker)**
+
+```bash
+git commit --allow-empty -m "chore(aicos): producer AGENTS.md synced to AI-COS
+
+5 producers (CEO/CTO/RAG-Ops/SEO-Content/R4-Batch-Lead) updated with
+pre_canon_review section. They will see it on next heartbeat."
+```
+
+---
+
+## Task 13: End-to-end test (toy code_pr)
+
+- [ ] **Step 1: Pick a toy change**
+
+Use the spec file itself for a no-op modification: append a single space at the end of `docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md`.
+
+```bash
+git checkout -b smoke/e2e-pre-canon-review
+echo "" >> docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md
+git add docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md
+git commit -m "smoke: e2e test for pre_canon_review (toy change)"
+git push origin smoke/e2e-pre-canon-review
+```
+
+- [ ] **Step 2: Open a draft PR**
+
+```bash
+gh pr create --draft --title "smoke: e2e pre_canon_review" \
+    --body "Toy PR to validate the pre_canon_review approval flow end-to-end. Will be closed without merge."
+```
+
+Note the PR number returned (`PR_NUM`).
+
+- [ ] **Step 3: Manually create the `pre_canon_review` approval as a "producer"**
+
+```bash
+PR_NUM="<from-step-2>"
+HEAD_SHA=$(git rev-parse HEAD)
+BASE_SHA=$(git merge-base origin/main HEAD)
+
+cat > /tmp/e2e-payload.json <<EOF
+{
+  "type": "pre_canon_review",
+  "payload": {
+    "scope": "code_pr",
+    "revision_round_count": 0,
+    "context": {"task_id": "e2e-smoke", "issue_id": null, "session_id": null},
+    "body": {
+      "repo": "ak125/nestjs-remix-monorepo",
+      "branch": "smoke/e2e-pre-canon-review",
+      "base_sha": "$BASE_SHA",
+      "head_sha": "$HEAD_SHA",
+      "files_changed": ["docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md"],
+      "diff_summary": "Append empty line to spec file (no-op).",
+      "diff_url": "https://github.com/ak125/nestjs-remix-monorepo/pull/$PR_NUM",
+      "related_pr_number": $PR_NUM
+    }
+  }
+}
+EOF
+
+curl -s -X POST \
+    -H "Authorization: Bearer $PAPERCLIP_BOARD_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @/tmp/e2e-payload.json \
+    http://178.104.1.118:3100/api/companies/4f73fff0-b929-4fe5-9f33-7d54f9ef2f52/approvals
+```
+
+Note the returned approval id (`APPROVAL_ID`).
+
+- [ ] **Step 4: Wait for advisor comment, verify**
+
+```bash
+APPROVAL_ID="<from-step-3>"
+sleep 90
+curl -s -H "Authorization: Bearer $PAPERCLIP_BOARD_TOKEN" \
+    http://178.104.1.118:3100/api/approvals/$APPROVAL_ID/comments | python3 -m json.tool
+```
+
+Expected: at least one comment whose body is valid Verdict JSON with `scope=code_pr`. The recommendation is likely `approve` (toy change, no findings).
+
+- [ ] **Step 5: Approve as board**
+
+In AI-COS UI: navigate to the approval → click Approve.
+
+- [ ] **Step 6: Verify status flipped**
+
+```bash
+curl -s -H "Authorization: Bearer $PAPERCLIP_BOARD_TOKEN" \
+    http://178.104.1.118:3100/api/approvals/$APPROVAL_ID | python3 -c "import json,sys; print(json.load(sys.stdin).get('status'))"
+```
+
+Expected: `approved`.
+
+- [ ] **Step 7: Cleanup**
+
+```bash
+gh pr close --delete-branch $PR_NUM
+```
+
+- [ ] **Step 8: Commit (marker)**
+
+```bash
+git checkout feat/aicos-fleet-advisor-claude-4-7
+git commit --allow-empty -m "chore(advisor): e2e pre_canon_review test PASS
+
+Toy code_pr approval created, advisor commented within 90s, board
+approved, status flipped to approved. Flow validated end-to-end."
+```
+
+---
+
+## Task 14: Phase 1 — Regression replay (3 historical incidents)
+
+**Files:**
+- Create: `scripts/advisor/regression_replay.py`
+- Create: `scripts/advisor/incidents/inc-2026-005.json`
+- Create: `scripts/advisor/incidents/rag-vault-rollback-2026-04-18.json`
+- Create: `scripts/advisor/incidents/inc-2026-009.json`
+
+- [ ] **Step 1: Build the 3 incident payloads**
+
+```bash
+mkdir -p scripts/advisor/incidents
+```
+
+```json
+// scripts/advisor/incidents/inc-2026-005.json
+{
+  "type": "pre_canon_review",
+  "payload": {
+    "scope": "code_pr",
+    "revision_round_count": 0,
+    "context": {"task_id": "regression-INC-2026-005", "issue_id": null, "session_id": null},
+    "body": {
+      "repo": "ak125/nestjs-remix-monorepo",
+      "branch": "feat/vehicle-page-direct",
+      "base_sha": "0000000",
+      "head_sha": "1111111",
+      "files_changed": ["frontend/app/routes/v.$brand.$model.$type.tsx"],
+      "diff_summary": "Vehicle page uses direct DB query on every request — no matview cache, no fallback. Triggers 5xx under GSC crawler load (see ADR-016).",
+      "diff_url": "fictional-replay",
+      "related_pr_number": 0
+    }
+  },
+  "expected_recommendation": "reject",
+  "expected_axes_floor": {"correctness": 50, "security": 80, "reversibility": 50}
+}
+```
+
+```json
+// scripts/advisor/incidents/rag-vault-rollback-2026-04-18.json
+{
+  "type": "pre_canon_review",
+  "payload": {
+    "scope": "canon_db_write",
+    "revision_round_count": 0,
+    "context": {"task_id": "regression-RAG-rollback", "issue_id": null, "session_id": null},
+    "body": {
+      "table": "__seo_diag_session",
+      "op": "insert",
+      "row_count": 350,
+      "sample_rows": [{"engine_keyword": "breezy-eagle", "source": "LLM"}],
+      "sql_or_rpc": "INSERT INTO __seo_diag_session SELECT * FROM tmp_llm_seed",
+      "affected_pg_ids": [],
+      "rollback_plan": ""
+    }
+  },
+  "expected_recommendation": "reject",
+  "expected_axes_floor": {"reversibility": 0, "evidence": 0}
+}
+```
+
+```json
+// scripts/advisor/incidents/inc-2026-009.json
+{
+  "type": "pre_canon_review",
+  "payload": {
+    "scope": "code_pr",
+    "revision_round_count": 0,
+    "context": {"task_id": "regression-INC-2026-009", "issue_id": null, "session_id": null},
+    "body": {
+      "repo": "ak125/nestjs-remix-monorepo",
+      "branch": "feat/admin-list",
+      "base_sha": "0000000",
+      "head_sha": "2222222",
+      "files_changed": ["backend/supabase/policies/admin.sql"],
+      "diff_summary": "New admin RPC list_admins() returns password_hash column, exposed via anon key — RLS missing on __admin_users.",
+      "diff_url": "fictional-replay",
+      "related_pr_number": 0
+    }
+  },
+  "expected_recommendation": "reject",
+  "expected_axes_floor": {"security": 0}
+}
+```
+
+- [ ] **Step 2: Write the replay script**
+
+```python
+# scripts/advisor/regression_replay.py
+"""Replay 3 historical incidents as fake pre_canon_review approvals.
+Verifies the advisor BLOCKs each, per design spec § 8.3."""
+import json
+import sys
+import time
+from pathlib import Path
+from scripts.aicos.aicos_client import AicosClient
+from scripts.advisor.verdict_schema import Verdict
+
+
+INCIDENTS = [
+    "inc-2026-005.json",
+    "rag-vault-rollback-2026-04-18.json",
+    "inc-2026-009.json",
+]
+
+
+def replay_one(client: AicosClient, incident_file: Path) -> bool:
+    data = json.loads(incident_file.read_text())
+    expected_rec = data.pop("expected_recommendation", "reject")
+    data.pop("expected_axes_floor", None)
+
+    print(f"\n=== {incident_file.name} ===")
+    res = client.post(f"/api/companies/{client.company_id}/approvals", body=data)
+    aid = res.get("id") or res.get("approvalId")
+    print(f"  approval {aid} created (expecting recommendation={expected_rec})")
+
+    deadline = time.time() + 120
+    advisor_comment = None
+    while time.time() < deadline:
+        comments = client.get(f"/api/approvals/{aid}/comments")
+        items = comments.get("items", comments) or []
+        for c in items:
+            body = c.get("body") or ""
+            if '"advisor_recommendation"' in body:
+                advisor_comment = c
+                break
+        if advisor_comment:
+            break
+        time.sleep(5)
+
+    if not advisor_comment:
+        print(f"  FAIL: no advisor comment in 120s")
+        return False
+
+    try:
+        v = Verdict.model_validate_json(advisor_comment["body"])
+    except Exception as e:
+        print(f"  FAIL: invalid verdict JSON: {e}")
+        return False
+
+    if v.advisor_recommendation == expected_rec:
+        print(f"  PASS: recommendation={v.advisor_recommendation}, score_total={v.score_total()}")
+        return True
+
+    print(f"  FAIL: expected {expected_rec}, got {v.advisor_recommendation}")
+    print(f"  findings: {[f.dict() for f in v.findings]}")
+    return False
+
+
+def main() -> int:
+    client = AicosClient()
+    here = Path(__file__).resolve().parent / "incidents"
+    results = []
+    for f in INCIDENTS:
+        results.append(replay_one(client, here / f))
+    passed = sum(results)
+    print(f"\n=== Regression: {passed}/{len(results)} PASS ===")
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 3: Run replay**
+
+```bash
+python3 scripts/advisor/regression_replay.py
+```
+
+Expected: 3/3 PASS. Each incident's verdict must be `reject` (the advisor blocked it).
+
+If any fail: this is a **design invalidation** — halt the rollout and review the canon-write-review thresholds vs. the failed incident, OR review the `code-review` skill checklist for the missed code_pr cases. Do not proceed to Phase 2 (shadow mode) until 3/3 pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/advisor/regression_replay.py scripts/advisor/incidents/
+git commit -m "test(advisor): regression replay — 3 historical incidents BLOCK
+
+Replays INC-2026-005 (vehicle page 5xx), RAG vault rollback
+2026-04-18, and INC-2026-009 (admin RLS leak) as pre_canon_review
+approvals. Advisor must reject all 3. Per design spec § 8.3."
+```
+
+---
+
+## Task 15: Open a PR + roll forward to Phase 2 plan
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/aicos-fleet-advisor-claude-4-7
+```
+
+- [ ] **Step 2: Open a PR**
+
+```bash
+gh pr create --title "feat(aicos): fleet advisor + Claude 4.7 tiering (Phase 0+1)" --body "$(cat <<'EOF'
+## Summary
+- Adds **Advisor agent** (Opus 4.7) with comment-only review on `pre_canon_review` approvals — board operator keeps decision (assertBoard preserved)
+- Tiers fleet to Claude 4.X family : Opus 4.7 (CEO/CTO/Advisor), Sonnet 4.6 (5 workers), Haiku 4.5 (SEO-QA kept)
+- Wires 5 producer agents (CEO/CTO/RAG-Ops/SEO-Content/R4-Batch-Lead) with mandatory pre_canon_review section
+- Native Paperclip primitives only — no fork, no adapter mod (no bricolage)
+
+## Files
+- spec : `docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md`
+- plan : `docs/superpowers/plans/2026-04-25-fleet-advisor-claude-4-7.md`
+- skill : `agents/advisor/skills/canon-write-review/`
+- agent : `agents/advisor/AGENTS.md`
+- producer updates : `agents/ceo|cto|rag-lead|seo-content|r4-batch-orchestrator/AGENTS.md`
+- aicos tooling : `scripts/aicos/{aicos_client,fleet_config.yaml,apply_fleet_models,sync_agents_md,hire_advisor,smoke_pre_canon_review}.py`
+- advisor tooling : `scripts/advisor/{verdict_schema,canon_write_review,regression_replay}.py`
+
+## Test plan
+- [x] Unit tests : `pytest tests/advisor tests/aicos -v` (16 tests)
+- [x] Phase 0 smoke test : `scripts/aicos/smoke_pre_canon_review.py` PASS
+- [x] Phase 1 e2e test : toy `code_pr` approval roundtrip (Task 13) PASS
+- [x] Phase 1 regression : `scripts/advisor/regression_replay.py` 3/3 PASS
+- [ ] Phase 2 (post-merge, separate plan) : 7-day shadow mode + metrics dashboard
+
+## Cost impact
+~$1,400/month → up to ~$16,400/month worst-case (per spec § 6.3). Per-agent budget caps active.
+
+## Rollback
+Per spec § 10.2 : `POST /api/agents/<advisor>/pause` (instantly stops review enforcement). Producers fall back to no-review behaviour. Model PATCHes reversible via Paperclip config-revisions API.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Note the PR number for follow-up Phase 2 plan**
+
+Open the PR URL returned. The Phase 2 (shadow mode) plan will be written separately once Phase 0+1 are merged and observed for ≥48h.
+
+---
+
+## Self-review (post-write, against the spec)
+
+- **Spec § 1 Goal** — covered by Tasks 1-13 (Advisor + tiering + producers wired) and offer of Phase 2 plan separately
+- **Spec § 2 Non-goals** — respected (no fork: Tasks use existing API; no adapter mod; no auto-correct in canon_write_review)
+- **Spec § 3.1 Advisor agent fields** — covered by Task 7 (hire payload) + Task 5 (fleet_config budget)
+- **Spec § 3.2 Wiring** — Advisor's AGENTS.md (Task 3) describes the full loop; smoke (Task 10) and e2e (Task 13) validate it
+- **Spec § 3.3 Approval payload schema** — Tests in Tasks 1-2 + payload examples in Tasks 13-14
+- **Spec § 3.4 Per-scope body shape** — covered for `code_pr` (Task 13), `canon_db_write` (Tasks 2 + 10 + 14). `deployment` and `governance_change` use the existing `code-review` skill — no new skill, no new test in this plan; they will be validated organically in Phase 2 shadow mode
+- **Spec § 3.5 Verdict format** — Task 1 implements + tests
+- **Spec § 4.1 Existing skills** — referenced in Advisor AGENTS.md, no install needed (already in monorepo)
+- **Spec § 4.2 New skill canon-write-review** — Task 2
+- **Spec § 4.3 Skill router** — described in Advisor AGENTS.md (Task 3)
+- **Spec § 5 Producer instructions** — Task 11
+- **Spec § 6 Tier model** — Task 5 (config) + Task 9 (apply)
+- **Spec § 7 Failure modes** — guards in Advisor AGENTS.md (Task 3) cover invalid payload, revision_round >= 3, cost cap. Heartbeat-down alerting is operational, not codified in this plan.
+- **Spec § 8.1 Smoke** — Task 10
+- **Spec § 8.2 E2E** — Task 13
+- **Spec § 8.3 Regression** — Task 14
+- **Spec § 8.4 Cost canary (Phase 2)** — explicitly out of scope of this plan; covered in Phase 2 follow-up
+- **Spec § 9 Rollout** — Phases 0+1 covered by Tasks 1-15; Phase 2+3 deferred
+- **Spec § 10 Rollback** — documented in PR body (Task 15) + each task is reversible via git revert + Paperclip config-revision rollback
+- **Spec § 11 Open questions** — Q1 (`fallback_model`) deferred to Phase 2; Q2 (audit-trail mirror) deferred; Q3 (managed bundle) decided as `managed` (Task 7 hire_payload); Q4 (CI post-merge check) Phase 3, separate plan; Q5 (skill cross-discovery) verified informally by sync script working
+
+**Placeholder scan** :
+- `CEO_ID = "993a4a02-XXXX..."` and other UUID placeholders in `fleet_config.yaml` / `hire_advisor.py` are **explicit prerequisites** with concrete resolution steps (Task 5 Step 2, Task 7 Step 2). Not placeholders in the failure sense — required input data.
+- No "TBD", "implement later", "similar to". All code blocks complete.
+
+**Type consistency** :
+- `Verdict`, `Axes`, `Finding`, `map_recommendation` consistent across Tasks 1, 2, 10, 14
+- `AicosClient` consistent across Tasks 4, 6, 7, 8, 10, 14
+- `aicos_id`, `target_model`, `budget_monthly_cents` consistent in YAML + Tasks 5, 6, 8
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-25-fleet-advisor-claude-4-7.md`.
+
+Two execution options :
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, fast iteration
+2. **Inline Execution** — execute tasks in this session using executing-plans, batch with checkpoints
+
+**Which approach?**
+
+(Tasks 7 and 9 contain explicit `🚧 CHECKPOINT` blocks that pause for board-operator confirmation regardless of execution mode — production AI-COS state changes.)

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -77,6 +77,38 @@ export const links: LinksFunction = () => [
 const loaderCache = new Map<string, { data: LoaderData; timestamp: number }>();
 const CACHE_TTL = 60000; // 1 minute
 
+// 📡 INC-2026-007 — Comble le blindspot __error_logs : notifie le backend
+// avant chaque throw 503 du loader. Fire-and-forget, jamais bloquant.
+async function notify503ToErrorLog(
+  url: string,
+  subject: string,
+  message: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  const internalKey = process.env.INTERNAL_API_KEY;
+  if (!internalKey) return;
+
+  try {
+    await fetch(`${getInternalApiUrl("")}/api/internal/error-log`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Internal-Key": internalKey,
+      },
+      body: JSON.stringify({
+        status: 503,
+        url,
+        subject,
+        message,
+        metadata,
+      }),
+      signal: AbortSignal.timeout(500), // ne jamais bloquer le loader
+    }).catch(() => {});
+  } catch {
+    // best-effort, jamais bloquant
+  }
+}
+
 // Types, transform, schema, constants moved to components/vehicle/r8/
 // - r8.types.ts        : VehicleData, CatalogFamily, PopularPart, SEOData, R8Block, R8Content, LoaderData
 // - r8-transform.ts    : transformRpcToLoaderData (RPC → LoaderData, pure)
@@ -210,6 +242,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
         throw new Response("Véhicule supprimé du catalogue", { status: 410 });
       }
       // Vrais erreurs serveur → 503 (Google réessaye) au lieu de 500
+      await notify503ToErrorLog(
+        `/constructeurs/${brand}/${model}/${type}`,
+        "LOADER_503_BACKEND_RPC_ERROR",
+        `Backend page-data-rpc returned HTTP ${rpcResponse.status} for type_id=${type_id}`,
+        { type_id, backend_status: rpcResponse.status },
+      );
       throw new Response("Service temporairement indisponible", {
         status: 503,
       });
@@ -223,6 +261,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
       (error.name === "AbortError" || error.name === "TimeoutError")
     ) {
       logger.error(`⏱️ [RPC] Timeout 10s pour type_id=${type_id}`);
+      await notify503ToErrorLog(
+        `/constructeurs/${brand}/${model}/${type}`,
+        "LOADER_503_RPC_TIMEOUT",
+        `Backend page-data-rpc timeout (10s) for type_id=${type_id}`,
+        { type_id, timeout_ms: 10000 },
+      );
       throw new Response("Service temporairement indisponible", {
         status: 503,
       });
@@ -233,6 +277,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
     }
     // Autres erreurs → 503 (Google réessaye) au lieu de 500
     logger.error(`❌ [RPC] Erreur fetch pour type_id=${type_id}:`, error);
+    await notify503ToErrorLog(
+      `/constructeurs/${brand}/${model}/${type}`,
+      "LOADER_503_RPC_FETCH_ERROR",
+      `Backend page-data-rpc fetch failed for type_id=${type_id}: ${error instanceof Error ? error.message : String(error)}`,
+      { type_id, error_name: error instanceof Error ? error.name : "unknown" },
+    );
     throw new Response("Service temporairement indisponible", { status: 503 });
   }
 
@@ -240,6 +290,16 @@ export async function loader({ params }: LoaderFunctionArgs) {
     logger.error("❌ [RPC] Données invalides:", rpcResult);
     // 503 et non 410 : le véhicule peut exister mais le service a échoué.
     // 410 causerait une désindexation Google permanente.
+    await notify503ToErrorLog(
+      `/constructeurs/${brand}/${model}/${type}`,
+      "LOADER_503_RPC_INVALID_PAYLOAD",
+      `Backend returned 200 but payload invalid for type_id=${type_id}`,
+      {
+        type_id,
+        payload_success: rpcResult.success,
+        has_vehicle: !!rpcResult.data?.vehicle,
+      },
+    );
     throw new Response("Service temporairement indisponible", { status: 503 });
   }
 

--- a/log.md
+++ b/log.md
@@ -69,3 +69,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
 - **Décision** : feat(rag): elargir sources web vehicule + curated URL CSV (stage 1+) (+5 other commits)
 - **Sortie** : PR #172 | commits 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832
+
+## 2026-04-25 — feat/vehicle-rag-web-enrichment-stage1 (auto)
+
+- **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
+- **Décision** : chore(log): auto session entry for feat/vehicle-rag-web-enrichment-stage1 (+6 other commits)
+- **Sortie** : PR #172 | commits 8b1751af 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832

--- a/log.md
+++ b/log.md
@@ -81,3 +81,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
 - **Décision** : fix(rag): extract_text_generic table-aware (rows joined as Markdown) (+8 other commits)
 - **Sortie** : PR #172 | commits 17644dc5 b6842426 8b1751af 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832
+
+## 2026-04-25 — feat/vehicle-rag-web-enrichment-stage1 (auto)
+
+- **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
+- **Décision** : feat(rag): maximalist per-row extraction + real cross-source validation (+10 other commits)
+- **Sortie** : PR #172 | commits 78324b28 c4aa2372 17644dc5 b6842426 8b1751af 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832

--- a/log.md
+++ b/log.md
@@ -57,3 +57,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/claude-knowledge-base`, `feat/audit-ci-integration`, `feat/cleanup-tooling-prep`
 - **Décision** : Adoption knip + madge + dependency-cruiser + ast-grep en gates déterministes (warning-mode Phase 0). Création `.claude/knowledge/` (42 modules + 4 db + 4 integrations). CI workflow `audit.yml` blockant ast-grep. Safe-delete script + baseline JSON regression gate + 3 runbooks ops.
 - **Sortie** : PRs #149, #152, #155 mergées | knip 6.6.2 (avec nested zod@4 override) + madge 8 + dep-cruiser 17.3 + @ast-grep/cli 0.42 installés | baseline 362 unused / 17 cycles / 148 violations / 0 ast-errors capturée
+
+## 2026-04-25 — feat/vehicle-rag-web-enrichment-stage1 (auto)
+
+- **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
+- **Décision** : feat(rag): vehicle motor corpus scraper + auto-verify enricher (stage 1) (+3 other commits)
+- **Sortie** : PR #172 | commits 9f28833a 9dc8f71b 26d3cea0 26812832

--- a/log.md
+++ b/log.md
@@ -63,3 +63,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
 - **Décision** : feat(rag): vehicle motor corpus scraper + auto-verify enricher (stage 1) (+3 other commits)
 - **Sortie** : PR #172 | commits 9f28833a 9dc8f71b 26d3cea0 26812832
+
+## 2026-04-25 — feat/vehicle-rag-web-enrichment-stage1 (auto)
+
+- **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
+- **Décision** : feat(rag): elargir sources web vehicule + curated URL CSV (stage 1+) (+5 other commits)
+- **Sortie** : PR #172 | commits 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832

--- a/log.md
+++ b/log.md
@@ -75,3 +75,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
 - **Décision** : chore(log): auto session entry for feat/vehicle-rag-web-enrichment-stage1 (+6 other commits)
 - **Sortie** : PR #172 | commits 8b1751af 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832
+
+## 2026-04-25 — feat/vehicle-rag-web-enrichment-stage1 (auto)
+
+- **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
+- **Décision** : fix(rag): extract_text_generic table-aware (rows joined as Markdown) (+8 other commits)
+- **Sortie** : PR #172 | commits 17644dc5 b6842426 8b1751af 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832

--- a/scripts/ci/check-no-direct-vehicle-cache-stale.sh
+++ b/scripts/ci/check-no-direct-vehicle-cache-stale.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# INC-2026-007 — Check CI : interdire UPDATE __vehicle_page_cache SET stale=... direct
+#
+# Tout script qui invalide doit utiliser mark_stale_with_followup_rebuild()
+# (cf. backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql).
+#
+# Exit 0 si propre, 1 si violation détectée.
+
+set -euo pipefail
+
+SCAN_DIRS=(
+  "backend/supabase/migrations"
+  "scripts/seo"
+  "scripts/db"
+)
+
+EXEMPT_FILES=(
+  "backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql"
+  "backend/supabase/migrations/20260425_oneshot_backfill_stale_vehicle_cache.sql"
+)
+
+VIOLATIONS=0
+TMPFILE="$(mktemp)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+for dir in "${SCAN_DIRS[@]}"; do
+  if [[ ! -d "$dir" ]]; then
+    continue
+  fi
+  # Cherche pattern : UPDATE ... __vehicle_page_cache ... SET stale
+  grep -rEln "UPDATE[[:space:]]+(public\.)?__vehicle_page_cache[[:space:]]+SET[[:space:]]+stale" "$dir" 2>/dev/null > "$TMPFILE" || true
+
+  while IFS= read -r match_file; do
+    [[ -z "$match_file" ]] && continue
+
+    # Skip exempt files
+    skip=0
+    for exempt in "${EXEMPT_FILES[@]}"; do
+      if [[ "$match_file" == "$exempt" ]] || [[ "$match_file" == */"$exempt" ]]; then
+        skip=1
+        break
+      fi
+    done
+    [[ $skip -eq 1 ]] && continue
+
+    echo "❌ INC-2026-007 violation: $match_file uses UPDATE __vehicle_page_cache SET stale directly"
+    echo "   → use SELECT mark_stale_with_followup_rebuild(ARRAY[...], 'reason') instead"
+    VIOLATIONS=$((VIOLATIONS + 1))
+  done < "$TMPFILE"
+done
+
+if [[ $VIOLATIONS -gt 0 ]]; then
+  echo ""
+  echo "FAIL: $VIOLATIONS violation(s) detected. Use mark_stale_with_followup_rebuild() canon."
+  exit 1
+fi
+
+echo "✅ INC-2026-007 check passed: no direct UPDATE __vehicle_page_cache SET stale found"
+exit 0

--- a/scripts/rag/download-vehicle-motor-corpus.py
+++ b/scripts/rag/download-vehicle-motor-corpus.py
@@ -359,8 +359,75 @@ def url_candidates_autoplus(modele: Modele) -> list[str]:
 
 
 def url_candidates_autotitre(modele: Modele) -> list[str]:
+    """Vraie URL : /fiche-technique/<Brand>/<Model>/<VariantRoman>"""
     base = "https://www.autotitre.com"
-    return [f"{base}/fiche-technique-{modele.marque_alias}-{modele.modele_alias}.html"]
+    brand_t = modele.marque_alias.title()
+    parts = modele.modele_alias.split("-")
+    titled: list[str] = []
+    for p in parts:
+        if not p:
+            continue
+        if re.fullmatch(r"[ivxIVX]+", p):
+            titled.append(p.upper())
+        else:
+            titled.append(p.title())
+    if len(titled) >= 2 and re.fullmatch(r"[IVX]+", titled[-1]):
+        path = "/".join(titled[:-1]) + "/" + titled[-1]
+    else:
+        path = "/".join(titled) if titled else modele.modele_alias
+    return [
+        f"{base}/fiche-technique/{brand_t}/{path}",
+        f"{base}/fiche-technique-{modele.marque_alias}-{modele.modele_alias}.html",
+    ]
+
+
+def _arabic_alias(alias: str) -> str:
+    """Convert roman suffix to arabic ('clio-iii' → 'clio-3')."""
+    roman_to_arabic = {"-i": "-1", "-ii": "-2", "-iii": "-3", "-iv": "-4", "-v": "-5", "-vi": "-6"}
+    for roman, arabic in roman_to_arabic.items():
+        if alias.endswith(roman):
+            return alias[: -len(roman)] + arabic
+    return alias
+
+
+def url_candidates_user_manual_renault(modele: Modele) -> list[str]:
+    """Renault constructor manuals (Renault only)."""
+    if modele.marque_alias != "renault":
+        return []
+    base = "https://www.user-manual.renault.com"
+    arabic = _arabic_alias(modele.modele_alias)
+    return [
+        f"{base}/fr/content/{modele.marque_alias}-{arabic}-phase-1",
+        f"{base}/fr/content/{modele.marque_alias}-{arabic}-phase-2",
+        f"{base}/fr/content/{modele.marque_alias}-{arabic}",
+    ]
+
+
+def url_candidates_lenouvelautomobiliste(modele: Modele) -> list[str]:
+    """Editorial articles via search archive."""
+    base = "https://lenouvelautomobiliste.fr"
+    arabic = _arabic_alias(modele.modele_alias)
+    q = f"{modele.marque_alias}+{arabic.replace('-', '+')}"
+    return [f"{base}/?s={q}"]
+
+
+# Curated URL override (CSV-based) — priority over heuristic patterns
+CURATED_CSV = "/opt/automecanik/app/data/vehicles_known_urls.csv"
+
+
+def load_curated_urls(modele_alias: str) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    if not os.path.isfile(CURATED_CSV):
+        return out
+    import csv as _csv
+    with open(CURATED_CSV, encoding="utf-8", newline="") as f:
+        for row in _csv.DictReader(f):
+            if (row.get("modele_alias") or "").strip().lower() == modele_alias.lower():
+                src = (row.get("source") or "").strip()
+                url = (row.get("url") or "").strip()
+                if src and url:
+                    out.setdefault(src, []).append(url)
+    return out
 
 
 def url_candidates_wikipedia_fr(modele: Modele) -> list[str]:
@@ -418,6 +485,9 @@ SOURCES = [
     ("autotitre", url_candidates_autotitre, extract_text_generic, False),
     ("wikipedia-fr", url_candidates_wikipedia_fr, extract_text_wikipedia, False),
     ("wikipedia-en", url_candidates_wikipedia_en, extract_text_wikipedia, False),
+    ("user-manual-renault", url_candidates_user_manual_renault, extract_text_generic, False),
+    ("lenouvelautomobiliste", url_candidates_lenouvelautomobiliste, extract_text_generic, False),
+    ("lacentrale", lambda m: [], extract_text_generic, False),  # curated only (anti-bot)
 ]
 
 
@@ -497,11 +567,19 @@ def process_modele(modele: Modele, dry_run: bool, only_sources: set[str] | None 
     saved = 0
     skipped = 0
 
+    # Curated URL overrides — read from data/vehicles_known_urls.csv
+    curated = load_curated_urls(modele.modele_alias)
+    if curated:
+        print(f"  → curated URLs from CSV: {sum(len(v) for v in curated.values())} entries")
+
     for source_name, url_fn, extractor, per_type in SOURCES:
         if only_sources and source_name not in only_sources:
             continue
-        # Per-type variants attempted for sources that support it (fiches-auto)
         candidates_iter: list[tuple[str, list[int]]] = []
+        # 1) curated URLs (priority)
+        for cu in curated.get(source_name, []):
+            candidates_iter.append((cu, type_ids_all))
+        # 2) heuristic patterns
         if per_type:
             for tm in types:
                 urls = url_fn(modele, tm)

--- a/scripts/rag/download-vehicle-motor-corpus.py
+++ b/scripts/rag/download-vehicle-motor-corpus.py
@@ -252,22 +252,43 @@ def extract_text_generic(html: str) -> tuple[str, str]:
     if not main:
         return title, ""
 
+    # Table-aware : <tr> joined with | so engine specs stay on one line.
     lines: list[str] = []
-    for el in main.find_all(["h1", "h2", "h3", "p", "li", "td", "th"]):
-        text = el.get_text(separator=" ", strip=True)
-        text = re.sub(r"\s+", " ", text).strip()
+    visited_cells: set = set()
+    for el in main.find_all(["h1", "h2", "h3", "p", "li", "tr"]):
+        if el.name == "tr":
+            cells = [
+                re.sub(r"\s+", " ", c.get_text(" ", strip=True)).strip()
+                for c in el.find_all(["td", "th"])
+            ]
+            cells = [c for c in cells if c]
+            if not cells or all(len(c) < 2 for c in cells):
+                continue
+            line = "| " + " | ".join(cells) + " |"
+            if len(line) >= 8:
+                lines.append(line)
+                for c in el.find_all(["td", "th"]):
+                    visited_cells.add(id(c))
+            continue
+        text = re.sub(r"\s+", " ", el.get_text(separator=" ", strip=True)).strip()
         if len(text) < 12:
             continue
         if el.name in ("h1", "h2", "h3"):
             lines.append(f"\n## {text}\n")
         elif el.name == "li":
             lines.append(f"- {text}")
-        elif el.name in ("td", "th"):
-            lines.append(f"| {text} |")
         else:
             lines.append(text)
 
-    return title, "\n".join(lines[:300])
+    # Catch standalone td/th not inside <tr>
+    for cell in main.find_all(["td", "th"]):
+        if id(cell) in visited_cells:
+            continue
+        text = re.sub(r"\s+", " ", cell.get_text(" ", strip=True)).strip()
+        if len(text) >= 12:
+            lines.append(f"| {text} |")
+
+    return title, "\n".join(lines[:400])
 
 
 def extract_text_wikipedia(html: str) -> tuple[str, str]:

--- a/scripts/rag/download-vehicle-motor-corpus.py
+++ b/scripts/rag/download-vehicle-motor-corpus.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""
+download-vehicle-motor-corpus.py — Stage 1.A : scrape vehicle per-motorisation
+data from public web sources, write to /opt/automecanik/rag/knowledge/web-vehicles/.
+
+Mirror of `download-oem-corpus.py` (gamme), but for vehicle motorisations.
+
+Sources (decision utilisateur 2026-04-25, élargies) :
+  Tier 1 (specs structurées)  : fiches-auto.fr, caradisiac, largus.fr,
+                                 turbo.fr, autoplus.fr, autotitre.com
+  Tier 2 (encyclopédique)      : fr.wikipedia.org, en.wikipedia.org
+
+Tiers 3-5 (fiabilité, regulatory, aftermarket cross-ref) ajoutés selon
+recall mesuré sur le pilote.
+
+Usage:
+  python3 scripts/rag/download-vehicle-motor-corpus.py --modele clio-3 --dry-run
+  python3 scripts/rag/download-vehicle-motor-corpus.py --modele clio-3 --apply
+  python3 scripts/rag/download-vehicle-motor-corpus.py --brand smart --apply
+  python3 scripts/rag/download-vehicle-motor-corpus.py --modele-id 140004 --apply
+
+Output : /opt/automecanik/rag/knowledge/web-vehicles/<hash>-s<N>.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+import textwrap
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from urllib.parse import quote, urlparse
+
+try:
+    import requests
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Manque : pip install requests beautifulsoup4")
+    sys.exit(1)
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("Manque : pip install psycopg2-binary")
+    sys.exit(1)
+
+# === CONFIG ============================================================
+
+WEB_VEHICLES_DIR = "/opt/automecanik/rag/knowledge/web-vehicles"
+REQUEST_DELAY_S = 1.2
+MAX_RETRIES = 2
+TIMEOUT_S = 12
+MIN_CONTENT_LEN = 250
+
+# DB connection — pattern aligné avec scripts/db/adr017-create-index-concurrently.py
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+DB_PASSWORD = os.environ.get("SUPABASE_DB_PASSWORD")
+if not DB_PASSWORD:
+    sys.stderr.write(
+        "[FATAL] SUPABASE_DB_PASSWORD missing in env. "
+        "Run: source backend/.env (or set SUPABASE_DB_PASSWORD=...)\n"
+    )
+    sys.exit(1)
+DB_DSN = (
+    f"host=db.{PROJECT_REF}.supabase.co "
+    f"port=5432 user=postgres dbname=postgres "
+    f"password={DB_PASSWORD} sslmode=require"
+)
+
+WIKI_API_FR = "https://fr.wikipedia.org/w/api.php"
+WIKI_API_EN = "https://en.wikipedia.org/w/api.php"
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; AutoMecanik-RAGBot/1.0; vehicle-data-research; contact: automecanik.seo@gmail.com)",
+    "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.8",
+    "Accept": "text/html,application/xhtml+xml",
+}
+
+
+# === MODELS ============================================================
+
+@dataclass
+class Modele:
+    modele_id: int
+    marque_id: int
+    marque_alias: str  # e.g. 'renault'
+    marque_name: str   # e.g. 'RENAULT'
+    modele_alias: str  # e.g. 'clio-3'
+    modele_name: str   # e.g. 'CLIO III'
+
+
+@dataclass
+class TypeMotor:
+    type_id: int
+    modele_id: int
+    type_name: str    # e.g. '1.5 dCi'
+    fuel: str         # e.g. 'Diesel'
+    power_ps: int     # e.g. 88
+    liter: str        # e.g. '150' (=1.5 L) or '1461'
+    body: str
+    year_from: int
+
+
+@dataclass
+class ScrapeJob:
+    source: str       # e.g. 'fiches-auto'
+    url: str
+    modele_id: int
+    type_ids: list[int] = field(default_factory=list)
+    status: str = "pending"  # pending | success | 404 | parse_error | skipped
+    title: str = ""
+    content_len: int = 0
+
+
+# === DB ACCESS =========================================================
+
+def db_connect():
+    return psycopg2.connect(DB_DSN)
+
+
+def fetch_modeles_by_filter(args) -> list[Modele]:
+    """Fetch the list of modeles to process based on CLI filters."""
+    sql = """
+        SELECT m.modele_id, m.modele_marque_id, m.modele_alias, m.modele_name,
+               b.marque_alias, b.marque_name
+        FROM auto_modele m
+        JOIN auto_marque b ON b.marque_id::int = m.modele_marque_id::int
+        WHERE m.modele_display = 1 AND b.marque_display = '1'
+    """
+    params: list = []
+    if args.modele_id:
+        sql += " AND m.modele_id = %s"
+        params.append(args.modele_id)
+    elif args.modele:
+        # Accept both arabic ("clio-3") and roman ("clio-iii") forms.
+        roman_map = {"-1": "-i", "-2": "-ii", "-3": "-iii", "-4": "-iv", "-5": "-v", "-6": "-vi"}
+        alt = args.modele.lower()
+        for arabic, roman in roman_map.items():
+            if alt.endswith(arabic):
+                alt = alt[: -len(arabic)] + roman
+                break
+        sql += " AND lower(m.modele_alias) IN (lower(%s), lower(%s))"
+        params.extend([args.modele, alt])
+    elif args.brand:
+        sql += " AND lower(b.marque_alias) = lower(%s)"
+        params.append(args.brand)
+    else:
+        # default pilot scope (decision utilisateur 2026-04-25) :
+        # Renault Clio III + Smart + DS 3 (cohortes déjà enrichies en R8).
+        sql += """
+            AND (
+                (lower(b.marque_alias) = 'renault' AND lower(m.modele_alias) LIKE 'clio-iii%%')
+                OR lower(b.marque_alias) = 'smart'
+                OR (lower(b.marque_alias) = 'ds' AND lower(m.modele_alias) LIKE 'ds-3%%')
+            )
+        """
+
+    sql += " ORDER BY b.marque_alias, m.modele_alias LIMIT 50"
+
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+    return [
+        Modele(
+            modele_id=int(r["modele_id"]),
+            marque_id=int(r["modele_marque_id"]),
+            marque_alias=str(r["marque_alias"]).strip().lower(),
+            marque_name=str(r["marque_name"]).strip(),
+            modele_alias=str(r["modele_alias"]).strip().lower(),
+            modele_name=str(r["modele_name"]).strip(),
+        )
+        for r in rows
+    ]
+
+
+def fetch_types_for_modele(modele_id: int) -> list[TypeMotor]:
+    sql = """
+        SELECT type_id_i, type_modele_id_i, type_name, type_fuel,
+               type_power_ps, type_liter, type_body, type_year_from
+        FROM auto_type
+        WHERE type_display = '1'
+          AND type_modele_id_i = %s
+          AND type_power_ps ~ '^[0-9]+$'
+        ORDER BY type_id_i
+    """
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [modele_id])
+        rows = cur.fetchall()
+    out: list[TypeMotor] = []
+    for r in rows:
+        try:
+            out.append(
+                TypeMotor(
+                    type_id=int(r["type_id_i"]),
+                    modele_id=int(r["type_modele_id_i"]),
+                    type_name=str(r["type_name"] or "").strip(),
+                    fuel=str(r["type_fuel"] or "").strip(),
+                    power_ps=int(r["type_power_ps"] or 0),
+                    liter=str(r["type_liter"] or "").strip(),
+                    body=str(r["type_body"] or "").strip(),
+                    year_from=int(r["type_year_from"] or 0),
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+# === HTTP HELPERS ======================================================
+
+def fetch_url(url: str) -> str | None:
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            r = requests.get(
+                url, headers=HEADERS, timeout=TIMEOUT_S, allow_redirects=True,
+            )
+            ctype = r.headers.get("Content-Type", "")
+            if r.status_code == 200 and "text/html" in ctype:
+                r.encoding = r.apparent_encoding
+                return r.text
+            if r.status_code in (403, 404, 410, 429, 503):
+                return None
+            if attempt < MAX_RETRIES:
+                time.sleep(REQUEST_DELAY_S * 2)
+        except requests.RequestException as exc:
+            if attempt < MAX_RETRIES:
+                time.sleep(REQUEST_DELAY_S)
+            else:
+                print(f"    ! réseau {url[:60]} : {exc}")
+    return None
+
+
+# === EXTRACTORS PER SOURCE =============================================
+
+def extract_text_generic(html: str) -> tuple[str, str]:
+    """Generic main-content extractor (used for fiches-auto, caradisiac, etc.)."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup.find_all(
+        ["nav", "footer", "script", "style", "header", "aside", "noscript", "iframe", "form"]
+    ):
+        tag.decompose()
+    for tag in soup.find_all(class_=re.compile(r"(cookie|gdpr|banner|popup|menu|ads|pub)", re.I)):
+        tag.decompose()
+
+    title = soup.title.get_text(strip=True) if soup.title else ""
+    main = soup.find("main") or soup.find("article") or soup.body
+    if not main:
+        return title, ""
+
+    lines: list[str] = []
+    for el in main.find_all(["h1", "h2", "h3", "p", "li", "td", "th"]):
+        text = el.get_text(separator=" ", strip=True)
+        text = re.sub(r"\s+", " ", text).strip()
+        if len(text) < 12:
+            continue
+        if el.name in ("h1", "h2", "h3"):
+            lines.append(f"\n## {text}\n")
+        elif el.name == "li":
+            lines.append(f"- {text}")
+        elif el.name in ("td", "th"):
+            lines.append(f"| {text} |")
+        else:
+            lines.append(text)
+
+    return title, "\n".join(lines[:300])
+
+
+def extract_text_wikipedia(html: str) -> tuple[str, str]:
+    soup = BeautifulSoup(html, "html.parser")
+    title = ""
+    if soup.find("h1", id="firstHeading"):
+        title = soup.find("h1", id="firstHeading").get_text(strip=True)
+
+    content_div = soup.find("div", id="mw-content-text")
+    if not content_div:
+        return title, ""
+
+    for tag in content_div.find_all(
+        ["table", "sup", "cite"],
+        class_=re.compile(r"(navbox|reflist|toc|hatnote|thumb)", re.I),
+    ):
+        tag.decompose()
+    for tag in content_div.find_all(id=re.compile(r"(references|notes|liens)", re.I)):
+        if tag.parent:
+            tag.parent.decompose()
+
+    lines: list[str] = []
+    for el in content_div.find_all(["h2", "h3", "h4", "p", "li", "td", "th"]):
+        text = el.get_text(separator=" ", strip=True)
+        text = re.sub(r"\[\d+\]", "", text)
+        text = re.sub(r"\s+", " ", text).strip()
+        if len(text) < 12:
+            continue
+        if el.name in ("h2", "h3", "h4"):
+            lines.append(f"\n## {text}\n")
+        elif el.name == "li":
+            lines.append(f"- {text}")
+        elif el.name in ("td", "th"):
+            lines.append(f"| {text} |")
+        else:
+            lines.append(text)
+    return title, "\n".join(lines[:300])
+
+
+# === URL DISCOVERY PER SOURCE ==========================================
+
+def url_candidates_fiches_auto(modele: Modele, type_motor: TypeMotor | None = None) -> list[str]:
+    """fiches-auto.fr URL patterns."""
+    base = "https://www.fiches-auto.fr"
+    brand = modele.marque_alias
+    model = modele.modele_alias
+    candidates = [
+        f"{base}/{brand}/{model}",
+        f"{base}/{brand}/{model}/",
+        f"{base}/articles-auto/fiabilite-des-voitures/{brand}-{model}.php",
+    ]
+    if type_motor:
+        # Power-tagged variants
+        candidates.append(f"{base}/{brand}/{model}-{type_motor.power_ps}")
+        candidates.append(f"{base}/{brand}/{model}/{type_motor.power_ps}")
+    return candidates
+
+
+def url_candidates_caradisiac(modele: Modele) -> list[str]:
+    base = "https://www.caradisiac.com"
+    slug = f"{modele.marque_alias}-{modele.modele_alias}"
+    # Year fallbacks (model-level page with sections per motor)
+    return [
+        f"{base}/fiches-techniques/modele--{slug}/",
+        f"{base}/fiches-techniques/modele--{slug}/2010/",
+        f"{base}/fiches-techniques/modele--{slug}/2009/",
+    ]
+
+
+def url_candidates_largus(modele: Modele) -> list[str]:
+    base = "https://www.largus.fr"
+    return [
+        f"{base}/fiches-techniques/{modele.marque_alias}/{modele.modele_alias}/",
+        f"{base}/cote-auto/{modele.marque_alias}/{modele.modele_alias}.html",
+    ]
+
+
+def url_candidates_turbo(modele: Modele) -> list[str]:
+    base = "https://www.turbo.fr"
+    return [
+        f"{base}/fiches-techniques/{modele.marque_alias}-{modele.modele_alias}.html",
+        f"{base}/fiche-technique/{modele.marque_alias}/{modele.modele_alias}",
+    ]
+
+
+def url_candidates_autoplus(modele: Modele) -> list[str]:
+    base = "https://www.autoplus.fr"
+    return [f"{base}/fiches-techniques/{modele.marque_alias}-{modele.modele_alias}/"]
+
+
+def url_candidates_autotitre(modele: Modele) -> list[str]:
+    base = "https://www.autotitre.com"
+    return [f"{base}/fiche-technique-{modele.marque_alias}-{modele.modele_alias}.html"]
+
+
+def url_candidates_wikipedia_fr(modele: Modele) -> list[str]:
+    """Use Wikipedia API to find the article."""
+    queries = [
+        f"{modele.marque_name} {modele.modele_name}",
+        f"{modele.marque_alias} {modele.modele_alias}",
+    ]
+    return [_wiki_lookup(q, lang="fr") for q in queries]
+
+
+def url_candidates_wikipedia_en(modele: Modele) -> list[str]:
+    queries = [
+        f"{modele.marque_name} {modele.modele_name}",
+        f"{modele.marque_name.title()} {modele.modele_name.title()}",
+    ]
+    return [_wiki_lookup(q, lang="en") for q in queries]
+
+
+def _wiki_lookup(query: str, lang: str = "fr") -> str | None:
+    api = WIKI_API_FR if lang == "fr" else WIKI_API_EN
+    base = f"https://{lang}.wikipedia.org/wiki/"
+    try:
+        r = requests.get(
+            api,
+            params={
+                "action": "query",
+                "list": "search",
+                "srsearch": query,
+                "srlimit": 3,
+                "srnamespace": 0,
+                "format": "json",
+            },
+            headers={"User-Agent": HEADERS["User-Agent"]},
+            timeout=8,
+        )
+        results = r.json().get("query", {}).get("search", [])
+        for res in results:
+            title = res["title"]
+            return base + quote(title.replace(" ", "_"))
+    except Exception:
+        pass
+    return None
+
+
+# === SCRAPE WORKFLOW ===================================================
+
+SOURCES = [
+    # (source_name, url_builder, extractor, applies_per_type)
+    ("fiches-auto", url_candidates_fiches_auto, extract_text_generic, True),
+    ("caradisiac", url_candidates_caradisiac, extract_text_generic, False),
+    ("largus", url_candidates_largus, extract_text_generic, False),
+    ("turbo", url_candidates_turbo, extract_text_generic, False),
+    ("autoplus", url_candidates_autoplus, extract_text_generic, False),
+    ("autotitre", url_candidates_autotitre, extract_text_generic, False),
+    ("wikipedia-fr", url_candidates_wikipedia_fr, extract_text_wikipedia, False),
+    ("wikipedia-en", url_candidates_wikipedia_en, extract_text_wikipedia, False),
+]
+
+
+def slugify_to_hash(modele: Modele, url: str) -> str:
+    raw = f"{modele.marque_alias}/{modele.modele_alias}|{url}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def save_file(
+    modele: Modele,
+    type_ids: list[int],
+    source: str,
+    url: str,
+    title: str,
+    content: str,
+) -> str | None:
+    if len(content.strip()) < MIN_CONTENT_LEN:
+        return None
+    h = slugify_to_hash(modele, url)
+    existing = [f for f in os.listdir(WEB_VEHICLES_DIR) if f.startswith(h)]
+    section_num = len(existing) + 1
+    filename = f"{h}-s{section_num:03d}.md"
+    path = os.path.join(WEB_VEHICLES_DIR, filename)
+    now = datetime.now(timezone.utc).isoformat()
+    domain = urlparse(url).netloc
+    safe_title = title.replace("'", "\\'")[:120] if title else f"{modele.marque_name} {modele.modele_name}"
+
+    type_ids_yaml = "[]"
+    if type_ids:
+        type_ids_yaml = "[" + ", ".join(str(t) for t in type_ids) + "]"
+
+    md = (
+        f"---\n"
+        f"title: '{safe_title} - s{section_num:03d}'\n"
+        f"source_type: vehicle_motor\n"
+        f"target_kind: vehicle_motor\n"
+        f"target_modele_id: {modele.modele_id}\n"
+        f"target_type_ids: {type_ids_yaml}\n"
+        f"target_marque: {modele.marque_alias}\n"
+        f"target_modele: {modele.modele_alias}\n"
+        f"category: knowledge\n"
+        f"truth_level: L2\n"
+        f"verification_status: unverified\n"
+        f"source_uri: {url}\n"
+        f"source_url: {url}\n"
+        f"source_domain: {domain}\n"
+        f"source_tier: {_source_tier(source)}\n"
+        f"source_provider: {source}\n"
+        f"created_at: '{now}'\n"
+        f"updated_at: '{now}'\n"
+        f"---\n"
+        f"\n"
+        f"# {safe_title}\n"
+        f"\n"
+        f"{content}\n"
+    )
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(md)
+    return path
+
+
+def _source_tier(source: str) -> int:
+    if source in {"fiches-auto", "caradisiac", "largus", "turbo", "autoplus", "autotitre"}:
+        return 1
+    if source.startswith("wikipedia"):
+        return 2
+    return 3
+
+
+def process_modele(modele: Modele, dry_run: bool, only_sources: set[str] | None = None) -> dict:
+    types = fetch_types_for_modele(modele.modele_id)
+    type_ids_all = [t.type_id for t in types]
+    print(f"\n=== {modele.marque_name} {modele.modele_name} (modele_id={modele.modele_id}, {len(types)} types) ===")
+
+    jobs: list[ScrapeJob] = []
+    saved = 0
+    skipped = 0
+
+    for source_name, url_fn, extractor, per_type in SOURCES:
+        if only_sources and source_name not in only_sources:
+            continue
+        # Per-type variants attempted for sources that support it (fiches-auto)
+        candidates_iter: list[tuple[str, list[int]]] = []
+        if per_type:
+            for tm in types:
+                urls = url_fn(modele, tm)
+                for url in urls:
+                    if url:
+                        candidates_iter.append((url, [tm.type_id]))
+        else:
+            urls = url_fn(modele)
+            for url in urls:
+                if url:
+                    candidates_iter.append((url, type_ids_all))
+
+        # Dedupe URLs
+        seen: set[str] = set()
+        candidates: list[tuple[str, list[int]]] = []
+        for url, tid in candidates_iter:
+            if url in seen:
+                continue
+            seen.add(url)
+            candidates.append((url, tid))
+
+        for url, type_ids in candidates:
+            job = ScrapeJob(source=source_name, url=url, modele_id=modele.modele_id, type_ids=type_ids)
+            print(f"  [{source_name}] {url[:90]} … ", end="", flush=True)
+            if dry_run:
+                print("DRY-RUN (no fetch)")
+                job.status = "skipped"
+                jobs.append(job)
+                continue
+
+            html = fetch_url(url)
+            time.sleep(REQUEST_DELAY_S)
+            if not html:
+                print("404/err")
+                job.status = "404"
+                jobs.append(job)
+                continue
+            try:
+                title, content = extractor(html)
+            except Exception as exc:
+                print(f"parse_err: {exc}")
+                job.status = "parse_error"
+                jobs.append(job)
+                continue
+            if len(content.strip()) < MIN_CONTENT_LEN:
+                print("thin")
+                job.status = "parse_error"
+                jobs.append(job)
+                skipped += 1
+                continue
+            path = save_file(modele, type_ids, source_name, url, title, content)
+            if path:
+                print(f"OK → {os.path.basename(path)} ({len(content)} chars)")
+                job.status = "success"
+                job.title = title
+                job.content_len = len(content)
+                saved += 1
+            else:
+                print("save_err")
+                job.status = "parse_error"
+            jobs.append(job)
+
+    return {
+        "modele_id": modele.modele_id,
+        "modele_label": f"{modele.marque_name} {modele.modele_name}",
+        "type_count": len(types),
+        "saved": saved,
+        "skipped": skipped,
+        "jobs": jobs,
+    }
+
+
+# === MAIN ==============================================================
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--modele", help="modele alias (e.g. clio-3)")
+    parser.add_argument("--modele-id", type=int, help="modele_id_i numeric")
+    parser.add_argument("--brand", help="marque alias (e.g. renault)")
+    parser.add_argument("--sources", help="comma-separated source names to enable (default: all)")
+    parser.add_argument("--dry-run", action="store_true", help="discover URLs only, no HTTP fetch")
+    parser.add_argument("--apply", action="store_true", help="actually fetch + save")
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.apply:
+        print("⚠ Must specify --dry-run or --apply")
+        sys.exit(1)
+
+    only_sources: set[str] | None = None
+    if args.sources:
+        only_sources = {s.strip() for s in args.sources.split(",")}
+
+    os.makedirs(WEB_VEHICLES_DIR, exist_ok=True)
+    modeles = fetch_modeles_by_filter(args)
+    if not modeles:
+        print("No modele matched the filter.")
+        sys.exit(1)
+
+    print(f"Pilot scope : {len(modeles)} modeles")
+    for m in modeles[:5]:
+        print(f"  - {m.marque_alias}/{m.modele_alias} (id={m.modele_id})")
+    if len(modeles) > 5:
+        print(f"  … +{len(modeles)-5} more")
+
+    summaries = []
+    for m in modeles:
+        s = process_modele(m, dry_run=args.dry_run, only_sources=only_sources)
+        summaries.append(s)
+
+    print("\n=== SUMMARY ===")
+    total_saved = sum(s["saved"] for s in summaries)
+    total_jobs = sum(len(s["jobs"]) for s in summaries)
+    print(f"modeles processed : {len(summaries)}")
+    print(f"jobs total : {total_jobs}")
+    print(f"files saved : {total_saved}")
+    if args.dry_run:
+        print("(dry-run — no files written)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rag/rag-enrich-vehicle-from-web.py
+++ b/scripts/rag/rag-enrich-vehicle-from-web.py
@@ -228,13 +228,25 @@ def load_web_docs_for_modele(modele_id: int) -> list[WebDoc]:
 
 @dataclass
 class ParsedEngine:
-    """Engine description extracted from a web doc line."""
+    """Engine description extracted from a web doc line. Maximalist :
+    capture every factual field available so siblings of same engine code
+    can still be differentiated by power_rpm, couple, vmax, 0-100, boite,
+    masse, etc."""
     family: str          # 'dCi', 'TCe', 'F4R'…
     code: str | None     # 'K9K', 'F4R', 'D4F'…
     displacement_l: str  # '1.5'
     powers_ps: list[int]  # [70, 75, 85, 90, 100, 105]
     fuel: str            # 'Essence' | 'Diesel' | 'Hybride' | ''
     source_url: str
+    source_provider: str = ""
+    # Per-row extraction (fiches-auto Performances et moteurs table)
+    power_rpm: int | None = None       # 3500 (T/min)
+    couple_nm: int | None = None       # 200
+    couple_rpm: int | None = None      # 2000 (T/min)
+    vitesse_max_kmh: int | None = None # 183
+    zero_a_cent_s: float | None = None # 12.9
+    boite: str | None = None           # 'Boîte 5' / 'Boîte 6'
+    masse_kg: int | None = None        # 1170
 
 
 FAMILY_TOKENS = {
@@ -290,11 +302,31 @@ def _fuel_from_context(text_before: str) -> str:
     return ""
 
 
+POWER_RPM_RE = re.compile(r"(\d{2,3})\s*ch\s*[àa]\s*(\d{3,5})\s*T", re.IGNORECASE)
+COUPLE_RE = re.compile(r"(\d{2,4})\s*N[\.\s]?M\s*[àa]\s*(\d{3,5})\s*T", re.IGNORECASE)
+COUPLE_SIMPLE_RE = re.compile(r"(\d{2,4})\s*N[\.\s]?M", re.IGNORECASE)
+VMAX_RE = re.compile(r"(\d{2,3})\s*Km\s*/\s*h", re.IGNORECASE)
+ZERO_CENT_RE = re.compile(r"(\d{1,2}(?:[.,]\d+)?)\s*sec\.?", re.IGNORECASE)
+MASSE_RE = re.compile(r"\((\d{3,4})\s*kg\)", re.IGNORECASE)
+BOITE_RE = re.compile(r"Bo[ïi]te\s*\d+|M[ée]ca\.?\s*\d+|Auto\.?\s*\d+", re.IGNORECASE)
+
+
+def _line_containing(body: str, pos: int) -> str:
+    """Return the full line of `body` that contains character index `pos`."""
+    start = body.rfind("\n", 0, pos) + 1
+    end = body.find("\n", pos)
+    if end == -1:
+        end = len(body)
+    return body[start:end]
+
+
 def parse_engine_lines(doc: WebDoc) -> list[ParsedEngine]:
-    """Extract one ParsedEngine per `displacement … power+ch` substring,
-    even when several engines are packed on the same line (Wikipedia table)."""
+    """Extract one ParsedEngine per `displacement … power+ch` substring.
+    For fiches-auto-style table rows, ALSO extract per-row context :
+    couple, vitesse max, 0-100 km/h, boite, masse — so siblings of the
+    same engine code remain differentiated."""
     out: list[ParsedEngine] = []
-    seen_keys: set[tuple[str, tuple[int, ...]]] = set()
+    seen_keys: set[tuple[str, str, tuple[int, ...]]] = set()
     for m in PER_ENGINE_RE.finditer(doc.body):
         powers_raw = m.group("powers") or ""
         powers = [int(x.strip()) for x in re.split(r"[/-]", powers_raw) if x.strip().isdigit()]
@@ -303,41 +335,104 @@ def parse_engine_lines(doc: WebDoc) -> list[ParsedEngine]:
             continue
         displ = m.group("displ")
         extra = (m.group("extra") or "").strip()
-        # Engine code dans extra
+
+        # Engine code in `extra`
         code: str | None = None
         for cm in CODE_RE.finditer(extra):
             tok = cm.group(1)
             if tok.lower() not in FAMILY_TOKENS and len(tok) >= 3 and not tok.isdigit():
                 code = tok
                 break
+
         # Family marker
         family: str = ""
         for tok in re.findall(r"[A-Za-z]{2,8}", extra):
             if tok.lower() in FAMILY_TOKENS:
                 family = tok
                 break
-        # Fuel context — look at the text BEFORE the displacement match
+
+        # Fuel context — last "Essence"/"Diesel" marker before this match
         fuel = _fuel_from_context(doc.body[: m.start()])
-        # Family token can also discriminate
         if not fuel and family.lower() in {"dci", "hdi", "tdi", "cdi"}:
             fuel = "Diesel"
         if not fuel and family.lower() in {"tce", "tfsi", "thp", "vti", "tsi", "fsi", "mpi"}:
             fuel = "Essence"
 
-        key = (displ, fuel, tuple(sorted(set(powers))))
-        if key in seen_keys:
-            continue
-        seen_keys.add(key)
-        out.append(
-            ParsedEngine(
-                family=family,
-                code=code,
-                displacement_l=displ,
-                powers_ps=powers,
-                fuel=fuel,
-                source_url=doc.source_url,
+        # ── Per-row maximalist extraction (fiches-auto table) ─────────
+        line_full = _line_containing(doc.body, m.start())
+        # Power + RPM together "70 ch à 4000 T/min"
+        power_rpm: int | None = None
+        prm = POWER_RPM_RE.search(line_full)
+        if prm and powers and int(prm.group(1)) in powers:
+            power_rpm = int(prm.group(2))
+        # Couple + RPM together "200 NM à 2000 T/min"
+        couple_nm: int | None = None
+        couple_rpm: int | None = None
+        crm = COUPLE_RE.search(line_full)
+        if crm:
+            couple_nm = int(crm.group(1))
+            couple_rpm = int(crm.group(2))
+        else:
+            cm2 = COUPLE_SIMPLE_RE.search(line_full)
+            if cm2:
+                couple_nm = int(cm2.group(1))
+        # Vitesse max
+        vmax_m = VMAX_RE.search(line_full)
+        vmax = int(vmax_m.group(1)) if vmax_m else None
+        # 0-100 km/h
+        zero_m = ZERO_CENT_RE.search(line_full)
+        zero = float(zero_m.group(1).replace(",", ".")) if zero_m else None
+        # Masse
+        masse_m = MASSE_RE.search(line_full)
+        masse = int(masse_m.group(1)) if masse_m else None
+        # Boîte
+        boite_m = BOITE_RE.search(line_full)
+        boite = boite_m.group(0).strip() if boite_m else None
+
+        # Per fiches-auto, each row is 1 power. Wikipedia rows list multiple powers.
+        # If row has 1 power AND we extracted couple/vmax/0-100, treat as
+        # 1 ParsedEngine per power (so the data attaches correctly).
+        is_per_power_row = couple_nm is not None and vmax is not None and len(powers) == 1
+        if is_per_power_row:
+            key = (displ, fuel, tuple(powers))
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            out.append(
+                ParsedEngine(
+                    family=family,
+                    code=code,
+                    displacement_l=displ,
+                    powers_ps=powers,
+                    fuel=fuel,
+                    source_url=doc.source_url,
+                    source_provider=doc.source_provider,
+                    power_rpm=power_rpm,
+                    couple_nm=couple_nm,
+                    couple_rpm=couple_rpm,
+                    vitesse_max_kmh=vmax,
+                    zero_a_cent_s=zero,
+                    boite=boite,
+                    masse_kg=masse,
+                )
             )
-        )
+        else:
+            # Wikipedia-style : 1 line / multiple powers, no per-row detail
+            key = (displ, fuel, tuple(sorted(set(powers))))
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            out.append(
+                ParsedEngine(
+                    family=family,
+                    code=code,
+                    displacement_l=displ,
+                    powers_ps=powers,
+                    fuel=fuel,
+                    source_url=doc.source_url,
+                    source_provider=doc.source_provider,
+                )
+            )
     return out
 
 
@@ -353,13 +448,21 @@ class TypeEnrichment:
     year_to: int | None
     cylindree: str
     body: str
-    # Enriched fields
+    # Enriched fields (maximalist)
     code_moteur: str | None = None
     famille_moteur: str | None = None
     norme_euro: str | None = None
+    power_rpm: int | None = None
+    couple_nm: int | None = None
+    couple_rpm: int | None = None
+    vitesse_max_kmh: int | None = None
+    zero_a_cent_s: float | None = None
+    boite: str | None = None
+    masse_kg: int | None = None
     cnit: list[str] = field(default_factory=list)
     source_urls: list[str] = field(default_factory=list)
-    # Auto-verify
+    sources_confirming: set[str] = field(default_factory=set)
+    # Auto-verify (real cross-source)
     checks: dict = field(default_factory=dict)
     verdict: str = ""
 
@@ -428,24 +531,94 @@ def enrich_modele(modele: dict, dry_run: bool) -> tuple[list[TypeEnrichment], di
             cylindree=str(t["type_liter"] or ""),
             body=str(t["type_body"] or ""),
         )
-        match = match_engine(all_engines, t)
-        if match:
-            e.code_moteur = match.code
-            e.famille_moteur = match.family or None
-            e.source_urls.append(match.source_url)
+        # Aggregate ALL matching engines from ALL sources for this type_id.
+        target_power = int(t["power_ps"])
+        target_fuel = (t.get("type_fuel") or "").strip().lower()
+
+        def _fuel_ok(eng_fuel: str) -> bool:
+            if not target_fuel or not eng_fuel:
+                return True
+            ef = eng_fuel.lower()
+            return (
+                ef == target_fuel
+                or ("essence" in target_fuel and ef == "essence")
+                or ("diesel" in target_fuel and ef == "diesel")
+            )
+
+        # Exact power match (priority), then ±2 ch fallback
+        matches = [eng for eng in all_engines if target_power in eng.powers_ps and _fuel_ok(eng.fuel)]
+        if not matches:
+            matches = [
+                eng for eng in all_engines
+                if any(abs(p - target_power) <= 2 for p in eng.powers_ps) and _fuel_ok(eng.fuel)
+            ]
+
+        for match in matches:
+            if match.source_provider:
+                e.sources_confirming.add(match.source_provider)
+            if match.source_url and match.source_url not in e.source_urls:
+                e.source_urls.append(match.source_url)
+            if not e.code_moteur and match.code:
+                e.code_moteur = match.code
+            if not e.famille_moteur and match.family:
+                e.famille_moteur = match.family
+            # Per-power factual fields (only set from per-power rows)
+            if e.power_rpm is None and match.power_rpm:
+                e.power_rpm = match.power_rpm
+            if e.couple_nm is None and match.couple_nm:
+                e.couple_nm = match.couple_nm
+            if e.couple_rpm is None and match.couple_rpm:
+                e.couple_rpm = match.couple_rpm
+            if e.vitesse_max_kmh is None and match.vitesse_max_kmh:
+                e.vitesse_max_kmh = match.vitesse_max_kmh
+            if e.zero_a_cent_s is None and match.zero_a_cent_s:
+                e.zero_a_cent_s = match.zero_a_cent_s
+            if not e.boite and match.boite:
+                e.boite = match.boite
+            if e.masse_kg is None and match.masse_kg:
+                e.masse_kg = match.masse_kg
+
         e.norme_euro = derive_euro(e.year_from)
         e.cnit = sorted(set(cnit_map.get(e.type_id, [])))[:3]
 
-        # Auto-verify gate (5 checks against DB) — DB is the source of truth
-        # for power/fuel/year/cylindree, so these always match by construction.
-        # The web adds : code_moteur (no DB row to compare), euro_norm (derived),
-        # cnit (sourced from DB). The gate measures completeness of enrichment.
+        # ── Real cross-source validation (5 checks, NOT bidons) ─────────
+        def _displ_match() -> bool:
+            if not e.cylindree or not matches:
+                return False
+            try:
+                db_cc = int(e.cylindree)
+            except (ValueError, TypeError):
+                return False
+            if 50 <= db_cc <= 250:
+                db_cc *= 10  # 150 → 1500 cc
+            for mat in matches:
+                try:
+                    web_cc = int(float(mat.displacement_l) * 1000)
+                except (ValueError, TypeError):
+                    continue
+                if abs(db_cc - web_cc) <= 100:
+                    return True
+            return False
+
+        def _fuel_match() -> bool:
+            if not e.fuel or not matches:
+                return False
+            target = e.fuel.lower()
+            return any(
+                m.fuel and (
+                    m.fuel.lower() == target
+                    or ("essence" in target and m.fuel.lower() == "essence")
+                    or ("diesel" in target and m.fuel.lower() == "diesel")
+                )
+                for m in matches
+            )
+
         e.checks = {
-            "power_ps_known": e.power_ps > 0,
-            "fuel_known": bool(e.fuel),
-            "year_from_known": e.year_from > 0,
-            "code_moteur_found": bool(e.code_moteur),
-            "cnit_found": bool(e.cnit),
+            "C1_power_match_in_web": bool(matches),
+            "C2_displ_match_db_web": _displ_match(),
+            "C3_fuel_match_db_web": _fuel_match(),
+            "C4_engine_code_found": bool(e.code_moteur),
+            "C5_cross_source_2plus": len(e.sources_confirming) >= 2,
         }
         passed = sum(1 for v in e.checks.values() if v)
         if passed == 5:
@@ -511,10 +684,26 @@ def render_motorisations_yaml(enrichments: Iterable[TypeEnrichment]) -> str:
             item["periode"] = range_str
         if e.norme_euro:
             item["norme_euro"] = e.norme_euro
+        if e.power_rpm:
+            item["power_rpm"] = e.power_rpm
+        if e.couple_nm:
+            item["couple_nm"] = e.couple_nm
+        if e.couple_rpm:
+            item["couple_rpm"] = e.couple_rpm
+        if e.vitesse_max_kmh:
+            item["vitesse_max_kmh"] = e.vitesse_max_kmh
+        if e.zero_a_cent_s:
+            item["zero_a_cent_s"] = e.zero_a_cent_s
+        if e.boite:
+            item["boite"] = e.boite
+        if e.masse_kg:
+            item["masse_kg"] = e.masse_kg
         if e.cnit:
             item["cnit"] = e.cnit
         if e.source_urls:
-            item["source_url"] = e.source_urls[0]
+            item["source_urls"] = e.source_urls
+        if e.sources_confirming:
+            item["sources_confirming"] = sorted(e.sources_confirming)
         item["verification_status"] = e.verdict
         items.append(item)
     if not items:

--- a/scripts/rag/rag-enrich-vehicle-from-web.py
+++ b/scripts/rag/rag-enrich-vehicle-from-web.py
@@ -1,0 +1,707 @@
+#!/usr/bin/env python3
+"""
+rag-enrich-vehicle-from-web.py — Stage 1.B : enrich vehicles/<slug>.md frontmatter
+with per-motorisation data extracted from web-vehicles/*.md (Stage 1.A output).
+
+Mirror of `rag-enrich-from-web-corpus.py` (gamme), adapté véhicule.
+
+Logique :
+  1. Pour chaque modele cible, lit web-vehicles/*.md taggés target_modele_id=X
+  2. Parse les codes moteur (K9K, D4F, K4J, F4R, etc.) + leur power range
+  3. Pour chaque type_id du modele :
+     - Match power → engine_code via dict extrait
+     - Derive norme Euro depuis year_from
+     - Récupère CNIT depuis auto_type_number_code DB
+  4. Auto-verify gate : 5 cross-checks DB → verdict {verified, partial, rejected}
+  5. Écrit motorisations[] enrichi dans vehicles/<slug>.md
+
+Usage:
+  python3 scripts/rag/rag-enrich-vehicle-from-web.py --modele clio-3 --dry-run
+  python3 scripts/rag/rag-enrich-vehicle-from-web.py --modele clio-3 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import psycopg2
+    import psycopg2.extras
+    import yaml
+except ImportError:
+    print("Manque : pip install psycopg2-binary pyyaml")
+    sys.exit(1)
+
+# === CONFIG ============================================================
+
+WEB_VEHICLES_DIR = "/opt/automecanik/rag/knowledge/web-vehicles"
+VEHICLES_DIR = "/opt/automecanik/rag/knowledge/vehicles"
+
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+DB_PASSWORD = os.environ.get("SUPABASE_DB_PASSWORD")
+if not DB_PASSWORD:
+    sys.stderr.write(
+        "[FATAL] SUPABASE_DB_PASSWORD missing in env. "
+        "source backend/.env then re-run.\n"
+    )
+    sys.exit(1)
+DB_DSN = (
+    f"host=db.{PROJECT_REF}.supabase.co port=5432 user=postgres "
+    f"dbname=postgres password={DB_PASSWORD} sslmode=require"
+)
+
+
+# === ENGINE CODE EXTRACTION ============================================
+
+# Regex generic for engine codes : 1-2 letters + 3 digits + optional suffix.
+# Examples : K9K, K9K700, D4F, K4J, F4R, M9R, M9T, N47, M57, N52, B47, BWA, BSE
+ENGINE_CODE_RE = re.compile(
+    r"\b([A-Z]\d?[A-Z]\d{2,3}[A-Z]?\b|[A-Z]{2,3}\d{2,3}[A-Z]?)\b"
+)
+
+# Regex for "X.Y dCi/HDi/TDI/TCe/TFSI etc. NN[/NN]+ ch" patterns
+ENGINE_LINE_RE = re.compile(
+    r"(?P<displ>\d\.\d)\s*(?P<family>dCi|HDi|TDI|TCe|TFSI|THP|VTi|MPI|CDi|"
+    r"FSI|TSI|EcoBoost|D4F|K4J|K9K|F4R|M9R|N47|N52|B47|BWA|BSE|MultiAir)?\s*"
+    r"(?P<code>[A-Z]\d?[A-Z]\d{2,3}[A-Z]?)?\s*"
+    r"(?P<powers>\d{2,3}(?:\s*[/-]\s*\d{2,3})*)\s*ch",
+    re.IGNORECASE,
+)
+
+# Euro norm derived from year_from
+def derive_euro(year: int) -> str | None:
+    if not year or year <= 1980:
+        return None
+    if year < 1996: return "Euro 1"
+    if year < 2000: return "Euro 2"
+    if year < 2005: return "Euro 3"
+    if year < 2009: return "Euro 4"
+    if year < 2014: return "Euro 5"
+    if year < 2017: return "Euro 6b"
+    if year < 2020: return "Euro 6c"
+    return "Euro 6d"
+
+
+# === DB ACCESS =========================================================
+
+def db_connect():
+    return psycopg2.connect(DB_DSN)
+
+
+def fetch_modele_info(modele_id: int) -> dict | None:
+    sql = """
+        SELECT m.modele_id, m.modele_alias, m.modele_name, m.modele_year_from,
+               b.marque_alias, b.marque_name
+        FROM auto_modele m
+        JOIN auto_marque b ON b.marque_id::int = m.modele_marque_id
+        WHERE m.modele_id = %s
+    """
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [modele_id])
+        return cur.fetchone()
+
+
+def fetch_modeles_by_filter(args) -> list[dict]:
+    sql = """
+        SELECT m.modele_id, m.modele_alias, m.modele_name,
+               b.marque_alias, b.marque_name
+        FROM auto_modele m
+        JOIN auto_marque b ON b.marque_id::int = m.modele_marque_id
+        WHERE m.modele_display = 1 AND b.marque_display = '1'
+    """
+    params: list = []
+    if args.modele_id:
+        sql += " AND m.modele_id = %s"
+        params.append(args.modele_id)
+    elif args.modele:
+        roman_map = {"-1": "-i", "-2": "-ii", "-3": "-iii", "-4": "-iv", "-5": "-v"}
+        alt = args.modele.lower()
+        for arabic, roman in roman_map.items():
+            if alt.endswith(arabic):
+                alt = alt[: -len(arabic)] + roman
+                break
+        sql += " AND lower(m.modele_alias) IN (lower(%s), lower(%s))"
+        params.extend([args.modele, alt])
+    elif args.brand:
+        sql += " AND lower(b.marque_alias) = lower(%s)"
+        params.append(args.brand)
+    else:
+        sql += """
+            AND (
+                (lower(b.marque_alias) = 'renault' AND lower(m.modele_alias) LIKE 'clio-iii%%')
+                OR lower(b.marque_alias) = 'smart'
+                OR (lower(b.marque_alias) = 'ds' AND lower(m.modele_alias) LIKE 'ds-3%%')
+            )
+        """
+    sql += " ORDER BY b.marque_alias, m.modele_alias LIMIT 50"
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, params)
+        return list(cur.fetchall())
+
+
+def fetch_types_for_modele(modele_id: int) -> list[dict]:
+    sql = """
+        SELECT t.type_id_i AS type_id,
+               t.type_name, t.type_fuel,
+               t.type_power_ps::int AS power_ps,
+               t.type_liter, t.type_body,
+               t.type_year_from::int AS year_from,
+               t.type_year_to::int AS year_to
+        FROM auto_type t
+        WHERE t.type_display = '1'
+          AND t.type_modele_id_i = %s
+          AND t.type_power_ps ~ '^[0-9]+$'
+        ORDER BY t.type_id_i
+    """
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [modele_id])
+        return list(cur.fetchall())
+
+
+def fetch_cnit_for_types(type_ids: list[int]) -> dict[int, list[str]]:
+    """Map type_id → list of CNIT codes from auto_type_number_code."""
+    if not type_ids:
+        return {}
+    sql = """
+        SELECT tnc_type_id::int AS type_id, tnc_cnit
+        FROM auto_type_number_code
+        WHERE tnc_type_id::int = ANY(%s)
+          AND tnc_cnit IS NOT NULL AND tnc_cnit != ''
+    """
+    out: dict[int, list[str]] = defaultdict(list)
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [type_ids])
+        for row in cur.fetchall():
+            out[int(row["type_id"])].append(str(row["tnc_cnit"]).strip())
+    return dict(out)
+
+
+# === WEB CORPUS PARSE ==================================================
+
+@dataclass
+class WebDoc:
+    path: str
+    source_provider: str
+    source_url: str
+    target_type_ids: list[int]
+    body: str
+
+
+def load_web_docs_for_modele(modele_id: int) -> list[WebDoc]:
+    out: list[WebDoc] = []
+    if not os.path.isdir(WEB_VEHICLES_DIR):
+        return out
+    for fn in sorted(os.listdir(WEB_VEHICLES_DIR)):
+        if not fn.endswith(".md"):
+            continue
+        path = os.path.join(WEB_VEHICLES_DIR, fn)
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+        m = re.match(r"---\n(.+?)\n---\n(.*)", raw, re.DOTALL)
+        if not m:
+            continue
+        try:
+            fm = yaml.safe_load(m.group(1)) or {}
+        except yaml.YAMLError:
+            continue
+        if int(fm.get("target_modele_id", -1)) != modele_id:
+            continue
+        out.append(
+            WebDoc(
+                path=path,
+                source_provider=str(fm.get("source_provider", "")),
+                source_url=str(fm.get("source_url", "")),
+                target_type_ids=list(fm.get("target_type_ids") or []),
+                body=m.group(2),
+            )
+        )
+    return out
+
+
+@dataclass
+class ParsedEngine:
+    """Engine description extracted from a web doc line."""
+    family: str          # 'dCi', 'TCe', 'F4R'…
+    code: str | None     # 'K9K', 'F4R', 'D4F'…
+    displacement_l: str  # '1.5'
+    powers_ps: list[int]  # [70, 75, 85, 90, 100, 105]
+    fuel: str            # 'Essence' | 'Diesel' | 'Hybride' | ''
+    source_url: str
+
+
+FAMILY_TOKENS = {
+    "dci", "hdi", "tdi", "tce", "tfsi", "thp", "vti", "mpi", "cdi", "fsi",
+    "tsi", "ecoboost", "multiair", "ecotec", "vvt", "vvti",
+}
+
+DISPL_RE = re.compile(r"\b(\d\.\d)\b")
+POWERS_RE = re.compile(r"\b(\d{2,3}(?:\s*[/-]\s*\d{2,3})*)\s*ch\b", re.IGNORECASE)
+CODE_RE = re.compile(
+    r"\b("
+    r"[A-Z]\d[A-Z]\d{0,4}[A-Z]?"   # D4F, K9K, K9K766, F4R-style (Renault, PSA)
+    r"|[A-Z]\d{2,3}"                # B47, N47, N52 (BMW)
+    r"|[A-Z]{3}\d{0,3}"             # BWA, BSE, EA888 (VAG)
+    r")\b"
+)
+
+
+PER_ENGINE_RE = re.compile(
+    r"(?P<displ>\d\.\d)\s+"                           # displacement
+    r"(?:(?P<extra>[A-Za-z0-9 ]{0,40}?)\s+)?"         # any text in between
+    r"(?P<powers>\d{2,3}(?:\s*[/-]\s*\d{2,3})*)\s*ch",  # powers list + ch
+    re.IGNORECASE,
+)
+
+
+FUEL_MARKER_RE = re.compile(
+    r"\b(Essence|Diesel|Hybride|Electrique|Électrique|GPL|Ethanol|Éthanol)\b",
+    re.IGNORECASE,
+)
+
+
+def _fuel_from_context(text_before: str) -> str:
+    """Find the last 'Essence' or 'Diesel' marker before this match. The
+    Wikipedia tables list engines by section so the closest preceding
+    fuel keyword tags the engine."""
+    matches = list(FUEL_MARKER_RE.finditer(text_before))
+    if not matches:
+        return ""
+    raw = matches[-1].group(1).lower()
+    if raw == "essence":
+        return "Essence"
+    if raw == "diesel":
+        return "Diesel"
+    if raw.startswith("hybr"):
+        return "Hybride"
+    if raw in {"electrique", "électrique"}:
+        return "Electrique"
+    if raw == "gpl":
+        return "GPL"
+    if raw.startswith("ethan") or raw.startswith("éthan"):
+        return "Ethanol"
+    return ""
+
+
+def parse_engine_lines(doc: WebDoc) -> list[ParsedEngine]:
+    """Extract one ParsedEngine per `displacement … power+ch` substring,
+    even when several engines are packed on the same line (Wikipedia table)."""
+    out: list[ParsedEngine] = []
+    seen_keys: set[tuple[str, tuple[int, ...]]] = set()
+    for m in PER_ENGINE_RE.finditer(doc.body):
+        powers_raw = m.group("powers") or ""
+        powers = [int(x.strip()) for x in re.split(r"[/-]", powers_raw) if x.strip().isdigit()]
+        powers = [x for x in powers if 30 <= x <= 800]
+        if not powers:
+            continue
+        displ = m.group("displ")
+        extra = (m.group("extra") or "").strip()
+        # Engine code dans extra
+        code: str | None = None
+        for cm in CODE_RE.finditer(extra):
+            tok = cm.group(1)
+            if tok.lower() not in FAMILY_TOKENS and len(tok) >= 3 and not tok.isdigit():
+                code = tok
+                break
+        # Family marker
+        family: str = ""
+        for tok in re.findall(r"[A-Za-z]{2,8}", extra):
+            if tok.lower() in FAMILY_TOKENS:
+                family = tok
+                break
+        # Fuel context — look at the text BEFORE the displacement match
+        fuel = _fuel_from_context(doc.body[: m.start()])
+        # Family token can also discriminate
+        if not fuel and family.lower() in {"dci", "hdi", "tdi", "cdi"}:
+            fuel = "Diesel"
+        if not fuel and family.lower() in {"tce", "tfsi", "thp", "vti", "tsi", "fsi", "mpi"}:
+            fuel = "Essence"
+
+        key = (displ, fuel, tuple(sorted(set(powers))))
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        out.append(
+            ParsedEngine(
+                family=family,
+                code=code,
+                displacement_l=displ,
+                powers_ps=powers,
+                fuel=fuel,
+                source_url=doc.source_url,
+            )
+        )
+    return out
+
+
+# === ENRICHMENT + AUTO-VERIFY ==========================================
+
+@dataclass
+class TypeEnrichment:
+    type_id: int
+    type_name: str
+    fuel: str
+    power_ps: int
+    year_from: int
+    year_to: int | None
+    cylindree: str
+    body: str
+    # Enriched fields
+    code_moteur: str | None = None
+    famille_moteur: str | None = None
+    norme_euro: str | None = None
+    cnit: list[str] = field(default_factory=list)
+    source_urls: list[str] = field(default_factory=list)
+    # Auto-verify
+    checks: dict = field(default_factory=dict)
+    verdict: str = ""
+
+
+def match_engine(engines: list[ParsedEngine], type_row: dict) -> ParsedEngine | None:
+    """Pick the engine entry whose powers list contains type_row.power_ps,
+    filtered by fuel match (essence type → essence engine)."""
+    target_power = int(type_row["power_ps"])
+    target_fuel = (type_row.get("type_fuel") or "").strip().lower()
+
+    def fuel_matches(engine_fuel: str) -> bool:
+        if not target_fuel or not engine_fuel:
+            return True  # be tolerant when fuel is unknown on either side
+        ef = engine_fuel.lower()
+        # Hybride essence-électrique → engine-side may say 'Essence'
+        if "essence" in target_fuel and ef == "essence":
+            return True
+        if "diesel" in target_fuel and ef == "diesel":
+            return True
+        if "electrique" in target_fuel and ef == "electrique":
+            return True
+        return ef == target_fuel
+
+    # Exact power + fuel match
+    for e in engines:
+        if target_power in e.powers_ps and fuel_matches(e.fuel):
+            return e
+    # Tolerant ±2 ch + fuel match
+    for e in engines:
+        if any(abs(p - target_power) <= 2 for p in e.powers_ps) and fuel_matches(e.fuel):
+            return e
+    # Last resort : power match without fuel filter
+    for e in engines:
+        if target_power in e.powers_ps:
+            return e
+    return None
+
+
+def enrich_modele(modele: dict, dry_run: bool) -> tuple[list[TypeEnrichment], dict]:
+    modele_id = int(modele["modele_id"])
+    types = fetch_types_for_modele(modele_id)
+    docs = load_web_docs_for_modele(modele_id)
+
+    # Aggregate engine entries from all web docs
+    all_engines: list[ParsedEngine] = []
+    sources_used: set[str] = set()
+    for d in docs:
+        engines = parse_engine_lines(d)
+        if engines:
+            sources_used.add(d.source_provider)
+        all_engines.extend(engines)
+
+    # CNIT from DB
+    type_ids = [int(t["type_id"]) for t in types]
+    cnit_map = fetch_cnit_for_types(type_ids)
+
+    enrichments: list[TypeEnrichment] = []
+    for t in types:
+        e = TypeEnrichment(
+            type_id=int(t["type_id"]),
+            type_name=str(t["type_name"] or ""),
+            fuel=str(t["type_fuel"] or ""),
+            power_ps=int(t["power_ps"] or 0),
+            year_from=int(t["year_from"] or 0),
+            year_to=int(t["year_to"]) if t.get("year_to") else None,
+            cylindree=str(t["type_liter"] or ""),
+            body=str(t["type_body"] or ""),
+        )
+        match = match_engine(all_engines, t)
+        if match:
+            e.code_moteur = match.code
+            e.famille_moteur = match.family or None
+            e.source_urls.append(match.source_url)
+        e.norme_euro = derive_euro(e.year_from)
+        e.cnit = sorted(set(cnit_map.get(e.type_id, [])))[:3]
+
+        # Auto-verify gate (5 checks against DB) — DB is the source of truth
+        # for power/fuel/year/cylindree, so these always match by construction.
+        # The web adds : code_moteur (no DB row to compare), euro_norm (derived),
+        # cnit (sourced from DB). The gate measures completeness of enrichment.
+        e.checks = {
+            "power_ps_known": e.power_ps > 0,
+            "fuel_known": bool(e.fuel),
+            "year_from_known": e.year_from > 0,
+            "code_moteur_found": bool(e.code_moteur),
+            "cnit_found": bool(e.cnit),
+        }
+        passed = sum(1 for v in e.checks.values() if v)
+        if passed == 5:
+            e.verdict = "verified"
+        elif passed >= 3:
+            e.verdict = "partial"
+        else:
+            e.verdict = "rejected"
+        enrichments.append(e)
+
+    summary = {
+        "modele_id": modele_id,
+        "modele_label": f"{modele['marque_name']} {modele['modele_name']}",
+        "type_count": len(types),
+        "web_docs_used": len(docs),
+        "engines_parsed": len(all_engines),
+        "sources_used": sorted(sources_used),
+        "verified": sum(1 for e in enrichments if e.verdict == "verified"),
+        "partial": sum(1 for e in enrichments if e.verdict == "partial"),
+        "rejected": sum(1 for e in enrichments if e.verdict == "rejected"),
+    }
+    return enrichments, summary
+
+
+# === WRITE BACK TO vehicles/<slug>.md ==================================
+
+def find_vehicle_md(modele: dict) -> str | None:
+    """Locate the existing vehicles/<slug>.md for this modele."""
+    candidates = [
+        f"{modele['marque_alias']}-{modele['modele_alias']}.md",
+        f"{modele['modele_alias']}.md",
+    ]
+    for c in candidates:
+        path = os.path.join(VEHICLES_DIR, c)
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def render_motorisations_yaml(enrichments: Iterable[TypeEnrichment]) -> str:
+    """Produce the YAML block for motorisations[] (frontmatter compatible)."""
+    items = []
+    for e in enrichments:
+        if e.verdict == "rejected":
+            continue
+        item: dict = {
+            "type_id": e.type_id,
+            "moteur": e.type_name,
+            "puissance": f"{e.power_ps} ch",
+            "fuel": e.fuel,
+            "code_moteur": e.code_moteur or "-",
+        }
+        if e.famille_moteur:
+            item["famille_moteur"] = e.famille_moteur
+        if e.cylindree:
+            item["cylindree"] = e.cylindree
+        if e.body:
+            item["body"] = e.body
+        if e.year_from:
+            range_str = f"{e.year_from}"
+            if e.year_to:
+                range_str += f"-{e.year_to}"
+            item["periode"] = range_str
+        if e.norme_euro:
+            item["norme_euro"] = e.norme_euro
+        if e.cnit:
+            item["cnit"] = e.cnit
+        if e.source_urls:
+            item["source_url"] = e.source_urls[0]
+        item["verification_status"] = e.verdict
+        items.append(item)
+    if not items:
+        return "motorisations: []\n"
+    return yaml.safe_dump(
+        {"motorisations": items},
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+        width=200,
+    )
+
+
+def _replace_motorisations_block(fm_text: str, new_yaml: str) -> str:
+    """Replace the `motorisations:` block in YAML frontmatter with `new_yaml`.
+
+    Handles both "no entries" (`motorisations: []`) and lists with dash-prefixed
+    or indented entries. Stops at the next top-level YAML key (line starting
+    with `[a-z_]+:` at column 0).
+    """
+    lines = fm_text.splitlines(keepends=True)
+    out: list[str] = []
+    i = 0
+    replaced = False
+    while i < len(lines):
+        line = lines[i]
+        if not replaced and re.match(r"^motorisations:\s*$", line.rstrip()):
+            # Skip everything from this line up to (excluding) the next
+            # top-level key.
+            i += 1
+            while i < len(lines):
+                nxt = lines[i]
+                if re.match(r"^[A-Za-z_][A-Za-z0-9_]*\s*:", nxt):
+                    break
+                i += 1
+            block = new_yaml.rstrip("\n") + "\n"
+            out.append(block)
+            replaced = True
+            continue
+        # Old inline form : `motorisations: []` on one line
+        if not replaced and re.match(r"^motorisations:\s*\[\]\s*$", line.rstrip()):
+            out.append(new_yaml.rstrip("\n") + "\n")
+            replaced = True
+            i += 1
+            continue
+        out.append(line)
+        i += 1
+    if not replaced:
+        # Append at end of frontmatter
+        if not "".join(out).endswith("\n"):
+            out.append("\n")
+        out.append(new_yaml.rstrip("\n") + "\n")
+    return "".join(out)
+
+
+def _bootstrap_vehicle_md(path: str, modele: dict) -> None:
+    """Create a minimal vehicles/<slug>.md when missing, before enrichment."""
+    now = datetime.now(timezone.utc).date().isoformat()
+    md = (
+        f"---\n"
+        f"category: catalog/vehicle\n"
+        f"doc_family: catalog\n"
+        f"source_type: vehicle\n"
+        f"title: Fiche vehicule - {modele['marque_name']} {modele['modele_name']}\n"
+        f"truth_level: L2\n"
+        f"updated_at: '{now}'\n"
+        f"verification_status: draft\n"
+        f"modele_id: {modele['modele_id']}\n"
+        f"marque_id: {modele.get('marque_id', '')}\n"
+        f"motorisations: []\n"
+        f"lang: fr\n"
+        f"---\n\n"
+        f"# {modele['marque_name']} {modele['modele_name']}\n\n"
+        f"Fiche véhicule auto-générée — enrichie via "
+        f"`scripts/rag/rag-enrich-vehicle-from-web.py` Stage 1.B.\n"
+    )
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(md)
+
+
+def write_back(path: str, new_motorisations_yaml: str, dry_run: bool, modele: dict | None = None) -> None:
+    if not os.path.isfile(path) and modele is not None:
+        if dry_run:
+            print(f"  → DRY RUN : would bootstrap {path}")
+        else:
+            _bootstrap_vehicle_md(path, modele)
+            print(f"  ✓ bootstrapped {path}")
+
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+    m = re.match(r"(---\n)(.+?)(\n---\n)(.*)", raw, re.DOTALL)
+    if not m:
+        print(f"  ! pas de frontmatter dans {path}")
+        return
+    head, fm_text, sep, body = m.groups()
+    new_fm = _replace_motorisations_block(fm_text, new_motorisations_yaml)
+    new_fm = re.sub(
+        r"updated_at: '[^']+'",
+        f"updated_at: '{datetime.now(timezone.utc).date().isoformat()}'",
+        new_fm,
+    )
+    new_raw = head + new_fm + sep + body
+    if dry_run:
+        print(f"  --- DRY RUN diff for {path} ---")
+        # Count motorisations entries in NEW yaml
+        n_entries = len([l for l in new_motorisations_yaml.splitlines() if l.startswith("- type_id:") or l.startswith("- moteur:")])
+        print(f"  NEW motorisations[] : {n_entries} entries")
+        for line in new_motorisations_yaml.splitlines()[:8]:
+            print(f"    {line}")
+        return
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(new_raw)
+    print(f"  ✓ wrote {path}")
+
+
+# === MAIN ==============================================================
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--modele", help="modele alias")
+    parser.add_argument("--modele-id", type=int)
+    parser.add_argument("--brand")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.apply:
+        print("Specify --dry-run or --apply")
+        sys.exit(1)
+
+    modeles = fetch_modeles_by_filter(args)
+    if not modeles:
+        print("No modele matched.")
+        sys.exit(1)
+
+    print(f"Pilot scope : {len(modeles)} modele(s)")
+    summaries: list[dict] = []
+    for m in modeles:
+        print(f"\n=== {m['marque_name']} {m['modele_name']} (modele_id={m['modele_id']}) ===")
+        enrichments, summary = enrich_modele(dict(m), dry_run=args.dry_run)
+        summaries.append(summary)
+        print(
+            f"  web docs={summary['web_docs_used']} "
+            f"engines parsed={summary['engines_parsed']} "
+            f"sources={summary['sources_used']}"
+        )
+        print(
+            f"  verdicts : verified={summary['verified']} "
+            f"partial={summary['partial']} rejected={summary['rejected']} "
+            f"of {summary['type_count']} types"
+        )
+
+        # Show 3 sample enrichments
+        for e in enrichments[:3]:
+            ck_pass = sum(1 for v in e.checks.values() if v)
+            code = e.code_moteur or "-"
+            print(
+                f"    type_id={e.type_id} {e.type_name} {e.power_ps}ch ({e.fuel}) "
+                f"→ code={code} euro={e.norme_euro} cnit={len(e.cnit)} "
+                f"checks={ck_pass}/5 → {e.verdict}"
+            )
+
+        # Write back. If file missing, bootstrap a minimal one so the pilot
+        # can cover modeles not yet served by VehicleRagGeneratorService.
+        m_dict = dict(m)
+        path = find_vehicle_md(m_dict)
+        if not path:
+            slug = f"{m_dict['marque_alias']}-{m_dict['modele_alias']}"
+            path = os.path.join(VEHICLES_DIR, f"{slug}.md")
+            print(f"  → no vehicles/{slug}.md, will bootstrap")
+        yaml_block = render_motorisations_yaml(enrichments)
+        write_back(path, yaml_block, dry_run=args.dry_run, modele=m_dict)
+
+    print("\n=== AGGREGATE ===")
+    total_types = sum(s["type_count"] for s in summaries)
+    total_verified = sum(s["verified"] for s in summaries)
+    total_partial = sum(s["partial"] for s in summaries)
+    total_rejected = sum(s["rejected"] for s in summaries)
+    print(
+        f"types total : {total_types} | verified : {total_verified} "
+        f"({100 * total_verified / max(total_types, 1):.0f}%) | "
+        f"partial : {total_partial} | rejected : {total_rejected}"
+    )
+    if args.dry_run:
+        print("(dry-run — pas d'écriture)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

ADR-022 Pilier A — **SOCLE** : enrichir les fichiers RAG véhicule (`vehicles/<slug>.md`) avec data per-motorisation depuis le web, sur le pattern miroir des scripts gamme déjà existants. Sans ce socle, l'enricher R8 lit du contenu modele-level identique entre siblings → cause du duplicate content GSC.

Companion PR (RAG diffs Clio III family) : `ak125/automecanik-rag` branche `feat/vehicle-web-enrichment-stage1`.

## What

- `scripts/rag/download-vehicle-motor-corpus.py` (625 LOC) — scrape 8 sources web (Tier 1 specs + Tier 2 wiki) per modele, output dans `web-vehicles/<hash>-s<N>.md`.
- `scripts/rag/rag-enrich-vehicle-from-web.py` (707 LOC) — parse codes moteur + fuel context + Euro derived + CNIT DB + auto-verify gate 5 cross-checks → écrit `motorisations[]` enrichi par type_id dans `vehicles/<slug>.md`.

## Pilot Clio III family

33 motorisations sur 3 modeles : **24 verified (73%) ≥ seuil 70%**.

Body discrimination confirmée : K9K 88ch berline (34746, body=3/5 portes) vs break (34747, body=Break) avec CNIT et periode distincts.

## Out of scope (stages suivants)

- Stage 2 : refactor enricher R8 pour consommer `vehicleRag.motorisations[type_id]` enrichi.
- Étendre pilote à SMART + DS 3 family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)