### PR TITLE
refactor(skill): split seo-content-architect SKILL.md into references (-44% tokens)

### DIFF
--- a/.claude/skills/seo-content-architect/SKILL.md
+++ b/.claude/skills/seo-content-architect/SKILL.md
@@ -59,57 +59,18 @@ Tu n'es PAS :
 
 ### Phase 0 — Triage de contenu brut (SI contenu externe fourni)
 
-**Déclencheur** : L'utilisateur fournit un texte brut (copié-collé, PDF, sortie ChatGPT/Gemini, document tiers).
+**Déclencheur** : l'utilisateur fournit un texte brut (copié-collé, PDF, sortie ChatGPT/Gemini/Perplexity, document tiers).
 
-**Objectif** : Classifier chaque bloc du texte vers le rôle de page approprié AVANT la rédaction.
+**Objectif** : classifier chaque bloc vers le rôle de page approprié AVANT la rédaction. Phase 0 ne produit jamais de contenu rédigé — uniquement un rapport de triage + une recommandation d'ordre de production.
 
-**Étape 1 — Scanner et classifier**
+**Détail canonique** : voir [`references/triage-phase0.md`](references/triage-phase0.md) — déclencheurs, matrice de classification, règles d'arbitrage cas ambigus, template de rapport, edge cases observés.
 
-Pour chaque section/paragraphe du contenu brut, attribuer un rôle :
+**Règles invariantes (résumé) :**
 
-| Marqueurs détectés | Rôle cible | URL pattern |
-|---|---|---|
-| Définition, composition, rôle mécanique, "qu'est-ce que" | **R4 Reference** | `/reference-auto/{slug}` |
-| Symptômes, diagnostic, arbre de décision, codes DTC | **R5 Diagnostic** | (futur) |
-| Étapes de remplacement, démontage/remontage, outils, difficulté | **R3/conseils** | `/blog-pieces-auto/conseils/{alias}` |
-| Comment choisir, références OEM, checklist achat, marques | **R3/guide-achat** | `/blog-pieces-auto/guide-achat/{alias}` |
-| Sélection véhicule, variantes, filtrer par | **R1 Router** | `/pieces/{slug}-{pg_id}.html` |
-
-**Étape 2 — Produire le rapport de triage**
-
-```
-TRIAGE CONTENU BRUT — {nom_piece}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Source : {type — PDF/ChatGPT/copié-collé/autre}
-Sections analysées : {N}
-
-RÉPARTITION PAR RÔLE :
-• R3/conseils    : {X}% — {N} blocs (étapes, outils, erreurs)
-• R3/guide-achat : {X}% — {N} blocs (choix, références, checklist)
-• R4 Reference   : {X}% — {N} blocs (définition, composition)
-• R5 Diagnostic  : {X}% — {N} blocs (symptômes, causes)
-• R1 Router      : {X}% — {N} blocs (sélection véhicule)
-
-PROBLÈMES DÉTECTÉS :
-• Répétitions : {liste des blocs qui disent la même chose}
-• Incohérences : {contradictions entre blocs}
-• Vocabulaire mixte : {termes exclusifs de plusieurs rôles dans le même paragraphe}
-
-RECOMMANDATION :
-Rôle prioritaire : {rôle avec le % le plus élevé}
-→ Produire d'abord le contenu {rôle} avec /seo-content-architect {gamme}
-→ Les blocs {autres rôles} seront utilisés comme seed pour les autres pages
-```
-
-**Étape 3 — Demander confirmation**
-
-Avant de rédiger, présenter le rapport et demander :
-> "Le contenu brut couvre {N} rôles. Je recommande de commencer par {rôle prioritaire}. Les blocs des autres rôles seront conservés comme seed. On lance ?"
-
-**Règles Phase 0 :**
-- Ne JAMAIS produire un contenu qui mélange les rôles — toujours séparer
-- Les blocs classés dans un rôle différent du rôle cible sont ignorés (pas supprimés — conservés pour les autres pages)
-- Si > 50% du contenu ne correspond à aucun rôle → signaler "contenu non structuré" et proposer `/content-audit`
+- Ne JAMAIS produire un contenu qui mélange les rôles
+- Blocs hors rôle cible : conservés comme seed (pas supprimés)
+- Si > 50 % du contenu = INCLASSABLE → signaler "contenu non structuré" et proposer `/content-audit`
+- Confirmation explicite requise avant de passer Phase 1
 
 ### Phase 1 — Analyse (VISIBLE)
 

--- a/.claude/skills/seo-content-architect/SKILL.md
+++ b/.claude/skills/seo-content-architect/SKILL.md
@@ -130,95 +130,19 @@ Si GO AVEC RÉSERVES → les zones à vérifier utilisent des formulations condi
 
 ### Phase 1b — Vérification RAG (obligatoire si le sujet est une pièce/gamme)
 
-Avant toute rédaction portant sur une pièce automobile, exécuter ce workflow en 4 étapes :
+**Déclencheur** : la rédaction porte sur une pièce automobile (gamme du catalogue).
 
-#### Étape 1 — Récupérer le knowledge doc
+**Objectif** : ancrer le contenu sur le knowledge doc RAG vérifié, extraire les règles `domain.*` (v4) ou `mechanical_rules.*` (legacy), et qualifier la fraîcheur. Workflow en 4 étapes : (1) `POST /api/rag/search` avec `target_role`, (2) extraire règles du frontmatter YAML, (3) recherche complémentaire par section, (4) vérifier `updated_at`.
 
-Construire le slug depuis le nom de la gamme : "Disque de frein" → `disque-de-frein`
+**Détail canonique** : voir [`references/rag-verification.md`](references/rag-verification.md) — commandes curl, table truth_level/verification_status, mapping v4/legacy complet, formats `confusion_with` (array vs map), table de fraîcheur (3/6/12 mois).
 
-```bash
-# Recherche RAG avec role targeting (v2.5)
-# {ROLE} selon page cible : R1_ROUTER, R3_GUIDE, R4_REFERENCE, R5_DIAGNOSTIC
-curl -s -X POST http://localhost:3000/api/rag/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{nom_piece}", "limit": 5, "routing": {"target_role": "{ROLE}"}}' \
-  | jq '.results[] | {title, truth_level, updated_at, confidence_score, primary_role, purity_score, chunk_kind, source_path, page_contract_id, media_slots_hint}'
-```
+**Règles invariantes (résumé) :**
 
