### PR TITLE
feat(seo-roles): backend Zod boundary + parseResponseOrSoft (PR-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,10 @@ jobs:
         env:
           SUPABASE_URL: "https://mock.supabase.co"
           SUPABASE_SERVICE_ROLE_KEY: "mock-key-for-ci"
+          # PR-2 : strict mode for SEO role normalization — throws on schema
+          # parse failure instead of soft fallback. Catches regressions in CI
+          # that would otherwise pass silently in prod (where soft is the default).
+          SEO_ROLE_STRICT: "true"
 
       - name: 📊 Backend coverage summary
         if: always()

--- a/backend/src/modules/admin/controllers/admin-rag-pipeline-status.controller.ts
+++ b/backend/src/modules/admin/controllers/admin-rag-pipeline-status.controller.ts
@@ -14,6 +14,11 @@ import { IsAdminGuard } from '@auth/is-admin.guard';
 import { FeatureFlagsService } from '../../../config/feature-flags.service';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { RagChangeWatcherService } from '../../../workers/services/rag-change-watcher.service';
+import {
+  ragPipelineStatusResponseSchema,
+  type RagPipelineStatusResponse,
+} from '../../seo/schemas/rag-pipeline-status.response.schema';
+import { parseResponseOrSoft } from '../../seo/utils/parse-response';
 
 type Phase = 'DISABLED' | 'A' | 'B' | 'C' | 'C_BREAKER';
 
@@ -33,7 +38,7 @@ export class AdminRagPipelineStatusController extends SupabaseBaseService {
   }
 
   @Get('status')
-  async getStatus() {
+  async getStatus(): Promise<RagPipelineStatusResponse> {
     // Persisted flags (env values only, without overrides)
     const allFlags = this.flags.listFlags();
     const persistedFlags = {
@@ -164,7 +169,7 @@ export class AdminRagPipelineStatusController extends SupabaseBaseService {
       .order('rpi_created_at', { ascending: false })
       .limit(5);
 
-    return {
+    const raw = {
       phaseEffective: finalPhase,
       phasePersisted,
       effectiveFlags,
@@ -186,12 +191,27 @@ export class AdminRagPipelineStatusController extends SupabaseBaseService {
       recentErrors: (recentErrors ?? []).map((r: any) => ({
         id: r.pcq_id,
         gamme: r.pcq_pg_alias,
+        // role: pcq_page_type may contain legacy worker page_type values
+        // (R1_pieces, R3_guide_howto, ...). Zod tolerantRoleSchema in
+        // ragPipelineStatusResponseSchema normalizes to canonical RoleId.
         role: r.pcq_page_type,
         error: r.pcq_error,
         at: r.pcq_created_at,
       })),
       openIncidents: openIncidents ?? [],
     };
+
+    // Zod boundary : normalize legacy role values to canonical, log + counter
+    // on parse failure (soft fallback returns raw to avoid breaking the UI).
+    return parseResponseOrSoft(
+      ragPipelineStatusResponseSchema,
+      raw,
+      {
+        controller: AdminRagPipelineStatusController.name,
+        endpoint: 'getStatus',
+      },
+      this.logger,
+    ) as RagPipelineStatusResponse;
   }
 
   private deducePhase(flags: {

--- a/backend/src/modules/seo/schemas/README.md
+++ b/backend/src/modules/seo/schemas/README.md
@@ -1,0 +1,61 @@
+# `seo/schemas/`
+
+Zod response schemas for SEO/admin endpoints (PR-2 boundary).
+
+## Convention
+
+One schema file per controller endpoint. Pattern :
+
+```typescript
+// my-endpoint.response.schema.ts
+import { z } from 'zod';
+import { tolerantRoleSchema, canonicalRoleSchema } from '@repo/seo-roles';
+
+export const myEndpointResponseSchema = z.object({
+  role: tolerantRoleSchema,   // accepts legacy DB inputs, transforms to canonical
+  // ...other fields
+});
+
+export type MyEndpointResponse = z.infer<typeof myEndpointResponseSchema>;
+```
+
+In the controller :
+
+```typescript
+@Controller('api/admin/...')
+export class MyController {
+  @Get(':id')
+  async getOne(): Promise<MyEndpointResponse> {
+    const raw = await this.service.findOne(...);
+    return parseResponseOrSoft(
+      myEndpointResponseSchema,
+      raw,
+      { controller: MyController.name, endpoint: 'getOne' },
+      this.logger,
+    ) as MyEndpointResponse;
+  }
+}
+```
+
+## Rules
+
+- **Use `tolerantRoleSchema`** for fields populated from DB (DB may contain legacy values like `R3_BLOG`, `R3_guide_howto`)
+- **Use `canonicalRoleSchema`** for fields that MUST be canonical (e.g. when re-exposing a normalized value)
+- **Pas de Pipe NestJS sur outputs** : Pipes opèrent sur les arguments d'entrée. Pour valider la réponse, utiliser `parseResponseOrSoft` (Option A) explicitement, ou un Interceptor typé (Option B, voir PR-2-bis si la répétition devient pénible)
+- **Pas d'interceptor walker générique** : chaque schema déclaré explicitement par le caller, pas de regex sur les clés de l'objet
+
+## Observability
+
+`parseResponseOrSoft` instruments :
+
+- `seo_role_normalization_failed_total{controller,endpoint}` — increments on parse failure (soft mode)
+- `seo_role_normalize_response_disabled_total{controller,endpoint}` — increments when `SEO_ROLE_NORMALIZE_RESPONSE=false` kill switch is active
+- Pino structured warning logs per failure (queryable via LogQL)
+
+## Strict mode
+
+Set `SEO_ROLE_STRICT=true` in DEV / CI to throw on parse failure instead of soft fallback. Wired in `.github/workflows/ci.yml` test job.
+
+## Kill switch
+
+Set `SEO_ROLE_NORMALIZE_RESPONSE=false` in production to disable normalization entirely (returns raw). Use only in incident response — the failure counter still tracks it.

--- a/backend/src/modules/seo/schemas/rag-pipeline-status.response.schema.ts
+++ b/backend/src/modules/seo/schemas/rag-pipeline-status.response.schema.ts
@@ -1,0 +1,95 @@
+/**
+ * Zod response schema for GET /api/admin/rag-pipeline/status.
+ *
+ * Migrated to Zod boundary (PR-2). The `recentErrors[].role` field used to
+ * expose `__pipeline_chain_queue.pcq_page_type` raw, which can contain
+ * legacy worker page_type values (`R1_pieces`, `R3_guide_howto`, etc.).
+ *
+ * `tolerantRoleSchema` from @repo/seo-roles transforms those to canonical
+ * `RoleId` values at the response boundary.
+ */
+
+import { z } from 'zod';
+import { tolerantRoleSchema } from '@repo/seo-roles';
+
+const phaseSchema = z.enum(['DISABLED', 'A', 'B', 'C', 'C_BREAKER']);
+
+const flagsSchema = z.object({
+  pipelineEnabled: z.boolean(),
+  autoEnqueue: z.boolean(),
+  dryRun: z.boolean(),
+  allowedRoles: z.array(z.string()).optional(),
+  allowedGammes: z.array(z.string()).optional(),
+});
+
+const queueStatsSchema = z.object({
+  pending: z.number().int().nonnegative(),
+  done_24h: z.number().int().nonnegative(),
+  failed_24h: z.number().int().nonnegative(),
+  failed_ratio_24h: z.number(),
+});
+
+const eventStatsSchema = z.object({
+  pending: z.number().int().nonnegative(),
+  done_24h: z.number().int().nonnegative(),
+  skipped_24h: z.number().int().nonnegative(),
+});
+
+const breakerStateSchema = z
+  .object({
+    active: z.boolean(),
+    // Other fields are passed through — keep tolerant to avoid unrelated breakage
+  })
+  .passthrough();
+
+const topGammeSchema = z.object({
+  alias: z.string(),
+  total: z.number().int().nonnegative(),
+  done: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+});
+
+/**
+ * Recent error entry — `role` is normalized via tolerantRoleSchema.
+ *
+ * Legacy values like `R1_pieces`, `R3_guide_howto` are accepted from DB
+ * (`pcq_page_type` column) and transformed to canonical `R1_ROUTER`, `R3_CONSEILS`.
+ *
+ * `null` accepted because `pcq_page_type` is nullable in some legacy rows.
+ */
+const recentErrorSchema = z.object({
+  id: z.union([z.number(), z.string()]),
+  gamme: z.string().nullable(),
+  role: z.union([tolerantRoleSchema, z.null()]),
+  error: z.string().nullable(),
+  at: z.string().nullable(),
+});
+
+const openIncidentSchema = z
+  .object({
+    rpi_id: z.union([z.number(), z.string()]),
+    rpi_type: z.string().nullable().optional(),
+    rpi_reason: z.string().nullable().optional(),
+    rpi_created_at: z.string().nullable().optional(),
+    rpi_threshold_name: z.string().nullable().optional(),
+    rpi_current_value: z.union([z.number(), z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+
+export const ragPipelineStatusResponseSchema = z.object({
+  phaseEffective: phaseSchema,
+  phasePersisted: phaseSchema,
+  effectiveFlags: flagsSchema,
+  persistedFlags: flagsSchema,
+  overrides: z.record(z.union([z.string(), z.null()])),
+  queue: queueStatsSchema,
+  events: eventStatsSchema,
+  circuitBreaker: breakerStateSchema,
+  topGammes_24h: z.array(topGammeSchema),
+  recentErrors: z.array(recentErrorSchema),
+  openIncidents: z.array(openIncidentSchema),
+});
+
+export type RagPipelineStatusResponse = z.infer<
+  typeof ragPipelineStatusResponseSchema
+>;

--- a/backend/src/modules/seo/utils/__tests__/parse-response.test.ts
+++ b/backend/src/modules/seo/utils/__tests__/parse-response.test.ts
@@ -1,0 +1,153 @@
+import { Logger } from '@nestjs/common';
+import { z } from 'zod';
+import {
+  _resetRoleNormalizationCounters,
+  getRoleNormalizationFailCount,
+  getRoleNormalizationKillSwitchCount,
+  parseResponseOrSoft,
+} from '../parse-response';
+
+describe('parseResponseOrSoft', () => {
+  const mockLogger = {
+    warn: jest.fn(),
+  } as unknown as Logger;
+
+  const fixedSchema = z.object({
+    role: z.string().transform((v) => (v === 'R3_BLOG' ? 'R3_CONSEILS' : v)),
+    name: z.string(),
+  });
+
+  const ctx = {
+    controller: 'TestController',
+    endpoint: 'testEndpoint',
+  };
+
+  beforeEach(() => {
+    _resetRoleNormalizationCounters();
+    (mockLogger.warn as jest.Mock).mockClear();
+    delete process.env.SEO_ROLE_STRICT;
+    delete process.env.SEO_ROLE_NORMALIZE_RESPONSE;
+  });
+
+  describe('success path', () => {
+    it('returns parsed/transformed value', () => {
+      const result = parseResponseOrSoft(
+        fixedSchema,
+        { role: 'R3_BLOG', name: 'test' },
+        ctx,
+        mockLogger,
+      );
+      expect(result).toEqual({ role: 'R3_CONSEILS', name: 'test' });
+    });
+
+    it('does not call logger.warn on success', () => {
+      parseResponseOrSoft(
+        fixedSchema,
+        { role: 'R3_CONSEILS', name: 'test' },
+        ctx,
+        mockLogger,
+      );
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('does not increment fail counter on success', () => {
+      parseResponseOrSoft(
+        fixedSchema,
+        { role: 'R3_CONSEILS', name: 'test' },
+        ctx,
+        mockLogger,
+      );
+      expect(getRoleNormalizationFailCount()).toBe(0);
+    });
+
+    it('still succeeds when SEO_ROLE_STRICT=true and input is valid', () => {
+      process.env.SEO_ROLE_STRICT = 'true';
+      const result = parseResponseOrSoft(
+        fixedSchema,
+        { role: 'R3_CONSEILS', name: 'test' },
+        ctx,
+        mockLogger,
+      );
+      expect(result).toEqual({ role: 'R3_CONSEILS', name: 'test' });
+    });
+  });
+
+  describe('soft fallback path (default, prod-safe)', () => {
+    it('returns raw input on parse failure', () => {
+      const raw = { role: 42, name: null };
+      const result = parseResponseOrSoft(fixedSchema, raw, ctx, mockLogger);
+      expect(result).toBe(raw);
+    });
+
+    it('logs structured warning with metric name', () => {
+      parseResponseOrSoft(fixedSchema, { role: 42 }, ctx, mockLogger);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      const call = (mockLogger.warn as jest.Mock).mock.calls[0];
+      expect(call[0]).toMatchObject({
+        metric: 'seo_role_normalization_failed',
+        controller: 'TestController',
+        endpoint: 'testEndpoint',
+      });
+    });
+
+    it('increments fail counter per controller+endpoint', () => {
+      parseResponseOrSoft(fixedSchema, { role: 42 }, ctx, mockLogger);
+      parseResponseOrSoft(fixedSchema, { role: 42 }, ctx, mockLogger);
+      expect(
+        getRoleNormalizationFailCount('TestController', 'testEndpoint'),
+      ).toBe(2);
+      expect(getRoleNormalizationFailCount()).toBe(2);
+    });
+  });
+
+  describe('strict mode (SEO_ROLE_STRICT=true)', () => {
+    it('throws on parse failure', () => {
+      process.env.SEO_ROLE_STRICT = 'true';
+      expect(() =>
+        parseResponseOrSoft(fixedSchema, { role: 42 }, ctx, mockLogger),
+      ).toThrow(/seo_role_normalization_failed_strict/);
+    });
+
+    it('error message includes controller + endpoint context', () => {
+      process.env.SEO_ROLE_STRICT = 'true';
+      expect(() =>
+        parseResponseOrSoft(fixedSchema, { role: 42 }, ctx, mockLogger),
+      ).toThrow(/TestController\.testEndpoint/);
+    });
+  });
+
+  describe('kill switch (SEO_ROLE_NORMALIZE_RESPONSE=false)', () => {
+    it('returns raw immediately, skipping parse', () => {
+      process.env.SEO_ROLE_NORMALIZE_RESPONSE = 'false';
+      const raw = { role: 'R3_BLOG', name: 'test' };
+      const result = parseResponseOrSoft(fixedSchema, raw, ctx, mockLogger);
+      // Kill switch returns raw without transformation
+      expect(result).toBe(raw);
+      // Counter incremented separately
+      expect(getRoleNormalizationKillSwitchCount()).toBe(1);
+      // Fail counter NOT touched
+      expect(getRoleNormalizationFailCount()).toBe(0);
+    });
+
+    it('does not log warn (kill switch is silent)', () => {
+      process.env.SEO_ROLE_NORMALIZE_RESPONSE = 'false';
+      parseResponseOrSoft(
+        fixedSchema,
+        { role: 'R3_BLOG', name: 'test' },
+        ctx,
+        mockLogger,
+      );
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('takes precedence over strict mode', () => {
+      process.env.SEO_ROLE_STRICT = 'true';
+      process.env.SEO_ROLE_NORMALIZE_RESPONSE = 'false';
+      const raw = { role: 42 }; // would fail parse
+      // Should NOT throw — kill switch bypasses parse entirely
+      expect(() =>
+        parseResponseOrSoft(fixedSchema, raw, ctx, mockLogger),
+      ).not.toThrow();
+    });
+  });
+});

--- a/backend/src/modules/seo/utils/parse-response.ts
+++ b/backend/src/modules/seo/utils/parse-response.ts
@@ -42,6 +42,12 @@ function isNormalizationDisabled(): boolean {
  *
  * Ces compteurs alimentent la précondition mesurable de PR-5
  * ("0 fail sur 7 jours consécutifs sur les controllers décorés").
+ *
+ * **Cluster / multi-process caveat** : ces Maps sont per-process. En cluster
+ * (PM2 / Node cluster module / Kubernetes replicas), chaque worker tient sa
+ * propre instance — Prometheus scrape doit collecter via /metrics par worker
+ * (pattern standard). Pour un total agrégé applicatif, agréger côté Prometheus
+ * via `sum()` et non via lecture du compteur in-memory côté code.
  */
 const FAIL_COUNTER = new Map<string, number>();
 const KILL_SWITCH_COUNTER = new Map<string, number>();

--- a/backend/src/modules/seo/utils/parse-response.ts
+++ b/backend/src/modules/seo/utils/parse-response.ts
@@ -1,0 +1,151 @@
+import type { Logger } from '@nestjs/common';
+import type { ZodSchema } from 'zod';
+
+/**
+ * Context attached to every parse-or-soft call for observability.
+ */
+export interface ParseResponseContext {
+  /** Class name of the controller (e.g. "ReferenceController"). */
+  controller: string;
+  /** Method or route handler name (e.g. "getStatus"). */
+  endpoint: string;
+}
+
+/**
+ * Strict mode flag — when true, throws on parse failure instead of returning
+ * the raw input. Read at call time (not module load) so per-test overrides work
+ * with `process.env.SEO_ROLE_STRICT` mutations between cases.
+ *
+ * Set `SEO_ROLE_STRICT=true` in DEV / CI to catch regressions early.
+ */
+function isStrictMode(): boolean {
+  return process.env.SEO_ROLE_STRICT === 'true';
+}
+
+/**
+ * Kill-switch — when true, bypasses normalization entirely and returns raw.
+ * Read at call time, see {@link isStrictMode}.
+ *
+ * Use to disable response normalization in production without a code rollback,
+ * e.g. if a schema is mis-written and causes broken responses.
+ */
+function isNormalizationDisabled(): boolean {
+  return process.env.SEO_ROLE_NORMALIZE_RESPONSE === 'false';
+}
+
+/**
+ * Compteurs Prometheus-friendly (in-memory, non persistant).
+ *
+ * Format des metric names (à exposer via /metrics ou pino):
+ *  - seo_role_normalization_failed_total{controller,endpoint}
+ *  - seo_role_normalize_response_disabled_total{controller,endpoint}
+ *
+ * Ces compteurs alimentent la précondition mesurable de PR-5
+ * ("0 fail sur 7 jours consécutifs sur les controllers décorés").
+ */
+const FAIL_COUNTER = new Map<string, number>();
+const KILL_SWITCH_COUNTER = new Map<string, number>();
+
+function incrementCounter(
+  store: Map<string, number>,
+  ctx: ParseResponseContext,
+): void {
+  const key = `${ctx.controller}:${ctx.endpoint}`;
+  store.set(key, (store.get(key) ?? 0) + 1);
+}
+
+/**
+ * Read-only access to the failure counter for tests / metrics endpoints.
+ */
+export function getRoleNormalizationFailCount(
+  controller?: string,
+  endpoint?: string,
+): number {
+  if (controller && endpoint) {
+    return FAIL_COUNTER.get(`${controller}:${endpoint}`) ?? 0;
+  }
+  return [...FAIL_COUNTER.values()].reduce((a, b) => a + b, 0);
+}
+
+/**
+ * Read-only access to the kill-switch counter.
+ */
+export function getRoleNormalizationKillSwitchCount(): number {
+  return [...KILL_SWITCH_COUNTER.values()].reduce((a, b) => a + b, 0);
+}
+
+/**
+ * Reset counters — for unit tests only.
+ */
+export function _resetRoleNormalizationCounters(): void {
+  FAIL_COUNTER.clear();
+  KILL_SWITCH_COUNTER.clear();
+}
+
+/**
+ * Parse `raw` against `schema` with three behaviors :
+ *
+ * - **Success** : returns the parsed (and normalized) value.
+ * - **Failure + STRICT_MODE** (DEV/CI) : throws `ZodError`.
+ * - **Failure + soft** (PROD default) : logs structured warning, increments
+ *   counter, returns `raw` unchanged so the response doesn't break.
+ *
+ * Kill switch : if `SEO_ROLE_NORMALIZE_RESPONSE=false`, skip parse and return raw
+ * immediately (counter incremented separately).
+ *
+ * Use at the controller boundary for SEO/admin response validation, e.g.:
+ *
+ *   @Get('status')
+ *   async getStatus(): Promise<StatusResponse> {
+ *     const raw = await this.service.compute();
+ *     return parseResponseOrSoft(statusResponseSchema, raw, {
+ *       controller: AdminRagPipelineStatusController.name,
+ *       endpoint: 'getStatus',
+ *     }, this.logger) as StatusResponse;
+ *   }
+ *
+ * @returns Parsed value (success), or raw input (soft fallback). Caller is
+ *   responsible for typing — runtime guarantees only when `STRICT_MODE=true`.
+ */
+export function parseResponseOrSoft<T>(
+  schema: ZodSchema<T>,
+  raw: unknown,
+  context: ParseResponseContext,
+  logger: Logger,
+): T | unknown {
+  if (isNormalizationDisabled()) {
+    incrementCounter(KILL_SWITCH_COUNTER, context);
+    return raw;
+  }
+
+  const result = schema.safeParse(raw);
+  if (result.success) return result.data;
+
+  // Failure path
+  if (isStrictMode()) {
+    // Re-throw with context so DEV/CI catches the regression
+    const issues = result.error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('; ');
+    throw new Error(
+      `[seo_role_normalization_failed_strict] ${context.controller}.${context.endpoint}: ${issues}`,
+    );
+  }
+
+  logger.warn(
+    {
+      metric: 'seo_role_normalization_failed',
+      controller: context.controller,
+      endpoint: context.endpoint,
+      issues: result.error.issues.map((i) => ({
+        path: i.path.join('.'),
+        message: i.message,
+        received:
+          'received' in i ? (i as { received?: unknown }).received : undefined,
+      })),
+    },
+    `seo_role_normalization_failed: ${context.controller}.${context.endpoint}`,
+  );
+  incrementCounter(FAIL_COUNTER, context);
+  return raw;
+}

--- a/log.md
+++ b/log.md
@@ -351,3 +351,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/seo-roles-pr0b-zod-branded`
 - **Décision** : feat(seo-roles): branded CanonicalRoleId + Zod schemas (PR-0B v0.2.0) (+2 other commits)
 - **Sortie** : PR #307 | commits e57ccc95 ee73add6 80b84c40
+
+## 2026-05-05 — chore/seo-roles-pr2-backend-zod (auto)
+
+- **Branche** : `chore/seo-roles-pr2-backend-zod`
+- **Décision** : feat(seo-roles): backend Zod boundary + parseResponseOrSoft helper (PR-2) (+4 other commits)
+- **Sortie** : PR #308 | commits 57ec4721 9c7d2aac e57ccc95 ee73add6 80b84c40

--- a/log.md
+++ b/log.md
@@ -345,3 +345,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/canon-mirrors-relocation`
 - **Décision** : chore(canon): relocate AEC + Marketing Voice mirrors to canon-mirrors/
 - **Sortie** : PR aucune | commits aa0e8980
+
+## 2026-05-05 — chore/seo-roles-pr0b-zod-branded (auto)
+
+- **Branche** : `chore/seo-roles-pr0b-zod-branded`
+- **Décision** : feat(seo-roles): branded CanonicalRoleId + Zod schemas (PR-0B v0.2.0) (+2 other commits)
+- **Sortie** : PR #307 | commits e57ccc95 ee73add6 80b84c40


### PR DESCRIPTION
## Summary
PR-2 : établit le pattern Zod boundary pour la normalisation des rôles SEO en sortie d'API + migre le premier consumer concret. **Stacked sur PR-0B** (#307).

## Helper `parseResponseOrSoft`

Nouveau fichier [`backend/src/modules/seo/utils/parse-response.ts`](backend/src/modules/seo/utils/parse-response.ts) avec 4 chemins d'exécution :

| Cas | Behavior |
|-----|----------|
| Success | Retourne valeur parsée + transformée |
| Failure + soft (default prod) | Log warn structuré + counter, retourne raw (pas de break UI) |
| Failure + `SEO_ROLE_STRICT=true` (DEV/CI) | Throw avec contexte controller + endpoint |
| `SEO_ROLE_NORMALIZE_RESPONSE=false` kill switch | Skip parse, retourne raw, counter séparé, **précédence sur strict** |

Env vars lus à l'**appel** (pas au module load) → tests jest peuvent muter `process.env` entre cas sans `isolateModules`.

## Compteurs Prometheus-friendly

```
seo_role_normalization_failed_total{controller, endpoint}
seo_role_normalize_response_disabled_total{controller, endpoint}
```

Exposés via `getRoleNormalizationFailCount()` + log Pino structuré (queryable LogQL). Précondition mesurable de PR-5 (« 0 fail sur 7j consécutifs sur les controllers décorés »).

## Convention `seo/schemas/`

Nouveau répertoire [`backend/src/modules/seo/schemas/`](backend/src/modules/seo/schemas/) avec README et premier schema concret :
- `rag-pipeline-status.response.schema.ts` — schema Zod pour `GET /api/admin/rag-pipeline/status`
- `recentErrors[].role` typé via `tolerantRoleSchema` de `@repo/seo-roles` (PR-0B)

## Premier migration : `admin-rag-pipeline-status.controller.ts`

Avant : `recentErrors[].role` exposait `pcq_page_type` brut (legacy `R1_pieces`, `R3_guide_howto`, etc.).
Après : typé `Promise<RagPipelineStatusResponse>` + `parseResponseOrSoft` au return → Zod normalise legacy → canonical `RoleId`.

## CI strict mode

`.github/workflows/ci.yml` job `🧪 Backend Tests` : ajout `env: SEO_ROLE_STRICT: \"true\"`. Catche les régressions de schema en CI qui passeraient en soft en prod.

## Hors scope

- **`ZodResponseInterceptor` (Option B du plan)** : reportable en PR-2-bis si la répétition `.parse()` devient pénible (>10 controllers)
- **`RoleDisambiguationService` (URL → role)** : reporté en PR-4B (la PL/pgSQL `assign_page_role_from_url()` doit être patchée pour retourner canonical en sub-step 0 — voir décision PR-0B)
- **Audit + migration des autres controllers SEO/admin** : par PR ciblée. Ce PR-2 établit pattern + premier consumer.

## Test plan
- [x] 12 Jest tests verts sur `parse-response.test.ts` (success, soft, strict, kill switch, kill-switch precedence)
- [x] Typecheck clean sur `parse-response.ts` + `rag-pipeline-status.response.schema.ts`
- [x] @repo/seo-roles symlink résolu
- [ ] CI green
- [ ] CI strict mode validé : la régression d'un schema doit fail en CI

## Order of merge

Stack PR-0A #304 → PR-0B #307 → PR-2 (this).

PR-3 (lint enforcement phase 3a → 3b) peut commencer après merge de PR-2 + PR-1 + PR-4A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)