### PR TITLE
feat(ci): auto-merge Dependabot avec review intelligente Claude (P0 dry-run)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,24 @@ updates:
       dev-dependencies:
         dependency-type: "development"
         update-types: ["minor", "patch"]
+      # Ecosystem-coupling groups : forcent les bumps cohérents pour les
+      # familles qui doivent rester alignées sur le même major (sinon
+      # incompat runtime, cf. cas #280 storybook 9 vs addon-onboarding@10
+      # le 2026-05-04). Dependabot émettra une seule PR par écosystème
+      # plutôt que des PRs partielles.
+      storybook-ecosystem:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      tiptap-ecosystem:
+        patterns:
+          - "@tiptap/*"
+      vite-ecosystem:
+        patterns:
+          - "vite"
+          - "vitest"
+          - "@vitejs/*"
+          - "vite-tsconfig-paths"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -34,8 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-
+      # Pas de `actions/checkout` ici : DEV Safety GATE-3 interdit la combinaison
+      # `pull_request_target` + `actions/checkout` (risque d'exécution de code
+      # malveillant si une PR fork modifie un script). `dependabot/fetch-metadata`
+      # n'a pas besoin du repo en local. L'action `anthropics/claude-code-action@v1`
+      # gère son propre checkout en interne.
       - name: Fetch Dependabot metadata
         id: meta
         uses: dependabot/fetch-metadata@v2

