### PR TITLE
feat(seo-roles): map frontend short values R0/R1/R2/R4/R5/R7/R8 + R6_GUIDE to canonical RoleId (A2 recovery)

### DIFF
--- a/log.md
+++ b/log.md
@@ -363,3 +363,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-roles-keyword-intent-canon`
 - **Décision** : feat(seo-roles): keyword-intent canonical SoT @repo/seo-roles@0.3.0 (PR-0C)
 - **Sortie** : PR #317 | commits 94aabb03
+
+## 2026-05-06 — fix/seo-roles-normalize-frontend-shortvalues (auto)
+
+- **Branche** : `fix/seo-roles-normalize-frontend-shortvalues`
+- **Décision** : feat(seo-roles): map frontend short values R0/R1/R2/R4/R5/R7/R8 + R6_GUIDE to canonical RoleId (A2) (+1 other commit)
+- **Sortie** : PR #323 | commits ffe1eb01 9b2c12c4

--- a/packages/seo-roles/package.json
+++ b/packages/seo-roles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/seo-roles",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Single source of truth for canonical SEO page roles (R0..R8). Normalization, display labels, badge colors, branded CanonicalRoleId type, Zod schemas. Legacy accepted in input, canon mandatory in output.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/seo-roles/src/__tests__/normalize.test.ts
+++ b/packages/seo-roles/src/__tests__/normalize.test.ts
@@ -49,6 +49,48 @@ describe("normalizeRoleId", () => {
     });
   });
 
+  describe("frontend short values (page-role.types.ts PageRole enum)", () => {
+    test("maps R0 → R0_HOME", () => {
+      assert.equal(normalizeRoleId("R0"), RoleId.R0_HOME);
+    });
+
+    test("maps R1 → R1_ROUTER", () => {
+      assert.equal(normalizeRoleId("R1"), RoleId.R1_ROUTER);
+    });
+
+    test("maps R2 → R2_PRODUCT", () => {
+      assert.equal(normalizeRoleId("R2"), RoleId.R2_PRODUCT);
+    });
+
+    test("maps R4 → R4_REFERENCE", () => {
+      assert.equal(normalizeRoleId("R4"), RoleId.R4_REFERENCE);
+    });
+
+    test("maps R5 → R5_DIAGNOSTIC", () => {
+      assert.equal(normalizeRoleId("R5"), RoleId.R5_DIAGNOSTIC);
+    });
+
+    test("maps R7 → R7_BRAND", () => {
+      assert.equal(normalizeRoleId("R7"), RoleId.R7_BRAND);
+    });
+
+    test("maps R8 → R8_VEHICLE", () => {
+      assert.equal(normalizeRoleId("R8"), RoleId.R8_VEHICLE);
+    });
+
+    test("maps R6_GUIDE → R6_GUIDE_ACHAT (frontend distinct value)", () => {
+      assert.equal(normalizeRoleId("R6_GUIDE"), RoleId.R6_GUIDE_ACHAT);
+    });
+
+    test("preserves R3 ambiguity discipline (still null)", () => {
+      assert.equal(normalizeRoleId("R3"), null);
+    });
+
+    test("preserves R6 ambiguity discipline (still null)", () => {
+      assert.equal(normalizeRoleId("R6"), null);
+    });
+  });
+
   describe("worker page types", () => {
     test("maps R3_guide_howto → R3_CONSEILS", () => {
       assert.equal(normalizeRoleId("R3_guide_howto"), RoleId.R3_CONSEILS);

--- a/packages/seo-roles/src/legacy.ts
+++ b/packages/seo-roles/src/legacy.ts
@@ -7,9 +7,22 @@ import { RoleId, WorkerPageType } from "./canonical";
  * are intentionally absent — they are ambiguous and must be resolved via URL
  * context (see `RoleDisambiguationService` in backend, not in this pure package).
  *
+ * Frontend short values: the Remix frontend stores `PageRole` enum values as
+ * short strings (`"R0"`, `"R1"`, `"R2"`, `"R4"`, `"R5"`, `"R7"`, `"R8"`) for
+ * historical reasons (cf. `frontend/app/utils/page-role.types.ts`). These
+ * unambiguous shorts are mapped to their canonical RoleId here so analytics
+ * exports / dashboards / GSC integrations can pass through `normalizeRoleId()`
+ * without producing `null`. `"R3"` and `"R6"` shorts remain forbidden — they
+ * stay in `FORBIDDEN_ROLE_IDS` because the frontend uses `R3_BLOG = "R3"` and
+ * `R6_SUPPORT = "R6"` which conflict with `R3_CONSEILS` / `R6_GUIDE_ACHAT`.
+ *
+ * `"R6_GUIDE"` is the frontend-specific value of `PageRole.R6_GUIDE_ACHAT`
+ * (distinct from bare `"R6"`) — mapped here as it is unambiguous.
+ *
  * See `.spec/00-canon/db-governance/legacy-canon-map.md` v1.1.0+
  */
 export const LEGACY_ROLE_ALIASES: Record<string, RoleId> = {
+  // Backend-side legacy aliases
   R3_guide: RoleId.R6_GUIDE_ACHAT,
   R3_guide_achat: RoleId.R6_GUIDE_ACHAT,
   R3_BLOG: RoleId.R3_CONSEILS,
@@ -18,6 +31,16 @@ export const LEGACY_ROLE_ALIASES: Record<string, RoleId> = {
   R4_GLOSSARY: RoleId.R4_REFERENCE,
   R5_diagnostic: RoleId.R5_DIAGNOSTIC,
   R6_BUYING_GUIDE: RoleId.R6_GUIDE_ACHAT,
+  // Frontend short values (PageRole enum values from page-role.types.ts) —
+  // unambiguous shorts only; R3 and R6 stay forbidden (see FORBIDDEN_ROLE_IDS)
+  R0: RoleId.R0_HOME,
+  R1: RoleId.R1_ROUTER,
+  R2: RoleId.R2_PRODUCT,
+  R4: RoleId.R4_REFERENCE,
+  R5: RoleId.R5_DIAGNOSTIC,
+  R7: RoleId.R7_BRAND,
+  R8: RoleId.R8_VEHICLE,
+  R6_GUIDE: RoleId.R6_GUIDE_ACHAT,
 };
 
 /**


### PR DESCRIPTION
## Summary

**Recovery PR.** [PR #323](https://github.com/ak125/nestjs-remix-monorepo/pull/323) was opened with `base = fix/ast-grep-yaml-quote-headers-rule` (the hotfix branch from PR #322) for stacking purposes. Auto-merge fired before the base could be retargeted to `main`, so #323's changes landed in the **hotfix branch**, not main. The hotfix branch's HEAD now contains the A2 commits but main does not.

This PR cherry-picks the squash commit `2e4b29b6` from the hotfix branch onto a fresh branch off `main`, restoring the intended A2 delivery.

## Content

Identical to PR #323 — see that PR for full rationale and test plan. Quick recap:

- Closes claim #8 from audit verification : `normalizeRoleId("R1") → null` (was) → `R1_ROUTER` (now)
- Extends `LEGACY_ROLE_ALIASES` with 8 frontend short-value mappings (`R0`/`R1`/`R2`/`R4`/`R5`/`R7`/`R8` + `R6_GUIDE`)
- Preserves `R3`/`R6` ambiguity discipline (still `null`)
- 10 new golden tests (8 positive + 2 anti-regression)
- Version bump `0.3.0` → `0.4.0`

## Verification

- [x] Branch is fresh off `origin/main` (no hotfix-branch contamination)
- [x] Cherry-picked commit `2e4b29b6` cleanly applies (4 files, 72 ins, 1 del)
- [x] Tests pass locally (was 150/150 in #323 — content unchanged)
- [ ] CI green
- [ ] Verify hotfix branch `fix/ast-grep-yaml-quote-headers-rule` deletion / cleanup post-merge

## Diff vs main

```
log.md                                              |  6 ++++
packages/seo-roles/package.json                     |  2 +-
packages/seo-roles/src/__tests__/normalize.test.ts  | 42 ++++++++++++++++++++++
packages/seo-roles/src/legacy.ts                    | 23 ++++++++++++
4 files changed, 72 insertions(+), 1 deletion(-)
```

(The `log.md` line is an automatic session-log entry from the Stop hook on the original branch — kept since stripping it would diverge content from #323.)

## Lesson learned

`gh pr edit --base` currently fails silently (GraphQL Projects classic deprecation issue). When stacking PRs and depending on `gh pr edit --base main` to retarget post-merge, the operation may not actually fire — leaving auto-merge to consume the original (non-main) base. Mitigation: use `gh api -X PATCH /repos/.../pulls/N -f base=main` directly, which fails fast with a clear validation error if the PR is in a state that disallows base changes.

A memory entry will be added to track this gotcha.

## References

- Misrouted PR : [#323](https://github.com/ak125/nestjs-remix-monorepo/pull/323) (merged into hotfix branch by mistake)
- Hotfix : [#322](https://github.com/ak125/nestjs-remix-monorepo/pull/322) (already in main)
- Plan : `~/.claude/plans/verifier-premier-constat-atomic-turtle.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)