### PR TITLE
feat(adr-033-pr-b): workspace workspaces/wiki/ + skill wiki-proposal-writer

### DIFF
--- a/workspaces/wiki/.claude/rules/agent-exit-contract.md
+++ b/workspaces/wiki/.claude/rules/agent-exit-contract.md
@@ -1,0 +1,83 @@
+# Rules — Agent Exit Contract (AEC)
+
+> **Source de vérité canonique** — règles obligatoires de sortie pour TOUT agent, run, audit, ou analyse au 2026-04-28.
+> **Version** : 1.0.0 | **Status** : CANON
+> **Taxonomie** : règle transverse — s'applique avant les règles spécifiques de domaine (T*, G*, Q*, AP*).
+
+Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
+
+---
+
+## Règles fondamentales
+
+1. **Jamais de correction automatique.** Un agent scanne, analyse, propose — il ne modifie RIEN sans validation humaine explicite.
+2. **Jamais d'overclaim.** Les phrases "tout scanné/vérifié/corrigé", "100% couvert", "aucun problème", "audit complet" (FR/EN) sont **interdites** sans coverage manifest.
+3. **Séparation obligatoire** de 5 états dans tout rapport : `scan` | `analysis` | `correction (proposée)` | `validation` | `verdict`.
+
+## Statuts autorisés / interdits
+
+| Autorisés | Interdits |
+|-----------|-----------|
+| `PARTIAL_COVERAGE` | `PROJECT_FULLY_SCANNED` |
+| `SCOPE_SCANNED` | `ALL_FIXED`, `COMPLETE`, `DONE` |
+| `REVIEW_REQUIRED` | `NO_ISSUES`, `PATCH_APPLIED` |
+| `VALIDATED_FOR_SCOPE_ONLY` | `AUTO_FIXED` |
+| `INSUFFICIENT_EVIDENCE` | |
+
+Verdict par défaut = `PARTIAL_COVERAGE` ou `INSUFFICIENT_EVIDENCE`, jamais `COMPLETE`.
+
+Pour déclarer `SCOPE_SCANNED` : fournir nombre exact de fichiers lus, répertoires parcourus, exclusions, et au moins 1 evidence par conclusion.
+
+## Coverage manifest obligatoire
+
+Tout run/audit DOIT produire :
+
+```
+scope_requested / scope_actually_scanned / files_read_count
+excluded_paths / unscanned_zones (OBLIGATOIRE même si vide)
+corrections_proposed (JAMAIS appliquées auto) / validation_executed
+remaining_unknowns (OBLIGATOIRE) / final_status (statut autorisé)
+```
+
+`corrections_applied` doit être vide/absent sauf validation humaine explicite.
+
+## Reformulation obligatoire
+
+- "Tout scanné" → "Scan du périmètre X terminé"
+- "Tout corrigé" → "N recommandations proposées, en attente de validation humaine"
+- "100% couvert" → "Couverture estimée à N% sur le périmètre X"
+
+## Decision Dossiers
+
+Inclure Section 13 (Coverage Manifest) + Section 14 (Exit Conditions). Verdict `PASS` si toutes conditions section 14 cochées.
+
+---
+
+## Distribution canonique
+
+Ce fichier est la **source unique**. Les copies dans les repos applicatifs sont synchronisées via mécanisme `canon-publish` :
+
+1. **Source de vérité** : ce fichier (`governance-vault/ledger/rules/rules-agent-exit-contract.md`)
+2. **Hash SHA-256 publié** : `99-meta/canon-hashes.json` clé `aec` (à créer Phase B.1.b)
+3. **Copies dérivées dans les repos applicatifs** :
+   - `automecanik-wiki/_meta/agent-exit-contract.md`
+   - `automecanik-raw/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`
+4. **Vérification CI** : chaque repo applicatif inclut un workflow `agent-exit-contract-hash.yml` qui compare le hash de sa copie locale vs `99-meta/canon-hashes.json` (via `gh api`)
+5. **Mise à jour** : modification de ce fichier → workflow `canon-publish.yml` (à créer Phase B.1.c) ouvre une PR auto dans chaque repo applicatif pour resync. Auto-merge avec label `canon-sync` autorisé.
+
+## Versionnage
+
+Bump majeur (X.0) = nouvelle règle ou statut interdit ajouté. Bump mineur (X.Y) = clarification / précision. Bump patch (X.Y.Z) = typo / formatting.
+
+| Version | Date | Changements |
+|---|---|---|
+| 1.0.0 | 2026-04-28 | Canonisation depuis copies orphelines monorepo + seo-batch (drift constaté empiriquement). Ajout §"Distribution canonique". |
+
+## Référence
+
+- ADR-031 — Raw / Wiki / RAG / SEO Separation (à créer post-Phase C)
+- `rules-engineering-quality.md` (Q1-Q4 — solution structurelle vs bricolage)
+- `rules-ai-antipatterns.md` (AP-* — anti-patterns IA)
+- `rules-governance-process.md` (G5-G8 — processus)

