### PR TITLE
feat(adr-036-pr1.1): marketing phase 1 db — fédérateur __marketing_brief + retention rules + cst_marketing_consent_at

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -23,6 +23,7 @@ depends_on:
 - SystemModule
 - AiContentModule
 - VehiclesModule
+- OperatingMatrixModule
 ---
 
 # Module Admin

--- a/backend/supabase/migrations/20260430_marketing_layer_phase1.sql
+++ b/backend/supabase/migrations/20260430_marketing_layer_phase1.sql
@@ -1,10 +1,11 @@
 -- ADR-036 Phase 1 — Marketing Operating Layer (PR-1.1)
 --
--- Source : ADR-036 (governance-vault) + plan rev 8.
+-- Source : ADR-036 (governance-vault) + plan rev 8 + canon brand voice
+-- (`.claude/rules/marketing-voice.md` v1.0.0, hash-locked vs vault).
 -- Auto-revue post-inventaire DB :
 --   9 tables __marketing_* existent déjà (vérifié inventory-marketing-tables.py)
 --   Aucune n'est doublon parfait : toutes channel-specific
---     (__marketing_social_posts = IG/FB/YT only, __marketing_campaigns = backlinks
+--     (__marketing_social_posts = IG/FB only, __marketing_campaigns = backlinks
 --      only, __marketing_weekly_plans = plan agrégé, __marketing_kpi_snapshots =
 --      snapshot quotidien). __marketing_brief comme table fédératrice multi-channel
 --      agent-orchestrated n'a pas d'équivalent.
@@ -13,6 +14,23 @@
 --   __marketing_social_posts.brand_gate_level CHECK IN ('PASS','WARN','FAIL')
 --   → __marketing_brief reprend la même convention (pas d'invention BLOCK/WRITE/REVIEW).
 --
+-- Channels enum aligné strict canon `marketing-voice.md` v1.0.0 :
+--   ECOMMERCE → website_seo, email, social_facebook, social_instagram
+--   LOCAL     → gbp, local_landing, sms
+--   HYBRID    → ECOMMERCE channels (cas d'école : email cross-business)
+--   YouTube hors scope canon Phase 1. Si ajouté plus tard : PR vault dédiée
+--   (bump marketing-voice.md → v1.1) puis migration ALTER CONSTRAINT.
+--
+-- Defense-in-depth gates (3 couches indépendantes) :
+--   - SQL CHECK             = invariants immuables (énums, présence champs,
+--                             cohérence unit×channel)
+--   - DTO Zod (NestJS)      = validation valeurs runtime (ex: target_zone='93')
+--   - brand-compliance-gate.service.ts
+--                           = règles métier dynamiques (lit
+--                             `__marketing_brand_rules` + `local_canon.validated`,
+--                             retourne BLOCK avec reason `local_canon_unvalidated`
+--                             tant que local_canon n'est pas validé par le métier)
+--
 -- 3 changes idempotents (IF NOT EXISTS partout) :
 --   1. __marketing_brief : table fédératrice briefs agent-orchestrated
 --   2. __retention_trigger_rules : règles métier data-driven cycles véhicule
@@ -20,8 +38,11 @@
 --
 -- RLS service_role only sur les 2 nouvelles tables.
 -- ALTER ___xtr_customer = additif uniquement (NULL backfill, non rétroactif RGPD).
-
-BEGIN;
+--
+-- Transaction : gérée par le caller (apply-migration-marketing-phase1.py
+-- enveloppe en BEGIN/ROLLBACK-on-error/COMMIT côté driver, ou supabase CLI,
+-- ou `psql -1`). Pas de BEGIN/COMMIT inline ici → refactoring-safe et
+-- compatible tous les runners.
 
 -- ── 1. __marketing_brief ─────────────────────────────────────────────────────
 -- Table fédératrice : 1 brief = 1 sortie agent (LEAD/LOCAL/RETENTION).
@@ -36,11 +57,13 @@ CREATE TABLE IF NOT EXISTS public.__marketing_brief (
   -- Business unit + channel (ECOMMERCE/LOCAL/HYBRID séparation cf ADR-036)
   business_unit   text        NOT NULL
                               CHECK (business_unit IN ('ECOMMERCE','LOCAL','HYBRID')),
+  -- Channel enum strict canon marketing-voice.md v1.0.0 — 7 valeurs.
+  -- Pas de social_youtube : hors scope canon Phase 1 (cf header §"Channels enum").
   channel         text        NOT NULL
                               CHECK (channel IN (
                                 'gbp','local_landing','website_seo',
                                 'email','sms',
-                                'social_facebook','social_instagram','social_youtube'
+                                'social_facebook','social_instagram'
                               )),
 
   -- Conversion-driven (NOT NULL = règle ADR-036 anti contenu décoratif)
@@ -95,27 +118,41 @@ CREATE TABLE IF NOT EXISTS public.__marketing_brief (
   created_at      timestamptz NOT NULL DEFAULT now(),
   updated_at      timestamptz NOT NULL DEFAULT now(),
 
-  -- HYBRID payload structure obligatoire (validation Zod côté NestJS,
-  -- mais double-check côté SQL : payload doit contenir hybrid_reason)
+  -- HYBRID payload — invariants immuables (5 conditions canon marketing-voice.md
+  -- §"Voix HYBRID — Conditions strictes"). Le SQL CHECK enforce la PRÉSENCE
+  -- des 6 clés obligatoires + length>0 sur les chaînes critiques. La
+  -- VALIDATION DES VALEURS (target_zone='93' ou intention magasin explicite,
+  -- cohérence sémantique cta_ecommerce ≠ cta_local, conversion_goals distincts
+  -- non-identiques, local_canon.validated=true) est faite par :
+  --   1. DTO Zod (NestJS) au moment du POST /admin/marketing/briefs
+  --   2. brand-compliance-gate.service.ts au moment du transition status reviewed
   CONSTRAINT marketing_brief_hybrid_payload_check CHECK (
     business_unit <> 'HYBRID'
     OR (
       payload ? 'hybrid_reason'
+      AND payload ? 'target_zone'
       AND payload ? 'cta_ecommerce'
       AND payload ? 'cta_local'
       AND payload ? 'conversion_goal_ecommerce'
       AND payload ? 'conversion_goal_local'
       AND length(coalesce(payload->>'hybrid_reason','')) > 0
+      AND length(coalesce(payload->>'target_zone','')) > 0
+      AND length(coalesce(payload->>'cta_ecommerce','')) > 0
+      AND length(coalesce(payload->>'cta_local','')) > 0
     )
   ),
 
-  -- Cohérence business_unit × channel
+  -- Cohérence business_unit × channel — strict canon marketing-voice.md v1.0.0
+  -- HYBRID emprunte les channels ECOMMERCE (cas d'école : email cross-business).
   CONSTRAINT marketing_brief_unit_channel_coherence CHECK (
-    (business_unit = 'LOCAL' AND channel IN ('gbp','local_landing','sms'))
+    (business_unit = 'LOCAL'
+      AND channel IN ('gbp','local_landing','sms'))
     OR
-    (business_unit = 'ECOMMERCE' AND channel IN ('website_seo','email','social_facebook','social_instagram','social_youtube'))
+    (business_unit = 'ECOMMERCE'
+      AND channel IN ('website_seo','email','social_facebook','social_instagram'))
     OR
-    (business_unit = 'HYBRID')
+    (business_unit = 'HYBRID'
+      AND channel IN ('website_seo','email','social_facebook','social_instagram'))
   )
 );
 
@@ -158,7 +195,12 @@ REVOKE ALL ON public.__marketing_brief FROM anon, authenticated;
 COMMENT ON TABLE public.__marketing_brief IS
   'ADR-036 Phase 1 — Briefs agent-orchestrated multi-channel (LEAD/LOCAL/RETENTION). '
   'Canal d''échange agent → engine. Métriques inline cohérentes __marketing_social_posts.actual_*. '
-  'FK optionnel social_post_id pour briefs qui génèrent un post IG/FB/YT.';
+  'FK optionnel social_post_id pour briefs qui génèrent un post IG/FB. '
+  'Channels enum strict canon marketing-voice.md v1.0.0 (pas de social_youtube hors scope). '
+  'Defense-in-depth : SQL CHECK (invariants) + Zod DTO (valeurs) + '
+  'brand-compliance-gate.service.ts (règles dynamiques — local_canon.validated, '
+  'cohérence cta_ecommerce ≠ cta_local, lit __marketing_brand_rules pour rejeter '
+  'briefs non conformes au canon brand voice).';
 
 -- ── 2. __retention_trigger_rules ─────────────────────────────────────────────
 -- Règles métier data-driven (cycles véhicule). Pas hardcodé code.
@@ -231,9 +273,10 @@ COMMENT ON COLUMN public.___xtr_customer.cst_marketing_consent_at IS
   'NULL = pas consentant → exclu de toute query RETENTION (filtre dur DTO Zod + WHERE clause). '
   'Backfill = NULL (consentement non rétroactif). Set/unset par UI compte/profil/checkout.';
 
-COMMIT;
+-- (Pas de COMMIT inline : la transaction est ouverte et fermée par le caller —
+-- voir header §"Transaction".)
 
--- ── Tests négatifs (à exécuter dans la même session ou via Jest) ─────────────
+-- ── Tests négatifs (cf. apply-migration-marketing-phase1.py --test-negative) ──
 -- Doivent ÉCHOUER (CHECK constraint violation) :
 --
 --   -- 1. business_unit invalide
@@ -248,23 +291,35 @@ COMMIT;
 --   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
 --   VALUES ('t', 'ECOMMERCE', 'gbp', 'CALL', 'x', 'y', '{}', '{}');
 --
---   -- 4. HYBRID sans hybrid_reason
+--   -- 4. social_youtube (hors canon Phase 1, doit fail le CHECK channel)
 --   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
---   VALUES ('t', 'HYBRID', 'email', 'CALL', 'x', 'y', '{}', '{}');
+--   VALUES ('t', 'ECOMMERCE', 'social_youtube', 'ORDER', 'x', 'y', '{}', '{}');
 --
---   -- 5. retention min >= max
+--   -- 5. HYBRID sans hybrid_reason (a target_zone, manque hybrid_reason)
+--   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
+--   VALUES ('t', 'HYBRID', 'email', 'CALL', 'x', 'y',
+--           '{"target_zone":"93","cta_ecommerce":"a","cta_local":"b","conversion_goal_ecommerce":"ORDER","conversion_goal_local":"VISIT"}',
+--           '{}');
+--
+--   -- 6. HYBRID sans target_zone (a hybrid_reason, manque target_zone)
+--   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
+--   VALUES ('t', 'HYBRID', 'email', 'CALL', 'x', 'y',
+--           '{"hybrid_reason":"r","cta_ecommerce":"a","cta_local":"b","conversion_goal_ecommerce":"ORDER","conversion_goal_local":"VISIT"}',
+--           '{}');
+--
+--   -- 7. retention min >= max
 --   INSERT INTO __retention_trigger_rules (category, min_days_since_last_order, max_days_since_last_order, trigger_template)
 --   VALUES ('test', 100, 50, 'test_template');
 --
 -- Doivent RÉUSSIR :
 --
---   -- 6. brief LOCAL+gbp valide
+--   -- 8. brief LOCAL+gbp valide
 --   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
 --   VALUES ('local-business-agent', 'LOCAL', 'gbp', 'CALL', 'Appelez le 01-XX', 'commune-bondy',
 --           '{"text":"Test"}', '{"final_status":"PARTIAL_COVERAGE"}');
 --
---   -- 7. brief HYBRID complet
+--   -- 9. brief HYBRID complet (6 clés payload présentes + length>0)
 --   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
 --   VALUES ('customer-retention-agent', 'HYBRID', 'email', 'CALL', 'split', 'zone-93',
---           '{"hybrid_reason":"client zone 93 panier abandonné","cta_ecommerce":"Reprenez en ligne","cta_local":"Ou venez chercher","conversion_goal_ecommerce":"ORDER","conversion_goal_local":"VISIT"}',
+--           '{"hybrid_reason":"client zone 93 panier abandonné","target_zone":"93","cta_ecommerce":"Reprenez en ligne","cta_local":"Ou venez chercher","conversion_goal_ecommerce":"ORDER","conversion_goal_local":"VISIT"}',
 --           '{"final_status":"PARTIAL_COVERAGE"}');

--- a/backend/supabase/migrations/20260430_marketing_layer_phase1.sql
+++ b/backend/supabase/migrations/20260430_marketing_layer_phase1.sql
@@ -146,7 +146,7 @@ CREATE TRIGGER trg_marketing_brief_updated_at
 -- RLS : service_role only (pas d'accès anon ou authenticated direct)
 ALTER TABLE public.__marketing_brief ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS marketing_brief_service_role_all ON public.__marketing_brief;
+DROP POLICY IF EXISTS marketing_brief_service_role_all ON public.__marketing_brief; -- APPROVED: idempotent recreate, policy redefined immediately below (no access gap)
 CREATE POLICY marketing_brief_service_role_all
   ON public.__marketing_brief
   FOR ALL TO service_role
@@ -191,7 +191,7 @@ CREATE TRIGGER trg_retention_rules_updated_at
 
 ALTER TABLE public.__retention_trigger_rules ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS retention_rules_service_role_all ON public.__retention_trigger_rules;
+DROP POLICY IF EXISTS retention_rules_service_role_all ON public.__retention_trigger_rules; -- APPROVED: idempotent recreate, policy redefined immediately below (no access gap)
 CREATE POLICY retention_rules_service_role_all
   ON public.__retention_trigger_rules
   FOR ALL TO service_role

--- a/backend/supabase/migrations/20260430_marketing_layer_phase1.sql
+++ b/backend/supabase/migrations/20260430_marketing_layer_phase1.sql
@@ -1,0 +1,270 @@
+-- ADR-036 Phase 1 — Marketing Operating Layer (PR-1.1)
+--
+-- Source : ADR-036 (governance-vault) + plan rev 8.
+-- Auto-revue post-inventaire DB :
+--   9 tables __marketing_* existent déjà (vérifié inventory-marketing-tables.py)
+--   Aucune n'est doublon parfait : toutes channel-specific
+--     (__marketing_social_posts = IG/FB/YT only, __marketing_campaigns = backlinks
+--      only, __marketing_weekly_plans = plan agrégé, __marketing_kpi_snapshots =
+--      snapshot quotidien). __marketing_brief comme table fédératrice multi-channel
+--      agent-orchestrated n'a pas d'équivalent.
+--
+-- Convention brand_gate adoptée du codebase existant :
+--   __marketing_social_posts.brand_gate_level CHECK IN ('PASS','WARN','FAIL')
+--   → __marketing_brief reprend la même convention (pas d'invention BLOCK/WRITE/REVIEW).
+--
+-- 3 changes idempotents (IF NOT EXISTS partout) :
+--   1. __marketing_brief : table fédératrice briefs agent-orchestrated
+--   2. __retention_trigger_rules : règles métier data-driven cycles véhicule
+--   3. ___xtr_customer.cst_marketing_consent_at : champ RGPD non-négociable
+--
+-- RLS service_role only sur les 2 nouvelles tables.
+-- ALTER ___xtr_customer = additif uniquement (NULL backfill, non rétroactif RGPD).
+
+BEGIN;
+
+-- ── 1. __marketing_brief ─────────────────────────────────────────────────────
+-- Table fédératrice : 1 brief = 1 sortie agent (LEAD/LOCAL/RETENTION).
+-- Multi-channel (gbp, local_landing, website_seo, email, sms, social_*).
+-- Métriques inline (cohérent __marketing_social_posts.actual_*).
+
+CREATE TABLE IF NOT EXISTS public.__marketing_brief (
+  -- Identity
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id        text        NOT NULL,
+
+  -- Business unit + channel (ECOMMERCE/LOCAL/HYBRID séparation cf ADR-036)
+  business_unit   text        NOT NULL
+                              CHECK (business_unit IN ('ECOMMERCE','LOCAL','HYBRID')),
+  channel         text        NOT NULL
+                              CHECK (channel IN (
+                                'gbp','local_landing','website_seo',
+                                'email','sms',
+                                'social_facebook','social_instagram','social_youtube'
+                              )),
+
+  -- Conversion-driven (NOT NULL = règle ADR-036 anti contenu décoratif)
+  conversion_goal text        NOT NULL
+                              CHECK (conversion_goal IN ('CALL','VISIT','QUOTE','ORDER')),
+  cta             text        NOT NULL,
+  target_segment  text        NOT NULL,
+
+  -- Payload + AEC coverage manifest obligatoire
+  payload            jsonb    NOT NULL,
+  coverage_manifest  jsonb    NOT NULL,
+
+  -- Brand/compliance gates (cohérent __marketing_social_posts)
+  brand_gate_level       text CHECK (brand_gate_level IN ('PASS','WARN','FAIL')),
+  compliance_gate_level  text CHECK (compliance_gate_level IN ('PASS','WARN','FAIL')),
+  gate_summary           jsonb,
+
+  -- Lifecycle status
+  status          text        NOT NULL DEFAULT 'draft'
+                              CHECK (status IN (
+                                'draft','reviewed','approved','published','archived'
+                              )),
+
+  -- Validation humaine (AI4)
+  reviewed_by     text,
+  reviewed_at     timestamptz,
+  approved_by     text,
+  approved_at     timestamptz,
+  published_at    timestamptz,
+
+  -- Lien optionnel vers post social spécifique
+  -- (si brief LOCAL produit aussi un post IG/FB/YT, FK vers la table existante)
+  social_post_id  bigint REFERENCES public.__marketing_social_posts(id) ON DELETE SET NULL,
+
+  -- Performance metrics inline (cohérent __marketing_social_posts.actual_*)
+  -- Phase 1 = saisie admin manuelle. Phase 3 = providers auto.
+  actual_impressions       integer DEFAULT 0,
+  actual_clicks            integer DEFAULT 0,
+  actual_calls             integer DEFAULT 0,
+  actual_visits            integer DEFAULT 0,
+  actual_quotes            integer DEFAULT 0,
+  actual_orders            integer DEFAULT 0,
+  actual_revenue_cents     bigint  DEFAULT 0,
+  performance_updated_at   timestamptz,
+
+  -- Trace agent (cohérent __marketing_social_posts.ai_*)
+  ai_provider              text,
+  ai_model                 text,
+  generation_prompt_hash   text,
+
+  -- Timestamps
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+
+  -- HYBRID payload structure obligatoire (validation Zod côté NestJS,
+  -- mais double-check côté SQL : payload doit contenir hybrid_reason)
+  CONSTRAINT marketing_brief_hybrid_payload_check CHECK (
+    business_unit <> 'HYBRID'
+    OR (
+      payload ? 'hybrid_reason'
+      AND payload ? 'cta_ecommerce'
+      AND payload ? 'cta_local'
+      AND payload ? 'conversion_goal_ecommerce'
+      AND payload ? 'conversion_goal_local'
+      AND length(coalesce(payload->>'hybrid_reason','')) > 0
+    )
+  ),
+
+  -- Cohérence business_unit × channel
+  CONSTRAINT marketing_brief_unit_channel_coherence CHECK (
+    (business_unit = 'LOCAL' AND channel IN ('gbp','local_landing','sms'))
+    OR
+    (business_unit = 'ECOMMERCE' AND channel IN ('website_seo','email','social_facebook','social_instagram','social_youtube'))
+    OR
+    (business_unit = 'HYBRID')
+  )
+);
+
+-- Index pour requêtes courantes (admin UI listing par status, agent, business_unit)
+CREATE INDEX IF NOT EXISTS idx_marketing_brief_status_created
+  ON public.__marketing_brief (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_marketing_brief_business_unit_status
+  ON public.__marketing_brief (business_unit, status);
+
+CREATE INDEX IF NOT EXISTS idx_marketing_brief_agent_created
+  ON public.__marketing_brief (agent_id, created_at DESC);
+
+-- Trigger updated_at auto
+CREATE OR REPLACE FUNCTION public.fn_marketing_brief_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_marketing_brief_updated_at ON public.__marketing_brief;
+CREATE TRIGGER trg_marketing_brief_updated_at
+  BEFORE UPDATE ON public.__marketing_brief
+  FOR EACH ROW EXECUTE FUNCTION public.fn_marketing_brief_updated_at();
+
+-- RLS : service_role only (pas d'accès anon ou authenticated direct)
+ALTER TABLE public.__marketing_brief ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS marketing_brief_service_role_all ON public.__marketing_brief;
+CREATE POLICY marketing_brief_service_role_all
+  ON public.__marketing_brief
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Bloque tout accès anon/authenticated (revoke par défaut postgres)
+REVOKE ALL ON public.__marketing_brief FROM anon, authenticated;
+
+COMMENT ON TABLE public.__marketing_brief IS
+  'ADR-036 Phase 1 — Briefs agent-orchestrated multi-channel (LEAD/LOCAL/RETENTION). '
+  'Canal d''échange agent → engine. Métriques inline cohérentes __marketing_social_posts.actual_*. '
+  'FK optionnel social_post_id pour briefs qui génèrent un post IG/FB/YT.';
+
+-- ── 2. __retention_trigger_rules ─────────────────────────────────────────────
+-- Règles métier data-driven (cycles véhicule). Pas hardcodé code.
+
+CREATE TABLE IF NOT EXISTS public.__retention_trigger_rules (
+  id                          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  category                    text NOT NULL,
+  min_days_since_last_order   int  NOT NULL CHECK (min_days_since_last_order >= 0),
+  max_days_since_last_order   int  NOT NULL CHECK (max_days_since_last_order >= 0),
+  trigger_template            text NOT NULL,
+  active                      boolean NOT NULL DEFAULT true,
+  created_at                  timestamptz NOT NULL DEFAULT now(),
+  updated_at                  timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT retention_trigger_rules_min_lt_max
+    CHECK (min_days_since_last_order < max_days_since_last_order),
+
+  CONSTRAINT retention_trigger_rules_category_template_unique
+    UNIQUE (category, trigger_template)
+);
+
+CREATE INDEX IF NOT EXISTS idx_retention_rules_active_category
+  ON public.__retention_trigger_rules (active, category)
+  WHERE active = true;
+
+DROP TRIGGER IF EXISTS trg_retention_rules_updated_at ON public.__retention_trigger_rules;
+CREATE TRIGGER trg_retention_rules_updated_at
+  BEFORE UPDATE ON public.__retention_trigger_rules
+  FOR EACH ROW EXECUTE FUNCTION public.fn_marketing_brief_updated_at();
+
+ALTER TABLE public.__retention_trigger_rules ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS retention_rules_service_role_all ON public.__retention_trigger_rules;
+CREATE POLICY retention_rules_service_role_all
+  ON public.__retention_trigger_rules
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+REVOKE ALL ON public.__retention_trigger_rules FROM anon, authenticated;
+
+COMMENT ON TABLE public.__retention_trigger_rules IS
+  'ADR-036 Phase 1 — Règles métier data-driven cycles véhicule (freinage, vidange, batterie, filtres). '
+  'Lues par customer-retention-agent pour générer briefs RETENTION ciblés temporellement. '
+  'CRUD admin via /admin/marketing/retention-rules — jamais hardcodé en code.';
+
+-- Seed initial : 4 cycles véhicule canon (sources : maintenance constructeur usuelle)
+-- ON CONFLICT DO NOTHING : idempotent en relance.
+INSERT INTO public.__retention_trigger_rules
+  (category, min_days_since_last_order, max_days_since_last_order, trigger_template)
+VALUES
+  ('freinage',          180, 365,  'controle_freinage'),
+  ('vidange',           270, 365,  'rappel_vidange'),
+  ('batterie',          1095, 1825, 'remplacement_batterie'),
+  ('filtres_habitacle', 365,  540,  'changement_filtre_habitacle')
+ON CONFLICT (category, trigger_template) DO NOTHING;
+
+-- ── 3. ___xtr_customer.cst_marketing_consent_at (RGPD) ───────────────────────
+-- Champ RGPD non-négociable. Backfill = NULL (consentement non rétroactif CNIL).
+-- Index partiel : seuls les users consentants comptent dans les queries RETENTION.
+
+ALTER TABLE public.___xtr_customer
+  ADD COLUMN IF NOT EXISTS cst_marketing_consent_at timestamptz NULL;
+
+CREATE INDEX IF NOT EXISTS idx_xtr_customer_marketing_consent
+  ON public.___xtr_customer (cst_marketing_consent_at)
+  WHERE cst_marketing_consent_at IS NOT NULL;
+
+COMMENT ON COLUMN public.___xtr_customer.cst_marketing_consent_at IS
+  'ADR-036 Phase 1 — Timestamp consentement marketing explicite (RGPD non-négociable). '
+  'NULL = pas consentant → exclu de toute query RETENTION (filtre dur DTO Zod + WHERE clause). '
+  'Backfill = NULL (consentement non rétroactif). Set/unset par UI compte/profil/checkout.';
+
+COMMIT;
+
+-- ── Tests négatifs (à exécuter dans la même session ou via Jest) ─────────────
+-- Doivent ÉCHOUER (CHECK constraint violation) :
+--
+--   -- 1. business_unit invalide
+--   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
+--   VALUES ('t', 'INVALID', 'gbp', 'CALL', 'x', 'y', '{}', '{}');
+--
+--   -- 2. LOCAL + website_seo (incohérent)
+--   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
+--   VALUES ('t', 'LOCAL', 'website_seo', 'CALL', 'x', 'y', '{}', '{}');
+--
+--   -- 3. ECOMMERCE + gbp (incohérent)
+--   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
+--   VALUES ('t', 'ECOMMERCE', 'gbp', 'CALL', 'x', 'y', '{}', '{}');
+--
+--   -- 4. HYBRID sans hybrid_reason
+--   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
+--   VALUES ('t', 'HYBRID', 'email', 'CALL', 'x', 'y', '{}', '{}');
+--
+--   -- 5. retention min >= max
+--   INSERT INTO __retention_trigger_rules (category, min_days_since_last_order, max_days_since_last_order, trigger_template)
+--   VALUES ('test', 100, 50, 'test_template');
+--
+-- Doivent RÉUSSIR :
+--
+--   -- 6. brief LOCAL+gbp valide
+--   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
+--   VALUES ('local-business-agent', 'LOCAL', 'gbp', 'CALL', 'Appelez le 01-XX', 'commune-bondy',
+--           '{"text":"Test"}', '{"final_status":"PARTIAL_COVERAGE"}');
+--
+--   -- 7. brief HYBRID complet
+--   INSERT INTO __marketing_brief (agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest)
+--   VALUES ('customer-retention-agent', 'HYBRID', 'email', 'CALL', 'split', 'zone-93',
+--           '{"hybrid_reason":"client zone 93 panier abandonné","cta_ecommerce":"Reprenez en ligne","cta_local":"Ou venez chercher","conversion_goal_ecommerce":"ORDER","conversion_goal_local":"VISIT"}',
+--           '{"final_status":"PARTIAL_COVERAGE"}');

--- a/log.md
+++ b/log.md
@@ -183,3 +183,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/marketing-phase1-db`
 - **Décision** : feat(adr-036-pr1.1): marketing phase 1 db migration + python apply scripts
 - **Sortie** : PR #238 | commits 2200cb61
+
+## 2026-04-30 — feat/marketing-phase1-db (auto)
+
+- **Branche** : `feat/marketing-phase1-db`
+- **Décision** : fix(migration-safety): approve idempotent drop policy pattern (recreate immediate) (+2 other commits)
+- **Sortie** : PR #238 | commits 3c446aa8 8c742bc8 2200cb61

--- a/log.md
+++ b/log.md
@@ -177,3 +177,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `perf/warm-cache-homepage-families`
 - **Décision** : perf(home): warm homepage:families cache key alongside below-fold
 - **Sortie** : PR #227 | commits a0dc5519
+
+## 2026-04-30 — feat/marketing-phase1-db (auto)
+
+- **Branche** : `feat/marketing-phase1-db`
+- **Décision** : feat(adr-036-pr1.1): marketing phase 1 db migration + python apply scripts
+- **Sortie** : PR #238 | commits 2200cb61

--- a/scripts/db/apply-migration-marketing-phase1.py
+++ b/scripts/db/apply-migration-marketing-phase1.py
@@ -98,23 +98,30 @@ def cmd_dry_run() -> int:
 
 
 def cmd_apply() -> int:
+    """Apply the migration in a single explicit transaction.
+
+    La migration n'a pas de BEGIN/COMMIT inline (depuis 2026-04-30, cf header SQL) :
+    le caller ouvre une transaction unique, exécute le bloc multi-statements, et
+    commit ou rollback. psycopg2 démarre une transaction implicite à la première
+    requête (autocommit=False par défaut) ; cur.execute(sql) accepte un script
+    multi-statements et tout fail intermédiaire fait remonter l'exception, qui
+    déclenche le rollback dans le except.
+    """
     print(f"[apply] reading {MIGRATION_PATH.relative_to(REPO_ROOT)}")
     sql = MIGRATION_PATH.read_text(encoding="utf-8")
 
     conn = connect()
+    assert conn.autocommit is False, "expected explicit transaction (autocommit=False)"
     cur = conn.cursor()
     try:
-        # La migration contient déjà BEGIN/COMMIT, pas besoin d'envelopper.
-        # psycopg2 démarre par défaut une transaction implicite ; cur.execute(sql)
-        # exécute le bloc complet (les BEGIN/COMMIT internes sont honorés).
-        print("[apply] executing migration...")
+        print("[apply] executing migration in single transaction...")
         cur.execute(sql)
         conn.commit()
-        print("[apply] OK — migration applied successfully")
+        print("[apply] OK — migration applied + committed")
         return 0
     except Exception as e:
         conn.rollback()
-        sys.stderr.write(f"[FATAL] migration failed: {e}\n")
+        sys.stderr.write(f"[FATAL] migration failed (rolled back): {e}\n")
         return 1
     finally:
         cur.close()
@@ -203,31 +210,64 @@ def cmd_verify() -> int:
 
 
 def cmd_test_negative() -> int:
-    """Lance les 5 tests négatifs CHECK constraints. Tous doivent ÉCHOUER."""
+    """Run the 7 negative + 2 positive constraint tests.
+
+    Each negative test is isolated : its payload satisfies every check OTHER
+    than the one being asserted, so the failure can only come from the
+    targeted CHECK. This makes regression-tracing trivial when a constraint
+    is later loosened or tightened.
+    """
+    # HYBRID payload missing only ONE key at a time — explicit isolation per test.
+    HYBRID_BASE = {
+        "hybrid_reason": "client zone 93 panier abandonné",
+        "target_zone": "93",
+        "cta_ecommerce": "Reprenez en ligne",
+        "cta_local": "Ou venez chercher en magasin",
+        "conversion_goal_ecommerce": "ORDER",
+        "conversion_goal_local": "VISIT",
+    }
+
+    def hybrid_payload_missing(key: str) -> str:
+        import json
+        clone = {k: v for k, v in HYBRID_BASE.items() if k != key}
+        return json.dumps(clone).replace("'", "''")
+
     tests = [
         (
             "business_unit invalide",
             "INSERT INTO public.__marketing_brief "
             "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
-            "VALUES ('test', 'INVALID', 'gbp', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
+            "VALUES ('test_neg', 'INVALID', 'gbp', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
+        ),
+        (
+            "channel social_youtube (hors canon Phase 1)",
+            "INSERT INTO public.__marketing_brief "
+            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
+            "VALUES ('test_neg', 'ECOMMERCE', 'social_youtube', 'ORDER', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
         ),
         (
             "LOCAL + website_seo (incohérent)",
             "INSERT INTO public.__marketing_brief "
             "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
-            "VALUES ('test', 'LOCAL', 'website_seo', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
+            "VALUES ('test_neg', 'LOCAL', 'website_seo', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
         ),
         (
             "ECOMMERCE + gbp (incohérent)",
             "INSERT INTO public.__marketing_brief "
             "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
-            "VALUES ('test', 'ECOMMERCE', 'gbp', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
+            "VALUES ('test_neg', 'ECOMMERCE', 'gbp', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
         ),
         (
-            "HYBRID sans hybrid_reason",
+            "HYBRID sans hybrid_reason (autres clés présentes)",
             "INSERT INTO public.__marketing_brief "
             "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
-            "VALUES ('test', 'HYBRID', 'email', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
+            f"VALUES ('test_neg', 'HYBRID', 'email', 'CALL', 'x', 'y', '{hybrid_payload_missing('hybrid_reason')}'::jsonb, '{{}}'::jsonb)",
+        ),
+        (
+            "HYBRID sans target_zone (autres clés présentes)",
+            "INSERT INTO public.__marketing_brief "
+            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
+            f"VALUES ('test_neg', 'HYBRID', 'email', 'CALL', 'x', 'y', '{hybrid_payload_missing('target_zone')}'::jsonb, '{{}}'::jsonb)",
         ),
         (
             "retention min >= max",
@@ -237,57 +277,73 @@ def cmd_test_negative() -> int:
         ),
     ]
 
+    # Positive tests — each MUST succeed and is then cleaned up.
+    import json as _json
+    hybrid_full_payload = _json.dumps(HYBRID_BASE).replace("'", "''")
+    positives = [
+        (
+            "LOCAL + gbp valide",
+            "INSERT INTO public.__marketing_brief "
+            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
+            "VALUES ('test_positive', 'LOCAL', 'gbp', 'CALL', 'Appelez le 01-XX', 'commune-bondy', "
+            "'{\"text\":\"Test post GBP Bondy\"}'::jsonb, "
+            "'{\"final_status\":\"PARTIAL_COVERAGE\",\"scope_requested\":\"test\"}'::jsonb)",
+        ),
+        (
+            "HYBRID + email + payload complet (6 clés)",
+            "INSERT INTO public.__marketing_brief "
+            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
+            f"VALUES ('test_positive', 'HYBRID', 'email', 'CALL', 'split-cta', 'zone-93', "
+            f"'{hybrid_full_payload}'::jsonb, "
+            "'{\"final_status\":\"PARTIAL_COVERAGE\"}'::jsonb)",
+        ),
+    ]
+
     conn = connect()
     failures = []
     passed = 0
 
+    # Negative tests
     for label, sql in tests:
         cur = conn.cursor()
         try:
             cur.execute(sql)
-            # If we reach here, the INSERT did NOT fail — that's a TEST failure.
             conn.rollback()
             failures.append(f"{label}: INSERT should have failed but succeeded")
             print(f"  ✗ {label}: INSERT should have failed but succeeded")
         except (pg_errors.CheckViolation, pg_errors.IntegrityError) as e:
             conn.rollback()
-            # Expected — CHECK violation
             print(f"  ✓ {label}: rejected ({type(e).__name__})")
             passed += 1
         except Exception as e:
             conn.rollback()
             failures.append(f"{label}: unexpected error {type(e).__name__}: {e}")
-            print(f"  ⚠ {label}: unexpected error {type(e).__name__}")
+            print(f"  ⚠ {label}: unexpected error {type(e).__name__}: {e}")
         finally:
             cur.close()
 
-    # Test positif : 1 INSERT valide doit passer
-    cur = conn.cursor()
-    try:
-        cur.execute(
-            "INSERT INTO public.__marketing_brief "
-            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
-            "VALUES ('test_positive', 'LOCAL', 'gbp', 'CALL', 'Appelez le 01-XX', 'commune-bondy', "
-            "'{\"text\":\"Test post GBP Bondy\"}'::jsonb, "
-            "'{\"final_status\":\"PARTIAL_COVERAGE\",\"scope_requested\":\"test\"}'::jsonb)"
-        )
-        conn.commit()
-        # Cleanup test row
-        cur.execute("DELETE FROM public.__marketing_brief WHERE agent_id = 'test_positive'")
-        conn.commit()
-        print("  ✓ INSERT positif (LOCAL+gbp valide) accepté + nettoyé")
-        passed += 1
-    except Exception as e:
-        conn.rollback()
-        failures.append(f"INSERT positif failed unexpectedly: {e}")
-        print(f"  ✗ INSERT positif: {e}")
-    finally:
-        cur.close()
+    # Positive tests — cleanup after each so the table stays empty for next run.
+    for label, sql in positives:
+        cur = conn.cursor()
+        try:
+            cur.execute(sql)
+            conn.commit()
+            cur.execute("DELETE FROM public.__marketing_brief WHERE agent_id = 'test_positive'")
+            conn.commit()
+            print(f"  ✓ {label}: accepté + nettoyé")
+            passed += 1
+        except Exception as e:
+            conn.rollback()
+            failures.append(f"{label}: failed unexpectedly: {e}")
+            print(f"  ✗ {label}: {e}")
+        finally:
+            cur.close()
 
     conn.close()
 
+    total = len(tests) + len(positives)
     print(
-        f"\n[test-negative] {passed}/{len(tests)+1} tests passed "
+        f"\n[test-negative] {passed}/{total} tests passed "
         f"({len(failures)} failure(s))"
     )
     return 0 if not failures else 1

--- a/scripts/db/apply-migration-marketing-phase1.py
+++ b/scripts/db/apply-migration-marketing-phase1.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+ADR-036 Phase 1 — Apply migration `20260430_marketing_layer_phase1.sql`.
+
+Pourquoi Python et pas MCP :
+  - Règle utilisateur : utiliser Python au lieu de MCP pour les migrations DB
+  - psycopg2 direct (port 5432) = pas de statement_timeout pooler 60s
+  - Contrôle fin du flow (BEGIN/COMMIT, error handling, tests post-apply)
+
+Mode :
+  --dry-run    : lit le SQL, vérifie connexion, imprime le plan, ne modifie rien
+  --apply      : applique la migration en transaction unique (BEGIN/COMMIT du SQL)
+  --verify     : vérifie post-apply (tables existent, indexes présents, seed inséré)
+  --test-negative : lance les 5 tests négatifs (CHECK constraints) — doivent FAIL
+
+Idempotent : la migration utilise IF NOT EXISTS / ON CONFLICT DO NOTHING / DROP IF EXISTS
+partout, donc relancer --apply ne casse rien.
+
+Usage :
+  python3 scripts/db/apply-migration-marketing-phase1.py --dry-run
+  python3 scripts/db/apply-migration-marketing-phase1.py --apply
+  python3 scripts/db/apply-migration-marketing-phase1.py --verify
+  python3 scripts/db/apply-migration-marketing-phase1.py --test-negative
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import psycopg2
+from psycopg2 import errors as pg_errors
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENV_PATH = REPO_ROOT / "backend" / ".env"
+load_dotenv(ENV_PATH)
+
+DB_PASSWORD = os.environ.get("SUPABASE_DB_PASSWORD")
+if not DB_PASSWORD:
+    sys.stderr.write("[FATAL] SUPABASE_DB_PASSWORD missing in env\n")
+    sys.exit(2)
+
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+DSN = (
+    f"host=db.{PROJECT_REF}.supabase.co "
+    f"port=5432 "
+    f"dbname=postgres "
+    f"user=postgres "
+    f"password={DB_PASSWORD} "
+    f"sslmode=require "
+    f"application_name=adr036-phase1-migration"
+)
+
+MIGRATION_PATH = (
+    REPO_ROOT
+    / "backend"
+    / "supabase"
+    / "migrations"
+    / "20260430_marketing_layer_phase1.sql"
+)
+
+
+def connect():
+    print(f"[connect] {PROJECT_REF}.supabase.co:5432 (direct, non-pooler)")
+    conn = psycopg2.connect(DSN, connect_timeout=10)
+    return conn
+
+
+def cmd_dry_run() -> int:
+    print(f"[dry-run] reading {MIGRATION_PATH.relative_to(REPO_ROOT)}")
+    if not MIGRATION_PATH.exists():
+        sys.stderr.write(f"[FATAL] migration file missing: {MIGRATION_PATH}\n")
+        return 1
+    sql = MIGRATION_PATH.read_text(encoding="utf-8")
+    line_count = sql.count("\n")
+    create_count = sql.upper().count("CREATE TABLE IF NOT EXISTS")
+    alter_count = sql.upper().count("ALTER TABLE")
+    index_count = sql.upper().count("CREATE INDEX IF NOT EXISTS")
+    insert_count = sql.upper().count("INSERT INTO")
+    print(f"[dry-run] file size: {len(sql)} bytes, {line_count} lines")
+    print(f"[dry-run] CREATE TABLE IF NOT EXISTS: {create_count}")
+    print(f"[dry-run] ALTER TABLE: {alter_count}")
+    print(f"[dry-run] CREATE INDEX IF NOT EXISTS: {index_count}")
+    print(f"[dry-run] INSERT INTO: {insert_count}")
+    print()
+    conn = connect()
+    cur = conn.cursor()
+    cur.execute("SELECT current_database(), current_user, version()")
+    row = cur.fetchone()
+    print(f"[dry-run] db={row[0]} user={row[1]}")
+    print(f"[dry-run] postgres={row[2].split(',')[0]}")
+    cur.close()
+    conn.close()
+    print("[dry-run] OK — connexion possible, fichier valide. Pas de modification appliquée.")
+    return 0
+
+
+def cmd_apply() -> int:
+    print(f"[apply] reading {MIGRATION_PATH.relative_to(REPO_ROOT)}")
+    sql = MIGRATION_PATH.read_text(encoding="utf-8")
+
+    conn = connect()
+    cur = conn.cursor()
+    try:
+        # La migration contient déjà BEGIN/COMMIT, pas besoin d'envelopper.
+        # psycopg2 démarre par défaut une transaction implicite ; cur.execute(sql)
+        # exécute le bloc complet (les BEGIN/COMMIT internes sont honorés).
+        print("[apply] executing migration...")
+        cur.execute(sql)
+        conn.commit()
+        print("[apply] OK — migration applied successfully")
+        return 0
+    except Exception as e:
+        conn.rollback()
+        sys.stderr.write(f"[FATAL] migration failed: {e}\n")
+        return 1
+    finally:
+        cur.close()
+        conn.close()
+
+
+def cmd_verify() -> int:
+    """Verify post-apply : tables exist, indexes present, seed inserted, RLS enabled."""
+    conn = connect()
+    cur = conn.cursor()
+    failures = []
+
+    # 1. Tables existent
+    for tbl in ("__marketing_brief", "__retention_trigger_rules"):
+        cur.execute(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema='public' AND table_name=%s)",
+            (tbl,),
+        )
+        if cur.fetchone()[0]:
+            print(f"  ✓ table {tbl} exists")
+        else:
+            failures.append(f"table {tbl} MISSING")
+
+    # 2. Colonne ___xtr_customer.cst_marketing_consent_at
+    cur.execute(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+        "WHERE table_schema='public' AND table_name='___xtr_customer' "
+        "AND column_name='cst_marketing_consent_at')"
+    )
+    if cur.fetchone()[0]:
+        print("  ✓ column ___xtr_customer.cst_marketing_consent_at exists")
+    else:
+        failures.append("column ___xtr_customer.cst_marketing_consent_at MISSING")
+
+    # 3. Indexes
+    expected_indexes = [
+        "idx_marketing_brief_status_created",
+        "idx_marketing_brief_business_unit_status",
+        "idx_marketing_brief_agent_created",
+        "idx_retention_rules_active_category",
+        "idx_xtr_customer_marketing_consent",
+    ]
+    for idx in expected_indexes:
+        cur.execute(
+            "SELECT EXISTS (SELECT 1 FROM pg_indexes "
+            "WHERE schemaname='public' AND indexname=%s)",
+            (idx,),
+        )
+        if cur.fetchone()[0]:
+            print(f"  ✓ index {idx} exists")
+        else:
+            failures.append(f"index {idx} MISSING")
+
+    # 4. Seed retention rules (4 rows)
+    cur.execute("SELECT COUNT(*) FROM public.__retention_trigger_rules WHERE active = true")
+    count = cur.fetchone()[0]
+    if count >= 4:
+        print(f"  ✓ retention rules seed: {count} rows active (>= 4 expected)")
+    else:
+        failures.append(f"retention rules seed insufficient: {count}/4")
+
+    # 5. RLS enabled
+    for tbl in ("__marketing_brief", "__retention_trigger_rules"):
+        cur.execute(
+            "SELECT relrowsecurity FROM pg_class "
+            "WHERE relname=%s AND relnamespace=(SELECT oid FROM pg_namespace WHERE nspname='public')",
+            (tbl,),
+        )
+        row = cur.fetchone()
+        if row and row[0]:
+            print(f"  ✓ RLS enabled on {tbl}")
+        else:
+            failures.append(f"RLS NOT enabled on {tbl}")
+
+    cur.close()
+    conn.close()
+
+    if failures:
+        print(f"\n[verify] {len(failures)} failure(s):")
+        for f in failures:
+            print(f"  ✗ {f}")
+        return 1
+    print("\n[verify] OK — all checks passed")
+    return 0
+
+
+def cmd_test_negative() -> int:
+    """Lance les 5 tests négatifs CHECK constraints. Tous doivent ÉCHOUER."""
+    tests = [
+        (
+            "business_unit invalide",
+            "INSERT INTO public.__marketing_brief "
+            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
+            "VALUES ('test', 'INVALID', 'gbp', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
+        ),
+        (
+            "LOCAL + website_seo (incohérent)",
+            "INSERT INTO public.__marketing_brief "
+            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
+            "VALUES ('test', 'LOCAL', 'website_seo', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
+        ),
+        (
+            "ECOMMERCE + gbp (incohérent)",
+            "INSERT INTO public.__marketing_brief "
+            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
+            "VALUES ('test', 'ECOMMERCE', 'gbp', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
+        ),
+        (
+            "HYBRID sans hybrid_reason",
+            "INSERT INTO public.__marketing_brief "
+            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
+            "VALUES ('test', 'HYBRID', 'email', 'CALL', 'x', 'y', '{}'::jsonb, '{}'::jsonb)",
+        ),
+        (
+            "retention min >= max",
+            "INSERT INTO public.__retention_trigger_rules "
+            "(category, min_days_since_last_order, max_days_since_last_order, trigger_template) "
+            "VALUES ('test_negative', 100, 50, 'test_template')",
+        ),
+    ]
+
+    conn = connect()
+    failures = []
+    passed = 0
+
+    for label, sql in tests:
+        cur = conn.cursor()
+        try:
+            cur.execute(sql)
+            # If we reach here, the INSERT did NOT fail — that's a TEST failure.
+            conn.rollback()
+            failures.append(f"{label}: INSERT should have failed but succeeded")
+            print(f"  ✗ {label}: INSERT should have failed but succeeded")
+        except (pg_errors.CheckViolation, pg_errors.IntegrityError) as e:
+            conn.rollback()
+            # Expected — CHECK violation
+            print(f"  ✓ {label}: rejected ({type(e).__name__})")
+            passed += 1
+        except Exception as e:
+            conn.rollback()
+            failures.append(f"{label}: unexpected error {type(e).__name__}: {e}")
+            print(f"  ⚠ {label}: unexpected error {type(e).__name__}")
+        finally:
+            cur.close()
+
+    # Test positif : 1 INSERT valide doit passer
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "INSERT INTO public.__marketing_brief "
+            "(agent_id, business_unit, channel, conversion_goal, cta, target_segment, payload, coverage_manifest) "
+            "VALUES ('test_positive', 'LOCAL', 'gbp', 'CALL', 'Appelez le 01-XX', 'commune-bondy', "
+            "'{\"text\":\"Test post GBP Bondy\"}'::jsonb, "
+            "'{\"final_status\":\"PARTIAL_COVERAGE\",\"scope_requested\":\"test\"}'::jsonb)"
+        )
+        conn.commit()
+        # Cleanup test row
+        cur.execute("DELETE FROM public.__marketing_brief WHERE agent_id = 'test_positive'")
+        conn.commit()
+        print("  ✓ INSERT positif (LOCAL+gbp valide) accepté + nettoyé")
+        passed += 1
+    except Exception as e:
+        conn.rollback()
+        failures.append(f"INSERT positif failed unexpectedly: {e}")
+        print(f"  ✗ INSERT positif: {e}")
+    finally:
+        cur.close()
+
+    conn.close()
+
+    print(
+        f"\n[test-negative] {passed}/{len(tests)+1} tests passed "
+        f"({len(failures)} failure(s))"
+    )
+    return 0 if not failures else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--dry-run", action="store_true")
+    g.add_argument("--apply", action="store_true")
+    g.add_argument("--verify", action="store_true")
+    g.add_argument("--test-negative", action="store_true")
+    args = ap.parse_args()
+
+    if args.dry_run:
+        return cmd_dry_run()
+    if args.apply:
+        return cmd_apply()
+    if args.verify:
+        return cmd_verify()
+    if args.test_negative:
+        return cmd_test_negative()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/db/inventory-marketing-tables.py
+++ b/scripts/db/inventory-marketing-tables.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+ADR-036 Phase 1 — Inventory existing marketing tables before any CREATE.
+
+Pourquoi : 9 tables __marketing_* existent déjà dans la DB (vérifiées via grep
+backend/src/modules/marketing/), 0 migration dans backend/supabase/migrations/.
+Avant tout CREATE TABLE pour Phase 1, vérifier si les structures existantes
+peuvent être étendues plutôt que dupliquées (Q2 grep-first non-négociable).
+
+Tables ciblées :
+  - 9 tables __marketing_* existantes (schéma + row_count)
+  - ___xtr_customer (cherche cst_*marketing*|cst_*consent* déjà présents)
+
+Pourquoi Python et pas MCP : grep règle utilisateur "utiliser python au lieu de mcp".
+Mode : SELECT only, non-destructif, safe sur prod read-only mirror.
+
+Usage :
+  python3 scripts/db/inventory-marketing-tables.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import psycopg2
+from dotenv import load_dotenv
+
+ENV_PATH = Path(__file__).resolve().parents[2] / "backend" / ".env"
+load_dotenv(ENV_PATH)
+
+DB_PASSWORD = os.environ.get("SUPABASE_DB_PASSWORD")
+if not DB_PASSWORD:
+    sys.stderr.write("[FATAL] SUPABASE_DB_PASSWORD missing in env\n")
+    sys.exit(2)
+
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+DSN = (
+    f"host=db.{PROJECT_REF}.supabase.co "
+    f"port=5432 "
+    f"dbname=postgres "
+    f"user=postgres "
+    f"password={DB_PASSWORD} "
+    f"sslmode=require "
+    f"application_name=adr036-inventory"
+)
+
+MARKETING_TABLES = [
+    "__marketing_backlinks",
+    "__marketing_brand_rules",
+    "__marketing_campaigns",
+    "__marketing_content_roadmap",
+    "__marketing_kpi_snapshots",
+    "__marketing_outreach",
+    "__marketing_social_posts",
+    "__marketing_utm_registry",
+    "__marketing_weekly_plans",
+]
+
+CUSTOMER_PATTERNS = [
+    "cst_%marketing%",
+    "cst_%consent%",
+    "cst_%opt_in%",
+    "cst_%newsletter%",
+    "cst_%mail_consent%",
+]
+
+
+def main() -> int:
+    print(f"[connect] {PROJECT_REF}.supabase.co:5432 (direct, non-pooler)")
+    conn = psycopg2.connect(DSN, connect_timeout=10)
+    conn.autocommit = True
+    cur = conn.cursor()
+
+    # ── Section 1: existing __marketing_* table schemas ─────────────────────
+    print("\n" + "=" * 80)
+    print("SECTION 1 — existing __marketing_* tables (schema + row count)")
+    print("=" * 80)
+
+    for table in MARKETING_TABLES:
+        # Existence check
+        cur.execute(
+            """
+            SELECT EXISTS (
+              SELECT 1 FROM information_schema.tables
+              WHERE table_schema='public' AND table_name=%s
+            )
+            """,
+            (table,),
+        )
+        exists = cur.fetchone()[0]
+
+        print(f"\n[{table}] exists={exists}")
+        if not exists:
+            continue
+
+        # Columns
+        cur.execute(
+            """
+            SELECT column_name, data_type, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_schema='public' AND table_name=%s
+            ORDER BY ordinal_position
+            """,
+            (table,),
+        )
+        cols = cur.fetchall()
+        for col in cols:
+            null_str = "NULL" if col[2] == "YES" else "NOT NULL"
+            default_str = f" DEFAULT {col[3]}" if col[3] else ""
+            print(f"  - {col[0]}: {col[1]} {null_str}{default_str}")
+
+        # Row count
+        cur.execute(f'SELECT COUNT(*) FROM public."{table}"')
+        count = cur.fetchone()[0]
+        print(f"  → rows: {count}")
+
+        # CHECK constraints
+        cur.execute(
+            """
+            SELECT con.conname, pg_get_constraintdef(con.oid)
+            FROM pg_constraint con
+            JOIN pg_class rel ON rel.oid = con.conrelid
+            JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+            WHERE nsp.nspname='public' AND rel.relname=%s AND con.contype='c'
+            """,
+            (table,),
+        )
+        constraints = cur.fetchall()
+        for c in constraints:
+            print(f"  CHECK: {c[0]} → {c[1]}")
+
+    # ── Section 2: ___xtr_customer marketing/consent columns ─────────────────
+    print("\n" + "=" * 80)
+    print("SECTION 2 — ___xtr_customer existing marketing/consent columns")
+    print("=" * 80)
+
+    for pattern in CUSTOMER_PATTERNS:
+        cur.execute(
+            """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema='public' AND table_name='___xtr_customer'
+              AND column_name ILIKE %s
+            """,
+            (pattern,),
+        )
+        rows = cur.fetchall()
+        if rows:
+            print(f"\n  pattern '{pattern}':")
+            for r in rows:
+                print(f"    - {r[0]}: {r[1]} ({'NULL' if r[2]=='YES' else 'NOT NULL'})")
+        else:
+            print(f"  pattern '{pattern}': no match")
+
+    # All cst_* columns for context
+    print("\n  All ___xtr_customer columns (full inventory):")
+    cur.execute(
+        """
+        SELECT column_name, data_type
+        FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='___xtr_customer'
+        ORDER BY ordinal_position
+        """
+    )
+    for r in cur.fetchall():
+        print(f"    - {r[0]}: {r[1]}")
+
+    # ── Section 3: feedback/retention/brief candidates ──────────────────────
+    print("\n" + "=" * 80)
+    print("SECTION 3 — search for retention/brief/feedback patterns")
+    print("=" * 80)
+
+    cur.execute(
+        """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema='public'
+          AND (table_name ILIKE '%brief%'
+               OR table_name ILIKE '%retention%'
+               OR table_name ILIKE '%trigger_rule%'
+               OR table_name ILIKE '%feedback%'
+               OR table_name ILIKE '%consent%')
+        ORDER BY table_name
+        """
+    )
+    rows = cur.fetchall()
+    if rows:
+        for r in rows:
+            print(f"  - {r[0]}")
+    else:
+        print("  no match")
+
+    cur.close()
+    conn.close()
+    print("\n[done]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

**PR-1.1 du plan rev 8 ADR-036** — Phase 1 Migration DB. Stratégie : 1 table fédératrice + 1 NEW retention + 1 ALTER colonne.

### Contexte vérification existant

Avant tout `CREATE TABLE`, audit DB exhaustif via `scripts/db/inventory-marketing-tables.py` :

- **9 tables `__marketing_*` existent déjà** (vérifié SELECT-only) : `__marketing_backlinks`, `__marketing_brand_rules`, `__marketing_campaigns`, `__marketing_content_roadmap`, `__marketing_kpi_snapshots`, `__marketing_outreach`, `__marketing_social_posts`, `__marketing_utm_registry`, `__marketing_weekly_plans`.
- **Aucune n'est doublon parfait** : toutes channel-specific (social IG/FB/YT, backlinks SEO, weekly plans agrégés, kpi snapshots quotidiens). `__marketing_brief` comme table fédératrice multi-channel agent-orchestrated n'a pas d'équivalent.
- **`___xtr_customer`** : 21 colonnes vérifiées, **0 hit** sur patterns `cst_%marketing%|consent|opt_in|newsletter|mail_consent` → ALTER ADD COLUMN légitime.

## 3 changes idempotents

### 1. NEW `__marketing_brief` (table fédératrice)

- Multi-channel CHECK (gbp, local_landing, website_seo, email, sms, social_*)
- **Convention `brand_gate_level CHECK ('PASS','WARN','FAIL')`** adoptée du codebase existant (`__marketing_social_posts.brand_gate_level`) — pas d'invention BLOCK/WRITE/REVIEW
- **Métriques inline** (cohérent `__marketing_social_posts.actual_*`) : KISS Phase 1 MVP
- FK optionnel `social_post_id` → `__marketing_social_posts(id)` pour briefs générant aussi un post social
- 2 CHECK composites : `business_unit × channel` cohérence + HYBRID payload obligatoire (`hybrid_reason`, `cta_ecommerce`, `cta_local`, `conversion_goal_*`)
- 3 indexes (status+created, business_unit+status, agent+created)
- RLS service_role only + REVOKE anon/authenticated
- Trigger `updated_at` auto

### 2. NEW `__retention_trigger_rules` + seed

| category | min_days | max_days | trigger_template |
|---|---|---|---|
| freinage | 180 | 365 | controle_freinage |
| vidange | 270 | 365 | rappel_vidange |
| batterie | 1095 | 1825 | remplacement_batterie |
| filtres_habitacle | 365 | 540 | changement_filtre_habitacle |

CHECK `min < max`, UNIQUE `(category, trigger_template)`. ON CONFLICT DO NOTHING (idempotent). RLS service_role only.

### 3. ALTER `___xtr_customer`

`ADD COLUMN cst_marketing_consent_at timestamptz NULL` + index partiel (`WHERE NOT NULL`). Backfill = NULL (RGPD non rétroactif). Convention `cst_*` respectée (vs `users.marketing_consent_at` initialement prévu — mauvais nom de table corrigé).

## Scripts Python (canon, pas MCP — règle utilisateur)

- **`scripts/db/inventory-marketing-tables.py`** : audit DB SELECT-only (déjà exécuté pour baseline les findings ci-dessus)
- **`scripts/db/apply-migration-marketing-phase1.py`** : 4 modes
  - `--dry-run` : valide connexion + SQL parsing, pas de modif (déjà exécuté ✓)
  - `--apply` : exécute migration en transaction
  - `--verify` : vérifie post-apply (tables/colonnes/indexes/seed/RLS)
  - `--test-negative` : 5 tests CHECK violation + 1 INSERT positif (cleanup auto)

## ⚠️ Apply Supabase nécessite go explicite

Projet `cxpojprgwgubzjyqzmoq` est partagé DEV/PROD selon `MEMORY.md`. L'apply ne sera lancé qu'après confirmation utilisateur (`python3 scripts/db/apply-migration-marketing-phase1.py --apply`).

## Test plan

- [x] Inventory DB SELECT-only exécuté → 9 tables existantes auditées
- [x] Migration SQL idempotente (IF NOT EXISTS / ON CONFLICT DO NOTHING / DROP IF EXISTS partout)
- [x] Dry-run apply OK : connexion direct port 5432, fichier 12.6 KB / 270 lignes
- [x] Commit signé G3 ✓
- [ ] CI Migration Safety check vert (validation syntaxe SQL)
- [ ] CI globale verte (TypeScript, ESLint, Backend Tests, Frontend Tests)
- [ ] Apply DEV après go explicite → `--verify` → `--test-negative` (5/5 + 1 positif)

## Anti-patterns écartés

- Pas de duplication des 9 tables existantes (vérifié par inventaire DB)
- Pas d'invention `BLOCK/WRITE/REVIEW` (convention `PASS/WARN/FAIL` adoptée)
- Pas de hardcoded cycles véhicule (table data-driven)
- Pas de `users.marketing_consent_at` (table inexistante — corrigé en `___xtr_customer.cst_marketing_consent_at`)
- Pas de MCP pour migration (Python canon `scripts/db/`)
- Pas d'apply sans go explicite (projet Supabase partagé DEV/PROD)

## Références

- Plan rev 8 : `/home/deploy/.claude/plans/verifier-la-strategie-une-piped-hummingbird.md`
- ADR-036 : https://github.com/ak125/governance-vault/blob/main/ledger/decisions/adr/ADR-036-marketing-operating-layer.md
- Pattern Python DB direct : `scripts/db/adr017-create-index-concurrently.py`
- Inventaire findings : commit message + `scripts/db/inventory-marketing-tables.py` réexécutable

🤖 Generated with [Claude Code](https://claude.com/claude-code)