### PR TITLE
chore(ci): remove auto-deploy-prod job from ci.yml (regression vs deployment.md)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/entities/error-log.entity.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/gamme-rest/gamme-rest-optimized.controller.ts
 - backend/src/modules/gamme-rest/gamme-rest-rpc-v2.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-04-25'
+last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1035,107 +1035,13 @@ jobs:
           echo "> Non-blocking: violations signalees mais ne bloquent pas le pipeline." >> $GITHUB_STEP_SUMMARY
 
   # ============================================
-  # AUTO-DEPLOY to PROD (after PREPROD passes)
-  # ============================================
-  # Utilise docker-compose.ci-deploy.yml (monorepo + redis uniquement)
-  # Les autres services (remotion, minio, lighthouse) sont geres manuellement
-
-  deploy-prod:
-    name: 🚀 Deploy to PROD
-    runs-on: [self-hosted, Linux, X64]
-    needs: [lighthouse]
-    if: ${{ (github.ref == 'refs/heads/main') && github.event_name == 'push' }}
-    steps:
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v4
-
-      - name: 🔍 Validate production env vars
-        run: |
-          PROD_DIR=~/production
-          if [ ! -f "$PROD_DIR/.env" ]; then
-            echo "❌ FATAL: .env file missing at $PROD_DIR/.env"
-            exit 1
-          fi
-          source "$PROD_DIR/.env"
-          REQUIRED_VARS="SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY SYSTEMPAY_SITE_ID PAYBOX_SITE PAYBOX_HMAC_KEY PAYBOX_CALLBACK_MODE SESSION_SECRET"
-          for var in $REQUIRED_VARS; do
-            if [ -z "${!var}" ]; then
-              echo "❌ FATAL: Missing required env var: $var"
-              exit 1
-            fi
-          done
-          echo "✅ All required environment variables present"
-
-      - name: 🏷️ Promote preprod → production
-        run: |
-          docker tag massdoc/nestjs-remix-monorepo:preprod massdoc/nestjs-remix-monorepo:production
-          echo "✅ Image retagged: preprod → production"
-
-      - name: 🐳 Push production image to DockerHub
-        run: |
-          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-          docker push massdoc/nestjs-remix-monorepo:production
-          echo "✅ Image pushed to DockerHub"
-
-      - name: 🚀 Deploy PROD
-        run: |
-          PROD_DIR=~/production
-
-          # Copier le compose CI dedie (monorepo + redis uniquement)
-          cp $GITHUB_WORKSPACE/docker-compose.ci-deploy.yml $PROD_DIR/
-
-          cd $PROD_DIR
-
-          # Arreter et supprimer le container monorepo (redis reste up)
-          docker stop nestjs-remix-monorepo-prod 2>/dev/null || true
-          docker rm nestjs-remix-monorepo-prod 2>/dev/null || true
-
-          # Demarrer avec le compose dedie
-          docker compose -f docker-compose.ci-deploy.yml up -d
-
-          # Health check via docker exec (pas de port mapping sur l'hote)
-          echo "⏳ Waiting for PROD to start..."
-          HEALTHY=0
-          for i in {1..24}; do
-            if docker exec nestjs-remix-monorepo-prod wget -qO- http://localhost:3000/health > /dev/null 2>&1; then
-              echo "✅ PROD is healthy after $((i*5))s"
-              HEALTHY=1
-              break
-            fi
-            echo "Attempt $i/24 - waiting 5s..."
-            sleep 5
-          done
-
-          if [ "$HEALTHY" != "1" ]; then
-            echo "❌ PROD health check failed after 2 minutes"
-            docker logs nestjs-remix-monorepo-prod --tail 100
-            exit 1
-          fi
-
-          echo "✅ PROD deployed successfully"
-
-          # Cleanup vieilles images
-          docker image prune -f
-
-      - name: 📊 Deploy summary
-        if: always()
-        run: |
-          STATUS=$(docker inspect --format='{{.State.Status}}' nestjs-remix-monorepo-prod 2>/dev/null || echo "unknown")
-          HEALTH=$(docker inspect --format='{{.State.Health.Status}}' nestjs-remix-monorepo-prod 2>/dev/null || echo "unknown")
-          echo "## 🚀 PROD Deployment" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Commit:** \`${GITHUB_SHA::7}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Image:** massdoc/nestjs-remix-monorepo:production" >> $GITHUB_STEP_SUMMARY
-          echo "- **Container:** $STATUS (health: $HEALTH)" >> $GITHUB_STEP_SUMMARY
-
-  # ============================================
   # Notifications (Phase 3)
   # ============================================
 
   notify-failure:
     name: 🔔 Notify on Failure
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test, test-frontend, security, core-build, import-firewall, rpc-gate-check, governance-check, gitleaks, migration-safety, build, deploy, e2e-smoke, lighthouse, deploy-prod]
+    needs: [lint, typecheck, test, test-frontend, security, core-build, import-firewall, rpc-gate-check, governance-check, gitleaks, migration-safety, build, deploy, e2e-smoke, lighthouse]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
     steps:
       - name: 🔔 Send Slack notification


### PR DESCRIPTION
## Summary

`ci.yml` contained a `deploy-prod` job that auto-promoted `:preprod` → `:production` and redeployed the PROD container on every push to `main`. This contradicts the canonical deployment flow documented in `.claude/rules/deployment.md` and prior ADRs:

- `main` push = **DEV preprod only**
- `tag v*` push = **PROD** (via `deploy-prod.yml`)

## Why this is a regression, not an optimization

The canon `deploy-prod.yml` (triggered by tag `v*`) already exists with strictly stronger safety than the duplicate job:

- ✅ SHA consistency gate (rejects deploy if `:preprod` OCI label ≠ tag commit, prevents INC-2026-006 class)
- ✅ Automatic rollback to `production-previous` on healthcheck failure
- ✅ Image assertion (verifies container runs the right image tag)
- ✅ Stricter env validation
- ✅ Slack notifications on success/failure

The removed job in `ci.yml` had none of these. It also bypassed the human validation window that the canon flow requires (soak DEV → tag → PROD).

## Changes

- `.github/workflows/ci.yml` : remove `deploy-prod` job (94 lines) + its block comment header
- `.github/workflows/ci.yml` : adjust `notify-failure.needs` to drop `deploy-prod` reference

## Test plan

- [ ] CI runs green on this PR (lint, typecheck, test, build, deploy preprod, e2e-smoke, lighthouse, **no deploy-prod**)
- [ ] After merge: push to main triggers preprod-only — verify GitHub Actions tab shows no `deploy-prod` job
- [ ] After merge: image `massdoc/nestjs-remix-monorepo:production` on DockerHub is **not** updated
- [ ] After merge: PROD container 49.12.233.2 unchanged (still running previous image)
- [ ] Future PROD promotion: create tag `v*` → triggers `deploy-prod.yml` (canonical path)

## Side note — auto-staged files

The pre-commit hook `scripts/knowledge/refresh-knowledge.py --headers-only` auto-refreshed `last_scan` timestamps in 42 `.claude/knowledge/modules/*.md` files (documented behavior in CLAUDE.md). Cosmetic only, no semantic content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)