### PR TITLE
refactor(write-guard): use OperatingMatrixService.formatBootLog() as single source

### DIFF
--- a/backend/src/config/operating-matrix.module.ts
+++ b/backend/src/config/operating-matrix.module.ts
@@ -1,17 +1,24 @@
 /**
  * OperatingMatrixModule — minimal NestJS context exposing OperatingMatrixService.
  *
- * Used by scripts/seo/dump-agent-matrix.ts via NestFactory.createApplicationContext.
+ * Imported by:
+ *   - WriteGuardModule (boot-log invariant — single source of truth for the
+ *     "WriteGuard: role X owns N fields…" lines; cf. formatBootLog()).
  *
- * Why a dedicated lightweight module rather than reusing WriteGuardModule:
- *   - WriteGuardModule is `@Global` and pulls Redis, feature-flags and ledger
- *     services via OnModuleInit — booting from a CLI would require live env
- *     vars (REDIS_URL, SUPABASE_*) and risk runtime drift.
+ * Reused by scripts/seo/dump-agent-matrix.ts in standalone mode (the CLI
+ * bypasses NestJS DI and instantiates OperatingMatrixService directly with a
+ * stub ConfigService — esbuild/tsx does not emit emitDecoratorMetadata).
+ *
+ * Why a dedicated lightweight module rather than embedding the provider in
+ * WriteGuardModule directly:
  *   - The matrix is read-only by construction (registry × catalog × filesystem
- *     scan of .claude/agents). It deserves a context with zero infra deps.
- *
- * Purely additive: this module is not imported anywhere in the live app today.
- * Wiring into AdminModule (for an admin endpoint) is a separate decision.
+ *     scan of .claude/agents). It deserves a context with zero infra deps so
+ *     it can later be imported by AdminModule (REST endpoint) without dragging
+ *     in WriteGuardModule's @Global Redis / ledger / feature-flag stack.
+ *   - Plain `ConfigModule` (no forRoot/isGlobal) is sufficient: ConfigModule
+ *     is already initialized at app root by AppModule, and a non-global
+ *     re-import is idempotent. The CLI does not import this module so does
+ *     not depend on the global config context.
  */
 
 import { Module } from '@nestjs/common';
@@ -19,7 +26,7 @@ import { ConfigModule } from '@nestjs/config';
 import { OperatingMatrixService } from './operating-matrix.service';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true })],
+  imports: [ConfigModule],
   providers: [OperatingMatrixService],
   exports: [OperatingMatrixService],
 })

--- a/backend/src/config/write-guard.module.ts
+++ b/backend/src/config/write-guard.module.ts
@@ -24,12 +24,12 @@ import { ContentRegressionGuard } from './content-regression-guard.service';
 import { ContentWriteExecutor } from './content-write-executor.service';
 import { ContentWriteGateService } from './content-write-gate.service';
 import { FeatureFlagsModule } from './feature-flags.module';
