### PR TITLE
chore(auth): session secret fail-fast in prod + random fallback in dev (Sprint 1)

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -75,20 +75,49 @@ async function bootstrap() {
       throw new Error('SESSION_SECRET requis en production');
     }
 
-    // SECURITE: Vérifier que SESSION_SECRET est configuré
-    const sessionSecret = process.env.SESSION_SECRET;
-    if (!sessionSecret || sessionSecret === '123') {
-      logger.warn(
-        'ALERTE SECURITE: SESSION_SECRET non configuré ou utilise la valeur par défaut!',
-      );
-      logger.warn('Générez un secret sécurisé avec: openssl rand -base64 32');
-      logger.warn('Ajoutez-le dans votre fichier .env');
+    // SECURITE: SESSION_SECRET fail-fast en non-DEV + détection placeholders.
+    // Référence STRIDE 03-sessions critique #3, ADR-043 Sprint 1 Plan F.
+    const sessionSecretRaw = process.env.SESSION_SECRET ?? '';
+    const sessionSecretNorm = sessionSecretRaw.trim();
+    const KNOWN_WEAK_PLACEHOLDERS = [
+      '123',
+      'changeme',
+      'change-me',
+      'secret',
+      'mysecret',
+      'insecure_dev_secret_change_me',
+      'your-secret-here',
+      'todo',
+      'xxxxx',
+    ];
+    const isWeakSecret =
+      !sessionSecretNorm ||
+      sessionSecretNorm.length < 32 ||
+      KNOWN_WEAK_PLACEHOLDERS.includes(sessionSecretNorm.toLowerCase());
 
-      if (process.env.NODE_ENV === 'production' && !readOnly) {
+    let sessionSecret = sessionSecretNorm;
+    if (isWeakSecret) {
+      // PROD/PREPROD: refuse de démarrer même en read-only — un secret faible
+      // expose toutes les sessions actives, indépendamment du mode RW/RO.
+      if (process.env.NODE_ENV === 'production') {
         throw new Error(
-          'SESSION_SECRET OBLIGATOIRE en production! Impossible de démarrer.',
+          `SESSION_SECRET ${sessionSecretNorm ? 'FAIBLE' : 'MANQUANT'} en production. ` +
+            `Génère un secret >= 32 caractères avec: openssl rand -base64 32`,
         );
       }
+
+      // DEV: génère un secret aléatoire runtime (sessions invalidées au restart,
+      // accepté en DEV). Plus jamais le hardcoded `INSECURE_DEV_SECRET_CHANGE_ME`
+      // qui était identique entre toutes les instances DEV — vector de spoofing.
+      sessionSecret = crypto.randomBytes(32).toString('base64');
+      logger.warn(
+        `[SECURITY] SESSION_SECRET ${sessionSecretNorm ? 'FAIBLE' : 'MANQUANT'} en DEV. ` +
+          `Secret aléatoire généré (32 bytes). Sessions perdues au restart.`,
+      );
+      logger.warn(
+        '[SECURITY] Pour des sessions persistantes, ajoute dans .env: ' +
+          'SESSION_SECRET=$(openssl rand -base64 32)',
+      );
     }
 
     app.use(
@@ -96,7 +125,7 @@ async function bootstrap() {
         store: redisStore,
         resave: false,
         saveUninitialized: false, // Session créée uniquement quand des données y sont écrites (login, panier)
-        secret: sessionSecret || 'INSECURE_DEV_SECRET_CHANGE_ME',
+        secret: sessionSecret,
         name: 'connect.sid', // ✅ Nom explicite du cookie
         cookie: {
           maxAge: 1000 * 60 * 60 * 24 * 30, // 30 jours


### PR DESCRIPTION
## Résumé

Plan F Phase 1 Sprint 1 — second ticket livré (STRIDE 03-sessions critique #3, ADR-043).

**Audit terrain** : `main.ts:80-92` a déjà une logique fail-fast partielle, mais 3 trous :
- Check `=== '123'` rate `'INSECURE_DEV_SECRET_CHANGE_ME'`
- Fallback hardcoded `'INSECURE_DEV_SECRET_CHANGE_ME'` = secret **identique entre toutes les instances DEV** (vector spoofing cross-instance)
- Exception `!readOnly` laisse preprod sans protection si `readOnly=false`

## Changements `main.ts:78-119`

| # | Fix | Why |
|---|-----|-----|
| 1 | Détection secret faible élargie : 9 placeholders connus + longueur < 32 chars + case-insensitive | Couvre tous les patterns évidents, pas juste `123` |
| 2 | PROD : throw inconditionnel (retire exception `!readOnly`) | Secret faible en preprod expose les sessions actives même en lecture |
| 3 | DEV : `crypto.randomBytes(32).toString('base64')` au lieu de hardcoded fallback | Plus de spoofing cross-instance via secret connu |
| 4 | Logger.warn loud si fallback généré + instructions persistance | Visibilité dev pour ne pas oublier le secret |

## Backward compatibility

- ✅ Configurations existantes (`SESSION_SECRET` >= 32 chars + non-placeholder) → aucun changement
- ⚠️ DEV sans `SESSION_SECRET` configuré → sessions invalidées au restart (comportement attendu, plus sûr que l'identique hardcoded)

## Self-review verdict: APPROVE

8-item checklist :
- ✅ Pas de nouveau pattern, juste durcissement de la détection existante
- ✅ Factuel : code refs ligne précise (`main.ts:78-119`)
- ✅ Cohérence canon : `crypto.randomBytes` standard Node.js, pas de dépendance
- ✅ Anti-patterns : aucun overclaim ; caveat DEV explicite
- ✅ Précédent : ADR-043 Sprint 1 cadre, STRIDE 03-sessions
- ✅ Pas de régression UX en config valide
- ✅ Defense in depth (la couche 4 du pattern ADR-040)

## Tests

- [x] Typecheck full project clean (`tsc --noEmit -p tsconfig.json` exit 0)
- [ ] DEV sans `SESSION_SECRET` → vérifier warn log + démarrage OK + sessions perdues au restart
- [ ] DEV avec `SESSION_SECRET` valide >= 32 chars → comportement inchangé
- [ ] PROD avec secret faible (test) → throw "SESSION_SECRET FAIBLE en production" attendu
- [ ] PROD avec secret valide → démarrage OK

## Refs

- ADR-043 (vault, proposed) — Plan F Phase 1 cadre Sprint 1
- Audit-trail vault #164 — Plan F Phase 0 verdict
- Audit-trail vault #163 — Sprint arbitrage F par défaut P0→P8
- STRIDE 03-sessions critique #3 — `~/.claude/plans/F0.2-threat-model-stride/03-sessions.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
