### PR TITLE
fix(config-services): apply getEffectiveSupabaseKey to 4 write-guard services (ADR-028 Option D)

### DIFF
--- a/backend/src/config/content-write-executor.service.ts
+++ b/backend/src/config/content-write-executor.service.ts
@@ -17,6 +17,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import type {
   ResourceGroup,
   WriteLockHandle,
@@ -52,7 +53,8 @@ export class ContentWriteExecutor {
     private readonly featureFlags: FeatureFlagsService,
   ) {
     const url = this.config.get<string>('SUPABASE_URL') || '';
-    const key = this.config.get<string>('SUPABASE_SERVICE_ROLE_KEY') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     this.supabase = createClient(url, key);
   }
 

--- a/backend/src/config/content-write-gate.service.ts
+++ b/backend/src/config/content-write-gate.service.ts
@@ -15,6 +15,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import type { ResourceGroup } from './execution-registry.types';
 import type { RoleId } from './role-ids';
 import {
@@ -63,7 +64,8 @@ export class ContentWriteGateService {
     private readonly featureFlags: FeatureFlagsService,
   ) {
     const url = this.config.get<string>('SUPABASE_URL') || '';
-    const key = this.config.get<string>('SUPABASE_SERVICE_ROLE_KEY') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     this.supabase = createClient(url, key);
   }
 

--- a/backend/src/config/write-guard-cas.service.ts
+++ b/backend/src/config/write-guard-cas.service.ts
@@ -26,6 +26,7 @@ import {
   GROUP_TABLE_MAP,
 } from './field-catalog.constants';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 
 export interface OwnershipViolation {
   field: string;
@@ -41,7 +42,8 @@ export class WriteGuardCasService {
 
   constructor(private readonly config: ConfigService) {
     const url = this.config.get<string>('SUPABASE_URL') || '';
-    const key = this.config.get<string>('SUPABASE_SERVICE_ROLE_KEY') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     this.supabase = createClient(url, key);
   }
 

--- a/backend/src/config/write-guard-ledger.service.ts
+++ b/backend/src/config/write-guard-ledger.service.ts
@@ -13,6 +13,7 @@ import type {
   WriteReceiptEntry,
 } from './execution-registry.types';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
 
 @Injectable()
 export class WriteGuardLedgerService {
@@ -21,7 +22,8 @@ export class WriteGuardLedgerService {
 
   constructor(private readonly config: ConfigService) {
     const url = this.config.get<string>('SUPABASE_URL') || '';
-    const key = this.config.get<string>('SUPABASE_SERVICE_ROLE_KEY') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     this.supabase = createClient(url, key);
   }
 


### PR DESCRIPTION
## Summary

Follow-up to [#284](https://github.com/ak125/nestjs-remix-monorepo/pull/284). Applies the canonical helper to **4 eager services in `backend/src/config/`** that were missed by the previous sweep (which was scoped to `backend/src/modules/`).

## Bug

Deploy main run [25318507147](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25318507147) (commit `bb7ae4a6`, post-#284) crashed at \`🧪 Deploy PREPROD\` with :

```
Error: supabaseKey is required.
  at new SupabaseClient (...supabase-js...)
  at new WriteGuardCasService (.../config/write-guard-cas.service.js:28:56)
```

Same root cause as #284 (eager constructor + empty key), different file location.

## Files fixed

| # | File | Pre-fix |
|---|---|---|
| 1 | `backend/src/config/write-guard-cas.service.ts` | crashed in bb7ae4a6 |
| 2 | `backend/src/config/write-guard-ledger.service.ts` | same pattern, would crash next |
| 3 | `backend/src/config/content-write-gate.service.ts` | same pattern |
| 4 | `backend/src/config/content-write-executor.service.ts` | same pattern |

All 4 had identical pattern :

```ts
const key = this.config.get<string>('SUPABASE_SERVICE_ROLE_KEY') || '';
this.supabase = createClient(url, key);  // crash if key empty
```

Fix : same helper-based pattern as #284 :

```ts
import { getEffectiveSupabaseKey } from '@common/utils';
// ...
const key = getEffectiveSupabaseKey();  // ANON_KEY fallback in read-only
this.supabase = createClient(url, key);
```

## Sweep verification

`rg createClient backend/src/config/` returns ONLY these 4 files (other than already-fixed config files like `app.config.ts`). Sweep complete for `backend/src/`.

## Cascade history (5 PRs total)

| # | Site | PR |
|---|---|---|
| 1 | env-validation.ts (boot validator) | #274 |
| 2 | payment.config.ts (ConfigModule load) | #276 |
| 3 | app.config.ts (createAppConfig load) | #277 |
| 4 | 15 services in backend/src/modules/ (helper) | #284 |
| 5 | **4 services in backend/src/config/ (helper)** | **THIS PR** |

If still red after this : sweep \`rg \"@supabase/supabase-js\" backend/\` to find any remaining hidden eager constructors outside src/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)