### PR TITLE
chore(skills): trim 8 verbose SEO skill descriptions to triggers

### DIFF
--- a/workspaces/seo-batch/.claude/skills/content-quality-gate/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/content-quality-gate/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: content-quality-gate
-description: |
-  Quality gate pour le contenu des sections conseils dans __seo_gamme_conseil (Supabase). Utilise cette skill quand l'utilisateur veut "vérifier qualité", "scorer contenu", "quality check", "audit qualité section", "comparer contenu", "détecter sections faibles", "gap analysis", ou "review queue". Aussi quand on parle de verdicts WRITE/REVIEW/BLOCK, scoring de contenu, ou détection de régressions. Peut être utilisé seul pour un audit qualité, ou en combinaison avec surgical-cleaner et legacy-recycler comme gate de validation.
+description: "Quality gate sections __seo_gamme_conseil : scoring + verdicts WRITE/REVIEW/BLOCK. Use when user mentions vérifier qualité, audit qualité section, gap analysis, sections faibles, review queue, détection régressions."
 ---
 
 # Content Quality Gate — Scoring et validation de contenu

--- a/workspaces/seo-batch/.claude/skills/legacy-recycler/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/legacy-recycler/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: legacy-recycler
-description: |
-  Recycleur de contenu legacy expert pour enrichir les sections v5 dans __seo_gamme_conseil (Supabase). Utilise cette skill quand l'utilisateur veut "recycler legacy", "injecter contenu expert", "enrichir depuis CSV", "récupérer ancien contenu", "importer blog advice", ou "mapper legacy vers v5". Aussi quand on parle de __blog_advice, __blog_advice_h2, __blog_advice_h3, cross-refs legacy, contenu CMS hérité, ou "enrichir sections faibles". Doit toujours être utilisé APRÈS un scan (pollution-scanner) pour cibler les sections faibles/vides.
+description: "Recycle contenu legacy (__blog_advice*) vers __seo_gamme_conseil v5. Use when user mentions recycler legacy, injecter contenu expert, enrichir depuis CSV, importer blog advice. À utiliser après pollution-scanner."
 ---
 
 # Legacy Recycler — Recyclage de contenu expert hérité

--- a/workspaces/seo-batch/.claude/skills/pollution-scanner/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/pollution-scanner/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pollution-scanner
-description: |
-  Scanner de pollution OEM/scraping pour les sections conseils AutoMecanik. Utilise cette skill dès que l'utilisateur mentionne "scanner pollution", "détecter scraping", "audit contenu", "vérifier gamme", "chercher fragments OEM", "qualité des sections", ou veut analyser le contenu de __seo_gamme_conseil dans Supabase. Aussi quand on parle de Textar, Brembo, "Skip to main content", "Source: web/", ou de contenu scrapé. Utiliser même si l'utilisateur dit simplement "scanner" ou "audit" dans le contexte du pipeline v5.
+description: "Scanner pollution OEM/scraping dans __seo_gamme_conseil. Use when user mentions scanner pollution, détecter scraping, fragments OEM, Textar, Brembo, 'Skip to main content', 'Source: web/', ou audit contenu pipeline v5."
 ---
 
 # Pollution Scanner — Détection de contenu scrapé/pollué

--- a/workspaces/seo-batch/.claude/skills/r8-diversity-check/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/r8-diversity-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r8-diversity-check
-description: "Mesure la diversité réelle entre pages R8 motorisations sœurs (même modele_id) pour détecter le duplicate content SEO avant publication. Invoque IMPÉRATIVEMENT ce skill dès que l'utilisateur pose une question du genre : \"vérifier variation R8\", \"duplicate content motorisations\", \"mes pages véhicule sont-elles distinctes\", \"Clio 3 motorisations ont-elles le même contenu\", \"rapport diversity R8\", \"fingerprint audit R8\", \"anti-duplicate motorisations\", \"collisions sibling véhicule\", \"combien de h1 distincts par modèle\", ou après chaque batch d'enrichissement R8 avant passage INDEX. Ne PAS utiliser pour : génération de contenu (content-gen), audit SEO global R1-R8 (seo-gamme-audit), qualité éditoriale (content-audit), anti-cannibalisation cross-role R1/R3/R4 (blog-hub-planner). Usage CLI : python3 scripts/qa/r8-diversity-check.py [--brand|--modele-id|--slug|--batch] [--threshold N] [--format markdown|json]."
+description: "Mesure la diversité fingerprint entre pages R8 motorisations sœurs (même modele_id). Use when user mentions duplicate content motorisations, variation R8, fingerprint audit, anti-duplicate sibling véhicule, ou avant batch INDEX."
 argument-hint: "<brand|modele-id|slug|--batch> [--threshold N] [--format markdown|json]"
 allowed-tools: Read, Bash
 ---

--- a/workspaces/seo-batch/.claude/skills/seo-gamme-audit/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/seo-gamme-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: seo-gamme-audit
-description: "Audit SEO complet d'une gamme OU d'un véhicule : métriques R1-R8, couverture RAG, scores qualité, vocabulaire interdit, maillage, historique, score composite, actions recommandées + auto-fix. Détecte auto gamme/véhicule. Usage : /seo-gamme-audit <pg_alias|vehicle_slug> [--batch top20|worst|ready] [--fix]"
+description: "Audit SEO complet gamme/véhicule : métriques R1-R8, RAG coverage, scores, maillage, score composite + auto-fix. Use when user wants gamme audit, vehicle SEO audit. CLI: /seo-gamme-audit <pg_alias|vehicle_slug>"
 argument-hint: "<pg_alias ou vehicle_slug> [--batch top20|worst|ready] [--fix] [--history]"
 ---
 

