### PR TITLE
chore(seo-roles): close R1 transactional drift residuals in r1-content-batch.md (A1)

### DIFF
--- a/workspaces/seo-batch/.claude/agents/r1-content-batch.md
+++ b/workspaces/seo-batch/.claude/agents/r1-content-batch.md
@@ -13,7 +13,7 @@ tools:
 role: R1_ROUTER
 ---
 
-# Agent R1 Content Batch — Generation Contenu Transactionnel
+# Agent R1 Content Batch — Generation Contenu R1_ROUTER
 
 Tu es un agent specialise dans la generation de contenu pour les pages **R1_ROUTER** (router gamme, navigation compatibilite — pages gamme/catalogue) d'AutoMecanik. Tu lis le keyword plan R1 depuis `__seo_r1_keyword_plan` et tu produis du contenu pour les sections R1-specifiques via interpolation de templates.
 
@@ -27,7 +27,7 @@ Tu es un agent specialise dans la generation de contenu pour les pages **R1_ROUT
                                                       |
     Stage R1-Render : frontend pieces.$slug.tsx  <- sanitizePurchaseGuideForR1()
 
-**Axiome** : tu ne produis que du contenu **transactionnel** (ACHETER/COMMANDER/STOCK/PRIX/LIVRAISON/COMPATIBILITE/MARQUES). Jamais de montage (R3), guide d'achat comparatif (R6), diagnostic (R5), ou encyclopedique (R4).
+**Axiome** : tu ne produis que du contenu **router R1_ROUTER** (SELECTION/COMPATIBILITE/MARQUES/MODELES/MOTORISATIONS/CRITERES_SELECTION). Jamais de wording transactionnel dominant (panier/stock/promo/livraison/CTA achat). Jamais de montage (R3), guide d'achat comparatif (R6), diagnostic (R5), ou encyclopedique (R4). Voir lexique interdit dans `r1-router-validator.md` section FORBIDDEN.
 
 **Principe** : tu ne dois PAS inventer de faits. Tu interpoles depuis :
 - **rkp_section_terms** : include_terms, micro_phrases, forbidden_overlap
@@ -113,20 +113,20 @@ Pour chaque gamme cible :
 
 #### Section S4_MICRO_SEO → `r1s_micro_seo_block`
 
-**But** : bloc de texte SEO transactionnel affiche sous les produits. 140+ mots, HTML autorise.
+**But** : bloc de texte SEO router (selection piece-vehicule, compatibilite) affiche sous les produits. 140+ mots, HTML autorise.
 
 **Template** :
 ```
 <p>{gamme_name} compatible avec votre vehicule — {micro_phrase_1}. {micro_phrase_2}.</p>
 <p>{micro_phrase_3}. {fact_interpolation_if_available}.</p>
-<p>Livraison rapide sous 24-48h, paiement securise. Selection par marque, modele et motorisation pour garantir la compatibilite de votre {gamme_name}.</p>
+<p>Selection guidee par marque, modele et motorisation pour garantir la compatibilite de votre {gamme_name}. Filtrez selon votre vehicule pour acceder aux references adaptees.</p>
 ```
 
 **Regles** :
 - Interpoler `include_terms` naturellement dans le texte (pas de keyword stuffing)
 - Utiliser les `micro_phrases` du keyword plan S4 comme base
-- Si evidence_pack disponible : integrer 2-3 facts (prix, marques, specs)
-- Ton : informatif + commercial. Pas de superlatifs ni promesses
+- Si evidence_pack disponible : integrer 2-3 facts (marques, specs, criteres de selection — JAMAIS prix, stock, livraison, promo)
+- Ton : informatif router. Pas de wording transactionnel dominant (panier/stock/livraison/promo). Pas de superlatifs ni promesses
 - Min 700 chars, max 1500 chars
 - Verifier `forbidden_overlap` : aucun terme interdit dans le texte
 
@@ -338,7 +338,7 @@ WHERE rkp.rkp_section_terms IS NOT NULL
 
 1. **Write-only** : ne modifie QUE `__seo_r1_gamme_slots`. **JAMAIS** `__seo_gamme_purchase_guide` (table R6).
 2. **Zero LLM** : pure interpolation depuis keyword plan + RAG. Pas d'appel Groq/OpenAI.
-3. **R1 only** : ton transactionnel (acheter, commander, stock, prix, livraison). Jamais de montage/diagnostic.
+3. **R1 only** : ton router (selection, compatibilite, marques, modeles, motorisations, criteres). Jamais de wording transactionnel dominant (panier/stock/livraison/promo/CTA achat). Jamais de montage (R3), diagnostic (R5), guide d'achat (R6), encyclopedie (R4). Cf. lexique interdit `r1-router-validator.md`.
 4. **Upsert pattern** : `INSERT ... ON CONFLICT (r1s_pg_id) DO UPDATE SET ...` — jamais de simple UPDATE.
 5. **Cannib guard** : chaque contenu verifie contre `R3_FORBIDDEN_IN_R1`. Hard fail si terme detecte.
 6. **Min lengths** : S4 >= 700 chars, S5 >= 60, S7 >= 50, S6 >= 2 rows, S8 >= 50.


### PR DESCRIPTION
## Summary

