### PR TITLE
chore(seo-roles): migrate 4 blog routes R3_BLOG → R3_CONSEILS

### DIFF
--- a/frontend/app/routes/blog-pieces-auto.advice._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.advice._index.tsx
@@ -34,7 +34,7 @@ import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
  * Handle export pour propager le rôle SEO au root Layout
  */
 export const handle = {
-  pageRole: createPageRoleMeta(PageRole.R3_BLOG, {
+  pageRole: createPageRoleMeta(PageRole.R3_CONSEILS, {
     clusterId: "advice",
   }),
 };

--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -80,7 +80,7 @@ const VehicleCarousel = lazy(() => import("~/components/blog/VehicleCarousel"));
  * Handle export pour propager le rôle SEO au root Layout
  */
 export const handle = {
-  pageRole: createPageRoleMeta(PageRole.R3_BLOG, {
+  pageRole: createPageRoleMeta(PageRole.R3_CONSEILS, {
     clusterId: "conseils",
   }),
 };

--- a/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
@@ -50,7 +50,7 @@ import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
 // ── Handle ──────────────────────────────────────────────
 
 export const handle = {
-  pageRole: createPageRoleMeta(PageRole.R3_BLOG, {
+  pageRole: createPageRoleMeta(PageRole.R3_CONSEILS, {
     clusterId: "conseils",
     canonicalEntity: "conseils-index",
   }),

--- a/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
@@ -35,7 +35,7 @@ import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
  * Handle export pour propager le rôle SEO au root Layout
  */
 export const handle = {
-  pageRole: createPageRoleMeta(PageRole.R3_BLOG, {
+  pageRole: createPageRoleMeta(PageRole.R3_CONSEILS, {
     clusterId: "constructeurs",
   }),
 };


### PR DESCRIPTION
## Summary

Cosmetic GTM follow-up after seo-roles canon stack (PRs #304–#312 merged 2026-05-05). Replaces deprecated `PageRole.R3_BLOG` with canonical `PageRole.R3_CONSEILS` on 4 blog-pieces-auto routes.

## Routes migrated (4)

| Route | Before | After |
|-------|--------|-------|
| `blog-pieces-auto.conseils._index.tsx` | R3_BLOG | R3_CONSEILS |
| `blog-pieces-auto.conseils.\$pg_alias.tsx` | R3_BLOG | R3_CONSEILS |
| `blog-pieces-auto.advice._index.tsx` | R3_BLOG | R3_CONSEILS |
| `blog-pieces-auto.constructeurs._index.tsx` | R3_BLOG | R3_CONSEILS |

## Out of scope

`blog-pieces-auto.guide-achat.comment-utiliser-selecteur-vehicule-pieces-auto.tsx` is the 5th remaining `R3_BLOG` occurrence but it is semantically a buying guide (R6_GUIDE_ACHAT), not conseils — separate PR with semantic re-roling.

## Impact

- **Behavior** : none (handle metadata only, propagated via Remix `handle` to GTM/analytics)
- **SEO** : no URL change, no canonical change, no robots change
- **Wire format** : unchanged (page-role meta is internal to FE analytics dataLayer)

## Test plan

- [x] Typecheck `frontend` clean (`tsc --noEmit`)
- [x] No remaining `PageRole.R3_BLOG` on the 4 conseils routes
- [ ] Visual smoke: `/blog-pieces-auto/conseils` renders unchanged
- [ ] GTM dataLayer reflects `R3_CONSEILS` instead of `R3` for the 4 routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)