### PR TITLE
feat(rag): vehicle motor scraping — propose-before-write canon (CEO directive)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/entities/error-log.entity.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/gamme-rest/gamme-rest-optimized.controller.ts
 - backend/src/modules/gamme-rest/gamme-rest-rpc-v2.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-04-25'
+last_scan: '2026-04-26'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/docs/superpowers/specs/2026-04-25-r8-html-distinct-render.md
+++ b/docs/superpowers/specs/2026-04-25-r8-html-distinct-render.md
@@ -1,0 +1,71 @@
+# R8 HTML Distinct Render — Spec courte
+
+**Date** : 2026-04-25
+**Branche** : `feat/r8-html-distinct-render`
+**Objectif** : Réduire le duplicate content cross-motorisations sur les pages R8 (`/constructeurs/:brand/:model/:type.html`) en câblant les données DB existantes + le système de switches legacy + JSON-LD Vehicle, **sans scraping et sans toucher au RAG** (respecte ADR-022 L1).
+
+## Baseline (mesuré 2026-04-25 21:32 UTC)
+
+`r8-diversity-check --modele-id 140004` (Clio III) :
+- 3 sibling pages dans `__seo_r8_pages` (la majorité des 30+ motorisations Clio III rendent via fallback DB)
+- avg_diversity 68.3 %, verdict REVIEW
+- Collisions sur `faq_signature` (pool 7) et `category_signature` (pool 7)
+
+## Diagnostic frontend
+
+`frontend/app/routes/constructeurs.$brand.$model.$type.tsx` (1258 LOC) rend 7 sections :
+- HeroSection — variable ✅
+- BreadcrumbSection — variable ✅
+- SeoIntroSection — vient du RAG enricher (souvent vide)
+- **TrustSection — 100 % boilerplate, identique sur 53 959 pages** ❌
+- AntiErrorsSection — 85 % boilerplate ❌
+- HowtoSection — 80 % boilerplate ❌
+- R8EnrichedSection — optionnel, souvent vide
+
+## Données déjà disponibles (vérifiées 2026-04-25)
+
+| Source | Contenu | Lien type_id |
+|---|---|---|
+| `auto_type` | type_name, type_engine, type_fuel, type_power_ps, type_power_kw, type_liter, type_year_*, type_month_*, type_body | direct |
+| `__cross_gamme_car_new` | Gammes applicables au véhicule | `cgc_type_id` |
+| `__diag_maintenance_operation` | Ops entretien (label, intervalles km/mois, sévérité) | via `related_pg_id` |
+| `__diag_related_parts` | Pièces co-changées + probabilité | via `drp_source_pg_id` |
+| `__diag_symptom` | Pannes/symptômes (label, urgence) | via `system_id` |
+| `__seo_type_switch` | 134 phrases (5 alias) | rotation hash(type_id) |
+| `__seo_item_switch` | 7 964 phrases (3 alias) | rotation hash(type_id) |
+| `__seo_gamme_car_switch` | 6 542 phrases (3 alias) | rotation hash(type_id) |
+| `__seo_family_gamme_car_switch` | 3 790 phrases (6 alias) | rotation hash(type_id) |
+
+**Total : 18 430 phrases switch + 6 tables data, 0 % câblées sur R8 actuellement.**
+
+## Plan d'implémentation (incrémental, commits atomiques)
+
+1. **Cut TrustSection** de la page R8 (déplacement vers footer global ou layout partagé) — gain immédiat, commit isolé.
+2. **TechSpecsSection** (nouvelle) : table specs depuis `auto_type` (kW, cylindrée, body, période mensuelle, code moteur si dispo).
+3. **JSON-LD Vehicle Schema.org** dans `<head>` via `meta()` Remix (`@type:Vehicle`, `vehicleEngine`, `vehicleConfiguration`, `manufacturer`, `dateVehicleFirstRegistered`, `vehicleModelDate`).
+4. **MaintenanceSection** : top 3-5 ops depuis `__diag_maintenance_operation × cross_gamme_car_new`.
+5. **TopPartsSection** : pièces co-changées depuis `__diag_related_parts` triées par `drp_probability`.
+6. **SymptomsSection** : top symptômes depuis `__diag_symptom` filtrés par system applicable.
+7. **Switches rotation** câblée sur Howto/AntiErrors/SeoIntro avec seed=type_id (pattern `brand-bestsellers.service.ts:235-280`).
+
+## Mesure post-implémentation
+
+- `python3 scripts/qa/r8-diversity-check.py --modele-id 140004` après chaque commit majeur
+- Si verdict toujours REVIEW/FAIL après les 7 étapes → **2e PR distincte** pour scraping (couple, vmax, masse, code moteur K9K) via `__rag_proposals` propose-before-write (ADR-022).
+
+## Hors scope explicite
+
+- ❌ Scraping web (reporté à PR séparée si nécessaire après mesure)
+- ❌ Modifications RAG `vehicles/*.md` (ADR-022 L1 violée si on touche)
+- ❌ Modifications du backend RPC `build_vehicle_page_payload` au-delà de l'ajout de fields lus depuis DB
+
+## Réversibilité
+
+`git revert` du squash-merge annule tout. Aucun write DB/RAG, uniquement frontend + ajout SQL dans le RPC loader (read-only).
+
+## Refs
+
+- ADR-022 R8 RAG Control Plane (vault, accepted 2026-04-25)
+- Honest debrief : `governance-vault/ledger/knowledge/r8-vehicle-enrichment-stage1-honest-debrief-20260425.md`
+- Pattern legacy switch : `backend/src/modules/vehicles/services/brand-bestsellers.service.ts:235-280`
+- Config switches : `backend/src/config/seo-switch-aliases.config.ts`

