### PR TITLE
fix(adr-033-pr-d): switch export from psycopg2 to PostgREST API (reuse existing secrets)

### DIFF
--- a/.github/workflows/diag-canon-slugs-export.yml
+++ b/.github/workflows/diag-canon-slugs-export.yml
@@ -14,12 +14,14 @@ name: diag-canon-slugs-export
 # differs. So a no-op run = no commit, no PR noise.
 #
 # Required secrets (monorepo Settings → Secrets and variables → Actions) :
-#   - SUPABASE_DB_PASSWORD : password for postgres user (port 5432 direct)
+#   - SUPABASE_URL : Supabase project base URL (already in monorepo CI secrets)
+#   - SUPABASE_SERVICE_ROLE_KEY : RLS-bypass JWT for PostgREST queries
+#                                  (already in monorepo CI secrets)
 #   - WIKI_REPO_TOKEN : PAT or GitHub App token with contents:write on
 #                       ak125/automecanik-wiki (for committing exports/)
 #
-# Optional :
-#   - SUPABASE_PROJECT_REF : default is the prod project ref (hardcoded in script)
+# Note : the script uses Supabase REST API (PostgREST) via stdlib urllib.request.
+# No psycopg2/SUPABASE_DB_PASSWORD needed. Reuses existing secrets.
 #
 # Refs :
 #   - ADR-033 §"Phase 3" vault PR #108 commit 77085ef
@@ -54,13 +56,10 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Python deps
-        run: |
-          python3 -m pip install --quiet psycopg2-binary
-
       - name: Run export
         env:
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           python3 monorepo/scripts/wiki/export-diag-canon-slugs.py \
             --output /tmp/diag-canon-slugs.json

--- a/scripts/wiki/export-diag-canon-slugs.py
+++ b/scripts/wiki/export-diag-canon-slugs.py
@@ -2,29 +2,29 @@
 """export-diag-canon-slugs.py — ADR-033 §"Phase 3" nightly export of canon
 __diag_symptom slugs from production DB to automecanik-wiki/exports/.
 
-Queries Supabase Postgres directly (psycopg2, port 5432, non-pooler) for
-deterministic results : sorted by symptom_slug, JSON serialization with
-sorted keys + 2-space indent + final newline. This guarantees idempotence —
-the workflow only commits if the JSON content actually differs from what's
-already in the wiki repo.
+Uses Supabase REST API (PostgREST) via stdlib urllib.request — no external
+deps, no `SUPABASE_DB_PASSWORD` secret to provision (reuses existing
+`SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` already in monorepo CI secrets).
+
+Output : deterministic JSON (sorted keys, 2-space indent, trailing newline)
+to make idempotence trivial — workflow only commits if content actually
+differs from current wiki HEAD.
 
 The output file `automecanik-wiki/exports/diag-canon-slugs.json` is
 consumed by :
   - PR-C validator (scripts/wiki/validate-gamme-diagnostic-relations.py)
-    to validate `diagnostic_relations[].symptom_slug` FK
-  - PR-E migration script (scripts/wiki/migrate-symptoms-to-relations.ts)
-    to validate target slugs at migration time
+  - PR-E migration script (deferred — Partie 3 sync-from-rag)
   - Wiki repo's own _scripts/quality-gates.py (read-only consumer)
 
 Schema of the output JSON :
 
   [
     {
+      "active": true,
+      "label": "Grincement aigu au freinage",
       "symptom_slug": "brake_noise_metallic",
       "system_slug": "freinage",
-      "label": "Grincement aigu au freinage",
-      "urgency": "haute",
-      "active": true
+      "urgency": "haute"
     },
     ...
   ]
@@ -35,14 +35,13 @@ Usage :
 
 Exit :
   0 — export written
-  1 — DB error
+  1 — HTTP/parse error
   2 — config error (missing env var)
 
 Refs :
   - ADR-033 §"Phase 3" vault PR #108 commit 77085ef
   - canon DB convention : memory diag-symptom-db-convention.md
-  - schema __diag_symptom : id, slug, system_id, label, description, signal_mode, urgency, active, created_at
-  - schema __diag_system : id, slug, label, ...
+  - PostgREST embedded resource : __diag_symptom?select=...,__diag_system(slug)
 """
 from __future__ import annotations
 
@@ -50,97 +49,101 @@ import argparse
 import json
 import os
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
-try:
-    import psycopg2
-    from psycopg2.extras import RealDictCursor
-except ImportError:
-    sys.stderr.write("FATAL: psycopg2 required (pip install psycopg2-binary)\n")
-    sys.exit(2)
 
