### PR TITLE
feat(spec-canon): repo-map.md drift detector + CI workflow (ADR-048 sprint 2 P1)

### DIFF
--- a/.github/workflows/spec-canon-repo-map-drift.yml
+++ b/.github/workflows/spec-canon-repo-map-drift.yml
@@ -56,29 +56,75 @@ jobs:
 
       - name: Run drift check
         id: drift_check
+        # Fix #4 (PR review) : set -euo pipefail explicite + jq pour valider la
+        # forme JSON avant les python3 -c. Si le script crashe, le step echoue
+        # bruyamment plutot que de silencieusement produire un JSON malforme.
+        # Mode warn-only : on accepte exit 0 du script meme avec drift, mais
+        # un crash technique (regex bug, ImportError) DOIT echouer la step.
         run: |
-          python3 scripts/spec-canon/check-repo-map-drift.py --json > /tmp/repo-map-drift.json
-          # Toujours exit 0 (mode warn-only) — la sortie JSON contient les findings
+          set -euo pipefail
+          # Run script en --json. Si ca crashe (exit != 0 sur error severity),
+          # on continue (mode warn-only) mais on emet une annotation explicite.
+          if ! python3 scripts/spec-canon/check-repo-map-drift.py --json > /tmp/repo-map-drift.json 2>/tmp/repo-map-drift.stderr; then
+            echo "::warning::check-repo-map-drift.py exit non-zero (ERROR severity findings present, mode warn-only -- voir step summary pour detail)"
+          fi
+          # Validate JSON shape avant de l'utiliser (sinon les python3 -c suivants explosent opaquement)
+          if ! python3 -c "import json,sys; d=json.load(open('/tmp/repo-map-drift.json')); assert 'summary' in d and 'findings' in d, 'JSON shape invalide'" 2>/tmp/json-validation.err; then
+            echo "::error::JSON output du script invalide. stderr script :"
+            cat /tmp/repo-map-drift.stderr || true
+            echo "JSON validation error :"
+            cat /tmp/json-validation.err || true
+            exit 1
+          fi
           cat /tmp/repo-map-drift.json
-          # Extraire le compte de warnings pour decision UI
-          WARN_COUNT=$(python3 -c "import json; d=json.load(open('/tmp/repo-map-drift.json')); print(d['summary']['warning'])")
-          ERROR_COUNT=$(python3 -c "import json; d=json.load(open('/tmp/repo-map-drift.json')); print(d['summary']['error'])")
-          echo "warn_count=$WARN_COUNT" >> $GITHUB_OUTPUT
-          echo "error_count=$ERROR_COUNT" >> $GITHUB_OUTPUT
+          # Extraire compteurs pour decision UI (JSON deja valide a ce point)
+          WARN_COUNT=$(python3 -c "import json; print(json.load(open('/tmp/repo-map-drift.json'))['summary']['warning'])")
+          ERROR_COUNT=$(python3 -c "import json; print(json.load(open('/tmp/repo-map-drift.json'))['summary']['error'])")
+          echo "warn_count=$WARN_COUNT" >> "$GITHUB_OUTPUT"
+          echo "error_count=$ERROR_COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Surface error findings as annotations
+        # Fix #4 (PR review) : error_count etait capture ligne 67 mais jamais
+        # utilise. Maintenant les errors (dir missing, format change, etc.) sont
+        # remontees via ::error:: annotations visibles dans la PR checks UI,
+        # meme en mode warn-only (exit 0). Distinct du drift legitime.
+        if: always() && steps.drift_check.outputs.error_count != '0'
+        run: |
+          set -euo pipefail
+          python3 -c "
+          import json
+          d = json.load(open('/tmp/repo-map-drift.json'))
+          for f in d['findings']:
+              if f['severity'] == 'error':
+                  print(f'::error file={f.get(\"file\", \"?\")}::{f[\"rule\"]}: {f[\"message\"]}')"
 
       - name: Generate step summary
+        # Fix #4 (PR review) : || true retire. Si le script crashe ici, on
+        # surface l'erreur via ::error:: annotation explicite plutot que de
+        # silencieusement coller un traceback dans le summary.
         if: always()
         run: |
