### PR TITLE
chore(husky): pre-push hook blocking direct pushes to main/dev

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,51 @@
+# pre-push — block direct pushes to protected branches (main, dev)
+#
+# Per .claude/rules/deployment.md, pushes to main/dev trigger the DEV
+# pre-prod deploy workflow (.github/workflows/ci.yml deploy job). Direct
+# pushes bypass PR review and reduce CI gating to a single linear check;
+# they must go through reviewed PRs.
+#
+# Tag pushes (refs/tags/v*) for PROD deploy are allowed.
+#
+# Bypass: `git push --no-verify` (logged in reflog; reserve for documented
+# emergencies — e.g. revert + roll-forward when waiting on PR review is
+# itself the risk).
+#
+# Hook contract (git pre-push):
+#   - args: $1 = remote name, $2 = remote URL
+#   - stdin: one line per ref being pushed,
+#            "<local_ref> <local_sha> <remote_ref> <remote_sha>"
+
+zero=0000000000000000000000000000000000000000
+
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  case "$remote_ref" in
+    refs/heads/main | refs/heads/dev)
+      branch=${remote_ref#refs/heads/}
+      if [ "$local_sha" = "$zero" ]; then
+        op="deletion of"
+      elif [ "$remote_sha" = "$zero" ]; then
+        op="creation of"
+      else
+        op="direct push to"
+      fi
+      echo
+      echo "✗ Refused by .husky/pre-push: $op '$branch'."
+      echo
+      echo "  Per .claude/rules/deployment.md, pushes to $branch trigger the"
+      echo "  DEV pre-prod deploy and must go through a reviewed PR. Branch"
+      echo "  creation/deletion of $branch is also refused as defense-in-depth"
+      echo "  against accidental destructive operations."
+      echo
+      echo "  Open a PR instead:"
+      echo "    git push -u origin HEAD:refs/heads/<type>/<topic>"
+      echo "    gh pr create --base $branch"
+      echo
+      echo "  Tag pushes for PROD (refs/tags/v*) remain allowed."
+      echo "  Emergency bypass (leaves reflog trail): git push --no-verify"
+      exit 1
+      ;;
+  esac
+done
+
+exit 0

--- a/log.md
+++ b/log.md
@@ -273,3 +273,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/p3-diag-canon-flat-map-composite-fk`
 - **Décision** : Merge branch 'main' into feat/p3-diag-canon-flat-map-composite-fk (+18 other commits)
 - **Sortie** : PR #262 | commits 21ea2b3a 0d300149 9d5af4da baa8ee78 6992eea5 ce7f7c7f cd2789fe 2fd4f936 9b94dc04 0862f103 a0c05032 683178d4 2a4cf7d7 8fe27520 7669f75d 4e24f1b9 85214f84 9a6b9240 714b742e
+
+## 2026-05-02 — chore/husky-pre-push-main-guard (auto)
+
+- **Branche** : `chore/husky-pre-push-main-guard`
+- **Décision** : chore(husky): add pre-push hook blocking direct pushes to main/dev
+- **Sortie** : PR aucune | commits e5c5d261


### PR DESCRIPTION
## Summary

- Adds `.husky/pre-push` that refuses direct pushes, branch creation, and branch deletion targeting `refs/heads/main` or `refs/heads/dev`.
- Tag pushes (`refs/tags/v*`) for PROD deploy remain allowed.
- Other branches (`feat/*`, `fix/*`, `chore/*`, …) are not affected.

## Why

Per [.claude/rules/deployment.md](.claude/rules/deployment.md), pushes to `main`/`dev` trigger the DEV pre-prod deploy workflow (`.github/workflows/ci.yml` deploy job). Direct pushes bypass PR review and reduce CI gating to a single linear check. The hook is defense-in-depth; GitHub branch protection remains the authoritative gate.

Pattern reference: `governance-vault/ledger/knowledge/pre-push-local-check-pattern.md` — "tout check CI déterministe de <5s doit exister en parallèle en hook git local".

## Wiring

- `.husky/_/pre-push` shim already present (regenerated by `husky` on `npm install` via `package.json` `prepare` script).
- No `package.json` change needed.
- New contributors get the hook automatically after `npm install`.

## Bypass

`git push --no-verify` — leaves a reflog trail. Reserved for documented emergencies.

## Test plan

Verified locally with 8 simulated stdin payloads:

| # | Scenario | Expected | Actual |
|---|---|---|---|
| T1 | `push refs/heads/main` | exit 1 | ✅ "direct push to" |
| T2 | `push refs/heads/feat/foo` | exit 0 | ✅ |
| T3 | `push refs/heads/dev` | exit 1 | ✅ "direct push to" |
| T4 | `push refs/tags/v1.0` | exit 0 | ✅ |
| T5 | `delete refs/heads/main` | exit 1 | ✅ "deletion of" |
| T6 | `delete refs/heads/feat/foo` | exit 0 | ✅ |
| T7 | `create refs/heads/main` | exit 1 | ✅ "creation of" |
| T8 | multi-ref clean | exit 0 | ✅ |

Reproduce: `printf 'refs/heads/x abc refs/heads/main def\n' | sh .husky/pre-push origin x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)