### PR TITLE
fix(supabase-key): centralized helper + READ_ONLY ANON_KEY fallback — final unblock of 3-day deploy

### DIFF
--- a/backend/src/common/utils/index.ts
+++ b/backend/src/common/utils/index.ts
@@ -11,3 +11,4 @@ export {
   extractAliasFromSlug,
 } from './url-builder.utils';
 export { getErrorMessage, getErrorStack, serializeError } from './error.utils';
+export { getEffectiveSupabaseKey } from './supabase-key.util';

--- a/backend/src/common/utils/supabase-key.util.ts
+++ b/backend/src/common/utils/supabase-key.util.ts
@@ -1,0 +1,59 @@
+/**
+ * ADR-028 Option D — preprod read-only hardening
+ *
+ * Centralized key resolver for direct `createClient(url, key)` callers.
+ *
+ * Background : preprod intentionally omits `SUPABASE_SERVICE_ROLE_KEY` from
+ * `.env.preprod` (cf. ci.yml :722). Services that instantiate a Supabase
+ * client at NestJS module-load using `process.env.SUPABASE_SERVICE_ROLE_KEY`
+ * directly crash with `Error: supabaseKey is required.` because supabase-js
+ * v2 throws when called with an empty string.
+ *
+ * The canonical fix is to use this helper everywhere instead of touching
+ * `process.env.SUPABASE_SERVICE_ROLE_KEY` directly. It returns :
+ *   - SERVICE_ROLE_KEY  if present (writeable mode — full privilege)
+ *   - ANON_KEY         if READ_ONLY=true and SERVICE_ROLE_KEY absent
+ *                      (RLS protects writes per ADR-021)
+ *   - empty string     if nothing usable found (caller decides what to do)
+ *
+ * The third case still lets supabase-js throw — that's the right thing to
+ * do in a misconfigured environment, but tests / CI should never reach it
+ * for a properly-deployed preprod or prod.
+ *
+ * Read-only callers : the returned ANON_KEY only allows operations RLS
+ * permits. Mutation attempts will fail at the SQL boundary, which is the
+ * intended ADR-028 Option D behaviour.
+ *
+ * If a future ADR re-enables writes in preprod (or moves to a different
+ * privilege model), this helper is the single chokepoint to revisit.
+ *
+ * @see backend/src/config/env-validation.ts::isReadOnlyMode
+ * @see backend/src/database/services/supabase-base.service.ts (companion
+ *      class-based path with the same fallback)
+ */
+
+/**
+ * Returns the right Supabase key for the current environment :
+ * SERVICE_ROLE_KEY when available, ANON_KEY in read-only mode, or `""`.
+ *
+ * Use at every direct `createClient(url, KEY)` call site instead of
+ * `process.env.SUPABASE_SERVICE_ROLE_KEY` or its `|| ''` variants.
+ */
+export function getEffectiveSupabaseKey(): string {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (serviceKey) {
+    return serviceKey;
+  }
+
+  // ADR-028 Option D — read-only mode falls back to ANON_KEY.
+  // Use the canonical literal "true" (case-sensitive) — same convention as
+  // env-validation.ts::isReadOnlyMode.
+  if (process.env.READ_ONLY === 'true') {
+    const anonKey = process.env.SUPABASE_ANON_KEY;
+    if (anonKey) {
+      return anonKey;
+    }
+  }
+
+  return '';
+}

--- a/backend/src/modules/admin/controllers/admin-keyword-clusters.controller.ts
+++ b/backend/src/modules/admin/controllers/admin-keyword-clusters.controller.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { AuthenticatedGuard } from '@auth/authenticated.guard';
 import { IsAdminGuard } from '@auth/is-admin.guard';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import { KeywordDensityGateService } from '../services/keyword-density-gate.service';
 
 // Expected overlaps (source of truth: scripts/seo/expected-overlaps.json)