--- a/.github/workflows/dependabot-claude-review.yml
+++ b/.github/workflows/dependabot-claude-review.yml
@@ -1,0 +1,116 @@
+name: 🤖 Dependabot Claude Review
+
+# Review automatique des PRs Dependabot que les règles déterministes de
+# `dependabot-auto-merge.yml` ne couvrent pas (= dev-majors et runtime-bumps).
+# Pour les patches / dev-minors / GitHub Actions, le job se skip et laisse
+# l'auto-merge déterministe faire son travail.
+#
+# Activation contrôlée par deux variables repo (à créer côté Settings) :
+#   - vars.CLAUDE_REVIEW_ENABLED  : kill-switch global (true|false)
+#   - vars.CLAUDE_REVIEW_DRY_RUN  : commenter sans merger (true|false)
+# Et le secret repo `ANTHROPIC_API_KEY`.
+#
+# Voir plan rev 1 : /home/deploy/.claude/plans/aller-au-contenu-utiliser-dapper-rose.md
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      vars.CLAUDE_REVIEW_ENABLED == 'true' &&
+      !contains(github.event.pull_request.labels.*.name, 'dependabot-hold')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Skip if already auto-mergeable (deterministic rules)
+        id: skip-check
+        run: |
+          ut="${{ steps.meta.outputs.update-type }}"
+          dt="${{ steps.meta.outputs.dependency-type }}"
+          eco="${{ steps.meta.outputs.package-ecosystem }}"
+          if [ "$ut" = "version-update:semver-patch" ] || \
+             { [ "$ut" = "version-update:semver-minor" ] && [ "$dt" = "direct:development" ]; } || \
+             [ "$eco" = "github_actions" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Bump couvert par dependabot-auto-merge.yml — Claude review skipped."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "🔎 Bump non couvert par les règles déterministes — Claude review nécessaire."
+            echo "   update-type=$ut dependency-type=$dt ecosystem=$eco"
+          fi
+
+      - name: Claude review
+        if: steps.skip-check.outputs.skip == 'false'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "dependabot[bot]"
+          claude_args: "--model claude-haiku-4-5-20251001"
+          prompt: |
+            You are reviewing a Dependabot PR on ak125/nestjs-remix-monorepo
+            (NestJS backend + Remix frontend). Bias toward HOLD on any doubt.
+
+            BUMP DETAILS
+            - Dependency: ${{ steps.meta.outputs.dependency-names }}
+            - Update type: ${{ steps.meta.outputs.update-type }}
+            - Dependency scope: ${{ steps.meta.outputs.dependency-type }}
+            - Ecosystem: ${{ steps.meta.outputs.package-ecosystem }}
+            - PR number: ${{ github.event.pull_request.number }}
+            - PR URL: ${{ github.event.pull_request.html_url }}
+
+            STEPS
+            1. Read PR body / release notes via `gh pr view ${{ github.event.pull_request.number }}`.
+            2. Read the actual diff via `gh pr diff ${{ github.event.pull_request.number }}`.
+            3. Grep usage in codebase:
+               `grep -rn '<dep>' --include='*.ts' --include='*.tsx' frontend/app backend/src packages | head -50`.
+            4. Ecosystem coupling check — if the dep matches `@storybook/*`,
+               `@nestjs/*`, `@remix-run/*`, `@tiptap/*`, `@radix-ui/*`,
+               `@vitejs/*`, verify all peers in `package.json` (root +
+               frontend + backend + packages/*) are at the same major. If
+               mismatch → HOLD.
+            5. Decide GO only if ALL of:
+               (a) no breaking change applies to current code usage,
+               (b) ecosystem peers compatible (no major mismatch),
+               (c) changelog reports no runtime behavior change OR change is opt-in.
+
+            ACTIONS
+            - GO + (update-type ≠ semver-major OR dependency-type ≠ direct:production):
+              run
+              `gh pr review ${{ github.event.pull_request.number }} --approve --body "Auto-approved by Claude review (model: claude-haiku-4-5)."`
+              then
+              `gh pr merge ${{ github.event.pull_request.number }} --auto --squash`.
+            - GO + (update-type == semver-major AND dependency-type == direct:production):
+              post comment via
+              `gh pr comment ${{ github.event.pull_request.number }} --body "VERDICT: GO (manual approval required for runtime-major bump)\n\nReason: <your reason>"` —
+              DO NOT run `gh pr merge`.
+            - HOLD: post comment via
+              `gh pr comment ${{ github.event.pull_request.number }} --body "VERDICT: HOLD\n\nReason: <your reason>"`
+              then run
+              `gh pr edit ${{ github.event.pull_request.number }} --add-label dependabot-hold`.
+
+            DRY-RUN MODE
+            If `${{ vars.CLAUDE_REVIEW_DRY_RUN }}` == "true": post the verdict
+            as a comment ONLY (with prefix "[DRY-RUN] "), never run
+            `gh pr merge` or add the label.
+
+            End your reply with one line: `VERDICT: GO|HOLD - <reason ≤200 chars>`.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Automatise la review des PRs Dependabot **non couvertes** par les règles déterministes actuelles de [dependabot-auto-merge.yml](.github/workflows/dependabot-auto-merge.yml) (= dev-majors et runtime-bumps).
- Utilise l'action officielle [anthropics/claude-code-action@v1](https://github.com/anthropics/claude-code-action) avec Claude Haiku 4.5 — **0 script shell custom**, prompt versionné dans le YAML.
- Préventif côté `.github/dependabot.yml` : 3 groupes ecosystem (`storybook-ecosystem`, `tiptap-ecosystem`, `vite-ecosystem`) qui forcent les bumps cohérents pour les familles couplées (résout structurellement le cas du jour, cf. PR #280).

## Pourquoi maintenant

5 PRs Dependabot ont été simultanément bloquées le 2026-05-04 (#279-#283), résolues via PRs #285 + #289. Pour les débloquer j'ai fait une review manuelle qui a donné 4 GO + 1 HOLD (#280 storybook ecosystem incompat). Cette PR systématise ce travail manuel.

## Architecture (minimale canonique)

| Couche | Outil | Rôle |
|---|---|---|
| Préventif | `dependabot.yml` groups | Bumps groupés par écosystème, pas de pièces détachées |
| Déterministe | `dependabot-auto-merge.yml` (existant, intact) | Patches + dev-minors + GH-Actions auto-merge sans LLM |
| Intelligent | `dependabot-claude-review.yml` (NOUVEAU) | Dev-majors + runtime-bumps reviewés par Claude → auto-merge si GO |
| Manuel | Human review | Runtime-majors → Claude commente seulement, jamais merge |

## Contenu

- **`.github/dependabot.yml`** : +3 groupes ecosystem (~18 lignes), 0 ligne touchée du group `dev-dependencies` existant
- **`.github/workflows/dependabot-claude-review.yml`** : NOUVEAU, ~110 lignes, utilise uniquement `actions/checkout@v4` + `dependabot/fetch-metadata@v2` + `anthropics/claude-code-action@v1`

## Garde-fous

| Garde-fou | Implémentation |
|---|---|
| Kill-switch global | `vars.CLAUDE_REVIEW_ENABLED == 'true'` |
| Mode dry-run | `vars.CLAUDE_REVIEW_DRY_RUN == 'true'` (initialement vrai pour P0) |
| Anti-fork | `head.repo.full_name == github.repository` |
| Anti-loop | label `dependabot-hold` skip à la prochaine sync |
| Concurrency cancel | `claude-review-${PR}` |
| Timeout | 5 min |
| Runtime-major never auto | logique explicite dans le prompt |
| Coût | Haiku 4.5, ~\$0.005/PR, 5-7 PRs/mois → < \$0.20/mois |

## Activation (à faire **après merge** de cette PR)

```bash
# 1. Créer le secret ANTHROPIC_API_KEY (clé d'API Anthropic)
gh secret set ANTHROPIC_API_KEY --repo ak125/nestjs-remix-monorepo

# 2. Créer les 2 variables repo (les deux doivent exister pour que le workflow tourne)
gh variable set CLAUDE_REVIEW_ENABLED --repo ak125/nestjs-remix-monorepo --body true
gh variable set CLAUDE_REVIEW_DRY_RUN --repo ak125/nestjs-remix-monorepo --body true   # P0 dry-run

# 3. Audit rétroactif : rejouer en dry-run sur les 5 PRs de référence d'aujourd'hui
#    (en commentant `@dependabot recreate` ou en attendant la prochaine fournée)
#    Vérifier que les verdicts Claude correspondent à la review humaine :
#    #279 vite-tsconfig-paths 4→6     → GO attendu
#    #280 @storybook/addon-onboarding 9→10 → HOLD attendu (ecosystem coupling)
#    #281 eslint-config-prettier 9→10 → GO attendu
#    #282/#283 minor → skipped (déjà couverts par règles déterministes)

# 4. Si l'audit P0 est OK → passer en P1 actif
gh variable set CLAUDE_REVIEW_DRY_RUN --body false
```

## Plan de mise en production en 4 phases

| Phase | Durée | Scope traité par Claude | Action sur GO |
|---|---|---|---|
| **P0 dry-run** | 2 sem | dev-major | Comment verdict, **aucun merge** |
| **P1 actif** | 4 sem | dev-major | Auto-merge si GO + checks verts |
| **P2 étendu** | si P1 stable | + runtime-minor | Auto-merge si GO |
| **P3 max** | si P2 stable | + runtime-major | **Comment seulement, jamais merge** (human-in-loop maintenu) |

## Test plan

- [ ] CI passe sur cette PR (le workflow est nouveau, ne déclenche rien tant que `CLAUDE_REVIEW_ENABLED` n'existe pas — comportement attendu)
- [ ] Une fois mergé + secret + variables créés en dry-run : ouvrir une PR Dependabot factice ou attendre la prochaine fournée Dependabot, vérifier que Claude commente le verdict
- [ ] `vars.CLAUDE_REVIEW_DRY_RUN=true` → pas de `gh pr merge --auto` exécuté
- [ ] Kill-switch : `gh variable set CLAUDE_REVIEW_ENABLED --body false` → workflow skip entièrement
- [ ] Anti-fork : PR depuis un fork → workflow ne se déclenche pas
- [ ] Groups Dependabot : prochaine fournée hebdo, vérifier qu'un bump Storybook crée une seule PR groupée

## Hors scope

- ❌ PAS de modification de `dependabot-auto-merge.yml` (contrainte explicite du plan)
- ❌ PAS de scripts shell custom (toute la logique dans le YAML + action officielle)
- ❌ PAS d'auto-merge runtime-major (human-in-loop maintenu en P3)
- ❌ PAS de Dependabot secrets — `ANTHROPIC_API_KEY` est un Actions secret classique

## Références

- Action officielle : https://github.com/anthropics/claude-code-action
- PR #285 (READ_ONLY=true CI) : `bb7ae4a6`
- PR #289 (paths-strict) : merged 2026-05-04 12:57Z
- 5 PRs Dependabot débloquées par #285 + #289 : #279 ✅ GO, #280 ⏸ HOLD, #281 ✅ GO, #282 ✅ GO, #283 ✅ GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)