### PR TITLE
feat(r1-cache): ADR-024 Phase 5a — switch SSR read path to caches with legacy fallback

### DIFF
--- a/backend/src/modules/gamme-rest/services/gamme-rpc.service.ts
+++ b/backend/src/modules/gamme-rest/services/gamme-rpc.service.ts
@@ -136,8 +136,13 @@ export class GammeRpcService extends SupabaseBaseService {
     });
 
     // 🛡️ Utilisation du wrapper callRpc avec RPC Safety Gate
+    // ADR-024 Phase 5a: bascule vers get_gamme_page_data_cached (cache-first
+    // sur __gamme_page_cache, rebuild-on-miss). Identité de payload garantie
+    // par construction (la fonction cached délègue à build_gamme_page_payload
+    // qui wrappe l'ancienne RPC). Hot path: ~5ms (cache hit), cold path: même
+    // qu'avant + UPSERT du cache pour le hit suivant.
     const rpcPromise = this.callRpc<Record<string, unknown>>(
-      'get_gamme_page_data_optimized',
+      'get_gamme_page_data_cached',
       { p_pg_id: pgIdNum },
       { source: 'api' },
     );

--- a/backend/src/modules/gamme-rest/services/r1-related-resources.service.ts
+++ b/backend/src/modules/gamme-rest/services/r1-related-resources.service.ts
@@ -33,6 +33,31 @@ export class R1RelatedResourcesService extends SupabaseBaseService {
     pgName: string,
     _options?: { referenceSlug?: string | null },
   ): Promise<R1RelatedBlocksPayload> {
+    // ADR-024 Phase 5a: cache-first via get_r1_related_blocks_cached.
+    // Hit (~5ms) = retour immédiat sans RAG fs read ni 3 sub-queries.
+    // Miss (NULL ou stale=TRUE) = fallback sur le calcul legacy ci-dessous.
+    try {
+      const { data: cachedPayload, error } =
+        await this.callRpc<R1RelatedBlocksPayload | null>(
+          'get_r1_related_blocks_cached',
+          { p_pg_id: pgId },
+          { source: 'api' },
+        );
+      if (
+        !error &&
+        cachedPayload &&
+        Array.isArray(cachedPayload.blocks) &&
+        cachedPayload.blocks.length > 0
+      ) {
+        return cachedPayload;
+      }
+    } catch (e) {
+      this.logger.debug(
+        `[R1-related-cache] miss/error pg_id=${pgId}, fallback legacy: ${e instanceof Error ? e.message : e}`,
+      );
+    }
+
+    // Cache miss / empty / error → legacy path (RAG fs read + 3 sub-queries).
     // Lire le RAG (virtual merge si flag ON)
     const mergeResult =
       await this.ragReader.readAndParseWithDbKnowledge(pgAlias);


### PR DESCRIPTION
## Phase 5a (minimal) du plan ADR-024

**Bascule structurelle** : le SSR R1 lit maintenant depuis les caches `__gamme_page_cache` + `__seo_r1_related_blocks_cache` créés en Phase 1+2 et backfillés en Phase 3.

- **Cache hit** (238/238 G1/G2 sur __gamme_page_cache) → ~5ms PK lookup, plus de 4 queries séquentielles en code applicatif
- **Cache miss / stale** → fallback transparent sur le code legacy → comportement identique à aujourd'hui

## Q-rules trace (canon vault)

| Q-rule | Application |
|---|---|
| **Q1** | Switch structurel via les caches construits Phase 1+2. Fallback préservé = aucune régression possible. Scope honnête : Phase 5a, pas la full refactor 948→50 lignes (= Phase 5b future). |
| **Q2** | `get_gamme_page_data_cached` et `get_r1_related_blocks_cached` déjà dans `rpc_allowlist.json`. `callRpc` est le canonical entry point. Code legacy intact. |
| **Q3** | Verified Supabase massdoc : 238/238 cached __gamme_page_cache (Phase 3 batch A), `__seo_r1_related_blocks_cache` 0/238 (Batch B awaiting preprod), legacy fallback handle ce cas par construction. |
| **Q4** | Retire l'antipattern de filesystem RAG read en SSR critique sur le hot path (cache hit). Phase 5b finira le job. |

## Diff

### `gamme-rpc.service.ts:140` (+7 lignes commentaires)
```diff
-      'get_gamme_page_data_optimized',
+      'get_gamme_page_data_cached',
```

### `r1-related-resources.service.ts:30` (+25 lignes)
Ajoute un try-cache-first au début de `buildRelatedBlocks` :
- `callRpc('get_r1_related_blocks_cached', { p_pg_id: pgId })`
- Si data && blocks.length > 0 → return immédiat (~5ms)
- Sinon fallback (RAG fs read + 3 sub-queries Promise.all)

## Tests locaux

```
✅ Typecheck (NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit) exit 0
✅ ESLint propre (prettier auto-fix appliqué)
✅ RPC allowlist coverage 31/31
```

## Phase 5b (future scope, hors PR)

- Étendre `build_gamme_page_payload` SQL pour inclure image_prompts + buying_guide + sg_content en JSON aggregation
- Refactor `gamme-response-builder.service.ts` 948 → ~50 lignes (transformation pure post-RPC)
- Retirer `RESPONSE_CACHE_PREFIX` Redis double-cache de `gamme-rest-rpc-v2.controller.ts`
- Réduire `r1-related-resources.service.ts` à un seed-only service (cache-only path après Phase 5b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)