### PR TITLE
fix(main): SESSION_SECRET soft-required when READ_ONLY=true (ADR-028 Option D)

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,7 +3,10 @@ import 'dotenv/config';
 
 // Validate environment variables BEFORE any other imports
 // This ensures the app fails fast if required vars are missing
-import { validateRequiredEnvVars } from './config/env-validation';
+import {
+  validateRequiredEnvVars,
+  isReadOnlyMode,
+} from './config/env-validation';
 import { buildCSPDirectives } from './config/csp.config';
 validateRequiredEnvVars();
 
@@ -60,8 +63,12 @@ async function bootstrap() {
       ttl: 86400 * 30,
     });
 
-    // Sécurité de session et cookies selon l'environnement
-    if (isProd && !process.env.SESSION_SECRET) {
+    // Sécurité de session et cookies selon l'environnement.
+    // ADR-028 Option D : preprod sets NODE_ENV=production but READ_ONLY=true
+    // means no mutable session state to protect — SESSION_SECRET becomes
+    // a soft warning instead of a hard requirement.
+    const readOnly = isReadOnlyMode();
+    if (isProd && !readOnly && !process.env.SESSION_SECRET) {
       throw new Error('SESSION_SECRET requis en production');
     }
 
@@ -74,7 +81,7 @@ async function bootstrap() {
       logger.warn('Générez un secret sécurisé avec: openssl rand -base64 32');
       logger.warn('Ajoutez-le dans votre fichier .env');
 
-      if (process.env.NODE_ENV === 'production') {
+      if (process.env.NODE_ENV === 'production' && !readOnly) {
         throw new Error(
           'SESSION_SECRET OBLIGATOIRE en production! Impossible de démarrer.',
         );


### PR DESCRIPTION
## Summary

7th PR in the ADR-028 Option D unblock chain. Same pattern as [#277](https://github.com/ak125/nestjs-remix-monorepo/pull/277) (app.config.ts) — add `!readOnly` to a strict `NODE_ENV === 'production'` throw check that was forgotten during the original Option D rollout.

## Bug

After [#291](https://github.com/ak125/nestjs-remix-monorepo/pull/291) merged (RAG env vars), deploy main 00fde552 crashed :

```
Erreur lors du démarrage du serveur: Error: SESSION_SECRET requis en production
```

Source : [`backend/src/main.ts:64-65`](backend/src/main.ts#L64) :

```ts
if (isProd && !process.env.SESSION_SECRET) {
  throw new Error('SESSION_SECRET requis en production');
}
```

`isProd` = `NODE_ENV === 'production'` (Dockerfile + docker-compose). But READ_ONLY=true is the real gating flag.

## Fix

Add `!readOnly` to both throw checks (lines 64 + 77). In read-only mode there's no mutable session state to protect — SESSION_SECRET becomes a soft warning. Existing `INSECURE_DEV_SECRET_CHANGE_ME` fallback (line 89) handles the empty-secret case for cookie signing.

Refactor uses `isReadOnlyMode()` from env-validation.ts (PR #274).

## 7-PR cascade

| # | Site | PR |
|---|---|---|
| 1 | env-validation.ts | [#274](https://github.com/ak125/nestjs-remix-monorepo/pull/274) ✅ |
| 2 | payment.config.ts | [#276](https://github.com/ak125/nestjs-remix-monorepo/pull/276) ✅ |
| 3 | app.config.ts | [#277](https://github.com/ak125/nestjs-remix-monorepo/pull/277) ✅ |
| 4 | 15 services backend/src/modules/ | [#284](https://github.com/ak125/nestjs-remix-monorepo/pull/284) ✅ |
| 5 | 4 services backend/src/config/ | [#287](https://github.com/ak125/nestjs-remix-monorepo/pull/287) ✅ |
| 6 | RAG_SERVICE_URL + RAG_API_KEY in .env.preprod | [#291](https://github.com/ak125/nestjs-remix-monorepo/pull/291) ✅ |
| 7 | **SESSION_SECRET in main.ts bootstrap** | **THIS PR** |

## Validation

- [x] tsc syntax check OK
- [x] prettier --check OK
- [x] Pre-push hooks pass (G3 ED25519 signed)
- [ ] CI : 🧪 Deploy PREPROD step exits 0 (8th attempt at 3-day block resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)