### PR TITLE
ci: add nightly report-violations workflow (depcruise + tsc) — non blocking

### DIFF
--- a/.github/workflows/report-violations.yml
+++ b/.github/workflows/report-violations.yml
@@ -1,0 +1,90 @@
+name: Report Violations (depcruise + tsc)
+
+# Quantifies dependency-cruiser violations and TypeScript backend errors.
+# Non-blocking — produces JSON artifacts for offline review.
+# Output is the input for ADR P1.2 (depcruise warn→error) and P1.3 (noEmitOnError flip).
+# Local tooling cannot produce this report (V8 OOM on backend size, --max-old-space-size=8192 needed).
+
+on:
+  workflow_dispatch:
+  schedule:
+    # nightly 03:00 UTC (low activity window)
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  depcruise-report:
+    name: dependency-cruiser report
+    runs-on: [self-hosted, Linux, X64]
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci --ignore-scripts
+
+      - name: Run depcruise (JSON)
+        run: |
+          npx depcruise --config .dependency-cruiser.cjs \
+            --output-type json backend/src frontend/app shared \
+            > depcruise-report.json
+
+      - name: Summarize per-rule
+        run: |
+          {
+            echo "## dependency-cruiser violations"
+            echo ""
+            echo "| Rule | Severity | Count |"
+            echo "|------|----------|-------|"
+            jq -r '.violations
+              | group_by(.rule.name)
+              | map({rule: .[0].rule.name, severity: .[0].rule.severity, count: length})
+              | sort_by(-.count)
+              | .[]
+              | "| \(.rule) | \(.severity) | \(.count) |"' depcruise-report.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: depcruise-report
+          path: depcruise-report.json
+          retention-days: 30
+
+  tsc-noemit-report:
+    name: tsc --noEmit report (backend)
+    runs-on: [self-hosted, Linux, X64]
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci --ignore-scripts
+
+      - name: Run tsc --noEmit (capture errors)
+        run: |
+          cd backend
+          npx tsc --noEmit 2>&1 | tee tsc-errors.txt || true
+          ERROR_COUNT=$(grep -cE '^[^:]+\.ts\(' tsc-errors.txt || true)
+          echo "## tsc --noEmit (backend)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Errors: \`$ERROR_COUNT\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tsc-errors
+          path: backend/tsc-errors.txt
+          retention-days: 30

--- a/log.md
+++ b/log.md
@@ -129,3 +129,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/permissions-canonical-backend`
 - **Décision** : feat(auth): add UserPermissions DTO + level constants (+2 other commits)
 - **Sortie** : PR aucune | commits fa3c03ef 8ba4394a 2b9678b3
+
+## 2026-04-30 — feat/p1.1-report-violations-workflow (auto)
+
+- **Branche** : `feat/p1.1-report-violations-workflow`
+- **Décision** : ci(workflows): add nightly report-violations.yml (depcruise + tsc) — non blocking
+- **Sortie** : PR #223 | commits 2ce82b9a


### PR DESCRIPTION
## Summary

- Ajoute `.github/workflows/report-violations.yml` : nightly + workflow_dispatch, self-hosted runner, `NODE_OPTIONS=--max-old-space-size=8192`.
- Produit 2 artifacts JSON 30j de rétention : `depcruise-report` (violations dependency-cruiser par règle) et `tsc-errors` (compte d'erreurs TS backend).
- Non-blocking : aucun gate CI, juste une mesure périodique.

## Pourquoi ce workflow

L'audit utilisateur 2026-04-30 demandait de bumper les severity dependency-cruiser de `warn` à `error` et d'activer `noEmitOnError: true` sur backend TS. Avant tout bump, il faut **mesurer** le nombre de violations actuelles ; sinon la CI peut bloquer d'un coup.

Le tooling local crashe en V8 OOM (`Aborted (core dumped)`) sur la taille du backend NestJS — impossible de produire le rapport depuis un dev laptop. Ce workflow le produit en CI self-hosted où la RAM est dispo.

## Followups dépendants

- P1.2 : bump dep-cruiser warn→error rule par rule selon le compte
- P1.3 : flip `backend/tsconfig.json:noEmitOnError:true` selon le compte d'erreurs TS

## Test plan

- [ ] Trigger manuel via Actions UI sur cette branche → vérifier les 2 artifacts upload
- [ ] Vérifier le step summary : table dep-cruiser violations par règle, compte tsc errors
- [ ] Schedule cron 03:00 UTC fire première fois → confirmer self-hosted runner pickup

🤖 Generated with [Claude Code](https://claude.com/claude-code)