### PR TITLE
feat(ast-grep): règle no-direct-rag-knowledge-write (Étape 9 plan v3)

### DIFF
--- a/.ast-grep/rules/no-direct-rag-knowledge-write.yml
+++ b/.ast-grep/rules/no-direct-rag-knowledge-write.yml
@@ -1,0 +1,42 @@
+id: no-direct-rag-knowledge-write
+language: python
+severity: warning
+message: |
+  Écriture directe vers `automecanik-rag/knowledge/` (ou `/opt/automecanik/rag/knowledge/`)
+  interdite. Ce répertoire est un MIRROR généré automatiquement depuis
+  `automecanik-wiki/exports/rag/` via le CI workflow `sync-rag-from-wiki.yml`
+  (ADR-031 §D20/D22, plan v3 §Étape 7).
+
+  Pipeline canon :
+    automecanik-raw/         (sources brutes)
+        ↓
+    scripts/wiki-generators/ (lit raw + DB → wiki/exports/rag/)
+        ↓
+    automecanik-wiki/exports/rag/<entity>/<slug>.md
+        ↓ CI sync
+    automecanik-rag/knowledge/<entity>/<slug>.md  ← MIRROR, jamais écrit à la main
+
+  Si vous avez besoin de produire du contenu RAG, écrivez dans
+  `automecanik-wiki/exports/rag/<cat>/` via un script `wiki-generators/` ou
+  `wiki-exports/` au lieu de cibler rag/knowledge/ directement.
+
+  Pour rejouer une migration legacy ou un rollback ponctuel, le marker
+  `rollback-documented` dans le commit message bypass la garde D22 côté
+  `automecanik-rag` (voir `.githooks/commit-msg` + workflow CI
+  `d22-protected-paths.yml` côté rag).
+files:
+  # Scope étroit aux dossiers refactorisés du plan v3 §Étape 5. Les scripts
+  # legacy `scripts/seo/` et `scripts/rag/` (ingester) sont hors scope —
+  # à intégrer quand ce chantier sera entrepris séparément.
+  - scripts/wiki-generators/**/*.py
+  - scripts/wiki-exports/**/*.py
+  - scripts/raw-downloaders/**/*.py
+ignores:
+  # Le sync officiel a le droit d'écrire vers rag/knowledge — c'est sa raison d'être.
+  - scripts/rag-sync/**
+  # Tests / fixtures peuvent référencer le path en literal.
+  - scripts/**/test_*.py
+  - scripts/**/*_test.py
+rule:
+  kind: string
+  regex: '(automecanik-rag/knowledge/|/opt/automecanik/rag/knowledge/)'

--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-03'
+last_scan: '2026-05-04'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/scripts/raw-downloaders/download-brand-oem-corpus.py
+++ b/scripts/raw-downloaders/download-brand-oem-corpus.py
@@ -23,7 +23,7 @@ brute avec l'URL d'origine dans le frontmatter/_meta. Toute synthèse doit
 passer par un humain ou un second script dédié avec validation.
 
 Output :
-  /opt/automecanik/rag/knowledge/web/brands/{alias}/
+  automecanik-raw/recycled/rag-knowledge/web/brands/{alias}/
     wikipedia-fr-main.md
     wikipedia-fr-models.md
     wikipedia-en-main.md
@@ -59,11 +59,12 @@ except ImportError:
     sys.exit(1)
 
 # === CONFIG ========================================================
