### PR TITLE
fix(adr-028-pra): read-only runtime guards (8e classe handoff #158)

### DIFF
--- a/backend/src/database/services/supabase-base.service.ts
+++ b/backend/src/database/services/supabase-base.service.ts
@@ -241,6 +241,36 @@ export abstract class SupabaseBaseService {
     return this.supabase;
   }
 
+  /**
+   * READ_ONLY write guard (ADR-028 Option D — 8e classe).
+   *
+   * Court-circuite les opérations d'écriture / RPC mutantes en mode read-only
+   * (preprod sans SERVICE_ROLE_KEY, anon key + RLS hardening ADR-021).
+   * À appeler en début de toute méthode qui ferait un INSERT/UPDATE/DELETE
+   * ou un RPC qui écrit dans une table service_role-only.
+   *
+   * Émet un warn structuré Pino exploitable par LogQL :
+   *   `count_over_time({app="nestjs"} |~ "readonly.skipped" [1h]) by (operation)`
+   *
+   * @param operation nom de la méthode protégée (ex: "recordSuccess")
+   * @param context optionnel — désambiguïse entre instances (queueName, jobId)
+   * @returns true si on doit court-circuiter, false si on peut continuer
+   */
+  protected guardReadOnly(operation: string, context?: string): boolean {
+    if (this.isReadOnlyMode) {
+      this.logger.warn(
+        {
+          metric: 'readonly.skipped',
+          operation,
+          context: context ?? null,
+        },
+        `[READ_ONLY] Skip ${operation}${context ? ` (${context})` : ''} — write blocked (ADR-028 Option D)`,
+      );
+      return true;
+    }
+    return false;
+  }
+
   protected get headers() {
     return {
       'Content-Type': 'application/json',

--- a/backend/src/modules/admin/services/admin-job-health.service.ts
+++ b/backend/src/modules/admin/services/admin-job-health.service.ts
@@ -28,6 +28,7 @@ export class AdminJobHealthService extends SupabaseBaseService {
    * and computes a running average duration.
    */
   async recordSuccess(queueName: string, durationMs: number): Promise<void> {
+    if (this.guardReadOnly('recordSuccess', queueName)) return;
     try {
       const { error } = await this.supabase.rpc('__admin_job_health_success', {
         p_queue: queueName,
@@ -47,6 +48,7 @@ export class AdminJobHealthService extends SupabaseBaseService {
     queueName: string,
     durationMs: number,
   ): Promise<void> {
+    if (this.guardReadOnly('recordSuccessFallback', queueName)) return;
     try {
       // Read current row
       const { data: current } = await this.supabase
@@ -86,6 +88,7 @@ export class AdminJobHealthService extends SupabaseBaseService {
    * Updates lastFailure, increments totalFailed + consecutiveFailures, stores error message.
    */
   async recordFailure(queueName: string, errorMessage: string): Promise<void> {
+    if (this.guardReadOnly('recordFailure', queueName)) return;
     try {
       // Read current row
       const { data: current } = await this.supabase

--- a/backend/src/modules/cart/services/shipping-calculator.service.ts
+++ b/backend/src/modules/cart/services/shipping-calculator.service.ts
@@ -75,12 +75,35 @@ export class ShippingCalculatorService
 
   /**
    * Charger les paliers de TOUTES les zones depuis la DB (cache mémoire)
+   *
+   * ADR-028 Option D — dual-fallback distinct (Principe 3) :
+   * - `[READ_ONLY]` early-exit : décision environnementale attendue (preprod
+   *   anon-only, tables `___xtr_delivery_*` revoked from anon par ADR-021)
+   * - `[RLS BLOCKED]` try/catch : erreur DB inattendue, signale un drift
+   *
+   * Préfixes log distincts → Loki LogQL queries séparées, alerting differential.
    */
   private async loadAllZoneTiers(): Promise<void> {
     const fallbackTier: ShippingTier[] = [
       { minWeightG: 0, maxWeightG: 999999, feeTTC: 15.9, feeHT: 13.25 },
     ];
 
+    // Fallback environnemental — décision READ_ONLY explicite, pas un drift
+    if (this.isReadOnlyMode) {
+      this.logger.warn(
+        {
+          metric: 'readonly.skipped',
+          operation: 'loadAllZoneTiers',
+        },
+        '[READ_ONLY] Shipping tiers forced to hardcoded fallback — DB tables RLS service_role-only (ADR-021 + ADR-028 Option D)',
+      );
+      for (const zone of Object.keys(ZONE_TABLES)) {
+        this.zoneTiers.set(zone as ShippingZone, fallbackTier);
+      }
+      return;
+    }
+
+    // Fallback technique — erreur DB inattendue, signale un drift
     for (const [zone, table] of Object.entries(ZONE_TABLES)) {
       try {
         const { data, error } = await this.supabase
@@ -90,7 +113,7 @@ export class ShippingCalculatorService
 
         if (error || !data || data.length === 0) {
           this.logger.warn(
-            `Zone ${zone}: impossible de charger (${error?.message || 'table vide'}). Fallback.`,
+            `[RLS BLOCKED] Zone ${zone}: impossible de charger (${error?.message || 'table vide'}). Fallback.`,
           );
           this.zoneTiers.set(zone as ShippingZone, fallbackTier);
           continue;

--- a/backend/src/modules/rag-proxy/services/rag-web-ingest-db.service.ts
+++ b/backend/src/modules/rag-proxy/services/rag-web-ingest-db.service.ts
@@ -26,6 +26,7 @@ export class RagWebIngestDbService extends SupabaseBaseService {
 
   /** Upsert a web ingest job record (fire-and-forget safe). */
   async upsertJob(job: WebJob, gammesDetected?: string[]): Promise<void> {
+    if (this.guardReadOnly('upsertJob', job.jobId)) return;
     const errorMessage = this.extractErrorMessage(job.logLines);
     const { error } = await this.supabase.from('__rag_web_ingest_jobs').upsert(
       {
@@ -114,6 +115,7 @@ export class RagWebIngestDbService extends SupabaseBaseService {
 
   /** Mark all "running" jobs as failed (orphan cleanup on startup). */
   async failOrphanedRunningJobs(): Promise<number> {
+    if (this.guardReadOnly('failOrphanedRunningJobs')) return 0;
     const { data, error } = await this.supabase
       .from('__rag_web_ingest_jobs')
       .update({

--- a/backend/src/modules/seo-logs/services/seo-audit-scheduler.service.ts
+++ b/backend/src/modules/seo-logs/services/seo-audit-scheduler.service.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { ExternalServiceException, ErrorCodes } from '@common/exceptions';
 import { getErrorMessage } from '@common/utils/error.utils';
+import { isReadOnlyMode } from '@config/env-validation';
 
 const execAsync = promisify(exec);
 
@@ -102,11 +103,28 @@ export class SeoAuditSchedulerService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * � Process un job (audit ou cleanup)
+   * 🔄 Process un job (audit ou cleanup)
+   *
+   * ADR-028 Option D — gate processor (Principe 1) : worker créé en preprod
+   * pour valider BullMQ wiring, mais le handler court-circuite sans
+   * `execAsync(scriptPath)` qui crasherait sur script absent du Docker image.
    */
   private async processJob(
     job: any,
   ): Promise<{ success: boolean; type: string } | Record<string, unknown>> {
+    if (isReadOnlyMode()) {
+      this.logger.warn(
+        {
+          metric: 'readonly.skipped',
+          operation: 'seo-audit.processJob',
+          jobId: job?.id,
+          taskType: job?.data?.task ?? job?.data?.auditType ?? 'unknown',
+        },
+        `[READ_ONLY] Skip seo-audit job #${job?.id} — script execution disabled (ADR-028 Option D)`,
+      );
+      return { skipped: true, reason: 'READ_ONLY' };
+    }
+
     // Job de nettoyage
     if (job.data.task === 'cleanup-old-jobs') {
       this.logger.log(`🗑️ Processing cleanup job #${job.id}`);

--- a/backend/src/workers/processors/seo-monitor.processor.ts
+++ b/backend/src/workers/processors/seo-monitor.processor.ts
@@ -116,6 +116,30 @@ export class SeoMonitorProcessor extends SupabaseBaseService {
   async handleMonitoring(
     job: Job<SeoMonitorJobData>,
   ): Promise<MonitoringResult> {
+    // ADR-028 Option D — 8e classe : cron registered en preprod (validation
+    // BullMQ wiring) mais le handler court-circuite sans appel DB/RPC.
+    // Ce gate vit dans le PROCESSOR, pas le scheduler — préserve la couche
+    // scheduling validée en preprod miroir prod.
+    if (this.isReadOnlyMode) {
+      this.logger.warn(
+        {
+          metric: 'readonly.skipped',
+          operation: 'seo-monitor.handleMonitoring',
+          jobId: job.id,
+          taskType: job.data.taskType,
+        },
+        `[READ_ONLY] Skip seo-monitor processor (job #${job.id}, ${job.data.taskType}) — cron registered but writes/RPC disabled`,
+      );
+      return {
+        totalChecked: 0,
+        okCount: 0,
+        warningCount: 0,
+        errorCount: 0,
+        alerts: [],
+        timestamp: new Date().toISOString(),
+      };
+    }
+
     this.logger.log(
       `🔍 [Job #${job.id}] Démarrage monitoring SEO (${job.data.taskType})`,
     );

--- a/backend/tests/unit/readonly-guards.test.ts
+++ b/backend/tests/unit/readonly-guards.test.ts
@@ -1,0 +1,265 @@
+/**
+ * ADR-028 Option D — 8e classe : READ_ONLY guards (PR-A)
+ *
+ * Tests minimum vital pour le helper `guardReadOnly()` sur SupabaseBaseService
+ * et son usage dans 5 services bloqués par RLS service_role-only en preprod
+ * read-only.
+ *
+ * Pattern : env `READ_ONLY=true` + mock `this.supabase` via spy throwing →
+ * assert pas appelé. Si le spy est touché, la garde n'a pas court-circuité.
+ *
+ * Couvre :
+ *   1. SupabaseBaseService.guardReadOnly()
+ *   2. SeoMonitorProcessor.handleMonitoring (skipped)
+ *   3. ShippingCalculatorService.loadAllZoneTiers (env fallback distinct)
+ *   4. AdminJobHealthService.recordSuccess + recordFailure (skipped)
+ *   5. RagWebIngestDbService.upsertJob + failOrphanedRunningJobs (skipped)
+ *
+ * Différé en PR consolidation : seo-audit-scheduler.processJob, intégration
+ * BullMQ E2E, regressions services hérités non-modifiés.
+ */
+
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '../../src/database/services/supabase-base.service';
+import { ShippingCalculatorService } from '../../src/modules/cart/services/shipping-calculator.service';
+import { AdminJobHealthService } from '../../src/modules/admin/services/admin-job-health.service';
+import { RagWebIngestDbService } from '../../src/modules/rag-proxy/services/rag-web-ingest-db.service';
+
+const ORIGINAL_ENV = process.env;
+
+const setReadOnlyEnv = (readOnly: boolean) => {
+  process.env = {
+    ...ORIGINAL_ENV,
+    SUPABASE_URL: 'https://mock.supabase.co',
+    SUPABASE_ANON_KEY: 'mock-anon-key',
+    READ_ONLY: readOnly ? 'true' : 'false',
+  };
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  // Reset cached app config singleton between tests
+  jest.resetModules();
+};
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+const mockConfigService = (readOnly: boolean): ConfigService =>
+  ({
+    get: jest.fn((key: string) => {
+      const config: Record<string, string> = {
+        SUPABASE_URL: 'https://mock.supabase.co',
+        SUPABASE_ANON_KEY: 'mock-anon-key',
+        READ_ONLY: readOnly ? 'true' : 'false',
+      };
+      return config[key];
+    }),
+  }) as unknown as ConfigService;
+
+const failingSupabase = () => ({
+  from: jest.fn(() => {
+    throw new Error('this.supabase.from called — guard failed');
+  }),
+  rpc: jest.fn(() => {
+    throw new Error('this.supabase.rpc called — guard failed');
+  }),
+});
+
+describe('ADR-028 Option D — READ_ONLY guards (PR-A)', () => {
+  describe('1. SupabaseBaseService.guardReadOnly()', () => {
+    class TestService extends SupabaseBaseService {
+      public callGuard(op: string, ctx?: string): boolean {
+        return this.guardReadOnly(op, ctx);
+      }
+    }
+
+    it('returns true and logs [READ_ONLY] warn when READ_ONLY=true', () => {
+      setReadOnlyEnv(true);
+      const svc = new TestService(mockConfigService(true));
+      const warnSpy = jest
+        .spyOn((svc as any).logger, 'warn')
+        .mockImplementation();
+
+      const result = svc.callGuard('testOp', 'queue-1');
+      expect(result).toBe(true);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const call = warnSpy.mock.calls[0] as [Record<string, unknown>, string];
+      expect(call[0]).toEqual(
+        expect.objectContaining({
+          metric: 'readonly.skipped',
+          operation: 'testOp',
+          context: 'queue-1',
+        }),
+      );
+      expect(call[1]).toContain('[READ_ONLY] Skip testOp (queue-1)');
+    });
+
+    it('returns false (no log) when READ_ONLY!=true', () => {
+      setReadOnlyEnv(true);
+      const svc = new TestService(mockConfigService(true));
+      // Override post-construct (le singleton appConfig est cache entre tests)
+      // — cohérent avec runtime : isReadOnlyMode est lu une fois au constructor.
+      (svc as any).isReadOnlyMode = false;
+      const warnSpy = jest
+        .spyOn((svc as any).logger, 'warn')
+        .mockImplementation();
+
+      const result = svc.callGuard('testOp');
+      expect(result).toBe(false);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('handles missing context (only operation)', () => {
+      setReadOnlyEnv(true);
+      const svc = new TestService(mockConfigService(true));
+      const warnSpy = jest
+        .spyOn((svc as any).logger, 'warn')
+        .mockImplementation();
+
+      const result = svc.callGuard('opOnly');
+      expect(result).toBe(true);
+      const call = warnSpy.mock.calls[0] as [Record<string, unknown>, string];
+      expect(call[0].context).toBeNull();
+      expect(call[1]).toContain('[READ_ONLY] Skip opOnly');
+      expect(call[1]).not.toContain('()');
+    });
+  });
+
+  describe('2. SeoMonitorProcessor.handleMonitoring — skipped', () => {
+    // Import dynamique pour éviter les conflits decorator @nestjs/bull au module load
+    let SeoMonitorProcessor: any;
+
+    beforeAll(async () => {
+      const mod = await import(
+        '../../src/workers/processors/seo-monitor.processor'
+      );
+      SeoMonitorProcessor = mod.SeoMonitorProcessor;
+    });
+
+    it('returns zero-counter MonitoringResult without RPC/DB calls when READ_ONLY=true', async () => {
+      setReadOnlyEnv(true);
+      const mockRpcGate = {
+        evaluate: jest.fn(() => ({ decision: 'ALLOW', reason: 'TEST' })),
+        log: jest.fn(),
+      };
+      const mockJobHealth = {
+        recordSuccess: jest.fn(),
+        recordFailure: jest.fn(),
+      };
+      const proc = new SeoMonitorProcessor(
+        mockConfigService(true),
+        mockRpcGate as any,
+        mockJobHealth as any,
+      );
+      (proc as any).supabase = failingSupabase();
+      jest.spyOn((proc as any).logger, 'warn').mockImplementation();
+
+      const fakeJob = {
+        id: 'job-42',
+        data: { taskType: 'check-critical-urls', triggeredBy: 'scheduler' },
+        progress: jest.fn(),
+      };
+      const result = await proc.handleMonitoring(fakeJob);
+
+      expect(result.totalChecked).toBe(0);
+      expect(result.okCount).toBe(0);
+      expect(result.warningCount).toBe(0);
+      expect(result.errorCount).toBe(0);
+      expect(result.alerts).toEqual([]);
+      expect((proc as any).supabase.from).not.toHaveBeenCalled();
+      expect((proc as any).supabase.rpc).not.toHaveBeenCalled();
+      expect(fakeJob.progress).not.toHaveBeenCalled();
+      expect(mockJobHealth.recordSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('3. ShippingCalculatorService.loadAllZoneTiers — env fallback distinct', () => {
+    it('uses hardcoded fallback WITHOUT DB call when READ_ONLY=true, logs [READ_ONLY]', async () => {
+      setReadOnlyEnv(true);
+      const svc = new ShippingCalculatorService();
+      (svc as any).supabase = failingSupabase();
+      const warnSpy = jest
+        .spyOn((svc as any).logger, 'warn')
+        .mockImplementation();
+
+      await (svc as any).loadAllZoneTiers();
+
+      expect((svc as any).supabase.from).not.toHaveBeenCalled();
+      const messages = warnSpy.mock.calls.map((c) => c[1] ?? c[0]);
+      const readOnlyLog = messages.find(
+        (m) => typeof m === 'string' && m.includes('[READ_ONLY]'),
+      );
+      expect(readOnlyLog).toBeDefined();
+      expect(readOnlyLog).toContain(
+        'Shipping tiers forced to hardcoded fallback',
+      );
+      // Aucun log [RLS BLOCKED] ne doit fire en mode env fallback
+      const rlsLog = messages.find(
+        (m) => typeof m === 'string' && m.includes('[RLS BLOCKED]'),
+      );
+      expect(rlsLog).toBeUndefined();
+      // 4 zones doivent avoir le fallback
+      expect((svc as any).zoneTiers.size).toBe(4);
+    });
+  });
+
+  describe('4. AdminJobHealthService — recordSuccess + recordFailure skipped', () => {
+    it('recordSuccess does not call supabase when READ_ONLY=true', async () => {
+      setReadOnlyEnv(true);
+      const svc = new AdminJobHealthService(mockConfigService(true));
+      (svc as any).supabase = failingSupabase();
+      jest.spyOn((svc as any).logger, 'warn').mockImplementation();
+
+      await expect(
+        svc.recordSuccess('test-queue', 100),
+      ).resolves.toBeUndefined();
+      expect((svc as any).supabase.rpc).not.toHaveBeenCalled();
+      expect((svc as any).supabase.from).not.toHaveBeenCalled();
+    });
+
+    it('recordFailure does not call supabase when READ_ONLY=true', async () => {
+      setReadOnlyEnv(true);
+      const svc = new AdminJobHealthService(mockConfigService(true));
+      (svc as any).supabase = failingSupabase();
+      jest.spyOn((svc as any).logger, 'warn').mockImplementation();
+
+      await expect(
+        svc.recordFailure('test-queue', 'err'),
+      ).resolves.toBeUndefined();
+      expect((svc as any).supabase.from).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('5. RagWebIngestDbService — upsertJob + failOrphanedRunningJobs skipped', () => {
+    const fakeJob = {
+      jobId: 'job-1',
+      url: 'https://example.com',
+      truthLevel: 'verified',
+      status: 'done',
+      returnCode: 0,
+      logLines: [],
+      startedAt: 1700000000,
+      finishedAt: 1700000100,
+    };
+
+    it('upsertJob does not call supabase when READ_ONLY=true', async () => {
+      setReadOnlyEnv(true);
+      const svc = new RagWebIngestDbService(mockConfigService(true));
+      (svc as any).supabase = failingSupabase();
+      jest.spyOn((svc as any).logger, 'warn').mockImplementation();
+
+      await expect(svc.upsertJob(fakeJob as any)).resolves.toBeUndefined();
+      expect((svc as any).supabase.from).not.toHaveBeenCalled();
+    });
+
+    it('failOrphanedRunningJobs returns 0 without DB call when READ_ONLY=true', async () => {
+      setReadOnlyEnv(true);
+      const svc = new RagWebIngestDbService(mockConfigService(true));
+      (svc as any).supabase = failingSupabase();
+      jest.spyOn((svc as any).logger, 'warn').mockImplementation();
+
+      const result = await svc.failOrphanedRunningJobs();
+      expect(result).toBe(0);
+      expect((svc as any).supabase.from).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/log.md
+++ b/log.md
@@ -351,3 +351,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/cleanup-dead-page-type-map`
 - **Décision** : chore(seo-roles): drop dead-code PAGE_TYPE_TO_CANONICAL_ROLE map
 - **Sortie** : PR #311 | commits 10135a2f
+
+## 2026-05-05 — canon SEO R0..R8 — 9 PRs livrées d'un trait
+
+- **Branche** : `main` (squash cascade)
+- **Décision** : Stack canon SEO complet livré : foundation `@repo/seo-roles@0.2.0` + admin display + Zod boundary + lint enforcement observe + dead-code cleanup + MCP inventory pivot Option C ; 4 couches enforcement (TS branded + Zod runtime + lint statique + observability), DB CHECK retiré (worker vocab vs canon séparation intentionnelle).
+- **Sortie** : PRs #304 #305 #306 #307 #308 #309 #310 #311 #312 | commits 0a792dcc 7f139d91 0545f36c d06677ae 179bbfdb | fichiers `packages/seo-roles/`, `frontend/app/routes/admin.*.tsx`, `backend/src/modules/seo/utils/parse-response.ts`, `.ast-grep/rules/seo-no-bare-role-literal.yml`, `.spec/00-canon/db-governance/legacy-canon-map.md`


### PR DESCRIPTION
## Summary

PR-A (P0) du plan ADR-028 Option D — 8e classe (handoff vault [PR #158](https://github.com/ak125/governance-vault/pull/158) merged commit `f7612521`).

**Objectif** : repasser deploy main GREEN en court-circuitant proprement les opérations runtime bloquées en preprod READ_ONLY (RLS service_role-only suite ADR-021 vagues 4a/4b).

**Approche** :
- 🛡️ Helper centralisé `SupabaseBaseService.guardReadOnly(operation, context?)` (renommé depuis `guardWrite` pour éviter collision avec `RagFoundationGateService.guardWrite()` existant)
- 🎯 Gates **au niveau processor** (pas scheduler) — préserve validation BullMQ wiring en preprod miroir prod
- 📝 Logs `[READ_ONLY]` obligatoires + Pino structured `{metric: 'readonly.skipped', operation, context}` pour LogQL
- 🔀 Dual-fallback distinct sur ShippingCalculator : `[READ_ONLY]` env-fallback vs `[RLS BLOCKED]` technique (try/catch erreur DB)

## Symptômes adressés (handoff #158)

| # | Erreur | Service | Fix PR-A |
|---|---|---|---|
| 8.1a | \`Invalid API key\` | `RagWebIngestDbService.upsertJob` + `.failOrphanedRunningJobs` | `guardReadOnly` early-exit |
| 8.1b | \`Invalid API key\` | `AdminJobHealthService.recordSuccess` + `.recordFailure` + fallback | `guardReadOnly` × 3 méthodes |
| 8.1c | \`Invalid API key\` | `ShippingCalculatorService.loadAllZoneTiers` | dual-fallback `[READ_ONLY]` |
| 8.2 | \`UNKNOWN_BLOCKED_PROD get_random_vehicle_gamme_combinations\` | `SeoMonitorProcessor.handleMonitoring` | gate processor → return zero-counter |
| 8.3 | \`seo-audit-weekly.sh: not found\` | `SeoAuditSchedulerService.processJob` | gate worker handler → return `{skipped}` |

## Architecture (principes plan v3)

- **P1** — Gate processor pas scheduler : `SeoMonitorScheduler.configureRepeatableJobs()` continue d'enregistrer les 2 cron BullMQ. `SeoAuditScheduler.onModuleInit()` continue de créer queue + worker. Le HANDLER court-circuite avant tout I/O. Préserve validation cron/scheduling miroir prod.
- **P2** — Logs explicites obligatoires : aucun return silencieux. Préfixe `[READ_ONLY]` + structured field `metric: 'readonly.skipped'` pour LogQL `count_over_time({app="nestjs"} |~ "readonly.skipped" [1h]) by (operation)`.
- **P3** — Dual-fallback distinct : ShippingCalculator sépare décision environnementale (early-exit warn `[READ_ONLY]`) du fallback technique (try/catch warn `[RLS BLOCKED]`). Préfixes log distincts → debug différencié.
- **P4** — Helper centralisé : `protected guardReadOnly(operation, context?)` sur `SupabaseBaseService` évite duplication. Le param `context?` désambiguïse entre instances (queueName, jobId).

## Tests

`backend/tests/unit/readonly-guards.test.ts` (9 tests, scope minimum vital incident-safe) :

- ✅ `guardReadOnly` true/false/no-context (3 cas)
- ✅ `SeoMonitorProcessor.handleMonitoring` zero-counter sans RPC/DB call
- ✅ `ShippingCalculator.loadAllZoneTiers` `[READ_ONLY]` distinct de `[RLS BLOCKED]`
- ✅ `AdminJobHealth.recordSuccess` + `.recordFailure` sans appel supabase
- ✅ `RagWebIngestDb.upsertJob` + `.failOrphanedRunningJobs` sans appel supabase

**Suite complète** : 968 tests PASS (51 suites), 0 régression.
**TypeScript** : `npx tsc --noEmit` exit 0.

## Test plan

- [ ] CI verts (lint + test + build)
- [ ] Auto-merge squash après status checks PASS
- [ ] Watch deploy preprod post-merge — verdict ✅ GREEN attendu
- [ ] Asserts logs Loki preprod : `grep -c "[READ_ONLY] Skip"` ≥ 5, `grep -c "Invalid API key"` = 0
- [ ] Suivre PR-B (RPC allowlist) + PR-C1 (Dockerfile script COPY)

## Hors scope (différé, plan v3)

- PR-B : audit `pg_get_functiondef` SECURITY DEFINER + ajout `get_random_vehicle_gamme_combinations` allowlist + processor fallback gracieux + ast-grep rule no-service-role-context-outside-workers
- PR-C1 : Dockerfile COPY ciblé `seo-audit-weekly.sh` (conditionnel à audit deps bash + env vars prod)
- PR-C2 : TypeScript port `seo-audit-weekly.sh` → `SeoAuditRunnerService` (backlog issue séparée)
- Mode `READ_ONLY_STRICT=true` throw au lieu de skip (nécessite ADR séparé)

## Refs

- Plan v3 : `.claude/plans/utiliser-les-meilleure-approche-purrfect-unicorn.md`
- Vault handoff : [adr-028-8th-class-handoff-20260505](https://github.com/ak125/governance-vault/blob/main/ledger/knowledge/adr-028-8th-class-handoff-20260505.md)
- Parent cascade : ADR-028 Option D (PRs #246/#248/#274/#276/#277/#284/#287/#291/#298)

🤖 Generated with [Claude Code](https://claude.com/claude-code)