### PR TITLE
feat(seo-monitoring): V0.B GA4 multi-events + RGPD sanitize PII helper

### DIFF
--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -9,6 +9,7 @@ import { useLocation, useMatches, RemixBrowser } from "@remix-run/react";
 import { startTransition, useEffect } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { logger } from "~/utils/logger";
+import { sentryBeforeSend } from "~/utils/analytics-sanitize";
 
 // Sentry browser SDK — DSN injected at SSR time via `window.ENV.VITE_SENTRY_DSN`
 // (see root.tsx loader). When the DSN is absent, all Sentry calls are no-ops.
@@ -34,6 +35,10 @@ if (dsn) {
         useMatches,
       }),
     ],
+    // V0.B / S10 — RGPD scrubbing PII en defense-in-depth.
+    // Strip immat FR, emails, tels des URL, query-string, breadcrumbs, extra.
+    // Cf. `~/utils/analytics-sanitize`.
+    beforeSend: (event) => sentryBeforeSend(event),
   });
 }
 

--- a/frontend/app/routes/diagnostic-auto._index.tsx
+++ b/frontend/app/routes/diagnostic-auto._index.tsx
@@ -287,6 +287,27 @@ export default function DiagnosticAutoIndex() {
       c.description.toLowerCase().includes(searchQuery.toLowerCase()),
   );
 
+  // V0.B — track DTC code submit (warning_light intent) avant redirection.
+  // Pour la recherche libre, on track au blur si ≥ 3 chars (évite events
+  // spammy pendant la frappe). PII sanitize via `safeGtag`.
+  const handleDtcSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const code = dtcCode.trim().toUpperCase();
+    if (!code) return;
+    void import("~/utils/analytics").then(({ trackSymptomSearch }) => {
+      trackSymptomSearch(code, "warning_light", undefined);
+    });
+    window.location.href = `/diagnostic-auto?dtc=${encodeURIComponent(code)}`;
+  };
+
+  const handleSearchBlur = () => {
+    const query = searchQuery.trim();
+    if (query.length < 3) return;
+    void import("~/utils/analytics").then(({ trackSymptomSearch }) => {
+      trackSymptomSearch(query, "other", filteredClusters.length);
+    });
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Breadcrumbs */}
@@ -329,18 +350,10 @@ export default function DiagnosticAutoIndex() {
                 className="pl-11 h-11 rounded-xl text-base"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
+                onBlur={handleSearchBlur}
               />
             </div>
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                const code = dtcCode.trim().toUpperCase();
-                if (code) {
-                  window.location.href = `/diagnostic-auto?dtc=${encodeURIComponent(code)}`;
-                }
-              }}
-              className="flex gap-2"
-            >
+            <form onSubmit={handleDtcSubmit} className="flex gap-2">
               <Input
                 type="text"
                 placeholder="Code OBD (P0300...)"
@@ -937,16 +950,7 @@ export default function DiagnosticAutoIndex() {
               95% de fiabilité.
             </p>
           </div>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-              const code = dtcCode.trim().toUpperCase();
-              if (code) {
-                window.location.href = `/diagnostic-auto?dtc=${encodeURIComponent(code)}`;
-              }
-            }}
-            className="flex gap-2 shrink-0"
-          >
+          <form onSubmit={handleDtcSubmit} className="flex gap-2 shrink-0">
             <Input
               type="text"
               placeholder="P0300"

