### PR TITLE
fix(adr-033-pr-d): strip() env vars to handle trailing \\n in secrets

### DIFF
--- a/scripts/wiki/export-diag-canon-slugs.py
+++ b/scripts/wiki/export-diag-canon-slugs.py
@@ -55,9 +55,15 @@ from pathlib import Path
 
 
 def get_supabase_config() -> tuple[str, str]:
-    """Reads SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY from env. Both required."""
-    url = os.environ.get("SUPABASE_URL", "").rstrip("/")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    """Reads SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY from env. Both required.
+
+    `.strip()` defensively against trailing whitespace/newlines — secrets
+    set from a file or pasted via UI commonly carry a trailing `\\n` that
+    `urllib.request` rejects with `InvalidURL: URL can't contain control
+    characters` (run `25211636616` confirmed this failure mode).
+    """
+    url = os.environ.get("SUPABASE_URL", "").strip().rstrip("/")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
     if not url:
         sys.stderr.write("FATAL: SUPABASE_URL missing in env\n")
         sys.exit(2)


### PR DESCRIPTION
## Summary

Hotfix-of-the-hotfix for PR #256. The PostgREST switch went green on tests
but the first manual dispatch ([run `25211636616`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25211636616))
failed with :

```
http.client.InvalidURL: URL can't contain control characters.
'cxpojprgwgubzjyqzmoq.supabase.co\n' (found at least '\n')
```

## Root cause

`SUPABASE_URL` secret carries a trailing `\n` (common when secret is pasted
or set from a file with trailing newline). The script's
`os.environ.get(...).rstrip("/")` only stripped trailing slashes, not
whitespace, so the `\n` survived all the way to `urllib.request.urlopen()`
which rejected it.

## Fix

`.strip()` both env vars defensively before any further processing :

```python
url = os.environ.get("SUPABASE_URL", "").strip().rstrip("/")
key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
```

Robust against the same gotcha for any future Supabase secret provisioning,
no env-side surgery needed (i.e. no need to re-paste the secret in
GitHub Settings — code-side fix handles it).

## Verification

- Local Python syntax check ✅
- Local simulation with synthetic env (trailing `\n`) confirms `.strip()`
  produces clean URL/key ✅
- Will be validated by re-running `diag-canon-slugs-export.yml` after merge

## Test plan

- [x] Python syntax compile
- [x] Local strip simulation passes
- [ ] CI checks (pending)
- [ ] Manual workflow dispatch post-merge → verify `automecanik-wiki/exports/diag-canon-slugs.json` is created