### PR TITLE
fix(ci): remove PORT=3200 from preprod .env (9th-class Patch #1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,7 +730,6 @@ jobs:
           READ_ONLY=true
           REDIS_URL=redis://redis-preprod:6379
           APP_URL=http://localhost:3200
-          PORT=3200
           # RAG service disabled in preprod (4 rag-proxy services use
           # configService.getOrThrow<string>('RAG_SERVICE_URL') and 'RAG_API_KEY'
           # at constructor — both crash without sentinel values).


### PR DESCRIPTION
## Summary

- Removes the single line `PORT=3200` injected into `.env.preprod` by [ci.yml](.github/workflows/ci.yml) at the deploy step.
- That line forced Nest to bind to **port 3200 inside the container**, while [docker-compose.preprod.yml](docker-compose.preprod.yml#L22-L27) maps host `3200 → container 3000` and the internal healthcheck targets `localhost:3000/health`.
- Net effect : every `deploy main` run since [#248](https://github.com/ak125/nestjs-remix-monorepo/pull/248) (2026-05-01) failed the 2-min health gate, masking the true regression behind ADR-028 read-only refactor noise.

## Why this is the canonical fix

- `main.ts:197` already defaults to `process.env.PORT || 3000`. With the line gone, Nest binds to 3000 inside the container, which matches:
  - the compose port mapping `3200:3000` (host:container),
  - the compose internal healthcheck `wget http://localhost:3000/health`,
  - the runner-side curl on `http://localhost:3200/health` (routed via Docker NAT to container 3000).
- `APP_URL=http://localhost:3200` is **kept** — it is the externally-visible URL exposed for runner-side checks, not the bind address.

## Out of scope (PR-A.1 next)

The 4 known boot-time log noises (LegalService write at `OnApplicationBootstrap`, RagWebIngestDbService.listJobsByStatus on revoked anon role, MeilisearchService init failure, Catalog/InternalLinking warming cascade) remain. They do not block `/health`. Sweep handled separately.

## Test plan

- [ ] CI green on this PR (lint / typecheck / unit / build).
- [ ] After merge to main, the `deploy` job in `ci.yml` reaches `✅ PREPROD is healthy` within the 2-min window.
- [ ] `ssh deploy@46.224.118.55 'curl -sf http://localhost:3200/health'` returns 200 with the new image deployed.

Refs : 9th-class handoff (vault [PR #160](https://github.com/ak125/governance-vault/pull/160), commit `76cca65a`), MEMORY entry `adr-028-9th-class-handoff-20260505.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)