### PR TITLE
feat(preview): mobile-V5 visual preview for V4 funnel validation

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -26,6 +26,24 @@ module.exports = {
 			caughtErrorsIgnorePattern: '^_',
 		}],
 		'jsx-a11y/anchor-has-content': 'off',
+		// Mobile-V5 preview anti-leak — fixtures et hook preview ne doivent JAMAIS
+		// fuiter dans les routes V4 réelles. Whitelist : routes preview-mobile.* +
+		// composants components/mobile-v5/ (cf. overrides plus bas).
+		'no-restricted-imports': ['error',
+			{
+				patterns: [
+					{
+						group: [
+							'~/components/mobile-v5/preview-fixtures',
+							'~/components/mobile-v5/preview-fixtures.*',
+							'~/components/mobile-v5/usePreviewCart',
+							'~/components/mobile-v5/usePreviewCart.*',
+						],
+						message: '❌ Mobile-V5 preview fixtures / cart sont réservés aux routes preview-mobile.* et components/mobile-v5/. Pour la vraie app, utiliser useCart + PiecesService.',
+					},
+				],
+			},
+		],
 		// UI Lint: Classes Tailwind interdites + SEO role legacy literals (PR-3a warn)
 		'no-restricted-syntax': [
 			'warn',
@@ -83,6 +101,19 @@ module.exports = {
 			],
 			rules: {
 				'no-restricted-syntax': 'off',
+			},
+		},
+		// ── Mobile-V5 preview namespace exempt — fixtures + cart preview
+		// légitimes ici. Les routes preview-mobile.* et components/mobile-v5/**
+		// sont les seuls autorisés à importer preview-fixtures et usePreviewCart.
+		{
+			files: [
+				'app/routes/preview-mobile.{ts,tsx}',
+				'app/routes/preview-mobile.*.{ts,tsx}',
+				'app/components/mobile-v5/**/*.{ts,tsx}',
+			],
+			rules: {
+				'no-restricted-imports': 'off',
 			},
 		},
 	],

