### PR TITLE
chore: revert PR #242 — restore SERVICE_ROLE_KEY (PR 2A blocked by missing DEV_SUPABASE_KEY)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,15 +697,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: 🧪 Deploy to PREPROD (read-only hardening — ADR-028 Option D)
+      - name: 🧪 Deploy to PREPROD
         env:
-          # Couche 1+2 ADR-028 Option D : aucune SERVICE_ROLE_KEY distribuée au conteneur préprod
-          # (privilege downgrade + anon key only). Voir ADR-021 RLS hardening (couche 3) +
-          # READ_ONLY guard backend (couche 4, PR 2B) + write-detect (couche 5, PR 2B).
           NODE_ENV: preprod
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          READ_ONLY: "true"
+          ALLOW_PROD_ENV_COPY: "1"
+          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: |
           docker pull massdoc/nestjs-remix-monorepo:preprod
 
@@ -715,21 +712,22 @@ jobs:
           # Copier docker-compose.preprod.yml
           cp $GITHUB_WORKSPACE/docker-compose.preprod.yml $PREPROD_DIR/
 
-          # Génération in-place .env.preprod minimal
-          # Plus de copie de ~/production/.env (ALLOW_PROD_ENV_COPY supprimé — voir plan AI-COS rev5).
-          cat > "$PREPROD_DIR/.env" <<EOF
-          NODE_ENV=preprod
-          SUPABASE_URL=${SUPABASE_URL}
-          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
-          READ_ONLY=true
-          REDIS_URL=redis://redis-preprod:6379
-          APP_URL=http://localhost:3200
-          PORT=3200
-          EOF
+          # Copier le .env de prod (controle par flag)
+          if [ "${ALLOW_PROD_ENV_COPY:-0}" = "1" ] && [ -f ~/production/.env ]; then
+            echo "⚠️  ALLOW_PROD_ENV_COPY=1 enabled: copying production env (should be temporary)"
+            cp ~/production/.env "$PREPROD_DIR/.env"
+          else
+            echo "ℹ️  Skipping prod env copy (default safe mode)"
+          fi
 
           cd $PREPROD_DIR
 
-          echo "✅ .env.preprod generated (anon key only, no SERVICE_ROLE_KEY, READ_ONLY=true)"
+          # Inject Supabase keys from GitHub Secrets (overrides .env values)
+          if [ -n "$SUPABASE_SECRET_KEY" ] && [ -f ".env" ]; then
+            sed -i "s|^SUPABASE_SERVICE_ROLE_KEY=.*|SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SECRET_KEY}|" .env
+            sed -i "s|^SUPABASE_ANON_KEY=.*|SUPABASE_ANON_KEY=${SUPABASE_PUBLISHABLE_KEY}|" .env
+            echo "✅ Supabase keys injected from GitHub Secrets"
+          fi
 
           # Arreter anciens conteneurs
           docker stop nestjs-remix-monorepo-preprod redis-preprod 2>/dev/null || true


### PR DESCRIPTION
## Summary

**Hotfix urgent** : revert PR #242 (\`c2b778b8\`) qui retirait \`SUPABASE_SERVICE_ROLE_KEY\` du déploiement preprod sans avoir d'abord modifié \`SupabaseBaseService\` pour supporter le mode anon key only.

## Pourquoi

\`SupabaseBaseService:109-114\` throw inconditionnellement \`ConfigurationException\` si \`supabaseServiceKey\` absent — y compris en preprod. PR #242 a retiré la SERVICE_ROLE_KEY du \`.env.preprod\` généré, donc le boot du conteneur preprod va crasher au prochain redéploiement.

Diagnostic post-merge : aucun secret \`DEV_SUPABASE_KEY\` n'existe dans gh secrets monorepo, donc le pattern existant \`DEV_KILL_SWITCH\` ne peut pas servir de fallback (le \`effectiveKey\` retombe sur \`SUPABASE_SERVICE_ROLE_KEY\` qui n'existe plus dans le \`.env.preprod\`).

## Bon ordre revisé

L'ordre canonique du plan AI-COS rev5 doit être :

1. **PR 2B** (à venir) : modifier \`SupabaseBaseService\` pour respecter \`READ_ONLY=true\` + utiliser \`SUPABASE_ANON_KEY\` quand SERVICE_ROLE_KEY absent. Plus de throw inconditionnel sur SERVICE_ROLE_KEY si READ_ONLY=true et ANON_KEY présent.
2. **PR 2A reprise** (après PR 2B mergée) : ci.yml retire ALLOW_PROD_ENV_COPY + retire SERVICE_ROLE_KEY + injecte READ_ONLY=true + ANON_KEY only.

PR #242 a fait l'inverse → revert + reprise dans le bon ordre.

## Files

Annulation des changements de \`.github/workflows/ci.yml\` lignes 700-735 : restoration de l'état avant PR #242.

## Test plan

- [ ] CI vert (lint, typecheck, tests, build)
- [ ] Deploy preprod réussit sans throw ConfigurationException
- [ ] Smoke tests catalog/families, /, /pieces/catalogue, admin guards passent

## Risk

**Faible** — restoration d'un état stable connu. Le risque latent "preprod écrit prod avec SERVICE_ROLE_KEY" reste mais c'était déjà l'état avant PR #242.

## Suite

PR 2B sera créée immédiatement après merge de ce revert. Plan AI-COS rev5 mis à jour avec leçon apprise (séquencement PR 2B → PR 2A).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)