### PR TITLE
feat(adr-036-pr1.3): marketing brief dto + scoring config + tests

### DIFF
--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -9,9 +9,9 @@ primary_files:
 - backend/src/modules/marketing/controllers/marketing-dashboard.controller.ts
 - backend/src/modules/marketing/controllers/marketing-pipeline.controller.ts
 - backend/src/modules/marketing/controllers/marketing-social-posts.controller.ts
+- backend/src/modules/marketing/dto/marketing-brief.dto.ts
 - backend/src/modules/marketing/interfaces/marketing-hub.interfaces.ts
 - backend/src/modules/marketing/interfaces/marketing.interfaces.ts
-- backend/src/modules/marketing/marketing.module.ts
 depends_on:
 - DatabaseModule
 - AiContentModule

--- a/backend/src/modules/marketing/dto/marketing-brief.dto.ts
+++ b/backend/src/modules/marketing/dto/marketing-brief.dto.ts
@@ -1,0 +1,247 @@
+/**
+ * Marketing Brief DTO — Zod schemas + types inférés.
+ *
+ * Validation triple verrou (defense in depth, ADR-036) :
+ *   1. CHECK SQL `__marketing_brief.business_unit/channel/conversion_goal`
+ *   2. DTO Zod côté NestJS (ce fichier — refuse en amont avant query DB)
+ *   3. Invariant OperatingMatrix `requires` (snapshot CI deterministic)
+ *
+ * Enums importées de `marketing-matrix.types` (PR-1.2) — single source of truth :
+ *   - MarketingBusinessUnit : ECOMMERCE / LOCAL / HYBRID
+ *   - MarketingChannel : 8 canaux fermés
+ *   - MarketingConversionGoal : CALL / VISIT / QUOTE / ORDER
+ *   - MarketingGateLevel : PASS / WARN / FAIL (cohérent __marketing_social_posts)
+ *
+ * Refinements :
+ *   - business_unit × channel coherence (LOCAL = gbp/local_landing/sms uniquement)
+ *   - HYBRID payload obligatoire (5 champs : hybrid_reason, cta_ecommerce, cta_local,
+ *     conversion_goal_ecommerce, conversion_goal_local)
+ *   - RGPD : pas applicable au DTO brief direct, mais le SERVICE (PR-1.5) qui
+ *     query `___xtr_customer` filtre `cst_marketing_consent_at IS NOT NULL`
+ *     pour les briefs RETENTION ECOMMERCE/HYBRID ciblant email/sms.
+ *
+ * Source vérité enum values : ADR-036 + canon `rules-marketing-voice.md`.
+ */
+
+import { z } from 'zod';
+
+import {
+  MarketingBusinessUnit,
+  MarketingChannel,
+  MarketingConversionGoal,
+  MarketingGateLevel,
+} from '@config/marketing-matrix.types';
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 🎯 Brief status enum (cohérent CHECK SQL __marketing_brief.status)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export enum MarketingBriefStatus {
+  DRAFT = 'draft',
+  REVIEWED = 'reviewed',
+  APPROVED = 'approved',
+  PUBLISHED = 'published',
+  ARCHIVED = 'archived',
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 📋 AEC Coverage Manifest (rules-agent-exit-contract.md canon)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export const AecFinalStatusSchema = z.enum([
+  'PARTIAL_COVERAGE',
+  'SCOPE_SCANNED',
+  'REVIEW_REQUIRED',
+  'VALIDATED_FOR_SCOPE_ONLY',
+  'INSUFFICIENT_EVIDENCE',
+]);
+
+/** Coverage manifest obligatoire pour TOUT brief (AEC v1.0.0). */
+export const CoverageManifestSchema = z.object({
+  scope_requested: z.string().min(1),
+  scope_actually_scanned: z.string().min(1).optional(),
+  files_read_count: z.number().int().min(0).optional(),
+  excluded_paths: z.array(z.string()).default([]),
+  unscanned_zones: z.array(z.string()).default([]),
+  corrections_proposed: z.array(z.string()).default([]),
+  validation_executed: z.boolean().default(false),
+  remaining_unknowns: z.array(z.string()).default([]),
+  final_status: AecFinalStatusSchema,
+});
+
+export type CoverageManifest = z.infer<typeof CoverageManifestSchema>;
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 🔀 HYBRID payload sub-schema (5 conditions strictes ADR-036)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export const HybridPayloadSchema = z
+  .object({
+    hybrid_reason: z
+      .string()
+      .min(1, 'hybrid_reason obligatoire (ADR-036 §HYBRID)'),
+    cta_ecommerce: z.string().min(1),
+    cta_local: z.string().min(1),
+    conversion_goal_ecommerce: z.nativeEnum(MarketingConversionGoal),
+    conversion_goal_local: z.nativeEnum(MarketingConversionGoal),
+    /** Optionnel : zone géographique cible (default '93' pour smart routing). */
+    target_zone: z.string().optional(),
+  })
+  .refine((data) => data.cta_ecommerce !== data.cta_local, {
+    message:
+      'cta_ecommerce et cta_local doivent être DISTINCTS (sinon non-HYBRID)',
+    path: ['cta_local'],
+  })
+  .refine(
+    (data) => data.conversion_goal_ecommerce !== data.conversion_goal_local,
+    {
+      message:
+        'conversion_goal_ecommerce et conversion_goal_local doivent être DISTINCTS',
+      path: ['conversion_goal_local'],
+    },
+  );
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 🎨 Cohérence business_unit × channel (CHECK SQL miroir)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+const LOCAL_CHANNELS = new Set<MarketingChannel>([
+  MarketingChannel.GBP,
+  MarketingChannel.LOCAL_LANDING,
+  MarketingChannel.SMS,
+]);
+
+const ECOMMERCE_CHANNELS = new Set<MarketingChannel>([
+  MarketingChannel.WEBSITE_SEO,
+  MarketingChannel.EMAIL,
+  MarketingChannel.SOCIAL_FACEBOOK,
+  MarketingChannel.SOCIAL_INSTAGRAM,
+  MarketingChannel.SOCIAL_YOUTUBE,
+]);
+
+/** Vrai si la combinaison business_unit × channel est valide. */
+export function isCoherentUnitChannel(
+  businessUnit: MarketingBusinessUnit,
+  channel: MarketingChannel,
+): boolean {
+  if (businessUnit === MarketingBusinessUnit.HYBRID) return true;
+  if (businessUnit === MarketingBusinessUnit.LOCAL) {
+    return LOCAL_CHANNELS.has(channel);
+  }
+  if (businessUnit === MarketingBusinessUnit.ECOMMERCE) {
+    return ECOMMERCE_CHANNELS.has(channel);
+  }
+  return false;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 📦 CreateMarketingBriefSchema — DTO insertion principale
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export const CreateMarketingBriefSchema = z
+  .object({
+    agent_id: z.string().min(1).max(100),
+    business_unit: z.nativeEnum(MarketingBusinessUnit),
+    channel: z.nativeEnum(MarketingChannel),
+    conversion_goal: z.nativeEnum(MarketingConversionGoal),
+    cta: z.string().min(1).max(500),
+    target_segment: z.string().min(1).max(200),
+
+    /** Payload : structure libre sauf si HYBRID (validé après). */
+    payload: z.record(z.string(), z.unknown()),
+
+    /** AEC coverage manifest obligatoire. */
+    coverage_manifest: CoverageManifestSchema,
+
+    /** Lien optionnel vers post social spécifique (FK __marketing_social_posts). */
+    social_post_id: z.number().int().positive().optional(),
+
+    /** Trace agent (cohérent __marketing_social_posts.ai_*). */
+    ai_provider: z.string().optional(),
+    ai_model: z.string().optional(),
+    generation_prompt_hash: z.string().optional(),
+  })
+  // Refinement 1 : business_unit × channel cohérence
+  .refine(
+    (data) => isCoherentUnitChannel(data.business_unit, data.channel),
+    (data) => ({
+      message:
+        `Channel '${data.channel}' incohérent avec business_unit '${data.business_unit}'. ` +
+        `LOCAL=[gbp,local_landing,sms] ECOMMERCE=[website_seo,email,social_*] HYBRID=any.`,
+      path: ['channel'],
+    }),
+  )
+  // Refinement 2 : HYBRID payload obligatoire
+  .refine(
+    (data) => {
+      if (data.business_unit !== MarketingBusinessUnit.HYBRID) return true;
+      // Tente de parser le payload comme HybridPayload — si échec, refinement fail
+      const result = HybridPayloadSchema.safeParse(data.payload);
+      return result.success;
+    },
+    (data) => ({
+      message:
+        data.business_unit === MarketingBusinessUnit.HYBRID
+          ? 'HYBRID exige payload avec hybrid_reason + cta_ecommerce + cta_local + ' +
+            'conversion_goal_ecommerce + conversion_goal_local (ADR-036 §HYBRID)'
+          : '',
+      path: ['payload'],
+    }),
+  );
+
+export type CreateMarketingBriefDto = z.infer<
+  typeof CreateMarketingBriefSchema
+>;
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 🔄 UpdateBriefStatusSchema — admin UI workflow
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export const UpdateBriefStatusSchema = z.object({
+  status: z.nativeEnum(MarketingBriefStatus),
+  reviewed_by: z.string().optional(),
+  approved_by: z.string().optional(),
+});
+
+export type UpdateBriefStatusDto = z.infer<typeof UpdateBriefStatusSchema>;
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 📊 RecordBriefFeedbackSchema — saisie métriques admin
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export const RecordBriefFeedbackSchema = z.object({
+  brief_id: z.string().uuid(),
+  impressions: z.number().int().min(0).optional(),
+  clicks: z.number().int().min(0).optional(),
+  calls: z.number().int().min(0).optional(),
+  visits: z.number().int().min(0).optional(),
+  quotes: z.number().int().min(0).optional(),
+  orders: z.number().int().min(0).optional(),
+  revenue_cents: z.number().int().min(0).optional(),
+  source: z.enum([
+    'manual_admin',
+    'ga4',
+    'gbp_api',
+    'mailjet',
+    'twilio',
+    'phone_tracker',
+    'meta_pixel',
+    'facebook_insights',
+  ]),
+});
+
+export type RecordBriefFeedbackDto = z.infer<typeof RecordBriefFeedbackSchema>;
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// 🛡️ Brand gate verdict (côté brand-compliance-gate.service)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export const BrandGateVerdictSchema = z.object({
+  brand_gate_level: z.nativeEnum(MarketingGateLevel),
+  compliance_gate_level: z.nativeEnum(MarketingGateLevel),
+  gate_summary: z.record(z.string(), z.unknown()).optional(),
+  /** Raison du verdict (ex: 'local_canon_unvalidated', 'forbidden_word', ...). */
+  reason: z.string().optional(),
+});
+
+export type BrandGateVerdictDto = z.infer<typeof BrandGateVerdictSchema>;

