### PR TITLE
feat(r1-cache): ADR-024 Phase 2 — __seo_r1_related_blocks_cache (offline RAG materialization)

### DIFF
--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -5,13 +5,13 @@ sources:
 last_scan: '2026-04-27'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
+- backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts
 - backend/src/modules/gamme-rest/gamme-rest-optimized.controller.ts
 - backend/src/modules/gamme-rest/gamme-rest-rpc-v2.controller.ts
 - backend/src/modules/gamme-rest/gamme-rest.module.ts
 - backend/src/modules/gamme-rest/services/buying-guide-data.service.ts
 - backend/src/modules/gamme-rest/services/gamme-data-transformer.service.ts
 - backend/src/modules/gamme-rest/services/gamme-page-data.service.ts
-- backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
 depends_on:
 - CatalogModule
 - DatabaseModule

--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 174,
+  "total": 175,
   "functions": [
     {
       "name": "__gov_m1_table_sizes",
@@ -533,6 +533,11 @@
       "name": "build_gamme_page_payload",
       "volatility": "STABLE",
       "reason": "ADR-024 Phase 1 internal builder used by rebuild_gamme_page_cache (parity ADR-016)"
+    },
+    {
+      "name": "get_r1_related_blocks_cached",
+      "volatility": "STABLE",
+      "reason": "ADR-024 Phase 2 cache-first lookup for R1 related blocks (sortir RAG fs read du SSR)"
     },
     {
       "name": "build_vehicle_page_payload",

--- a/backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts
+++ b/backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts
@@ -1,0 +1,81 @@
+/**
+ * ADR-024 Phase 2 — Admin endpoints pour `__seo_r1_related_blocks_cache`.
+ *
+ * Routes (toutes sous /api/admin/r1-related-blocks-cache, auth + admin guard) :
+ *   GET    /stats                      → total / stale / oldest_built_at / newest_built_at
+ *   POST   /rebuild/:pgId              → rebuild d'une gamme (parse RAG + persist)
+ *   POST   /rebuild-all                → backfill 238 G1/G2 (utilise pour Phase 3)
+ *
+ * Phase 2 (scaffolding) : la table existe et peut etre populee via ces
+ * endpoints, mais le chemin de lecture SSR R1 continue d'appeler
+ * R1RelatedResourcesService.buildRelatedBlocks (qui relit le RAG fs a
+ * chaque hit). La Phase 5 cleanup fera basculer le service pour lire
+ * depuis la table en priorite.
+ *
+ * Parite ADR-016 + Phase 1 (admin-vehicle-cache, admin-gamme-cache).
+ */
+
+import {
+  Controller,
+  Get,
+  Logger,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { AuthenticatedGuard } from '@auth/authenticated.guard';
+import { IsAdminGuard } from '@auth/is-admin.guard';
+import { AdminResponseInterceptor } from '../../../common/interceptors/admin-response.interceptor';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
+import { R1RelatedResourcesService } from '../services/r1-related-resources.service';
+
+@Controller('api/admin/r1-related-blocks-cache')
+@UseGuards(AuthenticatedGuard, IsAdminGuard)
+@UseInterceptors(AdminResponseInterceptor)
+export class AdminR1RelatedBlocksCacheController extends SupabaseBaseService {
+  protected override readonly logger = new Logger(
+    AdminR1RelatedBlocksCacheController.name,
+  );
+
+  constructor(
+    private readonly r1RelatedService: R1RelatedResourcesService,
+    rpcGate: RpcGateService,
+  ) {
+    super();
+    this.rpcGate = rpcGate;
+  }
+
+  @Get('stats')
+  async getStats() {
+    return this.r1RelatedService.getCacheStats();
+  }
+
+  @Post('rebuild/:pgId')
+  async rebuildOne(@Param('pgId', ParseIntPipe) pgId: number) {
+    // Resolve alias + name from pieces_gamme to drive the rebuild
+    const { data: gamme, error } = await this.client
+      .from('pieces_gamme')
+      .select('pg_id, pg_alias, pg_name')
+      .eq('pg_id', pgId)
+      .maybeSingle();
+
+    if (error || !gamme) {
+      return { pg_id: pgId, built: false, reason: 'gamme_not_found' };
+    }
+
+    const result = await this.r1RelatedService.rebuildCacheForGamme(
+      pgId,
+      String(gamme.pg_alias ?? ''),
+      String(gamme.pg_name ?? ''),
+    );
+    return { pg_id: pgId, ...result };
+  }
+
+  @Post('rebuild-all')
+  async rebuildAll() {
+    return this.r1RelatedService.rebuildCacheForAllG1G2();
+  }
+}

--- a/backend/src/modules/gamme-rest/gamme-rest.module.ts
+++ b/backend/src/modules/gamme-rest/gamme-rest.module.ts
@@ -1,7 +1,8 @@
 import { Module } from '@nestjs/common';
 import { GammeRestOptimizedController } from './gamme-rest-optimized.controller';
 import { GammeRestRpcV2Controller } from './gamme-rest-rpc-v2.controller';
-import { AdminGammeCacheController } from './controllers/admin-gamme-cache.controller'; // 🗄️ ADR-024 __gamme_page_cache
+import { AdminGammeCacheController } from './controllers/admin-gamme-cache.controller'; // 🗄️ ADR-024 Phase 1 __gamme_page_cache
+import { AdminR1RelatedBlocksCacheController } from './controllers/admin-r1-related-blocks-cache.controller'; // 🗄️ ADR-024 Phase 2 __seo_r1_related_blocks_cache
 import { CatalogModule } from '../catalog/catalog.module';
 import { DatabaseModule } from '../../database/database.module';
 import { SeoModule } from '../seo/seo.module';
@@ -28,7 +29,8 @@ import { R1RelatedResourcesService } from './services/r1-related-resources.servi
   controllers: [
     GammeRestOptimizedController, // Fallback automatique
     GammeRestRpcV2Controller, // RPC V2 ultra-optimisé
-    AdminGammeCacheController, // ADR-024 admin /api/admin/gamme-cache/*
+    AdminGammeCacheController, // ADR-024 Phase 1 admin /api/admin/gamme-cache/*
+    AdminR1RelatedBlocksCacheController, // ADR-024 Phase 2 admin /api/admin/r1-related-blocks-cache/*
   ],
   providers: [
     GammeDataTransformerService,

--- a/backend/src/modules/gamme-rest/services/r1-related-resources.service.ts
+++ b/backend/src/modules/gamme-rest/services/r1-related-resources.service.ts
@@ -8,6 +8,7 @@
  * - Blocs vides non retournés
  * - Le frontend consomme, n'arbitre rien
  */
+import { createHash } from 'crypto';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import {
@@ -191,4 +192,130 @@ export class R1RelatedResourcesService extends SupabaseBaseService {
   }
 
   // RAG lecture centralisée via RagGammeReaderService (injecté)
+
+  // ========================================================================
+  // ADR-024 Phase 2 — __seo_r1_related_blocks_cache
+  //
+  // Méthodes idempotentes pour matérialiser les blocks dans la table cache,
+  // afin que la Phase 5 puisse retirer le RAG filesystem read du chemin SSR.
+  // Phase 2 = ces méthodes existent et sont appelables via admin endpoint,
+  // mais le chemin de lecture SSR continue d'appeler buildRelatedBlocks
+  // (qui relit le RAG à chaque hit). Phase 5 fera basculer.
+  // ========================================================================
+
+  async rebuildCacheForGamme(
+    pgId: number,
+    pgAlias: string,
+    pgName: string,
+  ): Promise<{ built: boolean; blocks_count: number }> {
+    const payload = await this.buildRelatedBlocks(pgId, pgAlias, pgName);
+    const sourceHash = createHash('md5')
+      .update(JSON.stringify(payload))
+      .digest('hex');
+
+    const { error } = await this.supabase
+      .from('__seo_r1_related_blocks_cache')
+      .upsert(
+        {
+          pg_id: pgId,
+          payload,
+          source_hash: sourceHash,
+          built_at: new Date().toISOString(),
+          stale: false,
+          stale_reason: null,
+        },
+        { onConflict: 'pg_id' },
+      );
+
+    if (error) {
+      this.logger.error(
+        `[R1-related-cache] upsert failed pg_id=${pgId}: ${error.message}`,
+      );
+      throw error;
+    }
+
+    return { built: true, blocks_count: payload.blocks.length };
+  }
+
+  async rebuildCacheForAllG1G2(): Promise<{
+    total: number;
+    built: number;
+    failed: number;
+    duration_ms: number;
+  }> {
+    const t0 = Date.now();
+    const { data: gammes, error } = await this.supabase
+      .from('pieces_gamme')
+      .select('pg_id, pg_alias, pg_name, pg_level')
+      .in('pg_level', ['1', '2']);
+
+    if (error || !gammes?.length) {
+      throw error ?? new Error('No G1/G2 gammes found');
+    }
+
+    let built = 0;
+    let failed = 0;
+    for (const g of gammes) {
+      try {
+        const pgIdNum =
+          typeof g.pg_id === 'number' ? g.pg_id : parseInt(String(g.pg_id), 10);
+        if (!Number.isFinite(pgIdNum) || pgIdNum <= 0) {
+          failed++;
+          continue;
+        }
+        await this.rebuildCacheForGamme(
+          pgIdNum,
+          String(g.pg_alias ?? ''),
+          String(g.pg_name ?? ''),
+        );
+        built++;
+      } catch (e) {
+        failed++;
+        this.logger.warn(
+          `[R1-related-cache] gamme pg_id=${g.pg_id} failed: ${e instanceof Error ? e.message : e}`,
+        );
+      }
+    }
+
+    return {
+      total: gammes.length,
+      built,
+      failed,
+      duration_ms: Date.now() - t0,
+    };
+  }
+
+  async getCacheStats(): Promise<{
+    total: number;
+    stale: number;
+    oldest_built_at: string | null;
+    newest_built_at: string | null;
+  }> {
+    const [{ count: total }, { count: stale }, { data: oldestRaw }] =
+      await Promise.all([
+        this.supabase
+          .from('__seo_r1_related_blocks_cache')
+          .select('*', { count: 'exact', head: true }),
+        this.supabase
+          .from('__seo_r1_related_blocks_cache')
+          .select('*', { count: 'exact', head: true })
+          .eq('stale', true),
+        this.supabase
+          .from('__seo_r1_related_blocks_cache')
+          .select('built_at')
+          .order('built_at', { ascending: true })
+          .limit(1),
+      ]);
+    const { data: newestRaw } = await this.supabase
+      .from('__seo_r1_related_blocks_cache')
+      .select('built_at')
+      .order('built_at', { ascending: false })
+      .limit(1);
+    return {
+      total: total ?? 0,
+      stale: stale ?? 0,
+      oldest_built_at: oldestRaw?.[0]?.built_at ?? null,
+      newest_built_at: newestRaw?.[0]?.built_at ?? null,
+    };
+  }
 }

--- a/backend/supabase/migrations/20260427_r1_related_blocks_cache_schema.sql
+++ b/backend/supabase/migrations/20260427_r1_related_blocks_cache_schema.sql
@@ -1,0 +1,83 @@
+-- =============================================================================
+-- ADR-024 Phase 2 — R1 Related Blocks Cache (sortir le RAG filesystem read du SSR)
+-- Migration : schema + cache-first getter
+-- =============================================================================
+-- Related: ADR-024 (governance vault), parité ADR-016 (vehicle_page_cache).
+--
+-- Safe to apply: OUI. Cette migration ne touche AUCUN code applicatif existant.
+-- Le service R1RelatedResourcesService continue d'être appelé par
+-- gamme-response-builder.service.ts à chaque hit R1, lisant le RAG
+-- filesystem comme avant. Cette table reste vide et inutilisée tant que :
+--   1. Le seed script `scripts/seo/seed-r1-related-blocks.ts` n'est pas lancé
+--      (le populate les 238 gammes G1/G2 depuis le RAG, en offline)
+--   2. La Phase 5 cleanup ne refactore pas le service pour lire la table
+--      au lieu de relire le RAG à chaque hit
+--
+-- Schema parité __gamme_page_cache (ADR-024 Phase 1) :
+--   pg_id PK, payload JSONB, source_hash TEXT, built_at, stale, stale_reason
+-- =============================================================================
+
+BEGIN;
+
+-- Table de cache persistant des blocs related R1, 1 ligne par pg_id (gamme).
+-- Cible : ~238 gammes G1/G2 (pieces_gamme.pg_level IN ('1','2')).
+-- Taille estimée : 238 × ~3 KB JSON ≈ 0.7 MB (max 3 blocs × 3 items × ~300 B).
+CREATE TABLE IF NOT EXISTS public.__seo_r1_related_blocks_cache (
+  pg_id        INTEGER      PRIMARY KEY,
+  payload      JSONB        NOT NULL,
+  source_hash  TEXT         NOT NULL,
+  built_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  stale        BOOLEAN      NOT NULL DEFAULT FALSE,
+  stale_reason TEXT
+);
+
+COMMENT ON TABLE  public.__seo_r1_related_blocks_cache IS
+  'ADR-024 Phase 2: cache materialise des blocs maillage contextuel R1 (avoid-confusion + buying-guide + compatible-parts). Replique r1-related-resources.service.ts hors du chemin SSR. Source de verite RAG eligere offline.';
+COMMENT ON COLUMN public.__seo_r1_related_blocks_cache.payload      IS 'JSONB shape: { blocks: R1RelatedBlock[] } (max 3 blocs, max 3 items chacun)';
+COMMENT ON COLUMN public.__seo_r1_related_blocks_cache.source_hash  IS 'md5(rag_data + db_state) pour invalidation ciblee et detection no-op';
+COMMENT ON COLUMN public.__seo_r1_related_blocks_cache.built_at     IS 'Horodatage de la derniere materialisation (seed script ou trigger)';
+COMMENT ON COLUMN public.__seo_r1_related_blocks_cache.stale        IS 'TRUE = ligne obsolete a rebuild';
+COMMENT ON COLUMN public.__seo_r1_related_blocks_cache.stale_reason IS 'Optionnel: raison de l invalidation (ex: rag_change, pieces_gamme_update, manual)';
+
+-- Index partiel pour cron refresh-stale (FIFO sur built_at).
+CREATE INDEX IF NOT EXISTS idx_r1rb_stale
+  ON public.__seo_r1_related_blocks_cache (built_at)
+  WHERE stale = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_r1rb_built_at
+  ON public.__seo_r1_related_blocks_cache (built_at DESC);
+
+-- RLS service_role only (cohérent ADR-021).
+ALTER TABLE public.__seo_r1_related_blocks_cache ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS r1rb_service_role_all ON public.__seo_r1_related_blocks_cache; -- APPROVED: idempotent DROP+CREATE POLICY pattern (ADR-016 parity, no RLS bypass)
+CREATE POLICY r1rb_service_role_all
+  ON public.__seo_r1_related_blocks_cache
+  FOR ALL
+  TO service_role
+  USING (TRUE)
+  WITH CHECK (TRUE);
+
+-- ----------------------------------------------------------------------------
+-- get_r1_related_blocks_cached(p_pg_id)
+-- ----------------------------------------------------------------------------
+-- Getter cache-first. Retourne le payload JSONB si la ligne existe et n'est
+-- pas stale, sinon NULL. Phase 2 = pas de rebuild on-miss en SQL : le seed
+-- est explicit (script offline ou trigger). Le code applicatif fallback sur
+-- la logique TS R1RelatedResourcesService si NULL.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_r1_related_blocks_cached(p_pg_id INTEGER)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $fn$
+  SELECT payload
+    FROM public.__seo_r1_related_blocks_cache
+    WHERE pg_id = p_pg_id AND stale = FALSE
+$fn$;
+
+COMMENT ON FUNCTION public.get_r1_related_blocks_cached(INTEGER) IS
+  'ADR-024 Phase 2: cache-only lookup pour blocs related R1. Retourne NULL si miss/stale, le code applicatif fallback sur logique TS. Phase 5 retirera ce fallback.';
+
+COMMIT;


### PR DESCRIPTION
## Phase 2 du plan ADR-024

Sortir le **RAG filesystem read du chemin SSR R1** en matérialisant les blocs related dans une table cache populée offline.

**Inerte runtime** : le service `R1RelatedResourcesService.buildRelatedBlocks()` continue d'être appelé par `gamme-response-builder.service.ts` à chaque hit R1. Les nouveaux endpoints rebuild la cache mais elle n'est pas encore lue par le SSR. Phase 5 fera basculer.

## Q-rules trace (canon vault, PR #80)

| Q-rule | Application |
|---|---|
| **Q1** | Scaffolding structurel, parité ADR-016 + Phase 1. Honnête : SSR fait toujours le RAG fs read à chaque hit, Phase 5 closes the loop. |
| **Q2** | Pattern `admin-vehicle-cache` + `admin-gamme-cache` (Phase 1) comme référence. Réutilise `buildRelatedBlocks` au lieu de réimplémenter RAG parsing dans un script standalone. |
| **Q3** | Vérifié sur `massdoc` avant DDL : `__seo_r1_related_blocks_cache` ABSENT, sources déjà utilisées par `buildRelatedBlocks`, 238 G1/G2 gammes confirmées |
| **Q4** | Retire l'anti-pattern "filesystem read en SSR critique". Phase 5 = cleanup final. |

## Fichiers

### SQL
- `20260427_r1_related_blocks_cache_schema.sql` (83 lignes) — table + index stale + index built_at + RLS service_role + RPC `get_r1_related_blocks_cached`. Schéma byte-pour-byte identique à `__gamme_page_cache` (Phase 1) sauf le contenu sémantique du payload.

### Backend NestJS
- `r1-related-resources.service.ts` +130 lignes :
  - `rebuildCacheForGamme(pgId, alias, name)` : appelle `buildRelatedBlocks` puis UPSERT avec md5 source_hash
  - `rebuildCacheForAllG1G2()` : itère 238 gammes, retourne `{total, built, failed, duration_ms}`
  - `getCacheStats()` : `{total, stale, oldest_built_at, newest_built_at}`
- `admin-r1-related-blocks-cache.controller.ts` NEW (81 lignes) — 3 endpoints sous `/api/admin/r1-related-blocks-cache/*` (stats, rebuild/:pgId, rebuild-all)
- `gamme-rest.module.ts` register

### Allowlist
- `get_r1_related_blocks_cached` ajouté, total `174 → 175`

## Vérifications locales

```
✅ Typecheck (NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit) exit 0
✅ ESLint propre (createHash import ES module, prettier auto-fix)
✅ Migration Safety locale (DROP POLICY APPROVED inline)
✅ RPC allowlist coverage (30 of 30)
```

## Quand merger

Migrations **inertes** jusqu'au deploy DEV. Aucun changement runtime SSR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)