### PR TITLE
feat(rag): ADR-029 P1 - RAG v2.1 control plane fondation (emitter+detector+migration)

### DIFF
--- a/backend/src/modules/rag-proxy/rag-proxy.module.ts
+++ b/backend/src/modules/rag-proxy/rag-proxy.module.ts
@@ -43,6 +43,10 @@ import { RagAdmissibilityGateService } from './services/rag-admissibility-gate.s
 // Phase 2A — Legacy Adapted Shadow Audit
 import { RagPhase2aShadowAuditService } from './services/rag-phase2a-shadow-audit.service';
 
+// ADR-029 P1 — RAG v2.1 Control Plane Closure (observability)
+import { RagEnrichmentReportEmitterService } from './services/rag-enrichment-report-emitter.service';
+import { RagConflictDetectorService } from './services/rag-conflict-detector.service';
+
 // NOTE: CacheModule is @Global() (registered in app.module.ts) — CacheService
 // is available everywhere without explicit import.
 // EventEmitterModule.forRoot() is also imported globally in app.module.ts.
@@ -60,6 +64,9 @@ import { RagPhase2aShadowAuditService } from './services/rag-phase2a-shadow-audi
     RagAdmissibilityGateService,
     // Phase 2A — Legacy Adapted Shadow Audit
     RagPhase2aShadowAuditService,
+    // ADR-029 P1 — RAG v2.1 Control Plane Closure
+    RagEnrichmentReportEmitterService,
+    RagConflictDetectorService,
     // Existing services
     FrontmatterValidatorService,
     RagCleanupService,
@@ -114,6 +121,9 @@ import { RagPhase2aShadowAuditService } from './services/rag-phase2a-shadow-audi
     RagAdmissibilityGateService,
     // Phase 2A — Legacy Adapted Shadow Audit
     RagPhase2aShadowAuditService,
+    // ADR-029 P1 — RAG v2.1 Control Plane Closure
+    RagEnrichmentReportEmitterService,
+    RagConflictDetectorService,
   ],
 })
 export class RagProxyModule {}

