### PR TITLE
chore(hooks): prevent consecutive auto-log session entries

### DIFF
--- a/scripts/claude-hooks/stop-log-session-suggest.sh
+++ b/scripts/claude-hooks/stop-log-session-suggest.sh
@@ -55,6 +55,17 @@ esac
 commits_ahead="$(git log origin/main..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')"
 [ "${commits_ahead:-0}" -lt 1 ] && exit 0
 
+# Defence-in-depth against runaway auto-commit chains:
+# if the most recent commit is itself an auto-log entry, bail. The marker
+# file should already prevent re-fire on the same SHA, but if the hook is
+# invoked twice (parallel terminal, harness retry, marker race), this guard
+# guarantees we never produce two consecutive `chore(log): auto session
+# entry` commits.
+last_subject="$(git log -1 --pretty=%s 2>/dev/null || true)"
+case "$last_subject" in
+  "chore(log): auto session entry"*) exit 0 ;;
+esac
+
 # Idempotence: same SHA + same branch → already logged, skip.
 last_sha="$(cat "$LAST_SHA_FILE" 2>/dev/null || echo '')"
 last_branch="$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo '')"


### PR DESCRIPTION
## Summary

Le Stop hook `stop-log-session-suggest.sh` produisait parfois **deux entrées \`chore(log): auto session entry\` consécutives** sans commit réel entre les deux. L'historique de `feat/aicos-fleet-advisor-claude-4-7` montre au moins 2 paires concernées :

- `aebfa35c` → `3f438208`
- `8239dee4` → `7794bf86`

## Cause probable

Le marker SHA (`.claude/.session-log-state/last-suggested-head`) est censé bloquer la re-trigger sur la même HEAD. Mais si le hook est invoqué deux fois (deuxième terminal Claude Code en parallèle, retry du harness, race d'écriture sur le fichier marker), un second auto-commit peut passer parce que le test d'idempotence lit le marker AVANT le premier write.

## Fix

Defence-in-depth : si le **dernier commit** sur la branche est déjà un auto-log entry, on bail immédiatement. Le marker SHA reste actif (priorité, prévient les fires sur même SHA en mono-process), le case-match est juste un filet de sécurité supplémentaire.

```bash
last_subject="$(git log -1 --pretty=%s 2>/dev/null || true)"
case "\$last_subject" in
  "chore(log): auto session entry"*) exit 0 ;;
esac
```

Garantit qu'aucune chaîne de N auto-log consécutifs n'est jamais produite, peu importe ce qui se passe au niveau du marker file.

## Test plan

Pattern matching validé localement sur 3 cas :

- Last subject = \`chore(log): auto session entry for feat/foo\` → match → bail ✓
- Last subject = \`feat(api): real work\` → no match → proceed ✓
- Last subject = empty → no match → proceed ✓

\`bash -n\` syntax check : OK.

- [ ] Après merge, vérifier que les prochaines branches ne produisent plus de doublons
- [ ] Aucun impact sur le cas nominal (Stop après commit réel → 1 auto-log entry attendue)

## Refs

Identifié pendant la session de diagnostic dual-workspace (Phase E.1 du plan `je-veux-savoir-pourquoi-zippy-crayon`). Suit la PR #200 (`chore(claude): split SEO batch agents/skills`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)