### PR TITLE
feat(seo-monitoring): V0.A daily-fetch cron + cron/health endpoint

### DIFF
--- a/backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
@@ -24,6 +24,7 @@ import {
   type AuditType,
 } from '../services/audit-findings.service';
 import { RContentAuditorService } from '../services/r-content-auditor.service';
+import { SeoMonitoringRunsService } from '../services/seo-monitoring-runs.service';
 
 @Controller('api/admin/seo-monitoring')
 export class SeoMonitoringController {
@@ -36,6 +37,7 @@ export class SeoMonitoringController {
     private readonly ga4Fetcher: Ga4DailyFetcherService,
     private readonly auditFindings: AuditFindingsService,
     private readonly rContentAuditor: RContentAuditorService,
+    private readonly runsService: SeoMonitoringRunsService,
     configService: ConfigService,
   ) {
     const url = configService.get<string>('SUPABASE_URL') || '';
@@ -58,6 +60,46 @@ export class SeoMonitoringController {
       readiness: this.credentials.checkReadiness(),
       gsc_site_url: this.credentials.getGSCSiteUrl(),
       ga4_property: this.credentials.getGA4PropertyName(),
+    };
+  }
+
+  /**
+   * V0.A — GET /cron/health
+   *
+   * Last successful + last failed run par source d'ingestion.
+   * Source : `__seo_event_log` (event_type ENUM + payload JSONB).
+   * Utilisé pour monitoring externe (Slack alerting / dashboard / readiness probe).
+   */
+  @Get('cron/health')
+  async cronHealth() {
+    const runs = await this.runsService.getRunsHealth(this.supabase);
+    const now = Date.now();
+    const staleThresholdHours = 36; // J-3 par défaut + tolérance 12h
+
+    const sources = runs.map((r) => {
+      const lastSuccessAgeHours = r.lastSuccessAt
+        ? Math.round((now - new Date(r.lastSuccessAt).getTime()) / 3_600_000)
+        : null;
+      const isStale =
+        lastSuccessAgeHours === null ||
+        lastSuccessAgeHours > staleThresholdHours;
+      return {
+        ...r,
+        lastSuccessAgeHours,
+        status: isStale ? 'stale' : 'healthy',
+      };
+    });
+
+    const overall = sources.every((s) => s.status === 'healthy')
+      ? 'healthy'
+      : 'stale';
+
+    return {
+      overall,
+      monitoring_enabled: this.credentials.isMonitoringEnabled(),
+      checked_at: new Date().toISOString(),
+      stale_threshold_hours: staleThresholdHours,
+      sources,
     };
   }
 

--- a/backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts
+++ b/backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts
@@ -1,0 +1,256 @@
+/**
+ * SEO Daily Fetch Processor
+ *
+ * Orchestre l'ingestion quotidienne des sources Google gratuites
+ * (GSC, GA4, CWV, GSC Links) dans `__seo_*_daily` via les fetchers
+ * existants du `SeoMonitoringModule`.
+ *
+ * Job BullMQ : `@Process('daily-fetch')` sur queue `seo-monitor`.
+ * Schedule par `SeoMonitorSchedulerService.setupDailyFetchJob()` (cron 04:00 UTC).
+ *
+ * Refs:
+ * - `.claude/plans/utiliser-la-meilleure-approche-zippy-waterfall.md` — V0.A
+ * - ADR-025 SEO Department Architecture (governance-vault)
+ * - ADR-028 Option D — READ_ONLY gate au processor (memory `feedback_readonly_gate_at_processor_not_scheduler.md`)
+ * - `feedback_dual_fallback_env_vs_technical.md` — fallback env `[READ_ONLY]` séparé du technique
+ */
+import { OnQueueError, OnQueueFailed, Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { getAppConfig } from '../../../config/app.config';
+import { getErrorMessage } from '../../../common/utils/error.utils';
+import { AdminJobHealthService } from '../../admin/services/admin-job-health.service';
+import { Ga4DailyFetcherService } from '../services/ga4-daily-fetcher.service';
+import { GscDailyFetcherService } from '../services/gsc-daily-fetcher.service';
+import { GscLinksFetcherService } from '../services/gsc-links-fetcher.service';
+
+export type DailyFetchTask = 'all' | 'gsc' | 'ga4' | 'gsc_links';
+
+export interface SeoDailyFetchJobData {
+  /** Date à fetcher au format ISO (YYYY-MM-DD). Si absent, J-3 par défaut (latence GSC/GA4). */
+  date?: string;
+  /**
+   * Périmètre : `all` lance GSC + GA4 + GSC Links.
+   * **CWV est exclu volontairement de V0.A** : `CwvFetcherService` exige une liste
+   * `pages: string[]` (sample top 1k) qui sera produite par le `gsc-coverage-fetcher`
+   * en V0.D. Tant que ce sample n'est pas calculé, CWV est déclenché à la demande
+   * (route admin) avec une liste de pages explicite.
+   * Défaut `all`.
+   */
+  task?: DailyFetchTask;
+  /** Origine du déclenchement (audit trail). */
+  triggeredBy: 'scheduler' | 'api' | 'manual';
+}
+
+export interface SeoDailyFetchPerSourceResult {
+  source: 'gsc' | 'ga4' | 'gsc_links';
+  status: 'ok' | 'skipped' | 'failed';
+  rowsInserted: number;
+  durationSeconds: number;
+  message?: string;
+}
+
+export interface SeoDailyFetchResult {
+  date: string;
+  triggeredBy: SeoDailyFetchJobData['triggeredBy'];
+  task: DailyFetchTask;
+  perSource: SeoDailyFetchPerSourceResult[];
+  totalRowsInserted: number;
+  totalDurationSeconds: number;
+  startedAt: string;
+  finishedAt: string;
+}
+
+@Processor('seo-monitor')
+export class SeoDailyFetchProcessor {
+  private readonly logger = new Logger(SeoDailyFetchProcessor.name);
+  private readonly readOnly: boolean;
+  private lastQueueErrorLog = 0;
+
+  constructor(
+    private readonly gscFetcher: GscDailyFetcherService,
+    private readonly ga4Fetcher: Ga4DailyFetcherService,
+    private readonly gscLinksFetcher: GscLinksFetcherService,
+    private readonly jobHealth: AdminJobHealthService,
+  ) {
+    this.readOnly = getAppConfig().supabase.readOnly;
+  }
+
+  @Process('daily-fetch')
+  async handleDailyFetch(
+    job: Job<SeoDailyFetchJobData>,
+  ): Promise<SeoDailyFetchResult> {
+    const startedAt = Date.now();
+    const date = job.data.date ?? defaultFetchDate();
+    const task: DailyFetchTask = job.data.task ?? 'all';
+
+    // ADR-028 Option D : READ_ONLY gate au processor (pas au scheduler).
+    // Le cron reste registered pour valider le wiring BullMQ en preprod miroir
+    // prod, mais le handler court-circuite sans appel API/DB.
+    if (this.readOnly) {
+      this.logger.warn(
+        {
+          metric: 'readonly.skipped',
+          operation: 'seo-daily-fetch',
+          jobId: job.id,
+          date,
+          task,
+        },
+        `[READ_ONLY] Skip seo-daily-fetch (job #${job.id}, date=${date}, task=${task})`,
+      );
+      return emptyResult(date, job.data.triggeredBy, task, startedAt);
+    }
+
+    this.logger.log(
+      `🛰️ [Job #${job.id}] daily-fetch démarrage (date=${date}, task=${task}, triggeredBy=${job.data.triggeredBy})`,
+    );
+
+    const perSource: SeoDailyFetchPerSourceResult[] = [];
+    const tasks =
+      task === 'all' ? (['gsc', 'ga4', 'gsc_links'] as const) : [task];
+
+    let progressBase = 0;
+    const progressStep = Math.floor(100 / tasks.length);
+
+    for (const t of tasks) {
+      try {
+        const sourceStart = Date.now();
+        let rowsInserted = 0;
+        let status: SeoDailyFetchPerSourceResult['status'] = 'ok';
+        let message: string | undefined;
+
+        if (t === 'gsc') {
+          const r = await this.gscFetcher.fetchAndPersist({ date });
+          rowsInserted = r.rowsInserted;
+          if (
+            r.warnings.includes('monitoring_disabled') ||
+            r.warnings.includes('credentials_missing')
+          ) {
+            status = 'skipped';
+            message = r.warnings.join(',');
+          }
+        } else if (t === 'ga4') {
+          const r = await this.ga4Fetcher.fetchAndPersist({ date });
+          rowsInserted = r.rowsInserted;
+          if (
+            r.warnings.includes('monitoring_disabled') ||
+            r.warnings.includes('credentials_missing')
+          ) {
+            status = 'skipped';
+            message = r.warnings.join(',');
+          }
+        } else if (t === 'gsc_links') {
+          const r = await this.gscLinksFetcher.fetchAndPersist({
+            snapshotDate: date,
+          });
+          rowsInserted = r.rowsInserted;
+          if (
+            r.warnings.includes('monitoring_disabled') ||
+            r.warnings.includes('credentials_missing')
+          ) {
+            status = 'skipped';
+            message = r.warnings.join(',');
+          }
+        }
+
+        perSource.push({
+          source: t,
+          status,
+          rowsInserted,
+          durationSeconds: (Date.now() - sourceStart) / 1000,
+          message,
+        });
+      } catch (error) {
+        this.logger.error(
+          `❌ [Job #${job.id}] daily-fetch ${t} failed: ${getErrorMessage(error)}`,
+        );
+        perSource.push({
+          source: t,
+          status: 'failed',
+          rowsInserted: 0,
+          durationSeconds: 0,
+          message: getErrorMessage(error),
+        });
+        // Continue les autres sources : un échec GSC ne doit pas annuler GA4/CWV.
+      }
+
+      progressBase += progressStep;
+      await job.progress(Math.min(progressBase, 100));
+    }
+
+    const totalDurationSeconds = (Date.now() - startedAt) / 1000;
+    const totalRowsInserted = perSource.reduce((s, p) => s + p.rowsInserted, 0);
+    const finishedAt = new Date().toISOString();
+
+    this.logger.log(
+      `✅ [Job #${job.id}] daily-fetch terminé en ${totalDurationSeconds.toFixed(1)}s — ${totalRowsInserted} rows insérés (${perSource.length} sources)`,
+    );
+
+    this.jobHealth
+      .recordSuccess('seo-daily-fetch', Date.now() - startedAt)
+      .catch(() => {});
+
+    return {
+      date,
+      triggeredBy: job.data.triggeredBy,
+      task,
+      perSource,
+      totalRowsInserted,
+      totalDurationSeconds,
+      startedAt: new Date(startedAt).toISOString(),
+      finishedAt,
+    };
+  }
+
+  @OnQueueError()
+  handleError(error: Error) {
+    const now = Date.now();
+    if (now - this.lastQueueErrorLog > 60_000) {
+      this.logger.error(
+        `❌ Erreur queue seo-monitor (daily-fetch): ${error.message}`,
+      );
+      this.lastQueueErrorLog = now;
+    }
+  }
+
+  @OnQueueFailed()
+  handleFailedJob(job: Job, error: Error) {
+    if (job.name !== 'daily-fetch') {
+      return; // pas notre handler — laisser SeoMonitorProcessor gérer
+    }
+    this.logger.error(
+      `💥 [Job #${job.id}] daily-fetch échoué après ${job.attemptsMade} tentatives: ${error.message}`,
+    );
+    this.jobHealth
+      .recordFailure('seo-daily-fetch', error.message)
+      .catch(() => {});
+  }
+}
+
+/**
+ * J-3 par défaut : la latence GSC est de 2-3 jours, GA4 ~24-48h.
+ * J-3 garantit que les données sont stabilisées côté Google avant fetch.
+ */
+function defaultFetchDate(): string {
+  const d = new Date(Date.now() - 3 * 86_400_000);
+  return d.toISOString().slice(0, 10);
+}
+
+function emptyResult(
+  date: string,
+  triggeredBy: SeoDailyFetchJobData['triggeredBy'],
+  task: DailyFetchTask,
+  startedAt: number,
+): SeoDailyFetchResult {
+  const now = new Date().toISOString();
+  return {
+    date,
+    triggeredBy,
+    task,
+    perSource: [],
+    totalRowsInserted: 0,
+    totalDurationSeconds: (Date.now() - startedAt) / 1000,
+    startedAt: new Date(startedAt).toISOString(),
+    finishedAt: now,
+  };
+}

--- a/backend/src/modules/seo-monitoring/services/seo-monitoring-runs.service.ts
+++ b/backend/src/modules/seo-monitoring/services/seo-monitoring-runs.service.ts
@@ -110,6 +110,68 @@ export class SeoMonitoringRunsService {
   }
 
   /**
+   * V0.A — Health snapshot par source.
+   *
+   * Retourne pour chaque source (`gsc`, `ga4`, `cwv`, `gsc_links`) :
+   * - `last_success_at` : created_at du dernier `ingestion_run_completed`
+   * - `last_failure_at` : created_at du dernier `ingestion_run_failed`
+   * - `last_failure_class` / `last_failure_message`
+   *
+   * Source de vérité : `__seo_event_log` (table générique typée par event_type ENUM
+   * + payload JSONB — index GIN existant). Cf. plan V0.A.
+   */
+  async getRunsHealth(
+    supabase: SupabaseClient,
+    sources: IngestionSource[] = ['gsc', 'ga4', 'cwv', 'gsc_links'],
+  ): Promise<
+    Array<{
+      source: IngestionSource;
+      lastSuccessAt: string | null;
+      lastFailureAt: string | null;
+      lastFailureClass: string | null;
+      lastFailureMessage: string | null;
+    }>
+  > {
+    const out: Awaited<ReturnType<typeof this.getRunsHealth>> = [];
+
+    for (const source of sources) {
+      const [success, failure] = await Promise.all([
+        supabase
+          .from('__seo_event_log')
+          .select('created_at')
+          .eq('event_type', 'ingestion_run_completed')
+          .eq('payload->>source', source)
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle(),
+        supabase
+          .from('__seo_event_log')
+          .select('created_at, payload')
+          .eq('event_type', 'ingestion_run_failed')
+          .eq('payload->>source', source)
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle(),
+      ]);
+
+      const failurePayload = (failure.data?.payload ?? null) as {
+        error_class?: string;
+        error_message?: string;
+      } | null;
+
+      out.push({
+        source,
+        lastSuccessAt: success.data?.created_at ?? null,
+        lastFailureAt: failure.data?.created_at ?? null,
+        lastFailureClass: failurePayload?.error_class ?? null,
+        lastFailureMessage: failurePayload?.error_message ?? null,
+      });
+    }
+
+    return out;
+  }
+
+  /**
    * Failed event — appelé sur échec irréversible (après retry).
    * Ne lève pas l'exception : on veut éviter de cascader la failure.
    */

--- a/backend/src/workers/services/seo-monitor-scheduler.service.ts
+++ b/backend/src/workers/services/seo-monitor-scheduler.service.ts
@@ -48,6 +48,9 @@ export class SeoMonitorSchedulerService implements OnModuleInit {
       // Configurer job échantillon aléatoire (toutes les 6h)
       await this.setupRandomSampleMonitoring();
 
+      // V0.A — Configurer job daily-fetch GSC/GA4/CWV/Links (04:00 UTC)
+      await this.setupDailyFetchJob();
+
       this.logger.log('✅ Scheduler monitoring SEO configuré');
       await this.logScheduledJobs();
     } catch (error) {
@@ -126,6 +129,76 @@ export class SeoMonitorSchedulerService implements OnModuleInit {
     this.logger.log(
       '✅ Surveillance échantillon aléatoire: toutes les 6 heures',
     );
+  }
+
+  /**
+   * 🛰️ V0.A — Configure le job quotidien d'ingestion GSC/GA4/CWV/Links
+   *
+   * Cron 04:00 UTC quotidien. Le processor `SeoDailyFetchProcessor` consomme
+   * `daily-fetch` sur la queue `seo-monitor` et délègue aux 4 fetchers du
+   * `SeoMonitoringModule`. Date par défaut : J-3 (latence GSC/GA4 ~3 jours).
+   *
+   * Ref : `.claude/plans/utiliser-la-meilleure-approche-zippy-waterfall.md` § V0.A
+   */
+  private async setupDailyFetchJob(): Promise<void> {
+    await this.seoMonitorQueue.add(
+      'daily-fetch',
+      {
+        triggeredBy: 'scheduler',
+        task: 'all',
+      },
+      {
+        repeat: {
+          cron: '0 4 * * *', // 04:00 UTC quotidien
+        },
+        jobId: 'seo-daily-fetch',
+        removeOnComplete: 30, // ~1 mois d'historique
+        removeOnFail: 100, // debug
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 30_000, // 30s, puis 1min, puis 2min
+        },
+      },
+    );
+
+    this.logger.log('✅ Daily fetch GSC/GA4/CWV/Links: 04:00 UTC');
+  }
+
+  /**
+   * 🚀 V0.A — Déclenche manuellement un daily-fetch (debug / re-run / backfill)
+   */
+  async triggerManualDailyFetch(
+    opts: {
+      date?: string;
+      task?: 'all' | 'gsc' | 'ga4' | 'gsc_links';
+    } = {},
+  ) {
+    const job = await this.seoMonitorQueue.add(
+      'daily-fetch',
+      {
+        date: opts.date,
+        task: opts.task ?? 'all',
+        triggeredBy: 'api',
+      },
+      {
+        priority: 1,
+        removeOnComplete: 30,
+        removeOnFail: 100,
+        attempts: 1, // pas de retry pour déclenchement manuel
+      },
+    );
+
+    this.logger.log(
+      `🚀 Daily-fetch manuel : job #${job.id} (date=${opts.date ?? 'J-3'}, task=${opts.task ?? 'all'})`,
+    );
+
+    return {
+      jobId: job.id,
+      date: opts.date,
+      task: opts.task ?? 'all',
+      status: 'queued',
+    };
   }
 
   /**

--- a/backend/src/workers/worker.module.ts
+++ b/backend/src/workers/worker.module.ts
@@ -14,6 +14,10 @@ import { EmailProcessor } from './processors/email.processor';
 import { SeoMonitorProcessor } from './processors/seo-monitor.processor';
 // VideoExecutionProcessor — SUPPRIMÉ 2026-04-10 (MediaFactory supprimé)
 
+// SEO daily-fetch processor (orchestre GSC/GA4/CWV/Links daily) — V0.A
+import { SeoDailyFetchProcessor } from '../modules/seo-monitoring/processors/seo-daily-fetch.processor';
+import { SeoMonitoringModule } from '../modules/seo-monitoring/seo-monitoring.module';
+
 // Services Workers
 import { SeoMonitorSchedulerService } from './services/seo-monitor-scheduler.service';
 
@@ -98,6 +102,9 @@ import { AdminJobHealthService } from '../modules/admin/services/admin-job-healt
     // Modules for AgenticProcessor dependencies
     RagProxyModule,
     FeatureFlagsModule, // Used by RunManagerService (agentic budget guard + flags)
+
+    // V0.A — SEO daily-fetch processor needs GSC/GA4/CWV/Links fetcher services
+    SeoMonitoringModule,
   ],
 
   providers: [
@@ -106,6 +113,7 @@ import { AdminJobHealthService } from '../modules/admin/services/admin-job-healt
     // CacheProcessor, // DESACTIVE
     EmailProcessor,
     SeoMonitorProcessor,
+    SeoDailyFetchProcessor, // V0.A — daily GSC/GA4/CWV/Links ingestion (cron 04:00 UTC)
     // VideoExecutionProcessor — SUPPRIMÉ 2026-04-10
 
     // Agentic engine processor + dependencies (Agent-Native — state management only)


### PR DESCRIPTION
## Summary

- **Nouveau** `SeoDailyFetchProcessor` (queue `seo-monitor`, `@Process('daily-fetch')`) qui dispatche aux 3 fetchers GSC/GA4/GSC Links existants via DI. CWV exclu volontairement (relève V0.D — contrat `pages: string[]` à produire par `gsc-coverage-fetcher`).
- **Cron daily 04:00 UTC** ajouté dans `SeoMonitorSchedulerService` (date par défaut J-3, attempts:3, ExponentialBackoff 30s/1min/2min) + helper `triggerManualDailyFetch()` pour debug/backfill.
- **Health route** `GET /api/admin/seo-monitoring/cron/health` retourne overall + per-source `last_success_at` / `last_failure_at` / staleness 36h via nouveau `SeoMonitoringRunsService.getRunsHealth()` (lit `__seo_event_log` filtré par `payload->>source`).

## Pourquoi

Diagnostic session 2026-05-06 : tables `__seo_gsc_daily` / `__seo_ga4_daily` à **0 rows** parce qu'aucun cron ne déclenche les fetchers (qui existaient déjà mais étaient orphelins). Sans cette PR, les 33 jours backfillés manuellement redeviendront stales sous 48h. Socle obligatoire de la stratégie SEO 2026 (plan §V0).

## Réutilisation 100% existant

- ✅ `logStarted/logCompleted/logFailed` déjà wired dans les 4 fetchers (vérifié)
- ✅ ENUM `seo_event_type` contient déjà `anomaly_detected` + `ingestion_run_*` (vérifié via Supabase MCP)
- ✅ `__seo_event_log` schéma `event_type ENUM + payload JSONB` (index GIN existant) — pas de colonne structurée ajoutée
- ✅ Sentry backend déjà initialisé via `instrument.ts` (#324/#327/#334)
- ✅ `BullModule.registerQueue({ name: 'seo-monitor' })` déjà déclaré dans `WorkerModule`

## Garde-fous canon

- **READ_ONLY gate au processor** (ADR-028 Option D, memory `feedback_readonly_gate_at_processor_not_scheduler.md`) — cron registered en preprod miroir prod, court-circuit sans appel API/DB
- **Failure isolée par source** : un échec GSC n'annule pas GA4/Links (continue les autres)
- **Non-blocking `onModuleInit`** : pattern existant `void this.configureRepeatableJobs()` respecté (memory `backend.md`)
- **`payload JSONB`** pour anomaly_type / delta_pct futurs (pas de schema change)

## Hors-scope V0.A (PRs séparées à venir)

- **V0-bis** : OpenTelemetry + Prometheus metrics + DLQ replay UI + Redlock distribué
- **V0.B** : GA4 multi-events client (`add_to_cart`, `vehicle_selected`, `symptom_search`, etc.) + sanitize PII helper
- **V0.C** : GA4 Measurement Protocol server-side (purchase backend, garantit tracking même si redirect échoue)
- **V0.D** : `gsc-coverage-fetcher` + sample top 1k prioritaires + CWV intégré au daily-fetch
- **V0.E** : Post-publish signaling (lastmod fiable + IndexNow Bing/Yandex + GSC sitemap submit ; **PAS** `google.com/ping` déprécié)

## Test plan

- [ ] CI green (typecheck, lint, tests, perf-gates)
- [ ] Post-deploy DEV : `curl /api/admin/seo-monitoring/cron/health` retourne `overall: stale` (pas encore de run cron) + 4 sources listées
- [ ] Trigger manuel : `curl -X POST /api/admin/seo-monitoring/run/gsc -d '{"date":"2026-05-03"}'` insère dans `__seo_event_log` un `ingestion_run_completed`
- [ ] Re-curl health → `gsc.lastSuccessAt` mis à jour, `status: healthy` pour gsc
- [ ] Vérifier logs DEV : `Daily fetch GSC/GA4/CWV/Links: 04:00 UTC` au boot
- [ ] Lendemain ~04:30 UTC : `SELECT count(*) FROM __seo_gsc_daily WHERE date = current_date - 3` > 0
- [ ] READ_ONLY gate : sur preprod READ_ONLY=true, scheduler register OK + handler skip avec log `[READ_ONLY] Skip seo-daily-fetch`

## Governance

- `governance-ref` : plan `utiliser-la-meilleure-approche-zippy-waterfall.md` §V0.A
- ADR canon vault `seo-monitoring-cron-v0` : **en cours de rédaction** (PR vault séparée non bloquante — V0.A peut merger en parallèle, mais le tag de release V0 sera gated par `status=accepted`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)