--- a/backend/src/modules/marketing/marketing-scoring.config.test.ts
+++ b/backend/src/modules/marketing/marketing-scoring.config.test.ts
@@ -16,7 +16,7 @@ describe('Marketing scoring config', () => {
       const w = getMarketingScoringWeights({
         MARKETING_SCORING_CALL: '5',
         MARKETING_SCORING_ORDER: '20',
-      } as unknown as NodeJS.ProcessEnv);
+      });
       expect(w.call).toBe(5);
       expect(w.order).toBe(20);
       // unchanged
@@ -26,21 +26,21 @@ describe('Marketing scoring config', () => {
     it('falls back to default on invalid env value', () => {
       const w = getMarketingScoringWeights({
         MARKETING_SCORING_CALL: 'not-a-number',
-      } as unknown as NodeJS.ProcessEnv);
+      });
       expect(w.call).toBe(MARKETING_SCORING_DEFAULTS.call);
     });
 
     it('falls back to default on empty string', () => {
       const w = getMarketingScoringWeights({
         MARKETING_SCORING_CALL: '',
-      } as unknown as NodeJS.ProcessEnv);
+      });
       expect(w.call).toBe(MARKETING_SCORING_DEFAULTS.call);
     });
 
     it('accepts decimal values (revenue ratio)', () => {
       const w = getMarketingScoringWeights({
         MARKETING_SCORING_REVENUE_EUR_PER_UNIT: '0.05',
-      } as unknown as NodeJS.ProcessEnv);
+      });
       expect(w.revenue_eur_per_unit).toBe(0.05);
     });
   });

