### PR TITLE
feat(aec): sync 2 monorepo AEC copies vs canon + hash-check CI

### DIFF
--- a/.claude/rules/agent-exit-contract.md
+++ b/.claude/rules/agent-exit-contract.md
@@ -1,16 +1,22 @@
-# Contrat de Sortie Obligatoire — Agents & Auto Research
+# Rules — Agent Exit Contract (AEC)
 
-> Regle non-negociable. S'applique a TOUT agent, run, audit, ou analyse.
+> **Source de vérité canonique** — règles obligatoires de sortie pour TOUT agent, run, audit, ou analyse au 2026-04-28.
+> **Version** : 1.0.0 | **Status** : CANON
+> **Taxonomie** : règle transverse — s'applique avant les règles spécifiques de domaine (T*, G*, Q*, AP*).
 
-## Regles fondamentales
+Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
+
+---
+
+## Règles fondamentales
 
 1. **Jamais de correction automatique.** Un agent scanne, analyse, propose — il ne modifie RIEN sans validation humaine explicite.
-2. **Jamais d'overclaim.** Les phrases "tout scanne/verifie/corrige", "100% couvert", "aucun probleme", "audit complet" (FR/EN) sont **interdites** sans coverage manifest.
-3. **Separation obligatoire** de 5 etats dans tout rapport : scan | analysis | correction (proposee) | validation | verdict.
+2. **Jamais d'overclaim.** Les phrases "tout scanné/vérifié/corrigé", "100% couvert", "aucun problème", "audit complet" (FR/EN) sont **interdites** sans coverage manifest.
+3. **Séparation obligatoire** de 5 états dans tout rapport : `scan` | `analysis` | `correction (proposée)` | `validation` | `verdict`.
 
-## Statuts autorises / interdits
+## Statuts autorisés / interdits
 
-| Autorises | Interdits |
+| Autorisés | Interdits |
 |-----------|-----------|
 | `PARTIAL_COVERAGE` | `PROJECT_FULLY_SCANNED` |
 | `SCOPE_SCANNED` | `ALL_FIXED`, `COMPLETE`, `DONE` |
@@ -18,9 +24,9 @@
 | `VALIDATED_FOR_SCOPE_ONLY` | `AUTO_FIXED` |
 | `INSUFFICIENT_EVIDENCE` | |
 
-Verdict par defaut = `PARTIAL_COVERAGE` ou `INSUFFICIENT_EVIDENCE`, jamais `COMPLETE`.
+Verdict par défaut = `PARTIAL_COVERAGE` ou `INSUFFICIENT_EVIDENCE`, jamais `COMPLETE`.
 
-Pour declarer `SCOPE_SCANNED` : fournir nombre exact de fichiers lus, repertoires parcourus, exclusions, et au moins 1 evidence par conclusion.
+Pour déclarer `SCOPE_SCANNED` : fournir nombre exact de fichiers lus, répertoires parcourus, exclusions, et au moins 1 evidence par conclusion.
 
 ## Coverage manifest obligatoire
 
@@ -28,19 +34,50 @@ Tout run/audit DOIT produire :
 
 ```
 scope_requested / scope_actually_scanned / files_read_count
-excluded_paths / unscanned_zones (OBLIGATOIRE meme si vide)
-corrections_proposed (JAMAIS appliquees auto) / validation_executed
-remaining_unknowns (OBLIGATOIRE) / final_status (statut autorise)
+excluded_paths / unscanned_zones (OBLIGATOIRE même si vide)
+corrections_proposed (JAMAIS appliquées auto) / validation_executed
+remaining_unknowns (OBLIGATOIRE) / final_status (statut autorisé)
 ```
 
-`corrections_applied` doit etre vide/absent sauf validation humaine explicite.
+`corrections_applied` doit être vide/absent sauf validation humaine explicite.
 
 ## Reformulation obligatoire
 