-
-# ── Configuration ────────────────────────────────────────────────────────────
-
-
-def get_dsn() -> str:
-    password = os.environ.get("SUPABASE_DB_PASSWORD")
-    if not password:
-        sys.stderr.write("FATAL: SUPABASE_DB_PASSWORD missing in env\n")
+def get_supabase_config() -> tuple[str, str]:
+    """Reads SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY from env. Both required."""
+    url = os.environ.get("SUPABASE_URL", "").rstrip("/")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    if not url:
+        sys.stderr.write("FATAL: SUPABASE_URL missing in env\n")
         sys.exit(2)
-    project_ref = os.environ.get("SUPABASE_PROJECT_REF", "cxpojprgwgubzjyqzmoq")
-    return (
-        f"host=db.{project_ref}.supabase.co "
-        f"port=5432 "
-        f"dbname=postgres "
-        f"user=postgres "
-        f"password={password} "
-        f"sslmode=require "
-        f"application_name=adr-033-export-diag-canon-slugs"
+    if not key:
+        sys.stderr.write("FATAL: SUPABASE_SERVICE_ROLE_KEY missing in env\n")
+        sys.exit(2)
+    return url, key
+
+
+# PostgREST embedded resource : __diag_symptom?select=slug,...,__diag_system(slug)
+# returns rows with system nested. We flatten in post-processing for the
+# canonical output schema (system_slug at top level).
+QUERY_PATH = (
+    "/rest/v1/__diag_symptom"
+    "?select=slug,label,urgency,active,__diag_system(slug)"
+    "&active=eq.true"
+    "&order=slug.asc"
+)
+
+
+def fetch_canon_slugs(supabase_url: str, service_role_key: str) -> list[dict]:
+    """GET via PostgREST embedded resource. service_role bypasses RLS."""
+    url = supabase_url + QUERY_PATH
+    req = urllib.request.Request(
+        url,
+        headers={
+            "apikey": service_role_key,
+            "Authorization": f"Bearer {service_role_key}",
+            "Accept": "application/json",
+        },
+        method="GET",
     )
+    print(f"[fetch] GET {supabase_url}/rest/v1/__diag_symptom?...&order=slug.asc")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace") if hasattr(e, "read") else str(e)
+        sys.stderr.write(f"FATAL: HTTP {e.code} {e.reason}: {body[:500]}\n")
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        sys.stderr.write(f"FATAL: network error: {e.reason}\n")
+        sys.exit(1)
 
+    raw = json.loads(payload)
+    if not isinstance(raw, list):
+        sys.stderr.write(f"FATAL: PostgREST returned non-array payload: {type(raw)}\n")
+        sys.exit(1)
 
-# ── Query ────────────────────────────────────────────────────────────────────
-
-
-CANON_QUERY = """
-SELECT
-    s.slug AS symptom_slug,
-    sys.slug AS system_slug,
-    s.label,
-    s.urgency,
-    s.active
-FROM public.__diag_symptom s
-JOIN public.__diag_system sys ON sys.id = s.system_id
-WHERE s.active = true
-ORDER BY s.slug ASC
-""".strip()
-
-
-def fetch_canon_slugs() -> list[dict]:
-    print("[connect] db.<project>.supabase.co:5432 (direct, non-pooler)")
-    with psycopg2.connect(get_dsn(), connect_timeout=10) as conn:
-        conn.autocommit = True
-        with conn.cursor(cursor_factory=RealDictCursor) as cur:
-            cur.execute(CANON_QUERY)
-            rows = cur.fetchall()
-    print(f"[fetch] {len(rows)} active __diag_symptom rows")
-    return [dict(r) for r in rows]
-
-
-# ── Serialization ────────────────────────────────────────────────────────────
+    # Flatten embedded __diag_system into system_slug at top level
+    # + rename slug → symptom_slug for output schema clarity
+    flattened = []
+    for row in raw:
+        sys_obj = row.get("__diag_system") or {}
+        flattened.append({
+            "active": row.get("active"),
+            "label": row.get("label"),
+            "symptom_slug": row.get("slug"),
+            "system_slug": sys_obj.get("slug") if isinstance(sys_obj, dict) else None,
+            "urgency": row.get("urgency"),
+        })
+    print(f"[fetch] {len(flattened)} active __diag_symptom rows")
+    return flattened
 
 
 def serialize_canonical(rows: list[dict]) -> str:
-    """Deterministic JSON : sorted keys, indent 2, trailing newline.
-
-    Sort by symptom_slug ASC at SQL level already, but also sort keys
-    inside each row for stability across psycopg2 versions / json libs.
-    """
+    """Deterministic JSON : sorted keys, indent 2, trailing newline."""
     return json.dumps(rows, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
-
-
-# ── Main ─────────────────────────────────────────────────────────────────────
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--output", required=True, help="Path to write JSON output (e.g. /tmp/diag-canon-slugs.json)")
-    ap.add_argument("--dry-run", action="store_true", help="Connect + fetch + log row count, do NOT write file")
+    ap.add_argument("--output", required=True, help="Path to write JSON output")
+    ap.add_argument("--dry-run", action="store_true", help="Fetch + log row count, do NOT write file")
     args = ap.parse_args()
 
-    try:
-        rows = fetch_canon_slugs()
-    except psycopg2.Error as e:
-        sys.stderr.write(f"FATAL: DB error: {e}\n")
-        return 1
+    supabase_url, service_role_key = get_supabase_config()
+    rows = fetch_canon_slugs(supabase_url, service_role_key)
 
     out = Path(args.output)
     serialized = serialize_canonical(rows)
 
     if args.dry_run:
         print(f"[dry-run] would write {len(serialized)} bytes to {out}")
-        print(f"[dry-run] first row sample: {rows[0] if rows else '(none)'}")
+        if rows:
+            print(f"[dry-run] first row sample: {rows[0]}")
         return 0
 
     out.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Hotfix for PR-D #251 (`96837b95`) — the cron workflow `diag-canon-slugs-export.yml` shipped using `psycopg2` + `SUPABASE_DB_PASSWORD` secret. Inventory of monorepo Actions secrets shows **`SUPABASE_DB_PASSWORD` is not provisioned**, so the first nightly run would fail at the script step.

Fix : switch to Supabase REST API (PostgREST) via stdlib `urllib.request`. Reuses the already-provisioned `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` secrets. No new secret to provision, no external deps.

## Changes

| File | Change |
|---|---|
| `scripts/wiki/export-diag-canon-slugs.py` | Rewrite : `psycopg2` → `urllib.request` (stdlib). Same output schema (deterministic JSON, sorted keys, indent 2, trailing newline). PostgREST embedded resource flattened to `system_slug` at top level. |
| `.github/workflows/diag-canon-slugs-export.yml` | Remove `pip install psycopg2-binary` step. Update env vars : `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (was `SUPABASE_DB_PASSWORD`). Update header comment with new secret requirements. |

## Output schema (unchanged for downstream consumers PR-C / PR-F)

```json
[
  {
    "active": true,
    "label": "Grincement aigu au freinage",
    "symptom_slug": "brake_noise_metallic",
    "system_slug": "freinage",
    "urgency": "haute"
  },
  ...
]
```

## Why PostgREST + service_role over direct DB

| Approach | Pros | Cons |
|---|---|---|
| psycopg2 (PR-D shipped) | Standard pattern matching `apply-migration-marketing-phase1.py` | Requires `SUPABASE_DB_PASSWORD` secret (not provisioned) + `psycopg2-binary` install |
| **PostgREST stdlib (this PR)** | **Reuses existing secrets, no deps, faster cold start** | RLS bypass via `service_role` JWT (same effective access for read-only export) |

`service_role` already used elsewhere in CI for the same level of access. PostgREST embedded resource (`__diag_symptom?select=...,__diag_system(slug)`) achieves the same join semantics as `SELECT ... JOIN ... WHERE active=true ORDER BY slug ASC`.

## Test Plan

- [x] `python3 -m py_compile scripts/wiki/export-diag-canon-slugs.py` → OK
- [x] Workflow YAML syntax valid (env vars match available secrets)
- [x] Scope-firewall : 0 match marketing/adr-036/adr-038
- [x] Header commit `adr-033-scope: scripts-wiki` présent
- [ ] Post-merge : `gh workflow run diag-canon-slugs-export.yml --repo ak125/nestjs-remix-monorepo` → expect SUCCESS, initial commit lands in wiki repo

## Refs

- PR-D #251 (parent fix) commit `96837b95`
- sibling PR-C #250 (validator consumer)
- sibling PR-F #253 (readiness check consumer)
- plan rev 3 PR-D : `/home/deploy/.claude/plans/mvp-et-raw-et-wobbly-brooks.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)