--- a/workspaces/seo-batch/.claude/skills/seo-vault-verify/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/seo-vault-verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: seo-vault-verify
-description: "Audit reproductible d'un vault Obsidian SEO (ZIP ou dossier). Vérifie 8 fichiers régénérés + non-régression SHA256 sur fichiers inchangés + cross-refs ADR + cohérence stratégique via subagent unique. Invoquer dès qu'un vault SEO, un zip de docs stratégie, ou un bundle Obsidian est fourni pour validation — notamment quand l'utilisateur parle de 'vérifier vault', 'audit vault SEO', 'valider livrable Obsidian', 'team verification vault', ou livre un artefact ADR-002 maillage. NE PAS utiliser pour audit contenu site web (content-audit), audit gammes production (seo-gamme-audit), ou operations governance-vault (governance-vault-ops)."
+description: "Audit reproductible vault Obsidian SEO (ZIP ou dir) : 8 fichiers regen + SHA256 non-régression + cross-refs ADR. Use when user mentions vérifier vault, audit vault SEO, valider livrable Obsidian, ADR-002 maillage."
 argument-hint: "<path-zip-or-dir> [--manifest <path.yaml>]"
 allowed-tools: Read, Bash, Glob, Grep, Agent
 version: "1.0"

--- a/workspaces/seo-batch/.claude/skills/surgical-cleaner/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/surgical-cleaner/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: surgical-cleaner
-description: |
-  Nettoyeur chirurgical de sections polluées dans __seo_gamme_conseil (Supabase). Utilise cette skill quand l'utilisateur veut "nettoyer une section", "supprimer la pollution", "clean gamme", "retirer le scraping", "corriger le contenu", ou après qu'un scan pollution-scanner a identifié des sections à traiter. Aussi quand on parle de "couper la pollution", "remplacer S4_DEPOSE", ou "pipeline-v5-surgical-clean". Doit toujours être utilisé APRÈS un scan (pollution-scanner), jamais en aveugle.
+description: "Nettoyage chirurgical sections polluées __seo_gamme_conseil. Use when user mentions nettoyer section, supprimer pollution, clean gamme, couper pollution, remplacer S4_DEPOSE. À utiliser APRÈS pollution-scanner."
 ---
 
 # Surgical Cleaner — Nettoyage section par section

--- a/workspaces/seo-batch/.claude/skills/v5-guardian/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/v5-guardian/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: v5-guardian
-description: |
-  Gardien unifié du pipeline v5 : combine détection de pollution, quality gate, et protection anti-régression en un seul skill. Utilise cette skill dès que l'utilisateur mentionne "vérifier qualité v5", "guardian", "audit rapide", "check pipeline", "protection contenu", "anti-régression", "guard v5", "health check gamme", ou "scan qualité". Remplace l'usage séparé de pollution-scanner + content-quality-gate pour les checks de routine. Aussi utile en mode batch pour un health check global.
+description: "Gardien unifié pipeline v5 : pollution + quality gate + anti-régression. Use when user mentions guardian, vérifier qualité v5, check pipeline, anti-régression, health check gamme. Remplace pollution-scanner + content-quality-gate combinés."
 argument-hint: "<pg_alias|pg_id|--batch|--health>"
 allowed-tools: Read, mcp__claude_ai_Supabase__execute_sql, Glob
 ---


### PR DESCRIPTION
## Summary

Trim 8 descriptions skills SEO (sous \`workspaces/seo-batch/.claude/skills/\`) de paragraphes pédagogiques à des triggers conformes à la convention Anthropic. Économise ~2700 chars / ~700 tokens **par tour** chargés dans la system-reminder des sessions \`seo-batch\`.

## Avant / après

| Skill | Avant | Après |
|---|---:|---:|
| r8-diversity-check | 916 | 228 |
| seo-vault-verify | 636 | 213 |
| legacy-recycler | 542 | 212 |
| content-quality-gate | 529 | 215 |
| pollution-scanner | 520 | 218 |
| surgical-cleaner | 493 | 210 |
| v5-guardian | 491 | 239 |
| seo-gamme-audit | 305 | 209 |
| **Total** | **4432** | **1744** |

## Pourquoi

La convention Anthropic pour les skills frontmatter \`description\` :
\`\`\`yaml
description: WHAT + key trigger phrases (when user says X, Y, Z)
\`\`\`

Les anciennes descriptions étaient des paragraphes pédagogiques (jusqu'à 916 chars) qui :
1. Polluaient la system-reminder du LLM à **chaque turn** (cost direct)
2. Augmentaient le risque de fausse-trigger sur des sujets périphériques (la règle "1% chance — invoke" du superpowers).
3. Dupliquaient le contenu \`SKILL.md\` corps qui est déjà chargé quand le skill est réellement invoqué.

Le **contenu pédagogique reste intact** dans chaque \`SKILL.md\` body — pas de perte d'info, juste relocation au bon endroit (lazy-load).

## Test plan

- [ ] yaml.safe_load OK sur les 8 frontmatters (validé localement avant commit)
- [ ] Après merge : nouvelle session \`cd workspaces/seo-batch && claude\` → vérifier que les 8 skills apparaissent toujours dans la liste runtime avec le nouveau libellé
- [ ] Smoke test trigger : poser une question contenant un keyphrase pour vérifier que le skill s'invoque toujours (ex: \"vérifie pollution gamme X\" → \`pollution-scanner\` doit toujours fire)

## Refs

- Phase E.2 du plan diagnostic \`je-veux-savoir-pourquoi-zippy-crayon\`
- Suit PR #200 (split workspace) et #201 (stop-hook fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)