--- a/backend/src/modules/marketing/marketing-scoring.config.test.ts
+++ b/backend/src/modules/marketing/marketing-scoring.config.test.ts
@@ -1,0 +1,108 @@
+import {
+  computeBriefScore,
+  getMarketingScoringWeights,
+  MARKETING_SCORING_DEFAULTS,
+  MarketingBriefMetrics,
+} from './marketing-scoring.config';
+
+describe('Marketing scoring config', () => {
+  describe('getMarketingScoringWeights()', () => {
+    it('returns defaults when env vars absent', () => {
+      const w = getMarketingScoringWeights({});
+      expect(w).toEqual(MARKETING_SCORING_DEFAULTS);
+    });
+
+    it('overrides individual weights via ENV', () => {
+      const w = getMarketingScoringWeights({
+        MARKETING_SCORING_CALL: '5',
+        MARKETING_SCORING_ORDER: '20',
+      } as NodeJS.ProcessEnv);
+      expect(w.call).toBe(5);
+      expect(w.order).toBe(20);
+      // unchanged
+      expect(w.visit).toBe(MARKETING_SCORING_DEFAULTS.visit);
+    });
+
+    it('falls back to default on invalid env value', () => {
+      const w = getMarketingScoringWeights({
+        MARKETING_SCORING_CALL: 'not-a-number',
+      } as NodeJS.ProcessEnv);
+      expect(w.call).toBe(MARKETING_SCORING_DEFAULTS.call);
+    });
+
+    it('falls back to default on empty string', () => {
+      const w = getMarketingScoringWeights({
+        MARKETING_SCORING_CALL: '',
+      } as NodeJS.ProcessEnv);
+      expect(w.call).toBe(MARKETING_SCORING_DEFAULTS.call);
+    });
+
+    it('accepts decimal values (revenue ratio)', () => {
+      const w = getMarketingScoringWeights({
+        MARKETING_SCORING_REVENUE_EUR_PER_UNIT: '0.05',
+      } as NodeJS.ProcessEnv);
+      expect(w.revenue_eur_per_unit).toBe(0.05);
+    });
+  });
+
+  describe('computeBriefScore()', () => {
+    it('returns 0 for empty metrics', () => {
+      expect(computeBriefScore({})).toBe(0);
+    });
+
+    it('applies default weights correctly', () => {
+      const metrics: MarketingBriefMetrics = {
+        actual_calls: 1,
+        actual_clicks: 5,
+        actual_orders: 1,
+      };
+      // call=3 + click=1*5 + order=10 = 18
+      expect(computeBriefScore(metrics)).toBe(18);
+    });
+
+    it('treats undefined fields as 0', () => {
+      const metrics: MarketingBriefMetrics = { actual_calls: 2 };
+      // 2 * 3 = 6, all other = 0
+      expect(computeBriefScore(metrics)).toBe(6);
+    });
+
+    it('converts revenue_cents to euros for ratio', () => {
+      const metrics: MarketingBriefMetrics = {
+        actual_revenue_cents: 10000, // 100 €
+      };
+      // 100 € * 0.1 = 10
+      expect(computeBriefScore(metrics)).toBe(10);
+    });
+
+    it('respects custom weights override', () => {
+      const customWeights = {
+        ...MARKETING_SCORING_DEFAULTS,
+        call: 100,
+      };
+      const metrics: MarketingBriefMetrics = { actual_calls: 1 };
+      expect(computeBriefScore(metrics, customWeights)).toBe(100);
+    });
+
+    it('impressions default to 0 weight (no ROI per-impression)', () => {
+      const metrics: MarketingBriefMetrics = {
+        actual_impressions: 1_000_000,
+      };
+      expect(computeBriefScore(metrics)).toBe(0);
+    });
+
+    it('compose all metrics correctly', () => {
+      const metrics: MarketingBriefMetrics = {
+        actual_impressions: 100,
+        actual_clicks: 10,
+        actual_calls: 2,
+        actual_visits: 1,
+        actual_quotes: 1,
+        actual_orders: 1,
+        actual_revenue_cents: 5000, // 50 €
+      };
+      // impression=0*100 + click=1*10 + call=3*2 + visit=2*1 + quote=2*1 + order=10*1 + revenue=0.1*50
+      // = 0 + 10 + 6 + 2 + 2 + 10 + 5 = 35
+      expect(computeBriefScore(metrics)).toBe(35);
+    });
+  });
+});