-- "Tout scanne" → "Scan du perimetre X termine"
-- "Tout corrige" → "N recommandations proposees, en attente de validation humaine"
-- "100% couvert" → "Couverture estimee a N% sur le perimetre X"
+- "Tout scanné" → "Scan du périmètre X terminé"
+- "Tout corrigé" → "N recommandations proposées, en attente de validation humaine"
+- "100% couvert" → "Couverture estimée à N% sur le périmètre X"
 
 ## Decision Dossiers
 
-Inclure Section 13 (Coverage Manifest) + Section 14 (Exit Conditions). Verdict `PASS` si toutes conditions section 14 cochees.
+Inclure Section 13 (Coverage Manifest) + Section 14 (Exit Conditions). Verdict `PASS` si toutes conditions section 14 cochées.
+
+---
+
+## Distribution canonique
+
+Ce fichier est la **source unique**. Les copies dans les repos applicatifs sont synchronisées via mécanisme `canon-publish` :
+
+1. **Source de vérité** : ce fichier (`governance-vault/ledger/rules/rules-agent-exit-contract.md`)
+2. **Hash SHA-256 publié** : `99-meta/canon-hashes.json` clé `aec` (à créer Phase B.1.b)
+3. **Copies dérivées dans les repos applicatifs** :
+   - `automecanik-wiki/_meta/agent-exit-contract.md`
+   - `automecanik-raw/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`
+4. **Vérification CI** : chaque repo applicatif inclut un workflow `agent-exit-contract-hash.yml` qui compare le hash de sa copie locale vs `99-meta/canon-hashes.json` (via `gh api`)
+5. **Mise à jour** : modification de ce fichier → workflow `canon-publish.yml` (à créer Phase B.1.c) ouvre une PR auto dans chaque repo applicatif pour resync. Auto-merge avec label `canon-sync` autorisé.
+
+## Versionnage
+
+Bump majeur (X.0) = nouvelle règle ou statut interdit ajouté. Bump mineur (X.Y) = clarification / précision. Bump patch (X.Y.Z) = typo / formatting.
+
+| Version | Date | Changements |
+|---|---|---|
+| 1.0.0 | 2026-04-28 | Canonisation depuis copies orphelines monorepo + seo-batch (drift constaté empiriquement). Ajout §"Distribution canonique". |
+
+## Référence
+
+- ADR-031 — Raw / Wiki / RAG / SEO Separation (à créer post-Phase C)
+- `rules-engineering-quality.md` (Q1-Q4 — solution structurelle vs bricolage)
+- `rules-ai-antipatterns.md` (AP-* — anti-patterns IA)
+- `rules-governance-process.md` (G5-G8 — processus)

--- a/.github/workflows/agent-exit-contract-hash.yml
+++ b/.github/workflows/agent-exit-contract-hash.yml
@@ -1,0 +1,43 @@
+name: agent-exit-contract-hash
+
+# Verify the two monorepo AEC copies match the canonical distribution_sha256
+# published by ak125/governance-vault in 99-meta/canon-hashes.json (key `aec`).
+# Source: AEC §"Distribution canonique".
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".claude/rules/agent-exit-contract.md"
+      - "workspaces/seo-batch/.claude/rules/agent-exit-contract.md"
+      - "scripts/ci/check-aec-hash.sh"
+      - ".github/workflows/agent-exit-contract-hash.yml"
+  pull_request:
+    paths:
+      - ".claude/rules/agent-exit-contract.md"
+      - "workspaces/seo-batch/.claude/rules/agent-exit-contract.md"
+      - "scripts/ci/check-aec-hash.sh"
+      - ".github/workflows/agent-exit-contract-hash.yml"
+  schedule:
+    # Daily at 03:30 UTC — catch drift between merges.
+    - cron: "30 3 * * *"
+  repository_dispatch:
+    types: [canon-updated]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        copy:
+          - .claude/rules/agent-exit-contract.md
+          - workspaces/seo-batch/.claude/rules/agent-exit-contract.md
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify ${{ matrix.copy }}
+        run: bash scripts/ci/check-aec-hash.sh "${{ matrix.copy }}"

