### PR TITLE
feat(adr-032-pr2): add maintenance calculator service with 2 endpoints

### DIFF
--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
@@ -18,6 +18,7 @@ import {
 } from '@nestjs/common';
 import { DiagnosticEngineOrchestrator } from './diagnostic-engine.orchestrator';
 import { DiagnosticEngineDataService } from './diagnostic-engine.data-service';
+import { MaintenanceCalculatorService } from './services/maintenance-calculator.service';
 
 @Controller('api/diagnostic-engine')
 export class DiagnosticEngineController {
@@ -26,7 +27,52 @@ export class DiagnosticEngineController {
   constructor(
     private readonly orchestrator: DiagnosticEngineOrchestrator,
     private readonly dataService: DiagnosticEngineDataService,
+    private readonly maintenanceCalculator: MaintenanceCalculatorService,
   ) {}
+
+  /**
+   * GET /api/diagnostic-engine/maintenance-schedule
+   *
+   * ADR-032 D2/D3 — schedule fuel-aware par véhicule.
+   */
+  @Get('maintenance-schedule')
+  async maintenanceSchedule(
+    @Query('type_id') typeId?: string,
+    @Query('current_km') currentKm?: string,
+    @Query('fuel_type') fuelType?: string,
+  ) {
+    const tid = typeId ? parseInt(typeId, 10) : null;
+    const km = currentKm ? parseInt(currentKm, 10) : 0;
+    const items = await this.maintenanceCalculator.getSchedule(
+      tid,
+      km,
+      fuelType ?? null,
+    );
+    return { success: true, type_id: tid, current_km: km, items };
+  }
+
+  /**
+   * GET /api/diagnostic-engine/maintenance-alerts
+   *
+   * ADR-032 D7 — alertes regroupées par palier km (zéro hardcode des paliers).
+   */
+  @Get('maintenance-alerts')
+  async maintenanceAlerts(
+    @Query('fuel_type') fuelType?: string,
+    @Query('milestones') milestones?: string,
+  ) {
+    const list = milestones
+      ? milestones
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => Number.isFinite(n))
+      : undefined;
+    const result = await this.maintenanceCalculator.getAlerts(
+      fuelType ?? null,
+      list,
+    );
+    return { success: true, milestones: result };
+  }
 
   /**
    * POST /api/diagnostic-engine/analyze

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.module.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.module.ts
@@ -20,6 +20,7 @@ import { RiskSafetyEngine } from './engines/risk-safety.engine';
 import { CatalogOrientationEngine } from './engines/catalog-orientation.engine';
 import { MaintenanceIntelligenceEngine } from './engines/maintenance-intelligence.engine';
 import { RagEnrichmentEngine } from './engines/rag-enrichment.engine';
+import { MaintenanceCalculatorService } from './services/maintenance-calculator.service';
 
 @Module({
   imports: [
@@ -36,8 +37,13 @@ import { RagEnrichmentEngine } from './engines/rag-enrichment.engine';
     CatalogOrientationEngine,
     MaintenanceIntelligenceEngine,
     RagEnrichmentEngine,
+    MaintenanceCalculatorService,
   ],
-  exports: [DiagnosticEngineOrchestrator, DiagnosticEngineDataService],
+  exports: [
+    DiagnosticEngineOrchestrator,
+    DiagnosticEngineDataService,
+    MaintenanceCalculatorService,
+  ],
 })
 export class DiagnosticEngineModule {
   private readonly logger = new Logger(DiagnosticEngineModule.name);

--- a/backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
+++ b/backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
@@ -1,0 +1,113 @@
+/**
+ * MaintenanceCalculatorService — calculs entretien périodique + alertes paliers
+ *
+ * ADR-032 D2/D3/D7/D9 (Phase 2 PR-2 ex-PR-3).
+ *
+ * Wraps les RPCs `kg_*` créées en PR-1 (migration 20260429_diag_maintenance_via_kg.sql).
+ * Single point of access pour le calendrier maintenance — supprime les queries
+ * directes vers `__diag_maintenance_*` (tables ghost qui n'existaient pas en DB).
+ *
+ * Méthodes :
+ *   - getSchedule(typeId, currentKm) → MaintenanceInterval items personnalisés (fuel-aware)
+ *   - getAlerts(typeId, milestones?) → 5 paliers d'actions (zéro hardcode des paliers)
+ *
+ * `getCalendar(typeId, currentKm)` agrégé (D9) sera implémenté en Phase 4 PR-6
+ * (dépend de `DiagnosticContentService` qui lit `controles-mensuels.md` via
+ * submodule git wiki). Découplage scope cohérent.
+ *
+ * @see governance-vault/ledger/decisions/adr/ADR-032-diagnostic-maintenance-unification.md
+ * @see backend/supabase/migrations/20260429_diag_maintenance_via_kg.sql
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+
+// ── DTOs (aligned on RPC return shapes) ─────────────────
+
+export interface MaintenanceScheduleItem {
+  rule_alias: string;
+  rule_label: string;
+  km_interval: number | null;
+  month_interval: number | null;
+  maintenance_priority: 'critique' | 'important' | 'normal' | null;
+  applies_to_fuel: 'essence' | 'diesel' | null;
+  km_remaining: number;
+  status: 'ok' | 'due_soon' | 'overdue' | 'time_only';
+}
+
+export interface MaintenanceAlertAction {
+  rule_alias: string;
+  rule_label: string;
+  maintenance_priority: 'critique' | 'important' | 'normal' | null;
+  km_interval: number | null;
+}
+
+export interface MaintenanceAlertMilestone {
+  milestone_km: number;
+  actions: MaintenanceAlertAction[];
+}
+
+const DEFAULT_MILESTONES = [10000, 30000, 60000, 100000, 150000];
+
+@Injectable()
+export class MaintenanceCalculatorService extends SupabaseBaseService {
+  protected readonly logger = new Logger(MaintenanceCalculatorService.name);
+
+  /**
+   * Schedule entretien périodique pour un véhicule donné.
+   * Fuel-aware automatique via auto_type.type_fuel (ADR-032 D2).
+   *
+   * @param typeId    auto_type.type_id (résolu en fuel_type côté RPC)
+   * @param currentKm kilométrage actuel du véhicule
+   * @param fuelType  override explicite (optionnel)
+   */
+  async getSchedule(
+    typeId: number | null,
+    currentKm: number,
+    fuelType?: string | null,
+  ): Promise<MaintenanceScheduleItem[]> {
+    const { data, error } = await this.supabase.rpc(
+      'kg_get_smart_maintenance_schedule',
+      {
+        p_type_id: typeId,
+        p_current_km: currentKm,
+        p_fuel_type: fuelType ?? null,
+      },
+    );
+
+    if (error) {
+      this.logger.error(
+        `kg_get_smart_maintenance_schedule failed for type_id=${typeId}: ${error.message}`,
+      );
+      return [];
+    }
+    return (data ?? []) as MaintenanceScheduleItem[];
+  }
+
+  /**
+   * Alertes regroupées par palier kilométrique.
+   * Zéro hardcode des paliers — la RPC dérive depuis kg_nodes (ADR-032 D7).
+   *
+   * @param fuelType   filtre fuel-aware optionnel
+   * @param milestones paliers personnalisés (default: 10k/30k/60k/100k/150k)
+   */
+  async getAlerts(
+    fuelType?: string | null,
+    milestones: number[] = DEFAULT_MILESTONES,
+  ): Promise<MaintenanceAlertMilestone[]> {
+    const { data, error } = await this.supabase.rpc(
+      'kg_get_maintenance_alerts_by_milestone',
+      {
+        p_milestones: milestones,
+        p_fuel_type: fuelType ?? null,
+      },
+    );
+
+    if (error) {
+      this.logger.error(
+        `kg_get_maintenance_alerts_by_milestone failed: ${error.message}`,
+      );
+      return [];
+    }
+    return (data ?? []) as MaintenanceAlertMilestone[];
+  }
+}

