### PR TITLE
ci(seo-matrix): determinism guard via audit:seo-matrix:check workflow

### DIFF
--- a/.github/workflows/seo-matrix-check.yml
+++ b/.github/workflows/seo-matrix-check.yml
@@ -1,0 +1,48 @@
+name: 🛡️ SEO Matrix Determinism Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/src/config/operating-matrix.*'
+      - 'backend/src/config/execution-registry*'
+      - 'backend/src/config/field-catalog*'
+      - 'backend/src/config/role-ids*'
+      - 'backend/src/config/group-table-map*'
+      - '.claude/agents/**'
+      - 'scripts/seo/dump-agent-matrix.ts'
+      - 'audit-reports/seo-agent-matrix.json'
+      # Self-trigger : changes to this workflow (paths, permissions,
+      # node version) must re-run the workflow to validate them.
+      # Pattern canonique post-PR #228 (cf. perf-gates.yml).
+      - '.github/workflows/seo-matrix-check.yml'
+
+# La matrice est read-only par construction. Pas de PR comment auto, pas
+# d'accès écriture nécessaire. Least-privilege par défaut.
+permissions:
+  contents: read
+
+jobs:
+  determinism:
+    name: 🛡️ Matrix JSON determinism
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run matrix determinism check
+        # Régénère audit-reports/seo-agent-matrix.json et compare au committé.
+        # Si diff non vide → fail (le contributeur doit committer le JSON regen).
+        # Le Markdown porte un timestamp humain → exclu du check (cf. invariant
+        # R6 du plan : seul le JSON est strictement déterministe).
+        run: npm run audit:seo-matrix:check

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "audit:baseline": "node scripts/cleanup/audit-compare-baseline.js",
     "audit:baseline:json": "node scripts/cleanup/audit-compare-baseline.js --json",
     "audit:baseline:strict": "node scripts/cleanup/audit-compare-baseline.js --strict",
-    "audit:all": "npm run audit:ast && npm run audit:madge && npm run audit:depcruise && npm run audit:knip"
+    "audit:all": "npm run audit:ast && npm run audit:madge && npm run audit:depcruise && npm run audit:knip",
+    "audit:seo-matrix": "tsx scripts/seo/dump-agent-matrix.ts",
+    "audit:seo-matrix:check": "npm run audit:seo-matrix && git diff --exit-code -- audit-reports/seo-agent-matrix.json"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary

Adds a CI guard that prevents drift between the committed `audit-reports/seo-agent-matrix.json` and a fresh CLI run. The matrix is deterministic by construction (R6 invariant of #222 : zero timestamp, canonicalized key order, raw-file hashes). Without this guard, anyone can edit `operating-matrix.service.ts` or `.claude/agents/*` without regenerating the committed JSON → silent divergence between HEAD-view and runtime-view.

This is **PR-A** of the 4-PR follow-up plan after #222 merge (cf. plan `~/.claude/plans/je-parle-de-ce-enumerated-octopus.md`).

## What changes

### `package.json` — 2 new audit scripts
Aligned with the existing `audit:*` convention (`audit:knip`, `audit:madge`, `audit:depcruise`, `audit:ast`, `audit:graph`, `audit:baseline`, `audit:baseline:strict`). The matrix **is** a governance audit; it belongs in that family. The `:check` suffix mirrors `audit:baseline` / `audit:baseline:strict` pattern.

```json
"audit:seo-matrix": "tsx scripts/seo/dump-agent-matrix.ts",
"audit:seo-matrix:check": "npm run audit:seo-matrix && git diff --exit-code -- audit-reports/seo-agent-matrix.json"
```

### `.github/workflows/seo-matrix-check.yml` — new dedicated workflow

- **`on: pull_request`** scoped to matrix-touching paths (operating-matrix.*, execution-registry*, field-catalog*, role-ids*, group-table-map*, .claude/agents/**, scripts/seo/dump-agent-matrix.ts, audit JSON, the workflow itself)
- **Self-trigger** on the workflow file (post-#228 convention from perf-gates.yml — fixes to the workflow re-validate themselves)
- **`permissions: contents: read`** only (no PR comment posting → no `pull-requests: write` needed, least-privilege)
- **5-min timeout** (CLI is in-memory + fs scan, zero remote IO)

## Why this is the structural answer (not bricolage)

- ✅ Reuses the CLI already shipped in #222 (`scripts/seo/dump-agent-matrix.ts`) — zero 2nd source of truth
- ✅ Dedicated workflow per separation-of-concerns (each `.github/workflows/*.yml` has one focus)
- ✅ Self-trigger paths included → matches the canonical pattern after PR #228
- ✅ `audit:*` naming = co-located with siblings, discoverable via `npm run audit:` autocomplete
- ✅ JSON-only check (Markdown carries a human timestamp by design and is excluded)

## Verification

```bash
# Local determinism (must exit 0)
npm run audit:seo-matrix:check && echo OK

# Manual drift simulation
sed -i 's/registryVersion/registryVersion_FAKE/' backend/src/config/operating-matrix.service.ts
npm run audit:seo-matrix:check  # → exit 1 (would-be-CI fail)
git checkout backend/src/config/operating-matrix.service.ts
```

## Test plan

- [x] Local `npm run audit:seo-matrix:check` exits 0 on clean tree
- [ ] CI workflow triggers on this PR (touches `package.json` paths NOT matched, but workflow self-trigger path is matched → workflow runs and validates itself)
- [ ] Future PR touching `.claude/agents/` or `operating-matrix.service.ts` without regen → workflow fails as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)