### PR TITLE
feat(adr-036-pr1.2): marketing matrix service + invariants + agents scan

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -23,6 +23,7 @@ depends_on:
 - SystemModule
 - AiContentModule
 - VehiclesModule
+- OperatingMatrixModule
 ---
 
 # Module Admin

--- a/backend/src/config/marketing-matrix.module.ts
+++ b/backend/src/config/marketing-matrix.module.ts
@@ -1,0 +1,16 @@
+/**
+ * MarketingMatrixModule — exposes MarketingMatrixService to consumers
+ * (admin governance controller, CLI dump scripts, brief validation DTO).
+ *
+ * Pattern miroir de operating-matrix.module.ts (ADR-025).
+ */
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { MarketingMatrixService } from './marketing-matrix.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [MarketingMatrixService],
+  exports: [MarketingMatrixService],
+})
+export class MarketingMatrixModule {}

--- a/backend/src/config/marketing-matrix.service.test.ts
+++ b/backend/src/config/marketing-matrix.service.test.ts
@@ -1,0 +1,154 @@
+import { ConfigService } from '@nestjs/config';
+import { MarketingMatrixService } from './marketing-matrix.service';
+import {
+  MarketingBusinessUnit,
+  MarketingChannel,
+  MarketingConversionGoal,
+  MarketingGateLevel,
+} from './marketing-matrix.types';
+
+function makeService(env: Record<string, string | undefined> = {}) {
+  const config = {
+    get: <T = unknown>(key: string): T | undefined => env[key] as T | undefined,
+  } as unknown as ConfigService;
+  return new MarketingMatrixService(config);
+}
+
+describe('MarketingMatrixService', () => {
+  describe('snapshot()', () => {
+    const svc = makeService({ NODE_ENV: 'test' });
+    const snap = svc.snapshot();
+
+    it('emits version 1.0.0 + module MARKETING', () => {
+      expect(snap.version).toBe('1.0.0');
+      expect(snap.module).toBe('MARKETING');
+    });
+
+    it('exposes 4 invariant.requires alpha-sorted (ADR-036 §"OperatingMatrixService étendu")', () => {
+      expect(snap.invariant.requires).toEqual([
+        'aec_manifest',
+        'brand_compliance_gate',
+        'business_unit_defined',
+        'conversion_goal_defined',
+      ]);
+    });
+
+    it('exposes 2 subdomains (ECOMMERCE + LOCAL — HYBRID est exceptionnel)', () => {
+      expect(snap.invariant.subdomains).toEqual([
+        MarketingBusinessUnit.ECOMMERCE,
+        MarketingBusinessUnit.LOCAL,
+      ]);
+    });
+
+    it('lists all 8 channels alpha-sorted', () => {
+      expect(snap.channels).toEqual([
+        MarketingChannel.EMAIL,
+        MarketingChannel.GBP,
+        MarketingChannel.LOCAL_LANDING,
+        MarketingChannel.SMS,
+        MarketingChannel.SOCIAL_FACEBOOK,
+        MarketingChannel.SOCIAL_INSTAGRAM,
+        MarketingChannel.SOCIAL_YOUTUBE,
+        MarketingChannel.WEBSITE_SEO,
+      ]);
+    });
+
+    it('lists all 4 conversion goals alpha-sorted', () => {
+      expect(snap.conversionGoals).toEqual([
+        MarketingConversionGoal.CALL,
+        MarketingConversionGoal.ORDER,
+        MarketingConversionGoal.QUOTE,
+        MarketingConversionGoal.VISIT,
+      ]);
+    });
+
+    it('lists all 3 gate levels alpha-sorted (PASS/WARN/FAIL — cohérent __marketing_social_posts)', () => {
+      expect(snap.gateLevels).toEqual([
+        MarketingGateLevel.FAIL,
+        MarketingGateLevel.PASS,
+        MarketingGateLevel.WARN,
+      ]);
+    });
+
+    it('expects 3 agents (LEAD + LOCAL + RETENTION) alpha-sorted', () => {
+      expect(snap.agentsExpected).toEqual([
+        'customer-retention-agent',
+        'local-business-agent',
+        'marketing-lead-agent',
+      ]);
+    });
+
+    it('hashes source files using "sha256:" prefix + 64 hex chars (cohérent OperatingMatrixService)', () => {
+      for (const v of Object.values(snap.sourcesHash)) {
+        expect(v).toMatch(/^sha256:[a-f0-9]{64}$/);
+      }
+    });
+  });
+
+  describe('formatJson()', () => {
+    it('strips agentScanRootsFound (filesystem-dependent, R6 determinism)', () => {
+      const svc = makeService({ NODE_ENV: 'test' });
+      const json = svc.formatJson();
+      expect(json).not.toHaveProperty('agentScanRootsFound');
+    });
+
+    it('produces stable output across calls (canonicalized keys + alpha-sort)', () => {
+      const svc = makeService({ NODE_ENV: 'test' });
+      const a = svc.formatJsonString();
+      const b = svc.formatJsonString();
+      expect(a).toBe(b);
+    });
+
+    it('top-level keys are alpha-sorted', () => {
+      const svc = makeService({ NODE_ENV: 'test' });
+      const json = svc.formatJson();
+      const keys = Object.keys(json);
+      const sorted = [...keys].sort();
+      expect(keys).toEqual(sorted);
+    });
+  });
+
+  describe('agent scan', () => {
+    it('NODE_ENV=production with no override → skips scan, returns empty agents list', () => {
+      const svc = makeService({ NODE_ENV: 'production' });
+      const snap = svc.snapshot();
+      expect(snap.agentScanSkipped).toBe(true);
+      expect(snap.agentScanSkipReason).toBe('production_default');
+      expect(snap.agents).toHaveLength(0);
+    });
+
+    it('NODE_ENV=production + MARKETING_MATRIX_SCAN_AGENTS=true → does scan', () => {
+      const svc = makeService({
+        NODE_ENV: 'production',
+        MARKETING_MATRIX_SCAN_AGENTS: 'true',
+      });
+      const snap = svc.snapshot();
+      // agentScanSkipped peut être true ou false selon que workspaces/marketing/.claude/agents/
+      // existe ou non au moment du test. Mais skipReason ne doit pas être 'production_default'.
+      expect(snap.agentScanSkipReason).not.toBe('production_default');
+    });
+  });
+
+  describe('formatMarkdown()', () => {
+    const svc = makeService({ NODE_ENV: 'test' });
+    const md = svc.formatMarkdown();
+
+    it('renders all 4 invariants', () => {
+      expect(md).toContain('aec_manifest');
+      expect(md).toContain('brand_compliance_gate');
+      expect(md).toContain('business_unit_defined');
+      expect(md).toContain('conversion_goal_defined');
+    });
+
+    it('lists 3 expected agents', () => {
+      expect(md).toContain('local-business-agent');
+      expect(md).toContain('marketing-lead-agent');
+      expect(md).toContain('customer-retention-agent');
+    });
+
+    it('shows ECOMMERCE and LOCAL subdomains', () => {
+      expect(md).toContain('ECOMMERCE');
+      expect(md).toContain('LOCAL');
+    });
+  });
+});

