### PR TITLE
feat(wiki-generators): redirection OUTPUT vers wiki/exports/rag/<cat>/ (Etape 5 PR-3 plan v3)

### DIFF
--- a/log.md
+++ b/log.md
@@ -315,3 +315,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/bump-wiki-submodule-pointer`
 - **Décision** : chore: bump wiki submodule pointer to current origin/main
 - **Sortie** : PR #273 | commits 707a1775
+
+## 2026-05-03 — feat/wiki-generators-output-redirect (auto)
+
+- **Branche** : `feat/wiki-generators-output-redirect`
+- **Décision** : feat(scripts): refactor placement vers sous-dossiers thematiques (Etape 5 plan v3)
+- **Sortie** : PR aucune | commits b6400f07

--- a/scripts/wiki-generators/brand-fiche-generator.py
+++ b/scripts/wiki-generators/brand-fiche-generator.py
@@ -11,11 +11,14 @@ NOTE : faq / common_issues / maintenance_tips ne sont PAS dans ce frontmatter.
 L'enricher R7 les charge directement depuis la table __seo_brand_editorial
 au runtime, pour permettre la curation admin sans rebuild du .md.
 
-Écrit : /opt/automecanik/rag/knowledge/constructeurs/{slug}.md
+Écrit : automecanik-wiki/exports/rag/constructeurs/{slug}.md (artefact auto, ADR-031 §D20)
 Body préservé (seul le frontmatter est régénéré).
 
+Configurable via env :
+  AUTOMECANIK_WIKI_PATH (default /opt/automecanik/automecanik-wiki)
+
 Usage :
-  python3 scripts/rag/build-brand-rag.py [--brand alias] [--limit N] [--dry-run]
+  python3 scripts/wiki-generators/brand-fiche-generator.py [--brand alias] [--limit N] [--dry-run]
 """
 
 from __future__ import annotations
@@ -39,7 +42,12 @@ except ImportError:
     sys.exit(1)
 
 # === CONFIG ===
-BRANDS_DIR = Path("/opt/automecanik/rag/knowledge/constructeurs")
+# OUTPUT path : wiki/exports/rag/constructeurs/ (ADR-031 §D20).
+# Cohérent avec pipeline canon : générateur produit l'auto-gen direct dans
+# wiki/exports/rag/, qui est ensuite mirroré vers automecanik-rag/knowledge/
+# via CI workflow sync-from-wiki (Étape 7 plan v3 pending).
+WIKI_REPO = Path(os.environ.get("AUTOMECANIK_WIKI_PATH", "/opt/automecanik/automecanik-wiki"))
+BRANDS_DIR = WIKI_REPO / "exports" / "rag" / "constructeurs"
 SUPABASE_URL = os.environ.get("SUPABASE_URL", "https://cxpojprgwgubzjyqzmoq.supabase.co")
 SERVICE_ROLE_KEY = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
 WIKIDATA_SPARQL = "https://query.wikidata.org/sparql"

--- a/scripts/wiki-generators/gamme-from-db-template-generator.py
+++ b/scripts/wiki-generators/gamme-from-db-template-generator.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 """
-Enrichit en masse les entrées __rag_knowledge 'Données techniques OEM' sparse (< 500c).
-Génère du contenu technique par template selon le nom de la pièce.
+gamme-from-db-template-generator.py — Enrichit les entrées DB __rag_knowledge
+'Données techniques OEM' sparse (< 500c) par templates de contenu technique.
+
+⚠️ CAS PARTICULIER : ce générateur écrit dans la **DB Supabase** (table
+__rag_knowledge), pas dans le filesystem wiki/exports/rag/. Sa logique métier
+produit du contenu RAG consommé directement par le backend NestJS (pas
+mirroré via sync-from-wiki). Placement dans wiki-generators/ reflète son
+rôle de producteur de contenu RAG, mais l'OUTPUT path est DB-only.
 
 Usage:
-  python3 scripts/rag/enrich-rag-bulk.py [--dry-run] [--gamme disque-de-frein]
+  python3 scripts/wiki-generators/gamme-from-db-template-generator.py [--dry-run] [--gamme disque-de-frein]
 
 Requiert : SUPABASE_SERVICE_ROLE_KEY dans l'environnement (.env.vps)
 """

--- a/scripts/wiki-generators/gamme-from-web-corpus-generator.py
+++ b/scripts/wiki-generators/gamme-from-web-corpus-generator.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 """
-rag-enrich-from-web-corpus.py — Enrichit les gammes .md depuis le corpus web OEM existant.
+gamme-from-web-corpus-generator.py — Génère les gammes .md depuis le corpus web OEM.
 
-Lit les 1273 fichiers dans /opt/automecanik/rag/knowledge/web/,
-mappe chaque fichier vers les gammes correspondantes,
-extrait les données techniques (normes, matériaux, valeurs, types),
-et injecte dans le frontmatter des gammes.
+Lit le corpus web depuis automecanik-raw/recycled/rag-knowledge/web/ (1771 fichiers
+post PR raw #15) + web-catalog/ (182 fichiers), mappe chaque fichier vers les
+gammes correspondantes, extrait les données techniques (normes, matériaux,
+valeurs, types), et écrit les .md gammes dans automecanik-wiki/exports/rag/gammes/
+(ADR-031 §D20, plan v3 §Étape 5).
+
+Configurable via env :
+  AUTOMECANIK_RAW_PATH  (default /opt/automecanik/automecanik-raw) — INPUT corpus web
+  AUTOMECANIK_WIKI_PATH (default /opt/automecanik/automecanik-wiki) — OUTPUT artefact
 
 Usage:
-  python3 scripts/rag/rag-enrich-from-web-corpus.py [--dry-run] [--gamme disque-de-frein] [--force]
+  python3 scripts/wiki-generators/gamme-from-web-corpus-generator.py [--dry-run] [--gamme disque-de-frein] [--force]
 """
 
 import os
@@ -18,12 +23,17 @@ import argparse
 from collections import defaultdict
 from datetime import datetime
 
-# AUTOMECANIK_RAW_PATH overrides the rag-knowledge root for ADR-031 Phase D.
-# Default keeps the legacy location so unset = no behavioral change.
-RAW_KNOWLEDGE_ROOT = os.getenv("AUTOMECANIK_RAW_PATH", "/opt/automecanik/rag/knowledge")
-WEB_DIR = f"{RAW_KNOWLEDGE_ROOT}/web"
-WEB_CATALOG_DIR = f"{RAW_KNOWLEDGE_ROOT}/web-catalog"
-GAMMES_DIR = f"{RAW_KNOWLEDGE_ROOT}/gammes"
+# INPUT : corpus web brut hébergé dans automecanik-raw/recycled/rag-knowledge/
+# (post PR raw #15 — Phase C extension import contenu métier).
+RAW_REPO = os.getenv("AUTOMECANIK_RAW_PATH", "/opt/automecanik/automecanik-raw")
+RECYCLED_RAG_KNOWLEDGE = f"{RAW_REPO}/recycled/rag-knowledge"
+WEB_DIR = f"{RECYCLED_RAG_KNOWLEDGE}/web"
+WEB_CATALOG_DIR = f"{RECYCLED_RAG_KNOWLEDGE}/web-catalog"
+
+# OUTPUT : artefact auto-généré dans wiki/exports/rag/ (ADR-031 §D20).
+# Mirror downstream vers automecanik-rag/knowledge/ via CI workflow sync.
+WIKI_REPO = os.getenv("AUTOMECANIK_WIKI_PATH", "/opt/automecanik/automecanik-wiki")
+GAMMES_DIR = f"{WIKI_REPO}/exports/rag/gammes"
 
 # === MAPPING GAMME → TERMES DE RECHERCHE ===
 # Chaque gamme a des termes FR + EN qui matchent dans le contenu web


### PR DESCRIPTION
## Summary

**Étape 5 PR-3** du plan v3 (`/home/deploy/.claude/plans/je-comprend-rien-a-spicy-reddy.md`) — suite de [PR #270](https://github.com/ak125/nestjs-remix-monorepo/pull/270) mergée. Les 3 wiki-generators écrivent désormais dans `automecanik-wiki/exports/rag/<cat>/` (ADR-031 §D20) au lieu de `automecanik-rag/knowledge/<cat>/` (legacy).

**Logique métier des 3 scripts intouchée**. Seuls les path constants + docstring header changent.

## Changements OUTPUT path

| Script | Avant | Après |
|---|---|---|
| `brand-fiche-generator.py` | `Path("/opt/automecanik/rag/knowledge/constructeurs")` hardcodé | `WIKI_REPO/exports/rag/constructeurs` via env `AUTOMECANIK_WIKI_PATH` |
| `gamme-from-web-corpus-generator.py` | `${AUTOMECANIK_RAW_PATH}/gammes` (default `/opt/automecanik/rag/knowledge/gammes`) | `WIKI_REPO/exports/rag/gammes` via env `AUTOMECANIK_WIKI_PATH` |
| `gamme-from-db-template-generator.py` | DB Supabase `__rag_knowledge` (pas filesystem) | **inchangé** — cas particulier documenté en tête |

## Cas particulier `gamme-from-web-corpus-generator.py`

Ce script lit le corpus web ET écrit les fiches gammes. La PR sépare les 2 paths :

- **INPUT** : `automecanik-raw/recycled/rag-knowledge/{web,web-catalog}/` (corrige le path post [PR raw #15](https://github.com/ak125/automecanik-raw/pull/15) — Phase C extension import contenu métier).
- **OUTPUT** : `automecanik-wiki/exports/rag/gammes/` (ADR-031 §D20).

2 env vars distinctes : `AUTOMECANIK_RAW_PATH` (default `/opt/automecanik/automecanik-raw`) + `AUTOMECANIK_WIKI_PATH` (default `/opt/automecanik/automecanik-wiki`).

## Cas particulier `gamme-from-db-template-generator.py`

⚠️ Ce générateur écrit dans la **DB Supabase** (table `__rag_knowledge`), pas dans le filesystem `wiki/exports/rag/`. Sa logique métier produit du contenu RAG consommé directement par le backend NestJS. Placement dans `wiki-generators/` reflète son rôle de producteur de contenu RAG, mais l'OUTPUT path est DB-only (commentaire ajouté en tête).

## Verification pré-merge

- ✅ 3 scripts compile (`py_compile.compile(..., doraise=True)`)
- ✅ Paths cibles existent localement :
  - `/opt/automecanik/automecanik-raw/recycled/rag-knowledge/{web,web-catalog}/` (PR raw #15 mergée)
  - `/opt/automecanik/automecanik-wiki/exports/rag/` (existait, vide)
- ✅ Aucune modification de logique downstream (les générateurs tournent même chemin de calcul, juste write au nouveau path)

## Suite (next session)

- **Étape 5 follow-up rag** : update wrapper `automecanik-rag/scripts/pipeline/run-phase-f.sh` paths (lignes 49, 55, 140 référencent encore `scripts/rag/` qui n'existe plus).
- **Étape 2** : créer workflow CI `sync-rag-from-wiki.yml`.
- **Étape 6** : régénération via générateurs refactorisés (lancer en local, vérifier diff vs legacy minimal).
- **Étape 7** : activer workflow CI sync (premier run réel).
- **Étape 8** : cleanup legacy contenu rag/knowledge/ + adapter backend `rag-pipeline.service.ts:224`.
- **Étape 9** : gardes permanentes (pre-commit + ast-grep).

## Test plan

- [ ] CI verte (TypeScript, ESLint, tests, RPC Safety, Migration Safety, ADR-010 Governance, etc.)
- [ ] Pas de régression code (aucune modif logique)
- [ ] Pre-commit pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
