### PR TITLE
feat(ast-grep): promote no-direct-rag-knowledge-write to error + tighten allowlist (PR-A)

### DIFF
--- a/.ast-grep/rules/no-direct-rag-knowledge-write.yml
+++ b/.ast-grep/rules/no-direct-rag-knowledge-write.yml
@@ -1,11 +1,13 @@
 id: no-direct-rag-knowledge-write
 language: python
-severity: warning
+# Phase 1 PR-A — bumped warning → error (ADR-046 § Layer L3 RAG MIRROR
+# read-only). Pre-commit hook bloque les commits avec violations error.
+severity: error
 message: |
   Écriture directe vers `automecanik-rag/knowledge/` (ou `/opt/automecanik/rag/knowledge/`)
-  interdite. Ce répertoire est un MIRROR généré automatiquement depuis
+  interdite. Ce répertoire est un MIRROR L3 généré automatiquement depuis
   `automecanik-wiki/exports/rag/` via le CI workflow `sync-rag-from-wiki.yml`
-  (ADR-031 §D20/D22, plan v3 §Étape 7).
+  (ADR-031 §D20/D22, ADR-046 § Layer L3 RAG MIRROR read-only).
 
   Pipeline canon :
     automecanik-raw/         (sources brutes)
@@ -32,8 +34,10 @@ files:
   - scripts/wiki-exports/**/*.py
   - scripts/raw-downloaders/**/*.py
 ignores:
-  # Le sync officiel a le droit d'écrire vers rag/knowledge — c'est sa raison d'être.
-  - scripts/rag-sync/**
+  # Phase 1 PR-A — allowlist canon : un seul script peut écrire vers L3
+  # RAG MIRROR. Tout autre fichier dans `scripts/rag-sync/` est
+  # délibérément non-allowlisté (drift garde-fou).
+  - scripts/rag-sync/sync-wiki-exports-to-rag.py
   # Tests / fixtures peuvent référencer le path en literal.
   - scripts/**/test_*.py
   - scripts/**/*_test.py


### PR DESCRIPTION
## Summary

Phase 1 **PR-A** du plan **Refondation R-stack** (ADR-046 § L3 RAG MIRROR read-only). Élève la garde mécanique ast-grep `no-direct-rag-knowledge-write.yml` du status `warning` (passive, ignorée par husky pre-commit) à `error` (bloquante).

- `severity: warning → error` — husky bloque désormais les commits avec écriture directe vers `rag/knowledge/`
- `ignores: scripts/rag-sync/**` → `scripts/rag-sync/sync-wiki-exports-to-rag.py` (allowlist canon précis — drift garde-fou)
- Référence ajoutée vers **ADR-046 § Layer L3 RAG MIRROR read-only**

## Vérification

```bash
npx ast-grep scan --config sgconfig.yml \
  --rule .ast-grep/rules/no-direct-rag-knowledge-write.yml
# 0 violations dans le scope actuel (scripts/wiki-generators/**,
# scripts/wiki-exports/**, scripts/raw-downloaders/**)
```

## Pourquoi

Le rule en `warning` était passive — `sgconfig.yml` documente : *"Severity starts at warning for new rules; promote to error once the codebase is clean."* La codebase est clean dans le scope, donc cette PR fait la promotion canonique.

L'allowlist `scripts/rag-sync/**` était trop large : elle autoriserait n'importe quel futur script ajouté dans ce dir à écrire vers L3. La nouvelle allowlist nomme explicitement `sync-wiki-exports-to-rag.py` (le seul script légitime, voir ADR-031 §D20/D22).

## Hors-scope (PRs Phase 1 séparées)

- **PR-B** : créer `no-anthropic-direct-import-in-scripts-seo.yml`
- **PR-C** : `workspaces/seo-batch/AGENTS.md` ownership canon (1 LIVE par rôle)
- **PR-D** : deprecate banners 5 fichiers déviants (sunset 2026-06-07)
- **PR-E** : L3 mechanically read-only (chmod 555 + manifest TTL + boot fail-fast + git pre-push)

## Test plan

- [x] `npx ast-grep scan` clean dans le scope
- [ ] CI green (typecheck, ESLint, tests, ast-grep CI gate)
- [ ] husky pre-commit bloque effectivement une violation test (verifié post-merge sur prochaine PR qui touche `scripts/`)

## Références

- governance-ref : vault PR #183 (ADR-046 + ADR-047 MERGED 2026-05-07)
- Plan détaillé : `/home/deploy/.claude/plans/je-remarque-une-faiblesse-eventual-flamingo.md` § Phase 1 PR-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)