### PR TITLE
ci(preprod): retire ALLOW_PROD_ENV_COPY + SERVICE_ROLE_KEY — ADR-028 Option D Phase A

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,12 +697,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: 🧪 Deploy to PREPROD
+      - name: 🧪 Deploy to PREPROD (read-only hardening — ADR-028 Option D)
         env:
+          # Couche 1+2 ADR-028 Option D : aucune SERVICE_ROLE_KEY distribuée au conteneur préprod
+          # (privilege downgrade + anon key only). Voir ADR-021 RLS hardening (couche 3) +
+          # READ_ONLY guard backend (couche 4, PR 2B) + write-detect (couche 5, PR 2B).
           NODE_ENV: preprod
-          ALLOW_PROD_ENV_COPY: "1"
-          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          READ_ONLY: "true"
         run: |
           docker pull massdoc/nestjs-remix-monorepo:preprod
 
@@ -712,22 +715,21 @@ jobs:
           # Copier docker-compose.preprod.yml
           cp $GITHUB_WORKSPACE/docker-compose.preprod.yml $PREPROD_DIR/
 
-          # Copier le .env de prod (controle par flag)
-          if [ "${ALLOW_PROD_ENV_COPY:-0}" = "1" ] && [ -f ~/production/.env ]; then
-            echo "⚠️  ALLOW_PROD_ENV_COPY=1 enabled: copying production env (should be temporary)"
-            cp ~/production/.env "$PREPROD_DIR/.env"
-          else
-            echo "ℹ️  Skipping prod env copy (default safe mode)"
-          fi
+          # Génération in-place .env.preprod minimal
+          # Plus de copie de ~/production/.env (ALLOW_PROD_ENV_COPY supprimé — voir plan AI-COS rev5).
+          cat > "$PREPROD_DIR/.env" <<EOF
+          NODE_ENV=preprod
+          SUPABASE_URL=${SUPABASE_URL}
+          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+          READ_ONLY=true
+          REDIS_URL=redis://redis-preprod:6379
+          APP_URL=http://localhost:3200
+          PORT=3200
+          EOF
 
           cd $PREPROD_DIR
 
-          # Inject Supabase keys from GitHub Secrets (overrides .env values)
-          if [ -n "$SUPABASE_SECRET_KEY" ] && [ -f ".env" ]; then
-            sed -i "s|^SUPABASE_SERVICE_ROLE_KEY=.*|SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SECRET_KEY}|" .env
-            sed -i "s|^SUPABASE_ANON_KEY=.*|SUPABASE_ANON_KEY=${SUPABASE_PUBLISHABLE_KEY}|" .env
-            echo "✅ Supabase keys injected from GitHub Secrets"
-          fi
+          echo "✅ .env.preprod generated (anon key only, no SERVICE_ROLE_KEY, READ_ONLY=true)"
 
           # Arreter anciens conteneurs
           docker stop nestjs-remix-monorepo-preprod redis-preprod 2>/dev/null || true


### PR DESCRIPTION
## Summary

Hardening minimal preprod (PR 2A du plan AI-COS rev5, Phase A read-only). Couches 1+2 d'ADR-028 Option D appliquées :

- **Couche 1 (privilege downgrade)** : `SUPABASE_SERVICE_ROLE_KEY` n'est plus distribuée au conteneur preprod
- **Couche 2 (anon key only)** : `SUPABASE_ANON_KEY` exclusif

Les couches 3-5 (RLS hardening ADR-021 + READ_ONLY guard backend + write-detect job CI) seront livrées en **PR 2B** (split conditionnel justifié par grep préalable — voir §"READ_ONLY coverage" ci-dessous).

## Changements ci.yml lignes 700-735