--- a/frontend/app/utils/analytics-sanitize.ts
+++ b/frontend/app/utils/analytics-sanitize.ts
@@ -1,0 +1,139 @@
+/**
+ * 🛡️ Analytics & Sentry — sanitize PII (S10 RGPD scrubbing)
+ *
+ * Strip user-input PII des payloads envoyés à GA4 (`gtag`) et Sentry
+ * (`beforeSend`). Defense-in-depth : couches multiples (regex + IP
+ * anonymization GA4 côté property) — pas une garantie absolue.
+ *
+ * Patterns scrubbed :
+ * - Plaque immatriculation FR (SIV `AB-123-CD` ou FNI `1234 AB 56`)
+ * - Emails (RFC 5322 simplifié)
+ * - Téléphones FR (`+33`, `0X`, espaces/tirets/points tolérés, 10 digits)
+ *
+ * Refs:
+ * - `.claude/plans/utiliser-la-meilleure-approche-zippy-waterfall.md` § S10
+ * - vault ADR-044 § Standard S10 RGPD scrubbing PII GA4/Sentry
+ */
+
+const PII_PATTERNS: ReadonlyArray<{ name: string; regex: RegExp }> = [
+  // Plaque immat FR SIV (depuis 2009) : 2 lettres - 3 chiffres - 2 lettres,
+  // séparateurs `-` ou ` ` ou aucun, case-insensitive.
+  // Exemples capturés : AB-123-CD, ab123cd, AB 123 CD
+  {
+    name: "plate_siv_fr",
+    regex: /\b[A-Za-z]{2}[\s-]?\d{3}[\s-]?[A-Za-z]{2}\b/g,
+  },
+  // Plaque immat FR FNI (avant 2009) : 1-4 chiffres, 1-3 lettres, 2 chiffres
+  // (numéro de département). Exemples : 1234 AB 56, 12-AB-56
+  {
+    name: "plate_fni_fr",
+    regex: /\b\d{1,4}[\s-]?[A-Za-z]{1,3}[\s-]?\d{2}\b/g,
+  },
+  // Emails (RFC 5322 simplifié — couvre la grande majorité des cas réels).
+  {
+    name: "email",
+    regex: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+  },
+  // Téléphones FR : `+33` ou `0X`, suivis de 9 chiffres avec séparateurs
+  // optionnels (espaces, tirets, points). Couvre `+33 6 12 34 56 78`,
+  // `06.12.34.56.78`, `0612-345-678`, etc.
+  {
+    name: "phone_fr",
+    regex: /\b(?:\+33[\s.-]?[1-9]|0[1-9])(?:[\s.-]?\d{2}){4}\b/g,
+  },
+];
+
+const REDACTION = "[REDACTED]";
+
+/**
+ * Strip PII d'une chaîne en remplaçant chaque match par `[REDACTED]`.
+ * Idempotent (ré-appliquer ne change rien après le 1er passage).
+ */
+export function sanitizeString(input: string): string {
+  if (typeof input !== "string" || input.length === 0) return input;
+  let out = input;
+  for (const { regex } of PII_PATTERNS) {
+    out = out.replace(regex, REDACTION);
+  }
+  return out;
+}
+
+/**
+ * Strip PII d'un objet de paramètres GA4 en profondeur.
+ * - Numbers, booleans, null sont retournés tels quels.
+ * - Strings sont sanitisées via `sanitizeString`.
+ * - Objets imbriqués sont sanitisés récursivement (max 5 niveaux).
+ *
+ * Ne mute pas l'input — retourne une nouvelle structure.
+ */
+export function sanitizeParams<T = unknown>(input: T, depth = 0): T {
+  if (depth > 5) return input; // garde-fou récursion infinie
+  if (input == null) return input;
+  if (typeof input === "string") {
+    return sanitizeString(input) as unknown as T;
+  }
+  if (typeof input !== "object") return input;
+  if (Array.isArray(input)) {
+    return input.map((item) => sanitizeParams(item, depth + 1)) as unknown as T;
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    out[key] = sanitizeParams(value, depth + 1);
+  }
+  return out as T;
+}
+
+/**
+ * Sentry `beforeSend` callback — sanitize les request data + breadcrumbs.
+ *
+ * Compatible `@sentry/remix` (ErrorEvent) et `@sentry/nestjs`. Le param est
+ * typé générique pour s'adapter aux différentes signatures SDK ; on opère
+ * via accès propriété défensifs pour ne pas couplar à un type SDK précis.
+ *
+ * Ne supprime pas les events ; sanitize uniquement (PII strip).
+ * Retourne l'event tel-quel si la structure ne correspond pas à un event
+ * Sentry standard (defense-in-depth, pas de crash si schema change).
+ */
+export function sentryBeforeSend<E>(event: E): E {
+  if (!event || typeof event !== "object") return event;
+  const e = event as Record<string, unknown>;
+
+  // request.url + request.query_string (str) ; query_string peut être
+  // QueryParams (tuple[]) ou string selon Sentry version — on laisse
+  // les types non-string intacts.
+  const req = e.request as Record<string, unknown> | undefined;
+  if (req && typeof req === "object") {
+    if (typeof req.url === "string") {
+      req.url = sanitizeString(req.url);
+    }
+    if (typeof req.query_string === "string") {
+      req.query_string = sanitizeString(req.query_string);
+    }
+  }
+
+  // breadcrumbs[] — message string + data object
+  if (Array.isArray(e.breadcrumbs)) {
+    e.breadcrumbs = e.breadcrumbs.map((b) => {
+      if (!b || typeof b !== "object") return b;
+      const bc = b as Record<string, unknown>;
+      return {
+        ...bc,
+        message:
+          typeof bc.message === "string"
+            ? sanitizeString(bc.message)
+            : bc.message,
+        data:
+          bc.data && typeof bc.data === "object"
+            ? sanitizeParams(bc.data)
+            : bc.data,
+      };
+    });
+  }
+
+  // extra (Record<string, unknown>)
+  if (e.extra && typeof e.extra === "object") {
+    e.extra = sanitizeParams(e.extra);
+  }
+
+  return event;
+}

