### PR TITLE
fix(agents): harden validator (H1 fork PR + S1 husky reorder + regression tests)

### DIFF
--- a/.github/workflows/agents-md-validation.yml
+++ b/.github/workflows/agents-md-validation.yml
@@ -37,7 +37,10 @@ jobs:
 
       - name: Validate diff vs base (anti-patterns sur lignes ajoutées)
         if: github.event_name == 'pull_request'
-        run: bash scripts/agents/validate-agents-md.sh --diff origin/${{ github.base_ref }}
+        # Use base.sha (unambiguous) au lieu de origin/<base_ref> :
+        # sur une PR forkée externe, `origin` peut pointer vers le fork
+        # → `git diff origin/main` retournerait vide silencieusement (gate passerait à tort).
+        run: bash scripts/agents/validate-agents-md.sh --diff ${{ github.event.pull_request.base.sha }}
 
       - name: Validate full repo (structure check)
         run: bash scripts/agents/validate-agents-md.sh --all

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,6 +15,14 @@ if [ -n "$BLOCKED" ]; then
   exit 1
 fi
 
+# Validateur AGENTS.md / CLAUDE.md (anti-pattern + structure).
+# Placé AVANT lint-staged et autres transformations : check bloquant doit
+# voir le contenu tel que stagé par l'utilisateur, pas une version
+# auto-formatée. Mémoire : feedback_no_hardcoded_infra_in_agentsmd.md
+if git diff --cached --name-only | grep -qE '(^|/)(AGENTS|CLAUDE)\.md$'; then
+  bash scripts/agents/validate-agents-md.sh --staged || exit 1
+fi
+
 npx lint-staged
 
 # Refresh auto-generated YAML frontmatter + AUTO-GENERATED blocks in
@@ -31,12 +39,6 @@ if command -v python3 >/dev/null 2>&1 \
   if [ -n "$CHANGED" ]; then
     git add $CHANGED 2>/dev/null || true
   fi
-fi
-
-# Validateur AGENTS.md / CLAUDE.md (anti-pattern + structure).
-# Mémoire associée : feedback_no_hardcoded_infra_in_agentsmd.md
-if git diff --cached --name-only | grep -qE '(^|/)(AGENTS|CLAUDE)\.md$'; then
-  bash scripts/agents/validate-agents-md.sh --staged || exit 1
 fi
 
 # Fast deterministic gate: ast-grep rules in .ast-grep/rules/

--- a/scripts/agents/validate-agents-md.sh
+++ b/scripts/agents/validate-agents-md.sh
@@ -271,8 +271,21 @@ EOF
   bash "$0" --file "$tmp/clean.md" >/dev/null 2>&1
   test_case "PASS — fichier propre" 0 $?
 
+  # 8. PASS — non-régression : "présente" lowercase = français normal,
+  #    pas une assertion d'état infra. Le filtre case-sensitive per-ligne
+  #    doit rejeter (seul ABSENTE/PRÉSENTE/DOWN uppercase = vraie assertion).
+  echo 'La documentation présente les modules backend.' > "$tmp/fr-presente.md"
+  bash "$0" --file "$tmp/fr-presente.md" >/dev/null 2>&1
+  test_case "PASS — 'présente' lowercase (FR normal, pas assertion)" 0 $?
+
+  # 9. PASS — non-régression : "down" lowercase dans une phrase FR
+  #    n'est pas une assertion d'état infra (qui s'écrit "DOWN" par convention).
+  echo "Quand l'API est down, les jobs s'accumulent." > "$tmp/fr-down.md"
+  bash "$0" --file "$tmp/fr-down.md" >/dev/null 2>&1
+  test_case "PASS — 'down' lowercase (FR normal, pas assertion)" 0 $?
+
   if [ $failed -eq 0 ]; then
-    echo "✅ all 7 self-tests passed"
+    echo "✅ all 9 self-tests passed"
     exit 0
   else
     echo "❌ $failed self-test(s) failed"


### PR DESCRIPTION
## Summary

Suite à la review de PR #271 (skill `code-review` + agent indépendant `superpowers:code-reviewer`) → verdict APPROVE avec 2 HAUTE / 1 SUGGESTION advisory non bloquants. Cette PR adresse les 3 points avec **vérification empirique** avant action.

