### PR TITLE
fix(seo): write minimal R6 gatekeeper even when all sections are skipped

### DIFF
--- a/backend/src/modules/admin/services/buying-guide-enricher.service.ts
+++ b/backend/src/modules/admin/services/buying-guide-enricher.service.ts
@@ -220,6 +220,52 @@ export class BuyingGuideEnricherService {
       .map(([key]) => key);
 
     if (okSections.length === 0) {
+      // ── Metadata-only gatekeeper write ──
+      // Even when all RAG sections are skipped (anti-wiki / anti-dup / pollution),
+      // write the gate verdict so the row stops being NULL. NULL = "we don't know"
+      // is worse than {score, flags: [ALL_SECTIONS_SKIPPED]} = "known RAG-incomplete".
+      // The fn_invalidate_sgpg_gatekeeper trigger only fires on content changes,
+      // so this metadata-only write is safe.
+      const gatekeeper = this.qualityGates.computeGatekeeperScore({
+        sectionResults,
+        qualityFlags: uniqueFlags,
+        qualityScore,
+        antiWikiGate,
+      });
+      const gateOnlyPayload: Record<string, unknown> = {
+        sgpg_gatekeeper_score: gatekeeper.score,
+        sgpg_gatekeeper_flags: [...gatekeeper.flags, 'ALL_SECTIONS_SKIPPED'],
+        sgpg_gatekeeper_checks: {
+          ...gatekeeper.checks,
+          all_sections_skipped: true,
+        },
+        sgpg_source_verified: false,
+        sgpg_source_verified_by: 'pipeline:rag-enrich-skipped',
+        sgpg_source_verified_at: new Date().toISOString(),
+      };
+      const writeContext: WriteGuardContext | undefined = this.flags
+        .writeGuardEnabled
+        ? {
+            roleId: RoleId.R6_GUIDE_ACHAT,
+            correlationId: `enrich-skipped-${pgId}-${Date.now().toString(36)}`,
+          }
+        : undefined;
+      try {
+        await this.dbService.upsertBuyingGuide(
+          pgId,
+          gateOnlyPayload,
+          writeContext,
+        );
+        this.logger.log(
+          `Gatekeeper-only write for pgId=${pgId} (all sections skipped, RAG-incomplete cluster)`,
+        );
+      } catch (err) {
+        this.logger.error(
+          `Gatekeeper-only write failed for pgId=${pgId}: ${err instanceof Error ? err.message : err}`,
+        );
+        // Non-blocking: fall through to the early-return result
+      }
+
       return {
         pgId,
         sections: {},


### PR DESCRIPTION
## Summary

Closes follow-up **§7 #1** of [`2026-04-23-r6-gatekeeper-wiring-and-vlevel-script-port`](https://github.com/ak125/governance-vault/blob/main/ledger/audit-trail/2026-04-23-r6-gatekeeper-wiring-and-vlevel-script-port.md) — the 18 rows of `__seo_gamme_purchase_guide` that stayed NULL after the PR #138 backfill (RAG-incomplete cluster).

## Root cause

`BuyingGuideEnricherService.enrichSingle()` had an early-return at `if (okSections.length === 0)` BEFORE writing the gatekeeper. When all RAG sections were skipped (anti-wiki / anti-dup / pollution), the row was left untouched and the gatekeeper stayed NULL forever.

Cluster pg_ids : `26, 76, 141, 158, 170, 249, 259, 291, 292, 293, 294, 789, 807, 1362, 1365, 1375, 1787, 3220` (identified in [`2026-04-21-pipeline-content-hardening.md §P0.5.c1`](https://github.com/ak125/governance-vault/blob/main/ledger/audit-trail/2026-04-21-pipeline-content-hardening.md#L100-L120)).

## Fix

In the early-return path, write a metadata-only payload before returning:

```typescript
sgpg_gatekeeper_score    = <low penalty score>
sgpg_gatekeeper_flags    = [...quality_flags, 'ALL_SECTIONS_SKIPPED']
sgpg_gatekeeper_checks   = { ..., all_sections_skipped: true }
sgpg_source_verified     = false
sgpg_source_verified_by  = 'pipeline:rag-enrich-skipped'
sgpg_source_verified_at  = now()
```

NULL was "we don't know" — explicit verdict is "known RAG-incomplete, fix the `.md`". Operationally actionable.

Trigger `fn_invalidate_sgpg_gatekeeper` only fires on content-column changes, so this metadata-only write is preserved (no early-nulling).

WriteGuard ownership : R6_GUIDE_ACHAT × `purchase_guide_main`, field-catalog entries already added in #130.

Write errors are logged but **non-blocking** — early-return result unchanged on failure (worst-case parity with current behavior).

## Test plan

- [x] `tsc --noEmit -p backend/tsconfig.json` → `REAL_EXIT=0` (no errors)
- [ ] Live test on one NULL pg_id (e.g. pg_id=26) post-merge → expect `sgpg_gatekeeper_score = <low>`, `flags includes 'ALL_SECTIONS_SKIPPED'`
- [ ] Re-run [`scripts/seo/backfill-r6-gatekeeper.py`](https://github.com/ak125/nestjs-remix-monorepo/blob/main/scripts/seo/backfill-r6-gatekeeper.py) on the 18 NULL rows → expect 18/18 now_scored, 0 still_null
- [ ] DB cross-check : `COUNT(*) FILTER (WHERE sgpg_gatekeeper_score IS NULL) = 0` → R6 100 % scored

## Symmetry status post-merge

| Role | Total | Scored target | Status |
|---|---|---|---|
| R1_ROUTER | 169 | 169 (100 %) | already at 100 % (PR #178) |
| R6_GUIDE_ACHAT | 241 | 241 (100 %) | reachable after backfill of 18 RAG-incomplete |

🤖 Generated with [Claude Code](https://claude.com/claude-code)