- ❌ `ALLOW_PROD_ENV_COPY: "1"` → retiré (env var)
- ❌ `SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}` → retiré (env var)
- ❌ `cp ~/production/.env "$PREPROD_DIR/.env"` → retiré (transmettait credentials prod)
- ❌ Bloc `sed -i "s|^SUPABASE_SERVICE_ROLE_KEY=.*..."` → retiré (injectait SERVICE_ROLE_KEY)
- ✅ Génération in-place `.env.preprod` minimal via heredoc (NODE_ENV / SUPABASE_URL / SUPABASE_ANON_KEY / READ_ONLY=true / REDIS_URL / APP_URL / PORT)
- ✅ `READ_ONLY=true` env var ajoutée (consommée par le backend en PR 2B via guard)

## READ_ONLY coverage (verrou n°1 plan rev5 — preliminary scope PR 2A)

PR 2A applique uniquement les couches 1+2 (CI-level). Pas de guard backend dans cette PR — c'est PR 2B.

**Grep préalable (verrou n°1)** déjà effectué pour préparer PR 2B :

- Supabase client centralisé : **NON** — 10+ fichiers `createClient` direct (`config/write-guard-cas`, `config/write-guard-ledger`, `config/content-write-gate`, `seo-monitoring/controllers/seo-monitoring`, `seo-monitoring/services/gsc-links-fetcher`, `seo/internal-linking`, `seo-monitoring/services/cwv-fetcher`, `seo-monitoring/services/r-content-auditor`, etc.)
- `SupabaseBaseService` héritage : 15+ services (CartValidation, Gamme, Substitution, Archives, SEO, Sitemap, Legal, Quote, Vehicles, etc.)
- WriteGuard pattern existant : `WriteGuardCasService` (P1.5), `WriteGuardLedgerService`, `ContentWriteGateService`, `WriteGuardModule`, `WriteGuardLockService`
- **Décision PR 2B** : Option 1+3 hybride (étendre `SupabaseBaseService` + `WriteGuardModule` existants pour respecter `READ_ONLY=true`, ajouter check au boot pour les 10+ `createClient` directs, write-detect CI comme couche 5)
- Services NON couverts par PR 2A : tous (PR 2A ne touche pas backend) — c'est délibéré (split du scope per plan rev5)

## Test plan

- [ ] CI vert (lint, typecheck, test, test-frontend, security, core-build, import-firewall, rpc-gate-check, governance-check, gitleaks, migration-safety, build, deploy)
- [ ] Job `🧪 Deploy to PREPROD` passe (smoke tests catalog/families, /, /pieces/catalogue, admin guards)
- [ ] Aucune référence `ALLOW_PROD_ENV_COPY` active dans `.github/workflows/ci.yml` job preprod (vérifié: 1 match restant = commentaire explicatif ligne 719)
- [ ] `SUPABASE_SERVICE_ROLE_KEY` absent de la section preprod (lignes 700-735) — vérifié: 0 match
- [ ] `READ_ONLY=true` injecté dans `.env.preprod` du conteneur

## Risk

**Modéré** — risque qu'un chemin code preprod tente une écriture avec anon key. Atténué par :
- ADR-021 RLS hardening (couche 3, 204 objets DB hardenizés)
- Risque résiduel sur tables créées post-ADR-021 sans RLS → couvert par PR 2B (READ_ONLY guard backend)

**Pas un blocage** : le smoke test deploy preprod actuel ne fait que des GET (curl /health, /api/catalog/families, /, /pieces/catalogue, admin guards) — aucune écriture. Audit `ci.yml:700-799` confirme read-only en pratique, c'est précisément ce qui justifie l'Option D ($0/mois) au lieu d'Option C ($10-20/mois Supabase branch).

## Hors scope

- **PR 2B** (à venir) : Backend READ_ONLY guard (Option 1+3 hybride) + write-detect job + RPC whitelist + section "READ_ONLY coverage" complète
- **PR 3 vault** (à venir) : ADR-028 réécrit Option D directement, après PR 2A+2B mergées
- **PR 4 vault** (à venir) : Routine pilote `supabase-cost-check` V1

## Références

- ADR-034 AI-COS Operating Contract (mergé vault `a0e0b51`, 2026-04-30)
- ADR-021 RLS Hardening
- Plan: \`/home/deploy/.claude/plans/harmonic-mapping-elephant.md\` (rev5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)