### PR TITLE
chore(seo-roles): ast-grep enforcement + R1 docs drift fixes (PR-3)

### DIFF
--- a/.ast-grep/rules/seo-no-inline-role-keyword-pattern.yml
+++ b/.ast-grep/rules/seo-no-inline-role-keyword-pattern.yml
@@ -1,0 +1,50 @@
+id: seo-no-inline-role-keyword-pattern
+language: typescript
+severity: error
+message: |
+  Inline keyword → role classification map detected. Use the canonical
+  `classifyKeywordToRole()` from `@repo/seo-roles` instead — it is the single
+  source of truth for keyword → CanonicalRoleId resolution and eliminates
+  R1 drift by construction (R2_PRODUCT evaluated first in priority order).
+
+  Historical drift (corrected by PR #317 + #318) :
+    - `ROLE_KEYWORD_PATTERNS` map mixed transactional triggers (acheter,
+      prix, livraison) into the R1 bucket → "acheter filtre huile" mis-routed
+      to R1_ROUTER instead of R2_PRODUCT.
+    - `ROLE_INTENT_AFFINITY` matrix duplicated the canon role/intent mapping
+      already living in `@repo/seo-roles`.
+
+  Migration :
+      // BEFORE — inline duplication
+      const ROLE_KEYWORD_PATTERNS: Record<PageRole, RegExp> = { ... };
+      const ROLE_INTENT_AFFINITY: Record<PageRole, SearchIntent[]> = { ... };
+
+      // AFTER — canon SoT
+      import { classifyKeywordToRole, RoleId } from '@repo/seo-roles';
+      const { role } = classifyKeywordToRole(keyword);
+
+  See : `feedback_no_bricolage_align_existing_contract.md`,
+        `seo-roles-package-pr-stack-20260505.md`,
+        plan `verifier-r1-est-officiellement-eager-fog.md` PR-3.
+
+  Note : `type PageRole = 'R1' | ...` is NOT blocked here — `build-keyword-clusters.ts`
+  conserves the legacy bucket shape (Record<PageRole, RoleKeywords>) for output
+  compatibility. That restriction will be added when the JSON shape migrates to
+  Record<CanonicalRoleId, _> (deprecate → migrate → drop pattern).
+
+files:
+  - scripts/**/*.ts
+  - backend/src/modules/seo*/**/*.ts
+
+ignores:
+  - packages/seo-roles/**       # canon SoT — exempt
+  - '**/*.test.ts'              # tests may compare literal patterns
+  - '**/*.spec.ts'
+
+rule:
+  any:
+    # Historical exact symbols that materialised the drift
+    - pattern: 'const ROLE_KEYWORD_PATTERNS = $$$'
+    - pattern: 'const ROLE_KEYWORD_PATTERNS: $_ = $$$'
+    - pattern: 'const ROLE_INTENT_AFFINITY = $$$'
+    - pattern: 'const ROLE_INTENT_AFFINITY: $_ = $$$'

--- a/.claude/knowledge/db/rpcs-critical.md
+++ b/.claude/knowledge/db/rpcs-critical.md
@@ -20,7 +20,7 @@ port 5432, autocommit, `statement_timeout=0`). MCP Supabase ne le supporte pas.
 |---|---|---|
 | `match_keyword_text_to_vehicle(p_text)` | Extrait véhicules d'un keyword texte (cas anciens : 2cv, 4L, C15, Espace, Xantia, Saxo...) | PR #132. Remplace regex hardcodé du script `insert-missing-keywords.ts`. |
 | `extract_vehicle_keywords(pg_id)` / `_batch(text[])` | Batch : keyword → vehicles + type_ids | STABLE, cache-friendly. |
-| `sgpg_gatekeeper_*` | Gate R6 (symétrie R1) | PR #130. Protège Purchase Guide gamme contre insertion sans gate. |
+| `sgpg_gatekeeper_*` | Gate R6_GUIDE_ACHAT (R1_ROUTER distinct, pas symétrique) | PR #130. Protège Purchase Guide gamme contre insertion sans gate. |
 
 ## RPCs Véhicule & compatibilité
 

--- a/.spec/00-canon/db-governance/domain-map.md
+++ b/.spec/00-canon/db-governance/domain-map.md
@@ -225,7 +225,7 @@ Usage non confirme en hot path. 25 GB (24% de la DB) pour des donnees historique
 
 | Table | Lignes | Role |
 |-------|--------|------|
-| `__seo_r1_keyword_plan` | 10 | R1 transactionnel |
+| `__seo_r1_keyword_plan` | 10 | R1_ROUTER navigationnel |
 | `__seo_r2_keyword_plan` | 0 | R2 categorie (vide) |
 | `__seo_r3_keyword_plan` | 15 | R3 conseil |
 | `__seo_r4_keyword_plan` | 36 | R4 reference |

--- a/.spec/content-roles/R4-reference.md
+++ b/.spec/content-roles/R4-reference.md
@@ -28,7 +28,7 @@
 ### Ce que R4 N'EST PAS
 
 - Pas une page produit → R1 `/pieces/{slug}-{pgId}.html`
