### PR TITLE
feat(seo-r3): canon violation sentry counter (r3 pr-e)

### DIFF
--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -63,6 +63,7 @@ import {
 // R1ContentPipelineService SUPPRIME — pipeline Groq remplace par skills /content-gen
 // ContentRefreshService SUPPRIME — pipeline auto remplace par skills /content-gen
 import { ConseilEnricherService } from './services/conseil-enricher.service'; // 🔄 R3 Conseils enricher
+import { CanonObservabilityService } from './services/canon-observability.service'; // 🛡️ Canon violation Sentry emitter
 import { PageBriefService } from './services/page-brief.service'; // 📋 Page Briefs CRUD + overlap
 import { BriefGatesService } from './services/brief-gates.service'; // 🚦 Pre-publish gates anti-cannibalisation
 import { HardGatesService } from './services/hard-gates.service'; // 🚦 Hard gates (attribution, no_guess, scope, contradiction, seo)
@@ -216,6 +217,7 @@ import { InternalSeoAuditController } from './controllers/internal-seo-audit.con
     BuyingGuideDbService, // 📖 DB operations (anti-regression)
     BuyingGuideSeoDraftService, // 📖 SEO draft generation
     ConseilEnricherService, // 🔄 R3 Conseils S1-S8 enricher
+    CanonObservabilityService, // 🛡️ Canon violation Sentry emitter (R3 PR-E)
     PageBriefService, // 📋 Page Briefs CRUD + overlap detection
     BriefGatesService, // 🚦 Pre-publish gates anti-cannibalisation
     HardGatesService, // 🚦 Hard gates (attribution, no_guess, scope, contradiction, seo)

--- a/backend/src/modules/admin/services/canon-observability.service.ts
+++ b/backend/src/modules/admin/services/canon-observability.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+
+/**
+ * Canon violation observability — single entry point for emitting structured
+ * Sentry events when role-purity rules fire.
+ *
+ * Usage : `runCanonGate` in role enrichers (R3 PR-C, future R6/R7/R8) calls
+ * `recordViolation(role, gamme, violation)` for each canon failure before
+ * returning the `CANON_BLOCK` result.
+ *
+ * Sentry counter cardinality (Plan §viii) :
+ *   - flag    : ~5-10 unique values (CANON_FLAGS set)
+ *   - role    : ~9 unique values (RoleId enum, minus deprecated)
+ *   - gamme   : ~232 unique values — high cardinality, opt-out available
+ *   - source  : ~3-5 unique values ('script' | 'agent' | 'manual' | 'enricher')
+ *
+ * Set `SENTRY_CANON_DROP_GAMME=true` to drop the gamme tag (use event log
+ * JSONB in DB for investigation instead) if Sentry tier hits cardinality
+ * limits.
+ *
+ * No-op if `SENTRY_DSN` unset (local dev) — same pattern as `instrument.ts`.
+ */
+@Injectable()
+export class CanonObservabilityService {
+  private readonly logger = new Logger(CanonObservabilityService.name);
+  private readonly dropGammeTag: boolean;
+
+  constructor() {
+    this.dropGammeTag = process.env.SENTRY_CANON_DROP_GAMME === 'true';
+  }
+
+  /**
+   * Emit a structured warning to Sentry for a canon violation.
+   *
+   * @param role     The canonical role being enforced (e.g. 'R3_CONSEILS')
+   * @param gamme    Gamme alias (or pg_id stringified). Dropped if
+   *                 `SENTRY_CANON_DROP_GAMME=true`.
+   * @param violation `{ flag: string, evidence: string }` from the canon gate
+   * @param source   The component that emitted this — defaults to 'enricher'.
+   *                 Use 'script' for batch scripts, 'agent' for AI agents,
+   *                 'manual' for admin UI writes.
+   */
+  recordViolation(
+    role: string,
+    gamme: string,
+    violation: { flag: string; evidence: string },
+    source: 'enricher' | 'script' | 'agent' | 'manual' = 'enricher',
+  ): void {
+    const tags: Record<string, string> = {
+      role,
+      flag: violation.flag,
+      source,
+    };
+    if (!this.dropGammeTag) {
+      tags.gamme = gamme;
+    }
+
+    // Logger first — local visibility regardless of Sentry config.
+    this.logger.warn(
+      `[canon-violation] role=${role} gamme=${gamme} flag=${violation.flag} ` +
+        `evidence=${violation.evidence}`,
+    );
+
+    Sentry.captureMessage(`canon_violation: ${violation.flag}`, {
+      level: 'warning',
+      tags,
+      extra: {
+        evidence: violation.evidence,
+        gamme_full: gamme, // kept in extra for investigation when tag dropped
+      },
+    });
+  }
+
+  /**
+   * Emit a batch of violations from a single enrichment cycle.
+   * Each violation produces one Sentry event for granular grouping.
+   */
+  recordViolations(
+    role: string,
+    gamme: string,
+    violations: ReadonlyArray<{ flag: string; evidence: string }>,
+    source?: 'enricher' | 'script' | 'agent' | 'manual',
+  ): void {
+    for (const v of violations) {
+      this.recordViolation(role, gamme, v, source);
+    }
+  }
+}

--- a/backend/src/modules/admin/services/conseil-enricher.service.ts
+++ b/backend/src/modules/admin/services/conseil-enricher.service.ts
@@ -29,6 +29,7 @@ import {
   getForbiddenOverlap,
   tokenizeAndStem,
 } from '@repo/seo-roles';
+import { CanonObservabilityService } from './canon-observability.service';
 
 // ── Section type constants matching DB values ──
 
@@ -239,6 +240,8 @@ export class ConseilEnricherService extends SupabaseBaseService {
     private readonly foundationGate?: RagFoundationGateService,
     @Optional()
     private readonly writeGate?: ContentWriteGateService,
+    @Optional()
+    private readonly canonObservability?: CanonObservabilityService,
   ) {
     super(configService);
   }
@@ -683,6 +686,16 @@ export class ConseilEnricherService extends SupabaseBaseService {
         .map((v) => `${v.flag}@${v.evidence}`)
         .join('|')}`;
       this.logger.warn(`[R3] Canon block ${pgId}: ${flagsList.join(',')}`);
+
+      // Sentry observability — emit one structured event per violation. No-op
+      // if SENTRY_DSN unset (local dev). See `canon-observability.service.ts`.
+      this.canonObservability?.recordViolations(
+        CanonRoleId.R3_CONSEILS,
+        pgAlias,
+        canon.violations,
+        'enricher',
+      );
+
       return {
         status: 'failed',
         score: 0,

--- a/log.md
+++ b/log.md
@@ -387,3 +387,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-roles-canon-pr-a-classification`
 - **Décision** : feat(seo-roles): intents + forbidden-overlap + text-normalize @0.5.0 (R3 PR-A)
 - **Sortie** : PR #342 | commits 9f58b1ca
+
+## 2026-05-07 — feat/r3-canon-observability-pr-e (auto)
+
+- **Branche** : `feat/r3-canon-observability-pr-e`
+- **Décision** : feat(seo-r3): conseil-enricher 2-gate canon refactor (r3 canon hardening pr-c)
+- **Sortie** : PR aucune | commits 35ae7726

--- a/log.md
+++ b/log.md
@@ -393,3 +393,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/r3-canon-observability-pr-e`
 - **Décision** : feat(seo-r3): conseil-enricher 2-gate canon refactor (r3 canon hardening pr-c)
 - **Sortie** : PR aucune | commits 35ae7726
+
+## 2026-05-07 — feat/r3-canon-observability-pr-e (auto)
+
+- **Branche** : `feat/r3-canon-observability-pr-e`
+- **Décision** : feat(seo-r3): canon violation sentry counter (r3 canon hardening pr-e) (+2 other commits)
+- **Sortie** : PR aucune | commits 10e247bd 09177259 35ae7726


### PR DESCRIPTION
## Summary

PR-E du chantier **R3 Canon Hardening** — observabilité Sentry. **Stack sur PR-C #348** : utilise le `runCanonGate` ajouté en PR-C pour émettre les violations vers Sentry. À retarget sur main après merge de PR-C.

- Plan : `~/.claude/plans/verifier-a-fond-purrfect-marshmallow.md`
- PR-A foundation (#342, mergée) : `@repo/seo-roles@0.5.0`
- PR-C runtime layer (#348, en revue) : `runCanonGate` + `CANON_FLAGS`
- PR-D DB trigger (#349, en revue) : `__seo_role_canon_forbidden` + `tg_skp_canon_check`

## Service `CanonObservabilityService`

Single entry point pour tous les enrichers (R3 PR-C, futurs R6/R7/R8). API :

```ts
recordViolation(role, gamme, { flag, evidence }, source)
recordViolations(role, gamme, violations[], source)
```

Émet `Sentry.captureMessage('canon_violation: <flag>', { level: 'warning', tags })`.

| Tag | Cardinality | Notes |
|---|---|---|
| `role` | ~9 | `RoleId` enum sans deprecated |
| `flag` | ~5-10 | `CANON_FLAGS` set (PR-C) |
| `source` | ~3-5 | `'enricher' \| 'script' \| 'agent' \| 'manual'` |
| `gamme` | **~232** | DROP via `SENTRY_CANON_DROP_GAMME=true` si limit hit (Plan §viii) |

Pattern identique à `instrument.ts` : no-op si `SENTRY_DSN` unset (local dev). Logger.warn local précède toujours Sentry pour visibilité.

## Wiring `ConseilEnricherService.enrichSingle`

Avant `return CANON_BLOCK`, appelle :
```ts
this.canonObservability?.recordViolations(
  CanonRoleId.R3_CONSEILS,
  pgAlias,
  canon.violations,
  'enricher',
);
```

Injection `@Optional()` — service prod sans Sentry config fonctionne identique. DI registration dans `admin.module.ts`.

## Cardinality (Plan §viii)

R3 seul : ~232 gammes × 3 flags × 1 source = **~700 séries**. Bien sous les limites Sentry standard. Pour ajout R6/R7/R8 plus tard : monitor + drop `gamme` si > 5k actives.

## Files changed

- [backend/src/modules/admin/services/canon-observability.service.ts](backend/src/modules/admin/services/canon-observability.service.ts) (new, ~95 lines)
- [backend/src/modules/admin/services/conseil-enricher.service.ts](backend/src/modules/admin/services/conseil-enricher.service.ts) (+10 lines : import + inject + recordViolations call)
- [backend/src/modules/admin/admin.module.ts](backend/src/modules/admin/admin.module.ts) (+2 lines : import + provider)

## Test plan

- [x] Backend `tsc --noEmit` 0 error
- [x] Service no-op pattern verified (no DSN → silent)
- [x] Optional injection (rebuild without provider works)
- [ ] CI greenlight
- [ ] Post-merge : trigger known canon violation in DEV, verify Sentry event with tags

## Hors scope (R3 canon Phase 3, follow-ups)

- **GSC cannibalization measurement** (R3↔R5 sample queries) → cron VPS DEV séparé.
- **ESLint warn→error promotion** : déclenchée à T+7d si `seo_r3_canon_violation_total=0/7d`. Suit pattern `pr-3b-promotion-trigger-20260512`.
- **CI guard hash check** : vérifier `hash(canon TS) == hash(canon DB)` après chaque release `@repo/seo-roles`. Vault routine séparée.
- **Tests** : skip dans PR-E (service pure SDK Sentry). Suite mock `@sentry/nestjs` en follow-up.

## Stack relations

| PR | Layer | Status |
|---|---|---|
| #342 | Layer 1 — package canon | ✅ MERGED |
| (PR-B in #342) | Layer 2 — script consumer | ✅ MERGED |
| #348 | Layer 3 — service 2-gate | 🔄 base de ce PR |
| #349 | Layer 4 — DB trigger | 🔄 sibling |
| **#TBD** | **Layer 5 — Sentry observability** | **THIS PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)