### PR TITLE
feat(adr-032-pr3): add breakdown intent and POST /breakdown endpoint

### DIFF
--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
@@ -55,6 +55,42 @@ export class DiagnosticEngineController {
   }
 
   /**
+   * POST /api/diagnostic-engine/breakdown
+   *
+   * ADR-032 — endpoint urgence routière (panne immobilisante).
+   * Force `intent_type: 'breakdown'` et délègue à l'orchestrator standard
+   * (le `RiskSafetyEngine` priorise les rules safety_gate=stop_immediate
+   * via la priority haute du flag breakdown).
+   */
+  @Post('breakdown')
+  async breakdown(@Body() body: unknown) {
+    this.logger.log('POST /breakdown');
+
+    const input = (body && typeof body === 'object' ? body : {}) as Record<
+      string,
+      unknown
+    >;
+    const result = await this.orchestrator.analyze({
+      ...input,
+      intent_type: 'breakdown',
+    });
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: result.error,
+        hint: 'Voir le schema AnalyzeDiagnosticInput pour le format attendu (intent_type forcé à breakdown).',
+      };
+    }
+
+    return {
+      success: true,
+      session_id: result.data!.session_id,
+      ...result.data!.evidence,
+    };
+  }
+
+  /**
    * GET /api/diagnostic-engine/systems
    *
    * List active diagnostic systems

--- a/backend/src/modules/diagnostic-engine/types/diagnostic-contract.schema.ts
+++ b/backend/src/modules/diagnostic-engine/types/diagnostic-contract.schema.ts
@@ -20,6 +20,7 @@ export const DiagnosticIntentEnum = z.enum([
   'maintenance_check',
   'revision_check',
   'preventive_check',
+  'breakdown', // ADR-032 D-intents : urgence routière (panne immobilisante)
 ]);
 export type DiagnosticIntent = z.infer<typeof DiagnosticIntentEnum>;
 

--- a/backend/tests/unit/breakdown-intent.test.ts
+++ b/backend/tests/unit/breakdown-intent.test.ts
@@ -7,7 +7,8 @@
  *
  * @see backend/src/modules/diagnostic-engine/types/diagnostic-contract.schema.ts
  */
-import { describe, it, expect } from '@jest/globals';
+// Note: jest globals (describe/it/expect) are auto-injected by ts-jest
+// preset. Pattern aligned on tests/unit/rag-proxy.service.test.ts.
 import { DiagnosticIntentEnum } from '../../src/modules/diagnostic-engine/types/diagnostic-contract.schema';
 
 describe('ADR-032 PR-3 — DiagnosticIntent breakdown', () => {

--- a/backend/tests/unit/breakdown-intent.test.ts
+++ b/backend/tests/unit/breakdown-intent.test.ts
@@ -1,0 +1,43 @@
+/**
+ * ADR-032 PR-3 — DiagnosticIntent breakdown extension
+ *
+ * Vérifie l'ajout du 7e intent `breakdown` au Zod enum (urgence routière).
+ * Aucun consommateur secondaire à patcher : le seul site canonique est
+ * `DiagnosticIntentEnum`. Voir mémoire `diag-intent-enum-canonical-only.md`.
+ *
+ * @see backend/src/modules/diagnostic-engine/types/diagnostic-contract.schema.ts
+ */
+import { describe, it, expect } from '@jest/globals';
+import { DiagnosticIntentEnum } from '../../src/modules/diagnostic-engine/types/diagnostic-contract.schema';
+
+describe('ADR-032 PR-3 — DiagnosticIntent breakdown', () => {
+  it('exposes 7 intent values including breakdown', () => {
+    const options = DiagnosticIntentEnum.options;
+    expect(options).toHaveLength(7);
+    expect(options).toContain('breakdown');
+  });
+
+  it('parses breakdown as a valid intent', () => {
+    const result = DiagnosticIntentEnum.safeParse('breakdown');
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown intents (still strict enum)', () => {
+    const result = DiagnosticIntentEnum.safeParse('panne');
+    expect(result.success).toBe(false);
+  });
+
+  it('preserves the 6 legacy intents', () => {
+    const expected = [
+      'diagnostic_symptom',
+      'warning_light_analysis',
+      'dtc_analysis',
+      'maintenance_check',
+      'revision_check',
+      'preventive_check',
+    ];
+    for (const intent of expected) {
+      expect(DiagnosticIntentEnum.options).toContain(intent);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 PR-3 d'ADR-032 — minimaliste après audits empiriques 2026-04-29.

**Replaces #209** (closed) — rebase clean from main + fix `@jest/globals` import.

## Scope minimal

1. Ajout `'breakdown'` à `DiagnosticIntentEnum` Zod (1 ligne, 7e intent).
2. `POST /api/diagnostic-engine/breakdown` : force `intent_type='breakdown'` puis délègue à `orchestrator.analyze()`.
3. 4 tests Jest (sans `@jest/globals`).

## Indépendance

✅ ADR-032 vault MERGED commit `3fd78208`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)