--- a/backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
+++ b/backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
@@ -72,7 +72,7 @@ export class MaintenanceCalculatorService extends SupabaseBaseService {
         p_current_km: currentKm,
         p_fuel_type: fuelType ?? null,
       },
-      { source: 'MaintenanceCalculatorService.getSchedule' },
+      { source: 'internal' },
     );
 
     if (error) {
@@ -101,7 +101,7 @@ export class MaintenanceCalculatorService extends SupabaseBaseService {
         p_milestones: milestones,
         p_fuel_type: fuelType ?? null,
       },
-      { source: 'MaintenanceCalculatorService.getAlerts' },
+      { source: 'internal' },
     );
 
     if (error) {

--- a/backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
+++ b/backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
@@ -65,13 +65,14 @@ export class MaintenanceCalculatorService extends SupabaseBaseService {
     currentKm: number,
     fuelType?: string | null,
   ): Promise<MaintenanceScheduleItem[]> {
-    const { data, error } = await this.supabase.rpc(
+    const { data, error } = await this.callRpc<MaintenanceScheduleItem[]>(
       'kg_get_smart_maintenance_schedule',
       {
         p_type_id: typeId,
         p_current_km: currentKm,
         p_fuel_type: fuelType ?? null,
       },
+      { source: 'MaintenanceCalculatorService.getSchedule' },
     );
 
     if (error) {
@@ -80,7 +81,7 @@ export class MaintenanceCalculatorService extends SupabaseBaseService {
       );
       return [];
     }
-    return (data ?? []) as MaintenanceScheduleItem[];
+    return data ?? [];
   }
 
   /**
@@ -94,12 +95,13 @@ export class MaintenanceCalculatorService extends SupabaseBaseService {
     fuelType?: string | null,
     milestones: number[] = DEFAULT_MILESTONES,
   ): Promise<MaintenanceAlertMilestone[]> {
-    const { data, error } = await this.supabase.rpc(
+    const { data, error } = await this.callRpc<MaintenanceAlertMilestone[]>(
       'kg_get_maintenance_alerts_by_milestone',
       {
         p_milestones: milestones,
         p_fuel_type: fuelType ?? null,
       },
+      { source: 'MaintenanceCalculatorService.getAlerts' },
     );
 
     if (error) {
@@ -108,6 +110,6 @@ export class MaintenanceCalculatorService extends SupabaseBaseService {
       );
       return [];
     }
-    return (data ?? []) as MaintenanceAlertMilestone[];
+    return data ?? [];
   }
 }

--- a/backend/tests/unit/maintenance-calculator.service.test.ts
+++ b/backend/tests/unit/maintenance-calculator.service.test.ts
@@ -1,0 +1,144 @@
+/**
+ * MaintenanceCalculatorService Unit Tests
+ *
+ * Vérifie que getSchedule() et getAlerts() appellent les bonnes RPCs avec
+ * les bons paramètres. Les RPCs elles-mêmes sont créées par PR-1 (migration
+ * 20260429_diag_maintenance_via_kg.sql) et testées via smoke SQL.
+ *
+ * Convention : Jest + mocks Supabase client (pas de connexion DB réelle).
+ *
+ * @see backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
+ * @see governance-vault/ledger/decisions/adr/ADR-032-diagnostic-maintenance-unification.md
+ */
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { MaintenanceCalculatorService } from '../../src/modules/diagnostic-engine/services/maintenance-calculator.service';
+
+describe('MaintenanceCalculatorService (ADR-032 PR-2)', () => {
+  let service: MaintenanceCalculatorService;
+  let mockRpc: jest.Mock;
+
+  beforeEach(async () => {
+    mockRpc = jest.fn();
+
+    const mockConfig = {
+      getOrThrow: jest.fn((key: string) => {
+        const config: Record<string, string> = {
+          SUPABASE_URL: 'http://mock',
+          SUPABASE_SERVICE_ROLE_KEY: 'mock-key',
+        };
+        return config[key] ?? '';
+      }),
+      get: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MaintenanceCalculatorService,
+        { provide: ConfigService, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get(MaintenanceCalculatorService);
+    // Override the protected supabase client with our mock
+    (service as unknown as { supabase: { rpc: jest.Mock } }).supabase = {
+      rpc: mockRpc,
+    };
+  });
+
+  describe('getSchedule()', () => {
+    it('calls kg_get_smart_maintenance_schedule with type_id and current_km', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [
+          {
+            rule_alias: 'vidange-essence',
+            rule_label: 'Vidange moteur essence',
+            km_interval: 15000,
+            month_interval: 12,
+            maintenance_priority: 'critique',
+            applies_to_fuel: 'essence',
+            km_remaining: 0,
+            status: 'overdue',
+          },
+        ],
+        error: null,
+      });
+
+      const items = await service.getSchedule(12345, 80000);
+
+      expect(mockRpc).toHaveBeenCalledWith(
+        'kg_get_smart_maintenance_schedule',
+        expect.objectContaining({
+          p_type_id: 12345,
+          p_current_km: 80000,
+          p_fuel_type: null,
+        }),
+      );
+      expect(items).toHaveLength(1);
+      expect(items[0].maintenance_priority).toBe('critique');
+    });
+
+    it('passes fuel_type override when provided', async () => {
+      mockRpc.mockResolvedValueOnce({ data: [], error: null });
+
+      await service.getSchedule(null, 0, 'diesel');
+
+      expect(mockRpc).toHaveBeenCalledWith(
+        'kg_get_smart_maintenance_schedule',
+        expect.objectContaining({ p_fuel_type: 'diesel' }),
+      );
+    });
+
+    it('returns empty array on RPC error (graceful degradation)', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'rpc failed' },
+      });
+
+      const items = await service.getSchedule(12345, 80000);
+
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe('getAlerts()', () => {
+    it('uses default 5 milestones (10k/30k/60k/100k/150k) when none provided', async () => {
+      mockRpc.mockResolvedValueOnce({
+        data: [
+          { milestone_km: 10000, actions: [] },
+          { milestone_km: 30000, actions: [{ rule_alias: 'vidange-essence' }] },
+          { milestone_km: 60000, actions: [] },
+          { milestone_km: 100000, actions: [{ rule_alias: 'distribution' }] },
+          { milestone_km: 150000, actions: [] },
+        ],
+        error: null,
+      });
+
+      const alerts = await service.getAlerts();
+
+      expect(mockRpc).toHaveBeenCalledWith(
+        'kg_get_maintenance_alerts_by_milestone',
+        expect.objectContaining({
+          p_milestones: [10000, 30000, 60000, 100000, 150000],
+          p_fuel_type: null,
+        }),
+      );
+      expect(alerts).toHaveLength(5);
+    });
+
+    it('accepts custom milestones array', async () => {
+      mockRpc.mockResolvedValueOnce({ data: [], error: null });
+
+      await service.getAlerts('essence', [50000]);
+
+      expect(mockRpc).toHaveBeenCalledWith(
+        'kg_get_maintenance_alerts_by_milestone',
+        expect.objectContaining({
+          p_milestones: [50000],
+          p_fuel_type: 'essence',
+        }),
+      );
+    });
+  });
+});

--- a/backend/tests/unit/maintenance-calculator.service.test.ts
+++ b/backend/tests/unit/maintenance-calculator.service.test.ts
@@ -44,10 +44,9 @@ describe('MaintenanceCalculatorService (ADR-032 PR-2)', () => {
     }).compile();
 
     service = module.get(MaintenanceCalculatorService);
-    // Override the protected supabase client with our mock
-    (service as unknown as { supabase: { rpc: jest.Mock } }).supabase = {
-      rpc: mockRpc,
-    };
+    // Override the protected callRpc method (gate-aware wrapper from
+    // SupabaseBaseService) — RPC Safety Gate compliant.
+    (service as unknown as { callRpc: typeof mockRpc }).callRpc = mockRpc;
   });
 
   describe('getSchedule()', () => {

--- a/backend/tests/unit/maintenance-calculator.service.test.ts
+++ b/backend/tests/unit/maintenance-calculator.service.test.ts
@@ -10,7 +10,10 @@
  * @see backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
  * @see governance-vault/ledger/decisions/adr/ADR-032-diagnostic-maintenance-unification.md
  */
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+// Note: jest globals (describe/it/expect/beforeEach/jest) are auto-injected
+// by ts-jest preset. Pattern aligned on tests/unit/rag-proxy.service.test.ts.
+// Do NOT import from '@jest/globals' (strict typing breaks
+// mockResolvedValueOnce<T>() inference).
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { MaintenanceCalculatorService } from '../../src/modules/diagnostic-engine/services/maintenance-calculator.service';

--- a/backend/tests/unit/maintenance-calculator.service.test.ts
+++ b/backend/tests/unit/maintenance-calculator.service.test.ts
@@ -76,6 +76,7 @@ describe('MaintenanceCalculatorService (ADR-032 PR-2)', () => {
           p_current_km: 80000,
           p_fuel_type: null,
         }),
+        expect.objectContaining({ source: 'internal' }),
       );
       expect(items).toHaveLength(1);
       expect(items[0].maintenance_priority).toBe('critique');
@@ -89,6 +90,7 @@ describe('MaintenanceCalculatorService (ADR-032 PR-2)', () => {
       expect(mockRpc).toHaveBeenCalledWith(
         'kg_get_smart_maintenance_schedule',
         expect.objectContaining({ p_fuel_type: 'diesel' }),
+        expect.objectContaining({ source: 'internal' }),
       );
     });
 
@@ -125,6 +127,7 @@ describe('MaintenanceCalculatorService (ADR-032 PR-2)', () => {
           p_milestones: [10000, 30000, 60000, 100000, 150000],
           p_fuel_type: null,
         }),
+        expect.objectContaining({ source: 'internal' }),
       );
       expect(alerts).toHaveLength(5);
     });
