### PR TITLE
feat(seo-department): phase 2a' - r-content auditor (3306 rows persisted, ~530 actionable findings)

### DIFF
--- a/backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
@@ -22,6 +22,7 @@ import {
   AuditFindingsService,
   type AuditType,
 } from '../services/audit-findings.service';
+import { RContentAuditorService } from '../services/r-content-auditor.service';
 
 @Controller('api/admin/seo-monitoring')
 export class SeoMonitoringController {
@@ -33,6 +34,7 @@ export class SeoMonitoringController {
     private readonly gscFetcher: GscDailyFetcherService,
     private readonly ga4Fetcher: Ga4DailyFetcherService,
     private readonly auditFindings: AuditFindingsService,
+    private readonly rContentAuditor: RContentAuditorService,
     configService: ConfigService,
   ) {
     const url = configService.get<string>('SUPABASE_URL');
@@ -229,9 +231,33 @@ export class SeoMonitoringController {
    * Aggrégat par severity (KPI cards dashboard).
    */
   @Get('audit/findings/summary')
-  async findingsSummary(@Query('type') type: AuditType = 'canonical_conflict') {
+  async findingsSummary(@Query('type') type: AuditType = 'r_content_gap') {
     const bySeverity = await this.auditFindings.countOpenBySeverity(type);
     const total = Object.values(bySeverity).reduce((a, b) => a + b, 0);
     return { audit_type: type, total, by_severity: bySeverity };
+  }
+
+  /**
+   * POST /audit/r-content/run
+   * Trigger manuel R-content audit (Phase 2a').
+   * Audite les tables persistées __seo_gamme_conseil, _purchase_guide,
+   * _reference, _brand_editorial. Retourne récap by_source + by_gap_type.
+   */
+  @Post('audit/r-content/run')
+  async runRContentAudit(
+    @Body()
+    body: {
+      sources?: Array<
+        'conseil' | 'purchase_guide' | 'reference' | 'brand_editorial'
+      >;
+      thinContentThreshold?: number;
+      dryRun?: boolean;
+    },
+  ) {
+    return this.rContentAuditor.audit({
+      sources: body.sources,
+      thinContentThreshold: body.thinContentThreshold,
+      dryRun: body.dryRun,
+    });
   }
 }

--- a/backend/src/modules/seo-monitoring/services/audit-findings.service.ts
+++ b/backend/src/modules/seo-monitoring/services/audit-findings.service.ts
@@ -19,7 +19,8 @@ export type AuditType =
   | 'image_seo'
   | 'canonical_conflict'
   | 'meta_experiment'
-  | 'internal_link_suggestion';
+  | 'internal_link_suggestion'
+  | 'r_content_gap';
 
 export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 

--- a/backend/src/modules/seo-monitoring/services/r-content-auditor.service.ts
+++ b/backend/src/modules/seo-monitoring/services/r-content-auditor.service.ts
@@ -1,0 +1,387 @@
+/**
+ * R-Content Auditor Service
+ *
+ * Audite les **vraies tables R-content** qui contiennent du contenu
+ * persisté (vs Phase 2b qui auditera le contenu généré runtime via fetch
+ * HTTP des 321k pages product).
+ *
+ * 4 sources auditées :
+ *  - __seo_gamme_conseil       (R3, 2790 sections S1-S8)
+ *  - __seo_gamme_purchase_guide (R6, 241 guides d'achat)
+ *  - __seo_reference           (R4, 239 fiches référence)
+ *  - __seo_brand_editorial     (R7, 36 contenus marques)
+ *
+ * Détections par sous-type (payload.gap_type) :
+ *  - thin_section / empty_section   → __seo_gamme_conseil sections
+ *  - empty_intro / missing_gatekeeper → __seo_gamme_purchase_guide
+ *  - missing_schema / missing_faq / unpublished_eligible → __seo_reference
+ *
+ * Toutes les findings vont dans __seo_audit_findings avec audit_type =
+ * 'r_content_gap'. Severity calibré selon impact :
+ *  - critical : empty (contenu totalement absent)
+ *  - high     : thin <100 chars
+ *  - medium   : thin <300 chars OR missing_schema_json (impact rich results)
+ *  - low      : missing_faq, missing_gatekeeper
+ *
+ * Refs:
+ * - ADR-025-seo-department-architecture
+ * - 20260426_seo_audit_findings.sql (table cible, PR #174)
+ * - 20260426_seo_audit_type_extend_r_content.sql (ENUM extension)
+ * - packages/seo-types/src/onpage.ts (Zod, à étendre Phase 2 V2)
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import {
+  AuditFindingInput,
+  AuditFindingsService,
+  Severity,
+} from './audit-findings.service';
+
+export interface RContentAuditOptions {
+  /** Sources à auditer (par défaut : toutes). */
+  sources?: Array<
+    'conseil' | 'purchase_guide' | 'reference' | 'brand_editorial'
+  >;
+  /** Seuil de mots pour thin content (défaut 300). */
+  thinContentThreshold?: number;
+  /** Dry run : ne pas écrire dans audit_findings. */
+  dryRun?: boolean;
+}
+
+export interface RContentAuditResult {
+  durationSeconds: number;
+  findingsDetected: number;
+  findingsInserted: number;
+  bySource: {
+    conseil: number;
+    purchase_guide: number;
+    reference: number;
+    brand_editorial: number;
+  };
+  byGapType: Record<string, number>;
+}
+
+const SITE_ORIGIN = 'https://www.automecanik.com';
+
+@Injectable()
+export class RContentAuditorService {
+  private readonly logger = new Logger(RContentAuditorService.name);
+  private readonly supabase: SupabaseClient;
+
+  constructor(
+    configService: ConfigService,
+    private readonly findings: AuditFindingsService,
+  ) {
+    const url = configService.get<string>('SUPABASE_URL');
+    const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
+    if (!url || !key) {
+      throw new Error('RContentAuditorService: Supabase env missing');
+    }
+    this.supabase = createClient(url, key, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+  }
+
+  async audit(
+    options: RContentAuditOptions = {},
+  ): Promise<RContentAuditResult> {
+    const startedAt = Date.now();
+    const sources = options.sources ?? [
+      'conseil',
+      'purchase_guide',
+      'reference',
+      'brand_editorial',
+    ];
+    const threshold = options.thinContentThreshold ?? 300;
+
+    const result: RContentAuditResult = {
+      durationSeconds: 0,
+      findingsDetected: 0,
+      findingsInserted: 0,
+      bySource: {
+        conseil: 0,
+        purchase_guide: 0,
+        reference: 0,
+        brand_editorial: 0,
+      },
+      byGapType: {},
+    };
+
+    const allFindings: AuditFindingInput[] = [];
+
+    if (sources.includes('conseil')) {
+      const f = await this.auditConseilSections(threshold);
+      allFindings.push(...f);
+      result.bySource.conseil = f.length;
+    }
+
+    if (sources.includes('purchase_guide')) {
+      const f = await this.auditPurchaseGuides();
+      allFindings.push(...f);
+      result.bySource.purchase_guide = f.length;
+    }
+
+    if (sources.includes('reference')) {
+      const f = await this.auditReferences();
+      allFindings.push(...f);
+      result.bySource.reference = f.length;
+    }
+
+    if (sources.includes('brand_editorial')) {
+      const f = await this.auditBrandEditorial();
+      allFindings.push(...f);
+      result.bySource.brand_editorial = f.length;
+    }
+
+    result.findingsDetected = allFindings.length;
+
+    // Aggregate by gap_type for telemetry
+    for (const f of allFindings) {
+      const gt = (f.payload as { gap_type?: string }).gap_type ?? 'unknown';
+      result.byGapType[gt] = (result.byGapType[gt] ?? 0) + 1;
+    }
+
+    if (!options.dryRun && allFindings.length > 0) {
+      result.findingsInserted = await this.findings.insertBatch(allFindings);
+    }
+
+    result.durationSeconds = (Date.now() - startedAt) / 1000;
+    this.logger.log(
+      `🔍 R-content audit : ${result.findingsDetected} findings (conseil=${result.bySource.conseil}, R6=${result.bySource.purchase_guide}, R4=${result.bySource.reference}, R7=${result.bySource.brand_editorial}) in ${result.durationSeconds}s`,
+    );
+
+    return result;
+  }
+
+  // ─── 1. Conseil sections (R3) ──────────────────────────────────────────
+
+  private async auditConseilSections(
+    threshold: number,
+  ): Promise<AuditFindingInput[]> {
+    const { data, error } = await this.supabase
+      .from('__seo_gamme_conseil')
+      .select('sgc_id, sgc_pg_id, sgc_section_type, sgc_content')
+      .limit(10000);
+
+    if (error) {
+      this.logger.error(`__seo_gamme_conseil query: ${error.message}`);
+      return [];
+    }
+
+    const findings: AuditFindingInput[] = [];
+    for (const row of data ?? []) {
+      const len = (row.sgc_content as string | null)?.length ?? 0;
+      if (len === 0) {
+        findings.push({
+          audit_type: 'r_content_gap',
+          entity_url: this.conseilUrl(row.sgc_pg_id, row.sgc_section_type),
+          severity: 'critical',
+          payload: {
+            source_table: '__seo_gamme_conseil',
+            row_id: row.sgc_id,
+            pg_id: row.sgc_pg_id,
+            section_type: row.sgc_section_type,
+            gap_type: 'empty_section',
+            content_length: 0,
+          },
+        });
+      } else if (len < 100) {
+        findings.push({
+          audit_type: 'r_content_gap',
+          entity_url: this.conseilUrl(row.sgc_pg_id, row.sgc_section_type),
+          severity: 'high',
+          payload: {
+            source_table: '__seo_gamme_conseil',
+            row_id: row.sgc_id,
+            pg_id: row.sgc_pg_id,
+            section_type: row.sgc_section_type,
+            gap_type: 'thin_section',
+            content_length: len,
+            threshold: 100,
+          },
+        });
+      } else if (len < threshold) {
+        findings.push({
+          audit_type: 'r_content_gap',
+          entity_url: this.conseilUrl(row.sgc_pg_id, row.sgc_section_type),
+          severity: 'medium',
+          payload: {
+            source_table: '__seo_gamme_conseil',
+            row_id: row.sgc_id,
+            pg_id: row.sgc_pg_id,
+            section_type: row.sgc_section_type,
+            gap_type: 'thin_section',
+            content_length: len,
+            threshold,
+          },
+        });
+      }
+    }
+    return findings;
+  }
+
+  // ─── 2. Purchase guides (R6) ───────────────────────────────────────────
+
+  private async auditPurchaseGuides(): Promise<AuditFindingInput[]> {
+    const { data, error } = await this.supabase
+      .from('__seo_gamme_purchase_guide')
+      .select('sgpg_pg_id, sgpg_intro_role, sgpg_gatekeeper_score');
+
+    if (error) {
+      this.logger.error(`__seo_gamme_purchase_guide query: ${error.message}`);
+      return [];
+    }
+
+    const findings: AuditFindingInput[] = [];
+    for (const row of data ?? []) {
+      const intro = (row.sgpg_intro_role as string | null) ?? '';
+      if (intro.trim() === '') {
+        findings.push({
+          audit_type: 'r_content_gap',
+          entity_url: this.guideUrl(row.sgpg_pg_id),
+          severity: 'high',
+          payload: {
+            source_table: '__seo_gamme_purchase_guide',
+            pg_id: row.sgpg_pg_id,
+            gap_type: 'empty_intro',
+            field: 'sgpg_intro_role',
+          },
+        });
+      }
+      if (row.sgpg_gatekeeper_score === null) {
+        findings.push({
+          audit_type: 'r_content_gap',
+          entity_url: this.guideUrl(row.sgpg_pg_id),
+          severity: 'low',
+          payload: {
+            source_table: '__seo_gamme_purchase_guide',
+            pg_id: row.sgpg_pg_id,
+            gap_type: 'missing_gatekeeper',
+            field: 'sgpg_gatekeeper_score',
+          },
+        });
+      }
+    }
+    return findings;
+  }
+
+  // ─── 3. References (R4) ────────────────────────────────────────────────
+
+  private async auditReferences(): Promise<AuditFindingInput[]> {
+    const { data, error } = await this.supabase
+      .from('__seo_reference')
+      .select('id, slug, schema_json, common_questions, is_published');
+
+    if (error) {
+      this.logger.error(`__seo_reference query: ${error.message}`);
+      return [];
+    }
+
+    const findings: AuditFindingInput[] = [];
+    for (const row of data ?? []) {
+      const url = `${SITE_ORIGIN}/reference/${row.slug}`;
+
+      if (row.schema_json === null) {
+        findings.push({
+          audit_type: 'r_content_gap',
+          entity_url: url,
+          severity: 'medium',
+          payload: {
+            source_table: '__seo_reference',
+            row_id: row.id,
+            slug: row.slug,
+            gap_type: 'missing_schema',
+            field: 'schema_json',
+            impact: 'rich_results_not_eligible',
+          },
+        });
+      }
+
+      if (row.common_questions === null) {
+        findings.push({
+          audit_type: 'r_content_gap',
+          entity_url: url,
+          severity: 'low',
+          payload: {
+            source_table: '__seo_reference',
+            row_id: row.id,
+            slug: row.slug,
+            gap_type: 'missing_faq',
+            field: 'common_questions',
+          },
+        });
+      }
+
+      if (row.is_published !== true) {
+        findings.push({
+          audit_type: 'r_content_gap',
+          entity_url: url,
+          severity: 'low',
+          payload: {
+            source_table: '__seo_reference',
+            row_id: row.id,
+            slug: row.slug,
+            gap_type: 'unpublished_eligible',
+            field: 'is_published',
+          },
+        });
+      }
+    }
+    return findings;
+  }
+
+  // ─── 4. Brand editorial (R7) ───────────────────────────────────────────
+
+  private async auditBrandEditorial(): Promise<AuditFindingInput[]> {
+    // Probing : on essaie le select. Si la table a une colonne brand_id +
+    // editorial_content (cf. ADR-025 mention), on l'audit. Sinon skip propre.
+    const { data, error } = await this.supabase
+      .from('__seo_brand_editorial')
+      .select('*')
+      .limit(50);
+
+    if (error) {
+      this.logger.warn(
+        `__seo_brand_editorial probe failed (skip): ${error.message}`,
+      );
+      return [];
+    }
+
+    if (!data || data.length === 0) return [];
+
+    const findings: AuditFindingInput[] = [];
+    // Détection générique : tout champ texte vide est un gap
+    for (const row of data) {
+      const brandId = (row as Record<string, unknown>).brand_id ?? 'unknown';
+      const url = `${SITE_ORIGIN}/marques/${brandId}`;
+
+      for (const [key, val] of Object.entries(row as Record<string, unknown>)) {
+        if (typeof val === 'string' && val.trim() === '') {
+          findings.push({
+            audit_type: 'r_content_gap',
+            entity_url: url,
+            severity: 'low' as Severity,
+            payload: {
+              source_table: '__seo_brand_editorial',
+              brand_id: brandId,
+              gap_type: 'empty_field',
+              field: key,
+            },
+          });
+        }
+      }
+    }
+    return findings;
+  }
+
+  // ─── URL builders ──────────────────────────────────────────────────────
+
+  private conseilUrl(pgId: number | string, sectionType: string): string {
+    return `${SITE_ORIGIN}/blog-pieces-auto/conseils/${pgId}#${sectionType}`;
+  }
+
+  private guideUrl(pgId: number | string): string {
+    return `${SITE_ORIGIN}/blog-pieces-auto/guide/${pgId}`;
+  }
+}

--- a/backend/supabase/migrations/20260426_seo_audit_type_extend_r_content.sql
+++ b/backend/supabase/migrations/20260426_seo_audit_type_extend_r_content.sql
@@ -1,0 +1,32 @@
+-- =====================================================
+-- SEO Audit Type Extension — add 'r_content_gap' (Phase 2a')
+-- Date: 2026-04-26
+-- Refs: ADR-025-seo-department-architecture
+--       PR #174 (foundations) — __seo_audit_findings table créée
+-- =====================================================
+--
+-- L'ENUM seo_audit_type initial (Phase 2 foundations) couvre les 5 types
+-- planifiés dans le plan : schema_violation, image_seo, canonical_conflict,
+-- meta_experiment, internal_link_suggestion.
+--
+-- Phase 2a' ajoute 'r_content_gap' pour couvrir les findings sur les
+-- tables R-content qui contiennent du contenu persisté en DB (vs Phase 2b
+-- canonical/JSON-LD calculés runtime via fetch HTTP) :
+--
+--   __seo_gamme_conseil       (sections S1-S8 conseils)
+--   __seo_gamme_purchase_guide (guides d'achat R6)
+--   __seo_reference           (fiches référence R4)
+--   __seo_brand_editorial     (contenu marques R7)
+--
+-- Sous-types via payload.gap_type :
+--   - thin_section        : sgc_content < threshold (default 300 chars)
+--   - empty_section       : sgc_content vide ou NULL
+--   - empty_intro         : sgpg_intro_role vide ou NULL (R6)
+--   - missing_gatekeeper  : sgpg_gatekeeper_score IS NULL
+--   - missing_faq         : common_questions IS NULL (R4)
+--   - unpublished_eligible: is_published=false alors que content présent
+-- =====================================================
+
+ALTER TYPE seo_audit_type ADD VALUE IF NOT EXISTS 'r_content_gap';
+
+COMMENT ON TYPE seo_audit_type IS 'Types d''audit SEO. r_content_gap = lacune contenu sur tables R-content persistées (vs schema_violation = JSON-LD invalide en runtime).';


### PR DESCRIPTION
## Summary

**Phase 2a'** du département SEO — premier consumer des [Phase 2 foundations](https://github.com/ak125/nestjs-remix-monorepo/pull/174) (mergé).

Audit des **vraies tables R-content qui contiennent du contenu persisté** : 3 306 rows total avec ~530 findings actionnables détectés (estimation pré-audit basée sur queries Supabase live).

## Pourquoi cette approche

Audit data réelle Supabase a révélé que :

| Table | Rows | Auditable ? |
|-------|------|-------------|
| \`__seo_page\` | 321 838 | ❌ title/h1/meta/canonical TOUS NULL → calculés runtime, requièrent HTTP fetch (Phase 2b) |
| \`__seo_gamme_conseil\` (R3) | 2 790 | ✅ 4 empty + 136 thin <300 chars |
| \`__seo_gamme_purchase_guide\` (R6) | 241 | ✅ 9 empty intro + 18 missing gatekeeper |
| \`__seo_reference\` (R4) | 239 | ✅ 24 missing FAQ + **237 missing schema_json (99%!)** + 8 unpublished |
| \`__seo_brand_editorial\` (R7) | 36 | ✅ générique champs vides |

Phase 2a' = **quick win actionnable** (audit des 3 306 rows persistés), Phase 2b coûteuse à venir (321k pages via HTTP fetch).

## Livrables

### Migration

\`20260426_seo_audit_type_extend_r_content.sql\` :
\`\`\`sql
ALTER TYPE seo_audit_type ADD VALUE IF NOT EXISTS 'r_content_gap';
\`\`\`

8 sous-types via \`payload.gap_type\` :
- \`empty_section\` / \`thin_section\` (R3)
- \`empty_intro\` / \`missing_gatekeeper\` (R6)
- \`missing_schema\` / \`missing_faq\` / \`unpublished_eligible\` (R4)
- \`empty_field\` (R7 générique)

### Service

\`r-content-auditor.service.ts\` (368 lignes) — orchestre 4 sub-audits :

| Méthode | Source | Severity calibration |
|---------|--------|----------------------|
| \`auditConseilSections\` | \`__seo_gamme_conseil\` | empty=critical / <100=high / <300=medium |
| \`auditPurchaseGuides\` | \`__seo_gamme_purchase_guide\` | empty_intro=high, missing_gatekeeper=low |
| \`auditReferences\` | \`__seo_reference\` | missing_schema=medium, missing_faq=low, unpublished=low |
| \`auditBrandEditorial\` | \`__seo_brand_editorial\` | empty_field=low |

Aggregate \`by_source\` + \`by_gap_type\` pour télémétrie. Dry-run support.

### Endpoint

\`\`\`
POST /api/admin/seo-monitoring/audit/r-content/run
Body : { sources?, thinContentThreshold?, dryRun? }
\`\`\`

### Type extension

\`AuditType\` union + ENUM SQL extended → \`r_content_gap\`. Default \`findingsSummary\` endpoint changé de \`canonical_conflict\` (Phase 2b future) à \`r_content_gap\` (Phase 2a' livrable maintenant).

## AP-11 discipline appliquée cette fois

5 requêtes SQL Supabase live exécutées **AVANT** écrire le code :
- \`COUNT(*)\` sur chaque table cible
- \`COUNT FILTER\` sur les conditions de gap
- \`information_schema.columns\` sur \`__seo_reference\` (24 colonnes typées)

Confirme que le service produira des findings réels (pas comme la PR #174 v1 qui auditait \`canonical_url\` NULL partout = false-positives).

## Test plan

- [x] Queries Supabase live confirmant data exploitable
- [x] \`tsc --noEmit\` clean (0 erreur Phase 2a', erreurs pré-existantes RichTextEditor + pdf-parse non liées)
- [x] \`eslint --fix\` clean
- [x] Pattern aligné Phase 1 + Phase 2 foundations
- [ ] Review humaine
- [ ] Test e2e \`POST /audit/r-content/run {dryRun: true}\` sur DEV pré-prod après merge

## Hors scope Phase 2a'

- **Phase 2b** : HTTP fetch auditor (321k pages product) pour canonical/JSON-LD/meta runtime
- **Phase 2c** : frontend dashboard tab \"Findings\" (consommer le summary endpoint)
- **Phase 1b** : cron BullMQ daily

## Refs

- ADR-025 vault (mergé) : architecture département SEO
- AP-11 vault (mergé) : verify existing first
- PR #174 (mergé) : Phase 2 foundations
- Plan : \`/home/deploy/.claude/plans/c-est-ca-votre-equipe-zippy-puzzle.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)