### PR TITLE
feat(seo): SEO Agent Operating Matrix — single-source view (additive)

### DIFF
--- a/audit-reports/seo-agent-matrix.json
+++ b/audit-reports/seo-agent-matrix.json
@@ -21,7 +21,7 @@
     "r1-router-validator": "R1_ROUTER",
     "r2-keyword-planner": "R2_PRODUCT",
     "r2-product-validator": "R2_PRODUCT",
-    "r3-conseils-validator": "UNKNOWN",
+    "r3-conseils-validator": "R3_CONSEILS",
     "r3-image-prompt": "UNKNOWN",
     "r3-keyword-plan-batch": "UNKNOWN",
     "r3-keyword-planner": "UNKNOWN",
@@ -33,10 +33,10 @@
     "r5-diagnostic-validator": "R5_DIAGNOSTIC",
     "r5-keyword-planner": "R5_DIAGNOSTIC",
     "r6-content-batch": "UNKNOWN",
-    "r6-guide-achat-validator": "UNKNOWN",
+    "r6-guide-achat-validator": "R6_GUIDE_ACHAT",
     "r6-image-prompt": "UNKNOWN",
     "r6-keyword-planner": "UNKNOWN",
-    "r6-support-validator": "UNKNOWN",
+    "r6-support-validator": "R6_SUPPORT",
     "r7-brand-execution": "R7_BRAND",
     "r7-brand-rag-generator": "R7_BRAND",
     "r7-brand-validator": "R7_BRAND",
@@ -62,6 +62,14 @@
       ],
       "reason": "agents_without_registry",
       "roleId": "R0_HOME"
