### PR TITLE
feat(backend): SupabaseBaseService READ_ONLY mode + ANON_KEY fallback — ADR-028 Option D Phase B

### DIFF
--- a/backend/src/config/app.config.ts
+++ b/backend/src/config/app.config.ts
@@ -10,6 +10,8 @@ export interface AppConfig {
   supabase: {
     url: string;
     serviceKey: string;
+    anonKey: string;
+    readOnly: boolean;
   };
   redis: {
     url?: string;
@@ -29,6 +31,8 @@ export function createAppConfig(): AppConfig {
     supabase: {
       url: process.env.SUPABASE_URL || '',
       serviceKey: process.env.SUPABASE_SERVICE_ROLE_KEY || '',
+      anonKey: process.env.SUPABASE_ANON_KEY || '',
+      readOnly: process.env.READ_ONLY === 'true',
     },
     redis: {
       url: process.env.REDIS_URL,
@@ -46,6 +50,15 @@ export function createAppConfig(): AppConfig {
     throw new ConfigurationException({
       code: ErrorCodes.CONFIG.MISSING,
       message: 'SUPABASE_SERVICE_ROLE_KEY is required in production',
+    });
+  }
+
+  // ADR-028 Option D : READ_ONLY mode requires SUPABASE_ANON_KEY (privilege downgrade)
+  if (config.supabase.readOnly && !config.supabase.anonKey) {
+    throw new ConfigurationException({
+      code: ErrorCodes.CONFIG.MISSING,
+      message:
+        'READ_ONLY=true requires SUPABASE_ANON_KEY (ADR-028 Option D — anon key + RLS protection per ADR-021)',
     });
   }
 

--- a/backend/src/database/services/supabase-base.service.ts
+++ b/backend/src/database/services/supabase-base.service.ts
@@ -83,6 +83,9 @@ export abstract class SupabaseBaseService {
   // Kill-switch DEV: Track if running in read-only mode
   protected readonly isDevKillSwitchEnabled: boolean;
 
+  // ADR-028 Option D: READ_ONLY mode (preprod hardening — anon key only, RLS protection)
+  protected readonly isReadOnlyMode: boolean;
+
   constructor(protected configService?: ConfigService) {
     // Context7 : Resilient configuration loading
     const appConfig = getAppConfig();
@@ -106,11 +109,23 @@ export abstract class SupabaseBaseService {
       });
     }
 
+    // ADR-028 Option D: READ_ONLY mode preprod — fallback to anon key when SERVICE_ROLE_KEY absent
+    // (privilege downgrade + RLS protection per ADR-021, no SERVICE_ROLE_KEY distributed in preprod)
+    this.isReadOnlyMode = appConfig.supabase.readOnly;
     if (!this.supabaseServiceKey) {
-      throw new ConfigurationException({
-        code: ErrorCodes.DATABASE.CONFIG_MISSING,
-        message: 'SUPABASE_SERVICE_ROLE_KEY not found in environment variables',
-      });
+      if (this.isReadOnlyMode && appConfig.supabase.anonKey) {
+        this.supabaseServiceKey = appConfig.supabase.anonKey;
+        this.logger.warn(
+          '🔒 READ_ONLY mode active — using SUPABASE_ANON_KEY (no SERVICE_ROLE_KEY distributed). RLS hardening (ADR-021) protects writes.',
+        );
+      } else {
+        throw new ConfigurationException({
+          code: ErrorCodes.DATABASE.CONFIG_MISSING,
+          message: this.isReadOnlyMode
+            ? 'READ_ONLY=true requires SUPABASE_ANON_KEY when SUPABASE_SERVICE_ROLE_KEY is absent (ADR-028 Option D)'
+            : 'SUPABASE_SERVICE_ROLE_KEY not found in environment variables',
+        });
+      }
     }
 
     // 🔒 Kill-switch DEV: Use dev_readonly key in non-production when enabled
@@ -207,7 +222,11 @@ export abstract class SupabaseBaseService {
     this.logger.log(
       `🔑 Service key present: ${this.supabaseServiceKey ? 'Yes' : 'No'}`,
     );
-    if (this.isDevKillSwitchEnabled) {
+    if (this.isReadOnlyMode) {
+      this.logger.warn(
+        `🔒 READ_ONLY mode ACTIVE (ADR-028 Option D) — anon key only, RLS protects writes per ADR-021`,
+      );
+    } else if (this.isDevKillSwitchEnabled) {
       this.logger.warn(`🔒 Kill-switch DEV: ACTIVE - READ-ONLY mode enabled`);
       this.logger.warn(`🔓 RLS: NOT bypassed (using dev_readonly role)`);
     } else {


### PR DESCRIPTION
## Summary

Étend \`SupabaseBaseService\` pour supporter le mode \`READ_ONLY=true\` (couches 1+2 d'ADR-028 Option D : privilege downgrade + anon key only, RLS protection per ADR-021).

**Bon ordre canonique** (post-incident PR #242→#244) :
1. **PR 2B (cette PR)** — backend tolérant à l'absence de SERVICE_ROLE_KEY si READ_ONLY=true + ANON_KEY présent
2. **PR 2A reprise (à venir)** — \`ci.yml\` retire SERVICE_ROLE_KEY du \`.env.preprod\` (sera safe car backend ne crash plus)
3. **PR 2C (futur)** — étendre les 10+ services \`createClient\` direct (write-guard-*, seo-monitoring/*) au mode READ_ONLY

## Changements

### \`backend/src/config/app.config.ts\`

- \`AppConfig.supabase\` ajoute \`anonKey: string\` (lit \`SUPABASE_ANON_KEY\`)
- \`AppConfig.supabase\` ajoute \`readOnly: boolean\` (lit \`READ_ONLY=true\`)
- Validation : si \`readOnly=true\` ET \`anonKey\` absent → throw \`ConfigurationException\` explicite

### \`backend/src/database/services/supabase-base.service.ts\`

- Nouveau field \`isReadOnlyMode\` (lit \`appConfig.supabase.readOnly\`)
- Si \`SERVICE_ROLE_KEY\` absent ET \`isReadOnlyMode=true\` ET \`anonKey\` présent → fallback à anon key avec log warn explicite
- Sinon → throw \`ConfigurationException\` avec message contextuel précisant le mode
- Logger init affiche le mode actif : READ_ONLY (ADR-028 Option D) / Kill-switch DEV / SERVICE_ROLE bypass

## READ_ONLY coverage (verrou n°1 plan rev5 — Phase B partial)

| Couverture backend | Status |
|---|---|
| \`SupabaseBaseService\` (héritage 15+ services) | ✅ COUVERT par cette PR |
| 10+ services avec \`createClient\` direct | ❌ NON couvert (différé à PR 2C) |
| \`WriteGuardCasService\`, \`WriteGuardLedgerService\`, \`ContentWriteGateService\` | ❌ NON couvert (différé à PR 2C) |
| Smoke tests preprod actuels (catalog/families, /, /pieces/catalogue, admin guards) | ✅ Lecture only — passent par services héritant de SupabaseBaseService |

**Décision retenue** : Option 1 partial (SupabaseBaseService SEULEMENT). Option 3 hybride complète différée pour limiter la taille de la diff et permettre review rigoureuse.

## Pas de breaking change

Code prod actuel non modifié. \`READ_ONLY\` env var absente par défaut → comportement inchangé. Pas de risque sur prod (\`NODE_ENV=production\`).

## Test plan

- [ ] CI vert (ESLint, TypeScript, Backend Tests, Frontend Tests, Security Audit)
- [ ] Pas de régression sur les 15+ services héritant de SupabaseBaseService
- [ ] Smoke tests preprod (au prochain merge sur main) passent en mode actuel (READ_ONLY=false par défaut)

## Risk

**Faible** — modification additive, pas de changement de comportement par défaut. Le mode READ_ONLY n'est activé que si la variable d'environnement \`READ_ONLY=true\` est explicitement définie (sera fait par PR 2A reprise dans \`.env.preprod\`).

## Hors scope

- **PR 2A reprise** (séquence post-merge) : \`ci.yml\` retire \`ALLOW_PROD_ENV_COPY\` + \`SERVICE_ROLE_KEY\` + ajoute \`READ_ONLY=true\`
- **PR 2C** (futur) : extension des 10+ services \`createClient\` direct
- **PR 3 vault** (post PR 2A reprise) : ADR-028 réécrit Option D accepted

## Références

- ADR-034 (mergé vault \`a0e0b51\`, 2026-04-30) — AI-COS Operating Contract
- ADR-021 — RLS Hardening (couche 3 de défense, base de cette stratégie)
- Mémoire \`feedback_read_backend_before_modifying_ci.md\` — leçon de l'incident PR #242→#244
- Plan: \`/home/deploy/.claude/plans/harmonic-mapping-elephant.md\` (rev5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)