### PR TITLE
chore(blog): mark R3GuideController/Service/interfaces @deprecated (PR-1, ADR-044)

### DIFF
--- a/backend/src/modules/blog/blog.module.ts
+++ b/backend/src/modules/blog/blog.module.ts
@@ -72,7 +72,7 @@ import { SeoModule } from '../seo/seo.module';
   ],
   controllers: [
     BlogController, // API générale blog et recherche
-    R3GuideController, // R3 page engine — single endpoint /api/r3-guide/:pg_alias
+    R3GuideController, // R3_CONSEILS page engine — single endpoint /api/r3-guide/:pg_alias. @deprecated misnamed (canon = R3_CONSEILS), rename → R3ConseilsController post-2026-06-05 per ADR-044.
     R6GuideController, // R6 guide d'achat — single endpoint /api/r6-guide/:pg_alias
     AdviceController, // Endpoints spécifiques conseils
     AdviceHierarchyController, // Hiérarchie conseils par famille catalogue
@@ -100,7 +100,7 @@ import { SeoModule } from '../seo/seo.module';
     ConstructeurTransformService,
     AdviceTransformService,
     AdviceEnrichmentService,
-    R3GuideService, // R3 page engine orchestrator
+    R3GuideService, // R3_CONSEILS page engine orchestrator. @deprecated misnamed (canon = R3_CONSEILS), rename → R3ConseilsService post-2026-06-05 per ADR-044.
     R6GuideService, // R6 guide d'achat orchestrator
   ],
   exports: [

--- a/backend/src/modules/blog/controllers/r3-guide.controller.ts
+++ b/backend/src/modules/blog/controllers/r3-guide.controller.ts
@@ -1,6 +1,12 @@
 /**
  * R3GuideController — Single endpoint for R3 conseil guide pages.
  * GET /api/r3-guide/:pg_alias → R3GuidePayload
+ *
+ * @deprecated Misnamed legacy: serves R3_CONSEILS canonical content (per
+ * @repo/seo-roles), not the deprecated R3_GUIDE role. Will be renamed to
+ * `R3ConseilsController @Controller('api/r3-conseils')` after a 30-day
+ * deprecation window. See ADR-044 (vault). Do not extend this controller —
+ * add new endpoints to its successor when it lands.
  */
 
 import { Controller, Get, Param, Logger } from '@nestjs/common';
@@ -11,6 +17,10 @@ import {
 } from '@common/exceptions';
 import { getErrorMessage } from '@common/utils/error.utils';
 
+/**
+ * @deprecated See file-level note. Replacement: `R3ConseilsController`
+ * (post-2026-06-05, per ADR-044).
+ */
 @Controller('api/r3-guide')
 export class R3GuideController {
   private readonly logger = new Logger(R3GuideController.name);

--- a/backend/src/modules/blog/interfaces/r3-guide.interfaces.ts
+++ b/backend/src/modules/blog/interfaces/r3-guide.interfaces.ts
@@ -1,10 +1,18 @@
 /**
  * R3 Guide Page Engine — Typed payload contract.
  * Single endpoint GET /api/r3-guide/:pg_alias returns this structure.
+ *
+ * @deprecated Misnamed legacy: this contract serves R3_CONSEILS canonical
+ * content (per @repo/seo-roles), not the deprecated R3_GUIDE role. Will be
+ * renamed to `R3ConseilsPage` / `R3ConseilsPayload` after a 30-day
+ * deprecation window (post-2026-06-05). See ADR-044 (vault).
  */
 
 import type { BlogArticle } from './blog.interfaces';
 
+/**
+ * @deprecated Renamed to `R3ConseilsPage` post-2026-06-05 per ADR-044.
+ */
 export interface R3GuidePage {
   pg_alias: string;
   pg_id: number;

--- a/backend/src/modules/blog/services/r3-guide.service.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.ts
@@ -2,6 +2,12 @@
  * R3GuideService — Page engine orchestrator for R3 conseil guide pages.
  * Single method composes 5 existing services into one typed R3GuidePayload.
  * Replaces 5 separate HTTP calls from the Remix route.
+ *
+ * @deprecated Misnamed legacy: serves R3_CONSEILS canonical content (per
+ * @repo/seo-roles), not the deprecated R3_GUIDE role. Will be renamed to
+ * `R3ConseilsService` after a 30-day deprecation window (post-2026-06-05).
+ * See ADR-044 (vault). Do not extend this service — its successor will
+ * delegate here during the rename phase.
  */
 
 import { Injectable, Logger } from '@nestjs/common';
@@ -26,6 +32,10 @@ import {
 import { PRIX_PAS_CHER } from '../../seo/seo-v4.types';
 import { InternalLinkingService } from '../../seo/internal-linking.service';
 
+/**
+ * @deprecated See file-level note. Replacement: `R3ConseilsService`
+ * (post-2026-06-05, per ADR-044).
+ */
 @Injectable()
 export class R3GuideService {
   private readonly logger = new Logger(R3GuideService.name);


### PR DESCRIPTION
## Summary

Phase 1 of the deprecate-then-rename plan for the misnamed backend triplet `R3GuideController` / `R3GuideService` / `R3GuidePage`. These symbols actually serve **R3_CONSEILS** canonical content (per `@repo/seo-roles`), not the deprecated `R3_GUIDE` role:

- The Remix consumer route is already named `blog-pieces-auto.conseils.$pg_alias.tsx`
- The validator backend method is already `validateR3Conseils()`
- Only the backend module triplet is still legacy

## Changes

**No behavior change. No file rename. No route change.**

- `@deprecated` JSDoc + rename pointer on `R3GuideController` class + file (`r3-guide.controller.ts`)
- `@deprecated` JSDoc + rename pointer on `R3GuideService` class + file (`r3-guide.service.ts`)
- `@deprecated` JSDoc + rename pointer on `R3GuidePage` interface + file (`r3-guide.interfaces.ts`)
- `@deprecated` inline comments on `R3GuideController` / `R3GuideService` entries in `blog.module.ts`

**Effect**: IDE/LSP shows the `@deprecated` hint to any consumer of these symbols, signalling the upcoming rename. No runtime impact.

## Phase plan (per ADR-043)

| Phase | When | Scope |
|-------|------|-------|
| 1 (this PR) | T0 = 2026-05-06 | `@deprecated` JSDoc IN-PLACE |
| 2 | T0 + 30d = 2026-06-05 | Create `R3ConseilsController @Controller('api/r3-conseils')` delegating to `R3GuideService`, migrate frontend consumer, keep `/api/r3-guide` as backward-compat alias |
| 3 | T0 + 60d = 2026-07-05 | Drop the alias once `/api/r3-guide` receives 0 requests on 7 consecutive days |

## Refs

- ADR-043 (vault PR — opened in parallel) — full plan + promotion criteria
- PR #330 (R3 label normalization admin) — Phase 0 of the R3 cleanup
- `@repo/seo-roles@0.4.0` (PR-stack #304-#319, ADR-040)

## Test plan

- [x] No code path changed; `@deprecated` is JSDoc-only
- [x] `grep -c "@deprecated"` returns 2 in each of 4 files
- [ ] CI typecheck (`tsc`) — `@deprecated` is non-blocking for compilation
- [ ] CI ESLint — `@deprecated` is non-blocking
- [ ] Existing tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)