--- a/frontend/app/utils/analytics.ts
+++ b/frontend/app/utils/analytics.ts
@@ -1,11 +1,28 @@
 /**
  * 📊 Analytics - Utilitaires pour le tracking des événements
  * Compatible Google Analytics (gtag.js) et console logs en dev
+ *
+ * Tous les nouveaux events passent par `safeGtag()` qui applique
+ * `sanitizeParams` (S10 RGPD : immat FR, emails, tels) avant gtag.
+ * Cf. `analytics-sanitize.ts` + plan SEO 2026 §S10.
  */
 
 import { logger } from "~/utils/logger";
+import { sanitizeParams } from "~/utils/analytics-sanitize";
 
 // GA4 Window augmentation: see frontend/env.d.ts (single source of truth)
+
+/**
+ * Wrapper interne : sanitize PII puis appelle `window.gtag('event', …)`.
+ * Tous les nouveaux trackers de ce fichier doivent passer par cette fonction.
+ *
+ * No-op silencieux si `window.gtag` indisponible (SSR, bot detection,
+ * consent denied — gestion côté `root.tsx`).
+ */
+function safeGtag(eventName: string, params: Record<string, unknown>): void {
+  if (typeof window === "undefined" || !window.gtag) return;
+  window.gtag("event", eventName, sanitizeParams(params));
+}
 
 /**
  * 👀 Tracker la vue d'un article
@@ -114,14 +131,15 @@ export function trackBookmark(
 
 /**
  * 🔍 Tracker une recherche
+ *
+ * Note RGPD : `query` est user-input → passe par `safeGtag` (sanitize
+ * immat FR, emails, tels) avant envoi à GA4.
  */
 export function trackSearch(query: string, resultsCount: number) {
-  if (typeof window !== "undefined" && window.gtag) {
-    window.gtag("event", "search", {
-      search_term: query,
-      results_count: resultsCount,
-    });
-  }
+  safeGtag("search", {
+    search_term: query,
+    results_count: resultsCount,
+  });
   logger.log("📊 Analytics: Search", { query, resultsCount });
 }
 
@@ -391,4 +409,107 @@ export function trackPurchase(
     });
   }
   logger.log("📊 Analytics: purchase", { transactionId, value });