-          echo "# 📐 Repo Map Drift Report" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Compare \`.spec/00-canon/repo-map.md\` claims with filesystem reality." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          # Re-run in human-readable mode and append to summary
-          python3 scripts/spec-canon/check-repo-map-drift.py >> $GITHUB_STEP_SUMMARY 2>&1 || true
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "---" >> $GITHUB_STEP_SUMMARY
-          echo "**Mode** : warn-only (ADR-048 escalade J+30). Drift = signal de mise à jour" >> $GITHUB_STEP_SUMMARY
-          echo "manuelle de \`repo-map.md\`, pas blocage CI. Promo \`--strict\` à évaluer post-30j." >> $GITHUB_STEP_SUMMARY
+          set -euo pipefail
+          echo "# 📐 Repo Map Drift Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Compare \`.spec/00-canon/repo-map.md\` claims with filesystem reality." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          # Re-run en mode human-readable. Si crash, capture stderr separement
+          # pour surface en annotation -- pas de masquage silencieux.
+          if ! python3 scripts/spec-canon/check-repo-map-drift.py >> "$GITHUB_STEP_SUMMARY" 2>/tmp/summary-stderr.log; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**⚠️ Script exit non-zero (errors detectes -- voir annotations CI).**" >> "$GITHUB_STEP_SUMMARY"
+            if [ -s /tmp/summary-stderr.log ]; then
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              cat /tmp/summary-stderr.log >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              echo "::warning::check-repo-map-drift.py stderr present, voir step summary"
+            fi
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "---" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Mode** : warn-only (ADR-048 escalade J+30). Drift = signal de mise à jour" >> "$GITHUB_STEP_SUMMARY"
+          echo "manuelle de \`repo-map.md\`, pas blocage CI. Promo \`--strict\` à évaluer post-30j." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment PR with drift report (if drift detected)
         if: github.event_name == 'pull_request' && steps.drift_check.outputs.warn_count != '0'

--- a/.github/workflows/spec-canon-repo-map-drift.yml
+++ b/.github/workflows/spec-canon-repo-map-drift.yml
@@ -1,0 +1,112 @@
+name: 📐 Repo Map Drift Check (ADR-048 sprint 2 P1)
+
+# Detecte les ecarts entre les chiffres declares dans .spec/00-canon/repo-map.md
+# et la realite du filesystem (backend modules, frontend routes, packages, docker configs).
+#
+# Mode warn-only initial (cohérent ADR-048 strategie escalade J+30) — affiche
+# les findings dans le step summary mais ne bloque pas la PR. Apres 30j
+# d'observation, le check pourra etre promu en `--strict` (exit 1 si drift) si
+# le signal est clair et le bruit faible.
+#
+# Reference :
+#  - ADR-048 §Implementation Sprint 2 ("PR monorepo : repo-map.md auto-generator
+#    + drift CI")
+#  - REG-002 (governance-vault) : repo-map.md state prose-only -> enforced
+#    post-merge cette PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.spec/00-canon/repo-map.md'
+      - 'backend/src/modules/**'
+      - 'frontend/app/routes/**'
+      - 'packages/**'
+      - 'docker-compose*.yml'
+      - 'scripts/spec-canon/check-repo-map-drift.py'
+      - '.github/workflows/spec-canon-repo-map-drift.yml'
+
+  push:
+    branches: [main]
+    paths:
+      - '.spec/00-canon/repo-map.md'
+      - 'backend/src/modules/**'
+      - 'frontend/app/routes/**'
+      - 'packages/**'
+      - 'docker-compose*.yml'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-repo-map-drift:
+    name: Repo Map Drift Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Run drift check
+        id: drift_check
+        run: |
+          python3 scripts/spec-canon/check-repo-map-drift.py --json > /tmp/repo-map-drift.json
+          # Toujours exit 0 (mode warn-only) — la sortie JSON contient les findings
+          cat /tmp/repo-map-drift.json
+          # Extraire le compte de warnings pour decision UI
+          WARN_COUNT=$(python3 -c "import json; d=json.load(open('/tmp/repo-map-drift.json')); print(d['summary']['warning'])")
+          ERROR_COUNT=$(python3 -c "import json; d=json.load(open('/tmp/repo-map-drift.json')); print(d['summary']['error'])")
+          echo "warn_count=$WARN_COUNT" >> $GITHUB_OUTPUT
+          echo "error_count=$ERROR_COUNT" >> $GITHUB_OUTPUT
+
+      - name: Generate step summary
+        if: always()
+        run: |
+          echo "# 📐 Repo Map Drift Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Compare \`.spec/00-canon/repo-map.md\` claims with filesystem reality." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          # Re-run in human-readable mode and append to summary
+          python3 scripts/spec-canon/check-repo-map-drift.py >> $GITHUB_STEP_SUMMARY 2>&1 || true
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "**Mode** : warn-only (ADR-048 escalade J+30). Drift = signal de mise à jour" >> $GITHUB_STEP_SUMMARY
+          echo "manuelle de \`repo-map.md\`, pas blocage CI. Promo \`--strict\` à évaluer post-30j." >> $GITHUB_STEP_SUMMARY
+
+      - name: Comment PR with drift report (if drift detected)
+        if: github.event_name == 'pull_request' && steps.drift_check.outputs.warn_count != '0'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const drift = JSON.parse(fs.readFileSync('/tmp/repo-map-drift.json', 'utf8'));
+            const findings = drift.findings || [];
+            if (findings.length === 0) return;
+            const lines = findings.map(f => {
+              if (f.metric) {
+                return `- **${f.metric}** : claim=\`${f.claimed ?? '—'}\`, réel=\`${f.actual ?? '—'}\` (drift=\`${f.drift !== undefined ? (f.drift > 0 ? '+' : '') + f.drift : '—'}\`)`;
+              }
+              return `- ${f.message}`;
+            });
+            const body = [
+              '## 📐 Repo Map Drift detecte',
+              '',
+              '`.spec/00-canon/repo-map.md` ne reflete plus la realite filesystem :',
+              '',
+              ...lines,
+              '',
+              '> Mode warn-only (ADR-048 escalade J+30). Met à jour `repo-map.md` ou ajoute la metric manquante au prochain canon refresh.',
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/log.md
+++ b/log.md
@@ -399,3 +399,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/r3-canon-observability-pr-e`
 - **Décision** : feat(seo-r3): canon violation sentry counter (r3 canon hardening pr-e) (+2 other commits)
 - **Sortie** : PR aucune | commits 10e247bd 09177259 35ae7726
+
+## 2026-05-07 — feat/adr-048-repo-map-drift-detector (auto)
+
+- **Branche** : `feat/adr-048-repo-map-drift-detector`
+- **Décision** : feat(spec-canon): repo-map.md drift detector + CI workflow (ADR-048 sprint 2 P1)
+- **Sortie** : PR #358 | commits 7b031164

--- a/scripts/spec-canon/check-repo-map-drift.py
+++ b/scripts/spec-canon/check-repo-map-drift.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""check-repo-map-drift.py - Detect drift between .spec/00-canon/repo-map.md claims and filesystem reality.
+
+Implemente le critere C2 d'ADR-048 sprint 2 P1 : detecter mecaniquement les
+ecarts entre les chiffres declares dans `repo-map.md` (canon prose au
+2026-01-06) et la realite du filesystem.
+
+Approche :
+  1. Parse `.spec/00-canon/repo-map.md` table "Statistiques"
+  2. Compare les claims numeriques (Backend modules, Frontend routes,
+     Shared packages, Docker configs) a la realite filesystem
+  3. Flag chaque metric avec drift en `warning` ; exit 0 toujours en
+     mode default (warn-only, coherent ADR-048 escalade J+30) ; exit 1
+     en mode `--strict` (test local)
+
+Usage:
+  python3 scripts/spec-canon/check-repo-map-drift.py [--json] [--strict]
+
+Reference :
+  - ADR-048 §Implementation Sprint 2 ("PR monorepo : repo-map.md auto
+    -generator + drift CI")
+  - REG-002 (governance-vault) : repo-map.md state prose-only -> enforced
+    (post-merge cette PR)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+CHECK_NAME = "repo-map-drift"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent  # scripts/spec-canon/<this> -> repo root
+REPO_MAP_PATH = REPO_ROOT / ".spec" / "00-canon" / "repo-map.md"
+
+
+def parse_repo_map_claims(text: str) -> dict[str, int]:
+    """Extract numeric claims from repo-map.md "Statistiques" table.
+
+    Expected pattern: `| Backend modules | 40 |` etc.
+    """
+    claims: dict[str, int] = {}
+    # Match table rows like "| Metric Name | 123 |"
+    for m in re.finditer(r"\|\s*([A-Z][\w\s]+?)\s*\|\s*(\d+)(\+|k\+)?\s*\|", text):
+        metric = m.group(1).strip()
+        value = int(m.group(2))
+        # Only keep the "structurel" metrics (not "Produits DB 4M+" / "Utilisateurs 59k+" / "Categories 9k+"
+        # which are external/data-driven, not filesystem-driven)
+        if metric in {
+            "Backend modules",
+            "Frontend routes",
+            "Shared packages",
+            "Docker configs",
+        }:
+            claims[metric] = value
+    return claims
+
+
+def count_filesystem_reality() -> dict[str, int]:
+    """Count actual filesystem state for each tracked metric."""
+    reality: dict[str, int] = {}
+
+    # Backend modules : dirs in backend/src/modules/ (exclude .module.ts files)
+    backend_modules_dir = REPO_ROOT / "backend" / "src" / "modules"
+    if backend_modules_dir.exists():
+        reality["Backend modules"] = sum(
+            1 for p in backend_modules_dir.iterdir() if p.is_dir()
+        )
+    else:
+        reality["Backend modules"] = 0
+
+    # Frontend routes : .tsx + .ts files in frontend/app/routes/ (top-level only)
+    frontend_routes_dir = REPO_ROOT / "frontend" / "app" / "routes"
+    if frontend_routes_dir.exists():
+        reality["Frontend routes"] = sum(
+            1
+            for p in frontend_routes_dir.iterdir()
+            if p.is_file() and p.suffix in {".tsx", ".ts"}
+        )
+    else:
+        reality["Frontend routes"] = 0
+
+    # Shared packages : dirs in packages/
+    packages_dir = REPO_ROOT / "packages"
+    if packages_dir.exists():
+        reality["Shared packages"] = sum(
+            1 for p in packages_dir.iterdir() if p.is_dir()
+        )
+    else:
+        reality["Shared packages"] = 0
+
+    # Docker configs : docker-compose*.yml at repo root
+    reality["Docker configs"] = sum(
+        1 for p in REPO_ROOT.iterdir() if p.is_file() and p.name.startswith("docker-compose") and p.suffix == ".yml"
+    )
+
+    return reality
+
+
+def main(argv: list[str]) -> int:
+    args = list(argv[1:])
+    emit_json = "--json" in args
+    strict = "--strict" in args
+
+    findings: list[dict] = []
+
+    if not REPO_MAP_PATH.exists():
+        findings.append({
+            "severity": "error",
+            "file": str(REPO_MAP_PATH.relative_to(REPO_ROOT)),
+            "rule": f"{CHECK_NAME}.repo-map-missing",
+            "message": f"repo-map.md introuvable a {REPO_MAP_PATH}. Le check ne peut pas s'executer.",
+        })
+    else:
+        try:
+            text = REPO_MAP_PATH.read_text(encoding="utf-8", errors="ignore")
+        except OSError as e:
+            findings.append({
+                "severity": "error",
+                "file": str(REPO_MAP_PATH.relative_to(REPO_ROOT)),
+                "rule": f"{CHECK_NAME}.repo-map-unreadable",
+                "message": f"Lecture impossible : {e}",
+            })
+        else:
+            claims = parse_repo_map_claims(text)
+            reality = count_filesystem_reality()
+
+            if not claims:
+                findings.append({
+                    "severity": "warning",
+                    "file": str(REPO_MAP_PATH.relative_to(REPO_ROOT)),
+                    "rule": f"{CHECK_NAME}.no-claims-found",
+                    "message": "Aucun claim numerique extrait de repo-map.md table 'Statistiques'. Le format a peut-etre change.",
+                })
+
+            for metric, claimed in claims.items():
+                actual = reality.get(metric, 0)
+                if claimed != actual:
+                    findings.append({
+                        "severity": "warning",
+                        "file": str(REPO_MAP_PATH.relative_to(REPO_ROOT)),
+                        "rule": f"{CHECK_NAME}.metric-drift",
+                        "metric": metric,
+                        "claimed": claimed,
+                        "actual": actual,
+                        "drift": actual - claimed,
+                        "message": (
+                            f"{metric} : claim={claimed}, reel={actual} "
+                            f"(drift={actual - claimed:+d}). repo-map.md est stale."
+                        ),
+                    })
+
+            # Detect metrics in reality but not in claims (new tracked dimensions ?)
+            for metric in reality:
+                if metric not in claims:
+                    findings.append({
+                        "severity": "warning",
+                        "file": str(REPO_MAP_PATH.relative_to(REPO_ROOT)),
+                        "rule": f"{CHECK_NAME}.metric-not-claimed",
+                        "metric": metric,
+                        "actual": reality[metric],
+                        "message": (
+                            f"Metric {metric} ({reality[metric]} sur filesystem) "
+                            f"absente de repo-map.md table Statistiques."
+                        ),
+                    })
+
+    if strict:
+        for f in findings:
+            if f["severity"] == "warning":
+                f["severity"] = "error"
+
+    summary = {"error": 0, "warning": 0, "info": 0}
+    for f in findings:
+        summary[f["severity"]] = summary.get(f["severity"], 0) + 1
+
+    if emit_json:
+        print(json.dumps({"check": CHECK_NAME, "findings": findings, "summary": summary}, indent=2))
+    else:
+        print(f"# Repo Map Drift Check ({REPO_MAP_PATH.relative_to(REPO_ROOT)})")
+        print()
+        if findings:
+            for f in findings:
+                marker = "[ERROR]" if f["severity"] == "error" else "[WARN]"
+                print(f"{marker} {f['rule']}: {f['message']}")
+            print()
+        print(f"Total: {summary['error']} error(s), {summary['warning']} warning(s)")
+        if "Backend modules" in (claim_dict := parse_repo_map_claims(text) if REPO_MAP_PATH.exists() else {}):
+            reality = count_filesystem_reality()
+            print()
+            print("| Metric | Claimed | Actual | Drift |")
+            print("|---|---:|---:|---:|")
+            for metric in sorted(set(list(claim_dict.keys()) + list(reality.keys()))):
+                c = claim_dict.get(metric, "—")
+                a = reality.get(metric, "—")
+                d = (a - c) if isinstance(c, int) and isinstance(a, int) else "—"
+                d_str = f"{d:+d}" if isinstance(d, int) else d
+                print(f"| {metric} | {c} | {a} | {d_str} |")
+
+    return 1 if summary["error"] > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/spec-canon/check-repo-map-drift.py
+++ b/scripts/spec-canon/check-repo-map-drift.py
@@ -39,11 +39,26 @@ REPO_MAP_PATH = REPO_ROOT / ".spec" / "00-canon" / "repo-map.md"
 def parse_repo_map_claims(text: str) -> dict[str, int]:
     """Extract numeric claims from repo-map.md "Statistiques" table.
 
-    Expected pattern: `| Backend modules | 40 |` etc.
+    Fix #2 (PR review) : regex ancree a la section `## Statistiques` pour
+    eviter de matcher des tables ailleurs (changelog, exemple, futur).
+    Si la section est absente, retourne dict vide -> finding `error`
+    (no-claims-found, fix #5 : detector casse, pas un simple drift).
+
+    Expected pattern within section : `| Backend modules | 40 |` etc.
     """
     claims: dict[str, int] = {}
-    # Match table rows like "| Metric Name | 123 |"
-    for m in re.finditer(r"\|\s*([A-Z][\w\s]+?)\s*\|\s*(\d+)(\+|k\+)?\s*\|", text):
+    # Section anchor : depuis "## Statistiques" jusqu'au prochain H2 ou EOF
+    section_match = re.search(
+        r"^##\s+Statistiques.*?\n(.*?)(?=^##\s|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not section_match:
+        return claims
+    section_body = section_match.group(1)
+
+    # Match table rows like "| Metric Name | 123 |" within the section only
+    for m in re.finditer(r"\|\s*([A-Z][\w\s]+?)\s*\|\s*(\d+)(\+|k\+)?\s*\|", section_body):
         metric = m.group(1).strip()
         value = int(m.group(2))
         # Only keep the "structurel" metrics (not "Produits DB 4M+" / "Utilisateurs 59k+" / "Categories 9k+"
@@ -58,45 +73,102 @@ def parse_repo_map_claims(text: str) -> dict[str, int]:
     return claims
 
 
-def count_filesystem_reality() -> dict[str, int]:
-    """Count actual filesystem state for each tracked metric."""
+def _count_dir_entries(
+    metric: str,
+    dir_path: Path,
+    predicate,
+    findings: list[dict],
+    reality: dict[str, int],
+) -> None:
+    """Helper : count entries matching predicate, with explicit error findings.
+
+    Fix #3 (PR review) : iterdir() peut lever PermissionError (NFS, sandbox),
+    FileNotFoundError TOCTOU (dir disparait apres .exists()), ou autre OSError.
+    Au lieu de silencieusement retourner 0 (ce qui masque la vraie cause comme
+    drift), on emet un finding `error` distinct -> le reader voit "dir missing"
+    pas "drift -40".
+    """
+    if not dir_path.exists():
+        findings.append({
+            "severity": "error",
+            "file": str(dir_path.relative_to(REPO_ROOT)) if dir_path.is_relative_to(REPO_ROOT) else str(dir_path),
+            "rule": f"{CHECK_NAME}.tracked-dir-missing",
+            "metric": metric,
+            "message": (
+                f"Repertoire suivi pour metric '{metric}' introuvable : {dir_path}. "
+                f"Drift detector ne peut pas compter -- dir absent != claim=0."
+            ),
+        })
+        return
+    try:
+        reality[metric] = sum(1 for p in dir_path.iterdir() if predicate(p))
+    except OSError as e:
+        findings.append({
+            "severity": "error",
+            "file": str(dir_path.relative_to(REPO_ROOT)) if dir_path.is_relative_to(REPO_ROOT) else str(dir_path),
+            "rule": f"{CHECK_NAME}.iterdir-failed",
+            "metric": metric,
+            "message": f"iterdir({dir_path}) leve {type(e).__name__}: {e}",
+        })
+
+
+def count_filesystem_reality() -> tuple[dict[str, int], list[dict]]:
+    """Count actual filesystem state for each tracked metric.
+
+    Fix #3 (PR review) : retourne (reality, findings) au lieu de juste reality.
+    Les findings cumulent les erreurs FS (dir missing, PermissionError, OSError)
+    distinctes du drift legitime.
+    """
     reality: dict[str, int] = {}
+    findings: list[dict] = []
 
-    # Backend modules : dirs in backend/src/modules/ (exclude .module.ts files)
-    backend_modules_dir = REPO_ROOT / "backend" / "src" / "modules"
-    if backend_modules_dir.exists():
-        reality["Backend modules"] = sum(
-            1 for p in backend_modules_dir.iterdir() if p.is_dir()
-        )
-    else:
-        reality["Backend modules"] = 0
-
-    # Frontend routes : .tsx + .ts files in frontend/app/routes/ (top-level only)
-    frontend_routes_dir = REPO_ROOT / "frontend" / "app" / "routes"
-    if frontend_routes_dir.exists():
-        reality["Frontend routes"] = sum(
-            1
-            for p in frontend_routes_dir.iterdir()
-            if p.is_file() and p.suffix in {".tsx", ".ts"}
-        )
-    else:
-        reality["Frontend routes"] = 0
-
-    # Shared packages : dirs in packages/
-    packages_dir = REPO_ROOT / "packages"
-    if packages_dir.exists():
-        reality["Shared packages"] = sum(
-            1 for p in packages_dir.iterdir() if p.is_dir()
-        )
-    else:
-        reality["Shared packages"] = 0
-
-    # Docker configs : docker-compose*.yml at repo root
-    reality["Docker configs"] = sum(
-        1 for p in REPO_ROOT.iterdir() if p.is_file() and p.name.startswith("docker-compose") and p.suffix == ".yml"
+    # Backend modules : dirs in backend/src/modules/
+    _count_dir_entries(
+        "Backend modules",
+        REPO_ROOT / "backend" / "src" / "modules",
+        lambda p: p.is_dir(),
+        findings,
+        reality,
     )
 
-    return reality
+    # Frontend routes : .tsx + .ts files in frontend/app/routes/ (top-level only)
+    # NOTE: cette metrique compte les fichiers top-level, pas les routes Remix
+    # effectives (les flat-routes peuvent etre dans des sous-dossiers via
+    # convention `routes/_layout/...`). C'est un proxy, le canon `repo-map.md`
+    # doit clarifier le perimetre exact (cf. PR review Suggestion).
+    _count_dir_entries(
+        "Frontend routes",
+        REPO_ROOT / "frontend" / "app" / "routes",
+        lambda p: p.is_file() and p.suffix in {".tsx", ".ts"},
+        findings,
+        reality,
+    )
+
+    # Shared packages : dirs in packages/
+    _count_dir_entries(
+        "Shared packages",
+        REPO_ROOT / "packages",
+        lambda p: p.is_dir(),
+        findings,
+        reality,
+    )
+
+    # Docker configs : docker-compose*.yml at repo root
+    try:
+        reality["Docker configs"] = sum(
+            1 for p in REPO_ROOT.iterdir()
+            if p.is_file() and p.name.startswith("docker-compose") and p.suffix == ".yml"
+        )
+    except OSError as e:
+        findings.append({
+            "severity": "error",
+            "file": str(REPO_ROOT),
+            "rule": f"{CHECK_NAME}.iterdir-failed",
+            "metric": "Docker configs",
+            "message": f"iterdir({REPO_ROOT}) leve {type(e).__name__}: {e}",
+        })
+
+    return reality, findings
 
 
 def main(argv: list[str]) -> int:
@@ -105,6 +177,10 @@ def main(argv: list[str]) -> int:
     strict = "--strict" in args
 
     findings: list[dict] = []
+    # Fix #1 (PR review) : claims/reality au scope main, pas de re-parse
+    # double + walrus avec `text` undefined dans le bloc human-readable.
+    claims: dict[str, int] = {}
+    reality: dict[str, int] = {}
 
     if not REPO_MAP_PATH.exists():
         findings.append({
@@ -125,14 +201,22 @@ def main(argv: list[str]) -> int:
             })
         else:
             claims = parse_repo_map_claims(text)
-            reality = count_filesystem_reality()
+            # Fix #3 : count_filesystem_reality retourne maintenant tuple (reality, fs_findings)
+            reality, fs_findings = count_filesystem_reality()
+            findings.extend(fs_findings)
 
             if not claims:
+                # Fix #5 (PR review) : severity error (pas warning) -- format change
+                # = detector casse, pas un simple drift. Doit etre visible
+                # immediatement, pas noye dans des warnings drift.
                 findings.append({
-                    "severity": "warning",
+                    "severity": "error",
                     "file": str(REPO_MAP_PATH.relative_to(REPO_ROOT)),
                     "rule": f"{CHECK_NAME}.no-claims-found",
-                    "message": "Aucun claim numerique extrait de repo-map.md table 'Statistiques'. Le format a peut-etre change.",
+                    "message": (
+                        "Aucun claim numerique extrait de repo-map.md table 'Statistiques'. "
+                        "Le format a change ou la section est absente -- detector casse."
+                    ),
                 })
 
             for metric, claimed in claims.items():
@@ -187,13 +271,13 @@ def main(argv: list[str]) -> int:
                 print(f"{marker} {f['rule']}: {f['message']}")
             print()
         print(f"Total: {summary['error']} error(s), {summary['warning']} warning(s)")
-        if "Backend modules" in (claim_dict := parse_repo_map_claims(text) if REPO_MAP_PATH.exists() else {}):
-            reality = count_filesystem_reality()
+        # Fix #1 : utilise claims/reality du scope, pas de re-parse + walrus.
+        if claims or reality:
             print()
             print("| Metric | Claimed | Actual | Drift |")
             print("|---|---:|---:|---:|")
-            for metric in sorted(set(list(claim_dict.keys()) + list(reality.keys()))):
-                c = claim_dict.get(metric, "—")
+            for metric in sorted(set(list(claims.keys()) + list(reality.keys()))):
+                c = claims.get(metric, "—")
                 a = reality.get(metric, "—")
                 d = (a - c) if isinstance(c, int) and isinstance(a, int) else "—"
                 d_str = f"{d:+d}" if isinstance(d, int) else d


### PR DESCRIPTION
## Summary

Migre `.spec/00-canon/repo-map.md` de prose-only → enforced via **drift detection en CI** (pas auto-fix). Critère **C2 d'ADR-048 sprint 2 P1**.

Le script compare les claims numériques de repo-map.md (Backend modules, Frontend routes, Shared packages, Docker configs) à la réalité filesystem. Si drift → warning + commentaire PR. **Pas de blocage CI initial** (warn-only, cohérent stratégie escalade ADR-048 J+30).

## Pourquoi drift detection seulement (pas auto-generator)

- repo-map.md contient **prose éditoriale humaine** (Vue d'ensemble, descriptions par domaine, paths critiques) qu'un generator ne peut pas reproduire fidèlement
- **Auto-fix des chiffres dans le canon = bricolage** : le canon doit rester sous contrôle humain (G1)
- Drift detection = signal au humain de faire la mise à jour manuellement, en commit signé

## Audit baseline 2026-05-07 — drift réel détecté

repo-map.md datait de **2026-01-06 (4 mois)**. Tous les chiffres ont dérivé :

| Metric | Claimed | Actual | Drift |
|---|---:|---:|---:|
| Backend modules | 40 | 45 | **+5** |
| Frontend routes | 158 | 238 | **+80** |
| Shared packages | 9 | 6 | **−3** |
| Docker configs | 7 | 10 | **+3** |

Sans ce gate, repo-map.md aurait continué à dériver silencieusement. **Le détecteur prouve immédiatement sa valeur**.

## Changements

**Nouveau script** `scripts/spec-canon/check-repo-map-drift.py` :
- Parse table "Statistiques" via regex tolérante
- Compte filesystem reality (4 metrics)
- Modes : `--json` (orchestrator pattern), `--strict` (warnings → errors), default (human-readable + tableau drift)

**Nouveau workflow** `.github/workflows/spec-canon-repo-map-drift.yml` :
- Triggers sur PRs touchant scope (canon repo-map.md, backend modules, frontend routes, packages, docker-compose)
- Mode warn-only (exit 0 toujours, n'échoue pas la PR)
- Step summary avec tableau drift visuel
- **Commentaire PR auto** si drift détecté (`actions/github-script@v9`)
- Promo `--strict` à évaluer après 30j (cohérent ADR-048)

## Self-review checklist

- [x] **Scope** : 2 nouveaux fichiers (script + workflow), aucun autre changement
- [x] **Anti-bricolage** : drift detection (signal humain), pas auto-fix (G1 préservé)
- [x] **Pattern réutilisé** : orchestrator JSON contract identique aux scripts vault (`check-moc-integrity`, `check-canon-freshness`)
- [x] **Pas de nouvelle dep** : Python stdlib uniquement (re, json, pathlib)
- [x] **Mode warn-only** : cohérent stratégie escalade ADR-048 J+30
- [x] **Test exécuté** : drift détecté sur 4/4 metrics au baseline
- [x] **CI compatible** : workflow déclenche uniquement sur paths pertinents
- [x] **Commentaire PR auto** : signal visible au reviewer si drift introduit

Self-review verdict: APPROVE

## Test plan
- [x] `python3 scripts/spec-canon/check-repo-map-drift.py` → 4 warnings (drift baseline)
- [x] `python3 scripts/spec-canon/check-repo-map-drift.py --json` → JSON valide
- [x] `python3 scripts/spec-canon/check-repo-map-drift.py --strict` → exit 1 si drift présent
- [x] Mode default human-readable produit tableau drift visuel

## Suite (séparée, non incluse dans cette PR)

1. **PR vault** : update REG-002 row `repo-map.md` state `prose-only` → `enforced`, enforcement_mechanism cite cette PR + workflow
2. **PR monorepo follow-up** : refresh `repo-map.md` content avec les chiffres réels (sous contrôle humain G1) — séparée pour préserver la séparation enforcement / canon mutation

## Refs

- ADR-048 §Implementation Sprint 2 ("PR monorepo : repo-map.md auto-generator + drift CI")
- REG-002 (governance-vault PR #193) : `repo-map.md` state `prose-only` threshold 90j → enforced après merge cette PR
- `.spec/00-canon/repo-map.md` v2.0.0 (status CANON, 2026-01-06)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
