### PR TITLE
feat(seo): r1 micro-seo synth 1500-3000c (option b) + backfill script

### DIFF
--- a/backend/src/modules/admin/services/r1-enricher.service.ts
+++ b/backend/src/modules/admin/services/r1-enricher.service.ts
@@ -19,9 +19,16 @@ import { RoleId } from '../../../config/role-ids';
 import type { ResourceGroup } from '../../../config/execution-registry.types';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import * as yaml from 'js-yaml';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
 import { EnricherTextUtils } from './enricher-text-utils.service';
 import { EnricherYamlParser } from './enricher-yaml-parser.service';
+
+// ── Canon thresholds (Option B sweet-spot 2026-05-07) ─────────────────────────
+// Aligned with workspaces/seo-batch/.claude/agents/r1-content-batch.md.
+// Min not enforced here (synth produces best-effort) ; max is the truncate cap.
+const R1_MICRO_SEO_MIN_CHARS = 1500;
+const R1_MICRO_SEO_MAX_CHARS = 3000;
 
 export interface R1EnrichResult {
   pgId: string;
@@ -113,8 +120,14 @@ export class R1EnricherService extends SupabaseBaseService {
       if (!microSeo && fm) {
         microSeo = this.synthesizeMicroSeo(fm, gammeName, sections);
       }
-      slots.r1s_micro_seo_block = this.textUtils.truncateText(microSeo, 1000);
+      slots.r1s_micro_seo_block = this.textUtils.truncateText(
+        microSeo,
+        R1_MICRO_SEO_MAX_CHARS,
+      );
       if (!microSeo) flags.push('MISSING_MICRO_SEO');
+      else if (microSeo.length < R1_MICRO_SEO_MIN_CHARS) {
+        flags.push('R1_MICRO_SEO_BELOW_MIN');
+      }
 
       // Equipementiers line
       const equipList = fm
@@ -310,45 +323,141 @@ export class R1EnricherService extends SupabaseBaseService {
     return match ? match[1].trim().replace(/^['"]|['"]$/g, '') : null;
   }
 
+  /**
+   * Synthesise the R1 micro-SEO block from RAG frontmatter.
+   *
+   * Targets the Option B canonical envelope (2026-05-07) :
+   * `R1_MICRO_SEO_MIN_CHARS` = 1500c min / `R1_MICRO_SEO_MAX_CHARS` = 3000c max,
+   * structured as 3-5 short HTML `<p>` paragraphs covering :
+   *
+   *   §1 fonction / role (intro)
+   *   §2 critères de sélection (full criteria list)
+   *   §3 distinctions vs pièces voisines (confusion_with) — optional
+   *   §4 équipementiers reconnus (selection.brands.premium) — optional
+   *   §5 cas d'usage / symptômes top 3 + invitation à filtrer
+   *
+   * Stays single-block (no R3 multi-section drift). Forbidden_overlap
+   * enforcement is performed by `r1-router-validator` downstream — not here.
+   *
+   * Sources : RAG `.md` YAML frontmatter ; nested fields parsed via js-yaml
+   * (the legacy regex extractor handles only top-level lists).
+   */
   private synthesizeMicroSeo(
     fm: string,
     gammeName: string,
     sections: Map<string, string>,
   ): string {
-    const parts: string[] = [];
+    const fullYaml = this.parseFullFrontmatter(fm);
+    const domain = (fullYaml?.domain ?? {}) as Record<string, unknown>;
+    const selection = (fullYaml?.selection ?? {}) as Record<string, unknown>;
+    const diagnostic = (fullYaml?.diagnostic ?? {}) as Record<string, unknown>;
+    const paragraphs: string[] = [];
 
-    // Extract domain.role from YAML
-    const role = this.extractYamlValue(fm, 'role');
+    // ── §1 — fonction / rôle ────────────────────────────────────────────
+    const role =
+      this.extractYamlValue(fm, 'role') || (domain.role as string) || '';
+    const mustBeTrue = this.yamlParser.extractYamlList(fm, 'must_be_true');
+    const introBits: string[] = [];
     if (role) {
-      parts.push(
+      introBits.push(
         `Le ${gammeName} ${role.charAt(0).toLowerCase()}${role.slice(1)}.`,
       );
     }
-
-    // Extract must_be_true keywords
-    const mustBeTrue = this.yamlParser.extractYamlList(fm, 'must_be_true');
     if (mustBeTrue.length > 0) {
-      parts.push(
-        `Fonctions essentielles : ${mustBeTrue.slice(0, 3).join(', ')}.`,
+      introBits.push(
+        `Pièce essentielle du système, son fonctionnement implique : ${mustBeTrue.slice(0, 5).join(', ')}.`,
       );
     }
+    if (introBits.length > 0) paragraphs.push(`<p>${introBits.join(' ')}</p>`);
 
-    // Extract selection criteria if available
+    // ── §2 — critères de sélection ──────────────────────────────────────
     const criteria = this.yamlParser.extractYamlList(fm, 'criteria');
     if (criteria.length > 0) {
-      parts.push(`Critères de choix : ${criteria.slice(0, 3).join(', ')}.`);
+      const criteriaProse = criteria
+        .slice(0, 5)
+        .map((c) => c.replace(/^['"]|['"]$/g, '').trim())
+        .join(' ; ');
+      paragraphs.push(`<p>Critères de sélection : ${criteriaProse}.</p>`);
     }
 
-    // Fallback to role section content
-    if (parts.length === 0) {
-      const roleSection =
-        sections.get('role') || sections.get('fonctionnement') || '';
-      if (roleSection) {
-        parts.push(roleSection.slice(0, 300));
+    // ── §3 — distinctions vs pièces voisines ────────────────────────────
+    const confusionItems =
+      (domain.confusion_with as
+        | Array<{ term: string; difference: string }>
+        | undefined) ?? [];
+    if (confusionItems.length > 0) {
+      const distinguish = confusionItems
+        .slice(0, 2)
+        .filter((c) => c?.term && c?.difference)
+        .map((c) => `${c.term} (${c.difference})`)
+        .join(', et de ');
+      if (distinguish) {
+        paragraphs.push(`<p>À distinguer de : ${distinguish}.</p>`);
       }
     }
 
-    return parts.join(' ');
+    // ── §4 — équipementiers reconnus ────────────────────────────────────
+    const brands = (selection.brands as Record<string, unknown>) ?? {};
+    const brandsPremium = (brands.premium as string[]) ?? [];
+    if (brandsPremium.length > 0) {
+      paragraphs.push(
+        `<p>Équipementiers reconnus pour cette gamme : ${brandsPremium.slice(0, 6).join(', ')}.</p>`,
+      );
+    }
+
+    // ── §5 — cas d'usage + invitation filtrage ──────────────────────────
+    const symptoms =
+      (diagnostic.symptoms as
+        | Array<{ id: string; label: string }>
+        | undefined) ?? [];
+    const closing = `Identifiez le ${gammeName} adapté en filtrant par marque, modèle et motorisation pour garantir la compatibilité avec votre véhicule.`;
+    if (symptoms.length > 0) {
+      const symptomList = symptoms
+        .slice(0, 3)
+        .map((s) => s?.label)
+        .filter(Boolean)
+        .join(' ; ');
+      if (symptomList) {
+        paragraphs.push(
+          `<p>Cas d'usage typiques justifiant un remplacement : ${symptomList}. ${closing}</p>`,
+        );
+      } else {
+        paragraphs.push(`<p>${closing}</p>`);
+      }
+    } else {
+      paragraphs.push(`<p>${closing}</p>`);
+    }
+
+    // ── Fallback if everything was empty ────────────────────────────────
+    if (paragraphs.length === 0) {
+      const roleSection =
+        sections.get('role') || sections.get('fonctionnement') || '';
+      if (roleSection) {
+        paragraphs.push(`<p>${roleSection.slice(0, 800)}</p>`);
+      }
+    }
+
+    return paragraphs.join('\n');
+  }
+
+  /**
+   * Parse the full YAML frontmatter as a JavaScript object. Returns `null`
+   * on parse failure — the legacy regex extractor remains the fallback for
+   * top-level lists. Use this only when nested fields are required.
+   */
+  private parseFullFrontmatter(fm: string): Record<string, unknown> | null {
+    if (!fm) return null;
+    try {
+      const parsed = yaml.load(fm);
+      return typeof parsed === 'object' && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch (err) {
+      this.logger.warn(
+        `Failed to parse YAML frontmatter: ${(err as Error).message}`,
+      );
+      return null;
+    }
   }
 
   private extractBuyArgs(

--- a/scripts/seo/backfill-r1-micro-seo.py
+++ b/scripts/seo/backfill-r1-micro-seo.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+Backfill r1s_micro_seo_block for __seo_r1_gamme_slots rows where the
+content length is below the canonical Option B threshold (1500c min).
+
+Mirror of `scripts/seo/backfill-r1-gatekeeper.py` — same psycopg2 + .env +
+dry-run + resume-safe + sleep pattern. The actual content synthesis runs
+inside `R1EnricherService.synthesizeMicroSeo` (richer 5-paragraph synth +
+truncate cap 3000c, see commit feat/r1-enricher-micro-seo-1500c-canon),
+invoked via the canonical pipeline endpoint :
+
+    POST /api/internal/pipeline/execute
+    { "roleId": "R1_ROUTER", "targetIds": [<pg_id>], "dryRun": false }
+
+Strategy : re-enrich every R1 slot whose `r1s_micro_seo_block` is NULL or
+shorter than `MIN_CHARS`. Resume-safe (each iteration re-queries the
+under-dimensioned list) and idempotent (UPSERT pattern in the service).
+
+Footprint at ship-time (audit 2026-05-07) :
+  169 slots total, avg 221c, 132 < 300c, 31 in [300, 499], 6 in [700, 1499],
+  0 ≥ 1500c. Expected backfill : 163 rows (or 169 if `--include-legacy-band`).
+
+Usage:
+  python3 scripts/seo/backfill-r1-micro-seo.py [--limit N] [--dry-run] [--sleep 2.0] [--include-legacy-band]
+
+Required env (backend/.env):
+  SUPABASE_DB_PASSWORD       Postgres password for direct DB queries
+  INTERNAL_API_KEY           X-Internal-Key for /api/internal/pipeline/execute
+  BACKFILL_API_BASE          (optional) defaults to http://localhost:3000
+"""
+from __future__ import annotations
+
+import argparse
+import json as jsonlib
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+import psycopg2
+from dotenv import load_dotenv
+
+ENV_PATH = Path(__file__).resolve().parents[2] / "backend" / ".env"
+load_dotenv(ENV_PATH)
+
+PROJECT_REF = "cxpojprgwgubzjyqzmoq"
+API_BASE = os.environ.get("BACKFILL_API_BASE", "http://localhost:3000")
+ENDPOINT = f"{API_BASE}/api/internal/pipeline/execute"
+HEALTH_URL = f"{API_BASE}/health"
+
+# Canon threshold — must match R1_MICRO_SEO_MIN_CHARS in r1-enricher.service.ts
+MIN_CHARS = 1500
+# Legacy band : rows in [700, 1499] are above the old threshold but below
+# the new one. Excluded by default (the user explicitly scoped 163 rows in
+# Option B), included with --include-legacy-band to canonicalise everything.
+LEGACY_LOW_BOUND = 700
+
+
+def log(msg: str) -> None:
+    ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    sys.stderr.write(f"[{ts}] {msg}\n")
+    sys.stderr.flush()
+
+
+def build_dsn() -> str:
+    pwd = os.environ.get("SUPABASE_DB_PASSWORD")
+    if not pwd:
+        sys.stderr.write("[FATAL] SUPABASE_DB_PASSWORD missing in env\n")
+        sys.exit(2)
+    return (
+        f"host=db.{PROJECT_REF}.supabase.co port=5432 dbname=postgres "
+        f"user=postgres password={pwd} sslmode=require "
+        f"application_name=backfill-r1-micro-seo"
+    )
+
+
+def require_internal_key() -> str:
+    key = os.environ.get("INTERNAL_API_KEY")
+    if not key:
+        sys.stderr.write("[FATAL] INTERNAL_API_KEY missing in env\n")
+        sys.exit(2)
+    return key
+
+
+def health_check() -> None:
+    try:
+        with urllib.request.urlopen(HEALTH_URL, timeout=5) as resp:
+            body = jsonlib.loads(resp.read())
+            if body.get("status") != "ok":
+                log(f"[FATAL] backend health not OK: {body}")
+                sys.exit(4)
+    except Exception as err:
+        log(f"[FATAL] backend health check failed ({err})")
+        sys.exit(4)
+
+
+def fetch_under_dim_pg_ids(conn, include_legacy_band: bool) -> list[tuple[str, int]]:
+    """Return (pg_id, current_chars) for slots needing backfill, low-first."""
+    upper = MIN_CHARS if include_legacy_band else LEGACY_LOW_BOUND
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT r1s_pg_id, char_length(COALESCE(r1s_micro_seo_block, ''))
+            FROM __seo_r1_gamme_slots
+            WHERE char_length(COALESCE(r1s_micro_seo_block, '')) < %s
+            ORDER BY char_length(COALESCE(r1s_micro_seo_block, '')) ASC,
+                     r1s_pg_id ASC
+            """,
+            (upper,),
+        )
+        return [(row[0], row[1]) for row in cur.fetchall()]
+
+
+def fetch_row_chars(conn, pg_id: str) -> int | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT char_length(COALESCE(r1s_micro_seo_block, ''))
+            FROM __seo_r1_gamme_slots
+            WHERE r1s_pg_id = %s
+            """,
+            (pg_id,),
+        )
+        r = cur.fetchone()
+        return r[0] if r else None
+
+
+def enrich_one(pg_id: str, key: str) -> tuple[bool, str]:
+    payload = jsonlib.dumps(
+        {"roleId": "R1_ROUTER", "targetIds": [pg_id], "dryRun": False}
+    ).encode()
+    req = urllib.request.Request(
+        ENDPOINT,
+        data=payload,
+        headers={"X-Internal-Key": key, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            body = jsonlib.loads(resp.read())
+            data = body.get("data", {})
+            results = data.get("results", [])
+            if not results:
+                return (False, "no_result")
+            r = results[0]
+            if r.get("status") != "success":
+                return (False, f"status:{r.get('status')}")
+            inner = r.get("data", {})
+            inner_status = inner.get("status")
+            if inner_status == "enriched":
+                slots = inner.get("slotsWritten", 0)
+                score = inner.get("qualityScore")
+                return (True, f"slots={slots} score={score}")
+            if inner_status == "skipped":
+                flags = inner.get("qualityFlags", [])
+                return (False, f"skipped:{','.join(flags)[:60]}")
+            return (False, f"inner_status:{inner_status}")
+    except urllib.error.HTTPError as e:
+        return (False, f"http_{e.code}")
+    except urllib.error.URLError as e:
+        return (False, f"url_error:{e.reason}")
+    except Exception as e:
+        return (False, f"error:{type(e).__name__}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Backfill r1s_micro_seo_block for under-dimensioned R1 slots"
+    )
+    ap.add_argument("--limit", type=int, default=0, help="cap iterations (0=all)")
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="list under-dim pg_ids with current chars, no writes",
+    )
+    ap.add_argument("--sleep", type=float, default=2.0, help="seconds between calls")
+    ap.add_argument(
+        "--include-legacy-band",
+        action="store_true",
+        help=(
+            f"also re-enrich rows in [{LEGACY_LOW_BOUND}, {MIN_CHARS}) (legacy band, "
+            "above old threshold but below Option B canon)"
+        ),
+    )
+    args = ap.parse_args()
+
+    log(
+        f"backfill-r1-micro-seo start — api={API_BASE} sleep={args.sleep}s "
+        f"limit={args.limit or 'all'} legacy_band={args.include_legacy_band} "
+        f"min_chars={MIN_CHARS}"
+    )
+
+    if not args.dry_run:
+        health_check()
+
+    key = require_internal_key() if not args.dry_run else ""
+    conn = psycopg2.connect(build_dsn())
+
+    try:
+        rows = fetch_under_dim_pg_ids(conn, args.include_legacy_band)
+        log(f"found {len(rows)} row(s) with chars < target threshold")
+
+        if args.dry_run:
+            for pg_id, chars in rows[: args.limit] if args.limit else rows:
+                print(f"{pg_id}\t{chars}")
+            log(
+                f"[DRY-RUN] done — {len(rows)} total, "
+                f"listed {min(args.limit or len(rows), len(rows))}"
+            )
+            return 0
+
+        target = rows[: args.limit] if args.limit else rows
+        log(f"processing {len(target)} pg_id(s)")
+
+        stats = {"ok": 0, "now_at_min": 0, "still_short": 0, "error": 0}
+        for i, (pg_id, before_chars) in enumerate(target, 1):
+            ok, detail = enrich_one(pg_id, key)
+            if ok:
+                stats["ok"] += 1
+                after = fetch_row_chars(conn, pg_id)
+                if after is not None and after >= MIN_CHARS:
+                    stats["now_at_min"] += 1
+                    log(
+                        f"  [{i:3d}/{len(target)}] pg_id={pg_id:5s} "
+                        f"{before_chars}→{after}c ✓ ({detail})"
+                    )
+                else:
+                    stats["still_short"] += 1
+                    log(
+                        f"  [{i:3d}/{len(target)}] pg_id={pg_id:5s} "
+                        f"{before_chars}→{after}c ⚠ STILL SHORT ({detail})"
+                    )
+            else:
+                stats["error"] += 1
+                log(f"  [{i:3d}/{len(target)}] pg_id={pg_id:5s} → FAIL ({detail})")
+
+            if i < len(target):
+                time.sleep(args.sleep)
+
+        log(
+            f"[DONE] ok={stats['ok']} now_at_min={stats['now_at_min']} "
+            f"still_short={stats['still_short']} error={stats['error']}"
+        )
+        remaining = fetch_under_dim_pg_ids(conn, args.include_legacy_band)
+        log(f"remaining under-dim after run: {len(remaining)}")
+        return 0 if stats["error"] == 0 else 1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Suite logique de **PR #345** (rule update R1_S4 700→1500/3000c) — apporte le **moteur** capable d'atteindre le nouveau seuil et le **script** pour backfiller les 169 slots existants.

Sans ce PR, la rule update de #345 est purement déclarative : le service backend `R1EnricherService` ne peut pas générer >1000c (cap legacy). Avec ce PR, le moteur monte à 3000c et la synthèse extrait richement la matière RAG.

## Changements

### `R1EnricherService.synthesizeMicroSeo` — synth 5-paragraphes 0-LLM

Ancien : 3 fragments courts (~200c moyen, plafond 1000c hardcoded).
Nouveau : 5 paragraphes HTML structurés sourcés du YAML frontmatter via `js-yaml`.

| § | Section | Source RAG | Cible |
|---|---------|-----------|-------|
| 1 | fonction / role | `domain.role` + `must_be_true` | ~250-350c |
| 2 | critères de sélection | `selection.criteria` (full list) | ~400-500c |
| 3 | distinctions vs voisines | `domain.confusion_with[0..2]` | ~300-400c |
| 4 | équipementiers reconnus | `selection.brands.premium` | ~200-300c |
| 5 | cas d'usage + filtrage CTA | `diagnostic.symptoms` top 3 | ~250-400c |

Total visé : **1500-2500c**, plafonné à **3000c** via `truncateText`.

Reste **single-block** (pas de drift R3 multi-section). Le validator `r1-router-validator` reste responsable du `forbidden_overlap` downstream.

Constantes `R1_MICRO_SEO_MIN_CHARS=1500` / `R1_MICRO_SEO_MAX_CHARS=3000` alignées sur l'agent canon ([workspaces/seo-batch/.claude/agents/r1-content-batch.md](workspaces/seo-batch/.claude/agents/r1-content-batch.md), PR #345).

Nouveau flag qualité `R1_MICRO_SEO_BELOW_MIN` (warning, pas hard-block) pour observabilité.

### `scripts/seo/backfill-r1-micro-seo.py` — script canon

Mirror du pattern existant `backfill-r1-gatekeeper.py` :
- psycopg2 → liste `r1s_pg_id` avec `char_length(r1s_micro_seo_block) < 1500`
- POST `/api/internal/pipeline/execute` `roleId=R1_ROUTER, targetIds=[pg_id]`
- Resume-safe (re-query après chaque iter), idempotent (UPSERT côté service)
- `--dry-run`, `--limit N`, `--sleep 2.0`, `--include-legacy-band`
- Health check + INTERNAL_API_KEY guard

## Audit footprint (2026-05-07)

```
169 slots total ; avg 221c
- 132 < 300c     (78%)
- 31  ∈ [300, 499]  (18%)
-  6  ∈ [700, 1499] (legacy band, opt-in via flag)
-  0  ≥ 1500c    (canon target)
```

Backfill cible : **163 rows** par défaut, 169 avec `--include-legacy-band`.

## Test plan post-merge

```bash
# 1. Dry-run preview (no DB writes)
python3 scripts/seo/backfill-r1-micro-seo.py --dry-run --limit 5

# 2. Sample 5 gammes pour calibrer (~30s)
python3 scripts/seo/backfill-r1-micro-seo.py --limit 5 --sleep 2.0

# 3. Full backfill (~6-8 min selon RAG read latency)
python3 scripts/seo/backfill-r1-micro-seo.py --sleep 1.5

# 4. Inclure le legacy band (700-1499c) pour 100% canonique
python3 scripts/seo/backfill-r1-micro-seo.py --include-legacy-band --sleep 1.5
```

Verify post-run :
```sql
SELECT count(*) FILTER (WHERE chars >= 1500) AS at_canon,
       count(*) FILTER (WHERE chars < 1500) AS still_short,
       round(avg(chars)) AS avg_chars
FROM (SELECT char_length(COALESCE(r1s_micro_seo_block, '')) AS chars
      FROM __seo_r1_gamme_slots) s;
```

Cible : `at_canon ≥ 150 / 169` (~89%+). Slots restants `still_short` = RAG trop pauvre → flagged `R1_MICRO_SEO_BELOW_MIN`, à traiter en LLM-driven follow-up si > 20%.

## Hors scope (par discipline)

- **LLM-driven synthesis** (Anthropic API, prompt complet de `r1-content-batch.md`) — reservé aux gammes où RAG est trop pauvre. Décision data-driven post-backfill.
- Refactor `__seo_r1_keyword_plan.rkp_section_terms` injection (déjà fait par `injectKeywordTerms` line 394).
- ESLint coverage scripts/ (séparé).

## Files changed

- [backend/src/modules/admin/services/r1-enricher.service.ts](backend/src/modules/admin/services/r1-enricher.service.ts) (+126 / -17)
- [scripts/seo/backfill-r1-micro-seo.py](scripts/seo/backfill-r1-micro-seo.py) (new, 255 lines)

## Test plan

- [x] Backend `tsc --noEmit` 0 error
- [x] Python `ast.parse` syntax OK
- [x] Audit DB confirmé (169 slots, 78% <300c)
- [x] Synth produces 5 paragraphs from sample RAG (`disque-de-frein.md` covers all sections)
- [ ] CI greenlight (typecheck, lint, secrets, etc.)
- [ ] Post-merge : dry-run sample 5 + full backfill DEV

🤖 Generated with [Claude Code](https://claude.com/claude-code)