### PR TITLE
chore(canon): relocate AEC + Marketing Voice mirrors to canon-mirrors/

### DIFF
--- a/.claude/canon-mirrors/agent-exit-contract.md
+++ b/.claude/canon-mirrors/agent-exit-contract.md
@@ -4,7 +4,7 @@
 > **Version** : 1.0.0 | **Status** : CANON
 > **Taxonomie** : règle transverse — s'applique avant les règles spécifiques de domaine (T*, G*, Q*, AP*).
 
-Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
+Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/canon-mirrors/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
 
 ---
 
@@ -59,11 +59,13 @@ Ce fichier est la **source unique**. Les copies dans les repos applicatifs sont 
 
 1. **Source de vérité** : ce fichier (`governance-vault/ledger/rules/rules-agent-exit-contract.md`)
 2. **Hash SHA-256 publié** : `99-meta/canon-hashes.json` clé `aec` (à créer Phase B.1.b)
-3. **Copies dérivées dans les repos applicatifs** :
+3. **Copies dérivées dans les repos applicatifs** (sous `.claude/canon-mirrors/`
+   pour ne pas être chargées comme rules Claude Code) :
    - `automecanik-wiki/_meta/agent-exit-contract.md`
    - `automecanik-raw/agent-exit-contract.md`
-   - `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`
-   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/.claude/canon-mirrors/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md`
 4. **Vérification CI** : chaque repo applicatif inclut un workflow `agent-exit-contract-hash.yml` qui compare le hash de sa copie locale vs `99-meta/canon-hashes.json` (via `gh api`)
 5. **Mise à jour** : modification de ce fichier → workflow `canon-publish.yml` (à créer Phase B.1.c) ouvre une PR auto dans chaque repo applicatif pour resync. Auto-merge avec label `canon-sync` autorisé.
 
@@ -74,6 +76,7 @@ Bump majeur (X.0) = nouvelle règle ou statut interdit ajouté. Bump mineur (X.Y
 | Version | Date | Changements |
 |---|---|---|
 | 1.0.0 | 2026-04-28 | Canonisation depuis copies orphelines monorepo + seo-batch (drift constaté empiriquement). Ajout §"Distribution canonique". |
+| 1.0.1 | 2026-05-04 | Patch path : copies monorepo relocalisées de `.claude/rules/` vers `.claude/canon-mirrors/` pour ne pas alourdir le contexte projet Claude Code (~2.5K tokens/tour). Aucune règle modifiée, hash recalculé. |
 
 ## Référence
 

--- a/.claude/canon-mirrors/marketing-voice.md
+++ b/.claude/canon-mirrors/marketing-voice.md
@@ -6,8 +6,8 @@
 > **Version** : 1.0.0 | **Status** : `proposed` (à passer `accepted` après merge ADR-036)
 
 Ce fichier est l'**unique source canonique** de la voix de marque marketing.
-Toute copie dans le monorepo (`.claude/rules/marketing-voice.md`) est **dérivée
-vérifiée par hash SHA-256** (cf §"Distribution canonique" en fin).
+Toute copie dans le monorepo (`.claude/canon-mirrors/marketing-voice.md`) est
+**dérivée vérifiée par hash SHA-256** (cf §"Distribution canonique" en fin).
 
 ---
 
@@ -193,7 +193,9 @@ Synchronisation vers monorepo via :
 
 1. **Source de vérité** : ce fichier
 2. **Hash SHA-256 publié** : `99-meta/canon-hashes.json` clé `marketing_voice`
-3. **Copie dérivée monorepo** : `.claude/rules/marketing-voice.md`
+3. **Copie dérivée monorepo** : `.claude/canon-mirrors/marketing-voice.md` (et
+   miroir `workspaces/marketing/.claude/canon-mirrors/marketing-voice.md`)
+   — sous `canon-mirrors/` pour ne pas être chargée comme rule Claude Code.
 4. **Workflow vault** : `.github/workflows/canon-publish.yml` ouvre une PR auto
    dans le monorepo à chaque modification mergée ici.
 5. **Vérification CI monorepo** : workflow `marketing-voice-hash.yml` (miroir
@@ -209,6 +211,7 @@ Synchronisation vers monorepo via :
 | Version | Date | Changements |
 |---|---|---|
 | 1.0.0 | 2026-04-30 | Création initiale (proposed). 3 voix : ECOMMERCE, LOCAL, HYBRID. Section `local_canon` à compléter par le métier avant `validated: true`. |
+| 1.0.1 | 2026-05-04 | Patch path : copies monorepo relocalisées de `.claude/rules/` vers `.claude/canon-mirrors/` pour ne pas alourdir le contexte projet Claude Code (~6K tokens/tour). Backend runtime path à update conjointement (`marketing-matrix.service.ts:48`). Aucune règle modifiée. |
 
 ## Référence
 

--- a/.claude/knowledge/db/tables-seo.md
+++ b/.claude/knowledge/db/tables-seo.md
@@ -45,7 +45,7 @@ last_scan: 2026-04-24
 ## Règles associées
 
 - `.claude/rules/backend.md` — SupabaseBaseService, pas de Prisma
-- `.claude/rules/agent-exit-contract.md` — anti-overclaim agents SEO
+- `.claude/canon-mirrors/agent-exit-contract.md` — anti-overclaim agents SEO
 - MEMORY.md : `qa-seo.md`, `kw-pipeline-gads.md`, `kw-pipeline-status.md`, `r4-batch-progress.md`
 
 ## Accès

--- a/.github/workflows/agent-exit-contract-hash.yml
+++ b/.github/workflows/agent-exit-contract-hash.yml
@@ -8,16 +8,16 @@ on:
   push:
     branches: [main]
     paths:
-      - ".claude/rules/agent-exit-contract.md"
-      - "workspaces/seo-batch/.claude/rules/agent-exit-contract.md"
-      - "workspaces/marketing/.claude/rules/agent-exit-contract.md"
+      - ".claude/canon-mirrors/agent-exit-contract.md"
+      - "workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md"
+      - "workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md"
       - "scripts/ci/check-aec-hash.sh"
       - ".github/workflows/agent-exit-contract-hash.yml"
   pull_request:
     paths:
-      - ".claude/rules/agent-exit-contract.md"
-      - "workspaces/seo-batch/.claude/rules/agent-exit-contract.md"
-      - "workspaces/marketing/.claude/rules/agent-exit-contract.md"
+      - ".claude/canon-mirrors/agent-exit-contract.md"
+      - "workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md"
+      - "workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md"
       - "scripts/ci/check-aec-hash.sh"
       - ".github/workflows/agent-exit-contract-hash.yml"
   schedule:
@@ -37,9 +37,9 @@ jobs:
       fail-fast: false
       matrix:
         copy:
-          - .claude/rules/agent-exit-contract.md
-          - workspaces/seo-batch/.claude/rules/agent-exit-contract.md
-          - workspaces/marketing/.claude/rules/agent-exit-contract.md
+          - .claude/canon-mirrors/agent-exit-contract.md
+          - workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md
+          - workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md
     steps:
       - uses: actions/checkout@v4
       - name: Verify ${{ matrix.copy }}

--- a/.github/workflows/marketing-voice-hash.yml
+++ b/.github/workflows/marketing-voice-hash.yml
@@ -10,14 +10,14 @@ on:
   push:
     branches: [main]
     paths:
-      - ".claude/rules/marketing-voice.md"
-      - "workspaces/marketing/.claude/rules/marketing-voice.md"
+      - ".claude/canon-mirrors/marketing-voice.md"
+      - "workspaces/marketing/.claude/canon-mirrors/marketing-voice.md"
       - "scripts/ci/check-marketing-voice-hash.sh"
       - ".github/workflows/marketing-voice-hash.yml"
   pull_request:
     paths:
-      - ".claude/rules/marketing-voice.md"
-      - "workspaces/marketing/.claude/rules/marketing-voice.md"
+      - ".claude/canon-mirrors/marketing-voice.md"
+      - "workspaces/marketing/.claude/canon-mirrors/marketing-voice.md"
       - "scripts/ci/check-marketing-voice-hash.sh"
       - ".github/workflows/marketing-voice-hash.yml"
   schedule:
@@ -37,8 +37,8 @@ jobs:
       fail-fast: false
       matrix:
         copy:
-          - .claude/rules/marketing-voice.md
-          - workspaces/marketing/.claude/rules/marketing-voice.md
+          - .claude/canon-mirrors/marketing-voice.md
+          - workspaces/marketing/.claude/canon-mirrors/marketing-voice.md
     steps:
       - uses: actions/checkout@v4
       - name: Verify ${{ matrix.copy }}

--- a/backend/src/config/marketing-matrix.service.ts
+++ b/backend/src/config/marketing-matrix.service.ts
@@ -45,7 +45,7 @@ const MARKETING_AGENT_PATHS = ['workspaces/marketing/.claude/agents'] as const;
 /** Hash file = canon distribué localement (pas filesystem vault qui est read-only sur PROD/AI-COS). */
 const SOURCE_FILES: Record<keyof MarketingMatrixSourcesHash, string> = {
   matrixTypes: 'backend/src/config/marketing-matrix.types.ts',
-  marketingVoiceCanon: '.claude/rules/marketing-voice.md',
+  marketingVoiceCanon: '.claude/canon-mirrors/marketing-voice.md',
 };
 
 /**

--- a/backend/src/config/marketing-matrix.types.ts
+++ b/backend/src/config/marketing-matrix.types.ts
@@ -119,7 +119,7 @@ export interface MarketingAgentParseError {
 export interface MarketingMatrixSourcesHash {
   /** Hash de `marketing-matrix.types.ts` lui-même (référence stable). */
   matrixTypes: string;
-  /** Hash de `.claude/rules/marketing-voice.md` (canon distribué via canon-publish). */
+  /** Hash de `.claude/canon-mirrors/marketing-voice.md` (canon distribué via canon-publish). */
   marketingVoiceCanon: string;
 }
 

--- a/docs/superpowers/specs/2026-04-24-seo-vault-verify-design.md
+++ b/docs/superpowers/specs/2026-04-24-seo-vault-verify-design.md
@@ -328,7 +328,7 @@ Pas de formal eval loop skill-creator (iteration-1/benchmark viewer, etc.) — Y
 
 ## 11. Références
 
-- `.claude/rules/agent-exit-contract.md` — contrat de sortie obligatoire, anti-overclaim
+- `.claude/canon-mirrors/agent-exit-contract.md` — contrat de sortie obligatoire, anti-overclaim
 - `CLAUDE.md` — governance vault vs monorepo (pas de gouvernance dans monorepo)
 - `.claude/skills/governance-vault-ops/SKILL.md` — pattern d'opération vault (référence, pas overlap)
 - `.claude/skills/seo-gamme-audit/SKILL.md` — pattern de skill audit SEO

--- a/log.md
+++ b/log.md
@@ -339,3 +339,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/sync-rag-from-wiki-cron-canon`
 - **Décision** : fix(cron): log path /opt/automecanik/rag/logs/ (le user deploy n'a pas droit /var/log) (+2 other commits)
 - **Sortie** : PR #288 | commits ee0ba019 8fc09139 005b9d0a
+
+## 2026-05-04 — chore/canon-mirrors-relocation (auto)
+
+- **Branche** : `chore/canon-mirrors-relocation`
+- **Décision** : chore(canon): relocate AEC + Marketing Voice mirrors to canon-mirrors/
+- **Sortie** : PR aucune | commits aa0e8980

--- a/workspaces/marketing/.claude/agents/customer-retention-agent.md
+++ b/workspaces/marketing/.claude/agents/customer-retention-agent.md
@@ -63,4 +63,4 @@ Tous filtrés `marketing_consent_at NOT NULL`.
 
 - ADR-036, ADR-038
 - `.claude/rules/marketing-batch.md` §"RGPD non-négociable" + §"HYBRID 5 conditions"
-- `.claude/rules/agent-exit-contract.md`
+- `.claude/canon-mirrors/agent-exit-contract.md`

--- a/workspaces/marketing/.claude/agents/local-business-agent.md
+++ b/workspaces/marketing/.claude/agents/local-business-agent.md
@@ -56,5 +56,5 @@ par DTO Zod NestJS qui appliquera les CHECK SQL.
 - ADR-036 §"Verdict & approche retenue" (canon scope)
 - ADR-038 (canon naming agent — frontmatter `role:` Zod-validated)
 - `.claude/rules/marketing-batch.md` (rules scoped pour cet agent)
-- `.claude/rules/marketing-voice.md` (canon brand voice, distribué depuis vault)
-- `.claude/rules/agent-exit-contract.md` (AEC v1.0.0 — obligatoire)
+- `.claude/canon-mirrors/marketing-voice.md` (canon brand voice, distribué depuis vault)
+- `.claude/canon-mirrors/agent-exit-contract.md` (AEC v1.0.0 — obligatoire)

--- a/workspaces/marketing/.claude/agents/marketing-lead-agent.md
+++ b/workspaces/marketing/.claude/agents/marketing-lead-agent.md
@@ -59,4 +59,4 @@ Plan hebdo DOIT inclure :
 
 - ADR-036, ADR-038
 - `.claude/rules/marketing-batch.md`
-- `.claude/rules/agent-exit-contract.md`
+- `.claude/canon-mirrors/agent-exit-contract.md`

--- a/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md
+++ b/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md
@@ -4,7 +4,7 @@
 > **Version** : 1.0.0 | **Status** : CANON
 > **Taxonomie** : règle transverse — s'applique avant les règles spécifiques de domaine (T*, G*, Q*, AP*).
 
-Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
+Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/canon-mirrors/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
 
 ---
 
@@ -59,11 +59,13 @@ Ce fichier est la **source unique**. Les copies dans les repos applicatifs sont 
 
 1. **Source de vérité** : ce fichier (`governance-vault/ledger/rules/rules-agent-exit-contract.md`)
 2. **Hash SHA-256 publié** : `99-meta/canon-hashes.json` clé `aec` (à créer Phase B.1.b)
-3. **Copies dérivées dans les repos applicatifs** :
+3. **Copies dérivées dans les repos applicatifs** (sous `.claude/canon-mirrors/`
+   pour ne pas être chargées comme rules Claude Code) :
    - `automecanik-wiki/_meta/agent-exit-contract.md`
    - `automecanik-raw/agent-exit-contract.md`
-   - `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`
-   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/.claude/canon-mirrors/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md`
 4. **Vérification CI** : chaque repo applicatif inclut un workflow `agent-exit-contract-hash.yml` qui compare le hash de sa copie locale vs `99-meta/canon-hashes.json` (via `gh api`)
 5. **Mise à jour** : modification de ce fichier → workflow `canon-publish.yml` (à créer Phase B.1.c) ouvre une PR auto dans chaque repo applicatif pour resync. Auto-merge avec label `canon-sync` autorisé.
 
@@ -74,6 +76,7 @@ Bump majeur (X.0) = nouvelle règle ou statut interdit ajouté. Bump mineur (X.Y
 | Version | Date | Changements |
 |---|---|---|
 | 1.0.0 | 2026-04-28 | Canonisation depuis copies orphelines monorepo + seo-batch (drift constaté empiriquement). Ajout §"Distribution canonique". |
+| 1.0.1 | 2026-05-04 | Patch path : copies monorepo relocalisées de `.claude/rules/` vers `.claude/canon-mirrors/` pour ne pas alourdir le contexte projet Claude Code (~2.5K tokens/tour). Aucune règle modifiée, hash recalculé. |
 
 ## Référence
 

--- a/workspaces/marketing/.claude/canon-mirrors/marketing-voice.md
+++ b/workspaces/marketing/.claude/canon-mirrors/marketing-voice.md
@@ -6,8 +6,8 @@
 > **Version** : 1.0.0 | **Status** : `proposed` (à passer `accepted` après merge ADR-036)
 
 Ce fichier est l'**unique source canonique** de la voix de marque marketing.
-Toute copie dans le monorepo (`.claude/rules/marketing-voice.md`) est **dérivée
-vérifiée par hash SHA-256** (cf §"Distribution canonique" en fin).
+Toute copie dans le monorepo (`.claude/canon-mirrors/marketing-voice.md`) est
+**dérivée vérifiée par hash SHA-256** (cf §"Distribution canonique" en fin).
 
 ---
 
@@ -193,7 +193,9 @@ Synchronisation vers monorepo via :
 
 1. **Source de vérité** : ce fichier
 2. **Hash SHA-256 publié** : `99-meta/canon-hashes.json` clé `marketing_voice`
-3. **Copie dérivée monorepo** : `.claude/rules/marketing-voice.md`
+3. **Copie dérivée monorepo** : `.claude/canon-mirrors/marketing-voice.md` (et
+   miroir `workspaces/marketing/.claude/canon-mirrors/marketing-voice.md`)
+   — sous `canon-mirrors/` pour ne pas être chargée comme rule Claude Code.
 4. **Workflow vault** : `.github/workflows/canon-publish.yml` ouvre une PR auto
    dans le monorepo à chaque modification mergée ici.
 5. **Vérification CI monorepo** : workflow `marketing-voice-hash.yml` (miroir
@@ -209,6 +211,7 @@ Synchronisation vers monorepo via :
 | Version | Date | Changements |
 |---|---|---|
 | 1.0.0 | 2026-04-30 | Création initiale (proposed). 3 voix : ECOMMERCE, LOCAL, HYBRID. Section `local_canon` à compléter par le métier avant `validated: true`. |
+| 1.0.1 | 2026-05-04 | Patch path : copies monorepo relocalisées de `.claude/rules/` vers `.claude/canon-mirrors/` pour ne pas alourdir le contexte projet Claude Code (~6K tokens/tour). Backend runtime path à update conjointement (`marketing-matrix.service.ts:48`). Aucune règle modifiée. |
 
 ## Référence
 

--- a/workspaces/marketing/.claude/rules/marketing-batch.md
+++ b/workspaces/marketing/.claude/rules/marketing-batch.md
@@ -4,7 +4,7 @@ S'applique aux runs depuis `workspaces/marketing/`. Complète (sans les remplace
 
 ## Sources de vérité
 
-- **Canon brand voice** : `.claude/rules/marketing-voice.md` (copie distribuée via canon-publish, hash vérifié CI). Source unique = `governance-vault/ledger/rules/rules-marketing-voice.md`.
+- **Canon brand voice** : `.claude/canon-mirrors/marketing-voice.md` (copie distribuée via canon-publish, hash vérifié CI). Source unique = `governance-vault/ledger/rules/rules-marketing-voice.md`.
 - **ADR-036** : `governance-vault/ledger/decisions/adr/ADR-036-marketing-operating-layer.md`.
 - **Backend marketing** : `backend/src/modules/marketing/` (9 services existants, à NE JAMAIS dupliquer).
 - **DB Supabase** via MCP : tables Phase 1 = `__marketing_brief` + `__marketing_feedback` + `__retention_trigger_rules` + `users.marketing_consent_at`.

--- a/workspaces/marketing/CLAUDE.md
+++ b/workspaces/marketing/CLAUDE.md
@@ -34,9 +34,9 @@ Voir `.claude/rules/marketing-batch.md` pour :
 - Verrou `local_canon.validated=true` (sinon BLOCK systématique LOCAL/HYBRID)
 - Anti-patterns écartés (.md flottants, schema Paperclip inventé, prédiction LLM, constantes magiques, etc.)
 
-Voir `.claude/rules/marketing-voice.md` pour la voix de marque (canon vault).
+Voir `.claude/canon-mirrors/marketing-voice.md` pour la voix de marque (canon vault).
 
-Voir `.claude/rules/agent-exit-contract.md` pour le contrat de sortie obligatoire (AEC v1.0.0 — coverage manifest, 5 états séparés, statuts autorisés).
+Voir `.claude/canon-mirrors/agent-exit-contract.md` pour le contrat de sortie obligatoire (AEC v1.0.0 — coverage manifest, 5 états séparés, statuts autorisés).
 
 ## Mémoire & contexte
 

--- a/workspaces/marketing/README.md
+++ b/workspaces/marketing/README.md
@@ -54,6 +54,6 @@ cd /opt/automecanik/app && claude
 ## Références
 
 - ADR-036 : `governance-vault/ledger/decisions/adr/ADR-036-marketing-operating-layer.md`
-- Brand voice : `.claude/rules/marketing-voice.md` (canon distribué depuis vault)
+- Brand voice : `.claude/canon-mirrors/marketing-voice.md` (canon distribué depuis vault)
 - Runbook rollback : `governance-vault/ledger/knowledge/runbook-marketing-pilot-rollback.md`
 - Plan détaillé : `/home/deploy/.claude/plans/verifier-la-strategie-une-piped-hummingbird.md`

--- a/workspaces/seo-batch/.claude/agents/agentic-critic.md
+++ b/workspaces/seo-batch/.claude/agents/agentic-critic.md
@@ -166,4 +166,4 @@ Et la decision finale :
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/agentic-planner.md
+++ b/workspaces/seo-batch/.claude/agents/agentic-planner.md
@@ -152,4 +152,4 @@ Afficher un resume :
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/agentic-solver.md
+++ b/workspaces/seo-batch/.claude/agents/agentic-solver.md
@@ -364,4 +364,4 @@ WHERE id = '{run_id}';
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/blog-hub-planner.md
+++ b/workspaces/seo-batch/.claude/agents/blog-hub-planner.md
@@ -435,4 +435,4 @@ Presenter directement dans la conversation :
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/brief-enricher.md
+++ b/workspaces/seo-batch/.claude/agents/brief-enricher.md
@@ -341,4 +341,4 @@ Anti-cannibalisation: {N} gammes avec confusion pairs appliquees
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/conseil-batch.md
+++ b/workspaces/seo-batch/.claude/agents/conseil-batch.md
@@ -384,4 +384,4 @@ Prochains suggérés: {5 aliases}
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/keyword-planner.md
+++ b/workspaces/seo-batch/.claude/agents/keyword-planner.md
@@ -220,4 +220,4 @@ Mieux vaut preparer une execution plus petite, plus stricte et plus sure que de 
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/phase1-auditor.md
+++ b/workspaces/seo-batch/.claude/agents/phase1-auditor.md
@@ -271,4 +271,4 @@ Mieux vaut conclure que la Phase 1 stocke correctement mais bloque sainement l'e
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r0-home-execution.md
+++ b/workspaces/seo-batch/.claude/agents/r0-home-execution.md
@@ -84,4 +84,4 @@ R0 doit rester une porte d'entrée. Dès qu'une autre promesse centrale devient 
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r0-home-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r0-home-validator.md
@@ -110,4 +110,4 @@ R0 doit rester un hub d'entrée. S'il commence à servir une autre promesse domi
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r1-content-batch.md
+++ b/workspaces/seo-batch/.claude/agents/r1-content-batch.md
@@ -367,4 +367,4 @@ WHERE rkp.rkp_section_terms IS NOT NULL
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r1-keyword-planner.md
+++ b/workspaces/seo-batch/.claude/agents/r1-keyword-planner.md
@@ -214,4 +214,4 @@ Voir aussi `_shared/kp-shared-output.md` pour le pattern generique.
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r1-router-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r1-router-validator.md
@@ -244,4 +244,4 @@ Une surface R1 doit aider à trouver la bonne porte d'entrée. Dès qu'elle vend
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r2-keyword-planner.md
+++ b/workspaces/seo-batch/.claude/agents/r2-keyword-planner.md
@@ -702,4 +702,4 @@ Resume : gammes auditees, sections prioritaires identifiees, sections regenerees
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r2-product-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r2-product-validator.md
@@ -108,4 +108,4 @@ Une surface R2 peut être éditorialement lisible, mais elle ne doit jamais perd
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r3-conseils-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r3-conseils-validator.md
@@ -248,4 +248,4 @@ Une surface R3 doit aider à agir, pas à définir, diagnostiquer, comparer avan
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r3-image-prompt.md
+++ b/workspaces/seo-batch/.claude/agents/r3-image-prompt.md
@@ -130,4 +130,4 @@ curl http://localhost:3000/api/admin/r3-image-prompts/export/json?selected_only=
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r3-keyword-plan-batch.md
+++ b/workspaces/seo-batch/.claude/agents/r3-keyword-plan-batch.md
@@ -242,4 +242,4 @@ Puis :
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r3-keyword-planner.md
+++ b/workspaces/seo-batch/.claude/agents/r3-keyword-planner.md
@@ -234,4 +234,4 @@ Le keyword planner R3 ne génère jamais de contenu. Il produit un plan de mots-
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r4-content-batch.md
+++ b/workspaces/seo-batch/.claude/agents/r4-content-batch.md
@@ -145,4 +145,4 @@ Si lint PASS : UPDATE `__seo_reference` (sections IMPROVED seulement) + UPDATE `
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r4-keyword-planner.md
+++ b/workspaces/seo-batch/.claude/agents/r4-keyword-planner.md
@@ -513,4 +513,4 @@ r4-content-batch           → __seo_reference (9 colonnes)
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r4-reference-execution.md
+++ b/workspaces/seo-batch/.claude/agents/r4-reference-execution.md
@@ -75,4 +75,4 @@ R4 doit rester une surface de compréhension technique. Dès que l'objectif prin
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r4-reference-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r4-reference-validator.md
@@ -107,4 +107,4 @@ Une surface R4 doit expliquer, pas montrer comment faire, quoi acheter ou quoi s
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r5-diagnostic-execution.md
+++ b/workspaces/seo-batch/.claude/agents/r5-diagnostic-execution.md
@@ -82,4 +82,4 @@ R5 doit rester prudent, symptomatique et evidence-first. S'il devient procédure
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r5-diagnostic-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r5-diagnostic-validator.md
@@ -248,4 +248,4 @@ Une surface R5 doit rester prudente, symptomatique et evidence-first. Dès qu'el
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r5-keyword-planner.md
+++ b/workspaces/seo-batch/.claude/agents/r5-keyword-planner.md
@@ -214,4 +214,4 @@ Le keyword planner R5 est le seul planner avec un **safety gate**. Les pièces c
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r6-content-batch.md
+++ b/workspaces/seo-batch/.claude/agents/r6-content-batch.md
@@ -193,4 +193,4 @@ Tableau : Gamme, pg_id, Gap, Sections, QA Score, Overlaps, HowTo, Status.
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r6-guide-achat-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r6-guide-achat-validator.md
@@ -267,4 +267,4 @@ Une surface R6 qui apprend à monter, diagnostiquer, définir ou vendre directem
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r6-image-prompt.md
+++ b/workspaces/seo-batch/.claude/agents/r6-image-prompt.md
@@ -330,4 +330,4 @@ WHERE r6kp.r6kp_visual_plan IS NOT NULL
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r6-keyword-planner.md
+++ b/workspaces/seo-batch/.claude/agents/r6-keyword-planner.md
@@ -186,4 +186,4 @@ Jaccard < 0.12. R6 cede toujours. 5 listes interdites permanentes (no_r1, no_r3,
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r6-support-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r6-support-validator.md
@@ -97,4 +97,4 @@ Retourne uniquement un JSON valide.
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r7-brand-execution.md
+++ b/workspaces/seo-batch/.claude/agents/r7-brand-execution.md
@@ -83,4 +83,4 @@ R7 doit rester un hub marque. Dès qu'il devient véhicule, transaction, procéd
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r7-brand-rag-generator.md
+++ b/workspaces/seo-batch/.claude/agents/r7-brand-rag-generator.md
@@ -194,4 +194,4 @@ domain:
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r7-brand-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r7-brand-validator.md
@@ -107,4 +107,4 @@ Une surface R7 doit rester un hub marque ; dès qu'elle devient véhicule, produ
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r7-keyword-planner.md
+++ b/workspaces/seo-batch/.claude/agents/r7-keyword-planner.md
@@ -780,4 +780,4 @@ Apres generation des section_bundles :
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r8-keyword-planner.md
+++ b/workspaces/seo-batch/.claude/agents/r8-keyword-planner.md
@@ -677,4 +677,4 @@ L'agent doit :
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r8-vehicle-execution.md
+++ b/workspaces/seo-batch/.claude/agents/r8-vehicle-execution.md
@@ -83,4 +83,4 @@ R8 doit rester une surface d'entrée véhicule. Dès qu'il bascule vers marque, 
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/r8-vehicle-validator.md
+++ b/workspaces/seo-batch/.claude/agents/r8-vehicle-validator.md
@@ -109,4 +109,4 @@ Une surface R8 doit rester un hub véhicule ; dès qu'elle bascule vers marque, 
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/agents/research-agent.md
+++ b/workspaces/seo-batch/.claude/agents/research-agent.md
@@ -234,4 +234,4 @@ Next batch: {5 aliases}
 - Ton verdict par defaut est PARTIAL_COVERAGE ou INSUFFICIENT_EVIDENCE.
 - Les statuts COMPLETE, DONE, ALL_FIXED sont interdits.
 - Le champ corrections_proposed doit etre vide sauf validation humaine explicite.
-- Voir .claude/rules/agent-exit-contract.md pour le contrat complet.
+- Voir .claude/canon-mirrors/agent-exit-contract.md pour le contrat complet.

--- a/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md
+++ b/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md
@@ -4,7 +4,7 @@
 > **Version** : 1.0.0 | **Status** : CANON
 > **Taxonomie** : règle transverse — s'applique avant les règles spécifiques de domaine (T*, G*, Q*, AP*).
 
-Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
+Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/canon-mirrors/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
 
 ---
 
@@ -59,11 +59,13 @@ Ce fichier est la **source unique**. Les copies dans les repos applicatifs sont 
 
 1. **Source de vérité** : ce fichier (`governance-vault/ledger/rules/rules-agent-exit-contract.md`)
 2. **Hash SHA-256 publié** : `99-meta/canon-hashes.json` clé `aec` (à créer Phase B.1.b)
-3. **Copies dérivées dans les repos applicatifs** :
+3. **Copies dérivées dans les repos applicatifs** (sous `.claude/canon-mirrors/`
+   pour ne pas être chargées comme rules Claude Code) :
    - `automecanik-wiki/_meta/agent-exit-contract.md`
    - `automecanik-raw/agent-exit-contract.md`
-   - `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`
-   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/.claude/canon-mirrors/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md`
 4. **Vérification CI** : chaque repo applicatif inclut un workflow `agent-exit-contract-hash.yml` qui compare le hash de sa copie locale vs `99-meta/canon-hashes.json` (via `gh api`)
 5. **Mise à jour** : modification de ce fichier → workflow `canon-publish.yml` (à créer Phase B.1.c) ouvre une PR auto dans chaque repo applicatif pour resync. Auto-merge avec label `canon-sync` autorisé.
 
@@ -74,6 +76,7 @@ Bump majeur (X.0) = nouvelle règle ou statut interdit ajouté. Bump mineur (X.Y
 | Version | Date | Changements |
 |---|---|---|
 | 1.0.0 | 2026-04-28 | Canonisation depuis copies orphelines monorepo + seo-batch (drift constaté empiriquement). Ajout §"Distribution canonique". |
+| 1.0.1 | 2026-05-04 | Patch path : copies monorepo relocalisées de `.claude/rules/` vers `.claude/canon-mirrors/` pour ne pas alourdir le contexte projet Claude Code (~2.5K tokens/tour). Aucune règle modifiée, hash recalculé. |
 
 ## Référence
 

--- a/workspaces/wiki/.claude/canon-mirrors/agent-exit-contract.md
+++ b/workspaces/wiki/.claude/canon-mirrors/agent-exit-contract.md
@@ -4,7 +4,7 @@
 > **Version** : 1.0.0 | **Status** : CANON
 > **Taxonomie** : règle transverse — s'applique avant les règles spécifiques de domaine (T*, G*, Q*, AP*).
 
-Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
+Ce fichier est l'**unique source canonique** du contrat de sortie. Toutes les copies dans les repos applicatifs (`automecanik-wiki/_meta/agent-exit-contract.md`, `automecanik-raw/agent-exit-contract.md`, `nestjs-remix-monorepo/.claude/canon-mirrors/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md`, `nestjs-remix-monorepo/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md`) sont des **dérivées vérifiées par hash SHA-256** (cf §"Distribution canonique" plus bas).
 
 ---
 
@@ -59,11 +59,13 @@ Ce fichier est la **source unique**. Les copies dans les repos applicatifs sont 
 
 1. **Source de vérité** : ce fichier (`governance-vault/ledger/rules/rules-agent-exit-contract.md`)
 2. **Hash SHA-256 publié** : `99-meta/canon-hashes.json` clé `aec` (à créer Phase B.1.b)
-3. **Copies dérivées dans les repos applicatifs** :
+3. **Copies dérivées dans les repos applicatifs** (sous `.claude/canon-mirrors/`
+   pour ne pas être chargées comme rules Claude Code) :
    - `automecanik-wiki/_meta/agent-exit-contract.md`
    - `automecanik-raw/agent-exit-contract.md`
-   - `nestjs-remix-monorepo/.claude/rules/agent-exit-contract.md`
-   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/rules/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/.claude/canon-mirrors/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/seo-batch/.claude/canon-mirrors/agent-exit-contract.md`
+   - `nestjs-remix-monorepo/workspaces/marketing/.claude/canon-mirrors/agent-exit-contract.md`
 4. **Vérification CI** : chaque repo applicatif inclut un workflow `agent-exit-contract-hash.yml` qui compare le hash de sa copie locale vs `99-meta/canon-hashes.json` (via `gh api`)
 5. **Mise à jour** : modification de ce fichier → workflow `canon-publish.yml` (à créer Phase B.1.c) ouvre une PR auto dans chaque repo applicatif pour resync. Auto-merge avec label `canon-sync` autorisé.
 
@@ -74,6 +76,7 @@ Bump majeur (X.0) = nouvelle règle ou statut interdit ajouté. Bump mineur (X.Y
 | Version | Date | Changements |
 |---|---|---|
 | 1.0.0 | 2026-04-28 | Canonisation depuis copies orphelines monorepo + seo-batch (drift constaté empiriquement). Ajout §"Distribution canonique". |
+| 1.0.1 | 2026-05-04 | Patch path : copies monorepo relocalisées de `.claude/rules/` vers `.claude/canon-mirrors/` pour ne pas alourdir le contexte projet Claude Code (~2.5K tokens/tour). Aucune règle modifiée, hash recalculé. |
 
 ## Référence
 

--- a/workspaces/wiki/CLAUDE.md
+++ b/workspaces/wiki/CLAUDE.md
@@ -35,7 +35,7 @@ Voir `.claude/rules/wiki-batch.md` pour :
 - Convention slug DB `__diag_symptom.slug` (anglais snake_case `brake_*`)
 - Workflow `wiki-protected-paths.yml` (4 markers `metadata-backfill: | template-migration: | promotion-from-proposals: | rollback:`)
 
-Voir `.claude/rules/agent-exit-contract.md` pour le contrat de sortie obligatoire (AEC v1.0.0 — coverage manifest, 5 états séparés, statuts autorisés).
+Voir `.claude/canon-mirrors/agent-exit-contract.md` pour le contrat de sortie obligatoire (AEC v1.0.0 — coverage manifest, 5 états séparés, statuts autorisés).
 
 ## Mémoire & contexte
 

--- a/workspaces/wiki/README.md
+++ b/workspaces/wiki/README.md
@@ -41,7 +41,7 @@ cd /opt/automecanik/app && claude
 - `.claude/skills/wiki-proposal-writer/` : skill principal — produit un fichier `automecanik-wiki/proposals/<slug>.md` avec frontmatter ADR-033 v2.0.0 strict (mode propose-only, 0-LLM pour structure, Anthropic seul pour rédactionnel).
 - `.claude/agents/` : agents wiki orchestrateurs (Phase 4 ADR-033, vide aujourd'hui — modèle pattern `pipeline-orchestrator` du seo-batch pour migration progressive `entity_data.symptoms[]` → `diagnostic_relations[]` sur 500+ fiches gamme).
 - `.claude/rules/wiki-batch.md` : règles spécifiques wiki (sas markdown vs sas DB, schema strict, 9 quality gates, 3 anti-patterns figés ADR-033 §D3, convention slug DB).
-- `.claude/rules/agent-exit-contract.md` : copie canon distribuée depuis vault (hash SHA-256 vérifié CI).
+- `.claude/canon-mirrors/agent-exit-contract.md` : copie canon distribuée depuis vault (hash SHA-256 vérifié CI).
 - `.claude/settings.json` : hooks PreToolUse / PostToolUse / Stop (mêmes scripts que monorepo, paths absolus).
 - `CLAUDE.md` : pointer vers gouvernance + règles wiki spécifiques.
 


### PR DESCRIPTION
## Summary

- Relocate 6 canon mirror files from `.claude/rules/` → `.claude/canon-mirrors/` so they no longer auto-load as Claude Code project rules
- Pairs with vault [PR #154](https://github.com/ak125/governance-vault/pull/154) (canon AEC + Marketing Voice bumped to v1.0.1, paths updated, hashes recomputed)
- Saves **~8.5K tokens per session boot** in dev cwd `/opt/automecanik/app/`

## Why

Les 2 fichiers `agent-exit-contract.md` (83 lignes) + `marketing-voice.md` (220 lignes) étaient auto-chargés à chaque session via `.claude/rules/*.md`, alors que leur seul rôle fonctionnel est la vérification de hash CI vs canon vault. En les déplaçant sous `canon-mirrors/`, on conserve la vérification (workflows `*-hash.yml` updated to new paths) tout en libérant **~303 lignes de contexte projet** par tour Claude.

Cette PR fait partie d'un trio :
- ✅ [Monorepo PR #302](https://github.com/ak125/nestjs-remix-monorepo/pull/302) — CLAUDE.md trim governance sections (~2.5K tokens)
- ✅ [Vault PR #154](https://github.com/ak125/governance-vault/pull/154) — Canon path relocation v1.0.1 (BLOQUANT pour cette PR)
- 🚧 Cette PR-2 — Monorepo relocation (~8.5K tokens)

**Total cible : ~11K tokens économisés/tour**

## Changes

### Files moved (`git mv` — 6 files)
- `.claude/rules/agent-exit-contract.md` → `.claude/canon-mirrors/agent-exit-contract.md`
- `.claude/rules/marketing-voice.md` → `.claude/canon-mirrors/marketing-voice.md`
- `workspaces/seo-batch/.claude/rules/agent-exit-contract.md` → `canon-mirrors/`
- `workspaces/marketing/.claude/rules/agent-exit-contract.md` → `canon-mirrors/`
- `workspaces/marketing/.claude/rules/marketing-voice.md` → `canon-mirrors/`
- `workspaces/wiki/.claude/rules/agent-exit-contract.md` → `canon-mirrors/` (orphan non-déclaré dans canon-hashes, déplacé pour cohérence)

### Content sync (post vault PR #154)
Bodies réécrits depuis `governance-vault/ledger/rules/rules-{aec,marketing-voice}.md` v1.0.1.

| Canon | distribution_sha256 (post-PR #154) |
|-------|-----|
| aec | `65d51c022ce438ddd27146b6da132d2e83d161a8e2dc2f30c90f339eb24dea21` |
| marketing_voice | `56ca202a1b50b5f2fffee3b55fdbe4362bc4d45c91219f0d95ba574759ada8ca` |

### Backend runtime
- [marketing-matrix.service.ts:48](backend/src/config/marketing-matrix.service.ts#L48) — \`marketingVoiceCanon\` path
- [marketing-matrix.types.ts:122](backend/src/config/marketing-matrix.types.ts#L122) — jsdoc comment

### CI workflows
- `.github/workflows/agent-exit-contract-hash.yml` — 3 paths × 3 sections + matrix
- `.github/workflows/marketing-voice-hash.yml` — 2 paths × 3 sections + matrix

### Doc updates (~50 narrative references)
Tous les agents `workspaces/seo-batch/.claude/agents/*.md`, `workspaces/marketing/.claude/agents/*.md`, README/CLAUDE.md des 3 workspaces, `.claude/knowledge/db/tables-seo.md`, `docs/superpowers/specs/2026-04-24-seo-vault-verify-design.md`.

### Out of scope
- `backend/content/automecanik-wiki/_meta/agent-exit-contract.md` — distribution target différente (wiki repo content), pas `.claude/`
- `backend/dist/` — build artifacts, regenerated

## Test plan

- [x] 6 monorepo mirrors hash-match new vault distribution_sha256 (vérifié local)
- [x] `tsc --noEmit` backend OK
- [x] Husky pre-commit + commitlint verts
- [ ] **BLOCKING** : vault PR #154 mergée AVANT cette PR (sinon `*-hash.yml` fail car `canon-hashes.json` sur main vault a encore les anciens paths/hashes)
- [ ] Workflows `agent-exit-contract-hash.yml` + `marketing-voice-hash.yml` verts après merge vault
- [ ] Tests backend `marketing-matrix.service.test.ts` toujours verts

## Sequencing

1. ✅ Vault PR #154 ouverte
2. 🚧 Cette PR-2 ouverte en **draft** (CI fail par design jusqu'à merge vault)
3. ⏳ Merge vault PR #154 → `canon-publish` regénère `canon-hashes.json` sur main vault
4. ⏳ Mark PR-2 ready, re-run CI, merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)