--- a/workspaces/wiki/.claude/rules/wiki-batch.md
+++ b/workspaces/wiki/.claude/rules/wiki-batch.md
@@ -1,0 +1,132 @@
+# Règles Wiki Batch
+
+S'applique aux runs depuis `workspaces/wiki/`. Complète (sans les remplacer) les règles génériques monorepo (`/opt/automecanik/app/CLAUDE.md`) + le canon ADR-033 (`automecanik-wiki/_meta/schema/frontmatter.schema.json`) + le contrat AEC (`agent-exit-contract.md`).
+
+## Sources de vérité
+
+- **Canon frontmatter wiki** : `automecanik-wiki/_meta/schema/frontmatter.schema.json` v2.0.0 (Draft 2020-12). Source unique pour la structure des fiches `proposals/<slug>.md` et `wiki/<entity_type>/<slug>.md`.
+- **Canon contract data downstream** : `automecanik-rag/docs/GAMME_PAGE_CONTRACT.md` v2.0 (PR-A.rag mergée 2026-04-30 commit `224e4c63`). Décrit le shape `GammeContentContract.v2.0` produit par le pipeline RAG.
+- **ADR-031** : 4-layer raw/wiki/exports/consumers (`governance-vault/ledger/decisions/adr/ADR-031-four-layer-content-architecture.md`)
+- **ADR-032** : diagnostic & maintenance unification (cohabitation `entity_data.maintenance{}` avec `diagnostic_relations[]`)
+- **ADR-033** : wiki gamme `diagnostic_relations[]` contract — `governance-vault/ledger/decisions/adr/ADR-033-wiki-gamme-diagnostic-relations-contract.md` (status `accepted` 2026-04-29, PR vault #108 commit `77085ef`)
+- **Templates canoniques** : `automecanik-wiki/_meta/templates/{gamme,vehicle,constructeur,support}.md` v2.0.0
+- **Source catalog** : `automecanik-wiki/_meta/source-catalog.yaml` (registre slugs sources stables, PR wiki #9)
+- **DB convention** : mémoire `diag-symptom-db-convention.md` — slugs `__diag_symptom.slug` en anglais snake_case `brake_*`, JOIN via `system_id`
+
+## Sas markdown wiki ≠ sas DB RAG (NE PAS CONFONDRE)
+
+**Verrou conceptuel critique** (mémoire `feedback_wiki_scope_discipline.md`) :
+
+| Sas | Localisation | Schema | Promotion |
+|---|---|---|---|
+| **Wiki proposals** (markdown) | `automecanik-wiki/proposals/<slug>.md` | frontmatter v2.0.0 ADR-033 | manuelle reviewer humain → `wiki/<entity_type>/<slug>.md` (commit message `promotion-from-proposals: <slug>`) |
+| **RAG proposals** (DB) | table Supabase `__rag_proposals` | colonnes typées | gérée par `RagProposalService` (ADR-022 L1) côté backend NestJS, **distinct du sas markdown** |
+
+Le skill `wiki-proposal-writer` écrit **uniquement** dans le sas markdown wiki. **Jamais** d'écriture DB depuis ce workspace. Si une fiche markdown doit être promue en DB RAG, c'est via le pipeline `sync-from-wiki` côté Partie 3 (différée).
+
+## Schema frontmatter v2.0.0 strict (canon ADR-033)
+
+Tout fichier `automecanik-wiki/proposals/<slug>.md` produit par ce workspace doit avoir :
+
+- `schema_version: 2.0.0`
+- `entity_type` ∈ `{gamme, vehicle, constructeur, support}` (cf. ADR-031 §D15)
+- `slug`, `title`, `aliases[]`, `lang: fr`, `created_at`, `updated_at`, `truth_level` ∈ `{L1, L2, L3, L4}`
+- `source_refs[]` (≥ 1) : `{kind: recycled|external|wiki, origin_repo, origin_path, captured_at}`
+- `provenance: {ingested_by: human:<email> | skill:wiki-proposal-writer, promoted_from: null}`
+- `review_status: proposed` (par défaut), `reviewed_by: null`, `reviewed_at: null`, `review_notes: <string>`
+- `no_disputed_claims: true`, `exportable: {rag: false, seo: false, support: false}` (canon défaut Partie 3 différée)
+- `confidence_score: <number 0-1>` (calculé par formule §4 `_meta/quality-gates.md`)
+
+**Pour `entity_type: gamme` uniquement** :
+- `diagnostic_relations[]` (canon ADR-033 §D1) : optionnel mais recommandé. Chaque entrée = `{symptom_slug, system_slug, relation_to_part, part_role, evidence{confidence, source_policy, reviewed, diagnostic_safe}, sources[]}`. Defaults conservateurs ADR-033 §D4 : `reviewed: false`, `diagnostic_safe: false`.
+- `entity_data.maintenance{}` (canon ADR-032 §D1) : obligatoire si la gamme matche un slug `kg_nodes.MaintenanceInterval`. Champs : `educational_advice` (1-2 lignes), `related_pages[]`.
+- `entity_data.{pg_id, family, intents, vlevel, related_parts}` : champs business spécifiques.
+
+## 9 quality gates Python (canon `automecanik-wiki/_scripts/quality-gates.py`)
+
+Le validateur Python côté wiki repo implémente 9 `blocked_reasons` enum :
+
+1. `relation_to_part_missing` — entrée `diagnostic_relations[]` sans `relation_to_part`
+2. `symptom_unstructured` — symptôme implicite dans le body (lexique FR `bruit|grincement|vibration|voyant|fumée|surchauffe|fuite|usure|claquement|sifflement`) non miroité dans `diagnostic_relations[].part_role` — solution : enrichir le `part_role` avec le label FR du symptôme cible
+3. `confidence_overclaimed` — `evidence.confidence: high` mais aucun `source_type` éligible (cf. `source-policy.md` §9 : `oem_*`, `tecdoc_official`, `normative_standard` requis pour `high`)
+4. `source_policy_violated` — `source_policy: 1_high` mais aucune source `confidence: high` ; ou `source_policy: 2_medium_concordant` mais < 2 sources medium concordantes
+5. `legacy_symptoms_block` — présence de `entity_data.symptoms[]` ou `diagnostic.symptoms[]` (anti-pattern ADR-033 §D2)
+6. `forbidden_systemes_dir` — fichier sous `wiki/systemes/` (anti-pattern §D3)
+7. `forbidden_per_symptom_file` — fichier `wiki/diagnostic/<symptom>-*.md` matchant pattern `(bruit|grincement|vibration|voyant|fumee|surchauffe|fuite|usure|symptome|claquement|sifflement)-*.md` (anti-pattern §D3)
+8. `source_slug_unknown` — slug cité dans `diagnostic_relations[].sources[]` absent de `_meta/source-catalog.yaml`
+9. `maintenance_advice_missing` — fiche gamme dont le slug matche un `kg_nodes.MaintenanceInterval` mais sans `entity_data.maintenance.educational_advice`
+
+Le skill `wiki-proposal-writer` doit invoquer `python3 _scripts/quality-gates.py <fichier>` après génération et reporter le verdict + `blocked_reasons` dans son output AEC. **Pas d'auto-correction** — propose-only.
+
+## 3 anti-patterns figés ADR-033 §D3
+
+1. ❌ **NE PAS créer** `wiki/systemes/<slug>.md` ni aucun `entity_type: system` — DB `__diag_system` est SoT
+2. ❌ **NE PAS créer** fichier-par-symptôme `wiki/diagnostic/<symptom>-*.md` (frontend Remix sert `/diagnostic-auto/symptome/$slug`). **Note** : le dossier `wiki/diagnostic/` lui-même reste autorisé pour fiches macro-pédagogiques (vocab, FAQ, wizard-steps — ADR-032 §D1)
+3. ❌ **NE PAS réécrire** le moteur diagnostic (DB `__diag_*` / RPCs / backend / frontend) — hors scope ADR-033
+
+## Convention slug DB `__diag_symptom.slug` (mémoire `diag-symptom-db-convention.md`)
+
+- **Anglais snake_case** avec préfixe par système : `brake_noise_metallic`, `brake_vibration_pedal`, `brake_pulling_side`, `brake_soft_pedal`, `brake_noise_grinding` (5 actifs freinage en DB, 2026-04-30)
+- JOIN via `system_id` (pas de colonne `system_slug` directe sur `__diag_symptom`)
+- Si un symptom_slug souhaité n'existe pas en DB → **retirer** de `diagnostic_relations[]` + tracer dans `review_notes` du frontmatter, ne pas l'inventer. Ouvrir PR `__diag_symptom` extension séparée pour ajouter.
+
+Query SQL canon (référence pour PR-D cron export) :
+```sql
+SELECT s.slug AS symptom_slug, sys.slug AS system_slug, s.label, s.urgency, s.active
+FROM public.__diag_symptom s
+JOIN public.__diag_system sys ON sys.id = s.system_id
+WHERE s.active = true
+ORDER BY s.slug;
+```
+
+## Workflow `wiki-protected-paths.yml` (4 markers commit message)
+
+Tout commit qui touche `wiki/<entity_type>/*.md` doit inclure dans son message un de ces markers (déployé PR wiki #8) :
+
+- `promotion-from-proposals: <slug>` — promotion d'un proposal validé vers canon
+- `rollback: <slug>` — rétrogradation §10 quality-gates
+- `template-migration: <type>@<old>→<new>` — semver bump §3.7 (utilisé par migration progressive PR-E)
+- `metadata-backfill: <field> (<reason>)` — update frontmatter-only par tooling déterministe (ex: `compute-confidence-score.py --fix`)
+
+Sans marker → CI fail. Le sas `proposals/` n'est **pas** couvert par ce workflow (proposals = WIP par construction).
+
+## Output AEC v1.0.0 obligatoire
+
+Tout run depuis ce workspace produit un coverage manifest (cf. `agent-exit-contract.md`) :
+
+```yaml
+final_status: PARTIAL_COVERAGE | SCOPE_SCANNED | REVIEW_REQUIRED
+scope_requested: <description>
+scope_actually_scanned: <chemins ou slugs>
+files_read_count: <int>
+excluded_paths: [<paths>]
+unscanned_zones: [<paths>]    # OBLIGATOIRE même si vide
+corrections_proposed: <int>    # nombre de fiches proposals générées
+corrections_applied: 0         # toujours 0 — propose-only
+remaining_unknowns: [<liste>]  # OBLIGATOIRE
+```
+
+Statuts interdits : `COMPLETE`, `DONE`, `ALL_FIXED`, `NO_ISSUES`, `PATCH_APPLIED`, `AUTO_FIXED`, `100% covered`.
+
+## Anti-patterns wiki (en plus des Q1-Q4 monorepo)
+
+- **Pas de skill qui écrit DB** — ce workspace écrit **uniquement** des fichiers `automecanik-wiki/proposals/<slug>.md`. Toute écriture Supabase / `__rag_proposals` / `__seo_*` / `kg_*` est interdite (Partie 3 différée).
+- **Pas de scrape OEM** — sources provenance via `automecanik-raw/{sources,recycled,normalized}/` uniquement. Si gap, ouvrir issue raw repo, ne pas scraper depuis le skill.
+- **Pas de prédiction LLM des `evidence.confidence`** — formule déterministe `_scripts/compute-symptom-confidence.py` (canon).
+- **Pas d'invention de slug DB** — si un `symptom_slug` souhaité n'existe pas en `__diag_symptom`, retirer + tracer review_notes (cf. P0(b) session 2026-04-30 : `distance_freinage_allongee`, `voyant_freinage_allume` retirés de `plaquette-de-frein.md` faute de slug DB existant).
+- **Pas de bricolage hybride transitoire** — Partie 3 = consommateurs (DB / RAG / SEO / blog / diagnostic / chatbot) attend `wiki-readiness-check.py = READY` (PR-F). Pas de pipeline custom en attendant. Big-bang quand la chaîne est prête (garde-fou utilisateur #12).
+- **Pas de duplication backend** — les modules NestJS `backend/src/modules/admin/services/rag-proposal.service.ts` (ADR-022 L1) et `backend/src/modules/wiki/` (Partie 3) ne sont **pas** modifiés depuis ce workspace.
+
+## Contrat de sortie agents
+
+`./agent-exit-contract.md` — règle non-négociable applicable à tout skill ou agent du workspace wiki.
+
+## Référence
+
+- ADR-031 — 4-layer architecture (vault)
+- ADR-032 — diagnostic & maintenance unification (vault)
+- ADR-033 — wiki gamme `diagnostic_relations[]` (vault)
+- Plan rev 3 — `/home/deploy/.claude/plans/mvp-et-raw-et-wobbly-brooks.md`
+- Mémoire `mvp-g6-adr033-handoff.md` — état Phase 1 closed 2026-04-30
+- Mémoire `diag-symptom-db-convention.md` — convention slug DB
+- Mémoire `feedback_wiki_scope_discipline.md` — sas markdown ≠ sas DB

--- a/workspaces/wiki/.claude/settings.json
+++ b/workspaces/wiki/.claude/settings.json
@@ -1,0 +1,71 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__claude_ai_Supabase__execute_sql",
+      "mcp__claude_ai_Supabase__list_tables",
+      "mcp__claude_ai_Supabase__get_project",
+      "mcp__claude_ai_Supabase__get_project_url"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /opt/automecanik/app/scripts/claude-hooks/pretool-bash-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /opt/automecanik/app/scripts/claude-hooks/pretool-file-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__supabase__apply_migration|mcp__supabase__execute_sql|mcp__claude_ai_Supabase__apply_migration|mcp__claude_ai_Supabase__execute_sql",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /opt/automecanik/app/scripts/claude-hooks/pretool-supabase-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Agent|TeamCreate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /opt/automecanik/app/scripts/claude-hooks/pretool-agent-guard.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /opt/automecanik/app/scripts/claude-hooks/posttool-lint-check.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /opt/automecanik/app/scripts/claude-hooks/stop-log-session-suggest.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/workspaces/wiki/.claude/skills/wiki-proposal-writer/SKILL.md
+++ b/workspaces/wiki/.claude/skills/wiki-proposal-writer/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: wiki-proposal-writer
+description: Génère une fiche `automecanik-wiki/proposals/<slug>.md` au format frontmatter ADR-033 v2.0.0 strict. Mode propose-only (jamais d'écriture canon `wiki/<entity_type>/`, jamais de DB). Lit `automecanik-raw/{sources,recycled,normalized}/` comme source de vérité. Produit coverage manifest AEC v1.0.0 obligatoire. Use when user asks to "create a proposal", "draft a wiki gamme", "ajouter une proposal", etc. Pour migration legacy `entity_data.symptoms[]` → `diagnostic_relations[]`, utiliser plutôt le script `scripts/wiki/migrate-symptoms-to-relations.ts` (PR-E ADR-033) — pas ce skill.
+---
+
+# Wiki Proposal Writer
+
+## Mission
+
+Produire **un seul** fichier `automecanik-wiki/proposals/<slug>.md` par invocation, conforme au schema frontmatter v2.0.0 ADR-033, prêt pour revue humaine et promotion vers `wiki/<entity_type>/`.
+
+Le skill est **propose-only** : il n'écrit jamais dans `wiki/<entity_type>/` (canon), ni dans la DB Supabase, ni dans les `exports/`. Toute fiche produite reste sous review humain avant promotion.
+
+## Scope autorisé / interdit
+
+| Lecture | Écriture |
+|---|---|
+| ✅ `automecanik-raw/{sources,recycled,normalized}/` (matière brute) | ✅ `automecanik-wiki/proposals/<slug>.md` (1 fiche par invocation) |
+| ✅ `automecanik-wiki/_meta/` (canon templates, schemas, source-catalog) | ❌ `automecanik-wiki/wiki/<entity_type>/` (canon) |
+| ✅ `automecanik-wiki/exports/diag-canon-slugs.json` (FK `__diag_symptom`) | ❌ DB Supabase (toute table `__*`, `kg_*`) |
+| ✅ `automecanik-wiki/wiki/<entity_type>/` (lecture seule, anti-duplication slug) | ❌ `automecanik-rag/knowledge/` (RAG repo, géré par sync-from-wiki Partie 3) |
+| ✅ governance-vault canon ADR-031/032/033 (référence) | ❌ `automecanik-wiki/exports/` (auto-généré par PR-D cron) |
+| ✅ source-policy.md (règles `source_type → max_confidence`) | ❌ `_meta/source-catalog.yaml` (modification = PR séparée monorepo) |
+
+## Anti-patterns figés (canon ADR-033 §D3)
+
+Le skill **refuse** systématiquement de :
+
+1. ❌ Créer `wiki/systemes/<slug>.md` (DB `__diag_system` est SoT)
+2. ❌ Créer `wiki/diagnostic/<symptom>-*.md` matchant le pattern `(bruit|grincement|vibration|voyant|fumee|surchauffe|fuite|usure|symptome|claquement|sifflement)-*.md`
+3. ❌ Toucher au moteur diagnostic (DB `__diag_*`, RPCs, backend, frontend)
+
+Si l'utilisateur demande explicitement l'un de ces 3, le skill répond avec verdict `REVIEW_REQUIRED` + note explicite renvoyant vers ADR-033 §D3.
+
+## Architecture skills-first (mémoire `skills-first-architecture.md`)
+
+| Étape | Mode | Outil |
+|---|---|---|
+| 1. Lecture matière brute (`automecanik-raw/`) | 0-LLM | `Read`, `Glob`, `Grep` |
+| 2. Détection `entity_type` (gamme/vehicle/constructeur/support) | 0-LLM | heuristique sur path source + naming |
+| 3. Anti-duplication slug | 0-LLM | `Glob automecanik-wiki/wiki/<entity_type>/*.md` |
+| 4. Lecture template canon (`_meta/templates/<entity_type>.md` v2.0.0) | 0-LLM | `Read` |
+| 5. Lecture source-catalog (slugs sources stables) | 0-LLM | `Read _meta/source-catalog.yaml` |
+| 6. Pour entity_type=gamme : lecture `exports/diag-canon-slugs.json` (si présent) | 0-LLM | `Read` (fallback liste hardcoded `brake_*` si absent — cf. PR-D) |
+| 7. Génération frontmatter (champs structurés) | 0-LLM | template fill avec valeurs détectées |
+| 8. Calcul `confidence_score` (formule `_meta/quality-gates.md` §4) | 0-LLM | invoque `python3 _scripts/compute-confidence-score.py --check` |
+| 9. Rédaction body markdown (sections obligatoires `entity_type`) | **Anthropic** | rédactionnel uniquement (Définition / Fonctionnement / Symptômes / FAQ / etc.) |
+| 10. Validation post-génération via 9 quality gates | 0-LLM | invoque `python3 _scripts/quality-gates.py <fichier>` |
+| 11. Output AEC coverage manifest | 0-LLM | YAML structuré |
+
+**Aucune chaîne LLM custom**, aucun wrapper maison. Anthropic Claude est invoqué **uniquement** pour le rédactionnel (étape 9), pas pour la structure ni pour la validation.
+
+## Flow d'invocation
+
+### Inputs requis
+
+L'utilisateur fournit au minimum :
+- **Slug cible** (ex: `amortisseur`, `volkswagen-golf-7`, `dacia`, `livraison-gratuite`)
+- **Entity type** (si le slug est ambigu)
+- **Sources brutes** : path(s) vers `automecanik-raw/sources/<...>` ou `recycled/<...>` ou indication implicite (« la doc Bosch sur les amortisseurs »)
+
+### Flow étape par étape
+
+```
+1. Vérifier scope (refuser anti-patterns §D3 immédiatement)
+2. Vérifier slug uniqueness (Glob automecanik-wiki/wiki/<entity_type>/<slug>.md)
+   → si existant, abort avec REVIEW_REQUIRED
+3. Lire automecanik-wiki/_meta/templates/<entity_type>.md
+   → squelette frontmatter v2.0.0
+4. Lire automecanik-wiki/_meta/source-catalog.yaml
+   → registre slugs sources stables
+5. Pour entity_type=gamme :
+   - Lire automecanik-wiki/exports/diag-canon-slugs.json (si présent)
+     → liste FK __diag_symptom.slug + __diag_system.slug pour validation
+   - Sinon fallback hardcoded courte (cf. PR-D ADR-033 — 5 slugs `brake_*`)
+6. Lire les sources brutes fournies (automecanik-raw/<...>)
+7. Générer le frontmatter :
+   - schema_version: 2.0.0
+   - entity_type: <détecté>
+   - slug, title, aliases, lang, created_at, updated_at, truth_level
+   - source_refs[] (1 par source brute)
+   - provenance: ingested_by: skill:wiki-proposal-writer
+   - review_status: proposed
+   - exportable: { rag: false, seo: false, support: false }
+   - Pour gamme : entity_data.{pg_id, family, intents, vlevel, related_parts}
+   - Pour gamme avec MaintenanceInterval matche : entity_data.maintenance.{educational_advice, related_pages}
+   - Pour gamme avec diagnostic_relations[] souhaités : entrées avec defaults conservateurs ADR-033 §D4
+     (reviewed: false, diagnostic_safe: false, confidence: medium par défaut)
+8. Rédiger le body markdown (Anthropic, sections obligatoires) :
+   - Pour gamme : Définition / Fonctionnement / Symptômes système (mirror diagnostic_relations[]) /
+                  Conseil pédagogique d'entretien (mirror entity_data.maintenance.educational_advice) /
+                  Choix selon véhicule / FAQ
+   - Pour vehicle : Identité / Spécificités / Pièces fréquentes / FAQ
+   - Pour constructeur : Identité / Modèles principaux / Spécificités techniques / FAQ
+   - Pour support : Question / Réponse / Cas particuliers / Liens internes
+9. Calculer confidence_score (Python compute-confidence-score.py)
+10. Écrire automecanik-wiki/proposals/<slug>.md
+11. Invoquer python3 _scripts/quality-gates.py proposals/<slug>.md
+    → reporter verdict (PASS / FAIL + blocked_reasons[])
+12. Output AEC coverage manifest (cf. ci-dessous)
+```
+
+## Defaults conservateurs (ADR-033 §D4)
+
+Toutes les entrées `diagnostic_relations[].evidence` produites par le skill ont :
+
+```yaml
+evidence:
+  confidence: medium                    # jamais high par défaut (overclaim)
+  source_policy: 2_medium_concordant    # ou manual_review si < 2 sources medium
+  reviewed: false                       # canon défaut, flip true uniquement après revue humaine
+  diagnostic_safe: false                # canon défaut, flip true uniquement reviewer ≠ auteur
+```
+
+Le skill **ne flip jamais** `evidence.diagnostic_safe: true`. Cette autorité est réservée à un commit signé reviewer ≠ auteur (audit ad hoc).
+
+## Output Coverage Manifest AEC v1.0.0 (obligatoire)
+
+Tout output du skill inclut :
+
+```yaml
+final_status: PARTIAL_COVERAGE | SCOPE_SCANNED | REVIEW_REQUIRED | INSUFFICIENT_EVIDENCE
+scope_requested: "<description user>"
+scope_actually_scanned: "<slug + sources lues>"
+files_read_count: <int>                # automecanik-raw + _meta lus
+excluded_paths: ["wiki/<entity_type>/", "exports/", "DB Supabase"]
+unscanned_zones: [<liste si applicable>]
+corrections_proposed: 1                 # 1 fiche proposals générée
+corrections_applied: 0                  # toujours 0 — propose-only
+remaining_unknowns: [<liste>]
+quality_gates_verdict: PASS | FAIL
+blocked_reasons: [<liste si FAIL>]
+```
+
+Statuts interdits : `COMPLETE`, `DONE`, `ALL_FIXED`, `NO_ISSUES`, `PATCH_APPLIED`, `AUTO_FIXED`. Verdict par défaut = `PARTIAL_COVERAGE`.
+
+## Garde-fous absolus
+
+1. **1 fiche par invocation.** Si l'utilisateur demande N proposals, refuser et expliquer que le batch passe par PR-E `migrate-symptoms-to-relations.ts` (mode `--per-system`) ou par invocations séparées.
+2. **Pas d'auto-correction.** Si `quality-gates.py` retourne FAIL avec `blocked_reasons[]`, le skill **propose** la correction dans son output mais n'écrit pas une version "corrigée auto" du fichier. La correction passe par un nouveau commit reviewer.
+3. **Pas d'invention de slug DB.** Si un `symptom_slug` souhaité n'existe pas dans `__diag_symptom.slug` (vérifié via `exports/diag-canon-slugs.json` ou fallback hardcoded), le skill **retire** l'entrée de `diagnostic_relations[]` et trace dans `review_notes` du frontmatter (cf. P0(b) précédent : `distance_freinage_allongee`, `voyant_freinage_allume` retirés faute de slug DB existant).
+4. **Pas de scrape OEM externe.** Les sources viennent de `automecanik-raw/{sources,recycled,normalized}/` exclusivement. Si gap, le skill output `INSUFFICIENT_EVIDENCE` et propose à l'utilisateur d'enrichir le raw repo.
+5. **Pas de prédiction LLM des `evidence.confidence`.** Formule déterministe via `compute-symptom-confidence.py` (canon).
+
+## Cas d'usage typique
+
+```
+User: « Crée une proposal pour la gamme amortisseur, sources : automecanik-raw/recycled/rag-knowledge/amortisseur-overview-fr.md + automecanik-raw/sources/web-clips/oem-renault-clio-amortisseur.md »
+
+Skill:
+1. ✅ Scope vérifié (gamme, pas d'anti-pattern §D3)
+2. ✅ Slug 'amortisseur' uniquement présent en proposals/ (pas dans wiki/gammes/)
+3. ✅ Template _meta/templates/gamme.md lu (v2.0.0)
+4. ✅ source-catalog.yaml lu, sources mappées : 'oem_renault_clio_amortisseur' (status: to_capture par défaut nouvelle entrée — note review_notes)
+5. ✅ exports/diag-canon-slugs.json lu (8 slugs disponibles)
+6. ✅ Sources brutes lues (2 fichiers, 12kB total)
+7. ✅ Frontmatter généré : schema_version: 2.0.0, entity_type: gamme, slug: amortisseur, family: suspension, intents: [diagnostic, achat, entretien, remplacement], vlevel: V2, diagnostic_relations[] (3 entrées avec defaults conservateurs), entity_data.maintenance.educational_advice (1 ligne sur intervalle de remplacement)
+8. ✅ Body rédigé via Anthropic : Définition, Fonctionnement, Symptômes système, Conseil pédagogique, Choix selon véhicule, FAQ
+9. ✅ confidence_score calculé : 0.42 (formule §4)
+10. ✅ proposals/amortisseur.md écrit
+11. ✅ quality-gates.py PASS (0 FAIL, 0 WARN)
+
+Output AEC :
+final_status: SCOPE_SCANNED
+scope_requested: "Proposal gamme amortisseur from 2 raw sources"
+scope_actually_scanned: "amortisseur (gamme)"
+files_read_count: 6  # 2 sources + 4 _meta canon
+excluded_paths: ["wiki/gammes/", "exports/", "DB Supabase"]
+unscanned_zones: []
+corrections_proposed: 1
+corrections_applied: 0
+remaining_unknowns: ["evidence.diagnostic_safe à valider par reviewer ≠ auteur avant promotion"]
+quality_gates_verdict: PASS
+blocked_reasons: []
+```
+
+## Promotion vers canon (hors scope du skill)
+
+Pour promouvoir une fiche `proposals/<slug>.md` validée vers `wiki/<entity_type>/<slug>.md` :
+
+1. Reviewer humain valide la diff frontmatter + body
+2. Bumpe `review_status: proposed` → `reviewed` ou `approved`
+3. Renseigne `reviewed_by: <email>`, `reviewed_at: <ISO>`
+4. `git mv proposals/<slug>.md wiki/<entity_type>/<slug>.md`
+5. Commit avec marker `promotion-from-proposals: <slug>` (workflow `wiki-protected-paths.yml`)
+
+Le skill **ne fait jamais** ce mv. C'est une décision humaine.
+
+## Références
+
+- ADR-031 vault — 4-layer architecture (raw / wiki / exports / consumers)
+- ADR-032 vault — `entity_data.maintenance{}` cohabite avec `diagnostic_relations[]`
+- ADR-033 vault PR #108 commit `77085ef` — `diagnostic_relations[]` canon
+- canon frontmatter : `automecanik-wiki/_meta/schema/frontmatter.schema.json` v2.0.0
+- canon templates : `automecanik-wiki/_meta/templates/{gamme,vehicle,constructeur,support}.md`
+- canon source-catalog : `automecanik-wiki/_meta/source-catalog.yaml`
+- canon contract data : `automecanik-rag/docs/GAMME_PAGE_CONTRACT.md` v2.0 (PR-A.rag mergée 2026-04-30 commit `224e4c63`)
+- 9 quality gates Python : `automecanik-wiki/_scripts/quality-gates.py`
+- formule `confidence_score` : `_meta/quality-gates.md` §4
+- workflow `wiki-protected-paths.yml` (4 markers commit message)
+- mémoire `skills-first-architecture.md` (0-LLM structure, Anthropic seul rédactionnel)
+- mémoire `feedback_wiki_scope_discipline.md` (sas markdown ≠ sas DB)
+- mémoire `diag-symptom-db-convention.md` (slugs anglais snake_case `brake_*`)
+- mémoire `mvp-g6-adr033-handoff.md` (Phase 1 closed 2026-04-30)
+- contrat AEC : `./agent-exit-contract.md` (canon distribué)
+- workspace rules : `../wiki-batch.md`

--- a/workspaces/wiki/CLAUDE.md
+++ b/workspaces/wiki/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md — Workspace Wiki (AutoMecanik)
+
+> Workspace dédié au sas wiki documentaire (ADR-031 / ADR-033) : production de proposals frontmatter v2.0.0, validation locale via les quality gates, anti-patterns figés ADR-033 §D3.
+
+## Quand utiliser ce workspace
+
+```bash
+cd /opt/automecanik/app/workspaces/wiki && claude
+```
+
+Cette racine charge **uniquement** :
+- skill `wiki-proposal-writer` (Phase 5 ADR-033)
+- agents wiki orchestrateurs (Phase 4 future, pour la migration `entity_data.symptoms[]` → `diagnostic_relations[]`)
+- canon `agent-exit-contract.md` distribué depuis vault (hash SHA-256 vérifié CI)
+- règles spécifiques wiki (`wiki-batch.md`)
+
+Pour le dev quotidien (backend NestJS, frontend Remix, hooks, refactor, CI, governance vault), utilise plutôt la racine monorepo `/opt/automecanik/app/`. Pour les campagnes SEO R0-R8, utilise `workspaces/seo-batch/`. Pour les briefs marketing G1, utilise `workspaces/marketing/`.
+
+## Règles génériques (héritées du monorepo)
+
+Les règles globales suivantes s'appliquent même en wiki workspace — voir `/opt/automecanik/app/CLAUDE.md` pour le détail :
+
+- **Source de vérité gouvernance** : `/opt/automecanik/governance-vault/` (jamais écrire dans `app/.local/`)
+- **Vérifier l'existant AVANT d'inventer** : grep `automecanik-wiki/_meta/`, lire `_meta/source-catalog.yaml` et `_meta/templates/gamme.md` v2.0.0 (canon vivant côté wiki repo). Le validateur Python `_scripts/quality-gates.py` côté wiki implemente déjà 9 gates ADR-033/032 — JAMAIS dupliquer la logique.
+- **3-VPS Architecture** : DEV `46.224.118.55` = SoT, PROD `49.12.233.2` = read-only mirror, AI-COS `178.104.1.118` = agents IA
+- **Démarrage de session** : lire `/opt/automecanik/app/log.md` pour le contexte récent
+
+## Règles spécifiques wiki
+
+Voir `.claude/rules/wiki-batch.md` pour :
+- Sas markdown `automecanik-wiki/proposals/` ≠ sas DB `__rag_proposals` (ADR-022 L1, NE PAS confondre)
+- Schema frontmatter v2.0.0 strict (canon `automecanik-wiki/_meta/schema/frontmatter.schema.json`)
+- 9 quality gates Python (`_scripts/quality-gates.py` côté wiki repo)
+- Anti-patterns figés ADR-033 §D3 (3 interdits absolus)
+- Convention slug DB `__diag_symptom.slug` (anglais snake_case `brake_*`)
+- Workflow `wiki-protected-paths.yml` (4 markers `metadata-backfill: | template-migration: | promotion-from-proposals: | rollback:`)
+
+Voir `.claude/rules/agent-exit-contract.md` pour le contrat de sortie obligatoire (AEC v1.0.0 — coverage manifest, 5 états séparés, statuts autorisés).
+
+## Mémoire & contexte
+
+L'auto-memory Claude Code utilise un store distinct par workspace : ce workspace écrit dans `~/.claude/projects/-opt-automecanik-app-workspaces-wiki/memory/`. Le contexte wiki ne pollue donc pas la mémoire dev daily ni SEO ni marketing.
+
+L'index `MEMORY.md` du monorepo (`-opt-automecanik-app/memory/`) reste consultable manuellement pour les faits cross-workload (notamment `mvp-g6-adr033-handoff.md`, `diag-symptom-db-convention.md`, `feedback_wiki_scope_discipline.md`).
+
+## Phase actuelle
+
+**Phase 1 (closed)** — scaffold wiki/raw + 5 pilotes G6 + 9 quality gates Python (PR wiki #8 + raw #6 + wiki #9 mergées 2026-04-30).
+
+**Phase 2 (en cours)** — propagation canon ADR-033 monorepo + skill `wiki-proposal-writer` (cette PR-B) + validateur TS + CI bloquant (PR-C).
+
+**Phase 3 (à venir)** — cron export `diag-canon-slugs.json` + migration progressive `entity_data.symptoms[]` → `diagnostic_relations[]` sur 500+ fiches gamme.
+
+**Critère go Partie 3 consommateurs** (DB / RAG / SEO / blog / diag / chatbot) : `wiki-readiness-check.py = READY` (PR-F). Tant que ce n'est pas vrai, **aucun branchement consommateur**. Big-bang quand la chaîne est prête (garde-fou utilisateur #12 : pas de bricolage hybride transitoire).
+
+---
+
+## Références
+
+- ADR-031 (vault, accepted 2026-04-28) : 4-layer raw/wiki/exports/consumers
+- ADR-032 (vault, accepted 2026-04-29, PR #107) : diagnostic & maintenance unification, bloc `entity_data.maintenance{}` cohabite avec `diagnostic_relations[]`
+- ADR-033 (vault, accepted 2026-04-29, PR #108 commit `77085ef`) : wiki gamme `diagnostic_relations[]` contract, anti-patterns §D3
+- canon frontmatter wiki : `automecanik-wiki/_meta/schema/frontmatter.schema.json` v2.0.0
+- canon source registry : `automecanik-wiki/_meta/source-catalog.yaml` (PR wiki #9)
+- contrat data downstream : `automecanik-rag/docs/GAMME_PAGE_CONTRACT.md` v2.0 (PR-A.rag mergée `224e4c63`)
+- Plan rev 3 : `/home/deploy/.claude/plans/mvp-et-raw-et-wobbly-brooks.md`
+
+---
+
+_Workspace créé Phase 2 ADR-033 (PR-B) — voir `README.md` pour usage._

--- a/workspaces/wiki/README.md
+++ b/workspaces/wiki/README.md
@@ -1,0 +1,71 @@
+# Wiki Workspace
+
+Claude Code project root pour la production de fiches `automecanik-wiki/proposals/<slug>.md` au format ADR-033 v2.0.0. Charge uniquement le skill `wiki-proposal-writer` + agents wiki orchestrateurs (Phase 4 future), sans charger les 39 agents R0-R8 SEO, les 8 skills dev daily, ni les 3 agents G1 marketing.
+
+## Pourquoi ce workspace existe
+
+ADR-033 a redéfini le frontmatter des fiches gamme : retrait de `entity_data.symptoms[]` (anti-pattern, la pièce ne possède pas le symptôme), ajout de `diagnostic_relations[]` top-level (FK strict vers `__diag_symptom.slug`). 5 pilotes G6 + 9 quality gates Python sont déjà mergés côté wiki repo (PR wiki #8 + #9). La suite est de :
+
+1. Propager le canon vers le monorepo (PR-A.rag mergée pour `automecanik-rag/docs/GAMME_PAGE_CONTRACT.md` v2.0).
+2. Outiller la production de proposals — c'est ce workspace.
+3. Outiller la validation — c'est PR-C downstream (validateur TS + CI bloquant).
+4. Outiller la migration des 500+ fiches gamme legacy — c'est PR-D + PR-E downstream.
+
+Mélanger les agents wiki avec les 39 agents R0-R8 SEO (`workspaces/seo-batch/`) ou les 3 agents G1 marketing (`workspaces/marketing/`) diluerait le scope. Le pattern dual-workspace (PR #200) est étendu ici — 4 racines Claude Code distinctes :
+
+| cwd | Surface chargée | Usage |
+|-----|-----------------|-------|
+| `/opt/automecanik/app/` | 8 skills DEV | dev backend/frontend, refactor, CI, ADR, governance |
+| `/opt/automecanik/app/workspaces/seo-batch/` | 39 agents R0-R8 + 16 skills SEO | campagnes SEO, KW planning, content gen, RAG enrich |
+| `/opt/automecanik/app/workspaces/marketing/` | 3 agents G1 marketing + skills marketing-relevant | briefs marketing, GBP posts, retention campaigns |
+| `/opt/automecanik/app/workspaces/wiki/` | skill `wiki-proposal-writer` + agents wiki orchestrateurs | proposals frontmatter ADR-033, migration `entity_data.symptoms[]` → `diagnostic_relations[]` |
+
+## Usage
+
+```bash
+# Session wiki (charge uniquement le skill wiki-proposal-writer + agents wiki future)
+cd /opt/automecanik/app/workspaces/wiki && claude
+
+# Session marketing (charge les 3 agents G1 marketing)
+cd /opt/automecanik/app/workspaces/marketing && claude
+
+# Session SEO (charge les 39 agents R0-R8)
+cd /opt/automecanik/app/workspaces/seo-batch && claude
+
+# Session dev daily (ne charge AUCUN agent métier)
+cd /opt/automecanik/app && claude
+```
+
+## Contenu
+
+- `.claude/skills/wiki-proposal-writer/` : skill principal — produit un fichier `automecanik-wiki/proposals/<slug>.md` avec frontmatter ADR-033 v2.0.0 strict (mode propose-only, 0-LLM pour structure, Anthropic seul pour rédactionnel).
+- `.claude/agents/` : agents wiki orchestrateurs (Phase 4 ADR-033, vide aujourd'hui — modèle pattern `pipeline-orchestrator` du seo-batch pour migration progressive `entity_data.symptoms[]` → `diagnostic_relations[]` sur 500+ fiches gamme).
+- `.claude/rules/wiki-batch.md` : règles spécifiques wiki (sas markdown vs sas DB, schema strict, 9 quality gates, 3 anti-patterns figés ADR-033 §D3, convention slug DB).
+- `.claude/rules/agent-exit-contract.md` : copie canon distribuée depuis vault (hash SHA-256 vérifié CI).
+- `.claude/settings.json` : hooks PreToolUse / PostToolUse / Stop (mêmes scripts que monorepo, paths absolus).
+- `CLAUDE.md` : pointer vers gouvernance + règles wiki spécifiques.
+
+## Phase actuelle
+
+**Phase 1 (closed 2026-04-30)** — scaffold + 5 pilotes G6 + 9 quality gates Python : PR wiki #8 (`989cb0cc`) + raw #6 (`361e9b0b`) + wiki #9 (`ee5ee3c4`) mergées.
+
+**Phase 2 (en cours, J+3 → J+9)** — propagation canon ADR-033 monorepo + skill `wiki-proposal-writer` + validateur TS + CI bloquant. Plan rev 3 (`/home/deploy/.claude/plans/mvp-et-raw-et-wobbly-brooks.md`) :
+- ✅ PR-A.rag : `GammeContentContract.v1` → `v2.0` mergée commit `224e4c63`
+- 🟡 PR-B : ce workspace (cette PR)
+- ⏳ PR-C : validateur TS `validate-gamme-diagnostic-relations.ts` + workflow `wiki-validate.yml`
+
+**Phase 3 (J+10 → J+16)** — cron export `diag-canon-slugs.json` (PR-D) + migration progressive 500+ fiches gamme (PR-E batch `--per-system freinage` pilote).
+
+**Phase Maturité G9-B (J+17 → J+30)** — `wiki-readiness-check.py` (PR-F, critère go Partie 3) + cron audit hebdo + rollback drill.
+
+**Critère go Partie 3 consommateurs** (DB `__seo_*`, RAG ingestion, SEO R0-R8, blog, diagnostic, chatbot) : `wiki-readiness-check.py = READY`. Tant que ce n'est pas vrai, aucun branchement consommateur. Big-bang quand la chaîne est prête.
+
+## Références
+
+- ADR-031 vault (4-layer raw/wiki/exports/consumers)
+- ADR-032 vault (`entity_data.maintenance{}` cohabite avec `diagnostic_relations[]`)
+- ADR-033 vault (`diagnostic_relations[]` canon, anti-patterns §D3)
+- Plan rev 3 : `/home/deploy/.claude/plans/mvp-et-raw-et-wobbly-brooks.md`
+- canon frontmatter : `automecanik-wiki/_meta/schema/frontmatter.schema.json`
+- canon source registry : `automecanik-wiki/_meta/source-catalog.yaml`
+- canon DB convention : mémoire `diag-symptom-db-convention.md`


### PR DESCRIPTION
## Summary

PR-B of plan rev 3 (`mvp-et-raw-et-wobbly-brooks.md`) — implements **Phase 5 ADR-033** (skill `wiki-proposal-writer`) + extends the dual-workspace pattern (PR #200) with a 4th Claude Code root dedicated to the wiki documentary sas.

Builds on PR-A.rag (`automecanik-rag` GammeContentContract v2.0 mergée `224e4c63`).

**Net new** : 6 files under `workspaces/wiki/`, no existing file modified.

## Why a dedicated `workspaces/wiki/` and not the root dev or `workspaces/seo-batch/`

3 reasons (cf. plan rev 3 §"PR-B — Justification workspace dédié") :
1. **Memory isolation** : ADR-031/033 ≠ SEO. The `seo-batch` workspace loads 39 R0-R8 agents + 16 SEO skills ; mixing a wiki skill in there = workspace memory pollution + skill choice confusion for the user.
2. **Established pattern** : `seo-batch` and `marketing` are two precedents that isolate each business domain in its own workspace. Wiki (raw → wiki → exports → consumers) = distinct domain.
3. **Canonical distribution** : ADR-031/033 share `agent-exit-contract.md` distributed via canon-publish (SHA-256 hash CI-verified). A `wiki/` workspace can also distribute `adr-031-rules.md`, `adr-033-rules.md` following the existing `marketing-batch.md` pattern.

## Files (6)

| File | Lines | Purpose |
|---|---|---|
| `workspaces/wiki/CLAUDE.md` | 56 | Pointer + scope wiki + canon refs |
| `workspaces/wiki/README.md` | 67 | Usage + 4 Claude Code roots table |
| `workspaces/wiki/.claude/settings.json` | 71 | byte-identical to `workspaces/marketing/.claude/settings.json` (hooks centraux) |
| `workspaces/wiki/.claude/rules/agent-exit-contract.md` | — | copie canon AEC v1.0.0 distribuée depuis vault (`governance-vault/ledger/rules/rules-agent-exit-contract.md`) |
| `workspaces/wiki/.claude/rules/wiki-batch.md` | NEW | 9 quality gates Python, 3 anti-patterns figés ADR-033 §D3, sas markdown ≠ sas DB, convention slug DB `brake_*`, 4 markers `wiki-protected-paths.yml` |
| `workspaces/wiki/.claude/skills/wiki-proposal-writer/SKILL.md` | NEW | skill principal — propose-only, mode 0-LLM structure + Anthropic seul rédactionnel, output AEC v1.0.0 obligatoire |

## Architecture du skill `wiki-proposal-writer`

- **Scope** : 1 fiche `automecanik-wiki/proposals/<slug>.md` par invocation, frontmatter v2.0.0 strict
- **Lecture** : `automecanik-raw/{sources,recycled,normalized}/` + `automecanik-wiki/_meta/` + `exports/diag-canon-slugs.json` (FK validation)
- **Écriture** : `automecanik-wiki/proposals/<slug>.md` uniquement. Pas d'écriture canon `wiki/<entity_type>/`, pas de DB Supabase, pas de `exports/`
- **Pattern skills-first** : 0-LLM pour structure (template fill, source_refs, `confidence_score`, validation), Anthropic seul pour rédactionnel
- **Defaults conservateurs ADR-033 §D4** : `evidence.reviewed=false`, `diagnostic_safe=false`, `confidence=medium`
- **Anti-patterns refusés systématiquement** : `wiki/systemes/`, `wiki/diagnostic/<symptom>-*`, réécriture moteur diagnostic DB
- **Validation post-génération** : invoque `python3 _scripts/quality-gates.py <fichier>` du wiki repo, reporte verdict + `blocked_reasons[]` dans output AEC

## Garde-fous

- 1 fiche par invocation (batch via PR-E `migrate-symptoms-to-relations.ts`)
- Pas d'auto-correction sur quality-gates FAIL
- Pas d'invention de slug DB (retire de `diagnostic_relations[]` + trace `review_notes`)
- Pas de scrape OEM externe
- Pas de prédiction LLM `evidence.confidence`

## Scope-disjoint firewall (plan rev 3)

```bash
git status --porcelain | grep -E "(workspaces/marketing|backend/src/modules/marketing|__marketing_|cst_marketing_consent|local-business-agent|customer-retention-agent|marketing-lead-agent|adr-036|adr-038)"
# 0 match → ✅ scope clean
```

Le worktree dédié `.worktrees/adr-033-pr-b/` garantit l'isolation physique du main worktree où le user édite parallèlement marketing.

## Test Plan

- [x] Pure additif (6 fichiers nouveaux sous `workspaces/wiki/`, 0 fichier modifié)
- [x] Scope-firewall pre-commit : 0 match marketing
- [x] Header commit `adr-033-scope: workspaces-wiki` présent
- [x] settings.json byte-identical à marketing
- [x] AEC canon copié depuis vault (hash vérifiable post-merge via `marketing-voice-hash.yml` pattern réutilisable)
- [ ] CI (lint + tests existants)
- [ ] Test manuel post-merge : `cd workspaces/wiki && claude` charge bien le skill `wiki-proposal-writer`

## Hors scope (Phase 3 ADR-033)

- PR-C : validateur TS `scripts/wiki/validate-gamme-diagnostic-relations.ts` + workflow `wiki-validate.yml` (downstream)
- PR-D : cron `export-diag-canon-slugs.ts` + workflow nightly (Phase 3 ADR-033)
- PR-E : migration progressive `migrate-symptoms-to-relations.ts` (Phase 4 ADR-033, batch `--per-system freinage` pilote)
- PR-F : `wiki-readiness-check.py` (critère go Partie 3)
- Agents wiki orchestrateurs (`workspaces/wiki/.claude/agents/` — vide aujourd'hui, modèle pattern `pipeline-orchestrator` du seo-batch)

## Refs

- Plan rev 3 PR-B : `/home/deploy/.claude/plans/mvp-et-raw-et-wobbly-brooks.md`
- PR-A.rag mergée 2026-04-30 commit `224e4c63` (GammeContentContract.v2.0)
- ADR-033 vault PR #108 commit `77085ef` (status `accepted`)
- canon frontmatter wiki : `automecanik-wiki/_meta/schema/frontmatter.schema.json` v2.0.0 (PR wiki #8 mergée `989cb0cc`)
- canon source-catalog : `automecanik-wiki/_meta/source-catalog.yaml` (PR wiki #9 mergée `ee5ee3c4`)
- mémoires : `skills-first-architecture.md`, `feedback_wiki_scope_discipline.md`, `diag-symptom-db-convention.md`, `mvp-g6-adr033-handoff.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)