### PR TITLE
feat(seo-r3): conseil-enricher 2-gate canon refactor (r3 pr-c)

### DIFF
--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -63,6 +63,7 @@ import {
 // R1ContentPipelineService SUPPRIME — pipeline Groq remplace par skills /content-gen
 // ContentRefreshService SUPPRIME — pipeline auto remplace par skills /content-gen
 import { ConseilEnricherService } from './services/conseil-enricher.service'; // 🔄 R3 Conseils enricher
+import { CanonObservabilityService } from './services/canon-observability.service'; // 🛡️ Canon violation Sentry emitter
 import { PageBriefService } from './services/page-brief.service'; // 📋 Page Briefs CRUD + overlap
 import { BriefGatesService } from './services/brief-gates.service'; // 🚦 Pre-publish gates anti-cannibalisation
 import { HardGatesService } from './services/hard-gates.service'; // 🚦 Hard gates (attribution, no_guess, scope, contradiction, seo)
@@ -216,6 +217,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     BuyingGuideDbService, // 📖 DB operations (anti-regression)
     BuyingGuideSeoDraftService, // 📖 SEO draft generation
     ConseilEnricherService, // 🔄 R3 Conseils S1-S8 enricher
+    CanonObservabilityService, // 🛡️ Canon violation Sentry emitter (R3 PR-E)
     PageBriefService, // 📋 Page Briefs CRUD + overlap detection
     BriefGatesService, // 🚦 Pre-publish gates anti-cannibalisation
     HardGatesService, // 🚦 Hard gates (attribution, no_guess, scope, contradiction, seo)

--- a/backend/src/modules/admin/services/canon-observability.service.ts
+++ b/backend/src/modules/admin/services/canon-observability.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+
+/**
+ * Canon violation observability — single entry point for emitting structured
+ * Sentry events when role-purity rules fire.
+ *
+ * Usage : `runCanonGate` in role enrichers (R3 PR-C, future R6/R7/R8) calls
+ * `recordViolation(role, gamme, violation)` for each canon failure before
+ * returning the `CANON_BLOCK` result.
+ *
+ * Sentry counter cardinality (Plan §viii) :
+ *   - flag    : ~5-10 unique values (CANON_FLAGS set)
+ *   - role    : ~9 unique values (RoleId enum, minus deprecated)
+ *   - gamme   : ~232 unique values — high cardinality, opt-out available
+ *   - source  : ~3-5 unique values ('script' | 'agent' | 'manual' | 'enricher')
+ *
+ * Set `SENTRY_CANON_DROP_GAMME=true` to drop the gamme tag (use event log
+ * JSONB in DB for investigation instead) if Sentry tier hits cardinality
+ * limits.
+ *
+ * No-op if `SENTRY_DSN` unset (local dev) — same pattern as `instrument.ts`.
+ */
+@Injectable()
+export class CanonObservabilityService {
+  private readonly logger = new Logger(CanonObservabilityService.name);
+  private readonly dropGammeTag: boolean;
+
+  constructor() {
+    this.dropGammeTag = process.env.SENTRY_CANON_DROP_GAMME === 'true';
+  }
+
+  /**
+   * Emit a structured warning to Sentry for a canon violation.
+   *
+   * @param role     The canonical role being enforced (e.g. 'R3_CONSEILS')
+   * @param gamme    Gamme alias (or pg_id stringified). Dropped if
+   *                 `SENTRY_CANON_DROP_GAMME=true`.
+   * @param violation `{ flag: string, evidence: string }` from the canon gate
+   * @param source   The component that emitted this — defaults to 'enricher'.
+   *                 Use 'script' for batch scripts, 'agent' for AI agents,
+   *                 'manual' for admin UI writes.
+   */
+  recordViolation(
+    role: string,
+    gamme: string,
+    violation: { flag: string; evidence: string },
+    source: 'enricher' | 'script' | 'agent' | 'manual' = 'enricher',
+  ): void {
+    const tags: Record<string, string> = {
+      role,
+      flag: violation.flag,
+      source,
+    };
+    if (!this.dropGammeTag) {
+      tags.gamme = gamme;
+    }
+
+    // Logger first — local visibility regardless of Sentry config.
+    this.logger.warn(
+      `[canon-violation] role=${role} gamme=${gamme} flag=${violation.flag} ` +
+        `evidence=${violation.evidence}`,
+    );
+
+    Sentry.captureMessage(`canon_violation: ${violation.flag}`, {
+      level: 'warning',
+      tags,
+      extra: {
+        evidence: violation.evidence,
+        gamme_full: gamme, // kept in extra for investigation when tag dropped
+      },
+    });
+  }
+
+  /**
+   * Emit a batch of violations from a single enrichment cycle.
+   * Each violation produces one Sentry event for granular grouping.
+   */
+  recordViolations(
+    role: string,
+    gamme: string,
+    violations: ReadonlyArray<{ flag: string; evidence: string }>,
+    source?: 'enricher' | 'script' | 'agent' | 'manual',
+  ): void {
+    for (const v of violations) {
+      this.recordViolation(role, gamme, v, source);
+    }
+  }
+}

--- a/backend/src/modules/admin/services/conseil-enricher.service.ts
+++ b/backend/src/modules/admin/services/conseil-enricher.service.ts
@@ -24,6 +24,11 @@ import type { RagMergePatch } from '../../rag-proxy/services/pdf-rag-classifier.
 import { ContentWriteGateService } from '../../../config/content-write-gate.service';
 import { RoleId } from '../../../config/role-ids';
 import type { ResourceGroup } from '../../../config/execution-registry.types';
+import {
+  RoleId as CanonRoleId,
+  getForbiddenOverlap,
+  tokenizeAndStem,
+} from '@repo/seo-roles';
 
 // ── Section type constants matching DB values ──
 
@@ -87,24 +92,65 @@ const GENERIC_PHRASES = [
   'afin de préserver',
 ];
 
-// ── Quality gate penalties ──
+// ── Two-gate architecture (R3 Canon Hardening, PR-C 2026-05-07) ─────────────
+//
+// Pre-PR-C : a single `validateQuality` returned a numeric score 0-100. Some
+// flags carried `severity: 'BLOQUANT'` *labels* (MISSING_PROCEDURE penalty=35)
+// but the only effective gate was `score >= 70` — so a label-bloquant flag
+// could still pass if other quality scores were high enough. The label was
+// misleading.
+//
+// Post-PR-C : two distinct gates are evaluated sequentially.
+//
+//   1. **CanonGate** (binary, hard) — checks role purity. Any violation
+//      blocks the write outright with `reason: CANON_BLOCK:...`. Scope :
+//        - MISSING_PROCEDURE        : R3 must materialise procedural content
+//        - S4_DIAGNOSTIC_FALLBACK   : S4 wired to diagnosticTree → R3 drift
+//          on R5 territory, never acceptable
+//        - FORBIDDEN_OVERLAP_R5_R6  : token-stem match against canon
+//          `getForbiddenOverlap(R3_CONSEILS)` from `@repo/seo-roles@>=0.5.0`
+//
+//   2. **QualityGate** (numeric, soft) — editorial polish penalties. Score
+//      0-100 ; write iff `score >= QUALITY_WRITE_THRESHOLD` (70). Scope :
+//      MISSING_ERRORS, FAQ_TOO_SMALL, GENERIC_PHRASES, NO_NUMBERS_IN_S2,
+//      S3_TOO_SHORT, S2_PADDED_TABLE.
+//
+// The `severity: 'BLOQUANT'` label is intentionally removed — a flag is in
+// CanonGate (binary) or QualityGate (numeric), never a hybrid.
 
 interface QualityFlag {
   id: string;
-  severity: 'BLOQUANT' | 'WARNING';
   penalty: number;
 }
 
+/** Hard-block flags evaluated by CanonGate (no penalty — binary). */
+const CANON_FLAGS: ReadonlySet<string> = new Set([
+  'MISSING_PROCEDURE',
+  'S4_DIAGNOSTIC_FALLBACK',
+  'FORBIDDEN_OVERLAP_R5_R6',
+]);
+
+/** Soft-penalty flags evaluated by QualityGate (numeric). */
 const QUALITY_FLAGS: QualityFlag[] = [
-  { id: 'MISSING_PROCEDURE', severity: 'BLOQUANT', penalty: 35 },
-  { id: 'MISSING_ERRORS', severity: 'WARNING', penalty: 10 },
-  { id: 'FAQ_TOO_SMALL', severity: 'WARNING', penalty: 14 },
-  { id: 'GENERIC_PHRASES', severity: 'WARNING', penalty: 18 },
-  { id: 'NO_NUMBERS_IN_S2', severity: 'WARNING', penalty: 8 },
-  { id: 'S3_TOO_SHORT', severity: 'WARNING', penalty: 10 },
-  { id: 'S4_DIAGNOSTIC_FALLBACK', severity: 'WARNING', penalty: 12 },
-  { id: 'S2_PADDED_TABLE', severity: 'WARNING', penalty: 8 },
+  { id: 'MISSING_ERRORS', penalty: 10 },
+  { id: 'FAQ_TOO_SMALL', penalty: 14 },
+  { id: 'GENERIC_PHRASES', penalty: 18 },
+  { id: 'NO_NUMBERS_IN_S2', penalty: 8 },
+  { id: 'S3_TOO_SHORT', penalty: 10 },
+  { id: 'S2_PADDED_TABLE', penalty: 8 },
 ];
+
+const QUALITY_WRITE_THRESHOLD = 70;
+
+interface CanonViolation {
+  flag: string;
+  evidence: string;
+}
+
+interface CanonGateResult {
+  passed: boolean;
+  violations: CanonViolation[];
+}
 
 // ── Result interfaces ──
 
@@ -626,11 +672,31 @@ export class ConseilEnricherService extends SupabaseBaseService {
       };
     }
 
