### PR TITLE
refactor(scripts): build-keyword-clusters consumes @repo/seo-roles canon (PR-2)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-05'
+last_scan: '2026-05-06'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@remix-run/react": "^2.17.4",
         "@remix-run/serve": "^2.17.4",
         "@remix-run/server-runtime": "^2.17.4",
+        "@repo/seo-roles": "*",
         "@supabase/supabase-js": "^2.95.0",
         "abort-controller": "^3.0.0",
         "autoprefixer": "^10.4.14",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   },
   "dependencies": {
     "@remix-run/express": "^2.17.4",
+    "@repo/seo-roles": "*",
     "@remix-run/node": "^2.17.4",
     "@remix-run/react": "^2.17.4",
     "@remix-run/serve": "^2.17.4",

--- a/scripts/seo/build-keyword-clusters.ts
+++ b/scripts/seo/build-keyword-clusters.ts
@@ -27,6 +27,12 @@ import { createClient } from '@supabase/supabase-js';
 import * as dotenv from 'dotenv';
 import * as yaml from 'js-yaml';
 
+import {
+  type CanonicalRoleId,
+  classifyKeywordToRole,
+  RoleId,
+} from '@repo/seo-roles';
+
 // ── Load environment ─────────────────────────────────────────────────────────
 
 dotenv.config({ path: path.join(__dirname, '../../backend/.env'), quiet: true } as dotenv.DotenvConfigOptions);
@@ -107,76 +113,90 @@ interface ClusterBuildResult {
   keywordsProcessed: number;
   rolesCovered: PageRole[];
   cluster?: SeoCluster;
+  /** Keywords classified R2_PRODUCT by canon (transactional pure) — not bucketed
+   *  in roleKeywords (no R2 bucket in legacy SeoCluster shape).
+   *  Observability-only field added in PR-2 (drift elimination at source). */
+  excludedTransactionalKeywords?: string[];
   error?: string;
 }
 
-// ── Intent classification (deterministic regex) ──────────────────────────────
+// ── Canonical role classification — delegates to @repo/seo-roles ─────────────
+//
+// All keyword → role decisions go through `classifyKeywordToRole` (canon
+// SoT, single point of entry). This eliminates the historical R1 drift by
+// construction : R2_PRODUCT is evaluated first in the package classifier.
+// See packages/seo-roles/src/keyword-intent.ts for the priority order.
 
-const INTENT_RULES: Array<{ pattern: RegExp; intent: SearchIntent }> = [
-  // Diagnostique — symptomes, pannes, problemes
-  {
-    pattern:
-      /(?:^|\s)(symptome|bruit|fuite|vibration|voyant|panne|probleme|claquement|sifflement|grince|tremble|casse|defaillance|usure|use)/i,
-    intent: 'diagnostique',
-  },
-  // Navigationnelle — definitions, termes techniques
-  {
-    pattern:
-      /(?:^|\s)(definition|c'est quoi|qu'est.ce qu|role |fonction |signification|glossaire|compose de)/i,
-    intent: 'navigationnelle',
-  },
-  // Informationnelle — guides, conseils, how-to
-  {
-    pattern:
-      /(?:^|\s)(comment |pourquoi |quand |quel |quelle |guide |conseil |choisir |meilleur |comparatif|entretien|remplacement|changer |remplacer |duree de vie|frequence)/i,
-    intent: 'informationnelle',
-  },
-  // Transactionnelle — achat, prix
-  {
-    pattern:
-      /(?:^|\s)(acheter|achat|prix|tarif|pas cher|commander|promo|promotion|solde|discount|livraison)/i,
-    intent: 'transactionnelle',
-  },
-];
+/**
+ * Map canonical RoleId (returned by `classifyKeywordToRole`) → script-local
+ * `PageRole` bucket. Only roles that have a matching script bucket are listed.
+ * Other canonical roles (R0_HOME, R6_SUPPORT, R7_BRAND, R8_VEHICLE) have no
+ * historical bucket and are dropped silently.
+ *
+ * Note : R6_GUIDE_ACHAT is NOT in this table — it is split locally into
+ * `R3_guide` vs `R6` via `splitR6Bucket()` to preserve the legacy 2-bucket
+ * shape. Fusion R3_guide → R6 planned in a follow-up PR.
+ *
+ * R2_PRODUCT is intentionally absent : transactional keywords are excluded
+ * from `roleKeywords` and collected in `excludedTransactionalKeywords` for
+ * observability — preserves the SeoCluster shape (no breaking change).
+ */
+const CANONICAL_TO_CLUSTER_BUCKET = {
+  [RoleId.R1_ROUTER]: 'R1',
+  [RoleId.R3_CONSEILS]: 'R3_conseils',
+  [RoleId.R4_REFERENCE]: 'R4',
+  [RoleId.R5_DIAGNOSTIC]: 'R5',
+} as const satisfies Partial<Record<CanonicalRoleId, PageRole>>;
 
-function inferIntent(keyword: string): SearchIntent {
-  const normalized = keyword
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
+/**
+ * Local R3_guide vs R6 split — only invoked for keywords classified
+ * `R6_GUIDE_ACHAT` by the canon. Transitional : preserves the historical
+ * 2-bucket shape. To be removed in a follow-up PR when downstream consumers
+ * migrate to a single `R6` bucket.
+ */
+const R3_GUIDE_HEURISTIC =
+  /(?:^|\s)(comment\s+choisir|guide|meilleur|quel\s|quelle\s|critere)/i;
 
-  for (const rule of INTENT_RULES) {
-    if (rule.pattern.test(normalized)) {
-      return rule.intent;
-    }
-  }
-
-  // Default: informationnelle (generic product keywords are informational searches)
-  return 'informationnelle';
+function splitR6Bucket(normalized: string): 'R3_guide' | 'R6' {
+  return R3_GUIDE_HEURISTIC.test(normalized) ? 'R3_guide' : 'R6';
 }
 
-// ── Role ↔ Intent affinity matrix ────────────────────────────────────────────
+/**
+ * Map canonical role → local SearchIntent label (4-value enum kept for DB
+ * schema compatibility — `__seo_keyword_cluster.primary_intent` and YAML
+ * frontmatter `intent` field). Drops the package's `investigation_commerciale`
+ * to historical `informationnelle` (matches the legacy R6 affinity).
+ */
+function intentFromRole(role: CanonicalRoleId): SearchIntent {
+  switch (role) {
+    case RoleId.R2_PRODUCT:
+      return 'transactionnelle';
+    case RoleId.R5_DIAGNOSTIC:
+      return 'diagnostique';
+    case RoleId.R4_REFERENCE:
+      return 'navigationnelle';
+    case RoleId.R1_ROUTER:
+    case RoleId.R7_BRAND:
+    case RoleId.R8_VEHICLE:
+      return 'navigationnelle';
+    case RoleId.R3_CONSEILS:
+    case RoleId.R6_GUIDE_ACHAT:
+    case RoleId.R6_SUPPORT:
+    case RoleId.R0_HOME:
+    default:
+      return 'informationnelle';
+  }
+}
 
-const ROLE_INTENT_AFFINITY: Record<PageRole, SearchIntent[]> = {
-  R1: ['transactionnelle', 'navigationnelle'],
-  R3_guide: ['informationnelle'],
-  R3_conseils: ['diagnostique', 'informationnelle'],
-  R4: ['navigationnelle', 'informationnelle'],
-  R5: ['diagnostique'],
-  R6: ['informationnelle'],
-};
-
-// More specific patterns for role assignment (overrides general intent)
-const ROLE_KEYWORD_PATTERNS: Record<PageRole, RegExp> = {
-  R1: /(?:^|\s)(acheter|achat|prix|tarif|pas cher|commander|voiture|auto )/i,
-  R3_guide:
-    /(?:^|\s)(comment choisir|guide|meilleur|comparatif|quel |quelle |plein ou ventile|ventile ou plein|critere)/i,
-  R3_conseils:
-    /(?:^|\s)(quand changer|quand remplacer|entretien|remplacement|duree de vie|frequence|comment remplacer|comment changer|epaisseur mini|usure)/i,
-  R4: /(?:^|\s)(definition|c'est quoi|qu'est|role |fonction |compose|glossaire)/i,
-  R5: /(?:^|\s)(symptome|bruit|vibration|voyant|panne|probleme|claquement|sifflement|diagnostic)/i,
-  R6: /(?:^|\s)(versus|(?<!\w)vs(?!\w)|avis|review|reviews|test[eé]|tests?\b|oem|adaptable|equivalen|alternatif|top\s*\d+|classement|ranking|rapport\s+qualite|prix.?performance|purflux|mann[\s-]?filter|bosch|mahle|hengst|knecht|filtron|champion|wix|donaldson|fleetguard|meyle|febi[\s-]?bilstein|brembo|trw|ate\b|valeo|luk\b|sachs|nk\b|blue\s*print|japanparts|ashika|nipparts|herth|topran|swag|mapco|ridex|stark|metzger|optimal|skf\b|snr\b|ina\b|fag\b|gates\b|dayco|contitech|corteco|elring|ajusa|glaser|goetze|kolbenschmidt|nural|glyco)/i,
-};
+/**
+ * Structured trace for keyword classification (observability layer).
+ * Opt-in via `KW_CLASSIFY_TRACE=1` env. Writes to stderr to keep stdout
+ * (`--output=json:stdout`) pipeable to `jq` without pollution.
+ */
+function traceClassification(payload: Record<string, unknown>): void {
+  if (process.env.KW_CLASSIFY_TRACE !== '1') return;
+  process.stderr.write(JSON.stringify(payload) + '\n');
+}
 
 /**
  * Generate synthetic keywords for roles that have no natural keyword match.
@@ -247,10 +267,17 @@ function generateSyntheticKeywords(
   };
 }
 
+/** Result of role segmentation : per-role keyword buckets + transactional excludes. */
+interface SegmentByRoleResult {
+  roleKeywords: Record<PageRole, RoleKeywords>;
+  excludedTransactionalKeywords: string[];
+}
+
 function segmentByRole(
   keywords: ClassifiedKeyword[],
   gammeName: string,
-): Record<PageRole, RoleKeywords> {
+  pgAlias: string,
+): SegmentByRoleResult {
   const buckets: Record<PageRole, ClassifiedKeyword[]> = {
     R1: [],
     R3_guide: [],
@@ -259,31 +286,43 @@ function segmentByRole(
     R5: [],
     R6: [],
   };
+  const excludedTransactionalKeywords: string[] = [];
 
   for (const kw of keywords) {
-    const normalized = kw.keyword
-      .toLowerCase()
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '');
+    const { role, matched } = classifyKeywordToRole(kw.keyword);
+    traceClassification({
+      event: 'kw_classified',
+      pg_alias: pgAlias,
+      kw: kw.keyword,
+      role,
+      matched,
+    });
 
-    // First: try specific role pattern match
-    let assigned = false;
-    for (const [role, pattern] of Object.entries(ROLE_KEYWORD_PATTERNS)) {
-      if (pattern.test(normalized)) {
-        buckets[role as PageRole].push(kw);
-        assigned = true;
-        break;
-      }
+    // R2_PRODUCT : transactional pure → no historical bucket → observability only
+    if (role === RoleId.R2_PRODUCT) {
+      excludedTransactionalKeywords.push(kw.keyword);
+      continue;
     }
 
-    // Fallback: use intent affinity
-    if (!assigned) {
-      for (const [role, intents] of Object.entries(ROLE_INTENT_AFFINITY)) {
-        if (intents.includes(kw.intent)) {
-          buckets[role as PageRole].push(kw);
-          break;
-        }
-      }
+    // R6_GUIDE_ACHAT : split locally between R3_guide (informational pre-purchase)
+    // and R6 (investigation commerciale + brands) to preserve the legacy 2-bucket
+    // shape. Fusion R3_guide → R6 planned in a follow-up PR.
+    if (role === RoleId.R6_GUIDE_ACHAT) {
+      const normalized = kw.keyword
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '');
+      const bucket = splitR6Bucket(normalized);
+      buckets[bucket].push(kw);
+      continue;
+    }
+
+    // Other roles : direct lookup in canon → script bucket table.
+    // Roles without a script bucket (R0_HOME, R6_SUPPORT, R7_BRAND, R8_VEHICLE)
+    // are dropped silently — they should not appear at gamme scope anyway.
+    const bucket = (CANONICAL_TO_CLUSTER_BUCKET as Record<string, PageRole | undefined>)[role];
+    if (bucket !== undefined) {
+      buckets[bucket].push(kw);
     }
   }
 
@@ -313,7 +352,7 @@ function segmentByRole(
     }
   }
 
-  return result;
+  return { roleKeywords: result, excludedTransactionalKeywords };
 }
 
 function deduplicateKeywords(
@@ -519,11 +558,17 @@ function isKeywordStrictlyPertinent(
   return gammeTerms.every((term) => kwNorm.includes(term));
 }
 
+/** Build result : the SeoCluster + observability extras (transactional excludes). */
+interface BuildClusterResult {
+  cluster: SeoCluster;
+  excludedTransactionalKeywords: string[];
+}
+
 function buildCluster(
   pgAlias: string,
   pgId: number,
   keywords: KeywordRow[],
-): SeoCluster {
+): BuildClusterResult {
   // Derive gamme display name
   const gammeName = pgAlias.replace(/-/g, ' ');
 
@@ -547,10 +592,12 @@ function buildCluster(
     `  Pertinence: ${strictPertinent.length} strict / ${loosePertinent.length} loose / ${keywords.length} total → using ${effective.length}`,
   );
 
-  // 1. Classify intent for each keyword
+  // 1. Classify intent for each keyword via canon classifier (single SoT).
+  //    Intent label is derived from the canonical role to preserve the legacy
+  //    JSON/DB shape (`primary_intent`, YAML `intent` field).
   const classified: ClassifiedKeyword[] = effective.map((kw) => ({
     ...kw,
-    intent: inferIntent(kw.keyword),
+    intent: intentFromRole(classifyKeywordToRole(kw.keyword).role),
   }));
 
   // 2. Select primary keyword (highest volume, strictly pertinent to THIS gamme)
@@ -569,8 +616,13 @@ function buildCluster(
     ),
   ).slice(0, 20);
 
-  // 4. Segment by role (with synthetic fallback for roles without natural keywords)
-  const roleKeywords = segmentByRole(classified, gammeName);
+  // 4. Segment by role (with synthetic fallback for roles without natural keywords).
+  //    Returns roleKeywords + R2_PRODUCT excludes for observability.
+  const { roleKeywords, excludedTransactionalKeywords } = segmentByRole(
+    classified,
+    gammeName,
+    pgAlias,
+  );
 
   // 5. Build forbidden overlap per role
   const forbiddenOverlap: Record<PageRole, string[]> = {} as any;
@@ -578,7 +630,7 @@ function buildCluster(
     forbiddenOverlap[role] = FORBIDDEN_OVERLAP[role];
   }
 
-  return {
+  const cluster: SeoCluster = {
     pgId,
     pgAlias,
     primaryKeyword: {
@@ -598,6 +650,7 @@ function buildCluster(
     source: 'keyword-dataset',
     schemaVersion: '1.0',
   };
+  return { cluster, excludedTransactionalKeywords };
 }
 
 // ── DB operations ────────────────────────────────────────────────────────────
@@ -1022,7 +1075,11 @@ async function processGamme(
     }
 
     // Build cluster
-    const cluster = buildCluster(pgAlias, pgId, keywords);
+    const { cluster, excludedTransactionalKeywords } = buildCluster(
+      pgAlias,
+      pgId,
+      keywords,
+    );
 
     // Identify covered roles
     const rolesCovered = (
@@ -1039,6 +1096,7 @@ async function processGamme(
         keywordsProcessed: keywords.length,
         rolesCovered,
         cluster,
+        excludedTransactionalKeywords,
       };
     }
 
@@ -1084,6 +1142,7 @@ async function processGamme(
       keywordsProcessed: keywords.length,
       rolesCovered,
       cluster,
+      excludedTransactionalKeywords,
     };
   } catch (err: any) {
     return {
@@ -1242,6 +1301,9 @@ Examples:
         primaryKeyword: r.cluster?.primaryKeyword || null,
         roleKeywords: r.cluster?.roleKeywords || null,
         intentDistribution: intentDist,
+        // PR-2 (canon @repo/seo-roles) : R2_PRODUCT keywords excluded from
+        // roleKeywords for observability — drift elimination at source.
+        excludedTransactionalKeywords: r.excludedTransactionalKeywords ?? [],
         error: r.error || null,
       };
     });


### PR DESCRIPTION
## Summary

PR-2 of the R1 drift normalization sequence. Replaces inline keyword classification in `scripts/seo/build-keyword-clusters.ts` with `classifyKeywordToRole()` from `@repo/seo-roles@0.3.0` (shipped in #317).

**Plan** : `/home/deploy/.claude/plans/verifier-r1-est-officiellement-eager-fog.md` PR-2 section.
**Sequence** : PR-1 #317 (MERGED) → **PR-2 (this)** → PR-3 (ast-grep enforcement + docs).

## Drift elimination by construction

`classifyKeywordToRole` evaluates `R2_PRODUCT` first in priority order, so `acheter filtre huile voiture` returns `R2_PRODUCT` despite the R1 trigger capturing `voiture`. No defensive regex needed.

## Removed (~90 lines of duplication)

- `INTENT_RULES` (4-rule regex array)
- `inferIntent()` function
- `ROLE_INTENT_AFFINITY` matrix
- `ROLE_KEYWORD_PATTERNS` (including the 50+ brand list — now lives in canon)

## Added

- `CANONICAL_TO_CLUSTER_BUCKET` adapter (canon `RoleId` → script `PageRole`)
- `splitR6Bucket()` — local heuristic preserving legacy 2-bucket shape (`R3_guide` informational pre-purchase vs `R6` investigation commerciale + brands). Transitional ; fusion R3_guide → R6 planned in a follow-up
- `intentFromRole()` — derives the 4-value `SearchIntent` label from canon role (preserves DB schema `__seo_keyword_cluster.primary_intent` and YAML `intent`)
- `traceClassification()` — opt-in observability (`KW_CLASSIFY_TRACE=1`), writes to **stderr** to keep `--output=json:stdout` jq-pipeable
- `excludedTransactionalKeywords[]` field — collects R2_PRODUCT keywords redirected away from R1 (additive, no breaking change to SeoCluster shape)

## Compat shape preserved

- `SeoCluster` shape unchanged
- DB column `primary_intent` keeps the 4-value enum (`transactionnelle | informationnelle | navigationnelle | diagnostique`)
- New `excludedTransactionalKeywords` is **additive** at JSON output root
- Legacy 2-bucket `R3_guide`/`R6` preserved via `splitR6Bucket`

## Smoke tests (3 gammes, dry-run)

| Gamme | R1.primary | R1.secondary | R1 drift | excludedTransactional |
|-------|------------|--------------|----------|----------------------|
| `filtre-a-huile` | `filtre a huile` (vol=5000) | 5 | **0** | 32 |
| `plaquette-de-frein` | `disque et plaquette de frein clio 4` | 5 | **0** | 38 |
| `filtre-a-air` | `filtre à air` | 5 | **0** | 5 |

R1 never falls to zero (no SEO regression). Transactional triggers (acheter/prix/commander/livraison) fully redirected to `excludedTransactionalKeywords` for downstream R2_PRODUCT routing.

## Test plan

- [x] Smoke test on 3 gammes (filtre-a-huile, plaquette-de-frein, filtre-a-air)
- [x] R1.primary != NULL on all 3
- [x] 0 transactional drift in R1 buckets
- [x] excludedTransactionalKeywords typed array, populated correctly
- [x] `--output=json:stdout` remains jq-pipeable (stderr trace doesn't pollute)
- [x] DB shape unchanged (primary_intent 4-value, R3_guide/R6 buckets preserved)
- [ ] CI: typecheck + ESLint + Backend Tests + Frontend Tests
- [ ] Post-merge: monitor next batch run for `excludedTransactionalKeywords` distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)