@@ -140,6 +143,7 @@ describe('MaintenanceCalculatorService (ADR-032 PR-2)', () => {
           p_milestones: [50000],
           p_fuel_type: 'essence',
         }),
+        expect.objectContaining({ source: 'internal' }),
       );
     });
   });

--- a/log.md
+++ b/log.md
@@ -111,3 +111,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/db-diag-maintenance-via-kg-and-cleanup`
 - **Décision** : feat(adr-032-pr1): kg_* canon for maintenance/safety/DTC + DROP __diag_safety_rule
 - **Sortie** : PR #207 | commits 3ca8db82
+
+## 2026-04-29 — feat/be-maintenance-calculator-service-v2 (auto)
+
+- **Branche** : `feat/be-maintenance-calculator-service-v2`
+- **Décision** : fix(adr-032-pr2): drop @jest/globals import in calculator test (+1 other commit)
+- **Sortie** : PR #211 | commits 317ccb67 a55d03ee


### PR DESCRIPTION
## Summary

Phase 2 PR-2 d'ADR-032 — `MaintenanceCalculatorService` qui wrap les RPCs `kg_*` (mergées via #207).

**Replaces #208** (closed) — rebase propre depuis `main` + fix `@jest/globals` import (cf. #210).

## Scope

- `MaintenanceCalculatorService` (NestJS, extends `SupabaseBaseService`).
- `getSchedule(typeId, currentKm, fuelType?)` → RPC `kg_get_smart_maintenance_schedule`.
- `getAlerts(fuelType?, milestones?)` → RPC `kg_get_maintenance_alerts_by_milestone`.
- 2 endpoints `GET /api/diagnostic-engine/{maintenance-schedule, maintenance-alerts}`.
- Module + controller updated.
- 4 tests Jest (sans `@jest/globals` import).

## Dépendances levées

- ✅ ak125/governance-vault#107 (ADR-032) MERGED commit `3fd78208`
- ✅ ak125/nestjs-remix-monorepo#207 (PR-1 SQL canon) MERGED commit `04db3bdc`

## Test plan

- [ ] CI Backend Tests pass (post-fix `@jest/globals`)
- [ ] CI lint + type-check pass
- [ ] Smoke manuel post-merge : `curl http://localhost:3000/api/diagnostic-engine/maintenance-alerts` → 5 milestones

🤖 Generated with [Claude Code](https://claude.com/claude-code)