### PR TITLE
test(seo-roles): canon fixture drift detection — count + sha256 pinning

### DIFF
--- a/packages/seo-roles/src/__tests__/canon-fixture.test.ts
+++ b/packages/seo-roles/src/__tests__/canon-fixture.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Canon fixture stability — drift detection for `getForbiddenOverlap()`.
+ *
+ * The canon forbidden vocabulary is mirrored to DB via
+ * `scripts/seo/export-canon-forbidden.ts` (PR-D, ADR-049). Any change to the
+ * TS source (`forbidden-overlap.ts`) shifts the count and hash recorded here ;
+ * the test fails as a forcing function to remind operators to :
+ *
+ *   1. Re-run the export script against the active DB
+ *   2. Update the fixture values below
+ *   3. Bump `@repo/seo-roles` version (additive minor or breaking major)
+ *
+ * Without this fixture, a silent TS edit could land in main and stay
+ * out-of-sync with the DB cache for days. The DB trigger
+ * `tg_skp_canon_check` (PR-D) reads from the cache, so drift = wrong rules
+ * enforced.
+ *
+ * Reference :
+ *   - PR-A `forbidden-overlap.ts` (ADR-040 + ADR-047 separation identité/comportement)
+ *   - PR-D migration `__seo_role_canon_forbidden` (ADR-049)
+ *   - Plan re-audit item iv : "Drift detection canon.json en CI"
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import {
+  RoleId,
+  FORBIDDEN_ROLE_IDS,
+  DEPRECATED_OUTPUT_ROLES,
+  getForbiddenOverlap,
+} from "../index";
+
+interface FixtureEntry {
+  readonly role: RoleId;
+  readonly count: number;
+  readonly sha256: string;
+}
+
+function canonHash(role: RoleId): { count: number; sha256: string } {
+  const terms = [...getForbiddenOverlap(role)].sort();
+  const sha256 = createHash("sha256").update(terms.join("|")).digest("hex");
+  return { count: terms.length, sha256 };
+}
+
+const CANON_FIXTURE: readonly FixtureEntry[] = [
+  {
+    role: RoleId.R1_ROUTER,
+    count: 25,
+    sha256: "c2abb413b9ca9c60501f4f6a1f80097e94ca1360bde2126f3f4a4bae6bff43c2",
+  },
+  {
+    role: RoleId.R3_CONSEILS,
+    count: 20,
+    sha256: "a2693bd12c7c62fd7989924b79153d451e0047091594aba2ecb4ac3e717cb40d",
+  },
+  {
+    role: RoleId.R4_REFERENCE,
+    count: 18,
+    sha256: "2baa87ee1fc4a8fc28ee5e8d0136925351204983422085f34670aeca9daadb85",
+  },
+  {
+    role: RoleId.R5_DIAGNOSTIC,
+    count: 13,
+    sha256: "f5cde252664809bbb97aaa2fee74a2dd2d70589c1ae83a6fd2b00dda90332976",
+  },
+  {
+    role: RoleId.R6_GUIDE_ACHAT,
+    count: 22,
+    sha256: "526a0398e8d5fae323b351fa08f96b7b66841939b05b60ae9c010463efb663f5",
+  },
+  {
+    role: RoleId.R6_SUPPORT,
+    count: 8,
+    sha256: "5a07df225b2161923be26b409dd49be46dc2462b60e934dac84eaae3290bdf19",
+  },
+  {
+    role: RoleId.R7_BRAND,
+    count: 12,
+    sha256: "27d4b3fe4879cc2d164b73fcf295340d80715753b7e48f31f41f9c03df8e85de",
+  },
+  {
+    role: RoleId.R8_VEHICLE,
+    count: 8,
+    sha256: "eb4a4023c67fa4ab8999c7cbfd1087bf6497d186fd1113e2cf0bc5a47d928d53",
+  },
+];
+
+describe("canon fixture — drift detection between TS source and DB cache", () => {
+  for (const expected of CANON_FIXTURE) {
+    test(`${expected.role} count is pinned at ${expected.count}`, () => {
+      const actual = canonHash(expected.role);
+      assert.equal(
+        actual.count,
+        expected.count,
+        `Canon count drifted for ${expected.role} : expected ${expected.count}, got ${actual.count}.\n` +
+          `Update CANON_FIXTURE in canon-fixture.test.ts AND re-run scripts/seo/export-canon-forbidden.ts to sync DB.\n` +
+          `Current sha256 = ${actual.sha256}`,
+      );
+    });
+
+    test(`${expected.role} content sha256 matches pinned value`, () => {
+      const actual = canonHash(expected.role);
+      assert.equal(
+        actual.sha256,
+        expected.sha256,
+        `Canon content drifted for ${expected.role} (count may match but terms differ).\n` +
+          `Expected sha256 = ${expected.sha256}\n` +
+          `Actual   sha256 = ${actual.sha256}\n` +
+          `Update CANON_FIXTURE if intentional, revert otherwise.`,
+      );
+    });
+  }
+
+  test("total canon size matches the sum of fixture entries", () => {
+    const expectedTotal = CANON_FIXTURE.reduce((sum, e) => sum + e.count, 0);
+    let actualTotal = 0;
+    for (const role of Object.values(RoleId)) {
+      if ((FORBIDDEN_ROLE_IDS as readonly string[]).includes(role)) continue;
+      if (DEPRECATED_OUTPUT_ROLES.has(role as never)) continue;
+      actualTotal += getForbiddenOverlap(role).length;
+    }
+    assert.equal(
+      actualTotal,
+      expectedTotal,
+      `Total canon size drift : expected ${expectedTotal}, got ${actualTotal}.`,
+    );
+  });
+
+  test("forbidden + deprecated roles still emit zero terms", () => {
+    for (const role of Object.values(RoleId)) {
+      const inForbidden = (FORBIDDEN_ROLE_IDS as readonly string[]).includes(role);
+      const inDeprecated = DEPRECATED_OUTPUT_ROLES.has(role as never);
+      if (inForbidden || inDeprecated) {
+        assert.equal(
+          getForbiddenOverlap(role).length,
+          0,
+          `Role ${role} is forbidden/deprecated but emits forbidden terms.`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Item iv du re-audit du plan R3 Canon Hardening : **drift detection canon TS source ↔ DB cache**. Approche zero-overhead infra : test fixture pinning au lieu d'un workflow CI lourd.

Le pipeline test existant (`tsx --test`) couvre déjà l'objectif. Un workflow CI dédié (`seo-canon-drift-check.yml` envisagé initialement) n'apporterait rien sauf overhead — le canon est small (126 terms total), une fixture stable suffit.

## Mécanique

Pour chaque RoleId qui exporte des forbidden terms, le test pin :
- **count** : nombre de termes (catch add/remove)
- **sha256** : hash des termes triés-joinés (catch edit/reorder)

Captures 2026-05-07 post-PR-A (#342) :

| Role | Count | sha256 (tronqué) |
|---|---|---|
| R1_ROUTER | 25 | `c2abb413…` |
| R3_CONSEILS | 20 | `a2693bd1…` |
| R4_REFERENCE | 18 | `2baa87ee…` |
| R5_DIAGNOSTIC | 13 | `f5cde252…` |
| R6_GUIDE_ACHAT | 22 | `526a0398…` |
| R6_SUPPORT | 8 | `5a07df22…` |
| R7_BRAND | 12 | `27d4b3fe…` |
| R8_VEHICLE | 8 | `eb4a4023…` |
| **Total** | **126** | matches DB `__seo_role_canon_forbidden` count exactement |

## Forcing function

Toute modification de `forbidden-overlap.ts` casse le test. L'opérateur doit alors :
1. Re-run `npm test -w @repo/seo-roles` (assertion message donne les nouvelles valeurs)
2. Update `CANON_FIXTURE` dans `canon-fixture.test.ts`
3. Run `npx tsx scripts/seo/export-canon-forbidden.ts` contre DEV DB
4. Verify `SELECT count(*) FROM __seo_role_canon_forbidden` matches new total
5. Commit fixture + service code dans la même PR

Sans cette fixture, un edit silent dans `forbidden-overlap.ts` pouvait land en main et rester out-of-sync avec la DB cache pendant des jours — le DB trigger `tg_skp_canon_check` (PR-D #349) lit du cache, donc drift TS = wrong rules enforced en prod.

## Tests ajoutés (18)

- 8 × pinned count par role
- 8 × pinned sha256 par role
- 1 × total canon size cohérent
- 1 × invariant : forbidden + deprecated roles emit 0 terms

`npm test -w @repo/seo-roles` : **220/220 verts** (était 202).

## Files changed

- [packages/seo-roles/src/__tests__/canon-fixture.test.ts](packages/seo-roles/src/__tests__/canon-fixture.test.ts) (new, 143 lines)

## Test plan

- [x] Local `npm test -w @repo/seo-roles` : 220/220 ✓
- [ ] CI greenlight

## Refs

- Plan : `~/.claude/plans/verifier-a-fond-purrfect-marshmallow.md` item iv
- PR-A #342 (foundation `@repo/seo-roles@0.5.0`)
- PR-D #349 (DB trigger lisant `__seo_role_canon_forbidden`)
- Vault ADR-049 (DB governance canon enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)