### PR TITLE
feat(seo-types): export GA4_CHANNEL_CANON const for sessionDefaultChannelGroup

### DIFF
--- a/packages/seo-types/src/observability.ts
+++ b/packages/seo-types/src/observability.ts
@@ -43,10 +43,51 @@ export type GSCTimeseriesResponse = z.infer<typeof GSCTimeseriesResponseSchema>;
 
 // ─── GA4 Data API ────────────────────────────────────────────────────────
 
+/**
+ * GA4 `sessionDefaultChannelGroup` canonical values (lowercased).
+ *
+ * Reference: GA4 Default channel group, 19 standard values returned by the
+ * Data API dimension `sessionDefaultChannelGroup`. The fetcher service
+ * (`ga4-daily-fetcher.service.ts:133`) lowercases the value before insert,
+ * so this canon mirrors that normalization.
+ *
+ * Schema below stays permissive (`z.string()`) to absorb new channels GA4
+ * may add over time — this const is the documented expectation, not a
+ * runtime enum gate. Consumers wanting strict validation can build a
+ * `z.enum(GA4_CHANNEL_CANON)` schema locally.
+ */
+export const GA4_CHANNEL_CANON = [
+  "direct",
+  "organic search",
+  "paid search",
+  "display",
+  "paid social",
+  "organic social",
+  "referral",
+  "email",
+  "affiliates",
+  "audio",
+  "video",
+  "cross-network",
+  "sms",
+  "mobile push notifications",
+  "unassigned",
+  "organic shopping",
+  "paid shopping",
+  "paid other",
+  "organic video",
+] as const;
+export type GA4ChannelCanon = (typeof GA4_CHANNEL_CANON)[number];
+
 /** One row of GA4 daily data — one (date, page, channel) tuple. */
 export const GA4DailyRowSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   page: z.string().url(),
+  /**
+   * GA4 default channel group, lowercased by the fetcher. Not enum-gated
+   * because GA4 may add new channels (e.g. "audio" was added 2024). See
+   * `GA4_CHANNEL_CANON` for the documented expected values.
+   */
   channel: z.string().default("organic"),
   sessions: z.number().int().nonnegative(),
   conversions: z.number().int().nonnegative(),


### PR DESCRIPTION
Adds `GA4_CHANNEL_CANON` exported const (19 lowercased values) + type alias `GA4ChannelCanon` to `packages/seo-types/src/observability.ts`.

GA4 Data API dimension `sessionDefaultChannelGroup` returns 19 standard channel-group values. Fetcher (`ga4-daily-fetcher.service.ts:133`) lowercases each before upsert. This const documents the expectation.

**Empirical prod (2026-05-06, 6400 rows / 33 days)** : direct 3212, organic search 3034, referral 116, unassigned 38. All ⊂ canon.

**Schema stays permissive** : `channel: z.string()` not `z.enum(...)` — GA4 adds new channels over time ("audio" 2024). Locking with enum would break ingest on value #20. Consumers wanting strict validation can extend locally : `z.enum(GA4_CHANNEL_CANON)`.

Pattern parallèle à `device: z.enum(["all","mobile","desktop","tablet"])` ligne 21, mais adapté à open-list canon GA4.

Diff purement additif (+41 / -0), aucun type signature changé. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)