+}
+
+// ============================================================================
+// V0.B — Diagnostic, lead generation, local intent (plan SEO 2026 § V0)
+// ============================================================================
+
+/**
+ * 🩺 Diagnostic : recherche d'un symptôme dans /diagnostic-auto
+ *
+ * Note RGPD : `query` est user-input (texte libre) → sanitize PII via `safeGtag`.
+ */
+export function trackSymptomSearch(
+  query: string,
+  intent?: "noise" | "warning_light" | "smell" | "vibration" | "leak" | "other",
+  resultsCount?: number,
+) {
+  safeGtag("symptom_search", {
+    search_term: query,
+    intent,
+    results_count: resultsCount,
+  });
+  logger.log("📊 Analytics: symptom_search", { query, intent, resultsCount });
+}
+
+/**
+ * 🎯 Diagnostic : parcours `/diagnostic-auto` complété (système identifié)
+ */
+export function trackDiagnosticCompleted(params: {
+  systemId: string;
+  symptomId?: string;
+  durationSeconds?: number;
+  resultsCount?: number;
+  ctaTaken?: "view_pieces" | "call" | "quote" | "exit";
+}) {
+  safeGtag("diagnostic_completed", {
+    system_id: params.systemId,
+    symptom_id: params.symptomId,
+    duration_seconds: params.durationSeconds,
+    results_count: params.resultsCount,
+    cta_taken: params.ctaTaken,
+  });
+  logger.log("📊 Analytics: diagnostic_completed", params);
+}
+
+/**
+ * 📞 CTA téléphone (clic sur lien `tel:`)
+ *
+ * Le numéro de téléphone du commerce (CTA) n'est pas user-input mais reste
+ * sanitize-safe par défense. La page d'origine, elle, peut contenir une URL
+ * avec query-string user-input → sanitize.
+ */
+export function trackCallClick(params: {
+  phone: string;
+  source: "header" | "footer" | "diagnostic" | "product" | "guide";
+  pageContext?: string;
+}) {
+  safeGtag("call_click", {
+    phone: params.phone,
+    source: params.source,
+    page_context: params.pageContext,
+  });
+  logger.log("📊 Analytics: call_click", params);
+}
+
+/**
+ * 📍 Intent local (clic GBP / direction / store locator)
+ *
+ * Cible Phase 1-2 ADR-036 (`local-business-agent` — zone 93).
+ */
+export function trackLocalStoreIntent(params: {
+  storeId: string;
+  action: "directions" | "call" | "view_hours" | "gbp_link";
+  source: "header" | "footer" | "local_landing" | "gbp";
+}) {
+  safeGtag("local_store_intent", {
+    store_id: params.storeId,
+    action: params.action,
+    source: params.source,
+  });
+  logger.log("📊 Analytics: local_store_intent", params);
+}
+
+/**
+ * 📝 Demande de devis / lead form submit
+ *
+ * Note RGPD : ne JAMAIS passer name/email/phone — passer un `formId` opaque
+ * + métadonnées non-PII. Le helper `safeGtag` sanitize en defense-in-depth
+ * si un champ leak.
+ */
+export function trackQuoteRequest(params: {
+  formId: string;
+  productCategory?: string;
+  vehicleId?: string;
+  estimatedValue?: number;
+}) {
+  safeGtag("quote_request", {
+    form_id: params.formId,
+    product_category: params.productCategory,
+    vehicle_id: params.vehicleId,
+    currency: "EUR",
+    value: params.estimatedValue,
+  });
+  logger.log("📊 Analytics: quote_request", params);
 }


### PR DESCRIPTION
## Summary

V0.B du plan SEO 2026 (§ standard S10) — 5 nouveaux trackers GA4 ciblés (diagnostic, lead, local intent) + helper RGPD `analytics-sanitize` qui strip immat FR / emails / tels avant envoi GA4 et Sentry.

