### PR TITLE
feat(diag): add 2 missing brake symptoms (distance_freinage_allongee + voyant_freinage_allume)

### DIFF
--- a/backend/supabase/migrations/20260502_diag_brake_signals_distance_warning.sql
+++ b/backend/supabase/migrations/20260502_diag_brake_signals_distance_warning.sql
@@ -1,0 +1,52 @@
+-- ══════════════════════════════════════════════════════════
+-- Diagnostic Engine — 2 symptoms freinage manquants (slugs FR canon)
+-- ADR-033 + ADR-040 + plan deja-verifier-existant Phase 2
+-- ══════════════════════════════════════════════════════════
+--
+-- Contexte : pilote Phase E (plaquette-de-frein.md) nécessite des slugs
+-- __diag_symptom pour diagnostic_relations[]. La fiche originale avait
+-- TENTÉ ces 2 slugs FR (distance_freinage_allongee, voyant_freinage_allume)
+-- puis les avait retirés faute de slug DB existant. Cette migration crée
+-- les 2 slugs canon FR pour débloquer la fiche.
+--
+-- Convention slug canon (cf. feedback_french_only_for_content.md +
+-- système filtration : perte_puissance_filtration, voyant_huile,
+-- surconsommation_carburant, odeur_habitacle) :
+--   - FR snake_case obligatoire
+--   - signal_mode = 'symptom_slugs' (cohérence freinage existant) ou
+--     'customer_reported' (cohérence filtration existant)
+--   - urgency = 'haute' (système safety-critical)
+--
+-- Hors scope cette migration (déjà existant en DB) :
+--   - filtration system (id=11, créé migration 20260321)
+--   - perte_puissance_filtration (id=55, FR canon pour symptômes filtration)
+--     → filtre-a-air.md doit pointer vers ce slug, pas inventer
+--
+-- Note legacy à isoler (5 slugs brake_* en EN, drift batch 20260308) :
+--   - brake_noise_grinding, brake_noise_metallic, brake_pulling_side,
+--     brake_soft_pedal, brake_vibration_pedal
+--   Ces slugs existants restent utilisés par plaquette-de-frein.md mais
+--   tout NOUVEAU slug DOIT être FR (cf. règle FR-only).
+--
+-- Plan : /home/deploy/.claude/plans/deja-verifier-existant-de-abundant-hanrahan.md
+-- ADR : governance-vault/ledger/decisions/adr/ADR-040-wiki-proposal-evidence-and-conditional-promotion.md
+
+INSERT INTO __diag_symptom (slug, system_id, label, description, signal_mode, urgency, active)
+VALUES
+  ('distance_freinage_allongee',
+   (SELECT id FROM __diag_system WHERE slug='freinage'),
+   'Distance de freinage allongée',
+   'Sensation de distance d''arrêt anormalement longue, pédale parfois plus enfoncée. Causes possibles : plaquettes usées/contaminées, disques voilés, ABS défaillant, liquide de frein vieillissant.',
+   'symptom_slugs', 'haute', true),
+  ('voyant_freinage_allume',
+   (SELECT id FROM __diag_system WHERE slug='freinage'),
+   'Voyant freinage allumé',
+   'Témoin freinage rouge ou orange au tableau de bord. Causes possibles : niveau liquide bas, plaquettes en fin de vie (capteur d''usure), frein à main partiellement engagé, ABS défaillant.',
+   'symptom_slugs', 'haute', true)
+ON CONFLICT (slug) DO NOTHING;
+
+-- Validation post-migration :
+--   SELECT slug, label, signal_mode, urgency
+--   FROM __diag_symptom
+--   WHERE slug IN ('distance_freinage_allongee','voyant_freinage_allume');
+--   -- attendu : 2 rows


### PR DESCRIPTION
## Summary

Migration SQL pour ajouter 2 symptômes manquants au système `freinage` dans `__diag_symptom`, débloquant `diagnostic_relations[]` dans la fiche wiki `plaquette-de-frein.md` (plan `deja-verifier-existant-de-abundant-hanrahan` Phase 2 + ADR-040 §3).

- `distance_freinage_allongee` (FR canon)
- `voyant_freinage_allume` (FR canon)

## Audit existant (CLAUDE.md "vérifier l'existant AVANT d'inventer")

MCP Supabase 2026-05-02 a confirmé :

| Slug initialement prévu | État DB | Décision |
|---|---|---|
| `filtration` system | EXISTE (id=11, créé 20260321) | ❌ Pas re-créer |
| `air_filter_clogged` | Équivalent existant `perte_puissance_filtration` (id=55) | ❌ Réutiliser slug DB ; `filtre-a-air.md` pointera dessus |
| `brake_distance_long` (EN) | Aucun | ✅ Créer en FR : `distance_freinage_allongee` |
| `brake_warning_lamp` (EN) | Aucun | ✅ Créer en FR : `voyant_freinage_allume` |

## Convention slug FR canon

Suite au feedback utilisateur 2026-05-02 ("interdit d'utiliser autre langue que le français pour les contenus") :
- TOUT NOUVEAU slug DB doit être FR snake_case
- Système `filtration` est l'exemple canon (perte_puissance_filtration, voyant_huile, surconsommation_carburant, odeur_habitacle)
- 5 slugs `brake_*` legacy (drift batch 20260308) restent utilisés mais aucun nouveau slug ne sera EN
- Renommage rétroactif `brake_*` → FR = hors scope ce PR

## Note importante

La fiche `plaquette-de-frein.md` originale avait TENTÉ ces 2 slugs FR exact (`distance_freinage_allongee`, `voyant_freinage_allume`) puis les avait retirés faute de slug DB existant (review_notes ligne 35). Cette migration crée les slugs canon FR exactement comme la fiche les attendait — alignement parfait sur l'intention initiale.

## Test plan

- [ ] CI lint + types passent
- [ ] Validation post-merge : `SELECT slug, label, signal_mode, urgency FROM __diag_symptom WHERE slug IN ('distance_freinage_allongee','voyant_freinage_allume');` retourne 2 rows
- [ ] Phase 5 du plan parent peut alors ré-ajouter `diagnostic_relations[]` dans `plaquette-de-frein.md` (4 entrées totales : 2 existantes brake_noise_metallic/brake_vibration_pedal + 2 nouvelles distance_freinage_allongee/voyant_freinage_allume)

## Références

- Plan exécution : \`/home/deploy/.claude/plans/deja-verifier-existant-de-abundant-hanrahan.md\`
- ADR-033 — Wiki Gamme Diagnostic Relations Contract
- ADR-040 (proposed, vault PR pending) — Wiki Proposal Evidence & Conditional Promotion Contract §3 WikiReasonCode + §2 Coverage Map
- Memory : \`feedback_french_only_for_content.md\` (règle FR exclusive contenus)
- Plan parent skill : \`automecanik-raw/.claude/skills/web-clip-template/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)