-- Pas un guide d'achat → R1 purchase guide (sgpg)
+- Pas un guide d'achat → R6_GUIDE_ACHAT
 - Pas un article conseils → R3 `/blog-pieces-auto/conseils/{alias}`
 - Pas un diagnostic de panne → R5 `/diagnostic-auto/{slug}`
 - Pas une page marketing — zéro CTA commercial, zéro prix promotionnel

--- a/workspaces/seo-batch/.claude/agents/r1-content-batch.md
+++ b/workspaces/seo-batch/.claude/agents/r1-content-batch.md
@@ -1,7 +1,7 @@
 ---
 name: r1-content-batch
 description: >-
-  Generation contenu R1 transactionnel. Lit
+  Generation contenu R1_ROUTER (router gamme, navigation compatibilite). Lit
   __seo_r1_keyword_plan.rkp_section_terms + RAG, genere 5 colonnes R1 dans
   __seo_r1_gamme_slots. Zero LLM.
 model: sonnet
@@ -15,7 +15,7 @@ role: R1_ROUTER
 
 # Agent R1 Content Batch — Generation Contenu Transactionnel
 
-Tu es un agent specialise dans la generation de contenu pour les pages **R1 transactionnelles** (pages gamme/catalogue) d'AutoMecanik. Tu lis le keyword plan R1 depuis `__seo_r1_keyword_plan` et tu produis du contenu pour les sections R1-specifiques via interpolation de templates.
+Tu es un agent specialise dans la generation de contenu pour les pages **R1_ROUTER** (router gamme, navigation compatibilite — pages gamme/catalogue) d'AutoMecanik. Tu lis le keyword plan R1 depuis `__seo_r1_keyword_plan` et tu produis du contenu pour les sections R1-specifiques via interpolation de templates.
 
 **Projet Supabase** : `cxpojprgwgubzjyqzmoq`
 


### PR DESCRIPTION
## Summary

PR-3 of the R1 drift normalisation sequence — closes the loop with **static enforcement** + corrects the 4 documentation sources of truth that still carried legacy R1 wording.

**Sequence** : PR-1 #317 ✅ → PR-2 #318 ✅ → **PR-3 (this)** → PR-4 deferred.

## 3.a — ast-grep rule `seo-no-inline-role-keyword-pattern.yml`

Blocks reintroduction of inline `ROLE_KEYWORD_PATTERNS` / `ROLE_INTENT_AFFINITY` maps in `scripts/**/*.ts` and `backend/src/modules/seo*/**/*.ts`. Targets the historical exact symbol names — zero false positives on generic `Record<X, RegExp>` patterns.

`type PageRole = 'R1' | ...` is **deliberately NOT blocked** yet — `build-keyword-clusters.ts` keeps the legacy bucket shape (`Record<PageRole, RoleKeywords>`) for output compatibility. That restriction will land when the JSON shape migrates to `Record<CanonicalRoleId, _>`.

**Verified locally** :
- ✅ 0 violations on current `scripts/` + `backend/src/modules/seo*/` (PR-2 already cleaned the duplication)
- ✅ Catches violations on synthetic fixture (regression test passed)

## 3.b — 4 documentation drift fixes

| File | Before | After |
|------|--------|-------|
| `.spec/content-roles/R4-reference.md:31` | `R1 purchase guide (sgpg)` | `R6_GUIDE_ACHAT` |
| `.spec/00-canon/db-governance/domain-map.md:228` | `R1 transactionnel` | `R1_ROUTER navigationnel` |
| `workspaces/seo-batch/.claude/agents/r1-content-batch.md` | `R1 transactionnel(les)` | `R1_ROUTER (router gamme, navigation compatibilite)` |
| `.claude/knowledge/db/rpcs-critical.md:23` | `Gate R6 (symétrie R1)` | `Gate R6_GUIDE_ACHAT (R1_ROUTER distinct, pas symétrique)` |

## 4 couches enforcement canon désormais actives

| Couche | Mécanisme | PR |
|--------|-----------|-----|
| TS branded type | `CanonicalRoleId` | PR-0B v0.2.0 |
| Zod runtime | `SearchIntentSchema`, `assertCanonicalRoleStrict` | PR-1 #317 |
| node:test golden | 46 anti-regression cases | PR-1 #317 |
| ast-grep static | `seo-no-inline-role-keyword-pattern` | **PR-3 (this)** |

## Test plan

- [x] ast-grep scan PASS on current scripts/ + backend/src/modules/seo*/
- [x] ast-grep regression test on synthetic fixture (catches violations)
- [x] All 4 doc files contain the corrected wording
- [ ] CI : ast-grep job runs the new rule (wired automatically via `ruleDirs: .ast-grep/rules`)

## Périmètre exclu

- PR-4 (différée) : renommage `PurchaseGuideDataService.getR1Slots()` — chantier dédié pattern deprecate→migrate→drop
- Brand list R6 externalisation DB (`__seo_r6_brand_dictionary`) — ticket suivant
- DB column `page_type='R1_pieces'` — legacy DB toléré, hors scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)