### PR TITLE
refactor(skills): seo-content-architect progressive disclosure (-34% lines)

### DIFF
--- a/.claude/skills/seo-content-architect/SKILL.md
+++ b/.claude/skills/seo-content-architect/SKILL.md
@@ -11,11 +11,16 @@ disable-model-invocation: true
 
 Skill de rédaction SEO industriel pour e-commerce automobile à fort volume. Produit du contenu fiable, vérifié contre le corpus RAG, optimisé pour l'extraction par les moteurs IA (ChatGPT, Perplexity, Google AI Overviews), avec scoring qualité aligné sur le backend.
 
-**Architecture modulaire :**
-- Ce fichier = logique + workflow + règles de rédaction
-- `references/page-roles.md` = vocabulaire exclusif R1-R6 + maillage interne
+**Architecture modulaire (progressive disclosure) :**
+- Ce fichier (SKILL.md) = workflow + règles bloquantes + index des references
+- `references/rag-verification.md` = Phase 1b détaillée (queries, truth_level, fraîcheur)
+- `references/gamme-enrichment.md` = Phase 1d détaillée (mapping v3→v4, 21 champs, regles)
+- `references/batch-mode.md` = Mode batch détaillé (pré-check, format sortie)
+- `references/lang-correction.md` = Correction linguistique détaillée (BDD/RAG, MCP queries)
+- `references/page-roles.md` = vocabulaire exclusif R1-R8 + maillage interne
 - `references/quality-scoring.md` = dimensions, pénalités, seuils
 - `references/schema-templates.md` = Schema.org + structure contenu + patterns meta + provenance
+- `references/{r1,r2,r4,r5,r7,r8}-*-role.md` + `conseils-role.md` + `guide-achat-role.md` = templates par rôle
 - Knowledge docs : frontmatter YAML — schema v4 (5 blocs: domain, selection, diagnostic, maintenance, installation + rendering + _sources) OU legacy (mechanical_rules, page_contract)
 
 ## Axiome n°0 (Non-négociable)
@@ -169,95 +174,13 @@ Si GO AVEC RÉSERVES → les zones à vérifier utilisent des formulations condi
 
 ### Phase 1b — Vérification RAG (obligatoire si le sujet est une pièce/gamme)
 
-Avant toute rédaction portant sur une pièce automobile, exécuter ce workflow en 4 étapes :
+Workflow 4 étapes :
+1. Récupérer le knowledge doc (POST `/api/rag/search` avec role targeting)
+2. Extraire les règles domaine (v4 `domain.*` ou legacy `mechanical_rules.*`)
+3. Recherche complémentaire par section (selon rôle R*)
+4. Vérifier fraîcheur (`updated_at` < 6 mois sinon STALE_SOURCE)
 
-#### Étape 1 — Récupérer le knowledge doc
-
-Construire le slug depuis le nom de la gamme : "Disque de frein" → `disque-de-frein`
-
-```bash
-# Recherche RAG avec role targeting (v2.5)
-# {ROLE} selon page cible : R1_ROUTER, R3_GUIDE, R4_REFERENCE, R5_DIAGNOSTIC
-curl -s -X POST http://localhost:3000/api/rag/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{nom_piece}", "limit": 5, "routing": {"target_role": "{ROLE}"}}' \
-  | jq '.results[] | {title, truth_level, updated_at, confidence_score, primary_role, purity_score, chunk_kind, source_path, page_contract_id, media_slots_hint}'
-```
-
-**Décision selon les résultats :**
-
-| Résultat | truth_level | verification_status | Action |
-|----------|-------------|---------------------|--------|
-| Doc trouvé | L1 | verified | Fait dur — utiliser directement, citer sans qualification |
-| Doc trouvé | L2 | verified | Confirmé — utiliser directement |
-| Doc trouvé | L2 | draft | Utilisable avec prudence, vérifier cohérence |
-| Doc trouvé | L3 | verified | Curaté — formulation conditionnelle obligatoire |
-| Doc trouvé | L3/L4 | draft/pending | **REJETER** — traiter comme non-confirmé |
-| 0 résultats | — | — | Signaler l'absence, continuer avec données utilisateur/BDD. Ne rien inventer |
-
-#### Étape 2 — Extraire les règles du domaine (v4) / mechanical_rules (legacy)
-
-Chaque knowledge doc gamme contient un frontmatter YAML avec des règles. Détecter la version du schema :
-
-- **v4** : `rendering.quality.version === 'GammeContentContract.v4'` → lire `domain.*`
-- **Legacy** (v1/v3) : lire `mechanical_rules.*` + `purchase_guardrails.*`
-
-| Champ v4 | Champ legacy (fallback) | Usage dans la rédaction |
-|----------|------------------------|------------------------|
-| `domain.must_be_true` | `mechanical_rules.must_be_true` | Ces termes DOIVENT apparaître dans le contenu produit |
-| `domain.must_not_contain` | `mechanical_rules.must_not_contain_concepts` | JAMAIS dans le contenu — confusion sémantique |
-| `domain.confusion_with` | `mechanical_rules.confusion_with` | Générer un bloc "Ne pas confondre avec..." explicite |
-| `domain.role` | `mechanical_rules.role_summary` | Seed pour le H1/intro — reformuler, ne pas copier verbatim |
-| `domain.must_not_contain` | `purchase_guardrails.forbidden_terms` | Ajouter aux MOTS INTERDITS du contenu |
-| *(v4: implicite si crossGammes)* | `purchase_guardrails.requires_vehicle` | Si true, inclure "vérifiez la compatibilité véhicule" |
-
-**2 formats `confusion_with` (v4 = array uniquement, legacy = array ou map) :**
-
-Format array (v4 + legacy) :
-```yaml
-confusion_with:
-  - term: tambour de frein
-    difference: Le tambour utilise des mâchoires internes...
-```
-
-Format map (legacy uniquement) :
-```yaml
-confusion_with:
-  batterie:
-    key_difference: L'alternateur recharge la batterie...
-```
-
-Traiter les deux formats : pour chaque entrée, générer un bloc "Ne pas confondre avec {terme}" dans le contenu.
-
-#### Étape 3 — Recherche complémentaire par section
-
-Interroger la section correspondant au rôle de page cible :
-
-```bash
-# Recherche complementaire avec role targeting (v2.5)
-# Enrichir la query avec des mots-cles de section selon le role cible :
-# R3 Blog/guide → "guide achat choix selection" (+ injecter template de conseils-role.md §7)
-# R3 Blog/conseils → "entretien remplacement etapes" (+ injecter template de conseils-role.md §7)
-# R4 Reference  → "definition technique composants" (+ injecter concepts partages de r4-reference-role.md §8)
-# R5 Diagnostic → "symptomes diagnostic panne"
-curl -s -X POST http://localhost:3000/api/rag/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{nom_piece} {section_keywords}", "limit": 5, "routing": {"target_role": "{ROLE}"}}' \
-  | jq '.results[:3] | .[] | {title, truth_level, content, primary_role, chunk_kind}'
-```
-
-Consolider les résultats des étapes 1 et 3 pour constituer la base de rédaction.
-
-#### Étape 4 — Vérifier la fraîcheur (`updated_at`)
-
-Vérifier le champ `updated_at` dans le frontmatter YAML du knowledge doc :
-
-| Âge du doc | Statut | Action | Annotation |
-|------------|--------|--------|------------|
-| < 3 mois | Frais | Utiliser directement | Aucune |
-| 3-6 mois | Acceptable | Vérifier cohérence | Ajouter date dans provenance |
-| 6-12 mois | Stale | Pénalité -6 (STALE_SOURCE) | Annoter `[source datée de {mois}]`, proposer `/rag-ops ingest` |
-| > 12 mois | Obsolète | NE PAS utiliser les données chiffrées | **STOP** : proposer `/rag-ops ingest` avant rédaction |
+> **Détail complet (queries, tables de décision truth_level/fraîcheur, formats `confusion_with`)** : `references/rag-verification.md`
 
 ### Phase 1c — Extraction des blocs v4 / page_contract (legacy)
 
@@ -299,203 +222,20 @@ Extraire les données pré-validées du frontmatter YAML du knowledge doc. Déte
 
 ### Phase 1d — Enrichissement gamme.md v4 (si docs supplementaires disponibles)
 
-**Declencheur** : Phase 1b a trouve des docs supplementaires (web/, pdf/, guides/) via la recherche RAG, ET le gamme.md presente des lacunes dans ses 5 blocs.
+**Déclencheur** : Phase 1b a trouvé des docs supplémentaires (web/, pdf/, guides/) ET le gamme.md a des lacunes dans ses 5 blocs.
 
-**Objectif** : Enrichir le frontmatter YAML du fichier `gammes/{slug}.md` selon le **schema v4 (5 blocs)** AVANT de rediger, pour que le contenu soit fonde sur des donnees riches et verifiees.
+Workflow d'enrichissement YAML (5 étapes) :
+- Etape 0 : Conversion v3 → v4 si nécessaire
+- Etape 1 : Découvrir docs supplémentaires (RAG search avec `includeFullContent`)
+- Etape 2 : Extraire données vers les 5 blocs v4 (domain, selection, diagnostic, maintenance, installation) + `_sources`
+- Etape 3 : Proposer diff YAML pour validation
+- Etape 4 : Appliquer modifications (Edit gamme.md, MAJ `updated_at` + `lifecycle.stage`)
 