--- a/scripts/ci/check-aec-hash.sh
+++ b/scripts/ci/check-aec-hash.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# check-aec-hash.sh — verify an AEC copy matches the canon distribution_sha256
+# published by ak125/governance-vault in 99-meta/canon-hashes.json (key `aec`).
+#
+# Usage:
+#   scripts/ci/check-aec-hash.sh <path-to-AEC-copy>
+#
+# The monorepo distributes AEC twice (.claude/rules/ + workspaces/seo-batch/.claude/rules/),
+# so the workflow calls this script for each path.
+#
+# Source: rules-agent-exit-contract.md §"Distribution canonique" in the vault.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <path-to-AEC-copy>" >&2
+  exit 2
+fi
+
+local_copy="$1"
+canon_url="https://raw.githubusercontent.com/ak125/governance-vault/main/99-meta/canon-hashes.json"
+
+if [[ ! -f "${local_copy}" ]]; then
+  echo "ERROR: ${local_copy} missing" >&2
+  exit 1
+fi
+
+local_sha=$(sha256sum "${local_copy}" | awk '{print $1}')
+
+# Vault is public — the raw URL works without auth. `gh api` would also work but
+# adds a token requirement to local runs; curl keeps the script standalone.
+canon_json=$(curl -fsSL "${canon_url}")
+vault_sha=$(printf '%s' "${canon_json}" | jq -r '.canons.aec.distribution_sha256')
+
+if [[ "${local_sha}" != "${vault_sha}" ]]; then
+  echo "::error::AEC distribution drift on ${local_copy}" >&2
+  echo "  local: ${local_sha}" >&2
+  echo "  vault: ${vault_sha}" >&2
+  echo "Resync: copy ledger/rules/rules-agent-exit-contract.md from the vault, strip the YAML frontmatter, write to ${local_copy}." >&2
+  exit 1
+fi
+
+echo "OK — ${local_copy} matches vault canon-hashes.json aec.distribution_sha256 (${vault_sha})"

--- a/workspaces/seo-batch/.claude/rules/agent-exit-contract.md
+++ b/workspaces/seo-batch/.claude/rules/agent-exit-contract.md
@@ -1,18 +1,22 @@
-# Contrat de Sortie Obligatoire — Agents & Auto Research
+# Rules — Agent Exit Contract (AEC)
 
-> Regle non-negociable. S'applique a TOUT agent, run, audit, ou analyse.
->
-> Copie verbatim de `/opt/automecanik/app/.claude/rules/agent-exit-contract.md` (le fichier source vit en racine monorepo, dupliqué ici pour que les agents R* du workspace seo-batch en bénéficient automatiquement).
+> **Source de vérité canonique** — règles obligatoires de sortie pour TOUT agent, run, audit, ou analyse au 2026-04-28.
+> **Version** : 1.0.0 | **Status** : CANON
+> **Taxonomie** : règle transverse — s'applique avant les règles spécifiques de domaine (T*, G*, Q*, AP*).
 
-## Regles fondamentales
+Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
+
+---
+
+## Règles fondamentales
 
 1. **Jamais de correction automatique.** Un agent scanne, analyse, propose — il ne modifie RIEN sans validation humaine explicite.
-2. **Jamais d'overclaim.** Les phrases "tout scanne/verifie/corrige", "100% couvert", "aucun probleme", "audit complet" (FR/EN) sont **interdites** sans coverage manifest.
-3. **Separation obligatoire** de 5 etats dans tout rapport : scan | analysis | correction (proposee) | validation | verdict.
+2. **Jamais d'overclaim.** Les phrases "tout scanné/vérifié/corrigé", "100% couvert", "aucun problème", "audit complet" (FR/EN) sont **interdites** sans coverage manifest.
+3. **Séparation obligatoire** de 5 états dans tout rapport : `scan` | `analysis` | `correction (proposée)` | `validation` | `verdict`.
 
