### PR TITLE
fix(ast-grep): quote patterns with colons in headers-with-s-maxage rule (unblocks all TS commits)

### DIFF
--- a/.ast-grep/rules/frontend-no-zero-arg-headers-with-s-maxage.yml
+++ b/.ast-grep/rules/frontend-no-zero-arg-headers-with-s-maxage.yml
@@ -33,8 +33,8 @@ rule:
   all:
     # An exported `headers` whose value is an arrow function with NO parameters.
     - any:
-        - pattern: export const headers: HeadersFunction = () => $BODY
-        - pattern: export const headers = (() => $BODY) as HeadersFunction
+        - pattern: "export const headers: HeadersFunction = () => $BODY"
+        - pattern: "export const headers = (() => $BODY) as HeadersFunction"
     # Whose body mentions s-maxage (the CDN-cache axis we must guard).
     - has:
         regex: 's-maxage'


### PR DESCRIPTION
## Summary

PR #320 (commit `a93b7dcb`) shipped a new ast-grep rule `.ast-grep/rules/frontend-no-zero-arg-headers-with-s-maxage.yml` that contains two unquoted YAML scalars with embedded colons:

```yaml
- pattern: export const headers: HeadersFunction = () => \$BODY
- pattern: export const headers = (() => \$BODY) as HeadersFunction
```

YAML's safe parser treats `headers:` as a nested mapping key, raising:

```
mapping values are not allowed in this context at line 36 column 40
```

This causes `ast-grep scan` (invoked by husky pre-commit) to fail with `Cannot parse rule .ast-grep/rules/frontend-no-zero-arg-headers-with-s-maxage.yml`, **blocking every commit that touches frontend/backend TS files**. Only commits with no TS files were unaffected (which is why PR #320 itself merged).

## Fix

Wrap both patterns in double quotes so YAML treats them as plain string scalars:

```yaml
- pattern: \"export const headers: HeadersFunction = () => \$BODY\"
- pattern: \"export const headers = (() => \$BODY) as HeadersFunction\"
```

**No semantic change to the rule** — the ast-grep patterns themselves are byte-identical, only the YAML encoding changes.

## Verification

- \`python3 -c \"import yaml; yaml.safe_load(open('<file>').read())\"\` — no error (was: ScannerError line 36 col 40)
- \`npx ast-grep scan --config sgconfig.yml --rule <file>\` — loads cleanly
- Diff: 1 file, 2 insertions, 2 deletions (literal quote pairs)

## Why urgent

This hotfix unblocks all contributors. Without it, every PR touching TS files (which is most of them) needs `--no-verify` to commit, which the team doesn't normally allow.

## Test plan

- [x] YAML now parses (`yaml.safe_load`)
- [x] ast-grep loads the rule without error
- [ ] CI green (the rule's intent — flagging zero-arg HeadersFunction with s-maxage — should still trigger correctly; same patterns, same matching)
- [ ] At least one TS commit lands successfully on a downstream branch after merge (proof the hook is unblocked)

## References

- Original rule introduction: PR #320 (commit `a93b7dcb`) — `fix(seo): stop Cloudflare caching loader-thrown 5xx on Remix routes`
- Pre-commit chain: `.husky/pre-commit` → `npm run audit:ast` → ast-grep scans `.ast-grep/rules/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)