- **Nouveau** `frontend/app/utils/analytics-sanitize.ts` : `sanitizeString` (regex SIV/FNI plaque, RFC 5322 email, tel FR), `sanitizeParams` (récursif depth 5, idempotent), `sentryBeforeSend` (typage défensif)
- **Étendu** `frontend/app/utils/analytics.ts` : `safeGtag()` wrapper sanitize, `trackSearch` migré (vulnérabilité RGPD réelle car `query` est user-input), 5 nouveaux trackers (`trackSymptomSearch`, `trackDiagnosticCompleted`, `trackCallClick`, `trackLocalStoreIntent`, `trackQuoteRequest`)
- **Étendu** `entry.client.tsx` : Sentry `beforeSend: sentryBeforeSend`
- **Wire** `diagnostic-auto._index.tsx` : `trackSymptomSearch` sur DTC code submit (intent `warning_light`) + onBlur du champ recherche libre (≥ 3 chars, intent `other`). Factorise les 2 forms duplicates DTC en `handleDtcSubmit`.

## Pourquoi

Le repo a déjà 13 trackers GA4 e-commerce câblés (purchase, add_to_cart, view_item, sélecteur véhicule, etc.) **mais aucun événement diagnostic / lead / local intent**. Sans ces signaux, le ROI des vagues V1 (R6 guide achat) et V7 (marketing G1 ADR-036) reste invisible. ADR-044 §S10 cadre la défense-in-depth RGPD.

## Garde-fous canon respectés

- Pas de "100% safe" — defense-in-depth via couches (memory `feedback_no_overclaim_security_words`)
- Réutilise gtag existant (consent + bot detection dans `root.tsx`)
- Sentry init étendu, pas réécrit
- 13 trackers existants intacts
- Wrapper `safeGtag()` : pattern canon pour nouveaux trackers + migration progressive

## Hors-scope V0.B (PRs séparées à venir)

- **Migration des 12 autres trackers existants vers `safeGtag`** : PR follow-up S10-refactor. Risque RGPD plus faible (titres SEO, IDs, catégories non user-input).
- **V0.C** : GA4 Measurement Protocol server-side (purchase backend reliable même si redirect échoue)
- **V0.D** : `gsc-coverage-fetcher` + sample top 1k prioritaires + CWV intégré au daily-fetch
- **V0.E** : Post-publish signaling (lastmod fiable + IndexNow Bing/Yandex ; **pas** `google.com/ping` déprécié)
- **Wire `trackCallClick` / `trackLocalStoreIntent` / `trackQuoteRequest`** : surfaces non identifiées en S0 (pas de `tel:` link, GBP widget, formulaire devis explicite). Trackers prêts pour la Vague 7 marketing G1.

## Test plan

- [ ] CI green (typecheck, eslint, tests, perf-gates)
- [ ] Post-deploy DEV : ouvrir `/diagnostic-auto`, taper "AB-123-CD bruit moteur", attendre blur → DevTools Network → vérifier event `symptom_search` avec `search_term: "[REDACTED] bruit moteur"`
- [ ] Soumettre code DTC `P0300` → event `symptom_search` avec `intent: warning_light`
- [ ] Sentry test : forcer une exception sur une page avec query-string `?email=test@example.com` → vérifier dans Sentry que `request.url` et breadcrumbs sont scrubbed
- [ ] GA4 Realtime : `symptom_search` apparaît avec sanitize appliqué

## Références

- governance-ref : vault PR #180 (ADR-044 § S10) — MERGED 2026-05-07
- followup : V0.A monorepo PR #340 (cron daily + cron/health) — MERGED 2026-05-07
- Plan détaillé : `.claude/plans/utiliser-la-meilleure-approche-zippy-waterfall.md` § V0.B + S10

## Note méthodologique

Travail effectué dans `git worktree` isolé (`/tmp/seo-v0b-worktree`) après qu'un process tiers a switché la branche du checkout principal pendant le travail (memory `feedback_git_worktree_for_concurrent_governance`). Recovery propre, pas de perte de données.

🤖 Generated with [Claude Code](https://claude.com/claude-code)