-# AUTOMECANIK_RAW_PATH overrides the rag-knowledge root for ADR-031 Phase D.
-# Default keeps the legacy location so unset = no behavioral change.
-RAW_KNOWLEDGE_ROOT = Path(os.getenv("AUTOMECANIK_RAW_PATH", "/opt/automecanik/rag/knowledge"))
-BRANDS_RAG_DIR = RAW_KNOWLEDGE_ROOT / "constructeurs"
-OUTPUT_ROOT = RAW_KNOWLEDGE_ROOT / "web" / "brands"
+# Post Phase C + PR raw #15 : le contenu rag/knowledge/ est migré dans
+# automecanik-raw/recycled/rag-knowledge/. Default canon = repo raw.
+RAW_REPO = Path(os.getenv("AUTOMECANIK_RAW_PATH", "/opt/automecanik/automecanik-raw"))
+RECYCLED_RAG_KNOWLEDGE = RAW_REPO / "recycled" / "rag-knowledge"
+BRANDS_RAG_DIR = RECYCLED_RAG_KNOWLEDGE / "constructeurs"
+OUTPUT_ROOT = RECYCLED_RAG_KNOWLEDGE / "web" / "brands"
 
 SUPABASE_URL = os.environ.get(
     "SUPABASE_URL", "https://cxpojprgwgubzjyqzmoq.supabase.co"

--- a/scripts/raw-downloaders/download-oem-corpus.py
+++ b/scripts/raw-downloaders/download-oem-corpus.py
@@ -7,11 +7,14 @@ Sources (ordre de priorité) :
   2. Pages OEM statiques vérifiées (textar.com, gates.com, monroe.com, bremboparts.com…)
 
 Cible : 221 gammes avec phase5_enrichment insuffisant (< 2 signaux types/mats/norms).
-Output : fichiers .md dans /opt/automecanik/rag/knowledge/web/ (format corpus existant).
+Output : fichiers .md dans automecanik-raw/recycled/rag-knowledge/web/ (format corpus existant).
+
+Configurable via env :
+  AUTOMECANIK_RAW_PATH (default /opt/automecanik/automecanik-raw)
 
 Usage:
-  python3 scripts/rag/download-oem-corpus.py [--dry-run] [--limit 20] [--category freinage]
-  python3 scripts/rag/download-oem-corpus.py --gamme alternateur
+  python3 scripts/raw-downloaders/download-oem-corpus.py [--dry-run] [--limit 20] [--category freinage]
+  python3 scripts/raw-downloaders/download-oem-corpus.py --gamme alternateur
 """
 
 import os


### PR DESCRIPTION
## Summary

Règle ast-grep `no-direct-rag-knowledge-write` qui refuse tout literal `automecanik-rag/knowledge/` ou `/opt/automecanik/rag/knowledge/` dans les scripts canon du pipeline. Garde permanente du plan v3 §Étape 9.

## Context

ADR-031 §D20/D22 : `automecanik-rag/knowledge/` devient mirror read-only de `automecanik-wiki/exports/rag/`. Aucune écriture directe (humain ou script) n'est plus autorisée. Cette règle empêche la **réintroduction** de writes directs lors de futurs développements.

## Severity : warning (transition douce)

Promote à `error` une fois la codebase clean (tous warnings résiduels traités). Pour l'instant 3 warnings résiduels existent dans `scripts/wiki-generators/` qui sont **déjà fixés par PR #275** (en cours auto-merge) — disparaîtront naturellement à la merge.

## Scope (étroit, anti-bricolage)

✅ Inclus :
- `scripts/wiki-generators/**/*.py`
- `scripts/wiki-exports/**/*.py`
- `scripts/raw-downloaders/**/*.py`

❌ Hors scope (chantier séparé) :
- `scripts/seo/**` — à refactorer ultérieurement
- `scripts/rag/ingest-oem-enriched-gammes.py` — legacy ingester

✅ Exempts par design :
- `scripts/rag-sync/**` — le sync officiel a le droit d'écrire vers rag/knowledge/

## Cleanup additionnel dans cette PR

- `scripts/raw-downloaders/download-oem-corpus.py` : docstring mise à jour pour refléter `automecanik-raw/recycled/rag-knowledge/web/` (post Phase C).
- `scripts/raw-downloaders/download-brand-oem-corpus.py` : default `RAW_REPO` pointe maintenant `/opt/automecanik/automecanik-raw` (post PR raw #15), `recycled/rag-knowledge/` ajouté au sub-path interne.

## Côté rag : déjà couvert

`automecanik-rag/.githooks/commit-msg` (D22 hook) + `.github/workflows/d22-protected-paths.yml` enforcent déjà la règle « marker `rollback-documented` obligatoire pour edits manuels `knowledge/` ». **Étape 9 côté rag = déjà en place** depuis Phase F0.c.2 (PR rag #5, 2026-04-28).

## Verification

```bash
npx ast-grep scan --config sgconfig.yml --rule .ast-grep/rules/no-direct-rag-knowledge-write.yml
```

Sortie attendue :
- 3 warnings dans `scripts/wiki-generators/` qui disparaîtront avec PR #275
- 0 violation post-merge #275

## Note sur le diff

Le pre-commit auto-refresh du repo a touché 42 fichiers `.claude/knowledge/modules/*.md` (mineure, 1-2 lignes par fichier). C'est le comportement standard du hook `refresh-knowledge.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)