### PR TITLE
perf(frontend): consolidate app-level chunks + activate Remix v3 future flags

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -35,32 +35,45 @@ export default defineConfig({
 				// Vendor chunking — only pure third-party node_modules (never @remix-run/*, react-router)
 				// Previous race condition was caused by splitting Remix internals; this config avoids that
 				manualChunks(id) {
-					if (!id.includes('node_modules')) return;
+					// ─── Vendor chunks (node_modules) ────────────────────
+					if (id.includes('node_modules')) {
+						// React core — stable, long-term cached
+						if (id.includes('/react-dom/') || id.includes('/react/') || id.includes('/scheduler/')) {
+							return 'react-vendor';
+						}
+						// HTML parser stack — only loaded on content routes
+						if (id.includes('/html-react-parser/') || id.includes('/dompurify/') || id.includes('/isomorphic-dompurify/') || id.includes('/htmlparser2/')) {
+							return 'html-parser-vendor';
+						}
+						// Radix UI primitives — shared across UI components
+						if (id.includes('/@radix-ui/')) {
+							return 'radix-vendor';
+						}
+						// Embla carousel — only on routes with carousels
+						if (id.includes('/embla-carousel')) {
+							return 'carousel-vendor';
+						}
+						// cmdk — only on routes with command palette/search
+						if (id.includes('/cmdk/')) {
+							return 'cmdk-vendor';
+						}
+						// Lucide icons — deduplicate across routes
+						if (id.includes('/lucide-react/')) {
+							return 'lucide-vendor';
+						}
+						return; // other node_modules → Rollup default
+					}
 
-					// React core — stable, long-term cached
-					if (id.includes('/react-dom/') || id.includes('/react/') || id.includes('/scheduler/')) {
-						return 'react-vendor';
-					}
-					// HTML parser stack — only loaded on content routes
-					if (id.includes('/html-react-parser/') || id.includes('/dompurify/') || id.includes('/isomorphic-dompurify/') || id.includes('/htmlparser2/')) {
-						return 'html-parser-vendor';
-					}
-					// Radix UI primitives — shared across UI components
-					if (id.includes('/@radix-ui/')) {
-						return 'radix-vendor';
-					}
-					// Embla carousel — only on routes with carousels
-					if (id.includes('/embla-carousel')) {
-						return 'carousel-vendor';
-					}
-					// cmdk — only on routes with command palette/search
-					if (id.includes('/cmdk/')) {
-						return 'cmdk-vendor';
-					}
-					// Lucide icons — deduplicate across routes
-					if (id.includes('/lucide-react/')) {
-						return 'lucide-vendor';
-					}
+					// ─── App-level shared chunks ─────────────────────────
+					// Avoid Rollup's per-shared-component micro-chunks. Each
+					// shared util/UI primitive used by ≥2 routes was emitted
+					// as its own chunk (button, input, card, Section, Footer,
+					// useRootData, logger, etc.) — 17 modulepreload tags on
+					// the home alone. Consolidate into 4 stable chunks that
+					// cache cross-route.
+					if (id.includes('/app/components/ui/')) return 'app-ui-primitives';
+					if (id.includes('/app/components/layout/') || /\/app\/components\/(Section|SectionHeader|Footer)\.tsx$/.test(id)) return 'app-shell';
+					if (id.includes('/app/utils/') || id.includes('/app/lib/')) return 'app-core';
 				},
 			},
 		},
