### PR TITLE
feat(adr-032-pr3): add breakdown intent and POST /breakdown endpoint

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-04-28'
+last_scan: '2026-04-29'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
@@ -55,6 +55,42 @@ export class DiagnosticEngineController {
   }
 
   /**
+   * POST /api/diagnostic-engine/breakdown
+   *
+   * ADR-032 — endpoint urgence routière (panne immobilisante).
+   * Force `intent_type: 'breakdown'` et délègue à l'orchestrator standard
+   * (le `RiskSafetyEngine` priorise les rules safety_gate=stop_immediate
+   * via la priority haute du flag breakdown).
+   */
+  @Post('breakdown')
+  async breakdown(@Body() body: unknown) {
+    this.logger.log('POST /breakdown');
+
+    const input = (body && typeof body === 'object' ? body : {}) as Record<
+      string,
+      unknown
+    >;
+    const result = await this.orchestrator.analyze({
+      ...input,
+      intent_type: 'breakdown',
+    });
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: result.error,
+        hint: 'Voir le schema AnalyzeDiagnosticInput pour le format attendu (intent_type forcé à breakdown).',
+      };
+    }
+
+    return {
+      success: true,
+      session_id: result.data!.session_id,
+      ...result.data!.evidence,
+    };
+  }
+
+  /**
    * GET /api/diagnostic-engine/systems
    *
    * List active diagnostic systems

--- a/backend/src/modules/diagnostic-engine/types/diagnostic-contract.schema.ts
+++ b/backend/src/modules/diagnostic-engine/types/diagnostic-contract.schema.ts
@@ -20,6 +20,7 @@ export const DiagnosticIntentEnum = z.enum([
   'maintenance_check',
   'revision_check',
   'preventive_check',
+  'breakdown', // ADR-032 D-intents : urgence routière (panne immobilisante)
 ]);
 export type DiagnosticIntent = z.infer<typeof DiagnosticIntentEnum>;
 

--- a/backend/tests/unit/breakdown-intent.test.ts
+++ b/backend/tests/unit/breakdown-intent.test.ts
@@ -1,0 +1,43 @@
+/**
+ * ADR-032 PR-3 — DiagnosticIntent breakdown extension
+ *
+ * Vérifie l'ajout du 7e intent `breakdown` au Zod enum (urgence routière).
+ * Aucun consommateur secondaire à patcher : le seul site canonique est
+ * `DiagnosticIntentEnum`. Voir mémoire `diag-intent-enum-canonical-only.md`.
+ *
+ * @see backend/src/modules/diagnostic-engine/types/diagnostic-contract.schema.ts
+ */
+import { describe, it, expect } from '@jest/globals';
+import { DiagnosticIntentEnum } from '../../src/modules/diagnostic-engine/types/diagnostic-contract.schema';
+
+describe('ADR-032 PR-3 — DiagnosticIntent breakdown', () => {
+  it('exposes 7 intent values including breakdown', () => {
+    const options = DiagnosticIntentEnum.options;
+    expect(options).toHaveLength(7);
+    expect(options).toContain('breakdown');
+  });
+
+  it('parses breakdown as a valid intent', () => {
+    const result = DiagnosticIntentEnum.safeParse('breakdown');
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown intents (still strict enum)', () => {
+    const result = DiagnosticIntentEnum.safeParse('panne');
+    expect(result.success).toBe(false);
+  });
+
+  it('preserves the 6 legacy intents', () => {
+    const expected = [
+      'diagnostic_symptom',
+      'warning_light_analysis',
+      'dtc_analysis',
+      'maintenance_check',
+      'revision_check',
+      'preventive_check',
+    ];
+    for (const intent of expected) {
+      expect(DiagnosticIntentEnum.options).toContain(intent);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 PR-3 d'ADR-032 — **minimaliste** après audits empiriques 2026-04-29.

**DRAFT** — dépend ak125/governance-vault#107 (ADR-032).

> Note : le scope V1 incluait wire `kg_record_case` dans `diag-orchestrator`. Audit empirique a invalidé ce wire comme 3e faux problème successif :
> 1. PR-2 prompts intent dynamic (faux : `DiagnosticIntentEnum` = unique site canonique).
> 2. PR-2bis safety rewire (faux : `__diag_safety_rule` ≠ `kg_check_safety_gate`, canons distincts).
> 3. **PR-3 wire `kg_record_case`** (faux : `__diag_*` slugs et `kg_*` UUIDs = univers disjoints, corpus diag déjà persisté `__diag_session.result`).
> Voir vault PR #107 commit `16b0281` + mémoire `diag-vs-kg-pipelines-disjoints.md`.

## Scope minimal

1. **Ajout `'breakdown'`** au `DiagnosticIntentEnum` Zod (1 ligne, 7e intent).
2. **`POST /api/diagnostic-engine/breakdown`** : force `intent_type='breakdown'` puis délègue à `orchestrator.analyze()`. Le `RiskSafetyEngine` priorise déjà les rules `safety_gate=stop_immediate`.
3. **4 tests Jest** : enum length, parse 'breakdown', reject unknown, preserve 6 legacy intents.

**Pas de modifications consommateurs** :
- `validate-phase0.ts:54,84,106,123` = fixtures `diagnostic_symptom` (cas particulier, pas exhaustif).
- `admin-keyword-planner.controller.ts:1797` = lookup RAG, pas literal.
- Aucun prompt LLM hardcode les 6 intents (mémoire `diag-intent-enum-canonical-only.md`).

## Test plan

- [ ] `cd backend && npx jest breakdown-intent` → 4 tests pass
- [ ] Smoke manuel post-merge :
  ```bash
  curl -X POST http://localhost:3000/api/diagnostic-engine/breakdown \
    -H "Content-Type: application/json" \
    -d '{"system_scope":"freinage","signal_input":{"primary_signal":"brake_noise_metallic","signal_mode":"symptom_slugs"}}'
  ```
- [ ] CI green (signed commit G3, lint, type-check)

## Indépendance

Cette PR est **indépendante** de PR-1 (#207) et PR-2 (#208) — peut merger en parallèle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)