-**Décision selon les résultats :**
-
-| Résultat | truth_level | verification_status | Action |
-|----------|-------------|---------------------|--------|
-| Doc trouvé | L1 | verified | Fait dur — utiliser directement, citer sans qualification |
-| Doc trouvé | L2 | verified | Confirmé — utiliser directement |
-| Doc trouvé | L2 | draft | Utilisable avec prudence, vérifier cohérence |
-| Doc trouvé | L3 | verified | Curaté — formulation conditionnelle obligatoire |
-| Doc trouvé | L3/L4 | draft/pending | **REJETER** — traiter comme non-confirmé |
-| 0 résultats | — | — | Signaler l'absence, continuer avec données utilisateur/BDD. Ne rien inventer |
-
-#### Étape 2 — Extraire les règles du domaine (v4) / mechanical_rules (legacy)
-
-Chaque knowledge doc gamme contient un frontmatter YAML avec des règles. Détecter la version du schema :
-
-- **v4** : `rendering.quality.version === 'GammeContentContract.v4'` → lire `domain.*`
-- **Legacy** (v1/v3) : lire `mechanical_rules.*` + `purchase_guardrails.*`
-
-| Champ v4 | Champ legacy (fallback) | Usage dans la rédaction |
-|----------|------------------------|------------------------|
-| `domain.must_be_true` | `mechanical_rules.must_be_true` | Ces termes DOIVENT apparaître dans le contenu produit |
-| `domain.must_not_contain` | `mechanical_rules.must_not_contain_concepts` | JAMAIS dans le contenu — confusion sémantique |
-| `domain.confusion_with` | `mechanical_rules.confusion_with` | Générer un bloc "Ne pas confondre avec..." explicite |
-| `domain.role` | `mechanical_rules.role_summary` | Seed pour le H1/intro — reformuler, ne pas copier verbatim |
-| `domain.must_not_contain` | `purchase_guardrails.forbidden_terms` | Ajouter aux MOTS INTERDITS du contenu |
-| *(v4: implicite si crossGammes)* | `purchase_guardrails.requires_vehicle` | Si true, inclure "vérifiez la compatibilité véhicule" |
-
-**2 formats `confusion_with` (v4 = array uniquement, legacy = array ou map) :**
-
-Format array (v4 + legacy) :
-```yaml
-confusion_with:
-  - term: tambour de frein
-    difference: Le tambour utilise des mâchoires internes...
-```
-
-Format map (legacy uniquement) :
-```yaml
-confusion_with:
-  batterie:
-    key_difference: L'alternateur recharge la batterie...
-```
-
-Traiter les deux formats : pour chaque entrée, générer un bloc "Ne pas confondre avec {terme}" dans le contenu.
-
-#### Étape 3 — Recherche complémentaire par section
-
-Interroger la section correspondant au rôle de page cible :
-
-```bash
-# Recherche complementaire avec role targeting (v2.5)
-# Enrichir la query avec des mots-cles de section selon le role cible :
-# R3 Blog/guide → "guide achat choix selection" (+ injecter template de conseils-role.md §7)
-# R3 Blog/conseils → "entretien remplacement etapes" (+ injecter template de conseils-role.md §7)
-# R4 Reference  → "definition technique composants" (+ injecter concepts partages de r4-reference-role.md §8)
-# R5 Diagnostic → "symptomes diagnostic panne"
-curl -s -X POST http://localhost:3000/api/rag/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{nom_piece} {section_keywords}", "limit": 5, "routing": {"target_role": "{ROLE}"}}' \
-  | jq '.results[:3] | .[] | {title, truth_level, content, primary_role, chunk_kind}'
-```
-
-Consolider les résultats des étapes 1 et 3 pour constituer la base de rédaction.
-
-#### Étape 4 — Vérifier la fraîcheur (`updated_at`)
-
-Vérifier le champ `updated_at` dans le frontmatter YAML du knowledge doc :
-
-| Âge du doc | Statut | Action | Annotation |
-|------------|--------|--------|------------|
-| < 3 mois | Frais | Utiliser directement | Aucune |
-| 3-6 mois | Acceptable | Vérifier cohérence | Ajouter date dans provenance |
-| 6-12 mois | Stale | Pénalité -6 (STALE_SOURCE) | Annoter `[source datée de {mois}]`, proposer `/rag-ops ingest` |
-| > 12 mois | Obsolète | NE PAS utiliser les données chiffrées | **STOP** : proposer `/rag-ops ingest` avant rédaction |
+- truth_level L3/L4 + status `draft/pending` → **REJETER**, traiter comme non-confirmé
+- 0 résultats RAG → signaler, continuer avec données utilisateur/BDD, **ne rien inventer**
+- `domain.must_be_true` / `mechanical_rules.must_be_true` : termes obligatoires dans le contenu produit
+- `domain.must_not_contain` / `mechanical_rules.must_not_contain_concepts` : termes interdits absolus
+- `updated_at` > 12 mois → **STOP**, proposer `/rag-ops ingest` avant rédaction
 
 ### Phase 1c — Extraction des blocs v4 / page_contract (legacy)
 
@@ -258,205 +182,25 @@ Extraire les données pré-validées du frontmatter YAML du knowledge doc. Déte
 
 > **Pour les pages routeur gamme (R1_ROUTER)** : consulter `references/r1-router-role.md` pour le template des 4 sections (variantes gamme, justification sélecteur, guide sélecteur, promesse post-sélection), les 6 quality gates, le vocabulaire exclusif R1, et les 3 profils gamme (safety-critical / DIY-friendly / pro-only). Budget : 150 mots max.
 
-### Phase 1d — Enrichissement gamme.md v4 (si docs supplementaires disponibles)
+### Phase 1d — Enrichissement gamme.md v4 (si docs supplémentaires disponibles)
 
-**Declencheur** : Phase 1b a trouve des docs supplementaires (web/, pdf/, guides/) via la recherche RAG, ET le gamme.md presente des lacunes dans ses 5 blocs.
+**Déclencheur** : Phase 1b a trouvé des docs supplémentaires (web/, pdf/, guides/) ET le gamme.md présente des lacunes dans ses 5 blocs.
 
-**Objectif** : Enrichir le frontmatter YAML du fichier `gammes/{slug}.md` selon le **schema v4 (5 blocs)** AVANT de rediger, pour que le contenu soit fonde sur des donnees riches et verifiees.
+**Objectif** : enrichir le frontmatter YAML de `gammes/{slug}.md` selon le **schema v4 (5 blocs : domain, selection, diagnostic, maintenance, rendering)** AVANT la rédaction. Si le doc est en v1/v3, proposer la conversion v3→v4 d'abord. Validation humaine obligatoire avant écriture.
 
-> **Schema de reference** : `.spec/00-canon/gamme-md-schema.md` — source de verite pour la structure, les types, et les regles de chaque bloc.
+**Schema de référence** : `.spec/00-canon/gamme-md-schema.md` — source de vérité pour la structure, les types, et les règles de chaque bloc.
 
-#### Detection de version
+**Détail canonique** : voir [`references/gamme-enrichment.md`](references/gamme-enrichment.md) — détection de version, mapping v3→v4 complet, table d'extraction par bloc (21 lignes), template `_sources`, format diff YAML attendu, hard gates.
 
-| Version detectee | Action |
-|-----------------|--------|
-| `GammeContentContract.v4` | Enrichir selon les 5 blocs ci-dessous |
-| `GammeContentContract.v3` ou absent | Convertir en v4 PUIS enrichir (voir Etape 0) |
+**Règles invariantes (résumé) :**
 
