### PR TITLE
chore: bump wiki submodule pointer to origin/main (post-PR #18)

### DIFF
--- a/log.md
+++ b/log.md
@@ -309,3 +309,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/audit-claude-md-agents-md`
 - **Décision** : feat(agents): audit + structural gate for AGENTS.md / CLAUDE.md
 - **Sortie** : PR aucune | commits 9842fa00
+
+## 2026-05-03 — chore/bump-wiki-submodule-pointer (auto)
+
+- **Branche** : `chore/bump-wiki-submodule-pointer`
+- **Décision** : chore: bump wiki submodule pointer to current origin/main
+- **Sortie** : PR #273 | commits 707a1775


### PR DESCRIPTION
## Summary

Bump `backend/content/automecanik-wiki` submodule pointer de `02cb4326` → `800a9d22` (origin/main du repo `ak125/automecanik-wiki` au 2026-05-03).

## Pourquoi

Le repo monorepo référence `automecanik-wiki` comme submodule. Le pointer pinné dans main pointait vers un commit pré-PR #18 (`02cb4326`) qui contenait encore l'ancienne note ADR-031 « à créer Phase C ». Sans bump, le workspace Claude Code `wiki/` charge un état stale — incohérence entre :
- ce que la PR monorepo #271 référence dans `CLAUDE.md` root (« ADR-031 accepted »)
- ce que le submodule pinné contient (« ADR-031 à créer »)

## Diff

```diff
-Subproject commit 02cb4326ea8951412ccb2e5575f2f8cc33856e85
+Subproject commit 800a9d2265b5a0aa64a4c0f6d34dcd82897020ee
```

## Commits wiki inclus dans ce bump

- **PR wiki #18** — docs(claude): refresh ADR refs (031 accepted, 022 conditional, 033 added) ← origine
- chore(diag-canon): nightly export 2026-05-03 + 2026-05-02 + 2026-05-01
- **PR wiki #17** — feat(audit): classifier origine des 329 fiches rag/knowledge (Étape 3 plan v3)
- **PR wiki #15** — feat(wiki): Phases 1+3 cohérence proposals
- **PR wiki #14** — feat(ci): cross-repo-source-catalog-gate workflow
- **PR wiki #13** — feat(p2): source-catalog raw_ref content-addressing
- **PR wiki #12** — feat(p5): wire wiki-symptom-confidence drift

## Impact

**Aucun impact fonctionnel** sur le monorepo : le submodule contient du contenu (wiki documentaire) lu par les agents IA via le workspace `wiki/` Claude Code, **pas du code applicatif**. Aucun build, test, route, ou job CI ne consomme le contenu wiki au runtime.

**Cohérence ADR-031 §D14** : la chaîne raw → wiki → consommateurs suppose que le pointer monorepo reflète l'état réel du repo wiki.

## Test plan

- [x] `git diff --submodule=log` montre les 9 commits wiki inclus
- [x] Aucune modification de code applicatif (1 fichier, 1 insertion, 1 deletion = juste le pointer)
- [ ] CI doit passer (gates standards — aucun gate spécifique submodule)

## Référence

- PR #271 (mergée) — audit AGENTS.md/CLAUDE.md monorepo
- PR wiki #18 (mergée dans `ak125/automecanik-wiki`) — corrections CLAUDE.md wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)