--- a/backend/src/modules/rag-proxy/services/rag-conflict-detector.service.ts
+++ b/backend/src/modules/rag-proxy/services/rag-conflict-detector.service.ts
@@ -1,0 +1,220 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import type {
+  RagConflictEntry,
+  RagConflictType,
+  RagSourceRef,
+} from '../types/rag-lifecycle.types';
+
+/**
+ * Liste des champs de gamme.md pour lesquels une divergence de valeur DOIT
+ * être classifiée comme `safety_conflict` (priorité Tech Lead).
+ *
+ * Cf. ADR-029 §"Decision matrix" et conflict.schema.yaml §"Owner de revue".
+ *
+ * Tout ajout à cette liste doit être discuté en ADR — c'est un domaine
+ * sensible (procédure / sécurité / conséquences mécaniques).
+ */
+const SAFETY_CRITICAL_FIELDS = new Set<string>([
+  'rendering.risk_explanation',
+  'rendering.risk_consequences',
+  'maintenance.do_not',
+  'installation.common_errors',
+  'diagnostic.causes',
+]);
+
+/**
+ * Liste de regex de fields traités comme `technical_conflict` quand la valeur
+ * diverge de manière non-mineure. Tout ce qui n'est pas matché ni dans
+ * SAFETY_CRITICAL_FIELDS sera classifié `minor_variation` par défaut.
+ */
+const TECHNICAL_FIELD_PATTERNS: RegExp[] = [
+  /^maintenance\.interval(\.|$)/,
+  /^selection\.cost_range(\.|$)/,
+  /^selection\.criteria(\[|\.|$)/,
+  /^diagnostic\.symptoms\[\d+\]\.severity$/,
+  /^domain\.must_be_true(\[|\.|$)/,
+  /^domain\.must_not_contain(\[|\.|$)/,
+];
+
+interface DetectInput {
+  /** Gamme slug (= pg_alias). */
+  alias: string;
+  /** UUID v4 of the current run. */
+  runId: string;
+  /** Map field.path → existing value (string-coerced). */
+  existingValues: Record<string, string>;
+  /** Map field.path → new value found this run (string-coerced). */
+  newValues: Record<string, string>;
+  /** Map field.path → sources for the existing value. */
+  existingSources: Record<string, RagSourceRef[]>;
+  /** Map field.path → sources for the new value. */
+  newSources: Record<string, RagSourceRef[]>;
+  /** ISO date YYYY-MM-DD. Defaults to today. */
+  runDate?: string;
+}
+
+/**
+ * RagConflictDetectorService — ADR-029 P1.
+ *
+ * Détecte les divergences entre la valeur actuelle d'un champ frontmatter
+ * gamme.md et la nouvelle valeur produite par le pipeline d'enrichissement.
+ * Classifie chaque divergence en `safety_conflict`, `technical_conflict` ou
+ * `minor_variation` selon :
+ *
+ *   1. Liste explicite SAFETY_CRITICAL_FIELDS → safety
+ *   2. Patterns TECHNICAL_FIELD_PATTERNS → technical
+ *   3. Sinon → minor (sera traitée comme normalisation, ne bloque pas L1)
+ *
+ * Le service est pur : il ne lit ni n'écrit le frontmatter. Le caller
+ * (P2 Audit / P3 QA) est responsable d'appliquer les conflits détectés au
+ * bloc `_conflicts[]` du fichier .md.
+ */
+@Injectable()
+export class RagConflictDetectorService {
+  private readonly logger = new Logger(RagConflictDetectorService.name);
+
+  /**
+   * Détecte les conflits entre `existingValues` et `newValues`.
+   * Retourne une entrée par champ divergent (selon les règles de
+   * classification ci-dessus).
+   */
+  detect(input: DetectInput): RagConflictEntry[] {
+    const today = input.runDate ?? new Date().toISOString().slice(0, 10);
+    const conflicts: RagConflictEntry[] = [];
+
+    // L'union des deux espaces de clés pour ne rien manquer
+    const allFields = new Set<string>([
+      ...Object.keys(input.existingValues),
+      ...Object.keys(input.newValues),
+    ]);
+
+    for (const field of allFields) {
+      const existing = input.existingValues[field];
+      const next = input.newValues[field];
+
+      // Champ absent d'un côté : ce n'est PAS un conflit (c'est un ajout
+      // ou une suppression, géré par les blocks[].action du report).
+      if (existing === undefined || next === undefined) continue;
+
+      if (areEquivalent(existing, next)) continue;
+
+      const conflictType = classifyConflict(field, existing, next);
+      const block = extractBlock(field);
+
+      if (!block) {
+        this.logger.warn(
+          `Skipping conflict for field='${field}' — cannot extract block prefix`,
+        );
+        continue;
+      }
+
+      conflicts.push({
+        block,
+        field,
+        conflict_type: conflictType,
+        run_id: input.runId,
+        existing_value: existing,
+        new_value: next,
+        existing_sources: input.existingSources[field] ?? [],
+        new_sources: input.newSources[field] ?? [],
+        resolution_status: 'open',
+        human_review_required:
+          conflictType === 'technical_conflict' ||
+          conflictType === 'safety_conflict',
+        created_at: today,
+        resolved_by: null,
+        resolution: null,
+        resolved_at: null,
+      });
+    }
+
+    if (conflicts.length > 0) {
+      this.logger.log(
+        `[${input.alias}] detected ${conflicts.length} conflict(s): ` +
+          summarizeByType(conflicts),
+      );
+    }
+
+    return conflicts;
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if two values represent the same business meaning. Trims and
+ * collapses whitespace, lowercase compare. Used to skip false positives.
+ */
+function areEquivalent(a: string, b: string): boolean {
+  return normalize(a) === normalize(b);
+}
+
+function normalize(s: string): string {
+  return s
+    .normalize('NFKC')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function classifyConflict(
+  field: string,
+  existing: string,
+  next: string,
+): RagConflictType {
+  if (SAFETY_CRITICAL_FIELDS.has(stripIndices(field))) {
+    return 'safety_conflict';
+  }
+  if (TECHNICAL_FIELD_PATTERNS.some((re) => re.test(field))) {
+    return 'technical_conflict';
+  }
+  // Existing != next mais ni safety ni technical : on regarde si c'est
+  // simplement une variation typographique acceptable.
+  if (isMinorTypographical(existing, next)) {
+    return 'minor_variation';
+  }
+  return 'minor_variation';
+}
+
+/** `selection.criteria[2]` → `selection.criteria` (array index agnostic). */
+function stripIndices(field: string): string {
+  return field.replace(/\[\d+\]/g, '');
+}
+
+/** Extract the top-level block from a dot-path field (`domain.role` → `domain`). */
+function extractBlock(field: string): RagConflictEntry['block'] | null {
+  const head = field.split('.')[0];
+  switch (head) {
+    case 'domain':
+    case 'selection':
+    case 'diagnostic':
+    case 'maintenance':
+    case 'installation':
+    case 'rendering':
+      return head;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Heuristic — true if both strings are equal modulo case/whitespace/punctuation.
+ * Used as a hint for `minor_variation` (the default fallback already returns
+ * minor_variation, so this helper is informational only for now and reserved
+ * for future expansion of the classifier).
+ */
+function isMinorTypographical(a: string, b: string): boolean {
+  const stripPunct = (s: string) => s.replace(/[.,;:!?'"()«»\[\]]/g, '');
+  return normalize(stripPunct(a)) === normalize(stripPunct(b));
+}
+
+function summarizeByType(conflicts: RagConflictEntry[]): string {
+  const counts = { safety: 0, technical: 0, minor: 0 };
+  for (const c of conflicts) {
+    if (c.conflict_type === 'safety_conflict') counts.safety += 1;
+    else if (c.conflict_type === 'technical_conflict') counts.technical += 1;
+    else counts.minor += 1;
+  }
+  return `safety=${counts.safety} technical=${counts.technical} minor=${counts.minor}`;
+}

--- a/backend/src/modules/rag-proxy/services/rag-enrichment-report-emitter.service.ts
+++ b/backend/src/modules/rag-proxy/services/rag-enrichment-report-emitter.service.ts
@@ -1,0 +1,189 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'crypto';
+import { promises as fsp } from 'fs';
+import { dirname } from 'path';
+import { ZodError } from 'zod';
+
+import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
+import {
+  RagEnrichmentReportSchema,
+  type RagEnrichmentReportInput,
+} from '../types/rag-lifecycle.schema';
+import type {
+  RagEnrichmentReport,
+  RagConflictType,
+} from '../types/rag-lifecycle.types';
+import { isDecisionCoherent } from '../types/rag-lifecycle.types';
+
+/**
+ * RagEnrichmentReportEmitterService — ADR-029 P1.
+ *
+ * Émet un `enrichment-report.json` par exécution du pipeline RAG v2.1.
+ * Chaque report est :
+ *   1. Validé contre `.spec/00-canon/enrichment-report.schema.json` (via Zod)
+ *   2. Vérifié pour cohérence du decision matrix (PROMOTE_L1 forbids conflicts)
+ *   3. Persisté en table `__rag_enrichment_runs` (Supabase, RLS service_role)
+ *   4. Dumpé en filesystem `{logsDir}/runs/{run_id}.json` (audit trail)
+ *
+ * Les callers (audit/enrich/qa runners de P2-P4) appellent `emit()` avec un
+ * payload partiel — le service complète `run_id` (UUID v4) et `run_date`
+ * (date du jour ISO) si absents.
+ */
+@Injectable()
+export class RagEnrichmentReportEmitterService extends SupabaseBaseService {
+  protected override readonly logger = new Logger(
+    RagEnrichmentReportEmitterService.name,
+  );
+
+  /**
+   * Répertoire des dumps JSON par run. Configurable via `RAG_RUN_LOGS_DIR`,
+   * défaut `/opt/automecanik/rag/logs/runs`.
+   */
+  private readonly runsLogDir: string;
+
+  constructor(configService: ConfigService) {
+    super(configService);
+    this.runsLogDir =
+      configService.get<string>('RAG_RUN_LOGS_DIR') ||
+      '/opt/automecanik/rag/logs/runs';
+  }
+
+  /**
+   * Persiste un enrichment report. Auto-génère `run_id` et `run_date` si
+   * absents.
+   *
+   * @throws BadRequestException si le payload échoue la validation Zod ou
+   *         la cohérence du decision matrix.
+   * @throws InternalServerErrorException si la persistance DB ou filesystem
+   *         échoue.
+   */
+  async emit(
+    input: Partial<RagEnrichmentReportInput>,
+  ): Promise<RagEnrichmentReport> {
+    const completed: RagEnrichmentReportInput = {
+      ...input,
+      run_id: input.run_id ?? randomUUID(),
+      run_date: input.run_date ?? new Date().toISOString().slice(0, 10),
+    } as RagEnrichmentReportInput;
+
+    let report: RagEnrichmentReport;
+    try {
+      report = RagEnrichmentReportSchema.parse(completed) as RagEnrichmentReport;
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const issues = err.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; ');
+        this.logger.warn(
+          `enrichment-report validation failed for alias=${input.alias ?? '?'} run_id=${
+            completed.run_id
+          }: ${issues}`,
+        );
+        throw new BadRequestException({
+          code: 'RAG_REPORT_SCHEMA_INVALID',
+          message: 'Enrichment report failed schema validation',
+          issues: err.issues,
+        });
+      }
+      throw err;
+    }
+
+    if (!isDecisionCoherent(report)) {
+      throw new BadRequestException({
+        code: 'RAG_REPORT_DECISION_INCOHERENT',
+        message:
+          'Decision matrix incoherent (e.g. PROMOTE_L1 with active conflicts, ' +
+          'safety_conflict not routed to PENDING_REVIEW/BLOCKED)',
+        decision: report.decision,
+        conflicts: report.conflicts,
+      });
+    }
+
+    const conflictsCounts = countConflictsByType(report);
+
+    // ── 1. Persist filesystem dump (best-effort first; if FS fails we still
+    //      try DB to avoid losing the report entirely) ─────────────────────
+    const filePath = `${this.runsLogDir}/${report.run_id}.json`;
+    try {
+      await fsp.mkdir(dirname(filePath), { recursive: true });
+      await fsp.writeFile(filePath, JSON.stringify(report, null, 2), 'utf-8');
+    } catch (err) {
+      this.logger.error(
+        `Failed to write run report to ${filePath}: ${(err as Error).message}`,
+      );
+      // Continue to DB persistence — DB is the SoT for the report.
+    }
+
+    // ── 2. Persist DB row in __rag_enrichment_runs ──────────────────────────
+    const { error } = await this.supabase
+      .from('__rag_enrichment_runs')
+      .insert({
+        run_id: report.run_id,
+        alias: report.alias,
+        run_date: report.run_date,
+        execution_mode: report.execution_mode,
+        state_before: report.state_before,
+        state_after: report.state_after,
+        truth_level_before: report.truth_level_before,
+        truth_level_after: report.truth_level_after,
+        decision: report.decision,
+        reason: report.reason,
+        report_json: report,
+        conflicts_count: conflictsCounts.total,
+        conflicts_safety: conflictsCounts.safety,
+        conflicts_technical: conflictsCounts.technical,
+        conflicts_minor: conflictsCounts.minor,
+      });
+
+    if (error) {
+      this.logger.error(
+        `Failed to persist enrichment report run_id=${report.run_id} alias=${report.alias}: ${error.message}`,
+      );
+      throw new InternalServerErrorException({
+        code: 'RAG_REPORT_DB_PERSIST_FAILED',
+        message: 'Failed to persist enrichment report to __rag_enrichment_runs',
+        cause: error.message,
+      });
+    }
+
+    this.logger.log(
+      `enrichment-report emitted alias=${report.alias} run_id=${report.run_id} ` +
+        `mode=${report.execution_mode} decision=${report.decision} ` +
+        `conflicts=${conflictsCounts.total} (safety=${conflictsCounts.safety}, ` +
+        `technical=${conflictsCounts.technical}, minor=${conflictsCounts.minor})`,
+    );
+
+    return report;
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+interface ConflictCounts {
+  total: number;
+  safety: number;
+  technical: number;
+  minor: number;
+}
+
+function countConflictsByType(report: RagEnrichmentReport): ConflictCounts {
+  const counts: ConflictCounts = {
+    total: report.conflicts.length,
+    safety: 0,
+    technical: 0,
+    minor: 0,
+  };
+  for (const c of report.conflicts) {
+    const t: RagConflictType = c.conflict_type;
+    if (t === 'safety_conflict') counts.safety += 1;
+    else if (t === 'technical_conflict') counts.technical += 1;
+    else if (t === 'minor_variation') counts.minor += 1;
+  }
+  return counts;
+}

--- a/backend/src/modules/rag-proxy/types/rag-lifecycle.schema.ts
+++ b/backend/src/modules/rag-proxy/types/rag-lifecycle.schema.ts
@@ -1,0 +1,90 @@
+/**
+ * ADR-029 P1 — Zod schema mirroring `.spec/00-canon/enrichment-report.schema.json`.
+ *
+ * Le RagEnrichmentReportEmitterService valide chaque payload contre ce schema
+ * AVANT persistance DB / filesystem. Tout drift entre ce schema et le canon
+ * JSON Schema est un bug qui DOIT être corrigé immédiatement (cf. ADR-029
+ * §"Décision: aucune divergence tolérée").
+ */
+
+import { z } from 'zod';
+import {
+  RAG_LIFECYCLE_STAGES,
+  RAG_EXECUTION_MODES,
+  RAG_DECISIONS,
+  RAG_VALIDATORS,
+} from './rag-lifecycle.types';
+
+// ── Atomic schemas ───────────────────────────────────────────────────────────
+
+const lifecycleStage = z.enum(RAG_LIFECYCLE_STAGES);
+const executionMode = z.enum(RAG_EXECUTION_MODES);
+const truthLevel = z.enum(['L1', 'L2']);
+const decision = z.enum(RAG_DECISIONS);
+const validatorName = z.enum(RAG_VALIDATORS);
+const validatorVerdict = z.enum(['PASS', 'PARTIAL', 'FAIL', 'SKIPPED']);
+const blockAction = z.enum(['unchanged', 'modified', 'added', 'removed']);
+const conflictType = z.enum([
+  'minor_variation',
+  'technical_conflict',
+  'safety_conflict',
+]);
+
+const blockResult = z.object({
+  action: blockAction,
+  qa_score: z.number().int().min(0).max(100).nullable(),
+  evidence_score: z.number().int().min(0).max(100).nullable(),
+  structural_complete: z.boolean().nullable(),
+});
+
+const conflictSummary = z.object({
+  block: z.string(),
+  field: z.string(),
+  conflict_type: conflictType,
+});
+
+const seoRegressionCheckDetail = z.object({
+  check_id: z.number().int().min(1).max(8),
+  status: z.enum(['pass', 'fail']),
+  detail: z.string().optional(),
+});
+
+const seoRegressionChecks = z.object({
+  passed: z.number().int().min(0),
+  failed: z.number().int().min(0),
+  details: z.array(seoRegressionCheckDetail),
+});
+
+// ── Top-level enrichment report schema ───────────────────────────────────────
+
+export const RagEnrichmentReportSchema = z
+  .object({
+    run_id: z.string().uuid(),
+    alias: z.string().min(1),
+    run_date: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'run_date must be ISO date YYYY-MM-DD'),
+    execution_mode: executionMode,
+    state_before: lifecycleStage,
+    state_after: lifecycleStage,
+    truth_level_before: truthLevel,
+    truth_level_after: truthLevel,
+    blocks: z.object({
+      domain: blockResult.optional(),
+      selection: blockResult.optional(),
+      maintenance: blockResult.optional(),
+      diagnostic: blockResult.optional(),
+      installation: blockResult.optional(),
+    }),
+    conflicts: z.array(conflictSummary),
+    pending_manual_sources: z.array(z.string()),
+    seo_regression_checks: seoRegressionChecks,
+    validators_invoked: z.array(validatorName),
+    validator_verdicts: z.record(validatorName, validatorVerdict),
+    decision: decision,
+    reason: z.string().min(1),
+  })
+  .strict();
+
+export type RagEnrichmentReportInput = z.input<typeof RagEnrichmentReportSchema>;
+export type RagEnrichmentReportParsed = z.output<typeof RagEnrichmentReportSchema>;

--- a/backend/src/modules/rag-proxy/types/rag-lifecycle.types.ts
+++ b/backend/src/modules/rag-proxy/types/rag-lifecycle.types.ts
@@ -1,0 +1,229 @@
+/**
+ * ADR-029 P1 — RAG v2.1 Control Plane lifecycle types.
+ *
+ * Source de vérité:
+ *   .spec/00-canon/enrichment-report.schema.json
+ *   .spec/00-canon/conflict.schema.yaml
+ *
+ * Toute évolution de ces types DOIT d'abord modifier les schemas canon, puis
+ * propager ici. Aucune divergence tolérée — le runtime valide la conformité
+ * via Ajv (cf. RagEnrichmentReportEmitterService).
+ */
+
+// ── Lifecycle stages (state machine 7 stages) ────────────────────────────────
+
+export const RAG_LIFECYCLE_STAGES = [
+  'v5_ssot',
+  'v5_audited',
+  'v5_enriched',
+  'v5_qa_passed',
+  'v5_indexed',
+  'v5_blocked',
+  'v5_pending_review',
+] as const;
+
+export type RagLifecycleStage = (typeof RAG_LIFECYCLE_STAGES)[number];
+
+// ── Execution modes ──────────────────────────────────────────────────────────
+
+export const RAG_EXECUTION_MODES = [
+  'audit_only',
+  'enrich_dry_run',
+  'enrich_write',
+  'qa_only',
+  'qa_write',
+  'index_ready_check',
+] as const;
+
+export type RagExecutionMode = (typeof RAG_EXECUTION_MODES)[number];
+
+// ── Truth level ──────────────────────────────────────────────────────────────
+
+export type RagTruthLevel = 'L1' | 'L2';
+
+// ── Decision matrix ──────────────────────────────────────────────────────────
+
+export const RAG_DECISIONS = [
+  'PROMOTE_L1',
+  'KEEP_L2',
+  'BLOCKED',
+  'PENDING_REVIEW',
+] as const;
+
+export type RagDecision = (typeof RAG_DECISIONS)[number];
+
+// ── Validators (R0-R8) ───────────────────────────────────────────────────────
+
+export const RAG_VALIDATORS = [
+  'R0',
+  'R1',
+  'R3',
+  'R4',
+  'R5',
+  'R6',
+  'R7',
+  'R8',
+] as const;
+
+export type RagValidator = (typeof RAG_VALIDATORS)[number];
+
+export type RagValidatorVerdict = 'PASS' | 'PARTIAL' | 'FAIL' | 'SKIPPED';
+
+// ── Block result (per-block enrichment outcome) ──────────────────────────────
+
+export type RagBlockAction = 'unchanged' | 'modified' | 'added' | 'removed';
+
+export interface RagBlockResult {
+  action: RagBlockAction;
+  /** 0-100. null if action=unchanged or not scored this run. */
+  qa_score: number | null;
+  /** 0-100. null if not measured this run. */
+  evidence_score: number | null;
+  /** Whether the block meets D5 minimal schema requirements. */
+  structural_complete: boolean | null;
+}
+
+export type RagBlockKey =
+  | 'domain'
+  | 'selection'
+  | 'maintenance'
+  | 'diagnostic'
+  | 'installation';
+
+// ── Conflicts (cf. conflict.schema.yaml) ─────────────────────────────────────
+
+export type RagConflictType =
+  /** Formulation différente, même sens métier. Ne bloque PAS L1. */
+  | 'minor_variation'
+  /** Valeur technique divergente. BLOQUE L1. */
+  | 'technical_conflict'
+  /** Contradiction sur procédure/sécurité. BLOQUE L1 + priorité revue. */
+  | 'safety_conflict';
+
+export type RagConflictResolutionStatus = 'open' | 'resolved' | 'dismissed';
+
+export type RagConflictResolution =
+  | 'accept_existing'
+  | 'accept_new'
+  | 'merge'
+  | 'rewrite'
+  | null;
+
+/** Source tier (A=constructeur/norme, B=revendeur/guide, C=généraliste). */
+export type RagSourceTier = 'A' | 'B' | 'C';
+
+export interface RagSourceRef {
+  url: string;
+  tier: RagSourceTier;
+}
+
+/**
+ * Conflict entry as stored in the gamme frontmatter `_conflicts[]`.
+ * Cf. conflict.schema.yaml §conflict_entry.
+ */
+export interface RagConflictEntry {
+  block: 'domain' | 'selection' | 'diagnostic' | 'maintenance' | 'installation' | 'rendering';
+  /** Dot path: ex `interval.value`, `symptoms[0].label`. */
+  field: string;
+  conflict_type: RagConflictType;
+  /** UUID v4 of the run that detected the conflict. */
+  run_id: string;
+  existing_value: string;
+  new_value: string;
+  existing_sources: RagSourceRef[];
+  new_sources: RagSourceRef[];
+  resolution_status: RagConflictResolutionStatus;
+  /** true if technical_conflict or safety_conflict; false only for minor_variation. */
+  human_review_required: boolean;
+  /** ISO date YYYY-MM-DD. */
+  created_at: string;
+  resolved_by: string | null;
+  resolution: RagConflictResolution;
+  resolved_at: string | null;
+}
+
+/** Compact summary embedded in the enrichment report. Full detail lives in the .md `_conflicts[]`. */
+export interface RagConflictSummary {
+  block: string;
+  field: string;
+  conflict_type: RagConflictType;
+}
+
+// ── SEO regression checks (8 checks, cf. enrichment-report.schema.json) ──────
+
+export interface RagSeoRegressionCheckDetail {
+  /** 1-8. */
+  check_id: number;
+  status: 'pass' | 'fail';
+  detail?: string;
+}
+
+export interface RagSeoRegressionChecks {
+  passed: number;
+  failed: number;
+  details: RagSeoRegressionCheckDetail[];
+}
+
+// ── Enrichment report (complete payload) ─────────────────────────────────────
+
+/**
+ * Payload validé contre `.spec/00-canon/enrichment-report.schema.json`.
+ * Persisté en table `__rag_enrichment_runs.report_json` (jsonb) + dump
+ * `/opt/automecanik/rag/logs/runs/{run_id}.json` (audit trail filesystem).
+ */
+export interface RagEnrichmentReport {
+  /** UUID v4, propagated to _archive, _conflicts, QA logs, lifecycle.last_enriched_run_id. */
+  run_id: string;
+  /** Gamme slug (= pg_alias). */
+  alias: string;
+  /** ISO date YYYY-MM-DD. */
+  run_date: string;
+  execution_mode: RagExecutionMode;
+  state_before: RagLifecycleStage;
+  state_after: RagLifecycleStage;
+  truth_level_before: RagTruthLevel;
+  truth_level_after: RagTruthLevel;
+  /** Per-block results. Keys are RagBlockKey. */
+  blocks: Partial<Record<RagBlockKey, RagBlockResult>>;
+  conflicts: RagConflictSummary[];
+  /** Fields requiring manual Tier A sourcing (format: `block.field`). */
+  pending_manual_sources: string[];
+  seo_regression_checks: RagSeoRegressionChecks;
+  validators_invoked: RagValidator[];
+  validator_verdicts: Partial<Record<RagValidator, RagValidatorVerdict>>;
+  decision: RagDecision;
+  /** Human-readable explanation of the decision. */
+  reason: string;
+}
+
+// ── Helper: validate decision matrix coherence ───────────────────────────────
+
+/**
+ * Returns true if the (decision, conflicts, validator_verdicts) triple is
+ * internally coherent per ADR-029 decision matrix.
+ *
+ * - PROMOTE_L1 forbids any technical_conflict/safety_conflict and requires all
+ *   invoked validators PASS.
+ * - safety_conflict forces PENDING_REVIEW (or BLOCKED). Never PROMOTE_L1.
+ * - technical_conflict open forces BLOCKED or PENDING_REVIEW.
+ */
+export function isDecisionCoherent(report: RagEnrichmentReport): boolean {
+  const hasSafety = report.conflicts.some((c) => c.conflict_type === 'safety_conflict');
+  const hasTechnical = report.conflicts.some((c) => c.conflict_type === 'technical_conflict');
+  const allValidatorsPass =
+    report.validators_invoked.length > 0 &&
+    report.validators_invoked.every(
+      (v) => report.validator_verdicts[v] === 'PASS',
+    );
+
+  if (report.decision === 'PROMOTE_L1') {
+    return !hasSafety && !hasTechnical && allValidatorsPass;
+  }
+  if (hasSafety) {
+    return report.decision === 'PENDING_REVIEW' || report.decision === 'BLOCKED';
+  }
+  if (hasTechnical) {
+    return report.decision === 'BLOCKED' || report.decision === 'PENDING_REVIEW';
+  }
+  return true;
+}

--- a/backend/supabase/migrations/20260425_rag_enrichment_runs.sql
+++ b/backend/supabase/migrations/20260425_rag_enrichment_runs.sql
@@ -1,0 +1,94 @@
+-- =============================================================================
+-- ADR-029 P1 — RAG v2.1 Control Plane: enrichment_runs observability table
+-- =============================================================================
+--
+-- Stocke un enrichment-report.json par exécution du pipeline d'enrichissement
+-- des gammes RAG. Aligné sur:
+--   .spec/00-canon/enrichment-report.schema.json
+--   .spec/00-canon/conflict.schema.yaml
+--
+-- Producteur:
+--   RagEnrichmentReportEmitterService (P1)
+--
+-- Consommateurs:
+--   - skill `seo-gamme-audit` (lecture historique enrichissement par gamme)
+--   - skill `pollution-scanner` (détection régressions silencieuses)
+--   - dashboard SEO findings
+--
+-- RLS aligné ADR-021 (zero trust): lecture admin only, écriture service_role only.
+
+CREATE TABLE IF NOT EXISTS __rag_enrichment_runs (
+  run_id UUID PRIMARY KEY,
+  alias TEXT NOT NULL,
+  run_date DATE NOT NULL,
+
+  execution_mode TEXT NOT NULL CHECK (execution_mode IN (
+    'audit_only',
+    'enrich_dry_run',
+    'enrich_write',
+    'qa_only',
+    'qa_write',
+    'index_ready_check'
+  )),
+
+  state_before TEXT NOT NULL CHECK (state_before IN (
+    'v5_ssot', 'v5_audited', 'v5_enriched', 'v5_qa_passed',
+    'v5_indexed', 'v5_blocked', 'v5_pending_review'
+  )),
+  state_after TEXT NOT NULL CHECK (state_after IN (
+    'v5_ssot', 'v5_audited', 'v5_enriched', 'v5_qa_passed',
+    'v5_indexed', 'v5_blocked', 'v5_pending_review'
+  )),
+
+  truth_level_before TEXT NOT NULL CHECK (truth_level_before IN ('L1', 'L2')),
+  truth_level_after  TEXT NOT NULL CHECK (truth_level_after  IN ('L1', 'L2')),
+
+  decision TEXT NOT NULL CHECK (decision IN (
+    'PROMOTE_L1', 'KEEP_L2', 'BLOCKED', 'PENDING_REVIEW'
+  )),
+  reason TEXT NOT NULL,
+
+  -- Payload validé contre enrichment-report.schema.json (jsonb pour requêtes)
+  report_json JSONB NOT NULL,
+
+  -- Conflits détectés ce run (vue agrégée; détail dans le frontmatter .md)
+  conflicts_count INTEGER NOT NULL DEFAULT 0,
+  conflicts_safety INTEGER NOT NULL DEFAULT 0,
+  conflicts_technical INTEGER NOT NULL DEFAULT 0,
+  conflicts_minor INTEGER NOT NULL DEFAULT 0,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rag_runs_alias_date
+  ON __rag_enrichment_runs(alias, run_date DESC);
+
+CREATE INDEX IF NOT EXISTS idx_rag_runs_decision
+  ON __rag_enrichment_runs(decision)
+  WHERE decision IN ('BLOCKED', 'PENDING_REVIEW');
+
+CREATE INDEX IF NOT EXISTS idx_rag_runs_created_at
+  ON __rag_enrichment_runs(created_at DESC);
+
+-- ── RLS (ADR-021 zero trust) ─────────────────────────────────────────────────
+
+ALTER TABLE __rag_enrichment_runs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS rag_runs_service_role_all ON __rag_enrichment_runs;
+CREATE POLICY rag_runs_service_role_all
+  ON __rag_enrichment_runs
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Lecture admin via la connexion authentifiée NestJS (anon key + admin guard
+-- côté application). Aucune policy 'authenticated' ouverte: l'accès passe par
+-- le service_role en backend après vérification IsAdminGuard.
+
+COMMENT ON TABLE __rag_enrichment_runs IS
+  'ADR-029 P1: enrichment-report.json persisté par run du pipeline RAG v2.1';
+COMMENT ON COLUMN __rag_enrichment_runs.report_json IS
+  'Validé contre .spec/00-canon/enrichment-report.schema.json';
+COMMENT ON COLUMN __rag_enrichment_runs.conflicts_count IS
+  'Total des _conflicts[] détectés ce run (cf. conflict.schema.yaml)';


### PR DESCRIPTION
## Summary

**P1 fondation du control plane RAG v2.1** (ADR-029, vault PR ak125/governance-vault#77 — proposed).

Pose les briques NestJS qui consommeront/émettront les artefacts définis par la spec mergée le 2026-04-07 (commit `c675c9a6`) — `enrichment-report.schema.json` + `conflict.schema.yaml` — sans encore câbler le pipeline d'enrichissement externe (le cron `run-phase-f.sh` et `auto-enrich-r4-rag.py` vivent dans le repo `automecanik-rag`, traités en PR séparée).

## What's in this PR

- ✅ Migration Supabase `__rag_enrichment_runs` (state machine 7 stages + 6 modes + decision matrix + RLS service_role)
- ✅ Types TypeScript miroirs des schemas canon (`.spec/00-canon/enrichment-report.schema.json`, `conflict.schema.yaml`)
- ✅ `RagEnrichmentReportEmitterService` — valide payload Zod, vérifie cohérence du decision matrix, persiste DB + dump JSON filesystem
- ✅ `RagConflictDetectorService` — classifie divergences en `safety_conflict` / `technical_conflict` / `minor_variation` selon 2 listes canon (5 fields safety + 6 patterns technical)
- ✅ Wiring `rag-proxy.module.ts` (providers + exports)

## What's NOT in this PR (still draft)

- ❌ Endpoint admin `POST /api/rag/admin/pipeline/emit-report` (pour smoke test)
- ❌ Tests unitaires (decision matrix coherence, conflict classification, normalisation NFKC/whitespace)
- ❌ Path fix `auto-enrich-r4-rag.py:279` + wiring `run-phase-f.sh` (repo `automecanik-rag` → PR séparée)

Cette PR ne mergera **pas** tant que tous les items ci-dessus ne sont pas couverts (cohérent avec ADR-029 §"Pas d'hybride en attendant").

## Refs

- Vault ADR-029 (proposed) : https://github.com/ak125/governance-vault/pull/77
- Spec canon mergée : commit [`c675c9a6`](https://github.com/ak125/nestjs-remix-monorepo/commit/c675c9a6) du 2026-04-07
- ADR-022 (R8 control plane, pattern propose-before-write réutilisé)
- ADR-021 (RLS hardening, aligné pour `__rag_enrichment_runs`)

## Test plan

- [x] Typecheck : 0 nouvelle erreur (`pdf-parse` préexistante sur main, vérifiée par stash)
- [ ] Migration appliquée en DEV → table créée + RLS active
- [ ] Smoke test `RagEnrichmentReportEmitterService.emit()` via endpoint admin (à ajouter)
- [ ] Test unitaire `isDecisionCoherent()` couvre les 4 décisions × {avec/sans conflits} × {validators PASS/FAIL}
- [ ] Test unitaire `RagConflictDetectorService.detect()` couvre 5 fields safety + 6 patterns technical + minor_variation par défaut

🤖 Generated with [Claude Code](https://claude.com/claude-code)