### PR TITLE
feat(seo-roles): map frontend short values R0/R1/R2/R4/R5/R7/R8 + R6_GUIDE to canonical RoleId (A2)

### DIFF
--- a/.ast-grep/rules/frontend-no-zero-arg-headers-with-s-maxage.yml
+++ b/.ast-grep/rules/frontend-no-zero-arg-headers-with-s-maxage.yml
@@ -33,8 +33,8 @@ rule:
   all:
     # An exported `headers` whose value is an arrow function with NO parameters.
     - any:
-        - pattern: export const headers: HeadersFunction = () => $BODY
-        - pattern: export const headers = (() => $BODY) as HeadersFunction
+        - pattern: "export const headers: HeadersFunction = () => $BODY"
+        - pattern: "export const headers = (() => $BODY) as HeadersFunction"
     # Whose body mentions s-maxage (the CDN-cache axis we must guard).
     - has:
         regex: 's-maxage'

--- a/log.md
+++ b/log.md
@@ -363,3 +363,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-roles-keyword-intent-canon`
 - **Décision** : feat(seo-roles): keyword-intent canonical SoT @repo/seo-roles@0.3.0 (PR-0C)
 - **Sortie** : PR #317 | commits 94aabb03
+
+## 2026-05-06 — fix/seo-roles-normalize-frontend-shortvalues (auto)
+
+- **Branche** : `fix/seo-roles-normalize-frontend-shortvalues`
+- **Décision** : feat(seo-roles): map frontend short values R0/R1/R2/R4/R5/R7/R8 + R6_GUIDE to canonical RoleId (A2) (+1 other commit)
+- **Sortie** : PR #323 | commits ffe1eb01 9b2c12c4

--- a/packages/seo-roles/package.json
+++ b/packages/seo-roles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/seo-roles",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Single source of truth for canonical SEO page roles (R0..R8). Normalization, display labels, badge colors, branded CanonicalRoleId type, Zod schemas. Legacy accepted in input, canon mandatory in output.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/seo-roles/src/__tests__/normalize.test.ts
+++ b/packages/seo-roles/src/__tests__/normalize.test.ts
@@ -49,6 +49,48 @@ describe("normalizeRoleId", () => {
     });
   });
 
+  describe("frontend short values (page-role.types.ts PageRole enum)", () => {
+    test("maps R0 → R0_HOME", () => {
+      assert.equal(normalizeRoleId("R0"), RoleId.R0_HOME);
+    });
+
+    test("maps R1 → R1_ROUTER", () => {
+      assert.equal(normalizeRoleId("R1"), RoleId.R1_ROUTER);
+    });
+
+    test("maps R2 → R2_PRODUCT", () => {
+      assert.equal(normalizeRoleId("R2"), RoleId.R2_PRODUCT);
+    });
+
+    test("maps R4 → R4_REFERENCE", () => {
+      assert.equal(normalizeRoleId("R4"), RoleId.R4_REFERENCE);
+    });
+
+    test("maps R5 → R5_DIAGNOSTIC", () => {
+      assert.equal(normalizeRoleId("R5"), RoleId.R5_DIAGNOSTIC);
+    });
+
+    test("maps R7 → R7_BRAND", () => {
+      assert.equal(normalizeRoleId("R7"), RoleId.R7_BRAND);
+    });
+
+    test("maps R8 → R8_VEHICLE", () => {
+      assert.equal(normalizeRoleId("R8"), RoleId.R8_VEHICLE);
+    });
+
+    test("maps R6_GUIDE → R6_GUIDE_ACHAT (frontend distinct value)", () => {
+      assert.equal(normalizeRoleId("R6_GUIDE"), RoleId.R6_GUIDE_ACHAT);
+    });
+
+    test("preserves R3 ambiguity discipline (still null)", () => {
+      assert.equal(normalizeRoleId("R3"), null);
+    });
+
+    test("preserves R6 ambiguity discipline (still null)", () => {
+      assert.equal(normalizeRoleId("R6"), null);
+    });
+  });
+
   describe("worker page types", () => {
     test("maps R3_guide_howto → R3_CONSEILS", () => {
       assert.equal(normalizeRoleId("R3_guide_howto"), RoleId.R3_CONSEILS);

--- a/packages/seo-roles/src/legacy.ts
+++ b/packages/seo-roles/src/legacy.ts
@@ -7,9 +7,22 @@ import { RoleId, WorkerPageType } from "./canonical";
  * are intentionally absent — they are ambiguous and must be resolved via URL
  * context (see `RoleDisambiguationService` in backend, not in this pure package).
  *
+ * Frontend short values: the Remix frontend stores `PageRole` enum values as
+ * short strings (`"R0"`, `"R1"`, `"R2"`, `"R4"`, `"R5"`, `"R7"`, `"R8"`) for
+ * historical reasons (cf. `frontend/app/utils/page-role.types.ts`). These
+ * unambiguous shorts are mapped to their canonical RoleId here so analytics
+ * exports / dashboards / GSC integrations can pass through `normalizeRoleId()`
+ * without producing `null`. `"R3"` and `"R6"` shorts remain forbidden — they
+ * stay in `FORBIDDEN_ROLE_IDS` because the frontend uses `R3_BLOG = "R3"` and
+ * `R6_SUPPORT = "R6"` which conflict with `R3_CONSEILS` / `R6_GUIDE_ACHAT`.
+ *
+ * `"R6_GUIDE"` is the frontend-specific value of `PageRole.R6_GUIDE_ACHAT`
+ * (distinct from bare `"R6"`) — mapped here as it is unambiguous.
+ *
  * See `.spec/00-canon/db-governance/legacy-canon-map.md` v1.1.0+
  */
 export const LEGACY_ROLE_ALIASES: Record<string, RoleId> = {
+  // Backend-side legacy aliases
   R3_guide: RoleId.R6_GUIDE_ACHAT,
   R3_guide_achat: RoleId.R6_GUIDE_ACHAT,
   R3_BLOG: RoleId.R3_CONSEILS,
@@ -18,6 +31,16 @@ export const LEGACY_ROLE_ALIASES: Record<string, RoleId> = {
   R4_GLOSSARY: RoleId.R4_REFERENCE,
   R5_diagnostic: RoleId.R5_DIAGNOSTIC,
   R6_BUYING_GUIDE: RoleId.R6_GUIDE_ACHAT,
+  // Frontend short values (PageRole enum values from page-role.types.ts) —
+  // unambiguous shorts only; R3 and R6 stay forbidden (see FORBIDDEN_ROLE_IDS)
+  R0: RoleId.R0_HOME,
+  R1: RoleId.R1_ROUTER,
+  R2: RoleId.R2_PRODUCT,
+  R4: RoleId.R4_REFERENCE,
+  R5: RoleId.R5_DIAGNOSTIC,
+  R7: RoleId.R7_BRAND,
+  R8: RoleId.R8_VEHICLE,
+  R6_GUIDE: RoleId.R6_GUIDE_ACHAT,
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes claim #8 from audit verification (plan `~/.claude/plans/verifier-premier-constat-atomic-turtle.md`) — `normalizeRoleId("R1") → null` gap.

The Remix frontend's `PageRole` enum at [`frontend/app/utils/page-role.types.ts:11-25`](frontend/app/utils/page-role.types.ts) stores short string values:

```ts
export enum PageRole {
  R0_HOME = "R0",
  R1_ROUTER = "R1",
  R2_PRODUCT = "R2",
  R3_BLOG = "R3",      // deprecated/ambiguous
  R3_CONSEILS = "R3_CONSEILS",
  R4_REFERENCE = "R4",
  R5_DIAGNOSTIC = "R5",
  R6_SUPPORT = "R6",   // ambiguous
  R6_GUIDE_ACHAT = "R6_GUIDE",
  R7_BRAND = "R7",
  R8_VEHICLE = "R8",
  ...
}
```

Any analytics export, admin dashboard, or GSC integration that piped a frontend role value through `normalizeRoleId()` got `null`, leading to silent drift in dashboards. After this PR, the 7 unambiguous shorts + the `R6_GUIDE` distinct frontend value normalize to their canonical `RoleId`.

## Changes

| File | Change |
|------|--------|
| [`packages/seo-roles/src/legacy.ts`](packages/seo-roles/src/legacy.ts) | Extended `LEGACY_ROLE_ALIASES` with 8 frontend mappings: `R0`/`R1`/`R2`/`R4`/`R5`/`R7`/`R8` + `R6_GUIDE` |
| [`packages/seo-roles/src/__tests__/normalize.test.ts`](packages/seo-roles/src/__tests__/normalize.test.ts) | Added 10 golden tests (8 positive mappings + 2 anti-regression for `R3`/`R6` still null) |
| [`packages/seo-roles/package.json`](packages/seo-roles/package.json) | Version bump `0.3.0` → `0.4.0` |

## Discipline preserved

`R3` and `R6` bare values stay in `FORBIDDEN_ROLE_IDS` — these frontend enum values (`R3_BLOG="R3"`, `R6_SUPPORT="R6"`) are deprecated/ambiguous on the backend canon side (multiple canonical descendants: `R3_CONSEILS`/`R3_GUIDE` deprecated; `R6_SUPPORT`/`R6_GUIDE_ACHAT`). The frontend has its own resolution path (`LEGACY_PAGE_ROLE_MAP` in `page-role.types.ts`) for these. The canon stays strict.

## Verification

```bash
npm test -w @repo/seo-roles    # 150/150 pass (was 140/140 — added 10 tests)
npm run typecheck -w @repo/seo-roles    # clean
```

Tests cover:

- Positive: `normalizeRoleId("R0")` → `R0_HOME`, `("R1")` → `R1_ROUTER`, `("R2")` → `R2_PRODUCT`, `("R4")` → `R4_REFERENCE`, `("R5")` → `R5_DIAGNOSTIC`, `("R7")` → `R7_BRAND`, `("R8")` → `R8_VEHICLE`, `("R6_GUIDE")` → `R6_GUIDE_ACHAT`
- Anti-regression: `("R3")` → `null` (still ambiguous), `("R6")` → `null` (still ambiguous)

## Stack

This PR is **stacked on [PR #322](https://github.com/ak125/nestjs-remix-monorepo/pull/322)** (ast-grep YAML hotfix that unblocks the pre-commit hook). The base will be re-pointed to `main` once #322 merges. The diff shown here only includes the 3 seo-roles files — the YAML fix is review-isolated in #322.

## Context

This is part A2 of a 4-step plan from audit verification:
- A1 ✅ shipped — [PR #321](https://github.com/ak125/nestjs-remix-monorepo/pull/321) — close R1 transactional drift residuals in `r1-content-batch.md`
- **A2 (this PR)** — close `normalizeRoleId("R1") → null` gap
- B (pending) — execute 5 SQL audit queries to measure R1 coverage / quality empirically
- C (pending) — ADR posture R1 router strict vs commerce-safe (decision after B data)

## Test plan

- [x] All 150 unit tests pass locally
- [x] Typecheck clean
- [x] Diff is purely additive (no existing entries removed/changed in `LEGACY_ROLE_ALIASES`)
- [ ] CI green
- [ ] Optional: smoke-check one frontend export site to confirm `"R1"` now resolves canonical (e.g., admin dashboard, analytics pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)