@@ -75,6 +88,22 @@ export default defineConfig({
 			ignoredRouteFiles: ['**/*'],
 			future: {
 				v3_fetcherPersist: true,
+				// Lazy route discovery: manifest of 239 routes (~85 KB) is
+				// loaded on demand per nav instead of injected fully at SSR.
+				// Initial __remixManifest payload drops to ~5 KB, eliminating
+				// the modulepreload cascade triggered by prefetch="intent".
+				v3_lazyRouteDiscovery: true,
+				// Surface AbortSignal.reason on aborted fetches. v3 default.
+				v3_throwAbortReason: true,
+				// Resolve relative paths inside splat ($) routes against the
+				// splat boundary. Audit confirmed all 5 splat routes
+				// ($.tsx, constructeurs.$, gammes.$, sitemaps.$, pieces.$)
+				// use absolute Links only — flag is a no-op for current
+				// code, opt-in for v3 readiness.
+				v3_relativeSplatPath: true,
+				// NOTE: v3_singleFetch deferred to a follow-up PR. Audit
+				// surfaced 18 useFetcher() and 6 headers() exports that
+				// need coordinated review before flipping this flag.
 			},
 
 			// When running locally in development mode, we use the built in remix


### PR DESCRIPTION
## Summary

- **Couche 3** du plan SSR/bundle (Couche 1 mergée [#227](https://github.com/ak125/nestjs-remix-monorepo/pull/227))
- 2 changements connexes dans [`frontend/vite.config.ts`](https://github.com/ak125/nestjs-remix-monorepo/blob/main/frontend/vite.config.ts) qui réduisent ensemble la cascade de modulepreload sur la home

## 1. `manualChunks` app-level

Vite/Rollup par défaut émet un chunk par module partagé entre ≥2 routes. Le manifest production de la home déclarait **20 imports**, dont **17 micro-chunks** pour des UI primitives (`button`, `input`, `tabs`, `card`, `badge`), layout shells (`Section`, `SectionHeader`, `Footer`) et utils (`useRootData`, `logger`, `utils`, `family-registry`...).

Consolidation en 4 chunks stables cross-route :
- `app-ui-primitives` — `app/components/ui/*`
- `app-shell` — `app/components/layout/*` + `Section{,Header}` + `Footer`
- `app-core` — `app/utils/*` + `app/lib/*`
- 6 vendor chunks existants inchangés

**Mesure build local sur cette branche** :
| | Avant (PR #227) | Après | Delta |
|---|---:|---:|---:|
| Imports déclarés `routes/_index` | 20 | **10** | -50% |
| Taille chunk `_index-*.js` | 51 901 B | 43 335 B | -17% |
| Cycles d'import | 0 | 0 | OK |
| Warnings chunkSizeWarningLimit | 0 | 0 | OK |

Nouveaux chunks visibles : `app-shell` 14 KB, `app-ui-primitives` 55 KB, `app-core` 155 KB.

## 2. Future flags Remix v3

Activation de 3 flags v3 (les 4 sont par défaut en v3, on prépare la migration) :

- **`v3_lazyRouteDiscovery: true`** — levier principal. Le manifest des 239 routes (~85 KB) était injecté entièrement dans `window.__remixManifest` au SSR. Avec le flag, seules les routes matchées sont sérialisées au SSR (~5 KB) ; les autres se chargent à la demande à la nav. Élimine la cascade de modulepreload déclenchée par les `prefetch=\"intent\"` rendus dans le tree home.
- **`v3_throwAbortReason: true`** — expose `AbortSignal.reason` sur les aborts. Pure correctness.
- **`v3_relativeSplatPath: true`** — résout les paths relatifs dans les splat routes contre la frontière splat. Audit confirme que les 5 splat routes (`$.tsx`, `constructeurs.$`, `gammes.$`, `sitemaps.$`, `pieces.$`) utilisent **uniquement des Links absolus** → no-op pour le code actuel, opt-in v3.

**`v3_singleFetch` reporté** à une PR séparée. L'audit a remonté **18 `useFetcher()` + 6 `headers()` exports** qui demandent une revue coordonnée avant de basculer (le flag change le format de payload des loaders).

## Plan complet

- [x] **Couche 1** — warm `homepage:families:v1` cache key (PR #227 merged)
- [x] **Couche 3** — app manualChunks + v3 flags (cette PR)
- [ ] **Couche 2** — remplacer HTTP loopback dans home loader par NestJS DI
- [ ] **Couche 4** — tighten lighthouse-budget après mesure

## Test plan

- [ ] CI perf-gates : LCP/CLS/TTFB doivent rester verts ; `script.count` et `script.size` doivent baisser
- [ ] Build clean (0 cycle, 0 warning)
- [ ] Smoke test multi-routes (`/`, `/pieces/<slug>`, `/blog`, `/constructeurs`) → 200 OK, durées ±10%
- [ ] Audit visuel HTML SSR : `__remixManifest` doit faire <10 KB (vs ~85 KB)

## Risques

Faibles. Audit préalable :
- Pas de cycle d'import révélé par le build local
- Tous les splat routes utilisent absolute Links → `v3_relativeSplatPath` no-op
- `v3_singleFetch` (le risqué) explicitement reporté

🤖 Generated with [Claude Code](https://claude.com/claude-code)