### PR TITLE
fix(ci): strip yaml comments in GATE-3 actions/checkout match

### DIFF
--- a/tools/validator-gates/gate-3-runner-blast-radius.sh
+++ b/tools/validator-gates/gate-3-runner-blast-radius.sh
@@ -17,7 +17,11 @@ while IFS= read -r wf; do
   [[ ! -f "$wf" ]] && continue
 
   # Check 1: pull_request_target avec checkout = supply chain risk
-  if grep -q "pull_request_target" "$wf" 2>/dev/null && grep -q "actions/checkout" "$wf" 2>/dev/null; then
+  # Strip yaml comments before matching: a `#` comment like
+  # "# Pas de `actions/checkout` ici" is documentation, not a real `uses:`.
+  wf_uncommented=$(sed 's/[[:space:]]*#.*//' "$wf" 2>/dev/null)
+  if grep -q "pull_request_target" <<<"$wf_uncommented" \
+    && grep -qE "uses:[[:space:]]*actions/checkout" <<<"$wf_uncommented"; then
     echo "❌ CRITICAL: $wf uses pull_request_target with actions/checkout"
     critical=$((critical+1))
   fi


### PR DESCRIPTION
## Summary

GATE-3 (runner blast-radius control) was failing on every PR with:

```
❌ CRITICAL: .github/workflows/dependabot-claude-review.yml uses pull_request_target with actions/checkout
```

But the workflow **does not** use `actions/checkout`. The grep matched two **comment lines** (yaml `#`) that document *why* checkout is deliberately omitted:

```yaml
# Pas de `actions/checkout` ici : DEV Safety GATE-3 interdit la combinaison
# `pull_request_target` + `actions/checkout` (risque d'exécution de code …)
```

Result: every "🔍 DEV Safety (Observe)" check has been red on every PR since the workflow landed. Verified across the 5 MVP-0 R-stack PRs (#356/#357/#361/#362/#363) merged earlier today.

## Fix

In `tools/validator-gates/gate-3-runner-blast-radius.sh`:

1. Strip yaml comments via `sed 's/[[:space:]]*#.*//'` before grepping.
2. Require the precise yaml form `uses:[[:space:]]*actions/checkout` (not just the substring).

Real risk still fires — a workflow that genuinely combines `pull_request_target` with `uses: actions/checkout@vN` will still be flagged CRITICAL.

## Test plan

- [x] Run `MODE=observe bash tools/validator-gates/gate-3-runner-blast-radius.sh` locally on main + this fix → `✅ GATE-3 PASSED`
- [x] Two unchanged "production paths" warnings on `ci.yml` / `deploy-prod.yml` (separate check, not affected)
- [ ] CI on this PR shows "🔍 DEV Safety (Observe)" green
- [ ] After merge, follow-up PRs no longer have a permanent red Observe check

🤖 Generated with [Claude Code](https://claude.com/claude-code)