### PR TITLE
feat(wiki-canon): ADR-039 wiki-frontmatter-zod-canon — TS mirror of JSON Schema, CLI validator (PR-C ADR-033)

### DIFF
--- a/backend/src/config/wiki-proposal-frontmatter.schema.test.ts
+++ b/backend/src/config/wiki-proposal-frontmatter.schema.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Tests for wiki-proposal-frontmatter.schema.ts (ADR-039 / canon mirror of
+ * `automecanik-wiki/_meta/schema/frontmatter.schema.json`).
+ */
+
+import {
+  parseWikiProposalFrontmatter,
+  safeParseWikiProposalFrontmatter,
+  WikiProposalFrontmatterSchema,
+  WikiSourceRefSchema,
+  DiagnosticRelationSchema,
+} from './wiki-proposal-frontmatter.schema';
+
+const VALID_GAMME_V2: Record<string, unknown> = {
+  schema_version: '2.0.0',
+  id: 'gamme:plaquette-de-frein',
+  entity_type: 'gamme',
+  slug: 'plaquette-de-frein',
+  title: 'Plaquette de frein',
+  aliases: ['plaquettes', 'brake pads'],
+  lang: 'fr',
+  created_at: '2026-04-30',
+  updated_at: '2026-04-30',
+  truth_level: 'L2',
+  source_refs: [
+    {
+      kind: 'recycled',
+      origin_repo: 'automecanik-rag',
+      origin_path: 'knowledge/gammes/plaquette-de-frein.md',
+      captured_at: '2026-04-29',
+    },
+  ],
+  provenance: {
+    ingested_by: 'skill:wiki-proposal-writer',
+    promoted_from: null,
+  },
+  review_status: 'proposed',
+  reviewed_by: null,
+  reviewed_at: null,
+  review_notes: '',
+  no_disputed_claims: true,
+  exportable: { rag: false, seo: false, support: false },
+  target_classes: [],
+  entity_data: {
+    pg_id: 142,
+    family: 'freinage',
+    intents: ['diagnostic', 'achat', 'remplacement'],
+    vlevel: 'V2',
+  },
+  diagnostic_relations: [
+    {
+      symptom_slug: 'brake_noise_metallic',
+      system_slug: 'brake_system',
+      relation_to_part: 'possible_cause',
+      part_role:
+        'Plaquettes usées émettent un grincement métallique au freinage',
+      evidence: {
+        confidence: 'medium',
+        source_policy: '2_medium_concordant',
+        reviewed: false,
+        diagnostic_safe: false,
+      },
+      sources: ['oem_renault_brakes', 'tecdoc_brake_pads_2026'],
+    },
+  ],
+};
+
+describe('WikiProposalFrontmatterSchema (ADR-039)', () => {
+  describe('valid inputs', () => {
+    it('accepts a complete v2.0.0 gamme proposal with diagnostic_relations[]', () => {
+      const result = parseWikiProposalFrontmatter(VALID_GAMME_V2);
+      expect(result.entity_type).toBe('gamme');
+      expect(result.diagnostic_relations).toHaveLength(1);
+    });
+
+    it('accepts schema_version 0.legacy (recycled fiche)', () => {
+      const input = { ...VALID_GAMME_V2, schema_version: '0.legacy' };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts schema_version 1.0.0 (pré-ADR-033)', () => {
+      const input = {
+        ...VALID_GAMME_V2,
+        schema_version: '1.0.0',
+        diagnostic_relations: [],
+      };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts L4 truth_level without any source_refs', () => {
+      const input = { ...VALID_GAMME_V2, truth_level: 'L4', source_refs: [] };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts entity_type=vehicle/constructeur/support/diagnostic', () => {
+      for (const t of ['vehicle', 'constructeur', 'support', 'diagnostic']) {
+        const slug = 'foo-bar';
+        const input = {
+          ...VALID_GAMME_V2,
+          entity_type: t,
+          id: `${t}:${slug}`,
+          slug,
+          diagnostic_relations: [],
+        };
+        const result = safeParseWikiProposalFrontmatter(input);
+        expect(result.success).toBe(true);
+      }
+    });
+  });
+
+  describe('rejects invalid schema_version / id / slug', () => {
+    it('rejects unknown schema_version pattern', () => {
+      const input = { ...VALID_GAMME_V2, schema_version: 'foo' };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects id that does not match `<entity_type>:<slug>`', () => {
+      const input = { ...VALID_GAMME_V2, id: 'gamme:wrong-slug' };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.some((i) => i.path.join('.') === 'id')).toBe(
+          true,
+        );
+      }
+    });
+
+    it('rejects entity_type unknown', () => {
+      const input = {
+        ...VALID_GAMME_V2,
+        entity_type: 'system', // forbidden — ADR-033 §D3
+        id: 'system:foo',
+      };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects slug starting or ending with hyphen', () => {
+      // NOTE: canon regex (JSON Schema source of truth) is
+      // `^[a-z0-9][a-z0-9-]{0,78}[a-z0-9]$` which allows internal double-hyphens
+      // ("foo--bar"). The JSON Schema description says "Pas de double-hyphen"
+      // but the regex itself does not enforce that. To strictly mirror the
+      // canon, this Zod also allows internal double-hyphens. The wiki repo's
+      // Python `quality-gates.py` enforces the stricter rule via a separate
+      // gate (out of scope for this top-level frontmatter schema).
+      for (const bad of ['-foo', 'foo-']) {
+        const input = { ...VALID_GAMME_V2, slug: bad, id: `gamme:${bad}` };
+        const result = safeParseWikiProposalFrontmatter(input);
+        expect(result.success).toBe(false);
+      }
+    });
+
+    it('rejects slug longer than 80 chars', () => {
+      const long = 'a' + 'b'.repeat(80);
+      const input = { ...VALID_GAMME_V2, slug: long, id: `gamme:${long}` };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('truth_level conditional source_refs validation (allOf §1)', () => {
+    it.each(['L1', 'L2', 'L3'])(
+      'rejects truth_level=%s with empty source_refs',
+      (level) => {
+        const input = {
+          ...VALID_GAMME_V2,
+          truth_level: level,
+          source_refs: [],
+        };
+        const result = safeParseWikiProposalFrontmatter(input);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(
+            result.error.issues.some((i) => i.path.join('.') === 'source_refs'),
+          ).toBe(true);
+        }
+      },
+    );
+  });
+
+  describe('exportable conditional review validation (allOf §2)', () => {
+    it('rejects exportable.rag=true if review_status != approved', () => {
+      const input = {
+        ...VALID_GAMME_V2,
+        exportable: { rag: true, seo: false, support: false },
+        review_status: 'proposed',
+      };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.join('.') === 'review_status'),
+        ).toBe(true);
+      }
+    });
+
+    it('rejects exportable.seo=true without reviewed_by', () => {
+      const input = {
+        ...VALID_GAMME_V2,
+        exportable: { rag: false, seo: true, support: false },
+        review_status: 'approved',
+        reviewed_by: null,
+        reviewed_at: '2026-04-30T10:00:00Z',
+      };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.join('.') === 'reviewed_by'),
+        ).toBe(true);
+      }
+    });
+
+    it('accepts exportable.rag=true if all review fields are populated', () => {
+      const input = {
+        ...VALID_GAMME_V2,
+        exportable: { rag: true, seo: false, support: false },
+        review_status: 'approved',
+        reviewed_by: '@fafa',
+        reviewed_at: '2026-04-30T10:00:00Z',
+        no_disputed_claims: true,
+      };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects exportable.support=true with no_disputed_claims=false', () => {
+      const input = {
+        ...VALID_GAMME_V2,
+        exportable: { rag: false, seo: false, support: true },
+        review_status: 'approved',
+        reviewed_by: '@fafa',
+        reviewed_at: '2026-04-30T10:00:00Z',
+        no_disputed_claims: false,
+      };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('source_refs[] discriminated union on `kind`', () => {
+    it('accepts kind=raw with path', () => {
+      const result = WikiSourceRefSchema.safeParse({
+        kind: 'raw',
+        path: 'recycled/rag-knowledge/foo.md',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects kind=external_url without captured_at', () => {
+      const result = WikiSourceRefSchema.safeParse({
+        kind: 'external_url',
+        url: 'https://example.com',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts kind=manual with note + author', () => {
+      const result = WikiSourceRefSchema.safeParse({
+        kind: 'manual',
+        note: 'Specific reason',
+        author: '@fafa',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects unknown kind', () => {
+      const result = WikiSourceRefSchema.safeParse({
+        kind: 'invented_kind',
+        url: 'https://x',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('diagnostic_relations[] (ADR-033 §D1)', () => {
+    it('accepts a valid possible_cause relation', () => {
+      const result = DiagnosticRelationSchema.safeParse({
+        symptom_slug: 'brake_noise_metallic',
+        system_slug: 'brake_system',
+        relation_to_part: 'possible_cause',
+        part_role: 'Plaquettes usées émettent grincement',
+        evidence: {
+          confidence: 'medium',
+          source_policy: '2_medium_concordant',
+          reviewed: false,
+          diagnostic_safe: false,
+        },
+        sources: ['oem_renault_brakes'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects part_role shorter than 10 chars', () => {
+      const result = DiagnosticRelationSchema.safeParse({
+        symptom_slug: 'brake_noise_metallic',
+        system_slug: 'brake_system',
+        relation_to_part: 'possible_cause',
+        part_role: 'Too short',
+        evidence: {
+          confidence: 'medium',
+          source_policy: '2_medium_concordant',
+          reviewed: false,
+          diagnostic_safe: false,
+        },
+        sources: ['oem_renault_brakes'],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects relation_to_part outside the 3-value enum', () => {
+      const result = DiagnosticRelationSchema.safeParse({
+        symptom_slug: 'brake_noise_metallic',
+        system_slug: 'brake_system',
+        relation_to_part: 'invented_relation',
+        part_role: 'Plaquettes usées émettent grincement',
+        evidence: {
+          confidence: 'medium',
+          source_policy: '2_medium_concordant',
+          reviewed: false,
+          diagnostic_safe: false,
+        },
+        sources: ['oem_renault_brakes'],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects sources empty (must have minItems: 1)', () => {
+      const result = DiagnosticRelationSchema.safeParse({
+        symptom_slug: 'brake_noise_metallic',
+        system_slug: 'brake_system',
+        relation_to_part: 'possible_cause',
+        part_role: 'Plaquettes usées émettent grincement',
+        evidence: {
+          confidence: 'medium',
+          source_policy: '2_medium_concordant',
+          reviewed: false,
+          diagnostic_safe: false,
+        },
+        sources: [],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects evidence.diagnostic_safe = true without explicit override (default is false)', () => {
+      // Schema does not enforce diagnostic_safe=false, but it defaults to false.
+      // Verify default behavior.
+      const result = DiagnosticRelationSchema.parse({
+        symptom_slug: 'brake_noise_metallic',
+        system_slug: 'brake_system',
+        relation_to_part: 'possible_cause',
+        part_role: 'Plaquettes usées émettent grincement',
+        evidence: {
+          confidence: 'medium',
+          source_policy: '2_medium_concordant',
+          reviewed: false,
+          diagnostic_safe: false,
+        },
+        sources: ['oem_renault_brakes'],
+      });
+      expect(result.evidence.diagnostic_safe).toBe(false);
+    });
+  });
+
+  describe('strict (no additional properties)', () => {
+    it('rejects unknown top-level field', () => {
+      const input = { ...VALID_GAMME_V2, surprise_field: 'oops' };
+      const result = safeParseWikiProposalFrontmatter(input);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('helper functions', () => {
+    it('parseWikiProposalFrontmatter throws on invalid input', () => {
+      expect(() => parseWikiProposalFrontmatter({ invalid: true })).toThrow();
+    });
+
+    it('safeParseWikiProposalFrontmatter returns success=false on invalid input', () => {
+      const result = safeParseWikiProposalFrontmatter({ invalid: true });
+      expect(result.success).toBe(false);
+    });
+
+    it('schema is exported and re-usable', () => {
+      expect(WikiProposalFrontmatterSchema).toBeDefined();
+    });
+  });
+});

--- a/backend/src/config/wiki-proposal-frontmatter.schema.ts
+++ b/backend/src/config/wiki-proposal-frontmatter.schema.ts
@@ -1,0 +1,342 @@
+/**
+ * Wiki Proposal Frontmatter Schema — Zod canonique TS, miroir du JSON Schema
+ * Draft 2020-12 défini dans `automecanik-wiki/_meta/schema/frontmatter.schema.json`
+ * (343 lignes). Source de vérité = ce JSON Schema, ce fichier en est la
+ * dérivation TS pour usage runtime côté monorepo (Partie 3 ADR-033 différée).
+ *
+ * Versions supportées :
+ *   - `schema_version: "0.legacy"`   — fiches recyclées de `automecanik-rag/knowledge/`
+ *   - `schema_version: "1.0.0"`      — schema initial ADR-031
+ *   - `schema_version: "2.0.0"`      — ajout `diagnostic_relations[]` top-level (ADR-033)
+ *                                      + `entity_data.maintenance{}` (ADR-032)
+ *
+ * Pendant la migration Phase 4 ADR-033 (500+ fiches gamme), v1.0.0 et v2.0.0
+ * cohabitent. Cette Zod accepte les 3 versions dans une même validation.
+ *
+ * Pattern : extension d'ADR-037 (`agent-frontmatter.schema.ts`) +
+ * ADR-038 (`marketing-agent-frontmatter.schema.ts`) au scope wiki.
+ *
+ * Référence canon : `governance-vault/ledger/decisions/adr/ADR-031-four-layer-content-architecture.md`
+ *                   `governance-vault/ledger/decisions/adr/ADR-032-diagnostic-maintenance-unification.md`
+ *                   `governance-vault/ledger/decisions/adr/ADR-033-wiki-gamme-diagnostic-relations-contract.md`
+ */
+
+import { z } from 'zod';
+
+// ────────────────────────────────────────────────────────────
+//  Sub-enums et patterns canon
+// ────────────────────────────────────────────────────────────
+
+export const WikiEntityType = z.enum([
+  'gamme',
+  'vehicle',
+  'constructeur',
+  'support',
+  'diagnostic',
+]);
+export type WikiEntityType = z.infer<typeof WikiEntityType>;
+
+export const WikiTruthLevel = z.enum(['L1', 'L2', 'L3', 'L4']);
+export type WikiTruthLevel = z.infer<typeof WikiTruthLevel>;
+
+export const WikiReviewStatus = z.enum([
+  'draft',
+  'proposed',
+  'in_review',
+  'approved',
+  'deprecated',
+]);
+export type WikiReviewStatus = z.infer<typeof WikiReviewStatus>;
+
+export const WikiTargetClass = z.enum([
+  'KB_Knowledge',
+  'KB_Catalog',
+  'KB_Diagnostic',
+  'KB_Media',
+  'KB_RouterMemory',
+]);
+export type WikiTargetClass = z.infer<typeof WikiTargetClass>;
+
+/** Slug kebab-case ASCII, max 80 chars, pas de double-hyphen, pas commencer/finir par hyphen. */
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,78}[a-z0-9]$/;
+
+/** UUIDv7 (timestamp-prefixed, sortable). */
+const UUIDV7_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** Content hash format `sha256:<64 hex>`. */
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+/** schema_version : 0.legacy ou semver. */
+const SCHEMA_VERSION_PATTERN = /^(0\.legacy|[0-9]+\.[0-9]+\.[0-9]+)$/;
+
+/** id URN : `<entity_type>:<slug>`. */
+const ID_PATTERN =
+  /^(gamme|vehicle|constructeur|support|diagnostic):[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+/** ISO 8601 date `YYYY-MM-DD`. */
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Slug source-catalog : kebab/snake mixte + suffixe optionnel `_p<N>` pour pagination. */
+const SOURCE_SLUG_PATTERN = /^[a-z][a-z0-9_-]*[a-z0-9](?:_p\d+)?$/;
+
+/** Slug `__diag_symptom.slug` ou `__diag_system.slug` : kebab/snake. */
+const DIAG_SLUG_PATTERN = /^[a-z][a-z0-9_-]*[a-z0-9]$/;
+
+/** fingerprint : SHA-256 [:16] hex. */
+const FINGERPRINT_PATTERN = /^[0-9a-f]{16}$/;
+
+// ────────────────────────────────────────────────────────────
+//  source_refs[] — discriminated union sur `kind`
+// ────────────────────────────────────────────────────────────
+
+const SourceRefRawSchema = z.object({
+  kind: z.literal('raw'),
+  path: z.string().min(1),
+  cid: z.string().regex(SHA256_PATTERN).optional(),
+  captured_at: z.string().regex(ISO_DATE_PATTERN).optional(),
+});
+
+const SourceRefExternalUrlSchema = z.object({
+  kind: z.literal('external_url'),
+  url: z.string().url(),
+  captured_at: z.string().regex(ISO_DATE_PATTERN),
+  archive_path: z.string().optional(),
+});
+
+const SourceRefManualSchema = z.object({
+  kind: z.literal('manual'),
+  note: z.string().min(1),
+  author: z.string().min(1),
+});
+
+const SourceRefRecycledSchema = z.object({
+  kind: z.literal('recycled'),
+  origin_repo: z.string().min(1),
+  origin_path: z.string().min(1),
+  captured_at: z.string().regex(ISO_DATE_PATTERN).optional(),
+});
+
+export const WikiSourceRefSchema = z.discriminatedUnion('kind', [
+  SourceRefRawSchema,
+  SourceRefExternalUrlSchema,
+  SourceRefManualSchema,
+  SourceRefRecycledSchema,
+]);
+export type WikiSourceRef = z.infer<typeof WikiSourceRefSchema>;
+
+// ────────────────────────────────────────────────────────────
+//  diagnostic_relations[] — canon ADR-033 §D1 (v2.0.0)
+// ────────────────────────────────────────────────────────────
+
+export const DiagnosticEvidenceConfidence = z.enum(['low', 'medium', 'high']);
+export const DiagnosticEvidenceSourcePolicy = z.enum([
+  '1_high',
+  '2_medium_concordant',
+  'manual_review',
+]);
+export const DiagnosticRelationToPart = z.enum([
+  'possible_cause',
+  'symptom_amplifier',
+  'secondary_effect',
+]);
+
+export const DiagnosticEvidenceSchema = z
+  .object({
+    confidence: DiagnosticEvidenceConfidence,
+    source_policy: DiagnosticEvidenceSourcePolicy,
+    reviewed: z.boolean().default(false),
+    diagnostic_safe: z.boolean().default(false),
+    confidence_score_computed: z.number().min(0).max(1).optional(),
+  })
+  .strict();
+
+export const DiagnosticRelationSchema = z
+  .object({
+    symptom_slug: z.string().regex(DIAG_SLUG_PATTERN).max(80),
+    system_slug: z.string().regex(DIAG_SLUG_PATTERN).max(60),
+    relation_to_part: DiagnosticRelationToPart,
+    part_role: z.string().min(10).max(280),
+    evidence: DiagnosticEvidenceSchema,
+    sources: z.array(z.string().regex(SOURCE_SLUG_PATTERN)).min(1),
+    fingerprint: z.string().regex(FINGERPRINT_PATTERN).optional(),
+  })
+  .strict();
+export type DiagnosticRelation = z.infer<typeof DiagnosticRelationSchema>;
+
+// ────────────────────────────────────────────────────────────
+//  exportable, provenance, target_classes
+// ────────────────────────────────────────────────────────────
+
+export const WikiExportableSchema = z
+  .object({
+    rag: z.boolean().default(false),
+    seo: z.boolean().default(false),
+    support: z.boolean().default(false),
+    content: z.boolean().default(false).optional(),
+  })
+  .strict();
+export type WikiExportable = z.infer<typeof WikiExportableSchema>;
+
+export const WikiProvenanceSchema = z
+  .object({
+    ingested_by: z.string().min(1).optional(),
+    promoted_from: z.string().nullable().optional(),
+    promoted_at: z.string().datetime().optional(),
+  })
+  .strict();
+export type WikiProvenance = z.infer<typeof WikiProvenanceSchema>;
+
+// ────────────────────────────────────────────────────────────
+//  entity_data — typage délégué aux sous-schemas par entity_type
+//  (validation light côté Zod top-level, validation stricte côté
+//  `_meta/schema/entity-data/<type>.schema.json` côté wiki repo)
+// ────────────────────────────────────────────────────────────
+
+export const WikiEntityDataSchema = z
+  .object({
+    // Champs gamme courants — non-strict pour cohabitation v1/v2 et hétérogénéité
+    pg_id: z.number().int().positive().optional(),
+    family: z.string().optional(),
+    intents: z.array(z.string()).optional(),
+    vlevel: z.string().optional(),
+    related_parts: z.array(z.unknown()).optional(),
+    // Bloc maintenance ADR-032 (v2.0.0) — cohabite avec diagnostic_relations[]
+    maintenance: z
+      .object({
+        educational_advice: z.string().optional(),
+        related_pages: z.array(z.unknown()).optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+export type WikiEntityData = z.infer<typeof WikiEntityDataSchema>;
+
+// ────────────────────────────────────────────────────────────
+//  Top-level frontmatter
+// ────────────────────────────────────────────────────────────
+
+const WikiProposalFrontmatterBase = z
+  .object({
+    schema_version: z.string().regex(SCHEMA_VERSION_PATTERN),
+    id: z.string().regex(ID_PATTERN),
+    entity_type: WikiEntityType,
+    slug: z.string().regex(SLUG_PATTERN).max(80),
+    title: z.string().min(1).max(200),
+    aliases: z.array(z.string().min(1)).default([]),
+    lang: z.enum(['fr', 'en']).default('fr'),
+    created_at: z.string().regex(ISO_DATE_PATTERN),
+    updated_at: z.string().regex(ISO_DATE_PATTERN),
+    truth_level: WikiTruthLevel,
+    source_refs: z.array(WikiSourceRefSchema).default([]),
+    provenance: WikiProvenanceSchema.optional(),
+    lineage_id: z.string().regex(UUIDV7_PATTERN).optional(),
+    content_hash: z.string().regex(SHA256_PATTERN).optional(),
+    parents: z.array(z.string().regex(UUIDV7_PATTERN)).default([]),
+    review_status: WikiReviewStatus,
+    reviewed_by: z.string().nullable().optional(),
+    reviewed_at: z.string().datetime().nullable().optional(),
+    review_notes: z.string().default(''),
+    no_disputed_claims: z.boolean().default(true),
+    quality_score: z.number().min(0).max(1).nullable().optional(),
+    confidence_score: z.number().min(0).max(1).nullable().optional(),
+    exportable: WikiExportableSchema,
+    target_classes: z.array(WikiTargetClass).default([]),
+    entity_data: WikiEntityDataSchema.optional(),
+    diagnostic_relations: z.array(DiagnosticRelationSchema).default([]),
+  })
+  .strict();
+
+/**
+ * Wiki Proposal Frontmatter Schema — strict, applies the JSON Schema's
+ * `allOf` conditional rules via `.superRefine()`.
+ *
+ * Conditional validations (mirror JSON Schema):
+ *  1. truth_level ∈ {L1, L2, L3} → source_refs.length >= 1
+ *  2. exportable.{rag|seo|support} = true → review_status = "approved"
+ *     ET no_disputed_claims = true ET reviewed_by/reviewed_at NOT NULL
+ */
+export const WikiProposalFrontmatterSchema =
+  WikiProposalFrontmatterBase.superRefine((data, ctx) => {
+    // Rule 1 : truth_level L1/L2/L3 require source_refs >= 1
+    if (
+      ['L1', 'L2', 'L3'].includes(data.truth_level) &&
+      data.source_refs.length === 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['source_refs'],
+        message: `truth_level=${data.truth_level} requires at least 1 source_refs entry (canon ADR-031, anti-pattern AP-LLM-only-seed)`,
+      });
+    }
+
+    // Rule 2 : exportable.{rag|seo|support}=true requires approved + no_disputed + reviewed_by/at
+    const isExported =
+      data.exportable.rag === true ||
+      data.exportable.seo === true ||
+      data.exportable.support === true;
+    if (isExported) {
+      if (data.review_status !== 'approved') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['review_status'],
+          message: `exportable=true requires review_status="approved" (got "${data.review_status}")`,
+        });
+      }
+      if (data.no_disputed_claims !== true) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['no_disputed_claims'],
+          message: `exportable=true requires no_disputed_claims=true`,
+        });
+      }
+      if (!data.reviewed_by) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['reviewed_by'],
+          message: `exportable=true requires reviewed_by (non-null)`,
+        });
+      }
+      if (!data.reviewed_at) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['reviewed_at'],
+          message: `exportable=true requires reviewed_at (non-null)`,
+        });
+      }
+    }
+
+    // Rule 3 : id must match `<entity_type>:<slug>` format
+    const expectedId = `${data.entity_type}:${data.slug}`;
+    if (data.id !== expectedId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['id'],
+        message: `id "${data.id}" must equal "${expectedId}" (entity_type + ":" + slug)`,
+      });
+    }
+  });
+
+export type WikiProposalFrontmatter = z.infer<
+  typeof WikiProposalFrontmatterSchema
+>;
+
+/**
+ * Parse + validate frontmatter. Throws ZodError au premier souci.
+ * Utilisé en strict (CLI validator, runtime backend ingestion future).
+ */
+export function parseWikiProposalFrontmatter(
+  raw: unknown,
+): WikiProposalFrontmatter {
+  return WikiProposalFrontmatterSchema.parse(raw);
+}
+
+/**
+ * Variante safe — retourne { success, data | error } sans throw.
+ * Utilisée par `scripts/wiki/validate-proposal.ts` pour agréger les erreurs
+ * sur N proposals avant de fail-fast la CI.
+ */
+export function safeParseWikiProposalFrontmatter(raw: unknown) {
+  return WikiProposalFrontmatterSchema.safeParse(raw);
+}

--- a/scripts/wiki/validate-proposal.ts
+++ b/scripts/wiki/validate-proposal.ts
@@ -1,0 +1,195 @@
+/**
+ * validate-proposal.ts — CLI canonique TS pour valider un fichier
+ * `automecanik-wiki/proposals/**\/*.md` ou `wiki/<entity_type>/**\/*.md` contre
+ * le schema Zod canon (ADR-039, miroir du JSON Schema `_meta/schema/frontmatter.schema.json`).
+ *
+ * Usage :
+ *   npx tsx scripts/wiki/validate-proposal.ts <file>...
+ *   npx tsx scripts/wiki/validate-proposal.ts --all <wiki-repo-root>
+ *
+ * Exit codes :
+ *   0 — all files valid
+ *   1 — at least one file invalid (frontmatter Zod errors)
+ *   2 — script error (file not found, YAML parse fail)
+ *
+ * Pattern : extension d'ADR-037 (`agent-frontmatter.schema.ts`) + ADR-038
+ * (`marketing-agent-frontmatter.schema.ts`) au scope wiki.
+ *
+ * Co-existe avec :
+ *   - `automecanik-wiki/_scripts/validate-frontmatter.py` (Python, JSON Schema canon)
+ *   - `automecanik-wiki/_scripts/validate-frontmatter.mjs` (JS, JSON Schema canon)
+ *   - `automecanik-wiki/_scripts/quality-gates.py` (Python, 9 quality gates)
+ *
+ * Différence de scope : ce TS validator est consommable par le backend NestJS
+ * (Phase 3 ADR-033 différée — quand `WikiProposalSyncService` arrive). Les
+ * 3 validators wiki repo restent autoritaires côté wiki repo CI.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import matter from 'gray-matter';
+
+import {
+  safeParseWikiProposalFrontmatter,
+  type WikiProposalFrontmatter,
+} from '../../backend/src/config/wiki-proposal-frontmatter.schema';
+
+interface ValidationResult {
+  file: string;
+  ok: boolean;
+  data?: WikiProposalFrontmatter;
+  errors?: Array<{ path: string; message: string }>;
+}
+
+function listMarkdownFiles(rootDir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [rootDir];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        // skip _meta, _scripts, exports, .git, node_modules, recycled-imports
+        if (
+          e.name.startsWith('.') ||
+          e.name === 'node_modules' ||
+          e.name === '_meta' ||
+          e.name === '_scripts' ||
+          e.name === 'exports'
+        ) {
+          continue;
+        }
+        stack.push(full);
+      } else if (e.isFile() && e.name.endsWith('.md')) {
+        // Skip canon meta files (`_index.md`, `_README.md`, `_changelog.md`, …) —
+        // they are not wiki proposals.
+        if (e.name.startsWith('_')) continue;
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+function validateFile(filePath: string): ValidationResult {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch (e) {
+    return {
+      file: filePath,
+      ok: false,
+      errors: [{ path: '<file>', message: `cannot read: ${(e as Error).message}` }],
+    };
+  }
+
+  let frontmatterData: unknown;
+  try {
+    frontmatterData = matter(raw).data;
+  } catch (e) {
+    return {
+      file: filePath,
+      ok: false,
+      errors: [
+        {
+          path: '<frontmatter>',
+          message: `YAML parse error: ${(e as Error).message}`,
+        },
+      ],
+    };
+  }
+
+  // Empty frontmatter (no `---`) → file is not a wiki proposal, skip with success.
+  if (
+    !frontmatterData ||
+    typeof frontmatterData !== 'object' ||
+    Object.keys(frontmatterData as object).length === 0
+  ) {
+    return {
+      file: filePath,
+      ok: false,
+      errors: [
+        {
+          path: '<frontmatter>',
+          message:
+            'no frontmatter found — wiki proposals require a `---`-delimited YAML block (ADR-031)',
+        },
+      ],
+    };
+  }
+
+  const result = safeParseWikiProposalFrontmatter(frontmatterData);
+  if (result.success) {
+    return { file: filePath, ok: true, data: result.data };
+  }
+  return {
+    file: filePath,
+    ok: false,
+    errors: result.error.issues.map((i) => ({
+      path: i.path.join('.') || '<root>',
+      message: i.message,
+    })),
+  };
+}
+
+function printResult(r: ValidationResult): void {
+  const rel = path.relative(process.cwd(), r.file);
+  if (r.ok) {
+    process.stdout.write(`✓ ${rel}\n`);
+    return;
+  }
+  process.stdout.write(`✗ ${rel}\n`);
+  for (const err of r.errors ?? []) {
+    process.stdout.write(`  ${err.path}: ${err.message}\n`);
+  }
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    process.stderr.write(
+      'Usage: validate-proposal.ts <file>... | --all <wiki-repo-root>\n',
+    );
+    process.exit(2);
+  }
+
+  let files: string[];
+  if (args[0] === '--all') {
+    if (!args[1]) {
+      process.stderr.write('--all requires a path argument (wiki repo root)\n');
+      process.exit(2);
+    }
+    const root = path.resolve(args[1]);
+    if (!fs.existsSync(root)) {
+      process.stderr.write(`path not found: ${root}\n`);
+      process.exit(2);
+    }
+    files = listMarkdownFiles(root);
+  } else {
+    files = args.map((f) => path.resolve(f));
+  }
+
+  if (files.length === 0) {
+    process.stdout.write('No .md files found.\n');
+    process.exit(0);
+  }
+
+  let nFail = 0;
+  for (const file of files) {
+    const r = validateFile(file);
+    printResult(r);
+    if (!r.ok) nFail++;
+  }
+
+  process.stdout.write(`\n${files.length - nFail}/${files.length} valid.\n`);
+  process.exit(nFail === 0 ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Establishes the canonical TS Zod schema mirror of `automecanik-wiki/_meta/schema/frontmatter.schema.json` (343 lines, Draft 2020-12) in the monorepo backend, plus a CLI validator callable from monorepo CI.

This is **PR-C** of the ADR-033 sequence (after PR-B = #249 mergered : workspace + skill `wiki-proposal-writer`).

**ADR** : [ak125/governance-vault#125](https://github.com/ak125/governance-vault/pull/125) — _ADR-039 wiki-frontmatter-zod-canon_ (Option A : Zod TS in monorepo, JSON Schema reste autoritaire).

## Why

When Phase 3 ADR-033 opens consumers (DB ingest `WikiProposalSyncService`, RAG sync, SEO export, blog hub), the backend NestJS will need to validate proposals at ingest. Without canonical TS, the risks are :

- Duplicate logic (rebuilt regex, AP-11)
- Sub-process Python from NestJS (fragile coupling, AP-10)
- Accept invalid proposals at runtime (bricolage)

## Mechanism (extends ADR-037 + ADR-038 to wiki scope)

| # | Change |
|---|---|
| 1 | New `WikiProposalFrontmatterSchema` Zod (mirror JSON Schema canon) |
| 2 | 3 cohabiting versions : `0.legacy`, `1.0.0`, `2.0.0` |
| 3 | 5 entity_types canon : `gamme`, `vehicle`, `constructeur`, `support`, `diagnostic` |
| 4 | Discriminated union on `source_refs[].kind` (4 variants : raw, external_url, manual, recycled) |
| 5 | `diagnostic_relations[]` (ADR-033 §D1) typed strict (3 enum `relation_to_part`, defaults conservateurs) |
| 6 | 2 conditional rules via `superRefine` (mirror JSON Schema `allOf`) |
| 7 | Cross-validation TS-only : `id === <entity_type>:<slug>` |
| 8 | CLI validator `scripts/wiki/validate-proposal.ts` callable via tsx |
| 9 | 30 Jest tests covering all the above |

## Test plan

- [x] Local : 30/30 tests pass on `wiki-proposal-frontmatter.schema.test.ts`
- [x] Local : typecheck clean (no errors)
- [x] Local : CLI smoke test on real wiki repo :
  - `automecanik-wiki/proposals/` → 12/12 valid (excluant `_index.md`)
  - `automecanik-wiki/wiki/diagnostic/` → 3/3 valid
- [ ] CI : Backend Tests + ESLint + TypeScript
- [ ] Smoke test post-merge : `npx tsx scripts/wiki/validate-proposal.ts --all /opt/automecanik/automecanik-wiki/proposals`

## Source de vérité

Le **JSON Schema** dans le wiki repo (`automecanik-wiki/_meta/schema/frontmatter.schema.json`) reste autoritaire. La Zod TS est une dérivation pour usage runtime monorepo. Si divergence détectée, la JSON Schema tranche, la Zod doit être ré-alignée.

## Companion / sequence

- Vault : [ak125/governance-vault#125](https://github.com/ak125/governance-vault/pull/125) (ADR-039, proposed)
- References : [ak125/governance-vault#118](https://github.com/ak125/governance-vault/pull/118) (ADR-037, SEO) + [ak125/governance-vault#121](https://github.com/ak125/governance-vault/pull/121) (ADR-038, marketing) — same canon pattern
- Continues : #249 mergered (PR-B, skill scaffold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)