-> **Schema de reference** : `.spec/00-canon/gamme-md-schema.md` — source de verite pour la structure, les types, et les regles de chaque bloc.
+> **Détail complet (mapping v3→v4, 21 champs d'extraction, regles d'enrichissement, hard gates)** : `references/gamme-enrichment.md`
 
-#### Detection de version
+> **Schema de référence** : `.spec/00-canon/gamme-md-schema.md`
 
-| Version detectee | Action |
-|-----------------|--------|
-| `GammeContentContract.v4` | Enrichir selon les 5 blocs ci-dessous |
-| `GammeContentContract.v3` ou absent | Convertir en v4 PUIS enrichir (voir Etape 0) |
-
-#### Etape 0 — Conversion v3 → v4 (si necessaire)
-
-Si le gamme.md est en v3 ou v1 (pas de `quality.version: GammeContentContract.v4`), proposer la conversion :
-
-```
-CONVERSION v3 → v4 proposee pour gammes/{slug}.md
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Mapping :
-  page_contract.symptoms → diagnostic.symptoms (ajouter id + severity)
-  page_contract.timing → maintenance.interval
-  page_contract.risk.costRange → selection.cost_range
-  page_contract.antiMistakes → selection.anti_mistakes
-  page_contract.howToChoose → selection.criteria
-  page_contract.faq → rendering.faq
-  mechanical_rules.must_be_true → domain.must_be_true
-  mechanical_rules.must_not_contain_concepts → domain.must_not_contain
-  mechanical_rules.confusion_with → domain.confusion_with
-  mechanical_rules.role_summary → domain.role
-
-Blocs a creer (absents en v3) :
-  - selection.checklist
-  - selection.brands
-  - diagnostic.causes (avec %)
-  - diagnostic.quick_checks
-  - maintenance.usage_factors
-  - maintenance.good_practices
-  - installation.* (si applicable)
-  - _sources (provenance)
-  - cross_gammes (relations)
-  - lifecycle
-
-Valider la conversion avant enrichissement ?
-```
-
-#### Etape 1 — Decouvrir les docs supplementaires
-
-```bash
-# Rechercher les docs non-gamme lies a cette piece
-curl -s -X POST http://localhost:3000/api/rag/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{nom_piece}", "limit": 10, "includeFullContent": true}' \
-  | jq '.results[] | select(.sourcePath | startswith("gammes/") | not) | {title, sourcePath, sourceType, score}'
-```
-
-Filtrer : garder uniquement les docs `web/`, `pdf/`, `guides/` avec `truth_level` L1 ou L2.
-
-#### Etape 2 — Lire et analyser le contenu complet
-
-Pour chaque doc supplementaire trouve, lire le fichier source :
-```
-/opt/automecanik/rag/knowledge/{source_path}
-```
-
-Extraire les donnees structurees pertinentes pour les **5 blocs v4** :
-
-| Donnee a extraire | Destination v4 | Critere d'extraction |
-|-------------------|----------------|---------------------|
-| Role mecanique detaille | `domain.role` (>80 chars) | Description fonctionnelle precise, sans verbe generique |
-| Termes techniques cles | `domain.must_be_true` | Vocabulaire metier obligatoire dans le contenu |
-| Confusions courantes | `domain.confusion_with` | Pieces proches ou causes confondues |
-| Pieces associees | `domain.related_parts` + `cross_gammes` | Mentions de pieces liees au remplacement |
-| Criteres de selection | `selection.criteria` (min 3) | Dimensions, types, compatibilites |
-| Checklist achat | `selection.checklist` (min 3) | Etapes verification avant commande |
-| Erreurs d'achat | `selection.anti_mistakes` (min 3) | Phrases "ne pas", "erreur", "eviter" |
-| Fourchette de cout | `selection.cost_range` | Montants en EUR avec unite (la paire, l'unite, le kit) |
-| Marques recommandees | `selection.brands` | Premium / equivalent / budget |
-| Symptomes de defaillance | `diagnostic.symptoms` (min 3) | Signes d'usure avec severity (confort/securite/immobilisation) |
-| Causes de panne | `diagnostic.causes` (min 2) | Ordonnees par frequence, % si connu |
-| Tests sans outil | `diagnostic.quick_checks` (min 2) | Verifications visuelles/manuelles |
-| Intervalles remplacement | `maintenance.interval` | Valeur + unite (km/mois/condition) + note |
-| Facteurs d'usure | `maintenance.usage_factors` | Conditions accelerant l'usure |
-| Bonnes pratiques | `maintenance.good_practices` | Gestes d'entretien preventif |
-| Interdits entretien | `maintenance.do_not` | Actions a ne jamais faire |
-| Etapes de montage | `installation.steps` (min 3) | Procedure pas a pas |
-| Outils necessaires | `installation.tools` | Liste outillage |
-| Erreurs de montage | `installation.common_errors` (min 2) | Erreurs de MONTAGE uniquement |
-| Questions frequentes | `rendering.faq` (min 4) | Q&A avec reponses sourcees |
-| Chiffres avec source | `rendering.arguments` | Claims chiffrees avec `source_ref` |
-
-#### Etape 2b — Registrer la provenance
-
-Pour chaque doc supplementaire utilise, ajouter une entree dans `_sources` :
-
-```yaml
-_sources:
-  {cle-unique}:                    # ex: bosch-2024, mopar-entretien
-    type: "manufacturer"|"norm"|"field-expertise"|"study"|"rag-doc"
-    doc: "{source_path}"           # chemin fichier RAG ou null
-    note: "{contexte en 1 phrase}" # optionnel
-```
-
-Les champs enrichis referencent la source via `source: "{cle}"` inline.
-
-#### Etape 3 — Proposer le diff YAML v4
-
-Presenter les enrichissements organises par bloc. Ne modifier QUE les champs absents ou insuffisants :
-
-```yaml
-# ENRICHISSEMENTS PROPOSES pour gammes/{slug}.md (schema v4)
-# Sources : {liste des docs avec titre abrege}
-# Blocs enrichis : {liste} / Blocs inchanges : {liste}
-
-_sources:  # +{N} nouvelles entrees
-  {cle}:
-    type: "{type}"
-    doc: "{path}"
-    note: "{contexte}"
-
-domain:  # Bloc A
-  role: "{enrichi si <80 chars}"
-  must_be_true:  # +{N}
-    - "{terme}" # [source: {cle}]
-  confusion_with:  # +{N}
-    - term: "{piece}"
-      difference: "{explication}" # [source: {cle}]
-  cross_gammes:  # NOUVEAU
-    - slug: "{gamme-liee}"
-      relation: "{type}"
-      context: "{explication}"
-
-selection:  # Bloc B
-  criteria:  # +{N}
-    - "{critere}" # [source: {cle}]
-  anti_mistakes:  # +{N}
-    - "{erreur}" # [source: {cle}]
-  cost_range:  # AVANT: absent → APRES: renseigne
-    min: {N}
-    max: {N}
-    currency: EUR
-    unit: "{unite}"
-    source: "{cle}"
-
-diagnostic:  # Bloc C
-  symptoms:  # +{N} (avec id + severity)
-    - id: "S{N}"
-      label: "{symptome}" # [source: {cle}]
-      severity: "{confort|securite|immobilisation}"
-  causes:  # +{N} (avec %)
-    - "{cause} ({X}%)" # [source: {cle}]
-
-maintenance:  # Bloc D
-  interval:  # AVANT: generique → APRES: chiffre
-    value: "{valeur}"
-    unit: "{km|mois|condition}"
-    note: "{condition critique}"
-    source: "{cle}"
-
-rendering:
-  faq:  # +{N}
-    - question: "{question}"
-      answer: "{reponse}" # [source: {cle}]
-  arguments:
-    - title: "{claim chiffree}"
-      icon: "{lucide-icon}"
-      source_ref: "{cle}" # OBLIGATOIRE si chiffre
-
-lifecycle:
-  stage: "v4_converted"  # ou "skill_enriched" si deja v4
-  last_enriched_by: "skill:seo-content"
-  last_enriched_at: {date du jour}
-```
-
-**Regles d'enrichissement :**
-1. **Ne jamais ecraser** — ajouter aux listes existantes, ne pas remplacer
-2. **Deduplication** — verifier que le nouveau contenu n'est pas deja present (meme sens)
-3. **Sourcer** — chaque ajout annote avec le doc source + entree dans `_sources`
-4. **Max 5 ajouts par champ** — au-dela, prioriser par pertinence
-5. **Validation obligatoire** — presenter le diff et demander : "Ces enrichissements sont corrects ? Je mets a jour gamme.md et je continue la redaction."
-6. **Hard gates** — verifier AVANT de proposer :
-   - `domain.role` > 80 chars et pas de pattern generique
-   - `selection.cost_range.max < 10 * cost_range.min`
-   - Tout chiffre dans `rendering.arguments` a un `source_ref`
-7. **Scoring** — estimer le score v4 apres enrichissement (ref: `.spec/00-canon/gamme-md-schema.md` §Scoring v4)
-
-#### Etape 4 — Appliquer les modifications
-
-Apres validation de l'admin, mettre a jour le fichier `gammes/{slug}.md` via l'outil Edit :
-- Mettre a jour `updated_at` a la date du jour
-- Mettre a jour `lifecycle.stage` et `lifecycle.last_enriched_by`
-- Mettre a jour `quality.version: GammeContentContract.v4` si conversion
-
-> **Si aucun doc supplementaire n'est trouve** : passer directement a Phase 2. Le skill fonctionne normalement avec les donnees existantes du gamme.md.
-
-> **Si le gamme.md v4 est deja riche** (tous les seuils minimums atteints par bloc) : noter "Gamme.md v4 deja complet, aucun ajout necessaire" et passer a Phase 2.
+> **Si aucun doc supplémentaire** ou **gamme.md v4 déjà riche** : passer directement à Phase 2.
 
 ### Phase 2 — Architecture du contenu
 
@@ -758,56 +498,14 @@ Si une information n'est pas confirmée, utiliser EXCLUSIVEMENT :
 
 ## Correction Linguistique (OBLIGATOIRE)
 
-**Toute sortie doit être irréprochable en français.** Cela s'applique aussi aux données provenant de la BDD ou du RAG.
+**Toute sortie doit être irréprochable en français** — y compris les données BDD/RAG.
 
-### Périmètre de correction
+Règles non-négociables :
+- Orthographe, grammaire, conjugaison, typographie française (espaces insécables, guillemets « »)
+- Erreur BDD/RAG → corriger dans le contenu généré ET générer une requête MCP de correction prête à exécuter (jamais de signalement passif)
+- Ne JAMAIS publier avec des fautes, même si la source en contient
 
-| Source | Action |
-|--------|--------|
-| Contenu rédigé par le skill | Corriger systématiquement avant livraison |
-| Données BDD (titres, descriptions, FAQ, symptômes) | Corriger dans le contenu généré. Signaler les erreurs d'origine pour correction en base |
-| Données RAG (knowledge docs) | Corriger dans le contenu généré. Signaler les erreurs d'origine |
-| Données utilisateur | Corriger silencieusement sauf si le sens change |
-
-### Règles de correction
-
-1. **Orthographe** — Aucune faute tolérée (accents, doubles consonnes, mots composés)
-   - ❌ "freinage d'urgance" → ✅ "freinage d'urgence"
-   - ❌ "ammortisseur" → ✅ "amortisseur"
-
-2. **Grammaire** — Accords (genre, nombre, participes), prépositions, syntaxe
-   - ❌ "les plaquette de frein est usé" → ✅ "les plaquettes de frein sont usées"
-
-3. **Conjugaison** — Temps, modes, accords du participe passé
-   - ❌ "le disque à été changé" → ✅ "le disque a été changé"
-
-4. **Typographie française** — Espaces insécables, guillemets « », ponctuation
-
-### Si une erreur vient de la BDD ou du RAG
-
-Générer des **requêtes MCP prêtes à exécuter** (pas de signalement passif) :
-
-```
-⚠️ Corrections BDD — requêtes MCP prêtes à exécuter :
-
-mcp__claude_ai_Supabase__execute_sql:
-  project_id: cxpojprgwgubzjyqzmoq
-  query: UPDATE pieces_gamme SET label = 'Disque de frein' WHERE label = 'Disque de Freins';
-
-Validation : SELECT pg_id, label FROM pieces_gamme WHERE pg_alias = 'disque-de-frein';
-```
-
-Pour les erreurs dans les knowledge docs RAG :
-
-```
-⚠️ Correction RAG — action Edit :
-- Fichier : /opt/automecanik/rag/knowledge/gammes/{slug}.md
-- Ligne {N} : "{erroné}" → "{corrigé}"
-- Action : Edit tool sur le fichier source
-```
-
-> Ne JAMAIS publier du contenu avec des fautes, même si la source en contient.
-> Toujours fournir la requête de correction ET la requête de validation.
+> **Détail complet (périmètre par source, exemples de corrections, format requêtes `mcp__claude_ai_Supabase__execute_sql` + Edit RAG)** : `references/lang-correction.md`
 
 ---
 
@@ -859,59 +557,13 @@ Avant de répondre, vérifier :
 
 Pour traiter plusieurs gammes en série :
 
-### Pré-check RAG (OBLIGATOIRE avant la boucle)
+1. **Pré-check RAG OBLIGATOIRE** : pour chaque gamme, vérifier knowledge doc + `truth_level` ≥ L2 + `updated_at` < 6 mois + `domain.must_be_true` non vide. Constituer PROCESS list et SKIP list
+2. **Workflow 4 phases complet** sur chaque gamme PROCESS — ne jamais baisser la qualité pour aller plus vite
+3. **Gate qualité** : score < 80 après Phase 4 → REVIEW (ne pas publier)
+4. **Sortie tabulaire** : Gamme | Slug | Score | Status (OK/SKIP/REVIEW) | Sources | Issues
+5. Si > 30% SKIP → proposer `/rag-ops audit`
 
-Pour chaque gamme cible, vérifier AVANT de lancer la rédaction :
-
-```bash
-# Pour chaque gamme, récupérer le knowledge doc via POST /api/rag/search (RAG v2.5)
-# target_role = R3_GUIDE pour batch guide-achat (les conseils partagent le rôle R3)
-curl -s -X POST http://localhost:3000/api/rag/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "{nom_gamme}", "limit": 1, "routing": {"target_role": "R3_GUIDE"}}' \
-  | jq '.results[0] | {title, truth_level, updated_at, primary_role, purity_score}'
-```
-
-**Critères de pré-qualification :**
-
-| Critère | Seuil | Si échec |
-|---------|-------|----------|
-| Knowledge doc existe | Obligatoire | SKIP — "No knowledge doc" |
-| `truth_level` | ≥ L2 | SKIP — "Low truth level (L3/L4)" |
-| `updated_at` | < 6 mois | SKIP — "Stale source, `/rag-ops ingest` recommandé" |
-| `domain.must_be_true` (v4) ou `mechanical_rules.must_be_true` (legacy) | Non vide | WARNING — "No domain rules, manual review needed" |
-
-**Pré-requis supplémentaires si rôle = guide-achat :**
-
-| Critère | Seuil | Si échec |
-|---------|-------|----------|
-| Champ `howToChoose` (RAG) | Non vide | SKIP — "Pas de données guide-achat (howToChoose manquant)" |
-| Champ `antiMistakes` (RAG) | Non vide | WARNING — "antiMistakes vide, S5/S6 dégradés" |
-| `sgpg_selection_criteria` (BDD) | ≥ 1 critère | WARNING — "Pas de critères sélection, S3 simplifié" |
-| `sgpg_use_cases` (BDD) | ≥ 1 profil | WARNING — "Pas de use cases, S4 sans profils conducteur" |
-| Word count cible | 600-900 mots | Ajuster si hors fourchette — voir `quality-scoring.md` |
-
-### Workflow batch
-
-1. **Pré-check** : pour chaque gamme cible, exécuter le pré-check RAG. Constituer PROCESS list et SKIP list
-2. **Exécuter** : workflow 4 phases complet pour chaque gamme de la PROCESS list
-3. **Variables template** : `{gamme}`, `{famille}`, `{pg_id}`, `{v_level}`, `{slug}`
-4. **Gate qualité** : si score < 80 après Phase 4, marquer REVIEW (ne pas publier)
-
-**Format de sortie batch :**
-
-| Gamme | Slug | Score | Status | Sources | Issues |
-|-------|------|-------|--------|---------|--------|
-| disque de frein | disque-de-frein | 88 | OK | rag://gammes.disque-de-frein | — |
-| plaquette de frein | plaquette-de-frein | 82 | OK | rag://gammes.plaquette-de-frein | mechanical_rules partielles |
-| étrier de frein | etrier-de-frein | SKIP | — | — | truth_level L3, updated_at > 6 mois |
-| flexible de frein | flexible-de-frein | 74 | REVIEW | rag://gammes.flexible-de-frein | score < 80, proposer `/content-audit` |
-
-**Règles batch :**
-- Ne jamais baisser la qualité pour aller plus vite — chaque gamme suit le workflow complet
-- Signaler les gammes SKIP en fin de batch avec la raison + action recommandée
-- Signaler les gammes REVIEW avec le score et les issues détectées
-- Si > 30% des gammes sont SKIP : proposer `/rag-ops audit` pour vérifier la santé du corpus
+> **Détail complet (queries pré-check, critères guide-achat, format sortie, règles)** : `references/batch-mode.md`
 
 ---
 

--- a/.claude/skills/seo-content-architect/references/batch-mode.md
+++ b/.claude/skills/seo-content-architect/references/batch-mode.md
@@ -1,0 +1,57 @@
+# Mode Batch (multi-gammes)
+
+> Référencée depuis `SKILL.md`. Utiliser pour traiter plusieurs gammes en série.
+
+## Pré-check RAG (OBLIGATOIRE avant la boucle)
+
+Pour chaque gamme cible, vérifier AVANT de lancer la rédaction :
+
+```bash
+# Pour chaque gamme, récupérer le knowledge doc via POST /api/rag/search (RAG v2.5)
+# target_role = R3_GUIDE pour batch guide-achat (les conseils partagent le rôle R3)
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{nom_gamme}", "limit": 1, "routing": {"target_role": "R3_GUIDE"}}' \
+  | jq '.results[0] | {title, truth_level, updated_at, primary_role, purity_score}'
+```
+
+**Critères de pré-qualification :**
+
+| Critère | Seuil | Si échec |
+|---------|-------|----------|
+| Knowledge doc existe | Obligatoire | SKIP — "No knowledge doc" |
+| `truth_level` | ≥ L2 | SKIP — "Low truth level (L3/L4)" |
+| `updated_at` | < 6 mois | SKIP — "Stale source, `/rag-ops ingest` recommandé" |
+| `domain.must_be_true` (v4) ou `mechanical_rules.must_be_true` (legacy) | Non vide | WARNING — "No domain rules, manual review needed" |
+
+**Pré-requis supplémentaires si rôle = guide-achat :**
+
+| Critère | Seuil | Si échec |
+|---------|-------|----------|
+| Champ `howToChoose` (RAG) | Non vide | SKIP — "Pas de données guide-achat (howToChoose manquant)" |
+| Champ `antiMistakes` (RAG) | Non vide | WARNING — "antiMistakes vide, S5/S6 dégradés" |
+| `sgpg_selection_criteria` (BDD) | ≥ 1 critère | WARNING — "Pas de critères sélection, S3 simplifié" |
+| `sgpg_use_cases` (BDD) | ≥ 1 profil | WARNING — "Pas de use cases, S4 sans profils conducteur" |
+| Word count cible | 600-900 mots | Ajuster si hors fourchette — voir `quality-scoring.md` |
+
+## Workflow batch
+
+1. **Pré-check** : pour chaque gamme cible, exécuter le pré-check RAG. Constituer PROCESS list et SKIP list
+2. **Exécuter** : workflow 4 phases complet pour chaque gamme de la PROCESS list
+3. **Variables template** : `{gamme}`, `{famille}`, `{pg_id}`, `{v_level}`, `{slug}`
+4. **Gate qualité** : si score < 80 après Phase 4, marquer REVIEW (ne pas publier)
+
+**Format de sortie batch :**
+
+| Gamme | Slug | Score | Status | Sources | Issues |
+|-------|------|-------|--------|---------|--------|
+| disque de frein | disque-de-frein | 88 | OK | rag://gammes.disque-de-frein | — |
+| plaquette de frein | plaquette-de-frein | 82 | OK | rag://gammes.plaquette-de-frein | mechanical_rules partielles |
+| étrier de frein | etrier-de-frein | SKIP | — | — | truth_level L3, updated_at > 6 mois |
+| flexible de frein | flexible-de-frein | 74 | REVIEW | rag://gammes.flexible-de-frein | score < 80, proposer `/content-audit` |
+
+**Règles batch :**
+- Ne jamais baisser la qualité pour aller plus vite — chaque gamme suit le workflow complet
+- Signaler les gammes SKIP en fin de batch avec la raison + action recommandée
+- Signaler les gammes REVIEW avec le score et les issues détectées
+- Si > 30% des gammes sont SKIP : proposer `/rag-ops audit` pour vérifier la santé du corpus

--- a/.claude/skills/seo-content-architect/references/gamme-enrichment.md
+++ b/.claude/skills/seo-content-architect/references/gamme-enrichment.md
@@ -1,0 +1,201 @@
+# Phase 1d — Enrichissement gamme.md v4
+
+> Référencée depuis `SKILL.md` (Phase 1d). Workflow d'enrichissement YAML quand des docs supplémentaires sont disponibles.
+
+**Declencheur** : Phase 1b a trouve des docs supplementaires (web/, pdf/, guides/) via la recherche RAG, ET le gamme.md presente des lacunes dans ses 5 blocs.
+
+**Objectif** : Enrichir le frontmatter YAML du fichier `gammes/{slug}.md` selon le **schema v4 (5 blocs)** AVANT de rediger, pour que le contenu soit fonde sur des donnees riches et verifiees.
+
+> **Schema de reference** : `.spec/00-canon/gamme-md-schema.md` — source de verite pour la structure, les types, et les regles de chaque bloc.
+
+## Detection de version
+
+| Version detectee | Action |
+|-----------------|--------|
+| `GammeContentContract.v4` | Enrichir selon les 5 blocs ci-dessous |
+| `GammeContentContract.v3` ou absent | Convertir en v4 PUIS enrichir (voir Etape 0) |
+
+## Etape 0 — Conversion v3 → v4 (si necessaire)
+
+Si le gamme.md est en v3 ou v1 (pas de `quality.version: GammeContentContract.v4`), proposer la conversion :
+
+```
+CONVERSION v3 → v4 proposee pour gammes/{slug}.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Mapping :
+  page_contract.symptoms → diagnostic.symptoms (ajouter id + severity)
+  page_contract.timing → maintenance.interval
+  page_contract.risk.costRange → selection.cost_range
+  page_contract.antiMistakes → selection.anti_mistakes
+  page_contract.howToChoose → selection.criteria
+  page_contract.faq → rendering.faq
+  mechanical_rules.must_be_true → domain.must_be_true
+  mechanical_rules.must_not_contain_concepts → domain.must_not_contain
+  mechanical_rules.confusion_with → domain.confusion_with
+  mechanical_rules.role_summary → domain.role
+
+Blocs a creer (absents en v3) :
+  - selection.checklist
+  - selection.brands
+  - diagnostic.causes (avec %)
+  - diagnostic.quick_checks
+  - maintenance.usage_factors
+  - maintenance.good_practices
+  - installation.* (si applicable)
+  - _sources (provenance)
+  - cross_gammes (relations)
+  - lifecycle
+
+Valider la conversion avant enrichissement ?
+```
+
+## Etape 1 — Decouvrir les docs supplementaires
+
+```bash
+# Rechercher les docs non-gamme lies a cette piece
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{nom_piece}", "limit": 10, "includeFullContent": true}' \
+  | jq '.results[] | select(.sourcePath | startswith("gammes/") | not) | {title, sourcePath, sourceType, score}'
+```
+
+Filtrer : garder uniquement les docs `web/`, `pdf/`, `guides/` avec `truth_level` L1 ou L2.
+
+## Etape 2 — Lire et analyser le contenu complet
+
+Pour chaque doc supplementaire trouve, lire le fichier source :
+```
+/opt/automecanik/rag/knowledge/{source_path}
+```
+
+Extraire les donnees structurees pertinentes pour les **5 blocs v4** :
+
+| Donnee a extraire | Destination v4 | Critere d'extraction |
+|-------------------|----------------|---------------------|
+| Role mecanique detaille | `domain.role` (>80 chars) | Description fonctionnelle precise, sans verbe generique |
+| Termes techniques cles | `domain.must_be_true` | Vocabulaire metier obligatoire dans le contenu |
+| Confusions courantes | `domain.confusion_with` | Pieces proches ou causes confondues |
+| Pieces associees | `domain.related_parts` + `cross_gammes` | Mentions de pieces liees au remplacement |
+| Criteres de selection | `selection.criteria` (min 3) | Dimensions, types, compatibilites |
+| Checklist achat | `selection.checklist` (min 3) | Etapes verification avant commande |
+| Erreurs d'achat | `selection.anti_mistakes` (min 3) | Phrases "ne pas", "erreur", "eviter" |
+| Fourchette de cout | `selection.cost_range` | Montants en EUR avec unite (la paire, l'unite, le kit) |
+| Marques recommandees | `selection.brands` | Premium / equivalent / budget |
+| Symptomes de defaillance | `diagnostic.symptoms` (min 3) | Signes d'usure avec severity (confort/securite/immobilisation) |
+| Causes de panne | `diagnostic.causes` (min 2) | Ordonnees par frequence, % si connu |
+| Tests sans outil | `diagnostic.quick_checks` (min 2) | Verifications visuelles/manuelles |
+| Intervalles remplacement | `maintenance.interval` | Valeur + unite (km/mois/condition) + note |
+| Facteurs d'usure | `maintenance.usage_factors` | Conditions accelerant l'usure |
+| Bonnes pratiques | `maintenance.good_practices` | Gestes d'entretien preventif |
+| Interdits entretien | `maintenance.do_not` | Actions a ne jamais faire |
+| Etapes de montage | `installation.steps` (min 3) | Procedure pas a pas |
+| Outils necessaires | `installation.tools` | Liste outillage |
+| Erreurs de montage | `installation.common_errors` (min 2) | Erreurs de MONTAGE uniquement |
+| Questions frequentes | `rendering.faq` (min 4) | Q&A avec reponses sourcees |
+| Chiffres avec source | `rendering.arguments` | Claims chiffrees avec `source_ref` |
+
+## Etape 2b — Registrer la provenance
+
+Pour chaque doc supplementaire utilise, ajouter une entree dans `_sources` :
+
+```yaml
+_sources:
+  {cle-unique}:                    # ex: bosch-2024, mopar-entretien
+    type: "manufacturer"|"norm"|"field-expertise"|"study"|"rag-doc"
+    doc: "{source_path}"           # chemin fichier RAG ou null
+    note: "{contexte en 1 phrase}" # optionnel
+```
+
+Les champs enrichis referencent la source via `source: "{cle}"` inline.
+
+## Etape 3 — Proposer le diff YAML v4
+
+Presenter les enrichissements organises par bloc. Ne modifier QUE les champs absents ou insuffisants :
+
+```yaml
+# ENRICHISSEMENTS PROPOSES pour gammes/{slug}.md (schema v4)
+# Sources : {liste des docs avec titre abrege}
+# Blocs enrichis : {liste} / Blocs inchanges : {liste}
+
+_sources:  # +{N} nouvelles entrees
+  {cle}:
+    type: "{type}"
+    doc: "{path}"
+    note: "{contexte}"
+
+domain:  # Bloc A
+  role: "{enrichi si <80 chars}"
+  must_be_true:  # +{N}
+    - "{terme}" # [source: {cle}]
+  confusion_with:  # +{N}
+    - term: "{piece}"
+      difference: "{explication}" # [source: {cle}]
+  cross_gammes:  # NOUVEAU
+    - slug: "{gamme-liee}"
+      relation: "{type}"
+      context: "{explication}"
+
+selection:  # Bloc B
+  criteria:  # +{N}
+    - "{critere}" # [source: {cle}]
+  anti_mistakes:  # +{N}
+    - "{erreur}" # [source: {cle}]
+  cost_range:  # AVANT: absent → APRES: renseigne
+    min: {N}
+    max: {N}
+    currency: EUR
+    unit: "{unite}"
+    source: "{cle}"
+
+diagnostic:  # Bloc C
+  symptoms:  # +{N} (avec id + severity)
+    - id: "S{N}"
+      label: "{symptome}" # [source: {cle}]
+      severity: "{confort|securite|immobilisation}"
+  causes:  # +{N} (avec %)
+    - "{cause} ({X}%)" # [source: {cle}]
+
+maintenance:  # Bloc D
+  interval:  # AVANT: generique → APRES: chiffre
+    value: "{valeur}"
+    unit: "{km|mois|condition}"
+    note: "{condition critique}"
+    source: "{cle}"
+
+rendering:
+  faq:  # +{N}
+    - question: "{question}"
+      answer: "{reponse}" # [source: {cle}]
+  arguments:
+    - title: "{claim chiffree}"
+      icon: "{lucide-icon}"
+      source_ref: "{cle}" # OBLIGATOIRE si chiffre
+
+lifecycle:
+  stage: "v4_converted"  # ou "skill_enriched" si deja v4
+  last_enriched_by: "skill:seo-content"
+  last_enriched_at: {date du jour}
+```
+
+**Regles d'enrichissement :**
+1. **Ne jamais ecraser** — ajouter aux listes existantes, ne pas remplacer
+2. **Deduplication** — verifier que le nouveau contenu n'est pas deja present (meme sens)
+3. **Sourcer** — chaque ajout annote avec le doc source + entree dans `_sources`
+4. **Max 5 ajouts par champ** — au-dela, prioriser par pertinence
+5. **Validation obligatoire** — presenter le diff et demander : "Ces enrichissements sont corrects ? Je mets a jour gamme.md et je continue la redaction."
+6. **Hard gates** — verifier AVANT de proposer :
+   - `domain.role` > 80 chars et pas de pattern generique
+   - `selection.cost_range.max < 10 * cost_range.min`
+   - Tout chiffre dans `rendering.arguments` a un `source_ref`
+7. **Scoring** — estimer le score v4 apres enrichissement (ref: `.spec/00-canon/gamme-md-schema.md` §Scoring v4)
+
+## Etape 4 — Appliquer les modifications
+
+Apres validation de l'admin, mettre a jour le fichier `gammes/{slug}.md` via l'outil Edit :
+- Mettre a jour `updated_at` a la date du jour
+- Mettre a jour `lifecycle.stage` et `lifecycle.last_enriched_by`
+- Mettre a jour `quality.version: GammeContentContract.v4` si conversion
+
+> **Si aucun doc supplementaire n'est trouve** : passer directement a Phase 2. Le skill fonctionne normalement avec les donnees existantes du gamme.md.
+
+> **Si le gamme.md v4 est deja riche** (tous les seuils minimums atteints par bloc) : noter "Gamme.md v4 deja complet, aucun ajout necessaire" et passer a Phase 2.

--- a/.claude/skills/seo-content-architect/references/lang-correction.md
+++ b/.claude/skills/seo-content-architect/references/lang-correction.md
@@ -1,0 +1,52 @@
+# Correction Linguistique (OBLIGATOIRE)
+
+> Référencée depuis `SKILL.md`. Toute sortie doit être irréprochable en français — y compris pour les données provenant de la BDD ou du RAG.
+
+## Périmètre de correction
+
+| Source | Action |
+|--------|--------|
+| Contenu rédigé par le skill | Corriger systématiquement avant livraison |
+| Données BDD (titres, descriptions, FAQ, symptômes) | Corriger dans le contenu généré. Signaler les erreurs d'origine pour correction en base |
+| Données RAG (knowledge docs) | Corriger dans le contenu généré. Signaler les erreurs d'origine |
+| Données utilisateur | Corriger silencieusement sauf si le sens change |
+
+## Règles de correction
+
+1. **Orthographe** — Aucune faute tolérée (accents, doubles consonnes, mots composés)
+   - ❌ "freinage d'urgance" → ✅ "freinage d'urgence"
+   - ❌ "ammortisseur" → ✅ "amortisseur"
+
+2. **Grammaire** — Accords (genre, nombre, participes), prépositions, syntaxe
+   - ❌ "les plaquette de frein est usé" → ✅ "les plaquettes de frein sont usées"
+
+3. **Conjugaison** — Temps, modes, accords du participe passé
+   - ❌ "le disque à été changé" → ✅ "le disque a été changé"
+
+4. **Typographie française** — Espaces insécables, guillemets « », ponctuation
+
+## Si une erreur vient de la BDD ou du RAG
+
+Générer des **requêtes MCP prêtes à exécuter** (pas de signalement passif) :
+
+```
+⚠️ Corrections BDD — requêtes MCP prêtes à exécuter :
+
+mcp__claude_ai_Supabase__execute_sql:
+  project_id: cxpojprgwgubzjyqzmoq
+  query: UPDATE pieces_gamme SET label = 'Disque de frein' WHERE label = 'Disque de Freins';
+
+Validation : SELECT pg_id, label FROM pieces_gamme WHERE pg_alias = 'disque-de-frein';
+```
+
+Pour les erreurs dans les knowledge docs RAG :
+
+```
+⚠️ Correction RAG — action Edit :
+- Fichier : /opt/automecanik/rag/knowledge/gammes/{slug}.md
+- Ligne {N} : "{erroné}" → "{corrigé}"
+- Action : Edit tool sur le fichier source
+```
+
+> Ne JAMAIS publier du contenu avec des fautes, même si la source en contient.
+> Toujours fournir la requête de correction ET la requête de validation.

--- a/.claude/skills/seo-content-architect/references/rag-verification.md
+++ b/.claude/skills/seo-content-architect/references/rag-verification.md
@@ -1,0 +1,93 @@
+# Phase 1b — Vérification RAG (obligatoire si le sujet est une pièce/gamme)
+
+> Référencée depuis `SKILL.md` (Phase 1b). Workflow 4 étapes pour vérifier le corpus RAG avant rédaction.
+
+Avant toute rédaction portant sur une pièce automobile, exécuter ce workflow en 4 étapes :
+
+## Étape 1 — Récupérer le knowledge doc
+
+Construire le slug depuis le nom de la gamme : "Disque de frein" → `disque-de-frein`
+
+```bash
+# Recherche RAG avec role targeting (v2.5)
+# {ROLE} selon page cible : R1_ROUTER, R3_GUIDE, R4_REFERENCE, R5_DIAGNOSTIC
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{nom_piece}", "limit": 5, "routing": {"target_role": "{ROLE}"}}' \
+  | jq '.results[] | {title, truth_level, updated_at, confidence_score, primary_role, purity_score, chunk_kind, source_path, page_contract_id, media_slots_hint}'
+```
+
+**Décision selon les résultats :**
+
+| Résultat | truth_level | verification_status | Action |
+|----------|-------------|---------------------|--------|
+| Doc trouvé | L1 | verified | Fait dur — utiliser directement, citer sans qualification |
+| Doc trouvé | L2 | verified | Confirmé — utiliser directement |
+| Doc trouvé | L2 | draft | Utilisable avec prudence, vérifier cohérence |
+| Doc trouvé | L3 | verified | Curaté — formulation conditionnelle obligatoire |
+| Doc trouvé | L3/L4 | draft/pending | **REJETER** — traiter comme non-confirmé |
+| 0 résultats | — | — | Signaler l'absence, continuer avec données utilisateur/BDD. Ne rien inventer |
+
+## Étape 2 — Extraire les règles du domaine (v4) / mechanical_rules (legacy)
+
+Chaque knowledge doc gamme contient un frontmatter YAML avec des règles. Détecter la version du schema :
+
+- **v4** : `rendering.quality.version === 'GammeContentContract.v4'` → lire `domain.*`
+- **Legacy** (v1/v3) : lire `mechanical_rules.*` + `purchase_guardrails.*`
+
+| Champ v4 | Champ legacy (fallback) | Usage dans la rédaction |
+|----------|------------------------|------------------------|
+| `domain.must_be_true` | `mechanical_rules.must_be_true` | Ces termes DOIVENT apparaître dans le contenu produit |
+| `domain.must_not_contain` | `mechanical_rules.must_not_contain_concepts` | JAMAIS dans le contenu — confusion sémantique |
+| `domain.confusion_with` | `mechanical_rules.confusion_with` | Générer un bloc "Ne pas confondre avec..." explicite |
+| `domain.role` | `mechanical_rules.role_summary` | Seed pour le H1/intro — reformuler, ne pas copier verbatim |
+| `domain.must_not_contain` | `purchase_guardrails.forbidden_terms` | Ajouter aux MOTS INTERDITS du contenu |
+| *(v4: implicite si crossGammes)* | `purchase_guardrails.requires_vehicle` | Si true, inclure "vérifiez la compatibilité véhicule" |
+
+**2 formats `confusion_with` (v4 = array uniquement, legacy = array ou map) :**
+
+Format array (v4 + legacy) :
+```yaml
+confusion_with:
+  - term: tambour de frein
+    difference: Le tambour utilise des mâchoires internes...
+```
+
+Format map (legacy uniquement) :
+```yaml
+confusion_with:
+  batterie:
+    key_difference: L'alternateur recharge la batterie...
+```
+
+Traiter les deux formats : pour chaque entrée, générer un bloc "Ne pas confondre avec {terme}" dans le contenu.
+
+## Étape 3 — Recherche complémentaire par section
+
+Interroger la section correspondant au rôle de page cible :
+
+```bash
+# Recherche complementaire avec role targeting (v2.5)
+# Enrichir la query avec des mots-cles de section selon le role cible :
+# R3 Blog/guide → "guide achat choix selection" (+ injecter template de conseils-role.md §7)
+# R3 Blog/conseils → "entretien remplacement etapes" (+ injecter template de conseils-role.md §7)
+# R4 Reference  → "definition technique composants" (+ injecter concepts partages de r4-reference-role.md §8)
+# R5 Diagnostic → "symptomes diagnostic panne"
+curl -s -X POST http://localhost:3000/api/rag/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{nom_piece} {section_keywords}", "limit": 5, "routing": {"target_role": "{ROLE}"}}' \
+  | jq '.results[:3] | .[] | {title, truth_level, content, primary_role, chunk_kind}'
+```
+
+Consolider les résultats des étapes 1 et 3 pour constituer la base de rédaction.
+
+## Étape 4 — Vérifier la fraîcheur (`updated_at`)
+
+Vérifier le champ `updated_at` dans le frontmatter YAML du knowledge doc :
+
+| Âge du doc | Statut | Action | Annotation |
+|------------|--------|--------|------------|
+| < 3 mois | Frais | Utiliser directement | Aucune |
+| 3-6 mois | Acceptable | Vérifier cohérence | Ajouter date dans provenance |
+| 6-12 mois | Stale | Pénalité -6 (STALE_SOURCE) | Annoter `[source datée de {mois}]`, proposer `/rag-ops ingest` |
+| > 12 mois | Obsolète | NE PAS utiliser les données chiffrées | **STOP** : proposer `/rag-ops ingest` avant rédaction |

--- a/docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md
+++ b/docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md
@@ -1,0 +1,446 @@
+# Fleet Advisor + Claude 4.7 — Design
+
+**Date** : 2026-04-25
+**Author** : Claude Opus 4.7 (1M context) on behalf of @ak125
+**Status** : Approved by user, ready for implementation plan
+**Scope** : AI-COS Paperclip fleet (7 agents synced + 19 platform-only) + new `Advisor` agent
+
+---
+
+## 1. Goal
+
+Add an **AI peer-review layer** (Anthropic-style code-reviewer / advisor sub-agent pattern) to the AI-COS Paperclip fleet, gating high-stakes canonical writes (code PRs to `main`, DB writes to `__seo_*`/`__rag_*`/`__pieces_*`, deployments, governance-vault PRs).
+
+In the same operation, **upgrade the fleet to the Claude 4.X family** with a tiered model assignment (Opus 4.7 for strategic + reviewer, Sonnet 4.6 for production workers, Haiku 4.5 for fast pattern checks).
+
+The reviewer **never decides** — it scores and recommends. The human board operator retains all governance decisions (G3 signed-commits, R12 exit-contract preserved).
+
+---
+
+## 2. Non-goals
+
+- No fork of Paperclip — uses native primitives only
+- No Claude Code adapter modification (no PreCommit hook, no `claude_local` patch)
+- No bypass of the human board operator on `assertBoard`-guarded routes
+- No automatic correction by the Advisor (R12 exit-contract: propose only, never `AUTO_FIXED`)
+- No review of low-stakes outputs (CMO drafts, internal CPO planning, SEO-QA quick checks) — out of scope
+- No change to the 19 AI-COS-only agents beyond the model field
+
+---
+
+## 3. Architecture
+
+### 3.1 New agent: Advisor
+
+| Field | Value |
+|---|---|
+| Name | `Advisor` |
+| Role | `advisor` |
+| Reports to | CEO (`993a4a02`) |
+| Adapter | `claude_local` |
+| Model | `claude-opus-4-7` |
+| Capabilities | "Pre-canon review for code PRs, DB writes, deployments, governance changes. Read-only. Never decides — proposes verdict + scored axes for board operator." |
+| Heartbeat | 60s (idle), 30s (queue non-empty) |
+| Budget | 5000 USD/month (initial — to be tuned post phase 2) |
+| Skills bundle | `code-review`, `canon-write-review` (new), `content-audit`, `seo-gamme-audit` (existing in monorepo) |
+| Instructions bundle | `managed`, source `agents/advisor/AGENTS.md` |
+
+### 3.2 Wiring (4 native Paperclip primitives, no fork)
+
+```
+┌──────────────┐                                                ┌──────────────┐
+│  Producer    │ 1. POST /api/companies/:id/approvals           │   Advisor    │
+│  Agent       ├─────► { type: "pre_canon_review",              │   Agent      │
+│ (CTO, RAG,   │         payload: {scope, body, ctx},           │              │
+│  R4, Content,│         requestedByAgentId }                   │              │
+│  SEO-QA*)    │                                                │              │
+└──────────────┘                                                └──────┬───────┘
+                                                                       │ 2. heartbeat
+                                                                       │    GET /approvals?status=pending
+                                                                       │       &type=pre_canon_review
+                                                                       ▼
+                                                              ┌─────────────────┐
+                                                              │ Skill router    │
+                                                              │ - code_pr →     │
+                                                              │   code-review   │
+                                                              │ - canon_db_*    │
+                                                              │   → canon-write │
+                                                              │ - deployment →  │
+                                                              │   code-review + │
+                                                              │   ops-checklist │
+                                                              │ - governance →  │
+                                                              │   adr-review    │
+                                                              └────────┬────────┘
+                                                                       │
+                                                                       │ 3. POST /approvals/:id/comments
+                                                                       │    { body: verdict_json }
+                                                                       │    (no decision, just recommendation)
+                                                                       ▼
+                                                              ┌─────────────────┐
+                                                              │   Board op      │
+                                                              │   (human)       │
+                                                              │   sees approval │
+                                                              │   + advisor cmt │
+                                                              │   /approve      │
+                                                              │   /reject       │
+                                                              │   /revision     │
+                                                              └────────┬────────┘
+                                                                       │
+                                                                       │ 4. Producer next heartbeat
+                                                                       ▼
+                                                              ┌─────────────────┐
+                                                              │   Producer      │
+                                                              │   reads status: │
+                                                              │   approved →    │
+                                                              │     merge/write │
+                                                              │   revision_req →│
+                                                              │     fix & re-   │
+                                                              │     submit      │
+                                                              │   rejected →    │
+                                                              │     abort + log │
+                                                              └─────────────────┘
+```
+
+### 3.3 Approval payload schema (canonical)
+
+```json
+{
+  "scope": "code_pr | canon_db_write | deployment | governance_change",
+  "revision_round_count": 0,
+  "context": {
+    "issue_id": "string|null",
+    "task_id": "string|null",
+    "session_id": "string|null"
+  },
+  "body": {
+    // shape varies per scope — see 3.4
+  }
+}
+```
+
+### 3.4 Per-scope `body` shape
+
+**`code_pr`**
+```json
+{
+  "repo": "ak125/nestjs-remix-monorepo | ak125/governance-vault",
+  "branch": "feat/...",
+  "base_sha": "abc...",
+  "head_sha": "def...",
+  "files_changed": ["path/a.ts", "path/b.sql"],
+  "diff_summary": "string ≤2000 chars",
+  "diff_url": "https://github.com/...",
+  "related_pr_number": 123
+}
+```
+
+**`canon_db_write`**
+```json
+{
+  "table": "__seo_keyword_results | __rag_documents | __pieces_media_img | ...",
+  "op": "insert | update | delete",
+  "row_count": 1234,
+  "sample_rows": [{"...": "..."}, "max 5"],
+  "sql_or_rpc": "INSERT INTO ... | RPC name + args",
+  "affected_pg_ids": [123, 456],
+  "rollback_plan": "string"
+}
+```
+
+**`deployment`**
+```json
+{
+  "from_image": "massdoc/nestjs-remix-monorepo:preprod",
+  "to_image": "massdoc/nestjs-remix-monorepo:production",
+  "tag": "v2.1.0",
+  "changelog_since_last_tag": "string",
+  "smoke_test_results": "PASS | FAIL | SKIPPED",
+  "rollback_image": "massdoc/...:v2.0.9"
+}
+```
+
+**`governance_change`**
+```json
+{
+  "vault_pr_number": 42,
+  "adr_id": "ADR-022 | null",
+  "files_changed": ["ledger/decisions/adr/...", "ops/rules/..."],
+  "diff_summary": "string ≤2000 chars",
+  "category": "rule_T | rule_G | rule_AI | rule_V | adr | policy | runbook"
+}
+```
+
+### 3.5 Verdict format (advisor comment body, JSON canonical)
+
+```json
+{
+  "version": "1.0",
+  "scope": "code_pr | canon_db_write | deployment | governance_change",
+  "verdict": "PASS | REVISE | BLOCK",
+  "axes": {
+    "correctness": 0,
+    "security": 0,
+    "anti_cannib": 0,
+    "evidence": 0,
+    "reversibility": 0
+  },
+  "score_total": 0,
+  "findings": [
+    {
+      "severity": "critical | major | minor",
+      "file_or_table": "string",
+      "line_or_row": "string|null",
+      "issue": "string",
+      "suggested_fix": "string",
+      "blocking": true
+    }
+  ],
+  "evidence_pack": [
+    "vault://ops/rules/rules-governance.md#G3",
+    "monorepo://CLAUDE.md",
+    "incident://INC-2026-005"
+  ],
+  "advisor_recommendation": "approve | request_revision | reject",
+  "model_used": "claude-opus-4-7",
+  "review_duration_ms": 12345,
+  "revision_round": 0
+}
+```
+
+Verdict mapping (default policy, board can override). Evaluated in order, first match wins:
+1. Any finding with `severity=critical` OR explicit `verdict=BLOCK` → recommend `reject`
+2. Score total < 60 → recommend `reject`
+3. Score 60–79 OR `verdict=REVISE` → recommend `request_revision`
+4. Score ≥ 80 AND `verdict=PASS` AND no `severity=major` → recommend `approve`
+5. Otherwise → recommend `request_revision` (safe default)
+
+---
+
+## 4. Skills
+
+### 4.1 Existing (reused as-is)
+- `code-review` (monorepo) — security, architecture, performance, business compliance
+- `content-audit` (monorepo) — Intent-First / Evidence-First / Decision-First, R1-R6
+- `seo-gamme-audit` (monorepo) — full SEO gamme audit
+- `responsive-audit` (monorepo) — mobile-first, shadcn/ui compliance
+
+### 4.2 New: `canon-write-review`
+
+Trigger : payload `scope = canon_db_write`. Validates a DB write to canonical tables before commit.
+
+**Checks**
+1. **Schema compliance** : columns match table schema, no NULL violations, no type coercion
+2. **RLS policies** : write respects RLS (cf. ADR-021 hardening)
+3. **Anti-cannibalisation** : keyword writes pass Jaccard threshold vs. existing rows (rules R-SEO-KW-01..07)
+4. **V-Level integrity** : if writes touch V-Level surfaces, sibling-set consistency check
+5. **Evidence requirement** : payload has `rollback_plan` non-empty + `sql_or_rpc` non-empty
+6. **Volume sanity** : `row_count > 1000` requires explicit batch flag, else BLOCK
+7. **Audit-trail** : write traceable to a vault rule, ADR, or task ID
+
+Implementation : Python skill in `agents/advisor/skills/canon-write-review/SKILL.md` + `scripts/advisor/canon-write-review.py` (zero-LLM where possible, just runs RPCs + grep against vault rules).
+
+### 4.3 Skill router (in Advisor's AGENTS.md)
+
+Pseudo-logic the Advisor follows on each pending approval:
+
+```
+payload.scope == "code_pr"           → run code-review skill
+payload.scope == "canon_db_write"    → run canon-write-review skill
+payload.scope == "deployment"        → run code-review on changelog + ops checklist (manual)
+payload.scope == "governance_change" → run code-review + cross-ref vault rules
+```
+
+---
+
+## 5. Producer-side instructions (AGENTS.md updates)
+
+The 5 producer agents get a new section in their `AGENTS.md`:
+
+```markdown
+## Pre-canon review (mandatory)
+
+Before any of the following actions, you MUST create a `pre_canon_review` approval and wait for board decision before proceeding:
+
+- [code_pr] git push of a PR to `main` on `ak125/nestjs-remix-monorepo` or `ak125/governance-vault`
+- [canon_db_write] write to any `__seo_*`, `__rag_*`, `__pieces_*` table with row_count >= 10 (or any DELETE)
+- [deployment] tag push `v*` triggering DEV→PROD promotion
+- [governance_change] PR to `ak125/governance-vault` (any file under `ledger/`, `ops/rules/`, `ops/moc/`)
+
+### How to create the approval
+
+1. Build payload per `docs/superpowers/specs/2026-04-25-fleet-advisor-claude-4-7-design.md` § 3.4
+2. POST `/api/companies/:companyId/approvals` with `type=pre_canon_review`
+3. Note the `approvalId` in your task / commit-message-prefix as `[approval:<id>]`
+4. Wait next heartbeat. Check status:
+   - `approved` → proceed with the action
+   - `revision_requested` → read advisor comment + board note, fix, then resubmit (`POST /approvals/:id/resubmit` with updated payload, increment `revision_round_count`)
+   - `rejected` → abort, log reason in your activity, escalate to manager
+5. Max 3 revision rounds. After round 3 + revise → escalate to CEO with full context.
+
+If your action is NOT in this list, no approval is needed.
+```
+
+Producers affected:
+- **CEO** : `governance_change` (when proposing ADRs)
+- **CTO** : `code_pr`, `deployment`, `governance_change`
+- **RAG-Ops** : `canon_db_write` (for `__rag_*` writes), `code_pr`
+- **R4-Batch-Lead** : `canon_db_write` (for batch writes to `__seo_*`)
+- **SEO-Content** : `canon_db_write` (for content writes)
+
+CMO, CPO, SEO-QA, the 19 platform-only agents : no producer-side change (out of review scope).
+
+---
+
+## 6. Tier model assignment (Claude 4.X)
+
+### 6.1 Local-synced fleet (8 agents post-hire)
+
+| Agent | Current | Target | Reason |
+|---|---|---|---|
+| CEO (`993a4a02`) | haiku-4-5 | `claude-opus-4-7` | Strategy, multi-step delegation |
+| CTO (`7fa3c971`) | haiku-4-5 | `claude-opus-4-7` | Architecture, complex code |
+| **Advisor** (NEW) | — | `claude-opus-4-7` | Must reason better than producers |
+| CMO (`7fb56320`) | haiku-4-5 | `claude-sonnet-4-6` | Marketing worker |
+| CPO (`41718022`) | haiku-4-5 | `claude-sonnet-4-6` | Product worker |
+| RAG-Ops (`c6762b10`) | haiku-4-5 | `claude-sonnet-4-6` | Pipeline ops |
+| SEO-Content (`0f978206`) | haiku-4-5 | `claude-sonnet-4-6` | Content gen |
+| R4-Batch-Lead (`e26ea228`) | haiku-4-5 | `claude-sonnet-4-6` | Batch orchestration |
+| SEO-QA (`8ff977f4`) | haiku-4-5 | `claude-haiku-4-5-20251001` | Pattern checks (kept) |
+
+### 6.2 Platform-only (19 agents on AI-COS without local sync)
+
+Default upgrade to `claude-sonnet-4-6`, EXCEPT agents whose role is `ceo`, `cto`, or `advisor`/`reviewer` (if any) → `claude-opus-4-7`. Discovered via `GET /api/companies/:id/agents` and bulk PATCH.
+
+### 6.3 Cost ceiling
+
+Assumes platform-only fleet split per § 6.2: of the 19 platform-only agents, 0–2 hold strategic roles (`ceo`/`cto`/`advisor`) and would be Opus, the rest Sonnet, and a small minority kept on Haiku for fast pattern checks. Worst-case (2 Opus) used below.
+
+| Tier | Local | Platform-only | Total agents | Per-agent monthly USD | Subtotal |
+|---|---|---|---|---|---|
+| Opus 4.7 | 3 (CEO, CTO, Advisor) | up to 2 | 5 | ~$2000 | $10,000 |
+| Sonnet 4.6 | 5 (CMO, CPO, RAG, R4, SEO-Content) | ~16 | 21 | ~$300 | $6,300 |
+| Haiku 4.5 | 1 (SEO-QA) | ~1 | 2 | ~$50 | $100 |
+| **Total** | **9** | **19** | **28** | | **~$16,400/month worst-case** |
+
+Realistic case (0 platform Opus) : ~$12,400/month. Baseline pre-upgrade : ~$1,400/month (all Haiku). Per-agent budget caps in `budgetMonthlyCents` enforce per-tier ceilings; alert threshold 80%.
+
+Budget caps enforced per agent via `budgetMonthlyCents` in Paperclip. Hard cap on Advisor budget triggers fallback to Sonnet 4.6 model in `adapterConfig.fallback_model` (TBD if Paperclip supports it; otherwise alert + manual swap).
+
+---
+
+## 7. Failure modes & guardrails
+
+| Failure mode | Detection | Mitigation |
+|---|---|---|
+| Advisor heartbeat down > 10 min | Paperclip dashboard heartbeat status | Board operator notified, can decide approval without IA recommendation (zero blocking on humans) |
+| Advisor returns malformed JSON | JSON schema validation on comment body | Advisor retries 1× with stricter prompt, else flags `INSUFFICIENT_EVIDENCE`, board decides blind |
+| Producer skips approval (forgets / bug) | Asynchronous CI check (post-merge) on commit messages — if `[approval:...]` missing for canon-touching commit, raise an issue auto | Detection only in phase 3; phase 2 logs warning, no enforcement |
+| Revision loop infinite | `revision_round_count` in payload, advisor escalates to BLOCK + tags `MANUAL_BOARD_DECISION_REQUIRED` after round 3 | Board reviews escalated approvals daily |
+| Advisor cost runaway | Per-agent budget cap, alert at 80% | Auto-pause via Paperclip `POST /agents/:id/pause` |
+| Advisor false positive (BLOCKs valid work) | Phase 2 shadow mode catches before phase 3 enforcement | Tune `canon-write-review` thresholds based on phase 2 data |
+| Wrong model assigned | Config revision history (`GET /api/agents/:id/config-revisions`) | Rollback via `POST /config-revisions/:id/rollback` |
+
+---
+
+## 8. Validation / tests
+
+### 8.1 Smoke tests (phase 0)
+1. Create faux `pre_canon_review` payload (one per scope) via curl
+2. Verify Advisor heartbeat picks it up within 90s
+3. Verify advisor comment posted with valid JSON verdict
+4. Verify `assertBoard` blocks Advisor from `/approve` and `/reject`
+
+### 8.2 End-to-end (phase 1)
+1. CTO creates a test PR (toy change) on a sandbox branch
+2. CTO creates `pre_canon_review` approval
+3. Advisor reviews → posts comment
+4. Board operator approves
+5. CTO next heartbeat → merges
+6. Verify audit trail full in approval + commit message + activity log
+
+### 8.3 Regression — historical incident replay
+Replay 3 incidents as `pre_canon_review` payloads. Advisor must `BLOCK` all 3:
+
+| Incident | Scope | Expected verdict | Reason advisor should catch |
+|---|---|---|---|
+| INC-2026-005 (GSC 5xx) | code_pr | BLOCK | Missing matview cache, anti-pattern flagged in code-review |
+| RAG vault rollback 2026-04-18 | canon_db_write | BLOCK | Source = LLM, not RAG/vault — caught by `canon-write-review` evidence check |
+| INC-2026-009 admin password leak | code_pr | BLOCK | RLS policy missing, caught by `code-review` security axis |
+
+If any of the 3 returns PASS, design is invalid → halt rollout.
+
+### 8.4 Cost canary (phase 2 = 1 week shadow)
+- Advisor commenting only, board ignores comments
+- Daily report : N approvals reviewed, avg cost per review, false-positive rate (board approves anyway), false-negative rate (board rejects despite advisor PASS)
+- Target : <10% FP, <5% FN before phase 3
+
+---
+
+## 9. Rollout plan
+
+| Phase | Duration | Activities | Exit criterion |
+|---|---|---|---|
+| **0 — Build** | 2-3 days | Create `canon-write-review` skill, write Advisor `AGENTS.md`, hire Advisor agent on AI-COS via `/agent-hires`, set models tiering on 7 local-synced agents via PATCH, sync DEV→AI-COS | Advisor heartbeat green, smoke tests pass |
+| **1 — Producers wired** | 2-3 days | Update AGENTS.md of 5 producer agents (CEO, CTO, RAG-Ops, R4-Batch-Lead, SEO-Content) with "Pre-canon review" section, sync DEV→AI-COS, run end-to-end test | E2E test pass, revision loop tested |
+| **2 — Shadow mode** | 7 days | Producers create approvals, advisor comments, board ignores comments. Daily metrics dashboard | <10% FP and <5% FN observed |
+| **3 — Enforcement** | ongoing | Producers must wait for board decision (approval status check is blocking); CI post-merge check active | Steady-state |
+
+Total elapsed : ~12-13 days.
+
+---
+
+## 10. Migration & rollback
+
+### 10.1 Forward
+- Atomic PATCHes per agent on AI-COS (one PATCH = one model change). Failure of one PATCH does not affect others.
+- Hire Advisor through `/agent-hires` (creates draft + approval) → board approves on AI-COS UI.
+- AGENTS.md sync via `PUT /api/agents/:id/instructions-bundle/file` (existing flow per memory `paperclip-agents-config.md`).
+
+### 10.2 Rollback
+- **Per-agent model rollback** : `POST /api/agents/:id/config-revisions/:revisionId/rollback` (Paperclip native)
+- **Advisor agent rollback** : `POST /api/agents/:id/pause` (revert all producers to no-review behavior); subsequently `POST /agents/:id/terminate` if needed
+- **AGENTS.md rollback** : git revert in `agents/` folder + re-sync
+- **Full rollback** : 4 commands + 1 board action ; estimated <10 min
+
+---
+
+## 11. Open questions (to resolve in implementation plan)
+
+1. **Paperclip `fallback_model` support** — does `adapterConfig` allow a fallback model on budget breach? If not, design uses pause-and-alert instead. (Verify in writing-plans phase.)
+2. **Approval comments retention** — verdict JSON is stored in `approval_comments.body` (text). For long-term audit, do we also mirror to `governance-vault/ledger/audit-trail/`? Decision deferred to phase 1.
+3. **Advisor instruction bundle managed vs external** — `managed` recommended (consistent with CEO/CTO), but external (cwd=/repo) gives more flexibility. Decide in phase 0.
+4. **CI post-merge check (phase 3)** — implement as GitHub Action workflow; design TBD in writing-plans.
+5. **Skill cross-discovery** — Advisor needs `code-review`, `content-audit`, `seo-gamme-audit` skills installed in its workspace. Verify Paperclip skill injection mechanism handles multi-skill bundle.
+
+---
+
+## 12. Decision matrix recap
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Review scope | Canon writes only (code PR, DB write, deploy, gov) | Aligns G3, R12, audit-trail; avoids advisor noise on low-stakes |
+| Wiring | Native approval + comment + heartbeat | No fork, no adapter mod, no bricolage |
+| Decision authority | Board operator only (`assertBoard` preserved) | G3 signed-commits, R12 exit-contract |
+| Advisor model | Opus 4.7 | Must reason better than producers |
+| Producer model | Sonnet 4.6 | Quality/cost balance for steady workers |
+| Pattern-check model | Haiku 4.5 (kept) | Fast, cheap, sufficient for SEO-QA |
+| Skills new | `canon-write-review` only | Reuse `code-review` / `content-audit` / `seo-gamme-audit` existing |
+| Rollout | 4 phases incl. 7-day shadow | De-risk via observation before enforcement |
+| Cost ceiling | ~$12,750/month at full enforcement | Vs ~$1,400 baseline; offset by quality + incident prevention |
+
+---
+
+## 13. References
+
+- `paperclip/docs/api/approvals.md`
+- `paperclip/docs/api/agents.md`
+- `paperclip/docs/adapters/claude-local.md`
+- `paperclip/server/src/routes/approvals.ts:121` (assertBoard guard)
+- `paperclip/packages/db/src/schema/approvals.ts` (text type field — extensible)
+- Memory : `paperclip-agents-config.md`, `vps-aicos.md`, `r12-exit-contract.md`, `feedback_no_hybrid_workarounds.md`
+- Vault canon : `ops/rules/rules-governance.md` (G3), `ledger/decisions/adr/ADR-021-rls-hardening.md`
+- Anthropic pattern : Claude Code subagent `code-reviewer` (this very environment, `superpowers:code-reviewer`)
+
+---
+
+_Status : design ready for writing-plans skill to produce a step-by-step implementation plan._


### PR DESCRIPTION
## Summary

- Apply [agentskills.io](https://agentskills.io/specification) progressive disclosure pattern to `seo-content-architect` SKILL.md
- SKILL.md: 1021 → 673 lines (-34%), ~9k → ~6.2k tokens at activation (-31%)
- Heavy procedural blocks moved to `references/` (loaded only when the skill needs them); zero information loss

## What changed

| Section | Before | After |
|---|---|---|
| Phase 1b — Vérification RAG | inline (92 lines) | `references/rag-verification.md` + 8-line pointer |
| Phase 1d — Enrichissement gamme.md v4 | inline (199 lines) | `references/gamme-enrichment.md` + 11-line pointer |
| Mode Batch (multi-gammes) | inline (58 lines) | `references/batch-mode.md` + 12-line pointer |
| Correction Linguistique | inline (52 lines) | `references/lang-correction.md` + 8-line pointer |

Each replaced section keeps a 4-12 line summary so the skill remains immediately actionable; full procedural detail (queries, mappings, hard gates, MCP request templates) lives in the reference and is loaded on demand.

## Why

The skill was 2× over the recommended SKILL.md size limit (≤500 lines per agentskills.io spec). Every activation paid ~9k tokens even when only the workflow was needed. Pattern matches the existing `references/` structure (11 role/scoring/template files already present).

## Out of scope

- `rag-ops` (681 lines) and `seo-gamme-audit` (858 lines) are also oversize — separate PRs after this one is validated, to keep review surface manageable and rollback isolated.

## Test plan

- [ ] Visual diff review: SKILL.md kept all H2/H3 anchors and non-negotiable rules
- [ ] Spot-check 3 references/ files render correctly in Claude Code skill picker
- [ ] Run `/seo-content-architect` against a known gamme post-merge and confirm outputs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)