--- a/frontend/app/components/mobile-v5/BottomBar.tsx
+++ b/frontend/app/components/mobile-v5/BottomBar.tsx
@@ -1,0 +1,86 @@
+import { Link, useLocation } from "@remix-run/react";
+import {
+  Home,
+  LayoutGrid,
+  ShoppingCart,
+  User,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
+
+type Item = {
+  key: string;
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  matchPrefix?: string;
+};
+
+const ITEMS: Item[] = [
+  {
+    key: "home",
+    to: "/preview-mobile",
+    label: "Accueil",
+    icon: Home,
+    matchPrefix: "/preview-mobile",
+  },
+  {
+    key: "catalog",
+    to: "/preview-mobile/catalog",
+    label: "Catalogue",
+    icon: LayoutGrid,
+    matchPrefix: "/preview-mobile/catalog",
+  },
+  {
+    key: "garage",
+    to: "/preview-mobile/garage",
+    label: "Garage",
+    icon: Wrench,
+    matchPrefix: "/preview-mobile/garage",
+  },
+  {
+    key: "cart",
+    to: "/preview-mobile/panier",
+    label: "Panier",
+    icon: ShoppingCart,
+    matchPrefix: "/preview-mobile/panier",
+  },
+  {
+    key: "account",
+    to: "/preview-mobile/compte",
+    label: "Compte",
+    icon: User,
+    matchPrefix: "/preview-mobile/compte",
+  },
+];
+
+const isActive = (pathname: string, item: Item): boolean => {
+  if (item.key === "home") {
+    return pathname === "/preview-mobile" || pathname === "/preview-mobile/";
+  }
+  return Boolean(item.matchPrefix && pathname.startsWith(item.matchPrefix));
+};
+
+export function MV5BottomBar() {
+  const { pathname } = useLocation();
+
+  return (
+    <nav className="mv5-bottombar" aria-label="Navigation principale">
+      {ITEMS.map((item) => {
+        const Icon = item.icon;
+        const active = isActive(pathname, item);
+        return (
+          <Link
+            key={item.key}
+            to={item.to}
+            className={`mv5-bottombar-item${active ? " is-active" : ""}`}
+            aria-current={active ? "page" : undefined}
+          >
+            <Icon size={22} aria-hidden="true" />
+            <span className="mv5-bottombar-label">{item.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/app/components/mobile-v5/Header.tsx
+++ b/frontend/app/components/mobile-v5/Header.tsx
@@ -1,0 +1,80 @@
+import { ChevronLeft, Menu, type LucideIcon } from "lucide-react";
+
+type RightIcon = {
+  icon: LucideIcon;
+  label: string;
+  badge?: number | null;
+  onClick?: () => void;
+};
+
+const LEFT_ICONS = {
+  back: ChevronLeft,
+  menu: Menu,
+} as const;
+
+export function MV5Header({
+  title = "",
+  light = false,
+  leftIcon = "menu",
+  leftLabel,
+  onLeft,
+  rightIcons = [],
+}: {
+  title?: string;
+  light?: boolean;
+  leftIcon?: "back" | "menu" | null;
+  leftLabel?: string;
+  onLeft?: () => void;
+  rightIcons?: RightIcon[];
+}) {
+  const LeftIcon = leftIcon ? LEFT_ICONS[leftIcon] : null;
+  const defaultLeftLabel =
+    leftIcon === "back"
+      ? "Retour"
+      : leftIcon === "menu"
+        ? "Ouvrir le menu"
+        : "";
+
+  return (
+    <header className={`mv5-header${light ? " mv5-header-light" : ""}`}>
+      {LeftIcon ? (
+        <button
+          type="button"
+          className="mv5-icon-btn"
+          onClick={onLeft}
+          aria-label={leftLabel ?? defaultLeftLabel}
+        >
+          <LeftIcon size={22} aria-hidden="true" />
+        </button>
+      ) : (
+        <span className="mv5-icon-btn" aria-hidden="true" />
+      )}
+
+      <h1 className="mv5-header-title">{title}</h1>
+
+      {rightIcons.map((it, i) => {
+        const Icon = it.icon;
+        const ariaLabel =
+          it.badge != null && it.badge > 0
+            ? `${it.label} — ${it.badge}`
+            : it.label;
+        return (
+          <button
+            key={i}
+            type="button"
+            className="mv5-icon-btn"
+            onClick={it.onClick}
+            aria-label={ariaLabel}
+          >
+            <Icon size={22} aria-hidden="true" />
+            {it.badge != null && it.badge > 0 && (
+              <span className="mv5-header-badge" aria-hidden="true">
+                {it.badge}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </header>
+  );
+}

--- a/frontend/app/components/mobile-v5/Plaque.tsx
+++ b/frontend/app/components/mobile-v5/Plaque.tsx
@@ -1,0 +1,29 @@
+import { Car, ChevronRight } from "lucide-react";
+
+export function MV5Plaque({
+  vehicle,
+  onClick,
+}: {
+  vehicle: string | null;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="mv5-plaque"
+      onClick={onClick}
+      aria-label={
+        vehicle
+          ? `Mon véhicule sélectionné : ${vehicle}. Modifier le véhicule.`
+          : "Sélectionner mon véhicule"
+      }
+    >
+      <Car size={28} strokeWidth={2} aria-hidden="true" />
+      <span className="mv5-plaque-body">
+        <span className="mv5-plaque-label">Mon véhicule</span>
+        <span className="mv5-plaque-value">{vehicle ?? "Sélectionner"}</span>
+      </span>
+      <ChevronRight size={20} aria-hidden="true" />
+    </button>
+  );
+}

--- a/frontend/app/components/mobile-v5/ProductCard.tsx
+++ b/frontend/app/components/mobile-v5/ProductCard.tsx
@@ -1,0 +1,89 @@
+import { Link } from "@remix-run/react";
+import { Plus } from "lucide-react";
+
+import { MV5Badge, type MV5BadgeVariant } from "./atoms";
+
+export type MV5Product = {
+  ref: string;
+  brand: string;
+  name: string;
+  price: number;
+  priceOld?: number;
+  stock: number;
+  badge?: string;
+  badgeVariant?: MV5BadgeVariant;
+};
+
+const stockClass = (stock: number): string => {
+  if (stock === 0) return "mv5-product-stock-out";
+  if (stock < 5) return "mv5-product-stock-low";
+  return "";
+};
+
+const stockText = (stock: number): string => {
+  if (stock === 0) return "Rupture";
+  if (stock < 5) return `Plus que ${stock}`;
+  return "En stock";
+};
+
+export function MV5ProductCard({
+  product,
+  onAdd,
+  href,
+}: {
+  product: MV5Product;
+  onAdd?: (product: MV5Product) => void;
+  /** Lien cible — par défaut /preview-mobile/produit/:ref pour la preview. Migration vers /pieces/* en V4. */
+  href?: string;
+}) {
+  const { ref, brand, name, price, priceOld, stock, badge } = product;
+  const disabled = stock === 0;
+  const target = href ?? `/preview-mobile/produit/${encodeURIComponent(ref)}`;
+
+  return (
+    <Link to={target} className="mv5-product" prefetch="intent">
+      <div className="mv5-product-img">
+        {badge && (
+          <span className="mv5-product-badge-tl">
+            <MV5Badge variant={product.badgeVariant ?? "promo"}>
+              {badge}
+            </MV5Badge>
+          </span>
+        )}
+        <span className="mv5-product-img-mono" aria-hidden="true">
+          {ref}
+        </span>
+      </div>
+      <div className="mv5-product-body">
+        <span className="mv5-product-brand">{brand}</span>
+        <span className="mv5-product-name">{name}</span>
+        <div className="flex items-baseline gap-2">
+          <span className="mv5-product-price">{price.toFixed(2)}€</span>
+          {priceOld != null && (
+            <span className="mv5-product-price-old">
+              {priceOld.toFixed(2)}€
+            </span>
+          )}
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <span className={`mv5-product-stock ${stockClass(stock)}`}>
+            {stockText(stock)}
+          </span>
+          <button
+            type="button"
+            className="mv5-btn mv5-btn-primary mv5-product-add"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (!disabled) onAdd?.(product);
+            }}
+            disabled={disabled}
+            aria-label={`Ajouter ${brand} ${name} au panier`}
+          >
+            <Plus size={16} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/frontend/app/components/mobile-v5/QuantityStepper.tsx
+++ b/frontend/app/components/mobile-v5/QuantityStepper.tsx
@@ -1,0 +1,45 @@
+export function MV5QuantityStepper({
+  value,
+  onChange,
+  min = 1,
+  max = 99,
+  label = "Quantité",
+}: {
+  value: number;
+  onChange: (next: number) => void;
+  min?: number;
+  max?: number;
+  label?: string;
+}) {
+  const labelLower = label.toLowerCase();
+
+  return (
+    <div className="mv5-stepper" role="group" aria-label={label}>
+      <button
+        type="button"
+        className="mv5-stepper-btn"
+        onClick={() => onChange(Math.max(min, value - 1))}
+        disabled={value <= min}
+        aria-label={`Diminuer la ${labelLower}`}
+      >
+        −
+      </button>
+      <span
+        className="mv5-stepper-val"
+        aria-live="polite"
+        aria-label={`${label} : ${value}`}
+      >
+        {value}
+      </span>
+      <button
+        type="button"
+        className="mv5-stepper-btn"
+        onClick={() => onChange(Math.min(max, value + 1))}
+        disabled={value >= max}
+        aria-label={`Augmenter la ${labelLower}`}
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/components/mobile-v5/atoms.tsx
+++ b/frontend/app/components/mobile-v5/atoms.tsx
@@ -1,0 +1,197 @@
+/**
+ * Mobile V5 atoms — composants visuels signature.
+ *
+ * Ces composants seront migrés vers leurs emplacements V4 finaux
+ * (`components/home/`, `components/ecommerce/`, `components/cart/`)
+ * après validation visuelle sur les routes /preview-mobile/*.
+ */
+
+import { Check, ChevronRight, type LucideIcon } from "lucide-react";
+import { type ReactNode } from "react";
+
+/* ─── Badge ───────────────────────────────────────────── */
+export type MV5BadgeVariant =
+  | "neutral"
+  | "success"
+  | "warning"
+  | "danger"
+  | "dark"
+  | "promo"
+  | "yellow";
+
+export function MV5Badge({
+  variant = "neutral",
+  children,
+}: {
+  variant?: MV5BadgeVariant;
+  children: ReactNode;
+}) {
+  return <span className={`mv5-badge mv5-badge-${variant}`}>{children}</span>;
+}
+
+/* ─── Pill ─────────────────────────────────────────────── */
+export function MV5Pill({
+  active,
+  icon: Icon,
+  children,
+  onClick,
+}: {
+  active?: boolean;
+  icon?: LucideIcon | null;
+  children: ReactNode;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="mv5-pill"
+      aria-pressed={active ?? false}
+      onClick={onClick}
+    >
+      {Icon && <Icon size={14} aria-hidden="true" />}
+      <span>{children}</span>
+    </button>
+  );
+}
+
+/* ─── HScroll ─────────────────────────────────────────── */
+export function MV5HScroll({ children }: { children: ReactNode }) {
+  return <div className="mv5-hscroll">{children}</div>;
+}
+
+/* ─── Section heading ─────────────────────────────────── */
+export function MV5SectionHeading({
+  eyebrow,
+  title,
+  action,
+  onAction,
+}: {
+  eyebrow?: string;
+  title: string;
+  action?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <div className="mv5-section-head">
+      <div className="mv5-section-head-text">
+        {eyebrow && <span className="mv5-eyebrow">{eyebrow}</span>}
+        <h2 className="mv5-h2">{title}</h2>
+      </div>
+      {action && (
+        <button
+          type="button"
+          className="mv5-btn mv5-btn-ghost mv5-btn-sm"
+          onClick={onAction}
+        >
+          {action}
+          <ChevronRight size={14} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+/* ─── Stats band ──────────────────────────────────────── */
+export function MV5StatsBand({
+  items,
+}: {
+  items: { num: string; label: string }[];
+}) {
+  return (
+    <div className="mv5-stats">
+      {items.map((s, i) => (
+        <div key={i}>
+          <div className="mv5-stats-num">{s.num}</div>
+          <div className="mv5-stats-label">{s.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ─── Fitment band ────────────────────────────────────── */
+export function MV5FitmentBand({
+  label,
+  sub,
+  eyebrow = "Compatibilité confirmée",
+  action,
+}: {
+  label: string;
+  sub?: string | null;
+  eyebrow?: string;
+  action?: { label: string; onClick: () => void };
+}) {
+  return (
+    <div className="mv5-fitment-band">
+      <Check size={20} strokeWidth={2.5} aria-hidden="true" />
+      <div className="mv5-fitment-band-text">
+        <span className="mv5-fitment-band-eyebrow">{eyebrow}</span>
+        <span className="mv5-fitment-band-value">
+          {label}
+          {sub ? ` · ${sub}` : ""}
+        </span>
+      </div>
+      {action && (
+        <button
+          type="button"
+          className="mv5-btn mv5-btn-ghost mv5-btn-sm"
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
+/* ─── Checkout steps ──────────────────────────────────── */
+export function MV5CheckoutSteps({
+  steps,
+  active,
+}: {
+  steps: string[];
+  active: number;
+}) {
+  return (
+    <ol className="mv5-steps" aria-label="Étapes de commande">
+      {steps.map((s, i) => (
+        <li
+          key={s}
+          className={`mv5-step${i === active ? " is-active" : ""}`}
+          aria-current={i === active ? "step" : undefined}
+        >
+          <span className="mv5-step-num">{i + 1}</span>
+          <span className="mv5-step-label">{s}</span>
+          {i < steps.length - 1 && (
+            <span className="mv5-step-line" aria-hidden="true" />
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/* ─── Sticky CTA ──────────────────────────────────────── */
+export function MV5StickyCTA({
+  variant = "light",
+  total,
+  children,
+}: {
+  variant?: "light" | "dark";
+  total?: { label: string; value: string };
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={`mv5-sticky-cta${variant === "dark" ? " mv5-sticky-cta-dark" : ""}`}
+    >
+      {total && (
+        <span className="mv5-sticky-cta-total">
+          <span className="mv5-sticky-cta-total-label">{total.label}</span>
+          <span className="mv5-sticky-cta-total-value">{total.value}</span>
+        </span>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/frontend/app/components/mobile-v5/preview-fixtures.ts
+++ b/frontend/app/components/mobile-v5/preview-fixtures.ts
@@ -1,0 +1,128 @@
+/**
+ * Fixtures de preview — UNIQUEMENT pour les routes /preview-mobile/*.
+ *
+ * Ces données simulent un parcours pieces auto pour permettre la validation
+ * visuelle des composants mobile-V5 avant migration vers les routes V4.
+ *
+ * Après validation et migration des composants vers les routes V4 réelles,
+ * ce fichier ET le dossier `preview-mobile/` complet seront supprimés.
+ */
+
+import { type MV5Product } from "./ProductCard";
+
+export type MV5Category = {
+  key: string;
+  label: string;
+  iconKey: string;
+};
+
+export const MV5_CATEGORIES: MV5Category[] = [
+  { key: "freinage", label: "Freinage", iconKey: "shield" },
+  { key: "moteur", label: "Moteur", iconKey: "bolt" },
+  { key: "filtration", label: "Filtration", iconKey: "filter" },
+  { key: "vidange", label: "Vidange", iconKey: "wrench" },
+  { key: "embrayage", label: "Embrayage", iconKey: "wrench" },
+  { key: "echappement", label: "Échappement", iconKey: "flame" },
+  { key: "suspension", label: "Suspension", iconKey: "truck" },
+  { key: "electricite", label: "Électricité", iconKey: "bolt" },
+];
+
+export const MV5_PRODUCTS: (MV5Product & { cat: string })[] = [
+  {
+    ref: "BR-2412",
+    brand: "Bosch",
+    name: "Plaquettes de frein avant — Peugeot 308",
+    price: 42.9,
+    priceOld: 58,
+    stock: 24,
+    badge: "-26%",
+    cat: "freinage",
+  },
+  {
+    ref: "FH-0921",
+    brand: "Mann-Filter",
+    name: "Filtre à huile original moteur 1.6 BlueHDi",
+    price: 9.9,
+    stock: 132,
+    cat: "filtration",
+  },
+  {
+    ref: "AM-3304",
+    brand: "Total",
+    name: "Huile moteur 5W-30 Quartz 9000 — bidon 5L",
+    price: 38.5,
+    stock: 48,
+    cat: "vidange",
+  },
+  {
+    ref: "CB-7812",
+    brand: "Valeo",
+    name: "Kit embrayage complet 3 pièces — 308 II",
+    price: 189.0,
+    priceOld: 235,
+    stock: 4,
+    badge: "STOCK BAS",
+    badgeVariant: "warning",
+    cat: "embrayage",
+  },
+  {
+    ref: "BD-5501",
+    brand: "ATE",
+    name: "Disques de frein avant Ø 283mm (paire)",
+    price: 67.2,
+    stock: 18,
+    cat: "freinage",
+  },
+  {
+    ref: "FA-0214",
+    brand: "Mann-Filter",
+    name: "Filtre à air panneau — moteur HDi",
+    price: 14.5,
+    stock: 96,
+    cat: "filtration",
+  },
+  {
+    ref: "AM-7755",
+    brand: "Castrol",
+    name: "Huile moteur Edge 5W-30 LL — bidon 5L",
+    price: 44.9,
+    priceOld: 52,
+    stock: 22,
+    badge: "PROMO",
+    cat: "vidange",
+  },
+  {
+    ref: "BL-3398",
+    brand: "Brembo",
+    name: "Liquide de frein DOT 4 — 1L",
+    price: 7.9,
+    stock: 0,
+    cat: "freinage",
+  },
+  {
+    ref: "EM-1102",
+    brand: "Bosch",
+    name: "Bougies d'allumage iridium (jeu de 4)",
+    price: 32.4,
+    stock: 12,
+    cat: "moteur",
+  },
+  {
+    ref: "EC-4408",
+    brand: "Bosal",
+    name: "Silencieux arrière inox — 308 II",
+    price: 124.9,
+    stock: 6,
+    cat: "echappement",
+  },
+];
+
+export const MV5_PREVIEW_VEHICLE = {
+  label: "Peugeot 308 II",
+  sub: "2017 · 1.6 BlueHDi 120",
+};
+
+export const findPreviewProduct = (
+  ref: string,
+): (MV5Product & { cat: string }) | undefined =>
+  MV5_PRODUCTS.find((p) => p.ref === ref);

--- a/frontend/app/components/mobile-v5/usePreviewCart.ts
+++ b/frontend/app/components/mobile-v5/usePreviewCart.ts
@@ -1,0 +1,130 @@
+/**
+ * Cart de preview — localStorage isolé, valable UNIQUEMENT pour les routes
+ * /preview-mobile/*. Permet la validation visuelle du parcours panier mobile.
+ *
+ * NE PAS confondre avec le `useCart` réel de V4 (~/hooks/useCart.ts) qui
+ * dialogue avec cartApi/backend. Une fois la migration vers V4 faite, ce
+ * hook disparaît et les composants utiliseront directement `useCart`.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { type MV5Product } from "./ProductCard";
+
+const STORAGE_KEY = "mv5.preview.cart";
+const SHIPPING_FREE_THRESHOLD = 49;
+const SHIPPING_RATE = 5.9;
+
+export type MV5CartItem = MV5Product & { qty: number };
+
+export type MV5CartState = {
+  items: MV5CartItem[];
+  count: number;
+  subtotal: number;
+  shipping: number;
+  total: number;
+  add: (product: MV5Product, qty?: number) => void;
+  setQty: (ref: string, qty: number) => void;
+  remove: (ref: string) => void;
+  clear: () => void;
+};
+
+const readStorage = (): MV5CartItem[] => {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as MV5CartItem[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeStorage = (items: MV5CartItem[]) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // localStorage may be full or blocked — silent for preview
+  }
+};
+
+export function usePreviewCart(): MV5CartState {
+  const [items, setItems] = useState<MV5CartItem[]>([]);
+
+  useEffect(() => {
+    setItems(readStorage());
+  }, []);
+
+  useEffect(() => {
+    writeStorage(items);
+  }, [items]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== STORAGE_KEY) return;
+      try {
+        const next = e.newValue
+          ? (JSON.parse(e.newValue) as MV5CartItem[])
+          : [];
+        setItems(Array.isArray(next) ? next : []);
+      } catch {
+        setItems([]);
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const add = useCallback((product: MV5Product, qty = 1) => {
+    setItems((prev) => {
+      const idx = prev.findIndex((it) => it.ref === product.ref);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = { ...next[idx], qty: next[idx].qty + qty };
+        return next;
+      }
+      return [...prev, { ...product, qty }];
+    });
+  }, []);
+
+  const remove = useCallback((ref: string) => {
+    setItems((prev) => prev.filter((it) => it.ref !== ref));
+  }, []);
+
+  const setQty = useCallback(
+    (ref: string, qty: number) => {
+      if (qty <= 0) {
+        remove(ref);
+        return;
+      }
+      setItems((prev) =>
+        prev.map((it) => (it.ref === ref ? { ...it, qty } : it)),
+      );
+    },
+    [remove],
+  );
+
+  const clear = useCallback(() => setItems([]), []);
+
+  return useMemo<MV5CartState>(() => {
+    const count = items.reduce((s, it) => s + it.qty, 0);
+    const subtotal = items.reduce((s, it) => s + it.price * it.qty, 0);
+    const shipping =
+      subtotal >= SHIPPING_FREE_THRESHOLD || subtotal === 0 ? 0 : SHIPPING_RATE;
+    const total = subtotal + shipping;
+    return {
+      items,
+      count,
+      subtotal,
+      shipping,
+      total,
+      add,
+      setQty,
+      remove,
+      clear,
+    };
+  }, [items, add, setQty, remove, clear]);
+}

--- a/frontend/app/routes/preview-mobile._index.tsx
+++ b/frontend/app/routes/preview-mobile._index.tsx
@@ -1,0 +1,235 @@
+/**
+ * Preview Mobile — Home (/preview-mobile)
+ *
+ * Validation visuelle de l'écran d'accueil mobile-V5 avec :
+ * plaque jaune signature, hero navy, stats band, catégories scrollables,
+ * sélection produits, why-card, recherches.
+ */
+
+import { useNavigate } from "@remix-run/react";
+import {
+  Bolt,
+  ChevronRight,
+  Filter as FilterIcon,
+  Flame,
+  Package,
+  Search as SearchIcon,
+  Shield,
+  ShoppingCart,
+  Truck,
+  User,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
+
+import {
+  MV5HScroll,
+  MV5Pill,
+  MV5SectionHeading,
+  MV5StatsBand,
+} from "~/components/mobile-v5/atoms";
+import { MV5Header } from "~/components/mobile-v5/Header";
+import { MV5Plaque } from "~/components/mobile-v5/Plaque";
+import {
+  MV5_CATEGORIES,
+  MV5_PREVIEW_VEHICLE,
+  MV5_PRODUCTS,
+} from "~/components/mobile-v5/preview-fixtures";
+import { MV5ProductCard } from "~/components/mobile-v5/ProductCard";
+import { usePreviewCart } from "~/components/mobile-v5/usePreviewCart";
+
+const CATEGORY_ICON: Record<string, LucideIcon> = {
+  shield: Shield,
+  bolt: Bolt,
+  filter: FilterIcon,
+  wrench: Wrench,
+  flame: Flame,
+  truck: Truck,
+};
+
+export default function PreviewMobileHome() {
+  const navigate = useNavigate();
+  const cart = usePreviewCart();
+  const featured = MV5_PRODUCTS.slice(0, 4);
+  const promos = MV5_PRODUCTS.filter((p) => p.priceOld);
+  const cartBadge = cart.count > 0 ? cart.count : null;
+
+  return (
+    <>
+      <MV5Header
+        title="AUTOMECANIK"
+        leftIcon="menu"
+        rightIcons={[
+          {
+            icon: User,
+            label: "Mon compte",
+            onClick: () => navigate("/preview-mobile/compte"),
+          },
+          {
+            icon: ShoppingCart,
+            label: "Panier",
+            badge: cartBadge,
+            onClick: () => navigate("/preview-mobile/panier"),
+          },
+        ]}
+      />
+
+      <main className="flex-1 pb-24">
+        <section className="mv5-hero">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <span className="mv5-eyebrow mv5-eyebrow-on-dark">
+                Pièces auto · Compatibilité garantie
+              </span>
+              <h1 className="mv5-h1">
+                La bonne pièce,
+                <br />
+                du premier coup.
+              </h1>
+            </div>
+            <MV5Plaque vehicle={MV5_PREVIEW_VEHICLE.label} />
+            <span className="mv5-hero-sub">{MV5_PREVIEW_VEHICLE.sub}</span>
+            <div className="mv5-search">
+              <SearchIcon
+                className="mv5-search-icon"
+                size={18}
+                aria-hidden="true"
+              />
+              <input
+                type="search"
+                className="mv5-input"
+                placeholder="Référence, pièce, marque…"
+                aria-label="Rechercher une pièce"
+              />
+            </div>
+          </div>
+        </section>
+
+        <MV5StatsBand
+          items={[
+            { num: "500K+", label: "Références" },
+            { num: "24h", label: "Livraison" },
+            { num: "30j", label: "Retours" },
+          ]}
+        />
+
+        <MV5SectionHeading
+          eyebrow="01 · Catalogue"
+          title="Par catégorie"
+          action="Tout voir"
+          onAction={() => navigate("/preview-mobile/catalog")}
+        />
+        <MV5HScroll>
+          {MV5_CATEGORIES.map((c) => (
+            <MV5Pill
+              key={c.key}
+              icon={CATEGORY_ICON[c.iconKey] ?? Wrench}
+              onClick={() => navigate("/preview-mobile/catalog")}
+            >
+              {c.label}
+            </MV5Pill>
+          ))}
+        </MV5HScroll>
+
+        <MV5SectionHeading
+          eyebrow="02 · Pour votre véhicule"
+          title="Sélection"
+          action="Voir tout"
+          onAction={() => navigate("/preview-mobile/catalog")}
+        />
+        <div className="px-4">
+          <div className="grid grid-cols-2 gap-3">
+            {featured.map((p) => (
+              <MV5ProductCard
+                key={p.ref}
+                product={p}
+                onAdd={(prod) => cart.add(prod)}
+              />
+            ))}
+          </div>
+        </div>
+
+        <MV5SectionHeading
+          eyebrow="03 · En ce moment"
+          title="Promotions"
+          action="Voir tout"
+          onAction={() => navigate("/preview-mobile/catalog")}
+        />
+        <MV5HScroll>
+          {promos.map((p) => (
+            <div key={p.ref} className="w-44 shrink-0">
+              <MV5ProductCard product={p} onAdd={(prod) => cart.add(prod)} />
+            </div>
+          ))}
+        </MV5HScroll>
+
+        <section className="px-4 py-6">
+          <div className="mv5-card mv5-card-dark">
+            <div className="mv5-card-body flex flex-col gap-4">
+              <span className="mv5-eyebrow mv5-eyebrow-on-dark">
+                Pourquoi AutoMecanik
+              </span>
+              <ul className="flex flex-col gap-3">
+                {[
+                  {
+                    icon: Shield,
+                    t: "Compatibilité vérifiée",
+                    d: "Recherche par véhicule, référence ou Mine.",
+                  },
+                  {
+                    icon: Truck,
+                    t: "Livraison 24–48h",
+                    d: "Expédition soignée, suivi en temps réel.",
+                  },
+                  {
+                    icon: Package,
+                    t: "Retours 30 jours",
+                    d: "Satisfait ou remboursé, pièce non montée.",
+                  },
+                ].map(({ icon: Icon, t, d }) => (
+                  <li key={t} className="flex items-start gap-3">
+                    <Icon
+                      size={22}
+                      className="shrink-0 text-cta"
+                      aria-hidden="true"
+                    />
+                    <div className="flex flex-col gap-1">
+                      <span className="text-sm font-bold">{t}</span>
+                      <span className="text-xs text-white/70">{d}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <MV5SectionHeading eyebrow="04 · Tendances" title="Recherches" />
+        <div className="px-4">
+          <ul className="flex flex-col gap-2">
+            {[
+              "Plaquettes de frein 308",
+              "Filtre à huile 1.6 BlueHDi",
+              "Kit embrayage Valeo",
+              "Disques avant Brembo",
+            ].map((t) => (
+              <li key={t} className="mv5-card">
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between px-4 py-3 mv5-text-soft"
+                  onClick={() => navigate("/preview-mobile/catalog")}
+                >
+                  <span className="flex items-center gap-2">
+                    <SearchIcon size={16} aria-hidden="true" />
+                    <span className="mv5-h3">{t}</span>
+                  </span>
+                  <ChevronRight size={16} aria-hidden="true" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/frontend/app/routes/preview-mobile.catalog.tsx
+++ b/frontend/app/routes/preview-mobile.catalog.tsx
@@ -1,0 +1,157 @@
+/**
+ * Preview Mobile — Catalogue (/preview-mobile/catalog)
+ *
+ * Validation visuelle du catalogue avec FitmentBand sticky jaune,
+ * pills filtres scrollables, grille 2-col mobile, ProductCard signature.
+ */
+
+import { useNavigate } from "@remix-run/react";
+import {
+  Bolt,
+  ChevronDown,
+  Filter as FilterIcon,
+  Flame,
+  Heart,
+  ShoppingCart,
+  Truck,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
+import { useState } from "react";
+
+import {
+  MV5FitmentBand,
+  MV5HScroll,
+  MV5Pill,
+} from "~/components/mobile-v5/atoms";
+import { MV5Header } from "~/components/mobile-v5/Header";
+import {
+  MV5_CATEGORIES,
+  MV5_PREVIEW_VEHICLE,
+  MV5_PRODUCTS,
+} from "~/components/mobile-v5/preview-fixtures";
+import { MV5ProductCard } from "~/components/mobile-v5/ProductCard";
+import { usePreviewCart } from "~/components/mobile-v5/usePreviewCart";
+
+const CATEGORY_PILL_ICON_MAP: Record<string, LucideIcon> = {
+  bolt: Bolt,
+  flame: Flame,
+  truck: Truck,
+  wrench: Wrench,
+};
+
+const pillIcon = (iconKey: string): LucideIcon =>
+  CATEGORY_PILL_ICON_MAP[iconKey] ?? Wrench;
+
+export default function PreviewMobileCatalog() {
+  const navigate = useNavigate();
+  const cart = usePreviewCart();
+  const [filter, setFilter] = useState<string>("all");
+
+  const items =
+    filter === "all"
+      ? MV5_PRODUCTS
+      : MV5_PRODUCTS.filter((p) => p.cat === filter);
+
+  const cartBadge = cart.count > 0 ? cart.count : null;
+
+  return (
+    <>
+      <MV5Header
+        title="Plaquettes de frein"
+        leftIcon="back"
+        light
+        onLeft={() => navigate("/preview-mobile")}
+        rightIcons={[
+          { icon: Heart, label: "Mes favoris" },
+          {
+            icon: ShoppingCart,
+            label: "Panier",
+            badge: cartBadge,
+            onClick: () => navigate("/preview-mobile/panier"),
+          },
+        ]}
+      />
+
+      <main className="flex-1 pb-24">
+        <MV5FitmentBand
+          label={MV5_PREVIEW_VEHICLE.label}
+          sub={MV5_PREVIEW_VEHICLE.sub}
+          action={{
+            label: "Modifier",
+            onClick: () => navigate("/preview-mobile"),
+          }}
+        />
+
+        <MV5HScroll>
+          <MV5Pill active={filter === "all"} onClick={() => setFilter("all")}>
+            Tous
+          </MV5Pill>
+          {MV5_CATEGORIES.slice(0, 5).map((c) => (
+            <MV5Pill
+              key={c.key}
+              icon={pillIcon(c.iconKey)}
+              active={filter === c.key}
+              onClick={() => setFilter(c.key)}
+            >
+              {c.label}
+            </MV5Pill>
+          ))}
+        </MV5HScroll>
+
+        <div className="flex items-center justify-between px-4 pb-2 pt-3">
+          <span className="mv5-text-soft text-xs">
+            {items.length} produit{items.length > 1 ? "s" : ""}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="mv5-btn mv5-btn-ghost mv5-btn-sm"
+              aria-label="Filtrer les produits"
+            >
+              <FilterIcon size={14} aria-hidden="true" /> Filtrer
+            </button>
+            <button
+              type="button"
+              className="mv5-btn mv5-btn-ghost mv5-btn-sm"
+              aria-label="Trier les produits"
+            >
+              Tri <ChevronDown size={14} aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        {items.length === 0 ? (
+          <div className="px-4 pb-4">
+            <div className="mv5-card">
+              <div className="mv5-card-body flex flex-col items-center gap-3 py-8 text-center">
+                <span className="mv5-text-soft">
+                  Aucun produit dans cette catégorie
+                </span>
+                <button
+                  type="button"
+                  className="mv5-btn mv5-btn-dark mv5-btn-sm"
+                  onClick={() => setFilter("all")}
+                >
+                  Voir tout le catalogue
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="px-4">
+            <div className="grid grid-cols-2 gap-3">
+              {items.map((p) => (
+                <MV5ProductCard
+                  key={p.ref}
+                  product={p}
+                  onAdd={(prod) => cart.add(prod)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/frontend/app/routes/preview-mobile.panier.tsx
+++ b/frontend/app/routes/preview-mobile.panier.tsx
@@ -1,0 +1,166 @@
+/**
+ * Preview Mobile — Panier (/preview-mobile/panier)
+ *
+ * Validation visuelle du panier avec checkout steps, fitment band,
+ * stepper inline sur items, sticky CTA dark navy + total jaune.
+ */
+
+import { useNavigate } from "@remix-run/react";
+import { ChevronRight, ShoppingCart, Tag, Trash2 } from "lucide-react";
+
+import { MV5CheckoutSteps, MV5StickyCTA } from "~/components/mobile-v5/atoms";
+import { MV5Header } from "~/components/mobile-v5/Header";
+import { MV5_PREVIEW_VEHICLE } from "~/components/mobile-v5/preview-fixtures";
+import { MV5QuantityStepper } from "~/components/mobile-v5/QuantityStepper";
+import { usePreviewCart } from "~/components/mobile-v5/usePreviewCart";
+
+export default function PreviewMobilePanier() {
+  const navigate = useNavigate();
+  const { items, setQty, remove, subtotal, shipping, total, count } =
+    usePreviewCart();
+
+  const hasItems = items.length > 0;
+  const mainBottomPadding = hasItems ? "pb-40" : "pb-24";
+
+  return (
+    <>
+      <MV5Header
+        title={`Panier · ${count}`}
+        leftIcon="back"
+        light
+        onLeft={() => navigate("/preview-mobile")}
+      />
+
+      <main className={`flex-1 ${mainBottomPadding}`}>
+        <MV5CheckoutSteps
+          steps={["Panier", "Livraison", "Paiement"]}
+          active={0}
+        />
+
+        {hasItems && (
+          <div className="mv5-fitment-band">
+            <span className="mv5-fitment-band-value flex-1">
+              ✓ Toutes les pièces compatibles avec {MV5_PREVIEW_VEHICLE.label}
+            </span>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3 px-4 pt-4">
+          {!hasItems ? (
+            <div className="mv5-card">
+              <div className="mv5-card-body flex flex-col items-center gap-3 py-8 text-center">
+                <ShoppingCart
+                  size={32}
+                  strokeWidth={1.5}
+                  className="mv5-text-faint"
+                  aria-hidden="true"
+                />
+                <span className="mv5-text-soft">Votre panier est vide</span>
+                <button
+                  type="button"
+                  className="mv5-btn mv5-btn-primary mv5-btn-md"
+                  onClick={() => navigate("/preview-mobile/catalog")}
+                >
+                  Voir le catalogue
+                </button>
+              </div>
+            </div>
+          ) : (
+            <ul className="flex flex-col gap-3">
+              {items.map((it) => (
+                <li key={it.ref} className="mv5-card">
+                  <div className="flex items-start gap-3 p-3">
+                    <div className="mv5-cart-item-img" aria-hidden="true">
+                      {it.ref}
+                    </div>
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                      <span className="mv5-product-brand">{it.brand}</span>
+                      <span className="text-[13px] font-semibold leading-snug">
+                        {it.name}
+                      </span>
+                      <div className="mt-1 flex items-center justify-between">
+                        <MV5QuantityStepper
+                          value={it.qty}
+                          onChange={(v) => setQty(it.ref, v)}
+                          label="Quantité"
+                        />
+                        <span className="mv5-num text-base">
+                          {(it.price * it.qty).toFixed(2)}€
+                        </span>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      className="mv5-icon-btn mv5-text-soft"
+                      onClick={() => remove(it.ref)}
+                      aria-label={`Supprimer ${it.brand} ${it.name} du panier`}
+                    >
+                      <Trash2 size={16} aria-hidden="true" />
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {hasItems && (
+            <>
+              <button
+                type="button"
+                className="mv5-card flex w-full items-center justify-between px-4 py-3 text-left"
+                aria-label="Saisir un code promo"
+              >
+                <span className="flex items-center gap-2">
+                  <Tag size={18} className="text-cta" aria-hidden="true" />
+                  <span className="font-semibold">Code promo</span>
+                </span>
+                <ChevronRight
+                  size={16}
+                  className="mv5-text-soft"
+                  aria-hidden="true"
+                />
+              </button>
+
+              <div className="mv5-card">
+                <div className="flex flex-col">
+                  <div className="flex items-center justify-between px-4 py-3">
+                    <span>Sous-total</span>
+                    <span className="font-semibold">
+                      {subtotal.toFixed(2)}€
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between px-4 pb-3">
+                    <span>Livraison</span>
+                    <span
+                      className={`font-semibold ${
+                        shipping === 0 ? "text-success" : ""
+                      }`}
+                    >
+                      {shipping === 0 ? "Offerte" : `${shipping.toFixed(2)}€`}
+                    </span>
+                  </div>
+                  <hr className="mv5-divider" />
+                  <div className="flex items-center justify-between px-4 py-3">
+                    <span className="mv5-h3">Total</span>
+                    <span className="mv5-num text-xl">{total.toFixed(2)}€</span>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </main>
+
+      {hasItems && (
+        <MV5StickyCTA
+          variant="dark"
+          total={{ label: "Total", value: `${total.toFixed(2)}€` }}
+        >
+          <button type="button" className="mv5-btn mv5-btn-primary mv5-btn-md">
+            Commander <ChevronRight size={16} aria-hidden="true" />
+          </button>
+        </MV5StickyCTA>
+      )}
+    </>
+  );
+}

--- a/frontend/app/routes/preview-mobile.produit.$ref.tsx
+++ b/frontend/app/routes/preview-mobile.produit.$ref.tsx
@@ -1,0 +1,200 @@
+/**
+ * Preview Mobile — Produit (/preview-mobile/produit/:ref)
+ *
+ * Validation visuelle de la fiche produit avec gallery navy + OEM mono jaune,
+ * fitment card sombre, specs, cross-sell, sticky CTA stepper + ajout panier.
+ */
+
+import { type LoaderFunctionArgs, json } from "@remix-run/node";
+import { useLoaderData, useNavigate } from "@remix-run/react";
+import { Check, Heart, ShoppingCart } from "lucide-react";
+import { useState } from "react";
+
+import { MV5Badge, MV5StickyCTA } from "~/components/mobile-v5/atoms";
+import { MV5Header } from "~/components/mobile-v5/Header";
+import {
+  findPreviewProduct,
+  MV5_PREVIEW_VEHICLE,
+  MV5_PRODUCTS,
+} from "~/components/mobile-v5/preview-fixtures";
+import { MV5ProductCard } from "~/components/mobile-v5/ProductCard";
+import { MV5QuantityStepper } from "~/components/mobile-v5/QuantityStepper";
+import { usePreviewCart } from "~/components/mobile-v5/usePreviewCart";
+
+export const loader = ({ params }: LoaderFunctionArgs) => {
+  const ref = params.ref ?? "";
+  const product = findPreviewProduct(decodeURIComponent(ref));
+  if (!product) {
+    throw new Response("Produit introuvable", { status: 404 });
+  }
+  const cross = MV5_PRODUCTS.filter(
+    (p) => p.cat === product.cat && p.ref !== product.ref,
+  ).slice(0, 3);
+  return json({ product, cross });
+};
+
+export default function PreviewMobileProduit() {
+  const navigate = useNavigate();
+  const { product, cross } = useLoaderData<typeof loader>();
+  const cart = usePreviewCart();
+  const [qty, setQty] = useState(1);
+
+  const total = (product.price * qty).toFixed(2);
+  const promoPct =
+    product.priceOld != null
+      ? Math.round(
+          ((product.priceOld - product.price) / product.priceOld) * 100,
+        )
+      : null;
+  const cartBadge = cart.count > 0 ? cart.count : null;
+
+  return (
+    <>
+      <MV5Header
+        title=" "
+        leftIcon="back"
+        light
+        onLeft={() => navigate("/preview-mobile/catalog")}
+        rightIcons={[
+          { icon: Heart, label: "Ajouter aux favoris" },
+          {
+            icon: ShoppingCart,
+            label: "Panier",
+            badge: cartBadge,
+            onClick: () => navigate("/preview-mobile/panier"),
+          },
+        ]}
+      />
+
+      <main className="flex-1 pb-32">
+        <div className="mv5-gallery">
+          <span className="mv5-gallery-mono" aria-hidden="true">
+            {product.ref}
+          </span>
+          {product.badge && (
+            <span className="mv5-gallery-badge">
+              <MV5Badge variant={product.badgeVariant ?? "promo"}>
+                {product.badge}
+              </MV5Badge>
+            </span>
+          )}
+          <span className="mv5-gallery-dots" aria-hidden="true">
+            {[0, 1, 2, 3].map((i) => (
+              <span
+                key={i}
+                className={`mv5-gallery-dot${i === 0 ? " is-active" : ""}`}
+              />
+            ))}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-4 px-4 pt-4">
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <MV5Badge variant="dark">{product.brand}</MV5Badge>
+              <MV5Badge variant="success">
+                <Check size={10} strokeWidth={3} aria-hidden="true" />{" "}
+                Compatible
+              </MV5Badge>
+            </div>
+            <h1 className="mv5-h2">{product.name}</h1>
+            <span className="mv5-mono mv5-text-soft text-xs">
+              Réf. OE · {product.ref}
+            </span>
+          </div>
+
+          <div className="flex items-baseline gap-3">
+            <span className="mv5-num text-3xl">
+              {product.price.toFixed(2)}€
+            </span>
+            {product.priceOld != null && (
+              <>
+                <span className="mv5-product-price-old text-sm">
+                  {product.priceOld.toFixed(2)}€
+                </span>
+                {promoPct != null && promoPct > 0 && (
+                  <MV5Badge variant="promo">−{promoPct}%</MV5Badge>
+                )}
+              </>
+            )}
+          </div>
+
+          <div className="mv5-card mv5-card-dark">
+            <div className="mv5-card-body">
+              <div className="flex items-center gap-3">
+                <Check
+                  size={22}
+                  strokeWidth={2.5}
+                  className="text-signatureYellow"
+                  aria-hidden="true"
+                />
+                <div className="flex flex-col gap-1">
+                  <span className="mv5-eyebrow text-signatureYellow">
+                    Compatible
+                  </span>
+                  <span className="text-sm font-bold">
+                    {MV5_PREVIEW_VEHICLE.label}
+                  </span>
+                  <span className="text-xs text-white/70">
+                    {MV5_PREVIEW_VEHICLE.sub}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <section className="flex flex-col gap-2">
+            <h2 className="mv5-h3">Caractéristiques</h2>
+            <div className="mv5-card">
+              <dl className="flex flex-col">
+                {[
+                  ["Fabricant", product.brand],
+                  ["Référence OE", product.ref],
+                  ["Type", "Plaquettes avant"],
+                  ["Diamètre", "Ø 283 mm"],
+                  ["Garantie", "2 ans"],
+                ].map(([k, v]) => (
+                  <div key={k} className="mv5-spec-row">
+                    <dt className="mv5-spec-key">{k}</dt>
+                    <dd className="mv5-spec-val">{v}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </section>
+
+          {cross.length > 0 && (
+            <section className="flex flex-col gap-3">
+              <h2 className="mv5-h3">Souvent achetés ensemble</h2>
+              <div className="grid grid-cols-3 gap-3">
+                {cross.map((p) => (
+                  <MV5ProductCard
+                    key={p.ref}
+                    product={p}
+                    onAdd={(prod) => cart.add(prod)}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </main>
+
+      <MV5StickyCTA>
+        <MV5QuantityStepper value={qty} onChange={setQty} />
+        <button
+          type="button"
+          className="mv5-btn mv5-btn-primary mv5-btn-md flex-1"
+          onClick={() => {
+            cart.add(product, qty);
+            navigate("/preview-mobile/panier");
+          }}
+          disabled={product.stock === 0}
+        >
+          <ShoppingCart size={18} aria-hidden="true" />
+          {product.stock === 0 ? "Indisponible" : `Ajouter — ${total}€`}
+        </button>
+      </MV5StickyCTA>
+    </>
+  );
+}

--- a/frontend/app/routes/preview-mobile.tsx
+++ b/frontend/app/routes/preview-mobile.tsx
@@ -1,0 +1,42 @@
+/**
+ * Layout des routes /preview-mobile/* — preview visuelle mobile-V5.
+ *
+ * Cette route est temporaire : elle permet à Fafa de valider visuellement
+ * les composants mobile-V5 (Plaque, FitmentBand, StickyCTA, BottomBar,
+ * MobileProductCard) avant qu'ils soient intégrés in-place dans les routes
+ * V4 réelles (`/`, `/pieces/*`, `/cart`).
+ *
+ * Une fois validé : tout le namespace `/preview-mobile/*` est supprimé,
+ * les composants migrent vers `components/home/`, `components/ecommerce/`,
+ * `components/cart/`, `components/layout/` et sont consommés par les routes V4.
+ */
+
+import { type LinksFunction, type MetaFunction } from "@remix-run/node";
+import { Outlet } from "@remix-run/react";
+
+import { MV5BottomBar } from "~/components/mobile-v5/BottomBar";
+import mobileSignaturesUrl from "~/styles/mobile-signatures.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: mobileSignaturesUrl },
+];
+
+export const meta: MetaFunction = () => [
+  { title: "AutoMecanik · Preview mobile" },
+  {
+    name: "viewport",
+    content:
+      "width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1",
+  },
+  // Preview-only : noindex pour ne pas polluer le SEO V4
+  { name: "robots", content: "noindex,nofollow" },
+];
+
+export default function PreviewMobileLayout() {
+  return (
+    <div className="mobile-v5 mx-auto flex min-h-screen max-w-md flex-col">
+      <Outlet />
+      <MV5BottomBar />
+    </div>
+  );
+}

--- a/frontend/app/styles/mobile-signatures.css
+++ b/frontend/app/styles/mobile-signatures.css
@@ -1,0 +1,908 @@
+/* ─────────────────────────────────────────────────────────
+   AUTOMECANIK · MOBILE V5 — SIGNATURE STYLES (preview)
+
+   Composants visuels mobile-first inspirés du design pack
+   `Automecanik Design System` (v5/parcours.html). Ces classes
+   sont scopées sous `.mobile-v5` pour ne PAS impacter les routes
+   V4 actuelles tant que la migration in-place n'a pas eu lieu.
+
+   Usage: <main className="mobile-v5">...</main> sur les routes
+   /preview-mobile/* (validation visuelle), puis migration vers
+   les composants V4 après go-utilisateur.
+
+   Z-INDEX SCALE (mobile collision gate)
+     --mv5-z-header:     20
+     --mv5-z-bottombar:  30
+     --mv5-z-sticky-cta: 40
+     --mv5-z-modal:      50
+   ───────────────────────────────────────────────────────── */
+
+.mobile-v5 {
+  /* ── COLORS ───────────────────────────────────────────── */
+  --mv5-navy-900: #0A1428;
+  --mv5-navy-800: #0F1E38;
+  --mv5-navy-700: #1B2D4F;
+  --mv5-orange-700: #C2410C;
+  --mv5-orange-600: #EA580C;
+  --mv5-orange-500: #F97316;
+  --mv5-orange-400: #FB923C;
+  --mv5-yellow-500: #FBE12C;
+  --mv5-yellow-300: #FFF38C;
+
+  --mv5-bg: #FAFAFA;
+  --mv5-surface: #FFFFFF;
+  --mv5-surface-2: #F4F6F9;
+  --mv5-line: rgba(15, 30, 56, 0.08);
+  --mv5-line-strong: rgba(15, 30, 56, 0.16);
+
+  --mv5-ink: #0F1E38;
+  --mv5-ink-muted: #475569;
+  --mv5-ink-soft: #64748B;
+  --mv5-ink-faint: #94A3B8;
+
+  --mv5-success: #1E8449;
+  --mv5-success-100: #DCFCE7;
+  --mv5-warning: #D68910;
+  --mv5-danger: #C0392B;
+
+  --mv5-cta: var(--mv5-orange-500);
+  --mv5-cta-hover: var(--mv5-orange-600);
+  --mv5-on-dark-muted: rgba(255, 255, 255, 0.7);
+  --mv5-on-dark-faint: rgba(255, 255, 255, 0.6);
+
+  /* ── TYPO ─────────────────────────────────────────────── */
+  --mv5-font-heading: "Outfit", system-ui, sans-serif;
+  --mv5-font-body: "DM Sans", system-ui, sans-serif;
+  --mv5-font-mono: "Roboto Mono", ui-monospace, monospace;
+  --mv5-tracking-tight: -0.035em;
+  --mv5-tracking-snug: -0.02em;
+  --mv5-tracking-wider: 0.12em;
+  --mv5-tracking-widest: 0.2em;
+
+  /* ── SPACING ──────────────────────────────────────────── */
+  --mv5-s-1: 4px;
+  --mv5-s-2: 8px;
+  --mv5-s-3: 12px;
+  --mv5-s-4: 16px;
+  --mv5-s-5: 20px;
+  --mv5-s-6: 24px;
+  --mv5-s-8: 32px;
+  --mv5-s-12: 48px;
+
+  /* ── RADII / SHADOWS / MOTION ─────────────────────────── */
+  --mv5-r-sm: 6px;
+  --mv5-r-md: 8px;
+  --mv5-r-lg: 10px;
+  --mv5-r-xl: 12px;
+  --mv5-r-2xl: 16px;
+  --mv5-r-pill: 9999px;
+  --mv5-sh-sm: 0 1px 2px rgba(15, 30, 56, 0.04);
+  --mv5-sh-md: 0 4px 12px rgba(15, 30, 56, 0.08);
+  --mv5-sh-cta: 0 4px 12px rgba(249, 115, 22, 0.25);
+  --mv5-sh-plate: 4px 4px 0 var(--mv5-orange-500);
+  --mv5-d-fast: 150ms;
+  --mv5-d-normal: 200ms;
+  --mv5-ease-out: cubic-bezier(0, 0, 0.2, 1);
+
+  /* ── LAYOUT ───────────────────────────────────────────── */
+  --mv5-header-h: 56px;
+  --mv5-bottombar-h: 64px;
+  --mv5-sticky-cta-h: 76px;
+  --mv5-sticky-cta-dark-h: 90px;
+  --mv5-safe-bottom: env(safe-area-inset-bottom, 0);
+
+  /* ── Z-INDEX SCALE ────────────────────────────────────── */
+  --mv5-z-header: 20;
+  --mv5-z-bottombar: 30;
+  --mv5-z-sticky-cta: 40;
+  --mv5-z-modal: 50;
+
+  font-family: var(--mv5-font-body);
+  color: var(--mv5-ink);
+  -webkit-font-smoothing: antialiased;
+  background: var(--mv5-bg);
+  min-height: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-v5 {
+    --mv5-d-fast: 0ms;
+    --mv5-d-normal: 0ms;
+  }
+}
+
+.mobile-v5 *,
+.mobile-v5 *::before,
+.mobile-v5 *::after {
+  box-sizing: border-box;
+}
+.mobile-v5 button { font-family: inherit; }
+.mobile-v5 a { color: inherit; text-decoration: none; }
+
+/* ═══════════════════════════════════════════════════════
+   TYPOGRAPHY
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-h1 {
+  font-family: var(--mv5-font-heading);
+  font-weight: 900;
+  font-size: 32px;
+  line-height: 1.05;
+  letter-spacing: var(--mv5-tracking-tight);
+  color: var(--mv5-ink);
+  margin: 0;
+}
+.mobile-v5 .mv5-h2 {
+  font-family: var(--mv5-font-heading);
+  font-weight: 800;
+  font-size: 20px;
+  line-height: 1.2;
+  letter-spacing: var(--mv5-tracking-snug);
+  color: var(--mv5-ink);
+  margin: 0;
+}
+.mobile-v5 .mv5-h3 {
+  font-family: var(--mv5-font-heading);
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.2;
+  color: var(--mv5-ink);
+  margin: 0;
+}
+.mobile-v5 .mv5-eyebrow {
+  font-family: var(--mv5-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: var(--mv5-tracking-widest);
+  text-transform: uppercase;
+  color: var(--mv5-ink-soft);
+}
+.mobile-v5 .mv5-eyebrow-on-dark { color: var(--mv5-orange-400); }
+.mobile-v5 .mv5-mono { font-family: var(--mv5-font-mono); }
+.mobile-v5 .mv5-num {
+  font-family: var(--mv5-font-heading);
+  font-weight: 800;
+  letter-spacing: var(--mv5-tracking-snug);
+  font-variant-numeric: tabular-nums;
+}
+.mobile-v5 .mv5-text-soft { color: var(--mv5-ink-soft); }
+.mobile-v5 .mv5-text-faint { color: var(--mv5-ink-faint); }
+
+/* ═══════════════════════════════════════════════════════
+   BUTTON
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--mv5-s-2);
+  border: 0;
+  cursor: pointer;
+  font-family: var(--mv5-font-body);
+  font-weight: 700;
+  border-radius: var(--mv5-r-md);
+  transition: background var(--mv5-d-fast) var(--mv5-ease-out),
+    box-shadow var(--mv5-d-fast) var(--mv5-ease-out),
+    transform var(--mv5-d-fast) var(--mv5-ease-out);
+  white-space: nowrap;
+  text-decoration: none;
+  min-height: 44px;
+}
+.mobile-v5 .mv5-btn:active { transform: scale(0.98); }
+.mobile-v5 .mv5-btn:focus-visible {
+  outline: 2px solid var(--mv5-cta);
+  outline-offset: 2px;
+}
+.mobile-v5 .mv5-btn-sm {
+  padding: 0 var(--mv5-s-3);
+  height: 36px;
+  min-height: 36px;
+  font-size: 12px;
+}
+.mobile-v5 .mv5-btn-md {
+  padding: 0 var(--mv5-s-4);
+  height: 44px;
+  font-size: 14px;
+}
+.mobile-v5 .mv5-btn-lg {
+  padding: 0 var(--mv5-s-5);
+  height: 52px;
+  font-size: 15px;
+}
+.mobile-v5 .mv5-btn-block { width: 100%; }
+.mobile-v5 .mv5-btn-primary {
+  background: var(--mv5-cta);
+  color: #fff;
+  box-shadow: var(--mv5-sh-cta);
+}
+.mobile-v5 .mv5-btn-primary:hover { background: var(--mv5-cta-hover); }
+.mobile-v5 .mv5-btn-primary:disabled {
+  background: var(--mv5-ink-faint);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+.mobile-v5 .mv5-btn-dark {
+  background: var(--mv5-navy-800);
+  color: #fff;
+}
+.mobile-v5 .mv5-btn-dark:hover { background: var(--mv5-navy-900); }
+.mobile-v5 .mv5-btn-ghost {
+  background: transparent;
+  color: var(--mv5-ink);
+  min-height: 36px;
+}
+.mobile-v5 .mv5-btn-ghost:hover { background: var(--mv5-surface-2); }
+
+/* Icon button — hit-area ≥ 44px, 24px icon visual */
+.mobile-v5 .mv5-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  min-width: 44px;
+  min-height: 44px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: inherit;
+  border-radius: var(--mv5-r-md);
+  transition: background var(--mv5-d-fast) var(--mv5-ease-out);
+}
+.mobile-v5 .mv5-icon-btn:hover { background: rgba(0, 0, 0, 0.05); }
+.mobile-v5 .mv5-icon-btn:focus-visible {
+  outline: 2px solid var(--mv5-cta);
+  outline-offset: 2px;
+}
+
+/* ═══════════════════════════════════════════════════════
+   BADGE
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mv5-s-1);
+  padding: 3px var(--mv5-s-2);
+  font-family: var(--mv5-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: var(--mv5-tracking-wider);
+  text-transform: uppercase;
+  border-radius: 4px;
+  line-height: 1;
+}
+.mobile-v5 .mv5-badge-neutral { background: var(--mv5-surface-2); color: var(--mv5-ink); }
+.mobile-v5 .mv5-badge-success { background: var(--mv5-success-100); color: var(--mv5-success); }
+.mobile-v5 .mv5-badge-warning { background: #FEF3C7; color: var(--mv5-warning); }
+.mobile-v5 .mv5-badge-danger { background: #FEE2E2; color: var(--mv5-danger); }
+.mobile-v5 .mv5-badge-dark { background: var(--mv5-ink); color: #fff; }
+.mobile-v5 .mv5-badge-promo { background: var(--mv5-cta); color: #fff; }
+.mobile-v5 .mv5-badge-yellow { background: var(--mv5-yellow-500); color: var(--mv5-ink); }
+
+/* ═══════════════════════════════════════════════════════
+   PILL — chip filtre / catégorie
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--mv5-s-2);
+  padding: 0 var(--mv5-s-4);
+  min-height: 44px;
+  background: var(--mv5-surface);
+  color: var(--mv5-ink);
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: var(--mv5-r-pill);
+  border: 0;
+  box-shadow: inset 0 0 0 1px var(--mv5-line-strong);
+  cursor: pointer;
+  transition: background var(--mv5-d-fast) var(--mv5-ease-out),
+    color var(--mv5-d-fast) var(--mv5-ease-out);
+  white-space: nowrap;
+  font-family: inherit;
+}
+.mobile-v5 .mv5-pill:hover { background: var(--mv5-surface-2); }
+.mobile-v5 .mv5-pill[aria-pressed="true"] {
+  background: var(--mv5-ink);
+  color: #fff;
+  box-shadow: none;
+}
+.mobile-v5 .mv5-pill:focus-visible {
+  outline: 2px solid var(--mv5-cta);
+  outline-offset: 2px;
+}
+
+/* ═══════════════════════════════════════════════════════
+   CARD
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-card {
+  background: var(--mv5-surface);
+  border-radius: var(--mv5-r-xl);
+  border: 1px solid var(--mv5-line);
+  overflow: hidden;
+}
+.mobile-v5 .mv5-card-dark {
+  background: var(--mv5-navy-800);
+  color: #fff;
+  border: 0;
+}
+.mobile-v5 .mv5-card-body { padding: var(--mv5-s-4); }
+
+/* ═══════════════════════════════════════════════════════
+   INPUT / SEARCH
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-input {
+  width: 100%;
+  height: 44px;
+  padding: 0 var(--mv5-s-4);
+  background: var(--mv5-surface);
+  border: 1.5px solid var(--mv5-line-strong);
+  border-radius: var(--mv5-r-md);
+  font-family: var(--mv5-font-body);
+  font-size: 14px;
+  color: var(--mv5-ink);
+  transition: border-color var(--mv5-d-fast) var(--mv5-ease-out);
+}
+.mobile-v5 .mv5-input:focus {
+  outline: none;
+  border-color: var(--mv5-cta);
+}
+.mobile-v5 .mv5-input::placeholder { color: var(--mv5-ink-faint); }
+.mobile-v5 .mv5-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.mobile-v5 .mv5-search-icon {
+  position: absolute;
+  left: var(--mv5-s-3);
+  width: 18px;
+  height: 18px;
+  color: var(--mv5-ink-soft);
+  pointer-events: none;
+}
+.mobile-v5 .mv5-search .mv5-input { padding-left: 40px; }
+
+/* ═══════════════════════════════════════════════════════
+   PLAQUE — sélecteur véhicule signature jaune
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-plaque {
+  display: flex;
+  align-items: center;
+  gap: var(--mv5-s-3);
+  background: var(--mv5-yellow-500);
+  color: var(--mv5-ink);
+  border-radius: var(--mv5-r-sm);
+  border: 2px solid var(--mv5-ink);
+  box-shadow: var(--mv5-sh-plate);
+  padding: var(--mv5-s-3) var(--mv5-s-4);
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  width: 100%;
+  min-height: 44px;
+  transition: transform var(--mv5-d-fast) var(--mv5-ease-out),
+    box-shadow var(--mv5-d-fast) var(--mv5-ease-out);
+}
+.mobile-v5 .mv5-plaque:active {
+  transform: translate(2px, 2px);
+  box-shadow: 2px 2px 0 var(--mv5-orange-500);
+}
+.mobile-v5 .mv5-plaque:focus-visible {
+  outline: 2px solid var(--mv5-ink);
+  outline-offset: 4px;
+}
+.mobile-v5 .mv5-plaque-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mv5-s-1);
+  flex: 1;
+  min-width: 0;
+}
+.mobile-v5 .mv5-plaque-label {
+  font-family: var(--mv5-font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: var(--mv5-tracking-widest);
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+.mobile-v5 .mv5-plaque-value {
+  font-family: var(--mv5-font-heading);
+  font-weight: 900;
+  font-size: 15px;
+  letter-spacing: var(--mv5-tracking-snug);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ═══════════════════════════════════════════════════════
+   PRODUCT CARD
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-product {
+  background: var(--mv5-surface);
+  border: 1px solid var(--mv5-line);
+  border-radius: var(--mv5-r-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow var(--mv5-d-fast) var(--mv5-ease-out);
+}
+.mobile-v5 .mv5-product:hover { box-shadow: var(--mv5-sh-md); }
+.mobile-v5 .mv5-product:focus-visible {
+  outline: 2px solid var(--mv5-cta);
+  outline-offset: 2px;
+}
+.mobile-v5 .mv5-product-img {
+  background: var(--mv5-surface-2);
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+.mobile-v5 .mv5-product-img-mono {
+  font-family: var(--mv5-font-mono);
+  font-size: 22px;
+  font-weight: 900;
+  color: var(--mv5-yellow-500);
+  letter-spacing: var(--mv5-tracking-snug);
+  -webkit-text-stroke: 1.5px var(--mv5-ink);
+}
+.mobile-v5 .mv5-product-badge-tl {
+  position: absolute;
+  top: var(--mv5-s-2);
+  left: var(--mv5-s-2);
+}
+.mobile-v5 .mv5-product-body {
+  padding: var(--mv5-s-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--mv5-s-2);
+  flex: 1;
+}
+.mobile-v5 .mv5-product-brand {
+  font-family: var(--mv5-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: var(--mv5-tracking-wider);
+  text-transform: uppercase;
+  color: var(--mv5-ink-soft);
+}
+.mobile-v5 .mv5-product-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--mv5-ink);
+  line-height: 1.2;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.mobile-v5 .mv5-product-price {
+  font-family: var(--mv5-font-heading);
+  font-weight: 900;
+  font-size: 18px;
+  color: var(--mv5-ink);
+}
+.mobile-v5 .mv5-product-price-old {
+  font-size: 11px;
+  color: var(--mv5-ink-faint);
+  text-decoration: line-through;
+}
+.mobile-v5 .mv5-product-stock {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--mv5-success);
+}
+.mobile-v5 .mv5-product-stock-low { color: var(--mv5-warning); }
+.mobile-v5 .mv5-product-stock-out { color: var(--mv5-ink-faint); }
+.mobile-v5 .mv5-product-add {
+  width: 44px;
+  min-width: 44px;
+  height: 44px;
+  padding: 0;
+}
+
+/* ═══════════════════════════════════════════════════════
+   HEADER (preview only — V4 a son SmartHeader)
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-header {
+  height: var(--mv5-header-h);
+  background: var(--mv5-navy-800);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding: 0 var(--mv5-s-2);
+  gap: var(--mv5-s-2);
+  position: sticky;
+  top: 0;
+  z-index: var(--mv5-z-header);
+}
+.mobile-v5 .mv5-header-light {
+  background: var(--mv5-surface);
+  color: var(--mv5-ink);
+  border-bottom: 1px solid var(--mv5-line);
+}
+.mobile-v5 .mv5-header-title {
+  font-family: var(--mv5-font-heading);
+  font-weight: 800;
+  font-size: 15px;
+  letter-spacing: var(--mv5-tracking-snug);
+  flex: 1;
+  min-width: 0;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mobile-v5 .mv5-header-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: var(--mv5-cta);
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  border-radius: var(--mv5-r-pill);
+  min-width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  pointer-events: none;
+}
+
+/* ═══════════════════════════════════════════════════════
+   BOTTOM BAR
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-bottombar {
+  position: sticky;
+  bottom: 0;
+  height: var(--mv5-bottombar-h);
+  background: var(--mv5-surface);
+  border-top: 1px solid var(--mv5-line);
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  padding-bottom: var(--mv5-safe-bottom);
+  z-index: var(--mv5-z-bottombar);
+}
+.mobile-v5 .mv5-bottombar-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  color: var(--mv5-ink-soft);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-decoration: none;
+  font-family: inherit;
+  transition: color var(--mv5-d-fast) var(--mv5-ease-out);
+  min-height: 44px;
+}
+.mobile-v5 .mv5-bottombar-item:hover { color: var(--mv5-ink); }
+.mobile-v5 .mv5-bottombar-item.is-active { color: var(--mv5-cta); }
+.mobile-v5 .mv5-bottombar-item:focus-visible {
+  outline: 2px solid var(--mv5-cta);
+  outline-offset: -2px;
+}
+.mobile-v5 .mv5-bottombar-label {
+  font-size: 10px;
+  font-weight: 600;
+}
+
+/* ═══════════════════════════════════════════════════════
+   STATS BAND
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-stats {
+  background: var(--mv5-navy-800);
+  color: #fff;
+  padding: var(--mv5-s-4);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--mv5-s-3);
+}
+.mobile-v5 .mv5-stats-num {
+  font-family: var(--mv5-font-heading);
+  font-weight: 900;
+  font-size: 22px;
+  color: var(--mv5-cta);
+  line-height: 1;
+  letter-spacing: var(--mv5-tracking-snug);
+}
+.mobile-v5 .mv5-stats-label {
+  font-family: var(--mv5-font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: var(--mv5-tracking-wider);
+  text-transform: uppercase;
+  color: var(--mv5-on-dark-faint);
+  margin-top: 4px;
+}
+
+/* ═══════════════════════════════════════════════════════
+   QUANTITY STEPPER
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-stepper {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1.5px solid var(--mv5-ink);
+  border-radius: var(--mv5-r-md);
+  overflow: hidden;
+  height: 44px;
+}
+.mobile-v5 .mv5-stepper-btn {
+  width: 44px;
+  min-width: 44px;
+  background: var(--mv5-surface);
+  border: 0;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  color: var(--mv5-ink);
+  font-family: inherit;
+}
+.mobile-v5 .mv5-stepper-btn:hover { background: var(--mv5-surface-2); }
+.mobile-v5 .mv5-stepper-btn:disabled {
+  color: var(--mv5-ink-faint);
+  cursor: not-allowed;
+}
+.mobile-v5 .mv5-stepper-val {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 40px;
+  font-family: var(--mv5-font-heading);
+  font-weight: 700;
+  font-size: 14px;
+  border-left: 1.5px solid var(--mv5-ink);
+  border-right: 1.5px solid var(--mv5-ink);
+  background: var(--mv5-surface);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ═══════════════════════════════════════════════════════
+   FITMENT BAND
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-fitment-band {
+  background: var(--mv5-yellow-500);
+  color: var(--mv5-ink);
+  padding: var(--mv5-s-3) var(--mv5-s-4);
+  display: flex;
+  align-items: center;
+  gap: var(--mv5-s-3);
+  position: sticky;
+  top: var(--mv5-header-h);
+  z-index: calc(var(--mv5-z-header) - 1);
+}
+.mobile-v5 .mv5-fitment-band-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mv5-s-1);
+  min-width: 0;
+}
+.mobile-v5 .mv5-fitment-band-eyebrow {
+  font-family: var(--mv5-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: var(--mv5-tracking-wider);
+  text-transform: uppercase;
+}
+.mobile-v5 .mv5-fitment-band-value {
+  font-family: var(--mv5-font-heading);
+  font-weight: 700;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ═══════════════════════════════════════════════════════
+   STICKY CTA
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-sticky-cta {
+  position: sticky;
+  bottom: var(--mv5-bottombar-h);
+  background: var(--mv5-surface);
+  border-top: 1px solid var(--mv5-line);
+  padding: var(--mv5-s-3) var(--mv5-s-4);
+  padding-bottom: calc(var(--mv5-s-3) + var(--mv5-safe-bottom));
+  display: flex;
+  gap: var(--mv5-s-3);
+  align-items: center;
+  z-index: var(--mv5-z-sticky-cta);
+}
+.mobile-v5 .mv5-sticky-cta-dark {
+  background: var(--mv5-navy-800);
+  color: #fff;
+  border-top: 0;
+}
+.mobile-v5 .mv5-sticky-cta-total {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+.mobile-v5 .mv5-sticky-cta-total-label {
+  font-family: var(--mv5-font-mono);
+  font-size: 10px;
+  letter-spacing: var(--mv5-tracking-wider);
+  text-transform: uppercase;
+  color: var(--mv5-on-dark-faint);
+}
+.mobile-v5 .mv5-sticky-cta-total-value {
+  font-family: var(--mv5-font-heading);
+  font-weight: 900;
+  font-size: 22px;
+  color: var(--mv5-yellow-500);
+}
+
+/* ═══════════════════════════════════════════════════════
+   CHECKOUT STEPS
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-steps {
+  display: flex;
+  gap: var(--mv5-s-2);
+  padding: var(--mv5-s-3) var(--mv5-s-4);
+  margin: 0;
+  list-style: none;
+}
+.mobile-v5 .mv5-step {
+  display: flex;
+  align-items: center;
+  gap: var(--mv5-s-2);
+  flex: 1;
+}
+.mobile-v5 .mv5-step-num {
+  width: 22px;
+  height: 22px;
+  border-radius: var(--mv5-r-pill);
+  background: var(--mv5-surface-2);
+  color: var(--mv5-ink-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mv5-font-heading);
+  font-weight: 700;
+  font-size: 11px;
+}
+.mobile-v5 .mv5-step-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--mv5-ink-soft);
+}
+.mobile-v5 .mv5-step-line {
+  flex: 1;
+  height: 1px;
+  background: var(--mv5-line);
+}
+.mobile-v5 .mv5-step.is-active .mv5-step-num {
+  background: var(--mv5-cta);
+  color: #fff;
+}
+.mobile-v5 .mv5-step.is-active .mv5-step-label {
+  color: var(--mv5-ink);
+  font-weight: 700;
+}
+
+/* ═══════════════════════════════════════════════════════
+   GALLERY (product detail)
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-gallery {
+  background: var(--mv5-navy-800);
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+.mobile-v5 .mv5-gallery-mono {
+  font-family: var(--mv5-font-mono);
+  font-size: 56px;
+  font-weight: 900;
+  color: var(--mv5-yellow-500);
+  letter-spacing: var(--mv5-tracking-snug);
+  -webkit-text-stroke: 2px var(--mv5-ink);
+}
+.mobile-v5 .mv5-gallery-badge {
+  position: absolute;
+  top: var(--mv5-s-4);
+  left: var(--mv5-s-4);
+}
+.mobile-v5 .mv5-gallery-dots {
+  position: absolute;
+  bottom: var(--mv5-s-3);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 4px;
+}
+.mobile-v5 .mv5-gallery-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--mv5-r-pill);
+  background: rgba(255, 255, 255, 0.4);
+}
+.mobile-v5 .mv5-gallery-dot.is-active { background: #fff; }
+
+/* ═══════════════════════════════════════════════════════
+   SPEC ROW (product detail)
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-spec-row {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--mv5-s-3) var(--mv5-s-4);
+  border-bottom: 1px solid var(--mv5-line);
+}
+.mobile-v5 .mv5-spec-row:last-child { border-bottom: 0; }
+.mobile-v5 .mv5-spec-key { font-size: 12px; color: var(--mv5-ink-soft); }
+.mobile-v5 .mv5-spec-val { font-size: 12px; font-weight: 600; color: var(--mv5-ink); }
+
+/* ═══════════════════════════════════════════════════════
+   HERO + CART ITEM
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-hero {
+  background: var(--mv5-navy-800);
+  color: #fff;
+  padding: var(--mv5-s-12) var(--mv5-s-4) var(--mv5-s-8);
+}
+.mobile-v5 .mv5-hero .mv5-h1 { color: #fff; }
+.mobile-v5 .mv5-hero-sub {
+  color: var(--mv5-on-dark-faint);
+  font-size: 12px;
+}
+.mobile-v5 .mv5-cart-item-img {
+  width: 80px;
+  height: 80px;
+  flex-shrink: 0;
+  background: var(--mv5-surface-2);
+  border-radius: var(--mv5-r-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mv5-font-mono);
+  font-size: 14px;
+  font-weight: 900;
+  color: var(--mv5-yellow-500);
+  -webkit-text-stroke: 1px var(--mv5-ink);
+}
+
+/* ═══════════════════════════════════════════════════════
+   HORIZONTAL SCROLL UTILITY + SECTION HEADING
+   ═══════════════════════════════════════════════════════ */
+.mobile-v5 .mv5-hscroll {
+  display: flex;
+  gap: var(--mv5-s-2);
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  padding: var(--mv5-s-1) var(--mv5-s-4);
+  margin: 0 calc(var(--mv5-s-4) * -1);
+}
+.mobile-v5 .mv5-hscroll::-webkit-scrollbar { display: none; }
+.mobile-v5 .mv5-hscroll > * { flex-shrink: 0; }
+
+.mobile-v5 .mv5-section-head {
+  padding: var(--mv5-s-5) var(--mv5-s-4) var(--mv5-s-3);
+  display: flex;
+  align-items: flex-end;
+  gap: var(--mv5-s-3);
+}
+.mobile-v5 .mv5-section-head-text {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mv5-s-1);
+  min-width: 0;
+}
+.mobile-v5 .mv5-divider {
+  height: 1px;
+  background: var(--mv5-line);
+  border: 0;
+  margin: 0;
+}

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -67,6 +67,8 @@ module.exports = {
         bleuClair: tokens.colors.accent.bleuClair,
         lightTurquoise: tokens.colors.accent.lightTurquoise,
         extraLightTurquoise: tokens.colors.accent.extraLightTurquoise,
+        signatureYellow: tokens.colors.accent.signatureYellow,
+        signatureYellowSoft: tokens.colors.accent.signatureYellowSoft,
         darkIron: tokens.colors.neutral.darkIron,
         iron: tokens.colors.neutral.iron,
         neutral: tokens.colors.neutral,

--- a/log.md
+++ b/log.md
@@ -405,3 +405,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/adr-048-repo-map-drift-detector`
 - **Décision** : feat(spec-canon): repo-map.md drift detector + CI workflow (ADR-048 sprint 2 P1)
 - **Sortie** : PR #358 | commits 7b031164
+
+## 2026-05-07 — feat/mobile-v5-preview (auto)
+
+- **Branche** : `feat/mobile-v5-preview`
+- **Décision** : feat(preview): mobile-V5 visual preview routes for V4 funnel validation
+- **Sortie** : PR #368 | commits b1a689fd

--- a/packages/design-tokens/src/styles/tokens.css
+++ b/packages/design-tokens/src/styles/tokens.css
@@ -65,6 +65,10 @@
   --color-accent-lightTurquoise-contrast: #000000;
   --color-accent-extraLightTurquoise: #F3F8F8;
   --color-accent-extraLightTurquoise-contrast: #000000;
+  --color-accent-signatureYellow: #FBE12C;
+  --color-accent-signatureYellow-contrast: #000000;
+  --color-accent-signatureYellowSoft: #FFF38C;
+  --color-accent-signatureYellowSoft-contrast: #000000;
   --color-neutral-50: #F5F7FA;
   --color-neutral-50-contrast: #000000;
   --color-neutral-100: #E5E7EB;
@@ -236,6 +240,8 @@
   --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   --shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
   --shadow-inner: inset 0 2px 4px 0 rgba(0, 0, 0, 0.05);
+  --shadow-plate: 4px 4px 0 0 #F97316;
+  --shadow-cta: 0 4px 12px rgba(249, 115, 22, 0.25);
 
   /* Border Radius */
   --radius-none: 0;

--- a/packages/design-tokens/src/styles/utilities.css
+++ b/packages/design-tokens/src/styles/utilities.css
@@ -129,6 +129,14 @@
 .text-extra-light-turquoise { color: var(--color-accent-extraLightTurquoise); }
 .border-extra-light-turquoise { border-color: var(--color-accent-extraLightTurquoise); }
 .text-extra-light-turquoise-contrast { color: var(--color-accent-extraLightTurquoise-contrast); }
+.bg-signature-yellow { background-color: var(--color-accent-signatureYellow); }
+.text-signature-yellow { color: var(--color-accent-signatureYellow); }
+.border-signature-yellow { border-color: var(--color-accent-signatureYellow); }
+.text-signature-yellow-contrast { color: var(--color-accent-signatureYellow-contrast); }
+.bg-signature-yellow-soft { background-color: var(--color-accent-signatureYellowSoft); }
+.text-signature-yellow-soft { color: var(--color-accent-signatureYellowSoft); }
+.border-signature-yellow-soft { border-color: var(--color-accent-signatureYellowSoft); }
+.text-signature-yellow-soft-contrast { color: var(--color-accent-signatureYellowSoft-contrast); }
 
 /* Semantic Colors */
 .bg-action { background-color: var(--color-semantic-action); }
@@ -631,6 +639,8 @@
 .shadow-xl { box-shadow: var(--shadow-xl); }
 .shadow-2xl { box-shadow: var(--shadow-2xl); }
 .shadow-inner { box-shadow: var(--shadow-inner); }
+.shadow-plate { box-shadow: var(--shadow-plate); }
+.shadow-cta { box-shadow: var(--shadow-cta); }
 
 /* === TYPOGRAPHY === */
 

--- a/packages/design-tokens/src/tokens/design-tokens.json
+++ b/packages/design-tokens/src/tokens/design-tokens.json
@@ -33,7 +33,9 @@
       "bleu": "#031754",
       "bleuClair": "#D0EDFC",
       "lightTurquoise": "#E2F2F1",
-      "extraLightTurquoise": "#F3F8F8"
+      "extraLightTurquoise": "#F3F8F8",
+      "signatureYellow": "#FBE12C",
+      "signatureYellowSoft": "#FFF38C"
     },
     "neutral": {
       "darkIron": "#B0B0B0",
@@ -209,7 +211,9 @@
     "lg": "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
     "xl": "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1)",
     "2xl": "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-    "inner": "inset 0 2px 4px 0 rgba(0, 0, 0, 0.05)"
+    "inner": "inset 0 2px 4px 0 rgba(0, 0, 0, 0.05)",
+    "plate": "4px 4px 0 0 #F97316",
+    "cta": "0 4px 12px rgba(249, 115, 22, 0.25)"
   },
   "borderRadius": {
     "none": "0",

--- a/packages/design-tokens/src/tokens/generated.ts
+++ b/packages/design-tokens/src/tokens/generated.ts
@@ -39,7 +39,9 @@ export const designTokens = {
       "bleu": "#031754",
       "bleuClair": "#D0EDFC",
       "lightTurquoise": "#E2F2F1",
-      "extraLightTurquoise": "#F3F8F8"
+      "extraLightTurquoise": "#F3F8F8",
+      "signatureYellow": "#FBE12C",
+      "signatureYellowSoft": "#FFF38C"
     },
     "neutral": {
       "50": "#F5F7FA",
@@ -215,7 +217,9 @@ export const designTokens = {
     "lg": "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
     "xl": "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1)",
     "2xl": "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-    "inner": "inset 0 2px 4px 0 rgba(0, 0, 0, 0.05)"
+    "inner": "inset 0 2px 4px 0 rgba(0, 0, 0, 0.05)",
+    "plate": "4px 4px 0 0 #F97316",
+    "cta": "0 4px 12px rgba(249, 115, 22, 0.25)"
   },
   "borderRadius": {
     "none": "0",

--- a/packages/seo-roles/src/__tests__/canon-fixture.test.ts
+++ b/packages/seo-roles/src/__tests__/canon-fixture.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Canon fixture stability — drift detection for `getForbiddenOverlap()`.
+ *
+ * The canon forbidden vocabulary is mirrored to DB via
+ * `scripts/seo/export-canon-forbidden.ts` (PR-D, ADR-049). Any change to the
+ * TS source (`forbidden-overlap.ts`) shifts the count and hash recorded here ;
+ * the test fails as a forcing function to remind operators to :
+ *
+ *   1. Re-run the export script against the active DB
+ *   2. Update the fixture values below
+ *   3. Bump `@repo/seo-roles` version (additive minor or breaking major)
+ *
+ * Without this fixture, a silent TS edit could land in main and stay
+ * out-of-sync with the DB cache for days. The DB trigger
+ * `tg_skp_canon_check` (PR-D) reads from the cache, so drift = wrong rules
+ * enforced.
+ *
+ * Reference :
+ *   - PR-A `forbidden-overlap.ts` (ADR-040 + ADR-047 separation identité/comportement)
+ *   - PR-D migration `__seo_role_canon_forbidden` (ADR-049)
+ *   - Plan re-audit item iv : "Drift detection canon.json en CI"
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import {
+  RoleId,
+  FORBIDDEN_ROLE_IDS,
+  DEPRECATED_OUTPUT_ROLES,
+  getForbiddenOverlap,
+} from "../index";
+
+interface FixtureEntry {
+  readonly role: RoleId;
+  readonly count: number;
+  readonly sha256: string;
+}
+
+function canonHash(role: RoleId): { count: number; sha256: string } {
+  const terms = [...getForbiddenOverlap(role)].sort();
+  const sha256 = createHash("sha256").update(terms.join("|")).digest("hex");
+  return { count: terms.length, sha256 };
+}
+
+const CANON_FIXTURE: readonly FixtureEntry[] = [
+  {
+    role: RoleId.R1_ROUTER,
+    count: 25,
+    sha256: "c2abb413b9ca9c60501f4f6a1f80097e94ca1360bde2126f3f4a4bae6bff43c2",
+  },
+  {
+    role: RoleId.R3_CONSEILS,
+    count: 20,
+    sha256: "a2693bd12c7c62fd7989924b79153d451e0047091594aba2ecb4ac3e717cb40d",
+  },
+  {
+    role: RoleId.R4_REFERENCE,
+    count: 18,
+    sha256: "2baa87ee1fc4a8fc28ee5e8d0136925351204983422085f34670aeca9daadb85",
+  },
+  {
+    role: RoleId.R5_DIAGNOSTIC,
+    count: 13,
+    sha256: "f5cde252664809bbb97aaa2fee74a2dd2d70589c1ae83a6fd2b00dda90332976",
+  },
+  {
+    role: RoleId.R6_GUIDE_ACHAT,
+    count: 22,
+    sha256: "526a0398e8d5fae323b351fa08f96b7b66841939b05b60ae9c010463efb663f5",
+  },
+  {
+    role: RoleId.R6_SUPPORT,
+    count: 8,
+    sha256: "5a07df225b2161923be26b409dd49be46dc2462b60e934dac84eaae3290bdf19",
+  },
+  {
+    role: RoleId.R7_BRAND,
+    count: 12,
+    sha256: "27d4b3fe4879cc2d164b73fcf295340d80715753b7e48f31f41f9c03df8e85de",
+  },
+  {
+    role: RoleId.R8_VEHICLE,
+    count: 8,
+    sha256: "eb4a4023c67fa4ab8999c7cbfd1087bf6497d186fd1113e2cf0bc5a47d928d53",
+  },
+];
+
+describe("canon fixture — drift detection between TS source and DB cache", () => {
+  for (const expected of CANON_FIXTURE) {
+    test(`${expected.role} count is pinned at ${expected.count}`, () => {
+      const actual = canonHash(expected.role);
+      assert.equal(
+        actual.count,
+        expected.count,
+        `Canon count drifted for ${expected.role} : expected ${expected.count}, got ${actual.count}.\n` +
+          `Update CANON_FIXTURE in canon-fixture.test.ts AND re-run scripts/seo/export-canon-forbidden.ts to sync DB.\n` +
+          `Current sha256 = ${actual.sha256}`,
+      );
+    });
+
+    test(`${expected.role} content sha256 matches pinned value`, () => {
+      const actual = canonHash(expected.role);
+      assert.equal(
+        actual.sha256,
+        expected.sha256,
+        `Canon content drifted for ${expected.role} (count may match but terms differ).\n` +
+          `Expected sha256 = ${expected.sha256}\n` +
+          `Actual   sha256 = ${actual.sha256}\n` +
+          `Update CANON_FIXTURE if intentional, revert otherwise.`,
+      );
+    });
+  }
+
+  test("total canon size matches the sum of fixture entries", () => {
+    const expectedTotal = CANON_FIXTURE.reduce((sum, e) => sum + e.count, 0);
+    let actualTotal = 0;
+    for (const role of Object.values(RoleId)) {
+      if ((FORBIDDEN_ROLE_IDS as readonly string[]).includes(role)) continue;
+      if (DEPRECATED_OUTPUT_ROLES.has(role as never)) continue;
+      actualTotal += getForbiddenOverlap(role).length;
+    }
+    assert.equal(
+      actualTotal,
+      expectedTotal,
+      `Total canon size drift : expected ${expectedTotal}, got ${actualTotal}.`,
+    );
+  });
+
+  test("forbidden + deprecated roles still emit zero terms", () => {
+    for (const role of Object.values(RoleId)) {
+      const inForbidden = (FORBIDDEN_ROLE_IDS as readonly string[]).includes(role);
+      const inDeprecated = DEPRECATED_OUTPUT_ROLES.has(role as never);
+      if (inForbidden || inDeprecated) {
+        assert.equal(
+          getForbiddenOverlap(role).length,
+          0,
+          `Role ${role} is forbidden/deprecated but emits forbidden terms.`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Routes **preview** noindex sous `/preview-mobile/*` (4 écrans : home / catalog / produit / panier) qui hébergent les **signatures visuelles mobile-V5** du design pack `Automecanik Design System.zip` (`v5/parcours.html`).

**But** : permettre la validation visuelle de ces composants avant de les migrer **in-place dans les routes V4 existantes** (`/`, `/pieces/$gamme/$marque/$modele/$type[.]html`, `/cart`). Aucune URL SEO V4 n'est touchée. Aucune logique métier V4 n'est modifiée.

Cette PR remplace l'approche initiale erronée de [PR #360](https://github.com/ak125/nestjs-remix-monorepo/pull/360) (parcours `/v5/*` parallèle complet → fermée), guidée par mémoire `feedback_design_pack_improves_existing_not_replaces.md` (2026-05-07).

## Routes preview

| URL | Fichier |
|---|---|
| `/preview-mobile` | `app/routes/preview-mobile._index.tsx` |
| `/preview-mobile/catalog` | `app/routes/preview-mobile.catalog.tsx` |
| `/preview-mobile/produit/:ref` | `app/routes/preview-mobile.produit.$ref.tsx` |
| `/preview-mobile/panier` | `app/routes/preview-mobile.panier.tsx` |

Toutes en `<meta name="robots" content="noindex,nofollow">` — non indexées.

## Composants livrés (à migrer en V4 après go)

- **`<MV5Plaque>`** — sélecteur véhicule jaune avec ombre orange offset (4px 4px 0)
- **`<MV5FitmentBand>`** — bandeau jaune compatibilité sticky sous header
- **`<MV5StickyCTA>`** — CTA flottant produit/panier (variants light/dark, total jaune)
- **`<MV5BottomBar>`** — nav mobile 5 items (home/catalog/garage/cart/account)
- **`<MV5ProductCard>`** — image navy + OEM mono jaune contour navy 1.5px
- **`<MV5QuantityStepper>`** — stepper +/- 44×44 px
- **`<MV5Header>`** + atoms : `Badge`, `Pill`, `HScroll`, `SectionHeading`, `StatsBand`, `CheckoutSteps`

## Design system enrichments (utiles hors preview)

- `accent.signatureYellow: "#FBE12C"` + `signatureYellowSoft: "#FFF38C"` (DS tokens)
- `shadow.plate: "4px 4px 0 0 #F97316"` + `shadow.cta`

Disponibles partout via Tailwind (`bg-signatureYellow`, `shadow-plate`) — pas réservés au preview.

## A11y conformance

- ✅ Touch targets ≥ 44×44 px (Header icons, Pill, Stepper, ProductCard `+`)
- ✅ `aria-label` sur tous les icon-only buttons (Header, BottomBar, ProductCard add, QuantityStepper)
- ✅ Sémantique : `<button>`, `<Link>` Remix natifs (pas de `<div onClick>`)
- ✅ Focus-visible cta sur Pill, Stepper, ProductCard, BottomBar
- ✅ z-index scale documentée (`--mv5-z-header: 20 / --mv5-z-bottombar: 30 / --mv5-z-sticky-cta: 40 / --mv5-z-modal: 50`)
- ✅ `prefers-reduced-motion` gate via tokens
- ✅ `env(safe-area-inset-bottom)` sur bottombar + sticky-cta (iOS notch)

## Anti-leak

`frontend/.eslintrc.cjs` : règle `no-restricted-imports` qui bloque `preview-fixtures` et `usePreviewCart` hors `routes/preview-mobile.*` / `components/mobile-v5/**`. Les routes V4 ne peuvent PAS importer le mock par accident.

## Out of scope (ship 2)

Migration des composants `MV5*` vers leurs emplacements V4 finaux après validation visuelle :
- `MV5Plaque` → `app/components/home/Plaque.tsx`, intégré dans `HeroSection.tsx`
- `MV5FitmentBand` → `app/components/ecommerce/FitmentBand.tsx`, intégré dans `pieces.$gamme.$marque.$modele.$type[.]html.tsx`
- `MV5ProductCard` → variant mobile de `app/components/ecommerce/ProductCard.tsx`
- `MV5StickyCTA` → `app/components/cart/StickyCTA.tsx`, intégré dans `cart.tsx`
- `MV5BottomBar` → `app/components/layout/MobileBottomBar.tsx`, monté conditionnellement (commerce only) dans `root.tsx`
- Suppression complète du namespace `/preview-mobile/*` + `components/mobile-v5/` + `usePreviewCart` + `preview-fixtures.ts`.

## Test plan

- [x] `npm run typecheck` (frontend) : 0 erreur
- [x] `npm run lint` : 0 erreur, 0 warning sur les fichiers nouveaux
- [x] `npm run build` : 5 chunks `preview-mobile-*.js` produits, build vert
- [ ] **Validation visuelle Fafa** : ouvrir les 4 routes preview en DevTools iPhone SE 375×667 et iPhone 14 Pro 393×852, comparer avec `parcours.html` du design pack. Identifier ce qui est OK vs ce qu'il faut ajuster avant migration V4.
- [ ] **Cart preview functional** : ajouter produit depuis `/preview-mobile/produit/BR-2412` → vérifier qu'il apparaît dans `/preview-mobile/panier` (localStorage isolé).
- [ ] **Lighthouse a11y mobile** sur les 4 routes preview : score ≥ 95.

## URLs (smoke test sur DEV preprod 46.224.118.55:3000)

- http://46.224.118.55:3000/preview-mobile
- http://46.224.118.55:3000/preview-mobile/catalog
- http://46.224.118.55:3000/preview-mobile/produit/BR-2412
- http://46.224.118.55:3000/preview-mobile/panier

🤖 Generated with [Claude Code](https://claude.com/claude-code)