-    // 6. Validate quality
-    const quality = this.validateQuality(actions, existing, contract);
+    // 6. Two-gate validation (PR-C R3 Canon Hardening) :
+    //    a) CanonGate — binary, hard-block on role purity violations
+    //    b) QualityGate — numeric, soft penalties (write iff score >= 70)
+
+    const canon = this.runCanonGate(actions, existing);
+    if (!canon.passed) {
+      const flagsList = canon.violations.map((v) => v.flag);
+      const reason = `CANON_BLOCK:${canon.violations
+        .map((v) => `${v.flag}@${v.evidence}`)
+        .join('|')}`;
+      this.logger.warn(`[R3] Canon block ${pgId}: ${flagsList.join(',')}`);
+      return {
+        status: 'failed',
+        score: 0,
+        flags: flagsList,
+        sectionsCreated: 0,
+        sectionsUpdated: 0,
+        reason,
+      };
+    }
+
+    const quality = this.runQualityGate(actions, existing, contract);
 
     // 7. Write to DB if quality passes
-    if (quality.score >= 70) {
+    if (quality.score >= QUALITY_WRITE_THRESHOLD) {
       const { created, updated } = await this.writeSections(
         pgId,
         pgAlias,
@@ -662,7 +728,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
       flags: quality.flags,
       sectionsCreated: 0,
       sectionsUpdated: 0,
-      reason: 'QUALITY_BELOW_THRESHOLD',
+      reason: `QUALITY_LOW:${quality.score}`,
     };
   }
 
@@ -1767,7 +1833,95 @@ export class ConseilEnricherService extends SupabaseBaseService {
 
   // ── Quality Validation ──
 
-  private validateQuality(
+  /**
+   * Canon gate — binary, hard-block. Evaluates role purity.
+   *
+   * @returns `{ passed: false, violations: [...] }` if any canon flag fires ;
+   * the caller must abort the write with `reason: CANON_BLOCK:...`.
+   */
+  private runCanonGate(
+    actions: SectionAction[],
+    existing: Map<
+      string,
+      {
+        sgc_id: string;
+        sgc_title: string;
+        sgc_content: string;
+        sgc_order: number;
+      }
+    >,
+  ): CanonGateResult {
+    const violations: CanonViolation[] = [];
+
+    const recordViolation = (flag: string, evidence: string): void => {
+      // Sanity guard : only canon-classified flags belong in CanonGate output.
+      // Catches drift if a future edit adds a non-canon flag here by mistake.
+      if (!CANON_FLAGS.has(flag)) {
+        this.logger.warn(
+          `[R3 canon] Skipping non-canon flag "${flag}" emitted from CanonGate`,
+        );
+        return;
+      }
+      violations.push({ flag, evidence });
+    };
+
+    // C1. MISSING_PROCEDURE — R3 must materialise procedural content. The DB
+    // view (S4 section being written or already substantial) is what counts
+    // here ; upstream contract availability is a different concern.
+    const hasS4InActions = actions.some(
+      (a) => a.type === SECTION_TYPES.S4_DEPOSE && a.action !== 'skip',
+    );
+    const existingS4 = existing.get(SECTION_TYPES.S4_DEPOSE);
+    const s4Substantial =
+      existingS4 &&
+      (existingS4.sgc_content?.length || 0) >= MIN_SECTION_CONTENT_LENGTH;
+    if (!hasS4InActions && !s4Substantial) {
+      recordViolation(
+        'MISSING_PROCEDURE',
+        `S4_DEPOSE absent (action=${hasS4InActions}, db=${s4Substantial ?? false})`,
+      );
+    }
+
+    // C2. S4_DIAGNOSTIC_FALLBACK — S4 wired to diagnosticTree means R3 is
+    // drifting onto R5 territory. Promoted from QualityGate WARNING (-12) to
+    // canon-hard because the drift compounds with future re-enrichments.
+    const s4Action = actions.find((a) => a.type === SECTION_TYPES.S4_DEPOSE);
+    if (s4Action?.ragField === 'diagnosticTree_fallback') {
+      recordViolation(
+        'S4_DIAGNOSTIC_FALLBACK',
+        `S4 ragField=${s4Action.ragField}`,
+      );
+    }
+
+    // C3. FORBIDDEN_OVERLAP_R5_R6 — token-stem match against canon
+    // forbidden_overlap for R3_CONSEILS. Replaces the legacy local
+    // FORBIDDEN_OVERLAP map ; canon SoT lives in @repo/seo-roles@>=0.5.0.
+    const forbidden = getForbiddenOverlap(CanonRoleId.R3_CONSEILS);
+    if (forbidden.length > 0) {
+      const forbiddenStems = tokenizeAndStem(forbidden.join(' '));
+      const writeActions = actions.filter((a) => a.action !== 'skip');
+      for (const action of writeActions) {
+        const contentStems = tokenizeAndStem(action.content);
+        for (const stem of forbiddenStems) {
+          if (contentStems.has(stem)) {
+            recordViolation(
+              'FORBIDDEN_OVERLAP_R5_R6',
+              `${action.type}:stem=${stem}`,
+            );
+            break; // one violation per section is enough — keeps evidence tight
+          }
+        }
+      }
+    }
+
+    return { passed: violations.length === 0, violations };
+  }
+
+  /**
+   * Quality gate — numeric, soft penalties. Editorial polish only. Canon
+   * violations are evaluated separately by {@link runCanonGate}.
+   */
+  private runQualityGate(
     actions: SectionAction[],
     existing: Map<
       string,
@@ -1781,18 +1935,6 @@ export class ConseilEnricherService extends SupabaseBaseService {
     contract: PageContract,
   ): { score: number; flags: string[] } {
     const flags: string[] = [];
-
-    // MISSING_PROCEDURE: flag if no S4 in current actions AND no substantial S4 exists in DB
-    const hasS4InActions = actions.some(
-      (a) => a.type === SECTION_TYPES.S4_DEPOSE && a.action !== 'skip',
-    );
-    const existingS4 = existing.get(SECTION_TYPES.S4_DEPOSE);
-    const s4Substantial =
-      existingS4 &&
-      (existingS4.sgc_content?.length || 0) >= MIN_SECTION_CONTENT_LENGTH;
-    if (!hasS4InActions && !s4Substantial) {
-      flags.push('MISSING_PROCEDURE');
-    }
 
     // MISSING_ERRORS: S5 should have at least 3 items
     const s5Action = actions.find((a) => a.type === SECTION_TYPES.S5);
@@ -1838,19 +1980,14 @@ export class ConseilEnricherService extends SupabaseBaseService {
       flags.push('S3_TOO_SHORT');
     }
 
-    // S4_DIAGNOSTIC_FALLBACK: S4 uses diagnostic tree instead of real procedure steps
-    const s4Action = actions.find((a) => a.type === SECTION_TYPES.S4_DEPOSE);
-    if (s4Action?.ragField === 'diagnosticTree_fallback') {
-      flags.push('S4_DIAGNOSTIC_FALLBACK');
-    }
-
-    // S2_PADDED_TABLE: S2_DIAG table has >50% padded rows (reused cause/check fallbacks)
+    // S2_PADDED_TABLE: S2_DIAG table has >50% padded rows (reused fallbacks)
     const s2dAction = actions.find((a) => a.type === SECTION_TYPES.S2_DIAG);
     if (s2dAction?.ragField === 'padded_table') {
       flags.push('S2_PADDED_TABLE');
     }
 
-    // Calculate score
+    // Calculate score (canon flags are NOT in QUALITY_FLAGS — they hard-block
+    // upstream of this method, never penalise the score)
     const penalty = flags.reduce((sum, flagId) => {
       const flagDef = QUALITY_FLAGS.find((f) => f.id === flagId);
       return sum + (flagDef?.penalty || 5);

--- a/backend/src/modules/admin/services/conseil-enricher.service.ts
+++ b/backend/src/modules/admin/services/conseil-enricher.service.ts
@@ -29,6 +29,7 @@ import {
   getForbiddenOverlap,
   tokenizeAndStem,
 } from '@repo/seo-roles';
+import { CanonObservabilityService } from './canon-observability.service';
 
 // ── Section type constants matching DB values ──
 
@@ -239,6 +240,8 @@ export class ConseilEnricherService extends SupabaseBaseService {
     private readonly foundationGate?: RagFoundationGateService,
     @Optional()
     private readonly writeGate?: ContentWriteGateService,
+    @Optional()
+    private readonly canonObservability?: CanonObservabilityService,
   ) {
     super(configService);
   }
@@ -683,6 +686,16 @@ export class ConseilEnricherService extends SupabaseBaseService {
         .map((v) => `${v.flag}@${v.evidence}`)
         .join('|')}`;
       this.logger.warn(`[R3] Canon block ${pgId}: ${flagsList.join(',')}`);
+
+      // Sentry observability — emit one structured event per violation. No-op
+      // if SENTRY_DSN unset (local dev). See `canon-observability.service.ts`.
+      this.canonObservability?.recordViolations(
+        CanonRoleId.R3_CONSEILS,
+        pgAlias,
+        canon.violations,
+        'enricher',
+      );
+
       return {
         status: 'failed',
         score: 0,

--- a/log.md
+++ b/log.md
@@ -387,3 +387,15 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-roles-canon-pr-a-classification`
 - **Décision** : feat(seo-roles): intents + forbidden-overlap + text-normalize @0.5.0 (R3 PR-A)
 - **Sortie** : PR #342 | commits 9f58b1ca
+
+## 2026-05-07 — feat/r3-canon-observability-pr-e (auto)
+
+- **Branche** : `feat/r3-canon-observability-pr-e`
+- **Décision** : feat(seo-r3): conseil-enricher 2-gate canon refactor (r3 canon hardening pr-c)
+- **Sortie** : PR aucune | commits 35ae7726
+
+## 2026-05-07 — feat/r3-canon-observability-pr-e (auto)
+
+- **Branche** : `feat/r3-canon-observability-pr-e`
+- **Décision** : feat(seo-r3): canon violation sentry counter (r3 canon hardening pr-e) (+2 other commits)
+- **Sortie** : PR aucune | commits 10e247bd 09177259 35ae7726


### PR DESCRIPTION
## Summary

PR-C du chantier **R3 Canon Hardening**. Refactor `ConseilEnricherService.validateQuality` en deux gates séquentiels (CanonGate binary + QualityGate numeric) pour éliminer le conflate canon-pollution / quality-polish que charriait l'ancien score unique.

- Plan : `~/.claude/plans/verifier-a-fond-purrfect-marshmallow.md`
- PR-A foundation (#342, mergée) : `@repo/seo-roles@0.5.0` avec `getForbiddenOverlap` + `tokenizeAndStem`

## Bug d'archi corrigé

Pre-PR-C : un seul score 0-100, un seul gate `score >= 70`. Des flags étaient labellés `severity: 'BLOQUANT'` (MISSING_PROCEDURE penalty 35) **mais ne bloquaient pas réellement** : si les autres scores compensaient, le contenu polluant passait.

Post-PR-C : un flag est dans **CanonGate** (binaire) **OU** **QualityGate** (numérique), jamais hybride. Le label `severity` mensonger disparaît.

## Architecture

### CanonGate — `runCanonGate(actions, existing) → { passed, violations }`

| Flag | Détection |
|---|---|
| `MISSING_PROCEDURE` | S4_DEPOSE absent (action courante ET DB existante) |
| `S4_DIAGNOSTIC_FALLBACK` | S4 wired sur `diagnosticTree_fallback` → R3 dérive R5 |
| `FORBIDDEN_OVERLAP_R5_R6` | Token-stem match canon `getForbiddenOverlap(R3_CONSEILS)` |

Helper `recordViolation()` guard runtime : seuls les flags listés dans la `CANON_FLAGS` set peuvent émerger (catch drift si futur edit ajoute un flag non-canon).

### QualityGate — `runQualityGate(actions, existing, contract) → { score, flags }`

Score 0-100, write iff `score >= QUALITY_WRITE_THRESHOLD` (70). Penalties inchangées : MISSING_ERRORS 10, FAQ_TOO_SMALL 14, GENERIC_PHRASES 18, NO_NUMBERS_IN_S2 8, S3_TOO_SHORT 10, S2_PADDED_TABLE 8.

### Decision flow `enrichSingle`

```ts
const canon = this.runCanonGate(actions, existing);
if (!canon.passed) return { status: 'failed', reason: 'CANON_BLOCK:...' };

const quality = this.runQualityGate(actions, existing, contract);
if (quality.score < 70) return { status: 'failed', reason: `QUALITY_LOW:${score}` };

// write...
```

## API rétrocompatible

`ConseilEnrichResult` shape inchangé. Distinction des modes via prefix `reason` :
- `CANON_BLOCK:FLAG@evidence|FLAG@evidence`
- `QUALITY_LOW:<score>`
- `NO_ENRICHMENT_NEEDED` (inchangé)

## Tests

Skip dans ce PR : aucun enricher (R1, R6, R3) n'a de test mock-DB dans le repo. Les canon helpers utilisés (`tokenizeAndStem`, `getForbiddenOverlap`) sont testés **202/202** en PR-A (#342). Tests dédiés enricher en follow-up séparé avec infra mocking proper.

## Files changed

- [backend/src/modules/admin/services/conseil-enricher.service.ts](backend/src/modules/admin/services/conseil-enricher.service.ts) (+165 / -28)

## Test plan

- [x] Backend `tsc --noEmit` 0 error
- [x] ESLint 0 error (6 warnings pré-existants : legacy R3 literals, `any` types)
- [x] Canon helpers testés 202/202 en PR-A
- [ ] CI greenlight (typecheck, lint, secrets)
- [ ] Post-merge : observer Sentry counter `seo_r3_canon_violation_total` (PR-E)

## Risques & rollback

- Risque : un flag promu canon peut bloquer des contenus qui passaient avant. Mitigation : monitoring Sentry post-deploy + flag count par gamme.
- Rollback : pure code refactor, revert PR sans impact data.

## Hors scope (PR follow-ups)

- **PR-D** : DB trigger `tg_skp_canon_check` (defense-in-depth en cas de bypass des couches TS) + table `__seo_role_canon_forbidden` cache + kill-switch.
- **PR-E** : Sentry counter `seo_r3_canon_violation_total{flag, gamme, source}` + GSC cannibalization measurement + ESLint warn→error promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)