### PR TITLE
chore(registry): remove R3_GUIDE entry — close 'deprecated_but_in_registry' anomaly

### DIFF
--- a/audit-reports/seo-agent-matrix.json
+++ b/audit-reports/seo-agent-matrix.json
@@ -46,12 +46,7 @@
     "r8-vehicle-validator": "R8_VEHICLE",
     "research-agent": "UNKNOWN"
   },
-  "anomalies": [
-    {
-      "reason": "deprecated_but_in_registry",
-      "roleId": "R3_GUIDE"
-    }
-  ],
+  "anomalies": [],
   "catalogFieldCount": 141,
   "gaps": [
     {
@@ -186,27 +181,9 @@
     {
       "agents": [],
       "deprecated": true,
-      "healthScore": 30,
+      "healthScore": 0,
       "registry": {
-        "agentFiles": [
-          "content-batch.md"
-        ],
-        "allowedModes": [
-          "create",
-          "regenerate",
-          "refresh_partial",
-          "refresh_full",
-          "repair",
-          "qa_only"
-        ],
-        "contractSchemaRef": "page-contract-r3.schema",
-        "defaultWriteMode": "draft_write",
-        "enricherServiceKey": "BuyingGuideEnricherService",
-        "present": true,
-        "stopPolicy": {
-          "maxRetries": 2,
-          "timeoutMs": 180000
-        }
+        "present": false
       },
       "roleId": "R3_GUIDE",
       "writeScope": {
@@ -460,7 +437,7 @@
     }
   ],
   "sourcesHash": {
-    "executionRegistry": "sha256:bf704a8c0627478c07ae2d74ec07fc1809e9dbe762e16eaec60c6382c4c0e0a9",
+    "executionRegistry": "sha256:16dba7bd8a61116ccc225af04d10d2c2d6b04eead18d799c2970bceabc915e1d",
     "executionRegistryTypes": "sha256:6c585a3075471f5189d5c1a48bd83e0f1ce6460cd1af9a9398a6d2b0d68c1d46",
     "fieldCatalog": "sha256:de4b23f16019338092340be58b0cfe421519aceb94a148efca07f99021fef0f7",
     "roleIds": "sha256:8c8257d1ad07acf06cd97a240822ca9ac6d625600300048a73c66d52134c2857"

--- a/audit-reports/seo-agent-matrix.md
+++ b/audit-reports/seo-agent-matrix.md
@@ -1,7 +1,7 @@
 # SEO Agent Operating Matrix
 
-> Généré le : 2026-04-30T11:49:46.539Z
-> Sources hash : registry=bf704a8c types=6c585a30 catalog=de4b23f1 roleIds=8c8257d1
+> Généré le : 2026-04-30T17:28:32.923Z
+> Sources hash : registry=16dba7bd types=6c585a30 catalog=de4b23f1 roleIds=8c8257d1
 > Registry version : 1.0.0 — Field catalog : 141 entrées
 
 ## Matrice principale
@@ -11,7 +11,7 @@
 | R0_HOME | 40 | ❌ | r0-home-execution, r0-home-validator | — | 0 |
 | R1_ROUTER | 100 | ✅ | r1-content-batch, r1-keyword-planner, r1-router-validator | __seo_gamme, __seo_r1_gamme_slots, __seo_page_brief | 38 |
 | R2_PRODUCT | 100 | ✅ | r2-keyword-planner, r2-product-validator | __seo_r2_keyword_plan | 15 |
-| R3_GUIDE (deprecated) | 30 | ✅ | — | — | 0 |
+| R3_GUIDE (deprecated) | 0 | ❌ | — | — | 0 |
 | R3_CONSEILS | 100 | ✅ | r3-conseils-validator | __seo_gamme_conseil | 12 |
 | R4_REFERENCE | 100 | ✅ | r4-content-batch, r4-keyword-planner, r4-reference-execution, r4-reference-validator | __seo_reference | 21 |
 | R5_DIAGNOSTIC | 100 | ✅ | r5-diagnostic-execution, r5-diagnostic-validator, r5-keyword-planner | __seo_observable | 16 |
@@ -29,7 +29,7 @@
 
 ## Anomalies
 
-- ⚠️ **R3_GUIDE** — deprecated_but_in_registry
+_Aucune anomalie._
 
 ## Agents non-mappables
 

--- a/backend/src/config/execution-registry.constants.ts
+++ b/backend/src/config/execution-registry.constants.ts
@@ -64,26 +64,12 @@ export const EXECUTION_REGISTRY: Record<string, ExecutionRegistryEntry> = {
     requiredUpstreamPhases: ['phase16_admissibility'],
   },
 
-  [RoleId.R3_GUIDE]: {
-    roleId: RoleId.R3_GUIDE,
-    pageType: 'R3_guide_howto',
-    contractSchemaRef: 'page-contract-r3.schema',
-    enricherServiceKey: 'BuyingGuideEnricherService',
-    agentFiles: ['content-batch.md'],
-    promptChain: ['guide_enrichment'],
-    allowedModes: [
-      'create',
-      'regenerate',
-      'refresh_partial',
-      'refresh_full',
-      'repair',
-      'qa_only',
-    ],
-    defaultWriteMode: 'draft_write',
-    stopPolicy: { maxRetries: 2, timeoutMs: 180_000 },
-    escalationPolicy: { onGateFail: 'block', onTimeout: 'hold' },
-    requiredUpstreamPhases: ['phase16_admissibility'],
-  },
+  // R3_GUIDE: deprecated since role-ids.ts:17 ("no route, no contract, no prompts").
+  // Already in FORBIDDEN_ROLE_IDS + DEPRECATED_OUTPUT_ROLES (role-ids.ts).
+  // Registry entry removed to align: a deprecated role MUST NOT have an
+  // executable plan. Legacy content uses R3_CONSEILS (how-to) or R6_GUIDE_ACHAT
+  // (buying guides) — see PAGE_TYPE_TO_ROLE remap. Closes the matrix anomaly
+  // `deprecated_but_in_registry` flagged by OperatingMatrixService.
 
   [RoleId.R3_CONSEILS]: {
     roleId: RoleId.R3_CONSEILS,

--- a/backend/src/config/operating-matrix.service.test.ts
+++ b/backend/src/config/operating-matrix.service.test.ts
@@ -71,9 +71,9 @@ describe('OperatingMatrixService', () => {
       if (r.agents.length > 0) expect(r.healthScore).toBe(100);
     });
 
-    it('R3_GUIDE — deprecated role still in registry, no FIELD_CATALOG ownership', () => {
+    it('R3_GUIDE — deprecated role removed from registry (closed deprecation)', () => {
       const r = byRole.get(RoleId.R3_GUIDE)!;
-      expect(r.registry.present).toBe(true);
+      expect(r.registry.present).toBe(false);
       expect(r.deprecated).toBe(true);
       expect(r.writeScope.ownedFieldsCount).toBe(0);
     });


### PR DESCRIPTION
## Summary

`R3_GUIDE` was already deprecated **end-to-end** in 4 surfaces:
- `role-ids.ts:17` — `@deprecated` comment "no route, no contract, no prompts"
- `role-ids.ts:83` — listed in `FORBIDDEN_ROLE_IDS` (rejected by `normalizeRoleId`)
- `role-ids.ts:108` — listed in `DEPRECATED_OUTPUT_ROLES` (throws in `assertCanonicalRole`)
- `role-ids.ts:49-50` — `PAGE_TYPE_TO_ROLE` remaps `R3_guide_howto` → `R3_CONSEILS`, `R3_guide_achat` → `R6_GUIDE_ACHAT`

Yet `EXECUTION_REGISTRY[RoleId.R3_GUIDE]` kept an executable plan, which the SEO Operating Matrix (PR #222) correctly flagged:

```
anomalies: [{ roleId: "R3_GUIDE", reason: "deprecated_but_in_registry" }]
```

A deprecated role with an executable plan is internally inconsistent: callers cannot reach `R3_GUIDE` through `normalize()`, but the dispatch layer still has a recipe for it. Removing the entry **closes** an in-progress deprecation — it does NOT introduce a new architectural decision.

This is **PR-D2** of the 4-PR follow-up plan (cf. `~/.claude/plans/je-parle-de-ce-enumerated-octopus.md`).

## What changes

### `backend/src/config/execution-registry.constants.ts`
- Drop the `[RoleId.R3_GUIDE]: { ... }` entry (20 LoC)
- Replace with a 5-line comment that explains the **intentional** absence (so a future contributor doesn't re-add it)

### `backend/src/config/operating-matrix.service.test.ts`
- 1 test reworded to assert the new ground truth (`R3_GUIDE no longer in registry`)
- The other R3_GUIDE deprecation tests are written dynamically against `EXECUTION_REGISTRY`, so they self-adapt — no changes needed

### `audit-reports/seo-agent-matrix.{json,md}`
- Regenerated — `anomalies[]` becomes empty, `R3_GUIDE.registry.present` flips to `false`
- The PR-A determinism guard (#231) requires the JSON to track the code change in the same commit

## Empirical verification (local)

```bash
npx tsx scripts/seo/dump-agent-matrix.ts

jq '.anomalies' audit-reports/seo-agent-matrix.json
# → []

jq '.roles[] | select(.roleId == "R3_GUIDE") | {roleId, registry, deprecated, healthScore}' audit-reports/seo-agent-matrix.json
# → { "roleId": "R3_GUIDE", "registry": { "present": false }, "deprecated": true, "healthScore": 0 }
```

## Why this is structural (not bricolage)

- ✅ Closes an existing deprecation that was 4/5 done
- ✅ Aligns all layers: enum / FORBIDDEN / DEPRECATED_OUTPUT / PAGE_TYPE_TO_ROLE / **EXECUTION_REGISTRY**
- ✅ The matrix anomaly was the ground-truth signal that this was inconsistent — now it's silent
- ✅ Includes the audit JSON regen so the determinism guard (PR-A) passes the same merge
- ✅ Tombstone comment in code prevents accidental re-add

## Out of scope (intentionally NOT touched)

These reference R3_GUIDE for **historical / legacy** reasons, not for active dispatch:
- `RoleId.R3_GUIDE` enum value (needed for legacy normalization of old labels)
- `admissibility-gate.constants.ts` references (historical gating rules; cleanup = separate ADR)
- `page-contract-r3.schema.ts` / `page-contract-r5.schema.ts` `target_role` enums (describe what historical content can target)

Touching these is a broader cleanup that warrants its own scope. This PR is intentionally narrow: close the anomaly, no more.

## Test plan

- [x] Local typecheck — 0 errors
- [x] Local matrix regen — `anomalies[] = []`, R3_GUIDE registry absent
- [ ] Backend Tests CI green (the 23 unit tests on `OperatingMatrixService` should still pass — 1 test reworded)
- [ ] PR-A determinism guard CI green (audit JSON regen included in this commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)