### PR TITLE
chore(audit): tool-version-aware baseline + dedicated dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,27 @@ updates:
       - dependency-name: "@remix-run/*"
         update-types: ["version-update:semver-major"]
     groups:
+      audit-tools:
+        # Audit tools have their own group because bumping them shifts the
+        # baseline counters in audit-reports/phase0-baseline.json. Reviewer
+        # is expected to refresh the baseline (`npm run audit:baseline:refresh`)
+        # in the same PR, otherwise the deterministic gate fires a false
+        # regression. Keeping them out of dev-dependencies preserves a clean
+        # signal on the main dev-deps bumps.
+        patterns:
+          - "knip"
+          - "madge"
+          - "dependency-cruiser"
+          - "@ast-grep/cli"
+        update-types: ["minor", "patch"]
       dev-dependencies:
         dependency-type: "development"
         update-types: ["minor", "patch"]
+        exclude-patterns:
+          - "knip"
+          - "madge"
+          - "dependency-cruiser"
+          - "@ast-grep/cli"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/audit-reports/phase0-baseline.json
+++ b/audit-reports/phase0-baseline.json
@@ -1,7 +1,13 @@
 {
-  "version": 1,
+  "version": 2,
   "captured_at": "2026-04-24",
   "captured_on_commit": "c18cd233",
+  "tool_versions": {
+    "knip": "6.6.2",
+    "madge": "8.0.0",
+    "dependency-cruiser": "17.3.10",
+    "@ast-grep/cli": "0.42.1"
+  },
   "thresholds": {
     "unused_files_delta": 5,
     "unused_exports_delta": 10,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "audit:baseline": "node scripts/cleanup/audit-compare-baseline.js",
     "audit:baseline:json": "node scripts/cleanup/audit-compare-baseline.js --json",
     "audit:baseline:strict": "node scripts/cleanup/audit-compare-baseline.js --strict",
+    "audit:baseline:refresh": "node scripts/cleanup/audit-compare-baseline.js --refresh",
     "audit:all": "npm run audit:ast && npm run audit:madge && npm run audit:depcruise && npm run audit:knip"
   },
   "keywords": [],

--- a/scripts/cleanup/audit-compare-baseline.js
+++ b/scripts/cleanup/audit-compare-baseline.js
@@ -9,10 +9,17 @@
  * Negative deltas (progress) always succeed. Positive deltas only fail when
  * above the threshold.
  *
+ * The baseline records the tool versions that produced its counters. When the
+ * installed audit tools differ from those versions, raw count comparison is
+ * meaningless (a tool upgrade routinely shifts counts by reasons unrelated to
+ * code quality). In that case the script aborts with a TOOL_VERSION_MISMATCH
+ * exit and asks the maintainer to refresh the baseline.
+ *
  * Usage:
- *   node scripts/cleanup/audit-compare-baseline.js            # run, print, exit
- *   node scripts/cleanup/audit-compare-baseline.js --json     # machine-readable
- *   node scripts/cleanup/audit-compare-baseline.js --strict   # zero-tolerance
+ *   node scripts/cleanup/audit-compare-baseline.js              # run, print, exit
+ *   node scripts/cleanup/audit-compare-baseline.js --json       # machine-readable
+ *   node scripts/cleanup/audit-compare-baseline.js --strict     # zero-tolerance
+ *   node scripts/cleanup/audit-compare-baseline.js --refresh    # rewrite baseline
  */
 
 const fs = require('fs');
@@ -21,6 +28,7 @@ const { execSync } = require('child_process');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const BASELINE_PATH = path.join(REPO_ROOT, 'audit-reports', 'phase0-baseline.json');
+const TRACKED_TOOLS = ['knip', 'madge', 'dependency-cruiser', '@ast-grep/cli'];
 
 function die(msg, code = 2) {
   process.stderr.write(`[audit-compare] ERROR: ${msg}\n`);
@@ -36,6 +44,39 @@ function loadBaseline() {
   } catch (e) {
     die(`invalid JSON in baseline: ${e.message}`);
   }
+}
+
+function readInstalledVersion(pkg) {
+  // Read node_modules/<pkg>/package.json directly — works regardless of the
+  // package's `exports` field, which can hide package.json from require().
+  const pkgJsonPath = path.join(REPO_ROOT, 'node_modules', pkg, 'package.json');
+  if (!fs.existsSync(pkgJsonPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8')).version || null;
+  } catch {
+    return null;
+  }
+}
+
+function getInstalledToolVersions() {
+  const out = {};
+  for (const pkg of TRACKED_TOOLS) {
+    out[pkg] = readInstalledVersion(pkg);
+  }
+  return out;
+}
+
+function compareToolVersions(baselineVersions, currentVersions) {
+  // Returns array of mismatches: { tool, baseline, current }
+  const mismatches = [];
+  for (const pkg of TRACKED_TOOLS) {
+    const base = baselineVersions ? baselineVersions[pkg] : null;
+    const cur = currentVersions[pkg];
+    if (base && cur && base !== cur) {
+      mismatches.push({ tool: pkg, baseline: base, current: cur });
+    }
+  }
+  return mismatches;
 }
 
 function runSilent(cmd, opts = {}) {
@@ -75,7 +116,6 @@ function parseMadge() {
   const out = runSilent(
     'npx madge --circular --extensions ts,tsx backend/src frontend/app 2>&1',
   );
-  // madge prints "Found N circular dependencies!" or "No circular dependency found!"
   const m = out.match(/Found (\d+) circular dependenc/);
   return { cycles: m ? parseInt(m[1], 10) : 0 };
 }
@@ -84,7 +124,6 @@ function parseDepcruise() {
   const out = runSilent(
     'npx depcruise --config .dependency-cruiser.cjs --output-type err-long backend/src frontend/app 2>&1',
   );
-  // line shape: "x 148 dependency violations (0 errors, 148 warnings). 2101 modules, 8425 dependencies cruised."
   const m = out.match(/(\d+) dependency violations \((\d+) errors?, (\d+) warnings?\)/);
   return {
     violations: m ? parseInt(m[1], 10) : 0,
@@ -98,6 +137,18 @@ function parseAstGrep() {
   const warnings = (out.match(/^warning\[/gm) || []).length;
   const errors = (out.match(/^error\[/gm) || []).length;
   return { warnings, errors };
+}
+
+function runAllAudits() {
+  process.stderr.write('[audit-compare] running knip...\n');
+  const knip = parseKnip();
+  process.stderr.write('[audit-compare] running madge...\n');
+  const madge = parseMadge();
+  process.stderr.write('[audit-compare] running depcruise...\n');
+  const depcruise = parseDepcruise();
+  process.stderr.write('[audit-compare] running ast-grep...\n');
+  const ast_grep = parseAstGrep();
+  return { knip, madge, depcruise, ast_grep };
 }
 
 function computeDelta(current, baseline, thresholds, strict) {
@@ -147,26 +198,115 @@ function renderTable(rows) {
   return [fmt(lines[0]), fmt(widths.map((w) => '-'.repeat(w))), ...lines.slice(1).map(fmt)].join('\n');
 }
 
+function renderVersionMismatch(mismatches) {
+  const header = ['Tool', 'Baseline version', 'Installed version'];
+  const lines = [header, ...mismatches.map((m) => [m.tool, m.baseline, m.current])];
+  const widths = header.map((_, i) => Math.max(...lines.map((l) => l[i].length)));
+  const pad = (s, w) => s + ' '.repeat(w - s.length);
+  const fmt = (l) => '  ' + l.map((c, i) => pad(c, widths[i])).join('  ');
+  return [fmt(lines[0]), fmt(widths.map((w) => '-'.repeat(w))), ...lines.slice(1).map(fmt)].join('\n');
+}
+
+function refresh(baseline) {
+  // Recapture current counts and tool versions, preserve thresholds and notes.
+  const current = runAllAudits();
+  const toolVersions = getInstalledToolVersions();
+
+  let commit = baseline.captured_on_commit;
+  try {
+    commit = execSync('git rev-parse --short HEAD', {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    // keep previous commit if git is unavailable (CI without checkout etc.)
+  }
+
+  const next = {
+    version: 2,
+    captured_at: new Date().toISOString().slice(0, 10),
+    captured_on_commit: commit,
+    tool_versions: toolVersions,
+    thresholds: baseline.thresholds,
+    knip: current.knip,
+    madge: { cycles: current.madge.cycles },
+    depcruise: {
+      violations: current.depcruise.violations,
+      errors: current.depcruise.errors,
+      modules_cruised: baseline.depcruise && baseline.depcruise.modules_cruised,
+      dependencies_cruised: baseline.depcruise && baseline.depcruise.dependencies_cruised,
+    },
+    ast_grep: current.ast_grep,
+    notes: baseline.notes,
+  };
+
+  // Only keep modules_cruised / dependencies_cruised if previously recorded;
+  // they are informational and not used by the gate.
+  if (next.depcruise.modules_cruised === undefined) delete next.depcruise.modules_cruised;
+  if (next.depcruise.dependencies_cruised === undefined) delete next.depcruise.dependencies_cruised;
+
+  // madge.backend_cycles / frontend_cycles are not collected here; preserve if
+  // they were in the previous baseline so manual edits aren't lost silently.
+  if (baseline.madge && baseline.madge.backend_cycles !== undefined) {
+    next.madge.backend_cycles = baseline.madge.backend_cycles;
+  }
+  if (baseline.madge && baseline.madge.frontend_cycles !== undefined) {
+    next.madge.frontend_cycles = baseline.madge.frontend_cycles;
+  }
+
+  fs.writeFileSync(BASELINE_PATH, JSON.stringify(next, null, 2) + '\n');
+  process.stdout.write('\n=== Audit Baseline Refresh ===\n');
+  process.stdout.write(`Wrote: ${path.relative(REPO_ROOT, BASELINE_PATH)}\n`);
+  process.stdout.write(`Captured on commit: ${commit}\n`);
+  process.stdout.write(`Tool versions: ${TRACKED_TOOLS.map((t) => `${t}@${toolVersions[t] || '?'}`).join(', ')}\n`);
+  process.stdout.write('Review the diff and commit it alongside the audit-tool bump.\n');
+}
+
 function main() {
   const strict = process.argv.includes('--strict');
   const jsonOut = process.argv.includes('--json');
+  const refreshMode = process.argv.includes('--refresh');
 
   const baseline = loadBaseline();
 
-  process.stderr.write('[audit-compare] running knip...\n');
-  const knip = parseKnip();
-  process.stderr.write('[audit-compare] running madge...\n');
-  const madge = parseMadge();
-  process.stderr.write('[audit-compare] running depcruise...\n');
-  const depcruise = parseDepcruise();
-  process.stderr.write('[audit-compare] running ast-grep...\n');
-  const ast_grep = parseAstGrep();
+  if (refreshMode) {
+    refresh(baseline);
+    process.exit(0);
+  }
 
-  const current = { knip, madge, depcruise, ast_grep };
+  const installedVersions = getInstalledToolVersions();
+  const versionMismatches = compareToolVersions(baseline.tool_versions, installedVersions);
+
+  if (versionMismatches.length > 0 && !jsonOut) {
+    process.stdout.write('\n=== Audit Tool Version Mismatch ===\n');
+    process.stdout.write(`Baseline captured: ${baseline.captured_at} (commit ${baseline.captured_on_commit || 'unknown'})\n\n`);
+    process.stdout.write(renderVersionMismatch(versionMismatches) + '\n\n');
+    process.stdout.write('TOOL_VERSION_MISMATCH: an audit tool has been upgraded since the baseline.\n');
+    process.stdout.write('Raw counter comparison is unreliable across tool versions.\n');
+    process.stdout.write('Refresh the baseline in this PR via `npm run audit:baseline:refresh`,\n');
+    process.stdout.write('then commit the updated audit-reports/phase0-baseline.json.\n');
+    process.exit(3);
+  }
+
+  const current = runAllAudits();
   const { rows, hasFailure } = computeDelta(current, baseline, baseline.thresholds, strict);
 
   if (jsonOut) {
-    process.stdout.write(JSON.stringify({ baseline_captured_at: baseline.captured_at, current, rows, failed: hasFailure }, null, 2) + '\n');
+    process.stdout.write(
+      JSON.stringify(
+        {
+          baseline_captured_at: baseline.captured_at,
+          baseline_tool_versions: baseline.tool_versions || null,
+          installed_tool_versions: installedVersions,
+          tool_version_mismatches: versionMismatches,
+          current,
+          rows,
+          failed: hasFailure || versionMismatches.length > 0,
+        },
+        null,
+        2,
+      ) + '\n',
+    );
   } else {
     process.stdout.write('\n=== Audit Baseline Comparison ===\n');
     process.stdout.write(`Baseline captured: ${baseline.captured_at} (commit ${baseline.captured_on_commit || 'unknown'})\n`);


### PR DESCRIPTION
## Problem

The Phase 0 audit baseline gate (`audit.yml` → `audit:baseline`) compares raw counters produced by `knip`, `madge`, `dependency-cruiser` and `ast-grep` to a frozen reference. When any of these tools is bumped, the counters shift for reasons unrelated to code quality (the tool got more thorough), firing **false REGRESSION** alerts.

Concrete trigger: PR #169 (Dependabot dev-deps) bumps `knip` 6.6.2 → 6.7.0; gate reports `knip.unused_types: 310 → 345 (+35, threshold +15) → REGRESSION`. No code change in the PR.

The current escape hatch — `npm run audit:baseline:refresh` — is **referenced in the script's error message and in `audit.yml` but does not exist in `package.json`**. The workflow lies to maintainers.

## Structural fix (3 parts)

### 1. `.github/dependabot.yml`
New `audit-tools` group containing `knip`, `madge`, `dependency-cruiser`, `@ast-grep/cli`. Explicitly excluded from `dev-dependencies`. Reviewer of an `audit-tools` PR knows by construction that the baseline must be refreshed in the same PR. `dev-dependencies` PRs keep a clean signal.

### 2. `audit-reports/phase0-baseline.json` (version 2)
Adds `tool_versions` block recording the versions of the four tools that produced the counters.

### 3. `scripts/cleanup/audit-compare-baseline.js`
- Reads installed versions from `node_modules/<pkg>/package.json` directly (works around `exports` field restrictions on knip/dependency-cruiser).
- If baseline versions differ from installed → exits **3 with `TOOL_VERSION_MISMATCH`** before running audits. Counts comparison is meaningless across tool versions; saying so explicitly beats fake regressions.
- New `--refresh` flag recaptures counters + tool versions atomically. Wired as `npm run audit:baseline:refresh` in `package.json`. Error message and script are now consistent.

## Tests run locally

| Scenario | Expected exit | Actual exit |
|---|---|---|
| Versions match, no regression | 0 | 0 ✅ |
| Baseline knip ≠ installed knip | 3 (`TOOL_VERSION_MISMATCH`) | 3 ✅ |
| Versions match, baseline forced low | 1 (real `REGRESSION`) | 1 ✅ |
| `--refresh` on matched versions | 0 + rewrite | 0 + diff verified ✅ |

The forced-regression test confirms the gate still blocks **real** code regressions when versions match. The version-mismatch path replaces the false REGRESSION with a clear, actionable message.

## Follow-up on PR #169

After this lands, the dependabot dev-deps PR #169 will need its **own** rebase (it currently still has knip in dev-deps). The next Dependabot run will route knip into the new `audit-tools` group, and the maintainer of that PR runs `npm run audit:baseline:refresh` on the branch to capture knip 6.7.0 counters.

## Out of scope

- Refreshing the baseline numbers themselves: I deliberately did **not** commit my local-machine refresh because those numbers (knip.unused_types=317 here vs 310 captured on CI 2026-04-24) reflect cache state, not a clean CI checkout. Baseline numbers must be captured on a CI runner. The infra in this PR enables that workflow; the actual refresh happens in the audit-tool bump PR.
- An ADR; this is plumbing, not policy. If subsequent maintenance suggests a Phase 0.6 promotion (e.g. blocking ast_grep warnings), that warrants its own ADR.

## Files changed

- `.github/dependabot.yml` (+18 / -0)
- `audit-reports/phase0-baseline.json` (+7 / -1)
- `package.json` (+1 / -0)
- `scripts/cleanup/audit-compare-baseline.js` (+155 / -15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)