@@ -17,9 +18,10 @@ export class AdminKeywordClustersController {
   private readonly supabase: SupabaseClient;
 
   constructor(private readonly configService: ConfigService) {
-    const url = this.configService.get<string>('SUPABASE_URL');
-    const key = this.configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
-    this.supabase = createClient(url!, key!);
+    const url = this.configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
+    this.supabase = createClient(url, key);
   }
 
   /**

--- a/backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts
+++ b/backend/src/modules/admin/controllers/admin-keyword-planner.controller.ts
@@ -19,6 +19,7 @@ import * as yaml from 'js-yaml';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
 import { AuthenticatedGuard } from '@auth/authenticated.guard';
 import { IsAdminGuard } from '@auth/is-admin.guard';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import { R1ContentFromRagService } from '../services/r1-content-from-rag.service';
 import { R1KeywordPlanBatchService } from '../services/r1-keyword-plan-batch.service';
 
@@ -46,9 +47,10 @@ export class AdminKeywordPlannerController {
     @Optional() private readonly r1ContentFromRag?: R1ContentFromRagService,
     @Optional() @Inject(CACHE_MANAGER) private readonly cacheManager?: Cache,
   ) {
-    const url = this.configService.get<string>('SUPABASE_URL');
-    const key = this.configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
-    this.supabase = createClient(url!, key!);
+    const url = this.configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
+    this.supabase = createClient(url, key);
   }
 
   /**

--- a/backend/src/modules/admin/controllers/internal-seo-audit.controller.ts
+++ b/backend/src/modules/admin/controllers/internal-seo-audit.controller.ts
@@ -10,6 +10,7 @@ import { Controller, Get, Logger, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { InternalApiKeyGuard } from '../../../auth/internal-api-key.guard';
+import { getEffectiveSupabaseKey } from '@common/utils';
 
 interface GammeRow {
   pg_id: string;
@@ -44,9 +45,10 @@ export class InternalSeoAuditController {
   private readonly supabase: SupabaseClient;
 
   constructor(private readonly configService: ConfigService) {
-    const url = this.configService.get<string>('SUPABASE_URL');
-    const key = this.configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
-    this.supabase = createClient(url!, key!);
+    const url = this.configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
+    this.supabase = createClient(url, key);
   }
 
   /**

--- a/backend/src/modules/seo-logs/services/crawl-budget-supabase.service.ts
+++ b/backend/src/modules/seo-logs/services/crawl-budget-supabase.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { DatabaseException, ErrorCodes } from '@common/exceptions';
+import { getEffectiveSupabaseKey } from '@common/utils';
 
 export interface CrawlBudgetExperiment {
   id: string;
@@ -43,13 +44,16 @@ export class CrawlBudgetSupabaseService {
 
   constructor() {
     const supabaseUrl = process.env.SUPABASE_URL;
-    const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const supabaseKey = getEffectiveSupabaseKey();
 
     if (!supabaseUrl || !supabaseKey) {
-      this.logger.warn('⚠️ SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set');
+      this.logger.warn(
+        '⚠️ SUPABASE_URL or Supabase key not set — CrawlBudgetSupabaseService disabled',
+      );
     }
 
-    this.supabase = createClient(supabaseUrl || '', supabaseKey || '');
+    this.supabase = createClient(supabaseUrl || '', supabaseKey);
   }
 
   /**

--- a/backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
@@ -15,6 +15,7 @@
 import { Body, Controller, Get, Logger, Post, Query } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import { GoogleCredentialsService } from '../services/google-credentials.service';
 import { GscDailyFetcherService } from '../services/gsc-daily-fetcher.service';
 import { Ga4DailyFetcherService } from '../services/ga4-daily-fetcher.service';
@@ -37,10 +38,13 @@ export class SeoMonitoringController {
     private readonly rContentAuditor: RContentAuditorService,
     configService: ConfigService,
   ) {
-    const url = configService.get<string>('SUPABASE_URL');
-    const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     if (!url || !key) {
-      throw new Error('SeoMonitoringController: Supabase env missing');
+      this.logger.warn(
+        'SeoMonitoringController: Supabase env missing — service will fail on first call',
+      );
     }
     this.supabase = createClient(url, key, {
       auth: { autoRefreshToken: false, persistSession: false },

--- a/backend/src/modules/seo-monitoring/services/audit-findings.service.ts
+++ b/backend/src/modules/seo-monitoring/services/audit-findings.service.ts
@@ -13,6 +13,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 
 export type AuditType =
   | 'schema_violation'
@@ -44,10 +45,13 @@ export class AuditFindingsService {
   private readonly supabase: SupabaseClient;
 
   constructor(configService: ConfigService) {
-    const url = configService.get<string>('SUPABASE_URL');
-    const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     if (!url || !key) {
-      throw new Error('AuditFindingsService: Supabase env missing');
+      this.logger.warn(
+        'AuditFindingsService: Supabase env missing — service will fail on first call',
+      );
     }
     this.supabase = createClient(url, key, {
       auth: { autoRefreshToken: false, persistSession: false },

--- a/backend/src/modules/seo-monitoring/services/cwv-fetcher.service.ts
+++ b/backend/src/modules/seo-monitoring/services/cwv-fetcher.service.ts
@@ -17,6 +17,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import { google } from 'googleapis';
 import { GoogleCredentialsService } from './google-credentials.service';
 import { SeoMonitoringRunsService } from './seo-monitoring-runs.service';
@@ -50,10 +51,13 @@ export class CwvFetcherService {
     private readonly runsService: SeoMonitoringRunsService,
     configService: ConfigService,
   ) {
-    const url = configService.get<string>('SUPABASE_URL');
-    const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     if (!url || !key) {
-      throw new Error('CwvFetcherService: Supabase env missing');
+      this.logger.warn(
+        'CwvFetcherService: Supabase env missing — service will fail on first call',
+      );
     }
     this.supabase = createClient(url, key, {
       auth: { autoRefreshToken: false, persistSession: false },

--- a/backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.service.ts
+++ b/backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.service.ts
@@ -15,6 +15,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import { GoogleCredentialsService } from './google-credentials.service';
 import { SeoMonitoringRunsService } from './seo-monitoring-runs.service';
 
@@ -47,11 +48,12 @@ export class Ga4DailyFetcherService {
     private readonly runsService: SeoMonitoringRunsService,
     configService: ConfigService,
   ) {
-    const url = configService.get<string>('SUPABASE_URL');
-    const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     if (!url || !key) {
-      throw new Error(
-        'Ga4DailyFetcherService: SUPABASE_URL ou SUPABASE_SERVICE_ROLE_KEY manquant',
+      this.logger.warn(
+        'Ga4DailyFetcherService: SUPABASE_URL ou clé Supabase manquant — service will fail on first call',
       );
     }
     this.supabase = createClient(url, key, {

--- a/backend/src/modules/seo-monitoring/services/gsc-daily-fetcher.service.ts
+++ b/backend/src/modules/seo-monitoring/services/gsc-daily-fetcher.service.ts
@@ -19,6 +19,7 @@ import { GoogleCredentialsService } from './google-credentials.service';
 import { SeoMonitoringRunsService } from './seo-monitoring-runs.service';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
 import { ConfigService } from '@nestjs/config';
+import { getEffectiveSupabaseKey } from '@common/utils';
 
 export interface GscFetchOptions {
   date: string; // YYYY-MM-DD
@@ -52,11 +53,12 @@ export class GscDailyFetcherService {
     private readonly runsService: SeoMonitoringRunsService,
     configService: ConfigService,
   ) {
-    const url = configService.get<string>('SUPABASE_URL');
-    const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     if (!url || !key) {
-      throw new Error(
-        'GscDailyFetcherService: SUPABASE_URL ou SUPABASE_SERVICE_ROLE_KEY manquant',
+      this.logger.warn(
+        'GscDailyFetcherService: SUPABASE_URL ou clé Supabase manquant — service will fail on first call',
       );
     }
     this.supabase = createClient(url, key, {

--- a/backend/src/modules/seo-monitoring/services/gsc-links-fetcher.service.ts
+++ b/backend/src/modules/seo-monitoring/services/gsc-links-fetcher.service.ts
@@ -14,6 +14,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import { google } from 'googleapis';
 import { GoogleCredentialsService } from './google-credentials.service';
 import { SeoMonitoringRunsService } from './seo-monitoring-runs.service';
@@ -43,10 +44,13 @@ export class GscLinksFetcherService {
     private readonly runsService: SeoMonitoringRunsService,
     configService: ConfigService,
   ) {
-    const url = configService.get<string>('SUPABASE_URL');
-    const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     if (!url || !key) {
-      throw new Error('GscLinksFetcherService: Supabase env missing');
+      this.logger.warn(
+        'GscLinksFetcherService: Supabase env missing — service will fail on first call',
+      );
     }
     this.supabase = createClient(url, key, {
       auth: { autoRefreshToken: false, persistSession: false },

--- a/backend/src/modules/seo-monitoring/services/r-content-auditor.service.ts
+++ b/backend/src/modules/seo-monitoring/services/r-content-auditor.service.ts
@@ -32,6 +32,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import {
   AuditFindingInput,
   AuditFindingsService,
@@ -73,10 +74,13 @@ export class RContentAuditorService {
     configService: ConfigService,
     private readonly findings: AuditFindingsService,
   ) {
-    const url = configService.get<string>('SUPABASE_URL');
-    const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     if (!url || !key) {
-      throw new Error('RContentAuditorService: Supabase env missing');
+      this.logger.warn(
+        'RContentAuditorService: Supabase env missing — service will fail on first call',
+      );
     }
     this.supabase = createClient(url, key, {
       auth: { autoRefreshToken: false, persistSession: false },

--- a/backend/src/modules/seo/services/googlebot-detector.service.ts
+++ b/backend/src/modules/seo/services/googlebot-detector.service.ts
@@ -12,6 +12,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 
 export interface GooglebotInfo {
   isGooglebot: boolean;
@@ -76,16 +77,15 @@ export class GooglebotDetectorService {
   ];
 
   constructor(private readonly configService: ConfigService) {
-    const supabaseUrl = this.configService.get<string>('SUPABASE_URL');
-    const supabaseKey = this.configService.get<string>(
-      'SUPABASE_SERVICE_ROLE_KEY',
-    );
+    const supabaseUrl = this.configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const supabaseKey = getEffectiveSupabaseKey();
 
     if (!supabaseUrl || !supabaseKey) {
       this.logger.warn('Supabase credentials not configured');
     }
 
-    this.supabase = createClient(supabaseUrl || '', supabaseKey || '');
+    this.supabase = createClient(supabaseUrl, supabaseKey);
   }
 
   /**

--- a/backend/src/modules/seo/services/seo-generator.service.ts
+++ b/backend/src/modules/seo/services/seo-generator.service.ts
@@ -1,12 +1,12 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const matter = require('gray-matter');
 
-import { DatabaseException, ErrorCodes } from '@common/exceptions';
 import { SITE_ORIGIN } from '../../../config/app.config';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
 
@@ -133,16 +133,14 @@ export class SeoGeneratorService {
     @Optional() private readonly qualityValidator?: QualityValidatorService,
     @Optional() private readonly aiContentService?: AiContentService,
   ) {
-    const supabaseUrl = this.configService.get<string>('SUPABASE_URL');
-    const supabaseKey = this.configService.get<string>(
-      'SUPABASE_SERVICE_ROLE_KEY',
-    );
+    const supabaseUrl = this.configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const supabaseKey = getEffectiveSupabaseKey();
 
     if (!supabaseUrl || !supabaseKey) {
-      throw new DatabaseException({
-        code: ErrorCodes.DATABASE.CONFIG_MISSING,
-        message: 'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be defined',
-      });
+      this.logger.warn(
+        'SeoGeneratorService: SUPABASE_URL ou clé Supabase manquant — service will fail on first call',
+      );
     }
 
     this.supabase = createClient(supabaseUrl, supabaseKey);

--- a/backend/src/modules/seo/services/sitemap-streaming.service.ts
+++ b/backend/src/modules/seo/services/sitemap-streaming.service.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 import { gzipAsync } from '../../../utils/promise-helpers';
 import { createHash } from 'crypto';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import { SITE_ORIGIN } from '../../../config/app.config';
 import {
   StreamingConfig,
@@ -61,10 +62,9 @@ export class SitemapStreamingService {
     };
 
     // Initialiser le client Supabase
-    const supabaseUrl = this.configService.get<string>('SUPABASE_URL');
-    const supabaseKey = this.configService.get<string>(
-      'SUPABASE_SERVICE_ROLE_KEY',
-    );
+    const supabaseUrl = this.configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const supabaseKey = getEffectiveSupabaseKey();
 
     if (!supabaseUrl || !supabaseKey) {
       this.logger.warn(
@@ -72,7 +72,7 @@ export class SitemapStreamingService {
       );
     }
 
-    this.supabase = createClient(supabaseUrl || '', supabaseKey || '');
+    this.supabase = createClient(supabaseUrl, supabaseKey);
 
     this.ensureOutputDirectory();
     this.logger.log('🗜️ SitemapStreamingService initialized');

--- a/backend/src/modules/vehicles/services/seo/brand-seo.service.ts
+++ b/backend/src/modules/vehicles/services/seo/brand-seo.service.ts
@@ -12,6 +12,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@supabase/supabase-js';
 import { TABLES } from '@repo/database-types';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import {
   SEO_PRICE_VARIATIONS,
   selectVariation,
@@ -42,9 +43,10 @@ export class BrandSeoService {
   private supabase: SupabaseClient;
 
   constructor() {
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
     this.supabase = createClient(
-      process.env.SUPABASE_URL!,
-      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      process.env.SUPABASE_URL || '',
+      getEffectiveSupabaseKey(),
     );
     this.logger.log('✅ BrandSeoService initialisé');
   }

--- a/backend/tests/unit/supabase-key-util.test.ts
+++ b/backend/tests/unit/supabase-key-util.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression test : `getEffectiveSupabaseKey()` must return :
+ *   - SERVICE_ROLE_KEY when set (priority)
+ *   - ANON_KEY when SERVICE_ROLE_KEY absent and READ_ONLY=true (ADR-028 Option D)
+ *   - "" otherwise
+ *
+ * Pins the read-only fallback so future refactors cannot silently re-introduce
+ * the 2026-04-30 to 2026-05-03 deploy main outage where ~20+ services crashed
+ * at NestJS module-load with `Error: supabaseKey is required.`.
+ */
+
+import { getEffectiveSupabaseKey } from '../../src/common/utils/supabase-key.util';
+
+describe('getEffectiveSupabaseKey — ADR-028 Option D fallback', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.SUPABASE_ANON_KEY;
+    delete process.env.READ_ONLY;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns SERVICE_ROLE_KEY when set (writeable mode)', () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key-xyz';
+    process.env.SUPABASE_ANON_KEY = 'anon-key-xyz';
+    expect(getEffectiveSupabaseKey()).toBe('service-key-xyz');
+  });
+
+  it('returns SERVICE_ROLE_KEY in read-only mode if it happens to be set', () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key-xyz';
+    process.env.SUPABASE_ANON_KEY = 'anon-key-xyz';
+    process.env.READ_ONLY = 'true';
+    expect(getEffectiveSupabaseKey()).toBe('service-key-xyz');
+  });
+
+  it('falls back to ANON_KEY when SERVICE_ROLE_KEY absent and READ_ONLY=true', () => {
+    process.env.SUPABASE_ANON_KEY = 'anon-key-xyz';
+    process.env.READ_ONLY = 'true';
+    expect(getEffectiveSupabaseKey()).toBe('anon-key-xyz');
+  });
+
+  it('does NOT fall back to ANON_KEY in writeable mode (READ_ONLY undefined)', () => {
+    process.env.SUPABASE_ANON_KEY = 'anon-key-xyz';
+    expect(getEffectiveSupabaseKey()).toBe('');
+  });
+
+  it('does NOT fall back to ANON_KEY when READ_ONLY=false', () => {
+    process.env.SUPABASE_ANON_KEY = 'anon-key-xyz';
+    process.env.READ_ONLY = 'false';
+    expect(getEffectiveSupabaseKey()).toBe('');
+  });
+
+  it('only matches canonical literal "true" (case-sensitive)', () => {
+    process.env.SUPABASE_ANON_KEY = 'anon-key-xyz';
+
+    process.env.READ_ONLY = 'TRUE';
+    expect(getEffectiveSupabaseKey()).toBe('');
+
+    process.env.READ_ONLY = '1';
+    expect(getEffectiveSupabaseKey()).toBe('');
+
+    process.env.READ_ONLY = 'yes';
+    expect(getEffectiveSupabaseKey()).toBe('');
+  });
+
+  it('returns "" when nothing usable is set', () => {
+    expect(getEffectiveSupabaseKey()).toBe('');
+  });
+
+  it('returns "" if READ_ONLY=true but ANON_KEY absent (misconfigured)', () => {
+    process.env.READ_ONLY = 'true';
+    expect(getEffectiveSupabaseKey()).toBe('');
+  });
+
+  it('treats empty SERVICE_ROLE_KEY same as absent', () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = '';
+    process.env.SUPABASE_ANON_KEY = 'anon-key-xyz';
+    process.env.READ_ONLY = 'true';
+    expect(getEffectiveSupabaseKey()).toBe('anon-key-xyz');
+  });
+});