--- a/backend/src/modules/marketing/marketing-scoring.config.test.ts
+++ b/backend/src/modules/marketing/marketing-scoring.config.test.ts
@@ -16,7 +16,7 @@ describe('Marketing scoring config', () => {
       const w = getMarketingScoringWeights({
         MARKETING_SCORING_CALL: '5',
         MARKETING_SCORING_ORDER: '20',
-      } as NodeJS.ProcessEnv);
+      } as unknown as NodeJS.ProcessEnv);
       expect(w.call).toBe(5);
       expect(w.order).toBe(20);
       // unchanged
@@ -26,21 +26,21 @@ describe('Marketing scoring config', () => {
     it('falls back to default on invalid env value', () => {
       const w = getMarketingScoringWeights({
         MARKETING_SCORING_CALL: 'not-a-number',
-      } as NodeJS.ProcessEnv);
+      } as unknown as NodeJS.ProcessEnv);
       expect(w.call).toBe(MARKETING_SCORING_DEFAULTS.call);
     });
 
     it('falls back to default on empty string', () => {
       const w = getMarketingScoringWeights({
         MARKETING_SCORING_CALL: '',
-      } as NodeJS.ProcessEnv);
+      } as unknown as NodeJS.ProcessEnv);
       expect(w.call).toBe(MARKETING_SCORING_DEFAULTS.call);
     });
 
     it('accepts decimal values (revenue ratio)', () => {
       const w = getMarketingScoringWeights({
         MARKETING_SCORING_REVENUE_EUR_PER_UNIT: '0.05',
-      } as NodeJS.ProcessEnv);
+      } as unknown as NodeJS.ProcessEnv);
       expect(w.revenue_eur_per_unit).toBe(0.05);
     });
   });

