### PR TITLE
fix(p3): un-export RelationCheckResult (internal return type only)

### DIFF
--- a/backend/src/config/diag-canon.schema.ts
+++ b/backend/src/config/diag-canon.schema.ts
@@ -68,15 +68,15 @@ export const DiagCanon = z
 export type DiagCanon = z.infer<typeof DiagCanon>;
 
 /**
- * Outcome of `checkDiagnosticRelation`. The `blockedReason` strings are
+ * Outcome of `checkDiagnosticRelation`. Internal: callers should infer via
+ * `ReturnType<typeof checkDiagnosticRelation>` or destructure `result.ok`
+ * directly (TypeScript narrows the union). The `blockedReason` strings are
  * **byte-identical** to those emitted by the Python validator
  * `scripts/wiki/validate-gamme-diagnostic-relations.py` (function
  * `gate_diagnostic_relations_fk`). Any future change in the Python validator
  * MUST update the spec assertions in this file.
  */
-export type RelationCheckResult =
-  | { ok: true }
-  | { ok: false; blockedReason: string };
+type RelationCheckResult = { ok: true } | { ok: false; blockedReason: string };
 
 /**
  * Validates a single `diagnostic_relations[]` entry of a wiki gamme proposal


### PR DESCRIPTION
## Summary

\`RelationCheckResult\` (in \`backend/src/config/diag-canon.schema.ts\`) is the return type of \`checkDiagnosticRelation\` and used nowhere outside this file. Exporting it added one entry to the knip \`unused_types\` ledger with no consumer benefit.

## Change

Single-line code change : remove the \`export\` keyword on the type. The function \`checkDiagnosticRelation\` itself remains exported, so callers still have full access to the behavior.

Updated the JSDoc to document how callers should infer the type when they need it explicitly :

\`\`\`ts
// Implicit narrowing
const result = checkDiagnosticRelation(canon, rel);
if (!result.ok) console.log(result.blockedReason);

// Explicit type, when needed
function handle(r: ReturnType<typeof checkDiagnosticRelation>) { ... }
\`\`\`

## What stays exported

The schema-derived public API (\`DiagCanonSlug\`, \`DiagCanon\`) remains exported — those are documented future entry points for runtime consumers (\`WikiProposalSyncService\`, \`wiki-proposal-writer\` skill, Phase 3 ADR-033).

## Verification

- [x] \`grep -rn RelationCheckResult backend/src\` — only references are in the source file itself
- [x] \`npx jest --testPathPattern=diag-canon.schema --no-coverage --maxWorkers=1\` — 10/10 pass

## Out of scope

The 28 other unused types accumulated from merged ADR-032 / marketing PRs (\`r-keyword-plan.constants\`, \`evidence-pack.schema\`, \`maintenance-calculator.service\`, etc.). Those are tracked for a dedicated cleanup wave (scheduled via /schedule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)