| Point | Niveau | Verdict empirique | Action |
|---|---|---|---|
| **H1** Edge case PR forkée externe | HAUTE | Risque réel | ✅ Fix |
| **H2** Faux positif `RE_STATE_FIGE` sur 'présente' FR | HAUTE | **Faux alarme** (testé) | Self-tests régression |
| **S1** Husky reorder validateur avant lint-staged | SUGGESTION | Pattern correct | ✅ Fix |

## Changements

### H1 — `.github/workflows/agents-md-validation.yml`

```diff
-        run: bash scripts/agents/validate-agents-md.sh --diff origin/${{ github.base_ref }}
+        run: bash scripts/agents/validate-agents-md.sh --diff ${{ github.event.pull_request.base.sha }}
```

`actions/checkout@v4` sur une PR forkée externe peut configurer `origin` vers le fork. `git diff origin/main` retournerait alors vide silencieusement → **gate passerait à tort**. `base.sha` est unambigu et toujours disponible côté GitHub. Recommandation directe de l'agent.

### S1 — `.husky/pre-commit`

Déplacer le bloc validateur avant `lint-staged` + `refresh-knowledge`. Pattern correct : checks bloquants d'abord. Aucun formatter `.md` actuellement, donc impact pratique = 0, mais défensif si un formatter `.md` arrivait demain.

### Self-tests 7 → 9 (figer la non-régression H2)

L'agent avait soulevé : « le filtre case-insensitive prefilter laisse passer 'présente' lowercase qui matcherait `RE_STATE_FIGE` → faux positif sur FR normal ».

**Vérification empirique** :

```bash
$ echo "La documentation présente les modules backend." > /tmp/h2-test1.md
$ bash scripts/agents/validate-agents-md.sh --file /tmp/h2-test1.md
final_status: PASS  # ← pas de faux positif

$ echo "Auth : ADMIN_API_KEY ABSENTE — endpoints retournent 401" > /tmp/h2-test2.md
$ bash scripts/agents/validate-agents-md.sh --file /tmp/h2-test2.md
final_status: BLOCK  # ← intent respecté

$ echo "Quand l'API est down, les jobs s'accumulent." > /tmp/h2-test3.md
$ bash scripts/agents/validate-agents-md.sh --file /tmp/h2-test3.md
final_status: PASS  # ← pas de faux positif
```

Le filtre per-ligne case-sensitive (sans `-i`) rejette correctement les variantes lowercase. Le BLOCK ne s'émet que pour `ABSENTE/PRÉSENTE/PRESENTE/DOWN` en majuscules (convention pour assertion d'état infra).

**Action prise** : ajouter 2 self-tests pour figer ce comportement (empêche une régression future si un dev ajoutait `-i` au per-ligne par mégarde) :

- Test 8 : « La documentation présente les modules » → PASS attendu
- Test 9 : « Quand l'API est down, les jobs s'accumulent » → PASS attendu

Annonce passe de « ✅ all 7 self-tests passed » à « ✅ all 9 self-tests passed ».

## Pas de bricolage

H2 n'est **pas** un vrai bug (vérifié empiriquement). La défense est un test (régression-prevention), pas une modification de la regex. Pas de complexification du validateur pour un faux problème — cf. mémoire `feedback_no_hybrid_workarounds.md`.

## Test plan

- [x] `bash scripts/agents/validate-agents-md.sh --self-test` → 9/9 PASS
- [x] `bash scripts/agents/validate-agents-md.sh --all` → 0 BLOCK, 3 WARN advisory (PASS)
- [x] H2 testé empiriquement (3 cas) — comportement correct figé par tests 8+9
- [ ] CI workflow `agents-md-validation` doit passer sur cette PR (vérifie son propre fix H1)

## Référence

- PR #271 (mergée) — audit AGENTS.md/CLAUDE.md + structural gate
- Agent review : verdict APPROVE, 2 HAUTE + 3 SUGGESTIONS advisory
- Skill `code-review` review : verdict APPROVE
- Mémoire : `feedback_no_hardcoded_infra_in_agentsmd.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)