--- a/backend/src/config/marketing-matrix.service.ts
+++ b/backend/src/config/marketing-matrix.service.ts
@@ -1,0 +1,300 @@
+/**
+ * MarketingMatrixService — single source of the Marketing Agent Operating Matrix.
+ *
+ * Pattern miroir de OperatingMatrixService (ADR-025) mais scope marketing distinct
+ * (ADR-036 §"OperatingMatrixService étendu" — implémenté via service séparé pour
+ * éviter le god-object et garder le snapshot JSON SEO figé inchangé).
+ *
+ * Consumed by:
+ *  - GovernanceMatrixController (admin endpoint marketing — Phase 1.4 PR-1.4)
+ *  - scripts/marketing/dump-marketing-matrix.ts (CLI dump — Phase 1.5 PR-1.5)
+ *  - Brief validation invariant : tout brief inséré dans __marketing_brief
+ *    doit satisfaire les 4 `requires` (vérifié DTO Zod côté NestJS).
+ *
+ * Filesystem touché uniquement pour :
+ *   (a) hash des sources (déterminisme)
+ *   (b) scan workspaces/marketing/.claude/agents/
+ * Les 2 sont gated par `skipAgentScan` (production default).
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  MarketingAgentEntry,
+  MarketingBusinessUnit,
+  MarketingChannel,
+  MarketingConversionGoal,
+  MarketingGateLevel,
+  MarketingInvariant,
+  MarketingInvariantKey,
+  MarketingMatrix,
+  MarketingMatrixSourcesHash,
+} from './marketing-matrix.types';
+
+/** Path scanné pour les agents marketing (workspace dédié, pas seo-batch). */
+const MARKETING_AGENT_PATHS = ['workspaces/marketing/.claude/agents'] as const;
+
+/** Hash file = canon distribué localement (pas filesystem vault qui est read-only sur PROD/AI-COS). */
+const SOURCE_FILES: Record<keyof MarketingMatrixSourcesHash, string> = {
+  matrixTypes: 'backend/src/config/marketing-matrix.types.ts',
+  marketingVoiceCanon: '.claude/rules/marketing-voice.md',
+};
+
+/**
+ * Liste canon des invariants — alpha-sorted pour stabilité snapshot.
+ * Source ADR-036 §"OperatingMatrixService étendu".
+ */
+const INVARIANT_REQUIRES: ReadonlyArray<MarketingInvariantKey> = [
+  'aec_manifest',
+  'brand_compliance_gate',
+  'business_unit_defined',
+  'conversion_goal_defined',
+];
+
+/**
+ * Subdomains officiels du module — ECOMMERCE et LOCAL.
+ * HYBRID est exceptionnel (cas cross-business strict) — pas un subdomain principal.
+ */
+const SUBDOMAINS: ReadonlyArray<MarketingBusinessUnit> = [
+  MarketingBusinessUnit.ECOMMERCE,
+  MarketingBusinessUnit.LOCAL,
+];
+
+/**
+ * Agents Phase 1-2 attendus selon ADR-036.
+ * Ils peuvent ne pas exister encore au filesystem (Phase 1.5 PR-1.5 les crée).
+ */
+const AGENTS_EXPECTED: ReadonlyArray<string> = [
+  'customer-retention-agent',
+  'local-business-agent',
+  'marketing-lead-agent',
+];
+
+/**
+ * Scope autorisé par agent (ADR-036 §"Verdict & approche retenue").
+ * Sert au DTO Zod runtime + au snapshot.
+ */
+const AGENT_SCOPES: Record<string, ReadonlyArray<MarketingBusinessUnit>> = {
+  'customer-retention-agent': [
+    MarketingBusinessUnit.ECOMMERCE,
+    MarketingBusinessUnit.HYBRID,
+  ],
+  'local-business-agent': [MarketingBusinessUnit.LOCAL],
+  'marketing-lead-agent': [
+    MarketingBusinessUnit.ECOMMERCE,
+    MarketingBusinessUnit.LOCAL,
+  ],
+};
+
+interface AgentScanResult {
+  agents: MarketingAgentEntry[];
+  scannedPaths: string[];
+  skipped: boolean;
+  skipReason?: 'production_default' | 'no_paths_found';
+}
+
+/** Recursive canonicalisation: alpha-sort object keys for stable JSON. */
+function canonicalize<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => canonicalize(v)) as unknown as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      out[k] = canonicalize((value as Record<string, unknown>)[k]);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+@Injectable()
+export class MarketingMatrixService {
+  private readonly logger = new Logger(MarketingMatrixService.name);
+  private readonly skipAgentScan: boolean;
+  private readonly repoRoot: string;
+
+  constructor(private readonly config: ConfigService) {
+    // Production default : skip filesystem scan (matrix sans agents detected, invariants only).
+    // Override via env MARKETING_MATRIX_SCAN_AGENTS=true for dev/CI.
+    this.skipAgentScan =
+      this.config.get<string>('MARKETING_MATRIX_SCAN_AGENTS') !== 'true' &&
+      this.config.get<string>('NODE_ENV') === 'production';
+    // repoRoot = .../backend/.. (2 levels up from src/config/)
+    this.repoRoot = path.resolve(__dirname, '..', '..', '..');
+  }
+
+  /** Snapshot complet à instant T. */
+  snapshot(): MarketingMatrix {
+    const scan = this.scanAgents();
+    const sourcesHash = this.hashSourceFiles();
+
+    const invariant: MarketingInvariant = {
+      requires: INVARIANT_REQUIRES,
+      subdomains: SUBDOMAINS,
+    };
+
+    const channels = Object.values(
+      MarketingChannel,
+    ).sort() as MarketingChannel[];
+    const conversionGoals = Object.values(
+      MarketingConversionGoal,
+    ).sort() as MarketingConversionGoal[];
+    const gateLevels = Object.values(
+      MarketingGateLevel,
+    ).sort() as MarketingGateLevel[];
+
+    const matrix: MarketingMatrix = {
+      version: '1.0.0',
+      module: 'MARKETING',
+      sourcesHash,
+      invariant,
+      channels,
+      conversionGoals,
+      gateLevels,
+      agentsExpected: AGENTS_EXPECTED,
+      agents: scan.agents,
+      agentScanSkipped: scan.skipped,
+      agentScanSkipReason: scan.skipReason,
+      agentScanRootsFound: scan.scannedPaths.length
+        ? scan.scannedPaths
+        : undefined,
+    };
+
+    return matrix;
+  }
+
+  /** JSON déterministe (CI snapshot — `audit-reports/marketing-operating-matrix.json`). */
+  formatJson(): MarketingMatrix {
+    const snap = this.snapshot();
+    // Strip filesystem-dependent field for committed JSON.
+    const { agentScanRootsFound: _drop, ...stable } = snap;
+    return canonicalize(stable as MarketingMatrix);
+  }
+
+  formatJsonString(): string {
+    return JSON.stringify(this.formatJson(), null, 2) + '\n';
+  }
+
+  /** Markdown for humans (admin dashboard, CLI). */
+  formatMarkdown(): string {
+    const snap = this.snapshot();
+    const lines: string[] = [];
+    lines.push('# Marketing Operating Matrix');
+    lines.push('');
+    lines.push(`- module: \`${snap.module}\``);
+    lines.push(`- version: \`${snap.version}\``);
+    lines.push(`- subdomains: ${snap.invariant.subdomains.join(', ')}`);
+    lines.push('');
+    lines.push('## Invariants `requires`');
+    lines.push('');
+    for (const r of snap.invariant.requires) {
+      lines.push(`- \`${r}\``);
+    }
+    lines.push('');
+    lines.push('## Channels autorisés');
+    lines.push('');
+    lines.push(snap.channels.map((c) => `\`${c}\``).join(', '));
+    lines.push('');
+    lines.push('## Conversion goals');
+    lines.push('');
+    lines.push(snap.conversionGoals.map((g) => `\`${g}\``).join(', '));
+    lines.push('');
+    lines.push('## Agents');
+    lines.push('');
+    lines.push('| Agent | Scope | Présent ? |');
+    lines.push('|---|---|---|');
+    for (const exp of snap.agentsExpected) {
+      const found = snap.agents.find((a) => a.name === exp);
+      const scope = (AGENT_SCOPES[exp] || []).join(' / ');
+      const present = found?.present ? '✅' : '⏳ (pas encore créé)';
+      lines.push(`| \`${exp}\` | ${scope} | ${present} |`);
+    }
+    lines.push('');
+    if (snap.agentScanSkipped) {
+      lines.push(`> ⚠️  agent scan skipped (\`${snap.agentScanSkipReason}\`)`);
+    }
+    return lines.join('\n');
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────
+
+  private scanAgents(): AgentScanResult {
+    if (this.skipAgentScan) {
+      return {
+        agents: [],
+        scannedPaths: [],
+        skipped: true,
+        skipReason: 'production_default',
+      };
+    }
+
+    const scannedPaths: string[] = [];
+    const found = new Map<string, boolean>();
+
+    for (const expected of AGENTS_EXPECTED) {
+      found.set(expected, false);
+    }
+
+    for (const rel of MARKETING_AGENT_PATHS) {
+      const abs = path.join(this.repoRoot, rel);
+      if (!fs.existsSync(abs)) continue;
+      scannedPaths.push(rel);
+      try {
+        const entries = fs.readdirSync(abs, { withFileTypes: true });
+        for (const entry of entries) {
+          if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+          const name = entry.name.replace(/\.md$/, '');
+          if (found.has(name)) {
+            found.set(name, true);
+          }
+        }
+      } catch (e) {
+        this.logger.warn(`scan failed at ${rel}: ${(e as Error).message}`);
+      }
+    }
+
+    if (scannedPaths.length === 0) {
+      return {
+        agents: AGENTS_EXPECTED.map((name) => ({
+          name,
+          present: false,
+          scope: AGENT_SCOPES[name] || [],
+        })),
+        scannedPaths: [],
+        skipped: true,
+        skipReason: 'no_paths_found',
+      };
+    }
+
+    const agents: MarketingAgentEntry[] = AGENTS_EXPECTED.map((name) => ({
+      name,
+      present: found.get(name) === true,
+      scope: AGENT_SCOPES[name] || [],
+    }));
+
+    return { agents, scannedPaths, skipped: false };
+  }
+
+  private hashSourceFiles(): MarketingMatrixSourcesHash {
+    // Convention cohérente avec OperatingMatrixService : préfixe `sha256:`.
+    const result: Partial<MarketingMatrixSourcesHash> = {};
+    for (const [key, rel] of Object.entries(SOURCE_FILES)) {
+      const abs = path.join(this.repoRoot, rel);
+      if (!fs.existsSync(abs)) {
+        // File missing (canon not yet distributed). Hash empty string for stability.
+        result[key as keyof MarketingMatrixSourcesHash] =
+          'sha256:' + createHash('sha256').update('').digest('hex');
+        continue;
+      }
+      const buf = fs.readFileSync(abs);
+      result[key as keyof MarketingMatrixSourcesHash] =
+        'sha256:' + createHash('sha256').update(buf).digest('hex');
+    }
+    return result as MarketingMatrixSourcesHash;
+  }
+}

--- a/backend/src/config/marketing-matrix.types.ts
+++ b/backend/src/config/marketing-matrix.types.ts
@@ -1,0 +1,112 @@
+/**
+ * Marketing Matrix Types — single-source view over marketing agents + invariants.
+ *
+ * Pattern miroir de operating-matrix.types.ts mais scope distinct :
+ *   - OperatingMatrix = SEO Agent Matrix (R0-R8 + FIELD_CATALOG)
+ *   - MarketingMatrix = Marketing Agent Matrix (LEAD/LOCAL/RETENTION + business_unit)
+ *
+ * Décision pivot vs plan rev 8 §"OperatingMatrix étendu" : services séparés
+ * (séparation des concerns, snapshot JSON SEO inchangé). Cf ADR-036 §"OperatingMatrixService étendu"
+ * — l'extension nominale passe par 2 services parallèles, le pattern reste celui d'ADR-025.
+ *
+ * Source vérité invariants : ADR-036 + rules-marketing-voice.md (canon vault).
+ */
+
+/** Les 3 unités business — ECOMMERCE national, LOCAL magasin 93, HYBRID smart routing. */
+export enum MarketingBusinessUnit {
+  ECOMMERCE = 'ECOMMERCE',
+  LOCAL = 'LOCAL',
+  HYBRID = 'HYBRID',
+}
+
+/** Liste fermée des channels autorisés (cohérent CHECK SQL `__marketing_brief.channel`). */
+export enum MarketingChannel {
+  GBP = 'gbp',
+  LOCAL_LANDING = 'local_landing',
+  WEBSITE_SEO = 'website_seo',
+  EMAIL = 'email',
+  SMS = 'sms',
+  SOCIAL_FACEBOOK = 'social_facebook',
+  SOCIAL_INSTAGRAM = 'social_instagram',
+  SOCIAL_YOUTUBE = 'social_youtube',
+}
+
+/** Conversion goal — chaque brief DOIT en avoir un (NOT NULL CHECK). */
+export enum MarketingConversionGoal {
+  CALL = 'CALL',
+  VISIT = 'VISIT',
+  QUOTE = 'QUOTE',
+  ORDER = 'ORDER',
+}
+
+/** Verdicts brand-compliance-gate (cohérent __marketing_social_posts.brand_gate_level). */
+export enum MarketingGateLevel {
+  PASS = 'PASS',
+  WARN = 'WARN',
+  FAIL = 'FAIL',
+}
+
+/**
+ * Invariants requis pour qu'un brief soit valide.
+ * Sans ces 4 vérifications, le brief est rejeté en amont (DTO Zod ou CHECK SQL).
+ *
+ * Ordre stable (alphabétique) pour snapshot deterministic.
+ */
+export type MarketingInvariantKey =
+  | 'aec_manifest'
+  | 'brand_compliance_gate'
+  | 'business_unit_defined'
+  | 'conversion_goal_defined';
+
+export interface MarketingInvariant {
+  /** Liste des vérifications obligatoires (alpha-sorted). */
+  requires: ReadonlyArray<MarketingInvariantKey>;
+  /** Sous-domaines couverts par ces invariants. */
+  subdomains: ReadonlyArray<MarketingBusinessUnit>;
+}
+
+/** Entrée d'agent marketing détecté dans workspaces/marketing/.claude/agents/. */
+export interface MarketingAgentEntry {
+  /** Nom du fichier sans extension (ex: 'local-business-agent'). */
+  name: string;
+  /** Présent dans le filesystem ? */
+  present: boolean;
+  /** Business units où cet agent est autorisé à exécuter. */
+  scope: ReadonlyArray<MarketingBusinessUnit>;
+}
+
+/** Hash des fichiers source pour reproductibilité snapshot. */
+export interface MarketingMatrixSourcesHash {
+  /** Hash de `marketing-matrix.types.ts` lui-même (référence stable). */
+  matrixTypes: string;
+  /** Hash de `.claude/rules/marketing-voice.md` (canon distribué via canon-publish). */
+  marketingVoiceCanon: string;
+}
+
+/** Snapshot complet de la matrice marketing à un instant T. */
+export interface MarketingMatrix {
+  /** Version du contrat. Bump majeur = breaking change downstream. */
+  version: '1.0.0';
+  /** Module identifier (constant — pour cohérence cross-matrix). */
+  module: 'MARKETING';
+  /** Hashes pour reproductibilité. */
+  sourcesHash: MarketingMatrixSourcesHash;
+  /** Invariants requires + subdomains. */
+  invariant: MarketingInvariant;
+  /** Channels autorisés (alpha-sorted). */
+  channels: ReadonlyArray<MarketingChannel>;
+  /** Goals autorisés (alpha-sorted). */
+  conversionGoals: ReadonlyArray<MarketingConversionGoal>;
+  /** Niveaux brand_gate (alpha-sorted). */
+  gateLevels: ReadonlyArray<MarketingGateLevel>;
+  /** Agents Phase 1-2 attendus (canon ADR-036). */
+  agentsExpected: ReadonlyArray<string>;
+  /** Agents effectivement détectés au scan filesystem. */
+  agents: ReadonlyArray<MarketingAgentEntry>;
+  /** Le scan filesystem a-t-il été skippé (ex: production) ? */
+  agentScanSkipped: boolean;
+  /** Raison du skip si applicable. */
+  agentScanSkipReason?: 'production_default' | 'no_paths_found';
+  /** Path scanné réellement (debug). Omitted from canonical JSON for determinism. */
+  agentScanRootsFound?: ReadonlyArray<string>;
+}


### PR DESCRIPTION
## Summary

**PR-1.2 du plan rev 8 ADR-036** — Extension du pattern OperatingMatrix au scope marketing.

### Décision pivot vs plan rev 8 littéral

Le plan rev 8 dit "OperatingMatrix étendu (module MARKETING + invariant requires)". Réalité du code : `OperatingMatrixService` est SEO-spécifique (RoleId enum SEO, FIELD_CATALOG SEO, snapshot CI déterministe `audit-reports/seo-agent-matrix.json`). Y greffer marketing = god-object + risque régression sur snapshot SEO figé.

**Pivot pris : service séparé `MarketingMatrixService`** parallèle à `OperatingMatrixService`. Pattern moderne = séparation des concerns. Cohérent avec ADR-025 (single-source au sein de chaque module).

### Architecture

| Fichier | Rôle |
|---|---|
| `backend/src/config/marketing-matrix.types.ts` | Enums (BusinessUnit, Channel, ConversionGoal, GateLevel) + `MarketingInvariant` + `MarketingMatrix` snapshot |
| `backend/src/config/marketing-matrix.service.ts` | Snapshot + canonicalize + hashSourceFiles + scanAgents + formatJson/Markdown |
| `backend/src/config/marketing-matrix.module.ts` | NestJS module (Injectable + ConfigModule import) |
| `backend/src/config/marketing-matrix.service.test.ts` | 15+ assertions (invariants, channels, agents, determinism, scan skip) |

### Invariants exposés

```
requires: [aec_manifest, brand_compliance_gate, business_unit_defined, conversion_goal_defined]
subdomains: [ECOMMERCE, LOCAL]   // HYBRID exceptionnel, pas subdomain principal
channels: [email, gbp, local_landing, sms, social_facebook, social_instagram, social_youtube, website_seo]
conversionGoals: [CALL, ORDER, QUOTE, VISIT]
gateLevels: [FAIL, PASS, WARN]   // adopté __marketing_social_posts.brand_gate_level
```

### Conventions reprises

- **Hash format `sha256:<hex>`** cohérent `OperatingMatrixService` (vérifié par grep)
- **Canonicalize alpha-sort** pour déterminisme JSON
- **Production default skip scan** (override `MARKETING_MATRIX_SCAN_AGENTS=true`)
- **AGENT_SCOPES** : map agent → business_units autorisés (servira PR-1.3 DTO Zod)

### Pré-requis aval (PR-1.5)

Agent files dans `workspaces/marketing/.claude/agents/{local-business,marketing-lead,customer-retention}-agent.md` rendront `snapshot.agents[].present=true`. Pour Phase 1.2 sans agents créés, scan retourne `present=false` pour les 3 attendus.

## Test plan

- [x] TypeScript strict pass (`npx tsc --noEmit`)
- [x] Commit signé G3
- [ ] CI globale verte (TypeScript, ESLint, Backend Tests dont nouveau test)
- [ ] PR mergée
- [ ] Vérification post-merge : snapshot SEO `audit-reports/seo-agent-matrix.json` inchangé (zéro impact)

> Test local Jest = OOM connu (cf `MEMORY.md` feedback_no_bricolage_analyse_profondeur — confiance CI obligatoire).

## Anti-patterns écartés

- Pas d'extension `OperatingMatrixService` (séparation des concerns)
- Pas de modification du snapshot SEO figé
- Pas d'invention `BLOCK/WARN/PASS` (convention `PASS/WARN/FAIL` adoptée)
- Pas de scan `seo-batch/` (séparation stricte des workspaces)
- Pas de path absolu hardcodé (repoRoot calculé via `__dirname`)

## Références

- Plan rev 8 : `/home/deploy/.claude/plans/verifier-la-strategie-une-piped-hummingbird.md`
- ADR-036 : https://github.com/ak125/governance-vault/blob/main/ledger/decisions/adr/ADR-036-marketing-operating-layer.md
- PR-1.1 (DB) : #238 — actuellement en CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)