-import { EXECUTION_REGISTRY } from './execution-registry.constants';
-import { deriveWriteScope, FIELD_CATALOG } from './field-catalog.constants';
+import { OperatingMatrixModule } from './operating-matrix.module';
+import { OperatingMatrixService } from './operating-matrix.service';
 
 @Global()
 @Module({
-  imports: [ConfigModule, FeatureFlagsModule],
+  imports: [ConfigModule, FeatureFlagsModule, OperatingMatrixModule],
   providers: [
     // P1.5 core
     WriteGuardLockService,
@@ -54,45 +54,15 @@ import { deriveWriteScope, FIELD_CATALOG } from './field-catalog.constants';
 export class WriteGuardModule implements OnModuleInit {
   private readonly logger = new Logger(WriteGuardModule.name);
 
+  constructor(private readonly matrix: OperatingMatrixService) {}
+
   onModuleInit(): void {
-    // ── Boot invariant: validate catalog ↔ registry coherence ──
-    const rolesSeen = new Set<string>();
-    let fieldsTotal = 0;
-
-    for (const entry of Object.values(EXECUTION_REGISTRY)) {
-      const scope = deriveWriteScope(entry.roleId);
-
-      if (scope.ownedFields.length === 0) {
-        this.logger.warn(
-          `WriteGuard: role ${entry.roleId} has no owned fields in FIELD_CATALOG`,
-        );
-      } else {
-        this.logger.log(
-          `WriteGuard: role ${entry.roleId} owns ${scope.ownedFields.length} fields ` +
-            `across ${scope.resourceGroups.length} groups (${scope.resourceGroups.join(', ')})`,
-        );
-      }
-
-      rolesSeen.add(entry.roleId);
-      fieldsTotal += scope.ownedFields.length;
+    // Boot invariant: validate catalog ↔ registry coherence.
+    // Single source of truth for these log lines = OperatingMatrixService.formatBootLog()
+    // (synchronous, in-memory iteration over EXECUTION_REGISTRY + FIELD_CATALOG —
+    // no remote IO, conforms to .claude/rules/backend.md § "Non-blocking onModuleInit").
+    for (const entry of this.matrix.formatBootLog()) {
+      this.logger[entry.level](entry.message);
     }
-
-    // Check for orphan catalog entries (fields referencing roles not in registry)
-    const orphanRoles = new Set<string>();
-    for (const field of FIELD_CATALOG) {
-      if (!rolesSeen.has(field.ownerRole)) {
-        orphanRoles.add(field.ownerRole);
-      }
-    }
-    if (orphanRoles.size > 0) {
-      this.logger.warn(
-        `WriteGuard: FIELD_CATALOG references roles not in registry: ${[...orphanRoles].join(', ')}`,
-      );
-    }
-
-    this.logger.log(
-      `WriteGuard: initialized — ${FIELD_CATALOG.length} catalog entries, ` +
-        `${fieldsTotal} owned fields across ${rolesSeen.size} roles`,
-    );
   }
 }


### PR DESCRIPTION
## Summary

`WriteGuardModule.onModuleInit()` had inlined the catalog↔registry boot invariant logging — the exact same logic that `OperatingMatrixService.formatBootLog()` (shipped in #222) already produces. **Two sources of truth → divergence guarantee.**

This **PR-C** of the 4-PR follow-up plan after #222 (cf. `~/.claude/plans/je-parle-de-ce-enumerated-octopus.md`) replaces the inline 40-line boot init with a 3-line iteration over `formatBootLog()`. Output is **byte-equivalent**: same iteration order, same log levels, same messages.

## What changes

### `backend/src/config/write-guard.module.ts`
- `imports: [..., OperatingMatrixModule]`
- Constructor injection of `OperatingMatrixService`
- `onModuleInit()` reduced to:
  ```ts
  for (const entry of this.matrix.formatBootLog()) {
    this.logger[entry.level](entry.message);
  }
  ```
- Drops now-unused imports of `EXECUTION_REGISTRY`, `deriveWriteScope`, `FIELD_CATALOG`

### `backend/src/config/operating-matrix.module.ts`
- `imports: [ConfigModule.forRoot({ isGlobal: true })]` → `imports: [ConfigModule]` (AppModule already initializes the global config; the CLI bypasses NestJS DI so no impact)
- Header docstring updated to document the new wiring with `WriteGuardModule`

## Why this is structural (not bricolage)

- ✅ Single source of truth for the boot invariant log lines
- ✅ Reuses code already shipped + already tested (23 unit tests on `OperatingMatrixService` from #222)
- ✅ `formatBootLog()` is fully sync (in-memory iteration over TS constants) → conforms to `.claude/rules/backend.md § "Non-blocking onModuleInit"` + ast-grep enforcer `.ast-grep/rules/backend-no-remote-io-in-onmoduleinit.yml`
- ✅ Module isolation preserved: `OperatingMatrixModule` stays free of Redis/DB deps so future imports (e.g. AdminModule for REST endpoint) don't drag in WriteGuard's @Global infra stack
- ✅ Boot output is byte-equivalent — no behavior change visible in logs

## Verification

```bash
# Local typecheck
cd backend && npx tsc --noEmit  # 0 errors

# ast-grep enforcer
npx ast-grep scan --config sgconfig.yml \
  --rule .ast-grep/rules/backend-no-remote-io-in-onmoduleinit.yml \
  backend/src/config/write-guard.module.ts  # 0 findings

# Unit tests (23 cases on operating-matrix.service)
# Local jest hits OOM on this monorepo — CI is the authority
```

### Boot regression check (post-deploy DEV)
```bash
ssh 46.224.118.55 "docker compose logs backend | grep 'WriteGuard:' | head -20"
# Expected: same lines as pre-PR (role X owns N fields…, initialized —…)
```

## Test plan

- [ ] Backend Tests CI green (jest 23/23 on operating-matrix.service)
- [ ] TypeScript CI green
- [ ] ast-grep enforcer green
- [ ] DEV pre-prod boot logs unchanged after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)