### PR TITLE
feat(seo-roles): admin display normalization via @repo/seo-roles (PR-1)

### DIFF
--- a/frontend/app/routes/admin.content-refresh.tsx
+++ b/frontend/app/routes/admin.content-refresh.tsx
@@ -9,6 +9,7 @@ import {
   useLoaderData,
   useSearchParams,
 } from "@remix-run/react";
+import { getRoleDisplayLabel } from "@repo/seo-roles";
 import {
   RefreshCw,
   Check,
@@ -441,7 +442,8 @@ export default function AdminContentRefresh() {
       header: "Page Type",
       render: (_val, row) => (
         <Badge variant="outline" className="text-xs font-mono">
-          {PAGE_TYPE_LABELS[row.page_type] || row.page_type}
+          {PAGE_TYPE_LABELS[row.page_type] ??
+            getRoleDisplayLabel(row.page_type)}
         </Badge>
       ),
     },

--- a/frontend/app/routes/admin.keyword-planner.tsx
+++ b/frontend/app/routes/admin.keyword-planner.tsx
@@ -1128,25 +1128,25 @@ function FamilyOverview({
         if (r1 < total)
           recs.push({
             role: "R1",
-            label: `${total - r1} gammes sans R1 (achat)`,
+            label: `${total - r1} gammes sans R1_ROUTER (router gamme)`,
             priority: r1 < total * 0.5 ? "high" : "medium",
           });
         if (r3 < total)
           recs.push({
             role: "R3",
-            label: `${total - r3} gammes sans R3 (conseils)`,
+            label: `${total - r3} gammes sans R3_CONSEILS (conseils)`,
             priority: r3 < total * 0.5 ? "high" : "medium",
           });
         if (r6 < total)
           recs.push({
             role: "R6",
-            label: `${total - r6} gammes sans R6 (guide achat)`,
+            label: `${total - r6} gammes sans R6_GUIDE_ACHAT (guide d'achat)`,
             priority: r6 < total * 0.5 ? "high" : "medium",
           });
         if (r4 < total * 0.3)
           recs.push({
             role: "R4",
-            label: `${total - r4} gammes sans R4 (reference)`,
+            label: `${total - r4} gammes sans R4_REFERENCE (référence)`,
             priority: "low",
           });
         if (r5 === 0 && total >= 3)

--- a/frontend/app/routes/admin.rag.cockpit.tsx
+++ b/frontend/app/routes/admin.rag.cockpit.tsx
@@ -4,6 +4,7 @@ import {
   type MetaFunction,
 } from "@remix-run/node";
 import { Link, useFetcher, useLoaderData } from "@remix-run/react";
+import { getRoleDisplayLabel } from "@repo/seo-roles";
 import {
   Activity,
   AlertTriangle,
@@ -543,7 +544,8 @@ function FeatureChip({ fd, value }: { fd: FeatureDisplay; value: unknown }) {
 
 function PageScoreCard({ ps }: { ps: PageScore }) {
   const [showDetails, setShowDetails] = useState(false);
-  const label = PAGE_TYPE_LABELS[ps.page_type] || ps.page_type;
+  const label =
+    PAGE_TYPE_LABELS[ps.page_type] ?? getRoleDisplayLabel(ps.page_type);
   const statusLabel = QUALITY_STATUS_LABELS[ps.status] || ps.status;
   const statusType = QUALITY_STATUS_MAP[ps.status] || "NEUTRAL";
 
@@ -718,7 +720,7 @@ function GammeExpandedRow({ row }: { row: GammeScore }) {
             <div className="flex gap-1 mt-1">
               {row.missing_page_types.map((pt) => (
                 <Badge key={pt} variant="outline" className="text-[10px]">
-                  {PAGE_TYPE_LABELS[pt] || pt}
+                  {PAGE_TYPE_LABELS[pt] ?? getRoleDisplayLabel(pt)}
                 </Badge>
               ))}
             </div>
@@ -972,7 +974,8 @@ export default function AdminRagCockpit() {
       header: "Type de page",
       render: (_val, row) => (
         <Badge variant="outline" className="text-xs">
-          {PAGE_TYPE_LABELS[row.page_type] || row.page_type}
+          {PAGE_TYPE_LABELS[row.page_type] ??
+            getRoleDisplayLabel(row.page_type)}
         </Badge>
       ),
     },

--- a/frontend/app/routes/admin.rag.pipeline.tsx
+++ b/frontend/app/routes/admin.rag.pipeline.tsx
@@ -9,6 +9,7 @@ import {
   useRevalidator,
   useSearchParams,
 } from "@remix-run/react";
+import { getRoleDisplayLabel } from "@repo/seo-roles";
 import {
   RefreshCw,
   Check,
@@ -1257,7 +1258,7 @@ export default function AdminRagPipeline() {
       header: "Type",
       render: (val) => (
         <Badge variant="outline" className="font-mono text-xs">
-          {PAGE_TYPE_LABELS[val as string] || String(val)}
+          {PAGE_TYPE_LABELS[val as string] ?? getRoleDisplayLabel(String(val))}
         </Badge>
       ),
     },

--- a/frontend/app/routes/admin.seo-hub.page-briefs.tsx
+++ b/frontend/app/routes/admin.seo-hub.page-briefs.tsx
@@ -15,6 +15,12 @@ import {
 } from "@remix-run/node";
 import { useLoaderData, useSearchParams, useFetcher } from "@remix-run/react";
 import {
+  ROLE_BADGE_COLORS,
+  getRoleDisplayLabel,
+  getRoleShortLabel,
+  normalizeRoleId,
+} from "@repo/seo-roles";
+import {
   CheckCircle2,
   ChevronDown,
   ChevronUp,
@@ -225,19 +231,19 @@ export async function action({ request }: ActionFunctionArgs) {
 
 // ── Helper components ──
 
-const roleBadgeColors: Record<string, string> = {
-  R1: "bg-blue-100 text-blue-700",
-  R3_guide: "bg-purple-100 text-purple-700",
-  R3_conseils: "bg-teal-100 text-teal-700",
-  R4: "bg-orange-100 text-orange-700",
-};
-
 function RoleBadge({ role }: { role: string }) {
+  // Normalize legacy DB value (R1, R3_guide, R3_conseils, ...) to canonical RoleId
+  const canonical = normalizeRoleId(role);
+  const colorClass = canonical
+    ? ROLE_BADGE_COLORS[canonical]
+    : "bg-gray-100 text-gray-700";
+  // Always display canonical FR label, never raw legacy
   return (
     <Badge
-      className={`text-xs ${roleBadgeColors[role] ?? "bg-gray-100 text-gray-700"}`}
+      className={`text-xs ${colorClass ?? "bg-gray-100 text-gray-700"}`}
+      title={getRoleDisplayLabel(role)}
     >
-      {role}
+      {getRoleShortLabel(role)}
     </Badge>
   );
 }

--- a/frontend/app/routes/blog-pieces-auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto._index.tsx
@@ -62,7 +62,7 @@ import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
  * Handle export pour propager le rôle SEO au root Layout
  */
 export const handle = {
-  pageRole: createPageRoleMeta(PageRole.R3_BLOG, {
+  pageRole: createPageRoleMeta(PageRole.R3_CONSEILS, {
     clusterId: "blog",
     canonicalEntity: "blog-pieces-auto",
   }),

--- a/log.md
+++ b/log.md
@@ -345,3 +345,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/canon-mirrors-relocation`
 - **Décision** : chore(canon): relocate AEC + Marketing Voice mirrors to canon-mirrors/
 - **Sortie** : PR aucune | commits aa0e8980
+
+## 2026-05-05 — chore/seo-roles-pr1-admin-display (auto)
+
+- **Branche** : `chore/seo-roles-pr1-admin-display`
+- **Décision** : chore(seo-matrix): regenerate roleIds hash after PR-0A re-export refactor (+1 other commit)
+- **Sortie** : PR aucune | commits ee73add6 80b84c40


### PR DESCRIPTION
## Summary
PR-1 : élimine les fuites de strings legacy dans 4 routes admin + 2 routes frontend en consommant `@repo/seo-roles` (PR-0A #304) comme **fallback de normalisation**. **Stacked sur PR-0A** — sera rebasée sur main après merge de #304.

## Approche pragmatique
- Les `PAGE_TYPE_LABELS` route-spécifiques (cockpit avec "Transactionnel", "Conseils DIY", etc.) **restent en place** — leurs libellés métier sont plus parlants que les libellés génériques du package
- `@repo/seo-roles` est consommé **uniquement au fallback** : si une valeur DB n'est pas dans le dict local, `getRoleDisplayLabel()` normalise legacy → canonical FR (jamais raw)
- Un seul dict dupliqué (`roleBadgeColors` dans `admin.seo-hub.page-briefs.tsx`) supprimé au profit de `ROLE_BADGE_COLORS` du package

## Files changed (6)

| File | Change |
|------|--------|
| `frontend/app/routes/admin.content-refresh.tsx` | line 444 fallback `\|\| row.page_type` → `?? getRoleDisplayLabel(row.page_type)` |
| `frontend/app/routes/admin.rag.cockpit.tsx` | 3 fallbacks remplacés (lines 546, 722, 975) |
| `frontend/app/routes/admin.rag.pipeline.tsx` | 1 fallback remplacé (line 1260) |
| `frontend/app/routes/admin.seo-hub.page-briefs.tsx` | `roleBadgeColors` local supprimé, `RoleBadge` utilise `ROLE_BADGE_COLORS` + `getRoleShortLabel` (display canonique systématique) |
| `frontend/app/routes/blog-pieces-auto._index.tsx` | `PageRole.R3_BLOG` → `PageRole.R3_CONSEILS` |
| `frontend/app/routes/admin.keyword-planner.tsx` | Recommandations affichent libellés canoniques : `R1_ROUTER`, `R3_CONSEILS`, `R6_GUIDE_ACHAT`, `R4_REFERENCE` |

## Hors scope (laissé pour PR-0B / autres)
- **`frontend/app/utils/page-role.types.ts` `PageRole` enum NON migré** — ses string values (`"R3"`, `"R6_GUIDE"`, etc.) divergent de `RoleId` canonique pour raisons legacy. Migration = behavior change requérant sa propre PR
- **Comparaisons internes `rec.role === "R1"`** dans keyword-planner laissées inchangées — elles sont scopées aux valeurs locales matchant les flags `has_rN`, pas des inputs DB externes

## Test plan
- [x] Frontend typecheck green
- [x] `@repo/seo-roles` symlink resolves correctly via npm workspace
- [x] No raw legacy DB value can leak (audited: 4 fallback sites + page-briefs RoleBadge)
- [ ] CI green
- [ ] Visual sanity check sur admin DEV après deploy

## Order of merge
Stack PR-0A #304 → PR-1 (this) → rebase onto main after #304 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)