### PR TITLE
feat(seo-role-contracts): create @repo/seo-role-contracts SoT comportemental (PR-F PIVOT)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9299,6 +9299,10 @@
       "resolved": "packages/database-types",
       "link": true
     },
+    "node_modules/@repo/seo-role-contracts": {
+      "resolved": "packages/seo-role-contracts",
+      "link": true
+    },
     "node_modules/@repo/seo-roles": {
       "resolved": "packages/seo-roles",
       "link": true
@@ -35211,9 +35215,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/seo-role-contracts": {
+      "name": "@repo/seo-role-contracts",
+      "version": "0.1.0",
+      "dependencies": {
+        "@repo/seo-roles": "*",
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.9.3"
+      }
+    },
     "packages/seo-roles": {
       "name": "@repo/seo-roles",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "dependencies": {
         "zod": "^3.25.76"
       },

--- a/packages/seo-role-contracts/package.json
+++ b/packages/seo-role-contracts/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@repo/seo-role-contracts",
+  "version": "0.1.0",
+  "description": "SoT comportemental R-stack — Zod RoleContract canon (sections, longueurs, intents, schemas Schema.org, thresholds, promotion gate). Séparé de @repo/seo-roles qui détient l'identité (RoleId, normalize). Cf. ADR-046 § L1.5 CONTRACTS + ADR-047 (vault).",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/**/*.test.ts"
+  },
+  "dependencies": {
+    "@repo/seo-roles": "*",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/seo-role-contracts/src/__tests__/conformance.test.ts
+++ b/packages/seo-role-contracts/src/__tests__/conformance.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Conformance tests — `@repo/seo-role-contracts`
+ *
+ * Garantit :
+ *   1. Chaque RoleId canon-content a un contract enregistré
+ *   2. Chaque contract passe la validation Zod RoleContract
+ *   3. Chaque contract respecte le canon promotion gate ADR-046
+ *   4. `getContract(roleId)` throw si rôle deprecated/sunset
+ *
+ * Lancer : `npm run test --workspace=@repo/seo-role-contracts`
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { RoleId } from "@repo/seo-roles";
+import {
+  CANON_CONTENT_ROLES,
+  CONTRACTS,
+  getContract,
+  RoleContract,
+} from "../index";
+
+describe("@repo/seo-role-contracts — conformance", () => {
+  it("each canon-content RoleId has a registered contract", () => {
+    for (const roleId of CANON_CONTENT_ROLES) {
+      const contract = CONTRACTS[roleId];
+      assert.ok(
+        contract,
+        `Missing contract for canon-content role ${roleId}`,
+      );
+    }
+  });
+
+  it("each contract passes Zod RoleContract validation", () => {
+    for (const roleId of CANON_CONTENT_ROLES) {
+      const contract = CONTRACTS[roleId]!;
+      const parsed = RoleContract.safeParse(contract);
+      assert.ok(
+        parsed.success,
+        `Contract for ${roleId} fails Zod validation: ${
+          parsed.success ? "" : JSON.stringify(parsed.error.format(), null, 2)
+        }`,
+      );
+    }
+  });
+
+  it("each contract has id matching its registry key", () => {
+    for (const roleId of CANON_CONTENT_ROLES) {
+      const contract = CONTRACTS[roleId]!;
+      assert.equal(
+        contract.id,
+        roleId,
+        `Contract id mismatch for ${roleId}: contract.id=${contract.id}`,
+      );
+    }
+  });
+
+  it("each contract requires the 4 canon validation domains (ADR-046)", () => {
+    const expected = ["semantic", "role", "diagnostic", "license"].sort();
+    for (const roleId of CANON_CONTENT_ROLES) {
+      const contract = CONTRACTS[roleId]!;
+      const got = [...contract.promotion_gate.requires_validations].sort();
+      assert.deepEqual(
+        got,
+        expected,
+        `${roleId} promotion_gate must require all 4 validations (ADR-046 fail-closed). Got: ${got.join(",")}`,
+      );
+    }
+  });
+
+  it("each contract has at least one semantic_intent", () => {
+    for (const roleId of CANON_CONTENT_ROLES) {
+      const contract = CONTRACTS[roleId]!;
+      assert.ok(
+        contract.semantic_intents.length >= 1,
+        `${roleId} must declare ≥ 1 semantic_intent`,
+      );
+    }
+  });
+
+  it("getContract throws for deprecated/sunset/non-content roles", () => {
+    const nonContent: RoleId[] = [
+      RoleId.R3_GUIDE, // deprecated
+      RoleId.R5_DIAGNOSTIC, // sunset ADR-027
+      RoleId.R6_SUPPORT,
+      RoleId.R9_GOVERNANCE, // deprecated
+      RoleId.AGENTIC_ENGINE, // non-writing
+      RoleId.FOUNDATION, // non-writing
+    ];
+    for (const roleId of nonContent) {
+      assert.throws(
+        () => getContract(roleId),
+        /No contract registered/,
+        `getContract(${roleId}) should throw — not a canon-content role`,
+      );
+    }
+  });
+});

--- a/packages/seo-role-contracts/src/contracts/r0.ts
+++ b/packages/seo-role-contracts/src/contracts/r0.ts
@@ -1,0 +1,24 @@
+/**
+ * R0_HOME — Surface navigation globale, home page
+ *
+ * Pas d'enricher dédié — composé via R1+R6+R7 (cf.
+ * `workspaces/seo-batch/AGENTS.md` § Ownership table).
+ *
+ * Stub initial — sections + thresholds à affiner en PR-H Phase 2 par
+ * migration depuis les constants existants. Promotion gate canon ADR-046.
+ */
+import { RoleId } from "@repo/seo-roles";
+import type { RoleContract } from "../schema";
+
+export const R0_HOME_CONTRACT: RoleContract = {
+  id: RoleId.R0_HOME,
+  allowed_sections: [],
+  forbidden_overlap: [],
+  allowed_schemas: ["BreadcrumbList"],
+  content_contracts: {},
+  semantic_intents: ["navigational", "informational"],
+  uniqueness_thresholds: {},
+  promotion_gate: {
+    requires_validations: ["semantic", "role", "diagnostic", "license"],
+  },
+};

--- a/packages/seo-role-contracts/src/contracts/r1.ts
+++ b/packages/seo-role-contracts/src/contracts/r1.ts
@@ -1,0 +1,41 @@
+/**
+ * R1_ROUTER — Slots gamme (5 colonnes compatibilité/sélection) + page HTML
+ *
+ * Services backend canon :
+ *   - `r1-enricher.service.ts` (slots DB)
+ *   - `r1-content-from-rag.service.ts` (page HTML)
+ *
+ * Section S4_MICRO_SEO bornes 1500/3000c migrées depuis les constants
+ * `R1_MICRO_SEO_MIN_CHARS`/`MAX_CHARS` (PR monorepo #346 commit
+ * `9f72a0bd`). Sections supplémentaires à compléter en PR-H Phase 2 par
+ * migration depuis `backend/src/config/r1-keyword-plan.constants.ts`.
+ */
+import { RoleId } from "@repo/seo-roles";
+import type { RoleContract } from "../schema";
+
+export const R1_ROUTER_CONTRACT: RoleContract = {
+  id: RoleId.R1_ROUTER,
+  allowed_sections: [
+    {
+      id: "R1_S4_MICRO_SEO",
+      min_chars: 1500,
+      max_chars: 3000,
+      required: true,
+      description:
+        "Synth micro-SEO router (Option B canon — bump 700→1500/3000 PR #346)",
+    },
+  ],
+  forbidden_overlap: [],
+  allowed_schemas: ["Article", "BreadcrumbList"],
+  content_contracts: {
+    definition:
+      "Router éditorial gamme — orientation pièce + véhicule, pas transactionnel pur",
+  },
+  semantic_intents: ["informational", "navigational"],
+  uniqueness_thresholds: {
+    // Seuils PR-M Phase 3B (r1-diversity-audit) — vides en PR-F structure
+  },
+  promotion_gate: {
+    requires_validations: ["semantic", "role", "diagnostic", "license"],
+  },
+};

--- a/packages/seo-role-contracts/src/contracts/r2.ts
+++ b/packages/seo-role-contracts/src/contracts/r2.ts
@@ -1,0 +1,25 @@
+/**
+ * R2_PRODUCT — Specs produit gamme
+ *
+ * Service backend canon : `r2-enricher.service.ts`.
+ *
+ * Stub initial — sections + thresholds à affiner en PR-H Phase 2.
+ */
+import { RoleId } from "@repo/seo-roles";
+import type { RoleContract } from "../schema";
+
+export const R2_PRODUCT_CONTRACT: RoleContract = {
+  id: RoleId.R2_PRODUCT,
+  allowed_sections: [],
+  forbidden_overlap: [],
+  allowed_schemas: ["Product", "Offer", "BreadcrumbList"],
+  content_contracts: {
+    definition:
+      "Fiche produit — caractéristiques techniques, non-promotionnel pur",
+  },
+  semantic_intents: ["transactional", "investigational"],
+  uniqueness_thresholds: {},
+  promotion_gate: {
+    requires_validations: ["semantic", "role", "diagnostic", "license"],
+  },
+};

--- a/packages/seo-role-contracts/src/contracts/r3.ts
+++ b/packages/seo-role-contracts/src/contracts/r3.ts
@@ -1,0 +1,32 @@
+/**
+ * R3_CONSEILS — Conseils maintenance / montage / usage
+ *
+ * Service backend canon : `conseil-enricher.service.ts`.
+ *
+ * Inclut la section S2_DIAG (diagnostic intégré dans R3 — ADR-027 R5
+ * sub-pages sunset, R5 vit comme section dans R3 avec ancre
+ * `#diagnostic-rapide`).
+ *
+ * Stub initial — sections + thresholds à affiner en PR-H Phase 2 par
+ * migration depuis `r3-keyword-plan.constants.ts`.
+ */
+import { RoleId } from "@repo/seo-roles";
+import type { RoleContract } from "../schema";
+
+export const R3_CONSEILS_CONTRACT: RoleContract = {
+  id: RoleId.R3_CONSEILS,
+  allowed_sections: [],
+  forbidden_overlap: [],
+  allowed_schemas: ["Article", "HowTo", "BreadcrumbList"],
+  content_contracts: {
+    procedure: "Étapes de montage / entretien / vérification",
+    diagnostic:
+      "Section S2_DIAG (ADR-027) — symptômes/causes/checks intégrés via RPC " +
+      "`get_diagnostic_for_gamme()` post Phase D",
+  },
+  semantic_intents: ["informational", "investigational"],
+  uniqueness_thresholds: {},
+  promotion_gate: {
+    requires_validations: ["semantic", "role", "diagnostic", "license"],
+  },
+};

--- a/packages/seo-role-contracts/src/contracts/r4.ts
+++ b/packages/seo-role-contracts/src/contracts/r4.ts
@@ -1,0 +1,25 @@
+/**
+ * R4_REFERENCE — Encyclopédique contexte mécanique
+ *
+ * Service backend canon : `r4-content-enricher.service.ts`.
+ *
+ * Stub initial — sections + thresholds à affiner en PR-H Phase 2.
+ */
+import { RoleId } from "@repo/seo-roles";
+import type { RoleContract } from "../schema";
+
+export const R4_REFERENCE_CONTRACT: RoleContract = {
+  id: RoleId.R4_REFERENCE,
+  allowed_sections: [],
+  forbidden_overlap: [],
+  allowed_schemas: ["Article", "BreadcrumbList"],
+  content_contracts: {
+    definition:
+      "Encyclopédique — termes, principes, contexte historique non-transactionnel",
+  },
+  semantic_intents: ["informational", "investigational"],
+  uniqueness_thresholds: {},
+  promotion_gate: {
+    requires_validations: ["semantic", "role", "diagnostic", "license"],
+  },
+};

--- a/packages/seo-role-contracts/src/contracts/r6.ts
+++ b/packages/seo-role-contracts/src/contracts/r6.ts
@@ -1,0 +1,39 @@
+/**
+ * R6_GUIDE_ACHAT — Comparatifs, budgets, top marques
+ *
+ * Service backend canon : `buying-guide-enricher.service.ts`.
+ *
+ * AggregateRating et Review sont conditionnels (ADR-046 § S5 Schema.org
+ * véracité — anti-spam Google) : émis uniquement si source vérifiable
+ * en DB. Le contract liste les schemas potentiels ; le runtime décide
+ * d'émettre selon présence de données réelles.
+ *
+ * Stub initial — sections + thresholds à affiner en PR-H Phase 2.
+ */
+import { RoleId } from "@repo/seo-roles";
+import type { RoleContract } from "../schema";
+
+export const R6_GUIDE_ACHAT_CONTRACT: RoleContract = {
+  id: RoleId.R6_GUIDE_ACHAT,
+  allowed_sections: [],
+  forbidden_overlap: [],
+  allowed_schemas: [
+    "Product",
+    "Offer",
+    "BreadcrumbList",
+    // AggregateRating / Review émis UNIQUEMENT si source vérifiable
+    // (ADR-046 § S5 — pas d'avis fictifs). Runtime check.
+    "AggregateRating",
+    "Review",
+  ],
+  content_contracts: {
+    comparison:
+      "Comparatifs marques/budgets — intent commercial, monétisable, E-E-A-T " +
+      "naturel via catalogue/prix/compatibilité réels",
+  },
+  semantic_intents: ["transactional", "investigational", "informational"],
+  uniqueness_thresholds: {},
+  promotion_gate: {
+    requires_validations: ["semantic", "role", "diagnostic", "license"],
+  },
+};

--- a/packages/seo-role-contracts/src/contracts/r7.ts
+++ b/packages/seo-role-contracts/src/contracts/r7.ts
@@ -1,0 +1,37 @@
+/**
+ * R7_BRAND — Hub marque transversal
+ *
+ * Service backend canon : `r7-brand-enricher.service.ts`.
+ *
+ * R7 = pattern de référence (36/36 sync `automecanik-wiki/exports/rag/constructeurs/`).
+ * Sert de modèle pour Phase 3 (gammes + vehicles).
+ *
+ * FAQPage conditionnel : émis uniquement si ≥ 3 Q/R curées en DB
+ * (`__seo_brand_editorial.faq` JSONB) — ADR-046 § S5 Schema.org véracité.
+ *
+ * Stub initial — sections + thresholds à affiner en PR-H Phase 2.
+ */
+import { RoleId } from "@repo/seo-roles";
+import type { RoleContract } from "../schema";
+
+export const R7_BRAND_CONTRACT: RoleContract = {
+  id: RoleId.R7_BRAND,
+  allowed_sections: [],
+  forbidden_overlap: [],
+  allowed_schemas: [
+    "Brand",
+    "BreadcrumbList",
+    // FAQPage émise UNIQUEMENT si ≥ 3 Q/R curées en DB.
+    "FAQPage",
+  ],
+  content_contracts: {
+    definition:
+      "Hub marque transversal — pas dérive vers fiche véhicule (R8) ni " +
+      "produit (R2). E-E-A-T via citations OEM + expertise cross-gammes.",
+  },
+  semantic_intents: ["informational", "navigational", "investigational"],
+  uniqueness_thresholds: {},
+  promotion_gate: {
+    requires_validations: ["semantic", "role", "diagnostic", "license"],
+  },
+};

--- a/packages/seo-role-contracts/src/contracts/r8.ts
+++ b/packages/seo-role-contracts/src/contracts/r8.ts
@@ -1,0 +1,35 @@
+/**
+ * R8_VEHICLE — Hub véhicule × motorisation × type
+ *
+ * Service backend canon : `r8-vehicle-enricher.service.ts`.
+ *
+ * Anti-duplicate motorisations sœurs via skill `r8-diversity-check`
+ * (memory `r7-vs-r8-content-rule.md`). Les seuils de diversité
+ * (`R8_DIVERSITY_FORMULA_WEIGHTS`, `R8_DIVERSITY_THRESHOLDS`) seront
+ * migrés depuis `backend/src/config/r8-keyword-plan.constants.ts` en
+ * PR-H Phase 2 vers `uniqueness_thresholds`.
+ *
+ * Stub initial — sections + thresholds à affiner en PR-H/I Phase 2.
+ */
+import { RoleId } from "@repo/seo-roles";
+import type { RoleContract } from "../schema";
+
+export const R8_VEHICLE_CONTRACT: RoleContract = {
+  id: RoleId.R8_VEHICLE,
+  allowed_sections: [],
+  forbidden_overlap: [],
+  allowed_schemas: ["Vehicle", "BreadcrumbList"],
+  content_contracts: {
+    definition:
+      "Hub véhicule — long-tail volumique. Pas de dérive vers gamme (R1) " +
+      "ni marque (R7). Anti-duplicate motorisations sœurs (memory " +
+      "r7-vs-r8-content-rule).",
+  },
+  semantic_intents: ["informational", "investigational", "navigational"],
+  uniqueness_thresholds: {
+    // R8_DIVERSITY_THRESHOLDS migré en PR-H — vide en structure PR-F
+  },
+  promotion_gate: {
+    requires_validations: ["semantic", "role", "diagnostic", "license"],
+  },
+};

--- a/packages/seo-role-contracts/src/index.ts
+++ b/packages/seo-role-contracts/src/index.ts
@@ -1,0 +1,92 @@
+/**
+ * @repo/seo-role-contracts — entry point
+ *
+ * Single source of truth comportementale R-stack. Lit identité depuis
+ * `@repo/seo-roles` (RoleId enum), expose `CONTRACTS: Record<RoleId, RoleContract>`
+ * pour les enrichers, validators, frontend badges, AGENTS.md.
+ *
+ * Cf. ADR-046 + ADR-047 (vault PR #183 accepted 2026-05-07).
+ */
+import { RoleId } from "@repo/seo-roles";
+import type { RoleContract } from "./schema";
+
+import { R0_HOME_CONTRACT } from "./contracts/r0";
+import { R1_ROUTER_CONTRACT } from "./contracts/r1";
+import { R2_PRODUCT_CONTRACT } from "./contracts/r2";
+import { R3_CONSEILS_CONTRACT } from "./contracts/r3";
+import { R4_REFERENCE_CONTRACT } from "./contracts/r4";
+import { R6_GUIDE_ACHAT_CONTRACT } from "./contracts/r6";
+import { R7_BRAND_CONTRACT } from "./contracts/r7";
+import { R8_VEHICLE_CONTRACT } from "./contracts/r8";
+
+// Schema + types
+export {
+  RoleContract,
+  SectionSpec,
+  SchemaOrgType,
+  SemanticIntent,
+  ValidationDomain,
+  ContentContracts,
+  UniquenessThresholds,
+  PromotionGate,
+} from "./schema";
+
+// Per-role contracts (named exports for direct import)
+export {
+  R0_HOME_CONTRACT,
+  R1_ROUTER_CONTRACT,
+  R2_PRODUCT_CONTRACT,
+  R3_CONSEILS_CONTRACT,
+  R4_REFERENCE_CONTRACT,
+  R6_GUIDE_ACHAT_CONTRACT,
+  R7_BRAND_CONTRACT,
+  R8_VEHICLE_CONTRACT,
+};
+
+/**
+ * Master registry — `Partial<Record<RoleId, RoleContract>>` car les rôles
+ * deprecated/sunset/non-content (R3_GUIDE, R5_DIAGNOSTIC, R6_SUPPORT,
+ * R9_GOVERNANCE, AGENTIC_ENGINE, FOUNDATION) n'ont pas de contract de
+ * page indexable.
+ *
+ * Pour résolution stricte d'un rôle canon-content, utiliser :
+ *   `getContract(roleId)` qui throw si manquant.
+ */
+export const CONTRACTS: Partial<Record<RoleId, RoleContract>> = {
+  [RoleId.R0_HOME]: R0_HOME_CONTRACT,
+  [RoleId.R1_ROUTER]: R1_ROUTER_CONTRACT,
+  [RoleId.R2_PRODUCT]: R2_PRODUCT_CONTRACT,
+  [RoleId.R3_CONSEILS]: R3_CONSEILS_CONTRACT,
+  [RoleId.R4_REFERENCE]: R4_REFERENCE_CONTRACT,
+  [RoleId.R6_GUIDE_ACHAT]: R6_GUIDE_ACHAT_CONTRACT,
+  [RoleId.R7_BRAND]: R7_BRAND_CONTRACT,
+  [RoleId.R8_VEHICLE]: R8_VEHICLE_CONTRACT,
+};
+
+/** Liste des rôles canon-content qui DOIVENT avoir un contract. */
+export const CANON_CONTENT_ROLES: ReadonlyArray<RoleId> = [
+  RoleId.R0_HOME,
+  RoleId.R1_ROUTER,
+  RoleId.R2_PRODUCT,
+  RoleId.R3_CONSEILS,
+  RoleId.R4_REFERENCE,
+  RoleId.R6_GUIDE_ACHAT,
+  RoleId.R7_BRAND,
+  RoleId.R8_VEHICLE,
+];
+
+/**
+ * Strict accessor — throw si le rôle n'a pas de contract.
+ * Préférer cette fonction dans les enrichers (fail-fast au lieu de
+ * undefined silencieux).
+ */
+export function getContract(roleId: RoleId): RoleContract {
+  const contract = CONTRACTS[roleId];
+  if (!contract) {
+    throw new Error(
+      `[seo-role-contracts] No contract registered for role ${roleId}. ` +
+        `Canon-content roles : ${CANON_CONTENT_ROLES.join(", ")}.`,
+    );
+  }
+  return contract;
+}

--- a/packages/seo-role-contracts/src/schema.ts
+++ b/packages/seo-role-contracts/src/schema.ts
@@ -1,0 +1,108 @@
+/**
+ * RoleContract Zod schema — SoT comportemental R-stack
+ *
+ * Single source of truth pour les règles métier R0..R8 :
+ *   - sections autorisées + longueurs min/max
+ *   - forbidden_overlap (termes interdits par paire de rôles)
+ *   - schemas Schema.org émis par template_type
+ *   - intents sémantiques
+ *   - uniqueness_thresholds (entropy, jaccard, template-phrase ratio)
+ *   - promotion_gate (validations multi-domaine fail-closed)
+ *
+ * Cf. ADR-046 § L1.5 CONTRACTS + ADR-047 (governance-vault PR #183 accepted).
+ */
+import { z } from "zod";
+import { RoleId } from "@repo/seo-roles";
+
+/** Spec d'une section éditoriale d'un rôle (ex: R1_S0..R1_S9). */
+export const SectionSpec = z.object({
+  id: z.string().min(1),
+  min_chars: z.number().int().nonnegative(),
+  max_chars: z.number().int().nonnegative(),
+  required: z.boolean().default(true),
+  description: z.string().optional(),
+});
+export type SectionSpec = z.infer<typeof SectionSpec>;
+
+/** Schema.org types acceptés par template_type SEO. */
+export const SchemaOrgType = z.enum([
+  "Article",
+  "FAQPage",
+  "HowTo",
+  "Product",
+  "Offer",
+  "AggregateRating",
+  "Review",
+  "Brand",
+  "Vehicle",
+  "BreadcrumbList",
+]);
+export type SchemaOrgType = z.infer<typeof SchemaOrgType>;
+
+/** Intents sémantiques canon (alignés sur @repo/seo-roles intents.ts). */
+export const SemanticIntent = z.enum([
+  "transactional",
+  "informational",
+  "navigational",
+  "investigational",
+]);
+export type SemanticIntent = z.infer<typeof SemanticIntent>;
+
+/** Validations multi-domaine requises pour promotion L1 wiki → L2 exports. */
+export const ValidationDomain = z.enum([
+  "semantic",
+  "role",
+  "diagnostic",
+  "license",
+]);
+export type ValidationDomain = z.infer<typeof ValidationDomain>;
+
+/** Règles de contenu spécifiques (definitions, procedures, comparisons, ...). */
+export const ContentContracts = z
+  .object({
+    definition: z.string().optional(),
+    procedure: z.string().optional(),
+    comparison: z.string().optional(),
+    diagnostic: z.string().optional(),
+  })
+  .partial();
+export type ContentContracts = z.infer<typeof ContentContracts>;
+
+/** Seuils de diversité/unicité (entropy lexicale Shannon, Jaccard inter-gamme, template-phrase ratio, ...). */
+export const UniquenessThresholds = z
+  .object({
+    min_specific_ratio: z.number().min(0).max(1).optional(),
+    max_boilerplate: z.number().min(0).max(1).optional(),
+    min_entropy_shannon: z.number().nonnegative().optional(),
+    max_jaccard_inter_gamme: z.number().min(0).max(1).optional(),
+    max_template_phrase_ratio: z.number().min(0).max(1).optional(),
+  })
+  .partial();
+export type UniquenessThresholds = z.infer<typeof UniquenessThresholds>;
+
+/** Promotion gate L1 → L2 — fail-closed multi-domaine. */
+export const PromotionGate = z.object({
+  requires_validations: z.array(ValidationDomain).min(1),
+});
+export type PromotionGate = z.infer<typeof PromotionGate>;
+
+/**
+ * Contract canonique d'un rôle R\* (1 instance par RoleId actif).
+ *
+ * Lecteurs canoniques (DI seul moyen) :
+ *   - L4 enrichers backend (`r1-enricher`, `conseil-enricher`, ...)
+ *   - Validators (`r1-router-validator`, `gatekeeper`, `content-quality-gate`)
+ *   - Frontend badges qualité admin
+ *   - AGENTS.md (référence textuelle vers `contracts/r{N}.ts`)
+ */
+export const RoleContract = z.object({
+  id: z.nativeEnum(RoleId),
+  allowed_sections: z.array(SectionSpec),
+  forbidden_overlap: z.array(z.union([z.string(), z.nativeEnum(RoleId)])),
+  allowed_schemas: z.array(SchemaOrgType),
+  content_contracts: ContentContracts,
+  semantic_intents: z.array(SemanticIntent).min(1),
+  uniqueness_thresholds: UniquenessThresholds,
+  promotion_gate: PromotionGate,
+});
+export type RoleContract = z.infer<typeof RoleContract>;

--- a/packages/seo-role-contracts/tsconfig.json
+++ b/packages/seo-role-contracts/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Phase 2 **PR-F** du plan **Refondation R-stack** — **PIVOT** de la refondation. Crée le package `@repo/seo-role-contracts` qui détient le **SoT comportemental** R-stack (sections, longueurs, schemas Schema.org, intents, thresholds, promotion gate). Séparé de `@repo/seo-roles` qui garde l'**identité only** (RoleId, normalize).

ADR-046 § L1.5 CONTRACTS + ADR-047 (vault PR #183 accepted 2026-05-07).

## Contenu (13 fichiers, 611 lignes)

| Fichier | Rôle |
|---|---|
| `package.json` + `tsconfig.json` | Calque pattern `@repo/seo-roles` |
| `src/schema.ts` | Zod `RoleContract` + sous-types (`SectionSpec`, `SchemaOrgType`, `SemanticIntent`, `ValidationDomain`, `ContentContracts`, `UniquenessThresholds`, `PromotionGate`) |
| `src/contracts/r{0,1,2,3,4,6,7,8}.ts` | 8 contracts canon-content |
| `src/index.ts` | `CONTRACTS: Partial<Record<RoleId, RoleContract>>` + `CANON_CONTENT_ROLES` + `getContract(roleId)` strict |
| `src/__tests__/conformance.test.ts` | 6 tests : registry coverage, Zod parse, id match, ADR-046 promotion_gate, semantic_intents ≥ 1, getContract throws non-content |

## Stubs initiaux conformes ADR-046

- `promotion_gate.requires_validations` = `['semantic', 'role', 'diagnostic', 'license']` sur **tous** les contracts (canon fail-closed multi-domaine)
- **R1 inclut déjà section S4_MICRO_SEO {min:1500, max:3000}** — migration depuis `R1_MICRO_SEO_MIN_CHARS` ligne 30 de `r1-enricher.service.ts` (PR #346 shipped, audit baseline 2026-05-07)
- `allowed_schemas` typés par rôle :
  - R6 : `Product, Offer, AggregateRating, Review, BreadcrumbList` (AggregateRating/Review **conditionnels runtime** — ADR-046 §S5 véracité)
  - R7 : `Brand, FAQPage, BreadcrumbList` (FAQPage si ≥3 Q/R curées)
  - R8 : `Vehicle, BreadcrumbList`
  - R3 : `Article, HowTo, BreadcrumbList`
- `semantic_intents` typés par rôle (R6 transactional, R3 informational, R8 navigational, etc.)

## Hors-scope (Phase 2 suivante)

- **PR-G** : migrer `forbidden-overlap.ts` depuis `@repo/seo-roles` → contracts + bump `seo-roles` 0.5.0 → **1.0.0 breaking** + migration consumers atomique
- **PR-H** : refactor enrichers Wave 1 R1/R3/R4/R6 lisent contracts (suppression constants dupliquées)
- **PR-I** : refactor enrichers Wave 2 R7/R8 + validators + AGENTS.md
- **Critère sortie Phase 2** : `grep min_chars|max_chars|FORBIDDEN_TERMS` dans `backend/src/modules/admin/services/*-enricher.service.ts` = 0 hors imports `@repo/seo-role-contracts`

## Pourquoi PIVOT

Avant cette PR : **triple SoT implicite** (audit baseline 2026-05-07) :
1. `@repo/seo-roles@0.5.0` détient identité **et** comportement (`forbidden-overlap.ts`)
2. Enrichers contiennent règles métier en dur (`R1_MICRO_SEO_MIN_CHARS = 1500`)
3. AGENTS.md déclare une 3ème vérité

Après cette PR + PR-G/H/I : **double SoT canon** :
1. `@repo/seo-roles` = identité (RoleId, normalize, alias)
2. `@repo/seo-role-contracts` = comportement (cet ADR-047)

→ Drift programmé à 6 mois éliminé. ast-grep `no-hardcoded-rules-in-enrichers` (Phase 2 étendu) bloquera tout regression.

## Test plan

- [ ] CI green (typecheck workspace, ESLint, tests `npm run test --workspace=@repo/seo-role-contracts`)
- [ ] `npm run test --workspace=@repo/seo-role-contracts` → 6 tests PASS
- [ ] Aucun consumer encore (PR-H/I à venir) — package autonome stable

## Pattern canon respecté

- Pas de valeurs métier inventées en stubs (`allowed_sections: []`, `forbidden_overlap: []`, `uniqueness_thresholds: {}` — à migrer PR-G/H/I)
- R1 garde la valeur réelle 1500/3000 issue du code (PR #346 shipped)
- R5 sunset ADR-027 respecté (pas de contract R5)
- R3_GUIDE deprecated respecté (pas de contract)
- `getContract()` throw au lieu de retourner undefined (fail-fast canon)

## Références

- governance-ref : vault PR #183 (ADR-046 + ADR-047 accepted 2026-05-07)
- Audit baseline : `governance-vault/ledger/audit-trail/2026-05-07-r-stack-audit.md`
- Plan détaillé : `/home/deploy/.claude/plans/je-remarque-une-faiblesse-eventual-flamingo.md` § Phase 2 PR-F

🤖 Generated with [Claude Code](https://claude.com/claude-code)