### PR TITLE
fix(auth): canonical permissions matrix at backend (unblock commercial actions)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -23,7 +23,6 @@ depends_on:
 - SystemModule
 - AiContentModule
 - VehiclesModule
-- OperatingMatrixModule
 ---
 
 # Module Admin

--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -23,6 +23,7 @@ depends_on:
 - SystemModule
 - AiContentModule
 - VehiclesModule
+- OperatingMatrixModule
 ---
 
 # Module Admin

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-content-roadmap.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-04-29'
+last_scan: '2026-04-30'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -13,6 +13,8 @@ import { CookieSerializer } from './cookie-serializer';
 import { IsAdminGuard } from './is-admin.guard';
 import { LocalAuthGuard } from './local-auth.guard';
 import { LocalStrategy } from './local.strategy';
+import { PermissionsService } from './permissions.service';
+import { PermissionsGuard } from './guards/permissions.guard';
 
 @Module({
   imports: [
@@ -41,7 +43,9 @@ import { LocalStrategy } from './local.strategy';
     LocalAuthGuard,
     CookieSerializer,
     IsAdminGuard,
+    PermissionsService,
+    PermissionsGuard,
   ],
-  exports: [AuthService],
+  exports: [AuthService, PermissionsService, PermissionsGuard],
 })
 export class AuthModule {}

--- a/backend/src/auth/controllers/auth-permissions.controller.ts
+++ b/backend/src/auth/controllers/auth-permissions.controller.ts
@@ -2,13 +2,21 @@ import { Controller, Get, Post, Body, Param, Logger } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthService } from '../auth.service';
 import { ModuleAccessDto, BulkModuleAccessDto } from '../dto/module-access.dto';
+import { PermissionsService } from '../permissions.service';
+import {
+  BASE_USER_PERMISSIONS,
+  UserPermissions,
+} from '../dto/user-permissions.dto';
 
 @ApiTags('auth')
 @Controller()
 export class AuthPermissionsController {
   private readonly logger = new Logger(AuthPermissionsController.name);
 
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly permissionsService: PermissionsService,
+  ) {}
 
   /**
    * POST /auth/module-access
@@ -63,40 +71,24 @@ export class AuthPermissionsController {
 
   /**
    * GET /auth/user-permissions/:userId
-   * Obtenir toutes les permissions d'un utilisateur (optimisé pour cache frontend)
+   * Returns the canonical UserPermissions shape (15 booleans) consumed by
+   * the frontend. Single source of truth for per-action permissions.
    */
   @Get('auth/user-permissions/:userId')
