### PR TITLE
feat(observability): instrument R2/R4/R7/R8 enrichers Sentry+OTel (MVP-0 PR-X2-min.bis)

### DIFF
--- a/backend/src/common/observability/enricher-observability.helper.ts
+++ b/backend/src/common/observability/enricher-observability.helper.ts
@@ -57,6 +57,9 @@ export function captureEnricherException(
 
   if (logger) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.error(`[${ctx.role}] enrich failed (${ctx.service}): ${message}`, err as any);
+    logger.error(
+      `[${ctx.role}] enrich failed (${ctx.service}): ${message}`,
+      err as any,
+    );
   }
 }

--- a/backend/src/modules/admin/services/r2-enricher.service.ts
+++ b/backend/src/modules/admin/services/r2-enricher.service.ts
@@ -28,6 +28,8 @@ import type { ResourceGroup } from '../../../config/execution-registry.types';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
+import { MetricsService } from '../../metrics/metrics.service';
+import { captureEnricherException } from '../../../common/observability/enricher-observability.helper';
 
 export interface R2EnrichResult {
   pgId: string;
@@ -49,6 +51,7 @@ export class R2EnricherService extends SupabaseBaseService {
   constructor(
     configService: ConfigService,
     private readonly flags: FeatureFlagsService,
+    private readonly metrics: MetricsService,
     @Optional() private readonly writeGate?: ContentWriteGateService,
   ) {
     super(configService);
@@ -236,6 +239,15 @@ export class R2EnricherService extends SupabaseBaseService {
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       this.logger.error(`${ctx} Failed: ${msg}`);
+      // ADR-050 Livrable 3 : Sentry capture obligatoire au catch level enricher.
+      captureEnricherException(error, {
+        role: 'R2_PRODUCT',
+        service: 'R2EnricherService',
+        pgId,
+        vehicleKey,
+        step: 'enrichSingle',
+      });
+      this.metrics.incrementEnrich('R2_PRODUCT', 'error');
       return {
         pgId,
         vehicleKey,

--- a/backend/src/modules/admin/services/r4-content-enricher.service.ts
+++ b/backend/src/modules/admin/services/r4-content-enricher.service.ts
@@ -23,6 +23,8 @@ import {
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
+import { MetricsService } from '../../metrics/metrics.service';
+import { captureEnricherException } from '../../../common/observability/enricher-observability.helper';
 
 // ── Types ──
 
@@ -83,6 +85,7 @@ export class R4ContentEnricherService extends SupabaseBaseService {
     configService: ConfigService,
     private readonly lintGates: R4LintGatesService,
     private readonly flags: FeatureFlagsService,
+    private readonly metrics: MetricsService,
     @Optional() private readonly writeGate?: ContentWriteGateService,
   ) {
     super(configService);
@@ -167,6 +170,14 @@ export class R4ContentEnricherService extends SupabaseBaseService {
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       this.logger.error(`[R4] enrichSingle error for ${pgAlias}: ${error}`);
+      // ADR-050 Livrable 3 : Sentry capture obligatoire au catch level enricher.
+      captureEnricherException(err, {
+        role: 'R4_REFERENCE',
+        service: 'R4ContentEnricherService',
+        pgId: pgAlias,
+        step: 'enrichSingle',
+      });
+      this.metrics.incrementEnrich('R4_REFERENCE', 'error');
       return this.buildResult(pgAlias, 0, 'failed', start, { error });
     }
   }

--- a/backend/src/modules/admin/services/r7-brand-enricher.service.ts
+++ b/backend/src/modules/admin/services/r7-brand-enricher.service.ts
@@ -23,6 +23,8 @@ import {
 } from '../../../config/brand-rag-frontmatter.schema';
 import { BrandEditorialService } from './brand-editorial.service';
 import { PageRoleValidatorService } from '../../seo/validation/page-role-validator.service';
+import { MetricsService } from '../../metrics/metrics.service';
+import { captureEnricherException } from '../../../common/observability/enricher-observability.helper';
 
 // ── Result ──
 
@@ -105,6 +107,7 @@ export class R7BrandEnricherService extends SupabaseBaseService {
     private readonly textUtils: EnricherTextUtils,
     private readonly editorial: BrandEditorialService,
     private readonly roleValidator: PageRoleValidatorService,
+    private readonly metrics: MetricsService,
   ) {
     super(configService);
   }
@@ -321,6 +324,14 @@ export class R7BrandEnricherService extends SupabaseBaseService {
       this.logger.error(
         `❌ R7 enrichment failed marque_id=${marqueId}: ${(error as Error).message}`,
       );
+      // ADR-050 Livrable 3 : Sentry capture obligatoire au catch level enricher.
+      captureEnricherException(error, {
+        role: 'R7_BRAND',
+        service: 'R7BrandEnricherService',
+        pgId: String(marqueId),
+        step: 'enrichSingle',
+      });
+      this.metrics.incrementEnrich('R7_BRAND', 'error');
       return {
         status: 'failed',
         seoDecision: 'REJECT',

--- a/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
+++ b/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
@@ -12,6 +12,8 @@ import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { EnricherTextUtils } from './enricher-text-utils.service';
 import { VehicleRagGeneratorService } from './vehicle-rag-generator.service';
+import { MetricsService } from '../../metrics/metrics.service';
+import { captureEnricherException } from '../../../common/observability/enricher-observability.helper';
 import {
   R8_TABLES,
   R8_HARD_GATES,
@@ -111,6 +113,7 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
     configService: ConfigService,
     private readonly textUtils: EnricherTextUtils,
     private readonly vehicleRagGenerator: VehicleRagGeneratorService,
+    private readonly metrics: MetricsService,
     @Optional() private readonly writeGate?: ContentWriteGateService,
     @Optional() private readonly featureFlags?: FeatureFlagsService,
   ) {
@@ -393,6 +396,14 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
       this.logger.error(
         `❌ R8 enrichment failed type_id=${typeId}: ${(error as Error).message}`,
       );
+      // ADR-050 Livrable 3 : Sentry capture obligatoire au catch level enricher.
+      captureEnricherException(error, {
+        role: 'R8_VEHICLE',
+        service: 'R8VehicleEnricherService',
+        pgId: String(typeId),
+        step: 'enrichSingle',
+      });
+      this.metrics.incrementEnrich('R8_VEHICLE', 'error');
       return {
         status: 'failed',
         seoDecision: 'REJECT',


### PR DESCRIPTION
## Summary

Suite immédiate de **PR #359** (PR-X2-min). Étend l'instrumentation Sentry `captureException` + metrics counter aux 4 enrichers avec catch top-level simple.

## Pattern canon (cf. R1EnricherService dans #359)

1. Import `MetricsService` + `captureEnricherException` helper
2. Inject `MetricsService` au constructor (avant params `@Optional()`)
3. Au catch top-level qui retourne `'failed'` :
   ```ts
   captureEnricherException(err, { role, service, pgId, step });
   this.metrics.incrementEnrich(role, 'error');
   ```

## Files

| Fichier | Lignes ajoutées | Catch instrumenté |
|---------|-----------------|--------------------|
| `r2-enricher.service.ts` | +12 | ligne 236 (enrichSingle) |
| `r4-content-enricher.service.ts` | +11 | ligne 167 (enrichSingle) |
| `r7-brand-enricher.service.ts` | +11 | ligne 320 (enrichSingle) |
| `r8-vehicle-enricher.service.ts` | +11 | ligne 392 (enrichSingle) |

## Coverage instrumentation enrichers (MVP-0)

| Rôle | Status | PR |
|------|--------|-----|
| R1_ROUTER | ✅ Instrumenté | #359 |
| R2_PRODUCT | ✅ Instrumenté | this PR |
| R4_REFERENCE | ✅ Instrumenté | this PR |
| R7_BRAND | ✅ Instrumenté | this PR |
| R8_VEHICLE | ✅ Instrumenté | this PR |
| R3_CONSEILS | 🟡 Pas de catch top-level sur enrichSingle | PR-X2-min.tris (refactor) |
| R6_GUIDE_ACHAT | 🟡 Boucle sur pgIds avec catches internes warn-level | PR-X2-min.tris |
| gamme-detail | 🟡 Service public route (rethrows) | PR-X2-min.tris |

**Total : 5/8 enrichers instrumentés (62.5%)**. Les 3 restants nécessitent une analyse structurelle des catches internes (refactor mineur des try/catch wrappers) — out-of-scope MVP-0.

## Stack

Cette PR cible **`feat/pr-x2-min-sentry-otel-smoke-test` comme base**, pas `main`. Quand PR #359 merge sur main, je rebase X2-min.bis sur main pour merge clean.

## Test plan

- [ ] CI typecheck backend (déclenché à l'ouverture)
- [ ] Smoke test post-deploy : `bash scripts/ops/seo-mvp0-smoke-test.sh dev` doit montrer ≥ 5 séries `seo_enrich_total{outcome="error"}` distinctes (R1+R2+R4+R7+R8) + 5 events Sentry distincts

## Refs

- **ADR-050** § Livrable 3 (Sentry obligatoire au catch level)
- **PR #359** (PR-X2-min : MetricsModule + helper + R1 canon)
- **Plan** : /home/deploy/.claude/plans/je-remarque-une-faiblesse-eventual-flamingo.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)