### PR TITLE
fix(ci): agents-md-validation — retirer paths filter (item P1 vault)

### DIFF
--- a/.github/workflows/agents-md-validation.yml
+++ b/.github/workflows/agents-md-validation.yml
@@ -1,20 +1,20 @@
 name: agents-md-validation
 
+# Aucun `paths` filter : le workflow tourne sur CHAQUE PR + push main.
+# Justification (P1 vault `audit-claude-md-agents-md-validator-20260503.md`) :
+#   - paths-filtered + required-check → PR ne touchant aucun path → check
+#     « expected mais missing » → blocage merge silencieux (cf. PR #273 BEHIND).
+#   - Le validateur lui-même est ultra-rapide (<10s total) sur un diff vide :
+#     `--diff` retourne 0 fichier scanné → exit 0 PASS, `--all` retourne 0 BLOCK.
+#   - Pas de coût CI significatif : shellcheck (~1s) + self-test (~1s) +
+#     diff (<1s sur diff vide) + all (~6s sur les 11 AGENTS.md/CLAUDE.md).
+# Si `agents-md-validation` est ajouté un jour aux required checks de
+# `branches/main/protection`, ce design empêche le piège paths-filter.
 on:
   pull_request:
-    paths:
-      - 'agents/**/AGENTS.md'
-      - '**/CLAUDE.md'
-      - '.claude/rules/**'
-      - 'scripts/agents/**'
-      - '.github/workflows/agents-md-validation.yml'
   push:
     branches:
       - main
-    paths:
-      - 'agents/**/AGENTS.md'
-      - '**/CLAUDE.md'
-      - 'scripts/agents/**'
 
 jobs:
   validate:

--- a/log.md
+++ b/log.md
@@ -345,3 +345,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/agents-md-validator-always-trigger`
 - **Décision** : fix(ci): agents-md-validation always-trigger (no paths filter)
 - **Sortie** : PR aucune | commits 828d0571
+
+## 2026-05-04 — fix/agents-md-validator-always-trigger (auto)
+
+- **Branche** : `fix/agents-md-validator-always-trigger`
+- **Décision** : Merge remote-tracking branch 'origin/main' into fix/agents-md-validator-always-trigger (+2 other commits)
+- **Sortie** : PR #293 | commits ae0a5e36 cc16626a 828d0571

--- a/log.md
+++ b/log.md
@@ -339,3 +339,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/sync-rag-from-wiki-cron-canon`
 - **Décision** : fix(cron): log path /opt/automecanik/rag/logs/ (le user deploy n'a pas droit /var/log) (+2 other commits)
 - **Sortie** : PR #288 | commits ee0ba019 8fc09139 005b9d0a
+
+## 2026-05-04 — fix/agents-md-validator-always-trigger (auto)
+
+- **Branche** : `fix/agents-md-validator-always-trigger`
+- **Décision** : fix(ci): agents-md-validation always-trigger (no paths filter)
+- **Sortie** : PR aucune | commits 828d0571


### PR DESCRIPTION
## Summary

Item **P1** du vault `audit-claude-md-agents-md-validator-20260503.md` (commit `1967fbc4`) §4 — *Améliorations futures*.

Retire le `paths` filter sur les triggers du workflow `agents-md-validation.yml`. Le validateur tourne désormais sur **chaque PR + push main**, sans coût significatif.

## Diff

```diff
 on:
   pull_request:
-    paths:
-      - 'agents/**/AGENTS.md'
-      - '**/CLAUDE.md'
-      - '.claude/rules/**'
-      - 'scripts/agents/**'
-      - '.github/workflows/agents-md-validation.yml'
   push:
     branches:
       - main
-    paths:
-      - 'agents/**/AGENTS.md'
-      - '**/CLAUDE.md'
-      - 'scripts/agents/**'
```

+ commentaire d'en-tête expliquant la justification (référence vault).

## Pourquoi

Le pattern « workflow paths-filtered » + « check required par branch protection » est un piège GitHub Actions classique :
- Sur une PR qui ne touche **aucun** path matchant, le check apparaît comme « expected mais missing »
- → blocage merge silencieux avec message obscur (« 14 of 14 required status checks are expected »)
- Observé empiriquement sur **PR #273** (submodule pointer bump uniquement) qui s'est retrouvée temporairement `BEHIND`, exigeant un merge `main` → branche pour débloquer

Bien que `agents-md-validation` ne soit **pas actuellement** dans les 14 required checks de `branches/main/protection` (vérifié via `gh api`), ce fix est **défensif** : si quelqu'un l'ajoute plus tard à la liste required, il ne réintroduira pas le piège.

## Coût CI

| Étape | Durée typique | Comportement sur diff vide |
|---|---|---|
| `shellcheck` | ~1s | identique |
| `--self-test` | ~1s | identique (9/9 cas embarqués) |
| `--diff base.sha` | <1s | 0 fichier scanné → exit 0 immédiat |
| `--all` | ~6s | scan structure des 11 AGENTS.md/CLAUDE.md → exit 0 (3 WARN advisory existants) |

**Total ~10s par PR.** Trade-off largement favorable vs la robustesse anti-piège.

## Pas de bricolage

Pas de short-circuit conditionnel custom (`if: steps.changed.outputs.relevant == 'true'` aurait ajouté ~30 lignes YAML pour un effet équivalent). Le validateur gère **nativement** les diffs vides :

```
FILES_SCANNED=0 → BLOCKS=0 → WARNS=0 → final_status: PASS → exit 0
```

Vérifié par `--self-test` 9/9 PASS (notamment les cas regression « fichier propre » et « 'présente' lowercase » figés depuis PR #272).

Le minimalisme l'emporte sur l'over-engineering.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` → YAML valide
- [x] `bash scripts/agents/validate-agents-md.sh --self-test` → 9/9 PASS
- [ ] CI sur cette PR : workflow `agents-md-validation` doit tourner et passer (auto-validation : la PR teste son propre fix)
- [ ] Sur une PR future qui ne touche aucun fichier de la liste précédente, le workflow doit toujours s'afficher en `success` (au lieu de ne pas apparaître)

## Référence

- Item P1 : `governance-vault/ledger/knowledge/audit-claude-md-agents-md-validator-20260503.md` §4
- Vault commit : `1967fbc4` (PR `governance-vault#140`)
- PR origine de l'incident : monorepo #273 (submodule bump qui a déclenché le BEHIND)

🤖 Generated with [Claude Code](https://claude.com/claude-code)