### PR TITLE
fix(app-config): allow missing SERVICE_ROLE_KEY when READ_ONLY=true (ADR-028 Option D)

### DIFF
--- a/backend/src/config/app.config.ts
+++ b/backend/src/config/app.config.ts
@@ -45,8 +45,17 @@ export function createAppConfig(): AppConfig {
     },
   };
 
-  // Validation Context7 : échouer rapidement si config invalide
-  if (!config.supabase.serviceKey && config.app.environment === 'production') {
+  // Validation Context7 : échouer rapidement si config invalide.
+  // ADR-028 Option D — READ_ONLY=true overrides this check : preprod sets
+  // NODE_ENV=production (Dockerfile L39/L63 + docker-compose.preprod.yml L9) for
+  // Node/library optimizations, but the deploy intentionally omits SERVICE_ROLE_KEY
+  // in favor of ANON_KEY + RLS protection. The dedicated check below validates
+  // the anon-key requirement for read-only mode.
+  if (
+    !config.supabase.serviceKey &&
+    config.app.environment === 'production' &&
+    !config.supabase.readOnly
+  ) {
     throw new ConfigurationException({
       code: ErrorCodes.CONFIG.MISSING,
       message: 'SUPABASE_SERVICE_ROLE_KEY is required in production',


### PR DESCRIPTION
## Summary

**Third and (verified by exhaustive sweep) FINAL** fix in the ADR-028 Option D unblock chain :
- [#274](https://github.com/ak125/nestjs-remix-monorepo/pull/274) — env-validation.ts (boot validator)
- [#276](https://github.com/ak125/nestjs-remix-monorepo/pull/276) — payment.config.ts (NestJS ConfigModule load-time)
- **this PR** — app.config.ts (createAppConfig load-time)

## Bug

After #274 + #276 merged, deploy main run \`25282305656\` (commit \`62880207\`) STILL crashed at \`🧪 Deploy PREPROD\` with a THIRD strict-validation site :

```
ERROR [ExceptionHandler]
  ConfigurationException: SUPABASE_SERVICE_ROLE_KEY is required in production
```

Source : [\`backend/src/config/app.config.ts:49\`](backend/src/config/app.config.ts#L49).

## Why my previous grep missed this

\`rg \"Missing required\" backend/src/config/\` found only env-validation.ts and payment.config.ts. This 3rd site uses a different message format (\`is required in production\`). Lesson : grep on broader patterns when sweeping for env-validation sites — included in the commit message for future contributors.

## Why the check fires in preprod (NODE_ENV stack)

| Layer | NODE_ENV |
|---|---|
| Dockerfile L39 + L63 | `production` (ENV) |
| docker-compose.preprod.yml L9 | `production` (environment:) |
| .env.preprod | `preprod` (env_file) |

docker-compose `environment:` overrides `env_file`, so the container ends up with **NODE_ENV=production**. That's intentional : Node.js + many libraries optimize for production (caching, tree-shaking, no dev-only code paths).

The whole point of `READ_ONLY=true` is to be the gating flag for read-only-ness, **NOT NODE_ENV**.

## Fix

Add `!config.supabase.readOnly` to the check :

```ts
if (
  !config.supabase.serviceKey &&
  config.app.environment === 'production' &&
  !config.supabase.readOnly  // ← ADR-028 Option D
) {
  throw new ConfigurationException({...});
}
```

The companion check on lines 57-63 **already** validates that `READ_ONLY=true → SUPABASE_ANON_KEY is present` (privilege downgrade properly enforced). This PR completes the symmetry on the service-key side.

## Exhaustive sweep — no more hidden sites

```
$ rg -l \"throw.+ConfigurationException\" backend/src
backend/src/database/services/supabase-base.service.ts   ← already ADR-028 aware (PR #246)
backend/src/modules/ai-content/ai-content.service.ts     ← lazy/runtime, fires only on AI generate
backend/src/modules/ai-content/providers/anthropic.provider.ts  ← lazy/runtime
backend/src/config/app.config.ts                          ← THIS PR
backend/src/config/payment.config.ts                      ← PR #276
```

Plus :

```
$ rg -n \"process\\.env\\.(SUPABASE_SERVICE_ROLE_KEY|SUPABASE_URL|SESSION_SECRET|SYSTEMPAY|PAYBOX|REDIS_URL)\" backend/src/config
```

Returns only `app.config.ts`, `payment.config.ts`, `csp.config.ts` (sanitize with fallback `''`, never throws).

**No 4th hidden site.** The lazy AI-related throws fire only when AI generation is invoked (doesn't happen in preprod read-only).

## Validation

- [x] tsc syntax check OK
- [x] prettier --check OK
- [x] Pre-push hooks pass (G3 ED25519 signed)
- [x] Exhaustive sweep done — all 3 load-time strict-validation sites identified and fixed
- [ ] CI : 🧪 Deploy PREPROD step exits 0 (the FINAL verification of the 3-day block resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)