### PR TITLE
perf(home): replace HTTP loopback in home loader with NestJS DI

### DIFF
--- a/backend/src/remix/remix-api.service.ts
+++ b/backend/src/remix/remix-api.service.ts
@@ -8,6 +8,7 @@
 
 import { Injectable, Inject, forwardRef, Logger } from '@nestjs/common';
 import { OrdersService } from '../database/services/orders.service';
+import { HomepageRpcService } from '../modules/catalog/services/homepage-rpc.service';
 import { ExternalServiceException, ErrorCodes } from '@common/exceptions';
 
 interface StaffMember {
@@ -30,7 +31,31 @@ export class RemixApiService {
   constructor(
     @Inject(forwardRef(() => OrdersService))
     private readonly ordersService: OrdersService,
+    private readonly homepageRpcService: HomepageRpcService,
   ) {}
+
+  /**
+   * 🏠 HOMEPAGE FAMILIES — direct service call (no HTTP loopback)
+   *
+   * Awaited by the home loader (`routes/_index.tsx`). Bypasses the
+   * `fetch('http://localhost:3000/api/catalog/homepage-families')` round
+   * trip, which created a TCP loopback connection per SSR (~10-50ms cold,
+   * port pressure under load).
+   */
+  async getHomepageFamilies() {
+    return this.homepageRpcService.getHomepageFamilies();
+  }
+
+  /**
+   * 🏠 HOMEPAGE BELOW-FOLD — direct service call (no HTTP loopback)
+   *
+   * Streamed via Remix `defer()` from the home loader. Even though
+   * deferred (non-blocking), eliminating the loopback frees a connection
+   * slot and shaves the cold TCP handshake.
+   */
+  async getHomepageBelowFold() {
+    return this.homepageRpcService.getHomepageBelowFold();
+  }
 
   /**
    * 🚀 Helper HTTP simplifié - L'auth passe par le contexte Remix

--- a/backend/src/remix/remix.module.ts
+++ b/backend/src/remix/remix.module.ts
@@ -8,6 +8,7 @@ import { CartModule } from '../modules/cart/cart.module';
 import { DatabaseModule } from '../database/database.module';
 import { MessagesModule } from '../modules/messages/messages.module';
 import { AuthModule } from '../auth/auth.module';
+import { CatalogModule } from '../modules/catalog/catalog.module';
 
 // Services spécialisés - TOUS SUPPRIMÉS car obsolètes
 // import { OrdersIntegrationService } from './integration/orders/orders-integration.service'; // Obsolète
@@ -22,6 +23,9 @@ import { AuthModule } from '../auth/auth.module';
     forwardRef(() => DatabaseModule),
     forwardRef(() => MessagesModule),
     forwardRef(() => AuthModule),
+    // CatalogModule exports HomepageRpcService — used by RemixApiService
+    // for direct DI calls in the home loader (eliminates HTTP loopback).
+    forwardRef(() => CatalogModule),
   ],
   controllers: [RemixController],
   providers: [

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -22,6 +22,7 @@ import {
   PopularSearches,
 } from "~/components/home";
 import { type BrandItem } from "~/components/home/constants";
+import { getRemixApiService } from "~/server/remix-api.server";
 import {
   type SlimFamily,
   mapFamiliesFromSplit,
@@ -101,15 +102,20 @@ export const meta: MetaFunction = () => [
 ];
 
 // ─── Loader (Phase 1 perf: split above-fold / below-fold) ─
-// Above-fold: families via lightweight /homepage-families → awaited (blocks SSR)
-// Below-fold: brands, equipementiers, blog via /homepage-below-fold → REAL deferred streaming
-export async function loader({ request }: LoaderFunctionArgs) {
-  // Below-fold + FAQ: fire immediately, NOT awaited (real streaming)
-  const belowFoldPromise = fetch(
-    getInternalApiUrl("/api/catalog/homepage-below-fold"),
-  )
-    .then((res) => (res.ok ? res.json() : null))
-    .then((data) => {
+// Above-fold: families via lightweight homepage-families → awaited (blocks SSR)
+// Below-fold: brands, equipementiers, blog via homepage-below-fold → REAL deferred streaming
+//
+// Layer 2 perf: families + below-fold come from NestJS DI (no HTTP loopback).
+// FAQ stays on internal HTTP because FaqService isn't exported by SupportModule
+// — separate scope, deferred so non-blocking anyway.
+export async function loader({ request, context }: LoaderFunctionArgs) {
+  const remixApi = await getRemixApiService(context);
+
+  // Below-fold: direct service call wrapped in a Promise so Remix can
+  // still defer-stream it via <Await>. The await is captured *inside* the
+  // Promise chain — the loader proceeds without blocking.
+  const belowFoldPromise = Promise.resolve(remixApi.getHomepageBelowFold())
+    .then((data: any) => {
       if (!data) return { brands: [], equipementiers: [], blogArticles: [] };
       return mapBelowFoldData(data);
     })
@@ -119,6 +125,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       blogArticles: [] as any[],
     }));
 
+  // FAQ: kept on HTTP (FaqService not exported by SupportModule yet)
   const faqPromise = fetch(
     getInternalApiUrl("/api/support/faq?status=published&limit=5"),
   )
@@ -133,22 +140,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
     )
     .catch(() => [] as Array<{ id: string; question: string; answer: string }>);
 
-  // Above-fold: AWAIT families only (lightweight, fast)
+  // Above-fold: AWAIT families only (lightweight, fast). Direct service
+  // call — bypasses TCP loopback handshake that previously cost ~10-50ms
+  // cold per SSR and consumed a connection pool slot.
   try {
-    const familiesRes = await fetch(
-      getInternalApiUrl("/api/catalog/homepage-families"),
-    );
-
-    const familiesRaw = familiesRes.ok ? await familiesRes.json() : null;
+    const familiesRaw = await remixApi.getHomepageFamilies();
     const families = mapFamiliesFromSplit(familiesRaw);
 
     return defer({
       families,
-      belowFold: belowFoldPromise, // REAL promise — enables Remix streaming
+      belowFold: belowFoldPromise,
       faqs: faqPromise,
     });
   } catch (err) {
-    logger.error("[homepage-families] Fetch failed:", {
+    logger.error("[homepage-families] Service call failed:", {
       error: err instanceof Error ? err.message : String(err),
     });
     return defer({


### PR DESCRIPTION
## Summary

**Couche 2** du plan SSR/bundle — élimine le HTTP loopback dans le loader home en exposant `HomepageRpcService` via le DI NestJS-Remix existant.

Couches précédentes mergées :
- [#227](https://github.com/ak125/nestjs-remix-monorepo/pull/227) — warm `homepage:families:v1` cache
- [#229](https://github.com/ak125/nestjs-remix-monorepo/pull/229) — manualChunks app-level + Remix v3 future flags

## Cause racine

[`frontend/app/utils/internal-api.server.ts:6`](https://github.com/ak125/nestjs-remix-monorepo/blob/main/frontend/app/utils/internal-api.server.ts#L6) le documente lui-même comme anti-pattern :

> *"Prefer getInternalApiUrlFromRequest() in loaders/actions to avoid creating outbound HTTP connections to localhost (causes port exhaustion)."*

Mais même `getInternalApiUrlFromRequest()` reste un HTTP loopback. La solution canonique : **appel DI direct au service NestJS** depuis le loader Remix via le `getLoadContext` déjà câblé.

## Changements

- `RemixApiService` (backend) injecte `HomepageRpcService` et expose 2 pass-throughs :
  - `getHomepageFamilies()`
  - `getHomepageBelowFold()`
  
  Pattern identique aux méthodes `getOrders()`-style déjà sur le service.

- `RemixModule` importe `CatalogModule` (qui exportait déjà `HomepageRpcService`) via `forwardRef` pour éviter cycle DI.

- Le home loader (`routes/_index.tsx`) récupère le service via `getRemixApiService(context)` (helper existant) et appelle directement. Le path deferred `belowFold` continue de streamer via `defer()`/`<Await>` — le `await` est capturé dans la chaîne `Promise.resolve().then()` pour ne pas bloquer le retour du loader.

## Scope notes

- **FAQ reste sur HTTP loopback** dans cette PR. `FaqService` n'est pas exporté par `SupportModule`. Étendre ces exports = scope creep d'un autre module. FAQ étant deferred (non-bloquant SSR), l'impact est mineur. À migrer dans une PR séparée si on étend `SupportModule.exports`.
- Une autre route (`routes/plan-du-site.tsx`) utilise `homepage-families` via fetch HTTP. Hors scope ici (page non critique perf-wise) ; à migrer dans une PR follow-up.

## Effet attendu

Sur la home (SSR cold) :
- Élimine 2 connexions TCP loopback par requête (DNS + handshake + close ~10-50ms cold chacune)
- Libère 2 slots du pool de connexions par requête → moins de pression sous burst
- Aucun changement fonctionnel : même DTO retourné par `getHomepageFamilies()` / `getHomepageBelowFold()`

## Test plan

- [ ] CI perf-gates : LCP/CLS/TTFB doivent rester verts ; TTFB peut baisser (élimination handshake loopback)
- [ ] Backend tests : nouvelle injection ne casse pas les tests existants
- [ ] Smoke test : `/`, `/pieces/<slug>`, `/blog`, `/constructeurs` retournent 200
- [ ] Smoke spécifique home : familles affichées sans `[homepage-families] Service call failed` dans les logs

## Risques

Faibles. Pattern `RemixApiService` injecte déjà des services NestJS (`OrdersService`). `forwardRef` standard pour éviter cycles. Build Vite client clean (verified locally — 0 cycle, 0 warning).

## Plan complet

- [x] Layer 1 — warm `homepage:families:v1` (PR #227)
- [x] Layer 3 — manualChunks + v3 flags (PR #229)
- [x] Layer 2 — DI direct loader (cette PR)
- [ ] Layer 4 — tighten lighthouse-budget après mesure

🤖 Generated with [Claude Code](https://claude.com/claude-code)