-## Statuts autorises / interdits
+## Statuts autorisés / interdits
 
-| Autorises | Interdits |
+| Autorisés | Interdits |
 |-----------|-----------|
 | `PARTIAL_COVERAGE` | `PROJECT_FULLY_SCANNED` |
 | `SCOPE_SCANNED` | `ALL_FIXED`, `COMPLETE`, `DONE` |
@@ -20,9 +24,9 @@
 | `VALIDATED_FOR_SCOPE_ONLY` | `AUTO_FIXED` |
 | `INSUFFICIENT_EVIDENCE` | |
 
-Verdict par defaut = `PARTIAL_COVERAGE` ou `INSUFFICIENT_EVIDENCE`, jamais `COMPLETE`.
+Verdict par défaut = `PARTIAL_COVERAGE` ou `INSUFFICIENT_EVIDENCE`, jamais `COMPLETE`.
 
-Pour declarer `SCOPE_SCANNED` : fournir nombre exact de fichiers lus, repertoires parcourus, exclusions, et au moins 1 evidence par conclusion.
+Pour déclarer `SCOPE_SCANNED` : fournir nombre exact de fichiers lus, répertoires parcourus, exclusions, et au moins 1 evidence par conclusion.
 
 ## Coverage manifest obligatoire
 
@@ -30,19 +34,50 @@ Tout run/audit DOIT produire :
 
 ```
 scope_requested / scope_actually_scanned / files_read_count
-excluded_paths / unscanned_zones (OBLIGATOIRE meme si vide)
-corrections_proposed (JAMAIS appliquees auto) / validation_executed
-remaining_unknowns (OBLIGATOIRE) / final_status (statut autorise)
+excluded_paths / unscanned_zones (OBLIGATOIRE même si vide)
+corrections_proposed (JAMAIS appliquées auto) / validation_executed
+remaining_unknowns (OBLIGATOIRE) / final_status (statut autorisé)
 ```
 
-`corrections_applied` doit etre vide/absent sauf validation humaine explicite.
+`corrections_applied` doit être vide/absent sauf validation humaine explicite.
 
 ## Reformulation obligatoire
 
-- "Tout scanne" → "Scan du perimetre X termine"
-- "Tout corrige" → "N recommandations proposees, en attente de validation humaine"
-- "100% couvert" → "Couverture estimee a N% sur le perimetre X"
+- "Tout scanné" → "Scan du périmètre X terminé"
+- "Tout corrigé" → "N recommandations proposées, en attente de validation humaine"
+- "100% couvert" → "Couverture estimée à N% sur le périmètre X"
 
 ## Decision Dossiers
 