--- a/docs/superpowers/specs/2026-04-26-rag-vehicle-scraping-canon.md
+++ b/docs/superpowers/specs/2026-04-26-rag-vehicle-scraping-canon.md
@@ -1,0 +1,98 @@
+# RAG Vehicle Scraping — Canon Path (propose-before-write)
+
+**Date** : 2026-04-26
+**Branche** : `feat/rag-vehicle-scraping-canon`
+**CEO directive** : "plus il y a enrichissement plus on peut varier les contenus" — la priorité est l'acquisition de **faits factuels distinguants par motorisation** (couple, vmax, masse, code moteur, norme Euro, période détaillée), à câbler ensuite sur le rendu R8.
+
+## Diagnostic factuel (mesuré 2026-04-26)
+
+Jaccard mesuré sur HTML rendu prod entre 2 motorisations sœurs Clio III 1.5 dCi (64 ch vs 68 ch) : **83.2 %**. 292 tokens communs, 14 + 45 uniques (presque tous des codes pièces, peu de tokens sémantiques distinctifs).
+
+PR #185 (frontend distinct render) seul = baisse estimée à 70-75 %. Toujours au-dessus du seuil 40 %.
+
+**Cause racine** : la DB `auto_type` n'a que ~6 champs distinctifs (puissance, body, fuel, period, type_name, cylindrée). Les **vrais faits différenciants par motorisation** (couple, vmax, masse, code moteur K9K vs D4F) ne sont pas en DB.
+
+## Stratégie
+
+Acquisition de ces faits **via web scraping**, écrits dans le RAG `vehicles/<slug>.md` mais **uniquement via `__rag_proposals`** (ADR-022 L1 — propose-before-write, jamais d'écriture disque directe).
+
+## Stack récupérée (commit tip 78324b28 de la PR #172 fermée)
+
+- `scripts/rag/download-vehicle-motor-corpus.py` (724 LOC) — scraper : download HTML web → scratch dir `web-vehicles/`. **Zéro write RAG.** Safe.
+- `data/vehicles_known_urls.csv` — URLs Clio III curated par l'utilisateur (Wikipedia FR/EN, lacentrale, autotitre, fiches-auto).
+- (à venir) `scripts/rag/rag-propose-vehicle-from-web.py` — enricher mode propose. Réécrit depuis l'ancien `rag-enrich-vehicle-from-web.py` (closed PR #172) qui faisait du direct-write `vehicles/*.md` → maintenant écrit dans `__rag_proposals` avec status `pending`.
+
+## Mécanique propose-before-write
+
+Pour chaque modèle (e.g. Clio III, modele_id=140004) :
+
+1. **Read** : charge le contenu actuel de `rag/knowledge/vehicles/clio-iii.md` (peut être vide / inexistant)
+2. **Compute** : génère le nouveau contenu enrichi avec les motorisations[] scrapées
+3. **Hash** : calcule `base_content_hash`, `proposed_content_hash`, `input_fingerprint` (déterministe sur les inputs scraping)
+4. **Diff** : `diff_unified` pour reviewing
+5. **Validate** : forbidden_terms_found + schema_valid + risk_level (low/medium/high selon nb lignes ajoutées)
+6. **INSERT** dans `__rag_proposals` avec :
+   - `target_path` = `vehicles/clio-iii.md`
+   - `target_kind` = `vehicle`
+   - `status` = `pending`
+   - `expires_at` = J+14
+   - `created_by` = `rag-vehicle-scraper-canon-v1`
+7. **Aucune écriture disque.** Le merge dans `vehicles/clio-iii.md` se fait par un autre processus après approbation manuelle.
+
+## Champs cibles par motorisation
+
+Extraits par motorisation type_id (validés cross-source ≥2 confirmations) :
+
+| Champ | Source primaire | Confirmation |
+|---|---|---|
+| `code_moteur` (K9K, D4F) | Wikipedia FR | fiches-auto |
+| `couple_nm` | fiches-auto | autotitre |
+| `couple_rpm` | fiches-auto | — |
+| `power_rpm` | fiches-auto | Wikipedia |
+| `vitesse_max_kmh` | fiches-auto | Wikipedia |
+| `zero_a_cent_s` | fiches-auto | Wikipedia |
+| `masse_kg` | fiches-auto | — |
+| `boite` (5/6 vitesses, manuelle/auto) | fiches-auto | — |
+| `norme_euro` | dérivé `derive_euro(year_from)` | — |
+| `période_mensuelle` | DB `type_month_*` | — |
+
+## Gouvernance — directive CEO 2026-04-26
+
+ADR-022 ligne 73 dit "Stage 2 canary 10 modèles low-profile (PAS Clio/208/Golf)". Le CEO @fafa a explicitement dirigé que **l'enrichissement scraping est la priorité depuis le début** et que le pilote se fait sur **Clio III**.
+
+Décision documentée :
+- Pilote = Clio III (modele_id 140004) en directive CEO override de la ligne 73 ADR-022
+- Vault PR séparée à ouvrir pour amender ADR-022 ligne 73 : ajouter "Stage 2 canary peut inclure des modèles top-trafic sur directive board"
+- Les écritures restent en propose-before-write (L1 respecté)
+- 2-3 motorisations Clio III en proposal pilot, review board avant merge
+
+## Articulation avec PR #185 (frontend)
+
+PR #185 et cette PR sont **indépendantes** et **complémentaires** :
+
+- PR #185 : utilise data DB existante (auto_type, diag_*, switches) → gain Jaccard 83 → 70 %
+- Cette PR : ajoute des champs scraping au RAG → après merge de proposals, le frontend (TechSpecsSection ou nouvelle MotorFactsSection) lit ces nouveaux champs → gain Jaccard 70 → 30-40 %
+
+Les 2 PRs peuvent merger dans n'importe quel ordre. La mesure post-merge des deux ensemble = vraie validation.
+
+## Hors scope explicite
+
+- ❌ Direct-write `vehicles/*.md` (interdit par ADR-022 L1)
+- ❌ Scraping de modèles autres que Clio III dans cette PR (1 pilote, mesure, puis Stage 2 canary low-profile en PR séparée)
+- ❌ Frontend modifications (couvert par PR #185)
+- ❌ LLM-based extraction (parsers déterministes uniquement)
+
+## Réversibilité
+
+- Si proposals rejected → status='rejected', aucune modification RAG
+- Si proposals approved + merged → écriture RAG via processus séparé
+- Le scraper n'écrit que dans `web-vehicles/` (scratch dir, gitignored)
+- Le proposeur écrit uniquement dans `__rag_proposals` table (aucune table de prod touchée)
+
+## Refs
+
+- ADR-022 R8 RAG Control Plane (vault, accepted 2026-04-25)
+- PR fermée #172 (monorepo, scraping direct-write — bricolage rejeté)
+- PR fermée #3 (rag, vehicles/*.md direct-write — bricolage rejeté)
+- Honest debrief : `governance-vault/ledger/knowledge/r8-vehicle-enrichment-stage1-honest-debrief-20260425.md`
+- PR #185 frontend distinct render (parallèle, complémentaire)

--- a/frontend/app/components/vehicle/r8/index.ts
+++ b/frontend/app/components/vehicle/r8/index.ts
@@ -22,4 +22,5 @@ export { HeroSection } from "./sections/HeroSection";
 export { HowtoSection } from "./sections/HowtoSection";
 export { R8EnrichedSection } from "./sections/R8EnrichedSection";
 export { SeoIntroSection } from "./sections/SeoIntroSection";
+export { TechSpecsSection } from "./sections/TechSpecsSection";
 export { TrustSection } from "./sections/TrustSection";

--- a/frontend/app/components/vehicle/r8/r8-schema.ts
+++ b/frontend/app/components/vehicle/r8/r8-schema.ts
@@ -12,6 +12,68 @@ export function generateVehicleSchema(
   const baseUrl = "https://www.automecanik.com";
   const canonicalUrl = `${baseUrl}/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}/${vehicle.modele_alias}-${vehicle.modele_id}/${vehicle.type_alias}-${vehicle.type_id}.html`;
 
+  // Puissance dérivée kW (commonly used aux côtés HP)
+  const powerPs = vehicle.type_power_ps
+    ? parseInt(vehicle.type_power_ps)
+    : null;
+  const powerKw = powerPs && powerPs > 0 ? Math.round(powerPs / 1.35962) : null;
+
+  // Période de production formatée
+  const periodValue = vehicle.type_year_from
+    ? vehicle.type_year_to
+      ? `${vehicle.type_year_from}-${vehicle.type_year_to}`
+      : `depuis ${vehicle.type_year_from}`
+    : null;
+
+  // additionalProperty : enrichi avec CNIT + code moteur si dispo
+  const additionalProperty: Array<{
+    "@type": "PropertyValue";
+    name: string;
+    value: string;
+  }> = [];
+  if (periodValue) {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "Période de production",
+      value: periodValue,
+    });
+  }
+  if (vehicle.cnit_codes_formatted) {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "CNIT",
+      value: vehicle.cnit_codes_formatted,
+    });
+  }
+  if (vehicle.motor_codes_formatted) {
+    additionalProperty.push({
+      "@type": "PropertyValue",
+      name: "Code moteur",
+      value: vehicle.motor_codes_formatted,
+    });
+  }
+
+  // EngineSpecification enrichi : displacement (cm3), engineType (codes), enginePower (HP+kW)
+  const enginePower: Array<{
+    "@type": "QuantitativeValue";
+    value: number;
+    unitCode: string;
+  }> = [];
+  if (powerPs) {
+    enginePower.push({
+      "@type": "QuantitativeValue",
+      value: powerPs,
+      unitCode: "HP",
+    });
+  }
+  if (powerKw) {
+    enginePower.push({
+      "@type": "QuantitativeValue",
+      value: powerKw,
+      unitCode: "KWT",
+    });
+  }
+
   return {
     "@context": "https://schema.org",
     "@graph": [
@@ -24,38 +86,36 @@ export function generateVehicleSchema(
         manufacturer: { "@type": "Organization", name: vehicle.marque_name },
         model: vehicle.modele_name,
         vehicleConfiguration: vehicle.type_name,
-        // 📅 Année modèle
+        // 📅 Année modèle (utilisé par Google + Bing)
         ...(vehicle.type_year_from && {
           vehicleModelDate: vehicle.type_year_from,
+          modelDate: vehicle.type_year_from,
+          dateVehicleFirstRegistered: vehicle.type_year_from,
         }),
-        // 🔧 Moteur
+        // 🔧 Moteur enrichi
         vehicleEngine: {
           "@type": "EngineSpecification",
           name: vehicle.type_name,
-          ...(vehicle.type_power_ps && {
-            enginePower: {
-              "@type": "QuantitativeValue",
-              value: parseInt(vehicle.type_power_ps),
-              unitCode: "HP",
-            },
+          ...(enginePower.length > 0 && { enginePower }),
+          ...(vehicle.cylinder_cm3 &&
+            vehicle.cylinder_cm3 > 0 && {
+              engineDisplacement: {
+                "@type": "QuantitativeValue",
+                value: vehicle.cylinder_cm3,
+                unitCode: "CMQ", // cm³
+              },
+            }),
+          ...(vehicle.type_fuel && { fuelType: vehicle.type_fuel }),
+          ...(vehicle.motor_codes_formatted && {
+            engineType: vehicle.motor_codes_formatted,
           }),
         },
-        // ⛽ Carburant
+        // ⛽ Carburant (top-level pour rétro-compat Google)
         ...(vehicle.type_fuel && { fuelType: vehicle.type_fuel }),
         // 🚗 Carrosserie
         ...(vehicle.type_body && { bodyType: vehicle.type_body }),
-        // 📅 Période de production
-        ...(vehicle.type_year_from && {
-          additionalProperty: [
-            {
-              "@type": "PropertyValue",
-              name: "Période de production",
-              value: vehicle.type_year_to
-                ? `${vehicle.type_year_from}-${vehicle.type_year_to}`
-                : `depuis ${vehicle.type_year_from}`,
-            },
-          ],
-        }),
+        // 📅 + 🔢 PropertyValues : période, CNIT, code moteur
+        ...(additionalProperty.length > 0 && { additionalProperty }),
         url: canonicalUrl,
       },
       // 2️⃣ BreadcrumbList - Fil d'ariane

--- a/frontend/app/components/vehicle/r8/sections/TechSpecsSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/TechSpecsSection.tsx
@@ -1,0 +1,140 @@
+// ⚙️ R8 Vehicle — S_TECH_SPECS
+// Table de specs techniques de la motorisation. Données 100% type_id-specific.
+// Casse le duplicate cross-motorisations en exposant les vrais chiffres distincts.
+
+import { Cog, Fuel, Gauge, Calendar, Hash, Car as CarIcon } from "lucide-react";
+import { type LoaderData } from "../r8.types";
+
+interface Props {
+  vehicle: LoaderData["vehicle"];
+}
+
+interface SpecRow {
+  label: string;
+  value: string | null | undefined;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+}
+
+function powerKwFromPs(ps: string): string | null {
+  const n = parseInt(ps, 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n / 1.35962).toString();
+}
+
+function formatPeriod(
+  monthFrom: string | undefined,
+  yearFrom: string | undefined,
+  monthTo: string | null | undefined,
+  yearTo: string | null | undefined,
+): string | null {
+  if (!yearFrom) return null;
+  const start = monthFrom
+    ? `${monthFrom.padStart(2, "0")}/${yearFrom}`
+    : yearFrom;
+  if (!yearTo) return `Depuis ${start}`;
+  const end = monthTo ? `${monthTo.padStart(2, "0")}/${yearTo}` : yearTo;
+  return `${start} – ${end}`;
+}
+
+function formatCylindree(
+  cm3: number | undefined,
+  fallback: string | undefined,
+): string | null {
+  if (cm3 && cm3 > 0) {
+    const liters = (cm3 / 1000).toFixed(1).replace(/\.0$/, "");
+    return `${liters} L (${cm3} cm³)`;
+  }
+  return fallback ?? null;
+}
+
+export function TechSpecsSection({ vehicle }: Props) {
+  const kw = powerKwFromPs(vehicle.type_power_ps);
+  const period = formatPeriod(
+    vehicle.type_month_from,
+    vehicle.type_year_from,
+    vehicle.type_month_to,
+    vehicle.type_year_to,
+  );
+  const cylindree = formatCylindree(
+    vehicle.cylinder_cm3,
+    vehicle.power_formatted,
+  );
+
+  const specs: SpecRow[] = [
+    {
+      label: "Cylindrée",
+      value: cylindree,
+      icon: Cog,
+    },
+    {
+      label: "Puissance",
+      value:
+        vehicle.type_power_ps && kw
+          ? `${vehicle.type_power_ps} ch (${kw} kW)`
+          : vehicle.type_power_ps
+            ? `${vehicle.type_power_ps} ch`
+            : null,
+      icon: Gauge,
+    },
+    {
+      label: "Carburant",
+      value: vehicle.type_fuel || null,
+      icon: Fuel,
+    },
+    {
+      label: "Carrosserie",
+      value: vehicle.type_body || null,
+      icon: CarIcon,
+    },
+    {
+      label: "Période",
+      value: period,
+      icon: Calendar,
+    },
+    {
+      label: "Code moteur",
+      value: vehicle.motor_codes_formatted || null,
+      icon: Hash,
+    },
+    {
+      label: "CNIT",
+      value: vehicle.cnit_codes_formatted || null,
+      icon: Hash,
+    },
+  ].filter((s): s is SpecRow => Boolean(s.value));
+
+  if (specs.length === 0) return null;
+
+  return (
+    <div className="mb-12" data-section="S_TECH_SPECS">
+      <div className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+          <h2 className="text-xl font-bold text-gray-900">
+            Spécifications techniques —{" "}
+            <span className="text-gray-700">
+              {vehicle.marque_name} {vehicle.modele_name} {vehicle.type_name}
+            </span>
+          </h2>
+        </div>
+        <dl className="divide-y divide-gray-100">
+          {specs.map(({ label, value, icon: Icon }) => (
+            <div
+              key={label}
+              className="flex items-center gap-4 px-6 py-3 hover:bg-gray-50 transition-colors"
+            >
+              <div className="inline-flex p-2 rounded-lg bg-blue-50 flex-shrink-0">
+                <Icon size={18} className="text-blue-600" />
+              </div>
+              <dt className="text-sm font-medium text-gray-600 w-32 flex-shrink-0">
+                {label}
+              </dt>
+              <dd className="text-sm font-semibold text-gray-900 break-words">
+                {value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -52,6 +52,7 @@ import {
   HowtoSection,
   R8EnrichedSection,
   SeoIntroSection,
+  TechSpecsSection,
   transformRpcToLoaderData,
   type LoaderData,
 } from "../components/vehicle/r8";
@@ -547,6 +548,8 @@ export default function VehicleDetailPage() {
         )}
 
         <SeoIntroSection r8Content={r8Content} seo={seo} />
+
+        <TechSpecsSection vehicle={vehicle} />
 
         {/* 📦 CATALOGUE PRINCIPAL - Design inspiré de la page index */}
         {catalogFamilies.length > 0 &&

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -53,7 +53,6 @@ import {
   R8EnrichedSection,
   SeoIntroSection,
   transformRpcToLoaderData,
-  TrustSection,
   type LoaderData,
 } from "../components/vehicle/r8";
 import { hierarchyApi } from "../services/api/hierarchy.api";
@@ -1126,8 +1125,6 @@ export default function VehicleDetailPage() {
             />
           </div>
         )}
-
-        <TrustSection />
 
         {/* 🔗 CTA retour hub marque R7 (maillage R8→R7) */}
         <div className="mt-8 text-center">

--- a/log.md
+++ b/log.md
@@ -93,3 +93,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/r8-html-distinct-render`
 - **Décision** : feat(r8): add TechSpecsSection — table specs depuis auto_type (+2 other commits)
 - **Sortie** : PR #185 | commits e7048c22 867808f4 9d9ac41e
+
+## 2026-04-25 — feat/r8-html-distinct-render (auto)
+
+- **Branche** : `feat/r8-html-distinct-render`
+- **Décision** : feat(r8): enrich JSON-LD Vehicle Schema.org with engine specs + identifiers (+4 other commits)
+- **Sortie** : PR #185 | commits f8cb914b 220726ba e7048c22 867808f4 9d9ac41e

--- a/log.md
+++ b/log.md
@@ -99,3 +99,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/r8-html-distinct-render`
 - **Décision** : feat(r8): enrich JSON-LD Vehicle Schema.org with engine specs + identifiers (+4 other commits)
 - **Sortie** : PR #185 | commits f8cb914b 220726ba e7048c22 867808f4 9d9ac41e
+
+## 2026-04-26 — feat/rag-vehicle-scraping-canon (auto)
+
+- **Branche** : `feat/rag-vehicle-scraping-canon`
+- **Décision** : feat(rag): vehicle motor scraper + spec — propose-before-write canon path (+6 other commits)
+- **Sortie** : PR #188 | commits 7642b26f 8fa5df77 f8cb914b 220726ba e7048c22 867808f4 9d9ac41e

--- a/log.md
+++ b/log.md
@@ -87,3 +87,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/r8-html-distinct-render`
 - **Décision** : feat(r8): cut TrustSection from R8 route + spec for HTML distinct render
 - **Sortie** : PR aucune | commits 9d9ac41e
+
+## 2026-04-25 — feat/r8-html-distinct-render (auto)
+
+- **Branche** : `feat/r8-html-distinct-render`
+- **Décision** : feat(r8): add TechSpecsSection — table specs depuis auto_type (+2 other commits)
+- **Sortie** : PR #185 | commits e7048c22 867808f4 9d9ac41e

--- a/log.md
+++ b/log.md
@@ -105,3 +105,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/rag-vehicle-scraping-canon`
 - **Décision** : feat(rag): vehicle motor scraper + spec — propose-before-write canon path (+6 other commits)
 - **Sortie** : PR #188 | commits 7642b26f 8fa5df77 f8cb914b 220726ba e7048c22 867808f4 9d9ac41e
+
+## 2026-04-26 — feat/rag-vehicle-scraping-canon (auto)
+
+- **Branche** : `feat/rag-vehicle-scraping-canon`
+- **Décision** : feat(rag): rag-propose-vehicle-from-web.py — propose-mode enricher (ADR-022 L1) (+8 other commits)
+- **Sortie** : PR #188 | commits 6a7f844f ae966167 7642b26f 8fa5df77 f8cb914b 220726ba e7048c22 867808f4 9d9ac41e

--- a/log.md
+++ b/log.md
@@ -81,3 +81,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-department-phase-2a`
 - **Décision** : feat(seo-department): phase 2a - audit findings table + canonical auditor
 - **Sortie** : PR #174 | commits 9581f6c2
+
+## 2026-04-25 — feat/r8-html-distinct-render (auto)
+
+- **Branche** : `feat/r8-html-distinct-render`
+- **Décision** : feat(r8): cut TrustSection from R8 route + spec for HTML distinct render
+- **Sortie** : PR aucune | commits 9d9ac41e

--- a/log.md
+++ b/log.md
@@ -111,3 +111,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/rag-vehicle-scraping-canon`
 - **Décision** : feat(rag): rag-propose-vehicle-from-web.py — propose-mode enricher (ADR-022 L1) (+8 other commits)
 - **Sortie** : PR #188 | commits 6a7f844f ae966167 7642b26f 8fa5df77 f8cb914b 220726ba e7048c22 867808f4 9d9ac41e
+
+## 2026-04-26 — feat/rag-vehicle-scraping-canon (auto)
+
+- **Branche** : `feat/rag-vehicle-scraping-canon`
+- **Décision** : fix(rag): use source_provider attribute (not source) in propose_to_db caller (+10 other commits)
+- **Sortie** : PR #188 | commits deb9f985 5769f8ef 6a7f844f ae966167 7642b26f 8fa5df77 f8cb914b 220726ba e7048c22 867808f4 9d9ac41e

--- a/scripts/rag/download-vehicle-motor-corpus.py
+++ b/scripts/rag/download-vehicle-motor-corpus.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+"""
+download-vehicle-motor-corpus.py — Stage 1.A : scrape vehicle per-motorisation
+data from public web sources, write to /opt/automecanik/rag/knowledge/web-vehicles/.
+
+Mirror of `download-oem-corpus.py` (gamme), but for vehicle motorisations.
+
+Sources (decision utilisateur 2026-04-25, élargies) :
+  Tier 1 (specs structurées)  : fiches-auto.fr, caradisiac, largus.fr,
+                                 turbo.fr, autoplus.fr, autotitre.com
+  Tier 2 (encyclopédique)      : fr.wikipedia.org, en.wikipedia.org
+
+Tiers 3-5 (fiabilité, regulatory, aftermarket cross-ref) ajoutés selon
+recall mesuré sur le pilote.
+
+Usage:
+  python3 scripts/rag/download-vehicle-motor-corpus.py --modele clio-3 --dry-run
+  python3 scripts/rag/download-vehicle-motor-corpus.py --modele clio-3 --apply
+  python3 scripts/rag/download-vehicle-motor-corpus.py --brand smart --apply
+  python3 scripts/rag/download-vehicle-motor-corpus.py --modele-id 140004 --apply
+
+Output : /opt/automecanik/rag/knowledge/web-vehicles/<hash>-s<N>.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+import textwrap
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from urllib.parse import quote, urlparse
+
+try:
+    import requests
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Manque : pip install requests beautifulsoup4")
+    sys.exit(1)
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    print("Manque : pip install psycopg2-binary")
+    sys.exit(1)
+
+# === CONFIG ============================================================
+
+WEB_VEHICLES_DIR = "/opt/automecanik/rag/knowledge/web-vehicles"
+REQUEST_DELAY_S = 1.2
+MAX_RETRIES = 2
+TIMEOUT_S = 12
+MIN_CONTENT_LEN = 250
+
+# DB connection — pattern aligné avec scripts/db/adr017-create-index-concurrently.py
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+DB_PASSWORD = os.environ.get("SUPABASE_DB_PASSWORD")
+if not DB_PASSWORD:
+    sys.stderr.write(
+        "[FATAL] SUPABASE_DB_PASSWORD missing in env. "
+        "Run: source backend/.env (or set SUPABASE_DB_PASSWORD=...)\n"
+    )
+    sys.exit(1)
+DB_DSN = (
+    f"host=db.{PROJECT_REF}.supabase.co "
+    f"port=5432 user=postgres dbname=postgres "
+    f"password={DB_PASSWORD} sslmode=require"
+)
+
+WIKI_API_FR = "https://fr.wikipedia.org/w/api.php"
+WIKI_API_EN = "https://en.wikipedia.org/w/api.php"
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; AutoMecanik-RAGBot/1.0; vehicle-data-research; contact: automecanik.seo@gmail.com)",
+    "Accept-Language": "fr-FR,fr;q=0.9,en;q=0.8",
+    "Accept": "text/html,application/xhtml+xml",
+}
+
+
+# === MODELS ============================================================
+
+@dataclass
+class Modele:
+    modele_id: int
+    marque_id: int
+    marque_alias: str  # e.g. 'renault'
+    marque_name: str   # e.g. 'RENAULT'
+    modele_alias: str  # e.g. 'clio-3'
+    modele_name: str   # e.g. 'CLIO III'
+
+
+@dataclass
+class TypeMotor:
+    type_id: int
+    modele_id: int
+    type_name: str    # e.g. '1.5 dCi'
+    fuel: str         # e.g. 'Diesel'
+    power_ps: int     # e.g. 88
+    liter: str        # e.g. '150' (=1.5 L) or '1461'
+    body: str
+    year_from: int
+
+
+@dataclass
+class ScrapeJob:
+    source: str       # e.g. 'fiches-auto'
+    url: str
+    modele_id: int
+    type_ids: list[int] = field(default_factory=list)
+    status: str = "pending"  # pending | success | 404 | parse_error | skipped
+    title: str = ""
+    content_len: int = 0
+
+
+# === DB ACCESS =========================================================
+
+def db_connect():
+    return psycopg2.connect(DB_DSN)
+
+
+def fetch_modeles_by_filter(args) -> list[Modele]:
+    """Fetch the list of modeles to process based on CLI filters."""
+    sql = """
+        SELECT m.modele_id, m.modele_marque_id, m.modele_alias, m.modele_name,
+               b.marque_alias, b.marque_name
+        FROM auto_modele m
+        JOIN auto_marque b ON b.marque_id::int = m.modele_marque_id::int
+        WHERE m.modele_display = 1 AND b.marque_display = '1'
+    """
+    params: list = []
+    if args.modele_id:
+        sql += " AND m.modele_id = %s"
+        params.append(args.modele_id)
+    elif args.modele:
+        # Accept both arabic ("clio-3") and roman ("clio-iii") forms.
+        roman_map = {"-1": "-i", "-2": "-ii", "-3": "-iii", "-4": "-iv", "-5": "-v", "-6": "-vi"}
+        alt = args.modele.lower()
+        for arabic, roman in roman_map.items():
+            if alt.endswith(arabic):
+                alt = alt[: -len(arabic)] + roman
+                break
+        sql += " AND lower(m.modele_alias) IN (lower(%s), lower(%s))"
+        params.extend([args.modele, alt])
+    elif args.brand:
+        sql += " AND lower(b.marque_alias) = lower(%s)"
+        params.append(args.brand)
+    else:
+        # default pilot scope (decision utilisateur 2026-04-25) :
+        # Renault Clio III + Smart + DS 3 (cohortes déjà enrichies en R8).
+        sql += """
+            AND (
+                (lower(b.marque_alias) = 'renault' AND lower(m.modele_alias) LIKE 'clio-iii%%')
+                OR lower(b.marque_alias) = 'smart'
+                OR (lower(b.marque_alias) = 'ds' AND lower(m.modele_alias) LIKE 'ds-3%%')
+            )
+        """
+
+    sql += " ORDER BY b.marque_alias, m.modele_alias LIMIT 50"
+
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+    return [
+        Modele(
+            modele_id=int(r["modele_id"]),
+            marque_id=int(r["modele_marque_id"]),
+            marque_alias=str(r["marque_alias"]).strip().lower(),
+            marque_name=str(r["marque_name"]).strip(),
+            modele_alias=str(r["modele_alias"]).strip().lower(),
+            modele_name=str(r["modele_name"]).strip(),
+        )
+        for r in rows
+    ]
+
+
+def fetch_types_for_modele(modele_id: int) -> list[TypeMotor]:
+    sql = """
+        SELECT type_id_i, type_modele_id_i, type_name, type_fuel,
+               type_power_ps, type_liter, type_body, type_year_from
+        FROM auto_type
+        WHERE type_display = '1'
+          AND type_modele_id_i = %s
+          AND type_power_ps ~ '^[0-9]+$'
+        ORDER BY type_id_i
+    """
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [modele_id])
+        rows = cur.fetchall()
+    out: list[TypeMotor] = []
+    for r in rows:
+        try:
+            out.append(
+                TypeMotor(
+                    type_id=int(r["type_id_i"]),
+                    modele_id=int(r["type_modele_id_i"]),
+                    type_name=str(r["type_name"] or "").strip(),
+                    fuel=str(r["type_fuel"] or "").strip(),
+                    power_ps=int(r["type_power_ps"] or 0),
+                    liter=str(r["type_liter"] or "").strip(),
+                    body=str(r["type_body"] or "").strip(),
+                    year_from=int(r["type_year_from"] or 0),
+                )
+            )
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+# === HTTP HELPERS ======================================================
+
+def fetch_url(url: str) -> str | None:
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            r = requests.get(
+                url, headers=HEADERS, timeout=TIMEOUT_S, allow_redirects=True,
+            )
+            ctype = r.headers.get("Content-Type", "")
+            if r.status_code == 200 and "text/html" in ctype:
+                r.encoding = r.apparent_encoding
+                return r.text
+            if r.status_code in (403, 404, 410, 429, 503):
+                return None
+            if attempt < MAX_RETRIES:
+                time.sleep(REQUEST_DELAY_S * 2)
+        except requests.RequestException as exc:
+            if attempt < MAX_RETRIES:
+                time.sleep(REQUEST_DELAY_S)
+            else:
+                print(f"    ! réseau {url[:60]} : {exc}")
+    return None
+
+
+# === EXTRACTORS PER SOURCE =============================================
+
+def extract_text_generic(html: str) -> tuple[str, str]:
+    """Generic main-content extractor (used for fiches-auto, caradisiac, etc.)."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup.find_all(
+        ["nav", "footer", "script", "style", "header", "aside", "noscript", "iframe", "form"]
+    ):
+        tag.decompose()
+    for tag in soup.find_all(class_=re.compile(r"(cookie|gdpr|banner|popup|menu|ads|pub)", re.I)):
+        tag.decompose()
+
+    title = soup.title.get_text(strip=True) if soup.title else ""
+    main = soup.find("main") or soup.find("article") or soup.body
+    if not main:
+        return title, ""
+
+    # Table-aware : <tr> joined with | so engine specs stay on one line.
+    lines: list[str] = []
+    visited_cells: set = set()
+    for el in main.find_all(["h1", "h2", "h3", "p", "li", "tr"]):
+        if el.name == "tr":
+            cells = [
+                re.sub(r"\s+", " ", c.get_text(" ", strip=True)).strip()
+                for c in el.find_all(["td", "th"])
+            ]
+            cells = [c for c in cells if c]
+            if not cells or all(len(c) < 2 for c in cells):
+                continue
+            line = "| " + " | ".join(cells) + " |"
+            if len(line) >= 8:
+                lines.append(line)
+                for c in el.find_all(["td", "th"]):
+                    visited_cells.add(id(c))
+            continue
+        text = re.sub(r"\s+", " ", el.get_text(separator=" ", strip=True)).strip()
+        if len(text) < 12:
+            continue
+        if el.name in ("h1", "h2", "h3"):
+            lines.append(f"\n## {text}\n")
+        elif el.name == "li":
+            lines.append(f"- {text}")
+        else:
+            lines.append(text)
+
+    # Catch standalone td/th not inside <tr>
+    for cell in main.find_all(["td", "th"]):
+        if id(cell) in visited_cells:
+            continue
+        text = re.sub(r"\s+", " ", cell.get_text(" ", strip=True)).strip()
+        if len(text) >= 12:
+            lines.append(f"| {text} |")
+
+    return title, "\n".join(lines[:400])
+
+
+def extract_text_wikipedia(html: str) -> tuple[str, str]:
+    soup = BeautifulSoup(html, "html.parser")
+    title = ""
+    if soup.find("h1", id="firstHeading"):
+        title = soup.find("h1", id="firstHeading").get_text(strip=True)
+
+    content_div = soup.find("div", id="mw-content-text")
+    if not content_div:
+        return title, ""
+
+    for tag in content_div.find_all(
+        ["table", "sup", "cite"],
+        class_=re.compile(r"(navbox|reflist|toc|hatnote|thumb)", re.I),
+    ):
+        tag.decompose()
+    for tag in content_div.find_all(id=re.compile(r"(references|notes|liens)", re.I)):
+        if tag.parent:
+            tag.parent.decompose()
+
+    lines: list[str] = []
+    for el in content_div.find_all(["h2", "h3", "h4", "p", "li", "td", "th"]):
+        text = el.get_text(separator=" ", strip=True)
+        text = re.sub(r"\[\d+\]", "", text)
+        text = re.sub(r"\s+", " ", text).strip()
+        if len(text) < 12:
+            continue
+        if el.name in ("h2", "h3", "h4"):
+            lines.append(f"\n## {text}\n")
+        elif el.name == "li":
+            lines.append(f"- {text}")
+        elif el.name in ("td", "th"):
+            lines.append(f"| {text} |")
+        else:
+            lines.append(text)
+    return title, "\n".join(lines[:300])
+
+
+# === URL DISCOVERY PER SOURCE ==========================================
+
+def url_candidates_fiches_auto(modele: Modele, type_motor: TypeMotor | None = None) -> list[str]:
+    """fiches-auto.fr URL patterns."""
+    base = "https://www.fiches-auto.fr"
+    brand = modele.marque_alias
+    model = modele.modele_alias
+    candidates = [
+        f"{base}/{brand}/{model}",
+        f"{base}/{brand}/{model}/",
+        f"{base}/articles-auto/fiabilite-des-voitures/{brand}-{model}.php",
+    ]
+    if type_motor:
+        # Power-tagged variants
+        candidates.append(f"{base}/{brand}/{model}-{type_motor.power_ps}")
+        candidates.append(f"{base}/{brand}/{model}/{type_motor.power_ps}")
+    return candidates
+
+
+def url_candidates_caradisiac(modele: Modele) -> list[str]:
+    base = "https://www.caradisiac.com"
+    slug = f"{modele.marque_alias}-{modele.modele_alias}"
+    # Year fallbacks (model-level page with sections per motor)
+    return [
+        f"{base}/fiches-techniques/modele--{slug}/",
+        f"{base}/fiches-techniques/modele--{slug}/2010/",
+        f"{base}/fiches-techniques/modele--{slug}/2009/",
+    ]
+
+
+def url_candidates_largus(modele: Modele) -> list[str]:
+    base = "https://www.largus.fr"
+    return [
+        f"{base}/fiches-techniques/{modele.marque_alias}/{modele.modele_alias}/",
+        f"{base}/cote-auto/{modele.marque_alias}/{modele.modele_alias}.html",
+    ]
+
+
+def url_candidates_turbo(modele: Modele) -> list[str]:
+    base = "https://www.turbo.fr"
+    return [
+        f"{base}/fiches-techniques/{modele.marque_alias}-{modele.modele_alias}.html",
+        f"{base}/fiche-technique/{modele.marque_alias}/{modele.modele_alias}",
+    ]
+
+
+def url_candidates_autoplus(modele: Modele) -> list[str]:
+    base = "https://www.autoplus.fr"
+    return [f"{base}/fiches-techniques/{modele.marque_alias}-{modele.modele_alias}/"]
+
+
+def url_candidates_autotitre(modele: Modele) -> list[str]:
+    """Vraie URL : /fiche-technique/<Brand>/<Model>/<VariantRoman>"""
+    base = "https://www.autotitre.com"
+    brand_t = modele.marque_alias.title()
+    parts = modele.modele_alias.split("-")
+    titled: list[str] = []
+    for p in parts:
+        if not p:
+            continue
+        if re.fullmatch(r"[ivxIVX]+", p):
+            titled.append(p.upper())
+        else:
+            titled.append(p.title())
+    if len(titled) >= 2 and re.fullmatch(r"[IVX]+", titled[-1]):
+        path = "/".join(titled[:-1]) + "/" + titled[-1]
+    else:
+        path = "/".join(titled) if titled else modele.modele_alias
+    return [
+        f"{base}/fiche-technique/{brand_t}/{path}",
+        f"{base}/fiche-technique-{modele.marque_alias}-{modele.modele_alias}.html",
+    ]
+
+
+def _arabic_alias(alias: str) -> str:
+    """Convert roman suffix to arabic ('clio-iii' → 'clio-3')."""
+    roman_to_arabic = {"-i": "-1", "-ii": "-2", "-iii": "-3", "-iv": "-4", "-v": "-5", "-vi": "-6"}
+    for roman, arabic in roman_to_arabic.items():
+        if alias.endswith(roman):
+            return alias[: -len(roman)] + arabic
+    return alias
+
+
+def url_candidates_user_manual_renault(modele: Modele) -> list[str]:
+    """Renault constructor manuals (Renault only)."""
+    if modele.marque_alias != "renault":
+        return []
+    base = "https://www.user-manual.renault.com"
+    arabic = _arabic_alias(modele.modele_alias)
+    return [
+        f"{base}/fr/content/{modele.marque_alias}-{arabic}-phase-1",
+        f"{base}/fr/content/{modele.marque_alias}-{arabic}-phase-2",
+        f"{base}/fr/content/{modele.marque_alias}-{arabic}",
+    ]
+
+
+def url_candidates_lenouvelautomobiliste(modele: Modele) -> list[str]:
+    """Editorial articles via search archive."""
+    base = "https://lenouvelautomobiliste.fr"
+    arabic = _arabic_alias(modele.modele_alias)
+    q = f"{modele.marque_alias}+{arabic.replace('-', '+')}"
+    return [f"{base}/?s={q}"]
+
+
+# Curated URL override (CSV-based) — priority over heuristic patterns
+CURATED_CSV = "/opt/automecanik/app/scripts/rag/vehicles-known-urls.csv"
+
+
+def load_curated_urls(modele_alias: str) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {}
+    if not os.path.isfile(CURATED_CSV):
+        return out
+    import csv as _csv
+    with open(CURATED_CSV, encoding="utf-8", newline="") as f:
+        for row in _csv.DictReader(f):
+            if (row.get("modele_alias") or "").strip().lower() == modele_alias.lower():
+                src = (row.get("source") or "").strip()
+                url = (row.get("url") or "").strip()
+                if src and url:
+                    out.setdefault(src, []).append(url)
+    return out
+
+
+def url_candidates_wikipedia_fr(modele: Modele) -> list[str]:
+    """Use Wikipedia API to find the article."""
+    queries = [
+        f"{modele.marque_name} {modele.modele_name}",
+        f"{modele.marque_alias} {modele.modele_alias}",
+    ]
+    return [_wiki_lookup(q, lang="fr") for q in queries]
+
+
+def url_candidates_wikipedia_en(modele: Modele) -> list[str]:
+    queries = [
+        f"{modele.marque_name} {modele.modele_name}",
+        f"{modele.marque_name.title()} {modele.modele_name.title()}",
+    ]
+    return [_wiki_lookup(q, lang="en") for q in queries]
+
+
+def _wiki_lookup(query: str, lang: str = "fr") -> str | None:
+    api = WIKI_API_FR if lang == "fr" else WIKI_API_EN
+    base = f"https://{lang}.wikipedia.org/wiki/"
+    try:
+        r = requests.get(
+            api,
+            params={
+                "action": "query",
+                "list": "search",
+                "srsearch": query,
+                "srlimit": 3,
+                "srnamespace": 0,
+                "format": "json",
+            },
+            headers={"User-Agent": HEADERS["User-Agent"]},
+            timeout=8,
+        )
+        results = r.json().get("query", {}).get("search", [])
+        for res in results:
+            title = res["title"]
+            return base + quote(title.replace(" ", "_"))
+    except Exception:
+        pass
+    return None
+
+
+# === SCRAPE WORKFLOW ===================================================
+
+SOURCES = [
+    # (source_name, url_builder, extractor, applies_per_type)
+    ("fiches-auto", url_candidates_fiches_auto, extract_text_generic, True),
+    ("caradisiac", url_candidates_caradisiac, extract_text_generic, False),
+    ("largus", url_candidates_largus, extract_text_generic, False),
+    ("turbo", url_candidates_turbo, extract_text_generic, False),
+    ("autoplus", url_candidates_autoplus, extract_text_generic, False),
+    ("autotitre", url_candidates_autotitre, extract_text_generic, False),
+    ("wikipedia-fr", url_candidates_wikipedia_fr, extract_text_wikipedia, False),
+    ("wikipedia-en", url_candidates_wikipedia_en, extract_text_wikipedia, False),
+    ("user-manual-renault", url_candidates_user_manual_renault, extract_text_generic, False),
+    ("lenouvelautomobiliste", url_candidates_lenouvelautomobiliste, extract_text_generic, False),
+    ("lacentrale", lambda m: [], extract_text_generic, False),  # curated only (anti-bot)
+]
+
+
+def slugify_to_hash(modele: Modele, url: str) -> str:
+    raw = f"{modele.marque_alias}/{modele.modele_alias}|{url}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def save_file(
+    modele: Modele,
+    type_ids: list[int],
+    source: str,
+    url: str,
+    title: str,
+    content: str,
+) -> str | None:
+    if len(content.strip()) < MIN_CONTENT_LEN:
+        return None
+    h = slugify_to_hash(modele, url)
+    existing = [f for f in os.listdir(WEB_VEHICLES_DIR) if f.startswith(h)]
+    section_num = len(existing) + 1
+    filename = f"{h}-s{section_num:03d}.md"
+    path = os.path.join(WEB_VEHICLES_DIR, filename)
+    now = datetime.now(timezone.utc).isoformat()
+    domain = urlparse(url).netloc
+    safe_title = title.replace("'", "\\'")[:120] if title else f"{modele.marque_name} {modele.modele_name}"
+
+    type_ids_yaml = "[]"
+    if type_ids:
+        type_ids_yaml = "[" + ", ".join(str(t) for t in type_ids) + "]"
+
+    md = (
+        f"---\n"
+        f"title: '{safe_title} - s{section_num:03d}'\n"
+        f"source_type: vehicle_motor\n"
+        f"target_kind: vehicle_motor\n"
+        f"target_modele_id: {modele.modele_id}\n"
+        f"target_type_ids: {type_ids_yaml}\n"
+        f"target_marque: {modele.marque_alias}\n"
+        f"target_modele: {modele.modele_alias}\n"
+        f"category: knowledge\n"
+        f"truth_level: L2\n"
+        f"verification_status: unverified\n"
+        f"source_uri: {url}\n"
+        f"source_url: {url}\n"
+        f"source_domain: {domain}\n"
+        f"source_tier: {_source_tier(source)}\n"
+        f"source_provider: {source}\n"
+        f"created_at: '{now}'\n"
+        f"updated_at: '{now}'\n"
+        f"---\n"
+        f"\n"
+        f"# {safe_title}\n"
+        f"\n"
+        f"{content}\n"
+    )
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(md)
+    return path
+
+
+def _source_tier(source: str) -> int:
+    if source in {"fiches-auto", "caradisiac", "largus", "turbo", "autoplus", "autotitre"}:
+        return 1
+    if source.startswith("wikipedia"):
+        return 2
+    return 3
+
+
+def process_modele(modele: Modele, dry_run: bool, only_sources: set[str] | None = None) -> dict:
+    types = fetch_types_for_modele(modele.modele_id)
+    type_ids_all = [t.type_id for t in types]
+    print(f"\n=== {modele.marque_name} {modele.modele_name} (modele_id={modele.modele_id}, {len(types)} types) ===")
+
+    jobs: list[ScrapeJob] = []
+    saved = 0
+    skipped = 0
+
+    # Curated URL overrides — read from data/vehicles_known_urls.csv
+    curated = load_curated_urls(modele.modele_alias)
+    if curated:
+        print(f"  → curated URLs from CSV: {sum(len(v) for v in curated.values())} entries")
+
+    for source_name, url_fn, extractor, per_type in SOURCES:
+        if only_sources and source_name not in only_sources:
+            continue
+        candidates_iter: list[tuple[str, list[int]]] = []
+        # 1) curated URLs (priority)
+        for cu in curated.get(source_name, []):
+            candidates_iter.append((cu, type_ids_all))
+        # 2) heuristic patterns
+        if per_type:
+            for tm in types:
+                urls = url_fn(modele, tm)
+                for url in urls:
+                    if url:
+                        candidates_iter.append((url, [tm.type_id]))
+        else:
+            urls = url_fn(modele)
+            for url in urls:
+                if url:
+                    candidates_iter.append((url, type_ids_all))
+
+        # Dedupe URLs
+        seen: set[str] = set()
+        candidates: list[tuple[str, list[int]]] = []
+        for url, tid in candidates_iter:
+            if url in seen:
+                continue
+            seen.add(url)
+            candidates.append((url, tid))
+
+        for url, type_ids in candidates:
+            job = ScrapeJob(source=source_name, url=url, modele_id=modele.modele_id, type_ids=type_ids)
+            print(f"  [{source_name}] {url[:90]} … ", end="", flush=True)
+            if dry_run:
+                print("DRY-RUN (no fetch)")
+                job.status = "skipped"
+                jobs.append(job)
+                continue
+
+            html = fetch_url(url)
+            time.sleep(REQUEST_DELAY_S)
+            if not html:
+                print("404/err")
+                job.status = "404"
+                jobs.append(job)
+                continue
+            try:
+                title, content = extractor(html)
+            except Exception as exc:
+                print(f"parse_err: {exc}")
+                job.status = "parse_error"
+                jobs.append(job)
+                continue
+            if len(content.strip()) < MIN_CONTENT_LEN:
+                print("thin")
+                job.status = "parse_error"
+                jobs.append(job)
+                skipped += 1
+                continue
+            path = save_file(modele, type_ids, source_name, url, title, content)
+            if path:
+                print(f"OK → {os.path.basename(path)} ({len(content)} chars)")
+                job.status = "success"
+                job.title = title
+                job.content_len = len(content)
+                saved += 1
+            else:
+                print("save_err")
+                job.status = "parse_error"
+            jobs.append(job)
+
+    return {
+        "modele_id": modele.modele_id,
+        "modele_label": f"{modele.marque_name} {modele.modele_name}",
+        "type_count": len(types),
+        "saved": saved,
+        "skipped": skipped,
+        "jobs": jobs,
+    }
+
+
+# === MAIN ==============================================================
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--modele", help="modele alias (e.g. clio-3)")
+    parser.add_argument("--modele-id", type=int, help="modele_id_i numeric")
+    parser.add_argument("--brand", help="marque alias (e.g. renault)")
+    parser.add_argument("--sources", help="comma-separated source names to enable (default: all)")
+    parser.add_argument("--dry-run", action="store_true", help="discover URLs only, no HTTP fetch")
+    parser.add_argument("--apply", action="store_true", help="actually fetch + save")
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.apply:
+        print("⚠ Must specify --dry-run or --apply")
+        sys.exit(1)
+
+    only_sources: set[str] | None = None
+    if args.sources:
+        only_sources = {s.strip() for s in args.sources.split(",")}
+
+    os.makedirs(WEB_VEHICLES_DIR, exist_ok=True)
+    modeles = fetch_modeles_by_filter(args)
+    if not modeles:
+        print("No modele matched the filter.")
+        sys.exit(1)
+
+    print(f"Pilot scope : {len(modeles)} modeles")
+    for m in modeles[:5]:
+        print(f"  - {m.marque_alias}/{m.modele_alias} (id={m.modele_id})")
+    if len(modeles) > 5:
+        print(f"  … +{len(modeles)-5} more")
+
+    summaries = []
+    for m in modeles:
+        s = process_modele(m, dry_run=args.dry_run, only_sources=only_sources)
+        summaries.append(s)
+
+    print("\n=== SUMMARY ===")
+    total_saved = sum(s["saved"] for s in summaries)
+    total_jobs = sum(len(s["jobs"]) for s in summaries)
+    print(f"modeles processed : {len(summaries)}")
+    print(f"jobs total : {total_jobs}")
+    print(f"files saved : {total_saved}")
+    if args.dry_run:
+        print("(dry-run — no files written)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rag/rag-propose-vehicle-from-web.py
+++ b/scripts/rag/rag-propose-vehicle-from-web.py
@@ -1,0 +1,1103 @@
+#!/usr/bin/env python3
+"""
+rag-propose-vehicle-from-web.py — Stage 1.B : propose vehicles/<slug>.md enrichments
+with per-motorisation data extracted from web-vehicles/*.md (Stage 1.A output).
+
+**Mode propose-before-write (ADR-022 L1)**. NEVER writes to disk RAG.
+Inserts proposals into __rag_proposals table with status='pending'.
+A separate process merges approved proposals into rag/knowledge/vehicles/<slug>.md.
+
+Diff vs ancienne version (closed PR #172, fermée car violait L1) :
+  - write_back / _bootstrap_vehicle_md → propose_to_db / _bootstrap_template (in-memory)
+  - INSERT __rag_proposals avec input_fingerprint (idempotence par no-op sur duplicate)
+  - hashes sha256 base + proposed
+  - diff_unified pour review humain
+  - risk_level + risk_flags ADR-022 L4
+  - expires_at = NOW() + 14 days
+
+Logique parsing (inchangée) :
+  1. Pour chaque modele cible, lit web-vehicles/*.md taggés target_modele_id=X
+  2. Parse codes moteur (K9K, D4F, K4J, F4R...) + per-row context (couple, vmax, 0-100, masse, boite)
+  3. Pour chaque type_id du modele :
+     - Match power → engine fields via parsed engines
+     - Derive norme Euro depuis year_from
+     - Récupère CNIT depuis auto_type_number_code DB
+  4. Auto-verify gate : 5 cross-checks DB → verdict {verified, partial, rejected}
+  5. Compute proposed file content + INSERT __rag_proposals (status=pending)
+
+Usage:
+  # Dry-run : compute proposal payload, no DB write
+  python3 scripts/rag/rag-propose-vehicle-from-web.py --modele clio-iii --dry-run
+
+  # Apply : INSERT __rag_proposals (status=pending, expires_at=now+14d)
+  python3 scripts/rag/rag-propose-vehicle-from-web.py --modele clio-iii --apply
+
+After --apply : approve proposals manually via SQL or admin endpoint, then
+a separate writer process merges the approved proposed_content into
+rag/knowledge/vehicles/<slug>.md via PR signed G3.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import os
+import re
+import sys
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import psycopg2
+    import psycopg2.extras
+    import yaml
+except ImportError:
+    print("Manque : pip install psycopg2-binary pyyaml")
+    sys.exit(1)
+
+# === CONFIG ============================================================
+
+WEB_VEHICLES_DIR = "/opt/automecanik/rag/knowledge/web-vehicles"
+VEHICLES_DIR = "/opt/automecanik/rag/knowledge/vehicles"
+
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+DB_PASSWORD = os.environ.get("SUPABASE_DB_PASSWORD")
+if not DB_PASSWORD:
+    sys.stderr.write(
+        "[FATAL] SUPABASE_DB_PASSWORD missing in env. "
+        "source backend/.env then re-run.\n"
+    )
+    sys.exit(1)
+DB_DSN = (
+    f"host=db.{PROJECT_REF}.supabase.co port=5432 user=postgres "
+    f"dbname=postgres password={DB_PASSWORD} sslmode=require"
+)
+
+
+# === ENGINE CODE EXTRACTION ============================================
+
+# Regex generic for engine codes : 1-2 letters + 3 digits + optional suffix.
+# Examples : K9K, K9K700, D4F, K4J, F4R, M9R, M9T, N47, M57, N52, B47, BWA, BSE
+ENGINE_CODE_RE = re.compile(
+    r"\b([A-Z]\d?[A-Z]\d{2,3}[A-Z]?\b|[A-Z]{2,3}\d{2,3}[A-Z]?)\b"
+)
+
+# Regex for "X.Y dCi/HDi/TDI/TCe/TFSI etc. NN[/NN]+ ch" patterns
+ENGINE_LINE_RE = re.compile(
+    r"(?P<displ>\d\.\d)\s*(?P<family>dCi|HDi|TDI|TCe|TFSI|THP|VTi|MPI|CDi|"
+    r"FSI|TSI|EcoBoost|D4F|K4J|K9K|F4R|M9R|N47|N52|B47|BWA|BSE|MultiAir)?\s*"
+    r"(?P<code>[A-Z]\d?[A-Z]\d{2,3}[A-Z]?)?\s*"
+    r"(?P<powers>\d{2,3}(?:\s*[/-]\s*\d{2,3})*)\s*ch",
+    re.IGNORECASE,
+)
+
+# Euro norm derived from year_from
+def derive_euro(year: int) -> str | None:
+    if not year or year <= 1980:
+        return None
+    if year < 1996: return "Euro 1"
+    if year < 2000: return "Euro 2"
+    if year < 2005: return "Euro 3"
+    if year < 2009: return "Euro 4"
+    if year < 2014: return "Euro 5"
+    if year < 2017: return "Euro 6b"
+    if year < 2020: return "Euro 6c"
+    return "Euro 6d"
+
+
+# === DB ACCESS =========================================================
+
+def db_connect():
+    return psycopg2.connect(DB_DSN)
+
+
+def fetch_modele_info(modele_id: int) -> dict | None:
+    sql = """
+        SELECT m.modele_id, m.modele_alias, m.modele_name, m.modele_year_from,
+               b.marque_alias, b.marque_name
+        FROM auto_modele m
+        JOIN auto_marque b ON b.marque_id::int = m.modele_marque_id
+        WHERE m.modele_id = %s
+    """
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [modele_id])
+        return cur.fetchone()
+
+
+def fetch_modeles_by_filter(args) -> list[dict]:
+    sql = """
+        SELECT m.modele_id, m.modele_alias, m.modele_name,
+               b.marque_alias, b.marque_name
+        FROM auto_modele m
+        JOIN auto_marque b ON b.marque_id::int = m.modele_marque_id
+        WHERE m.modele_display = 1 AND b.marque_display = '1'
+    """
+    params: list = []
+    if args.modele_id:
+        sql += " AND m.modele_id = %s"
+        params.append(args.modele_id)
+    elif args.modele:
+        roman_map = {"-1": "-i", "-2": "-ii", "-3": "-iii", "-4": "-iv", "-5": "-v"}
+        alt = args.modele.lower()
+        for arabic, roman in roman_map.items():
+            if alt.endswith(arabic):
+                alt = alt[: -len(arabic)] + roman
+                break
+        sql += " AND lower(m.modele_alias) IN (lower(%s), lower(%s))"
+        params.extend([args.modele, alt])
+    elif args.brand:
+        sql += " AND lower(b.marque_alias) = lower(%s)"
+        params.append(args.brand)
+    else:
+        sql += """
+            AND (
+                (lower(b.marque_alias) = 'renault' AND lower(m.modele_alias) LIKE 'clio-iii%%')
+                OR lower(b.marque_alias) = 'smart'
+                OR (lower(b.marque_alias) = 'ds' AND lower(m.modele_alias) LIKE 'ds-3%%')
+            )
+        """
+    sql += " ORDER BY b.marque_alias, m.modele_alias LIMIT 50"
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, params)
+        return list(cur.fetchall())
+
+
+def fetch_types_for_modele(modele_id: int) -> list[dict]:
+    sql = """
+        SELECT t.type_id_i AS type_id,
+               t.type_name, t.type_fuel,
+               t.type_power_ps::int AS power_ps,
+               t.type_liter, t.type_body,
+               t.type_year_from::int AS year_from,
+               t.type_year_to::int AS year_to
+        FROM auto_type t
+        WHERE t.type_display = '1'
+          AND t.type_modele_id_i = %s
+          AND t.type_power_ps ~ '^[0-9]+$'
+        ORDER BY t.type_id_i
+    """
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [modele_id])
+        return list(cur.fetchall())
+
+
+def fetch_cnit_for_types(type_ids: list[int]) -> dict[int, list[str]]:
+    """Map type_id → list of CNIT codes from auto_type_number_code."""
+    if not type_ids:
+        return {}
+    sql = """
+        SELECT tnc_type_id::int AS type_id, tnc_cnit
+        FROM auto_type_number_code
+        WHERE tnc_type_id::int = ANY(%s)
+          AND tnc_cnit IS NOT NULL AND tnc_cnit != ''
+    """
+    out: dict[int, list[str]] = defaultdict(list)
+    with db_connect() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(sql, [type_ids])
+        for row in cur.fetchall():
+            out[int(row["type_id"])].append(str(row["tnc_cnit"]).strip())
+    return dict(out)
+
+
+# === WEB CORPUS PARSE ==================================================
+
+@dataclass
+class WebDoc:
+    path: str
+    source_provider: str
+    source_url: str
+    target_type_ids: list[int]
+    body: str
+
+
+def load_web_docs_for_modele(modele_id: int) -> list[WebDoc]:
+    out: list[WebDoc] = []
+    if not os.path.isdir(WEB_VEHICLES_DIR):
+        return out
+    for fn in sorted(os.listdir(WEB_VEHICLES_DIR)):
+        if not fn.endswith(".md"):
+            continue
+        path = os.path.join(WEB_VEHICLES_DIR, fn)
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+        m = re.match(r"---\n(.+?)\n---\n(.*)", raw, re.DOTALL)
+        if not m:
+            continue
+        try:
+            fm = yaml.safe_load(m.group(1)) or {}
+        except yaml.YAMLError:
+            continue
+        if int(fm.get("target_modele_id", -1)) != modele_id:
+            continue
+        out.append(
+            WebDoc(
+                path=path,
+                source_provider=str(fm.get("source_provider", "")),
+                source_url=str(fm.get("source_url", "")),
+                target_type_ids=list(fm.get("target_type_ids") or []),
+                body=m.group(2),
+            )
+        )
+    return out
+
+
+@dataclass
+class ParsedEngine:
+    """Engine description extracted from a web doc line. Maximalist :
+    capture every factual field available so siblings of same engine code
+    can still be differentiated by power_rpm, couple, vmax, 0-100, boite,
+    masse, etc."""
+    family: str          # 'dCi', 'TCe', 'F4R'…
+    code: str | None     # 'K9K', 'F4R', 'D4F'…
+    displacement_l: str  # '1.5'
+    powers_ps: list[int]  # [70, 75, 85, 90, 100, 105]
+    fuel: str            # 'Essence' | 'Diesel' | 'Hybride' | ''
+    source_url: str
+    source_provider: str = ""
+    # Per-row extraction (fiches-auto Performances et moteurs table)
+    power_rpm: int | None = None       # 3500 (T/min)
+    couple_nm: int | None = None       # 200
+    couple_rpm: int | None = None      # 2000 (T/min)
+    vitesse_max_kmh: int | None = None # 183
+    zero_a_cent_s: float | None = None # 12.9
+    boite: str | None = None           # 'Boîte 5' / 'Boîte 6'
+    masse_kg: int | None = None        # 1170
+
+
+FAMILY_TOKENS = {
+    "dci", "hdi", "tdi", "tce", "tfsi", "thp", "vti", "mpi", "cdi", "fsi",
+    "tsi", "ecoboost", "multiair", "ecotec", "vvt", "vvti",
+}
+
+DISPL_RE = re.compile(r"\b(\d\.\d)\b")
+POWERS_RE = re.compile(r"\b(\d{2,3}(?:\s*[/-]\s*\d{2,3})*)\s*ch\b", re.IGNORECASE)
+CODE_RE = re.compile(
+    r"\b("
+    r"[A-Z]\d[A-Z]\d{0,4}[A-Z]?"   # D4F, K9K, K9K766, F4R-style (Renault, PSA)
+    r"|[A-Z]\d{2,3}"                # B47, N47, N52 (BMW)
+    r"|[A-Z]{3}\d{0,3}"             # BWA, BSE, EA888 (VAG)
+    r")\b"
+)
+
+
+PER_ENGINE_RE = re.compile(
+    r"(?P<displ>\d\.\d)\s+"                           # displacement
+    r"(?:(?P<extra>[A-Za-z0-9 ]{0,40}?)\s+)?"         # any text in between
+    r"(?P<powers>\d{2,3}(?:\s*[/-]\s*\d{2,3})*)\s*ch",  # powers list + ch
+    re.IGNORECASE,
+)
+
+
+FUEL_MARKER_RE = re.compile(
+    r"\b(Essence|Diesel|Hybride|Electrique|Électrique|GPL|Ethanol|Éthanol)\b",
+    re.IGNORECASE,
+)
+
+
+def _fuel_from_context(text_before: str) -> str:
+    """Find the last 'Essence' or 'Diesel' marker before this match. The
+    Wikipedia tables list engines by section so the closest preceding
+    fuel keyword tags the engine."""
+    matches = list(FUEL_MARKER_RE.finditer(text_before))
+    if not matches:
+        return ""
+    raw = matches[-1].group(1).lower()
+    if raw == "essence":
+        return "Essence"
+    if raw == "diesel":
+        return "Diesel"
+    if raw.startswith("hybr"):
+        return "Hybride"
+    if raw in {"electrique", "électrique"}:
+        return "Electrique"
+    if raw == "gpl":
+        return "GPL"
+    if raw.startswith("ethan") or raw.startswith("éthan"):
+        return "Ethanol"
+    return ""
+
+
+POWER_RPM_RE = re.compile(r"(\d{2,3})\s*ch\s*[àa]\s*(\d{3,5})\s*T", re.IGNORECASE)
+COUPLE_RE = re.compile(r"(\d{2,4})\s*N[\.\s]?M\s*[àa]\s*(\d{3,5})\s*T", re.IGNORECASE)
+COUPLE_SIMPLE_RE = re.compile(r"(\d{2,4})\s*N[\.\s]?M", re.IGNORECASE)
+VMAX_RE = re.compile(r"(\d{2,3})\s*Km\s*/\s*h", re.IGNORECASE)
+ZERO_CENT_RE = re.compile(r"(\d{1,2}(?:[.,]\d+)?)\s*sec\.?", re.IGNORECASE)
+MASSE_RE = re.compile(r"\((\d{3,4})\s*kg\)", re.IGNORECASE)
+BOITE_RE = re.compile(r"Bo[ïi]te\s*\d+|M[ée]ca\.?\s*\d+|Auto\.?\s*\d+", re.IGNORECASE)
+
+
+def _line_containing(body: str, pos: int) -> str:
+    """Return the full line of `body` that contains character index `pos`."""
+    start = body.rfind("\n", 0, pos) + 1
+    end = body.find("\n", pos)
+    if end == -1:
+        end = len(body)
+    return body[start:end]
+
+
+def parse_engine_lines(doc: WebDoc) -> list[ParsedEngine]:
+    """Extract one ParsedEngine per `displacement … power+ch` substring.
+    For fiches-auto-style table rows, ALSO extract per-row context :
+    couple, vitesse max, 0-100 km/h, boite, masse — so siblings of the
+    same engine code remain differentiated."""
+    out: list[ParsedEngine] = []
+    seen_keys: set[tuple[str, str, tuple[int, ...]]] = set()
+    for m in PER_ENGINE_RE.finditer(doc.body):
+        powers_raw = m.group("powers") or ""
+        powers = [int(x.strip()) for x in re.split(r"[/-]", powers_raw) if x.strip().isdigit()]
+        powers = [x for x in powers if 30 <= x <= 800]
+        if not powers:
+            continue
+        displ = m.group("displ")
+        extra = (m.group("extra") or "").strip()
+
+        # Engine code in `extra`
+        code: str | None = None
+        for cm in CODE_RE.finditer(extra):
+            tok = cm.group(1)
+            if tok.lower() not in FAMILY_TOKENS and len(tok) >= 3 and not tok.isdigit():
+                code = tok
+                break
+
+        # Family marker
+        family: str = ""
+        for tok in re.findall(r"[A-Za-z]{2,8}", extra):
+            if tok.lower() in FAMILY_TOKENS:
+                family = tok
+                break
+
+        # Fuel context — last "Essence"/"Diesel" marker before this match
+        fuel = _fuel_from_context(doc.body[: m.start()])
+        if not fuel and family.lower() in {"dci", "hdi", "tdi", "cdi"}:
+            fuel = "Diesel"
+        if not fuel and family.lower() in {"tce", "tfsi", "thp", "vti", "tsi", "fsi", "mpi"}:
+            fuel = "Essence"
+
+        # ── Per-row maximalist extraction (fiches-auto table) ─────────
+        line_full = _line_containing(doc.body, m.start())
+        # Power + RPM together "70 ch à 4000 T/min"
+        power_rpm: int | None = None
+        prm = POWER_RPM_RE.search(line_full)
+        if prm and powers and int(prm.group(1)) in powers:
+            power_rpm = int(prm.group(2))
+        # Couple + RPM together "200 NM à 2000 T/min"
+        couple_nm: int | None = None
+        couple_rpm: int | None = None
+        crm = COUPLE_RE.search(line_full)
+        if crm:
+            couple_nm = int(crm.group(1))
+            couple_rpm = int(crm.group(2))
+        else:
+            cm2 = COUPLE_SIMPLE_RE.search(line_full)
+            if cm2:
+                couple_nm = int(cm2.group(1))
+        # Vitesse max
+        vmax_m = VMAX_RE.search(line_full)
+        vmax = int(vmax_m.group(1)) if vmax_m else None
+        # 0-100 km/h
+        zero_m = ZERO_CENT_RE.search(line_full)
+        zero = float(zero_m.group(1).replace(",", ".")) if zero_m else None
+        # Masse
+        masse_m = MASSE_RE.search(line_full)
+        masse = int(masse_m.group(1)) if masse_m else None
+        # Boîte
+        boite_m = BOITE_RE.search(line_full)
+        boite = boite_m.group(0).strip() if boite_m else None
+
+        # Per fiches-auto, each row is 1 power. Wikipedia rows list multiple powers.
+        # If row has 1 power AND we extracted couple/vmax/0-100, treat as
+        # 1 ParsedEngine per power (so the data attaches correctly).
+        is_per_power_row = couple_nm is not None and vmax is not None and len(powers) == 1
+        if is_per_power_row:
+            key = (displ, fuel, tuple(powers))
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            out.append(
+                ParsedEngine(
+                    family=family,
+                    code=code,
+                    displacement_l=displ,
+                    powers_ps=powers,
+                    fuel=fuel,
+                    source_url=doc.source_url,
+                    source_provider=doc.source_provider,
+                    power_rpm=power_rpm,
+                    couple_nm=couple_nm,
+                    couple_rpm=couple_rpm,
+                    vitesse_max_kmh=vmax,
+                    zero_a_cent_s=zero,
+                    boite=boite,
+                    masse_kg=masse,
+                )
+            )
+        else:
+            # Wikipedia-style : 1 line / multiple powers, no per-row detail
+            key = (displ, fuel, tuple(sorted(set(powers))))
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            out.append(
+                ParsedEngine(
+                    family=family,
+                    code=code,
+                    displacement_l=displ,
+                    powers_ps=powers,
+                    fuel=fuel,
+                    source_url=doc.source_url,
+                    source_provider=doc.source_provider,
+                )
+            )
+    return out
+
+
+# === ENRICHMENT + AUTO-VERIFY ==========================================
+
+@dataclass
+class TypeEnrichment:
+    type_id: int
+    type_name: str
+    fuel: str
+    power_ps: int
+    year_from: int
+    year_to: int | None
+    cylindree: str
+    body: str
+    # Enriched fields (maximalist)
+    code_moteur: str | None = None
+    famille_moteur: str | None = None
+    norme_euro: str | None = None
+    power_rpm: int | None = None
+    couple_nm: int | None = None
+    couple_rpm: int | None = None
+    vitesse_max_kmh: int | None = None
+    zero_a_cent_s: float | None = None
+    boite: str | None = None
+    masse_kg: int | None = None
+    cnit: list[str] = field(default_factory=list)
+    source_urls: list[str] = field(default_factory=list)
+    sources_confirming: set[str] = field(default_factory=set)
+    # Auto-verify (real cross-source)
+    checks: dict = field(default_factory=dict)
+    verdict: str = ""
+
+
+def match_engine(engines: list[ParsedEngine], type_row: dict) -> ParsedEngine | None:
+    """Pick the engine entry whose powers list contains type_row.power_ps,
+    filtered by fuel match (essence type → essence engine)."""
+    target_power = int(type_row["power_ps"])
+    target_fuel = (type_row.get("type_fuel") or "").strip().lower()
+
+    def fuel_matches(engine_fuel: str) -> bool:
+        if not target_fuel or not engine_fuel:
+            return True  # be tolerant when fuel is unknown on either side
+        ef = engine_fuel.lower()
+        # Hybride essence-électrique → engine-side may say 'Essence'
+        if "essence" in target_fuel and ef == "essence":
+            return True
+        if "diesel" in target_fuel and ef == "diesel":
+            return True
+        if "electrique" in target_fuel and ef == "electrique":
+            return True
+        return ef == target_fuel
+
+    # Exact power + fuel match
+    for e in engines:
+        if target_power in e.powers_ps and fuel_matches(e.fuel):
+            return e
+    # Tolerant ±2 ch + fuel match
+    for e in engines:
+        if any(abs(p - target_power) <= 2 for p in e.powers_ps) and fuel_matches(e.fuel):
+            return e
+    # Last resort : power match without fuel filter
+    for e in engines:
+        if target_power in e.powers_ps:
+            return e
+    return None
+
+
+def enrich_modele(modele: dict, dry_run: bool) -> tuple[list[TypeEnrichment], dict]:
+    modele_id = int(modele["modele_id"])
+    types = fetch_types_for_modele(modele_id)
+    docs = load_web_docs_for_modele(modele_id)
+
+    # Aggregate engine entries from all web docs
+    all_engines: list[ParsedEngine] = []
+    sources_used: set[str] = set()
+    for d in docs:
+        engines = parse_engine_lines(d)
+        if engines:
+            sources_used.add(d.source_provider)
+        all_engines.extend(engines)
+
+    # CNIT from DB
+    type_ids = [int(t["type_id"]) for t in types]
+    cnit_map = fetch_cnit_for_types(type_ids)
+
+    enrichments: list[TypeEnrichment] = []
+    for t in types:
+        e = TypeEnrichment(
+            type_id=int(t["type_id"]),
+            type_name=str(t["type_name"] or ""),
+            fuel=str(t["type_fuel"] or ""),
+            power_ps=int(t["power_ps"] or 0),
+            year_from=int(t["year_from"] or 0),
+            year_to=int(t["year_to"]) if t.get("year_to") else None,
+            cylindree=str(t["type_liter"] or ""),
+            body=str(t["type_body"] or ""),
+        )
+        # Aggregate ALL matching engines from ALL sources for this type_id.
+        target_power = int(t["power_ps"])
+        target_fuel = (t.get("type_fuel") or "").strip().lower()
+
+        def _fuel_ok(eng_fuel: str) -> bool:
+            if not target_fuel or not eng_fuel:
+                return True
+            ef = eng_fuel.lower()
+            return (
+                ef == target_fuel
+                or ("essence" in target_fuel and ef == "essence")
+                or ("diesel" in target_fuel and ef == "diesel")
+            )
+
+        # Exact power match (priority), then ±2 ch fallback
+        matches = [eng for eng in all_engines if target_power in eng.powers_ps and _fuel_ok(eng.fuel)]
+        if not matches:
+            matches = [
+                eng for eng in all_engines
+                if any(abs(p - target_power) <= 2 for p in eng.powers_ps) and _fuel_ok(eng.fuel)
+            ]
+
+        for match in matches:
+            if match.source_provider:
+                e.sources_confirming.add(match.source_provider)
+            if match.source_url and match.source_url not in e.source_urls:
+                e.source_urls.append(match.source_url)
+            if not e.code_moteur and match.code:
+                e.code_moteur = match.code
+            if not e.famille_moteur and match.family:
+                e.famille_moteur = match.family
+            # Per-power factual fields (only set from per-power rows)
+            if e.power_rpm is None and match.power_rpm:
+                e.power_rpm = match.power_rpm
+            if e.couple_nm is None and match.couple_nm:
+                e.couple_nm = match.couple_nm
+            if e.couple_rpm is None and match.couple_rpm:
+                e.couple_rpm = match.couple_rpm
+            if e.vitesse_max_kmh is None and match.vitesse_max_kmh:
+                e.vitesse_max_kmh = match.vitesse_max_kmh
+            if e.zero_a_cent_s is None and match.zero_a_cent_s:
+                e.zero_a_cent_s = match.zero_a_cent_s
+            if not e.boite and match.boite:
+                e.boite = match.boite
+            if e.masse_kg is None and match.masse_kg:
+                e.masse_kg = match.masse_kg
+
+        e.norme_euro = derive_euro(e.year_from)
+        e.cnit = sorted(set(cnit_map.get(e.type_id, [])))[:3]
+
+        # ── Real cross-source validation (5 checks, NOT bidons) ─────────
+        def _displ_match() -> bool:
+            if not e.cylindree or not matches:
+                return False
+            try:
+                db_cc = int(e.cylindree)
+            except (ValueError, TypeError):
+                return False
+            if 50 <= db_cc <= 250:
+                db_cc *= 10  # 150 → 1500 cc
+            for mat in matches:
+                try:
+                    web_cc = int(float(mat.displacement_l) * 1000)
+                except (ValueError, TypeError):
+                    continue
+                if abs(db_cc - web_cc) <= 100:
+                    return True
+            return False
+
+        def _fuel_match() -> bool:
+            if not e.fuel or not matches:
+                return False
+            target = e.fuel.lower()
+            return any(
+                m.fuel and (
+                    m.fuel.lower() == target
+                    or ("essence" in target and m.fuel.lower() == "essence")
+                    or ("diesel" in target and m.fuel.lower() == "diesel")
+                )
+                for m in matches
+            )
+
+        e.checks = {
+            "C1_power_match_in_web": bool(matches),
+            "C2_displ_match_db_web": _displ_match(),
+            "C3_fuel_match_db_web": _fuel_match(),
+            "C4_engine_code_found": bool(e.code_moteur),
+            "C5_cross_source_2plus": len(e.sources_confirming) >= 2,
+        }
+        passed = sum(1 for v in e.checks.values() if v)
+        if passed == 5:
+            e.verdict = "verified"
+        elif passed >= 3:
+            e.verdict = "partial"
+        else:
+            e.verdict = "rejected"
+        enrichments.append(e)
+
+    summary = {
+        "modele_id": modele_id,
+        "modele_label": f"{modele['marque_name']} {modele['modele_name']}",
+        "type_count": len(types),
+        "web_docs_used": len(docs),
+        "engines_parsed": len(all_engines),
+        "sources_used": sorted(sources_used),
+        "verified": sum(1 for e in enrichments if e.verdict == "verified"),
+        "partial": sum(1 for e in enrichments if e.verdict == "partial"),
+        "rejected": sum(1 for e in enrichments if e.verdict == "rejected"),
+    }
+    return enrichments, summary
+
+
+# === WRITE BACK TO vehicles/<slug>.md ==================================
+
+def find_vehicle_md(modele: dict) -> str | None:
+    """Locate the existing vehicles/<slug>.md for this modele."""
+    candidates = [
+        f"{modele['marque_alias']}-{modele['modele_alias']}.md",
+        f"{modele['modele_alias']}.md",
+    ]
+    for c in candidates:
+        path = os.path.join(VEHICLES_DIR, c)
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def render_motorisations_yaml(enrichments: Iterable[TypeEnrichment]) -> str:
+    """Produce the YAML block for motorisations[] (frontmatter compatible)."""
+    items = []
+    for e in enrichments:
+        if e.verdict == "rejected":
+            continue
+        item: dict = {
+            "type_id": e.type_id,
+            "moteur": e.type_name,
+            "puissance": f"{e.power_ps} ch",
+            "fuel": e.fuel,
+            "code_moteur": e.code_moteur or "-",
+        }
+        if e.famille_moteur:
+            item["famille_moteur"] = e.famille_moteur
+        if e.cylindree:
+            item["cylindree"] = e.cylindree
+        if e.body:
+            item["body"] = e.body
+        if e.year_from:
+            range_str = f"{e.year_from}"
+            if e.year_to:
+                range_str += f"-{e.year_to}"
+            item["periode"] = range_str
+        if e.norme_euro:
+            item["norme_euro"] = e.norme_euro
+        if e.power_rpm:
+            item["power_rpm"] = e.power_rpm
+        if e.couple_nm:
+            item["couple_nm"] = e.couple_nm
+        if e.couple_rpm:
+            item["couple_rpm"] = e.couple_rpm
+        if e.vitesse_max_kmh:
+            item["vitesse_max_kmh"] = e.vitesse_max_kmh
+        if e.zero_a_cent_s:
+            item["zero_a_cent_s"] = e.zero_a_cent_s
+        if e.boite:
+            item["boite"] = e.boite
+        if e.masse_kg:
+            item["masse_kg"] = e.masse_kg
+        if e.cnit:
+            item["cnit"] = e.cnit
+        if e.source_urls:
+            item["source_urls"] = e.source_urls
+        if e.sources_confirming:
+            item["sources_confirming"] = sorted(e.sources_confirming)
+        item["verification_status"] = e.verdict
+        items.append(item)
+    if not items:
+        return "motorisations: []\n"
+    return yaml.safe_dump(
+        {"motorisations": items},
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+        width=200,
+    )
+
+
+def _replace_motorisations_block(fm_text: str, new_yaml: str) -> str:
+    """Replace the `motorisations:` block in YAML frontmatter with `new_yaml`.
+
+    Handles both "no entries" (`motorisations: []`) and lists with dash-prefixed
+    or indented entries. Stops at the next top-level YAML key (line starting
+    with `[a-z_]+:` at column 0).
+    """
+    lines = fm_text.splitlines(keepends=True)
+    out: list[str] = []
+    i = 0
+    replaced = False
+    while i < len(lines):
+        line = lines[i]
+        if not replaced and re.match(r"^motorisations:\s*$", line.rstrip()):
+            # Skip everything from this line up to (excluding) the next
+            # top-level key.
+            i += 1
+            while i < len(lines):
+                nxt = lines[i]
+                if re.match(r"^[A-Za-z_][A-Za-z0-9_]*\s*:", nxt):
+                    break
+                i += 1
+            block = new_yaml.rstrip("\n") + "\n"
+            out.append(block)
+            replaced = True
+            continue
+        # Old inline form : `motorisations: []` on one line
+        if not replaced and re.match(r"^motorisations:\s*\[\]\s*$", line.rstrip()):
+            out.append(new_yaml.rstrip("\n") + "\n")
+            replaced = True
+            i += 1
+            continue
+        out.append(line)
+        i += 1
+    if not replaced:
+        # Append at end of frontmatter
+        if not "".join(out).endswith("\n"):
+            out.append("\n")
+        out.append(new_yaml.rstrip("\n") + "\n")
+    return "".join(out)
+
+
+def _bootstrap_template(modele: dict) -> str:
+    """In-memory bootstrap content for vehicles/<slug>.md when missing.
+
+    Used as the *proposed* content base when no current file exists.
+    Returns the full markdown text. Does NOT write to disk.
+    """
+    now = datetime.now(timezone.utc).date().isoformat()
+    return (
+        f"---\n"
+        f"category: catalog/vehicle\n"
+        f"doc_family: catalog\n"
+        f"source_type: vehicle\n"
+        f"title: Fiche vehicule - {modele['marque_name']} {modele['modele_name']}\n"
+        f"truth_level: L2\n"
+        f"updated_at: '{now}'\n"
+        f"verification_status: draft\n"
+        f"modele_id: {modele['modele_id']}\n"
+        f"marque_id: {modele.get('marque_id', '')}\n"
+        f"motorisations: []\n"
+        f"lang: fr\n"
+        f"---\n\n"
+        f"# {modele['marque_name']} {modele['modele_name']}\n\n"
+        f"Fiche véhicule auto-générée — enrichie via "
+        f"`scripts/rag/rag-propose-vehicle-from-web.py` (mode propose-before-write).\n"
+    )
+
+
+def _sha256(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def _input_fingerprint(modele: dict, enrichments: list, sources: list[str]) -> str:
+    """Deterministic fingerprint of inputs (idempotence guard).
+
+    Same model + same enrichment fields + same source URLs → same fingerprint.
+    Used by partial unique index in __rag_proposals to no-op repeat regen.
+    """
+    payload = {
+        "modele_id": int(modele["modele_id"]),
+        "type_ids": sorted(int(e.type_id) for e in enrichments),
+        "fields_hash": _sha256(
+            "|".join(
+                f"{e.type_id}:{getattr(e, 'engine_code', '')}:"
+                f"{getattr(e, 'couple_nm', '')}:{getattr(e, 'vitesse_max_kmh', '')}:"
+                f"{getattr(e, 'masse_kg', '')}"
+                for e in enrichments
+            )
+        ),
+        "sources": sorted(sources),
+        "version": "rag-propose-vehicle-from-web/v1",
+    }
+    return _sha256(json.dumps(payload, sort_keys=True, ensure_ascii=True))
+
+
+def _compute_risk(diff_lines_added: int, diff_lines_removed: int) -> tuple[str, list[str]]:
+    """ADR-022 L4 risk classification (low/medium/high) + flags.
+
+    low : <=20 lines changed total
+    medium : 21-100 lines or removes >5 lines
+    high : >100 lines OR removes >20 lines OR new file
+    """
+    total = diff_lines_added + diff_lines_removed
+    flags = []
+    if diff_lines_removed > 20:
+        flags.append("removes_many_lines")
+    if total > 100:
+        flags.append("large_diff")
+    if total > 200:
+        flags.append("very_large_diff")
+    if diff_lines_added > 0 and diff_lines_removed == 0:
+        flags.append("additive_only")
+    if total > 100 or diff_lines_removed > 20:
+        risk = "high"
+    elif total > 20 or diff_lines_removed > 5:
+        risk = "medium"
+    else:
+        risk = "low"
+    return risk, flags
+
+
+def _build_proposed_content(
+    current_raw: str,
+    new_motorisations_yaml: str,
+    modele: dict,
+) -> str:
+    """Compute the proposed full file content in-memory. NEVER writes to disk."""
+    if not current_raw:
+        # Bootstrap from template, then apply motorisations block
+        current_raw = _bootstrap_template(modele)
+
+    m = re.match(r"(---\n)(.+?)(\n---\n)(.*)", current_raw, re.DOTALL)
+    if not m:
+        # Treat unmatched content as opaque body, prepend template frontmatter
+        bootstrap = _bootstrap_template(modele)
+        m = re.match(r"(---\n)(.+?)(\n---\n)(.*)", bootstrap, re.DOTALL)
+        if not m:
+            raise RuntimeError("bootstrap template has no valid frontmatter — bug")
+        head, fm_text, sep, body = m.groups()
+    else:
+        head, fm_text, sep, body = m.groups()
+
+    new_fm = _replace_motorisations_block(fm_text, new_motorisations_yaml)
+    new_fm = re.sub(
+        r"updated_at: '[^']+'",
+        f"updated_at: '{datetime.now(timezone.utc).date().isoformat()}'",
+        new_fm,
+    )
+    return head + new_fm + sep + body
+
+
+def propose_to_db(
+    path: str,
+    new_motorisations_yaml: str,
+    enrichments: list,
+    modele: dict,
+    sources: list[str],
+    dry_run: bool,
+) -> str | None:
+    """Compute a proposal and INSERT into __rag_proposals (status='pending').
+
+    NEVER writes to disk. Respects ADR-022 L1 (propose-before-write).
+    Returns the proposal_uuid on success, None on dry-run.
+    """
+    # 1. Load current content (empty if file missing)
+    current_raw = ""
+    if os.path.isfile(path):
+        with open(path, encoding="utf-8") as f:
+            current_raw = f.read()
+
+    # 2. Compute proposed full file content
+    proposed_raw = _build_proposed_content(current_raw, new_motorisations_yaml, modele)
+
+    # 3. Hashes + fingerprint
+    base_hash = _sha256(current_raw) if current_raw else None
+    proposed_hash = _sha256(proposed_raw)
+    fingerprint = _input_fingerprint(modele, enrichments, sources)
+
+    # 4. Diff unified
+    diff_lines = list(
+        difflib.unified_diff(
+            current_raw.splitlines(keepends=True),
+            proposed_raw.splitlines(keepends=True),
+            fromfile=f"a/{os.path.relpath(path, '/opt/automecanik/rag/knowledge')}",
+            tofile=f"b/{os.path.relpath(path, '/opt/automecanik/rag/knowledge')}",
+            n=3,
+        )
+    )
+    diff_unified = "".join(diff_lines)
+    added = sum(1 for line in diff_lines if line.startswith("+") and not line.startswith("+++"))
+    removed = sum(1 for line in diff_lines if line.startswith("-") and not line.startswith("---"))
+
+    # 5. Risk classification
+    risk_level, risk_flags = _compute_risk(added, removed)
+
+    # 6. Target metadata
+    relpath = os.path.relpath(path, "/opt/automecanik/rag/knowledge")
+    target_slug = modele.get("modele_alias") or os.path.splitext(os.path.basename(path))[0]
+
+    # 7. Validation report (lightweight — full schema validation done by CI workflow)
+    validation_report = {
+        "scraped_motorisations": len(enrichments),
+        "sources_used": sorted(sources),
+        "fingerprint_version": "v1",
+    }
+
+    print(f"  proposal {target_slug} ({relpath}):")
+    print(f"    base_content_hash : {base_hash[:12] if base_hash else 'NEW_FILE'}")
+    print(f"    proposed_hash     : {proposed_hash[:12]}")
+    print(f"    fingerprint       : {fingerprint[:12]}")
+    print(f"    diff              : +{added} -{removed} lines")
+    print(f"    risk_level        : {risk_level} {risk_flags or ''}")
+
+    if dry_run:
+        print(f"  → DRY RUN : would INSERT __rag_proposals (status=pending, expires_at=now+14d)")
+        return None
+
+    # 8. INSERT __rag_proposals
+    proposal_uuid = str(uuid.uuid4())
+    expires_at = datetime.now(timezone.utc) + timedelta(days=14)
+
+    conn = db_connect()
+    try:
+        with conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO __rag_proposals (
+                    proposal_uuid, target_path, target_slug, target_kind,
+                    base_commit_sha, base_content_hash,
+                    proposed_content, proposed_content_hash,
+                    diff_unified, input_fingerprint,
+                    status, created_at, created_by, expires_at,
+                    risk_level, risk_flags,
+                    diff_lines_added, diff_lines_removed,
+                    schema_valid, validation_report
+                ) VALUES (
+                    %s, %s, %s, 'vehicle',
+                    %s, %s,
+                    %s, %s,
+                    %s, %s,
+                    'pending', NOW(), %s, %s,
+                    %s, %s,
+                    %s, %s,
+                    NULL, %s
+                )
+                ON CONFLICT (input_fingerprint) WHERE status IN ('pending','validating','approved')
+                DO NOTHING
+                RETURNING proposal_uuid
+                """,
+                (
+                    proposal_uuid,
+                    relpath,
+                    target_slug,
+                    "HEAD",  # base_commit_sha — caller can override later if needed
+                    base_hash,
+                    proposed_raw,
+                    proposed_hash,
+                    diff_unified,
+                    fingerprint,
+                    "rag-propose-vehicle-from-web/v1",
+                    expires_at,
+                    risk_level,
+                    risk_flags,
+                    added,
+                    removed,
+                    json.dumps(validation_report),
+                ),
+            )
+            row = cur.fetchone()
+            if row:
+                print(f"  ✓ INSERT __rag_proposals proposal_uuid={row[0]}")
+                return str(row[0])
+            else:
+                print(f"  → no-op (fingerprint already pending — idempotence)")
+                return None
+    finally:
+        conn.close()
+
+
+# === MAIN ==============================================================
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--modele", help="modele alias")
+    parser.add_argument("--modele-id", type=int)
+    parser.add_argument("--brand")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.apply:
+        print("Specify --dry-run or --apply")
+        sys.exit(1)
+
+    modeles = fetch_modeles_by_filter(args)
+    if not modeles:
+        print("No modele matched.")
+        sys.exit(1)
+
+    print(f"Pilot scope : {len(modeles)} modele(s)")
+    summaries: list[dict] = []
+    for m in modeles:
+        print(f"\n=== {m['marque_name']} {m['modele_name']} (modele_id={m['modele_id']}) ===")
+        enrichments, summary = enrich_modele(dict(m), dry_run=args.dry_run)
+        summaries.append(summary)
+        print(
+            f"  web docs={summary['web_docs_used']} "
+            f"engines parsed={summary['engines_parsed']} "
+            f"sources={summary['sources_used']}"
+        )
+        print(
+            f"  verdicts : verified={summary['verified']} "
+            f"partial={summary['partial']} rejected={summary['rejected']} "
+            f"of {summary['type_count']} types"
+        )
+
+        # Show 3 sample enrichments
+        for e in enrichments[:3]:
+            ck_pass = sum(1 for v in e.checks.values() if v)
+            code = e.code_moteur or "-"
+            print(
+                f"    type_id={e.type_id} {e.type_name} {e.power_ps}ch ({e.fuel}) "
+                f"→ code={code} euro={e.norme_euro} cnit={len(e.cnit)} "
+                f"checks={ck_pass}/5 → {e.verdict}"
+            )
+
+        # Propose to __rag_proposals (ADR-022 L1 propose-before-write).
+        # If file missing, the proposal contains the bootstrap content as the
+        # proposed_content (base_content stays empty). Disk is never touched.
+        m_dict = dict(m)
+        path = find_vehicle_md(m_dict)
+        if not path:
+            slug = f"{m_dict['marque_alias']}-{m_dict['modele_alias']}"
+            path = os.path.join(VEHICLES_DIR, f"{slug}.md")
+            print(f"  → no vehicles/{slug}.md, proposal will bootstrap from template")
+        yaml_block = render_motorisations_yaml(enrichments)
+        sources_used = sorted({d.source for d in load_web_docs_for_modele(m_dict["modele_id"])})
+        propose_to_db(
+            path,
+            yaml_block,
+            list(enrichments),
+            m_dict,
+            sources_used,
+            dry_run=args.dry_run,
+        )
+
+    print("\n=== AGGREGATE ===")
+    total_types = sum(s["type_count"] for s in summaries)
+    total_verified = sum(s["verified"] for s in summaries)
+    total_partial = sum(s["partial"] for s in summaries)
+    total_rejected = sum(s["rejected"] for s in summaries)
+    print(
+        f"types total : {total_types} | verified : {total_verified} "
+        f"({100 * total_verified / max(total_types, 1):.0f}%) | "
+        f"partial : {total_partial} | rejected : {total_rejected}"
+    )
+    if args.dry_run:
+        print("(dry-run — pas d'écriture)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rag/rag-propose-vehicle-from-web.py
+++ b/scripts/rag/rag-propose-vehicle-from-web.py
@@ -975,7 +975,7 @@ def propose_to_db(
                     diff_lines_added, diff_lines_removed,
                     schema_valid, validation_report
                 ) VALUES (
-                    %s, %s, %s, 'vehicle',
+                    %s, %s, %s, 'vehicle_model',
                     %s, %s,
                     %s, %s,
                     %s, %s,

--- a/scripts/rag/rag-propose-vehicle-from-web.py
+++ b/scripts/rag/rag-propose-vehicle-from-web.py
@@ -1075,7 +1075,7 @@ def main():
             path = os.path.join(VEHICLES_DIR, f"{slug}.md")
             print(f"  → no vehicles/{slug}.md, proposal will bootstrap from template")
         yaml_block = render_motorisations_yaml(enrichments)
-        sources_used = sorted({d.source for d in load_web_docs_for_modele(m_dict["modele_id"])})
+        sources_used = sorted({d.source_provider for d in load_web_docs_for_modele(m_dict["modele_id"])})
         propose_to_db(
             path,
             yaml_block,

--- a/scripts/rag/vehicles-known-urls.csv
+++ b/scripts/rag/vehicles-known-urls.csv
@@ -1,0 +1,7 @@
+modele_alias,source,url
+clio-iii,wikipedia-fr,https://fr.wikipedia.org/wiki/Renault_Clio_III
+clio-iii,lacentrale,https://www.lacentrale.fr/fiches-techniques-voiture-renault-clio---.html
+clio-iii,autotitre,https://www.autotitre.com/fiche-technique/Renault/Clio/III
+clio-iii,fiches-auto,https://www.fiches-auto.fr/fiche-technique-renault/specs-106-technique-renault-clio-3.php
+clio-iii,user-manual-renault,https://www.user-manual.renault.com/fr/content/renault-clio-3-phase-1
+clio-iii,lenouvelautomobiliste,https://lenouvelautomobiliste.fr/actualites/histoire-de-la-renault-clio-3-4-2005-tout-ce-que-lon-demande-a-une-voiture/


### PR DESCRIPTION
## Summary

Track scraping web pour enrichir les fichiers RAG `vehicles/<slug>.md` avec des **faits factuels distinguants par motorisation** (couple, vmax, masse, code moteur K9K/D4F, norme Euro). Directive CEO : *"plus il y a enrichissement plus on peut varier les contenus"*.

**Spec complète** : `docs/superpowers/specs/2026-04-26-rag-vehicle-scraping-canon.md`

## Pourquoi cette PR (mesure factuelle 2026-04-26)

Jaccard mesuré sur HTML rendu prod entre 2 motorisations sœurs Clio III 1.5 dCi (64 ch vs 68 ch) : **83.2 %**.

PR #185 (frontend distinct render) seul plafonne à ~70-75 % Jaccard. Pour passer **sous 40 %**, il faut acquérir des champs absents de la DB :
- `couple_nm`, `couple_rpm`, `power_rpm`
- `vitesse_max_kmh`, `zero_a_cent_s`, `masse_kg`
- `code_moteur` (K9K, D4F — table `auto_type_motor_code` vide pour Clio)
- `norme_euro`, `boite`, `période_mensuelle_détaillée`

## Cette PR (commit 1)

3 fichiers, **zéro DB write, zéro RAG write** :

- `scripts/rag/download-vehicle-motor-corpus.py` (724 LOC) — scraper récupéré depuis le commit tip 78324b28 de la PR fermée #172. Télécharge HTML web → scratch dir `/opt/automecanik/rag/knowledge/web-vehicles/<hash>-s<N>.md`. Pas de touche au RAG canon.
- `scripts/rag/vehicles-known-urls.csv` — URLs Clio III curated par @fafa (Wikipedia FR, lacentrale, autotitre, fiches-auto)
- `docs/superpowers/specs/2026-04-26-rag-vehicle-scraping-canon.md` — spec : mécanique propose-before-write, articulation avec PR #185, gouvernance ADR-022

## Hors scope cette PR (commit 2 à venir)

L'**enricher mode propose** qui :
1. Lit le contenu actuel de `vehicles/<slug>.md` + l'output scraping
2. Compute le contenu enrichi proposé
3. **INSERT dans `__rag_proposals`** avec status `pending` (ADR-022 L1 propose-before-write)
4. **Aucune écriture disque** — le merge se fait par processus séparé après approval board

Pas le direct-write `vehicles/*.md` de la PR fermée #172. C'est la différence canon.

## Articulation avec PR #185 (frontend)

| | PR #185 frontend | Cette PR (#? scraping) |
|---|---|---|
| Cible | Render HTML distinct via DB existante | Acquérir nouveaux champs RAG via web |
| Source | `auto_type`, `__diag_*`, switches | Wikipedia FR, fiches-auto |
| Write | Aucun (frontend pur) | `__rag_proposals` (proposals only) |
| Gain Jaccard estimé | 83% → 70-75% | + champs scraping → 30-40% (combiné) |

Les 2 PRs sont **indépendantes**, peuvent merger dans n'importe quel ordre. La vraie validation Jaccard < 40 % vient des deux **ensemble**.

## Gouvernance — directive CEO override

ADR-022 ligne 73 dit *"Stage 2 canary 10 modèles low-profile (PAS Clio/208/Golf)"*. CEO @fafa a directivé que le scraping enrichissement est la priorité depuis le début et que le pilote se fait sur **Clio III**.

Vault PR séparée à ouvrir pour amender ADR-022 ligne 73 (ajouter "exceptions explicites par directive board"). En attendant, cette PR documente l'override dans le spec et travaille en propose-before-write (L1 respecté).

## Test plan (post-commit 2)

- [ ] Run scraper sur Clio III modele_id=140004 (`--apply`)
- [ ] Run propose-mode enricher → INSERT proposals dans `__rag_proposals` (status=pending)
- [ ] Review proposals via SQL ou endpoint admin
- [ ] Approve manuellement 1-2 proposals
- [ ] Merge via processus séparé (out of scope this PR)
- [ ] Mesure Jaccard après merge proposals + PR #185 mergé

🤖 Generated with [Claude Code](https://claude.com/claude-code)