### PR TITLE
fix(env-validation): respect READ_ONLY=true (ADR-028 Option D) — unblocks 3-day broken main deploy

### DIFF
--- a/backend/src/config/env-validation.ts
+++ b/backend/src/config/env-validation.ts
@@ -138,9 +138,7 @@ export function validateRequiredEnvVars(): void {
   // Log success in non-test environments
   if (process.env.NODE_ENV !== 'test') {
     if (readOnly) {
-      logger.log(
-        'READ_ONLY=true (ADR-028 Option D) — relaxed env baseline OK',
-      );
+      logger.log('READ_ONLY=true (ADR-028 Option D) — relaxed env baseline OK');
     } else {
       logger.log('All required environment variables present');
     }

--- a/backend/src/config/env-validation.ts
+++ b/backend/src/config/env-validation.ts
@@ -5,7 +5,13 @@
  * before the application starts. This prevents runtime errors
  * caused by missing configuration.
  *
+ * Read-only mode (READ_ONLY=true) is supported per ADR-028 Option D
+ * (preprod read-only hardening, monorepo PRs #246/#248, vault PR #123) :
+ * the SERVICE_ROLE_KEY and payment gateway secrets are NOT required, since
+ * the backend uses ANON_KEY + RLS and processes no real payments.
+ *
  * @since 2026-01-16
+ * @updated 2026-05-03 ADR-028 Option D read-only baseline (fix 3-day deploy main breakage)
  */
 
 import { Logger } from '@nestjs/common';
@@ -13,8 +19,10 @@ import { Logger } from '@nestjs/common';
 const logger = new Logger('EnvValidation');
 
 /**
- * Required environment variables for production
- * The application will NOT start if any of these are missing
+ * Required environment variables in normal (writeable) mode.
+ * The application will NOT start if any of these are missing — UNLESS
+ * READ_ONLY=true (ADR-028 Option D), in which case the read-only baseline
+ * below is used instead.
  */
 const REQUIRED_ENV_VARS = [
   'NODE_ENV',
@@ -25,6 +33,24 @@ const REQUIRED_ENV_VARS = [
   'SYSTEMPAY_SITE_ID',
   'PAYBOX_SITE',
   'PAYBOX_HMAC_KEY',
+] as const;
+
+/**
+ * Required environment variables when READ_ONLY=true (ADR-028 Option D).
+ *
+ * In this mode the backend cannot mutate Supabase (uses ANON_KEY + RLS) — there
+ * are no real payments and no need for SERVICE_ROLE_KEY or payment gateway
+ * secrets. SESSION_SECRET is also not required because preprod has no mutable
+ * server-side session state to protect (sessions are read-only or unused).
+ *
+ * If a future change re-enables writes in preprod, this list MUST be revisited
+ * AND the ADR-028 Option D acceptance criteria re-evaluated.
+ */
+const REQUIRED_ENV_VARS_READ_ONLY = [
+  'NODE_ENV',
+  'SUPABASE_URL',
+  'SUPABASE_ANON_KEY',
+  'REDIS_URL',
 ] as const;
 
 /**
@@ -47,18 +73,38 @@ const OPTIONAL_ENV_VARS_WITH_DEFAULTS: Record<string, string> = {
   // Kill-switch DEV - Read-only isolation for development environment
   DEV_KILL_SWITCH: 'false', // 'true' | 'false' - Enable read-only mode in DEV
   DEV_SUPABASE_KEY: '(dev_readonly role key)', // Supabase key for dev_readonly PostgreSQL role
+  // ADR-028 Option D — preprod read-only hardening (set in CI .env.preprod)
+  READ_ONLY: 'false', // 'true' enables relaxed env validation + ANON_KEY fallback
 };
+
+/**
+ * Returns true when the backend should boot in ADR-028 Option D read-only mode.
+ * Only the canonical literal "true" enables it — defends against accidental
+ * truthy values like "1" or "yes".
+ */
+export function isReadOnlyMode(): boolean {
+  return process.env.READ_ONLY === 'true';
+}
 
 /**
  * Validates that all required environment variables are present.
  * Call this function at the very start of the application (before any imports).
  *
+ * In READ_ONLY=true mode (ADR-028 Option D — preprod hardening), a relaxed
+ * baseline is used : SERVICE_ROLE_KEY, SESSION_SECRET and payment gateway
+ * secrets are not required.
+ *
  * @throws {Error} If any required variable is missing (exits with code 1)
  */
 export function validateRequiredEnvVars(): void {
+  const readOnly = isReadOnlyMode();
+  const requiredList: readonly string[] = readOnly
+    ? REQUIRED_ENV_VARS_READ_ONLY
+    : REQUIRED_ENV_VARS;
+
   const missing: string[] = [];
 
-  for (const varName of REQUIRED_ENV_VARS) {
+  for (const varName of requiredList) {
     if (!process.env[varName]) {
       missing.push(varName);
     }
@@ -68,6 +114,9 @@ export function validateRequiredEnvVars(): void {
     logger.error('');
     logger.error('═══════════════════════════════════════════════════════');
     logger.error('FATAL: Missing required environment variables');
+    if (readOnly) {
+      logger.error('(READ_ONLY=true mode — ADR-028 Option D baseline)');
+    }
     logger.error('═══════════════════════════════════════════════════════');
     logger.error('');
     logger.error('The following variables must be set in your .env file:');
@@ -88,7 +137,13 @@ export function validateRequiredEnvVars(): void {
 
   // Log success in non-test environments
   if (process.env.NODE_ENV !== 'test') {
-    logger.log('All required environment variables present');
+    if (readOnly) {
+      logger.log(
+        'READ_ONLY=true (ADR-028 Option D) — relaxed env baseline OK',
+      );
+    } else {
+      logger.log('All required environment variables present');
+    }
 
     // Log Kill-switch DEV status
     if (
@@ -108,11 +163,14 @@ export function validateRequiredEnvVars(): void {
 }
 
 /**
- * Gets a list of all required environment variables
- * Useful for documentation and testing
+ * Gets a list of all required environment variables.
+ *
+ * @param readOnly when true (or omitted with READ_ONLY=true env), returns the
+ *                 ADR-028 Option D read-only baseline.
  */
-export function getRequiredEnvVars(): readonly string[] {
-  return REQUIRED_ENV_VARS;
+export function getRequiredEnvVars(readOnly?: boolean): readonly string[] {
+  const useReadOnly = readOnly ?? isReadOnlyMode();
+  return useReadOnly ? REQUIRED_ENV_VARS_READ_ONLY : REQUIRED_ENV_VARS;
 }
 
 /**

--- a/backend/tests/unit/env-validation-readonly.test.ts
+++ b/backend/tests/unit/env-validation-readonly.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test : ADR-028 Option D (preprod read-only hardening) MUST allow
+ * boot without SUPABASE_SERVICE_ROLE_KEY / SESSION_SECRET / SYSTEMPAY_SITE_ID /
+ * PAYBOX_SITE / PAYBOX_HMAC_KEY when READ_ONLY=true.
+ *
+ * Context : monorepo PRs #246/#248 (2026-04-30) shipped Option D, but the
+ * EnvValidation kept the writeable baseline as REQUIRED → 9 consecutive failed
+ * `🚀 Deploy` runs on main between 2026-04-30 and 2026-05-03 (run 25281072359
+ * et al.), each crashing on the same `process.exit(1)` over 5 missing vars.
+ *
+ * This regression test pins the read-only baseline so a future refactor
+ * cannot silently re-introduce the same coupling.
+ */
+
+import {
+  getRequiredEnvVars,
+  isReadOnlyMode,
+} from '../../src/config/env-validation';
+
+describe('EnvValidation — ADR-028 Option D read-only baseline', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('isReadOnlyMode is false by default', () => {
+    delete process.env.READ_ONLY;
+    expect(isReadOnlyMode()).toBe(false);
+  });
+
+  it('isReadOnlyMode is true when READ_ONLY=true', () => {
+    process.env.READ_ONLY = 'true';
+    expect(isReadOnlyMode()).toBe(true);
+  });
+
+  it('isReadOnlyMode is false for non-canonical truthy strings', () => {
+    process.env.READ_ONLY = 'false';
+    expect(isReadOnlyMode()).toBe(false);
+
+    process.env.READ_ONLY = '1';
+    expect(isReadOnlyMode()).toBe(false);
+
+    process.env.READ_ONLY = 'yes';
+    expect(isReadOnlyMode()).toBe(false);
+
+    process.env.READ_ONLY = 'TRUE';
+    expect(isReadOnlyMode()).toBe(false);
+  });
+
+  it('writeable baseline contains the 8 historical required vars', () => {
+    const required = getRequiredEnvVars(false);
+    expect(required).toEqual(
+      expect.arrayContaining([
+        'NODE_ENV',
+        'SUPABASE_URL',
+        'SUPABASE_SERVICE_ROLE_KEY',
+        'REDIS_URL',
+        'SESSION_SECRET',
+        'SYSTEMPAY_SITE_ID',
+        'PAYBOX_SITE',
+        'PAYBOX_HMAC_KEY',
+      ]),
+    );
+    expect(required).toHaveLength(8);
+  });
+
+  it('read-only baseline contains exactly NODE_ENV/SUPABASE_URL/SUPABASE_ANON_KEY/REDIS_URL', () => {
+    const required = getRequiredEnvVars(true);
+    expect(required).toEqual(
+      expect.arrayContaining([
+        'NODE_ENV',
+        'SUPABASE_URL',
+        'SUPABASE_ANON_KEY',
+        'REDIS_URL',
+      ]),
+    );
+    expect(required).toHaveLength(4);
+  });
+
+  it('read-only baseline EXCLUDES SUPABASE_SERVICE_ROLE_KEY (ADR-028 Option D)', () => {
+    expect(getRequiredEnvVars(true)).not.toContain('SUPABASE_SERVICE_ROLE_KEY');
+  });
+
+  it('read-only baseline EXCLUDES payment gateway secrets', () => {
+    const required = getRequiredEnvVars(true);
+    expect(required).not.toContain('PAYBOX_SITE');
+    expect(required).not.toContain('PAYBOX_HMAC_KEY');
+    expect(required).not.toContain('SYSTEMPAY_SITE_ID');
+  });
+
+  it('read-only baseline EXCLUDES SESSION_SECRET (preprod has no mutable session state)', () => {
+    expect(getRequiredEnvVars(true)).not.toContain('SESSION_SECRET');
+  });
+
+  it('getRequiredEnvVars() with no arg follows current READ_ONLY env', () => {
+    process.env.READ_ONLY = 'true';
+    expect(getRequiredEnvVars()).toHaveLength(4);
+
+    process.env.READ_ONLY = 'false';
+    expect(getRequiredEnvVars()).toHaveLength(8);
+
+    delete process.env.READ_ONLY;
+    expect(getRequiredEnvVars()).toHaveLength(8);
+  });
+});


### PR DESCRIPTION
## Bug

Since 2026-04-30 (PRs #246/#248 shipped ADR-028 Option D preprod read-only hardening), **every push to main has crashed `🚀 Deploy → 🧪 Deploy PREPROD`**. **9 consecutive failures** ([run 25281072359](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25281072359) et al.) over 3 days. The container boots, then `EnvValidation` exits 1 with :

```
FATAL: Missing required environment variables
  - SUPABASE_SERVICE_ROLE_KEY
  - SESSION_SECRET
  - SYSTEMPAY_SITE_ID
  - PAYBOX_SITE
  - PAYBOX_HMAC_KEY
```

That's **exactly the set of vars Option D intentionally REMOVED** from `.env.preprod` (cf. [ci.yml:722](https://github.com/ak125/nestjs-remix-monorepo/blob/main/.github/workflows/ci.yml#L722) — \"anon key only, no SERVICE_ROLE_KEY\"). The deploy job and the runtime validator disagreed on what's required.

## Root cause

[`backend/src/config/env-validation.ts`](backend/src/config/env-validation.ts) had only the writeable baseline (8 vars including SERVICE_ROLE_KEY + SESSION_SECRET + payment secrets). PRs #246/#248 never updated it ; the validator kept enforcing the old contract while the deploy script enforced the new one.

## Fix

Add a second baseline `REQUIRED_ENV_VARS_READ_ONLY` (4 vars : `NODE_ENV`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `REDIS_URL`) used iff `process.env.READ_ONLY === \"true\"`.

- Only the canonical literal `\"true\"` enables it — defends against accidentally truthy strings (`\"1\"` / `\"yes\"` / `\"TRUE\"` are all rejected).
- `validateRequiredEnvVars()` switches list at boot. On success in read-only mode logs `READ_ONLY=true (ADR-028 Option D) — relaxed env baseline OK`.
- On failure, the FATAL banner now includes a `(READ_ONLY=true mode — ADR-028 Option D baseline)` qualifier so operators know which baseline is failing.
- `getRequiredEnvVars()` now takes an optional `readOnly` param (defaults to env-driven mode) so tests can pin behaviour without mutating env.
- `isReadOnlyMode()` exported for callers that need to gate other logic (SupabaseBaseService, session middleware, payment routes — not touched in this PR but available going forward).

## Why these specific vars are dropped in Option D

| Var | Why optional in read-only mode |
|---|---|
| `SUPABASE_SERVICE_ROLE_KEY` | preprod cannot mutate Supabase ; ANON_KEY + RLS is sufficient (cf. ADR-021 RLS hardening, 204 objects) |
| `SESSION_SECRET` | preprod has no mutable server-side session state (sessions are read-only or unused) |
| `SYSTEMPAY_*`, `PAYBOX_*` | preprod processes no real payments. Payment routes blocked by SupabaseBaseService write guards (PR #246) |

If a future PR re-enables writes in preprod, this list **MUST** be revisited and ADR-028 Option D re-evaluated. A comment in the code points this out.

## Regression test

`backend/tests/unit/env-validation-readonly.test.ts` (9 cases) :
- default `isReadOnlyMode() === false`
- `READ_ONLY=true` → true ; `\"1\"` / `\"yes\"` / `\"TRUE\"` → false (case-sensitive on purpose)
- writeable baseline = 8 vars (the historical set)
- read-only baseline = 4 vars (the new set)
- read-only baseline EXCLUDES `SERVICE_ROLE_KEY`, payment secrets, `SESSION_SECRET`
- `getRequiredEnvVars()` with no arg follows env

Pins the behaviour so a future refactor cannot silently re-introduce this exact regression.

## Validation

- [x] tsc syntax check OK
- [x] Pre-push hooks pass (G3 ED25519 signed)
- [ ] CI : ESLint / TypeScript / Backend Tests green
- [ ] CI : `🧪 Deploy PREPROD` step exits 0 (was failing for 3 days)
- [ ] Smoke test post-merge : main push triggers deploy → preprod container starts cleanly

## Out of scope (separate PRs)

- Documenting `READ_ONLY` in `backend/.env.example` — already covered by `OPTIONAL_ENV_VARS_WITH_DEFAULTS` map, low priority
- Wiring `isReadOnlyMode()` into other services — gradual, as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)