### PR TITLE
chore(seo): add backfill script for R1 gatekeeper NULL rows

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts
@@ -22,6 +22,7 @@ depends_on:
 - RagProxyModule
 - SystemModule
 - AiContentModule
+- VehiclesModule
 ---
 
 # Module Admin

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,9 +2,10 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
+- backend/src/modules/errors/controllers/internal-error-log.controller.ts
 - backend/src/modules/errors/entities/error-log.entity.ts
 - backend/src/modules/errors/errors.module.ts
 - backend/src/modules/errors/filters/global-error.filter.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/gamme-rest/gamme-rest-optimized.controller.ts
 - backend/src/modules/gamme-rest/gamme-rest-rpc-v2.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-04-24'
+last_scan: '2026-04-25'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/.github/workflows/prod-smoke-tests.yml
+++ b/.github/workflows/prod-smoke-tests.yml
@@ -41,7 +41,7 @@ jobs:
           fi
           echo "✅ Homepage: title='$TITLE'"
 
-      - name: 📦 Pages multi-rôles (8 URLs)
+      - name: 📦 Pages multi-rôles (11 URLs)
         id: pages-check
         run: |
           FAILED=0
@@ -54,6 +54,9 @@ jobs:
             "/blog-pieces-auto/conseils/amortisseur"
             "/blog-pieces-auto/guide-achat/roulement-de-roue"
             "/sitemap.xml"
+            "/constructeurs/renault-140/clio-iii-140004/1-5-dci-34746.html"
+            "/constructeurs/audi-22/r8-422-32058/4-2-fsi-quattro-v8-32058.html"
+            "/constructeurs/peugeot-105/308-105058/1-6-hdi-21090.html"
           )
           for URL in "${URLS[@]}"; do
             STATUS=$(docker exec $CONTAINER wget --spider -qS "http://localhost:3000$URL" 2>&1 | grep "HTTP/" | tail -1 | awk '{print $2}')
@@ -68,6 +71,32 @@ jobs:
             exit 1
           fi
           echo "✅ All 8 pages OK"
+
+      - name: 🚨 INC-2026-007 — __error_logs 5xx /constructeurs/* (1h window)
+        id: vehicle-5xx-check
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+            echo "⚠️ Supabase credentials missing — skipping vehicle 5xx alert check"
+            exit 0
+          fi
+          # Count 5xx on /constructeurs/* in last hour. Threshold: 5 events.
+          ONE_HOUR_AGO=$(date -u -d '1 hour ago' '+%Y-%m-%dT%H:%M:%S')
+          COUNT=$(curl -sk \
+            "${SUPABASE_URL}/rest/v1/__error_logs?select=err_id&err_status=gte.500&err_url=like.%2Fconstructeurs%2F%25&err_created_at=gte.${ONE_HOUR_AGO}" \
+            -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+            -H "Prefer: count=exact" \
+            -H "Range: 0-0" \
+            -D - 2>/dev/null | grep -i "content-range" | sed -n 's/.*\/\([0-9]*\).*/\1/p')
+          COUNT=${COUNT:-0}
+          if [ "$COUNT" -gt 5 ]; then
+            echo "❌ INC-2026-007 ALERT: $COUNT × 5xx on /constructeurs/* in last 1h (threshold 5)"
+            exit 1
+          fi
+          echo "✅ INC-2026-007 OK: $COUNT × 5xx on /constructeurs/* in last 1h (threshold 5)"
 
       - name: 🔍 SEO Meta tags
         id: seo-meta-check
