### PR TITLE
chore(dep-cruiser): promote 5 zero-violation rules from warn to error (Phase 1 partial)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,8 +1,19 @@
 /**
  * dependency-cruiser config for AutoMecanik monorepo
- * Starts permissive: hard errors on obvious wrongs, warnings on architectural
- * concerns so the pre-commit hook never blocks day 1.
- * Tighten severity as cleanup Phase 1 progresses.
+ *
+ * Phase 1 partial (2026-05-01) — 5 rules promoted from warn to error after
+ * audit confirmed zero existing violations on each :
+ *   - not-to-deprecated
+ *   - frontend-not-to-backend-src
+ *   - backend-not-to-frontend
+ *   - not-to-test
+ *   - not-to-spec
+ *
+ * Rules with existing technical debt remain warn until cleanup :
+ *   - no-circular         (41 violations, Phase 2)
+ *   - no-orphans          (48 violations, Phase 2)
+ *   - no-deep-module-access (77 violations, Phase 2)
+ *   - no-non-package-json (3 violations, Phase 1 bis after allowlist)
  */
 /** @type {import('dependency-cruiser').IConfiguration} */
 module.exports = {
@@ -33,24 +44,24 @@ module.exports = {
     },
     {
       name: 'not-to-deprecated',
-      severity: 'warn',
-      comment: 'Imported module is deprecated.',
+      severity: 'error',
+      comment: 'Imported module is deprecated. Promoted to error 2026-05-01 (Phase 1, 0 violations).',
       from: {},
       to: { dependencyTypes: ['deprecated'] },
     },
     {
       name: 'frontend-not-to-backend-src',
-      severity: 'warn',
+      severity: 'error',
       comment:
-        'Frontend must go through HTTP/API, never reach into backend source directly. Promote to error after Phase 1 cleanup.',
+        'Frontend must go through HTTP/API, never reach into backend source directly. Promoted to error 2026-05-01 (Phase 1, 0 violations).',
       from: { path: '^frontend/app/' },
       to: { path: '^backend/src/' },
     },
     {
       name: 'backend-not-to-frontend',
-      severity: 'warn',
+      severity: 'error',
       comment:
-        'Backend must not reach into frontend source (coupling + bundling disaster). Promote to error after Phase 1 cleanup.',
+        'Backend must not reach into frontend source (coupling + bundling disaster). Promoted to error 2026-05-01 (Phase 1, 0 violations).',
       from: { path: '^backend/src/' },
       to: { path: '^frontend/app/' },
     },
@@ -74,8 +85,8 @@ module.exports = {
     },
     {
       name: 'not-to-test',
-      severity: 'warn',
-      comment: 'Production code should not import tests. Promote to error after Phase 1 cleanup.',
+      severity: 'error',
+      comment: 'Production code should not import tests. Promoted to error 2026-05-01 (Phase 1, 0 violations).',
       from: {
         pathNot: [
           '\\.(spec|test|e2e-spec)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$',
@@ -87,8 +98,8 @@ module.exports = {
     },
     {
       name: 'not-to-spec',
-      severity: 'warn',
-      comment: 'No imports from documentation folder. Promote to error after Phase 1 cleanup.',
+      severity: 'error',
+      comment: 'No imports from documentation folder. Promoted to error 2026-05-01 (Phase 1, 0 violations).',
       from: {},
       to: { path: '^\\.spec/' },
     },


### PR DESCRIPTION
## Summary

Promotion de 5 règles dependency-cruiser de `severity: 'warn'` à `severity: 'error'`. Toutes vérifiées **0 violation actuelle** sur HEAD main avant promotion → pas de allowlist, pas de masquage de dette, juste un durcissement propre.

## Règles promotes (warn → error)

| Règle | Domain | Violations actuelles |
|---|---|---|
| `not-to-deprecated` | Imports de modules dépréciés | 0 |
| `frontend-not-to-backend-src` | Frontend → backend/src direct (doit passer par HTTP) | 0 |
| `backend-not-to-frontend` | Backend → frontend (coupling + bundling) | 0 |
| `not-to-test` | Production code → tests | 0 |
| `not-to-spec` | Production code → `.spec/` docs | 0 |

## Règles laissées en warn (Phase 2 / Phase 1 bis)

| Règle | Violations | Trajet |
|---|---|---|
| `no-circular` | 41 | Phase 2 — refactor cycles (madge/dpdm pour visualisation) |
| `no-orphans` | 48 | Phase 2 — dead-code cleanup |
| `no-deep-module-access` | 77 | Phase 2 — migration public barrels |
| `no-non-package-json` | 3 | Phase 1 bis — allowlist déclarative |

## Verification

```
$ npx depcruise --config .dependency-cruiser.cjs --output-type err backend/src frontend/app
  ... 148 warnings (règles encore warn) ...
x 148 dependency violations (0 errors, 148 warnings). 2149 modules, 8623 dependencies cruised.
exit 0
```

**0 errors** sur les 5 règles promotes → la CI passe (le pre-commit hook + audit.yml workflow continuent de fonctionner).

## Anti-bricolage discipline

- ✅ Promoter uniquement quand **0 violation** — pas de allowlist artificielle qui masquerait la dette
- ✅ Pas de touch sur les règles à dette > 0 — Phase 2 séparée après refactor effectif
- ✅ Pattern moderne baseline-aware **sans baseline file** : car 0 violation à exclure
- ✅ Header comment du fichier mis à jour avec liste promotes + dette restante (auto-doc, pas changelog parallèle)

## Test plan

- [x] Audit local (`npx depcruise --output-type json` + Counter) confirme 0 violation par règle promote
- [x] Verification post-modification (`--output-type err`) → exit 0
- [ ] CI lint/build/test passent sur cette PR (à vérifier sur le run)
- [ ] `audit.yml` workflow (regression gate baseline) continue à passer

## Refs

- Plan : [verifier-en-profondeure-ces-async-pie.md rev 10 §P3 Phase 1](https://github.com/ak125/automecanik-wiki) (local)
- Phase 1 bis suivante : `no-non-package-json` après identification des 3 exceptions légitimes (alias monorepo, packages internes, scripts) → allowlist déclarative dans `forbidden.exceptions[]`
- Phase 2 ultérieure : 3 règles avec dette historique, après refactor cycles + dead-code cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)