### PR TITLE
ci(preprod): retire ALLOW_PROD_ENV_COPY + SERVICE_ROLE_KEY — ADR-028 Option D Phase A reprise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,12 +697,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: 🧪 Deploy to PREPROD
+      - name: 🧪 Deploy to PREPROD (read-only hardening — ADR-028 Option D)
         env:
+          # ADR-028 Option D : couches 1+2 (privilege downgrade + anon key only).
+          # Le backend supporte ce mode depuis PR #246 (SupabaseBaseService READ_ONLY
+          # mode + ANON_KEY fallback, commit dfd81673). RLS protection enforce les
+          # writes restantes (couche 3, ADR-021, 204 objets DB hardenizés).
           NODE_ENV: preprod
-          ALLOW_PROD_ENV_COPY: "1"
-          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          READ_ONLY: "true"
         run: |
           docker pull massdoc/nestjs-remix-monorepo:preprod
 
@@ -712,22 +716,22 @@ jobs:
           # Copier docker-compose.preprod.yml
           cp $GITHUB_WORKSPACE/docker-compose.preprod.yml $PREPROD_DIR/
 
-          # Copier le .env de prod (controle par flag)
-          if [ "${ALLOW_PROD_ENV_COPY:-0}" = "1" ] && [ -f ~/production/.env ]; then
-            echo "⚠️  ALLOW_PROD_ENV_COPY=1 enabled: copying production env (should be temporary)"
-            cp ~/production/.env "$PREPROD_DIR/.env"
-          else
-            echo "ℹ️  Skipping prod env copy (default safe mode)"
-          fi
+          # Génération in-place .env.preprod minimal (anon key only, READ_ONLY=true).
+          # Plus de copie de ~/production/.env (ALLOW_PROD_ENV_COPY supprimé).
+          # Plus de SUPABASE_SERVICE_ROLE_KEY distribuée au conteneur preprod.
+          cat > "$PREPROD_DIR/.env" <<EOF
+          NODE_ENV=preprod
+          SUPABASE_URL=${SUPABASE_URL}
+          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+          READ_ONLY=true
+          REDIS_URL=redis://redis-preprod:6379
+          APP_URL=http://localhost:3200
+          PORT=3200
+          EOF
 
           cd $PREPROD_DIR
 
-          # Inject Supabase keys from GitHub Secrets (overrides .env values)
-          if [ -n "$SUPABASE_SECRET_KEY" ] && [ -f ".env" ]; then
-            sed -i "s|^SUPABASE_SERVICE_ROLE_KEY=.*|SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SECRET_KEY}|" .env
-            sed -i "s|^SUPABASE_ANON_KEY=.*|SUPABASE_ANON_KEY=${SUPABASE_PUBLISHABLE_KEY}|" .env
-            echo "✅ Supabase keys injected from GitHub Secrets"
-          fi
+          echo "✅ .env.preprod generated (anon key only, no SERVICE_ROLE_KEY, READ_ONLY=true)"
 
           # Arreter anciens conteneurs
           docker stop nestjs-remix-monorepo-preprod redis-preprod 2>/dev/null || true


### PR DESCRIPTION
## Summary

**Reprise de la PR #242** (revertée par #244 le 2026-04-30T21:42Z après détection du risque de crash boot). Maintenant safe car le backend supporte le mode READ_ONLY depuis **PR #246 mergée** (commit \`dfd81673\`, 22:04:13Z).

Couches 1+2 d'ADR-028 Option D appliquées :
- **Couche 1 (privilege downgrade)** : SERVICE_ROLE_KEY n'est plus distribuée au conteneur preprod
- **Couche 2 (anon key only)** : SUPABASE_ANON_KEY exclusif

## Bon ordre rétabli

| Étape | Repo | Status |
|---|---|---|
| 1. Backend READ_ONLY support (PR #246) | monorepo | ✅ MERGED \`dfd81673\` |
| 2. Cette PR — ci.yml hardening | monorepo | 🟡 OPEN |
| 3. PR 3 vault — ADR-028 reviser Option D accepted | vault | ⏸ à suivre |

## Pourquoi safe maintenant

\`SupabaseBaseService\` (PR #246) détecte \`READ_ONLY=true\` + \`SUPABASE_ANON_KEY\` présent + \`SUPABASE_SERVICE_ROLE_KEY\` absent → fallback à anon key avec log warn :

```
🔒 READ_ONLY mode active — using SUPABASE_ANON_KEY (no SERVICE_ROLE_KEY distributed). RLS hardening (ADR-021) protects writes.
```

Plus de \`ConfigurationException\` au boot. Le déploiement preprod fonctionnera.

## Changements (identique PR #242 contenu, safe contexte)

- Retire \`ALLOW_PROD_ENV_COPY: "1"\` env var
- Retire \`SUPABASE_SECRET_KEY\` env var (mappait SERVICE_ROLE_KEY)
- Retire \`cp ~/production/.env\` (transmettait credentials prod)
- Retire bloc \`sed\` qui injectait SERVICE_ROLE_KEY
- Ajoute génération in-place \`.env.preprod\` minimal via heredoc
- Ajoute \`READ_ONLY=true\` env var (consommée par PR #246)

## Risk

**Faible** — risque de crash boot levé par PR #246. Risque résiduel d'écriture preprod en prod atténué par 5 couches de défense :

1. Pas de SERVICE_ROLE_KEY distribuée [cette PR]
2. Anon key only [cette PR]
3. RLS hardening ADR-021 [déjà déployé, 204 objets DB]
4. READ_ONLY guard backend [PR #246]
5. write-detect job CI [PR 2C futur]

Risque résiduel : tables créées post-ADR-021 sans RLS activée pourraient accepter writes anon. Couvert par couches 4+5.

## Test plan

- [ ] CI vert (lint, typecheck, tests, build)
- [ ] Job 🧪 Deploy PREPROD passe sans ConfigurationException au boot
- [ ] Smoke tests catalog/families, /, /pieces/catalogue, admin guards passent
- [ ] Logs container preprod : "🔒 READ_ONLY mode active" warning visible

## Hors scope

- **PR 2C** (futur) : extension des 10+ services \`createClient\` direct (write-guard-*, seo-monitoring/*) au mode READ_ONLY + write-detect job CI
- **PR 3 vault** : ADR-028 réécrit Option D accepted

## Références

- ADR-034 vault (mergé \`a0e0b51\`) — AI-COS Operating Contract
- PR #246 monorepo (mergée \`dfd81673\`) — SupabaseBaseService READ_ONLY support
- Mémoire \`feedback_read_backend_before_modifying_ci.md\` — leçon de l'incident PR #242→#244
- Plan: \`/home/deploy/.claude/plans/harmonic-mapping-elephant.md\` (rev5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)