### PR TITLE
refactor(seo-roles): R6 payload discriminators → canonical R6_GUIDE_ACHAT

### DIFF
--- a/backend/src/config/page-contract-r6.schema.ts
+++ b/backend/src/config/page-contract-r6.schema.ts
@@ -556,7 +556,7 @@ export const R6PageContractSchema = z.object({
   gamme_name: z.string().min(3),
 
   // ── Intent & role V2 ───────────────────────────────────
-  intentType: z.literal('R6').default('R6'),
+  intentType: z.literal('R6_GUIDE_ACHAT').default('R6_GUIDE_ACHAT'),
   pageRole: z
     .literal('R6_BUYING_GUIDE' satisfies PageRole)
     .default('R6_BUYING_GUIDE'),

--- a/backend/src/config/schemas/PageContractR6.json
+++ b/backend/src/config/schemas/PageContractR6.json
@@ -18,8 +18,8 @@
     },
     "intentType": {
       "type": "string",
-      "const": "R6",
-      "default": "R6"
+      "const": "R6_GUIDE_ACHAT",
+      "default": "R6_GUIDE_ACHAT"
     },
     "pageRole": {
       "type": "string",

--- a/backend/src/modules/blog/interfaces/r6-guide.interfaces.ts
+++ b/backend/src/modules/blog/interfaces/r6-guide.interfaces.ts
@@ -187,8 +187,8 @@ export interface R6GuidePage {
 
 export interface R6GuidePayload {
   // ── Intent & role (always present) ─────────────────────
-  intentType: 'R6';
-  pageRole: 'R6_BUYING_GUIDE';
+  intentType: 'R6_GUIDE_ACHAT';
+  pageRole: 'R6_GUIDE_ACHAT';
   canonicalRoleUrl: string;
   roleVersion: 'v1' | 'v2';
 

--- a/backend/src/modules/blog/services/r6-guide.service.ts
+++ b/backend/src/modules/blog/services/r6-guide.service.ts
@@ -378,8 +378,8 @@ export class R6GuideService {
         : undefined;
 
     return {
-      intentType: 'R6',
-      pageRole: 'R6_BUYING_GUIDE',
+      intentType: 'R6_GUIDE_ACHAT',
+      pageRole: 'R6_GUIDE_ACHAT',
       canonicalRoleUrl: `/blog-pieces-auto/guide-achat/${pg_alias}`,
       roleVersion: 'v2',
       page,
@@ -452,8 +452,8 @@ export class R6GuideService {
       (row.sgpg_interest_nuggets as R6InterestNugget[]) || [];
 
     return {
-      intentType: 'R6',
-      pageRole: 'R6_BUYING_GUIDE',
+      intentType: 'R6_GUIDE_ACHAT',
+      pageRole: 'R6_GUIDE_ACHAT',
       canonicalRoleUrl: `/blog-pieces-auto/guide-achat/${pg_alias}`,
       roleVersion: 'v1',
       page,

--- a/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
@@ -166,7 +166,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
       const guide = result?.data as R6GuidePayload | null;
 
-      if (guide && (!guide.intentType || guide.intentType === "R6")) {
+      if (
+        guide &&
+        (!guide.intentType || guide.intentType === "R6_GUIDE_ACHAT")
+      ) {
         const r4Reference = await fetchR4Reference(guide.page.pg_id, request);
         return json({ guide, pg_alias, r4Reference });
       }
@@ -206,8 +209,8 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
     // Convert BlogArticle → R6GuidePayload (V1 format for rendering)
     const guide: R6GuidePayload = {
-      intentType: "R6",
-      pageRole: "R6_BUYING_GUIDE",
+      intentType: "R6_GUIDE_ACHAT",
+      pageRole: "R6_GUIDE_ACHAT",
       canonicalRoleUrl: `/blog-pieces-auto/guide-achat/${pg_alias}`,
       roleVersion: "v1",
       page: {

--- a/frontend/app/types/r6-guide.types.ts
+++ b/frontend/app/types/r6-guide.types.ts
@@ -177,8 +177,8 @@ export interface R6GuidePage {
 
 export interface R6GuidePayload {
   // Intent & role (always present)
-  intentType: "R6";
-  pageRole: "R6_BUYING_GUIDE";
+  intentType: "R6_GUIDE_ACHAT";
+  pageRole: "R6_GUIDE_ACHAT";
   canonicalRoleUrl: string;
   roleVersion: "v1" | "v2";
 

--- a/log.md
+++ b/log.md
@@ -357,3 +357,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `main` (squash cascade)
 - **Décision** : Stack canon SEO complet livré : foundation `@repo/seo-roles@0.2.0` + admin display + Zod boundary + lint enforcement observe + dead-code cleanup + MCP inventory pivot Option C ; 4 couches enforcement (TS branded + Zod runtime + lint statique + observability), DB CHECK retiré (worker vocab vs canon séparation intentionnelle).
 - **Sortie** : PRs #304 #305 #306 #307 #308 #309 #310 #311 #312 | commits 0a792dcc 7f139d91 0545f36c d06677ae 179bbfdb | fichiers `packages/seo-roles/`, `frontend/app/routes/admin.*.tsx`, `backend/src/modules/seo/utils/parse-response.ts`, `.ast-grep/rules/seo-no-bare-role-literal.yml`, `.spec/00-canon/db-governance/legacy-canon-map.md`
+
+## 2026-05-05 — chore/seo-roles-r6-intenttype-canonical (auto)
+
+- **Branche** : `chore/seo-roles-r6-intenttype-canonical`
+- **Décision** : refactor(seo-roles): migrate R6 payload discriminators to canonical R6_GUIDE_ACHAT
+- **Sortie** : PR #315 | commits f9824922


### PR DESCRIPTION
## Summary

Atomic migration of `R6GuidePayload`'s two discriminator fields from legacy literals to the canonical value (`@repo/seo-roles` `RoleId.R6_GUIDE_ACHAT`):

| Field | Before | After |
|-------|--------|-------|
| `intentType` | `'R6'` | `'R6_GUIDE_ACHAT'` |
| `pageRole` | `'R6_BUYING_GUIDE'` | `'R6_GUIDE_ACHAT'` |

## Why expand from intentType-only to both discriminators

Original scope was `intentType` only. Pre-commit lint (`no-restricted-syntax` from PR-3a) flagged the existing `pageRole: 'R6_BUYING_GUIDE'` literal in `blog-pieces-auto.guide-achat.\$pg_alias.tsx:210` once the file was touched. Two options were rejected as "bricolage":
- `eslint-disable-next-line` — localized suppression hides canon enforcement
- `--no-verify` bypass — forbidden per CLAUDE.md

Migrating both discriminators atomically is the canonical fix and matches the seo-roles canon stack (#304-#312) intent.

## Files (6, atomic)

- `backend/src/modules/blog/interfaces/r6-guide.interfaces.ts` — BE type
- `backend/src/modules/blog/services/r6-guide.service.ts` — V1+V2 emitters
- `backend/src/config/page-contract-r6.schema.ts` — Zod `intentType` literal only
- `backend/src/config/schemas/PageContractR6.json` — mirror
- `frontend/app/types/r6-guide.types.ts` — FE type mirror
- `frontend/app/routes/blog-pieces-auto.guide-achat.\$pg_alias.tsx`
  - line 169: consumer check `=== 'R6'` → `=== 'R6_GUIDE_ACHAT'`
  - line 209-210: V1 fallback emitter (BlogArticle → R6GuidePayload)

## Out of scope (intentional)

`R6_BUYING_GUIDE` remains in **page-contract storage vocabulary** (separate concern, intentional dual-vocab pattern per memory `worker-vocab-vs-canon-roleid.md`):
- `PAGE_ROLES` const in `page-contract-shared.constants.ts`
- `R6PageContractSchema.pageRole` Zod literal (validates stored contract)
- `PageContractR6.json.pageRole` field (Zod mirror)

## Test plan

- [x] Backend typecheck clean (`tsc --noEmit`)
- [x] Frontend typecheck clean
- [x] Lint clean (PR-3a `no-restricted-syntax` warnings cleared on touched file)
- [x] No remaining `'R6'` / `'R6_BUYING_GUIDE'` in `R6GuidePayload` runtime path
- [ ] Visual smoke: `/blog-pieces-auto/guide-achat/{slug}` renders both V1 and V2 paths
- [ ] Network: `/api/r6-guide/:pg_alias` response shows new discriminator values

## Risk

Low. Wire-format change but FE+BE deploy atomically (monorepo). Consumer at line 169 still accepts `undefined` (`!guide.intentType ||`) for any cache-window stale responses. No public API consumer outside this monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)