### PR TITLE
fix(adr-033-pr-d): strip newlines from SUPABASE_URL secret

### DIFF
--- a/scripts/wiki/export-diag-canon-slugs.py
+++ b/scripts/wiki/export-diag-canon-slugs.py
@@ -55,9 +55,14 @@ from pathlib import Path
 
 
 def get_supabase_config() -> tuple[str, str]:
-    """Reads SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY from env. Both required."""
-    url = os.environ.get("SUPABASE_URL", "").rstrip("/")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    """Reads SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY from env. Both required.
+
+    .strip() removes trailing whitespace including newlines that may sneak in
+    when secrets are copy-pasted via GitHub UI (urllib rejects control chars
+    in hostnames with InvalidURL).
+    """
+    url = os.environ.get("SUPABASE_URL", "").strip().rstrip("/")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "").strip()
     if not url:
         sys.stderr.write("FATAL: SUPABASE_URL missing in env\n")
         sys.exit(2)


### PR DESCRIPTION
Hotfix — run #25211659750 of `diag-canon-slugs-export.yml` failed with `http.client.InvalidURL: URL can't contain control characters. 'cxpojprgwgubzjyqzmoq.supabase.co\\n'`.

The `SUPABASE_URL` secret has a trailing newline (copy-paste artifact via GitHub UI). `urllib.request` rejects control chars in hostnames per RFC.

Fix : `.strip()` before `.rstrip("/")`. Same applied to `SUPABASE_SERVICE_ROLE_KEY` defensively. Canonical pattern for GitHub Actions secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)