### PR TITLE
perf(home): warm homepage:families cache key alongside below-fold

### DIFF
--- a/backend/src/modules/catalog/services/homepage-rpc.service.ts
+++ b/backend/src/modules/catalog/services/homepage-rpc.service.ts
@@ -402,14 +402,22 @@ export class HomepageRpcService extends SupabaseBaseService {
   async warmCache(): Promise<{ success: boolean; time: number }> {
     const startTime = performance.now();
     try {
-      await this.getHomepageBelowFold();
+      // Warm BOTH keys awaited by the home loader:
+      //   - homepage:families:v1   (above-fold, blocks SSR via _index.tsx loader await)
+      //   - homepage:below-fold:v2 (deferred but still nice to have warm)
+      // Without families warming, first Lighthouse hit = CACHE MISS = SSR blocked
+      // 1-3s on cold Supabase; FCP/TTI baseline ~10s on perf-gates CI.
+      await Promise.all([
+        this.getHomepageFamilies(),
+        this.getHomepageBelowFold(),
+      ]);
       const time = performance.now() - startTime;
       this.logger.log(
-        `🔥 Warm cache below-fold terminé en ${time.toFixed(1)}ms`,
+        `🔥 Warm cache homepage (families+below-fold) terminé en ${time.toFixed(1)}ms`,
       );
       return { success: true, time };
     } catch (error) {
-      this.logger.error('❌ Warm cache below-fold failed:', error);
+      this.logger.error('❌ Warm cache homepage failed:', error);
       return { success: false, time: performance.now() - startTime };
     }
   }

--- a/log.md
+++ b/log.md
@@ -171,3 +171,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/cache-warm-non-blocking`
 - **Décision** : Revert "perf(home): lazy-load below-the-fold sections via React.lazy + Suspense" (+17 other commits)
 - **Sortie** : PR #224 | commits 74148c9e 374cba10 e5b05cac 96fa0553 a580ba03 74c9305e fdf691af 20d8e294 5a6e63b4 5e034ca4 919ba33a abc6cd6a 45cddefd e489ecbe 5b7c5530 5d503e1a 31e9517e a0a67c66
+
+## 2026-04-30 — perf/warm-cache-homepage-families (auto)
+
+- **Branche** : `perf/warm-cache-homepage-families`
+- **Décision** : perf(home): warm homepage:families cache key alongside below-fold
+- **Sortie** : PR #227 | commits a0dc5519


### PR DESCRIPTION
## Summary

- `warmCache()` au démarrage n'appelait que `getHomepageBelowFold()` ; la clé `homepage:families:v1` que le loader home await explicitement via `/api/catalog/homepage-families` restait froide
- Premier hit Lighthouse CI = CACHE MISS garanti → 3 requêtes Supabase parallèles + mapping JS pendant que le SSR attend → FCP/TTI baseline 10.7s/11.6s ([`lighthouse-budget.README.md`](https://github.com/ak125/nestjs-remix-monorepo/blob/main/frontend/lighthouse-budget.README.md))
- Fix : warm les 2 clés en parallèle via `Promise.all` ; les deux méthodes existent déjà dans le même service (lignes 168 + 254)

**Couche 1 du plan SSR multi-couches.** Couches 2 (DI direct loader, élimine HTTP loopback) et 3 (manualChunks app-level + Remix v3 future flags) suivent comme PRs séparées.

## Cause racine — preuve dans le code

[`backend/src/modules/catalog/services/homepage-rpc.service.ts:402-415`](https://github.com/ak125/nestjs-remix-monorepo/blob/main/backend/src/modules/catalog/services/homepage-rpc.service.ts#L402-L415) avant fix :

```ts
async warmCache() {
  await this.getHomepageBelowFold();   // ← warm BELOW-FOLD only
  // ❌ getHomepageFamilies() NOT called
}
```

[`frontend/app/routes/_index.tsx:138`](https://github.com/ak125/nestjs-remix-monorepo/blob/main/frontend/app/routes/_index.tsx#L138) await `/api/catalog/homepage-families` qui utilise la clé `homepage:families:v1` (ligne 170 du service) — **non couverte par le warming**.

## Impact attendu

- FCP estimé : 10.7s → ~8.5s (amputation ~2s sur le first-visit cold)
- Pas d'effet sur navigations ultérieures (déjà cache HIT)
- Pas d'effet sur script count / TTI résiduel (couches 2-3)

## Test plan

- [ ] CI perf-gates passe (TTI doit baisser, ne devrait pas régresser)
- [ ] Logs au démarrage : `🔥 Warm cache homepage (families+below-fold) terminé en Xms`
- [ ] Premier hit endpoint après warming : log `🎯 CACHE HIT families en Xms`
- [ ] Smoke test multi-routes : `/`, `/pieces`, `/blog`, `/constructeurs`, `/diagnostic-auto` restent 200

## Risques

Aucun. Le warming reste non-bloquant pour le boot (`setTimeout(3000)` dans `cache-warming.service.ts:36`). L'ajout d'une RPC parallèle allonge le warming de ~50ms warmé / ~1s cold mais n'affecte pas la disponibilité — `/health` peut répondre avant la fin du warming, comportement identique à avant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)