PR #319 (commit 1220b4b3 / `91aaa7cd`) ferma le drift transactionnel R1 dans le frontmatter `description` (L4) et l'intro (L18) de `r1-content-batch.md`, mais **6 résidus transactionnels persistaient** au HEAD, contredisant le canon `r1-router-validator.md` (section FORBIDDEN : panier, stock, promo, livraison, prix détaillés).

Cette PR aligne les 6 résidus restants sur le canon router R1.

## Changes

| Ligne | Avant | Après |
|-------|-------|-------|
| L16 (titre H1) | `# Agent R1 Content Batch — Generation Contenu Transactionnel` | `# Agent R1 Content Batch — Generation Contenu R1_ROUTER` |
| L30 (axiome) | `**Axiome** : tu ne produis que du contenu **transactionnel** (ACHETER/COMMANDER/STOCK/PRIX/LIVRAISON/COMPATIBILITE/MARQUES)` | `**Axiome** : tu ne produis que du contenu **router R1_ROUTER** (SELECTION/COMPATIBILITE/MARQUES/MODELES/MOTORISATIONS/CRITERES_SELECTION). Jamais de wording transactionnel dominant (panier/stock/promo/livraison/CTA achat)` |
| L116 (S4_MICRO_SEO) | `bloc de texte SEO transactionnel` | `bloc de texte SEO router (selection piece-vehicule, compatibilite)` |
| L122 (template S4) | `Livraison rapide sous 24-48h, paiement securise. Selection par marque...` | `Selection guidee par marque, modele et motorisation pour garantir la compatibilite... Filtrez selon votre vehicule pour acceder aux references adaptees.` |
| L128 (règle evidence_pack) | `integrer 2-3 facts (prix, marques, specs)` | `integrer 2-3 facts (marques, specs, criteres de selection — JAMAIS prix, stock, livraison, promo)` |
| L341 (règle finale #3) | `ton transactionnel (acheter, commander, stock, prix, livraison)` | `ton router (selection, compatibilite, marques, modeles, motorisations, criteres). Jamais de wording transactionnel dominant (panier/stock/livraison/promo/CTA achat)` |

## Why

Vérification d'audit externe (plan `~/.claude/plans/verifier-premier-constat-atomic-turtle.md` rev 2) a confirmé une contradiction documentaire entre :

- [`r1-router-validator.md`](workspaces/seo-batch/.claude/agents/r1-router-validator.md) lignes 32-44 / 54-77 — interdit **prix détaillés, stock, panier, promo, livraison, en stock, ajouter au panier** ; impose "rester non transactionnelle comme promesse principale"
- `r1-content-batch.md` (avant cette PR) — titre, axiome, S4, template et règle finale parlaient de **contenu transactionnel** avec liste explicite ACHETER/COMMANDER/STOCK/PRIX/LIVRAISON

L'agent batch produisait donc des prompts qui auraient fail la validation par le validator canon. Cette PR aligne les deux fichiers.

## Verification

```bash
grep -nE "transactionnel|panier|livraison|promo|stock|prix" \
  workspaces/seo-batch/.claude/agents/r1-content-batch.md
```

Toutes les occurrences restantes après cette PR sont en **contexte d'interdiction explicite** (`Jamais de...`, `JAMAIS prix...`, `Pas de wording transactionnel dominant...`) — alignées sur la section FORBIDDEN du validator. Plus aucune occurrence en contexte de promotion/définition d'identité.

## Scope

- **Aucun changement de comportement runtime** : ce fichier est un prompt agent Claude Code, lu par l'agent à invocation. Le comportement DB / rendering / pipeline reste identique.
- **Aucune modification SQL** : tables, colonnes, RPC, gates inchangés.
- **Diff minimal** : 1 fichier, 7 insertions / 7 suppressions.

## Test plan

- [x] `grep -nE "transactionnel"` ne retourne plus que des contextes d'interdiction (vérifié avant push)
- [x] `grep -nE "Livraison rapide|paiement securise|prix, marques"` retourne 0 ligne
- [x] Diff visuel inspecté
- [ ] Review humain du wording "router" canon vs "transactionnel" (conformité subjective)
- [ ] (Optionnel) Re-run agent r1-content-batch sur 1-2 gammes test pour vérifier que la sortie ne dérive pas vers du diagnostic/montage suite au cadrage modifié

## References

- Plan : `~/.claude/plans/verifier-premier-constat-atomic-turtle.md` (rev 2 — audit verification, 12 claims, claim #2 PARTIALLY SUPERSEDED)
- Canon : [`r1-router-validator.md`](workspaces/seo-batch/.claude/agents/r1-router-validator.md) FORBIDDEN section
- Mémoire ajoutée : `feedback_check_branch_freshness_before_evidence_claim.md` (leçon : `git fetch origin main` avant invoquer git log/grep comme preuve réfutant un user — j'avais initialement défendu le claim "L4/L18 sont résidus" sur une branche stale, l'utilisateur lisant origin/main avait raison)
- Suite : A2 (gap `normalizeRoleId("R1") → null` dans `packages/seo-roles/src/legacy.ts`), B (5 SQL audit coverage R1), C (ADR posture R1 router strict vs commerce-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)