### PR TITLE
feat(rag): L3 mirror readonly enforcement + bootstrap guard (MVP-0 PR-E)

### DIFF
--- a/.github/workflows/rag-permissions-audit.yml
+++ b/.github/workflows/rag-permissions-audit.yml
@@ -1,0 +1,75 @@
+name: RAG L3 Permissions Audit
+
+# ADR-046 § Layer L3 RAG MIRROR + ADR-050 enforcement at PR/push time.
+#
+# Bloque toute PR qui modifie directement rag/knowledge/ sans passer par le
+# pipeline canonique L1→L2→L3 (wiki/exports/ → sync-wiki-exports-to-rag.py).
+#
+# Memory: feedback_canon_rule_live_iff_adr_accepted.md.
+
+on:
+  pull_request:
+    paths:
+      - 'rag/knowledge/**'
+      - 'scripts/rag-sync/**'
+      - 'scripts/wiki/**'
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  rag-direct-write-guard:
+    name: rag/knowledge direct modification guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for diff against base
+
+      - name: Detect direct modifications under rag/knowledge/
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+          fi
+          HEAD_SHA="${{ github.sha }}"
+
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "ℹ️  No base commit (initial push or branch creation) — skipping rag/knowledge diff."
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA..$HEAD_SHA" -- 'rag/knowledge/' || true)
+          if [ -n "$CHANGED" ]; then
+            echo "❌ Direct modification of rag/knowledge/ detected — refused per ADR-046/050."
+            echo ""
+            echo "Files modified:"
+            echo "$CHANGED" | sed 's/^/  /'
+            echo ""
+            echo "rag/knowledge/ est un MIRROR L3 read-only. Toute écriture doit passer"
+            echo "par automecanik-wiki/exports/rag/ + sync-wiki-exports-to-rag.py."
+            exit 1
+          fi
+          echo "✓ Aucune modification directe rag/knowledge/ détectée."
+
+  ast-grep-rag-write:
+    name: ast-grep no-direct-rag-knowledge-write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ast-grep rule
+        run: |
+          npx --yes @ast-grep/cli@latest scan \
+            --config sgconfig.yml \
+            --rule .ast-grep/rules/no-direct-rag-knowledge-write.yml || {
+            code=$?
+            # ast-grep returns 10 for warnings, non-zero for errors. Severity:error blocks here.
+            if [ "$code" != "0" ] && [ "$code" != "10" ]; then
+              echo "❌ ast-grep no-direct-rag-knowledge-write violations detected."
+              exit "$code"
+            fi
+          }
+          echo "✓ ast-grep no-direct-rag-knowledge-write : 0 violation."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -19,6 +19,7 @@
 zero=0000000000000000000000000000000000000000
 
 while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  # ── Check 1 : block direct pushes to protected branches (main, dev) ────
   case "$remote_ref" in
     refs/heads/main | refs/heads/dev)
       branch=${remote_ref#refs/heads/}
@@ -46,6 +47,41 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
       exit 1
       ;;
   esac
+
+  # ── Check 2 : block direct modifications to rag/knowledge/ (L3 mirror) ──
+  # ADR-046 § Layer L3 RAG MIRROR read-only + ADR-050.
+  # rag/knowledge/ est généré par sync-wiki-exports-to-rag.py — toute modif
+  # directe contourne le pipeline L1→L2→L3 et casse la SoT wiki.
+  if [ "$local_sha" = "$zero" ]; then
+    continue  # deletion of branch, nothing to check
+  fi
+
+  if [ "$remote_sha" = "$zero" ]; then
+    # New branch on remote — compare against origin/main
+    range="origin/main..$local_sha"
+  else
+    range="$remote_sha..$local_sha"
+  fi
+
+  RAG_CHANGED=$(git diff --name-only "$range" -- 'rag/knowledge/' 2>/dev/null || true)
+  if [ -n "$RAG_CHANGED" ]; then
+    echo
+    echo "✗ Refused by .husky/pre-push: direct modification of rag/knowledge/ (L3 mirror)."
+    echo
+    echo "  ADR-046 § Layer L3 RAG MIRROR + ADR-050 : rag/knowledge/ est un mirror"
+    echo "  read-only généré automatiquement depuis automecanik-wiki/exports/rag/."
+    echo "  Toute modification directe contourne le pipeline L1→L2→L3 canonique."
+    echo
+    echo "  Fichiers modifiés :"
+    echo "$RAG_CHANGED" | sed 's/^/    /'
+    echo
+    echo "  Pour produire du contenu RAG, écrire dans automecanik-wiki/exports/rag/."
+    echo "  Le sync vers rag/knowledge/ est fait par scripts/rag-sync/sync-wiki-exports-to-rag.py"
+    echo "  (canon ADR-031 §D22)."
+    echo
+    echo "  Emergency bypass (incident postmortem requis) : git push --no-verify"
+    exit 1
+  fi
 done
 
 exit 0

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -58,6 +58,7 @@ import { WorkerModule } from './workers/worker.module'; // 🔄 NOUVEAU - Module
 import { AiContentModule } from './modules/ai-content/ai-content.module';
 // import { KnowledgeGraphModule } from './modules/knowledge-graph/knowledge-graph.module'; // DEV ONLY - Experimental
 import { RagProxyModule } from './modules/rag-proxy/rag-proxy.module';
+import { RagKnowledgeBootstrapModule } from './modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module'; // 🛡️ ADR-046/050 — fail-fast L3 mirror state au boot
 import { RmModule } from './modules/rm/rm.module'; // ✅ RÉACTIVÉ - Fix Dockerfile: shared-types copié (2026-02-02)
 import { MarketingModule } from './modules/marketing/marketing.module'; // 📊 NOUVEAU - Module marketing avec backlinks, content roadmap et KPIs !
 // MediaFactoryModule — SUPPRIMÉ 2026-04-10 (prototype P1, axios vuln critique, 0 usage prod)
@@ -211,6 +212,7 @@ import { DiagnosticEngineModule } from './modules/diagnostic-engine/diagnostic-e
     ...(process.env.LLM_POLISH_ENABLED === 'true' ? [AiContentModule] : []),
     // KnowledgeGraphModule,   // DEV ONLY - AI-COS reasoning experimental
     ...(process.env.RAG_ENABLED === 'true' ? [RagProxyModule] : []),
+    RagKnowledgeBootstrapModule, // 🛡️ ADR-046/050 fail-fast L3 mirror state — toujours actif (gate independent of RAG_ENABLED)
     RmModule, // ✅ RÉACTIVÉ - Fix Dockerfile shared-types (2026-02-02)
   ],
   controllers: [

--- a/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
+++ b/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
@@ -1,0 +1,74 @@
+/**
+ * RagKnowledgeBootstrapGuardService
+ *
+ * Implémente ADR-046 § Layer L3 RAG MIRROR read-only enforcement runtime.
+ *
+ * Au boot NestJS :
+ *   1. Vérifie l'existence de `<RAG_KNOWLEDGE_PATH>/.last-sync.json` (manifest produit
+ *      par le cron sync-wiki-exports-to-rag).
+ *   2. Vérifie que ce manifest n'est pas obsolète (> 24h).
+ *
+ * En production (NODE_ENV=production), fail-fast si manifest absent ou obsolète :
+ * un L3 stale signale soit un cron mort, soit une migration incomplète, et le
+ * service ne doit pas démarrer dans cet état (mémoire incident-images-2026-04-11).
+ *
+ * En dev/preprod, soft-warn (le manifest peut ne pas exister tant que Phase 3B
+ * PR-P n'a pas livré le sync canon).
+ *
+ * Bypass : `SKIP_RAG_BOOTSTRAP_GUARD=true` (escape hatch dev/CI). À documenter
+ * dans tout usage en preprod si activé.
+ *
+ * Performance : 1 fs.statSync local au boot, < 5ms. Synchrone (memory backend.md
+ * "Aucun await d'I/O distante dans onModuleInit" — fs sync local OK).
+ */
+
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const MANIFEST_FILENAME = '.last-sync.json';
+const STALE_THRESHOLD_HOURS = 24;
+
+@Injectable()
+export class RagKnowledgeBootstrapGuardService implements OnModuleInit {
+  private readonly logger = new Logger(RagKnowledgeBootstrapGuardService.name);
+
+  onModuleInit(): void {
+    if (process.env.SKIP_RAG_BOOTSTRAP_GUARD === 'true') {
+      this.logger.warn(
+        'RAG L3 bootstrap guard SKIPPED via SKIP_RAG_BOOTSTRAP_GUARD=true',
+      );
+      return;
+    }
+
+    const ragDir =
+      process.env.RAG_KNOWLEDGE_PATH ?? '/opt/automecanik/rag/knowledge';
+    const manifestPath = path.join(ragDir, MANIFEST_FILENAME);
+    const isProd = process.env.NODE_ENV === 'production';
+
+    if (!fs.existsSync(manifestPath)) {
+      const msg = `[RagKnowledgeBootstrapGuard] manifest absent: ${manifestPath}. Le cron sync-wiki-exports-to-rag doit avoir produit ce fichier (Phase 3B PR-P du plan refondation R-stack).`;
+      if (isProd) {
+        throw new Error(msg);
+      }
+      this.logger.warn(`${msg} (dev/preprod : soft-warn — Phase 3B livre le sync)`);
+      return;
+    }
+
+    const stat = fs.statSync(manifestPath);
+    const ageHours = (Date.now() - stat.mtimeMs) / 3_600_000;
+
+    if (ageHours > STALE_THRESHOLD_HOURS) {
+      const msg = `[RagKnowledgeBootstrapGuard] manifest stale (age=${ageHours.toFixed(1)}h > ${STALE_THRESHOLD_HOURS}h). Le cron sync est probablement en panne — investiguer avant restart.`;
+      if (isProd) {
+        throw new Error(msg);
+      }
+      this.logger.warn(`${msg} (dev/preprod : soft-warn)`);
+      return;
+    }
+
+    this.logger.log(
+      `✓ RAG L3 manifest fresh (age=${ageHours.toFixed(1)}h, threshold=${STALE_THRESHOLD_HOURS}h)`,
+    );
+  }
+}

--- a/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
+++ b/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
@@ -51,7 +51,9 @@ export class RagKnowledgeBootstrapGuardService implements OnModuleInit {
       if (isProd) {
         throw new Error(msg);
       }
-      this.logger.warn(`${msg} (dev/preprod : soft-warn — Phase 3B livre le sync)`);
+      this.logger.warn(
+        `${msg} (dev/preprod : soft-warn — Phase 3B livre le sync)`,
+      );
       return;
     }
 

--- a/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts
+++ b/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts
@@ -1,0 +1,17 @@
+/**
+ * RagKnowledgeBootstrapModule
+ *
+ * Câble le RagKnowledgeBootstrapGuardService au boot NestJS pour vérifier
+ * l'état L3 RAG mirror (ADR-046 + ADR-050).
+ *
+ * Importé dans AppModule (rien d'autre à faire — OnModuleInit fait le check).
+ */
+
+import { Module } from '@nestjs/common';
+import { RagKnowledgeBootstrapGuardService } from './rag-knowledge-bootstrap.guard';
+
+@Module({
+  providers: [RagKnowledgeBootstrapGuardService],
+  exports: [RagKnowledgeBootstrapGuardService],
+})
+export class RagKnowledgeBootstrapModule {}

--- a/log.md
+++ b/log.md
@@ -405,3 +405,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/adr-048-repo-map-drift-detector`
 - **Décision** : feat(spec-canon): repo-map.md drift detector + CI workflow (ADR-048 sprint 2 P1)
 - **Sortie** : PR #358 | commits 7b031164
+
+## 2026-05-07 — feat/pr-e-l3-rag-mirror-readonly (auto)
+
+- **Branche** : `feat/pr-e-l3-rag-mirror-readonly`
+- **Décision** : feat(rag): L3 mirror readonly enforcement + bootstrap guard (MVP-0 PR-E)
+- **Sortie** : PR #356 | commits 2ed2e9b7

--- a/scripts/ops/lock-rag-knowledge.sh
+++ b/scripts/ops/lock-rag-knowledge.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# lock-rag-knowledge.sh
+#
+# Verrouille le mirror L3 (`rag/knowledge/`) en mode 3-tier permissions :
+#   - owner = compte sync (rag-sync) — write+read
+#   - group = compte runtime backend (nestjs) — read-only
+#   - other = aucun accès
+#
+# Implémente ADR-046 § Layer L3 RAG MIRROR read-only + ADR-050 (Phase 0 baseline).
+#
+# Usage : sudo bash scripts/ops/lock-rag-knowledge.sh
+#
+# Variables d'environnement (override possible) :
+#   RAG_DIR         (default: /opt/automecanik/rag/knowledge)
+#   SYNC_USER       (default: rag-sync)
+#   RUNTIME_GROUP   (default: nestjs)
+#
+# Pré-requis (étape 0 manuelle, doc dans governance-vault/runbooks/RB-rag-sync-user-bootstrap.md) :
+#   sudo useradd -r -m -s /bin/bash -c "RAG sync bot" rag-sync
+#   sudo groupadd -f nestjs
+#   sudo usermod -aG nestjs rag-sync
+#
+# Rollback : scripts/ops/unlock-rag-knowledge.sh (emergency-only).
+#
+# Memory: feedback_no_bricolage_clean_layer.md, feedback_branch_scope_discipline.md.
+
+set -euo pipefail
+
+RAG_DIR="${RAG_DIR:-/opt/automecanik/rag/knowledge}"
+SYNC_USER="${SYNC_USER:-rag-sync}"
+RUNTIME_GROUP="${RUNTIME_GROUP:-nestjs}"
+
+if [ ! -d "$RAG_DIR" ]; then
+  echo "❌ RAG_DIR introuvable : $RAG_DIR" >&2
+  exit 1
+fi
+
+if ! id -u "$SYNC_USER" >/dev/null 2>&1; then
+  echo "❌ Compte $SYNC_USER inexistant. Créer via :" >&2
+  echo "   sudo useradd -r -m -s /bin/bash -c 'RAG sync bot' $SYNC_USER" >&2
+  exit 2
+fi
+
+if ! getent group "$RUNTIME_GROUP" >/dev/null 2>&1; then
+  echo "❌ Groupe $RUNTIME_GROUP inexistant. Créer via :" >&2
+  echo "   sudo groupadd -f $RUNTIME_GROUP" >&2
+  exit 3
+fi
+
+echo "▶ Lock $RAG_DIR (3-tier permissions) :"
+echo "  owner=$SYNC_USER (rwx), group=$RUNTIME_GROUP (r-x), other=0"
+
+sudo chown -R "$SYNC_USER:$RUNTIME_GROUP" "$RAG_DIR"
+sudo find "$RAG_DIR" -type d -exec chmod 750 {} +
+sudo find "$RAG_DIR" -type f -exec chmod 640 {} +
+
+# Vérification
+DIR_MODE=$(stat -c '%a' "$RAG_DIR")
+DIR_OWNER=$(stat -c '%U:%G' "$RAG_DIR")
+
+if [ "$DIR_MODE" = "750" ] && [ "$DIR_OWNER" = "$SYNC_USER:$RUNTIME_GROUP" ]; then
+  echo "✓ rag/knowledge verrouillé : owner=$DIR_OWNER, mode=$DIR_MODE/640"
+else
+  echo "❌ Vérification post-lock échouée : owner=$DIR_OWNER, mode=$DIR_MODE" >&2
+  exit 4
+fi

--- a/scripts/ops/unlock-rag-knowledge.sh
+++ b/scripts/ops/unlock-rag-knowledge.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# unlock-rag-knowledge.sh
+#
+# ROLLBACK EMERGENCY-ONLY : restaure permissions 0775 deploy:deploy
+# (état pré-MVP-0). À utiliser UNIQUEMENT si lock-rag-knowledge.sh
+# déclenche un incident bloquant en prod.
+#
+# Cette opération annule l'enforcement L3 read-only d'ADR-046/050.
+# Un incident-postmortem doit être ouvert au vault après usage :
+#   governance-vault/ledger/incidents/INC-YYYY-NNN-rag-unlock.md
+#
+# Usage : sudo bash scripts/ops/unlock-rag-knowledge.sh
+#
+# Memory: feedback_no_bricolage_clean_layer.md.
+
+set -euo pipefail
+
+RAG_DIR="${RAG_DIR:-/opt/automecanik/rag/knowledge}"
+ROLLBACK_OWNER="${ROLLBACK_OWNER:-deploy}"
+
+if [ ! -d "$RAG_DIR" ]; then
+  echo "❌ RAG_DIR introuvable : $RAG_DIR" >&2
+  exit 1
+fi
+
+echo "⚠️  EMERGENCY ROLLBACK : unlock $RAG_DIR (permissions pré-MVP-0)"
+echo "    Un incident-postmortem est attendu après cette opération."
+echo ""
+
+sudo chown -R "$ROLLBACK_OWNER:$ROLLBACK_OWNER" "$RAG_DIR"
+sudo find "$RAG_DIR" -type d -exec chmod 775 {} +
+sudo find "$RAG_DIR" -type f -exec chmod 664 {} +
+
+echo "⚠️  rag/knowledge UNLOCKED — investiguer + relancer lock-rag-knowledge.sh ASAP."
+echo "    Référence ADR-046/050. Ouvrir incident-postmortem au vault."


### PR DESCRIPTION
## Summary

Implémente **ADR-046 § Layer L3 RAG MIRROR read-only** + **ADR-050** (Phase 0 baseline MVP-0). 4 couches defense in depth pour empêcher toute écriture directe dans \`rag/knowledge/\` :

1. **Filesystem 3-tier permissions** (`scripts/ops/lock-rag-knowledge.sh`) — owner=rag-sync (rwx), group=nestjs (r-x), other=0. Mode 750/640.
2. **NestJS bootstrap fail-fast** (`backend/src/modules/rag-knowledge-bootstrap/`) — vérifie `<RAG>/.last-sync.json` < 24h en prod, soft-warn dev/preprod.
3. **Husky pre-push hook** — refuse tout push modifiant `rag/knowledge/` directement.
4. **CI workflow** (`.github/workflows/rag-permissions-audit.yml`) — git diff guard + ast-grep guard.

## Files

| Fichier | Type | Rôle |
|---------|------|------|
| `scripts/ops/lock-rag-knowledge.sh` | new | Verrouille L3 (3-tier permissions) |
| `scripts/ops/unlock-rag-knowledge.sh` | new | Rollback emergency-only (incident postmortem requis) |
| `backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts` | new | OnModuleInit fail-fast prod, soft-warn dev |
| `backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts` | new | NestJS module wiring |
| `backend/src/app.module.ts` | mod | Import RagKnowledgeBootstrapModule (toujours actif) |
| `.husky/pre-push` | mod | Block direct rag/knowledge edits (range diff smart) |
| `.github/workflows/rag-permissions-audit.yml` | new | CI 2-jobs (diff guard + ast-grep) |

## Tests

- [x] Bash syntax check : `bash -n` OK pour les 3 scripts (lock/unlock/pre-push)
- [x] Permissions scripts ops : 750
- [x] Typecheck local backend : OK pour les nouveaux fichiers (rag-knowledge-bootstrap)
- [x] Workflow YAML valide
- [ ] CI ci.yml + audit.yml + new rag-permissions-audit.yml — déclenché à l'ouverture

## Pré-requis runbook (manuel, hors PR)

Avant `lock-rag-knowledge.sh` peut tourner sur VPS DEV/PROD :
\`\`\`bash
sudo useradd -r -m -s /bin/bash -c "RAG sync bot" rag-sync
sudo groupadd -f nestjs
sudo usermod -aG nestjs rag-sync
sudo usermod -aG nestjs deploy
echo "rag-sync ALL=(root) NOPASSWD: /opt/automecanik/app/scripts/ops/lock-rag-knowledge.sh" \\
  | sudo tee /etc/sudoers.d/rag-sync && sudo chmod 440 /etc/sudoers.d/rag-sync
\`\`\`

À documenter dans `governance-vault/runbooks/RB-rag-sync-user-bootstrap.md` (vault PR follow-up).

## Refs

- **ADR-046** (vault, accepted 2026-05-07) — R-stack canonique chaîne L0-L5
- **ADR-050** (vault, accepted 2026-05-07) — Quality history & drift detection (prérequis bloquant PR-T)
- **Plan** : /home/deploy/.claude/plans/je-remarque-une-faiblesse-eventual-flamingo.md Action 5
- **Commit prérequis** : PR monorepo #352 (ast-grep severity:error + tighten allowlist)

## Phase 3B follow-up (hors PR)

Le manifest `.last-sync.json` sera produit par `scripts/rag-sync/sync-wiki-exports-to-rag.py` (existe déjà au monorepo, à étendre Phase 3B PR-P pour cron + manifest write). Tant que Phase 3B non livrée, le bootstrap guard reste soft-warn en dev/preprod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)