### PR TITLE
fix(ci): perf-gates permissions + self-trigger (follow-up #224)

### DIFF
--- a/.github/workflows/perf-gates.yml
+++ b/.github/workflows/perf-gates.yml
@@ -7,13 +7,25 @@ on:
       - 'frontend/**'
       - 'backend/src/**'
       - 'packages/**'
+      # Self-trigger : changes to this workflow (budgets, permissions,
+      # env, paths) must re-run the workflow to validate them. Without
+      # this entry, fixes to the workflow file silently ship without CI
+      # verification on the same PR.
+      - '.github/workflows/perf-gates.yml'
+      - 'frontend/lighthouse-budget.json'
 
-# Thresholds (from lighthouse-budget.json):
-# - LCP: ≤2500ms (Google "Good")
-# - CLS: ≤0.1 (Google "Good")
-# - TTFB: ≤800ms (critical for SEO)
-# - TBT: ≤300ms (proxy for INP)
-# - FCP: ≤2000ms
+# Thresholds : voir frontend/lighthouse-budget.json (calibré sur baseline
+# mesuré, anti-régression). Documentation + procédure de mise à jour dans
+# frontend/lighthouse-budget.README.md.
+
+# `pull-requests: write` requis par le step "Comment PR with Results" pour
+# poster le récap performance. Sans cette permission le workflow échoue
+# avec "Resource not accessible by integration" même quand l'audit lui-même
+# passe (cf. PR #224 run 25176006026). Les autres permissions restent à
+# `read` par défaut (least-privilege).
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   lighthouse:


### PR DESCRIPTION
## Summary

Two micro-fixes that landed too late for PR #224's squash merge (pushed after merge to closed branch).

- **`permissions: pull-requests: write`** — without this, the "Comment PR with Results" step fails with \`Resource not accessible by integration\` on every PR, even when Lighthouse passes. Verified failing on #224 run [25176006026](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25176006026).
- **Self-trigger paths** — adds the workflow file and \`lighthouse-budget.json\` to the path filter so future budget tweaks/workflow fixes are CI-validated on the introducing PR.

Pure config, no code, no behavioral change beyond unblocking the PR comment + self-test loop.

## Test plan

- [ ] Open / merge this PR — perf-gates run should turn fully green (Comment step posts a comment instead of 403'ing)
- [ ] Verify the comment lands on the PR thread