### PR TITLE
feat(adr-032-d9): add aggregated /calendar endpoint

### DIFF
--- a/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
+++ b/backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts
@@ -99,6 +99,24 @@ export class DiagnosticEngineController {
    *
    * ADR-032 D7 — alertes regroupées par palier km (zéro hardcode des paliers).
    */
+  /**
+   * GET /api/diagnostic-engine/calendar
+   *
+   * ADR-032 D9 — endpoint agrégé pour calendrier-entretien.tsx.
+   * Single fetch côté frontend (zéro hardcode des 3 sections : schedule,
+   * alerts paliers, contrôles mensuels).
+   */
+  @Get('calendar')
+  async maintenanceCalendar(
+    @Query('type_id') typeId?: string,
+    @Query('current_km') currentKm?: string,
+    @Query('fuel_type') fuelType?: string,
+  ) {
+    const tid = typeId ? parseInt(typeId, 10) : null;
+    const km = currentKm ? parseInt(currentKm, 10) : 0;
+    return this.maintenanceCalculator.getCalendar(tid, km, fuelType ?? null);
+  }
+
   @Get('maintenance-alerts')
   async maintenanceAlerts(
     @Query('fuel_type') fuelType?: string,

--- a/backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
+++ b/backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
@@ -18,8 +18,9 @@
  * @see governance-vault/ledger/decisions/adr/ADR-032-diagnostic-maintenance-unification.md
  * @see backend/supabase/migrations/20260429_diag_maintenance_via_kg.sql
  */
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Inject, Logger } from '@nestjs/common';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { DiagnosticContentService } from './diagnostic-content.service';
 
 // ── DTOs (aligned on RPC return shapes) ─────────────────
 
@@ -46,11 +47,33 @@ export interface MaintenanceAlertMilestone {
   actions: MaintenanceAlertAction[];
 }
 
+/**
+ * Calendrier d'entretien agrégé (ADR-032 D9).
+ * Frontend `calendrier-entretien.tsx` consomme un seul fetch pour tout
+ * remplacer les 212 lignes de constants (`ENTRETIEN_PERIODIQUE`,
+ * `CONTROLES_MENSUELS`, `ALERTES_KM`).
+ */
+export interface MaintenanceCalendar {
+  type_id: number | null;
+  current_km: number;
+  fuel_type: string | null;
+  schedule: MaintenanceScheduleItem[];
+  alerts: MaintenanceAlertMilestone[];
+  controles_mensuels: Array<{
+    element: string;
+    icon: string;
+    detail: string;
+  }>;
+}
+
 const DEFAULT_MILESTONES = [10000, 30000, 60000, 100000, 150000];
 
 @Injectable()
 export class MaintenanceCalculatorService extends SupabaseBaseService {
   protected readonly logger = new Logger(MaintenanceCalculatorService.name);
+
+  @Inject(DiagnosticContentService)
+  protected readonly diagnosticContent!: DiagnosticContentService;
 
   /**
    * Schedule entretien périodique pour un véhicule donné.
@@ -111,5 +134,41 @@ export class MaintenanceCalculatorService extends SupabaseBaseService {
       return [];
     }
     return data ?? [];
+  }
+
+  /**
+   * Calendrier agrégé (ADR-032 D9).
+   *
+   * Combine schedule + alerts + controles-mensuels (wiki/support/) en un
+   * seul fetch pour le frontend `calendrier-entretien.tsx`.
+   *
+   * Note : la jointure `wiki/gamme/<slug>.md` pour `educational_advice`
+   * (D9 ADR-032) est différée Phase 4 RG-2/RG-3 (10 gammes entretien).
+   * Tant que ces wiki/gamme/ n'existent pas, `schedule[i].educational_advice`
+   * sera `undefined` et le frontend affiche un placeholder.
+   */
+  async getCalendar(
+    typeId: number | null,
+    currentKm: number,
+    fuelType?: string | null,
+  ): Promise<MaintenanceCalendar> {
+    const [schedule, alerts] = await Promise.all([
+      this.getSchedule(typeId, currentKm, fuelType),
+      this.getAlerts(fuelType),
+    ]);
+    const controlesEntry = this.diagnosticContent.getControlesMensuels();
+    const controlesItems = (controlesEntry?.entity_data?.items ?? []) as Array<{
+      element: string;
+      icon: string;
+      detail: string;
+    }>;
+    return {
+      type_id: typeId,
+      current_km: currentKm,
+      fuel_type: fuelType ?? null,
+      schedule,
+      alerts,
+      controles_mensuels: controlesItems,
+    };
   }
 }

--- a/backend/tests/unit/maintenance-calculator.service.test.ts
+++ b/backend/tests/unit/maintenance-calculator.service.test.ts
@@ -17,6 +17,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { MaintenanceCalculatorService } from '../../src/modules/diagnostic-engine/services/maintenance-calculator.service';
+import { DiagnosticContentService } from '../../src/modules/diagnostic-engine/services/diagnostic-content.service';
 
 describe('MaintenanceCalculatorService (ADR-032 PR-2)', () => {
   let service: MaintenanceCalculatorService;
@@ -40,6 +41,10 @@ describe('MaintenanceCalculatorService (ADR-032 PR-2)', () => {
       providers: [
         MaintenanceCalculatorService,
         { provide: ConfigService, useValue: mockConfig },
+        {
+          provide: DiagnosticContentService,
+          useValue: { getControlesMensuels: jest.fn().mockReturnValue(null) },
+        },
       ],
     }).compile();
 

--- a/backend/tests/unit/maintenance-calendar-endpoint.test.ts
+++ b/backend/tests/unit/maintenance-calendar-endpoint.test.ts
@@ -1,0 +1,121 @@
+/**
+ * MaintenanceCalculatorService.getCalendar() Unit Tests
+ *
+ * ADR-032 D9 — endpoint agrégé pour calendrier-entretien.tsx.
+ * Vérifie l'agrégation : schedule + alerts + controles_mensuels (wiki).
+ *
+ * @see backend/src/modules/diagnostic-engine/services/maintenance-calculator.service.ts
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { MaintenanceCalculatorService } from '../../src/modules/diagnostic-engine/services/maintenance-calculator.service';
+import { DiagnosticContentService } from '../../src/modules/diagnostic-engine/services/diagnostic-content.service';
+
+describe('MaintenanceCalculatorService.getCalendar() (ADR-032 D9)', () => {
+  let service: MaintenanceCalculatorService;
+  let mockRpc: jest.Mock;
+  let mockGetControles: jest.Mock;
+
+  beforeEach(async () => {
+    mockRpc = jest.fn();
+    mockGetControles = jest.fn();
+
+    const mockConfig = {
+      getOrThrow: jest.fn(() => 'mock'),
+      get: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MaintenanceCalculatorService,
+        { provide: ConfigService, useValue: mockConfig },
+        {
+          provide: DiagnosticContentService,
+          useValue: { getControlesMensuels: mockGetControles },
+        },
+      ],
+    }).compile();
+
+    service = module.get(MaintenanceCalculatorService);
+    (service as unknown as { callRpc: typeof mockRpc }).callRpc = mockRpc;
+  });
+
+  it('aggregates schedule + alerts + controles_mensuels into one payload', async () => {
+    // First RPC call : kg_get_smart_maintenance_schedule
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        {
+          rule_alias: 'vidange-essence',
+          rule_label: 'Vidange moteur essence',
+          km_interval: 15000,
+          month_interval: 12,
+          maintenance_priority: 'critique',
+          applies_to_fuel: 'essence',
+          km_remaining: 0,
+          status: 'overdue',
+        },
+      ],
+      error: null,
+    });
+    // Second RPC : kg_get_maintenance_alerts_by_milestone
+    mockRpc.mockResolvedValueOnce({
+      data: [
+        { milestone_km: 10000, actions: [] },
+        { milestone_km: 30000, actions: [{ rule_alias: 'vidange-essence' }] },
+        { milestone_km: 60000, actions: [] },
+        { milestone_km: 100000, actions: [] },
+        { milestone_km: 150000, actions: [] },
+      ],
+      error: null,
+    });
+    mockGetControles.mockReturnValue({
+      slug: 'controles-mensuels',
+      title: 'Contrôles mensuels',
+      entity_data: {
+        items: [
+          { element: 'Niveau d\'huile moteur', icon: 'Droplets', detail: '...' },
+          { element: 'Pression des pneus', icon: 'Gauge', detail: '...' },
+        ],
+      },
+      body: '',
+    });
+
+    const calendar = await service.getCalendar(12345, 80000);
+
+    expect(calendar.type_id).toBe(12345);
+    expect(calendar.current_km).toBe(80000);
+    expect(calendar.schedule).toHaveLength(1);
+    expect(calendar.alerts).toHaveLength(5);
+    expect(calendar.controles_mensuels).toHaveLength(2);
+    expect(calendar.controles_mensuels[0].element).toContain('huile');
+  });
+
+  it('returns empty controles_mensuels when wiki content missing (graceful)', async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+    mockGetControles.mockReturnValue(null);
+
+    const calendar = await service.getCalendar(null, 0);
+
+    expect(calendar.controles_mensuels).toEqual([]);
+    expect(calendar.schedule).toEqual([]);
+    expect(calendar.alerts).toEqual([]);
+  });
+
+  it('forwards fuel_type to both RPCs', async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+    mockGetControles.mockReturnValue(null);
+
+    await service.getCalendar(null, 50000, 'diesel');
+
+    expect(mockRpc).toHaveBeenCalledWith(
+      'kg_get_smart_maintenance_schedule',
+      expect.objectContaining({ p_fuel_type: 'diesel' }),
+      expect.any(Object),
+    );
+    expect(mockRpc).toHaveBeenCalledWith(
+      'kg_get_maintenance_alerts_by_milestone',
+      expect.objectContaining({ p_fuel_type: 'diesel' }),
+      expect.any(Object),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 5 préalable — endpoint **/calendar agrégé** (D9 ADR-032) pour PR-7 frontend `calendrier-entretien.tsx`.

\`MaintenanceCalculatorService.getCalendar(typeId, currentKm, fuelType?)\` agrège en un seul appel :
- \`schedule\` : RPC \`kg_get_smart_maintenance_schedule\` (D2/D3)
- \`alerts\` : RPC \`kg_get_maintenance_alerts_by_milestone\` (D7)
- \`controles_mensuels\` : \`DiagnosticContentService.getControlesMensuels()\` (D5 submodule wiki/support/)

Single fetch côté Remix loader = zéro hardcode des 3 sections (\`ENTRETIEN_PERIODIQUE\`, \`ALERTES_KM\`, \`CONTROLES_MENSUELS\`).

## Endpoint

\`\`\`
GET /api/diagnostic-engine/calendar?type_id=X&current_km=Y&fuel_type=Z
\`\`\`

## Note

Jointure \`wiki/gamme/<slug>.md\` pour \`educational_advice\` (D9 ADR-032) reportée Phase 4 RG-2/RG-3 (10 gammes entretien). Tant que les wiki/gamme/ pour l'entretien sont vides, le frontend affichera un placeholder pour les conseils. Pas bloquant.

## Test plan

- 3 tests Jest unit (aggregation, graceful empty controles, fuel_type forward).
- CI verte (Jest + ESLint + TS + RPC Safety Gate avec callRpc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)