### PR TITLE
fix(admin): unify role labels via @repo/seo-roles in 3 admin routes

### DIFF
--- a/frontend/app/routes/admin.content-refresh.tsx
+++ b/frontend/app/routes/admin.content-refresh.tsx
@@ -9,7 +9,11 @@ import {
   useLoaderData,
   useSearchParams,
 } from "@remix-run/react";
-import { getRoleDisplayLabel } from "@repo/seo-roles";
+import {
+  getRoleDisplayLabel,
+  PAGE_TYPE_TO_ROLE,
+  type WorkerPageType,
+} from "@repo/seo-roles";
 import {
   RefreshCw,
   Check,
@@ -156,14 +160,16 @@ const REFRESH_STATUS: Record<string, StatusType> = {
   skipped: "NEUTRAL",
 };
 
-const PAGE_TYPE_LABELS: Record<string, string> = {
-  R1_pieces: "R1 Pieces",
-  R3_conseils: "R3 Conseils",
-  R3_guide_howto: "R3 Guide How-To",
-  R4_reference: "R4 Reference",
-  R5_diagnostic: "R5 Diagnostic",
-  R6_guide_achat: "R6 Guide Achat",
-};
+// __rag_content_refresh_log.page_type lives across worker page types except
+// product/brand/vehicle pages (handled by separate refresh pipelines).
+const NON_RAG_REFRESH_PAGE_TYPES: ReadonlySet<WorkerPageType> = new Set([
+  "R2_product",
+  "R7_brand",
+  "R8_vehicle",
+]);
+const RAG_REFRESH_FILTER_PAGE_TYPES = (
+  Object.keys(PAGE_TYPE_TO_ROLE) as WorkerPageType[]
+).filter((pt) => !NON_RAG_REFRESH_PAGE_TYPES.has(pt));
 
 // ── Helpers ──
 
@@ -442,8 +448,7 @@ export default function AdminContentRefresh() {
       header: "Page Type",
       render: (_val, row) => (
         <Badge variant="outline" className="text-xs font-mono">
-          {PAGE_TYPE_LABELS[row.page_type] ??
-            getRoleDisplayLabel(row.page_type)}
+          {getRoleDisplayLabel(row.page_type)}
         </Badge>
       ),
     },
@@ -718,11 +723,11 @@ export default function AdminContentRefresh() {
                 className="h-9 rounded-md border border-input bg-background px-3 text-sm"
               >
                 <SelectItem value="">Tous</SelectItem>
-                <SelectItem value="R1_pieces">R1 Pieces</SelectItem>
-                <SelectItem value="R3_conseils">R3 Conseils</SelectItem>
-                <SelectItem value="R3_guide_howto">R3 Guide How-To</SelectItem>
-                <SelectItem value="R4_reference">R4 Reference</SelectItem>
-                <SelectItem value="R5_diagnostic">R5 Diagnostic</SelectItem>
+                {RAG_REFRESH_FILTER_PAGE_TYPES.map((pt) => (
+                  <SelectItem key={pt} value={pt}>
+                    {getRoleDisplayLabel(pt)}
+                  </SelectItem>
+                ))}
               </Select>
             </div>
             <div className="flex items-end gap-2">

--- a/frontend/app/routes/admin.rag.cockpit.tsx
+++ b/frontend/app/routes/admin.rag.cockpit.tsx
@@ -4,7 +4,7 @@ import {
   type MetaFunction,
 } from "@remix-run/node";
 import { Link, useFetcher, useLoaderData } from "@remix-run/react";
-import { getRoleDisplayLabel } from "@repo/seo-roles";
+import { getRoleDisplayLabel, getRoleShortLabel } from "@repo/seo-roles";
 import {
   Activity,
   AlertTriangle,
@@ -278,28 +278,6 @@ const QUALITY_STATUS_LABELS: Record<string, string> = {
   PENDING: "Non calcule",
 };
 
-const PAGE_TYPE_LABELS: Record<string, string> = {
-  R1_pieces: "Transactionnel",
-  R3_conseils: "Conseils DIY",
-  R3_guide_howto: "Guide How-To",
-  R4_reference: "Reference",
-  R5_diagnostic: "Diagnostic",
-  R6_guide_achat: "Guide d'achat",
-  // legacy aliases (DB backward compat)
-  R3_guide: "Guide d'achat",
-};
-
-const PAGE_TYPE_SHORT: Record<string, string> = {
-  R1_pieces: "R1",
-  R3_conseils: "R3c",
-  R3_guide_howto: "R3h",
-  R4_reference: "R4",
-  R5_diagnostic: "R5",
-  R6_guide_achat: "R6",
-  // legacy alias
-  R3_guide: "R6",
-};
-
 const DIMENSION_LABELS: Record<string, string> = {
   content_depth: "Contenu",
   seo_technical: "SEO",
@@ -544,8 +522,7 @@ function FeatureChip({ fd, value }: { fd: FeatureDisplay; value: unknown }) {
 
 function PageScoreCard({ ps }: { ps: PageScore }) {
   const [showDetails, setShowDetails] = useState(false);
-  const label =
-    PAGE_TYPE_LABELS[ps.page_type] ?? getRoleDisplayLabel(ps.page_type);
+  const label = getRoleDisplayLabel(ps.page_type);
   const statusLabel = QUALITY_STATUS_LABELS[ps.status] || ps.status;
   const statusType = QUALITY_STATUS_MAP[ps.status] || "NEUTRAL";
 
@@ -583,7 +560,7 @@ function PageScoreCard({ ps }: { ps: PageScore }) {
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
           <Badge variant="outline" className="text-[10px] font-mono px-1.5">
-            {PAGE_TYPE_SHORT[ps.page_type] || ps.page_type}
+            {getRoleShortLabel(ps.page_type)}
           </Badge>
           <span className="text-xs font-medium">{label}</span>
         </div>
@@ -720,7 +697,7 @@ function GammeExpandedRow({ row }: { row: GammeScore }) {
             <div className="flex gap-1 mt-1">
               {row.missing_page_types.map((pt) => (
                 <Badge key={pt} variant="outline" className="text-[10px]">
-                  {PAGE_TYPE_LABELS[pt] ?? getRoleDisplayLabel(pt)}
+                  {getRoleDisplayLabel(pt)}
                 </Badge>
               ))}
             </div>
@@ -974,8 +951,7 @@ export default function AdminRagCockpit() {
       header: "Type de page",
       render: (_val, row) => (
         <Badge variant="outline" className="text-xs">
-          {PAGE_TYPE_LABELS[row.page_type] ??
-            getRoleDisplayLabel(row.page_type)}
+          {getRoleDisplayLabel(row.page_type)}
         </Badge>
       ),
     },
@@ -1108,7 +1084,7 @@ export default function AdminRagCockpit() {
                 key={cat}
                 className="text-[9px] bg-muted px-1 py-0.5 rounded"
               >
-                {PAGE_TYPE_SHORT[cat] || cat}: {count}
+                {getRoleShortLabel(cat)}: {count}
               </span>
             ))}
           </div>

--- a/frontend/app/routes/admin.rag.pipeline.tsx
+++ b/frontend/app/routes/admin.rag.pipeline.tsx
@@ -9,7 +9,13 @@ import {
   useRevalidator,
   useSearchParams,
 } from "@remix-run/react";
-import { getRoleDisplayLabel } from "@repo/seo-roles";
+import {
+  getRoleDisplayLabel,
+  pageTypeToRoleId,
+  PAGE_TYPE_TO_ROLE,
+  RoleId,
+  type WorkerPageType,
+} from "@repo/seo-roles";
 import {
   RefreshCw,
   Check,
@@ -283,22 +289,21 @@ const REFRESH_STATUS: Record<string, StatusType> = {
   skipped: "NEUTRAL",
 };
 
-const PAGE_TYPE_LABELS: Record<string, string> = {
-  R1_pieces: "R1 Pieces",
-  R3_conseils: "R3 Conseils",
-  R3_guide_howto: "R3 Guide",
-  R4_reference: "R4 Reference",
-  R5_diagnostic: "R5 Diagnostic",
-  R6_guide_achat: "R6 Guide Achat",
-};
+// __rag_content_refresh_log.page_type lives across worker page types except
+// product/brand/vehicle pages (handled by separate refresh pipelines).
+const NON_RAG_REFRESH_PAGE_TYPES: ReadonlySet<WorkerPageType> = new Set([
+  "R2_product",
+  "R7_brand",
+  "R8_vehicle",
+]);
+const RAG_REFRESH_PAGE_TYPES = (
+  Object.keys(PAGE_TYPE_TO_ROLE) as WorkerPageType[]
+).filter((pt) => !NON_RAG_REFRESH_PAGE_TYPES.has(pt));
 
-const PAGE_TYPE_OPTIONS = [
-  { value: "R1_pieces", label: "R1 Pieces" },
-  { value: "R3_conseils", label: "R3 Conseils" },
-  { value: "R3_guide_howto", label: "R3 Guide How-To" },
-  { value: "R4_reference", label: "R4 Reference" },
-  { value: "R6_guide_achat", label: "R6 Guide Achat" },
-] as const;
+const PAGE_TYPE_OPTIONS = RAG_REFRESH_PAGE_TYPES.map((value) => ({
+  value,
+  label: getRoleDisplayLabel(value),
+}));
 
 const GATE_LABELS: Record<string, string> = {
   attribution: "Attribution des sources",
@@ -1132,7 +1137,10 @@ export default function AdminRagPipeline() {
   const [kpOpen, setKpOpen] = useState(false);
 
   const r1Items = useMemo(
-    () => items.filter((i) => i.page_type === "R1_pieces"),
+    () =>
+      items.filter(
+        (i) => pageTypeToRoleId(i.page_type) === RoleId.R1_ROUTER,
+      ),
     [items],
   );
   const r1DraftItems = useMemo(
@@ -1236,7 +1244,7 @@ export default function AdminRagPipeline() {
         return (
           <div className="flex items-center gap-1.5">
             <span className="text-sm font-medium">{String(val)}</span>
-            {item.page_type === "R1_pieces" && (
+            {pageTypeToRoleId(item.page_type) === RoleId.R1_ROUTER && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -1258,7 +1266,7 @@ export default function AdminRagPipeline() {
       header: "Type",
       render: (val) => (
         <Badge variant="outline" className="font-mono text-xs">
-          {PAGE_TYPE_LABELS[val as string] ?? getRoleDisplayLabel(String(val))}
+          {getRoleDisplayLabel(String(val))}
         </Badge>
       ),
     },
@@ -1957,13 +1965,11 @@ export default function AdminRagPipeline() {
                     className="h-9 rounded-md border border-input bg-background px-3 text-sm"
                   >
                     <SelectItem value="">Tous</SelectItem>
-                    <SelectItem value="R1_pieces">R1 Pieces</SelectItem>
-                    <SelectItem value="R3_conseils">R3 Conseils</SelectItem>
-                    <SelectItem value="R3_guide_howto">
-                      R3 Guide How-To
-                    </SelectItem>
-                    <SelectItem value="R4_reference">R4 Reference</SelectItem>
-                    <SelectItem value="R5_diagnostic">R5 Diagnostic</SelectItem>
+                    {RAG_REFRESH_PAGE_TYPES.map((pt) => (
+                      <SelectItem key={pt} value={pt}>
+                        {getRoleDisplayLabel(pt)}
+                      </SelectItem>
+                    ))}
                   </Select>
                 </div>
                 <div className="space-y-1.5 sm:w-52">

--- a/packages/seo-roles/src/__tests__/display.test.ts
+++ b/packages/seo-roles/src/__tests__/display.test.ts
@@ -47,6 +47,26 @@ describe("getRoleDisplayLabel — legacy → canonical FR", () => {
   test("R6_BUYING_GUIDE → 'R6 · Guide d'achat'", () => {
     assert.equal(getRoleDisplayLabel("R6_BUYING_GUIDE"), "R6 · Guide d'achat");
   });
+
+  test("R3_guide_achat → 'R6 · Guide d'achat'", () => {
+    assert.equal(getRoleDisplayLabel("R3_guide_achat"), "R6 · Guide d'achat");
+  });
+
+  test("R3_conseils → 'R3 · Conseils'", () => {
+    assert.equal(getRoleDisplayLabel("R3_conseils"), "R3 · Conseils");
+  });
+
+  test("R6_guide_achat → 'R6 · Guide d'achat'", () => {
+    assert.equal(getRoleDisplayLabel("R6_guide_achat"), "R6 · Guide d'achat");
+  });
+
+  test("R4_reference → 'R4 · Référence'", () => {
+    assert.equal(getRoleDisplayLabel("R4_reference"), "R4 · Référence");
+  });
+
+  test("R5_diagnostic → 'R5 · Diagnostic'", () => {
+    assert.equal(getRoleDisplayLabel("R5_diagnostic"), "R5 · Diagnostic");
+  });
 });
 
 describe("getRoleDisplayLabel — R6 ambigu", () => {
@@ -125,6 +145,26 @@ describe("getRoleShortLabel", () => {
 
   test("legacy R3_BLOG → 'R3'", () => {
     assert.equal(getRoleShortLabel("R3_BLOG"), "R3");
+  });
+
+  test("legacy R3_guide → 'R6'", () => {
+    assert.equal(getRoleShortLabel("R3_guide"), "R6");
+  });
+
+  test("legacy R3_guide_howto → 'R3'", () => {
+    assert.equal(getRoleShortLabel("R3_guide_howto"), "R3");
+  });
+
+  test("page_type R6_guide_achat → 'R6'", () => {
+    assert.equal(getRoleShortLabel("R6_guide_achat"), "R6");
+  });
+
+  test("page_type R4_reference → 'R4'", () => {
+    assert.equal(getRoleShortLabel("R4_reference"), "R4");
+  });
+
+  test("page_type R5_diagnostic → 'R5'", () => {
+    assert.equal(getRoleShortLabel("R5_diagnostic"), "R5");
   });
 
   test("null input → '—'", () => {


### PR DESCRIPTION
## Summary

`admin.rag.cockpit.tsx`, `admin.content-refresh.tsx` and `admin.rag.pipeline.tsx` each kept local `PAGE_TYPE_LABELS` / `PAGE_TYPE_SHORT` maps that **shadowed** `@repo/seo-roles` canonical helpers — even though all three already imported `getRoleDisplayLabel`. Result: the same `page_type` rendered with three divergent labels.

| `page_type` | cockpit | content-refresh | pipeline | canon |
|-------------|---------|-----------------|----------|-------|
| `R3_conseils` | "Conseils DIY" | "R3 Conseils" | "R3 Conseils" | **R3 · Conseils** |
| `R3_guide_howto` | "Guide How-To" | "R3 Guide How-To" | "R3 Guide" | **R3 · Conseils** |
| `R6_guide_achat` | "Guide d'achat" | "R6 Guide Achat" | "R6 Guide Achat" | **R6 · Guide d'achat** |
| `R3_guide` (legacy) | "Guide d'achat" | absent | absent | **R6 · Guide d'achat** |

## Changes

- **Drop the 3 shadow maps.** Display routes through `getRoleDisplayLabel` / `getRoleShortLabel`. Legacy `R3_guide` is normalized to `R6 · Guide d'achat` by canon `LEGACY_ROLE_ALIASES` — no local hardcode needed.
- **Replace hardcoded SelectItem lists** in `content-refresh.tsx` and `pipeline.tsx` (and `PAGE_TYPE_OPTIONS` trigger array in pipeline) with `Object.keys(PAGE_TYPE_TO_ROLE)` filtered to the RAG-eligible subset (excludes `R2_product` / `R7_brand` / `R8_vehicle` which have separate refresh pipelines). One source list, canonical labels, zero literal drift.
- **Replace `i.page_type === "R1_pieces"` comparisons** in `pipeline.tsx` with `pageTypeToRoleId(i.page_type) === RoleId.R1_ROUTER` (canon-mediated).
- **Extend `packages/seo-roles` regression tests** with 10 cases covering every `page_type` the three admin routes send through the canon. Drift in `LEGACY_ROLE_ALIASES` / `PAGE_TYPE_TO_ROLE` / `CANONICAL_DISPLAY_LABELS` now breaks CI in the SoT, not in admin.

## Behaviour change

Bare `R6` page_type values (rare, ambiguous) now render as `"R6 · Legacy à qualifier"` instead of the raw string. Surfaces existing DB drift instead of masking it.

## Out of scope (separate follow-ups)

- `frontend/app/routes/admin.keyword-planner.tsx` hardcodes a different list (`{key: "r1", label: "R1 Achat"}` ...) using lowercase short keys and UX-compact labels — needs product scoping before swapping to canon.
- `backend/src/modules/blog/blog.module.ts` `R3GuideController` / `R3GuideService` rename must follow the deprecate-30d-then-rename pattern (touches `/api/r3-guide` routes consumed by frontend).

## Refs

- `@repo/seo-roles@0.4.0` (PR-stack #304-#319, `seo-roles-canon-shipped-20260505`)
- `r1-drift-canon-shipped-20260506`

## Test plan

- [x] `npm run typecheck -w packages/seo-roles` — clean
- [x] `npm test -w packages/seo-roles` — 160/160 (10 new cases pass)
- [x] `npx tsc` (frontend) on the 3 modified routes — 0 errors
- [x] `npx eslint --max-warnings=0` on the 3 modified routes — 0 warnings (legacy literal regex no longer triggers)
- [ ] DEV preprod smoke `/admin/rag/cockpit` + `/admin/content-refresh` + `/admin/rag/pipeline` — confirm `R3 · Conseils`, `R6 · Guide d'achat`, `R4 · Référence`, `R5 · Diagnostic` render correctly
- [ ] DEV preprod smoke filter dropdowns — same canonical labels in options as in table column

🤖 Generated with [Claude Code](https://claude.com/claude-code)