### PR DESCRIPTION
## Summary

**Fourth and architectural** fix in the ADR-028 Option D unblock chain. Where #274/#276/#277 patched 3 isolated config sites, this PR addresses the root cause : ~20 services do `createClient(url, SERVICE_ROLE_KEY)` directly at NestJS module-load. Without SERVICE_ROLE_KEY in preprod, supabase-js v2 throws \`Error: supabaseKey is required.\` at the first such constructor.

The fix is a centralized helper applied across **15 services** in one PR.

## Bug

After #274/#276/#277 merged, deploy main run [25283388014](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25283388014) STILL crashed with :

```
ERROR [ExceptionHandler] supabaseKey is required.
  at new SupabaseClient (...supabase-js...)
  at new CrawlBudgetSupabaseService (...)
```

Sweep `rg -l \"createClient\" backend/src` returned 20+ services. Many use eager constructor + direct \`process.env.SUPABASE_SERVICE_ROLE_KEY\` or \`configService.get('SUPABASE_SERVICE_ROLE_KEY')\` + crash on empty.

## Helper

\`backend/src/common/utils/supabase-key.util.ts::getEffectiveSupabaseKey()\` :

| Condition | Returns |
|---|---|
| SERVICE_ROLE_KEY set | SERVICE_ROLE_KEY (writeable mode, full privilege) |
| SERVICE_ROLE_KEY absent + READ_ONLY=\"true\" + ANON_KEY set | ANON_KEY (read-only, RLS protects writes per ADR-021) |
| Otherwise | \`\"\"\` (caller fails downstream — only in misconfigured envs) |

Re-exported via \`@common/utils\`.

## 15 services updated

Crash-prone (eager constructor + non-null/throw on empty key) :

| # | File | Pre-fix pattern |
|---|---|---|
| 1 | seo-logs/services/crawl-budget-supabase.service.ts | createClient(url\\|\\|'', key\\|\\|'') |
| 2 | vehicles/services/seo/brand-seo.service.ts | uses \`!\` non-null |
| 3 | admin/controllers/admin-keyword-clusters.controller.ts | uses \`!\` non-null |
| 4 | admin/controllers/admin-keyword-planner.controller.ts | uses \`!\` non-null |
| 5 | admin/controllers/internal-seo-audit.controller.ts | uses \`!\` non-null |
| 6 | seo-monitoring/controllers/seo-monitoring.controller.ts | throws |
| 7 | seo-monitoring/services/audit-findings.service.ts | throws |
| 8 | seo-monitoring/services/cwv-fetcher.service.ts | throws |
| 9 | seo-monitoring/services/ga4-daily-fetcher.service.ts | throws |
| 10 | seo-monitoring/services/gsc-daily-fetcher.service.ts | throws |
| 11 | seo-monitoring/services/gsc-links-fetcher.service.ts | throws |
| 12 | seo-monitoring/services/r-content-auditor.service.ts | throws |
| 13 | seo/services/seo-generator.service.ts | throws DatabaseException |
| 14 | seo/services/googlebot-detector.service.ts | createClient(url, '') |
| 15 | seo/services/sitemap-streaming.service.ts | createClient(url, '') |

(\`mcp-alerting.service.ts\`, \`header.service.ts\`, \`footer.service.ts\`, \`internal-linking.service.ts\` already had soft fallbacks. Left as-is to keep diff focused. Can adopt the helper in a follow-up.)

## Pattern applied to each service

```ts
// Before
const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY');
if (!url || !key) {
  throw new Error('XService: Supabase env missing');
}
this.supabase = createClient(url, key, ...);

