### PR TITLE
fix(adr-032-pr1): drop @jest/globals import in kg-extensions test

### DIFF
--- a/backend/tests/unit/diagnostic-engine.kg-extensions.test.ts
+++ b/backend/tests/unit/diagnostic-engine.kg-extensions.test.ts
@@ -13,7 +13,10 @@
  * @see backend/supabase/migrations/20260429_diag_maintenance_via_kg.sql
  * @see governance-vault/ledger/decisions/adr/ADR-032-diagnostic-maintenance-unification.md
  */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+// Note: jest globals (describe/it/expect/beforeEach/jest) are auto-injected
+// by ts-jest preset — do NOT import from '@jest/globals' (typing strict
+// breaks mockResolvedValueOnce inference, parameter resolves to `never`).
+// Pattern aligned on tests/unit/rag-proxy.service.test.ts.
 
 type MockSupabaseClient = {
   rpc: jest.Mock;


### PR DESCRIPTION
## Summary

Backend Tests CI failed après merge PR-1 (#207, commit 04db3bdc) :

```
TS2345: Argument of type '{ data: ...; error: null; }' is not
assignable to parameter of type 'never'.
```

## Cause

Mon fichier `backend/tests/unit/diagnostic-engine.kg-extensions.test.ts` importait :
\`\`\`typescript
import { jest, describe, it, expect, beforeEach } from '@jest/globals';
\`\`\`

Ce typing strict ts-jest résout `mockResolvedValueOnce<T>()` en `never`, cassant l'inférence pour les data mocks.

## Fix

Le pattern projet (cf. `tests/unit/rag-proxy.service.test.ts:35` :  `let mockFetch: jest.Mock;`) utilise les jest globals auto-injectés par ts-jest preset, **sans import explicite**. Suppression de l'import + commentaire préventif anti-régression.

## Test plan

- [ ] CI Backend Tests pass post-fix (vérifie l'erreur TS2345 disparaît)
- [ ] Pas de régression sur les autres tests existants

🤖 Generated with [Claude Code](https://claude.com/claude-code)