### PR TITLE
feat(r1-enricher): read R1_S4_MICRO_SEO chars from contracts (PR-H.1, stacked on PR-G)

### DIFF
--- a/backend/src/modules/admin/services/r1-enricher.service.ts
+++ b/backend/src/modules/admin/services/r1-enricher.service.ts
@@ -20,15 +20,21 @@ import type { ResourceGroup } from '../../../config/execution-registry.types';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import * as yaml from 'js-yaml';
+import { RoleId as CanonRoleId } from '@repo/seo-roles';
+import { getSection } from '@repo/seo-role-contracts';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
 import { EnricherTextUtils } from './enricher-text-utils.service';
 import { EnricherYamlParser } from './enricher-yaml-parser.service';
 
-// ── Canon thresholds (Option B sweet-spot 2026-05-07) ─────────────────────────
-// Aligned with workspaces/seo-batch/.claude/agents/r1-content-batch.md.
+// ── Canon thresholds — read from @repo/seo-role-contracts (PR-H.1) ────────────
+// PR-H.1 (ADR-046 § L1.5 + ADR-047) : remplace les constants hardcodées par
+// lecture du contract canon `seo-role-contracts/contracts/r1.ts` (section
+// R1_S4_MICRO_SEO). Aligned with workspaces/seo-batch/.claude/agents/r1-content-batch.md.
 // Min not enforced here (synth produces best-effort) ; max is the truncate cap.
-const R1_MICRO_SEO_MIN_CHARS = 1500;
-const R1_MICRO_SEO_MAX_CHARS = 3000;
+// PR monorepo #346 (Option B sweet-spot 2026-05-07) — bornes 1500/3000.
+const R1_S4_MICRO_SEO = getSection(CanonRoleId.R1_ROUTER, 'R1_S4_MICRO_SEO');
+const R1_MICRO_SEO_MIN_CHARS = R1_S4_MICRO_SEO.min_chars;
+const R1_MICRO_SEO_MAX_CHARS = R1_S4_MICRO_SEO.max_chars;
 
 export interface R1EnrichResult {
   pgId: string;

--- a/packages/seo-role-contracts/src/index.ts
+++ b/packages/seo-role-contracts/src/index.ts
@@ -93,3 +93,31 @@ export function getContract(roleId: RoleId): RoleContract {
   }
   return contract;
 }
+
+/**
+ * Strict accessor pour une section d'un rôle. Throw si rôle ou section
+ * absent. Helper utilisé par les enrichers (PR-H Phase 2) pour lire
+ * `min_chars` / `max_chars` / `description` depuis le contract canon
+ * au lieu de constants hardcodées dans le service.
+ *
+ * @example
+ *   const s4 = getSection(RoleId.R1_ROUTER, 'R1_S4_MICRO_SEO');
+ *   const minChars = s4.min_chars; // 1500
+ *   const maxChars = s4.max_chars; // 3000
+ */
+export function getSection(
+  roleId: RoleId,
+  sectionId: string,
+): import("./schema").SectionSpec {
+  const contract = getContract(roleId);
+  const section = contract.allowed_sections.find((s) => s.id === sectionId);
+  if (!section) {
+    throw new Error(
+      `[seo-role-contracts] Section '${sectionId}' not registered in ` +
+        `${roleId} contract. Available : ${contract.allowed_sections
+          .map((s) => s.id)
+          .join(", ") || "(none — contract.allowed_sections is empty, see PR-H Phase 2)"}.`,
+    );
+  }
+  return section;
+}


### PR DESCRIPTION
## Summary