-Inclure Section 13 (Coverage Manifest) + Section 14 (Exit Conditions). Verdict `PASS` si toutes conditions section 14 cochees.
+Inclure Section 13 (Coverage Manifest) + Section 14 (Exit Conditions). Verdict `PASS` si toutes conditions section 14 cochées.
+
+---
+
+## Distribution canonique
+
+Ce fichier est la **source unique**. Les copies dans les repos applicatifs sont synchronisées via mécanisme `canon-publish` :
+
+1. **Source de vérité** : ce fichier (`governance-vault/ledger/rules/rules-agent-exit-contract.md`)
+2. **Hash SHA-256 publié** : `99-meta/canon-hashes.json` clé `aec` (à créer Phase B.1.b)
+3. **Copies dérivées dans les repos applicatifs** :
+   - `automecanik-wiki/_meta/agent-exit-contract.md`
+   - `automecanik-raw/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`
+4. **Vérification CI** : chaque repo applicatif inclut un workflow `agent-exit-contract-hash.yml` qui compare le hash de sa copie locale vs `99-meta/canon-hashes.json` (via `gh api`)
+5. **Mise à jour** : modification de ce fichier → workflow `canon-publish.yml` (à créer Phase B.1.c) ouvre une PR auto dans chaque repo applicatif pour resync. Auto-merge avec label `canon-sync` autorisé.
+
+## Versionnage
+
+Bump majeur (X.0) = nouvelle règle ou statut interdit ajouté. Bump mineur (X.Y) = clarification / précision. Bump patch (X.Y.Z) = typo / formatting.
+
+| Version | Date | Changements |
+|---|---|---|
+| 1.0.0 | 2026-04-28 | Canonisation depuis copies orphelines monorepo + seo-batch (drift constaté empiriquement). Ajout §"Distribution canonique". |
+
+## Référence
+
+- ADR-031 — Raw / Wiki / RAG / SEO Separation (à créer post-Phase C)
+- `rules-engineering-quality.md` (Q1-Q4 — solution structurelle vs bricolage)
+- `rules-ai-antipatterns.md` (AP-* — anti-patterns IA)
+- `rules-governance-process.md` (G5-G8 — processus)


### PR DESCRIPTION
## Summary

Suivi Phase B.3 — ferme la promesse §"Distribution canonique" du canon AEC ([`governance-vault/ledger/rules/rules-agent-exit-contract.md`](https://github.com/ak125/governance-vault/blob/main/ledger/rules/rules-agent-exit-contract.md)).

Le canon mandate **4 copies** synchronisées par hash. Les 2 copies wiki+raw ont été synchronisées par PRs séparées ([wiki #2](https://github.com/ak125/automecanik-wiki/pull/2), [raw #1](https://github.com/ak125/automecanik-raw/pull/1)). Les 2 copies monorepo restaient drift jusqu'ici.

## Drift constaté

| Copie | sha256 avant | sha256 après |
|---|---|---|
| \`.claude/rules/agent-exit-contract.md\` | \`1c9fdab9…\` | \`a3ab56f5…\` ✅ |
| \`workspaces/seo-batch/.claude/rules/agent-exit-contract.md\` | \`ec070774…\` | \`a3ab56f5…\` ✅ |

Les 2 copies divergeaient même entre elles avant ce PR (canonisation vault de la version la plus récente pendant Phase B.1, copies non resyncées).

## Hash de référence

Vault publie \`aec.distribution_sha256 = a3ab56f5e142cd9e7399ef835ced1d4d10cb538518547682bf3ae86c5644eca5\` dans [\`99-meta/canon-hashes.json\`](https://github.com/ak125/governance-vault/blob/main/99-meta/canon-hashes.json) (vault PR #99, mergée 2026-04-28).

## What's in

- \`.claude/rules/agent-exit-contract.md\` — regénéré depuis canon (frontmatter strippé)
- \`workspaces/seo-batch/.claude/rules/agent-exit-contract.md\` — idem
- \`scripts/ci/check-aec-hash.sh\` — fetch raw URL canon-hashes.json (vault est public, pas de secret nécessaire), compare sha256 vs \`.canons.aec.distribution_sha256\` via \`jq\`
- \`.github/workflows/agent-exit-contract-hash.yml\` — matrix sur les 2 copies, trigger push/PR/cron daily 03:30 UTC/repository_dispatch \`canon-updated\`

Cohérent avec les workflows déjà mergés dans wiki + raw.

## Test plan

- [x] \`bash scripts/ci/check-aec-hash.sh .claude/rules/agent-exit-contract.md\` → OK localement
- [x] \`bash scripts/ci/check-aec-hash.sh workspaces/seo-batch/.claude/rules/agent-exit-contract.md\` → OK localement
- [x] Commit signé (G3 — clé vault-signing ED25519)
- [ ] CI \`agent-exit-contract-hash\` matrix verte sur les 2 copies
- [ ] Aucune régression sur les autres workflows (ci.yml, build.yml, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)