### PR TITLE
feat(r8): HTML distinct render — step 1 (cut TrustSection + spec)

### DIFF
--- a/docs/superpowers/specs/2026-04-25-r8-html-distinct-render.md
+++ b/docs/superpowers/specs/2026-04-25-r8-html-distinct-render.md
@@ -1,0 +1,71 @@
+# R8 HTML Distinct Render — Spec courte
+
+**Date** : 2026-04-25
+**Branche** : `feat/r8-html-distinct-render`
+**Objectif** : Réduire le duplicate content cross-motorisations sur les pages R8 (`/constructeurs/:brand/:model/:type.html`) en câblant les données DB existantes + le système de switches legacy + JSON-LD Vehicle, **sans scraping et sans toucher au RAG** (respecte ADR-022 L1).
+
+## Baseline (mesuré 2026-04-25 21:32 UTC)
+
+`r8-diversity-check --modele-id 140004` (Clio III) :
+- 3 sibling pages dans `__seo_r8_pages` (la majorité des 30+ motorisations Clio III rendent via fallback DB)
+- avg_diversity 68.3 %, verdict REVIEW
+- Collisions sur `faq_signature` (pool 7) et `category_signature` (pool 7)
+
+## Diagnostic frontend
+
+`frontend/app/routes/constructeurs.$brand.$model.$type.tsx` (1258 LOC) rend 7 sections :
+- HeroSection — variable ✅
+- BreadcrumbSection — variable ✅
+- SeoIntroSection — vient du RAG enricher (souvent vide)
+- **TrustSection — 100 % boilerplate, identique sur 53 959 pages** ❌
+- AntiErrorsSection — 85 % boilerplate ❌
+- HowtoSection — 80 % boilerplate ❌
+- R8EnrichedSection — optionnel, souvent vide
+
+## Données déjà disponibles (vérifiées 2026-04-25)
+
+| Source | Contenu | Lien type_id |
+|---|---|---|
+| `auto_type` | type_name, type_engine, type_fuel, type_power_ps, type_power_kw, type_liter, type_year_*, type_month_*, type_body | direct |
+| `__cross_gamme_car_new` | Gammes applicables au véhicule | `cgc_type_id` |
+| `__diag_maintenance_operation` | Ops entretien (label, intervalles km/mois, sévérité) | via `related_pg_id` |
+| `__diag_related_parts` | Pièces co-changées + probabilité | via `drp_source_pg_id` |
+| `__diag_symptom` | Pannes/symptômes (label, urgence) | via `system_id` |
+| `__seo_type_switch` | 134 phrases (5 alias) | rotation hash(type_id) |
+| `__seo_item_switch` | 7 964 phrases (3 alias) | rotation hash(type_id) |
+| `__seo_gamme_car_switch` | 6 542 phrases (3 alias) | rotation hash(type_id) |
+| `__seo_family_gamme_car_switch` | 3 790 phrases (6 alias) | rotation hash(type_id) |
+
+**Total : 18 430 phrases switch + 6 tables data, 0 % câblées sur R8 actuellement.**
+
+## Plan d'implémentation (incrémental, commits atomiques)
+
+1. **Cut TrustSection** de la page R8 (déplacement vers footer global ou layout partagé) — gain immédiat, commit isolé.
+2. **TechSpecsSection** (nouvelle) : table specs depuis `auto_type` (kW, cylindrée, body, période mensuelle, code moteur si dispo).
+3. **JSON-LD Vehicle Schema.org** dans `<head>` via `meta()` Remix (`@type:Vehicle`, `vehicleEngine`, `vehicleConfiguration`, `manufacturer`, `dateVehicleFirstRegistered`, `vehicleModelDate`).
+4. **MaintenanceSection** : top 3-5 ops depuis `__diag_maintenance_operation × cross_gamme_car_new`.
+5. **TopPartsSection** : pièces co-changées depuis `__diag_related_parts` triées par `drp_probability`.
+6. **SymptomsSection** : top symptômes depuis `__diag_symptom` filtrés par system applicable.
+7. **Switches rotation** câblée sur Howto/AntiErrors/SeoIntro avec seed=type_id (pattern `brand-bestsellers.service.ts:235-280`).
+
+## Mesure post-implémentation
+
+- `python3 scripts/qa/r8-diversity-check.py --modele-id 140004` après chaque commit majeur
+- Si verdict toujours REVIEW/FAIL après les 7 étapes → **2e PR distincte** pour scraping (couple, vmax, masse, code moteur K9K) via `__rag_proposals` propose-before-write (ADR-022).
+
+## Hors scope explicite
+
+- ❌ Scraping web (reporté à PR séparée si nécessaire après mesure)
+- ❌ Modifications RAG `vehicles/*.md` (ADR-022 L1 violée si on touche)
+- ❌ Modifications du backend RPC `build_vehicle_page_payload` au-delà de l'ajout de fields lus depuis DB
+
+## Réversibilité
+
+`git revert` du squash-merge annule tout. Aucun write DB/RAG, uniquement frontend + ajout SQL dans le RPC loader (read-only).
+
+## Refs
+
+- ADR-022 R8 RAG Control Plane (vault, accepted 2026-04-25)
+- Honest debrief : `governance-vault/ledger/knowledge/r8-vehicle-enrichment-stage1-honest-debrief-20260425.md`
+- Pattern legacy switch : `backend/src/modules/vehicles/services/brand-bestsellers.service.ts:235-280`
+- Config switches : `backend/src/config/seo-switch-aliases.config.ts`