-#### Etape 0 — Conversion v3 → v4 (si necessaire)
-
-Si le gamme.md est en v3 ou v1 (pas de `quality.version: GammeContentContract.v4`), proposer la conversion :
-
-```
-CONVERSION v3 → v4 proposee pour gammes/{slug}.md
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Mapping :
-  page_contract.symptoms → diagnostic.symptoms (ajouter id + severity)
-  page_contract.timing → maintenance.interval
-  page_contract.risk.costRange → selection.cost_range
-  page_contract.antiMistakes → selection.anti_mistakes
-  page_contract.howToChoose → selection.criteria
-  page_contract.faq → rendering.faq
-  mechanical_rules.must_be_true → domain.must_be_true
-  mechanical_rules.must_not_contain_concepts → domain.must_not_contain
-  mechanical_rules.confusion_with → domain.confusion_with
-  mechanical_rules.role_summary → domain.role
-
-Blocs a creer (absents en v3) :
-  - selection.checklist
-  - selection.brands
-  - diagnostic.causes (avec %)
-  - diagnostic.quick_checks
-  - maintenance.usage_factors
-  - maintenance.good_practices
-  - installation.* (si applicable)
-  - _sources (provenance)
-  - cross_gammes (relations)
-  - lifecycle
-
-Valider la conversion avant enrichissement ?
-```
-
-#### Etape 1 — Decouvrir les docs supplementaires
-
-```bash
-# Rechercher les docs non-gamme lies a cette piece
-curl -s -X POST http://localhost:3000/api/rag/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{nom_piece}", "limit": 10, "includeFullContent": true}' \
-  | jq '.results[] | select(.sourcePath | startswith("gammes/") | not) | {title, sourcePath, sourceType, score}'
-```
-
-Filtrer : garder uniquement les docs `web/`, `pdf/`, `guides/` avec `truth_level` L1 ou L2.
-
-#### Etape 2 — Lire et analyser le contenu complet
-
-Pour chaque doc supplementaire trouve, lire le fichier source :
-```
-/opt/automecanik/rag/knowledge/{source_path}
-```
-
-Extraire les donnees structurees pertinentes pour les **5 blocs v4** :
-
-| Donnee a extraire | Destination v4 | Critere d'extraction |
-|-------------------|----------------|---------------------|
-| Role mecanique detaille | `domain.role` (>80 chars) | Description fonctionnelle precise, sans verbe generique |
-| Termes techniques cles | `domain.must_be_true` | Vocabulaire metier obligatoire dans le contenu |
-| Confusions courantes | `domain.confusion_with` | Pieces proches ou causes confondues |
-| Pieces associees | `domain.related_parts` + `cross_gammes` | Mentions de pieces liees au remplacement |
-| Criteres de selection | `selection.criteria` (min 3) | Dimensions, types, compatibilites |
-| Checklist achat | `selection.checklist` (min 3) | Etapes verification avant commande |
-| Erreurs d'achat | `selection.anti_mistakes` (min 3) | Phrases "ne pas", "erreur", "eviter" |
-| Fourchette de cout | `selection.cost_range` | Montants en EUR avec unite (la paire, l'unite, le kit) |
-| Marques recommandees | `selection.brands` | Premium / equivalent / budget |
-| Symptomes de defaillance | `diagnostic.symptoms` (min 3) | Signes d'usure avec severity (confort/securite/immobilisation) |
-| Causes de panne | `diagnostic.causes` (min 2) | Ordonnees par frequence, % si connu |
-| Tests sans outil | `diagnostic.quick_checks` (min 2) | Verifications visuelles/manuelles |
-| Intervalles remplacement | `maintenance.interval` | Valeur + unite (km/mois/condition) + note |
-| Facteurs d'usure | `maintenance.usage_factors` | Conditions accelerant l'usure |
-| Bonnes pratiques | `maintenance.good_practices` | Gestes d'entretien preventif |
-| Interdits entretien | `maintenance.do_not` | Actions a ne jamais faire |
-| Etapes de montage | `installation.steps` (min 3) | Procedure pas a pas |
-| Outils necessaires | `installation.tools` | Liste outillage |
-| Erreurs de montage | `installation.common_errors` (min 2) | Erreurs de MONTAGE uniquement |
-| Questions frequentes | `rendering.faq` (min 4) | Q&A avec reponses sourcees |
-| Chiffres avec source | `rendering.arguments` | Claims chiffrees avec `source_ref` |
-
-#### Etape 2b — Registrer la provenance
-
-Pour chaque doc supplementaire utilise, ajouter une entree dans `_sources` :
-
-```yaml
-_sources:
-  {cle-unique}:                    # ex: bosch-2024, mopar-entretien
-    type: "manufacturer"|"norm"|"field-expertise"|"study"|"rag-doc"
-    doc: "{source_path}"           # chemin fichier RAG ou null
-    note: "{contexte en 1 phrase}" # optionnel
-```
-
-Les champs enrichis referencent la source via `source: "{cle}"` inline.
-
-#### Etape 3 — Proposer le diff YAML v4
-
-Presenter les enrichissements organises par bloc. Ne modifier QUE les champs absents ou insuffisants :
-
-```yaml
-# ENRICHISSEMENTS PROPOSES pour gammes/{slug}.md (schema v4)
-# Sources : {liste des docs avec titre abrege}
-# Blocs enrichis : {liste} / Blocs inchanges : {liste}
-
-_sources:  # +{N} nouvelles entrees
-  {cle}:
-    type: "{type}"
-    doc: "{path}"
-    note: "{contexte}"
-
-domain:  # Bloc A
-  role: "{enrichi si <80 chars}"
-  must_be_true:  # +{N}
-    - "{terme}" # [source: {cle}]
-  confusion_with:  # +{N}
-    - term: "{piece}"
-      difference: "{explication}" # [source: {cle}]
-  cross_gammes:  # NOUVEAU
-    - slug: "{gamme-liee}"
-      relation: "{type}"
-      context: "{explication}"
-
-selection:  # Bloc B
-  criteria:  # +{N}
-    - "{critere}" # [source: {cle}]
-  anti_mistakes:  # +{N}
-    - "{erreur}" # [source: {cle}]
-  cost_range:  # AVANT: absent → APRES: renseigne
-    min: {N}
-    max: {N}
-    currency: EUR
-    unit: "{unite}"
-    source: "{cle}"
-
-diagnostic:  # Bloc C
-  symptoms:  # +{N} (avec id + severity)
-    - id: "S{N}"
-      label: "{symptome}" # [source: {cle}]
-      severity: "{confort|securite|immobilisation}"
-  causes:  # +{N} (avec %)
-    - "{cause} ({X}%)" # [source: {cle}]
-
-maintenance:  # Bloc D
-  interval:  # AVANT: generique → APRES: chiffre
-    value: "{valeur}"
-    unit: "{km|mois|condition}"
-    note: "{condition critique}"
-    source: "{cle}"
-
-rendering:
-  faq:  # +{N}
-    - question: "{question}"
-      answer: "{reponse}" # [source: {cle}]
-  arguments:
-    - title: "{claim chiffree}"
-      icon: "{lucide-icon}"
-      source_ref: "{cle}" # OBLIGATOIRE si chiffre
-
-lifecycle:
-  stage: "v4_converted"  # ou "skill_enriched" si deja v4
-  last_enriched_by: "skill:seo-content"
-  last_enriched_at: {date du jour}
-```
-
-**Regles d'enrichissement :**
-1. **Ne jamais ecraser** — ajouter aux listes existantes, ne pas remplacer
-2. **Deduplication** — verifier que le nouveau contenu n'est pas deja present (meme sens)
-3. **Sourcer** — chaque ajout annote avec le doc source + entree dans `_sources`
-4. **Max 5 ajouts par champ** — au-dela, prioriser par pertinence
-5. **Validation obligatoire** — presenter le diff et demander : "Ces enrichissements sont corrects ? Je mets a jour gamme.md et je continue la redaction."
-6. **Hard gates** — verifier AVANT de proposer :
-   - `domain.role` > 80 chars et pas de pattern generique
-   - `selection.cost_range.max < 10 * cost_range.min`
-   - Tout chiffre dans `rendering.arguments` a un `source_ref`
-7. **Scoring** — estimer le score v4 apres enrichissement (ref: `.spec/00-canon/gamme-md-schema.md` §Scoring v4)
-
-#### Etape 4 — Appliquer les modifications
-
-Apres validation de l'admin, mettre a jour le fichier `gammes/{slug}.md` via l'outil Edit :
-- Mettre a jour `updated_at` a la date du jour
-- Mettre a jour `lifecycle.stage` et `lifecycle.last_enriched_by`
-- Mettre a jour `quality.version: GammeContentContract.v4` si conversion
-
-> **Si aucun doc supplementaire n'est trouve** : passer directement a Phase 2. Le skill fonctionne normalement avec les donnees existantes du gamme.md.
-
-> **Si le gamme.md v4 est deja riche** (tous les seuils minimums atteints par bloc) : noter "Gamme.md v4 deja complet, aucun ajout necessaire" et passer a Phase 2.
+- **Ne jamais écraser** — ajouter aux listes, ne pas remplacer
+- **Déduplication** — vérifier que le nouveau contenu n'est pas déjà présent
+- **Sourcer chaque ajout** — annotation `[source: {cle}]` + entrée dans `_sources`
+- **Max 5 ajouts par champ**
+- **Validation obligatoire** — présenter le diff et demander confirmation avant Edit
+- **Hard gates** : `domain.role` > 80 chars, `cost_range.max < 10 × min`, tout chiffre `rendering.arguments` a un `source_ref`
+- Si aucun doc supplémentaire OU gamme.md déjà riche → passer directement à Phase 2
 
 ### Phase 2 — Architecture du contenu
 
@@ -719,56 +463,18 @@ Si une information n'est pas confirmée, utiliser EXCLUSIVEMENT :
 
 ## Correction Linguistique (OBLIGATOIRE)
 
-**Toute sortie doit être irréprochable en français.** Cela s'applique aussi aux données provenant de la BDD ou du RAG.
+**Toute sortie doit être irréprochable en français.** Cela s'applique aussi aux données provenant de la BDD ou du RAG — corriger dans le contenu généré, signaler l'erreur d'origine pour correction en base.
 
-### Périmètre de correction
+**Règles de correction (appliquer toutes) :**
 
-| Source | Action |
-|--------|--------|
-| Contenu rédigé par le skill | Corriger systématiquement avant livraison |
-| Données BDD (titres, descriptions, FAQ, symptômes) | Corriger dans le contenu généré. Signaler les erreurs d'origine pour correction en base |
-| Données RAG (knowledge docs) | Corriger dans le contenu généré. Signaler les erreurs d'origine |
-| Données utilisateur | Corriger silencieusement sauf si le sens change |
+1. **Orthographe** — accents, doubles consonnes, mots composés. Aucune faute tolérée.
+2. **Grammaire** — accords genre/nombre/participes, prépositions, syntaxe.
+3. **Conjugaison** — temps, modes, accords du participe passé.
+4. **Typographie française** — espaces insécables, guillemets « », ponctuation.
 
-### Règles de correction
+**Détail canonique** : voir [`references/lang-correction.md`](references/lang-correction.md) — périmètre par source (skill / BDD / RAG / utilisateur), exemples par règle, format des requêtes MCP de correction BDD prêtes à exécuter, format Edit pour erreurs RAG.
 
-1. **Orthographe** — Aucune faute tolérée (accents, doubles consonnes, mots composés)
-   - ❌ "freinage d'urgance" → ✅ "freinage d'urgence"
-   - ❌ "ammortisseur" → ✅ "amortisseur"
-
-2. **Grammaire** — Accords (genre, nombre, participes), prépositions, syntaxe
-   - ❌ "les plaquette de frein est usé" → ✅ "les plaquettes de frein sont usées"
-
-3. **Conjugaison** — Temps, modes, accords du participe passé
-   - ❌ "le disque à été changé" → ✅ "le disque a été changé"
-
-4. **Typographie française** — Espaces insécables, guillemets « », ponctuation
-
-### Si une erreur vient de la BDD ou du RAG
-
-Générer des **requêtes MCP prêtes à exécuter** (pas de signalement passif) :
-
-```
-⚠️ Corrections BDD — requêtes MCP prêtes à exécuter :
-
-mcp__claude_ai_Supabase__execute_sql:
-  project_id: cxpojprgwgubzjyqzmoq
-  query: UPDATE pieces_gamme SET label = 'Disque de frein' WHERE label = 'Disque de Freins';
-
-Validation : SELECT pg_id, label FROM pieces_gamme WHERE pg_alias = 'disque-de-frein';
-```
-
-Pour les erreurs dans les knowledge docs RAG :
-
-```
-⚠️ Correction RAG — action Edit :
-- Fichier : /opt/automecanik/rag/knowledge/gammes/{slug}.md
-- Ligne {N} : "{erroné}" → "{corrigé}"
-- Action : Edit tool sur le fichier source
-```
-
-> Ne JAMAIS publier du contenu avec des fautes, même si la source en contient.
-> Toujours fournir la requête de correction ET la requête de validation.
+> Ne JAMAIS publier du contenu avec des fautes, même si la source en contient. Toujours fournir la requête de correction ET la requête de validation.
 
 ---
 
@@ -818,61 +524,18 @@ Avant de répondre, vérifier :
 
 ## Mode Batch (multi-gammes)
 
-Pour traiter plusieurs gammes en série :
+**Déclencheur** : l'utilisateur demande un traitement batch sur plusieurs gammes en série.
 
-### Pré-check RAG (OBLIGATOIRE avant la boucle)
+**Workflow** : (1) pré-check RAG obligatoire pour chaque gamme avant la boucle (constitue PROCESS list + SKIP list), (2) workflow 4 phases complet pour chaque gamme PROCESS, (3) gate qualité (score < 80 → REVIEW), (4) rapport tabulaire final.
 
-Pour chaque gamme cible, vérifier AVANT de lancer la rédaction :
+**Détail canonique** : voir [`references/batch-mode.md`](references/batch-mode.md) — commandes curl pré-check, critères de pré-qualification (knowledge doc / truth_level / updated_at / domain rules), pré-requis spécifiques guide-achat (howToChoose / antiMistakes / sgpg_*), format de sortie batch.
 
-```bash
-# Pour chaque gamme, récupérer le knowledge doc via POST /api/rag/search (RAG v2.5)
-# target_role = R3_GUIDE pour batch guide-achat (les conseils partagent le rôle R3)
-curl -s -X POST http://localhost:3000/api/rag/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{nom_gamme}", "limit": 1, "routing": {"target_role": "R3_GUIDE"}}' \
-  | jq '.results[0] | {title, truth_level, updated_at, primary_role, purity_score}'
-```
+**Règles invariantes (résumé) :**
 
-**Critères de pré-qualification :**
-
-| Critère | Seuil | Si échec |
-|---------|-------|----------|
-| Knowledge doc existe | Obligatoire | SKIP — "No knowledge doc" |
-| `truth_level` | ≥ L2 | SKIP — "Low truth level (L3/L4)" |
-| `updated_at` | < 6 mois | SKIP — "Stale source, `/rag-ops ingest` recommandé" |
-| `domain.must_be_true` (v4) ou `mechanical_rules.must_be_true` (legacy) | Non vide | WARNING — "No domain rules, manual review needed" |
-
-**Pré-requis supplémentaires si rôle = guide-achat :**
-
-| Critère | Seuil | Si échec |
-|---------|-------|----------|
-| Champ `howToChoose` (RAG) | Non vide | SKIP — "Pas de données guide-achat (howToChoose manquant)" |
-| Champ `antiMistakes` (RAG) | Non vide | WARNING — "antiMistakes vide, S5/S6 dégradés" |
-| `sgpg_selection_criteria` (BDD) | ≥ 1 critère | WARNING — "Pas de critères sélection, S3 simplifié" |
-| `sgpg_use_cases` (BDD) | ≥ 1 profil | WARNING — "Pas de use cases, S4 sans profils conducteur" |
-| Word count cible | 600-900 mots | Ajuster si hors fourchette — voir `quality-scoring.md` |
-
-### Workflow batch
-
-1. **Pré-check** : pour chaque gamme cible, exécuter le pré-check RAG. Constituer PROCESS list et SKIP list
-2. **Exécuter** : workflow 4 phases complet pour chaque gamme de la PROCESS list
-3. **Variables template** : `{gamme}`, `{famille}`, `{pg_id}`, `{v_level}`, `{slug}`
-4. **Gate qualité** : si score < 80 après Phase 4, marquer REVIEW (ne pas publier)
-
-**Format de sortie batch :**
-
-| Gamme | Slug | Score | Status | Sources | Issues |
-|-------|------|-------|--------|---------|--------|
-| disque de frein | disque-de-frein | 88 | OK | rag://gammes.disque-de-frein | — |
-| plaquette de frein | plaquette-de-frein | 82 | OK | rag://gammes.plaquette-de-frein | mechanical_rules partielles |
-| étrier de frein | etrier-de-frein | SKIP | — | — | truth_level L3, updated_at > 6 mois |
-| flexible de frein | flexible-de-frein | 74 | REVIEW | rag://gammes.flexible-de-frein | score < 80, proposer `/content-audit` |
-
-**Règles batch :**
 - Ne jamais baisser la qualité pour aller plus vite — chaque gamme suit le workflow complet
-- Signaler les gammes SKIP en fin de batch avec la raison + action recommandée
-- Signaler les gammes REVIEW avec le score et les issues détectées
-- Si > 30% des gammes sont SKIP : proposer `/rag-ops audit` pour vérifier la santé du corpus
+- SKIP si : pas de knowledge doc, truth_level L3/L4, updated_at > 6 mois
+- REVIEW si : score Phase 4 < 80
+- Si > 30 % des gammes en SKIP → proposer `/rag-ops audit` pour vérifier la santé du corpus
 
 ---
 

--- a/.claude/skills/seo-content-architect/references/batch-mode.md
+++ b/.claude/skills/seo-content-architect/references/batch-mode.md
@@ -1,0 +1,59 @@
+# Mode Batch (multi-gammes)
+
+> Référencé depuis `SKILL.md`. Charger uniquement quand l'utilisateur demande un traitement batch sur plusieurs gammes en série.
+
+Pour traiter plusieurs gammes en série :
+
+## Pré-check RAG (OBLIGATOIRE avant la boucle)
+
+Pour chaque gamme cible, vérifier AVANT de lancer la rédaction :
+
+```bash
+# Pour chaque gamme, récupérer le knowledge doc via POST /api/rag/search (RAG v2.5)
+# target_role = R3_GUIDE pour batch guide-achat (les conseils partagent le rôle R3)
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{nom_gamme}", "limit": 1, "routing": {"target_role": "R3_GUIDE"}}' \
+  | jq '.results[0] | {title, truth_level, updated_at, primary_role, purity_score}'
+```
+
+**Critères de pré-qualification :**
+
+| Critère | Seuil | Si échec |
+|---------|-------|----------|
+| Knowledge doc existe | Obligatoire | SKIP — "No knowledge doc" |
+| `truth_level` | ≥ L2 | SKIP — "Low truth level (L3/L4)" |
+| `updated_at` | < 6 mois | SKIP — "Stale source, `/rag-ops ingest` recommandé" |
+| `domain.must_be_true` (v4) ou `mechanical_rules.must_be_true` (legacy) | Non vide | WARNING — "No domain rules, manual review needed" |
+
+**Pré-requis supplémentaires si rôle = guide-achat :**
+
+| Critère | Seuil | Si échec |
+|---------|-------|----------|
+| Champ `howToChoose` (RAG) | Non vide | SKIP — "Pas de données guide-achat (howToChoose manquant)" |
+| Champ `antiMistakes` (RAG) | Non vide | WARNING — "antiMistakes vide, S5/S6 dégradés" |
+| `sgpg_selection_criteria` (BDD) | ≥ 1 critère | WARNING — "Pas de critères sélection, S3 simplifié" |
+| `sgpg_use_cases` (BDD) | ≥ 1 profil | WARNING — "Pas de use cases, S4 sans profils conducteur" |
+| Word count cible | 600-900 mots | Ajuster si hors fourchette — voir `quality-scoring.md` |
+
+## Workflow batch
+
+1. **Pré-check** : pour chaque gamme cible, exécuter le pré-check RAG. Constituer PROCESS list et SKIP list
+2. **Exécuter** : workflow 4 phases complet pour chaque gamme de la PROCESS list
+3. **Variables template** : `{gamme}`, `{famille}`, `{pg_id}`, `{v_level}`, `{slug}`
+4. **Gate qualité** : si score < 80 après Phase 4, marquer REVIEW (ne pas publier)
+
+**Format de sortie batch :**
+
+| Gamme | Slug | Score | Status | Sources | Issues |
+|-------|------|-------|--------|---------|--------|
+| disque de frein | disque-de-frein | 88 | OK | rag://gammes.disque-de-frein | — |
+| plaquette de frein | plaquette-de-frein | 82 | OK | rag://gammes.plaquette-de-frein | mechanical_rules partielles |
+| étrier de frein | etrier-de-frein | SKIP | — | — | truth_level L3, updated_at > 6 mois |
+| flexible de frein | flexible-de-frein | 74 | REVIEW | rag://gammes.flexible-de-frein | score < 80, proposer `/content-audit` |
+
+**Règles batch :**
+- Ne jamais baisser la qualité pour aller plus vite — chaque gamme suit le workflow complet
+- Signaler les gammes SKIP en fin de batch avec la raison + action recommandée
+- Signaler les gammes REVIEW avec le score et les issues détectées
+- Si > 30% des gammes sont SKIP : proposer `/rag-ops audit` pour vérifier la santé du corpus

--- a/.claude/skills/seo-content-architect/references/gamme-enrichment.md
+++ b/.claude/skills/seo-content-architect/references/gamme-enrichment.md
@@ -1,0 +1,201 @@
+# Phase 1d — Enrichissement gamme.md v4 (si docs supplémentaires disponibles)
+
+> Référencé depuis `SKILL.md` § Workflow 5 Phases. Charger uniquement si la Phase 1b a trouvé des docs supplémentaires (web/, pdf/, guides/) et que le gamme.md présente des lacunes.
+
+**Déclencheur** : Phase 1b a trouve des docs supplementaires (web/, pdf/, guides/) via la recherche RAG, ET le gamme.md presente des lacunes dans ses 5 blocs.
+
+**Objectif** : Enrichir le frontmatter YAML du fichier `gammes/{slug}.md` selon le **schema v4 (5 blocs)** AVANT de rediger, pour que le contenu soit fonde sur des donnees riches et verifiees.
+
+> **Schema de reference** : `.spec/00-canon/gamme-md-schema.md` — source de verite pour la structure, les types, et les regles de chaque bloc.
+
+## Detection de version
+
+| Version detectee | Action |
+|-----------------|--------|
+| `GammeContentContract.v4` | Enrichir selon les 5 blocs ci-dessous |
+| `GammeContentContract.v3` ou absent | Convertir en v4 PUIS enrichir (voir Etape 0) |
+
+## Etape 0 — Conversion v3 → v4 (si necessaire)
+
+Si le gamme.md est en v3 ou v1 (pas de `quality.version: GammeContentContract.v4`), proposer la conversion :
+
+```
+CONVERSION v3 → v4 proposee pour gammes/{slug}.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Mapping :
+  page_contract.symptoms → diagnostic.symptoms (ajouter id + severity)
+  page_contract.timing → maintenance.interval
+  page_contract.risk.costRange → selection.cost_range
+  page_contract.antiMistakes → selection.anti_mistakes
+  page_contract.howToChoose → selection.criteria
+  page_contract.faq → rendering.faq
+  mechanical_rules.must_be_true → domain.must_be_true
+  mechanical_rules.must_not_contain_concepts → domain.must_not_contain
+  mechanical_rules.confusion_with → domain.confusion_with
+  mechanical_rules.role_summary → domain.role
+
+Blocs a creer (absents en v3) :
+  - selection.checklist
+  - selection.brands
+  - diagnostic.causes (avec %)
+  - diagnostic.quick_checks
+  - maintenance.usage_factors
+  - maintenance.good_practices
+  - installation.* (si applicable)
+  - _sources (provenance)
+  - cross_gammes (relations)
+  - lifecycle
+
+Valider la conversion avant enrichissement ?
+```
+
+## Etape 1 — Decouvrir les docs supplementaires
+
+```bash
+# Rechercher les docs non-gamme lies a cette piece
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{nom_piece}", "limit": 10, "includeFullContent": true}' \
+  | jq '.results[] | select(.sourcePath | startswith("gammes/") | not) | {title, sourcePath, sourceType, score}'
+```
+
+Filtrer : garder uniquement les docs `web/`, `pdf/`, `guides/` avec `truth_level` L1 ou L2.
+
+## Etape 2 — Lire et analyser le contenu complet
+
+Pour chaque doc supplementaire trouve, lire le fichier source :
+```
+/opt/automecanik/rag/knowledge/{source_path}
+```
+
+Extraire les donnees structurees pertinentes pour les **5 blocs v4** :
+
+| Donnee a extraire | Destination v4 | Critere d'extraction |
+|-------------------|----------------|---------------------|
+| Role mecanique detaille | `domain.role` (>80 chars) | Description fonctionnelle precise, sans verbe generique |
+| Termes techniques cles | `domain.must_be_true` | Vocabulaire metier obligatoire dans le contenu |
+| Confusions courantes | `domain.confusion_with` | Pieces proches ou causes confondues |
+| Pieces associees | `domain.related_parts` + `cross_gammes` | Mentions de pieces liees au remplacement |
+| Criteres de selection | `selection.criteria` (min 3) | Dimensions, types, compatibilites |
+| Checklist achat | `selection.checklist` (min 3) | Etapes verification avant commande |
+| Erreurs d'achat | `selection.anti_mistakes` (min 3) | Phrases "ne pas", "erreur", "eviter" |
+| Fourchette de cout | `selection.cost_range` | Montants en EUR avec unite (la paire, l'unite, le kit) |
+| Marques recommandees | `selection.brands` | Premium / equivalent / budget |
+| Symptomes de defaillance | `diagnostic.symptoms` (min 3) | Signes d'usure avec severity (confort/securite/immobilisation) |
+| Causes de panne | `diagnostic.causes` (min 2) | Ordonnees par frequence, % si connu |
+| Tests sans outil | `diagnostic.quick_checks` (min 2) | Verifications visuelles/manuelles |
+| Intervalles remplacement | `maintenance.interval` | Valeur + unite (km/mois/condition) + note |
+| Facteurs d'usure | `maintenance.usage_factors` | Conditions accelerant l'usure |
+| Bonnes pratiques | `maintenance.good_practices` | Gestes d'entretien preventif |
+| Interdits entretien | `maintenance.do_not` | Actions a ne jamais faire |
+| Etapes de montage | `installation.steps` (min 3) | Procedure pas a pas |
+| Outils necessaires | `installation.tools` | Liste outillage |
+| Erreurs de montage | `installation.common_errors` (min 2) | Erreurs de MONTAGE uniquement |
+| Questions frequentes | `rendering.faq` (min 4) | Q&A avec reponses sourcees |
+| Chiffres avec source | `rendering.arguments` | Claims chiffrees avec `source_ref` |
+
+## Etape 2b — Registrer la provenance
+
+Pour chaque doc supplementaire utilise, ajouter une entree dans `_sources` :
+
+```yaml
+_sources:
+  {cle-unique}:                    # ex: bosch-2024, mopar-entretien
+    type: "manufacturer"|"norm"|"field-expertise"|"study"|"rag-doc"
+    doc: "{source_path}"           # chemin fichier RAG ou null
+    note: "{contexte en 1 phrase}" # optionnel
+```
+
+Les champs enrichis referencent la source via `source: "{cle}"` inline.
+
+## Etape 3 — Proposer le diff YAML v4
+
+Presenter les enrichissements organises par bloc. Ne modifier QUE les champs absents ou insuffisants :
+
+```yaml
+# ENRICHISSEMENTS PROPOSES pour gammes/{slug}.md (schema v4)
+# Sources : {liste des docs avec titre abrege}
+# Blocs enrichis : {liste} / Blocs inchanges : {liste}
+
+_sources:  # +{N} nouvelles entrees
+  {cle}:
+    type: "{type}"
+    doc: "{path}"
+    note: "{contexte}"
+
+domain:  # Bloc A
+  role: "{enrichi si <80 chars}"
+  must_be_true:  # +{N}
+    - "{terme}" # [source: {cle}]
+  confusion_with:  # +{N}
+    - term: "{piece}"
+      difference: "{explication}" # [source: {cle}]
+  cross_gammes:  # NOUVEAU
+    - slug: "{gamme-liee}"
+      relation: "{type}"
+      context: "{explication}"
+
+selection:  # Bloc B
+  criteria:  # +{N}
+    - "{critere}" # [source: {cle}]
+  anti_mistakes:  # +{N}
+    - "{erreur}" # [source: {cle}]
+  cost_range:  # AVANT: absent → APRES: renseigne
+    min: {N}
+    max: {N}
+    currency: EUR
+    unit: "{unite}"
+    source: "{cle}"
+
+diagnostic:  # Bloc C
+  symptoms:  # +{N} (avec id + severity)
+    - id: "S{N}"
+      label: "{symptome}" # [source: {cle}]
+      severity: "{confort|securite|immobilisation}"
+  causes:  # +{N} (avec %)
+    - "{cause} ({X}%)" # [source: {cle}]
+
+maintenance:  # Bloc D
+  interval:  # AVANT: generique → APRES: chiffre
+    value: "{valeur}"
+    unit: "{km|mois|condition}"
+    note: "{condition critique}"
+    source: "{cle}"
+
+rendering:
+  faq:  # +{N}
+    - question: "{question}"
+      answer: "{reponse}" # [source: {cle}]
+  arguments:
+    - title: "{claim chiffree}"
+      icon: "{lucide-icon}"
+      source_ref: "{cle}" # OBLIGATOIRE si chiffre
+
+lifecycle:
+  stage: "v4_converted"  # ou "skill_enriched" si deja v4
+  last_enriched_by: "skill:seo-content"
+  last_enriched_at: {date du jour}
+```
+
+**Regles d'enrichissement :**
+1. **Ne jamais ecraser** — ajouter aux listes existantes, ne pas remplacer
+2. **Deduplication** — verifier que le nouveau contenu n'est pas deja present (meme sens)
+3. **Sourcer** — chaque ajout annote avec le doc source + entree dans `_sources`
+4. **Max 5 ajouts par champ** — au-dela, prioriser par pertinence
+5. **Validation obligatoire** — presenter le diff et demander : "Ces enrichissements sont corrects ? Je mets a jour gamme.md et je continue la redaction."
+6. **Hard gates** — verifier AVANT de proposer :
+   - `domain.role` > 80 chars et pas de pattern generique
+   - `selection.cost_range.max < 10 * cost_range.min`
+   - Tout chiffre dans `rendering.arguments` a un `source_ref`
+7. **Scoring** — estimer le score v4 apres enrichissement (ref: `.spec/00-canon/gamme-md-schema.md` §Scoring v4)
+
+## Etape 4 — Appliquer les modifications
+
+Apres validation de l'admin, mettre a jour le fichier `gammes/{slug}.md` via l'outil Edit :
+- Mettre a jour `updated_at` a la date du jour
+- Mettre a jour `lifecycle.stage` et `lifecycle.last_enriched_by`
+- Mettre a jour `quality.version: GammeContentContract.v4` si conversion
+
+> **Si aucun doc supplementaire n'est trouve** : passer directement a Phase 2. Le skill fonctionne normalement avec les donnees existantes du gamme.md.
+
+> **Si le gamme.md v4 est deja riche** (tous les seuils minimums atteints par bloc) : noter "Gamme.md v4 deja complet, aucun ajout necessaire" et passer a Phase 2.

--- a/.claude/skills/seo-content-architect/references/lang-correction.md
+++ b/.claude/skills/seo-content-architect/references/lang-correction.md
@@ -1,0 +1,54 @@
+# Correction Linguistique — détail BDD/RAG
+
+> Référencé depuis `SKILL.md` § Correction Linguistique. Charger uniquement si une erreur d'origine (BDD ou RAG) est détectée et qu'il faut produire la requête de correction. Les règles de base (orthographe, grammaire, conjugaison, typographie) restent dans SKILL.md.
+
+**Toute sortie doit être irréprochable en français.** Cela s'applique aussi aux données provenant de la BDD ou du RAG.
+
+## Périmètre de correction
+
+| Source | Action |
+|--------|--------|
+| Contenu rédigé par le skill | Corriger systématiquement avant livraison |
+| Données BDD (titres, descriptions, FAQ, symptômes) | Corriger dans le contenu généré. Signaler les erreurs d'origine pour correction en base |
+| Données RAG (knowledge docs) | Corriger dans le contenu généré. Signaler les erreurs d'origine |
+| Données utilisateur | Corriger silencieusement sauf si le sens change |
+
+## Règles de correction
+
+1. **Orthographe** — Aucune faute tolérée (accents, doubles consonnes, mots composés)
+   - ❌ "freinage d'urgance" → ✅ "freinage d'urgence"
+   - ❌ "ammortisseur" → ✅ "amortisseur"
+
+2. **Grammaire** — Accords (genre, nombre, participes), prépositions, syntaxe
+   - ❌ "les plaquette de frein est usé" → ✅ "les plaquettes de frein sont usées"
+
+3. **Conjugaison** — Temps, modes, accords du participe passé
+   - ❌ "le disque à été changé" → ✅ "le disque a été changé"
+
+4. **Typographie française** — Espaces insécables, guillemets « », ponctuation
+
+## Si une erreur vient de la BDD ou du RAG
+
+Générer des **requêtes MCP prêtes à exécuter** (pas de signalement passif) :
+
+```
+⚠️ Corrections BDD — requêtes MCP prêtes à exécuter :
+
+mcp__claude_ai_Supabase__execute_sql:
+  project_id: cxpojprgwgubzjyqzmoq
+  query: UPDATE pieces_gamme SET label = 'Disque de frein' WHERE label = 'Disque de Freins';
+
+Validation : SELECT pg_id, label FROM pieces_gamme WHERE pg_alias = 'disque-de-frein';
+```
+
+Pour les erreurs dans les knowledge docs RAG :
+
+```
+⚠️ Correction RAG — action Edit :
+- Fichier : /opt/automecanik/rag/knowledge/gammes/{slug}.md
+- Ligne {N} : "{erroné}" → "{corrigé}"
+- Action : Edit tool sur le fichier source
+```
+
+> Ne JAMAIS publier du contenu avec des fautes, même si la source en contient.
+> Toujours fournir la requête de correction ET la requête de validation.

--- a/.claude/skills/seo-content-architect/references/rag-verification.md
+++ b/.claude/skills/seo-content-architect/references/rag-verification.md
@@ -1,0 +1,93 @@
+# Phase 1b — Vérification RAG (obligatoire si le sujet est une pièce/gamme)
+
+> Référencé depuis `SKILL.md` § Workflow 5 Phases. Charger uniquement quand le sujet est une pièce automobile, après la Phase 1 (Analyse).
+
+Avant toute rédaction portant sur une pièce automobile, exécuter ce workflow en 4 étapes :
+
+## Étape 1 — Récupérer le knowledge doc
+
+Construire le slug depuis le nom de la gamme : "Disque de frein" → `disque-de-frein`
+
+```bash
+# Recherche RAG avec role targeting (v2.5)
+# {ROLE} selon page cible : R1_ROUTER, R3_GUIDE, R4_REFERENCE, R5_DIAGNOSTIC
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{nom_piece}", "limit": 5, "routing": {"target_role": "{ROLE}"}}' \
+  | jq '.results[] | {title, truth_level, updated_at, confidence_score, primary_role, purity_score, chunk_kind, source_path, page_contract_id, media_slots_hint}'
+```
+
+**Décision selon les résultats :**
+
+| Résultat | truth_level | verification_status | Action |
+|----------|-------------|---------------------|--------|
+| Doc trouvé | L1 | verified | Fait dur — utiliser directement, citer sans qualification |
+| Doc trouvé | L2 | verified | Confirmé — utiliser directement |
+| Doc trouvé | L2 | draft | Utilisable avec prudence, vérifier cohérence |
+| Doc trouvé | L3 | verified | Curaté — formulation conditionnelle obligatoire |
+| Doc trouvé | L3/L4 | draft/pending | **REJETER** — traiter comme non-confirmé |
+| 0 résultats | — | — | Signaler l'absence, continuer avec données utilisateur/BDD. Ne rien inventer |
+
+## Étape 2 — Extraire les règles du domaine (v4) / mechanical_rules (legacy)
+
+Chaque knowledge doc gamme contient un frontmatter YAML avec des règles. Détecter la version du schema :
+
+- **v4** : `rendering.quality.version === 'GammeContentContract.v4'` → lire `domain.*`
+- **Legacy** (v1/v3) : lire `mechanical_rules.*` + `purchase_guardrails.*`
+
+| Champ v4 | Champ legacy (fallback) | Usage dans la rédaction |
+|----------|------------------------|------------------------|
+| `domain.must_be_true` | `mechanical_rules.must_be_true` | Ces termes DOIVENT apparaître dans le contenu produit |
+| `domain.must_not_contain` | `mechanical_rules.must_not_contain_concepts` | JAMAIS dans le contenu — confusion sémantique |
+| `domain.confusion_with` | `mechanical_rules.confusion_with` | Générer un bloc "Ne pas confondre avec..." explicite |
+| `domain.role` | `mechanical_rules.role_summary` | Seed pour le H1/intro — reformuler, ne pas copier verbatim |
+| `domain.must_not_contain` | `purchase_guardrails.forbidden_terms` | Ajouter aux MOTS INTERDITS du contenu |
+| *(v4: implicite si crossGammes)* | `purchase_guardrails.requires_vehicle` | Si true, inclure "vérifiez la compatibilité véhicule" |
+
+**2 formats `confusion_with` (v4 = array uniquement, legacy = array ou map) :**
+
+Format array (v4 + legacy) :
+```yaml
+confusion_with:
+  - term: tambour de frein
+    difference: Le tambour utilise des mâchoires internes...
+```
+
+Format map (legacy uniquement) :
+```yaml
+confusion_with:
+  batterie:
+    key_difference: L'alternateur recharge la batterie...
+```
+
+Traiter les deux formats : pour chaque entrée, générer un bloc "Ne pas confondre avec {terme}" dans le contenu.
+
+## Étape 3 — Recherche complémentaire par section
+
+Interroger la section correspondant au rôle de page cible :
+
+```bash
+# Recherche complementaire avec role targeting (v2.5)
+# Enrichir la query avec des mots-cles de section selon le role cible :
+# R3 Blog/guide → "guide achat choix selection" (+ injecter template de conseils-role.md §7)
+# R3 Blog/conseils → "entretien remplacement etapes" (+ injecter template de conseils-role.md §7)
+# R4 Reference  → "definition technique composants" (+ injecter concepts partages de r4-reference-role.md §8)
+# R5 Diagnostic → "symptomes diagnostic panne"
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{nom_piece} {section_keywords}", "limit": 5, "routing": {"target_role": "{ROLE}"}}' \
+  | jq '.results[:3] | .[] | {title, truth_level, content, primary_role, chunk_kind}'
+```
+
+Consolider les résultats des étapes 1 et 3 pour constituer la base de rédaction.
+
+## Étape 4 — Vérifier la fraîcheur (`updated_at`)
+
+Vérifier le champ `updated_at` dans le frontmatter YAML du knowledge doc :
+
+| Âge du doc | Statut | Action | Annotation |
+|------------|--------|--------|------------|
+| < 3 mois | Frais | Utiliser directement | Aucune |
+| 3-6 mois | Acceptable | Vérifier cohérence | Ajouter date dans provenance |
+| 6-12 mois | Stale | Pénalité -6 (STALE_SOURCE) | Annoter `[source datée de {mois}]`, proposer `/rag-ops ingest` |
+| > 12 mois | Obsolète | NE PAS utiliser les données chiffrées | **STOP** : proposer `/rag-ops ingest` avant rédaction |

--- a/.claude/skills/seo-content-architect/references/triage-phase0.md
+++ b/.claude/skills/seo-content-architect/references/triage-phase0.md
@@ -1,0 +1,167 @@
+# Phase 0 — Triage de contenu brut
+
+> Référence canonique de la phase de classification multi-rôles déclenchée
+> AVANT toute rédaction lorsque l'utilisateur fournit un texte brut externe
+> (copié-collé, PDF, sortie ChatGPT/Gemini/Perplexity, document tiers).
+>
+> Cible exclusive de la modularité promise par `SKILL.md` : tout le détail
+> Phase 0 vit ici, le SKILL.md ne garde que le déclencheur et le pointeur.
+
+---
+
+## Déclencheur
+
+Un texte brut est fourni avec une intention de production de page. Indices :
+
+- "Voici un texte sur {gamme}, transforme-le en page"
+- "J'ai ce PDF / cette sortie ChatGPT, classe-le"
+- Bloc collé > 200 mots sans rôle de page explicite
+- Mélange visible de définitions + symptômes + étapes + sélections véhicule
+
+**Si aucun de ces indices** : pas de Phase 0, passer directement Phase 1.
+
+## Objectif
+
+Classifier chaque bloc/paragraphe vers le **rôle de page** approprié AVANT
+la rédaction, pour empêcher la production de pages cannibalisées (un seul
+rôle = un seul lexique = un seul intent).
+
+Sortie : un rapport de triage + une recommandation d'ordre de production.
+Aucun contenu n'est rédigé en Phase 0.
+
+---
+
+## Étape 1 — Scanner et classifier
+
+Pour chaque section ou paragraphe du contenu brut, attribuer un rôle selon
+les marqueurs dominants :
+
+| Marqueurs détectés | Rôle cible | URL pattern |
+|---|---|---|
+| Définition, composition, rôle mécanique, "qu'est-ce que" | **R4 Reference** | `/reference-auto/{slug}` |
+| Symptômes, diagnostic, arbre de décision, codes DTC | **R5 Diagnostic** | (futur) |
+| Étapes de remplacement, démontage/remontage, outils, difficulté | **R3/conseils** | `/blog-pieces-auto/conseils/{alias}` |
+| Comment choisir, références OEM, checklist achat, marques | **R3/guide-achat** | `/blog-pieces-auto/guide-achat/{alias}` |
+| Sélection véhicule, variantes, filtrer par | **R1 Router** | `/pieces/{slug}-{pg_id}.html` |
+
+Pour la sémantique complète (vocabulaire exclusif, maillage interne,
+matrice canonique R0-R8), voir [`page-roles.md`](page-roles.md).
+
+### Cas ambigus
+
+Un paragraphe peut contenir plusieurs marqueurs. Règles d'arbitrage :
+
+1. **Marqueur dominant en volume** (≥ 60 % des phrases) gagne
+2. **Sinon, marqueur dominant en finalité** (verbe d'action principal :
+   _définir_ → R4, _diagnostiquer_ → R5, _remplacer_ → R3/conseils,
+   _choisir_ → R3/guide-achat, _sélectionner véhicule_ → R1)
+3. **Sinon, signaler "vocabulaire mixte"** dans le rapport et proposer de
+   couper le bloc en deux
+
+Aucune classification "fourre-tout" autorisée — un bloc non classifiable
+est marqué `INCLASSABLE` (voir Étape 4).
+
+---
+
+## Étape 2 — Produire le rapport de triage
+
+```
+TRIAGE CONTENU BRUT — {nom_piece}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Source : {type — PDF/ChatGPT/copié-collé/autre}
+Sections analysées : {N}
+
+RÉPARTITION PAR RÔLE :
+• R3/conseils    : {X}% — {N} blocs (étapes, outils, erreurs)
+• R3/guide-achat : {X}% — {N} blocs (choix, références, checklist)
+• R4 Reference   : {X}% — {N} blocs (définition, composition)
+• R5 Diagnostic  : {X}% — {N} blocs (symptômes, causes)
+• R1 Router      : {X}% — {N} blocs (sélection véhicule)
+• INCLASSABLE    : {X}% — {N} blocs (signaler en sortie)
+
+PROBLÈMES DÉTECTÉS :
+• Répétitions    : {liste des blocs qui disent la même chose}
+• Incohérences   : {contradictions entre blocs}
+• Vocab. mixte   : {termes exclusifs de plusieurs rôles dans le même bloc}
+• Inclassables   : {blocs sans marqueur dominant}
+
+RECOMMANDATION :
+Rôle prioritaire : {rôle avec le % le plus élevé}
+→ Produire d'abord le contenu {rôle} avec /seo-content-architect {gamme}
+→ Les blocs {autres rôles} seront utilisés comme seed pour les autres pages
+```
+
+Le rapport est **structuré** (pas de prose libre). Le pourcentage est
+calculé en fraction de blocs (pas en mots) — un bloc court compte autant
+qu'un bloc long pour éviter les biais de longueur.
+
+---
+
+## Étape 3 — Demander confirmation
+
+Avant de passer en Phase 1, présenter le rapport et demander :
+
+> "Le contenu brut couvre {N} rôles. Je recommande de commencer par
+> **{rôle prioritaire}**. Les blocs des autres rôles seront conservés
+> comme seed. On lance ?"
+
+Attendre une réponse explicite (`go` / `lance` / `oui` / `start` …).
+
+Pas de réponse → ne pas démarrer Phase 1, signaler l'attente.
+
+Réponse de réorientation (`commence par R4 plutôt`) → recalculer la
+recommandation avec le rôle demandé en tête, sans relancer le scan.
+
+---
+
+## Étape 4 — Règles invariantes
+
+| Règle | Pourquoi |
+|---|---|
+| Ne JAMAIS produire un contenu qui mélange les rôles | Cannibalisation SEO + vocabulaire mixte = pénalité Google |
+| Blocs classés dans un rôle ≠ rôle cible : conservés (pas supprimés) | Seed des pages futures du même cluster |
+| Si > 50 % du contenu = INCLASSABLE → signaler "contenu non structuré" et proposer `/content-audit` | Pas de production sur base bancale |
+| Un bloc avec ≥ 3 marqueurs de rôles différents → couper avant classer | Pas de bloc "couteau suisse" |
+| Tout bloc INCLASSABLE est listé nominativement dans le rapport | Audit trail + apprentissage |
+
+Aucune de ces règles n'est négociable en Phase 0 — sinon Phase 1 hérite
+d'un dataset pollué.
+
+---
+
+## Edge cases observés
+
+- **Texte 100 % R4** (définition pure) : pas de triage utile — passer
+  directement à Phase 1 avec rôle = R4.
+- **PDF technique fournisseur** : souvent 70 % R4 + 30 % R3/conseils. Le
+  triage capte le R3 inline et le pose en seed séparé.
+- **Sortie ChatGPT longue** : généralement ~5 rôles mélangés à parts
+  égales. Le rapport doit être complet pour qu'on choisisse l'ordre de
+  production.
+- **Copié-collé d'une page concurrente** : signaler avant tout `vocab.
+  mixte` élevé → c'est précisément ce qui pénalise leur SEO, ne pas
+  reproduire.
+
+---
+
+## Sortie attendue
+
+Phase 0 produit **uniquement** :
+
+1. Le rapport de triage formaté ci-dessus
+2. Une recommandation de rôle prioritaire
+3. Un fichier seed implicite (les blocs hors rôle cible, conservés en
+   contexte pour les phases ultérieures du même cluster)
+
+Phase 0 ne produit **jamais** : du contenu rédigé, des meta-tags, du
+JSON-LD, des recommandations d'URL définitives.
+
+---
+
+## Liens
+
+- [`page-roles.md`](page-roles.md) — vocabulaire exclusif R1-R8 et
+  matrice canonique
+- [`quality-scoring.md`](quality-scoring.md) — seuils utilisés en Phase 4
+  (post-rédaction, hors scope Phase 0)
+- `SKILL.md` (parent) — orchestration des phases 0 → 4

--- a/log.md
+++ b/log.md
@@ -81,3 +81,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-department-phase-2a`
 - **Décision** : feat(seo-department): phase 2a - audit findings table + canonical auditor
 - **Sortie** : PR #174 | commits 9581f6c2
+
+## 2026-04-25 — refactor/seo-content-architect-extract-triage-phase0 (auto)
+
+- **Branche** : `refactor/seo-content-architect-extract-triage-phase0`
+- **Décision** : refactor(skill): extract Phase 0 triage into references/triage-phase0.md
+- **Sortie** : PR #183 | commits 618d4872


### PR DESCRIPTION
## Summary

Reduce default token cost of `seo-content-architect` skill by extracting **5 long conditional sections** from `SKILL.md` into `references/` (each loaded only when its scenario matches).

## What changed

| Section extracted | Lines | → Reference file | Loaded when |
|---|---|---|---|
| Phase 0 — Triage contenu brut | ~58 | `references/triage-phase0.md` | Contenu externe fourni |
| Phase 1b — Vérification RAG | ~92 | `references/rag-verification.md` | Sujet = pièce/gamme |
| Phase 1d — Enrichissement gamme.md v4 | ~199 | `references/gamme-enrichment.md` | Docs supplémentaires + lacunes |
| Correction Linguistique (détail BDD/RAG) | ~53 | `references/lang-correction.md` | Erreur détectée à corriger |
| Mode Batch (multi-gammes) | ~59 | `references/batch-mode.md` | Traitement batch |

**SKILL.md : 1021 → 645 lignes (-37 %)**, soit ~44 % de tokens en moins chargés à chaque invocation par défaut. Les sections gardent leur en-tête + déclencheur + objectif + règles invariantes dans SKILL.md, avec pointer explicite vers le fichier reference canonique.

## Architecture

Aligné sur le pattern des 11 references existants (`page-roles.md`, `quality-scoring.md`, `r1-router-role.md`, etc.) — un fichier par concern. Aucune duplication de contenu, contenu préservé verbatim dans les references.

## Commits

- `618d4872` Phase 0 (extracted in original PR scope)
- `828db743` Extension : Phase 1b + Phase 1d + Correction Linguistique + Mode Batch

## Test plan

- [x] `wc -l SKILL.md` confirme la réduction (645 lignes)
- [x] Toutes les sections extraites pointent vers leur reference avec lien markdown valide
- [x] Aucune information perdue (contenu verbatim dans les references)
- [x] Pattern cohérent avec les 11 references préexistants
- [ ] Smoke test : invoquer le skill sur une gamme réelle (validation manuelle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)