// After
import { getEffectiveSupabaseKey } from '@common/utils';
// ...
const url = configService.get<string>('SUPABASE_URL') || '';
const key = getEffectiveSupabaseKey();  // ANON_KEY fallback in read-only
if (!url || !key) {
  this.logger.warn('XService: Supabase env missing — service will fail on first call');
}
this.supabase = createClient(url, key, ...);
```

Behaviour : graceful degrade (warn instead of crash). First runtime call surfaces missing-config if it ever happens. RLS rejects mutations in read-only mode anyway.

## Regression test

\`backend/tests/unit/supabase-key-util.test.ts\` (9 cases) pins the read-only fallback :
- SERVICE_ROLE_KEY priority when set (writeable + read-only)
- ANON_KEY fallback when SERVICE_ROLE_KEY absent + READ_ONLY=\"true\"
- No fallback when READ_ONLY undefined or != \"true\"
- Case-sensitive on \"true\" (rejects \"TRUE\", \"1\", \"yes\")
- Returns \"\" when nothing usable
- Treats empty SERVICE_ROLE_KEY same as absent

## Validation

- [x] tsc syntax check OK on all 18 modified files (15 services + helper + index + test)
- [x] prettier --check OK (no formatting drift)
- [x] Pre-push hooks pass (G3 ED25519 signed)
- [ ] CI : 🧪 Deploy PREPROD step exits 0 (the 3-day block resolution)

## Chain history

| # | Site | PR |
|---|---|---|
| 1 | env-validation.ts (boot validator) | [#274](https://github.com/ak125/nestjs-remix-monorepo/pull/274) ✅ |
| 2 | payment.config.ts (ConfigModule load) | [#276](https://github.com/ak125/nestjs-remix-monorepo/pull/276) ✅ |
| 3 | app.config.ts (createAppConfig load) | [#277](https://github.com/ak125/nestjs-remix-monorepo/pull/277) ✅ |
| 4 | 15 service constructors (helper-based) | THIS PR |

If a 5th class of failure surfaces after merge, sweep broader : \`rg \"@supabase/supabase-js\" backend/src\` then audit each createClient call site individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)