### PR TITLE
fix(seo): stop Cloudflare caching loader-thrown 5xx on Remix routes

### DIFF
--- a/.ast-grep/rules/frontend-no-zero-arg-headers-with-s-maxage.yml
+++ b/.ast-grep/rules/frontend-no-zero-arg-headers-with-s-maxage.yml
@@ -1,0 +1,41 @@
+id: frontend-no-zero-arg-headers-with-s-maxage
+language: typescript
+severity: warning
+message: |
+  Zero-arg `HeadersFunction = () => ({...})` cannot inspect `loaderHeaders` /
+  `errorHeaders`, so the success Cache-Control policy (with `s-maxage`) is
+  applied to loader-thrown 4xx/5xx responses too. Cloudflare then caches the
+  failure for `s-maxage` seconds (24h on /pieces/* — see GSC INC-2026-005
+  recurrence: 27.8% of /pieces/* sample 5xx in cache HIT, age >300s).
+
+  Use the helper instead:
+
+      import { buildCacheHeaders } from "~/utils/cache-control";
+      export const headers = buildCacheHeaders(
+        "public, max-age=60, s-maxage=86400, stale-while-revalidate=3600",
+      );
+
+  The helper:
+    - reads `errorHeaders` first → loader-thrown Response wins
+    - falls back to `no-store` if the thrown Response has no Cache-Control
+    - reads `loaderHeaders.Cache-Control` next → loader can override the
+      success policy per-call (e.g. shorter TTL for low-confidence content)
+    - falls back to the `successPolicy` argument
+    - propagates `X-Robots-Tag` from whichever source set it
+
+  See:
+    - frontend/app/utils/cache-control.ts
+    - frontend/app/utils/cache-control.test.ts
+files:
+  - frontend/app/routes/**/*.tsx
+  - frontend/app/routes/**/*.ts
+rule:
+  all:
+    # An exported `headers` whose value is an arrow function with NO parameters.
+    - any:
+        - pattern: export const headers: HeadersFunction = () => $BODY
+        - pattern: export const headers = (() => $BODY) as HeadersFunction
+    # Whose body mentions s-maxage (the CDN-cache axis we must guard).
+    - has:
+        regex: 's-maxage'
+        stopBy: end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
       - name: 🔬 Lint
         run: npm run lint
 
+      # Cloudflare cache poisoning guard: zero-arg HeadersFunction with
+      # `s-maxage` lets Cloudflare cache 5xx for 24h (INC-2026-005-recurrence
+      # 2026-05-06). Use ~/utils/cache-control#buildCacheHeaders instead.
+      - name: 🛡️ Cache-Control discipline (Remix routes)
+        run: bash scripts/lint/check-no-zero-arg-headers-with-s-maxage.sh
+
   typecheck:
     name: ʦ TypeScript
     runs-on: ubuntu-latest

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -25,6 +25,17 @@ fi
 
 npx lint-staged
 
+# Block zero-arg HeadersFunction with `s-maxage` in Remix routes.
+# Mémoire INC-2026-005-recurrence (2026-05-06) : a naive
+# `() => ({ "Cache-Control": "public, s-maxage=86400" })` lets Cloudflare
+# cache loader-thrown 5xx for 24h. Use buildCacheHeaders helper instead.
+STAGED_ROUTES=$(git diff --cached --name-only --diff-filter=ACMR \
+  | grep -E '^frontend/app/routes/.*\.(ts|tsx)$' || true)
+if [ -n "$STAGED_ROUTES" ]; then
+  # shellcheck disable=SC2086
+  bash scripts/lint/check-no-zero-arg-headers-with-s-maxage.sh $STAGED_ROUTES || exit 1
+fi
+
 # Refresh auto-generated YAML frontmatter + AUTO-GENERATED blocks in
 # .claude/knowledge/modules/*.md so last_scan + primary_files stay honest.
 # Only touches files when the module .ts changed; otherwise no-op.

--- a/frontend/app/routes/blog-pieces-auto.guide-achat._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat._index.tsx
@@ -17,7 +17,6 @@
 
 import {
   json,
-  type HeadersFunction,
   type LoaderFunctionArgs,
   type MetaFunction,
 } from "@remix-run/node";
@@ -58,6 +57,7 @@ import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { ResponsiveImage } from "~/components/ui/ResponsiveImage";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
@@ -175,11 +175,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   );
 };
 
