### PR TITLE
feat(admin): expose SEO Operating Matrix via /api/admin/governance/seo-operating-matrix

### DIFF
--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -100,6 +100,8 @@ import { RagProposalService } from './services/rag-proposal.service'; // 📝 AD
 import { AdminVehicleRagController } from './controllers/admin-vehicle-rag.controller'; // 🚗 Vehicle RAG generation endpoints
 import { AdminVehicleCacheController } from './controllers/admin-vehicle-cache.controller'; // 🚗 INC-2026-007 — Vehicle cache rebuild/invalidate/stats
 import { VehiclesModule } from '../vehicles/vehicles.module'; // 🚗 INC-2026-007 — pour VehicleRpcService
+import { OperatingMatrixModule } from '../../config/operating-matrix.module'; // 🛡️ Read-only governance matrix (registry × catalog × agents)
+import { GovernanceMatrixController } from './controllers/governance-matrix.controller'; // 🛡️ Admin REST exposure of SEO Operating Matrix
 
 // Services - Stock services pour le controller consolidé
 import { ConfigurationService } from './services/configuration.service';
@@ -142,6 +144,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     SystemModule, // DB governance Phase 2 (DbGovernanceService)
     AiContentModule, // 🤖 Pour ConseilEnricher + BuyingGuideSEODraft (optional LLM polish)
     VehiclesModule, // 🚗 INC-2026-007 — pour AdminVehicleCacheController (VehicleRpcService)
+    OperatingMatrixModule, // 🛡️ Read-only governance matrix (zero infra deps)
   ],
   controllers: [
     ConfigurationController,
@@ -186,6 +189,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     AdminRagPipelineStatusController, // 📊 RAG pipeline dashboard - /api/admin/rag-pipeline/status
     InternalPipelineController, // 🚀 Internal pipeline (X-Internal-Key) - /api/internal/pipeline/*
     InternalSeoAuditController, // 📊 Internal SEO audit (X-Internal-Key) - /api/internal/seo/audit/*
+    GovernanceMatrixController, // 🛡️ SEO Operating Matrix - /api/admin/governance/seo-operating-matrix
   ],
   providers: [
     ConfigurationService,

--- a/backend/src/modules/admin/controllers/governance-matrix.controller.ts
+++ b/backend/src/modules/admin/controllers/governance-matrix.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Logger, Query, Res, UseGuards } from '@nestjs/common';
+import type { Response } from 'express';
+import { AuthenticatedGuard } from '@auth/authenticated.guard';
+import { IsAdminGuard } from '@auth/is-admin.guard';
+import { OperatingMatrixService } from '@config/operating-matrix.service';
+
+/**
+ * GovernanceMatrixController — admin-only HTTP exposure of the SEO Operating Matrix.
+ *
+ * Live runtime view of registry × catalog × .claude/agents inventory. Useful
+ * for prod debugging when the committed audit-reports/seo-agent-matrix.json
+ * may differ from runtime (env-dependent agent scan results).
+ *
+ * Single endpoint, two formats:
+ *   GET /api/admin/governance/seo-operating-matrix             → JSON canonical
+ *   GET /api/admin/governance/seo-operating-matrix?format=md   → Markdown
+ *
+ * Bypasses the AdminResponseInterceptor (uses @Res() directly): the JSON is
+ * already canonicalized by the service, and wrapping it would break the
+ * deterministic byte-for-byte equivalence with the committed artifact.
+ */
+@Controller('api/admin/governance')
+@UseGuards(AuthenticatedGuard, IsAdminGuard)
+export class GovernanceMatrixController {
+  private readonly logger = new Logger(GovernanceMatrixController.name);
+
+  constructor(private readonly matrix: OperatingMatrixService) {}
+
+  @Get('seo-operating-matrix')
+  getMatrix(
+    @Query('format') format: string | undefined,
+    @Res() res: Response,
+  ): void {
+    if (format === 'md' || format === 'markdown') {
+      res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+      res.send(this.matrix.formatMarkdown());
+      return;
+    }
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.send(this.matrix.formatJsonString());
+  }
+}


### PR DESCRIPTION
## Summary

Adds a read-only admin REST endpoint that returns the **live runtime view** of the SEO Operating Matrix (registry × catalog × `.claude/agents` inventory). Useful for prod debugging when the committed `audit-reports/seo-agent-matrix.json` may differ from runtime due to env-dependent agent scan results.

This is **PR-B** of the 4-PR follow-up plan after #222 (cf. `~/.claude/plans/je-parle-de-ce-enumerated-octopus.md`). PR-A (#231) and PR-C (#232) are already up.

## Endpoint

```
GET /api/admin/governance/seo-operating-matrix             → application/json (canonical)
GET /api/admin/governance/seo-operating-matrix?format=md   → text/markdown (human-readable)
```

Auth: `AuthenticatedGuard` + `IsAdminGuard` (mirrors `AdminFeatureFlagsController` and 30+ other admin controllers — established pattern, no new convention).

Bypasses `AdminResponseInterceptor` via `@Res()` — the JSON is already canonicalized by the service, so wrapping it would break byte-for-byte equivalence with the committed artifact (R6 invariant).

## Why this is structural (not bricolage)

- ✅ Reuses `OperatingMatrixService` 100% (already shipped + 23 unit tests in #222)
- ✅ `IsAdminGuard` is the canonical admin module guard — no new auth path invented
- ✅ Imports `OperatingMatrixModule` (the lightweight, infra-free module from #222) — does NOT pull WriteGuard's `@Global` Redis/DB stack
- ✅ Single endpoint, two formats via 1 query param — minimal interface, no premature pagination/filtering
- ✅ Aligned with the `/api/admin/governance/*` namespace already used by `AdminDbGovernanceController`

## Module wiring

- `admin.module.ts`:
  - `imports: [..., OperatingMatrixModule]`
  - `controllers: [..., GovernanceMatrixController]`

## Verification

```bash
# 401 unauthenticated
curl -i http://localhost:3000/api/admin/governance/seo-operating-matrix
# → 401

# 200 admin JSON
curl -i -b "connect.sid=<admin-cookie>" http://localhost:3000/api/admin/governance/seo-operating-matrix
# → 200 application/json (10 keys: agentScanRootsConfigured, agentScanSkipped, agentsIndex, anomalies, catalogFieldCount, gaps, registryVersion, roles, sourcesHash, unmappableAgents)

# 200 admin Markdown
curl -i -b "connect.sid=<admin-cookie>" "http://localhost:3000/api/admin/governance/seo-operating-matrix?format=md"
# → 200 text/markdown

# Coherence check: live runtime JSON ≡ committed JSON in DEV
diff <(curl -s -b "connect.sid=..." http://localhost:3000/api/admin/governance/seo-operating-matrix) audit-reports/seo-agent-matrix.json
# → empty diff (modulo agentScanSkipped if env differs)
```

## Test plan

- [x] Local typecheck (0 errors)
- [ ] Backend Tests CI green
- [ ] TypeScript CI green
- [ ] Manual: hit endpoint on DEV pre-prod after merge, verify 401 / 200 / MD

## Out of scope (deferred)

- **Frontend Remix admin UI** — explicitly deferred per the original plan. The endpoint is sufficient for ops; UI can be a follow-up if a real need surfaces.
- **E2E test** — `backend/test/` doesn't exist yet; setting it up is bigger than this scope. The controller pattern is identical to 30+ existing admin controllers, and the underlying service has 23 unit tests from #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)