### PR TITLE
fix(wiki-generators): mkdir(parents, exist_ok) avant écriture OUTPUT

### DIFF
--- a/scripts/wiki-generators/brand-fiche-generator.py
+++ b/scripts/wiki-generators/brand-fiche-generator.py
@@ -531,6 +531,9 @@ def main() -> int:
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
+    if not args.dry_run:
+        BRANDS_DIR.mkdir(parents=True, exist_ok=True)
+
     brands = fetch_brands()
     if args.brand:
         brands = [b for b in brands if b["marque_alias"] == args.brand]

--- a/scripts/wiki-generators/gamme-from-web-corpus-generator.py
+++ b/scripts/wiki-generators/gamme-from-web-corpus-generator.py
@@ -613,6 +613,9 @@ def main():
                         help='Écraser les gammes déjà oem_verified (défaut: skip)')
     args = parser.parse_args()
 
+    if not args.dry_run:
+        os.makedirs(GAMMES_DIR, exist_ok=True)
+
     print("Étape 1 : Mapping gammes → fichiers web OEM...")
     mapping = build_gamme_mapping()
 


### PR DESCRIPTION
## Summary

Bug discovered lors du smoke test Étape 6 sur 1 brand (`brand-fiche-generator.py --brand renault`) : les wiki-generators écrivent dans `wiki/exports/rag/{constructeurs,gammes}/` mais ne créent pas le dossier parent. Plante avec `FileNotFoundError` au 1er fichier généré.

## Fix minimal (pas de bricolage)

| Script | Patch |
|---|---|
| `brand-fiche-generator.py` | `BRANDS_DIR.mkdir(parents=True, exist_ok=True)` au début de `main()` |
| `gamme-from-web-corpus-generator.py` | `os.makedirs(GAMMES_DIR, exist_ok=True)` au début de `main()` |

Pattern : appel garde par `if not args.dry_run` pour préserver le comportement dry-run (pas d'effet de bord).

## Hors scope

`gamme-from-db-template-generator.py` n'a pas besoin du fix : ce script écrit en DB Supabase (`__rag_knowledge`), pas filesystem. Cas particulier documenté Étape 5 PR-3.

## Pré-requis Étape 6 batch run

Sans ce fix, le batch run plante au 1er fichier. Avec ce fix, le batch peut produire 36 brands + 200+ gammes sans intervention manuelle (le `mkdir` est idempotent).

## Test plan

- [x] `python3 -c "py_compile.compile(...)"` PASS sur les 2 scripts
- [ ] CI verte (TypeScript, ESLint, tests, etc. — ne touchent pas ces scripts Python)

🤖 Generated with [Claude Code](https://claude.com/claude-code)