--- a/backend/src/modules/marketing/marketing-scoring.config.ts
+++ b/backend/src/modules/marketing/marketing-scoring.config.ts
@@ -60,9 +60,13 @@ const DEFAULT_WEIGHTS: MarketingScoringWeights = {
 /**
  * Lit la config depuis l'env (avec fallback default).
  * Format attendu : ENV var `MARKETING_SCORING_<KEY>` numérique.
+ *
+ * Type signature `Record<string, string | undefined>` plutôt que `NodeJS.ProcessEnv`
+ * pour permettre aux tests d'injecter des objets littéraux sans cast inutile
+ * (NodeJS.ProcessEnv est un index signature opaque côté TS strict).
  */
 export function getMarketingScoringWeights(
-  env: NodeJS.ProcessEnv = process.env,
+  env: Record<string, string | undefined> = process.env,
 ): MarketingScoringWeights {
   const parseFloatOr = (val: string | undefined, fallback: number): number => {
     if (val === undefined || val === '') return fallback;

--- a/backend/src/modules/marketing/marketing-scoring.config.ts
+++ b/backend/src/modules/marketing/marketing-scoring.config.ts
@@ -1,0 +1,127 @@
+/**
+ * Marketing Scoring Config — pondération performance briefs.
+ *
+ * Justification (ADR-036) : la valeur business d'un appel vs un clic vs un
+ * achat n'est pas universelle — chaque shop a son propre arbitrage. On la
+ * met donc en CONFIG avec defaults raisonnables surchargeables par ENV.
+ *
+ * Usage : marketing-lead-agent (Phase 2) calcule un score par brief depuis
+ * `__marketing_brief.actual_*` et trie les briefs par ROI mesuré pour
+ * arbitrer les priorités hebdo.
+ *
+ * Defaults raisonnables (à étalonner après J+15 pilote LOCAL) :
+ *   - call         = 3   (intention forte, contact direct)
+ *   - visit        = 2   (intention moyenne, présence physique)
+ *   - quote        = 2   (intention moyenne, demande devis)
+ *   - click        = 1   (intention faible, exploration)
+ *   - order        = 10  (conversion finale, valeur max)
+ *   - revenue_eur  = 0.1 (1 unité de score par 10 €) — ajustable selon AOV
+ *   - impression   = 0   (vu mais pas cliqué = pas de valeur ROI)
+ *
+ * Override via ENV :
+ *   MARKETING_SCORING_CALL=5
+ *   MARKETING_SCORING_VISIT=3
+ *   MARKETING_SCORING_QUOTE=2
+ *   MARKETING_SCORING_CLICK=1
+ *   MARKETING_SCORING_ORDER=15
+ *   MARKETING_SCORING_REVENUE_EUR_PER_UNIT=0.1
+ *   MARKETING_SCORING_IMPRESSION=0
+ *
+ * Pas de constantes magiques en code (anti-pattern écarté ADR-036 §12).
+ */
+
+export interface MarketingScoringWeights {
+  /** Score par appel téléphone (intention forte). */
+  call: number;
+  /** Score par visite magasin physique. */
+  visit: number;
+  /** Score par demande devis. */
+  quote: number;
+  /** Score par clic (exploration). */
+  click: number;
+  /** Score par commande (conversion finale). */
+  order: number;
+  /** Score par tranche de N euros de revenue. Ratio = score / 1 € revenue. */
+  revenue_eur_per_unit: number;
+  /** Score par impression (default 0 = pas comptabilisé en ROI brut). */
+  impression: number;
+}
+
+const DEFAULT_WEIGHTS: MarketingScoringWeights = {
+  call: 3,
+  visit: 2,
+  quote: 2,
+  click: 1,
+  order: 10,
+  revenue_eur_per_unit: 0.1,
+  impression: 0,
+};
+
+/**
+ * Lit la config depuis l'env (avec fallback default).
+ * Format attendu : ENV var `MARKETING_SCORING_<KEY>` numérique.
+ */
+export function getMarketingScoringWeights(
+  env: NodeJS.ProcessEnv = process.env,
+): MarketingScoringWeights {
+  const parseFloatOr = (val: string | undefined, fallback: number): number => {
+    if (val === undefined || val === '') return fallback;
+    const parsed = Number.parseFloat(val);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  };
+
+  return {
+    call: parseFloatOr(env.MARKETING_SCORING_CALL, DEFAULT_WEIGHTS.call),
+    visit: parseFloatOr(env.MARKETING_SCORING_VISIT, DEFAULT_WEIGHTS.visit),
+    quote: parseFloatOr(env.MARKETING_SCORING_QUOTE, DEFAULT_WEIGHTS.quote),
+    click: parseFloatOr(env.MARKETING_SCORING_CLICK, DEFAULT_WEIGHTS.click),
+    order: parseFloatOr(env.MARKETING_SCORING_ORDER, DEFAULT_WEIGHTS.order),
+    revenue_eur_per_unit: parseFloatOr(
+      env.MARKETING_SCORING_REVENUE_EUR_PER_UNIT,
+      DEFAULT_WEIGHTS.revenue_eur_per_unit,
+    ),
+    impression: parseFloatOr(
+      env.MARKETING_SCORING_IMPRESSION,
+      DEFAULT_WEIGHTS.impression,
+    ),
+  };
+}
+
+/**
+ * Calcule le score d'un brief à partir de ses métriques mesurées.
+ *
+ * Formule simple : somme pondérée des metrics. Pas de pénalité, pas de
+ * normalisation (gérée downstream par le marketing-lead-agent).
+ *
+ * @param metrics      les actual_* d'un brief (peut être partiel)
+ * @param weights      pondération à appliquer (default = getMarketingScoringWeights())
+ * @returns score >= 0
+ */
+export interface MarketingBriefMetrics {
+  actual_impressions?: number;
+  actual_clicks?: number;
+  actual_calls?: number;
+  actual_visits?: number;
+  actual_quotes?: number;
+  actual_orders?: number;
+  actual_revenue_cents?: number;
+}
+
+export function computeBriefScore(
+  metrics: MarketingBriefMetrics,
+  weights: MarketingScoringWeights = getMarketingScoringWeights(),
+): number {
+  const revenueEur = (metrics.actual_revenue_cents ?? 0) / 100;
+  return (
+    (metrics.actual_impressions ?? 0) * weights.impression +
+    (metrics.actual_clicks ?? 0) * weights.click +
+    (metrics.actual_calls ?? 0) * weights.call +
+    (metrics.actual_visits ?? 0) * weights.visit +
+    (metrics.actual_quotes ?? 0) * weights.quote +
+    (metrics.actual_orders ?? 0) * weights.order +
+    revenueEur * weights.revenue_eur_per_unit
+  );
+}
+
+/** Re-export defaults pour usage en test ou audit. */
+export const MARKETING_SCORING_DEFAULTS = DEFAULT_WEIGHTS;

--- a/log.md
+++ b/log.md
@@ -201,3 +201,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/matrix-pr-d3-zero-unmappable`
 - **Décision** : fix(matrix): remove TOCTOU race in inject-agent-role.ts (CodeQL js/file-system-race) (+3 other commits)
 - **Sortie** : PR #239 | commits d62eafab 6d1b7db3 eba3c643 043daeb9
+
+## 2026-04-30 — feat/marketing-phase1-dto-scoring (auto)
+
+- **Branche** : `feat/marketing-phase1-dto-scoring`
+- **Décision** : fix(adr-036-pr1.3): broaden env signature to record (avoids unknown cast) (+2 other commits)
+- **Sortie** : PR #241 | commits d1baf143 a5c86dca 7f4ebdf1


### PR DESCRIPTION
## Summary

**PR-1.3 du plan rev 8 ADR-036** — DTO Zod validation triple verrou + scoring config marketing-lead-agent.

**Stacked sur PR-1.2** (#240) : `base = feat/marketing-phase1-operating-matrix`. Importe les enums depuis `@config/marketing-matrix.types` (single source of truth, évite duplication). Quand #240 mergera, cette PR retargetera automatiquement vers main.

## DTO Zod (defense in depth — triple verrou ADR-036)

`backend/src/modules/marketing/dto/marketing-brief.dto.ts` :

- **`CoverageManifestSchema`** : AEC v1.0.0 obligatoire (5 final_status autorisés alpha-sorted, pas de `COMPLETE/DONE/ALL_FIXED`)
- **`HybridPayloadSchema`** : 5 champs obligatoires + 2 refinements (`cta_ecommerce !== cta_local`, `conversion_goal_* distincts`)
- **`CreateMarketingBriefSchema`** : DTO insertion principale avec 2 refinements custom :
  1. `business_unit × channel` cohérence (`LOCAL=[gbp,local_landing,sms]` `ECOMMERCE=[website_seo,email,social_*]` `HYBRID=any`)
  2. `HYBRID` payload obligatoire (parse vers `HybridPayloadSchema`)
- Helper `isCoherentUnitChannel()` exposé pour réutilisation côté `brand-compliance-gate.service`
- `UpdateBriefStatusSchema` : workflow admin (draft → reviewed → approved → published → archived)
- `RecordBriefFeedbackSchema` : saisie métriques admin (8 sources enum)
- `BrandGateVerdictSchema` : retour `brand-compliance-gate` (`PASS/WARN/FAIL` cohérent `__marketing_social_posts`)

## Scoring config

`backend/src/modules/marketing/marketing-scoring.config.ts` :

| Metric | Default weight | Override env |
|---|---|---|
| call | 3 | `MARKETING_SCORING_CALL` |
| visit | 2 | `MARKETING_SCORING_VISIT` |
| quote | 2 | `MARKETING_SCORING_QUOTE` |
| click | 1 | `MARKETING_SCORING_CLICK` |
| order | 10 | `MARKETING_SCORING_ORDER` |
| revenue_eur_per_unit | 0.1 | `MARKETING_SCORING_REVENUE_EUR_PER_UNIT` |
| impression | 0 | `MARKETING_SCORING_IMPRESSION` |

- `getMarketingScoringWeights(env)` : lit ENV avec fallback default + parseFloat tolérant (NaN/empty → fallback)
- `computeBriefScore(metrics, weights?)` : somme pondérée
- Pas de constantes magiques en code (anti-pattern écarté ADR-036 §12)

## Tests

`marketing-scoring.config.test.ts` : 12 assertions
- 5 sur `getMarketingScoringWeights` (defaults, override, NaN, empty, decimals)
- 7 sur `computeBriefScore` (empty, defaults, undefined fields, revenue conversion, custom weights, impressions zero-weight, all-metrics composé)

## Test plan

- [x] TypeScript strict pass (`npx tsc --noEmit` projet entier)
- [x] Commit signé G3
- [ ] CI globale verte (TypeScript, ESLint, Backend Tests dont nouveau test)
- [ ] PR #240 mergée d'abord → cette PR retargete main → admin-merge

## Anti-patterns écartés

- Pas de constantes magiques (`DEFAULT_WEIGHTS const`, override env)
- Pas d'invention `BLOCK/WARN/PASS` (`PASS/WARN/FAIL` adopté)
- Pas de duplication enums (import depuis PR-1.2 single source)
- Pas de validation `if/throw` ad-hoc (Zod refinements + types inférés)
- Pas de CHECK SQL dupliqué en code dur (helper `isCoherentUnitChannel` exposé)

## Références

- Plan rev 8 : `/home/deploy/.claude/plans/verifier-la-strategie-une-piped-hummingbird.md`
- ADR-036 : https://github.com/ak125/governance-vault/blob/main/ledger/decisions/adr/ADR-036-marketing-operating-layer.md
- PR-1.1 (#238) : DB migration
- PR-1.2 (#240) : MarketingMatrixService

🤖 Generated with [Claude Code](https://claude.com/claude-code)