### PR TITLE
fix(seo-monitoring): wire RContentAuditorService into module DI

### DIFF
--- a/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
+++ b/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
@@ -18,6 +18,7 @@ import { Ga4DailyFetcherService } from './services/ga4-daily-fetcher.service';
 import { CwvFetcherService } from './services/cwv-fetcher.service';
 import { GscLinksFetcherService } from './services/gsc-links-fetcher.service';
 import { AuditFindingsService } from './services/audit-findings.service';
+import { RContentAuditorService } from './services/r-content-auditor.service';
 import { SeoMonitoringController } from './controllers/seo-monitoring.controller';
 
 @Module({
@@ -30,6 +31,7 @@ import { SeoMonitoringController } from './controllers/seo-monitoring.controller
     CwvFetcherService,
     GscLinksFetcherService,
     AuditFindingsService,
+    RContentAuditorService,
   ],
   controllers: [SeoMonitoringController],
   exports: [
@@ -39,6 +41,7 @@ import { SeoMonitoringController } from './controllers/seo-monitoring.controller
     CwvFetcherService,
     GscLinksFetcherService,
     AuditFindingsService,
+    RContentAuditorService,
   ],
 })
 export class SeoMonitoringModule {}


### PR DESCRIPTION
## Summary

Backend fails to boot on `main` (since merge of #170/#174/#179) with NestJS DI error :

```
Nest can't resolve dependencies of the SeoMonitoringController
(GoogleCredentialsService, GscDailyFetcherService, Ga4DailyFetcherService,
AuditFindingsService, ?, ConfigService).
RContentAuditorService at index [4] is not available in SeoMonitoringModule context.
```

`SeoMonitoringController:25,37` injects `RContentAuditorService`. The service was added in the SEO-department phase 2 series but never registered in [`seo-monitoring.module.ts`](backend/src/modules/seo-monitoring/seo-monitoring.module.ts) providers.

## Fix

Add `RContentAuditorService` to:
- `import` (line 21)
- `providers` array
- `exports` array (consistent with sibling services exposed for cross-module usage)

`RContentAuditorService` depends on `ConfigService` (already provided via `ConfigModule` import) + `AuditFindingsService` (already a provider in same module). No further wiring needed.

## Test plan

- [x] `tsc --noEmit -p backend/tsconfig.json` → `EXIT=0`
- [x] **Backend boot test** : `PORT=3100 node dist/main.js` boots without DI error
  - `GET /health` → HTTP 200, `{"status":"ok"}`
  - All routes mapped successfully (Meilisearch warning unrelated)
- [ ] Post-merge : verify DEV pré-prod deploys cleanly

## Discovered while

Trying to backfill 18 R6 NULL rows post-PR #180 — local backend wouldn't start. Diagnosed root cause as missing DI registration. Single-line fix unblocks the rest of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)