### PR TITLE
perf(ci): tighten lighthouse-budget after 3-layer TTI home fix

### DIFF
--- a/frontend/lighthouse-budget.README.md
+++ b/frontend/lighthouse-budget.README.md
@@ -14,26 +14,46 @@ d'imposer des objectifs aspirationnels.
 ## Calibration courante
 
 Mesures de référence prises sur CI run
-[`25175348869`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25175348869)
-(2026-04-30, après PR #224 qui a fixé le flake `exit 124` masquant
-ces mesures depuis des mois) :
+[`25178882039`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25178882039)
+(2026-04-30, après merge des 3 couches du plan TTI home : PR #227 warm
+cache families, PR #229 manualChunks app-level + Remix v3 future flags,
+PR #230 DI direct loader sans HTTP loopback) :
 
 | Métrique | Pic mesuré | Budget actuel | Headroom |
 |---|---:|---:|---:|
-| First Contentful Paint | 10 766 ms | 11 500 ms | +6.8 % |
-| Largest Contentful Paint | 11 527 ms | 12 500 ms | +8.4 % |
-| Time to Interactive | 11 656 ms | 12 500 ms | +7.2 % |
-| Total Blocking Time | n/a | 2 500 ms | défaut prudent |
+| First Contentful Paint | 9 195 ms (pieces) | 10 200 ms | +11 % |
+| Largest Contentful Paint | 10 005 ms (pieces) | 11 100 ms | +11 % |
+| Time to Interactive | 10 922 ms (pieces) | 12 100 ms | +11 % |
+| Total Blocking Time | 125 ms (home) | 500 ms | enveloppe variance |
 | Cumulative Layout Shift | n/a | 0.25 | défaut Lighthouse |
-| Script size | 1 197 KB | 1 300 KB | +8.6 % |
+| Script size | 1 117 KB (pieces) | 1 250 KB | +12 % |
 | Stylesheet size | 354 KB | 400 KB | +13 % |
-| Total size | n/a | 2 400 KB | enveloppe |
-| Script count | 44 | 50 | +13.6 % |
-| Stylesheet count | n/a | 10 | enveloppe |
+| Total size | 1 590 KB (pieces) | 1 800 KB | +13 % |
+| Script count | 22 (pieces, constructeurs) | 30 | +36 % |
+| Stylesheet count | 3 (constructeurs) | 10 | enveloppe |
 
 URLs auditées : `/`, `/pieces/<long-slug>`, `/constructeurs/renault-140.html`.
 Le budget `path: "/*"` couvre les trois — calibré sur la **pire** valeur
 observée à travers les trois pages.
+
+### Trajectoire vs baseline pré-plan
+
+Pour mémoire, la baseline pré-plan (CI run
+[`25175348869`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25175348869),
+post-PR #224 exit-124 flake fix mais avant les 3 couches) :
+
+| Métrique | Avant plan | Après plan | Delta home (CI) |
+|---|---:|---:|---:|
+| FCP home | 10 766 ms | **2 712 ms** | **−75 %** |
+| LCP home | 11 527 ms | 3 312 ms | −71 % |
+| TTI home | 11 656 ms | 8 776 ms | −25 % |
+| Script count peak | 44 | **22** | −50 % |
+
+Le pic se déplace : la **home** est maintenant clean (FCP < 3 s), mais
+les pages `/pieces/<slug>` et `/constructeurs/<slug>.html` restent
+contraintes par leur propre latence loader (TTFB pieces 3 264 ms,
+constructeurs 416 ms). Couches futures (5/6 hors plan TTI home actuel)
+devront s'attaquer à ces routes.
 
 ## Comment évoluer
 
@@ -58,7 +78,12 @@ qu'on bosse l'optim.
 
 ## Historique
 
-- **2026-04-30** : calibration initiale empirique post-fix exit-124
-  (PR #224). Budgets précédents (script 400 KB, stylesheet 150 KB,
-  TTI 6 s) étaient aspirationnels et n'avaient jamais réellement
-  tourné en CI à cause du flake. Premier baseline mesuré.
+- **2026-04-30 (rev 2)** : recalibration après merge des 3 couches du
+  plan TTI home (PR #227 warm cache, PR #229 manualChunks + v3 flags,
+  PR #230 DI direct loader). FCP home mesuré : 10 766 → 2 712 ms (−75 %).
+  Script count peak : 44 → 22 (−50 %). Budget resserré pour figer les
+  gains et détecter toute régression.
+- **2026-04-30 (rev 1)** : calibration initiale empirique post-fix
+  exit-124 (PR #224). Budgets précédents (script 400 KB, stylesheet
+  150 KB, TTI 6 s) étaient aspirationnels et n'avaient jamais
+  réellement tourné en CI à cause du flake. Premier baseline mesuré.

--- a/frontend/lighthouse-budget.json
+++ b/frontend/lighthouse-budget.json
@@ -2,19 +2,19 @@
   {
     "path": "/*",
     "timings": [
-      { "metric": "first-contentful-paint", "budget": 11500 },
-      { "metric": "largest-contentful-paint", "budget": 12500 },
-      { "metric": "interactive", "budget": 12500 },
-      { "metric": "total-blocking-time", "budget": 2500 },
+      { "metric": "first-contentful-paint", "budget": 10200 },
+      { "metric": "largest-contentful-paint", "budget": 11100 },
+      { "metric": "interactive", "budget": 12100 },
+      { "metric": "total-blocking-time", "budget": 500 },
       { "metric": "cumulative-layout-shift", "budget": 0.25 }
     ],
     "resourceSizes": [
-      { "resourceType": "script", "budget": 1300 },
+      { "resourceType": "script", "budget": 1250 },
       { "resourceType": "stylesheet", "budget": 400 },
-      { "resourceType": "total", "budget": 2400 }
+      { "resourceType": "total", "budget": 1800 }
     ],
     "resourceCounts": [
-      { "resourceType": "script", "budget": 50 },
+      { "resourceType": "script", "budget": 30 },
       { "resourceType": "stylesheet", "budget": 10 }
     ]
   }


### PR DESCRIPTION
## Summary

**Couche 4 (finale)** du plan SSR — recalibre `lighthouse-budget.json` sur les peaks mesurés par CI run [`25178882039`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25178882039) après merge des couches 1+2+3.

Couches précédentes mergées :
- [#227](https://github.com/ak125/nestjs-remix-monorepo/pull/227) — warm `homepage:families:v1` cache
- [#229](https://github.com/ak125/nestjs-remix-monorepo/pull/229) — manualChunks app-level + Remix v3 future flags
- [#230](https://github.com/ak125/nestjs-remix-monorepo/pull/230) — DI direct loader (HTTP loopback removed)

## Trajectoire home FCP

Le plan a tenu sa promesse principale sur la home — la métrique qui était à ~10 s :

  baseline (avant plan) → **10 766 ms**
  après 3 couches → **2 712 ms** (**−75 %**)

| Métrique | Avant plan | Après plan | Delta home |
|---|---:|---:|---:|
| FCP home | 10 766 ms | **2 712 ms** | **−75 %** |
| LCP home | 11 527 ms | 3 312 ms | −71 % |
| TTI home | 11 656 ms | 8 776 ms | −25 % |
| Script count peak | 44 | 22 | −50 % |

## Calibrage du budget — peaks across 3 URLs auditées + ~10 % headroom

| Métrique | Old budget | Pic CI #25178882039 | New budget | Delta budget |
|---|---:|---:|---:|---:|
| First Contentful Paint | 11 500 | 9 195 (pieces) | **10 200** | −11 % |
| Largest Contentful Paint | 12 500 | 10 005 (pieces) | **11 100** | −11 % |
| Time to Interactive | 12 500 | 10 922 (pieces) | **12 100** | −3 % |
| Total Blocking Time | 2 500 | 125 (home) | **500** | −80 % |
| Script size (KB) | 1 300 | 1 117 (pieces) | **1 250** | −4 % |
| Total size (KB) | 2 400 | 1 590 (pieces) | **1 800** | −25 % |
| Script count | 50 | 22 (pieces, constructeurs) | **30** | −40 % |

CLS, stylesheet size, stylesheet count : conservés (pas de changement significatif mesuré).

## Notes

- Le pic se déplace : la home est maintenant clean (FCP < 3 s, TBT 125 ms). Le bottleneck restant vient de `/pieces/<slug>` (TTFB 3 264 ms) — son propre loader. Hors scope de ce plan.
- Le budget continue de couvrir les 3 URLs via `path: "/*"` — le pic mesuré reste le critère.
- Philosophie inchangée (cf. README) : *"Start with a baseline, set budgets just above"* — gate anti-régression, pas objectif aspirationnel.

## Test plan

- [ ] CI perf-gates : LCP/CLS/TTFB doivent rester verts ; nouveaux seuils tighter doivent passer (peaks +10 %)
- [ ] README à jour avec rev 2 + trajectoire vs baseline pré-plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)