### PR TITLE
chore(cron): sync-rag-from-wiki canon DEV VPS — zero PAT, zero hosted runner

### DIFF
--- a/log.md
+++ b/log.md
@@ -327,3 +327,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/perf-gates-read-only-adr028`
 - **Décision** : fix(ci): mock SERVICE_ROLE_KEY for boot — ~30 services bypass SupabaseBaseService (+1 other commit)
 - **Sortie** : PR #285 | commits 442f5956 af006c72
+
+## 2026-05-04 — chore/sync-rag-from-wiki-cron-canon (auto)
+
+- **Branche** : `chore/sync-rag-from-wiki-cron-canon`
+- **Décision** : chore(cron): sync-rag-from-wiki canon DEV VPS — meilleure approche (zero PAT)
+- **Sortie** : PR #288 | commits 005b9d0a

--- a/log.md
+++ b/log.md
@@ -333,3 +333,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/sync-rag-from-wiki-cron-canon`
 - **Décision** : chore(cron): sync-rag-from-wiki canon DEV VPS — meilleure approche (zero PAT)
 - **Sortie** : PR #288 | commits 005b9d0a
+
+## 2026-05-04 — chore/sync-rag-from-wiki-cron-canon (auto)
+
+- **Branche** : `chore/sync-rag-from-wiki-cron-canon`
+- **Décision** : fix(cron): log path /opt/automecanik/rag/logs/ (le user deploy n'a pas droit /var/log) (+2 other commits)
+- **Sortie** : PR #288 | commits ee0ba019 8fc09139 005b9d0a

--- a/scripts/cron/sync-rag-from-wiki.README.md
+++ b/scripts/cron/sync-rag-from-wiki.README.md
@@ -19,7 +19,7 @@ Une seule ligne à ajouter au crontab DEV (`crontab -e`) :
 ```bash
 # Première run manuelle (pour vérifier les credentials, paths, idempotence)
 /opt/automecanik/app/scripts/cron/sync-rag-from-wiki.sh
-tail -50 /var/log/automecanik/sync-rag-from-wiki.log
+tail -50 /opt/automecanik/rag/logs/sync-rag-from-wiki.log
 
 # Status post-run
 cd /opt/automecanik/rag && git log --oneline -1

--- a/scripts/cron/sync-rag-from-wiki.README.md
+++ b/scripts/cron/sync-rag-from-wiki.README.md
@@ -1,0 +1,67 @@
+# sync-rag-from-wiki cron — installation
+
+ADR-031 §D20/D22 : `automecanik-rag/knowledge/` est un mirror read-only de
+`automecanik-wiki/exports/rag/`. Cette automation tourne sur **DEV VPS uniquement**
+(zéro PAT, zéro hosted runner — voir le knowledge entry vault
+`rag-to-wiki-sot-pipeline-20260503.md`).
+
+## Activation
+
+Une seule ligne à ajouter au crontab DEV (`crontab -e`) :
+
+```cron
+# Sync rag/knowledge ← wiki/exports/rag/ (toutes les heures, ADR-031 §D20)
+0 * * * * /opt/automecanik/app/scripts/cron/sync-rag-from-wiki.sh
+```
+
+## Vérification
+
+```bash
+# Première run manuelle (pour vérifier les credentials, paths, idempotence)
+/opt/automecanik/app/scripts/cron/sync-rag-from-wiki.sh
+tail -50 /var/log/automecanik/sync-rag-from-wiki.log
+
+# Status post-run
+cd /opt/automecanik/rag && git log --oneline -1
+# attendu : "synced-from-wiki: <wiki-sha>" si changes, sinon HEAD inchangé
+```
+
+## Désactivation
+
+Retirer la ligne du crontab. Le script est idempotent et ne tourne pas en
+arrière-plan — il s'arrête naturellement.
+
+## Pré-requis (déjà en place sur DEV VPS)
+
+| Pré-requis | Vérification |
+|---|---|
+| Clone `/opt/automecanik/automecanik-wiki/` | `git remote -v` |
+| Clone `/opt/automecanik/rag/` | idem |
+| Deploy bot SSH key configurée pour push | `ssh -T git@github.com` |
+| `python3` + dépendances `sync-wiki-exports-to-rag.py` (stdlib only) | `python3 -c "import hashlib, shutil, pathlib"` |
+| `flock` pour le global lock | `which flock` |
+
+## Pourquoi pas GitHub Actions
+
+Cf. discussion architecturale dans le knowledge vault. Résumé :
+
+- 3 clones git déjà locaux → re-checkout via runner = bricolage
+- Deploy bot SSH key déjà active → PAT cross-repo = bricolage
+- `python3` + stdlib disponibles → setup runner = bricolage
+- Cron pattern éprouvé (`qa-audit-cron.sh`, `queue-health.sh`, `health-check.sh`,
+  `disk-alert.sh`, `deploy-watcher.sh`) → cohérence > diversité
+
+## Troubleshooting
+
+| Symptôme | Cause probable | Fix |
+|---|---|---|
+| `ERROR: rag not on main` | Quelqu'un a checkout une branche dans `/opt/automecanik/rag/` | `git checkout main` dans le clone |
+| `Another RAG operation active` | `run-phase-f.sh` ou autre opération rag tourne en parallèle | Attendre la fin (lock global `/tmp/rag-global.lock`) |
+| Sync produit "No changes" alors qu'on attend des updates | Le contenu de `wiki/exports/rag/` n'a pas changé sur main | Vérifier `cd /opt/automecanik/automecanik-wiki && git log --oneline exports/rag/` |
+| Push échoue sur 403/permission denied | Deploy bot SSH key pas dans `~/.ssh/authorized_keys` côté GitHub | Configurer la clé via Settings → Deploy keys |
+
+## Référence
+
+- ADR-031 — Raw / Wiki / RAG / SEO Separation
+- Knowledge vault : `rag-to-wiki-sot-pipeline-20260503.md`
+- Plan v3 : `/home/deploy/.claude/plans/je-comprend-rien-a-spicy-reddy.md`

--- a/scripts/cron/sync-rag-from-wiki.sh
+++ b/scripts/cron/sync-rag-from-wiki.sh
@@ -20,7 +20,7 @@
 # Cron cadence : hourly. Le sync est idempotent (sha256 check) donc no-op si
 # rien n'a changé.
 #
-# Logs : /var/log/automecanik/sync-rag-from-wiki.log (mkdir -p si absent).
+# Logs : /opt/automecanik/rag/logs/sync-rag-from-wiki.log (mkdir -p si absent).
 #
 # Env (optionnels, defaults sains pour DEV VPS) :
 #   AUTOMECANIK_WIKI_PATH (default /opt/automecanik/automecanik-wiki)
@@ -33,7 +33,7 @@ WIKI_PATH="${AUTOMECANIK_WIKI_PATH:-/opt/automecanik/automecanik-wiki}"
 RAG_PATH="${AUTOMECANIK_RAG_PATH:-/opt/automecanik/rag}"
 APP_PATH="${APP_PATH:-/opt/automecanik/app}"
 SYNC_SCRIPT="$APP_PATH/scripts/rag-sync/sync-wiki-exports-to-rag.py"
-LOG_DIR="/var/log/automecanik"
+LOG_DIR="/opt/automecanik/rag/logs"
 LOG_FILE="$LOG_DIR/sync-rag-from-wiki.log"
 
 mkdir -p "$LOG_DIR"

--- a/scripts/cron/sync-rag-from-wiki.sh
+++ b/scripts/cron/sync-rag-from-wiki.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# sync-rag-from-wiki.sh — Mirror automecanik-wiki/exports/rag/ → automecanik-rag/knowledge/
+#
+# ADR-031 §D20/D22 : automecanik-rag/knowledge/ est un répertoire **généré**
+# (mirror read-only) dont la source autoritaire est automecanik-wiki/exports/rag/.
+# Ce cron exécute la chaîne canon en local sur DEV VPS :
+#
+#   1. git pull wiki (récupère contenu généré upstream)
+#   2. git pull rag (sync HEAD courant)
+#   3. sync-wiki-exports-to-rag.py --apply (D20 enforce + sha256 idempotent)
+#   4. git commit + push avec marker `synced-from-wiki: <wiki-sha>` (D22)
+#
+# Pourquoi cron VPS et pas GitHub Actions :
+#   - Les 3 clones git sont déjà locaux (zéro re-checkout)
+#   - Deploy bot SSH key déjà configurée (zéro PAT à rotater)
+#   - Pas de rate limit Wikidata/Wikipedia (zéro réseau hosted)
+#   - Cohérent avec le pattern existant (qa-audit-cron.sh, run-phase-f.sh)
+#
+# Cron cadence : hourly. Le sync est idempotent (sha256 check) donc no-op si
+# rien n'a changé.
+#
+# Logs : /var/log/automecanik/sync-rag-from-wiki.log (mkdir -p si absent).
+#
+# Env (optionnels, defaults sains pour DEV VPS) :
+#   AUTOMECANIK_WIKI_PATH (default /opt/automecanik/automecanik-wiki)
+#   AUTOMECANIK_RAG_PATH  (default /opt/automecanik/rag)
+#   APP_PATH              (default /opt/automecanik/app)
+# ==============================================================================
+set -euo pipefail
+
+WIKI_PATH="${AUTOMECANIK_WIKI_PATH:-/opt/automecanik/automecanik-wiki}"
+RAG_PATH="${AUTOMECANIK_RAG_PATH:-/opt/automecanik/rag}"
+APP_PATH="${APP_PATH:-/opt/automecanik/app}"
+SYNC_SCRIPT="$APP_PATH/scripts/rag-sync/sync-wiki-exports-to-rag.py"
+LOG_DIR="/var/log/automecanik"
+LOG_FILE="$LOG_DIR/sync-rag-from-wiki.log"
+
+mkdir -p "$LOG_DIR"
+ts() { date '+%Y-%m-%dT%H:%M:%S%z'; }
+log() { echo "[$(ts)] $*" | tee -a "$LOG_FILE"; }
+
+log "=== sync-rag-from-wiki start ==="
+
+# --- Sanity checks ---
+for d in "$WIKI_PATH" "$RAG_PATH" "$APP_PATH"; do
+  [ -d "$d/.git" ] || { log "ERROR: $d not a git repo"; exit 2; }
+done
+[ -x "$SYNC_SCRIPT" ] || [ -r "$SYNC_SCRIPT" ] || {
+  log "ERROR: sync script not found: $SYNC_SCRIPT"; exit 2;
+}
+
+# --- Global lock to avoid overlap with other rag operations ---
+GLOBAL_LOCK="/tmp/rag-global.lock"
+exec 8>"$GLOBAL_LOCK"
+if ! flock -n 8; then
+  log "Another RAG operation active, skipping this run"
+  exit 0
+fi
+
+# --- Step 1: Pull wiki main (source of truth) ---
+log "[1/4] git pull wiki main"
+cd "$WIKI_PATH"
+WIKI_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "detached")
+if [ "$WIKI_BRANCH" != "main" ]; then
+  log "WARN: wiki not on main (branch=$WIKI_BRANCH), skipping pull"
+else
+  git pull --ff-only origin main 2>&1 | tee -a "$LOG_FILE"
+fi
+WIKI_SHA=$(git rev-parse --short HEAD)
+log "  wiki HEAD: $WIKI_SHA"
+
+# --- Step 2: Pull rag main (target) ---
+log "[2/4] git pull rag main"
+cd "$RAG_PATH"
+RAG_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "detached")
+if [ "$RAG_BRANCH" != "main" ]; then
+  log "ERROR: rag not on main (branch=$RAG_BRANCH), aborting (manual cleanup needed)"
+  exit 3
+fi
+git pull --ff-only origin main 2>&1 | tee -a "$LOG_FILE"
+
+# --- Step 3: Run sync (D20 enforce + sha256 idempotent) ---
+log "[3/4] sync-wiki-exports-to-rag.py --apply"
+python3 "$SYNC_SCRIPT" \
+  --wiki-repo "$WIKI_PATH" \
+  --rag-repo "$RAG_PATH" \
+  --apply 2>&1 | tee -a "$LOG_FILE"
+
+# --- Step 4: Commit + push if changes ---
+cd "$RAG_PATH"
+if git diff --quiet -- knowledge/ && git diff --cached --quiet -- knowledge/; then
+  log "[4/4] No changes under knowledge/ — nothing to commit (idempotent)"
+  log "=== sync-rag-from-wiki done (no-op) ==="
+  exit 0
+fi
+
+log "[4/4] Committing + pushing changes"
+git add knowledge/
+
+# D22 marker : marker `synced-from-wiki: <sha>` requis par .githooks/commit-msg
+# et .github/workflows/d22-protected-paths.yml côté rag.
+COMMIT_MSG="synced-from-wiki: $WIKI_SHA
+
+Source: automecanik-wiki@$WIKI_SHA
+Sync: scripts/rag-sync/sync-wiki-exports-to-rag.py via cron VPS DEV.
+Pattern canon ADR-031 §D20/D22 — aucune écriture humaine directe."
+
+git commit -m "$COMMIT_MSG" 2>&1 | tee -a "$LOG_FILE"
+git push origin main 2>&1 | tee -a "$LOG_FILE"
+
+log "=== sync-rag-from-wiki done (synced @ $WIKI_SHA) ==="


### PR DESCRIPTION
## Summary

**Pivot architectural** post-feedback user *« meilleure solution pas de bricolage »*. Le pattern canonique pour le sync `automecanik-wiki/exports/rag/` → `automecanik-rag/knowledge/` est **un cron unique sur DEV VPS**, pas du dispatch GitHub Actions cross-repo.

## Pourquoi le PAT + GitHub Actions était du bricolage

Tout ce qui faisait que le pattern hosted runner avait du sens en théorie est **déjà acquis localement** :

| Asset DEV VPS | Permet de bypasser |
|---|---|
| 3 clones git locaux (`/opt/automecanik/{automecanik-wiki,rag,automecanik-raw}/`) | Le `actions/checkout` × 3 du runner |
| Deploy bot SSH key | Le PAT cross-repo (rotation 90j à gérer) |
| `python3` stdlib only | Le `actions/setup-python` |
| Pattern cron éprouvé (qa-audit, queue-health, disk-alert, etc.) | L'orchestration GitHub Actions |
| backend/.env credentials Supabase locaux | Les secrets GH Actions |

## Files

| Path | Rôle |
|---|---|
| `scripts/cron/sync-rag-from-wiki.sh` | Script bash idempotent : lock global, pull wiki + rag, sync via `scripts/rag-sync/sync-wiki-exports-to-rag.py`, commit+push avec marker D22 `synced-from-wiki: <sha>` |
| `scripts/cron/sync-rag-from-wiki.README.md` | Installation (1 ligne crontab) + verification + troubleshooting + ratio architectural |

## Activation (manuel)

1 ligne à ajouter au `crontab -e` du DEV VPS :

```cron
# Sync rag/knowledge ← wiki/exports/rag/ (toutes les heures, ADR-031 §D20)
0 * * * * /opt/automecanik/app/scripts/cron/sync-rag-from-wiki.sh
```

## Verification

- ✅ `bash -n scripts/cron/sync-rag-from-wiki.sh` syntax OK
- ✅ Sanity test local : sync-wiki-exports-to-rag.py exécutable, paths résolvent (0 fichiers à sync = no-op idempotent attendu — gitignore exports/rag/** Pattern à arbitrer Étape 6)
- ✅ Pre-flight : 3 git repos validés, sync script readable, lock global FD8
- ✅ `git pull --ff-only` (refuse merge si divergence)
- ✅ Refuse opération si rag pas sur main (zéro chance de push accidentel sur feature branch)

## Suite (PRs follow-up séparées, post-merge)

1. **PR rag** : `git rm .github/workflows/sync-rag-from-wiki.yml` (le workflow GitHub Actions devient redondant)
2. **PR wiki** : `git rm .github/workflows/dispatch-rag-sync.yml` (le dispatcher devient inutile)
3. **User** (UI GitHub) : retirer secret `RAG_DISPATCH_PAT` côté wiki settings/secrets/actions (security debt cleanup)

## Test plan

- [ ] CI verte (TypeScript, ESLint, tests, RPC Safety, Migration Safety, ADR-010, etc.)
- [ ] Pre-commit pass (script bash, README markdown)
- [ ] Pas de régression code (zero modif backend/frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)