### PR TITLE
fix(ci): propagate SESSION_SECRET to preprod deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,6 +716,13 @@ jobs:
           NODE_ENV: preprod
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          # SESSION_SECRET propagation : depuis PR #339 (commit 6c7df152), main.ts:102
+          # fail-fast si SESSION_SECRET manquant ou < 32 chars en NODE_ENV=production.
+          # Le container preprod tourne en NODE_ENV=production (Dockerfile:39+63 +
+          # docker-compose.preprod.yml:9 override le NODE_ENV=preprod du shell CI),
+          # donc le fail-fast trigger ici. Source : audit-trail vault
+          # 2026-05-07-pr339-deploy-regression.md.
+          SESSION_SECRET: ${{ secrets.PREPROD_SESSION_SECRET }}
           READ_ONLY: "true"
         run: |
           docker pull massdoc/nestjs-remix-monorepo:preprod
@@ -733,6 +740,7 @@ jobs:
           NODE_ENV=preprod
           SUPABASE_URL=${SUPABASE_URL}
           SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+          SESSION_SECRET=${SESSION_SECRET}
           READ_ONLY=true
           REDIS_URL=redis://redis-preprod:6379
           APP_URL=http://localhost:3200

--- a/docker-compose.preprod.yml
+++ b/docker-compose.preprod.yml
@@ -11,6 +11,10 @@ services:
       - DATABASE_URL
       - SUPABASE_SERVICE_ROLE_KEY
       - SUPABASE_URL
+      # SESSION_SECRET : required by main.ts:102 fail-fast (PR #339, NODE_ENV=production
+      # >= 32 chars non-placeholder). Injected via secrets.PREPROD_SESSION_SECRET → .env
+      # heredoc in ci.yml deploy job → loaded by env_file + shell `. .env`.
+      - SESSION_SECRET
       - USE_UNIFIED_RPC=true
       # 🛡️ RPC Safety Gate - ENFORCE P1 (2026-02-03)
       - RPC_GATE_MODE=enforce


### PR DESCRIPTION
## Summary

PR #339 (commit `6c7df152`) a activé `main.ts:102` fail-fast `SESSION_SECRET >= 32 chars + non-placeholder` en `NODE_ENV=production` mais a touché **uniquement `main.ts` (1 fichier)**. Propagation infra oubliée.

5 deploys main consécutifs failed depuis 2026-05-06 18:03 UTC. Container preprod crash au boot :
> Error: SESSION_SECRET MANQUANT en production. Génère un secret >= 32 caractères avec: openssl rand -base64 32

## Chain causale

| Couche | NODE_ENV | SESSION_SECRET |
|---|---|---|
| `Dockerfile:39,63` | force `production` | — |
| `docker-compose.preprod.yml:9` | force `production` (override shell CI) | ❌ pas listé |
| `ci.yml:716` heredoc `.env.preprod` | met `preprod` (ignoré par compose) | ❌ pas dans heredoc |
| `main.ts:102` | voit `production` | throw → crash boot |

## Fix (no bricolage, aligné pattern existant)

| Fichier | Diff | Pattern |
|---|---|---|
| `.github/workflows/ci.yml` job deploy `env:` | `+ SESSION_SECRET: ${{ secrets.PREPROD_SESSION_SECRET }}` | identique à `SUPABASE_URL` |
| `.github/workflows/ci.yml` heredoc | `+ SESSION_SECRET=${SESSION_SECRET}` | identique à `SUPABASE_URL=${SUPABASE_URL}` |
| `docker-compose.preprod.yml` `environment:` | `+ - SESSION_SECRET` (bare, inherit shell) | identique à `- SUPABASE_URL` |

**SOPS pas utilisé** ici — SOPS reste réservé Sentry (PR-D #324). Pattern app secrets DEV preprod = GH secret → heredoc, établi pour SUPABASE_*, vérifié 2026-05-07.

## Action opérateur (déjà faite)

```bash
openssl rand -base64 48 | tr -d '\n' | gh secret set PREPROD_SESSION_SECRET --repo ak125/nestjs-remix-monorepo
```

Verified : `gh secret list | grep SESSION` → `PREPROD_SESSION_SECRET 2026-05-07`.

## Test plan

- [ ] CI vert sur cette PR (lint + typecheck + perf-gates)
- [ ] Post-merge : ci.yml run → step `🧪 Deploy PREPROD` SUCCESS (vs FAILURE depuis 5 deploys)
- [ ] `curl -sf http://localhost:3200/health` côté VPS preprod : 200
- [ ] Container logs : pas de `SESSION_SECRET MANQUANT` ni `[SECURITY] FAIBLE`
- [ ] Smoke navigateur sur page R1 : pas de CSP violation Sentry (déblocage downstream PR #344)

## Hors scope

- ❌ Migrer vers SOPS — overkill, anti-pattern vs SUPABASE_* existant
- ❌ Modifier `~/production/.env` PROD — VPS PROD a déjà SESSION_SECRET (REQUIRED_VARS check `deploy-prod.yml:109` passe historiquement)
- ❌ Revert PR #339 — régression sécurité STRIDE 03-sessions critique #3

## Références

- PR #339 (`6c7df152`) : main.ts fail-fast logic Sprint 1 Plan F
- PR #344 (`ac4fb402`) : Sentry CSP fix bloqué en attente cette PR
- Memory `feedback_check_secret_propagation_when_adding_fail_fast.md` (créée)
- Audit-trail vault `2026-05-07-pr339-deploy-regression.md` (créé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)