+    },
+    {
+      "agentCount": 1,
+      "agents": [
+        "r6-support-validator"
+      ],
+      "reason": "agents_without_registry",
+      "roleId": "R6_SUPPORT"
     },
     {
       "agentCount": 4,
@@ -208,9 +216,11 @@
       }
     },
     {
-      "agents": [],
+      "agents": [
+        "r3-conseils-validator"
+      ],
       "deprecated": false,
-      "healthScore": 80,
+      "healthScore": 100,
       "registry": {
         "agentFiles": [
           "conseil-batch.md",
@@ -323,9 +333,11 @@
       }
     },
     {
-      "agents": [],
+      "agents": [
+        "r6-support-validator"
+      ],
       "deprecated": false,
-      "healthScore": 20,
+      "healthScore": 40,
       "registry": {
         "present": false
       },
@@ -337,9 +349,11 @@
       }
     },
     {
-      "agents": [],
+      "agents": [
+        "r6-guide-achat-validator"
+      ],
       "deprecated": false,
-      "healthScore": 80,
+      "healthScore": 100,
       "registry": {
         "agentFiles": [
           "r6-content-batch.md",
@@ -460,15 +474,12 @@
     "conseil-batch",
     "keyword-planner",
     "phase1-auditor",
-    "r3-conseils-validator",
     "r3-image-prompt",
     "r3-keyword-plan-batch",
     "r3-keyword-planner",
     "r6-content-batch",
-    "r6-guide-achat-validator",
     "r6-image-prompt",
     "r6-keyword-planner",
-    "r6-support-validator",
     "research-agent"
   ]
 }

--- a/audit-reports/seo-agent-matrix.json
+++ b/audit-reports/seo-agent-matrix.json
@@ -1,0 +1,474 @@
+{
+  "agentScanRootsConfigured": [
+    "workspaces/seo-batch/.claude/agents",
+    ".claude/agents",
+    "backend/.claude/agents"
+  ],
+  "agentScanSkipped": false,
+  "agentsIndex": {
+    "agentic-critic": "UNKNOWN",
+    "agentic-planner": "UNKNOWN",
+    "agentic-solver": "UNKNOWN",
+    "blog-hub-planner": "UNKNOWN",
+    "brief-enricher": "UNKNOWN",
+    "conseil-batch": "UNKNOWN",
+    "keyword-planner": "UNKNOWN",
+    "phase1-auditor": "UNKNOWN",
+    "r0-home-execution": "R0_HOME",
+    "r0-home-validator": "R0_HOME",
+    "r1-content-batch": "R1_ROUTER",
+    "r1-keyword-planner": "R1_ROUTER",
+    "r1-router-validator": "R1_ROUTER",
+    "r2-keyword-planner": "R2_PRODUCT",
+    "r2-product-validator": "R2_PRODUCT",
+    "r3-conseils-validator": "UNKNOWN",
+    "r3-image-prompt": "UNKNOWN",
+    "r3-keyword-plan-batch": "UNKNOWN",
+    "r3-keyword-planner": "UNKNOWN",
+    "r4-content-batch": "R4_REFERENCE",
+    "r4-keyword-planner": "R4_REFERENCE",
+    "r4-reference-execution": "R4_REFERENCE",
+    "r4-reference-validator": "R4_REFERENCE",
+    "r5-diagnostic-execution": "R5_DIAGNOSTIC",
+    "r5-diagnostic-validator": "R5_DIAGNOSTIC",
+    "r5-keyword-planner": "R5_DIAGNOSTIC",
+    "r6-content-batch": "UNKNOWN",
+    "r6-guide-achat-validator": "UNKNOWN",
+    "r6-image-prompt": "UNKNOWN",
+    "r6-keyword-planner": "UNKNOWN",
+    "r6-support-validator": "UNKNOWN",
+    "r7-brand-execution": "R7_BRAND",
+    "r7-brand-rag-generator": "R7_BRAND",
+    "r7-brand-validator": "R7_BRAND",
+    "r7-keyword-planner": "R7_BRAND",
+    "r8-keyword-planner": "R8_VEHICLE",
+    "r8-vehicle-execution": "R8_VEHICLE",
+    "r8-vehicle-validator": "R8_VEHICLE",
+    "research-agent": "UNKNOWN"
+  },
+  "anomalies": [
+    {
+      "reason": "deprecated_but_in_registry",
+      "roleId": "R3_GUIDE"
+    }
+  ],
+  "catalogFieldCount": 141,
+  "gaps": [
+    {
+      "agentCount": 2,
+      "agents": [
+        "r0-home-execution",
+        "r0-home-validator"
+      ],
+      "reason": "agents_without_registry",
+      "roleId": "R0_HOME"
+    },
+    {
+      "agentCount": 4,
+      "agents": [
+        "r7-brand-execution",
+        "r7-brand-rag-generator",
+        "r7-brand-validator",
+        "r7-keyword-planner"
+      ],
+      "reason": "agents_without_registry",
+      "roleId": "R7_BRAND"
+    }
+  ],
+  "registryVersion": "1.0.0",
+  "roles": [
+    {
+      "agents": [
+        "r0-home-execution",
+        "r0-home-validator"
+      ],
+      "deprecated": false,
+      "healthScore": 40,
+      "registry": {
+        "present": false
+      },
+      "roleId": "R0_HOME",
+      "writeScope": {
+        "ownedFieldsCount": 0,
+        "ownedTables": [],
+        "resourceGroups": []
+      }
+    },
+    {
+      "agents": [
+        "r1-content-batch",
+        "r1-keyword-planner",
+        "r1-router-validator"
+      ],
+      "deprecated": false,
+      "healthScore": 100,
+      "registry": {
+        "agentFiles": [
+          "r1-content-batch.md"
+        ],
+        "allowedModes": [
+          "create",
+          "regenerate",
+          "refresh_partial",
+          "refresh_full",
+          "repair",
+          "qa_only"
+        ],
+        "contractSchemaRef": "page-contract-r1.schema",
+        "defaultWriteMode": "draft_write",
+        "enricherServiceKey": "R1EnricherService",
+        "present": true,
+        "stopPolicy": {
+          "maxRetries": 2,
+          "timeoutMs": 120000
+        }
+      },
+      "roleId": "R1_ROUTER",
+      "writeScope": {
+        "ownedFieldsCount": 38,
+        "ownedTables": [
+          "__seo_gamme",
+          "__seo_r1_gamme_slots",
+          "__seo_page_brief"
+        ],
+        "resourceGroups": [
+          "seo_gamme_main",
+          "r1_gamme_slots",
+          "page_brief_main"
+        ]
+      }
+    },
+    {
+      "agents": [
+        "r2-keyword-planner",
+        "r2-product-validator"
+      ],
+      "deprecated": false,
+      "healthScore": 100,
+      "registry": {
+        "agentFiles": [
+          "r2-keyword-planner.md"
+        ],
+        "allowedModes": [
+          "create",
+          "regenerate",
+          "refresh_full",
+          "qa_only"
+        ],
+        "contractSchemaRef": "r2-content-contract.schema",
+        "defaultWriteMode": "draft_write",
+        "enricherServiceKey": "R2EnricherService",
+        "present": true,
+        "stopPolicy": {
+          "maxRetries": 1,
+          "timeoutMs": 120000
+        }
+      },
+      "roleId": "R2_PRODUCT",
+      "writeScope": {
+        "ownedFieldsCount": 15,
+        "ownedTables": [
+          "__seo_r2_keyword_plan"
+        ],
+        "resourceGroups": [
+          "r2_product_main"
+        ]
+      }
+    },
+    {
+      "agents": [],
+      "deprecated": true,
+      "healthScore": 30,
+      "registry": {
+        "agentFiles": [
+          "content-batch.md"
+        ],
+        "allowedModes": [
+          "create",
+          "regenerate",
+          "refresh_partial",
+          "refresh_full",
+          "repair",
+          "qa_only"
+        ],
+        "contractSchemaRef": "page-contract-r3.schema",
+        "defaultWriteMode": "draft_write",
+        "enricherServiceKey": "BuyingGuideEnricherService",
+        "present": true,
+        "stopPolicy": {
+          "maxRetries": 2,
+          "timeoutMs": 180000
+        }
+      },
+      "roleId": "R3_GUIDE",
+      "writeScope": {
+        "ownedFieldsCount": 0,
+        "ownedTables": [],
+        "resourceGroups": []
+      }
+    },
+    {
+      "agents": [],
+      "deprecated": false,
+      "healthScore": 80,
+      "registry": {
+        "agentFiles": [
+          "conseil-batch.md",
+          "keyword-planner.md"
+        ],
+        "allowedModes": [
+          "create",
+          "regenerate",
+          "refresh_partial",
+          "refresh_full",
+          "repair",
+          "qa_only"
+        ],
+        "contractSchemaRef": "page-contract-r3.schema",
+        "defaultWriteMode": "draft_write",
+        "enricherServiceKey": "ConseilEnricherService",
+        "present": true,
+        "stopPolicy": {
+          "maxRetries": 2,
+          "timeoutMs": 180000
+        }
+      },
+      "roleId": "R3_CONSEILS",
+      "writeScope": {
+        "ownedFieldsCount": 12,
+        "ownedTables": [
+          "__seo_gamme_conseil"
+        ],
+        "resourceGroups": [
+          "r3_conseil_section"
+        ]
+      }
+    },
+    {
+      "agents": [
+        "r4-content-batch",
+        "r4-keyword-planner",
+        "r4-reference-execution",
+        "r4-reference-validator"
+      ],
+      "deprecated": false,
+      "healthScore": 100,
+      "registry": {
+        "agentFiles": [
+          "r4-content-batch.md",
+          "r4-keyword-planner.md"
+        ],
+        "allowedModes": [
+          "create",
+          "regenerate",
+          "refresh_partial",
+          "refresh_full",
+          "repair",
+          "qa_only"
+        ],
+        "contractSchemaRef": "page-contract-r4.schema",
+        "defaultWriteMode": "draft_write",
+        "enricherServiceKey": "ReferenceService",
+        "present": true,
+        "stopPolicy": {
+          "maxRetries": 2,
+          "timeoutMs": 120000
+        }
+      },
+      "roleId": "R4_REFERENCE",
+      "writeScope": {
+        "ownedFieldsCount": 21,
+        "ownedTables": [
+          "__seo_reference"
+        ],
+        "resourceGroups": [
+          "r4_reference_main"
+        ]
+      }
+    },
+    {
+      "agents": [
+        "r5-diagnostic-execution",
+        "r5-diagnostic-validator",
+        "r5-keyword-planner"
+      ],
+      "deprecated": false,
+      "healthScore": 100,
+      "registry": {
+        "agentFiles": [],
+        "allowedModes": [
+          "create",
+          "regenerate",
+          "refresh_full",
+          "qa_only"
+        ],
+        "contractSchemaRef": "page-contract-r5.schema",
+        "defaultWriteMode": "draft_write",
+        "enricherServiceKey": "DiagnosticService",
+        "present": true,
+        "stopPolicy": {
+          "maxRetries": 1,
+          "timeoutMs": 60000
+        }
+      },
+      "roleId": "R5_DIAGNOSTIC",
+      "writeScope": {
+        "ownedFieldsCount": 16,
+        "ownedTables": [
+          "__seo_observable"
+        ],
+        "resourceGroups": [
+          "r5_diagnostic_main"
+        ]
+      }
+    },
+    {
+      "agents": [],
+      "deprecated": false,
+      "healthScore": 20,
+      "registry": {
+        "present": false
+      },
+      "roleId": "R6_SUPPORT",
+      "writeScope": {
+        "ownedFieldsCount": 0,
+        "ownedTables": [],
+        "resourceGroups": []
+      }
+    },
+    {
+      "agents": [],
+      "deprecated": false,
+      "healthScore": 80,
+      "registry": {
+        "agentFiles": [
+          "r6-content-batch.md",
+          "r6-keyword-planner.md"
+        ],
+        "allowedModes": [
+          "create",
+          "regenerate",
+          "refresh_partial",
+          "refresh_full",
+          "repair",
+          "qa_only"
+        ],
+        "contractSchemaRef": "page-contract-r6.schema",
+        "defaultWriteMode": "draft_write",
+        "enricherServiceKey": "BuyingGuideEnricherService",
+        "present": true,
+        "stopPolicy": {
+          "maxRetries": 2,
+          "timeoutMs": 180000
+        }
+      },
+      "roleId": "R6_GUIDE_ACHAT",
+      "writeScope": {
+        "ownedFieldsCount": 28,
+        "ownedTables": [
+          "__seo_gamme_purchase_guide"
+        ],
+        "resourceGroups": [
+          "purchase_guide_main"
+        ]
+      }
+    },
+    {
+      "agents": [
+        "r7-brand-execution",
+        "r7-brand-rag-generator",
+        "r7-brand-validator",
+        "r7-keyword-planner"
+      ],
+      "deprecated": false,
+      "healthScore": 40,
+      "registry": {
+        "present": false
+      },
+      "roleId": "R7_BRAND",
+      "writeScope": {
+        "ownedFieldsCount": 0,
+        "ownedTables": [],
+        "resourceGroups": []
+      }
+    },
+    {
+      "agents": [
+        "r8-keyword-planner",
+        "r8-vehicle-execution",
+        "r8-vehicle-validator"
+      ],
+      "deprecated": false,
+      "healthScore": 100,
+      "registry": {
+        "agentFiles": [
+          "r8-keyword-planner.md"
+        ],
+        "allowedModes": [
+          "create",
+          "regenerate",
+          "refresh_full",
+          "qa_only"
+        ],
+        "contractSchemaRef": "page-contract-r8.schema",
+        "defaultWriteMode": "draft_write",
+        "enricherServiceKey": "R8VehicleEnricherService",
+        "present": true,
+        "stopPolicy": {
+          "maxRetries": 1,
+          "timeoutMs": 120000
+        }
+      },
+      "roleId": "R8_VEHICLE",
+      "writeScope": {
+        "ownedFieldsCount": 11,
+        "ownedTables": [
+          "__seo_r8_pages"
+        ],
+        "resourceGroups": [
+          "r8_vehicle_main"
+        ]
+      }
+    },
+    {
+      "agents": [],
+      "deprecated": true,
+      "healthScore": 0,
+      "registry": {
+        "present": false
+      },
+      "roleId": "R9_GOVERNANCE",
+      "writeScope": {
+        "ownedFieldsCount": 0,
+        "ownedTables": [],
+        "resourceGroups": []
+      }
+    }
+  ],
+  "sourcesHash": {
+    "executionRegistry": "sha256:bf704a8c0627478c07ae2d74ec07fc1809e9dbe762e16eaec60c6382c4c0e0a9",
+    "executionRegistryTypes": "sha256:6c585a3075471f5189d5c1a48bd83e0f1ce6460cd1af9a9398a6d2b0d68c1d46",
+    "fieldCatalog": "sha256:de4b23f16019338092340be58b0cfe421519aceb94a148efca07f99021fef0f7",
+    "roleIds": "sha256:8c8257d1ad07acf06cd97a240822ca9ac6d625600300048a73c66d52134c2857"
+  },
+  "unmappableAgents": [
+    "agentic-critic",
+    "agentic-planner",
+    "agentic-solver",
+    "blog-hub-planner",
+    "brief-enricher",
+    "conseil-batch",
+    "keyword-planner",
+    "phase1-auditor",
+    "r3-conseils-validator",
+    "r3-image-prompt",
+    "r3-keyword-plan-batch",
+    "r3-keyword-planner",
+    "r6-content-batch",
+    "r6-guide-achat-validator",
+    "r6-image-prompt",
+    "r6-keyword-planner",
+    "r6-support-validator",
+    "research-agent"
+  ]
+}

--- a/audit-reports/seo-agent-matrix.md
+++ b/audit-reports/seo-agent-matrix.md
@@ -1,6 +1,6 @@
 # SEO Agent Operating Matrix
 
-> Généré le : 2026-04-30T11:40:16.372Z
+> Généré le : 2026-04-30T11:49:46.539Z
 > Sources hash : registry=bf704a8c types=6c585a30 catalog=de4b23f1 roleIds=8c8257d1
 > Registry version : 1.0.0 — Field catalog : 141 entrées
 
@@ -12,11 +12,11 @@
 | R1_ROUTER | 100 | ✅ | r1-content-batch, r1-keyword-planner, r1-router-validator | __seo_gamme, __seo_r1_gamme_slots, __seo_page_brief | 38 |
 | R2_PRODUCT | 100 | ✅ | r2-keyword-planner, r2-product-validator | __seo_r2_keyword_plan | 15 |
 | R3_GUIDE (deprecated) | 30 | ✅ | — | — | 0 |
-| R3_CONSEILS | 80 | ✅ | — | __seo_gamme_conseil | 12 |
+| R3_CONSEILS | 100 | ✅ | r3-conseils-validator | __seo_gamme_conseil | 12 |
 | R4_REFERENCE | 100 | ✅ | r4-content-batch, r4-keyword-planner, r4-reference-execution, r4-reference-validator | __seo_reference | 21 |
 | R5_DIAGNOSTIC | 100 | ✅ | r5-diagnostic-execution, r5-diagnostic-validator, r5-keyword-planner | __seo_observable | 16 |
-| R6_SUPPORT | 20 | ❌ | — | — | 0 |
-| R6_GUIDE_ACHAT | 80 | ✅ | — | __seo_gamme_purchase_guide | 28 |
+| R6_SUPPORT | 40 | ❌ | r6-support-validator | — | 0 |
+| R6_GUIDE_ACHAT | 100 | ✅ | r6-guide-achat-validator | __seo_gamme_purchase_guide | 28 |
 | R7_BRAND | 40 | ❌ | r7-brand-execution, r7-brand-rag-generator, r7-brand-validator, r7-keyword-planner | — | 0 |
 | R8_VEHICLE | 100 | ✅ | r8-keyword-planner, r8-vehicle-execution, r8-vehicle-validator | __seo_r8_pages | 11 |
 | R9_GOVERNANCE (deprecated) | 0 | ❌ | — | — | 0 |
@@ -24,6 +24,7 @@
 ## Gaps (agents sans entrée registry)
 
 - ❌ **R0_HOME** : 2 agent(s) — r0-home-execution, r0-home-validator
+- ❌ **R6_SUPPORT** : 1 agent(s) — r6-support-validator
 - ❌ **R7_BRAND** : 4 agent(s) — r7-brand-execution, r7-brand-rag-generator, r7-brand-validator, r7-keyword-planner
 
 ## Anomalies
@@ -40,15 +41,12 @@
 - conseil-batch
 - keyword-planner
 - phase1-auditor
-- r3-conseils-validator
 - r3-image-prompt
 - r3-keyword-plan-batch
 - r3-keyword-planner
 - r6-content-batch
-- r6-guide-achat-validator
 - r6-image-prompt
 - r6-keyword-planner
-- r6-support-validator
 - research-agent
 
 ## Index inverse (agent → rôle)
@@ -70,7 +68,7 @@
 | r1-router-validator | R1_ROUTER |
 | r2-keyword-planner | R2_PRODUCT |
 | r2-product-validator | R2_PRODUCT |
-| r3-conseils-validator | UNKNOWN |
+| r3-conseils-validator | R3_CONSEILS |
 | r3-image-prompt | UNKNOWN |
 | r3-keyword-plan-batch | UNKNOWN |
 | r3-keyword-planner | UNKNOWN |
@@ -82,10 +80,10 @@
 | r5-diagnostic-validator | R5_DIAGNOSTIC |
 | r5-keyword-planner | R5_DIAGNOSTIC |
 | r6-content-batch | UNKNOWN |
-| r6-guide-achat-validator | UNKNOWN |
+| r6-guide-achat-validator | R6_GUIDE_ACHAT |
 | r6-image-prompt | UNKNOWN |
 | r6-keyword-planner | UNKNOWN |
-| r6-support-validator | UNKNOWN |
+| r6-support-validator | R6_SUPPORT |
 | r7-brand-execution | R7_BRAND |
 | r7-brand-rag-generator | R7_BRAND |
 | r7-brand-validator | R7_BRAND |

--- a/audit-reports/seo-agent-matrix.md
+++ b/audit-reports/seo-agent-matrix.md
@@ -1,0 +1,103 @@
+# SEO Agent Operating Matrix
+
+> Généré le : 2026-04-30T11:40:16.372Z
+> Sources hash : registry=bf704a8c types=6c585a30 catalog=de4b23f1 roleIds=8c8257d1
+> Registry version : 1.0.0 — Field catalog : 141 entrées
+
+## Matrice principale
+
+| Rôle | Health | Registry | Agents | Tables ownées | # Fields |
+|---|---|---|---|---|---|
+| R0_HOME | 40 | ❌ | r0-home-execution, r0-home-validator | — | 0 |
+| R1_ROUTER | 100 | ✅ | r1-content-batch, r1-keyword-planner, r1-router-validator | __seo_gamme, __seo_r1_gamme_slots, __seo_page_brief | 38 |
+| R2_PRODUCT | 100 | ✅ | r2-keyword-planner, r2-product-validator | __seo_r2_keyword_plan | 15 |
+| R3_GUIDE (deprecated) | 30 | ✅ | — | — | 0 |
+| R3_CONSEILS | 80 | ✅ | — | __seo_gamme_conseil | 12 |
+| R4_REFERENCE | 100 | ✅ | r4-content-batch, r4-keyword-planner, r4-reference-execution, r4-reference-validator | __seo_reference | 21 |
+| R5_DIAGNOSTIC | 100 | ✅ | r5-diagnostic-execution, r5-diagnostic-validator, r5-keyword-planner | __seo_observable | 16 |
+| R6_SUPPORT | 20 | ❌ | — | — | 0 |
+| R6_GUIDE_ACHAT | 80 | ✅ | — | __seo_gamme_purchase_guide | 28 |
+| R7_BRAND | 40 | ❌ | r7-brand-execution, r7-brand-rag-generator, r7-brand-validator, r7-keyword-planner | — | 0 |
+| R8_VEHICLE | 100 | ✅ | r8-keyword-planner, r8-vehicle-execution, r8-vehicle-validator | __seo_r8_pages | 11 |
+| R9_GOVERNANCE (deprecated) | 0 | ❌ | — | — | 0 |
+
+## Gaps (agents sans entrée registry)
+
+- ❌ **R0_HOME** : 2 agent(s) — r0-home-execution, r0-home-validator
+- ❌ **R7_BRAND** : 4 agent(s) — r7-brand-execution, r7-brand-rag-generator, r7-brand-validator, r7-keyword-planner
+
+## Anomalies
+
+- ⚠️ **R3_GUIDE** — deprecated_but_in_registry
+
+## Agents non-mappables
+
+- agentic-critic
+- agentic-planner
+- agentic-solver
+- blog-hub-planner
+- brief-enricher
+- conseil-batch
+- keyword-planner
+- phase1-auditor
+- r3-conseils-validator
+- r3-image-prompt
+- r3-keyword-plan-batch
+- r3-keyword-planner
+- r6-content-batch
+- r6-guide-achat-validator
+- r6-image-prompt
+- r6-keyword-planner
+- r6-support-validator
+- research-agent
+
+## Index inverse (agent → rôle)
+
+| Agent | Rôle résolu |
+|---|---|
+| agentic-critic | UNKNOWN |
+| agentic-planner | UNKNOWN |
+| agentic-solver | UNKNOWN |
+| blog-hub-planner | UNKNOWN |
+| brief-enricher | UNKNOWN |
+| conseil-batch | UNKNOWN |
+| keyword-planner | UNKNOWN |
+| phase1-auditor | UNKNOWN |
+| r0-home-execution | R0_HOME |
+| r0-home-validator | R0_HOME |
+| r1-content-batch | R1_ROUTER |
+| r1-keyword-planner | R1_ROUTER |
+| r1-router-validator | R1_ROUTER |
+| r2-keyword-planner | R2_PRODUCT |
+| r2-product-validator | R2_PRODUCT |
+| r3-conseils-validator | UNKNOWN |
+| r3-image-prompt | UNKNOWN |
+| r3-keyword-plan-batch | UNKNOWN |
+| r3-keyword-planner | UNKNOWN |
+| r4-content-batch | R4_REFERENCE |
+| r4-keyword-planner | R4_REFERENCE |
+| r4-reference-execution | R4_REFERENCE |
+| r4-reference-validator | R4_REFERENCE |
+| r5-diagnostic-execution | R5_DIAGNOSTIC |
+| r5-diagnostic-validator | R5_DIAGNOSTIC |
+| r5-keyword-planner | R5_DIAGNOSTIC |
+| r6-content-batch | UNKNOWN |
+| r6-guide-achat-validator | UNKNOWN |
+| r6-image-prompt | UNKNOWN |
+| r6-keyword-planner | UNKNOWN |
+| r6-support-validator | UNKNOWN |
+| r7-brand-execution | R7_BRAND |
+| r7-brand-rag-generator | R7_BRAND |
+| r7-brand-validator | R7_BRAND |
+| r7-keyword-planner | R7_BRAND |
+| r8-keyword-planner | R8_VEHICLE |
+| r8-vehicle-execution | R8_VEHICLE |
+| r8-vehicle-validator | R8_VEHICLE |
+| research-agent | UNKNOWN |
+
+---
+
+_Paths agent configurés : workspaces/seo-batch/.claude/agents, .claude/agents, backend/.claude/agents_
+_Paths agent effectivement scannés : workspaces/seo-batch/.claude/agents_
+
+_Source : OperatingMatrixService (`backend/src/config/operating-matrix.service.ts`). Régénérer via `npm run seo:matrix`._

--- a/backend/src/config/operating-matrix.module.ts
+++ b/backend/src/config/operating-matrix.module.ts
@@ -1,0 +1,26 @@
+/**
+ * OperatingMatrixModule — minimal NestJS context exposing OperatingMatrixService.
+ *
+ * Used by scripts/seo/dump-agent-matrix.ts via NestFactory.createApplicationContext.
+ *
+ * Why a dedicated lightweight module rather than reusing WriteGuardModule:
+ *   - WriteGuardModule is `@Global` and pulls Redis, feature-flags and ledger
+ *     services via OnModuleInit — booting from a CLI would require live env
+ *     vars (REDIS_URL, SUPABASE_*) and risk runtime drift.
+ *   - The matrix is read-only by construction (registry × catalog × filesystem
+ *     scan of .claude/agents). It deserves a context with zero infra deps.
+ *
+ * Purely additive: this module is not imported anywhere in the live app today.
+ * Wiring into AdminModule (for an admin endpoint) is a separate decision.
+ */
+
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { OperatingMatrixService } from './operating-matrix.service';
+
+@Module({
+  imports: [ConfigModule.forRoot({ isGlobal: true })],
+  providers: [OperatingMatrixService],
+  exports: [OperatingMatrixService],
+})
+export class OperatingMatrixModule {}

--- a/backend/src/config/operating-matrix.service.test.ts
+++ b/backend/src/config/operating-matrix.service.test.ts
@@ -1,0 +1,190 @@
+import { ConfigService } from '@nestjs/config';
+import { OperatingMatrixService } from './operating-matrix.service';
+import { ROLE_ID_LIST, RoleId } from './role-ids';
+import { EXECUTION_REGISTRY } from './execution-registry.constants';
+
+function makeService(env: Record<string, string | undefined> = {}) {
+  const config = {
+    get: <T = unknown>(key: string): T | undefined => env[key] as T | undefined,
+  } as unknown as ConfigService;
+  return new OperatingMatrixService(config);
+}
+
+describe('OperatingMatrixService', () => {
+  describe('snapshot()', () => {
+    const svc = makeService({ NODE_ENV: 'test' });
+    const snap = svc.snapshot();
+
+    it('emits one entry per RoleId in ROLE_ID_LIST (12 entries)', () => {
+      expect(snap.roles.map((r) => r.roleId)).toEqual([...ROLE_ID_LIST]);
+      expect(snap.roles).toHaveLength(12);
+    });
+
+    it('records the registry version + catalog field count', () => {
+      expect(snap.registryVersion).toBe('1.0.0');
+      expect(snap.catalogFieldCount).toBeGreaterThan(0);
+    });
+
+    it('exposes the configured agent scan paths (deterministic, not the found ones)', () => {
+      expect(snap.agentScanRootsConfigured).toEqual([
+        'workspaces/seo-batch/.claude/agents',
+        '.claude/agents',
+        'backend/.claude/agents',
+      ]);
+    });
+
+    it('hashes source files using "sha256:" prefix + 64 hex chars', () => {
+      for (const v of Object.values(snap.sourcesHash)) {
+        expect(v).toMatch(/^sha256:[a-f0-9]{64}$/);
+      }
+    });
+
+    it('marks R3_GUIDE and R9_GOVERNANCE as deprecated', () => {
+      const r3 = snap.roles.find((r) => r.roleId === RoleId.R3_GUIDE);
+      const r9 = snap.roles.find((r) => r.roleId === RoleId.R9_GOVERNANCE);
+      expect(r3?.deprecated).toBe(true);
+      expect(r9?.deprecated).toBe(true);
+    });
+
+    it('flags deprecated_but_in_registry for any deprecated role still in EXECUTION_REGISTRY', () => {
+      const expected = ROLE_ID_LIST.filter(
+        (r) =>
+          EXECUTION_REGISTRY[r] &&
+          (r === RoleId.R3_GUIDE || r === RoleId.R9_GOVERNANCE),
+      );
+      const flagged = snap.anomalies
+        .filter((a) => a.reason === 'deprecated_but_in_registry')
+        .map((a) => a.roleId)
+        .filter((x): x is RoleId => Boolean(x));
+      expect(flagged.sort()).toEqual(expected.sort());
+    });
+  });
+
+  describe('healthScore', () => {
+    const svc = makeService({ NODE_ENV: 'test' });
+    const snap = svc.snapshot();
+    const byRole = new Map(snap.roles.map((r) => [r.roleId, r]));
+
+    it('R1_ROUTER scores ≥80 (registry + writeScope + non-deprecated; +20 if agents found)', () => {
+      const r = byRole.get(RoleId.R1_ROUTER)!;
+      expect(r.healthScore).toBeGreaterThanOrEqual(80);
+      if (r.agents.length > 0) expect(r.healthScore).toBe(100);
+    });
+
+    it('R3_GUIDE — deprecated role still in registry, no FIELD_CATALOG ownership', () => {
+      const r = byRole.get(RoleId.R3_GUIDE)!;
+      expect(r.registry.present).toBe(true);
+      expect(r.deprecated).toBe(true);
+      expect(r.writeScope.ownedFieldsCount).toBe(0);
+    });
+
+    it('R9_GOVERNANCE scores 0 (no registry, no fields, deprecated)', () => {
+      const r = byRole.get(RoleId.R9_GOVERNANCE)!;
+      expect(r.registry.present).toBe(false);
+      expect(r.writeScope.ownedFieldsCount).toBe(0);
+      expect(r.deprecated).toBe(true);
+      expect(r.healthScore).toBe(0);
+    });
+
+    it('R0_HOME has no registry entry (gap candidate)', () => {
+      const r = byRole.get(RoleId.R0_HOME)!;
+      expect(r.registry.present).toBe(false);
+    });
+  });
+
+  describe('agent role extraction', () => {
+    const svc = makeService({ NODE_ENV: 'test' });
+    const extract = (
+      svc as unknown as { extractRoleId: (f: string) => RoleId | 'UNKNOWN' }
+    ).extractRoleId.bind(svc);
+
+    it('returns UNKNOWN for non-prefixed agent files', () => {
+      expect(extract('research-agent.md')).toBe('UNKNOWN');
+      expect(extract('keyword-planner.md')).toBe('UNKNOWN');
+      expect(extract('brief-enricher.md')).toBe('UNKNOWN');
+    });
+
+    it('returns UNKNOWN for ambiguous R3 prefix', () => {
+      expect(extract('r3-keyword-planner.md')).toBe('UNKNOWN');
+    });
+
+    it('returns UNKNOWN for ambiguous R6 prefix', () => {
+      expect(extract('r6-keyword-planner.md')).toBe('UNKNOWN');
+    });
+
+    it('returns the unique RoleId for unambiguous prefix', () => {
+      expect(extract('r1-keyword-planner.md')).toBe(RoleId.R1_ROUTER);
+      expect(extract('r2-product-validator.md')).toBe(RoleId.R2_PRODUCT);
+      expect(extract('r4-content-batch.md')).toBe(RoleId.R4_REFERENCE);
+      expect(extract('r5-diagnostic-validator.md')).toBe(RoleId.R5_DIAGNOSTIC);
+      expect(extract('r7-brand-execution.md')).toBe(RoleId.R7_BRAND);
+      expect(extract('r8-vehicle-execution.md')).toBe(RoleId.R8_VEHICLE);
+      expect(extract('r0-home-validator.md')).toBe(RoleId.R0_HOME);
+    });
+  });
+
+  describe('skipAgentScan in production', () => {
+    it('defaults to skipped when NODE_ENV=production without override', () => {
+      const svc = makeService({ NODE_ENV: 'production' });
+      const snap = svc.snapshot();
+      expect(snap.agentScanSkipped).toBe(true);
+      expect(snap.agentScanSkipReason).toBe('production_default');
+      expect(snap.roles.every((r) => r.agents.length === 0)).toBe(true);
+    });
+
+    it('opts in via OPERATING_MATRIX_SCAN_AGENTS=1', () => {
+      const svc = makeService({
+        NODE_ENV: 'production',
+        OPERATING_MATRIX_SCAN_AGENTS: '1',
+      });
+      const snap = svc.snapshot();
+      if (snap.agentScanSkipped) {
+        expect(snap.agentScanSkipReason).toBe('no_paths_found');
+      } else {
+        expect(snap.agentScanSkipReason).toBeUndefined();
+      }
+    });
+  });
+
+  describe('JSON determinism (R6)', () => {
+    const svc = makeService({ NODE_ENV: 'test' });
+
+    it('emits byte-identical JSON across two consecutive calls', () => {
+      const a = svc.formatJsonString();
+      const b = svc.formatJsonString();
+      expect(a).toBe(b);
+    });
+
+    it('does not embed any timestamp field anywhere in the JSON', () => {
+      const json = svc.formatJsonString();
+      expect(json).not.toMatch(/"generatedAt"/);
+      expect(json).not.toMatch(/"timestamp"/);
+    });
+
+    it('drops agentScanRootsFound from JSON (filesystem-dependent)', () => {
+      const json = svc.formatJsonString();
+      expect(json).not.toMatch(/"agentScanRootsFound"/);
+    });
+  });
+
+  describe('formatBootLog()', () => {
+    const svc = makeService({ NODE_ENV: 'test' });
+
+    it('returns at least one line per registry entry + a final summary', () => {
+      const lines = svc.formatBootLog();
+      const registrySize = Object.keys(EXECUTION_REGISTRY).length;
+      expect(lines.length).toBeGreaterThanOrEqual(registrySize + 1);
+      expect(lines[lines.length - 1].message).toMatch(
+        /WriteGuard: initialized — \d+ catalog entries/,
+      );
+    });
+
+    it('emits a "WriteGuard: role X owns N fields" line for each registry entry with fields', () => {
+      const lines = svc.formatBootLog();
+      const ownsLines = lines
+        .filter((l) => /owns \d+ fields/.test(l.message))
+        .map((l) => l.message);
+      expect(ownsLines.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/backend/src/config/operating-matrix.service.test.ts
+++ b/backend/src/config/operating-matrix.service.test.ts
@@ -104,12 +104,27 @@ describe('OperatingMatrixService', () => {
       expect(extract('brief-enricher.md')).toBe('UNKNOWN');
     });
 
-    it('returns UNKNOWN for ambiguous R3 prefix', () => {
+    it('returns UNKNOWN for ambiguous R3 prefix WITHOUT disambiguation suffix in name', () => {
       expect(extract('r3-keyword-planner.md')).toBe('UNKNOWN');
+      expect(extract('r3-image-prompt.md')).toBe('UNKNOWN');
+      expect(extract('r3-keyword-plan-batch.md')).toBe('UNKNOWN');
     });
 
-    it('returns UNKNOWN for ambiguous R6 prefix', () => {
+    it('returns UNKNOWN for ambiguous R6 prefix WITHOUT disambiguation suffix', () => {
       expect(extract('r6-keyword-planner.md')).toBe('UNKNOWN');
+      expect(extract('r6-content-batch.md')).toBe('UNKNOWN');
+      expect(extract('r6-image-prompt.md')).toBe('UNKNOWN');
+    });
+
+    it('disambiguates R3 via suffix in filename', () => {
+      expect(extract('r3-conseils-validator.md')).toBe(RoleId.R3_CONSEILS);
+    });
+
+    it('disambiguates R6 via suffix in filename', () => {
+      expect(extract('r6-guide-achat-validator.md')).toBe(
+        RoleId.R6_GUIDE_ACHAT,
+      );
+      expect(extract('r6-support-validator.md')).toBe(RoleId.R6_SUPPORT);
     });
 
     it('returns the unique RoleId for unambiguous prefix', () => {

--- a/backend/src/config/operating-matrix.service.ts
+++ b/backend/src/config/operating-matrix.service.ts
@@ -252,13 +252,45 @@ export class OperatingMatrixService {
     return { agents, scannedPaths, skipped: false };
   }
 
+  /**
+   * Map an agent filename to a RoleId.
+   *
+   * Strategy:
+   *  1. Extract the `r\d` prefix (case-insensitive). No prefix → UNKNOWN.
+   *  2. Filter ROLE_ID_LIST to candidates starting with that prefix + "_".
+   *  3. If exactly one candidate, return it.
+   *  4. If multiple candidates (R3_GUIDE/R3_CONSEILS, R6_SUPPORT/R6_GUIDE_ACHAT),
+   *     try to disambiguate by checking the filename suffix against each
+   *     candidate's canonical suffix (e.g. R6_GUIDE_ACHAT → "guide-achat").
+   *     Pick the candidate with the longest matching suffix. If 0 or >1 match
+   *     unambiguously, return UNKNOWN — forces explicit disambiguation in the
+   *     filename (e.g. "r3-keyword-planner" stays UNKNOWN).
+   */
   private extractRoleId(filename: string): RoleId | 'UNKNOWN' {
     const m = filename.match(ROLE_PREFIX_RE);
     if (!m) return 'UNKNOWN';
     const prefix = m[1].toUpperCase();
     const candidates = ROLE_ID_LIST.filter((r) => r.startsWith(prefix + '_'));
+    if (candidates.length === 0) return 'UNKNOWN';
     if (candidates.length === 1) return candidates[0];
-    return 'UNKNOWN';
+
+    const rest = filename.replace(/\.md$/, '').slice(m[0].length).toLowerCase();
+
+    // Score each candidate by the length of its canonical suffix found in `rest`.
+    let best: { roleId: RoleId; len: number } | null = null;
+    for (const candidate of candidates) {
+      const suffix = candidate.split('_').slice(1).join('-').toLowerCase(); // R6_GUIDE_ACHAT → "guide-achat"
+      if (!suffix) continue;
+      if (rest.includes(suffix)) {
+        if (!best || suffix.length > best.len) {
+          best = { roleId: candidate, len: suffix.length };
+        } else if (suffix.length === best.len) {
+          // Tie on length → ambiguous. Bail out.
+          return 'UNKNOWN';
+        }
+      }
+    }
+    return best ? best.roleId : 'UNKNOWN';
   }
 
   private groupAgentsByRole(

--- a/backend/src/config/operating-matrix.service.ts
+++ b/backend/src/config/operating-matrix.service.ts
@@ -1,0 +1,548 @@
+/**
+ * OperatingMatrixService — single source of the SEO Agent Operating Matrix.
+ *
+ * Consumed by:
+ *  - WriteGuardModule.onModuleInit (boot invariant — same logs as before)
+ *  - GovernanceMatrixController (admin endpoint)
+ *  - scripts/seo/dump-agent-matrix.ts (CLI dump)
+ *
+ * Zero filesystem I/O on the canon side: registry/catalog are imported objects.
+ * Filesystem is only touched for (a) hashing source files and (b) scanning
+ * `.claude/agents/` directories — both gated by skipAgentScan in production.
+ *
+ * @see plan: /home/deploy/.claude/plans/verifier-analyse-plus-delegated-globe.md
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  EXECUTION_REGISTRY,
+  EXECUTION_REGISTRY_VERSION,
+} from './execution-registry.constants';
+import {
+  FIELD_CATALOG,
+  GROUP_TABLE_MAP,
+  deriveWriteScope,
+} from './field-catalog.constants';
+import { ROLE_ID_LIST, RoleId } from './role-ids';
+import type {
+  MatrixAnomaly,
+  MatrixGap,
+  MatrixRoleEntry,
+  MatrixRoleRegistrySnapshot,
+  MatrixRoleWriteScope,
+  MatrixSourcesHash,
+  OperatingMatrix,
+} from './operating-matrix.types';
+
+const AGENT_PATHS = [
+  'workspaces/seo-batch/.claude/agents',
+  '.claude/agents',
+  'backend/.claude/agents',
+] as const;
+
+const SOURCE_FILES: Record<keyof MatrixSourcesHash, string> = {
+  executionRegistry: 'backend/src/config/execution-registry.constants.ts',
+  executionRegistryTypes: 'backend/src/config/execution-registry.types.ts',
+  fieldCatalog: 'backend/src/config/field-catalog.constants.ts',
+  roleIds: 'backend/src/config/role-ids.ts',
+};
+
+/** Roles flagged @deprecated in role-ids.ts. Kept here as the single canon set used by the matrix. */
+const DEPRECATED_ROLES: ReadonlySet<RoleId> = new Set<RoleId>([
+  RoleId.R3_GUIDE,
+  RoleId.R9_GOVERNANCE,
+]);
+
+const ROLE_PREFIX_RE = /^(r\d)(_|-)/i;
+
+interface AgentFile {
+  source: string;
+  file: string;
+}
+
+interface AgentScanResult {
+  agents: AgentFile[];
+  scannedPaths: string[];
+  skipped: boolean;
+  skipReason?: 'production_default' | 'no_paths_found';
+}
+
+/**
+ * Recursive canonicalisation: sort object keys alphabetically at all depths.
+ * Arrays preserved in their incoming order — the service sorts arrays
+ * explicitly with a domain-aware comparator before passing data through here.
+ */
+function canonicalize<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => canonicalize(v)) as unknown as T;
+  }
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    (value as object).constructor === Object
+  ) {
+    const src = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const k of Object.keys(src).sort()) {
+      sorted[k] = canonicalize(src[k]);
+    }
+    return sorted as T;
+  }
+  return value;
+}
+
+@Injectable()
+export class OperatingMatrixService {
+  private readonly logger = new Logger(OperatingMatrixService.name);
+  private readonly repoRoot: string;
+  private readonly skipAgentScan: boolean;
+
+  constructor(private readonly configService: ConfigService) {
+    this.repoRoot =
+      this.configService.get<string>('REPO_ROOT') ??
+      path.resolve(__dirname, '../../..');
+
+    const isProd = this.configService.get<string>('NODE_ENV') === 'production';
+    const optIn =
+      this.configService.get<string>('OPERATING_MATRIX_SCAN_AGENTS') === '1';
+    this.skipAgentScan = isProd && !optIn;
+  }
+
+  /** Canonical snapshot — basis for both Markdown and JSON outputs. */
+  snapshot(): OperatingMatrix {
+    const scan = this.scanAllAgents();
+    const agentsByRole = this.groupAgentsByRole(scan.agents);
+    const unmappableAgents = (agentsByRole.get('UNKNOWN') ?? []).slice().sort();
+
+    const roles: MatrixRoleEntry[] = ROLE_ID_LIST.map((roleId) =>
+      this.buildRoleEntry(roleId, agentsByRole.get(roleId) ?? []),
+    );
+
+    const agentsIndex = this.buildAgentsIndex(scan.agents);
+    const gaps = this.detectGaps(roles);
+    const anomalies = this.detectAnomalies(roles);
+
+    const matrix: OperatingMatrix = {
+      registryVersion: EXECUTION_REGISTRY_VERSION,
+      catalogFieldCount: FIELD_CATALOG.length,
+      sourcesHash: this.hashSourceFiles(),
+      agentScanSkipped: scan.skipped,
+      agentScanSkipReason: scan.skipReason,
+      agentScanRootsConfigured: [...AGENT_PATHS],
+      agentScanRootsFound: scan.scannedPaths.length
+        ? scan.scannedPaths
+        : undefined,
+      roles,
+      agentsIndex,
+      gaps,
+      anomalies,
+      unmappableAgents,
+    };
+
+    return matrix;
+  }
+
+  /** JSON output (stable across runs — relied on by `seo:matrix:check` CI). */
+  formatJson(): OperatingMatrix {
+    const snap = this.snapshot();
+    // Strip filesystem-dependent field for committed JSON (R6 determinism).
+    const { agentScanRootsFound: _drop, ...stable } = snap;
+    return canonicalize(stable as OperatingMatrix);
+  }
+
+  /** Stable JSON serialised — what the CLI writes to disk. */
+  formatJsonString(): string {
+    return JSON.stringify(this.formatJson(), null, 2) + '\n';
+  }
+
+  /** Markdown for humans. Includes timestamp + filesystem-found paths. */
+  formatMarkdown(): string {
+    const snap = this.snapshot();
+    return this.renderMarkdown(snap);
+  }
+
+  /**
+   * Boot log lines reproducing the legacy WriteGuardModule.onModuleInit format.
+   * Returned as an ordered list so the consumer can `logger.log` / `logger.warn`
+   * each line preserving the original log levels.
+   */
+  formatBootLog(): Array<{ level: 'log' | 'warn'; message: string }> {
+    const lines: Array<{ level: 'log' | 'warn'; message: string }> = [];
+    const rolesSeen = new Set<string>();
+    let fieldsTotal = 0;
+
+    for (const entry of Object.values(EXECUTION_REGISTRY)) {
+      const scope = deriveWriteScope(entry.roleId);
+      if (scope.ownedFields.length === 0) {
+        lines.push({
+          level: 'warn',
+          message: `WriteGuard: role ${entry.roleId} has no owned fields in FIELD_CATALOG`,
+        });
+      } else {
+        lines.push({
+          level: 'log',
+          message:
+            `WriteGuard: role ${entry.roleId} owns ${scope.ownedFields.length} fields ` +
+            `across ${scope.resourceGroups.length} groups (${scope.resourceGroups.join(', ')})`,
+        });
+      }
+      rolesSeen.add(entry.roleId);
+      fieldsTotal += scope.ownedFields.length;
+    }
+
+    const orphanRoles = new Set<string>();
+    for (const field of FIELD_CATALOG) {
+      if (!rolesSeen.has(field.ownerRole)) {
+        orphanRoles.add(field.ownerRole);
+      }
+    }
+    if (orphanRoles.size > 0) {
+      lines.push({
+        level: 'warn',
+        message: `WriteGuard: FIELD_CATALOG references roles not in registry: ${[...orphanRoles].join(', ')}`,
+      });
+    }
+
+    lines.push({
+      level: 'log',
+      message:
+        `WriteGuard: initialized — ${FIELD_CATALOG.length} catalog entries, ` +
+        `${fieldsTotal} owned fields across ${rolesSeen.size} roles`,
+    });
+
+    return lines;
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────
+
+  private scanAllAgents(): AgentScanResult {
+    if (this.skipAgentScan) {
+      return {
+        agents: [],
+        scannedPaths: [],
+        skipped: true,
+        skipReason: 'production_default',
+      };
+    }
+    const scannedPaths: string[] = [];
+    const agents: AgentFile[] = [];
+    for (const rel of AGENT_PATHS) {
+      const abs = path.resolve(this.repoRoot, rel);
+      if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) continue;
+      scannedPaths.push(rel);
+      for (const file of fs.readdirSync(abs)) {
+        if (file.endsWith('.md')) {
+          agents.push({ source: rel, file });
+        }
+      }
+    }
+    if (scannedPaths.length === 0) {
+      return {
+        agents: [],
+        scannedPaths: [],
+        skipped: true,
+        skipReason: 'no_paths_found',
+      };
+    }
+    return { agents, scannedPaths, skipped: false };
+  }
+
+  private extractRoleId(filename: string): RoleId | 'UNKNOWN' {
+    const m = filename.match(ROLE_PREFIX_RE);
+    if (!m) return 'UNKNOWN';
+    const prefix = m[1].toUpperCase();
+    const candidates = ROLE_ID_LIST.filter((r) => r.startsWith(prefix + '_'));
+    if (candidates.length === 1) return candidates[0];
+    return 'UNKNOWN';
+  }
+
+  private groupAgentsByRole(
+    agents: AgentFile[],
+  ): Map<RoleId | 'UNKNOWN', string[]> {
+    const map = new Map<RoleId | 'UNKNOWN', string[]>();
+    for (const a of agents) {
+      const baseName = a.file.replace(/\.md$/, '');
+      const roleId = this.extractRoleId(a.file);
+      const list = map.get(roleId) ?? [];
+      list.push(baseName);
+      map.set(roleId, list);
+    }
+    for (const [k, v] of map) {
+      map.set(
+        k,
+        v.slice().sort((x, y) => x.localeCompare(y)),
+      );
+    }
+    return map;
+  }
+
+  private buildAgentsIndex(
+    agents: AgentFile[],
+  ): Record<string, RoleId | 'UNKNOWN'> {
+    const entries: Array<[string, RoleId | 'UNKNOWN']> = agents.map((a) => [
+      a.file.replace(/\.md$/, ''),
+      this.extractRoleId(a.file),
+    ]);
+    entries.sort(([x], [y]) => x.localeCompare(y));
+    return Object.fromEntries(entries);
+  }
+
+  private buildRoleEntry(roleId: RoleId, agents: string[]): MatrixRoleEntry {
+    const registry = this.buildRegistrySnapshot(roleId);
+    const writeScope = this.buildWriteScope(roleId);
+    const deprecated = DEPRECATED_ROLES.has(roleId);
+    const healthScore = this.computeHealthScore({
+      registry,
+      writeScope,
+      agentCount: agents.length,
+      deprecated,
+    });
+    return {
+      roleId,
+      deprecated,
+      registry,
+      writeScope,
+      agents,
+      healthScore,
+    };
+  }
+
+  private buildRegistrySnapshot(roleId: RoleId): MatrixRoleRegistrySnapshot {
+    const entry = EXECUTION_REGISTRY[roleId];
+    if (!entry) return { present: false };
+    return {
+      present: true,
+      contractSchemaRef: entry.contractSchemaRef,
+      enricherServiceKey: entry.enricherServiceKey,
+      agentFiles: entry.agentFiles,
+      allowedModes: entry.allowedModes,
+      defaultWriteMode: entry.defaultWriteMode,
+      stopPolicy: entry.stopPolicy,
+    };
+  }
+
+  private buildWriteScope(roleId: RoleId): MatrixRoleWriteScope {
+    const scope = deriveWriteScope(roleId);
+    const ownedTables = scope.resourceGroups
+      .map((g) => GROUP_TABLE_MAP[g]?.table)
+      .filter((t): t is string => Boolean(t));
+    return {
+      resourceGroups: scope.resourceGroups,
+      ownedTables,
+      ownedFieldsCount: scope.ownedFields.length,
+    };
+  }
+
+  private computeHealthScore(args: {
+    registry: MatrixRoleRegistrySnapshot;
+    writeScope: MatrixRoleWriteScope;
+    agentCount: number;
+    deprecated: boolean;
+  }): number {
+    let score = 0;
+    if (args.registry.present) score += 30;
+    if (args.agentCount >= 1) score += 20;
+    if (args.writeScope.ownedFieldsCount > 0) score += 30;
+    if (!args.deprecated) score += 20;
+    return score;
+  }
+
+  private detectGaps(roles: MatrixRoleEntry[]): MatrixGap[] {
+    return roles
+      .filter((r) => !r.registry.present && r.agents.length > 0)
+      .map((r) => ({
+        roleId: r.roleId,
+        reason: 'agents_without_registry' as const,
+        agentCount: r.agents.length,
+        agents: r.agents,
+      }))
+      .sort((a, b) => a.roleId.localeCompare(b.roleId));
+  }
+
+  private detectAnomalies(roles: MatrixRoleEntry[]): MatrixAnomaly[] {
+    const out: MatrixAnomaly[] = [];
+
+    // 1. Deprecated roles still in registry.
+    for (const r of roles) {
+      if (r.deprecated && r.registry.present) {
+        out.push({ roleId: r.roleId, reason: 'deprecated_but_in_registry' });
+      }
+    }
+
+    // 2. Duplicate (table.field) in FIELD_CATALOG (Map last-write-wins masks them).
+    const seen = new Set<string>();
+    for (const f of FIELD_CATALOG) {
+      const key = `${f.table}.${f.field}`;
+      if (seen.has(key)) {
+        out.push({
+          table: f.table,
+          field: f.field,
+          reason: 'duplicate_field_in_catalog',
+        });
+      } else {
+        seen.add(key);
+      }
+    }
+
+    // 3. Tables in FIELD_CATALOG with no GROUP_TABLE_MAP entry for their group.
+    const ungroupedTables = new Set<string>();
+    for (const f of FIELD_CATALOG) {
+      const target = GROUP_TABLE_MAP[f.resourceGroup];
+      if (!target) ungroupedTables.add(f.table);
+    }
+    for (const t of [...ungroupedTables].sort()) {
+      out.push({ table: t, reason: 'in_field_catalog_but_no_group_table_map' });
+    }
+
+    return out.sort((a, b) => {
+      const ka = (a.roleId ?? a.table ?? '') + '|' + a.reason;
+      const kb = (b.roleId ?? b.table ?? '') + '|' + b.reason;
+      return ka.localeCompare(kb);
+    });
+  }
+
+  private hashSourceFiles(): MatrixSourcesHash {
+    const out = {} as MatrixSourcesHash;
+    for (const [key, rel] of Object.entries(SOURCE_FILES) as Array<
+      [keyof MatrixSourcesHash, string]
+    >) {
+      const abs = path.resolve(this.repoRoot, rel);
+      let raw = '';
+      try {
+        raw = fs.readFileSync(abs, 'utf-8');
+      } catch (err) {
+        this.logger.warn(
+          `OperatingMatrix: cannot hash ${rel} (${(err as Error).message})`,
+        );
+      }
+      out[key] = 'sha256:' + createHash('sha256').update(raw).digest('hex');
+    }
+    return out;
+  }
+
+  // ── Markdown rendering ───────────────────────────────────────────
+
+  private renderMarkdown(snap: OperatingMatrix): string {
+    const lines: string[] = [];
+    lines.push('# SEO Agent Operating Matrix');
+    lines.push('');
+    lines.push(`> Généré le : ${new Date().toISOString()}`);
+    lines.push(
+      `> Sources hash : registry=${this.shortHash(snap.sourcesHash.executionRegistry)} ` +
+        `types=${this.shortHash(snap.sourcesHash.executionRegistryTypes)} ` +
+        `catalog=${this.shortHash(snap.sourcesHash.fieldCatalog)} ` +
+        `roleIds=${this.shortHash(snap.sourcesHash.roleIds)}`,
+    );
+    lines.push(
+      `> Registry version : ${snap.registryVersion} — Field catalog : ${snap.catalogFieldCount} entrées`,
+    );
+    lines.push('');
+
+    if (snap.agentScanSkipped) {
+      const reason =
+        snap.agentScanSkipReason === 'production_default'
+          ? "désactivé en production. Set `OPERATING_MATRIX_SCAN_AGENTS=1` pour l'activer."
+          : 'aucun chemin agent trouvé sur le filesystem.';
+      lines.push(`> ⚠️ **Agent scan désactivé** — ${reason}`);
+      lines.push('');
+    }
+
+    lines.push('## Matrice principale');
+    lines.push('');
+    lines.push(
+      '| Rôle | Health | Registry | Agents | Tables ownées | # Fields |',
+    );
+    lines.push('|---|---|---|---|---|---|');
+    for (const r of snap.roles) {
+      const reg = r.registry.present ? '✅' : '❌';
+      const dep = r.deprecated ? ' (deprecated)' : '';
+      const agents = r.agents.length ? r.agents.join(', ') : '—';
+      const tables = r.writeScope.ownedTables.length
+        ? r.writeScope.ownedTables.join(', ')
+        : '—';
+      lines.push(
+        `| ${r.roleId}${dep} | ${r.healthScore} | ${reg} | ${agents} | ${tables} | ${r.writeScope.ownedFieldsCount} |`,
+      );
+    }
+    lines.push('');
+
+    lines.push('## Gaps (agents sans entrée registry)');
+    lines.push('');
+    if (snap.gaps.length === 0) {
+      lines.push('_Aucun gap détecté._');
+    } else {
+      for (const g of snap.gaps) {
+        lines.push(
+          `- ❌ **${g.roleId}** : ${g.agentCount} agent(s) — ${g.agents.join(', ')}`,
+        );
+      }
+    }
+    lines.push('');
+
+    lines.push('## Anomalies');
+    lines.push('');
+    if (snap.anomalies.length === 0) {
+      lines.push('_Aucune anomalie._');
+    } else {
+      for (const a of snap.anomalies) {
+        const id = a.roleId
+          ? a.roleId
+          : a.field
+            ? `${a.table}.${a.field}`
+            : a.table;
+        lines.push(`- ⚠️ **${id}** — ${a.reason}`);
+      }
+    }
+    lines.push('');
+
+    lines.push('## Agents non-mappables');
+    lines.push('');
+    if (snap.unmappableAgents.length === 0) {
+      lines.push('_Aucun._');
+    } else {
+      for (const a of snap.unmappableAgents) {
+        lines.push(`- ${a}`);
+      }
+    }
+    lines.push('');
+
+    lines.push('## Index inverse (agent → rôle)');
+    lines.push('');
+    if (Object.keys(snap.agentsIndex).length === 0) {
+      lines.push('_Vide (scan désactivé ou aucun agent trouvé)._');
+    } else {
+      lines.push('| Agent | Rôle résolu |');
+      lines.push('|---|---|');
+      for (const [agent, roleId] of Object.entries(snap.agentsIndex)) {
+        lines.push(`| ${agent} | ${roleId} |`);
+      }
+    }
+    lines.push('');
+
+    lines.push('---');
+    lines.push('');
+    lines.push(
+      `_Paths agent configurés : ${snap.agentScanRootsConfigured.join(', ')}_`,
+    );
+    if (snap.agentScanRootsFound?.length) {
+      lines.push(
+        `_Paths agent effectivement scannés : ${snap.agentScanRootsFound.join(', ')}_`,
+      );
+    }
+    lines.push('');
+    lines.push(
+      '_Source : OperatingMatrixService (`backend/src/config/operating-matrix.service.ts`). Régénérer via `npm run seo:matrix`._',
+    );
+
+    return lines.join('\n') + '\n';
+  }
+
+  private shortHash(full: string): string {
+    return full.startsWith('sha256:') ? full.slice(7, 15) : full.slice(0, 8);
+  }
+}

--- a/backend/src/config/operating-matrix.types.ts
+++ b/backend/src/config/operating-matrix.types.ts
@@ -1,0 +1,82 @@
+/**
+ * Operating Matrix Types — single-source view over registry × catalog × agents.
+ *
+ * Consumed by OperatingMatrixService (boot invariant + admin endpoint + CLI dump).
+ * No runtime logic here — pure shapes.
+ */
+
+import type { RoleId } from './role-ids';
+import type {
+  ExecutionMode,
+  ResourceGroup,
+  WriteMode,
+} from './execution-registry.types';
+
+export interface MatrixSourcesHash {
+  executionRegistry: string;
+  executionRegistryTypes: string;
+  fieldCatalog: string;
+  roleIds: string;
+}
+
+export interface MatrixRoleRegistrySnapshot {
+  present: boolean;
+  contractSchemaRef?: string;
+  enricherServiceKey?: string;
+  agentFiles?: string[];
+  allowedModes?: ExecutionMode[];
+  defaultWriteMode?: WriteMode;
+  stopPolicy?: { maxRetries: number; timeoutMs: number };
+}
+
+export interface MatrixRoleWriteScope {
+  resourceGroups: ResourceGroup[];
+  ownedTables: string[];
+  ownedFieldsCount: number;
+}
+
+export interface MatrixRoleEntry {
+  roleId: RoleId;
+  deprecated: boolean;
+  registry: MatrixRoleRegistrySnapshot;
+  writeScope: MatrixRoleWriteScope;
+  agents: string[];
+  healthScore: number;
+}
+
+export type MatrixGapReason = 'agents_without_registry';
+
+export interface MatrixGap {
+  roleId: RoleId;
+  reason: MatrixGapReason;
+  agentCount: number;
+  agents: string[];
+}
+
+export type MatrixAnomalyReason =
+  | 'deprecated_but_in_registry'
+  | 'duplicate_field_in_catalog'
+  | 'in_field_catalog_but_no_group_table_map';
+
+export interface MatrixAnomaly {
+  roleId?: RoleId;
+  table?: string;
+  field?: string;
+  reason: MatrixAnomalyReason;
+}
+
+export interface OperatingMatrix {
+  registryVersion: string;
+  catalogFieldCount: number;
+  sourcesHash: MatrixSourcesHash;
+  agentScanSkipped: boolean;
+  agentScanSkipReason?: 'production_default' | 'no_paths_found';
+  agentScanRootsConfigured: string[];
+  /** Found at runtime — present in JSON only when scan ran. Not part of CI compare (filesystem-dependent). */
+  agentScanRootsFound?: string[];
+  roles: MatrixRoleEntry[];
+  agentsIndex: Record<string, RoleId | 'UNKNOWN'>;
+  gaps: MatrixGap[];
+  anomalies: MatrixAnomaly[];
+  unmappableAgents: string[];
+}

--- a/scripts/seo/dump-agent-matrix.ts
+++ b/scripts/seo/dump-agent-matrix.ts
@@ -1,0 +1,54 @@
+/**
+ * dump-agent-matrix.ts — write the SEO Agent Operating Matrix to disk.
+ *
+ * Outputs:
+ *   audit-reports/seo-agent-matrix.md    (human-readable, with timestamp)
+ *   audit-reports/seo-agent-matrix.json  (deterministic — for diff-based CI)
+ *
+ * Usage (matches the existing pattern, e.g. audit-cross-gamme-overlap.ts):
+ *   npx tsx scripts/seo/dump-agent-matrix.ts
+ *
+ * The CLI instantiates OperatingMatrixService directly with a minimal
+ * ConfigService stub backed by process.env. NestJS DI bootstrap is intentionally
+ * skipped: tsx (esbuild) does not emit `emitDecoratorMetadata` required by
+ * NestJS injection. For app-runtime usage, the service is exposed via
+ * OperatingMatrixModule the standard way (when wired into a NestJS module).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { ConfigService } from '@nestjs/config';
+import { OperatingMatrixService } from '../../backend/src/config/operating-matrix.service';
+
+function buildConfigStub(): ConfigService {
+  const env = process.env;
+  return {
+    get: <T = unknown>(key: string): T | undefined =>
+      env[key] as T | undefined,
+  } as unknown as ConfigService;
+}
+
+async function main(): Promise<void> {
+  const svc = new OperatingMatrixService(buildConfigStub());
+
+  const repoRoot = path.resolve(__dirname, '../..');
+  const outDir = path.join(repoRoot, 'audit-reports');
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const mdPath = path.join(outDir, 'seo-agent-matrix.md');
+  const jsonPath = path.join(outDir, 'seo-agent-matrix.json');
+
+  fs.writeFileSync(mdPath, svc.formatMarkdown(), 'utf-8');
+  fs.writeFileSync(jsonPath, svc.formatJsonString(), 'utf-8');
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `[seo:matrix] wrote ${path.relative(repoRoot, mdPath)} + ${path.relative(repoRoot, jsonPath)}`,
+  );
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error('[seo:matrix] failed', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Pure additive PR — zero modification to existing files. Introduces `OperatingMatrixService`: a read-only NestJS service that derives the **SEO Agent Operating Matrix** from canonical sources (`EXECUTION_REGISTRY` × `FIELD_CATALOG` × `.claude/agents/`) and exposes a stable JSON + human-readable Markdown view.

Generated outputs are committed to `audit-reports/seo-agent-matrix.{md,json}` for future diff-based CI checks.

## Why

The monorepo already has a battle-tested governance layer (Write Guard, Execution Registry, Field Catalog with bidirectional coupling). What was missing was a **lens humain** — a single, scannable artifact that exposes which roles are gouverned end-to-end vs. which have orphan agents writing outside `WriteGuard`.

The matrix immediately surfaces 3 actionable findings:
1. **Gaps**: `R0_HOME` (2 agents), `R6_SUPPORT` (1 agent), `R7_BRAND` (4 agents) write outside `EXECUTION_REGISTRY` — not governed by `WriteGuard`.
2. **Anomaly**: `R3_GUIDE` is `@deprecated` in `role-ids.ts` but still present in `EXECUTION_REGISTRY`.
3. **Naming hygiene**: 15 agents (`agentic-*`, `r3-keyword-*`, `r6-image-prompt`, etc.) resolve to `UNKNOWN` and need either explicit role suffix or removal.

## What's in the PR

| File | Lines | Role |
|---|---|---|
| `backend/src/config/operating-matrix.types.ts` | 82 | Canonical types (`OperatingMatrix`, `MatrixGap`, `MatrixAnomaly`...) |
| `backend/src/config/operating-matrix.service.ts` | 587 | Single-source service |
| `backend/src/config/operating-matrix.module.ts` | 26 | Minimal NestJS module (for future wiring) |
| `backend/src/config/operating-matrix.service.test.ts` | 200 | 23 unit tests, all green |
| `scripts/seo/dump-agent-matrix.ts` | 54 | Standalone CLI (`npx tsx`) |
| `audit-reports/seo-agent-matrix.{md,json}` | 580 | Generated outputs |

## Architecture

**Single source of truth**: the service reuses the existing helpers (`deriveWriteScope`, `GROUP_TABLE_MAP`, `ROLE_ID_LIST`) — no parallel parsing, no second source. The service is invokable in 2 ways today, with a 3rd ready when wired:

| Consumer | Status |
|---|---|
| CLI dump (`npx tsx scripts/seo/dump-agent-matrix.ts`) | ✅ Live in this PR |
| Unit tests (Jest) | ✅ 23/23 green |
| `WriteGuardModule.onModuleInit()` (single-source boot logs) | 🔜 `formatBootLog()` ready, wiring out of scope |
| `GovernanceMatrixController` (admin endpoint) | 🔜 Module ready, controller out of scope |

## Key design decisions (anti-bricolage)

- **JSON déterministe** : pas de \`generatedAt\` dans le JSON committé (timestamp humain dans le Markdown uniquement). Helper \`canonicalize()\` 8 lignes inline, pas de dep \`json-stable-stringify\`.
- **Hash sur fichiers TS bruts** (\`fs.readFileSync\` UTF-8) — jamais sur objets JS (instable).
- **Multi-path scan agents** + \`agentScanRootsConfigured\` (constants déterministes) émis dans le JSON, \`agentScanRootsFound\` (filesystem-dépendant) dans le Markdown uniquement.
- **R5 prod-safe**: \`NODE_ENV=production\` skippe le scan filesystem (Docker n'embarque pas \`.claude/agents/\`). Override via \`OPERATING_MATRIX_SCAN_AGENTS=1\`.
- **Strict R2 mapping** + disambiguation par suffixe : \`r3-conseils-validator\` → R3_CONSEILS, \`r6-guide-achat-validator\` → R6_GUIDE_ACHAT, \`r6-support-validator\` → R6_SUPPORT. Filenames sans suffixe canonique (\`r3-keyword-planner\`) restent UNKNOWN par design.
- **CLI bypass NestJS DI** : tsx (esbuild) n'émet pas \`emitDecoratorMetadata\`. Le CLI instancie directement le service avec un stub \`ConfigService\` minimal — même pattern que \`audit-cross-gamme-overlap.ts\`.

## Out of scope (each = separate decision)

- Wiring \`OperatingMatrixModule\` into \`AdminModule\` (admin REST endpoint)
- Refactoring \`WriteGuardModule.onModuleInit\` to consume \`formatBootLog()\` (single-source boot)
- Adding \`npm run seo:matrix\` + pre-commit/CI gate

## Test plan

- [x] \`cd backend && npm test -- operating-matrix\` → 23/23 green
- [x] \`npx tsx scripts/seo/dump-agent-matrix.ts\` → produces both files
- [x] Idempotence: 2 consecutive runs → JSON byte-identical (\`diff\` empty)
- [x] Sanity: gaps = R0_HOME + R6_SUPPORT + R7_BRAND, anomaly = R3_GUIDE deprecated_but_in_registry
- [x] \`NODE_ENV=production npx tsx scripts/seo/dump-agent-matrix.ts\` → \`agentScanSkipped: true\`, no agents leaked
- [ ] CI checks (knip / madge / depcruise / phase0) pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)