--- a/frontend/app/components/vehicle/r8/index.ts
+++ b/frontend/app/components/vehicle/r8/index.ts
@@ -22,4 +22,5 @@ export { HeroSection } from "./sections/HeroSection";
 export { HowtoSection } from "./sections/HowtoSection";
 export { R8EnrichedSection } from "./sections/R8EnrichedSection";
 export { SeoIntroSection } from "./sections/SeoIntroSection";
+export { TechSpecsSection } from "./sections/TechSpecsSection";
 export { TrustSection } from "./sections/TrustSection";

--- a/frontend/app/components/vehicle/r8/r8-schema.ts
+++ b/frontend/app/components/vehicle/r8/r8-schema.ts
@@ -12,6 +12,68 @@ export function generateVehicleSchema(
   const baseUrl = "https://www.automecanik.com";
   const canonicalUrl = `${baseUrl}/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}/${vehicle.modele_alias}-${vehicle.modele_id}/${vehicle.type_alias}-${vehicle.type_id}.html`;
 
+  // Puissance dérivée kW (commonly used aux côtés HP)
+  const powerPs = vehicle.type_power_ps
+    ? parseInt(vehicle.type_power_ps)
+    : null;
+  const powerKw = powerPs && powerPs > 0 ? Math.round(powerPs / 1.35962) : null;
+
+  // Période de production formatée
+  const periodValue = vehicle.type_year_from
+    ? vehicle.type_year_to
+      ? `${vehicle.type_year_from}-${vehicle.type_year_to}`
+      : `depuis ${vehicle.type_year_from}`
+    : null;
+
+  // additionalProperty : enrichi avec CNIT + code moteur si dispo
+  const additionalProperty: Array<{
+    "@type": "PropertyValue";
+    name: string;
+    value: string;
+  }> = [];
+  if (periodValue) {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "Période de production",
+      value: periodValue,
+    });
+  }
+  if (vehicle.cnit_codes_formatted) {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "CNIT",
+      value: vehicle.cnit_codes_formatted,
+    });
+  }
+  if (vehicle.motor_codes_formatted) {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "Code moteur",
+      value: vehicle.motor_codes_formatted,
+    });
+  }
+
+  // EngineSpecification enrichi : displacement (cm3), engineType (codes), enginePower (HP+kW)
+  const enginePower: Array<{
+    "@type": "QuantitativeValue";
+    value: number;
+    unitCode: string;
+  }> = [];
+  if (powerPs) {
+    enginePower.push({
+      "@type": "QuantitativeValue",
+      value: powerPs,
+      unitCode: "HP",
+    });
+  }
+  if (powerKw) {
+    enginePower.push({
+      "@type": "QuantitativeValue",
+      value: powerKw,
+      unitCode: "KWT",
+    });
+  }
+
   return {
     "@context": "https://schema.org",
     "@graph": [
@@ -24,38 +86,36 @@ export function generateVehicleSchema(
         manufacturer: { "@type": "Organization", name: vehicle.marque_name },
         model: vehicle.modele_name,
         vehicleConfiguration: vehicle.type_name,
-        // 📅 Année modèle
+        // 📅 Année modèle (utilisé par Google + Bing)
         ...(vehicle.type_year_from && {
           vehicleModelDate: vehicle.type_year_from,
+          modelDate: vehicle.type_year_from,
+          dateVehicleFirstRegistered: vehicle.type_year_from,
         }),
-        // 🔧 Moteur
+        // 🔧 Moteur enrichi
         vehicleEngine: {
           "@type": "EngineSpecification",
           name: vehicle.type_name,
-          ...(vehicle.type_power_ps && {
-            enginePower: {
-              "@type": "QuantitativeValue",
-              value: parseInt(vehicle.type_power_ps),
-              unitCode: "HP",
-            },
+          ...(enginePower.length > 0 && { enginePower }),
+          ...(vehicle.cylinder_cm3 &&
+            vehicle.cylinder_cm3 > 0 && {
+              engineDisplacement: {
+                "@type": "QuantitativeValue",
+                value: vehicle.cylinder_cm3,
+                unitCode: "CMQ", // cm³
+              },
+            }),
+          ...(vehicle.type_fuel && { fuelType: vehicle.type_fuel }),
+          ...(vehicle.motor_codes_formatted && {
+            engineType: vehicle.motor_codes_formatted,
           }),
         },
-        // ⛽ Carburant
+        // ⛽ Carburant (top-level pour rétro-compat Google)
         ...(vehicle.type_fuel && { fuelType: vehicle.type_fuel }),
         // 🚗 Carrosserie
         ...(vehicle.type_body && { bodyType: vehicle.type_body }),
-        // 📅 Période de production
-        ...(vehicle.type_year_from && {
-          additionalProperty: [
-            {
-              "@type": "PropertyValue",
-              name: "Période de production",
-              value: vehicle.type_year_to
-                ? `${vehicle.type_year_from}-${vehicle.type_year_to}`
-                : `depuis ${vehicle.type_year_from}`,
-            },
-          ],
-        }),
+        // 📅 + 🔢 PropertyValues : période, CNIT, code moteur
+        ...(additionalProperty.length > 0 && { additionalProperty }),
         url: canonicalUrl,
       },
       // 2️⃣ BreadcrumbList - Fil d'ariane

--- a/frontend/app/components/vehicle/r8/sections/TechSpecsSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/TechSpecsSection.tsx
@@ -1,0 +1,140 @@
+// ⚙️ R8 Vehicle — S_TECH_SPECS
+// Table de specs techniques de la motorisation. Données 100% type_id-specific.
+// Casse le duplicate cross-motorisations en exposant les vrais chiffres distincts.
+
+import { Cog, Fuel, Gauge, Calendar, Hash, Car as CarIcon } from "lucide-react";
+import { type LoaderData } from "../r8.types";
+
+interface Props {
+  vehicle: LoaderData["vehicle"];
+}
+
+interface SpecRow {
+  label: string;
+  value: string | null | undefined;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+}
+
+function powerKwFromPs(ps: string): string | null {
+  const n = parseInt(ps, 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n / 1.35962).toString();
+}
+
+function formatPeriod(
+  monthFrom: string | undefined,
+  yearFrom: string | undefined,
+  monthTo: string | null | undefined,
+  yearTo: string | null | undefined,
+): string | null {
+  if (!yearFrom) return null;
+  const start = monthFrom
+    ? `${monthFrom.padStart(2, "0")}/${yearFrom}`
+    : yearFrom;
+  if (!yearTo) return `Depuis ${start}`;
+  const end = monthTo ? `${monthTo.padStart(2, "0")}/${yearTo}` : yearTo;
+  return `${start} – ${end}`;
+}
+
+function formatCylindree(
+  cm3: number | undefined,
+  fallback: string | undefined,
+): string | null {
+  if (cm3 && cm3 > 0) {
+    const liters = (cm3 / 1000).toFixed(1).replace(/\.0$/, "");
+    return `${liters} L (${cm3} cm³)`;
+  }
+  return fallback ?? null;
+}
+
+export function TechSpecsSection({ vehicle }: Props) {
+  const kw = powerKwFromPs(vehicle.type_power_ps);
+  const period = formatPeriod(
+    vehicle.type_month_from,
+    vehicle.type_year_from,
+    vehicle.type_month_to,
+    vehicle.type_year_to,
+  );
+  const cylindree = formatCylindree(
+    vehicle.cylinder_cm3,
+    vehicle.power_formatted,
+  );
+
+  const specs: SpecRow[] = [
+    {
+      label: "Cylindrée",
+      value: cylindree,
+      icon: Cog,
+    },
+    {
+      label: "Puissance",
+      value:
+        vehicle.type_power_ps && kw
+          ? `${vehicle.type_power_ps} ch (${kw} kW)`
+          : vehicle.type_power_ps
+            ? `${vehicle.type_power_ps} ch`
+            : null,
+      icon: Gauge,
+    },
+    {
+      label: "Carburant",
+      value: vehicle.type_fuel || null,
+      icon: Fuel,
+    },
+    {
+      label: "Carrosserie",
+      value: vehicle.type_body || null,
+      icon: CarIcon,
+    },
+    {
+      label: "Période",
+      value: period,
+      icon: Calendar,
+    },
+    {
+      label: "Code moteur",
+      value: vehicle.motor_codes_formatted || null,
+      icon: Hash,
+    },
+    {
+      label: "CNIT",
+      value: vehicle.cnit_codes_formatted || null,
+      icon: Hash,
+    },
+  ].filter((s): s is SpecRow => Boolean(s.value));
+
+  if (specs.length === 0) return null;
+
+  return (
+    <div className="mb-12" data-section="S_TECH_SPECS">
+      <div className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+          <h2 className="text-xl font-bold text-gray-900">
+            Spécifications techniques —{" "}
+            <span className="text-gray-700">
+              {vehicle.marque_name} {vehicle.modele_name} {vehicle.type_name}
+            </span>
+          </h2>
+        </div>
+        <dl className="divide-y divide-gray-100">
+          {specs.map(({ label, value, icon: Icon }) => (
+            <div
+              key={label}
+              className="flex items-center gap-4 px-6 py-3 hover:bg-gray-50 transition-colors"
+            >
+              <div className="inline-flex p-2 rounded-lg bg-blue-50 flex-shrink-0">
+                <Icon size={18} className="text-blue-600" />
+              </div>
+              <dt className="text-sm font-medium text-gray-600 w-32 flex-shrink-0">
+                {label}
+              </dt>
+              <dd className="text-sm font-semibold text-gray-900 break-words">
+                {value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -52,6 +52,7 @@ import {
   HowtoSection,
   R8EnrichedSection,
   SeoIntroSection,
+  TechSpecsSection,
   transformRpcToLoaderData,
   type LoaderData,
 } from "../components/vehicle/r8";
@@ -547,6 +548,8 @@ export default function VehicleDetailPage() {
         )}
 
         <SeoIntroSection r8Content={r8Content} seo={seo} />
+
+        <TechSpecsSection vehicle={vehicle} />
 
         {/* 📦 CATALOGUE PRINCIPAL - Design inspiré de la page index */}
         {catalogFamilies.length > 0 &&

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -53,7 +53,6 @@ import {
   R8EnrichedSection,
   SeoIntroSection,
   transformRpcToLoaderData,
-  TrustSection,
   type LoaderData,
 } from "../components/vehicle/r8";
 import { hierarchyApi } from "../services/api/hierarchy.api";
@@ -1126,8 +1125,6 @@ export default function VehicleDetailPage() {
             />
           </div>
         )}
-
-        <TrustSection />
 
         {/* 🔗 CTA retour hub marque R7 (maillage R8→R7) */}
         <div className="mt-8 text-center">

--- a/log.md
+++ b/log.md
@@ -87,3 +87,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/r8-html-distinct-render`
 - **Décision** : feat(r8): cut TrustSection from R8 route + spec for HTML distinct render
 - **Sortie** : PR aucune | commits 9d9ac41e
+
+## 2026-04-25 — feat/r8-html-distinct-render (auto)
+
+- **Branche** : `feat/r8-html-distinct-render`
+- **Décision** : feat(r8): add TechSpecsSection — table specs depuis auto_type (+2 other commits)
+- **Sortie** : PR #185 | commits e7048c22 867808f4 9d9ac41e

--- a/log.md
+++ b/log.md
@@ -81,3 +81,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-department-phase-2a`
 - **Décision** : feat(seo-department): phase 2a - audit findings table + canonical auditor
 - **Sortie** : PR #174 | commits 9581f6c2
+
+## 2026-04-25 — feat/r8-html-distinct-render (auto)
+
+- **Branche** : `feat/r8-html-distinct-render`
+- **Décision** : feat(r8): cut TrustSection from R8 route + spec for HTML distinct render
+- **Sortie** : PR aucune | commits 9d9ac41e


### PR DESCRIPTION
## Summary

Step 1/N de la refonte R8 pour casser le duplicate content cross-motorisations. **Sans bricolage** : 0 scraping, 0 write RAG, respecte ADR-022 L1.

Spec complète : `docs/superpowers/specs/2026-04-25-r8-html-distinct-render.md`.

## Cette PR (step 1)

Cut `TrustSection` de la page R8. 100 % boilerplate identique sur 53 959 pages.

## Baseline mesurée

`r8-diversity-check --modele-id 140004` (Clio III) : avg_diversity **68.3 %**, verdict REVIEW, collisions sur `faq_signature` + `category_signature`.

## Steps suivants (commits dans cette PR)

2. TechSpecsSection (depuis `auto_type`)
3. JSON-LD Vehicle Schema.org
4. MaintenanceSection (`__diag_maintenance_operation × __cross_gamme_car_new`)
5. TopPartsSection (`__diag_related_parts × drp_probability`)
6. SymptomsSection (`__diag_symptom` filtré system_id)
7. Switches rotation (4 tables `__seo_*_switch` = 18 430 phrases, seed=type_id)

## Hors scope

- Scraping web → 2e PR si mesure post-merge le justifie
- RAG `vehicles/*.md` writes → ADR-022 L1 respecté

🤖 Generated with [Claude Code](https://claude.com/claude-code)