### PR TITLE
feat(adr-032-pr6): add diagnostic content service via wiki submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "backend/content/automecanik-wiki"]
+	path = backend/content/automecanik-wiki
+	url = https://github.com/ak125/automecanik-wiki
+	branch = main

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
@@ -19,6 +19,7 @@ import {
 import { DiagnosticEngineOrchestrator } from './diagnostic-engine.orchestrator';
 import { DiagnosticEngineDataService } from './diagnostic-engine.data-service';
 import { MaintenanceCalculatorService } from './services/maintenance-calculator.service';
+import { DiagnosticContentService } from './services/diagnostic-content.service';
 
 @Controller('api/diagnostic-engine')
 export class DiagnosticEngineController {
@@ -28,7 +29,49 @@ export class DiagnosticEngineController {
     private readonly orchestrator: DiagnosticEngineOrchestrator,
     private readonly dataService: DiagnosticEngineDataService,
     private readonly maintenanceCalculator: MaintenanceCalculatorService,
+    private readonly diagnosticContent: DiagnosticContentService,
   ) {}
+
+  /**
+   * GET /api/diagnostic-engine/wizard-steps
+   * GET /api/diagnostic-engine/safety-config
+   * GET /api/diagnostic-engine/vocab-clusters
+   * GET /api/diagnostic-engine/signs
+   * GET /api/diagnostic-engine/faq
+   * GET /api/diagnostic-engine/controles-mensuels
+   *
+   * ADR-032 D1+D5 — contenu UI servi depuis submodule git wiki/.
+   * Source unique : `backend/content/automecanik-wiki/wiki/{diagnostic,support}/<slug>.md`.
+   */
+  @Get('wizard-steps')
+  getWizardSteps() {
+    return this.diagnosticContent.getWizardSteps();
+  }
+
+  @Get('safety-config')
+  getSafetyConfig() {
+    return this.diagnosticContent.getSafetyConfig();
+  }
+
+  @Get('vocab-clusters')
+  getVocabClusters() {
+    return this.diagnosticContent.getVocabClusters();
+  }
+
+  @Get('signs')
+  getSigns() {
+    return this.diagnosticContent.getSigns();
+  }
+
+  @Get('faq')
+  getFaq() {
+    return this.diagnosticContent.getFaq();
+  }
+
+  @Get('controles-mensuels')
+  getControlesMensuels() {
+    return this.diagnosticContent.getControlesMensuels();
+  }
 
   /**
    * GET /api/diagnostic-engine/maintenance-schedule

--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.module.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.module.ts
@@ -21,6 +21,7 @@ import { CatalogOrientationEngine } from './engines/catalog-orientation.engine';
 import { MaintenanceIntelligenceEngine } from './engines/maintenance-intelligence.engine';
 import { RagEnrichmentEngine } from './engines/rag-enrichment.engine';
 import { MaintenanceCalculatorService } from './services/maintenance-calculator.service';
+import { DiagnosticContentService } from './services/diagnostic-content.service';
 
 @Module({
   imports: [
@@ -38,11 +39,13 @@ import { MaintenanceCalculatorService } from './services/maintenance-calculator.
     MaintenanceIntelligenceEngine,
     RagEnrichmentEngine,
     MaintenanceCalculatorService,
+    DiagnosticContentService,
   ],
   exports: [
     DiagnosticEngineOrchestrator,
     DiagnosticEngineDataService,
     MaintenanceCalculatorService,
+    DiagnosticContentService,
   ],
 })
 export class DiagnosticEngineModule {

--- a/backend/src/modules/diagnostic-engine/services/diagnostic-content.service.ts
+++ b/backend/src/modules/diagnostic-engine/services/diagnostic-content.service.ts
@@ -1,0 +1,125 @@
+/**
+ * DiagnosticContentService — lecture du contenu wiki diagnostic + support
+ *
+ * ADR-032 D1 + D5 (Phase 4 PR-6).
+ *
+ * Lit les fichiers Markdown frontmatter YAML depuis le submodule git
+ * `backend/content/automecanik-wiki/wiki/{diagnostic,support}/<slug>.md`,
+ * parse via gray-matter, cache LRU 5 min.
+ *
+ * Source unique = filesystem local (build-time injection via git submodule
+ * `update --init --recursive --depth 1`). PAS de table DB, PAS de CI sync,
+ * PAS d'exports JSON séparés.
+ *
+ * Graceful degradation : si fichier absent (submodule pas init, fichier
+ * pas encore mergé sur main wiki), retourne `null` + log error sans crash.
+ *
+ * @see governance-vault/ledger/decisions/adr/ADR-032-diagnostic-maintenance-unification.md
+ * @see automecanik-wiki/wiki/diagnostic/*.md (source canon)
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import matter from 'gray-matter';
+
+export type DiagnosticEntityType = 'diagnostic' | 'support';
+
+export interface DiagnosticContentEntry {
+  slug: string;
+  title: string;
+  entity_data: Record<string, unknown>;
+  body: string;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CONTENT_ROOT = path.resolve(
+  __dirname,
+  '../../../../content/automecanik-wiki/wiki',
+);
+
+@Injectable()
+export class DiagnosticContentService {
+  private readonly logger = new Logger(DiagnosticContentService.name);
+  private readonly cache = new Map<
+    string,
+    { entry: DiagnosticContentEntry; expiresAt: number }
+  >();
+
+  /**
+   * Lit `wiki/<entityType>/<slug>.md`, parse frontmatter + body.
+   * Returns `null` si fichier absent (graceful degradation).
+   */
+  read(
+    entityType: DiagnosticEntityType,
+    slug: string,
+  ): DiagnosticContentEntry | null {
+    const cacheKey = `${entityType}:${slug}`;
+    const now = Date.now();
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > now) {
+      return cached.entry;
+    }
+
+    const filePath = path.join(CONTENT_ROOT, entityType, `${slug}.md`);
+
+    if (!fs.existsSync(filePath)) {
+      this.logger.warn(
+        `Wiki content file not found: ${filePath} ` +
+          '(submodule init? wiki PR merged?). Returning null.',
+      );
+      return null;
+    }
+
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const parsed = matter(raw);
+      const fm = parsed.data as {
+        slug?: string;
+        title?: string;
+        entity_data?: Record<string, unknown>;
+      };
+
+      const entry: DiagnosticContentEntry = {
+        slug: fm.slug ?? slug,
+        title: fm.title ?? slug,
+        entity_data: fm.entity_data ?? {},
+        body: parsed.content,
+      };
+
+      this.cache.set(cacheKey, { entry, expiresAt: now + CACHE_TTL_MS });
+      return entry;
+    } catch (err) {
+      this.logger.error(
+        `Failed to parse wiki content ${filePath}: ${(err as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  /** Diagnostic content shortcuts (ADR-032 RG-1 wiki/diagnostic/) */
+  getWizardSteps() {
+    return this.read('diagnostic', 'wizard-steps');
+  }
+  getSafetyConfig() {
+    return this.read('diagnostic', 'safety-config');
+  }
+  getVocabClusters() {
+    return this.read('diagnostic', 'vocab-clusters');
+  }
+  getSigns() {
+    return this.read('diagnostic', 'signs');
+  }
+  getFaq() {
+    return this.read('diagnostic', 'faq');
+  }
+
+  /** Support content shortcuts (ADR-032 RG-1 wiki/support/) */
+  getControlesMensuels() {
+    return this.read('support', 'controles-mensuels');
+  }
+
+  /** For tests / cache busting */
+  clearCache() {
+    this.cache.clear();
+  }
+}

--- a/backend/tests/unit/diagnostic-content.service.test.ts
+++ b/backend/tests/unit/diagnostic-content.service.test.ts
@@ -1,0 +1,109 @@
+/**
+ * DiagnosticContentService Unit Tests
+ *
+ * Vérifie lecture frontmatter YAML via gray-matter, cache LRU 5 min,
+ * graceful degradation si fichier absent.
+ *
+ * Convention : Jest + mocks node:fs (pas de I/O réel).
+ *
+ * @see backend/src/modules/diagnostic-engine/services/diagnostic-content.service.ts
+ * @see governance-vault/ledger/decisions/adr/ADR-032-diagnostic-maintenance-unification.md
+ */
+import { DiagnosticContentService } from '../../src/modules/diagnostic-engine/services/diagnostic-content.service';
+import * as fs from 'node:fs';
+
+jest.mock('node:fs');
+
+describe('DiagnosticContentService (ADR-032 PR-6)', () => {
+  let service: DiagnosticContentService;
+  const mockExistsSync = fs.existsSync as jest.MockedFunction<
+    typeof fs.existsSync
+  >;
+  const mockReadFileSync = fs.readFileSync as jest.MockedFunction<
+    typeof fs.readFileSync
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new DiagnosticContentService();
+  });
+
+  describe('read()', () => {
+    it('parses frontmatter and returns entry when file exists', () => {
+      const sampleMd = `---
+schema_version: 1.0.0
+slug: wizard-steps
+title: Wizard test
+entity_data:
+  steps:
+    - id: 1
+      label: Step 1
+---
+
+# Body content
+`;
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(sampleMd);
+
+      const result = service.read('diagnostic', 'wizard-steps');
+
+      expect(result).not.toBeNull();
+      expect(result?.slug).toBe('wizard-steps');
+      expect(result?.title).toBe('Wizard test');
+      expect(result?.entity_data).toEqual({ steps: [{ id: 1, label: 'Step 1' }] });
+      expect(result?.body).toContain('# Body content');
+    });
+
+    it('returns null when file is absent (graceful degradation)', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const result = service.read('diagnostic', 'missing-slug');
+
+      expect(result).toBeNull();
+      expect(mockReadFileSync).not.toHaveBeenCalled();
+    });
+
+    it('returns null and logs error when frontmatter is malformed', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('parse boom');
+      });
+
+      const result = service.read('diagnostic', 'broken');
+
+      expect(result).toBeNull();
+    });
+
+    it('uses LRU cache (2nd read does not touch fs)', () => {
+      const sampleMd = `---
+slug: faq
+title: Cached FAQ
+entity_data:
+  faq: []
+---
+body
+`;
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(sampleMd);
+
+      service.read('diagnostic', 'faq');
+      service.read('diagnostic', 'faq');
+
+      expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('shortcuts', () => {
+    it('exposes 5 diagnostic shortcuts + 1 support shortcut', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      // Smoke : tous les helpers callables sans crash, retournent null
+      expect(service.getWizardSteps()).toBeNull();
+      expect(service.getSafetyConfig()).toBeNull();
+      expect(service.getVocabClusters()).toBeNull();
+      expect(service.getSigns()).toBeNull();
+      expect(service.getFaq()).toBeNull();
+      expect(service.getControlesMensuels()).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 PR-6 d'ADR-032 — `DiagnosticContentService` qui lit le contenu UI diagnostic + support depuis le submodule git \`automecanik-wiki\` (D1 + D5).

**Dépend** :
- ak125/automecanik-raw#5 (sources raw)
- ak125/automecanik-wiki#7 (wiki entries publish)

## Architecture (ADR-032 §"Decisions actively rejected")

- **PAS** de table \`__content_exports\` (duplication DB↔FS).
- **PAS** de CI sync cross-repo (ajoute coordination).
- **PAS** de Storage SDK (ajoute dépendance externe).
- **Source unique** = filesystem local via submodule git.

## Implementation

### Submodule git
- \`.gitmodules\` ajouté : \`backend/content/automecanik-wiki\` → \`https://github.com/ak125/automecanik-wiki:main\`.
- Contenu wiki accessible localement après \`git submodule update --init --recursive --depth 1\`.

### \`DiagnosticContentService\`
\`\`\`typescript
read(entityType: 'diagnostic' | 'support', slug: string): DiagnosticContentEntry | null
  // Lit backend/content/automecanik-wiki/wiki/<entityType>/<slug>.md
  // Parse frontmatter YAML via gray-matter (déjà en deps backend)
  // Cache LRU 5 min mémoire
  // Graceful degradation : null si fichier absent (no crash)
\`\`\`

6 shortcuts : \`getWizardSteps\`, \`getSafetyConfig\`, \`getVocabClusters\`, \`getSigns\`, \`getFaq\` (wiki/diagnostic/) + \`getControlesMensuels\` (wiki/support/).

### 6 endpoints \`@Controller('api/diagnostic-engine')\`

\`\`\`
GET /wizard-steps         → wiki/diagnostic/wizard-steps.md
GET /safety-config        → wiki/diagnostic/safety-config.md
GET /vocab-clusters       → wiki/diagnostic/vocab-clusters.md
GET /signs                → wiki/diagnostic/signs.md
GET /faq                  → wiki/diagnostic/faq.md
GET /controles-mensuels   → wiki/support/controles-mensuels.md
\`\`\`

### Tests Jest (5 cas)

- Parse frontmatter + entity_data
- Graceful null si fichier absent
- Graceful null si parse error
- Cache LRU (2e read = 0 fs call)
- Smoke 6 shortcuts callables

## Note CI

Submodule init en CI/build pas encore configuré dans \`.github/workflows/ci.yml\` (pas de \`submodules: recursive\`). Vu la **graceful degradation**, les endpoints retournent simplement \`null\` si le submodule n'est pas init — non-bloquant tant que Phase 5 frontend n'est pas merge. Mise à jour CI à venir dans PR séparée (\`actions/checkout@v4\` + \`with: submodules: recursive\` + Dockerfile \`git submodule update --init\`).

## Test plan

- [ ] CI Backend Tests pass (5 cas Jest, mocks fs)
- [ ] CI ESLint + TypeScript verts
- [ ] Smoke manuel post-merge : \`curl http://localhost:3000/api/diagnostic-engine/wizard-steps\` (retourne null avant init submodule, données après).

## Suivi (Phase 5)

5 PRs frontend pour consommer ces endpoints :
- PR-7 calendrier-entretien.tsx (loader \`/calendar\` agrégé D9 — endpoint à finaliser dans une mini-PR puisque pas inclus ici).
- PR-8 diagnostic-auto._index.tsx → \`/vocab-clusters\` + \`/signs\` + \`/faq\`.
- PR-9 diagnostic-auto.\$slug.tsx → \`/safety-config\`.
- PR-10 DiagnosticWizard.tsx → \`/wizard-steps\`.
- PR-11 cross-link pieces ↔ /depannage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)