### PR TITLE
feat(phase-d): wire AUTOMECANIK_RAW_PATH env var across 3 RAG corpus scripts (ADR-031)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts
@@ -22,6 +22,7 @@ depends_on:
 - RagProxyModule
 - SystemModule
 - AiContentModule
+- VehiclesModule
 ---
 
 # Module Admin

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,9 +2,10 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
+- backend/src/modules/errors/controllers/internal-error-log.controller.ts
 - backend/src/modules/errors/entities/error-log.entity.ts
 - backend/src/modules/errors/errors.module.ts
 - backend/src/modules/errors/filters/global-error.filter.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-04-27'
+last_scan: '2026-04-28'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/scripts/rag/download-brand-oem-corpus.py
+++ b/scripts/rag/download-brand-oem-corpus.py
@@ -59,8 +59,11 @@ except ImportError:
     sys.exit(1)
 
 # === CONFIG ========================================================
-BRANDS_RAG_DIR = Path("/opt/automecanik/rag/knowledge/constructeurs")
-OUTPUT_ROOT = Path("/opt/automecanik/rag/knowledge/web/brands")
+# AUTOMECANIK_RAW_PATH overrides the rag-knowledge root for ADR-031 Phase D.
+# Default keeps the legacy location so unset = no behavioral change.
+RAW_KNOWLEDGE_ROOT = Path(os.getenv("AUTOMECANIK_RAW_PATH", "/opt/automecanik/rag/knowledge"))
+BRANDS_RAG_DIR = RAW_KNOWLEDGE_ROOT / "constructeurs"
+OUTPUT_ROOT = RAW_KNOWLEDGE_ROOT / "web" / "brands"
 
 SUPABASE_URL = os.environ.get(
     "SUPABASE_URL", "https://cxpojprgwgubzjyqzmoq.supabase.co"

--- a/scripts/rag/download-oem-corpus.py
+++ b/scripts/rag/download-oem-corpus.py
@@ -32,8 +32,11 @@ except ImportError:
     sys.exit(1)
 
 # === CONFIG ===
-GAMMES_DIR = "/opt/automecanik/rag/knowledge/gammes"
-WEB_DIR = "/opt/automecanik/rag/knowledge/web"
+# AUTOMECANIK_RAW_PATH overrides the rag-knowledge root for ADR-031 Phase D.
+# Default keeps the legacy location so unset = no behavioral change.
+RAW_KNOWLEDGE_ROOT = os.getenv("AUTOMECANIK_RAW_PATH", "/opt/automecanik/rag/knowledge")
+GAMMES_DIR = f"{RAW_KNOWLEDGE_ROOT}/gammes"
+WEB_DIR = f"{RAW_KNOWLEDGE_ROOT}/web"
 REQUEST_DELAY = 1.2
 MAX_RETRIES = 2
 TIMEOUT = 12

--- a/scripts/rag/rag-enrich-from-web-corpus.py
+++ b/scripts/rag/rag-enrich-from-web-corpus.py
@@ -18,9 +18,12 @@ import argparse
 from collections import defaultdict
 from datetime import datetime
 
-WEB_DIR = "/opt/automecanik/rag/knowledge/web"
-WEB_CATALOG_DIR = "/opt/automecanik/rag/knowledge/web-catalog"
-GAMMES_DIR = "/opt/automecanik/rag/knowledge/gammes"
+# AUTOMECANIK_RAW_PATH overrides the rag-knowledge root for ADR-031 Phase D.
+# Default keeps the legacy location so unset = no behavioral change.
+RAW_KNOWLEDGE_ROOT = os.getenv("AUTOMECANIK_RAW_PATH", "/opt/automecanik/rag/knowledge")
+WEB_DIR = f"{RAW_KNOWLEDGE_ROOT}/web"
+WEB_CATALOG_DIR = f"{RAW_KNOWLEDGE_ROOT}/web-catalog"
+GAMMES_DIR = f"{RAW_KNOWLEDGE_ROOT}/gammes"
 
 # === MAPPING GAMME → TERMES DE RECHERCHE ===
 # Chaque gamme a des termes FR + EN qui matchent dans le contenu web


### PR DESCRIPTION
## Summary

ADR-031 Phase D — adds an env-var override for the rag-knowledge root in the 3 scripts that hardcoded `/opt/automecanik/rag/knowledge/...`, so they can switch between the legacy filesystem (default) and the new canonical clone of `automecanik-raw/recycled/rag-knowledge/` produced by Phase C ([raw#4](https://github.com/ak125/automecanik-raw/pull/4)) — without behavioral change for unset shells.

## Scripts touched

| File | Constants moved behind env var |
|---|---|
| `scripts/rag/download-oem-corpus.py` | `GAMMES_DIR`, `WEB_DIR` |
| `scripts/rag/download-brand-oem-corpus.py` | `BRANDS_RAG_DIR`, `OUTPUT_ROOT` |
| `scripts/rag/rag-enrich-from-web-corpus.py` | `WEB_DIR`, `WEB_CATALOG_DIR`, `GAMMES_DIR` |

## Pattern

```python
RAW_KNOWLEDGE_ROOT = os.getenv("AUTOMECANIK_RAW_PATH", "/opt/automecanik/rag/knowledge")
WEB_DIR = f"{RAW_KNOWLEDGE_ROOT}/web"
WEB_CATALOG_DIR = f"{RAW_KNOWLEDGE_ROOT}/web-catalog"
GAMMES_DIR = f"{RAW_KNOWLEDGE_ROOT}/gammes"
# ...
```

`download-brand-oem-corpus.py` uses `pathlib.Path` instead of f-strings to stay consistent with that script's existing style.

## Smoke test (Python `importlib` module-load for each script)

```
$ unset AUTOMECANIK_RAW_PATH
$ python3 -c "...exec_module(download-oem-corpus.py)..."
  WEB_DIR=/opt/automecanik/rag/knowledge/web
  GAMMES_DIR=/opt/automecanik/rag/knowledge/gammes              ← legacy preserved

$ AUTOMECANIK_RAW_PATH=/tmp/automecanik-raw/recycled/rag-knowledge python3 -c "..."
  WEB_DIR=/tmp/automecanik-raw/recycled/rag-knowledge/web
  WEB_CATALOG_DIR=/tmp/automecanik-raw/recycled/rag-knowledge/web-catalog
  GAMMES_DIR=/tmp/automecanik-raw/recycled/rag-knowledge/gammes ← Phase C tree
  BRANDS_RAG_DIR=/tmp/automecanik-raw/recycled/rag-knowledge/constructeurs
  OUTPUT_ROOT=/tmp/automecanik-raw/recycled/rag-knowledge/web/brands
```

Module-load itself catches syntax / missing-import errors; both passed for all 3 scripts.

## Companion fixes

- Removed a duplicate `import os` line in `rag-enrich-from-web-corpus.py` that landed via this edit.

## Out of scope (intentional)

- `knowledge_service.py` line 137 exclusion of `_raw` is still valid — legacy filesystem stays in place until Phase J+30+ cleanup.
- `gammes/` and `constructeurs/` themselves stay at the legacy path until Phase F migrates them to `wiki/<entity_type>/`. The env var is wired now so the day Phase F flips the consumer it's a single shell variable change.

## Auto-generated noise

42 of the changed files are `.claude/knowledge/modules/*.md` `last_scan` date bumps from the pre-commit `refresh-knowledge.py` hook (CLAUDE.md `<!-- AUTO-GENERATED -->` block). They're standard daily refresh noise, not Phase D edits.

## Test plan

- [x] Module load with env var unset → defaults match legacy paths
- [x] Module load with env var set → all 6 constants point at Phase C tree
- [x] Commit signed (ED25519 vault-signing@automecanik.com)
- [ ] CI lint passes
- [ ] Reviewer can run `AUTOMECANIK_RAW_PATH=/tmp/automecanik-raw/recycled/rag-knowledge python3 scripts/rag/rag-enrich-from-web-corpus.py --gamme disque-de-frein --dry-run` against the Phase C tree and see same enrichment proposals as the legacy filesystem run

## References

- ADR-031 §"Phase D" (vault [PR #100](https://github.com/ak125/governance-vault/pull/100))
- Runbook `governance-vault/ledger/knowledge/adr-031-migration-runbook-20260428.md` §"Phase D"
- Phase C migration: [automecanik-raw#4](https://github.com/ak125/automecanik-raw/pull/4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)