-  async getUserPermissions(@Param('userId') userId: string) {
+  async getUserPermissions(
+    @Param('userId') userId: string,
+  ): Promise<UserPermissions> {
     try {
-      const modules = [
-        'commercial',
-        'admin',
-        'seo',
-        'expedition',
-        'inventory',
-        'finance',
-        'reports',
-      ];
-      const permissions: Record<string, { read: boolean; write: boolean }> = {};
-
-      await Promise.all(
-        modules.map(async (module) => {
-          const [readAccess, writeAccess] = await Promise.all([
-            this.authService.checkModuleAccess(userId, module, 'read'),
-            this.authService.checkModuleAccess(userId, module, 'write'),
-          ]);
-
-          permissions[module] = {
-            read: readAccess.hasAccess,
-            write: writeAccess.hasAccess,
-          };
-        }),
-      );
-
-      return permissions;
+      const user = await this.authService.getUserById(userId);
+      if (!user || user.isActive === false) {
+        return BASE_USER_PERMISSIONS;
+      }
+      const level = parseInt(String(user.level ?? 0), 10) || 0;
+      return this.permissionsService.getPermissions(level);
     } catch (error: unknown) {
-      this.logger.error(`Error fetching user permissions: ${error}`);
-      return {};
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Error fetching user permissions: ${message}`);
+      return BASE_USER_PERMISSIONS;
     }
   }
 }

--- a/backend/src/auth/decorators/require-permission.decorator.ts
+++ b/backend/src/auth/decorators/require-permission.decorator.ts
@@ -1,0 +1,16 @@
+import { SetMetadata } from '@nestjs/common';
+import type { PermissionAction } from '../dto/user-permissions.dto';
+
+export const REQUIRE_PERMISSION_KEY = 'require_permission';
+
+/**
+ * Marks a controller method as requiring a specific per-action permission.
+ * Read by PermissionsGuard via Reflector.
+ *
+ * @example
+ *   @Post(':orderId/cancel')
+ *   @RequirePermission('canCancel')
+ *   async cancelOrder(...) { ... }
+ */
+export const RequirePermission = (action: PermissionAction) =>
+  SetMetadata(REQUIRE_PERMISSION_KEY, action);

--- a/backend/src/auth/dto/user-permissions.dto.ts
+++ b/backend/src/auth/dto/user-permissions.dto.ts
@@ -1,0 +1,103 @@
+/**
+ * Canonical permission shape — single source of truth for the per-action
+ * permission matrix. Mirror of the frontend interface, owned by the backend.
+ */
+export interface UserPermissions {
+  // Order actions
+  canValidate: boolean;
+  canShip: boolean;
+  canDeliver: boolean;
+  canCancel: boolean;
+  canReturn: boolean;
+  canRefund: boolean;
+  canSendEmails: boolean;
+  // Management
+  canCreateOrders: boolean;
+  canExport: boolean;
+  canMarkPaid: boolean;
+  // Display
+  canSeeFullStats: boolean;
+  canSeeFinancials: boolean;
+  canSeeCustomerDetails: boolean;
+  // Interface
+  showAdvancedFilters: boolean;
+  showActionButtons: boolean;
+}
+
+export const BASE_USER_PERMISSIONS: UserPermissions = {
+  canValidate: false,
+  canShip: false,
+  canDeliver: false,
+  canCancel: false,
+  canReturn: false,
+  canRefund: false,
+  canSendEmails: false,
+  canCreateOrders: false,
+  canExport: false,
+  canMarkPaid: false,
+  canSeeFullStats: false,
+  canSeeFinancials: false,
+  canSeeCustomerDetails: false,
+  showAdvancedFilters: false,
+  showActionButtons: false,
+};
+
+export const COMMERCIAL_PERMISSIONS: UserPermissions = {
+  canValidate: true,
+  canShip: true,
+  canDeliver: true,
+  canCancel: true,
+  canReturn: false,
+  canRefund: false,
+  canSendEmails: true,
+  canCreateOrders: false,
+  canExport: true,
+  canMarkPaid: true,
+  canSeeFullStats: false,
+  canSeeFinancials: false,
+  canSeeCustomerDetails: true,
+  showAdvancedFilters: true,
+  showActionButtons: true,
+};
+
+export const MANAGER_PERMISSIONS: UserPermissions = {
+  canValidate: false,
+  canShip: false,
+  canDeliver: false,
+  canCancel: false,
+  canReturn: false,
+  canRefund: false,
+  canSendEmails: false,
+  canCreateOrders: false,
+  canExport: true,
+  canMarkPaid: false,
+  canSeeFullStats: true,
+  canSeeFinancials: true,
+  canSeeCustomerDetails: true,
+  showAdvancedFilters: true,
+  showActionButtons: false,
+};
+
+export const ADMIN_PERMISSIONS: UserPermissions = {
+  canValidate: true,
+  canShip: true,
+  canDeliver: true,
+  canCancel: true,
+  canReturn: true,
+  canRefund: true,
+  canSendEmails: true,
+  canCreateOrders: true,
+  canExport: true,
+  canMarkPaid: true,
+  canSeeFullStats: true,
+  canSeeFinancials: true,
+  canSeeCustomerDetails: true,
+  showAdvancedFilters: true,
+  showActionButtons: true,
+};
+
+export const SUPER_ADMIN_PERMISSIONS: UserPermissions = {
+  ...ADMIN_PERMISSIONS,
+};
+
+export type PermissionAction = keyof UserPermissions;

--- a/backend/src/auth/guards/permissions.guard.test.ts
+++ b/backend/src/auth/guards/permissions.guard.test.ts
@@ -1,0 +1,62 @@
+import { Test } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import type { ExecutionContext } from '@nestjs/common';
+import { PermissionsGuard } from './permissions.guard';
+import { PermissionsService } from '../permissions.service';
+
+function makeContext(user: any): ExecutionContext {
+  const handler = () => undefined;
+  return {
+    switchToHttp: () => ({ getRequest: () => ({ user }) }),
+    getHandler: () => handler,
+    getClass: () => class {},
+  } as unknown as ExecutionContext;
+}
+
+describe('PermissionsGuard', () => {
+  let guard: PermissionsGuard;
+  let reflector: Reflector;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [PermissionsGuard, PermissionsService, Reflector],
+    }).compile();
+    guard = moduleRef.get(PermissionsGuard);
+    reflector = moduleRef.get(Reflector);
+  });
+
+  it('returns true when no @RequirePermission metadata', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue(undefined);
+    expect(guard.canActivate(makeContext({ level: 0 }))).toBe(true);
+  });
+
+  it('returns true when commercial (level 3) has canCancel', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canCancel');
+    expect(guard.canActivate(makeContext({ level: 3 }))).toBe(true);
+  });
+
+  it('returns false when base user (level 1) lacks canCancel', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canCancel');
+    expect(guard.canActivate(makeContext({ level: 1 }))).toBe(false);
+  });
+
+  it('returns false when user is undefined', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canCancel');
+    expect(guard.canActivate(makeContext(undefined))).toBe(false);
+  });
+
+  it('returns true when admin (level 7) has canRefund', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canRefund');
+    expect(guard.canActivate(makeContext({ level: 7 }))).toBe(true);
+  });
+
+  it('returns false when commercial (level 3) lacks canRefund', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canRefund');
+    expect(guard.canActivate(makeContext({ level: 3 }))).toBe(false);
+  });
+
+  it('coerces string level to number', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canCancel');
+    expect(guard.canActivate(makeContext({ level: '3' }))).toBe(true);
+  });
+});

--- a/backend/src/auth/guards/permissions.guard.ts
+++ b/backend/src/auth/guards/permissions.guard.ts
@@ -1,0 +1,45 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { REQUIRE_PERMISSION_KEY } from '../decorators/require-permission.decorator';
+import type { PermissionAction } from '../dto/user-permissions.dto';
+import { PermissionsService } from '../permissions.service';
+
+/**
+ * Guard reading @RequirePermission(action) metadata and consulting
+ * PermissionsService against the current user's level. Pairs with
+ * AuthenticatedGuard upstream for session validity.
+ */
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  private readonly logger = new Logger(PermissionsGuard.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly permissionsService: PermissionsService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const action = this.reflector.get<PermissionAction>(
+      REQUIRE_PERMISSION_KEY,
+      context.getHandler(),
+    );
+    if (!action) return true;
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const level = parseInt(String(user?.level ?? 0), 10) || 0;
+    const ok = this.permissionsService.hasPermission(level, action);
+
+    if (!ok) {
+      this.logger.warn(
+        `Permission denied: ${user?.email ?? 'anonymous'} (level=${level}) lacks "${action}"`,
+      );
+    }
+    return ok;
+  }
+}

--- a/backend/src/auth/permissions.service.test.ts
+++ b/backend/src/auth/permissions.service.test.ts
@@ -1,0 +1,90 @@
+import { Test } from '@nestjs/testing';
+import { PermissionsService } from './permissions.service';
+import type { PermissionAction } from './dto/user-permissions.dto';
+
+describe('PermissionsService', () => {
+  let service: PermissionsService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [PermissionsService],
+    }).compile();
+    service = moduleRef.get(PermissionsService);
+  });
+
+  describe('getPermissions', () => {
+    it('returns BASE_USER for level 0', () => {
+      const p = service.getPermissions(0);
+      expect(p.canCancel).toBe(false);
+      expect(p.showActionButtons).toBe(false);
+    });
+
+    it('returns COMMERCIAL for level 3', () => {
+      const p = service.getPermissions(3);
+      expect(p.canCancel).toBe(true);
+      expect(p.canShip).toBe(true);
+      expect(p.canDeliver).toBe(true);
+      expect(p.canMarkPaid).toBe(true);
+      expect(p.canRefund).toBe(false);
+      expect(p.canCreateOrders).toBe(false);
+    });
+
+    it('returns MANAGER for level 5', () => {
+      const p = service.getPermissions(5);
+      expect(p.canCancel).toBe(false);
+      expect(p.canExport).toBe(true);
+      expect(p.canSeeFinancials).toBe(true);
+    });
+
+    it('returns ADMIN for level 7', () => {
+      const p = service.getPermissions(7);
+      expect(p.canCancel).toBe(true);
+      expect(p.canRefund).toBe(true);
+      expect(p.canCreateOrders).toBe(true);
+    });
+
+    it('returns SUPER_ADMIN for level 9', () => {
+      const p = service.getPermissions(9);
+      expect(p.canRefund).toBe(true);
+      expect(p.canCreateOrders).toBe(true);
+    });
+  });
+
+  describe('hasPermission', () => {
+    const cases: Array<[number, PermissionAction, boolean]> = [
+      [3, 'canValidate', true],
+      [3, 'canShip', true],
+      [3, 'canDeliver', true],
+      [3, 'canCancel', true],
+      [3, 'canReturn', false],
+      [3, 'canRefund', false],
+      [3, 'canSendEmails', true],
+      [3, 'canCreateOrders', false],
+      [3, 'canExport', true],
+      [3, 'canMarkPaid', true],
+      [3, 'canSeeFullStats', false],
+      [3, 'canSeeFinancials', false],
+      [3, 'canSeeCustomerDetails', true],
+      [3, 'showAdvancedFilters', true],
+      [3, 'showActionButtons', true],
+      [5, 'canCancel', false],
+      [5, 'canShip', false],
+      [5, 'canDeliver', false],
+      [5, 'canMarkPaid', false],
+      [5, 'canExport', true],
+      [5, 'canSeeFinancials', true],
+      [7, 'canCancel', true],
+      [7, 'canRefund', true],
+      [7, 'canReturn', true],
+      [7, 'canCreateOrders', true],
+      [1, 'canCancel', false],
+      [1, 'canExport', false],
+      [0, 'canCancel', false],
+      [-1, 'canCancel', false],
+    ];
+
+    it.each(cases)('level %i / %s -> %s', (level, action, expected) => {
+      expect(service.hasPermission(level, action)).toBe(expected);
+    });
+  });
+});

--- a/backend/src/auth/permissions.service.ts
+++ b/backend/src/auth/permissions.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import {
+  ADMIN_PERMISSIONS,
+  BASE_USER_PERMISSIONS,
+  COMMERCIAL_PERMISSIONS,
+  MANAGER_PERMISSIONS,
+  PermissionAction,
+  SUPER_ADMIN_PERMISSIONS,
+  UserPermissions,
+} from './dto/user-permissions.dto';
+
+/**
+ * Canonical per-action permission resolver. Single source of truth for
+ * "can role X perform action Y". Consumed by PermissionsGuard at runtime
+ * and by GET /auth/user-permissions/:userId for the frontend.
+ */
+@Injectable()
+export class PermissionsService {
+  getPermissions(userLevel: number): UserPermissions {
+    const lvl = Number.isFinite(userLevel) ? userLevel : 0;
+    if (lvl >= 9) return SUPER_ADMIN_PERMISSIONS;
+    if (lvl >= 7) return ADMIN_PERMISSIONS;
+    if (lvl >= 5) return MANAGER_PERMISSIONS;
+    if (lvl >= 3) return COMMERCIAL_PERMISSIONS;
+    return BASE_USER_PERMISSIONS;
+  }
+
+  hasPermission(userLevel: number, action: PermissionAction): boolean {
+    return this.getPermissions(userLevel)[action] === true;
+  }
+}

--- a/backend/src/modules/orders/controllers/order-actions.controller.ts
+++ b/backend/src/modules/orders/controllers/order-actions.controller.ts
@@ -13,17 +13,20 @@ import {
 } from '@nestjs/common';
 import { Request } from 'express';
 import { AuthenticatedGuard } from '@auth/authenticated.guard';
-import { IsAdminGuard } from '@auth/is-admin.guard';
+import { PermissionsGuard } from '@auth/guards/permissions.guard';
+import { RequirePermission } from '@auth/decorators/require-permission.decorator';
 import { OrderActionsService } from '../services/order-actions.service';
 import { MailService } from '../../../services/mail.service';
 
 /**
  * 🎮 Controller Actions Commandes
  *
- * Endpoints pour toutes les actions backoffice
+ * Endpoints pour toutes les actions backoffice. Permissions per-action via
+ * @RequirePermission(canX) consultant la matrice canonique PermissionsService.
+ * Cf docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md
  */
 @Controller('api/admin/orders')
-@UseGuards(AuthenticatedGuard, IsAdminGuard)
+@UseGuards(AuthenticatedGuard, PermissionsGuard)
 export class OrderActionsController {
   private readonly logger = new Logger(OrderActionsController.name);
 
@@ -37,6 +40,7 @@ export class OrderActionsController {
    * Changer statut ligne (1-6, 91-94)
    */
   @Patch(':orderId/lines/:lineId/status/:newStatus')
+  @RequirePermission('canValidate')
   async updateLineStatus(
     @Param('orderId', ParseIntPipe) orderId: number,
     @Param('lineId', ParseIntPipe) lineId: number,
@@ -61,6 +65,7 @@ export class OrderActionsController {
    * Commander chez fournisseur (statut 6)
    */
   @Post(':orderId/lines/:lineId/order-from-supplier')
+  @RequirePermission('canValidate')
   async orderFromSupplier(
     @Param('orderId', ParseIntPipe) orderId: number,
     @Param('lineId', ParseIntPipe) lineId: number,
@@ -89,6 +94,7 @@ export class OrderActionsController {
    * Proposer équivalence (statut 91)
    */
   @Post(':orderId/lines/:lineId/propose-equivalent')
+  @RequirePermission('canValidate')
   async proposeEquivalent(
     @Param('orderId', ParseIntPipe) orderId: number,
     @Param('lineId', ParseIntPipe) lineId: number,
@@ -109,6 +115,7 @@ export class OrderActionsController {
    * Accepter équivalence (statut 92)
    */
   @Patch(':orderId/lines/:lineId/accept-equivalent')
+  @RequirePermission('canValidate')
   async acceptEquivalent(
     @Param('orderId', ParseIntPipe) orderId: number,
     @Param('lineId', ParseIntPipe) lineId: number,
@@ -121,6 +128,7 @@ export class OrderActionsController {
    * Refuser équivalence (statut 93)
    */
   @Patch(':orderId/lines/:lineId/reject-equivalent')
+  @RequirePermission('canValidate')
   async rejectEquivalent(
     @Param('orderId', ParseIntPipe) orderId: number,
     @Param('lineId', ParseIntPipe) lineId: number,
@@ -137,6 +145,7 @@ export class OrderActionsController {
    * Valider commande (statut 2 → 3)
    */
   @Post(':orderId/validate')
+  @RequirePermission('canValidate')
   async validateOrder(@Param('orderId') orderId: string) {
     try {
       this.logger.log(`🔍 Validation commande ${orderId} démarrée`);
@@ -172,6 +181,7 @@ export class OrderActionsController {
    * Expédier commande (statut 3 → 4)
    */
   @Post(':orderId/ship')
+  @RequirePermission('canShip')
   async shipOrder(
     @Param('orderId') orderId: string,
     @Body() body: { trackingNumber: string },
@@ -220,6 +230,7 @@ export class OrderActionsController {
    * Marquer comme livrée (statut 4 → 5)
    */
   @Post(':orderId/deliver')
+  @RequirePermission('canDeliver')
   async markAsDelivered(@Param('orderId') orderId: string) {
     try {
       this.logger.log(`🚚 Livraison commande ${orderId}`);
@@ -244,6 +255,7 @@ export class OrderActionsController {
    * Annuler commande
    */
   @Post(':orderId/cancel')
+  @RequirePermission('canCancel')
   async cancelOrder(
     @Param('orderId') orderId: string,
     @Body() body: { reason: string },
@@ -291,6 +303,7 @@ export class OrderActionsController {
    * Confirmer paiement manuellement (admin)
    */
   @Post(':orderId/confirm-payment')
+  @RequirePermission('canMarkPaid')
   async confirmPayment(@Param('orderId') orderId: string) {
     try {
       this.logger.log(`💰 Confirmation paiement manuel commande ${orderId}`);
@@ -315,6 +328,7 @@ export class OrderActionsController {
    * Envoyer rappel de paiement
    */
   @Post(':orderId/payment-reminder')
+  @RequirePermission('canSendEmails')
   async sendPaymentReminder(@Param('orderId') orderId: string) {
     try {
       this.logger.log(`📧 Envoi rappel paiement pour commande ${orderId}`);

--- a/docs/superpowers/plans/2026-04-30-permissions-canonical-backend.md
+++ b/docs/superpowers/plans/2026-04-30-permissions-canonical-backend.md
@@ -1,0 +1,1158 @@
+# Permissions Canonical Backend — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the per-action permission matrix from frontend to backend as single source of truth, replace `IsAdminGuard` with `@RequirePermission(action)` on `OrderActionsController`, and refactor frontend `permissions.ts` into a thin API client. Fix the prod bug where commercial-level users get HTTP 403 on order cancel/ship/deliver/mark-paid.
+
+**Architecture:** Backend `PermissionsService` owns the canonical matrix (5 user levels × 15 actions, ported as-is from frontend). `PermissionsGuard` reads `@RequirePermission('canCancel')` decorator and consults the service. Endpoint `GET /auth/user-permissions/:userId` returns `UserPermissions` shape. Frontend `permissions.ts` exposes `loadUserPermissions(userId)` instead of computing locally. `IsAdminGuard` stays in place for genuinely admin-only routes (out of scope).
+
+**Tech Stack:** NestJS 10, TypeScript 5, Jest, Remix 2 (loaders), Vitest (frontend tests if any).
+
+**Spec:** [`docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md`](../specs/2026-04-30-permissions-canonical-backend-design.md)
+
+**Branch:** Continue on `feat/fe-diagnostic-wizard-dynamic` is **NOT** acceptable (per memory `feedback_branch_scope_discipline.md`). Create dedicated branch from `main`: `fix/permissions-canonical-backend`.
+
+---
+
+## File Structure
+
+### Created (8 files)
+
+| Path | Responsibility |
+|---|---|
+| `backend/src/auth/dto/user-permissions.dto.ts` | `UserPermissions` interface + 5 level constants (BASE_USER / COMMERCIAL / MANAGER / ADMIN / SUPER_ADMIN) |
+| `backend/src/auth/permissions.service.ts` | `getPermissions(level)` + `hasPermission(level, action)` |
+| `backend/src/auth/permissions.service.spec.ts` | 75 cases unit (5 levels × 15 actions) |
+| `backend/src/auth/decorators/require-permission.decorator.ts` | `@RequirePermission(action)` SetMetadata helper |
+| `backend/src/auth/guards/permissions.guard.ts` | Reflector + `PermissionsService` → boolean |
+| `backend/src/auth/guards/permissions.guard.spec.ts` | Unit guard (with/without decorator, with/without user, level cases) |
+| `backend/test/orders-cancel-permissions.e2e-spec.ts` | E2E cancel with commercial / level-1 / no session |
+
+### Modified (5 files)
+
+| Path | Why |
+|---|---|
+| `backend/src/auth/auth.module.ts` | Register `PermissionsService` + `PermissionsGuard` (providers + exports) |
+| `backend/src/auth/controllers/auth-permissions.controller.ts` | Refactor `GET /auth/user-permissions/:userId` to return `UserPermissions` shape |
+| `backend/src/modules/orders/controllers/order-actions.controller.ts` | Replace `IsAdminGuard` with `PermissionsGuard` + add `@RequirePermission(...)` per endpoint |
+| `frontend/app/utils/permissions.ts` | Remove `getUserPermissions(level)`, add `loadUserPermissions(userId)` thin client |
+| `frontend/app/routes/admin.orders._index.tsx` | Loader + component use `loadUserPermissions(user.id)` |
+| `frontend/app/routes/commercial.orders._index.tsx` | Same |
+
+---
+
+## Pre-flight: branch setup
+
+- [ ] **Step 0.1: Create branch from main**
+
+```bash
+cd /opt/automecanik/app
+git fetch origin main
+git checkout -b fix/permissions-canonical-backend origin/main
+```
+
+Expected: `Switched to a new branch 'fix/permissions-canonical-backend'` (tracks `origin/main`).
+
+**Why a fresh branch from main:** memory `feedback_branch_scope_discipline.md` (incident PR #79) — never inherit a fourre-tout branch.
+
+- [ ] **Step 0.2: Cherry-pick the spec commit onto the new branch**
+
+```bash
+git cherry-pick 1007926e
+```
+
+Expected: spec doc applied. (The pre-commit hook may re-touch `.claude/knowledge/*` — that's fine.)
+
+---
+
+## Task 1: `UserPermissions` DTO + level constants
+
+**Files:**
+- Create: `backend/src/auth/dto/user-permissions.dto.ts`
+
+- [ ] **Step 1.1: Create the DTO file**
+
+Content (port matches `frontend/app/utils/permissions.ts:36-139` byte-for-byte semantically):
+
+```ts
+// backend/src/auth/dto/user-permissions.dto.ts
+/**
+ * Canonical permission shape — single source of truth.
+ * Mirror of the frontend interface, owned by the backend.
+ */
+export interface UserPermissions {
+  // Order actions
+  canValidate: boolean;
+  canShip: boolean;
+  canDeliver: boolean;
+  canCancel: boolean;
+  canReturn: boolean;
+  canRefund: boolean;
+  canSendEmails: boolean;
+  // Management
+  canCreateOrders: boolean;
+  canExport: boolean;
+  canMarkPaid: boolean;
+  // Display
+  canSeeFullStats: boolean;
+  canSeeFinancials: boolean;
+  canSeeCustomerDetails: boolean;
+  // Interface
+  showAdvancedFilters: boolean;
+  showActionButtons: boolean;
+}
+
+export const BASE_USER_PERMISSIONS: UserPermissions = {
+  canValidate: false,
+  canShip: false,
+  canDeliver: false,
+  canCancel: false,
+  canReturn: false,
+  canRefund: false,
+  canSendEmails: false,
+  canCreateOrders: false,
+  canExport: false,
+  canMarkPaid: false,
+  canSeeFullStats: false,
+  canSeeFinancials: false,
+  canSeeCustomerDetails: false,
+  showAdvancedFilters: false,
+  showActionButtons: false,
+};
+
+export const COMMERCIAL_PERMISSIONS: UserPermissions = {
+  canValidate: true,
+  canShip: true,
+  canDeliver: true,
+  canCancel: true,
+  canReturn: false,
+  canRefund: false,
+  canSendEmails: true,
+  canCreateOrders: false,
+  canExport: true,
+  canMarkPaid: true,
+  canSeeFullStats: false,
+  canSeeFinancials: false,
+  canSeeCustomerDetails: true,
+  showAdvancedFilters: true,
+  showActionButtons: true,
+};
+
+export const MANAGER_PERMISSIONS: UserPermissions = {
+  canValidate: false,
+  canShip: false,
+  canDeliver: false,
+  canCancel: false,
+  canReturn: false,
+  canRefund: false,
+  canSendEmails: false,
+  canCreateOrders: false,
+  canExport: true,
+  canMarkPaid: false,
+  canSeeFullStats: true,
+  canSeeFinancials: true,
+  canSeeCustomerDetails: true,
+  showAdvancedFilters: true,
+  showActionButtons: false,
+};
+
+export const ADMIN_PERMISSIONS: UserPermissions = {
+  canValidate: true,
+  canShip: true,
+  canDeliver: true,
+  canCancel: true,
+  canReturn: true,
+  canRefund: true,
+  canSendEmails: true,
+  canCreateOrders: true,
+  canExport: true,
+  canMarkPaid: true,
+  canSeeFullStats: true,
+  canSeeFinancials: true,
+  canSeeCustomerDetails: true,
+  showAdvancedFilters: true,
+  showActionButtons: true,
+};
+
+export const SUPER_ADMIN_PERMISSIONS: UserPermissions = {
+  ...ADMIN_PERMISSIONS,
+};
+
+export type PermissionAction = keyof UserPermissions;
+```
+
+- [ ] **Step 1.2: Type-check**
+
+```bash
+cd backend && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add backend/src/auth/dto/user-permissions.dto.ts
+git commit -m "feat(auth): add UserPermissions DTO + level constants"
+```
+
+---
+
+## Task 2: `PermissionsService` (TDD)
+
+**Files:**
+- Create: `backend/src/auth/permissions.service.ts`
+- Test: `backend/src/auth/permissions.service.spec.ts`
+
+- [ ] **Step 2.1: Write the failing test**
+
+```ts
+// backend/src/auth/permissions.service.spec.ts
+import { Test } from '@nestjs/testing';
+import { PermissionsService } from './permissions.service';
+import type { PermissionAction } from './dto/user-permissions.dto';
+
+describe('PermissionsService', () => {
+  let service: PermissionsService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [PermissionsService],
+    }).compile();
+    service = moduleRef.get(PermissionsService);
+  });
+
+  describe('getPermissions', () => {
+    it('returns BASE_USER for level 0', () => {
+      const p = service.getPermissions(0);
+      expect(p.canCancel).toBe(false);
+      expect(p.showActionButtons).toBe(false);
+    });
+
+    it('returns COMMERCIAL for level 3', () => {
+      const p = service.getPermissions(3);
+      expect(p.canCancel).toBe(true);
+      expect(p.canShip).toBe(true);
+      expect(p.canDeliver).toBe(true);
+      expect(p.canMarkPaid).toBe(true);
+      expect(p.canRefund).toBe(false);
+      expect(p.canCreateOrders).toBe(false);
+    });
+
+    it('returns MANAGER for level 5', () => {
+      const p = service.getPermissions(5);
+      expect(p.canCancel).toBe(false);
+      expect(p.canExport).toBe(true);
+      expect(p.canSeeFinancials).toBe(true);
+    });
+
+    it('returns ADMIN for level 7', () => {
+      const p = service.getPermissions(7);
+      expect(p.canCancel).toBe(true);
+      expect(p.canRefund).toBe(true);
+      expect(p.canCreateOrders).toBe(true);
+    });
+
+    it('returns SUPER_ADMIN for level 9', () => {
+      const p = service.getPermissions(9);
+      expect(p.canRefund).toBe(true);
+      expect(p.canCreateOrders).toBe(true);
+    });
+  });
+
+  describe('hasPermission', () => {
+    const cases: Array<[number, PermissionAction, boolean]> = [
+      // Commercial (3) — 15 actions
+      [3, 'canValidate', true],
+      [3, 'canShip', true],
+      [3, 'canDeliver', true],
+      [3, 'canCancel', true],
+      [3, 'canReturn', false],
+      [3, 'canRefund', false],
+      [3, 'canSendEmails', true],
+      [3, 'canCreateOrders', false],
+      [3, 'canExport', true],
+      [3, 'canMarkPaid', true],
+      [3, 'canSeeFullStats', false],
+      [3, 'canSeeFinancials', false],
+      [3, 'canSeeCustomerDetails', true],
+      [3, 'showAdvancedFilters', true],
+      [3, 'showActionButtons', true],
+      // Manager (5) — operational locked
+      [5, 'canCancel', false],
+      [5, 'canShip', false],
+      [5, 'canDeliver', false],
+      [5, 'canMarkPaid', false],
+      [5, 'canExport', true],
+      [5, 'canSeeFinancials', true],
+      // Admin (7) — full operational
+      [7, 'canCancel', true],
+      [7, 'canRefund', true],
+      [7, 'canReturn', true],
+      [7, 'canCreateOrders', true],
+      // Base (1) — nothing
+      [1, 'canCancel', false],
+      [1, 'canExport', false],
+      // Edge: 0
+      [0, 'canCancel', false],
+      // Edge: negative / NaN coerced upstream → treated as 0
+      [-1, 'canCancel', false],
+    ];
+
+    it.each(cases)('level %i / %s → %s', (level, action, expected) => {
+      expect(service.hasPermission(level, action)).toBe(expected);
+    });
+  });
+});
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+```bash
+cd backend && npx jest src/auth/permissions.service.spec.ts --no-coverage
+```
+
+Expected: FAIL — `Cannot find module './permissions.service'`.
+
+- [ ] **Step 2.3: Write minimal implementation**
+
+```ts
+// backend/src/auth/permissions.service.ts
+import { Injectable } from '@nestjs/common';
+import {
+  ADMIN_PERMISSIONS,
+  BASE_USER_PERMISSIONS,
+  COMMERCIAL_PERMISSIONS,
+  MANAGER_PERMISSIONS,
+  PermissionAction,
+  SUPER_ADMIN_PERMISSIONS,
+  UserPermissions,
+} from './dto/user-permissions.dto';
+
+@Injectable()
+export class PermissionsService {
+  getPermissions(userLevel: number): UserPermissions {
+    const lvl = Number.isFinite(userLevel) ? userLevel : 0;
+    if (lvl >= 9) return SUPER_ADMIN_PERMISSIONS;
+    if (lvl >= 7) return ADMIN_PERMISSIONS;
+    if (lvl >= 5) return MANAGER_PERMISSIONS;
+    if (lvl >= 3) return COMMERCIAL_PERMISSIONS;
+    return BASE_USER_PERMISSIONS;
+  }
+
+  hasPermission(userLevel: number, action: PermissionAction): boolean {
+    return this.getPermissions(userLevel)[action] === true;
+  }
+}
+```
+
+- [ ] **Step 2.4: Run test to verify it passes**
+
+```bash
+cd backend && npx jest src/auth/permissions.service.spec.ts --no-coverage
+```
+
+Expected: PASS — all `it.each` cases green.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add backend/src/auth/permissions.service.ts backend/src/auth/permissions.service.spec.ts
+git commit -m "feat(auth): add PermissionsService with canonical matrix"
+```
+
+---
+
+## Task 3: `@RequirePermission` decorator
+
+**Files:**
+- Create: `backend/src/auth/decorators/require-permission.decorator.ts`
+
+- [ ] **Step 3.1: Create the decorator**
+
+```ts
+// backend/src/auth/decorators/require-permission.decorator.ts
+import { SetMetadata } from '@nestjs/common';
+import type { PermissionAction } from '../dto/user-permissions.dto';
+
+export const REQUIRE_PERMISSION_KEY = 'require_permission';
+
+export const RequirePermission = (action: PermissionAction) =>
+  SetMetadata(REQUIRE_PERMISSION_KEY, action);
+```
+
+- [ ] **Step 3.2: Type-check**
+
+```bash
+cd backend && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add backend/src/auth/decorators/require-permission.decorator.ts
+git commit -m "feat(auth): add @RequirePermission decorator"
+```
+
+---
+
+## Task 4: `PermissionsGuard` (TDD)
+
+**Files:**
+- Create: `backend/src/auth/guards/permissions.guard.ts`
+- Test: `backend/src/auth/guards/permissions.guard.spec.ts`
+
+- [ ] **Step 4.1: Write the failing test**
+
+```ts
+// backend/src/auth/guards/permissions.guard.spec.ts
+import { Test } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
+import { PermissionsGuard } from './permissions.guard';
+import { PermissionsService } from '../permissions.service';
+import { REQUIRE_PERMISSION_KEY } from '../decorators/require-permission.decorator';
+import type { ExecutionContext } from '@nestjs/common';
+
+function makeContext(user: any, handler = () => undefined): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => ({ user }) }),
+    getHandler: () => handler,
+    getClass: () => class {},
+  } as unknown as ExecutionContext;
+}
+
+describe('PermissionsGuard', () => {
+  let guard: PermissionsGuard;
+  let reflector: Reflector;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [PermissionsGuard, PermissionsService, Reflector],
+    }).compile();
+    guard = moduleRef.get(PermissionsGuard);
+    reflector = moduleRef.get(Reflector);
+  });
+
+  it('returns true when no @RequirePermission metadata', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue(undefined);
+    expect(guard.canActivate(makeContext({ level: 0 }))).toBe(true);
+  });
+
+  it('returns true when commercial (level 3) has canCancel', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canCancel');
+    expect(guard.canActivate(makeContext({ level: 3 }))).toBe(true);
+  });
+
+  it('returns false when base user (level 1) lacks canCancel', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canCancel');
+    expect(guard.canActivate(makeContext({ level: 1 }))).toBe(false);
+  });
+
+  it('returns false when user is undefined', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canCancel');
+    expect(guard.canActivate(makeContext(undefined))).toBe(false);
+  });
+
+  it('returns true when admin (level 7) has canRefund', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canRefund');
+    expect(guard.canActivate(makeContext({ level: 7 }))).toBe(true);
+  });
+
+  it('returns false when commercial (level 3) lacks canRefund', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canRefund');
+    expect(guard.canActivate(makeContext({ level: 3 }))).toBe(false);
+  });
+
+  it('coerces string level to number', () => {
+    jest.spyOn(reflector, 'get').mockReturnValue('canCancel');
+    expect(guard.canActivate(makeContext({ level: '3' }))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 4.2: Run test to verify it fails**
+
+```bash
+cd backend && npx jest src/auth/guards/permissions.guard.spec.ts --no-coverage
+```
+
+Expected: FAIL — `Cannot find module './permissions.guard'`.
+
+- [ ] **Step 4.3: Write minimal implementation**
+
+```ts
+// backend/src/auth/guards/permissions.guard.ts
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import {
+  REQUIRE_PERMISSION_KEY,
+} from '../decorators/require-permission.decorator';
+import type { PermissionAction } from '../dto/user-permissions.dto';
+import { PermissionsService } from '../permissions.service';
+
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  private readonly logger = new Logger(PermissionsGuard.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly permissionsService: PermissionsService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const action = this.reflector.get<PermissionAction>(
+      REQUIRE_PERMISSION_KEY,
+      context.getHandler(),
+    );
+    if (!action) return true;
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const level = parseInt(String(user?.level ?? 0), 10) || 0;
+    const ok = this.permissionsService.hasPermission(level, action);
+
+    if (!ok) {
+      this.logger.warn(
+        `Permission denied: ${user?.email ?? 'anonymous'} (level=${level}) lacks "${action}"`,
+      );
+    }
+    return ok;
+  }
+}
+```
+
+- [ ] **Step 4.4: Run test to verify it passes**
+
+```bash
+cd backend && npx jest src/auth/guards/permissions.guard.spec.ts --no-coverage
+```
+
+Expected: PASS — 7 tests green.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add backend/src/auth/guards/permissions.guard.ts backend/src/auth/guards/permissions.guard.spec.ts
+git commit -m "feat(auth): add PermissionsGuard reading @RequirePermission"
+```
+
+---
+
+## Task 5: Wire into `AuthModule`
+
+**Files:**
+- Modify: `backend/src/auth/auth.module.ts`
+
+- [ ] **Step 5.1: Add imports + register providers**
+
+Apply this diff to `backend/src/auth/auth.module.ts` :
+
+Add these imports at the top of the imports block (alphabetical-ish, near the existing guards):
+
+```ts
+import { PermissionsService } from './permissions.service';
+import { PermissionsGuard } from './guards/permissions.guard';
+```
+
+In the `providers` array, add `PermissionsService` and `PermissionsGuard` (after `IsAdminGuard`):
+
+```ts
+  providers: [
+    AuthService,
+    LocalStrategy,
+    LocalAuthGuard,
+    CookieSerializer,
+    IsAdminGuard,
+    PermissionsService,
+    PermissionsGuard,
+  ],
+```
+
+In the `exports` array, add both so other modules can `@UseGuards(PermissionsGuard)`:
+
+```ts
+  exports: [AuthService, PermissionsService, PermissionsGuard],
+```
+
+- [ ] **Step 5.2: Type-check + boot smoke**
+
+```bash
+cd backend && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors. (No need to actually boot — module wiring failures show at typecheck.)
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add backend/src/auth/auth.module.ts
+git commit -m "feat(auth): register PermissionsService + PermissionsGuard in AuthModule"
+```
+
+---
+
+## Task 6: Refactor `GET /auth/user-permissions/:userId` endpoint
+
+**Files:**
+- Modify: `backend/src/auth/controllers/auth-permissions.controller.ts:68-101`
+
+- [ ] **Step 6.1: Verify current consumers (sanity)**
+
+```bash
+grep -rn "user-permissions" /opt/automecanik/app/frontend/app /opt/automecanik/app/backend/src 2>/dev/null
+```
+
+Expected: only references inside `auth-permissions.controller.ts` itself. If frontend has any consumer **other** than what we'll add in Task 8, STOP and reassess scope.
+
+- [ ] **Step 6.2: Replace `getUserPermissions` method**
+
+In `backend/src/auth/controllers/auth-permissions.controller.ts`, locate the existing `getUserPermissions` method (around line 68). Replace its body to return `UserPermissions` shape directly.
+
+Add imports at top:
+
+```ts
+import { PermissionsService } from '../permissions.service';
+import {
+  BASE_USER_PERMISSIONS,
+  UserPermissions,
+} from '../dto/user-permissions.dto';
+```
+
+Inject `PermissionsService` in the constructor:
+
+```ts
+  constructor(
+    private readonly authService: AuthService,
+    private readonly permissionsService: PermissionsService,
+  ) {}
+```
+
+Replace the entire `getUserPermissions` method:
+
+```ts
+  /**
+   * GET /auth/user-permissions/:userId
+   * Returns canonical UserPermissions shape (15 booleans) used by frontend.
+   */
+  @Get('auth/user-permissions/:userId')
+  async getUserPermissions(
+    @Param('userId') userId: string,
+  ): Promise<UserPermissions> {
+    try {
+      const user = await this.authService.findUserById(userId);
+      if (!user || user.isActive === false) {
+        return BASE_USER_PERMISSIONS;
+      }
+      const level = parseInt(String(user.level ?? 0), 10) || 0;
+      return this.permissionsService.getPermissions(level);
+    } catch (error) {
+      this.logger.error(
+        `Error fetching user permissions: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return BASE_USER_PERMISSIONS;
+    }
+  }
+```
+
+- [ ] **Step 6.3: Verify `AuthService.findUserById` exists with the right signature**
+
+```bash
+grep -n "findUserById\|findById" /opt/automecanik/app/backend/src/auth/auth.service.ts | head -10
+```
+
+If `findUserById` does not exist, replace the call by whatever method `AuthService` exposes that returns `{ level, isActive }` (likely `findById` via `userDataService`). If neither is reachable from `AuthService`, inject the underlying user data service. **Do not invent a method name.**
+
+- [ ] **Step 6.4: Type-check**
+
+```bash
+cd backend && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors. If `findUserById` doesn't exist, this is where you fix the call (Step 6.3).
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add backend/src/auth/controllers/auth-permissions.controller.ts
+git commit -m "refactor(auth): GET /auth/user-permissions returns canonical UserPermissions
+
+BREAKING: response shape changes from per-module read/write matrix to
+the canonical 15-booleans UserPermissions. Only known consumer is
+frontend permissions.ts (refactored in following commits)."
+```
+
+---
+
+## Task 7: Migrate `OrderActionsController` from `IsAdminGuard` to `PermissionsGuard`
+
+**Files:**
+- Modify: `backend/src/modules/orders/controllers/order-actions.controller.ts`
+
+- [ ] **Step 7.1: Replace controller-level guard + add per-method decorators**
+
+In `backend/src/modules/orders/controllers/order-actions.controller.ts`:
+
+Replace the import line:
+
+```ts
+// REMOVE
+import { IsAdminGuard } from '@auth/is-admin.guard';
+// ADD
+import { PermissionsGuard } from '@auth/guards/permissions.guard';
+import { RequirePermission } from '@auth/decorators/require-permission.decorator';
+```
+
+Replace the controller-level `@UseGuards`:
+
+```ts
+// FROM
+@UseGuards(AuthenticatedGuard, IsAdminGuard)
+// TO
+@UseGuards(AuthenticatedGuard, PermissionsGuard)
+```
+
+Add `@RequirePermission(...)` to each handler method. Apply exactly these mappings (per spec §3.4):
+
+| Method | Decorator |
+|---|---|
+| `updateLineStatus` | `@RequirePermission('canValidate')` |
+| `orderFromSupplier` | `@RequirePermission('canValidate')` |
+| `markAsShipped` | `@RequirePermission('canShip')` |
+| `markAsDelivered` | `@RequirePermission('canDeliver')` |
+| `cancelOrder` | `@RequirePermission('canCancel')` |
+| `confirmPayment` | `@RequirePermission('canMarkPaid')` |
+
+Place each decorator **immediately above** its `@Post(...)` / `@Patch(...)` decorator. Example:
+
+```ts
+  @Post(':orderId/cancel')
+  @RequirePermission('canCancel')
+  async cancelOrder(...) { /* unchanged body */ }
+```
+
+If the file contains methods not listed above (e.g. additional handlers added since this plan was written), **stop and review**: any operational endpoint must get a `@RequirePermission(...)`, otherwise the guard treats it as "no metadata" and lets everyone through.
+
+- [ ] **Step 7.2: Type-check**
+
+```bash
+cd backend && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: no errors.
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add backend/src/modules/orders/controllers/order-actions.controller.ts
+git commit -m "refactor(orders): replace IsAdminGuard with @RequirePermission per action
+
+Cancel/ship/deliver/mark-paid/validate/order-from-supplier now read
+the per-action matrix from PermissionsService instead of requiring
+level >= 7. Commercial users (level 3-4) can effectively perform
+operational actions, matching the documented frontend matrix."
+```
+
+---
+
+## Task 8: E2E test — commercial cancel + 403 cases
+
+**Files:**
+- Create: `backend/test/orders-cancel-permissions.e2e-spec.ts`
+
+- [ ] **Step 8.1: Inspect existing e2e setup**
+
+```bash
+ls /opt/automecanik/app/backend/test/ | head -20
+```
+
+If `backend/test/` doesn't exist or has no jest config (`jest-e2e.json`), check `backend/package.json` for the e2e script and existing test infrastructure. **If there is no e2e harness in the repo**, skip this task — the unit tests in Tasks 2 + 4 cover the logic, and the smoke test in Task 11 covers the integration. Note the skip in the PR description.
+
+- [ ] **Step 8.2: If e2e harness exists, write the test**
+
+```ts
+// backend/test/orders-cancel-permissions.e2e-spec.ts
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { PermissionsGuard } from '../src/auth/guards/permissions.guard';
+import { AuthenticatedGuard } from '../src/auth/authenticated.guard';
+
+describe('OrderActions cancel — permissions (e2e)', () => {
+  let app: INestApplication;
+
+  const buildApp = async (user: any) => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(AuthenticatedGuard)
+      .useValue({
+        canActivate: (ctx: any) => {
+          if (user) ctx.switchToHttp().getRequest().user = user;
+          return !!user;
+        },
+      })
+      .compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+  };
+
+  afterEach(async () => {
+    if (app) await app.close();
+  });
+
+  it('commercial (level 3) can cancel → 200 (or downstream error, NOT 403)', async () => {
+    await buildApp({ id: 'test-commercial', level: 3, email: 'commercial@test' });
+    const res = await request(app.getHttpServer())
+      .post('/api/admin/orders/ORD-TEST-NONEXISTENT/cancel')
+      .send({ reason: 'test' });
+    expect(res.status).not.toBe(403); // permissions OK; downstream may 404/500 because order doesn't exist
+  });
+
+  it('base user (level 1) cancel → 403', async () => {
+    await buildApp({ id: 'test-base', level: 1, email: 'base@test' });
+    const res = await request(app.getHttpServer())
+      .post('/api/admin/orders/ORD-TEST-NONEXISTENT/cancel')
+      .send({ reason: 'test' });
+    expect(res.status).toBe(403);
+  });
+
+  it('no session → 401/403 (caught by AuthenticatedGuard before PermissionsGuard)', async () => {
+    await buildApp(null);
+    const res = await request(app.getHttpServer())
+      .post('/api/admin/orders/ORD-TEST-NONEXISTENT/cancel')
+      .send({ reason: 'test' });
+    expect([401, 403]).toContain(res.status);
+  });
+});
+```
+
+- [ ] **Step 8.3: Run e2e**
+
+```bash
+cd backend && npx jest --config test/jest-e2e.json test/orders-cancel-permissions.e2e-spec.ts
+```
+
+Expected: 3 PASS. If the e2e config path differs, use the script in `backend/package.json` (likely `npm run test:e2e -- orders-cancel-permissions`).
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add backend/test/orders-cancel-permissions.e2e-spec.ts
+git commit -m "test(orders): e2e cancel permissions (commercial allowed, base 403)"
+```
+
+---
+
+## Task 9: Frontend — refactor `permissions.ts` to thin client
+
+**Files:**
+- Modify: `frontend/app/utils/permissions.ts`
+
+- [ ] **Step 9.1: Replace the file content**
+
+Full new content (replaces the existing file entirely):
+
+```ts
+// frontend/app/utils/permissions.ts
+/**
+ * Frontend permissions facade — backend is single source of truth.
+ * Use loadUserPermissions(userId) inside Remix loaders.
+ */
+
+export interface UserPermissions {
+  canValidate: boolean;
+  canShip: boolean;
+  canDeliver: boolean;
+  canCancel: boolean;
+  canReturn: boolean;
+  canRefund: boolean;
+  canSendEmails: boolean;
+  canCreateOrders: boolean;
+  canExport: boolean;
+  canMarkPaid: boolean;
+  canSeeFullStats: boolean;
+  canSeeFinancials: boolean;
+  canSeeCustomerDetails: boolean;
+  showAdvancedFilters: boolean;
+  showActionButtons: boolean;
+}
+
+export const BASE_USER_PERMISSIONS: UserPermissions = {
+  canValidate: false,
+  canShip: false,
+  canDeliver: false,
+  canCancel: false,
+  canReturn: false,
+  canRefund: false,
+  canSendEmails: false,
+  canCreateOrders: false,
+  canExport: false,
+  canMarkPaid: false,
+  canSeeFullStats: false,
+  canSeeFinancials: false,
+  canSeeCustomerDetails: false,
+  showAdvancedFilters: false,
+  showActionButtons: false,
+};
+
+/**
+ * Fetch the canonical permission set for a user from the backend.
+ * Call from Remix loaders (server-side); pass the request cookie through.
+ */
+export async function loadUserPermissions(
+  userId: string,
+  cookie?: string,
+): Promise<UserPermissions> {
+  const headers: Record<string, string> = {};
+  if (cookie) headers.Cookie = cookie;
+  try {
+    const res = await fetch(
+      `http://127.0.0.1:3000/api/auth/user-permissions/${encodeURIComponent(userId)}`,
+      { headers },
+    );
+    if (!res.ok) return BASE_USER_PERMISSIONS;
+    return (await res.json()) as UserPermissions;
+  } catch {
+    return BASE_USER_PERMISSIONS;
+  }
+}
+
+export function canPerformAction(
+  permissions: UserPermissions,
+  action: keyof UserPermissions,
+): boolean {
+  return permissions[action] === true;
+}
+
+/**
+ * Display-only role badge — derived from level locally (no API call).
+ */
+export function getUserRole(userLevel: number): {
+  label: string;
+  badge: string;
+  color: string;
+  bgColor: string;
+} {
+  if (userLevel >= 9) {
+    return { label: 'Super Admin', badge: '👑', color: 'text-purple-800', bgColor: 'bg-purple-100' };
+  }
+  if (userLevel >= 7) {
+    return { label: 'Administrateur', badge: '🔑', color: 'text-blue-800', bgColor: 'bg-blue-100' };
+  }
+  if (userLevel >= 5) {
+    return { label: 'Responsable', badge: '📊', color: 'text-green-800', bgColor: 'bg-green-100' };
+  }
+  if (userLevel >= 3) {
+    return { label: 'Commercial', badge: '👔', color: 'text-indigo-800', bgColor: 'bg-indigo-100' };
+  }
+  return { label: 'Utilisateur', badge: '👤', color: 'text-gray-800', bgColor: 'bg-gray-100' };
+}
+```
+
+- [ ] **Step 9.2: Type-check (frontend)**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: errors at the 5 known consumer call sites (because `getUserPermissions` no longer exists). That's the signal to do Task 10. **Do not commit yet** — broken state.
+
+---
+
+## Task 10: Frontend — migrate consumers
+
+**Files:**
+- Modify: `frontend/app/routes/admin.orders._index.tsx` (lines 54, 81, 399)
+- Modify: `frontend/app/routes/commercial.orders._index.tsx` (lines 32, 48, 152, 162)
+
+- [ ] **Step 10.1: Migrate `admin.orders._index.tsx`**
+
+Read the current file first to confirm line numbers haven't shifted, then apply the following changes.
+
+**Line 54** — change the import:
+
+```ts
+// FROM
+import { getUserPermissions, getUserRole } from "../utils/permissions";
+// TO
+import { loadUserPermissions, getUserRole } from "../utils/permissions";
+```
+
+**Line 81 (loader)** — replace the synchronous compute with the async loader fetch. The loader already has access to the request (Remix loader signature). Read the surrounding code to find the request variable name; pass `request.headers.get('Cookie') ?? undefined` as the second arg of `loadUserPermissions`.
+
+```ts
+// FROM
+const permissions = getUserPermissions(user.level);
+// TO
+const permissions = await loadUserPermissions(user.id, request.headers.get('Cookie') ?? undefined);
+```
+
+**Line 399 (component body)** — the component currently re-derives permissions from the user prop. Since the loader now ships `permissions` in `useLoaderData`, the component should consume that instead of re-computing. Locate `useLoaderData<...>()` and add `permissions` to the destructure; remove the `getUserPermissions(user.level || 0)` line.
+
+Concrete pattern (adjust to actual loader return shape):
+
+```tsx
+// FROM (component)
+const permissions = getUserPermissions(user.level || 0);
+// TO
+const { permissions } = useLoaderData<typeof loader>();
+```
+
+If `useLoaderData` is already destructured and `permissions` is now part of the loader return (Step 10.1 first sub-step), just add it to the destructure pattern.
+
+- [ ] **Step 10.2: Migrate `commercial.orders._index.tsx`**
+
+Apply the same three transformations. Lines indicated are from the current state — verify before editing.
+
+**Line 32** — import swap (same as 10.1).
+
+**Line 48 (loader)** — add `await loadUserPermissions(user.id, request.headers.get('Cookie') ?? undefined)`.
+
+**Line 152 (interface type)** — change `ReturnType<typeof getUserPermissions>` to just `UserPermissions`. Add `import type { UserPermissions } from "../utils/permissions";` if not already present.
+
+**Line 162 (component)** — same as line 399 of admin: consume `permissions` from `useLoaderData`.
+
+- [ ] **Step 10.3: Type-check (frontend)**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json
+```
+
+Expected: zero errors. If still failing, inspect the actual call sites and adjust — the line numbers in this plan are best-effort; the imports `getUserPermissions` must have ZERO remaining references.
+
+- [ ] **Step 10.4: Verify nothing else imports `getUserPermissions`**
+
+```bash
+grep -rn "getUserPermissions" /opt/automecanik/app/frontend/app
+```
+
+Expected: no output (function no longer exists, no references).
+
+- [ ] **Step 10.5: Build smoke**
+
+```bash
+cd /opt/automecanik/app && npm run build 2>&1 | tail -30
+```
+
+Expected: build succeeds (or fails only on unrelated existing issues — review carefully).
+
+- [ ] **Step 10.6: Commit**
+
+```bash
+git add frontend/app/utils/permissions.ts frontend/app/routes/admin.orders._index.tsx frontend/app/routes/commercial.orders._index.tsx
+git commit -m "refactor(frontend): permissions.ts becomes thin client of /api/auth/user-permissions
+
+Removes getUserPermissions(level) local computation. Loaders now fetch
+the canonical matrix from the backend. Components consume from
+useLoaderData. getUserRole stays local (display-only)."
+```
+
+---
+
+## Task 11: Smoke test on DEV
+
+- [ ] **Step 11.1: Push branch + open PR**
+
+```bash
+git push -u origin fix/permissions-canonical-backend
+gh pr create --title "fix(auth): canonical permissions matrix at backend (unblock commercial actions)" --body "$(cat <<'EOF'
+## Summary
+
+Move per-action permission matrix from frontend to backend as single source of truth. Replace `IsAdminGuard` with `@RequirePermission(action)` on `OrderActionsController`. Frontend `permissions.ts` becomes a thin API client.
+
+**Triggered by:** Order `ORD-1777531019900-837` cancel returned `Forbidden resource` (HTTP 403) to commercial-level user despite frontend declaring `canCancel: true`.
+
+**Spec:** [`docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md`](../blob/fix/permissions-canonical-backend/docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md)
+
+**Plan:** [`docs/superpowers/plans/2026-04-30-permissions-canonical-backend.md`](../blob/fix/permissions-canonical-backend/docs/superpowers/plans/2026-04-30-permissions-canonical-backend.md)
+
+## Scope
+
+- Backend: new `PermissionsService`, `PermissionsGuard`, `@RequirePermission` decorator, `UserPermissions` DTO.
+- Backend: `OrderActionsController` (6 endpoints) migrated from `IsAdminGuard` to `PermissionsGuard`.
+- Backend: `GET /api/auth/user-permissions/:userId` returns canonical `UserPermissions` shape (breaking — only consumer is frontend, refactored in same PR).
+- Frontend: `permissions.ts` rewritten as thin client. 2 routes (admin.orders, commercial.orders) migrated.
+- `IsAdminGuard` kept as-is for ~25 other controllers (out-of-scope, follow-up PRs).
+
+## Test plan
+
+- [ ] Unit: `PermissionsService` (~30 cases) green.
+- [ ] Unit: `PermissionsGuard` (7 cases) green.
+- [ ] E2E: cancel with commercial / base / no-session.
+- [ ] DEV smoke: log in as commercial level 3, cancel a test order, verify `___xtr_order.ord_ords_id = '6'` + `__admin_audit_log` row + email reception.
+- [ ] DEV smoke: same with admin level 7 → still works (regression).
+- [ ] DEV smoke: log in as base user level 1 → cancel button hidden (frontend) AND backend would 403 (defense in depth).
+EOF
+)"
+```
+
+- [ ] **Step 11.2: Wait for DEV deploy + run smoke checks**
+
+DEV redeploys on `push main` (per `.claude/rules/deployment.md`); on a feature branch the PR doesn't deploy. The smoke test must wait for **merge to main**, OR be run against a locally-running backend.
+
+For local smoke (preferred — faster feedback before merge):
+
+```bash
+cd /opt/automecanik/app && npm run dev 2>&1 | tail -5
+```
+
+Then in browser at `http://localhost:5173/admin/orders` :
+
+1. Log in with a commercial-level account (or temporarily flip an admin to level 3 in DB, then revert).
+2. Pick a test order in status `2` or `3` (NOT a real customer order).
+3. Click "Annuler", enter a reason, submit.
+4. Expected: success toast "❌ Commande annulée et client notifié par email".
+5. Verify in Supabase MCP:
+
+```sql
+SELECT ord_id, ord_ords_id, ord_cancel_date, ord_cancel_reason
+FROM "___xtr_order"
+WHERE ord_id = '<TEST_ORDER_ID>';
+-- Expected: ord_ords_id = '6', ord_cancel_date IS NOT NULL, ord_cancel_reason IS NOT NULL
+
+SELECT * FROM "__admin_audit_log"
+WHERE action = 'order_cancelled'
+ORDER BY created_at DESC LIMIT 1;
+-- Expected: a row matching the test order
+
+SELECT * FROM "___xtr_order_status_history"
+WHERE osh_ord_id = '<TEST_ORDER_ID>'
+ORDER BY osh_created_at DESC LIMIT 1;
+-- Expected: a row showing transition to status 6
+```
+
+If all three checks pass, the structural fix is verified end-to-end on DEV.
+
+- [ ] **Step 11.3: Mark PR ready for review**
+
+If the PR was opened as draft, mark it ready: `gh pr ready`.
+
+---
+
+## Rollback path
+
+If anything breaks post-merge to main:
+
+```bash
+git revert <merge-commit-sha>
+git push origin main
+```
+
+DEV redeploys automatically (per `.claude/rules/deployment.md`). No DB cleanup needed — orders cancelled by commercials between deploy and rollback remain valid (status 6, audit log, email sent are all preserved).
+
+---
+
+## Out-of-scope follow-ups (track in separate issues)
+
+1. Migrate ~25 other controllers under `IsAdminGuard` to `@RequirePermission` (blog, advice, seo, vehicles, search, configuration, admin-keyword-clusters, admin-vehicle-cache, admin-r1-related-blocks-cache, admin-vehicle-rag, errors, …). Same pattern, one PR per module.
+2. Add caching for `GET /api/auth/user-permissions/:userId` if latency becomes an issue (Redis 5min TTL or React Query client-side).
+3. Reconcile `auth.service.ts:checkModuleAccess` (module-coarse matrix at lines 877-885) with `PermissionsService` if a single endpoint is desired. Currently they coexist with distinct consumers.
+4. Add audit row for `PermissionsGuard` denials (currently `Logger.warn` only).

--- a/docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md
+++ b/docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md
@@ -1,0 +1,338 @@
+# Spec — Source canonique de permissions au backend
+
+> **Date** : 2026-04-30
+> **Auteur** : Fafa (avec Claude Code)
+> **Statut** : DRAFT — en attente review user
+> **Branche cible** : `fix/permissions-canonical-backend`
+> **Type** : refactor architectural (auth/permissions)
+
+---
+
+## 1. Contexte & motivation
+
+### 1.1 Bug observé (déclencheur)
+
+Le 2026-04-30, l'utilisateur tente d'annuler la commande `ORD-1777531019900-837` depuis l'interface admin. La commande affiche `Forbidden resource` et reste au statut `3` (Attente frais de port). Audit DB confirme :
+
+```sql
+SELECT ord_ords_id, ord_cancel_date, ord_cancel_reason
+FROM "___xtr_order"
+WHERE ord_id = 'ORD-1777531019900-837';
+-- ord_ords_id = '3', ord_cancel_date = NULL, ord_cancel_reason = NULL
+```
+
+L'annulation n'a pas eu lieu, aucun email client envoyé, aucun audit trail créé. Cause = HTTP 403 retourné par `IsAdminGuard` sur `POST /api/admin/orders/:id/cancel`.
+
+### 1.2 Cause racine — 3 sources de vérité divergentes
+
+| # | Localisation | Granularité | Verdict pour "commercial peut annuler" |
+|---|---|---|---|
+| 1 | [`backend/src/auth/auth.service.ts:877-885`](../../../backend/src/auth/auth.service.ts) | Module × `read`/`write` | Indéterminé (ne couvre pas l'action `cancel`) |
+| 2 | [`frontend/app/utils/permissions.ts:101-118`](../../../frontend/app/utils/permissions.ts) | Par-action (`canCancel`, `canShip`, …) | **OUI** (level 3-4 → `canCancel: true`) |
+| 3 | [`backend/src/auth/is-admin.guard.ts:20`](../../../backend/src/auth/is-admin.guard.ts) | Booléen (`level >= 7`) | **NON** (commercial level 3-6 rejeté) |
+
+Le frontend affiche le bouton "Annuler" au commercial, le backend le bloque. Toute action métier opérationnelle pour le commercial souffre du même symptôme : `canShip`, `canDeliver`, `canMarkPaid`, `canSendEmails`, `canValidate` sont déclarées `true` côté frontend mais le backend les bloque toutes via `IsAdminGuard`.
+
+### 1.3 Pourquoi maintenant, pourquoi structurel
+
+Trois précédents identiques peuvent déjà être ouverts en silence (commercial ne peut effectivement pas valider/expédier/livrer/marquer payé). Une rustine sur cancel reproduirait la dette ailleurs. Le pattern actuel n'est pas réparable par patch — l'architecture suppose un seul niveau de permission (admin/non-admin) alors que le métier en exige cinq (Utilisateur, Commercial, Responsable, Administrateur, Super Admin).
+
+---
+
+## 2. Décision d'architecture
+
+**Le backend devient l'unique source de vérité pour la matrice de permissions par-action.** Le frontend consomme cette matrice via API et n'héberge plus aucune logique de calcul.
+
+### 2.1 Principes appliqués
+
+- **Single source of truth** — une seule matrice, versionnée dans le repo, côté backend.
+- **Granularité par-action** — `canCancel`, `canShip`, etc. (modèle déjà existant côté frontend, simplement déplacé).
+- **YAGNI** — pas de lib externe (CASL/accesscontrol), pas d'ABAC, pas de DB-driven (la matrice change rarement, du code versionné est plus traçable que des rows).
+- **RBAC par level** — modèle existant conservé (level 1-9), seule l'application change.
+- **Migration progressive** — `IsAdminGuard` reste en place pour les endpoints réellement admin-only (settings système, audit, configuration). Cette PR ne migre que le module **orders**, l'infrastructure étant réutilisable pour les modules suivants en PRs séparées.
+
+### 2.2 Composants
+
+| Composant | Localisation | Type | Rôle |
+|---|---|---|---|
+| `PermissionsService` | `backend/src/auth/permissions.service.ts` | nouveau | Détient la matrice canonique. Méthode `getPermissions(userLevel: number): UserPermissions` |
+| `UserPermissions` interface | `backend/src/auth/dto/user-permissions.dto.ts` | nouveau | Shape canonique partagée backend/frontend (15 booléens) |
+| `@RequirePermission('canCancel')` | `backend/src/auth/decorators/require-permission.decorator.ts` | nouveau | Décorateur de méthode |
+| `PermissionsGuard` | `backend/src/auth/guards/permissions.guard.ts` | nouveau | Lit le décorateur, consulte `PermissionsService`, retourne `boolean` |
+| `GET /auth/user-permissions/:userId` | `backend/src/auth/controllers/auth-permissions.controller.ts:68` | refactor | Retourne `UserPermissions` complet (au lieu de la matrice module-coarse actuelle) |
+| `frontend/app/utils/permissions.ts` | idem | refactor | Devient un thin client qui hit l'endpoint et cache par session ; `getUserPermissions(level)` supprimé |
+| Endpoints orders | `backend/src/modules/orders/controllers/order-actions.controller.ts` | refactor | Remplace `IsAdminGuard` par `@RequirePermission(...)` ciblé par méthode |
+
+### 2.3 Matrice canonique (portée à l'identique depuis le frontend)
+
+La matrice est portée **sans modification métier** depuis [`frontend/app/utils/permissions.ts:36-139`](../../../frontend/app/utils/permissions.ts). Cette PR ne renégocie pas les règles — elle les déplace au bon endroit.
+
+| Niveau | Rôle | canCancel | canShip | canDeliver | canMarkPaid | canValidate | canSendEmails | canCreateOrders | canReturn | canRefund |
+|---|---|---|---|---|---|---|---|---|---|---|
+| 1-2 | Utilisateur | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| 3-4 | Commercial | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| 5-6 | Responsable | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| 7-8 | Administrateur | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 9 | Super Admin | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+(15 booléens au total — tableau abrégé. La shape complète est définie dans `UserPermissions`.)
+
+---
+
+## 3. Spécifications techniques
+
+### 3.1 `PermissionsService`
+
+```ts
+// backend/src/auth/permissions.service.ts
+@Injectable()
+export class PermissionsService {
+  getPermissions(userLevel: number): UserPermissions {
+    if (userLevel >= 9) return SUPER_ADMIN_PERMISSIONS;
+    if (userLevel >= 7) return ADMIN_PERMISSIONS;
+    if (userLevel >= 5) return MANAGER_PERMISSIONS;
+    if (userLevel >= 3) return COMMERCIAL_PERMISSIONS;
+    return BASE_USER_PERMISSIONS;
+  }
+
+  hasPermission(userLevel: number, action: keyof UserPermissions): boolean {
+    return this.getPermissions(userLevel)[action] === true;
+  }
+}
+```
+
+Les 5 constantes sont `as const`, exhaustives, et exportées pour les tests.
+
+### 3.2 Décorateur + Guard
+
+```ts
+// backend/src/auth/decorators/require-permission.decorator.ts
+export const REQUIRE_PERMISSION_KEY = 'require_permission';
+export const RequirePermission = (action: keyof UserPermissions) =>
+  SetMetadata(REQUIRE_PERMISSION_KEY, action);
+```
+
+```ts
+// backend/src/auth/guards/permissions.guard.ts
+@Injectable()
+export class PermissionsGuard implements CanActivate {
+  constructor(
+    private reflector: Reflector,
+    private permissionsService: PermissionsService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const action = this.reflector.get<keyof UserPermissions>(
+      REQUIRE_PERMISSION_KEY,
+      context.getHandler(),
+    );
+    if (!action) return true; // pas de décorateur = pas de check (compose avec IsAdminGuard)
+
+    const user = context.switchToHttp().getRequest().user;
+    const level = parseInt(String(user?.level ?? 0), 10);
+    return this.permissionsService.hasPermission(level, action);
+  }
+}
+```
+
+### 3.3 Endpoint de permissions (refactor)
+
+```ts
+// backend/src/auth/controllers/auth-permissions.controller.ts
+@Get('auth/user-permissions/:userId')
+async getUserPermissions(@Param('userId') userId: string): Promise<UserPermissions> {
+  const user = await this.userDataService.findById(userId);
+  if (!user || !user.isActive) return BASE_USER_PERMISSIONS;
+  return this.permissionsService.getPermissions(user.level);
+}
+```
+
+**Breaking change** : la shape de réponse change. Le seul consommateur connu est `frontend/app/utils/permissions.ts`, mis à jour dans la même PR. Pas de versionnement nécessaire — break franc.
+
+### 3.4 Migration des endpoints orders
+
+[`backend/src/modules/orders/controllers/order-actions.controller.ts`](../../../backend/src/modules/orders/controllers/order-actions.controller.ts) :
+
+```ts
+@Controller('api/admin/orders')
+@UseGuards(AuthenticatedGuard, PermissionsGuard) // ← remplace IsAdminGuard par PermissionsGuard
+export class OrderActionsController {
+
+  @Post(':orderId/cancel')
+  @RequirePermission('canCancel')
+  async cancelOrder(...) { /* inchangé */ }
+
+  @Post(':orderId/ship')
+  @RequirePermission('canShip')
+  async markAsShipped(...) { /* inchangé */ }
+
+  @Post(':orderId/deliver')
+  @RequirePermission('canDeliver')
+  async markAsDelivered(...) { /* inchangé */ }
+
+  @Post(':orderId/confirm-payment')
+  @RequirePermission('canMarkPaid')
+  async confirmPayment(...) { /* inchangé */ }
+
+  @Patch(':orderId/lines/:lineId/status/:newStatus')
+  @RequirePermission('canValidate') // statut ligne = validation
+  async updateLineStatus(...) { /* inchangé */ }
+
+  @Post(':orderId/lines/:lineId/order-from-supplier')
+  @RequirePermission('canValidate') // commande fournisseur = action métier opérationnelle
+  async orderFromSupplier(...) { /* inchangé */ }
+}
+```
+
+### 3.5 Frontend — `permissions.ts` thin client
+
+```ts
+// frontend/app/utils/permissions.ts (post-refactor)
+export interface UserPermissions { /* identique à aujourd'hui */ }
+
+export async function loadUserPermissions(userId: string): Promise<UserPermissions> {
+  const res = await fetch(`/api/auth/user-permissions/${userId}`, {
+    credentials: 'include',
+  });
+  if (!res.ok) return BASE_USER_PERMISSIONS;
+  return res.json();
+}
+
+// SUPPRIMÉ : getUserPermissions(userLevel: number) — le calcul ne vit plus côté frontend
+// CONSERVÉ : getUserRole(userLevel) — c'est de l'affichage (label + badge), pas une permission
+```
+
+Tous les loaders Remix qui appelaient `getUserPermissions(user.level)` doivent être migrés vers `await loadUserPermissions(user.id)` dans le `loader` Remix puis transmis au composant via `useLoaderData`.
+
+**Caching** : on ne cache pas dans cette PR. La latence d'un appel par page est acceptable (l'endpoint est <50ms). Si nécessaire en suivi, ajouter cache Redis 5min côté backend, ou cache React Query côté frontend.
+
+---
+
+## 4. Sécurité — chaîne d'authz post-fix
+
+```
+Browser (commercial level 3) clique "Annuler"
+  ↓ fetch POST /api/admin/orders/:id/cancel  (credentials: include)
+Backend reçoit la requête
+  ↓ AuthenticatedGuard          → session valide ? OK
+  ↓ PermissionsGuard            → reflector lit @RequirePermission('canCancel')
+                                  → permissionsService.hasPermission(3, 'canCancel') === true
+                                  → OK
+  ↓ cancelOrder() s'exécute
+  ↓ DB : UPDATE ord_ords_id='6', ord_cancel_date=NOW(), ord_cancel_reason=...
+  ↓ INSERT ___xtr_order_status_history
+  ↓ emit ORDER_EVENTS.CANCELLED
+      ├─ OrderAuditListener → INSERT __admin_audit_log (qui/quand/raison)
+      └─ OrderEmailListener → mailService.sendCancellationEmail(order, customer, reason)
+  → 200 OK { success: true, message: 'Commande annulée et client notifié' }
+```
+
+Aucun chemin ne contourne `PermissionsGuard` : tous les endpoints du controller sont décorés.
+
+---
+
+## 5. Tests
+
+### 5.1 Unit `PermissionsService`
+
+Table-driven, 5 niveaux × 15 actions = 75 cas :
+
+```ts
+describe('PermissionsService', () => {
+  const cases: Array<[number, keyof UserPermissions, boolean]> = [
+    [3, 'canCancel', true],   // commercial peut annuler
+    [3, 'canRefund', false],  // commercial ne peut pas rembourser
+    [5, 'canCancel', false],  // responsable ne peut pas annuler
+    [7, 'canCancel', true],   // admin peut annuler
+    [0, 'canCancel', false],  // anonymous = base user
+    // ... 70 autres cas
+  ];
+  it.each(cases)('level %i / %s = %s', (level, action, expected) => {
+    expect(service.hasPermission(level, action)).toBe(expected);
+  });
+});
+```
+
+### 5.2 Unit `PermissionsGuard`
+
+- Décorateur absent → `canActivate` retourne `true` (compose avec d'autres guards).
+- User level 3 + `@RequirePermission('canCancel')` → `true`.
+- User level 1 + `@RequirePermission('canCancel')` → `false`.
+- User absent (`req.user = undefined`) → `level = 0` → `false` pour toute action métier.
+
+### 5.3 E2E `OrderActionsController`
+
+- `POST /api/admin/orders/:id/cancel` avec session commercial level 3 → **200**, vérifier `___xtr_order.ord_ords_id = '6'` + email envoyé (mock `MailService`).
+- Même endpoint avec session level 1 → **403**.
+- Même endpoint sans session → **401** (intercepté par `AuthenticatedGuard` avant `PermissionsGuard`).
+
+### 5.4 Régression manuelle (post-déploiement DEV)
+
+Compte test commercial à créer ou identifier (level 3-4). Cycle complet sur une commande de test :
+- Annuler → vérifier statut 6 + email reçu + audit log + status history.
+- Expédier (sur autre commande) → vérifier statut 4 + email + tracking.
+- Livrer → statut 5.
+- Confirmer paiement → `payment_confirmed = true`.
+
+---
+
+## 6. Out of scope (suivis explicites)
+
+Ces points ne sont **pas** traités dans cette PR mais sont identifiés et notés :
+
+1. **Migration des autres modules** sous `IsAdminGuard` (blog, advice, seo, vehicles, search, admin-keyword-clusters, configuration, …) — ~25 controllers identifiés. PRs séparées en suivant le même pattern. `IsAdminGuard` reste utilisable et fonctionnel pour ces endpoints.
+2. **Caching de la matrice** côté frontend (React Query) ou backend (Redis). À ouvrir si latence devient un problème.
+3. **Renégociation des règles métier** (ex : "le commercial devrait-il aussi pouvoir refund jusqu'à X €") — pas de changement métier dans cette PR.
+4. **Audit log d'accès refusé** — `PermissionsGuard` peut logger les refus pour observabilité, mais pas de nouvelle table dans cette PR (réutilise les logs NestJS).
+5. **Cohérence avec `auth.service.ts:checkModuleAccess`** (matrice module-coarse, ligne 877-885) — cette matrice a des consommateurs distincts (`/auth/module-access`) et n'est pas touchée. À unifier dans une PR ultérieure si nécessaire.
+
+---
+
+## 7. Risques & mitigations
+
+| Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|
+| Commercial existant en prod a un niveau autre que 3-4 (ex : level 0) | Moyenne | Bug "boutons grisés" → escalade support | Audit DB pré-déploiement : `SELECT cst_level, COUNT(*) FROM ___xtr_customer GROUP BY cst_level` |
+| Endpoint `/auth/user-permissions/:userId` consommé ailleurs que `permissions.ts` | Faible | Casse silencieuse | `grep -rn "user-permissions" frontend/ backend/` avant merge |
+| `PermissionsGuard` empêche un test E2E sans user mocké | Faible | CI rouge | Audit des tests E2E orders existants, ajout fixture user admin |
+| Régression sur `IsAdminGuard` (utilisé ailleurs) | Très faible | Aucune — non touché dans cette PR | Vérifier `git diff` ne touche que les fichiers listés en §3 |
+
+---
+
+## 8. Critères d'acceptation
+
+La PR est mergeable si **toutes** ces conditions sont remplies :
+
+- [ ] `PermissionsService`, `PermissionsGuard`, `RequirePermission` décorateur, `UserPermissions` DTO existent et compilent.
+- [ ] `OrderActionsController` n'utilise plus `IsAdminGuard`. Tous ses endpoints sont décorés `@RequirePermission(...)`.
+- [ ] `frontend/app/utils/permissions.ts` n'exporte plus `getUserPermissions(userLevel)`. Aucun import de cette fonction n'existe dans `frontend/app/`.
+- [ ] Endpoint `GET /api/auth/user-permissions/:userId` renvoie une shape `UserPermissions` (15 booléens).
+- [ ] 75 cas unit `PermissionsService` passent.
+- [ ] E2E `cancelOrder` passe avec session commercial mockée.
+- [ ] Smoke test manuel sur DEV : compte commercial annule effectivement la commande de test (vérification triple : statut DB, audit log, email reçu).
+- [ ] Aucun fichier modifié hors de la liste §3 (sauf `auth.module.ts` pour DI et tests).
+- [ ] CI verte (typecheck, lint, tests, perf-gates).
+
+---
+
+## 9. Plan de rollback
+
+La PR introduit du nouveau code et remplace 6 décorateurs sur `OrderActionsController`. En cas de régression :
+
+1. **Hot-fix immédiat** : `git revert <merge-commit>` sur `main` → redéploie DEV pré-prod en <10min.
+2. **Données** : aucune migration DB, aucun changement de schéma. Les commandes annulées par commerciaux entre déploiement et rollback restent valides (statut 6, audit log, email envoyé). Pas de cleanup nécessaire.
+3. **Frontend** : `permissions.ts` nouvelle version contient un fallback (`BASE_USER_PERMISSIONS`) si l'endpoint répond 4xx/5xx → boutons grisés mais pas de crash.
+
+---
+
+## 10. Références
+
+- Bug déclencheur : commande `ORD-1777531019900-837` (DB `cxpojprgwgubzjyqzmoq`)
+- Frontend matrice originale : [`frontend/app/utils/permissions.ts:36-139`](../../../frontend/app/utils/permissions.ts)
+- Backend guard à remplacer : [`backend/src/auth/is-admin.guard.ts`](../../../backend/src/auth/is-admin.guard.ts)
+- Endpoint cancel impacté : [`backend/src/modules/orders/controllers/order-actions.controller.ts:246`](../../../backend/src/modules/orders/controllers/order-actions.controller.ts)
+- Listeners événement cancel (preserved, non touchés) :
+  - [`backend/src/modules/orders/listeners/order-email.listener.ts:48`](../../../backend/src/modules/orders/listeners/order-email.listener.ts)
+  - [`backend/src/modules/orders/listeners/order-audit.listener.ts:105`](../../../backend/src/modules/orders/listeners/order-audit.listener.ts)
+- CLAUDE.md backend pattern : `.claude/rules/backend.md`
+- CLAUDE.md règle "vérifier l'existant" : `CLAUDE.md` §"Vérifier l'existant AVANT d'inventer"

--- a/frontend/app/routes/admin.orders._index.tsx
+++ b/frontend/app/routes/admin.orders._index.tsx
@@ -51,7 +51,7 @@ import {
   type LoaderData,
   type Order,
 } from "../types/orders.types";
-import { getUserPermissions, getUserRole } from "../utils/permissions";
+import { loadUserPermissions, getUserRole } from "../utils/permissions";
 
 // ========================================
 // 📄 META
@@ -78,7 +78,10 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     return json<ActionData>({ error: "Accès refusé" }, { status: 403 });
   }
 
-  const permissions = getUserPermissions(user.level);
+  const permissions = await loadUserPermissions(
+    user.id,
+    request.headers.get("Cookie") ?? undefined,
+  );
   const userRole = getUserRole(user.level);
 
   const formData = await request.formData();
@@ -396,7 +399,10 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     throw new Response("Accès refusé", { status: 403 });
   }
 
-  const permissions = getUserPermissions(user.level || 0);
+  const permissions = await loadUserPermissions(
+    user.id,
+    request.headers.get("Cookie") ?? undefined,
+  );
   const userRole = getUserRole(user.level || 0);
 
   logger.log(

--- a/frontend/app/routes/commercial.orders._index.tsx
+++ b/frontend/app/routes/commercial.orders._index.tsx
@@ -29,7 +29,11 @@ import { OrdersTable } from "../components/orders/OrdersTable";
 import { Separator } from "../components/ui/separator";
 
 import { type ActionData, type Order } from "../types/orders.types";
-import { getUserPermissions, getUserRole } from "../utils/permissions";
+import {
+  loadUserPermissions,
+  getUserRole,
+  type UserPermissions,
+} from "../utils/permissions";
 
 export const meta = () => [
   { title: "Commandes | Commercial" },
@@ -45,7 +49,10 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     return json<ActionData>({ error: "Acces refuse" }, { status: 403 });
   }
 
-  const permissions = getUserPermissions(user.level);
+  const permissions = await loadUserPermissions(
+    user.id,
+    request.headers.get("Cookie") ?? undefined,
+  );
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
   const orderId = formData.get("orderId") as string;
@@ -149,7 +156,7 @@ interface LoaderData {
   total: number;
   currentPage: number;
   totalPages: number;
-  permissions: ReturnType<typeof getUserPermissions>;
+  permissions: UserPermissions;
   user: { level: number; email: string; role: ReturnType<typeof getUserRole> };
 }
 
@@ -159,7 +166,10 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     throw new Response("Acces refuse", { status: 403 });
   }
 
-  const permissions = getUserPermissions(user.level);
+  const permissions = await loadUserPermissions(
+    user.id,
+    request.headers.get("Cookie") ?? undefined,
+  );
   const userRole = getUserRole(user.level);
 
   try {

--- a/frontend/app/utils/permissions.ts
+++ b/frontend/app/utils/permissions.ts
@@ -1,158 +1,86 @@
 /**
- * 🔐 SYSTÈME DE PERMISSIONS UNIFIÉ
- * Gère les permissions selon le niveau utilisateur
+ * Frontend permissions facade — backend is single source of truth.
+ * Use loadUserPermissions(userId) inside Remix loaders, then ship the
+ * result through useLoaderData to components.
+ *
+ * Source canon : backend/src/auth/dto/user-permissions.dto.ts
+ * Spec : docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md
  */
 
 export interface UserPermissions {
-  // Actions sur les commandes
-  canValidate: boolean;        // Valider commande (2→3)
-  canShip: boolean;            // Expédier (3→4)
-  canDeliver: boolean;         // Marquer livrée (4→5)
-  canCancel: boolean;          // Annuler commande
-  canReturn: boolean;          // Gérer retours/SAV
-  canRefund: boolean;          // Émettre remboursements
-  canSendEmails: boolean;      // Envoyer emails clients
-  
-  // Gestion
-  canCreateOrders: boolean;    // Créer nouvelle commande
-  canExport: boolean;          // Export CSV
-  canMarkPaid: boolean;        // Marquer payé
-  
-  // Affichage
-  canSeeFullStats: boolean;    // Stats complètes (6 cartes)
-  canSeeFinancials: boolean;   // Montants impayés, CA détaillé
-  canSeeCustomerDetails: boolean; // Infos client complètes
-  
+  // Order actions
+  canValidate: boolean;
+  canShip: boolean;
+  canDeliver: boolean;
+  canCancel: boolean;
+  canReturn: boolean;
+  canRefund: boolean;
+  canSendEmails: boolean;
+  // Management
+  canCreateOrders: boolean;
+  canExport: boolean;
+  canMarkPaid: boolean;
+  // Display
+  canSeeFullStats: boolean;
+  canSeeFinancials: boolean;
+  canSeeCustomerDetails: boolean;
   // Interface
-  showAdvancedFilters: boolean; // Filtres avancés
-  showActionButtons: boolean;   // Boutons d'action
+  showAdvancedFilters: boolean;
+  showActionButtons: boolean;
 }
 
-/**
- * Détermine les permissions selon le niveau utilisateur
- * @param userLevel - Niveau de l'utilisateur (0-9)
- * @returns Objet de permissions
- */
-export function getUserPermissions(userLevel: number): UserPermissions {
-  // Super Admin (niveau 9)
-  if (userLevel >= 9) {
-    return {
-      canValidate: true,
-      canShip: true,
-      canDeliver: true,
-      canCancel: true,
-      canReturn: true,
-      canRefund: true,
-      canSendEmails: true,
-      canCreateOrders: true,
-      canExport: true,
-      canMarkPaid: true,
-      canSeeFullStats: true,
-      canSeeFinancials: true,
-      canSeeCustomerDetails: true,
-      showAdvancedFilters: true,
-      showActionButtons: true,
-    };
-  }
-  
-  // Admin (niveau 7-8)
-  if (userLevel >= 7) {
-    return {
-      canValidate: true,
-      canShip: true,
-      canDeliver: true,
-      canCancel: true,
-      canReturn: true,           // ✅ Admin peut gérer retours
-      canRefund: true,           // ✅ Admin peut rembourser
-      canSendEmails: true,
-      canCreateOrders: true,
-      canExport: true,
-      canMarkPaid: true,
-      canSeeFullStats: true,
-      canSeeFinancials: true,
-      canSeeCustomerDetails: true,
-      showAdvancedFilters: true,
-      showActionButtons: true,
-    };
-  }
-  
-  // Manager / Responsable (niveau 5-6)
-  if (userLevel >= 5) {
-    return {
-      canValidate: false,
-      canShip: false,
-      canDeliver: false,
-      canCancel: false,
-      canReturn: false,          // ❌ Pas de gestion retours
-      canRefund: false,          // ❌ Pas de remboursements
-      canSendEmails: false,
-      canCreateOrders: false,
-      canExport: true,
-      canMarkPaid: false,
-      canSeeFullStats: true,         // Peut voir stats complètes
-      canSeeFinancials: true,        // Peut voir finances
-      canSeeCustomerDetails: true,
-      showAdvancedFilters: true,
-      showActionButtons: false,
-    };
-  }
-  
-  // Commercial (niveau 3-4)
-  if (userLevel >= 3) {
-    return {
-      canValidate: true,             // ✅ Peut valider commandes
-      canShip: true,                 // ✅ Peut expédier
-      canDeliver: true,              // ✅ Peut marquer livrée
-      canCancel: true,               // ✅ Peut annuler
-      canReturn: false,              // ❌ Pas de gestion retours (réservé Admin)
-      canRefund: false,              // ❌ Pas de remboursements (réservé Admin)
-      canSendEmails: true,           // ✅ Peut envoyer emails clients
-      canCreateOrders: false,        // ❌ NE PEUT PAS créer de commandes
-      canExport: true,               // ✅ Peut exporter
-      canMarkPaid: true,             // ✅ Peut marquer payé
-      canSeeFullStats: false,        // ❌ PAS de statistiques
-      canSeeFinancials: false,       // ❌ PAS de montants financiers
-      canSeeCustomerDetails: true,   // ✅ Peut voir infos clients
-      showAdvancedFilters: true,     // ✅ Filtres avancés (pour gérer commandes)
-      showActionButtons: true,       // ✅ Boutons d'action visibles
-    };
-  }
-  
-  // Utilisateur de base (niveau 1-2) - Pas d'accès
-  return {
-    canValidate: false,
-    canShip: false,
-    canDeliver: false,
-    canCancel: false,
-    canReturn: false,
-    canRefund: false,
-    canSendEmails: false,
-    canCreateOrders: false,
-    canExport: false,
-    canMarkPaid: false,
-    canSeeFullStats: false,
-    canSeeFinancials: false,
-    canSeeCustomerDetails: false,
-    showAdvancedFilters: false,
-    showActionButtons: false,
-  };
-}
+export const BASE_USER_PERMISSIONS: UserPermissions = {
+  canValidate: false,
+  canShip: false,
+  canDeliver: false,
+  canCancel: false,
+  canReturn: false,
+  canRefund: false,
+  canSendEmails: false,
+  canCreateOrders: false,
+  canExport: false,
+  canMarkPaid: false,
+  canSeeFullStats: false,
+  canSeeFinancials: false,
+  canSeeCustomerDetails: false,
+  showAdvancedFilters: false,
+  showActionButtons: false,
+};
 
 /**
- * Vérifie si l'utilisateur peut effectuer une action spécifique
- * @param permissions - Objet de permissions
- * @param action - Action à vérifier
- * @returns true si autorisé
+ * Fetch the canonical permission set for a user from the backend.
+ * Call from Remix loaders (server-side); pass the request cookie through
+ * so the backend session is recognized.
  */
+export async function loadUserPermissions(
+  userId: string,
+  cookie?: string,
+): Promise<UserPermissions> {
+  const headers: Record<string, string> = {};
+  if (cookie) headers.Cookie = cookie;
+  try {
+    const res = await fetch(
+      `http://127.0.0.1:3000/api/auth/user-permissions/${encodeURIComponent(
+        userId,
+      )}`,
+      { headers },
+    );
+    if (!res.ok) return BASE_USER_PERMISSIONS;
+    return (await res.json()) as UserPermissions;
+  } catch {
+    return BASE_USER_PERMISSIONS;
+  }
+}
+
 export function canPerformAction(
   permissions: UserPermissions,
-  action: keyof UserPermissions
+  action: keyof UserPermissions,
 ): boolean {
   return permissions[action] === true;
 }
 
 /**
- * Retourne le rôle affiché selon le niveau
+ * Display-only role badge — derived from level locally (no API call).
  */
 export function getUserRole(userLevel: number): {
   label: string;
@@ -162,44 +90,40 @@ export function getUserRole(userLevel: number): {
 } {
   if (userLevel >= 9) {
     return {
-      label: 'Super Admin',
-      badge: '👑',
-      color: 'text-purple-800',
-      bgColor: 'bg-purple-100',
+      label: "Super Admin",
+      badge: "👑",
+      color: "text-purple-800",
+      bgColor: "bg-purple-100",
     };
   }
-  
   if (userLevel >= 7) {
     return {
-      label: 'Administrateur',
-      badge: '🔑',
-      color: 'text-blue-800',
-      bgColor: 'bg-blue-100',
+      label: "Administrateur",
+      badge: "🔑",
+      color: "text-blue-800",
+      bgColor: "bg-blue-100",
     };
   }
-  
   if (userLevel >= 5) {
     return {
-      label: 'Responsable',
-      badge: '📊',
-      color: 'text-green-800',
-      bgColor: 'bg-green-100',
+      label: "Responsable",
+      badge: "📊",
+      color: "text-green-800",
+      bgColor: "bg-green-100",
     };
   }
-  
   if (userLevel >= 3) {
     return {
-      label: 'Commercial',
-      badge: '👔',
-      color: 'text-indigo-800',
-      bgColor: 'bg-indigo-100',
+      label: "Commercial",
+      badge: "👔",
+      color: "text-indigo-800",
+      bgColor: "bg-indigo-100",
     };
   }
-  
   return {
-    label: 'Utilisateur',
-    badge: '👤',
-    color: 'text-gray-800',
-    bgColor: 'bg-gray-100',
+    label: "Utilisateur",
+    badge: "👤",
+    color: "text-gray-800",
+    bgColor: "bg-gray-100",
   };
 }

--- a/log.md
+++ b/log.md
@@ -123,3 +123,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/fe-diagnostic-wizard-dynamic`
 - **Décision** : feat(adr-032-pr10): make DiagnosticWizard.tsx dynamic via /wizard-steps endpoint
 - **Sortie** : PR #219 | commits d55e5beb
+
+## 2026-04-30 — fix/permissions-canonical-backend (auto)
+
+- **Branche** : `fix/permissions-canonical-backend`
+- **Décision** : feat(auth): add UserPermissions DTO + level constants (+2 other commits)
+- **Sortie** : PR aucune | commits fa3c03ef 8ba4394a 2b9678b3


### PR DESCRIPTION
## Summary

- Move per-action permission matrix from frontend to backend as **single source of truth**.
- Replace `IsAdminGuard` with `@RequirePermission(action)` on all 11 `OrderActionsController` endpoints.
- Frontend `permissions.ts` becomes a thin API client; loaders fetch the canonical matrix via `loadUserPermissions(userId, cookie)`.

**Trigger:** Order `ORD-1777531019900-837` cancel returned `Forbidden resource` (HTTP 403) to a commercial-level session despite `frontend/app/utils/permissions.ts` declaring `canCancel: true` for level 3+. Same root cause would silently break ship/deliver/mark-paid/validate/equiv-* for commerciaux.

**Spec:** [`docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md`](https://github.com/ak125/nestjs-remix-monorepo/blob/fix/permissions-canonical-backend/docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md)
**Plan:** [`docs/superpowers/plans/2026-04-30-permissions-canonical-backend.md`](https://github.com/ak125/nestjs-remix-monorepo/blob/fix/permissions-canonical-backend/docs/superpowers/plans/2026-04-30-permissions-canonical-backend.md)

## Architecture

| Layer | Component | File |
|---|---|---|
| Source of truth | `UserPermissions` interface + 5 level constants | `backend/src/auth/dto/user-permissions.dto.ts` |
| Resolver | `PermissionsService.getPermissions(level)` / `hasPermission` | `backend/src/auth/permissions.service.ts` |
| Decorator | `@RequirePermission('canX')` | `backend/src/auth/decorators/require-permission.decorator.ts` |
| Guard | `PermissionsGuard` (Reflector + service) | `backend/src/auth/guards/permissions.guard.ts` |
| Endpoint | `GET /api/auth/user-permissions/:userId` returns `UserPermissions` | `backend/src/auth/controllers/auth-permissions.controller.ts` |
| Consumer (back) | 11 endpoints `OrderActionsController` | `backend/src/modules/orders/controllers/order-actions.controller.ts` |
| Consumer (front) | `loadUserPermissions(userId, cookie)` thin client | `frontend/app/utils/permissions.ts` + 2 routes |

## Mapping endpoints orders → permissions

| Endpoint | Permission |
|---|---|
| `cancel` | `canCancel` |
| `ship` | `canShip` |
| `deliver` | `canDeliver` |
| `confirm-payment` | `canMarkPaid` |
| `validate` | `canValidate` |
| `lines/:id/status/:s` | `canValidate` |
| `lines/:id/order-from-supplier` | `canValidate` |
| `lines/:id/propose-equivalent` | `canValidate` |
| `lines/:id/accept-equivalent` | `canValidate` |
| `lines/:id/reject-equivalent` | `canValidate` |
| `payment-reminder` | `canSendEmails` |

## Breaking change

`GET /api/auth/user-permissions/:userId` response shape changes from per-module `read/write` matrix to the canonical 15-booleans `UserPermissions`. Only known consumer is `frontend/app/utils/permissions.ts`, refactored in this same PR. Verified via `grep -rn "user-permissions" frontend/ backend/`.

## Out of scope (follow-up PRs, same pattern)

`IsAdminGuard` is **kept as-is** for ~25 other controllers (blog, advice, seo, vehicles, configuration, search, admin-keyword-clusters, admin-vehicle-cache, admin-vehicle-rag, errors, admin-r1-related-blocks-cache, …). Each of these can be migrated to `@RequirePermission(...)` in dedicated PRs reusing the infrastructure shipped here.

## Tests

- ✅ Unit `PermissionsService` — 34 cases (5 levels × 15 actions sample, plus edge cases). PASS.
- ✅ Unit `PermissionsGuard` — 7 cases (no-decorator, commercial OK, base 403, no-user 403, admin OK, commercial-no-refund, string-level coercion). PASS.
- ⏭️ E2E — skipped (no `backend/test/` harness exists in repo). Smoke test on DEV covers integration.
- 🔜 Smoke on DEV (after merge to main → auto-deploy): commercial level 3 cancels test order, verify `___xtr_order.ord_ords_id = '6'` + `__admin_audit_log` row + email reception.

## Test plan

- [ ] CI green (typecheck, lint, perf-gates).
- [ ] Smoke DEV : se loguer en commercial level 3, annuler une commande de test (PAS une vraie commande client). Attendu : toast succès, statut → 6, audit log + history créés, email envoyé.
- [ ] Régression smoke DEV : se loguer en admin level 7, annuler une commande de test. Attendu : même résultat (régression évitée).
- [ ] Smoke DEV : level 1 (utilisateur de base) — bouton caché côté UI ET backend retourne 403 (defense in depth).
- [ ] Vérifier les logs `Permission denied: ... lacks "canCancel"` pour les rejets.

## Rollback

`git revert <merge-commit>` ; redéploie DEV automatiquement. Aucun cleanup DB nécessaire — les commandes annulées par commerciaux entre déploiement et rollback restent valides (statut 6, audit log, email envoyé sont préservés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)