### PR TITLE
ci(perf-gate): ADR-024 Phase 6a — R1 gamme perf gate (parity R2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,6 +851,14 @@ jobs:
           check_timing "$BASE/" "Homepage" 2000
           check_timing "$BASE/pieces/catalogue" "/pieces/catalogue" 2000
           check_timing "$BASE/pieces/plaquette-de-frein-402/renault-140/megane-iii-140049/1-5-dci-100413.html" "R2 Product Page" 3000
+          # ADR-024 R1 gamme perf gate (parity R2). Backed by __gamme_page_cache (Phase 1) +
+          # SSR cache-first read path (Phase 5a). Hot-path target ~5ms (PK lookup),
+          # cold-path/legacy ceiling 3000ms. Top 5 G1 gammes covering bulk of indexed traffic.
+          check_timing "$BASE/pieces/plaquette-de-frein-402.html"        "R1 Gamme (plaquette-de-frein)"  3000
+          check_timing "$BASE/pieces/disque-de-frein-82.html"            "R1 Gamme (disque-de-frein)"     3000
+          check_timing "$BASE/pieces/filtre-a-huile-7.html"              "R1 Gamme (filtre-a-huile)"      3000
+          check_timing "$BASE/pieces/filtre-a-air-8.html"                "R1 Gamme (filtre-a-air)"        3000
+          check_timing "$BASE/pieces/courroie-de-distribution-306.html"  "R1 Gamme (courroie-distribution)" 3000
 
       - name: ⏱️ API Timing Gate (blocking)
         run: |


### PR DESCRIPTION
## Phase 6a du plan ADR-024 — perf gate R1 parité R2

Ajoute un CI perf gate pour les pages R1 gamme, miroir du gate R2 existant ([ci.yml:853](.github/workflows/ci.yml#L853)). Cap structurel par construction = toute régression SSR R1 future bloquée au PR time.

## Top 5 G1 gammes ciblées (bulk traffic SEO)

| pg_id | alias | Note |
|---|---|---|
| 402 | plaquette-de-frein | Originally faisait timeout E2E sur cold-load |
| 82 | disque-de-frein | Co-replacement maillage |
| 7 | filtre-a-huile | Maintenance fréquente |
| 8 | filtre-a-air | Maintenance fréquente |
| 306 | courroie-de-distribution | Critique sécurité |

Toutes les 5 sont **pg_level='1'** ET **dans __gamme_page_cache** après Phase 3 batch A (vérifié via Supabase massdoc, tous `stale=FALSE`).

## Pourquoi 3000ms (parité R2)

Avec Phase 5a mergée, SSR lit le cache via `get_gamme_page_data_cached`. Hot path attendu ~5ms (PK lookup). Le ceiling 3000ms (= R2 budget) est **deux niveaux de marge** :

1. Si le cache hit normal → ~5ms (passé large)
2. Si le cache miss → fallback legacy (~3000ms typique cold)
3. Si même la fallback dépasse 3000ms → **vraie régression à investiguer**

Le gate alerte donc seulement quand le cache ET la fallback échouent en même temps = signal précieux.

## Q-rules trace

| Q-rule | Application |
|---|---|
| **Q1** | Invariant structurel ajouté par construction. Future régression bloquée au PR. |
| **Q2** | R2 gate ([ci.yml:853](.github/workflows/ci.yml#L853)) lu comme référence, helper `check_timing` réutilisé, pg_id/alias pairs vérifiés via Supabase. |
| **Q3** | 5 pg_ids confirmés pg_level=1 + présents dans __gamme_page_cache. |
| **Q4** | Ferme le gap "R1 sans perf gate" listé dans **Critères de Succès** de ADR-024. |

## Diff

`.github/workflows/ci.yml` +8 lignes après la ligne R2 :
```bash
check_timing "$BASE/pieces/plaquette-de-frein-402.html"        "R1 Gamme (plaquette-de-frein)"  3000
check_timing "$BASE/pieces/disque-de-frein-82.html"            "R1 Gamme (disque-de-frein)"     3000
check_timing "$BASE/pieces/filtre-a-huile-7.html"              "R1 Gamme (filtre-a-huile)"      3000
check_timing "$BASE/pieces/filtre-a-air-8.html"                "R1 Gamme (filtre-a-air)"        3000
check_timing "$BASE/pieces/courroie-de-distribution-306.html"  "R1 Gamme (courroie-distribution)" 3000
```

## Étapes suivantes (Phase 6b/6c)

- 6b : observation 14j post-deploy DEV (mesure p50/p95/p99 réelle vs cible <50ms hot path)
- 6c : promotion ADR-024 `proposed → accepted` avec evidence (pattern PR vault #82 pour ADR-016)

→ /schedule un agent à J+14 pour 6b+6c quand cette PR mergée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)