### PR TITLE
fix(ci): source preprod .env in deploy step to prevent env stripping on manual rerun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,6 +751,20 @@ jobs:
 
           echo "✅ .env.preprod generated (anon key only, no SERVICE_ROLE_KEY, READ_ONLY=true)"
 
+          # Source the just-generated .env into the shell. docker-compose.preprod.yml
+          # uses bare `environment: - SUPABASE_URL` style refs which inherit from the
+          # shell at compose-invocation time and OVERRIDE env_file when shell has no
+          # value. CI's job-level `env:` block already sets SUPABASE_*, but explicit
+          # sourcing here makes the deploy step robust to manual reruns from a shell
+          # that doesn't have those vars (e.g. `sudo -u deploy ... --force-recreate`
+          # outside of CI). Discovered post-PR-B redeploy 2026-05-06: a manual rerun
+          # had stripped SUPABASE_ANON_KEY from container, surfaced via Sentry as
+          # repeated 401 "Invalid API key" — which is exactly what observability is for.
+          set -a
+          # shellcheck disable=SC1091
+          . "$PREPROD_DIR/.env"
+          set +a
+
           # Arreter anciens conteneurs
           docker stop nestjs-remix-monorepo-preprod redis-preprod 2>/dev/null || true
           docker rm nestjs-remix-monorepo-preprod redis-preprod 2>/dev/null || true

--- a/log.md
+++ b/log.md
@@ -369,3 +369,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/observability-sentry-dev`
 - **Décision** : feat(observability): Sentry wiring + SOPS+age secret management infra
 - **Sortie** : PR #324 | commits aaa59617
+
+## 2026-05-06 — chore/trigger-redeploy-sentry-fix (auto)
+
+- **Branche** : `chore/trigger-redeploy-sentry-fix`
+- **Décision** : fix(ci): source preprod .env in deploy step to prevent env stripping on manual rerun
+- **Sortie** : PR #329 | commits a008b0fe


### PR DESCRIPTION
## Why

Hours after PR-B (#327) merged, Sentry caught its first real production bug — but the bug was caused **by my own #327 wrapper combined with a manual `--force-recreate` outside CI**. This PR fixes the wrapper.

## Root cause

docker-compose.preprod.yml uses bare \`environment: - SUPABASE_URL\` refs which inherit values from the shell at compose-invocation time. When the shell has no value, docker compose v2 **overrides** the env_file value with "unset" — leaving the container without the var.

CI's job-level \`env:\` block sets SUPABASE_URL/SUPABASE_ANON_KEY, so this was invisible until a manual rerun.

## What surfaced this

Right after #327 merged, the operator was asked to run on 49.12.233.2:

\`\`\`bash
sudo -u deploy bash -c 'sops exec-env ... docker compose up -d --force-recreate'
\`\`\`

The \`deploy\` user's shell had no SUPABASE_* vars. The wrapper successfully injected SENTRY_* via sops, **but the bare \`- SUPABASE_URL\` etc. resolved to empty in the container** — Supabase calls cascaded into 401 "Invalid API key".

Sentry caught the resulting 401 cascade within 17 seconds of container start :
- Issue id \`2a32cd25\` ([Sentry UI](https://auto-pieces-equipement.sentry.io/issues/?project=automecanik-backend-dev))
- Mechanism: \`auto.function.nestjs.exception_captured\` (= the \`@SentryExceptionCaptured()\` decorator from PR-A)
- Transaction: \`GET /api/vehicles/brands\`
- 3 events in 30s, all from headless Chrome (Lighthouse hitting the warm-up paths)

This is **exactly** what observability is for — the bug would otherwise have been silent until a user complaint.

## Fix

Add \`set -a; . \"\$PREPROD_DIR/.env\"; set +a\` immediately after the \`.env\` heredoc generation. The shell now has the values regardless of whether it inherited them from CI's \`env:\` block or not. Idempotent in CI, corrective for manual reruns.

\`\`\`yaml
# Source the just-generated .env into the shell. docker-compose.preprod.yml
# uses bare \`environment: - SUPABASE_URL\` style refs which inherit from the
# shell at compose-invocation time and OVERRIDE env_file when shell has no
# value. CI's job-level \`env:\` block already sets SUPABASE_*, but explicit
# sourcing here makes the deploy step robust to manual reruns from a shell
# that doesn't have those vars (e.g. \`sudo -u deploy ... --force-recreate\`
# outside of CI).
set -a
. \"\$PREPROD_DIR/.env\"
set +a
\`\`\`

## Validation post-merge

1. CI deploy job logs show \`✅ Injecting Sentry secrets via sops exec-env\` (already worked in #327)
2. \`curl http://49.12.233.2:3200/api/vehicles/brands\` returns 200 with real data (was failing with 401 cascade before)
3. Sentry issue \`2a32cd25\` should NOT receive new occurrences after redeploy
4. \`docker exec nestjs-remix-monorepo-preprod env\` should show BOTH \`SENTRY_DSN\` and \`SUPABASE_ANON_KEY\` present

## Why this is +14 lines and not more

The simplest, most surgical fix. Alternatives considered:

- **Remove bare \`- VAR\` from compose** : would lose the explicit allowlist of which vars reach the container (security audit posture)
- **Replace with \`\${VAR:?}\` mandatory syntax** : fails the deploy hard if env missing — too aggressive
- **Source \`.env\` only in fallback path** : doesn't help the SOPS path

Sourcing \`.env\` into the deploy shell is idempotent and matches the existing intent (env_file is already wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)