### PR TITLE
refactor(r8): extract 5 pure JSX sections (Phase 2b)

### DIFF
--- a/frontend/app/components/vehicle/r8/index.ts
+++ b/frontend/app/components/vehicle/r8/index.ts
@@ -16,5 +16,10 @@ export { generateVehicleSchema } from "./r8-schema";
 export { transformRpcToLoaderData } from "./r8-transform";
 
 // Sections
+export { AntiErrorsSection } from "./sections/AntiErrorsSection";
 export { BreadcrumbSection } from "./sections/BreadcrumbSection";
 export { HeroSection } from "./sections/HeroSection";
+export { HowtoSection } from "./sections/HowtoSection";
+export { R8EnrichedSection } from "./sections/R8EnrichedSection";
+export { SeoIntroSection } from "./sections/SeoIntroSection";
+export { TrustSection } from "./sections/TrustSection";

--- a/frontend/app/components/vehicle/r8/sections/AntiErrorsSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/AntiErrorsSection.tsx
@@ -1,0 +1,63 @@
+// ⚠️ R8 Vehicle — S_ANTI_ERRORS
+// Common mistakes to avoid when picking parts for this vehicle.
+
+import { AlertTriangle } from "lucide-react";
+import { type LoaderData } from "../r8.types";
+
+interface Props {
+  vehicle: LoaderData["vehicle"];
+}
+
+export function AntiErrorsSection({ vehicle }: Props) {
+  return (
+    <div className="mb-12" data-section="S_ANTI_ERRORS">
+      <div className="bg-amber-50 border border-amber-200 rounded-2xl p-6">
+        <div className="flex items-start gap-3 mb-4">
+          <AlertTriangle
+            size={24}
+            className="text-amber-600 flex-shrink-0 mt-0.5"
+          />
+          <h2 className="text-xl font-bold text-gray-900">
+            Erreurs fréquentes à éviter
+          </h2>
+        </div>
+        <ul className="space-y-3 ml-9">
+          <li className="flex items-start gap-2 text-gray-700">
+            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+            <span>
+              Vérifier l'année exacte ({vehicle.type_year_from}–
+              {vehicle.type_year_to || "aujourd'hui"}) : les pièces peuvent
+              différer d'une année à l'autre
+            </span>
+          </li>
+          <li className="flex items-start gap-2 text-gray-700">
+            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+            <span>
+              Puissance proche ≠ moteur identique : confirmez avec le CNIT ou le
+              code moteur
+              {vehicle.motor_codes_formatted
+                ? ` (${vehicle.motor_codes_formatted})`
+                : ""}
+            </span>
+          </li>
+          <li className="flex items-start gap-2 text-gray-700">
+            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+            <span>
+              En cas de doute entre deux motorisations, utilisez le VIN (17
+              caractères, carte grise case E)
+            </span>
+          </li>
+          {vehicle.type_body && vehicle.type_body.includes("/") && (
+            <li className="flex items-start gap-2 text-gray-700">
+              <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+              <span>
+                Attention à la carrosserie ({vehicle.type_body}) : les pièces
+                peuvent varier selon la version
+              </span>
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/vehicle/r8/sections/HowtoSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/HowtoSection.tsx
@@ -1,0 +1,62 @@
+// 📋 R8 Vehicle — S_HOWTO
+// Step-by-step guide for choosing the right part for this vehicle.
+
+import { ListChecks } from "lucide-react";
+import { type LoaderData } from "../r8.types";
+
+interface Props {
+  vehicle: LoaderData["vehicle"];
+}
+
+export function HowtoSection({ vehicle }: Props) {
+  return (
+    <div className="mb-12" data-section="S_HOWTO">
+      <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
+        <div className="flex items-start gap-3 mb-4">
+          <ListChecks
+            size={24}
+            className="text-blue-600 flex-shrink-0 mt-0.5"
+          />
+          <h2 className="text-xl font-bold text-gray-900">
+            Comment choisir sans se tromper
+          </h2>
+        </div>
+        <ol className="space-y-3 ml-9 list-decimal list-inside">
+          <li className="text-gray-700">
+            Vérifier la période de production ({vehicle.type_year_from}–
+            {vehicle.type_year_to || "aujourd'hui"})
+          </li>
+          <li className="text-gray-700">
+            Confirmer le carburant ({vehicle.type_fuel}) et la puissance (
+            {vehicle.type_power_ps} ch)
+          </li>
+          <li className="text-gray-700">
+            Identifier le code moteur
+            {vehicle.motor_codes_formatted
+              ? ` (${vehicle.motor_codes_formatted})`
+              : ""}{" "}
+            ou le CNIT (carte grise case D.2)
+          </li>
+          <li className="text-gray-700">
+            Choisir la gamme dans le{" "}
+            <a
+              href="#catalogue"
+              className="text-blue-600 hover:underline font-medium"
+            >
+              catalogue ci-dessus
+            </a>
+          </li>
+          <li className="text-gray-700">
+            En cas de doute →{" "}
+            <a
+              href="/contact"
+              className="text-blue-600 hover:underline font-medium"
+            >
+              contacter notre assistance
+            </a>
+          </li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/vehicle/r8/sections/R8EnrichedSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/R8EnrichedSection.tsx
@@ -1,0 +1,51 @@
+// 🎁 R8 Vehicle — S_R8_ENRICHED
+// Optional block with variant_difference and maintenance_context from R8 enricher.
+// Renders nothing if no matching blocks.
+
+import { Car, Wrench } from "lucide-react";
+import { HtmlContent } from "../../../seo/HtmlContent";
+import { type LoaderData } from "../r8.types";
+
+interface Props {
+  r8Content: LoaderData["r8Content"];
+}
+
+export function R8EnrichedSection({ r8Content }: Props) {
+  const blocks =
+    r8Content?.blocks.filter(
+      (b) =>
+        b.type === "variant_difference" || b.type === "maintenance_context",
+    ) ?? [];
+
+  if (blocks.length === 0) return null;
+
+  return (
+    <div className="mb-12 space-y-6" data-section="S_R8_ENRICHED">
+      {blocks.map((block) => (
+        <div
+          key={block.id}
+          className={`rounded-2xl border p-6 ${
+            block.type === "variant_difference"
+              ? "bg-indigo-50 border-indigo-200"
+              : "bg-blue-50 border-blue-200"
+          }`}
+        >
+          <div className="flex items-start gap-3 mb-3">
+            {block.type === "variant_difference" ? (
+              <Car size={24} className="text-indigo-600 flex-shrink-0 mt-0.5" />
+            ) : (
+              <Wrench
+                size={24}
+                className="text-blue-600 flex-shrink-0 mt-0.5"
+              />
+            )}
+            <h2 className="text-xl font-bold text-gray-900">{block.title}</h2>
+          </div>
+          <div className="prose prose-sm max-w-none text-gray-700 ml-9">
+            <HtmlContent html={block.renderedText} trackLinks={true} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/components/vehicle/r8/sections/SeoIntroSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/SeoIntroSection.tsx
@@ -1,0 +1,44 @@
+// 📝 R8 Vehicle — S_SEO_INTRO
+// R8 enriched content blocks (vehicle_identity, selection_help) or fallback SEO.
+
+import { HtmlContent } from "../../../seo/HtmlContent";
+import { type LoaderData } from "../r8.types";
+
+interface Props {
+  r8Content: LoaderData["r8Content"];
+  seo: LoaderData["seo"];
+}
+
+export function SeoIntroSection({ r8Content, seo }: Props) {
+  return (
+    <div
+      className="bg-white rounded-lg shadow-sm p-6 mb-8"
+      data-section="S_SEO_INTRO"
+    >
+      {r8Content && r8Content.blocks.length > 0 ? (
+        <div className="space-y-6">
+          {r8Content.blocks
+            .filter(
+              (b) =>
+                b.type === "vehicle_identity" || b.type === "selection_help",
+            )
+            .map((block) => (
+              <div key={block.id}>
+                <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                  {block.title}
+                </h2>
+                <div className="prose prose-sm max-w-none text-gray-700">
+                  <HtmlContent html={block.renderedText} trackLinks={true} />
+                </div>
+              </div>
+            ))}
+        </div>
+      ) : (
+        <div className="prose max-w-none">
+          <HtmlContent html={seo.content} trackLinks={true} />
+          <HtmlContent html={seo.content2} trackLinks={true} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/vehicle/r8/sections/TrustSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/TrustSection.tsx
@@ -1,0 +1,41 @@
+// 🛡️ R8 Vehicle — S_TRUST
+// Trust badges: warranty, shipping, support, returns.
+
+import { HeadphonesIcon, RotateCcw, Shield, Truck } from "lucide-react";
+
+export function TrustSection() {
+  return (
+    <div className="mb-12" data-section="S_TRUST">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="bg-white rounded-xl border border-gray-200 p-5 text-center hover:shadow-lg transition-shadow">
+          <div className="inline-flex p-3 rounded-full bg-green-100 mb-3">
+            <Shield size={28} className="text-green-600" />
+          </div>
+          <h3 className="font-bold text-gray-900">Garantie 1 an</h3>
+          <p className="text-sm text-gray-500 mt-1">Sur toutes nos pièces</p>
+        </div>
+        <div className="bg-white rounded-xl border border-gray-200 p-5 text-center hover:shadow-lg transition-shadow">
+          <div className="inline-flex p-3 rounded-full bg-blue-100 mb-3">
+            <Truck size={28} className="text-blue-600" />
+          </div>
+          <h3 className="font-bold text-gray-900">Livraison 24-48h</h3>
+          <p className="text-sm text-gray-500 mt-1">Expédition rapide</p>
+        </div>
+        <div className="bg-white rounded-xl border border-gray-200 p-5 text-center hover:shadow-lg transition-shadow">
+          <div className="inline-flex p-3 rounded-full bg-purple-100 mb-3">
+            <HeadphonesIcon size={28} className="text-purple-600" />
+          </div>
+          <h3 className="font-bold text-gray-900">Conseil expert</h3>
+          <p className="text-sm text-gray-500 mt-1">Service client dédié</p>
+        </div>
+        <div className="bg-white rounded-xl border border-gray-200 p-5 text-center hover:shadow-lg transition-shadow">
+          <div className="inline-flex p-3 rounded-full bg-orange-100 mb-3">
+            <RotateCcw size={28} className="text-orange-600" />
+          </div>
+          <h3 className="font-bold text-gray-900">Retour 30 jours</h3>
+          <p className="text-sm text-gray-500 mt-1">Satisfait ou remboursé</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -19,7 +19,6 @@ import {
 
 // SEO Page Role (Phase 5 - Quasi-Incopiable)
 import {
-  AlertTriangle,
   Award,
   Car,
   CheckCircle,
@@ -29,14 +28,12 @@ import {
   FileText,
   HeadphonesIcon,
   Info,
-  ListChecks,
   Package,
   RotateCcw,
   Search,
   Shield,
   Star,
   Truck,
-  Wrench,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 import brandColorsStyles from "~/styles/brand-colors.css?url";
@@ -47,11 +44,16 @@ import { ErrorGeneric } from "../components/errors";
 import { ModelContentV1Display } from "../components/model";
 import { HtmlContent } from "../components/seo/HtmlContent";
 import {
+  AntiErrorsSection,
   BreadcrumbSection,
   FAMILY_MICRO_DESCRIPTIONS,
   generateVehicleSchema,
   HeroSection,
+  HowtoSection,
+  R8EnrichedSection,
+  SeoIntroSection,
   transformRpcToLoaderData,
+  TrustSection,
   type LoaderData,
 } from "../components/vehicle/r8";
 import { hierarchyApi } from "../services/api/hierarchy.api";
@@ -545,40 +547,7 @@ export default function VehicleDetailPage() {
           </div>
         )}
 
-        {/* Description SEO — R8 enriched or fallback */}
-        <div
-          className="bg-white rounded-lg shadow-sm p-6 mb-8"
-          data-section="S_SEO_INTRO"
-        >
-          {r8Content && r8Content.blocks.length > 0 ? (
-            <div className="space-y-6">
-              {r8Content.blocks
-                .filter(
-                  (b) =>
-                    b.type === "vehicle_identity" ||
-                    b.type === "selection_help",
-                )
-                .map((block) => (
-                  <div key={block.id}>
-                    <h2 className="text-lg font-semibold text-gray-900 mb-2">
-                      {block.title}
-                    </h2>
-                    <div className="prose prose-sm max-w-none text-gray-700">
-                      <HtmlContent
-                        html={block.renderedText}
-                        trackLinks={true}
-                      />
-                    </div>
-                  </div>
-                ))}
-            </div>
-          ) : (
-            <div className="prose max-w-none">
-              <HtmlContent html={seo.content} trackLinks={true} />
-              <HtmlContent html={seo.content2} trackLinks={true} />
-            </div>
-          )}
-        </div>
+        <SeoIntroSection r8Content={r8Content} seo={seo} />
 
         {/* 📦 CATALOGUE PRINCIPAL - Design inspiré de la page index */}
         {catalogFamilies.length > 0 &&
@@ -1069,150 +1038,11 @@ export default function VehicleDetailPage() {
         </div>
 
         {/* R8 enriched sections — variant_difference + maintenance_context */}
-        {r8Content?.blocks.some(
-          (b) =>
-            b.type === "variant_difference" || b.type === "maintenance_context",
-        ) && (
-          <div className="mb-12 space-y-6" data-section="S_R8_ENRICHED">
-            {r8Content.blocks
-              .filter(
-                (b) =>
-                  b.type === "variant_difference" ||
-                  b.type === "maintenance_context",
-              )
-              .map((block) => (
-                <div
-                  key={block.id}
-                  className={`rounded-2xl border p-6 ${
-                    block.type === "variant_difference"
-                      ? "bg-indigo-50 border-indigo-200"
-                      : "bg-blue-50 border-blue-200"
-                  }`}
-                >
-                  <div className="flex items-start gap-3 mb-3">
-                    {block.type === "variant_difference" ? (
-                      <Car
-                        size={24}
-                        className="text-indigo-600 flex-shrink-0 mt-0.5"
-                      />
-                    ) : (
-                      <Wrench
-                        size={24}
-                        className="text-blue-600 flex-shrink-0 mt-0.5"
-                      />
-                    )}
-                    <h2 className="text-xl font-bold text-gray-900">
-                      {block.title}
-                    </h2>
-                  </div>
-                  <div className="prose prose-sm max-w-none text-gray-700 ml-9">
-                    <HtmlContent html={block.renderedText} trackLinks={true} />
-                  </div>
-                </div>
-              ))}
-          </div>
-        )}
+        <R8EnrichedSection r8Content={r8Content} />
 
-        {/* Erreurs fréquentes à éviter */}
-        <div className="mb-12" data-section="S_ANTI_ERRORS">
-          <div className="bg-amber-50 border border-amber-200 rounded-2xl p-6">
-            <div className="flex items-start gap-3 mb-4">
-              <AlertTriangle
-                size={24}
-                className="text-amber-600 flex-shrink-0 mt-0.5"
-              />
-              <h2 className="text-xl font-bold text-gray-900">
-                Erreurs fréquentes à éviter
-              </h2>
-            </div>
-            <ul className="space-y-3 ml-9">
-              <li className="flex items-start gap-2 text-gray-700">
-                <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
-                <span>
-                  Vérifier l'année exacte ({vehicle.type_year_from}–
-                  {vehicle.type_year_to || "aujourd'hui"}) : les pièces peuvent
-                  différer d'une année à l'autre
-                </span>
-              </li>
-              <li className="flex items-start gap-2 text-gray-700">
-                <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
-                <span>
-                  Puissance proche ≠ moteur identique : confirmez avec le CNIT
-                  ou le code moteur
-                  {vehicle.motor_codes_formatted
-                    ? ` (${vehicle.motor_codes_formatted})`
-                    : ""}
-                </span>
-              </li>
-              <li className="flex items-start gap-2 text-gray-700">
-                <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
-                <span>
-                  En cas de doute entre deux motorisations, utilisez le VIN (17
-                  caractères, carte grise case E)
-                </span>
-              </li>
-              {vehicle.type_body && vehicle.type_body.includes("/") && (
-                <li className="flex items-start gap-2 text-gray-700">
-                  <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
-                  <span>
-                    Attention à la carrosserie ({vehicle.type_body}) : les
-                    pièces peuvent varier selon la version
-                  </span>
-                </li>
-              )}
-            </ul>
-          </div>
-        </div>
+        <AntiErrorsSection vehicle={vehicle} />
 
-        {/* Comment choisir sans se tromper */}
-        <div className="mb-12" data-section="S_HOWTO">
-          <div className="bg-white rounded-2xl border border-gray-200 shadow-sm p-6">
-            <div className="flex items-start gap-3 mb-4">
-              <ListChecks
-                size={24}
-                className="text-blue-600 flex-shrink-0 mt-0.5"
-              />
-              <h2 className="text-xl font-bold text-gray-900">
-                Comment choisir sans se tromper
-              </h2>
-            </div>
-            <ol className="space-y-3 ml-9 list-decimal list-inside">
-              <li className="text-gray-700">
-                Vérifier la période de production ({vehicle.type_year_from}–
-                {vehicle.type_year_to || "aujourd'hui"})
-              </li>
-              <li className="text-gray-700">
-                Confirmer le carburant ({vehicle.type_fuel}) et la puissance (
-                {vehicle.type_power_ps} ch)
-              </li>
-              <li className="text-gray-700">
-                Identifier le code moteur
-                {vehicle.motor_codes_formatted
-                  ? ` (${vehicle.motor_codes_formatted})`
-                  : ""}{" "}
-                ou le CNIT (carte grise case D.2)
-              </li>
-              <li className="text-gray-700">
-                Choisir la gamme dans le{" "}
-                <a
-                  href="#catalogue"
-                  className="text-blue-600 hover:underline font-medium"
-                >
-                  catalogue ci-dessus
-                </a>
-              </li>
-              <li className="text-gray-700">
-                En cas de doute →{" "}
-                <a
-                  href="/contact"
-                  className="text-blue-600 hover:underline font-medium"
-                >
-                  contacter notre assistance
-                </a>
-              </li>
-            </ol>
-          </div>
-        </div>
+        <HowtoSection vehicle={vehicle} />
 
         {/* ❓ FAQ dynamique avec Schema.org */}
         <div className="mb-12" data-section="S_FAQ">
@@ -1297,43 +1127,7 @@ export default function VehicleDetailPage() {
           </div>
         )}
 
-        {/* 🛡️ Badges de confiance */}
-        <div className="mb-12" data-section="S_TRUST">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <div className="bg-white rounded-xl border border-gray-200 p-5 text-center hover:shadow-lg transition-shadow">
-              <div className="inline-flex p-3 rounded-full bg-green-100 mb-3">
-                <Shield size={28} className="text-green-600" />
-              </div>
-              <h3 className="font-bold text-gray-900">Garantie 1 an</h3>
-              <p className="text-sm text-gray-500 mt-1">
-                Sur toutes nos pièces
-              </p>
-            </div>
-            <div className="bg-white rounded-xl border border-gray-200 p-5 text-center hover:shadow-lg transition-shadow">
-              <div className="inline-flex p-3 rounded-full bg-blue-100 mb-3">
-                <Truck size={28} className="text-blue-600" />
-              </div>
-              <h3 className="font-bold text-gray-900">Livraison 24-48h</h3>
-              <p className="text-sm text-gray-500 mt-1">Expédition rapide</p>
-            </div>
-            <div className="bg-white rounded-xl border border-gray-200 p-5 text-center hover:shadow-lg transition-shadow">
-              <div className="inline-flex p-3 rounded-full bg-purple-100 mb-3">
-                <HeadphonesIcon size={28} className="text-purple-600" />
-              </div>
-              <h3 className="font-bold text-gray-900">Conseil expert</h3>
-              <p className="text-sm text-gray-500 mt-1">Service client dédié</p>
-            </div>
-            <div className="bg-white rounded-xl border border-gray-200 p-5 text-center hover:shadow-lg transition-shadow">
-              <div className="inline-flex p-3 rounded-full bg-orange-100 mb-3">
-                <RotateCcw size={28} className="text-orange-600" />
-              </div>
-              <h3 className="font-bold text-gray-900">Retour 30 jours</h3>
-              <p className="text-sm text-gray-500 mt-1">
-                Satisfait ou remboursé
-              </p>
-            </div>
-          </div>
-        </div>
+        <TrustSection />
 
         {/* 🔗 CTA retour hub marque R7 (maillage R8→R7) */}
         <div className="mt-8 text-center">


### PR DESCRIPTION
## Summary

Continues Phase 2 splitting of VehicleDetailPage. **5 of 11 remaining sections** extracted — all pure JSX, zero state, zero behavior change.

| Section | Component | Notes |
|---|---|---|
| \`S_SEO_INTRO\`    | [SeoIntroSection.tsx](frontend/app/components/vehicle/r8/sections/SeoIntroSection.tsx)    | r8Content blocks (vehicle_identity, selection_help) or seo fallback |
| \`S_R8_ENRICHED\`  | [R8EnrichedSection.tsx](frontend/app/components/vehicle/r8/sections/R8EnrichedSection.tsx)  | Renders null if no variant_difference/maintenance_context blocks |
| \`S_ANTI_ERRORS\`  | [AntiErrorsSection.tsx](frontend/app/components/vehicle/r8/sections/AntiErrorsSection.tsx)  | Uses vehicle.type_year_*, motor_codes, type_body |
| \`S_HOWTO\`        | [HowtoSection.tsx](frontend/app/components/vehicle/r8/sections/HowtoSection.tsx)       | Uses vehicle data for step-by-step guide |
| \`S_TRUST\`        | [TrustSection.tsx](frontend/app/components/vehicle/r8/sections/TrustSection.tsx)       | Self-contained, lucide icons (Shield/Truck/HeadphonesIcon/RotateCcw) |

## Impact

| Metric | Phase 0 (start) | After 2a | **After 2b** |
|---|---|---|---|
| Route lines | 2020 | 1464 | **1261** |
| Cumulative reduction | — | −28% | **−38%** |
| Sections extracted | 0 / 13 | 2 / 13 | **7 / 13** |

Lucide imports cleaned: \`AlertTriangle\`, \`ListChecks\`, \`Wrench\` moved into section components.

## Gates

- [x] \`tsc --noEmit\` 0 errors (1 pre-existing on \`VehicleSelector.tsx\` from origin/main, unrelated)
- [x] \`eslint --fix\` 0 warnings on modified files
- [x] hooks lint-staged + prettier passed on commit

## Untouched on purpose (critical SEO)

- 301/410/503 status codes + canonicalization
- TecDoc ≥100K remap redirect
- noindex range 60000-83456

## Remaining (Phase 2c+)

6 sections requiring state migration:
- \`S_IDENTITY\` (imageError state)
- \`S_FAST_ACCESS\` (searchQuery state)
- \`S_CATALOG\` (expandedFamilies state + FAMILY_MICRO_DESCRIPTIONS)
- \`S_BESTSELLERS\`
- \`S_SAFE_TABLE\`
- \`S_FAQ\` (openFaqIndex state + R8 dedicated_faq parser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)