Phase 2 **PR-H.1** du plan **Refondation R-stack** — premier consumer concret du SoT comportemental `@repo/seo-role-contracts` créé en PR-F (#372). Le service `r1-enricher.service.ts` lit maintenant `R1_S4_MICRO_SEO.min_chars` / `.max_chars` depuis le contract canon au lieu des constants hardcodées.

ADR-046 § L1.5 + ADR-047 (vault PR #183 accepted).

> **Stack note** : basé sur PR-G (#375), elle-même stacked sur PR-F (#372). Auto-rebase quand PR-F + PR-G mergent.

## Changements

### `@repo/seo-role-contracts/src/index.ts`
Nouveau helper `getSection(roleId, sectionId): SectionSpec` — accessor strict avec message d'erreur lisible si rôle ou section absent. Évite `.find()...!` dans chaque consumer.

```ts
export function getSection(roleId: RoleId, sectionId: string): SectionSpec {
  const contract = getContract(roleId);
  const section = contract.allowed_sections.find((s) => s.id === sectionId);
  if (!section) throw new Error(`Section '${sectionId}' not registered in ${roleId}...`);
  return section;
}
```

### `backend/src/modules/admin/services/r1-enricher.service.ts`

**Avant** :
```ts
// Lignes 30-31 — hardcoded
const R1_MICRO_SEO_MIN_CHARS = 1500;
const R1_MICRO_SEO_MAX_CHARS = 3000;
```

**Après** :
```ts
import { RoleId as CanonRoleId } from '@repo/seo-roles';
import { getSection } from '@repo/seo-role-contracts';

const R1_S4_MICRO_SEO = getSection(CanonRoleId.R1_ROUTER, 'R1_S4_MICRO_SEO');
const R1_MICRO_SEO_MIN_CHARS = R1_S4_MICRO_SEO.min_chars;  // 1500
const R1_MICRO_SEO_MAX_CHARS = R1_S4_MICRO_SEO.max_chars;  // 3000
```

Les **5 usages aval** (lignes 125, 128, etc.) restent identiques — seul le `=` change, le typage `const number` est préservé.

## Pas de changement comportemental

Les valeurs 1500/3000 sont identiques avant/après (issues du contract `r1.ts` créé en PR-F qui les a copiées de l'audit baseline 2026-05-07). Si le contract change demain, le service recharge automatiquement les bornes — sans regrep manuel ni nouveau commit dans backend/.

## Pourquoi PR-H.1 (R1 only) atomique

Le plan dit "Wave 1 = R1, R3, R4, R6" mais la sécurité et la review exigent du atomique. Approche :
- **PR-H.1** : R1 only (cette PR — risque minimal, validation du pattern getSection)
- **PR-H.2** : R3 conseil-enricher
- **PR-H.3** : R4 r4-content-enricher
- **PR-H.4** : R6 buying-guide-enricher

Si PR-H.1 valide proprement, les wave items suivants peuvent merger plus vite.

## Test plan

- [ ] CI green (typecheck workspace, ESLint, tests)
- [ ] Backend boot OK : `R1_MICRO_SEO_MIN_CHARS === 1500` (verify console log `init r1-enricher`)
- [ ] `npm run test --workspace=@repo/seo-role-contracts` PASS (test conformance + nouveau helper getSection — à étendre PR-H.1 si besoin)
- [ ] PR-F + PR-G mergent en cascade → cette PR rebase auto sur main

## Critère sortie Phase 2 (à atteindre PR-H.4 + PR-I)

```bash
$ grep -rEn 'min_chars|max_chars|FORBIDDEN_TERMS|allowed_sections' \
    backend/src/modules/admin/services/*-enricher.service.ts \
    | grep -v 'from .*seo-role-contracts'
# doit retourner 0 résultats
```

Cette PR-H.1 retire 2 lignes hardcodées sur le compteur ; reste 3 enrichers à migrer.

## Références

- governance-ref : vault PR #183 (ADR-046 + ADR-047 accepted)
- stacked-on : PR #375 (PR-G) → PR #372 (PR-F PIVOT)
- Plan : `/home/deploy/.claude/plans/je-remarque-une-faiblesse-eventual-flamingo.md` § Phase 2 PR-H

🤖 Generated with [Claude Code](https://claude.com/claude-code)