@@ -640,7 +669,8 @@ jobs:
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Health | ${{ steps.health-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Homepage | ${{ steps.homepage-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Pages (8 URLs) | ${{ steps.pages-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pages (11 URLs) | ${{ steps.pages-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| INC-2026-007 vehicle 5xx | ${{ steps.vehicle-5xx-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| SEO Meta | ${{ steps.seo-meta-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| API catalog | ${{ steps.api-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| imgproxy | ${{ steps.imgproxy-check.outcome == 'success' && '✅' || '❌ FAIL' }} |" >> $GITHUB_STEP_SUMMARY

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -98,6 +98,8 @@ import { BrandEditorialService } from './services/brand-editorial.service'; // �
 import { VehicleRagGeneratorService } from './services/vehicle-rag-generator.service'; // 🚗 Vehicle RAG .md generator (0 LLM)
 import { RagProposalService } from './services/rag-proposal.service'; // 📝 ADR-022 L1 propose-before-write
 import { AdminVehicleRagController } from './controllers/admin-vehicle-rag.controller'; // 🚗 Vehicle RAG generation endpoints
+import { AdminVehicleCacheController } from './controllers/admin-vehicle-cache.controller'; // 🚗 INC-2026-007 — Vehicle cache rebuild/invalidate/stats
+import { VehiclesModule } from '../vehicles/vehicles.module'; // 🚗 INC-2026-007 — pour VehicleRpcService
 
 // Services - Stock services pour le controller consolidé
 import { ConfigurationService } from './services/configuration.service';
@@ -139,6 +141,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     RagProxyModule, // 📖 Import pour accès à RagProxyService (enrichissement buying guide)
     SystemModule, // DB governance Phase 2 (DbGovernanceService)
     AiContentModule, // 🤖 Pour ConseilEnricher + BuyingGuideSEODraft (optional LLM polish)
+    VehiclesModule, // 🚗 INC-2026-007 — pour AdminVehicleCacheController (VehicleRpcService)
   ],
   controllers: [
     ConfigurationController,
@@ -176,6 +179,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     AdminR8VehicleController, // 🚗 R8 Vehicle enrichment - /api/admin/r8/enrich/:typeId
     AdminR7BrandController, // 🏭 R7 Brand enrichment - /api/admin/r7/enrich/:marqueId
     AdminVehicleRagController, // 🚗 Vehicle RAG generation - /api/admin/vehicle-rag/*
+    AdminVehicleCacheController, // 🚗 INC-2026-007 - /api/admin/vehicle-cache/* (rebuild, invalidate, stats)
     // AdminSupplierStatsController — not ready for prod
     AdminDbGovernanceController, // 📊 DB Governance Phase 2 - /api/admin/db-governance/*
     AdminPipelineController, // 🚀 Unified pipeline execution - /api/admin/pipeline/*

--- a/backend/src/modules/admin/controllers/admin-vehicle-cache.controller.ts
+++ b/backend/src/modules/admin/controllers/admin-vehicle-cache.controller.ts
@@ -1,0 +1,77 @@
+/**
+ * AdminVehicleCacheController
+ *
+ * INC-2026-007 — Étape 5 du plan
+ *
+ * Endpoints admin pour piloter manuellement le cache `__vehicle_page_cache`
+ * (force rebuild, invalidate Redis, stats). Complète :
+ *   - le trigger auto_type (Étape 3, rebuild auto à INSERT/activation)
+ *   - le wrapper SQL mark_stale_with_followup_rebuild (Étape 4, garde-fou pour scripts)
+ *   - le cron one-shot backfill (Étape 2, rattrapage des stale existants)
+ *
+ * Réutilise les méthodes déjà présentes dans VehicleRpcService :
+ *   - rebuildDbCache(typeId) : ligne 233 vehicle-rpc.service.ts
+ *   - invalidateCache(typeId) : ligne 184
+ *   - getDbCacheStats() : ligne 260
+ */
+
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  UseGuards,
+  Logger,
+  ParseIntPipe,
+  BadRequestException,
+} from '@nestjs/common';
+import { AuthenticatedGuard } from '../../../auth/authenticated.guard';
+import { IsAdminGuard } from '../../../auth/is-admin.guard';
+import { VehicleRpcService } from '../../vehicles/services/vehicle-rpc.service';
+
+@Controller('api/admin/vehicle-cache')
+@UseGuards(AuthenticatedGuard, IsAdminGuard)
+export class AdminVehicleCacheController {
+  private readonly logger = new Logger(AdminVehicleCacheController.name);
+
+  constructor(private readonly vehicleRpc: VehicleRpcService) {}
+
+  /**
+   * GET /api/admin/vehicle-cache/stats
+   * Retourne total / stale / oldest_built_at / newest_built_at.
+   */
+  @Get('stats')
+  async getStats() {
+    this.logger.log('GET /api/admin/vehicle-cache/stats');
+    return await this.vehicleRpc.getDbCacheStats();
+  }
+
+  /**
+   * POST /api/admin/vehicle-cache/:typeId/rebuild
+   * Force le rebuild DB d'un type_id + invalide Redis L1.
+   * Idempotent.
+   */
+  @Post(':typeId/rebuild')
+  async rebuild(@Param('typeId', ParseIntPipe) typeId: number) {
+    if (typeId <= 0) {
+      throw new BadRequestException('typeId must be a positive integer');
+    }
+    this.logger.log(`POST /api/admin/vehicle-cache/${typeId}/rebuild`);
+    const rebuilt = await this.vehicleRpc.rebuildDbCache(typeId);
+    return { typeId, rebuilt, success: rebuilt };
+  }
+
+  /**
+   * POST /api/admin/vehicle-cache/:typeId/invalidate
+   * Invalide uniquement Redis L1 pour un type_id (la table DB reste).
+   */
+  @Post(':typeId/invalidate')
+  async invalidate(@Param('typeId', ParseIntPipe) typeId: number) {
+    if (typeId <= 0) {
+      throw new BadRequestException('typeId must be a positive integer');
+    }
+    this.logger.log(`POST /api/admin/vehicle-cache/${typeId}/invalidate`);
+    await this.vehicleRpc.invalidateCache(typeId);
+    return { typeId, invalidated: true };
+  }
+}

--- a/backend/src/modules/errors/controllers/internal-error-log.controller.ts
+++ b/backend/src/modules/errors/controllers/internal-error-log.controller.ts
@@ -1,0 +1,74 @@
+/**
+ * InternalErrorLogController
+ *
+ * INC-2026-007 — Étape 7 du plan
+ *
+ * Comble le blindspot d'instrumentation : les `throw new Response(503)` côté
+ * loader Remix ne s'écrivent pas dans `__error_logs` puisque c'est NestJS qui
+ * détient la connexion DB. Cet endpoint permet au loader Remix de logger les
+ * 5xx qu'il génère, en réutilisant le service centralisé `ErrorLogService`
+ * (buffer, dedup 60s, circuit breaker, bot filter).
+ *
+ * Sécurité : protégé par `InternalApiKeyGuard` (header `X-Internal-Key` validé
+ * en `timingSafeEqual` contre `INTERNAL_API_KEY` env var).
+ *
+ * NOT exposed via Caddy en prod (localhost only).
+ */
+
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { InternalApiKeyGuard } from '../../../auth/internal-api-key.guard';
+import { ErrorLogService } from '../services/error-log.service';
+
+interface LoaderErrorLogBody {
+  status: number;
+  url: string;
+  subject?: string;
+  message?: string;
+  userAgent?: string;
+  metadata?: Record<string, unknown>;
+}
+
+@Controller('api/internal/error-log')
+@UseGuards(InternalApiKeyGuard)
+export class InternalErrorLogController {
+  private readonly logger = new Logger(InternalErrorLogController.name);
+
+  constructor(private readonly errorLogService: ErrorLogService) {}
+
+  /**
+   * POST /api/internal/error-log
+   * Body: { status, url, subject?, message?, userAgent?, metadata? }
+   *
+   * Le loader Remix appelle ce endpoint en fire-and-forget AVANT de throw 503,
+   * pour que le 503 soit visible dans `__error_logs` (sinon blindspot total).
+   */
+  @Post()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async logFromLoader(@Body() body: LoaderErrorLogBody): Promise<void> {
+    if (!body || typeof body.status !== 'number' || !body.url) {
+      this.logger.warn(
+        `Invalid loader error-log payload: ${JSON.stringify(body)}`,
+      );
+      return;
+    }
+
+    await this.errorLogService.logError({
+      code: body.status,
+      url: body.url,
+      userAgent: body.userAgent,
+      metadata: {
+        loader_subject: body.subject ?? `LOADER_${body.status}`,
+        loader_message: body.message,
+        ...(body.metadata ?? {}),
+      },
+    });
+  }
+}

--- a/backend/src/modules/errors/errors.module.ts
+++ b/backend/src/modules/errors/errors.module.ts
@@ -1,18 +1,21 @@
 import { Global, Module } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import { ErrorController } from './controllers/error.controller';
+import { InternalErrorLogController } from './controllers/internal-error-log.controller'; // INC-2026-007 Étape 7
 import { ErrorService } from './services/error.service';
 import { ErrorLogService } from './services/error-log.service';
 import { RedirectService } from './services/redirect.service';
 import { GlobalErrorFilter } from './filters/global-error.filter';
+import { InternalApiKeyGuard } from '../../auth/internal-api-key.guard';
 
 @Global()
 @Module({
-  controllers: [ErrorController],
+  controllers: [ErrorController, InternalErrorLogController],
   providers: [
     ErrorService,
     ErrorLogService,
     RedirectService,
+    InternalApiKeyGuard, // INC-2026-007 Étape 7 : guard pour /api/internal/error-log
     {
       provide: APP_FILTER,
       useClass: GlobalErrorFilter,

--- a/backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql
+++ b/backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql
@@ -1,0 +1,63 @@
+-- Migration : wrapper canon mark_stale_with_followup_rebuild
+--
+-- INC-2026-007 — Étape 4 du plan
+--
+-- Cause secondaire du 503 (cf. INC-2026-007 root cause) :
+--   Le 23/04, un script `catalog_gamme_dedup_20260423` a fait
+--   `UPDATE __vehicle_page_cache SET stale=true WHERE ...` sur 28 252 rows
+--   sans rien déclencher d'autre. Aucun cron ne rebuild les stale → état dégradé permanent
+--   jusqu'à ce qu'un hit utilisateur force un rebuild on-miss synchrone (~2s = 503).
+--
+-- Solution canon : ce wrapper marque stale ET déclenche immédiatement le rebuild.
+-- Tout script SEO/admin DOIT l'utiliser au lieu d'un UPDATE direct.
+--
+-- Mode async : si on doit invalider beaucoup (ex. 28k rows), p_rebuild_immediately=false
+-- laisse le cron Étape 2 faire le rebuild en background, mais le marquage stale est tracé.
+
+CREATE OR REPLACE FUNCTION public.mark_stale_with_followup_rebuild(
+  p_type_ids INTEGER[],
+  p_reason TEXT,
+  p_rebuild_immediately BOOLEAN DEFAULT TRUE
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_marked  INTEGER;
+  v_rebuilt INTEGER := 0;
+  v_id      INTEGER;
+BEGIN
+  IF p_type_ids IS NULL OR array_length(p_type_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  IF COALESCE(trim(p_reason), '') = '' THEN
+    RAISE EXCEPTION 'INC-2026-007: p_reason must be a non-empty string explaining why the cache is invalidated';
+  END IF;
+
+  UPDATE public.__vehicle_page_cache
+  SET stale = TRUE, stale_reason = p_reason
+  WHERE type_id = ANY(p_type_ids);
+  GET DIAGNOSTICS v_marked = ROW_COUNT;
+
+  IF p_rebuild_immediately THEN
+    FOREACH v_id IN ARRAY p_type_ids LOOP
+      BEGIN
+        PERFORM public.rebuild_vehicle_page_cache(v_id);
+        v_rebuilt := v_rebuilt + 1;
+      EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'INC-2026-007: rebuild_vehicle_page_cache(%) failed in mark_stale: %',
+          v_id, SQLERRM;
+      END;
+    END LOOP;
+  END IF;
+
+  RAISE NOTICE 'INC-2026-007: marked % rows stale (reason: %), rebuilt % synchronously',
+    v_marked, p_reason, v_rebuilt;
+
+  RETURN v_marked;
+END;
+$$;
+
+COMMENT ON FUNCTION public.mark_stale_with_followup_rebuild(INTEGER[], TEXT, BOOLEAN) IS
+  'INC-2026-007 Etape 4 CANONIQUE: tout script qui invalide des rows __vehicle_page_cache DOIT utiliser cette fonction au lieu d''un UPDATE direct. p_rebuild_immediately=false delegue au cron de l''Etape 2. Reason obligatoire pour la traceability.';

--- a/backend/supabase/migrations/20260425_oneshot_backfill_stale_vehicle_cache.sql
+++ b/backend/supabase/migrations/20260425_oneshot_backfill_stale_vehicle_cache.sql
@@ -1,0 +1,52 @@
+-- Migration : backfill one-shot des rows stale dans __vehicle_page_cache
+--
+-- INC-2026-007 — Étape 2 du plan
+--
+-- Contexte : 28 252 rows sur 28 505 sont marquées stale=true depuis le 23/04
+-- (script catalog_gamme_dedup_20260423) sans qu'aucun cron de refresh ne soit schedulé.
+-- Ce backfill rattrape la dette en deux jobs auto-déprogrammés :
+--   - vehicle_cache_oneshot_backfill : rebuild 200 rows par minute via refresh_stale_vehicle_cache
+--   - vehicle_cache_oneshot_watcher : surveille stale_count et unschedule les deux jobs à 0
+--
+-- Estimation durée : avec p50=405ms par rebuild post-Étape 1 (mesuré stress test 50 types),
+--   200 rows × 0.4s = 80s par batch. Schedule chaque minute → batch ne déborde pas.
+--   28252 / 200 = 141 ticks de 60s = ~2h20 total.
+--
+-- Ce job est éphémère : auto-déprogrammé dès que stale_count = 0. Pas un cron permanent
+-- (qui serait du bricolage). Le pattern long-terme = trigger auto_type Étape 3 + garde-fou
+-- mark_stale_with_followup_rebuild Étape 4.
+
+-- 1. Job principal : rebuild incremental
+SELECT cron.schedule(
+  'vehicle_cache_oneshot_backfill',
+  '* * * * *',
+  $$SELECT public.refresh_stale_vehicle_cache(200)$$
+);
+
+-- 2. Watcher : auto-unschedule des deux jobs quand stale_count = 0
+SELECT cron.schedule(
+  'vehicle_cache_oneshot_watcher',
+  '*/2 * * * *',
+  $watcher$
+  DO $$
+  BEGIN
+    IF (SELECT COUNT(*) FROM public.__vehicle_page_cache WHERE stale=true) = 0 THEN
+      PERFORM cron.unschedule('vehicle_cache_oneshot_backfill');
+      PERFORM cron.unschedule('vehicle_cache_oneshot_watcher');
+      RAISE NOTICE 'INC-2026-007: vehicle cache backfill complete, jobs unscheduled';
+    END IF;
+  END $$;
+  $watcher$
+);
+
+-- Vérification : les 2 jobs sont bien créés
+DO $$
+DECLARE
+  n INT;
+BEGIN
+  SELECT COUNT(*) INTO n FROM cron.job WHERE jobname IN ('vehicle_cache_oneshot_backfill', 'vehicle_cache_oneshot_watcher');
+  IF n != 2 THEN
+    RAISE EXCEPTION 'Expected 2 cron jobs created, got %', n;
+  END IF;
+  RAISE NOTICE 'INC-2026-007: 2 cron jobs scheduled, will auto-unschedule on stale_count=0';
+END $$;

--- a/backend/supabase/migrations/20260425_optimize_build_vehicle_page_payload_catalog.sql
+++ b/backend/supabase/migrations/20260425_optimize_build_vehicle_page_payload_catalog.sql
@@ -1,0 +1,269 @@
+-- Migration : optimisation de la sous-requête `catalog` dans build_vehicle_page_payload
+--
+-- INC-2026-007 — Pages véhicule R8 503 transitoires
+--
+-- Diagnostic root-cause :
+--   Phase 1 ADR-016 (commit fc9b94af, 21/04) a créé build_vehicle_page_payload avec une
+--   sous-requête `catalog` qui force le planner sur pieces_relation_type_v2_pkey
+--   (rtp_type_id, rtp_piece_id) 12 GB au lieu de l'index covering existant
+--   idx_pieces_relation_type_type_id_composite (rtp_type_id, rtp_pg_id) 4 GB.
+--
+--   Cause : la jointure forcée sur pieces.piece_id (pour filtrer piece_display=true)
+--   indique au planner qu'il a besoin de rtp_piece_id → choisit le PK 12 GB qui contient
+--   les deux colonnes, scanne 18 384 rows pour produire 116 résultats (≈ 692 ms warm,
+--   ≈ 2 s cold I/O).
+--
+-- Fix : décomposer la requête en deux phases.
+--   Phase 1 : index-only scan sur idx_..._composite (4 GB), récupère les rtp_pg_id
+--     distincts uniquement (skip totalement la jointure pieces).
+--   Phase 2 : pour chaque candidat, EXISTS sur (1) pieces_gamme display+level,
+--     (2) au moins une piece visible — chacun via index lookup ciblé.
+--
+-- Sémantique préservée : validé sur 10 types stale random (rtp_pg_id et piece_pg_id
+-- produisent les mêmes ensembles dans 100% des cas testés).
+--
+-- Mesures (warm cache, type_id=18110) :
+--   Avant : 692 ms / 18 384 row scans / Buffers hit=72 622 read=2 165
+--   Après : 27.6 ms / 113 rows / Buffers hit=11 868 read=0
+--
+-- Cold path : reste lent (~2 s) à cause de l'I/O brut sur pieces_relation_type 47 GB.
+-- Le 503 est évité structurellement par les Étapes 2+3+4 du plan (cron + trigger + garde-fou)
+-- qui garantissent steady state stale=0 → aucun rebuild on-miss en prod.
+
+CREATE OR REPLACE FUNCTION public.build_vehicle_page_payload(p_type_id integer)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+AS $function$
+DECLARE
+  v_result    JSONB;
+  v_marque_id INTEGER;
+BEGIN
+  SELECT jsonb_build_object(
+    'vehicle', (
+      SELECT jsonb_build_object(
+        'type_id', at.type_id,
+        'type_name', at.type_name,
+        'type_name_meta', at.type_name_meta,
+        'type_alias', at.type_alias,
+        'type_power_ps', at.type_power_ps,
+        'type_power_kw', at.type_power_kw,
+        'type_fuel', at.type_fuel,
+        'type_body', at.type_body,
+        'type_engine', at.type_engine,
+        'type_liter', at.type_liter,
+        'type_month_from', at.type_month_from,
+        'type_year_from', at.type_year_from,
+        'type_month_to', at.type_month_to,
+        'type_year_to', at.type_year_to,
+        'type_relfollow', at.type_relfollow,
+        'modele_id', am.modele_id,
+        'modele_name', am.modele_name,
+        'modele_name_meta', am.modele_name_meta,
+        'modele_alias', am.modele_alias,
+        'modele_pic', am.modele_pic,
+        'modele_ful_name', am.modele_ful_name,
+        'modele_body', am.modele_body,
+        'modele_relfollow', am.modele_relfollow,
+        'modele_year_from', am.modele_year_from,
+        'modele_year_to', am.modele_year_to,
+        'marque_id', amarq.marque_id,
+        'marque_name', amarq.marque_name,
+        'marque_name_meta', amarq.marque_name_meta,
+        'marque_name_meta_title', amarq.marque_name_meta_title,
+        'marque_alias', amarq.marque_alias,
+        'marque_logo', amarq.marque_logo,
+        'marque_relfollow', amarq.marque_relfollow,
+        'marque_top', amarq.marque_top
+      )
+      FROM auto_type at
+      INNER JOIN auto_modele am ON am.modele_id::TEXT = at.type_modele_id
+      INNER JOIN auto_marque amarq ON amarq.marque_id::SMALLINT = am.modele_marque_id
+      WHERE at.type_id = p_type_id::TEXT
+        AND at.type_display = '1'
+      LIMIT 1
+    ),
+    'motor_codes', (
+      SELECT COALESCE(jsonb_agg(tmc_code), '[]'::jsonb)
+      FROM auto_type_motor_code
+      WHERE tmc_type_id = p_type_id::TEXT
+    ),
+    'mine_codes', (
+      SELECT COALESCE(jsonb_agg(DISTINCT tnc_code), '[]'::jsonb)
+      FROM auto_type_number_code
+      WHERE tnc_type_id = p_type_id::TEXT
+        AND tnc_code IS NOT NULL
+        AND tnc_code != ''
+    ),
+    'cnit_codes', (
+      SELECT COALESCE(jsonb_agg(DISTINCT tnc_cnit), '[]'::jsonb)
+      FROM auto_type_number_code
+      WHERE tnc_type_id = p_type_id::TEXT
+        AND tnc_cnit IS NOT NULL
+        AND tnc_cnit != ''
+    ),
+    'seo_custom', (
+      SELECT jsonb_build_object(
+        'mta_title', mta_title,
+        'mta_descrip', mta_descrip,
+        'mta_keywords', mta_keywords,
+        'mta_h1', mta_h1,
+        'mta_content', mta_content,
+        'mta_relfollow', mta_relfollow
+      )
+      FROM ___meta_tags_ariane
+      WHERE mta_alias LIKE '%-' || p_type_id::TEXT
+      LIMIT 1
+    )
+  ) INTO v_result;
+
+  IF v_result IS NULL
+     OR jsonb_typeof(v_result->'vehicle') = 'null'
+     OR v_result->'vehicle' IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  v_marque_id := (v_result->'vehicle'->>'marque_id')::INTEGER;
+
+  v_result := v_result || jsonb_build_object(
+    'blog_content', (
+      SELECT jsonb_build_object(
+        'bsm_id', bsm_id,
+        'bsm_h1', bsm_h1,
+        'bsm_content', bsm_content,
+        'bsm_descrip', bsm_descrip
+      )
+      FROM __blog_seo_marque
+      WHERE bsm_marque_id = v_marque_id::TEXT
+      LIMIT 1
+    )
+  );
+
+  -- ============================================================================
+  -- OPTIMISATION INC-2026-007 : sous-requête `catalog` réécrite en deux phases
+  -- ============================================================================
+  -- Phase 1 (gamme_candidates) : index-only scan sur idx_pieces_relation_type_type_id_composite
+  --   pour récupérer les rtp_pg_id distincts SANS toucher la table pieces.
+  -- Phase 2 (visible_gammes) : EXISTS check ciblé pour vérifier la visibilité réelle
+  --   d'au moins une pièce par gamme.
+  -- Sémantique : équivalente à l'ancienne version (validé sur 10 types stale random).
+  v_result := v_result || jsonb_build_object(
+    'catalog', (
+      WITH gamme_candidates AS (
+        SELECT DISTINCT prt.rtp_pg_id AS pg_id
+        FROM pieces_relation_type prt
+        WHERE prt.rtp_type_id = p_type_id
+      ),
+      visible_gammes AS (
+        SELECT gc.pg_id
+        FROM gamme_candidates gc
+        INNER JOIN pieces_gamme pg ON pg.pg_id = gc.pg_id
+        WHERE pg.pg_display = '1'
+          AND pg.pg_level IN ('1', '2')
+          AND EXISTS (
+            SELECT 1
+            FROM pieces_relation_type prt2
+            INNER JOIN pieces p ON p.piece_id = prt2.rtp_piece_id
+            WHERE prt2.rtp_type_id = p_type_id
+              AND prt2.rtp_pg_id = gc.pg_id
+              AND p.piece_display = true
+            LIMIT 1
+          )
+        LIMIT 500
+      ),
+      gamme_data AS (
+        SELECT pg.pg_id, pg.pg_alias, pg.pg_name, pg.pg_name_meta, pg.pg_img, cg.mc_mf_id, cg.mc_sort
+        FROM visible_gammes vg
+        INNER JOIN pieces_gamme pg ON pg.pg_id = vg.pg_id
+        INNER JOIN catalog_gamme cg ON cg.mc_pg_id = pg.pg_id::TEXT
+      ),
+      families_with_gammes AS (
+        SELECT cf.mf_id, cf.mf_name, COALESCE(cf.mf_name_system, cf.mf_name) AS mf_name_display,
+          cf.mf_description, cf.mf_pic, cf.mf_sort,
+          jsonb_agg(
+            jsonb_build_object(
+              'pg_id', gd.pg_id,
+              'pg_alias', gd.pg_alias,
+              'pg_name', gd.pg_name,
+              'pg_name_meta', gd.pg_name_meta,
+              'pg_img', gd.pg_img,
+              'mc_sort', gd.mc_sort
+            ) ORDER BY gd.mc_sort::INTEGER NULLS LAST
+          ) AS gammes
+        FROM gamme_data gd
+        INNER JOIN catalog_family cf ON cf.mf_id = gd.mc_mf_id
+        WHERE cf.mf_display = '1'
+        GROUP BY cf.mf_id, cf.mf_name, cf.mf_name_system, cf.mf_description, cf.mf_pic, cf.mf_sort
+      )
+      SELECT jsonb_build_object(
+        'families', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'mf_id', mf_id,
+              'mf_name', mf_name_display,
+              'mf_description', mf_description,
+              'mf_pic', mf_pic,
+              'gammes', gammes,
+              'gammes_count', jsonb_array_length(gammes)
+            ) ORDER BY mf_sort::INTEGER NULLS LAST
+          ) FROM families_with_gammes),
+          '[]'::jsonb
+        ),
+        'total_families', (SELECT COUNT(*) FROM families_with_gammes),
+        'total_gammes', (SELECT COALESCE(SUM(jsonb_array_length(gammes)), 0) FROM families_with_gammes)
+      )
+    )
+  );
+  -- ============================================================================
+  -- FIN OPTIMISATION INC-2026-007
+  -- ============================================================================
+
+  v_result := v_result || jsonb_build_object(
+    'popular_parts', (
+      SELECT COALESCE(jsonb_agg(sub), '[]'::jsonb)
+      FROM (
+        SELECT DISTINCT ON (cgc.cgc_pg_id)
+          cgc.cgc_pg_id::INTEGER AS pg_id,
+          pg.pg_alias,
+          pg.pg_name,
+          pg.pg_name_meta,
+          pg.pg_img
+        FROM __cross_gamme_car_new cgc
+        INNER JOIN pieces_gamme pg ON pg.pg_id::TEXT = cgc.cgc_pg_id
+        WHERE cgc.cgc_type_id = p_type_id::TEXT
+          AND cgc.cgc_level IN ('1', '2')
+          AND pg.pg_display = '1'
+        ORDER BY cgc.cgc_pg_id, cgc.cgc_level ASC
+        LIMIT 8
+      ) sub
+    )
+  );
+
+  v_result := v_result || jsonb_build_object(
+    'seo_validation', jsonb_build_object(
+      'family_count', (v_result->'catalog'->>'total_families')::INTEGER,
+      'gamme_count', (v_result->'catalog'->>'total_gammes')::INTEGER,
+      'marque_relfollow', (v_result->'vehicle'->>'marque_relfollow')::INTEGER,
+      'modele_relfollow', (v_result->'vehicle'->>'modele_relfollow')::INTEGER,
+      'type_relfollow', (v_result->'vehicle'->>'type_relfollow')::INTEGER,
+      'is_indexable', (
+        (v_result->'catalog'->>'total_families')::INTEGER >= 3 AND
+        (v_result->'catalog'->>'total_gammes')::INTEGER >= 5 AND
+        COALESCE((v_result->'vehicle'->>'marque_relfollow')::INTEGER, 0) = 1 AND
+        COALESCE((v_result->'vehicle'->>'modele_relfollow')::INTEGER, 0) = 1 AND
+        COALESCE((v_result->'vehicle'->>'type_relfollow')::INTEGER, 0) = 1
+      )
+    )
+  );
+
+  v_result := v_result || jsonb_build_object(
+    'success', TRUE,
+    'type_id', p_type_id
+  );
+
+  RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.build_vehicle_page_payload(integer) IS
+  'INC-2026-007: sous-requete catalog optimisee (warm 27ms vs 692ms ancien). Cold path reste limite par I/O sur pieces_relation_type 47GB - protection structurelle assuree par cron + trigger auto_type + mark_stale_with_followup_rebuild garantissant steady state stale=0.';

--- a/backend/supabase/migrations/20260425_trigger_auto_type_rebuild_vehicle_cache.sql
+++ b/backend/supabase/migrations/20260425_trigger_auto_type_rebuild_vehicle_cache.sql
@@ -1,0 +1,60 @@
+-- Migration : trigger sur auto_type pour rebuild auto du cache véhicule
+--
+-- INC-2026-007 — Étape 3 du plan
+--
+-- Garantit que toute insertion/activation d'un type véhicule déclenche immédiatement
+-- le rebuild de sa ligne `__vehicle_page_cache`. Élimine le rebuild on-miss synchrone
+-- côté hit utilisateur, qui est la cause du 503 (cf. INC-2026-007).
+--
+-- Cas couverts :
+--   1. INSERT auto_type avec type_display=1 → rebuild immédiat
+--   2. UPDATE type_display 0→1 (activation d'un type existant) → rebuild immédiat
+--
+-- Cas NON couverts par ce trigger (gérés par les Étapes 2+4) :
+--   - Données sources (pieces, pieces_relation_type) modifiées : marquage stale via
+--     mark_stale_with_followup_rebuild() côté script de sync (Étape 4)
+--   - Stale rows existantes : cron de l'Étape 2 les rattrape
+--
+-- Conforme ADR-016 ligne 224 : pas de trigger sur pieces_relation_type (368M rows,
+-- dégraderait sync catalogue fournisseur).
+
+CREATE OR REPLACE FUNCTION public.trg_auto_type_rebuild_cache()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_type_id_int INTEGER;
+BEGIN
+  -- auto_type.type_id est TEXT, on cast en INT pour rebuild_vehicle_page_cache
+  v_type_id_int := NEW.type_id::INTEGER;
+
+  -- Cas 1 : INSERT avec type_display=1
+  -- Cas 2 : UPDATE type_display 0→1
+  IF (TG_OP = 'INSERT' AND NEW.type_display::INT = 1)
+     OR (TG_OP = 'UPDATE' AND COALESCE(OLD.type_display, '0')::INT = 0 AND NEW.type_display::INT = 1)
+  THEN
+    -- Best-effort : si rebuild échoue (vehicle pas trouvé, etc.), ne pas bloquer le INSERT
+    BEGIN
+      PERFORM public.rebuild_vehicle_page_cache(v_type_id_int);
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'INC-2026-007: rebuild_vehicle_page_cache(%) failed in trigger: %',
+        v_type_id_int, SQLERRM;
+    END;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_auto_type_rebuild_cache ON public.auto_type;
+
+CREATE TRIGGER trg_auto_type_rebuild_cache
+AFTER INSERT OR UPDATE OF type_display ON public.auto_type
+FOR EACH ROW EXECUTE FUNCTION public.trg_auto_type_rebuild_cache();
+
+COMMENT ON FUNCTION public.trg_auto_type_rebuild_cache() IS
+  'INC-2026-007 Etape 3: pre-rebuild __vehicle_page_cache des qu''un type est insere ou active. Garantit zero rebuild on-miss en steady state.';
+
+COMMENT ON TRIGGER trg_auto_type_rebuild_cache ON public.auto_type IS
+  'INC-2026-007: appelle rebuild_vehicle_page_cache(NEW.type_id) sur INSERT type_display=1 ou UPDATE display 0->1.';

--- a/data/vehicles_known_urls.csv
+++ b/data/vehicles_known_urls.csv
@@ -1,0 +1,7 @@
+modele_alias,source,url
+clio-iii,wikipedia-fr,https://fr.wikipedia.org/wiki/Renault_Clio_III
+clio-iii,lacentrale,https://www.lacentrale.fr/fiches-techniques-voiture-renault-clio---.html
+clio-iii,autotitre,https://www.autotitre.com/fiche-technique/Renault/Clio/III
+clio-iii,fiches-auto,https://www.fiches-auto.fr/fiche-technique-renault/specs-106-technique-renault-clio-3.php
+clio-iii,user-manual-renault,https://www.user-manual.renault.com/fr/content/renault-clio-3-phase-1
+clio-iii,lenouvelautomobiliste,https://lenouvelautomobiliste.fr/actualites/histoire-de-la-renault-clio-3-4-2005-tout-ce-que-lon-demande-a-une-voiture/

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -77,6 +77,38 @@ export const links: LinksFunction = () => [
 const loaderCache = new Map<string, { data: LoaderData; timestamp: number }>();
 const CACHE_TTL = 60000; // 1 minute
 
+// 📡 INC-2026-007 — Comble le blindspot __error_logs : notifie le backend
+// avant chaque throw 503 du loader. Fire-and-forget, jamais bloquant.
+async function notify503ToErrorLog(
+  url: string,
+  subject: string,
+  message: string,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  const internalKey = process.env.INTERNAL_API_KEY;
+  if (!internalKey) return;
+
+  try {
+    await fetch(`${getInternalApiUrl("")}/api/internal/error-log`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Internal-Key": internalKey,
+      },
+      body: JSON.stringify({
+        status: 503,
+        url,
+        subject,
+        message,
+        metadata,
+      }),
+      signal: AbortSignal.timeout(500), // ne jamais bloquer le loader
+    }).catch(() => {});
+  } catch {
+    // best-effort, jamais bloquant
+  }
+}
+
 // Types, transform, schema, constants moved to components/vehicle/r8/
 // - r8.types.ts        : VehicleData, CatalogFamily, PopularPart, SEOData, R8Block, R8Content, LoaderData
 // - r8-transform.ts    : transformRpcToLoaderData (RPC → LoaderData, pure)
@@ -210,6 +242,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
         throw new Response("Véhicule supprimé du catalogue", { status: 410 });
       }
       // Vrais erreurs serveur → 503 (Google réessaye) au lieu de 500
+      await notify503ToErrorLog(
+        `/constructeurs/${brand}/${model}/${type}`,
+        "LOADER_503_BACKEND_RPC_ERROR",
+        `Backend page-data-rpc returned HTTP ${rpcResponse.status} for type_id=${type_id}`,
+        { type_id, backend_status: rpcResponse.status },
+      );
       throw new Response("Service temporairement indisponible", {
         status: 503,
       });
@@ -223,6 +261,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
       (error.name === "AbortError" || error.name === "TimeoutError")
     ) {
       logger.error(`⏱️ [RPC] Timeout 10s pour type_id=${type_id}`);
+      await notify503ToErrorLog(
+        `/constructeurs/${brand}/${model}/${type}`,
+        "LOADER_503_RPC_TIMEOUT",
+        `Backend page-data-rpc timeout (10s) for type_id=${type_id}`,
+        { type_id, timeout_ms: 10000 },
+      );
       throw new Response("Service temporairement indisponible", {
         status: 503,
       });
@@ -233,6 +277,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
     }
     // Autres erreurs → 503 (Google réessaye) au lieu de 500
     logger.error(`❌ [RPC] Erreur fetch pour type_id=${type_id}:`, error);
+    await notify503ToErrorLog(
+      `/constructeurs/${brand}/${model}/${type}`,
+      "LOADER_503_RPC_FETCH_ERROR",
+      `Backend page-data-rpc fetch failed for type_id=${type_id}: ${error instanceof Error ? error.message : String(error)}`,
+      { type_id, error_name: error instanceof Error ? error.name : "unknown" },
+    );
     throw new Response("Service temporairement indisponible", { status: 503 });
   }
 
@@ -240,6 +290,16 @@ export async function loader({ params }: LoaderFunctionArgs) {
     logger.error("❌ [RPC] Données invalides:", rpcResult);
     // 503 et non 410 : le véhicule peut exister mais le service a échoué.
     // 410 causerait une désindexation Google permanente.
+    await notify503ToErrorLog(
+      `/constructeurs/${brand}/${model}/${type}`,
+      "LOADER_503_RPC_INVALID_PAYLOAD",
+      `Backend returned 200 but payload invalid for type_id=${type_id}`,
+      {
+        type_id,
+        payload_success: rpcResult.success,
+        has_vehicle: !!rpcResult.data?.vehicle,
+      },
+    );
     throw new Response("Service temporairement indisponible", { status: 503 });
   }
 

--- a/log.md
+++ b/log.md
@@ -69,3 +69,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
 - **Décision** : feat(rag): elargir sources web vehicule + curated URL CSV (stage 1+) (+5 other commits)
 - **Sortie** : PR #172 | commits 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832
+
+## 2026-04-25 — feat/vehicle-rag-web-enrichment-stage1 (auto)
+
+- **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
+- **Décision** : chore(log): auto session entry for feat/vehicle-rag-web-enrichment-stage1 (+6 other commits)
+- **Sortie** : PR #172 | commits 8b1751af 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832

--- a/log.md
+++ b/log.md
@@ -57,3 +57,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/claude-knowledge-base`, `feat/audit-ci-integration`, `feat/cleanup-tooling-prep`
 - **Décision** : Adoption knip + madge + dependency-cruiser + ast-grep en gates déterministes (warning-mode Phase 0). Création `.claude/knowledge/` (42 modules + 4 db + 4 integrations). CI workflow `audit.yml` blockant ast-grep. Safe-delete script + baseline JSON regression gate + 3 runbooks ops.
 - **Sortie** : PRs #149, #152, #155 mergées | knip 6.6.2 (avec nested zod@4 override) + madge 8 + dep-cruiser 17.3 + @ast-grep/cli 0.42 installés | baseline 362 unused / 17 cycles / 148 violations / 0 ast-errors capturée
+
+## 2026-04-25 — feat/vehicle-rag-web-enrichment-stage1 (auto)
+
+- **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
+- **Décision** : feat(rag): vehicle motor corpus scraper + auto-verify enricher (stage 1) (+3 other commits)
+- **Sortie** : PR #172 | commits 9f28833a 9dc8f71b 26d3cea0 26812832

--- a/log.md
+++ b/log.md
@@ -63,3 +63,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
 - **Décision** : feat(rag): vehicle motor corpus scraper + auto-verify enricher (stage 1) (+3 other commits)
 - **Sortie** : PR #172 | commits 9f28833a 9dc8f71b 26d3cea0 26812832
+
+## 2026-04-25 — feat/vehicle-rag-web-enrichment-stage1 (auto)
+
+- **Branche** : `feat/vehicle-rag-web-enrichment-stage1`
+- **Décision** : feat(rag): elargir sources web vehicule + curated URL CSV (stage 1+) (+5 other commits)
+- **Sortie** : PR #172 | commits 8e17940d b1926420 9f28833a 9dc8f71b 26d3cea0 26812832

--- a/scripts/ci/check-no-direct-vehicle-cache-stale.sh
+++ b/scripts/ci/check-no-direct-vehicle-cache-stale.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# INC-2026-007 — Check CI : interdire UPDATE __vehicle_page_cache SET stale=... direct
+#
+# Tout script qui invalide doit utiliser mark_stale_with_followup_rebuild()
+# (cf. backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql).
+#
+# Exit 0 si propre, 1 si violation détectée.
+
+set -euo pipefail
+
+SCAN_DIRS=(
+  "backend/supabase/migrations"
+  "scripts/seo"
+  "scripts/db"
+)
+
+EXEMPT_FILES=(
+  "backend/supabase/migrations/20260425_mark_stale_with_followup_rebuild.sql"
+  "backend/supabase/migrations/20260425_oneshot_backfill_stale_vehicle_cache.sql"
+)
+
+VIOLATIONS=0
+TMPFILE="$(mktemp)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+for dir in "${SCAN_DIRS[@]}"; do
+  if [[ ! -d "$dir" ]]; then
+    continue
+  fi
+  # Cherche pattern : UPDATE ... __vehicle_page_cache ... SET stale
+  grep -rEln "UPDATE[[:space:]]+(public\.)?__vehicle_page_cache[[:space:]]+SET[[:space:]]+stale" "$dir" 2>/dev/null > "$TMPFILE" || true
+
+  while IFS= read -r match_file; do
+    [[ -z "$match_file" ]] && continue
+
+    # Skip exempt files
+    skip=0
+    for exempt in "${EXEMPT_FILES[@]}"; do
+      if [[ "$match_file" == "$exempt" ]] || [[ "$match_file" == */"$exempt" ]]; then
+        skip=1
+        break
+      fi
+    done
+    [[ $skip -eq 1 ]] && continue
+
+    echo "❌ INC-2026-007 violation: $match_file uses UPDATE __vehicle_page_cache SET stale directly"
+    echo "   → use SELECT mark_stale_with_followup_rebuild(ARRAY[...], 'reason') instead"
+    VIOLATIONS=$((VIOLATIONS + 1))
+  done < "$TMPFILE"
+done
+
+if [[ $VIOLATIONS -gt 0 ]]; then
+  echo ""
+  echo "FAIL: $VIOLATIONS violation(s) detected. Use mark_stale_with_followup_rebuild() canon."
+  exit 1
+fi
+
+echo "✅ INC-2026-007 check passed: no direct UPDATE __vehicle_page_cache SET stale found"
+exit 0

--- a/scripts/rag/download-vehicle-motor-corpus.py
+++ b/scripts/rag/download-vehicle-motor-corpus.py
@@ -359,8 +359,75 @@ def url_candidates_autoplus(modele: Modele) -> list[str]:
 
 
 def url_candidates_autotitre(modele: Modele) -> list[str]:
+    """Vraie URL : /fiche-technique/<Brand>/<Model>/<VariantRoman>"""
     base = "https://www.autotitre.com"
-    return [f"{base}/fiche-technique-{modele.marque_alias}-{modele.modele_alias}.html"]
+    brand_t = modele.marque_alias.title()
+    parts = modele.modele_alias.split("-")
+    titled: list[str] = []
+    for p in parts:
+        if not p:
+            continue
+        if re.fullmatch(r"[ivxIVX]+", p):
+            titled.append(p.upper())
+        else:
+            titled.append(p.title())
+    if len(titled) >= 2 and re.fullmatch(r"[IVX]+", titled[-1]):
+        path = "/".join(titled[:-1]) + "/" + titled[-1]
+    else:
+        path = "/".join(titled) if titled else modele.modele_alias
+    return [
+        f"{base}/fiche-technique/{brand_t}/{path}",
+        f"{base}/fiche-technique-{modele.marque_alias}-{modele.modele_alias}.html",
+    ]
+
+
+def _arabic_alias(alias: str) -> str:
+    """Convert roman suffix to arabic ('clio-iii' → 'clio-3')."""
+    roman_to_arabic = {"-i": "-1", "-ii": "-2", "-iii": "-3", "-iv": "-4", "-v": "-5", "-vi": "-6"}
+    for roman, arabic in roman_to_arabic.items():
+        if alias.endswith(roman):
+            return alias[: -len(roman)] + arabic
+    return alias
+
+
+def url_candidates_user_manual_renault(modele: Modele) -> list[str]:
+    """Renault constructor manuals (Renault only)."""
+    if modele.marque_alias != "renault":
+        return []
+    base = "https://www.user-manual.renault.com"
+    arabic = _arabic_alias(modele.modele_alias)
+    return [
+        f"{base}/fr/content/{modele.marque_alias}-{arabic}-phase-1",
+        f"{base}/fr/content/{modele.marque_alias}-{arabic}-phase-2",
+        f"{base}/fr/content/{modele.marque_alias}-{arabic}",
+    ]
+
+
+def url_candidates_lenouvelautomobiliste(modele: Modele) -> list[str]:
+    """Editorial articles via search archive."""
+    base = "https://lenouvelautomobiliste.fr"
+    arabic = _arabic_alias(modele.modele_alias)
+    q = f"{modele.marque_alias}+{arabic.replace('-', '+')}"
+    return [f"{base}/?s={q}"]
+
+
+# Curated URL override (CSV-based) — priority over heuristic patterns
+CURATED_CSV = "/opt/automecanik/app/data/vehicles_known_urls.csv"
+
+
+def load_curated_urls(modele_alias: str) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    if not os.path.isfile(CURATED_CSV):
+        return out
+    import csv as _csv
+    with open(CURATED_CSV, encoding="utf-8", newline="") as f:
+        for row in _csv.DictReader(f):
+            if (row.get("modele_alias") or "").strip().lower() == modele_alias.lower():
+                src = (row.get("source") or "").strip()
+                url = (row.get("url") or "").strip()
+                if src and url:
+                    out.setdefault(src, []).append(url)
+    return out
 
 
 def url_candidates_wikipedia_fr(modele: Modele) -> list[str]:
@@ -418,6 +485,9 @@ SOURCES = [
     ("autotitre", url_candidates_autotitre, extract_text_generic, False),
     ("wikipedia-fr", url_candidates_wikipedia_fr, extract_text_wikipedia, False),
     ("wikipedia-en", url_candidates_wikipedia_en, extract_text_wikipedia, False),
+    ("user-manual-renault", url_candidates_user_manual_renault, extract_text_generic, False),
+    ("lenouvelautomobiliste", url_candidates_lenouvelautomobiliste, extract_text_generic, False),
+    ("lacentrale", lambda m: [], extract_text_generic, False),  # curated only (anti-bot)
 ]
 
 
@@ -497,11 +567,19 @@ def process_modele(modele: Modele, dry_run: bool, only_sources: set[str] | None 
     saved = 0
     skipped = 0
 
+    # Curated URL overrides — read from data/vehicles_known_urls.csv
+    curated = load_curated_urls(modele.modele_alias)
+    if curated:
+        print(f"  → curated URLs from CSV: {sum(len(v) for v in curated.values())} entries")
+
     for source_name, url_fn, extractor, per_type in SOURCES:
         if only_sources and source_name not in only_sources:
             continue
-        # Per-type variants attempted for sources that support it (fiches-auto)
         candidates_iter: list[tuple[str, list[int]]] = []
+        # 1) curated URLs (priority)
+        for cu in curated.get(source_name, []):
+            candidates_iter.append((cu, type_ids_all))
+        # 2) heuristic patterns
         if per_type:
             for tm in types:
                 urls = url_fn(modele, tm)

--- a/scripts/rag/download-vehicle-motor-corpus.py
+++ b/scripts/rag/download-vehicle-motor-corpus.py
@@ -252,22 +252,43 @@ def extract_text_generic(html: str) -> tuple[str, str]:
     if not main:
         return title, ""
 
+    # Table-aware : <tr> joined with | so engine specs stay on one line.
     lines: list[str] = []
-    for el in main.find_all(["h1", "h2", "h3", "p", "li", "td", "th"]):
-        text = el.get_text(separator=" ", strip=True)
-        text = re.sub(r"\s+", " ", text).strip()
+    visited_cells: set = set()
+    for el in main.find_all(["h1", "h2", "h3", "p", "li", "tr"]):
+        if el.name == "tr":
+            cells = [
+                re.sub(r"\s+", " ", c.get_text(" ", strip=True)).strip()
+                for c in el.find_all(["td", "th"])
+            ]
+            cells = [c for c in cells if c]
+            if not cells or all(len(c) < 2 for c in cells):
+                continue
+            line = "| " + " | ".join(cells) + " |"
+            if len(line) >= 8:
+                lines.append(line)
+                for c in el.find_all(["td", "th"]):
+                    visited_cells.add(id(c))
+            continue
+        text = re.sub(r"\s+", " ", el.get_text(separator=" ", strip=True)).strip()
         if len(text) < 12:
             continue
         if el.name in ("h1", "h2", "h3"):
             lines.append(f"\n## {text}\n")
         elif el.name == "li":
             lines.append(f"- {text}")
-        elif el.name in ("td", "th"):
-            lines.append(f"| {text} |")
         else:
             lines.append(text)
 
-    return title, "\n".join(lines[:300])
+    # Catch standalone td/th not inside <tr>
+    for cell in main.find_all(["td", "th"]):
+        if id(cell) in visited_cells:
+            continue
+        text = re.sub(r"\s+", " ", cell.get_text(" ", strip=True)).strip()
+        if len(text) >= 12:
+            lines.append(f"| {text} |")
+
+    return title, "\n".join(lines[:400])
 
 
 def extract_text_wikipedia(html: str) -> tuple[str, str]:

--- a/scripts/rag/download-vehicle-motor-corpus.py
+++ b/scripts/rag/download-vehicle-motor-corpus.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""
+download-vehicle-motor-corpus.py — Stage 1.A : scrape vehicle per-motorisation
+data from public web sources, write to /opt/automecanik/rag/knowledge/web-vehicles/.
+
+Mirror of `download-oem-corpus.py` (gamme), but for vehicle motorisations.
+
+Sources (decision utilisateur 2026-04-25, élargies) :
+  Tier 1 (specs structurées)  : fiches-auto.fr, caradisiac, largus.fr,
+                                 turbo.fr, autoplus.fr, autotitre.com
+  Tier 2 (encyclopédique)      : fr.wikipedia.org, en.wikipedia.org
+
+Tiers 3-5 (fiabilité, regulatory, aftermarket cross-ref) ajoutés selon
+recall mesuré sur le pilote.
+
+Usage:
+  python3 scripts/rag/download-vehicle-motor-corpus.py --modele clio-3 --dry-run
+  python3 scripts/rag/download-vehicle-motor-corpus.py --modele clio-3 --apply
+  python3 scripts/rag/download-vehicle-motor-corpus.py --brand smart --apply
+  python3 scripts/rag/download-vehicle-motor-corpus.py --modele-id 140004 --apply
+
+Output : /opt/automecanik/rag/knowledge/web-vehicles/<hash>-s<N>.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+import textwrap
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from urllib.parse import quote, urlparse
+
+try:
+    import requests
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Manque : pip install requests beautifulsoup4")
+    sys.exit(1)
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("Manque : pip install psycopg2-binary")
+    sys.exit(1)
+
+# === CONFIG ============================================================
+
+WEB_VEHICLES_DIR = "/opt/automecanik/rag/knowledge/web-vehicles"
+REQUEST_DELAY_S = 1.2
+MAX_RETRIES = 2
+TIMEOUT_S = 12
+MIN_CONTENT_LEN = 250
+
+# DB connection — pattern aligné avec scripts/db/adr017-create-index-concurrently.py
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+DB_PASSWORD = os.environ.get("SUPABASE_DB_PASSWORD")
+if not DB_PASSWORD:
+    sys.stderr.write(
+        "[FATAL] SUPABASE_DB_PASSWORD missing in env. "
+        "Run: source backend/.env (or set SUPABASE_DB_PASSWORD=...)\n"
+    )
+    sys.exit(1)
+DB_DSN = (
+    f"host=db.{PROJECT_REF}.supabase.co "
+    f"port=5432 user=postgres dbname=postgres "
+    f"password={DB_PASSWORD} sslmode=require"
+)
+
+WIKI_API_FR = "https://fr.wikipedia.org/w/api.php"
+WIKI_API_EN = "https://en.wikipedia.org/w/api.php"
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; AutoMecanik-RAGBot/1.0; vehicle-data-research; contact: automecanik.seo@gmail.com)",
+    "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.8",
+    "Accept": "text/html,application/xhtml+xml",
+}
+
+
+# === MODELS ============================================================
+
+@dataclass
+class Modele:
+    modele_id: int
+    marque_id: int
+    marque_alias: str  # e.g. 'renault'
+    marque_name: str   # e.g. 'RENAULT'
+    modele_alias: str  # e.g. 'clio-3'
+    modele_name: str   # e.g. 'CLIO III'
+
+
+@dataclass
+class TypeMotor:
+    type_id: int
+    modele_id: int
+    type_name: str    # e.g. '1.5 dCi'
+    fuel: str         # e.g. 'Diesel'
+    power_ps: int     # e.g. 88
+    liter: str        # e.g. '150' (=1.5 L) or '1461'
+    body: str
+    year_from: int
+
+
+@dataclass
+class ScrapeJob:
+    source: str       # e.g. 'fiches-auto'
+    url: str
+    modele_id: int
+    type_ids: list[int] = field(default_factory=list)
+    status: str = "pending"  # pending | success | 404 | parse_error | skipped
+    title: str = ""
+    content_len: int = 0
+
+
+# === DB ACCESS =========================================================
+
+def db_connect():
+    return psycopg2.connect(DB_DSN)
+
+
+def fetch_modeles_by_filter(args) -> list[Modele]:
+    """Fetch the list of modeles to process based on CLI filters."""
+    sql = """
+        SELECT m.modele_id, m.modele_marque_id, m.modele_alias, m.modele_name,
+               b.marque_alias, b.marque_name
+        FROM auto_modele m
+        JOIN auto_marque b ON b.marque_id::int = m.modele_marque_id::int
+        WHERE m.modele_display = 1 AND b.marque_display = '1'
+    """
+    params: list = []
+    if args.modele_id:
+        sql += " AND m.modele_id = %s"
+        params.append(args.modele_id)
+    elif args.modele:
+        # Accept both arabic ("clio-3") and roman ("clio-iii") forms.
+        roman_map = {"-1": "-i", "-2": "-ii", "-3": "-iii", "-4": "-iv", "-5": "-v", "-6": "-vi"}
+        alt = args.modele.lower()
+        for arabic, roman in roman_map.items():
+            if alt.endswith(arabic):
+                alt = alt[: -len(arabic)] + roman
+                break
+        sql += " AND lower(m.modele_alias) IN (lower(%s), lower(%s))"
+        params.extend([args.modele, alt])
+    elif args.brand:
+        sql += " AND lower(b.marque_alias) = lower(%s)"
+        params.append(args.brand)
+    else:
+        # default pilot scope (decision utilisateur 2026-04-25) :
+        # Renault Clio III + Smart + DS 3 (cohortes déjà enrichies en R8).
+        sql += """
+            AND (
+                (lower(b.marque_alias) = 'renault' AND lower(m.modele_alias) LIKE 'clio-iii%%')
+                OR lower(b.marque_alias) = 'smart'
+                OR (lower(b.marque_alias) = 'ds' AND lower(m.modele_alias) LIKE 'ds-3%%')
+            )
+        """
+
+    sql += " ORDER BY b.marque_alias, m.modele_alias LIMIT 50"
+
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+    return [
+        Modele(
+            modele_id=int(r["modele_id"]),
+            marque_id=int(r["modele_marque_id"]),
+            marque_alias=str(r["marque_alias"]).strip().lower(),
+            marque_name=str(r["marque_name"]).strip(),
+            modele_alias=str(r["modele_alias"]).strip().lower(),
+            modele_name=str(r["modele_name"]).strip(),
+        )
+        for r in rows
+    ]
+
+
+def fetch_types_for_modele(modele_id: int) -> list[TypeMotor]:
+    sql = """
+        SELECT type_id_i, type_modele_id_i, type_name, type_fuel,
+               type_power_ps, type_liter, type_body, type_year_from
+        FROM auto_type
+        WHERE type_display = '1'
+          AND type_modele_id_i = %s
+          AND type_power_ps ~ '^[0-9]+$'
+        ORDER BY type_id_i
+    """
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [modele_id])
+        rows = cur.fetchall()
+    out: list[TypeMotor] = []
+    for r in rows:
+        try:
+            out.append(
+                TypeMotor(
+                    type_id=int(r["type_id_i"]),
+                    modele_id=int(r["type_modele_id_i"]),
+                    type_name=str(r["type_name"] or "").strip(),
+                    fuel=str(r["type_fuel"] or "").strip(),
+                    power_ps=int(r["type_power_ps"] or 0),
+                    liter=str(r["type_liter"] or "").strip(),
+                    body=str(r["type_body"] or "").strip(),
+                    year_from=int(r["type_year_from"] or 0),
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+# === HTTP HELPERS ======================================================
+
+def fetch_url(url: str) -> str | None:
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            r = requests.get(
+                url, headers=HEADERS, timeout=TIMEOUT_S, allow_redirects=True,
+            )
+            ctype = r.headers.get("Content-Type", "")
+            if r.status_code == 200 and "text/html" in ctype:
+                r.encoding = r.apparent_encoding
+                return r.text
+            if r.status_code in (403, 404, 410, 429, 503):
+                return None
+            if attempt < MAX_RETRIES:
+                time.sleep(REQUEST_DELAY_S * 2)
+        except requests.RequestException as exc:
+            if attempt < MAX_RETRIES:
+                time.sleep(REQUEST_DELAY_S)
+            else:
+                print(f"    ! réseau {url[:60]} : {exc}")
+    return None
+
+
+# === EXTRACTORS PER SOURCE =============================================
+
+def extract_text_generic(html: str) -> tuple[str, str]:
+    """Generic main-content extractor (used for fiches-auto, caradisiac, etc.)."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup.find_all(
+        ["nav", "footer", "script", "style", "header", "aside", "noscript", "iframe", "form"]
+    ):
+        tag.decompose()
+    for tag in soup.find_all(class_=re.compile(r"(cookie|gdpr|banner|popup|menu|ads|pub)", re.I)):
+        tag.decompose()
+
+    title = soup.title.get_text(strip=True) if soup.title else ""
+    main = soup.find("main") or soup.find("article") or soup.body
+    if not main:
+        return title, ""
+
+    lines: list[str] = []
+    for el in main.find_all(["h1", "h2", "h3", "p", "li", "td", "th"]):
+        text = el.get_text(separator=" ", strip=True)
+        text = re.sub(r"\s+", " ", text).strip()
+        if len(text) < 12:
+            continue
+        if el.name in ("h1", "h2", "h3"):
+            lines.append(f"\n## {text}\n")
+        elif el.name == "li":
+            lines.append(f"- {text}")
+        elif el.name in ("td", "th"):
+            lines.append(f"| {text} |")
+        else:
+            lines.append(text)
+
+    return title, "\n".join(lines[:300])
+
+
+def extract_text_wikipedia(html: str) -> tuple[str, str]:
+    soup = BeautifulSoup(html, "html.parser")
+    title = ""
+    if soup.find("h1", id="firstHeading"):
+        title = soup.find("h1", id="firstHeading").get_text(strip=True)
+
+    content_div = soup.find("div", id="mw-content-text")
+    if not content_div:
+        return title, ""
+
+    for tag in content_div.find_all(
+        ["table", "sup", "cite"],
+        class_=re.compile(r"(navbox|reflist|toc|hatnote|thumb)", re.I),
+    ):
+        tag.decompose()
+    for tag in content_div.find_all(id=re.compile(r"(references|notes|liens)", re.I)):
+        if tag.parent:
+            tag.parent.decompose()
+
+    lines: list[str] = []
+    for el in content_div.find_all(["h2", "h3", "h4", "p", "li", "td", "th"]):
+        text = el.get_text(separator=" ", strip=True)
+        text = re.sub(r"\[\d+\]", "", text)
+        text = re.sub(r"\s+", " ", text).strip()
+        if len(text) < 12:
+            continue
+        if el.name in ("h2", "h3", "h4"):
+            lines.append(f"\n## {text}\n")
+        elif el.name == "li":
+            lines.append(f"- {text}")
+        elif el.name in ("td", "th"):
+            lines.append(f"| {text} |")
+        else:
+            lines.append(text)
+    return title, "\n".join(lines[:300])
+
+
+# === URL DISCOVERY PER SOURCE ==========================================
+
+def url_candidates_fiches_auto(modele: Modele, type_motor: TypeMotor | None = None) -> list[str]:
+    """fiches-auto.fr URL patterns."""
+    base = "https://www.fiches-auto.fr"
+    brand = modele.marque_alias
+    model = modele.modele_alias
+    candidates = [
+        f"{base}/{brand}/{model}",
+        f"{base}/{brand}/{model}/",
+        f"{base}/articles-auto/fiabilite-des-voitures/{brand}-{model}.php",
+    ]
+    if type_motor:
+        # Power-tagged variants
+        candidates.append(f"{base}/{brand}/{model}-{type_motor.power_ps}")
+        candidates.append(f"{base}/{brand}/{model}/{type_motor.power_ps}")
+    return candidates
+
+
+def url_candidates_caradisiac(modele: Modele) -> list[str]:
+    base = "https://www.caradisiac.com"
+    slug = f"{modele.marque_alias}-{modele.modele_alias}"
+    # Year fallbacks (model-level page with sections per motor)
+    return [
+        f"{base}/fiches-techniques/modele--{slug}/",
+        f"{base}/fiches-techniques/modele--{slug}/2010/",
+        f"{base}/fiches-techniques/modele--{slug}/2009/",
+    ]
+
+
+def url_candidates_largus(modele: Modele) -> list[str]:
+    base = "https://www.largus.fr"
+    return [
+        f"{base}/fiches-techniques/{modele.marque_alias}/{modele.modele_alias}/",
+        f"{base}/cote-auto/{modele.marque_alias}/{modele.modele_alias}.html",
+    ]
+
+
+def url_candidates_turbo(modele: Modele) -> list[str]:
+    base = "https://www.turbo.fr"
+    return [
+        f"{base}/fiches-techniques/{modele.marque_alias}-{modele.modele_alias}.html",
+        f"{base}/fiche-technique/{modele.marque_alias}/{modele.modele_alias}",
+    ]
+
+
+def url_candidates_autoplus(modele: Modele) -> list[str]:
+    base = "https://www.autoplus.fr"
+    return [f"{base}/fiches-techniques/{modele.marque_alias}-{modele.modele_alias}/"]
+
+
+def url_candidates_autotitre(modele: Modele) -> list[str]:
+    base = "https://www.autotitre.com"
+    return [f"{base}/fiche-technique-{modele.marque_alias}-{modele.modele_alias}.html"]
+
+
+def url_candidates_wikipedia_fr(modele: Modele) -> list[str]:
+    """Use Wikipedia API to find the article."""
+    queries = [
+        f"{modele.marque_name} {modele.modele_name}",
+        f"{modele.marque_alias} {modele.modele_alias}",
+    ]
+    return [_wiki_lookup(q, lang="fr") for q in queries]
+
+
+def url_candidates_wikipedia_en(modele: Modele) -> list[str]:
+    queries = [
+        f"{modele.marque_name} {modele.modele_name}",
+        f"{modele.marque_name.title()} {modele.modele_name.title()}",
+    ]
+    return [_wiki_lookup(q, lang="en") for q in queries]
+
+
+def _wiki_lookup(query: str, lang: str = "fr") -> str | None:
+    api = WIKI_API_FR if lang == "fr" else WIKI_API_EN
+    base = f"https://{lang}.wikipedia.org/wiki/"
+    try:
+        r = requests.get(
+            api,
+            params={
+                "action": "query",
+                "list": "search",
+                "srsearch": query,
+                "srlimit": 3,
+                "srnamespace": 0,
+                "format": "json",
+            },
+            headers={"User-Agent": HEADERS["User-Agent"]},
+            timeout=8,
+        )
+        results = r.json().get("query", {}).get("search", [])
+        for res in results:
+            title = res["title"]
+            return base + quote(title.replace(" ", "_"))
+    except Exception:
+        pass
+    return None
+
+
+# === SCRAPE WORKFLOW ===================================================
+
+SOURCES = [
+    # (source_name, url_builder, extractor, applies_per_type)
+    ("fiches-auto", url_candidates_fiches_auto, extract_text_generic, True),
+    ("caradisiac", url_candidates_caradisiac, extract_text_generic, False),
+    ("largus", url_candidates_largus, extract_text_generic, False),
+    ("turbo", url_candidates_turbo, extract_text_generic, False),
+    ("autoplus", url_candidates_autoplus, extract_text_generic, False),
+    ("autotitre", url_candidates_autotitre, extract_text_generic, False),
+    ("wikipedia-fr", url_candidates_wikipedia_fr, extract_text_wikipedia, False),
+    ("wikipedia-en", url_candidates_wikipedia_en, extract_text_wikipedia, False),
+]
+
+
+def slugify_to_hash(modele: Modele, url: str) -> str:
+    raw = f"{modele.marque_alias}/{modele.modele_alias}|{url}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def save_file(
+    modele: Modele,
+    type_ids: list[int],
+    source: str,
+    url: str,
+    title: str,
+    content: str,
+) -> str | None:
+    if len(content.strip()) < MIN_CONTENT_LEN:
+        return None
+    h = slugify_to_hash(modele, url)
+    existing = [f for f in os.listdir(WEB_VEHICLES_DIR) if f.startswith(h)]
+    section_num = len(existing) + 1
+    filename = f"{h}-s{section_num:03d}.md"
+    path = os.path.join(WEB_VEHICLES_DIR, filename)
+    now = datetime.now(timezone.utc).isoformat()
+    domain = urlparse(url).netloc
+    safe_title = title.replace("'", "\\'")[:120] if title else f"{modele.marque_name} {modele.modele_name}"
+
+    type_ids_yaml = "[]"
+    if type_ids:
+        type_ids_yaml = "[" + ", ".join(str(t) for t in type_ids) + "]"
+
+    md = (
+        f"---\n"
+        f"title: '{safe_title} - s{section_num:03d}'\n"
+        f"source_type: vehicle_motor\n"
+        f"target_kind: vehicle_motor\n"
+        f"target_modele_id: {modele.modele_id}\n"
+        f"target_type_ids: {type_ids_yaml}\n"
+        f"target_marque: {modele.marque_alias}\n"
+        f"target_modele: {modele.modele_alias}\n"
+        f"category: knowledge\n"
+        f"truth_level: L2\n"
+        f"verification_status: unverified\n"
+        f"source_uri: {url}\n"
+        f"source_url: {url}\n"
+        f"source_domain: {domain}\n"
+        f"source_tier: {_source_tier(source)}\n"
+        f"source_provider: {source}\n"
+        f"created_at: '{now}'\n"
+        f"updated_at: '{now}'\n"
+        f"---\n"
+        f"\n"
+        f"# {safe_title}\n"
+        f"\n"
+        f"{content}\n"
+    )
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(md)
+    return path
+
+
+def _source_tier(source: str) -> int:
+    if source in {"fiches-auto", "caradisiac", "largus", "turbo", "autoplus", "autotitre"}:
+        return 1
+    if source.startswith("wikipedia"):
+        return 2
+    return 3
+
+
+def process_modele(modele: Modele, dry_run: bool, only_sources: set[str] | None = None) -> dict:
+    types = fetch_types_for_modele(modele.modele_id)
+    type_ids_all = [t.type_id for t in types]
+    print(f"\n=== {modele.marque_name} {modele.modele_name} (modele_id={modele.modele_id}, {len(types)} types) ===")
+
+    jobs: list[ScrapeJob] = []
+    saved = 0
+    skipped = 0
+
+    for source_name, url_fn, extractor, per_type in SOURCES:
+        if only_sources and source_name not in only_sources:
+            continue
+        # Per-type variants attempted for sources that support it (fiches-auto)
+        candidates_iter: list[tuple[str, list[int]]] = []
+        if per_type:
+            for tm in types:
+                urls = url_fn(modele, tm)
+                for url in urls:
+                    if url:
+                        candidates_iter.append((url, [tm.type_id]))
+        else:
+            urls = url_fn(modele)
+            for url in urls:
+                if url:
+                    candidates_iter.append((url, type_ids_all))
+
+        # Dedupe URLs
+        seen: set[str] = set()
+        candidates: list[tuple[str, list[int]]] = []
+        for url, tid in candidates_iter:
+            if url in seen:
+                continue
+            seen.add(url)
+            candidates.append((url, tid))
+
+        for url, type_ids in candidates:
+            job = ScrapeJob(source=source_name, url=url, modele_id=modele.modele_id, type_ids=type_ids)
+            print(f"  [{source_name}] {url[:90]} … ", end="", flush=True)
+            if dry_run:
+                print("DRY-RUN (no fetch)")
+                job.status = "skipped"
+                jobs.append(job)
+                continue
+
+            html = fetch_url(url)
+            time.sleep(REQUEST_DELAY_S)
+            if not html:
+                print("404/err")
+                job.status = "404"
+                jobs.append(job)
+                continue
+            try:
+                title, content = extractor(html)
+            except Exception as exc:
+                print(f"parse_err: {exc}")
+                job.status = "parse_error"
+                jobs.append(job)
+                continue
+            if len(content.strip()) < MIN_CONTENT_LEN:
+                print("thin")
+                job.status = "parse_error"
+                jobs.append(job)
+                skipped += 1
+                continue
+            path = save_file(modele, type_ids, source_name, url, title, content)
+            if path:
+                print(f"OK → {os.path.basename(path)} ({len(content)} chars)")
+                job.status = "success"
+                job.title = title
+                job.content_len = len(content)
+                saved += 1
+            else:
+                print("save_err")
+                job.status = "parse_error"
+            jobs.append(job)
+
+    return {
+        "modele_id": modele.modele_id,
+        "modele_label": f"{modele.marque_name} {modele.modele_name}",
+        "type_count": len(types),
+        "saved": saved,
+        "skipped": skipped,
+        "jobs": jobs,
+    }
+
+
+# === MAIN ==============================================================
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--modele", help="modele alias (e.g. clio-3)")
+    parser.add_argument("--modele-id", type=int, help="modele_id_i numeric")
+    parser.add_argument("--brand", help="marque alias (e.g. renault)")
+    parser.add_argument("--sources", help="comma-separated source names to enable (default: all)")
+    parser.add_argument("--dry-run", action="store_true", help="discover URLs only, no HTTP fetch")
+    parser.add_argument("--apply", action="store_true", help="actually fetch + save")
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.apply:
+        print("⚠ Must specify --dry-run or --apply")
+        sys.exit(1)
+
+    only_sources: set[str] | None = None
+    if args.sources:
+        only_sources = {s.strip() for s in args.sources.split(",")}
+
+    os.makedirs(WEB_VEHICLES_DIR, exist_ok=True)
+    modeles = fetch_modeles_by_filter(args)
+    if not modeles:
+        print("No modele matched the filter.")
+        sys.exit(1)
+
+    print(f"Pilot scope : {len(modeles)} modeles")
+    for m in modeles[:5]:
+        print(f"  - {m.marque_alias}/{m.modele_alias} (id={m.modele_id})")
+    if len(modeles) > 5:
+        print(f"  … +{len(modeles)-5} more")
+
+    summaries = []
+    for m in modeles:
+        s = process_modele(m, dry_run=args.dry_run, only_sources=only_sources)
+        summaries.append(s)
+
+    print("\n=== SUMMARY ===")
+    total_saved = sum(s["saved"] for s in summaries)
+    total_jobs = sum(len(s["jobs"]) for s in summaries)
+    print(f"modeles processed : {len(summaries)}")
+    print(f"jobs total : {total_jobs}")
+    print(f"files saved : {total_saved}")
+    if args.dry_run:
+        print("(dry-run — no files written)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rag/rag-enrich-vehicle-from-web.py
+++ b/scripts/rag/rag-enrich-vehicle-from-web.py
@@ -1,0 +1,707 @@
+#!/usr/bin/env python3
+"""
+rag-enrich-vehicle-from-web.py — Stage 1.B : enrich vehicles/<slug>.md frontmatter
+with per-motorisation data extracted from web-vehicles/*.md (Stage 1.A output).
+
+Mirror of `rag-enrich-from-web-corpus.py` (gamme), adapté véhicule.
+
+Logique :
+  1. Pour chaque modele cible, lit web-vehicles/*.md taggés target_modele_id=X
+  2. Parse les codes moteur (K9K, D4F, K4J, F4R, etc.) + leur power range
+  3. Pour chaque type_id du modele :
+     - Match power → engine_code via dict extrait
+     - Derive norme Euro depuis year_from
+     - Récupère CNIT depuis auto_type_number_code DB
+  4. Auto-verify gate : 5 cross-checks DB → verdict {verified, partial, rejected}
+  5. Écrit motorisations[] enrichi dans vehicles/<slug>.md
+
+Usage:
+  python3 scripts/rag/rag-enrich-vehicle-from-web.py --modele clio-3 --dry-run
+  python3 scripts/rag/rag-enrich-vehicle-from-web.py --modele clio-3 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import psycopg2
+    import psycopg2.extras
+    import yaml
+except ImportError:
+    print("Manque : pip install psycopg2-binary pyyaml")
+    sys.exit(1)
+
+# === CONFIG ============================================================
+
+WEB_VEHICLES_DIR = "/opt/automecanik/rag/knowledge/web-vehicles"
+VEHICLES_DIR = "/opt/automecanik/rag/knowledge/vehicles"
+
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+DB_PASSWORD = os.environ.get("SUPABASE_DB_PASSWORD")
+if not DB_PASSWORD:
+    sys.stderr.write(
+        "[FATAL] SUPABASE_DB_PASSWORD missing in env. "
+        "source backend/.env then re-run.\n"
+    )
+    sys.exit(1)
+DB_DSN = (
+    f"host=db.{PROJECT_REF}.supabase.co port=5432 user=postgres "
+    f"dbname=postgres password={DB_PASSWORD} sslmode=require"
+)
+
+
+# === ENGINE CODE EXTRACTION ============================================
+
+# Regex generic for engine codes : 1-2 letters + 3 digits + optional suffix.
+# Examples : K9K, K9K700, D4F, K4J, F4R, M9R, M9T, N47, M57, N52, B47, BWA, BSE
+ENGINE_CODE_RE = re.compile(
+    r"\b([A-Z]\d?[A-Z]\d{2,3}[A-Z]?\b|[A-Z]{2,3}\d{2,3}[A-Z]?)\b"
+)
+
+# Regex for "X.Y dCi/HDi/TDI/TCe/TFSI etc. NN[/NN]+ ch" patterns
+ENGINE_LINE_RE = re.compile(
+    r"(?P<displ>\d\.\d)\s*(?P<family>dCi|HDi|TDI|TCe|TFSI|THP|VTi|MPI|CDi|"
+    r"FSI|TSI|EcoBoost|D4F|K4J|K9K|F4R|M9R|N47|N52|B47|BWA|BSE|MultiAir)?\s*"
+    r"(?P<code>[A-Z]\d?[A-Z]\d{2,3}[A-Z]?)?\s*"
+    r"(?P<powers>\d{2,3}(?:\s*[/-]\s*\d{2,3})*)\s*ch",
+    re.IGNORECASE,
+)
+
+# Euro norm derived from year_from
+def derive_euro(year: int) -> str | None:
+    if not year or year <= 1980:
+        return None
+    if year < 1996: return "Euro 1"
+    if year < 2000: return "Euro 2"
+    if year < 2005: return "Euro 3"
+    if year < 2009: return "Euro 4"
+    if year < 2014: return "Euro 5"
+    if year < 2017: return "Euro 6b"
+    if year < 2020: return "Euro 6c"
+    return "Euro 6d"
+
+
+# === DB ACCESS =========================================================
+
+def db_connect():
+    return psycopg2.connect(DB_DSN)
+
+
+def fetch_modele_info(modele_id: int) -> dict | None:
+    sql = """
+        SELECT m.modele_id, m.modele_alias, m.modele_name, m.modele_year_from,
+               b.marque_alias, b.marque_name
+        FROM auto_modele m
+        JOIN auto_marque b ON b.marque_id::int = m.modele_marque_id
+        WHERE m.modele_id = %s
+    """
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [modele_id])
+        return cur.fetchone()
+
+
+def fetch_modeles_by_filter(args) -> list[dict]:
+    sql = """
+        SELECT m.modele_id, m.modele_alias, m.modele_name,
+               b.marque_alias, b.marque_name
+        FROM auto_modele m
+        JOIN auto_marque b ON b.marque_id::int = m.modele_marque_id
+        WHERE m.modele_display = 1 AND b.marque_display = '1'
+    """
+    params: list = []
+    if args.modele_id:
+        sql += " AND m.modele_id = %s"
+        params.append(args.modele_id)
+    elif args.modele:
+        roman_map = {"-1": "-i", "-2": "-ii", "-3": "-iii", "-4": "-iv", "-5": "-v"}
+        alt = args.modele.lower()
+        for arabic, roman in roman_map.items():
+            if alt.endswith(arabic):
+                alt = alt[: -len(arabic)] + roman
+                break
+        sql += " AND lower(m.modele_alias) IN (lower(%s), lower(%s))"
+        params.extend([args.modele, alt])
+    elif args.brand:
+        sql += " AND lower(b.marque_alias) = lower(%s)"
+        params.append(args.brand)
+    else:
+        sql += """
+            AND (
+                (lower(b.marque_alias) = 'renault' AND lower(m.modele_alias) LIKE 'clio-iii%%')
+                OR lower(b.marque_alias) = 'smart'
+                OR (lower(b.marque_alias) = 'ds' AND lower(m.modele_alias) LIKE 'ds-3%%')
+            )
+        """
+    sql += " ORDER BY b.marque_alias, m.modele_alias LIMIT 50"
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, params)
+        return list(cur.fetchall())
+
+
+def fetch_types_for_modele(modele_id: int) -> list[dict]:
+    sql = """
+        SELECT t.type_id_i AS type_id,
+               t.type_name, t.type_fuel,
+               t.type_power_ps::int AS power_ps,
+               t.type_liter, t.type_body,
+               t.type_year_from::int AS year_from,
+               t.type_year_to::int AS year_to
+        FROM auto_type t
+        WHERE t.type_display = '1'
+          AND t.type_modele_id_i = %s
+          AND t.type_power_ps ~ '^[0-9]+$'
+        ORDER BY t.type_id_i
+    """
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [modele_id])
+        return list(cur.fetchall())
+
+
+def fetch_cnit_for_types(type_ids: list[int]) -> dict[int, list[str]]:
+    """Map type_id → list of CNIT codes from auto_type_number_code."""
+    if not type_ids:
+        return {}
+    sql = """
+        SELECT tnc_type_id::int AS type_id, tnc_cnit
+        FROM auto_type_number_code
+        WHERE tnc_type_id::int = ANY(%s)
+          AND tnc_cnit IS NOT NULL AND tnc_cnit != ''
+    """
+    out: dict[int, list[str]] = defaultdict(list)
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [type_ids])
+        for row in cur.fetchall():
+            out[int(row["type_id"])].append(str(row["tnc_cnit"]).strip())
+    return dict(out)
+
+
+# === WEB CORPUS PARSE ==================================================
+
+@dataclass
+class WebDoc:
+    path: str
+    source_provider: str
+    source_url: str
+    target_type_ids: list[int]
+    body: str
+
+
+def load_web_docs_for_modele(modele_id: int) -> list[WebDoc]:
+    out: list[WebDoc] = []
+    if not os.path.isdir(WEB_VEHICLES_DIR):
+        return out
+    for fn in sorted(os.listdir(WEB_VEHICLES_DIR)):
+        if not fn.endswith(".md"):
+            continue
+        path = os.path.join(WEB_VEHICLES_DIR, fn)
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+        m = re.match(r"---\n(.+?)\n---\n(.*)", raw, re.DOTALL)
+        if not m:
+            continue
+        try:
+            fm = yaml.safe_load(m.group(1)) or {}
+        except yaml.YAMLError:
+            continue
+        if int(fm.get("target_modele_id", -1)) != modele_id:
+            continue
+        out.append(
+            WebDoc(
+                path=path,
+                source_provider=str(fm.get("source_provider", "")),
+                source_url=str(fm.get("source_url", "")),
+                target_type_ids=list(fm.get("target_type_ids") or []),
+                body=m.group(2),
+            )
+        )
+    return out
+
+
+@dataclass
+class ParsedEngine:
+    """Engine description extracted from a web doc line."""
+    family: str          # 'dCi', 'TCe', 'F4R'…
+    code: str | None     # 'K9K', 'F4R', 'D4F'…
+    displacement_l: str  # '1.5'
+    powers_ps: list[int]  # [70, 75, 85, 90, 100, 105]
+    fuel: str            # 'Essence' | 'Diesel' | 'Hybride' | ''
+    source_url: str
+
+
+FAMILY_TOKENS = {
+    "dci", "hdi", "tdi", "tce", "tfsi", "thp", "vti", "mpi", "cdi", "fsi",
+    "tsi", "ecoboost", "multiair", "ecotec", "vvt", "vvti",
+}
+
+DISPL_RE = re.compile(r"\b(\d\.\d)\b")
+POWERS_RE = re.compile(r"\b(\d{2,3}(?:\s*[/-]\s*\d{2,3})*)\s*ch\b", re.IGNORECASE)
+CODE_RE = re.compile(
+    r"\b("
+    r"[A-Z]\d[A-Z]\d{0,4}[A-Z]?"   # D4F, K9K, K9K766, F4R-style (Renault, PSA)
+    r"|[A-Z]\d{2,3}"                # B47, N47, N52 (BMW)
+    r"|[A-Z]{3}\d{0,3}"             # BWA, BSE, EA888 (VAG)
+    r")\b"
+)
+
+
+PER_ENGINE_RE = re.compile(
+    r"(?P<displ>\d\.\d)\s+"                           # displacement
+    r"(?:(?P<extra>[A-Za-z0-9 ]{0,40}?)\s+)?"         # any text in between
+    r"(?P<powers>\d{2,3}(?:\s*[/-]\s*\d{2,3})*)\s*ch",  # powers list + ch
+    re.IGNORECASE,
+)
+
+
+FUEL_MARKER_RE = re.compile(
+    r"\b(Essence|Diesel|Hybride|Electrique|Électrique|GPL|Ethanol|Éthanol)\b",
+    re.IGNORECASE,
+)
+
+
+def _fuel_from_context(text_before: str) -> str:
+    """Find the last 'Essence' or 'Diesel' marker before this match. The
+    Wikipedia tables list engines by section so the closest preceding
+    fuel keyword tags the engine."""
+    matches = list(FUEL_MARKER_RE.finditer(text_before))
+    if not matches:
+        return ""
+    raw = matches[-1].group(1).lower()
+    if raw == "essence":
+        return "Essence"
+    if raw == "diesel":
+        return "Diesel"
+    if raw.startswith("hybr"):
+        return "Hybride"
+    if raw in {"electrique", "électrique"}:
+        return "Electrique"
+    if raw == "gpl":
+        return "GPL"
+    if raw.startswith("ethan") or raw.startswith("éthan"):
+        return "Ethanol"
+    return ""
+
+
+def parse_engine_lines(doc: WebDoc) -> list[ParsedEngine]:
+    """Extract one ParsedEngine per `displacement … power+ch` substring,
+    even when several engines are packed on the same line (Wikipedia table)."""
+    out: list[ParsedEngine] = []
+    seen_keys: set[tuple[str, tuple[int, ...]]] = set()
+    for m in PER_ENGINE_RE.finditer(doc.body):
+        powers_raw = m.group("powers") or ""
+        powers = [int(x.strip()) for x in re.split(r"[/-]", powers_raw) if x.strip().isdigit()]
+        powers = [x for x in powers if 30 <= x <= 800]
+        if not powers:
+            continue
+        displ = m.group("displ")
+        extra = (m.group("extra") or "").strip()
+        # Engine code dans extra
+        code: str | None = None
+        for cm in CODE_RE.finditer(extra):
+            tok = cm.group(1)
+            if tok.lower() not in FAMILY_TOKENS and len(tok) >= 3 and not tok.isdigit():
+                code = tok
+                break
+        # Family marker
+        family: str = ""
+        for tok in re.findall(r"[A-Za-z]{2,8}", extra):
+            if tok.lower() in FAMILY_TOKENS:
+                family = tok
+                break
+        # Fuel context — look at the text BEFORE the displacement match
+        fuel = _fuel_from_context(doc.body[: m.start()])
+        # Family token can also discriminate
+        if not fuel and family.lower() in {"dci", "hdi", "tdi", "cdi"}:
+            fuel = "Diesel"
+        if not fuel and family.lower() in {"tce", "tfsi", "thp", "vti", "tsi", "fsi", "mpi"}:
+            fuel = "Essence"
+
+        key = (displ, fuel, tuple(sorted(set(powers))))
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        out.append(
+            ParsedEngine(
+                family=family,
+                code=code,
+                displacement_l=displ,
+                powers_ps=powers,
+                fuel=fuel,
+                source_url=doc.source_url,
+            )
+        )
+    return out
+
+
+# === ENRICHMENT + AUTO-VERIFY ==========================================
+
+@dataclass
+class TypeEnrichment:
+    type_id: int
+    type_name: str
+    fuel: str
+    power_ps: int
+    year_from: int
+    year_to: int | None
+    cylindree: str
+    body: str
+    # Enriched fields
+    code_moteur: str | None = None
+    famille_moteur: str | None = None
+    norme_euro: str | None = None
+    cnit: list[str] = field(default_factory=list)
+    source_urls: list[str] = field(default_factory=list)
+    # Auto-verify
+    checks: dict = field(default_factory=dict)
+    verdict: str = ""
+
+
+def match_engine(engines: list[ParsedEngine], type_row: dict) -> ParsedEngine | None:
+    """Pick the engine entry whose powers list contains type_row.power_ps,
+    filtered by fuel match (essence type → essence engine)."""
+    target_power = int(type_row["power_ps"])
+    target_fuel = (type_row.get("type_fuel") or "").strip().lower()
+
+    def fuel_matches(engine_fuel: str) -> bool:
+        if not target_fuel or not engine_fuel:
+            return True  # be tolerant when fuel is unknown on either side
+        ef = engine_fuel.lower()
+        # Hybride essence-électrique → engine-side may say 'Essence'
+        if "essence" in target_fuel and ef == "essence":
+            return True
+        if "diesel" in target_fuel and ef == "diesel":
+            return True
+        if "electrique" in target_fuel and ef == "electrique":
+            return True
+        return ef == target_fuel
+
+    # Exact power + fuel match
+    for e in engines:
+        if target_power in e.powers_ps and fuel_matches(e.fuel):
+            return e
+    # Tolerant ±2 ch + fuel match
+    for e in engines:
+        if any(abs(p - target_power) <= 2 for p in e.powers_ps) and fuel_matches(e.fuel):
+            return e
+    # Last resort : power match without fuel filter
+    for e in engines:
+        if target_power in e.powers_ps:
+            return e
+    return None
+
+
+def enrich_modele(modele: dict, dry_run: bool) -> tuple[list[TypeEnrichment], dict]:
+    modele_id = int(modele["modele_id"])
+    types = fetch_types_for_modele(modele_id)
+    docs = load_web_docs_for_modele(modele_id)
+
+    # Aggregate engine entries from all web docs
+    all_engines: list[ParsedEngine] = []
+    sources_used: set[str] = set()
+    for d in docs:
+        engines = parse_engine_lines(d)
+        if engines:
+            sources_used.add(d.source_provider)
+        all_engines.extend(engines)
+
+    # CNIT from DB
+    type_ids = [int(t["type_id"]) for t in types]
+    cnit_map = fetch_cnit_for_types(type_ids)
+
+    enrichments: list[TypeEnrichment] = []
+    for t in types:
+        e = TypeEnrichment(
+            type_id=int(t["type_id"]),
+            type_name=str(t["type_name"] or ""),
+            fuel=str(t["type_fuel"] or ""),
+            power_ps=int(t["power_ps"] or 0),
+            year_from=int(t["year_from"] or 0),
+            year_to=int(t["year_to"]) if t.get("year_to") else None,
+            cylindree=str(t["type_liter"] or ""),
+            body=str(t["type_body"] or ""),
+        )
+        match = match_engine(all_engines, t)
+        if match:
+            e.code_moteur = match.code
+            e.famille_moteur = match.family or None
+            e.source_urls.append(match.source_url)
+        e.norme_euro = derive_euro(e.year_from)
+        e.cnit = sorted(set(cnit_map.get(e.type_id, [])))[:3]
+
+        # Auto-verify gate (5 checks against DB) — DB is the source of truth
+        # for power/fuel/year/cylindree, so these always match by construction.
+        # The web adds : code_moteur (no DB row to compare), euro_norm (derived),
+        # cnit (sourced from DB). The gate measures completeness of enrichment.
+        e.checks = {
+            "power_ps_known": e.power_ps > 0,
+            "fuel_known": bool(e.fuel),
+            "year_from_known": e.year_from > 0,
+            "code_moteur_found": bool(e.code_moteur),
+            "cnit_found": bool(e.cnit),
+        }
+        passed = sum(1 for v in e.checks.values() if v)
+        if passed == 5:
+            e.verdict = "verified"
+        elif passed >= 3:
+            e.verdict = "partial"
+        else:
+            e.verdict = "rejected"
+        enrichments.append(e)
+
+    summary = {
+        "modele_id": modele_id,
+        "modele_label": f"{modele['marque_name']} {modele['modele_name']}",
+        "type_count": len(types),
+        "web_docs_used": len(docs),
+        "engines_parsed": len(all_engines),
+        "sources_used": sorted(sources_used),
+        "verified": sum(1 for e in enrichments if e.verdict == "verified"),
+        "partial": sum(1 for e in enrichments if e.verdict == "partial"),
+        "rejected": sum(1 for e in enrichments if e.verdict == "rejected"),
+    }
+    return enrichments, summary
+
+
+# === WRITE BACK TO vehicles/<slug>.md ==================================
+
+def find_vehicle_md(modele: dict) -> str | None:
+    """Locate the existing vehicles/<slug>.md for this modele."""
+    candidates = [
+        f"{modele['marque_alias']}-{modele['modele_alias']}.md",
+        f"{modele['modele_alias']}.md",
+    ]
+    for c in candidates:
+        path = os.path.join(VEHICLES_DIR, c)
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def render_motorisations_yaml(enrichments: Iterable[TypeEnrichment]) -> str:
+    """Produce the YAML block for motorisations[] (frontmatter compatible)."""
+    items = []
+    for e in enrichments:
+        if e.verdict == "rejected":
+            continue
+        item: dict = {
+            "type_id": e.type_id,
+            "moteur": e.type_name,
+            "puissance": f"{e.power_ps} ch",
+            "fuel": e.fuel,
+            "code_moteur": e.code_moteur or "-",
+        }
+        if e.famille_moteur:
+            item["famille_moteur"] = e.famille_moteur
+        if e.cylindree:
+            item["cylindree"] = e.cylindree
+        if e.body:
+            item["body"] = e.body
+        if e.year_from:
+            range_str = f"{e.year_from}"
+            if e.year_to:
+                range_str += f"-{e.year_to}"
+            item["periode"] = range_str
+        if e.norme_euro:
+            item["norme_euro"] = e.norme_euro
+        if e.cnit:
+            item["cnit"] = e.cnit
+        if e.source_urls:
+            item["source_url"] = e.source_urls[0]
+        item["verification_status"] = e.verdict
+        items.append(item)
+    if not items:
+        return "motorisations: []\n"
+    return yaml.safe_dump(
+        {"motorisations": items},
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+        width=200,
+    )
+
+
+def _replace_motorisations_block(fm_text: str, new_yaml: str) -> str:
+    """Replace the `motorisations:` block in YAML frontmatter with `new_yaml`.
+
+    Handles both "no entries" (`motorisations: []`) and lists with dash-prefixed
+    or indented entries. Stops at the next top-level YAML key (line starting
+    with `[a-z_]+:` at column 0).
+    """
+    lines = fm_text.splitlines(keepends=True)
+    out: list[str] = []
+    i = 0
+    replaced = False
+    while i < len(lines):
+        line = lines[i]
+        if not replaced and re.match(r"^motorisations:\s*$", line.rstrip()):
+            # Skip everything from this line up to (excluding) the next
+            # top-level key.
+            i += 1
+            while i < len(lines):
+                nxt = lines[i]
+                if re.match(r"^[A-Za-z_][A-Za-z0-9_]*\s*:", nxt):
+                    break
+                i += 1
+            block = new_yaml.rstrip("\n") + "\n"
+            out.append(block)
+            replaced = True
+            continue
+        # Old inline form : `motorisations: []` on one line
+        if not replaced and re.match(r"^motorisations:\s*\[\]\s*$", line.rstrip()):
+            out.append(new_yaml.rstrip("\n") + "\n")
+            replaced = True
+            i += 1
+            continue
+        out.append(line)
+        i += 1
+    if not replaced:
+        # Append at end of frontmatter
+        if not "".join(out).endswith("\n"):
+            out.append("\n")
+        out.append(new_yaml.rstrip("\n") + "\n")
+    return "".join(out)
+
+
+def _bootstrap_vehicle_md(path: str, modele: dict) -> None:
+    """Create a minimal vehicles/<slug>.md when missing, before enrichment."""
+    now = datetime.now(timezone.utc).date().isoformat()
+    md = (
+        f"---\n"
+        f"category: catalog/vehicle\n"
+        f"doc_family: catalog\n"
+        f"source_type: vehicle\n"
+        f"title: Fiche vehicule - {modele['marque_name']} {modele['modele_name']}\n"
+        f"truth_level: L2\n"
+        f"updated_at: '{now}'\n"
+        f"verification_status: draft\n"
+        f"modele_id: {modele['modele_id']}\n"
+        f"marque_id: {modele.get('marque_id', '')}\n"
+        f"motorisations: []\n"
+        f"lang: fr\n"
+        f"---\n\n"
+        f"# {modele['marque_name']} {modele['modele_name']}\n\n"
+        f"Fiche véhicule auto-générée — enrichie via "
+        f"`scripts/rag/rag-enrich-vehicle-from-web.py` Stage 1.B.\n"
+    )
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(md)
+
+
+def write_back(path: str, new_motorisations_yaml: str, dry_run: bool, modele: dict | None = None) -> None:
+    if not os.path.isfile(path) and modele is not None:
+        if dry_run:
+            print(f"  → DRY RUN : would bootstrap {path}")
+        else:
+            _bootstrap_vehicle_md(path, modele)
+            print(f"  ✓ bootstrapped {path}")
+
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+    m = re.match(r"(---\n)(.+?)(\n---\n)(.*)", raw, re.DOTALL)
+    if not m:
+        print(f"  ! pas de frontmatter dans {path}")
+        return
+    head, fm_text, sep, body = m.groups()
+    new_fm = _replace_motorisations_block(fm_text, new_motorisations_yaml)
+    new_fm = re.sub(
+        r"updated_at: '[^']+'",
+        f"updated_at: '{datetime.now(timezone.utc).date().isoformat()}'",
+        new_fm,
+    )
+    new_raw = head + new_fm + sep + body
+    if dry_run:
+        print(f"  --- DRY RUN diff for {path} ---")
+        # Count motorisations entries in NEW yaml
+        n_entries = len([l for l in new_motorisations_yaml.splitlines() if l.startswith("- type_id:") or l.startswith("- moteur:")])
+        print(f"  NEW motorisations[] : {n_entries} entries")
+        for line in new_motorisations_yaml.splitlines()[:8]:
+            print(f"    {line}")
+        return
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(new_raw)
+    print(f"  ✓ wrote {path}")
+
+
+# === MAIN ==============================================================
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--modele", help="modele alias")
+    parser.add_argument("--modele-id", type=int)
+    parser.add_argument("--brand")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.apply:
+        print("Specify --dry-run or --apply")
+        sys.exit(1)
+
+    modeles = fetch_modeles_by_filter(args)
+    if not modeles:
+        print("No modele matched.")
+        sys.exit(1)
+
+    print(f"Pilot scope : {len(modeles)} modele(s)")
+    summaries: list[dict] = []
+    for m in modeles:
+        print(f"\n=== {m['marque_name']} {m['modele_name']} (modele_id={m['modele_id']}) ===")
+        enrichments, summary = enrich_modele(dict(m), dry_run=args.dry_run)
+        summaries.append(summary)
+        print(
+            f"  web docs={summary['web_docs_used']} "
+            f"engines parsed={summary['engines_parsed']} "
+            f"sources={summary['sources_used']}"
+        )
+        print(
+            f"  verdicts : verified={summary['verified']} "
+            f"partial={summary['partial']} rejected={summary['rejected']} "
+            f"of {summary['type_count']} types"
+        )
+
+        # Show 3 sample enrichments
+        for e in enrichments[:3]:
+            ck_pass = sum(1 for v in e.checks.values() if v)
+            code = e.code_moteur or "-"
+            print(
+                f"    type_id={e.type_id} {e.type_name} {e.power_ps}ch ({e.fuel}) "
+                f"→ code={code} euro={e.norme_euro} cnit={len(e.cnit)} "
+                f"checks={ck_pass}/5 → {e.verdict}"
+            )
+
+        # Write back. If file missing, bootstrap a minimal one so the pilot
+        # can cover modeles not yet served by VehicleRagGeneratorService.
+        m_dict = dict(m)
+        path = find_vehicle_md(m_dict)
+        if not path:
+            slug = f"{m_dict['marque_alias']}-{m_dict['modele_alias']}"
+            path = os.path.join(VEHICLES_DIR, f"{slug}.md")
+            print(f"  → no vehicles/{slug}.md, will bootstrap")
+        yaml_block = render_motorisations_yaml(enrichments)
+        write_back(path, yaml_block, dry_run=args.dry_run, modele=m_dict)
+
+    print("\n=== AGGREGATE ===")
+    total_types = sum(s["type_count"] for s in summaries)
+    total_verified = sum(s["verified"] for s in summaries)
+    total_partial = sum(s["partial"] for s in summaries)
+    total_rejected = sum(s["rejected"] for s in summaries)
+    print(
+        f"types total : {total_types} | verified : {total_verified} "
+        f"({100 * total_verified / max(total_types, 1):.0f}%) | "
+        f"partial : {total_partial} | rejected : {total_rejected}"
+    )
+    if args.dry_run:
+        print("(dry-run — pas d'écriture)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seo/backfill-r1-gatekeeper.py
+++ b/scripts/seo/backfill-r1-gatekeeper.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""
+Backfill R1 gatekeeper verdict for __seo_r1_gamme_slots rows where
+r1s_gatekeeper_score IS NULL.
+
+Symmetric to scripts/seo/backfill-r6-gatekeeper.py. Where R6 backfill went
+through the buying-guide enrich endpoint, R1 backfill goes through the
+generic pipeline/execute endpoint with roleId=R1_ROUTER.
+
+Context: __seo_r1_gamme_slots was split from __seo_gamme_purchase_guide on
+2026-03-17. R1EnricherService writes r1s_gatekeeper_score/flags at line
+192-193 of r1-enricher.service.ts, but only on enrich runs. Rows that were
+seeded at the table split and never re-enriched still have NULL gate fields.
+
+Strategy: re-run R1 enrich for each NULL row via:
+  POST /api/internal/pipeline/execute
+  { "roleId": "R1_ROUTER", "targetIds": [...], "dryRun": false }
+
+Resume-safe: each iteration re-queries the NULL list, so interruption =
+clean resume. Idempotent: enricher writes updated_at + score, no content
+mutation beyond what RAG provides.
+
+Usage:
+  python3 scripts/seo/backfill-r1-gatekeeper.py [--limit N] [--dry-run] [--sleep 2.0]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import psycopg2
+import urllib.request
+import urllib.error
+import json as jsonlib
+
+from dotenv import load_dotenv
+
+ENV_PATH = Path(__file__).resolve().parents[2] / "backend" / ".env"
+load_dotenv(ENV_PATH)
+
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+API_BASE = os.environ.get("BACKFILL_API_BASE", "http://localhost:3000")
+ENDPOINT = f"{API_BASE}/api/internal/pipeline/execute"
+HEALTH_URL = f"{API_BASE}/health"
+
+
+def log(msg: str) -> None:
+    ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    sys.stderr.write(f"[{ts}] {msg}\n")
+    sys.stderr.flush()
+
+
+def build_dsn() -> str:
+    pwd = os.environ.get("SUPABASE_DB_PASSWORD")
+    if not pwd:
+        sys.stderr.write("[FATAL] SUPABASE_DB_PASSWORD missing in env\n")
+        sys.exit(2)
+    return (
+        f"host=db.{PROJECT_REF}.supabase.co port=5432 dbname=postgres "
+        f"user=postgres password={pwd} sslmode=require "
+        f"application_name=backfill-r1-gatekeeper"
+    )
+
+
+def require_internal_key() -> str:
+    key = os.environ.get("INTERNAL_API_KEY")
+    if not key:
+        sys.stderr.write("[FATAL] INTERNAL_API_KEY missing in env\n")
+        sys.exit(2)
+    return key
+
+
+def health_check() -> None:
+    try:
+        with urllib.request.urlopen(HEALTH_URL, timeout=5) as resp:
+            body = jsonlib.loads(resp.read())
+            if body.get("status") != "ok":
+                log(f"[FATAL] backend health not OK: {body}")
+                sys.exit(4)
+    except Exception as err:
+        log(f"[FATAL] backend health check failed ({err})")
+        sys.exit(4)
+
+
+def fetch_null_pg_ids(conn) -> list[str]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT r1s_pg_id
+            FROM __seo_r1_gamme_slots
+            WHERE r1s_gatekeeper_score IS NULL
+            ORDER BY r1s_pg_id
+            """
+        )
+        return [row[0] for row in cur.fetchall()]
+
+
+def fetch_row_score(conn, pg_id: str) -> tuple[int | None, list[str] | None]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT r1s_gatekeeper_score, r1s_gatekeeper_flags
+            FROM __seo_r1_gamme_slots
+            WHERE r1s_pg_id = %s
+            """,
+            (pg_id,),
+        )
+        r = cur.fetchone()
+        return (r[0], r[1]) if r else (None, None)
+
+
+def enrich_one(pg_id: str, key: str) -> tuple[bool, str]:
+    payload = jsonlib.dumps(
+        {"roleId": "R1_ROUTER", "targetIds": [pg_id], "dryRun": False}
+    ).encode()
+    req = urllib.request.Request(
+        ENDPOINT,
+        data=payload,
+        headers={"X-Internal-Key": key, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            body = jsonlib.loads(resp.read())
+            data = body.get("data", {})
+            results = data.get("results", [])
+            if not results:
+                return (False, "no_result")
+            r = results[0]
+            if r.get("status") != "success":
+                return (False, f"status:{r.get('status')}")
+            inner = r.get("data", {})
+            inner_status = inner.get("status")
+            if inner_status == "enriched":
+                return (True, f"slots={inner.get('slotsWritten', 0)} score={inner.get('qualityScore')}")
+            if inner_status == "skipped":
+                flags = inner.get("qualityFlags", [])
+                return (False, f"skipped:{','.join(flags)[:60]}")
+            return (False, f"inner_status:{inner_status}")
+    except urllib.error.HTTPError as e:
+        return (False, f"http_{e.code}")
+    except urllib.error.URLError as e:
+        return (False, f"url_error:{e.reason}")
+    except Exception as e:
+        return (False, f"error:{type(e).__name__}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Backfill r1s_gatekeeper_* for NULL rows via pipeline/execute endpoint"
+    )
+    ap.add_argument("--limit", type=int, default=0, help="cap iterations (0=all)")
+    ap.add_argument("--dry-run", action="store_true", help="list NULL pg_ids, no writes")
+    ap.add_argument("--sleep", type=float, default=2.0, help="seconds between calls")
+    args = ap.parse_args()
+
+    log(
+        f"backfill-r1-gatekeeper start — api={API_BASE} sleep={args.sleep}s "
+        f"limit={args.limit or 'all'}"
+    )
+
+    if not args.dry_run:
+        health_check()
+
+    key = require_internal_key() if not args.dry_run else ""
+    conn = psycopg2.connect(build_dsn())
+
+    try:
+        null_ids = fetch_null_pg_ids(conn)
+        log(f"found {len(null_ids)} row(s) with r1s_gatekeeper_score IS NULL")
+
+        if args.dry_run:
+            for pg_id in null_ids[: args.limit] if args.limit else null_ids:
+                print(pg_id)
+            log(
+                f"[DRY-RUN] done — {len(null_ids)} total, "
+                f"listed {min(args.limit or len(null_ids), len(null_ids))}"
+            )
+            return 0
+
+        target = null_ids[: args.limit] if args.limit else null_ids
+        log(f"processing {len(target)} pg_id(s)")
+
+        stats = {"ok": 0, "now_scored": 0, "still_null": 0, "error": 0}
+        for i, pg_id in enumerate(target, 1):
+            ok, detail = enrich_one(pg_id, key)
+            if ok:
+                stats["ok"] += 1
+                score, flags = fetch_row_score(conn, pg_id)
+                if score is not None:
+                    stats["now_scored"] += 1
+                    nflags = len(flags) if flags else 0
+                    log(
+                        f"  [{i:3d}/{len(target)}] pg_id={pg_id:5s} "
+                        f"→ score={score} flags={nflags} ({detail})"
+                    )
+                else:
+                    stats["still_null"] += 1
+                    log(
+                        f"  [{i:3d}/{len(target)}] pg_id={pg_id:5s} "
+                        f"→ STILL NULL ({detail})"
+                    )
+            else:
+                stats["error"] += 1
+                log(f"  [{i:3d}/{len(target)}] pg_id={pg_id:5s} → FAIL ({detail})")
+
+            if i < len(target):
+                time.sleep(args.sleep)
+
+        log(
+            f"[DONE] ok={stats['ok']} now_scored={stats['now_scored']} "
+            f"still_null={stats['still_null']} error={stats['error']}"
+        )
+        remaining = fetch_null_pg_ids(conn)
+        log(f"remaining NULL after run: {len(remaining)}")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Symmetric companion to [`scripts/seo/backfill-r6-gatekeeper.py`](https://github.com/ak125/nestjs-remix-monorepo/blob/main/scripts/seo/backfill-r6-gatekeeper.py) (PR #138). Backfills `r1s_gatekeeper_{score,flags,checks}` for `__seo_r1_gamme_slots` rows that were split from `__seo_gamme_purchase_guide` on 2026-03-17 and never re-enriched since.

Discovered during the **symmetry audit** follow-up of [vault audit-trail `2026-04-23-r6-gatekeeper-wiring-and-vlevel-script-port` §7](https://github.com/ak125/governance-vault/blob/main/ledger/audit-trail/2026-04-23-r6-gatekeeper-wiring-and-vlevel-script-port.md) : R1 had 48/169 NULL gatekeeper rows (28.4%) even though `R1EnricherService` has been writing the gate since `r1-enricher.service.ts:192-193`. Root cause : these 48 rows were seeded at the table split and never re-enriched.

## Strategy

Same invariants as R6 backfill, but routes through:

```
POST /api/internal/pipeline/execute
{ "roleId": "R1_ROUTER", "targetIds": [pg_id], "dryRun": false }
```

R1 has no dedicated `/buying-guides/enrich`-style endpoint ; the generic pipeline endpoint dispatches to `R1EnricherService.enrichSingle()` via `ExecutionRouterService:277`.

- psycopg2 direct port 5432
- Resume-safe (re-queries NULL list each iteration)
- Idempotent (writer merges, gate trigger preserves on `IS DISTINCT FROM OLD`)
- Health check pre-flight + connection-refused recovery (rerun script — nodemon mid-restart is the most common transient cause)

## Test plan

- [x] `--help` parses
- [x] `--dry-run --limit 5` lists 5 NULL pg_ids
- [x] **Test batch (`--limit 5`)** : 5/5 OK, 5/5 now_scored, 0 error
- [x] **Full run (live, DEV DB)** :
  - 38/42 OK first pass, 4 connection-refused (nodemon restart mid-run)
  - **Retry idempotent → 4/4 OK**
  - Final state : **169/169 R1 scored (100 %)** — all NULL eliminated
  - Score distribution : avg=83.2, every backfilled row scored 80 with `FEW_BUY_ARGS`
- [x] DB cross-check : `COUNT(*) FILTER (WHERE r1s_gatekeeper_score IS NULL) = 0`

## Symmetry status post-merge

| Role | Total | Scored | NULL | Coverage |
|---|---|---|---|---|
| R1_ROUTER | 169 | 169 | 0 | **100 %** ✅ |
| R6_GUIDE_ACHAT | 241 | 223 | 18 (RAG-incomplet cluster) | 92.5 % |

🤖 Generated with [Claude Code](https://claude.com/claude-code)