-// Cache — 1min browser + 10min CDN (listing stable)
-export const headers: HeadersFunction = () => ({
-  "Cache-Control":
-    "public, max-age=60, s-maxage=600, stale-while-revalidate=86400",
-});
+// Cache — 1min browser + 10min CDN (listing stable). Errors hit no-store via
+// buildCacheHeaders so loader-thrown 5xx never inherit the success policy.
+export const headers = buildCacheHeaders(
+  "public, max-age=60, s-maxage=600, stale-while-revalidate=86400",
+);
 
 /* ===========================
    Meta + Structured Data

--- a/frontend/app/routes/pieces.$gamme.$marque.$modele.$type[.]html.tsx
+++ b/frontend/app/routes/pieces.$gamme.$marque.$modele.$type[.]html.tsx
@@ -11,7 +11,7 @@
  * sont delegues a des fichiers dedies.
  */
 
-import { type HeadersFunction, type MetaFunction } from "@remix-run/node";
+import { type MetaFunction } from "@remix-run/node";
 import {
   isRouteErrorResponse,
   useLoaderData,
@@ -24,6 +24,7 @@ import {
   type NoProductsData,
 } from "~/components/pieces/NoProductsAlternatives";
 import { PiecesVehicleContent } from "~/components/pieces/PiecesVehicleContent";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
 import { piecesVehicleLoader } from "~/utils/pieces-vehicle.loader.server";
@@ -47,13 +48,14 @@ export const handle = {
 export const loader = piecesVehicleLoader;
 
 // ========================================
-// CACHE — 1min browser + 24h CDN stale
+// CACHE — 1min browser + 24h CDN stale on success, no-store on errors.
+// `buildCacheHeaders` reads errorHeaders so loader-thrown 4xx/5xx never inherit
+// the success policy (would otherwise let Cloudflare cache 5xx for 24h).
 // ========================================
 
-export const headers: HeadersFunction = () => ({
-  "Cache-Control":
-    "public, max-age=60, s-maxage=86400, stale-while-revalidate=3600",
-});
+export const headers = buildCacheHeaders(
+  "public, max-age=60, s-maxage=86400, stale-while-revalidate=3600",
+);
 
 // ========================================
 // META - SEO (Schema.org genere par composant Breadcrumbs)

--- a/frontend/app/routes/pieces.$slug.tsx
+++ b/frontend/app/routes/pieces.$slug.tsx
@@ -54,6 +54,7 @@ import {
   extractEditorialBlocks,
   mergeFaqBlocks,
 } from "~/utils/editorial-parser";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { parseGammePageData } from "~/utils/gamme-page-contract.utils";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
@@ -531,16 +532,9 @@ export const meta: MetaFunction<typeof loader> = ({
   return result;
 };
 
-export function headers({ loaderHeaders }: { loaderHeaders: Headers }) {
-  const h: Record<string, string> = {
-    "Cache-Control":
-      loaderHeaders.get("Cache-Control") ||
-      "public, max-age=3600, s-maxage=86400, stale-while-revalidate=7200",
-  };
-  const xr = loaderHeaders.get("X-Robots-Tag");
-  if (xr) h["X-Robots-Tag"] = xr;
-  return h;
-}
+export const headers = buildCacheHeaders(
+  "public, max-age=3600, s-maxage=86400, stale-while-revalidate=7200",
+);
 
 // Sync data: disponible immediatement (above-fold + meta/JSON-LD)
 type PiecesPageSyncData = Omit<

--- a/frontend/app/utils/cache-control.ts
+++ b/frontend/app/utils/cache-control.ts
@@ -1,0 +1,48 @@
+import type { HeadersFunction } from "@remix-run/node";
+
+const NO_STORE = "no-cache, no-store, must-revalidate";
+
+/**
+ * Build a Remix `HeadersFunction` that forces `no-store` whenever the loader
+ * threw a Response (4xx/5xx) and applies the success policy otherwise.
+ *
+ * Why: Remix invokes `headers()` for both successful loaders AND thrown
+ * Responses. A naive arrow `() => ({ "Cache-Control": "public, s-maxage=86400" })`
+ * leaks the success policy onto error responses, letting Cloudflare cache the
+ * 5xx for `s-maxage` seconds. See ADR on cache-control discipline.
+ *
+ * Precedence (matches `pieces.$slug.tsx` historical pattern, generalised):
+ *   1. errorHeaders → loader threw a Response, honour its Cache-Control
+ *      (or default to `no-store` to refuse CDN caching of failures)
+ *   2. loaderHeaders → success path, honour the value the loader set on
+ *      `json()` / `defer()` (e.g. shorter TTL for low-confidence content)
+ *   3. `successPolicy` → fallback when neither set anything explicit
+ *
+ * X-Robots-Tag is propagated unchanged from whichever source carried it
+ * (loader on success, error response on failure).
+ */
+export function buildCacheHeaders(successPolicy: string): HeadersFunction {
+  return ({ loaderHeaders, errorHeaders }) => {
+    const out: Record<string, string> = {};
+
+    if (errorHeaders) {
+      out["Cache-Control"] = errorHeaders.get("Cache-Control") ?? NO_STORE;
+      const xRobots = errorHeaders.get("X-Robots-Tag");
+      if (xRobots) out["X-Robots-Tag"] = xRobots;
+      return out;
+    }
+
+    out["Cache-Control"] =
+      loaderHeaders?.get("Cache-Control") ?? successPolicy;
+    const xRobots = loaderHeaders?.get("X-Robots-Tag");
+    if (xRobots) out["X-Robots-Tag"] = xRobots;
+    return out;
+  };
+}
+
+/**
+ * Header value used when the response MUST NOT be cached by any tier
+ * (browser, CDN). Use on loader-thrown error Responses to prevent CDN
+ * cache poisoning across the route's `headers()` function.
+ */
+export const NO_STORE_CACHE_CONTROL = NO_STORE;

--- a/frontend/tests/unit/utils/cache-control.test.ts
+++ b/frontend/tests/unit/utils/cache-control.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  NO_STORE_CACHE_CONTROL,
+  buildCacheHeaders,
+} from "~/utils/cache-control";
+
+const SUCCESS_POLICY =
+  "public, max-age=60, s-maxage=86400, stale-while-revalidate=3600";
+
+const headers = (entries: Array<[string, string]>): Headers => {
+  const h = new Headers();
+  for (const [k, v] of entries) h.set(k, v);
+  return h;
+};
+
+describe("buildCacheHeaders", () => {
+  it("returns the success policy when neither loader nor error set anything", () => {
+    const fn = buildCacheHeaders(SUCCESS_POLICY);
+    const result = fn({
+      loaderHeaders: new Headers(),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders: undefined,
+    });
+
+    expect(result).toEqual({ "Cache-Control": SUCCESS_POLICY });
+  });
+
+  it("honours an explicit Cache-Control set by the loader on success", () => {
+    const fn = buildCacheHeaders(SUCCESS_POLICY);
+    const result = fn({
+      loaderHeaders: headers([
+        ["Cache-Control", "public, max-age=10, s-maxage=120"],
+      ]),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders: undefined,
+    });
+
+    expect(result["Cache-Control"]).toBe(
+      "public, max-age=10, s-maxage=120",
+    );
+  });
+
+  it("propagates X-Robots-Tag from loaderHeaders on success", () => {
+    const fn = buildCacheHeaders(SUCCESS_POLICY);
+    const result = fn({
+      loaderHeaders: headers([["X-Robots-Tag", "noindex, follow"]]),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders: undefined,
+    });
+
+    expect(result["X-Robots-Tag"]).toBe("noindex, follow");
+  });
+
+  it("forces no-store when the loader threw a Response without Cache-Control", () => {
+    const fn = buildCacheHeaders(SUCCESS_POLICY);
+    const result = fn({
+      loaderHeaders: new Headers(),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders: new Headers(),
+    });
+
+    expect(result["Cache-Control"]).toBe(NO_STORE_CACHE_CONTROL);
+  });
+
+  it("honours an explicit no-cache the loader set on the thrown Response", () => {
+    const fn = buildCacheHeaders(SUCCESS_POLICY);
+    const result = fn({
+      loaderHeaders: new Headers(),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders: headers([["Cache-Control", "no-cache"]]),
+    });
+
+    expect(result["Cache-Control"]).toBe("no-cache");
+  });
+
+  it("propagates X-Robots-Tag from errorHeaders on failure", () => {
+    const fn = buildCacheHeaders(SUCCESS_POLICY);
+    const result = fn({
+      loaderHeaders: new Headers(),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders: headers([
+        ["Cache-Control", "no-cache"],
+        ["X-Robots-Tag", "noindex"],
+      ]),
+    });
+
+    expect(result["X-Robots-Tag"]).toBe("noindex");
+  });
+
+  it("never leaks the success policy onto an error response (the cache-poisoning regression)", () => {
+    const fn = buildCacheHeaders(SUCCESS_POLICY);
+    const result = fn({
+      loaderHeaders: headers([["Cache-Control", SUCCESS_POLICY]]),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders: new Headers(),
+    });
+
+    expect(result["Cache-Control"]).not.toContain("s-maxage");
+    expect(result["Cache-Control"]).toBe(NO_STORE_CACHE_CONTROL);
+  });
+});

--- a/scripts/lint/check-no-zero-arg-headers-with-s-maxage.sh
+++ b/scripts/lint/check-no-zero-arg-headers-with-s-maxage.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Block any Remix route file that exports a zero-arg `HeadersFunction`
+# whose body sets `Cache-Control: ... s-maxage=...`.
+#
+# Why: a zero-arg `headers` cannot inspect `loaderHeaders` / `errorHeaders`,
+# so the success policy (with `s-maxage`) is applied to loader-thrown 4xx/5xx
+# responses too. Cloudflare then caches the failure for `s-maxage` seconds.
+# See `frontend/app/utils/cache-control.ts` for the canonical helper.
+#
+# Used by: .husky/pre-commit (changed files only) + CI lint job (full repo).
+# ast-grep equivalent: .ast-grep/rules/frontend-no-zero-arg-headers-with-s-maxage.yml
+# (severity warning until ast-grep version supports the combined `has`+regex
+# matcher reliably).
+
+set -euo pipefail
+
+# Default scope: every Remix route. CI passes no args; pre-commit passes the
+# subset of staged files to keep the check fast.
+ROUTES_GLOB="frontend/app/routes"
+if [ "$#" -gt 0 ]; then
+  FILES=("$@")
+else
+  mapfile -t FILES < <(find "$ROUTES_GLOB" -type f \( -name '*.tsx' -o -name '*.ts' \))
+fi
+
+violations=0
+violators=()
+
+for f in "${FILES[@]}"; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    "$ROUTES_GLOB"/*) ;;
+    *) continue ;;
+  esac
+
+  # awk state machine: capture the body of `export const headers: HeadersFunction = () => (`
+  # up to the matching `})`, then check whether it contains `s-maxage`.
+  bad=$(awk '
+    BEGIN { in_block = 0; depth = 0; buf = "" }
+    /^export const headers: HeadersFunction = \(\) => \(/ {
+      in_block = 1
+      depth = 1
+      buf = $0
+      next
+    }
+    in_block {
+      buf = buf "\n" $0
+      n = gsub(/\(/, "(", $0)
+      m = gsub(/\)/, ")", $0)
+      depth += n - m
+      if (depth <= 0) {
+        if (buf ~ /s-maxage/) {
+          print buf
+          exit 0
+        }
+        in_block = 0
+        depth = 0
+        buf = ""
+      }
+    }
+  ' "$f")
+
+  if [ -n "$bad" ]; then
+    violations=$((violations + 1))
+    violators+=("$f")
+  fi
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "ERROR: zero-arg HeadersFunction with \`s-maxage\` detected (${violations} file(s))."
+  echo ""
+  echo "A zero-arg \`headers\` cannot read errorHeaders/loaderHeaders, so the"
+  echo "success Cache-Control is applied to loader-thrown 5xx → Cloudflare"
+  echo "caches the failure for \`s-maxage\` seconds (24h on /pieces/* in"
+  echo "INC-2026-005-recurrence: 27.8% of /pieces/* sample 5xx in cache HIT)."
+  echo ""
+  echo "Fix: use the canonical helper:"
+  echo ""
+  echo "    import { buildCacheHeaders } from \"~/utils/cache-control\";"
+  echo "    export const headers = buildCacheHeaders("
+  echo "      \"public, max-age=60, s-maxage=86400, stale-while-revalidate=3600\","
+  echo "    );"
+  echo ""
+  echo "Files:"
+  for v in "${violators[@]}"; do
+    echo "  - $v"
+  done
+  echo ""
+  echo "See frontend/app/utils/cache-control.ts + .test.ts for the contract."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Audit empirique 2026-05-06 sur PROD (`https://www.automecanik.com`, sample stratifié 930 URLs sitemap) : **27,8 % des pages `/pieces/*` renvoient HTTP 500 + `cf-cache-status: HIT`** avec `age > 300 s`, latence retry < 50 ms. 100 % des 5xx sur type_id legacy `<60000` (URLs SEO prioritaires), distribution transversale aux gammes/brands → bug architectural, pas data.

**Root-cause** : `export const headers: HeadersFunction = () => ({...})` est invoquée par Remix pour TOUTES les réponses (succès ET loader-thrown 4xx/5xx). Le `Cache-Control: public, s-maxage=86400` du chemin heureux écrase le `no-cache` que `pieces-vehicle.loader.server.ts` met correctement sur ses 503 (l. 297, 463). Cloudflare honore le `s-maxage` et cache la 500 pendant 24 h → effet boule de neige sur Google Search Console (INC-2026-005, validation échouée 2026-05-02 sur 30,4 k pages).

## Fix canonique en defense-in-depth

- **Helper** `~/utils/cache-control#buildCacheHeaders` : lit `errorHeaders` d'abord (si loader threw → `no-store` ou ce que le loader a posé), puis `loaderHeaders` (succès, override possible), puis fallback `successPolicy`. `X-Robots-Tag` propagé depuis la bonne source.
- **Migration** des 3 routes route-level concernées :
  - `pieces.$gamme.$marque.$modele.$type[.]html.tsx` — **BUG critique 47 % 5xx**
  - `pieces.$slug.tsx` — refactor du pattern partiel existant (lisait `loaderHeaders` mais pas `errorHeaders`)
  - `blog-pieces-auto.guide-achat._index.tsx`
- **7 tests unitaires** couvrant chaque branche dont la régression no-leak-success-policy-onto-error.
- **Garde mécanique** :
  - `scripts/lint/check-no-zero-arg-headers-with-s-maxage.sh` (bash awk déterministe)
  - hook husky pre-commit (staged routes uniquement)
  - step CI lint (full repo, blocant)
  - règle ast-grep YAML correspondante en `severity: warning` (le script bash reste source de vérité tant que la version ast-grep utilisée ici ne match pas le pattern combiné fiable)

## Hors scope (follow-up séparés)

- 4 routes encore en `HeadersFunction = () => ({...})` SANS `s-maxage` (max-age=300 only) : `_index.tsx`, `constructeurs.\$brand[.]html.tsx`, `blog-pieces-auto.guide-achat.\$pg_alias.tsx`, `blog-pieces-auto.conseils.\$pg_alias.tsx`. Risque marginal (cache CDN court ~5 min).
- **Origine du timeout backend** `/api/rm/page-v2` (10-12 s) : nécessite SSH PROD logs ; ce PR limite la **PERSISTANCE 24 h**, pas l'occurrence initiale du 500. Incident à ouvrir séparément.
- **Purge Cloudflare** des URLs 5xx HIT actuelles : action manuelle utilisateur (token CF non disponible côté CI), sinon le fix prend jusqu'à 24 h pour propager.
- **Re-validation GSC** (action manuelle dans la console Search Console).

## Test plan

- [x] `vitest run tests/unit/utils/cache-control.test.ts` → **7/7 verts**
- [x] `tsc --noEmit` frontend → **0 erreur**
- [x] `bash scripts/lint/check-no-zero-arg-headers-with-s-maxage.sh` → 0 violation après migration ; fire correctement sur fichier synthétique
- [ ] CI green (lint + typecheck + audit + tests + build)
- [ ] Après merge sur main → DEV preprod déployé → `curl -sI https://www.automecanik.com/pieces/<sample-500>.html` montre `Cache-Control: no-store...` quand le loader throw 5xx (au lieu de `s-maxage=86400`)
- [ ] Purge Cloudflare ciblée sur `/pieces/*` (ou liste exacte des 259 URLs identifiées dans `/tmp/gsc-audit/urls-500.txt`)
- [ ] Tag PROD une fois DEV validé
- [ ] Re-validation GSC dans Search Console → "Erreur serveur (5xx)" → bouton "Valider la correction"

🤖 Generated with [Claude Code](https://claude.com/claude-code)