### PR TITLE
feat(auth): wire up login lockout after N failed attempts (Plan F Sprint 1 ticket #8)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,11 @@ REDIS_HOST=redis_prod
 REDIS_PORT=6379
 SESSION_SECRET=generate-a-64-char-random-string
 
+# Login lockout threshold (ADR-043 Sprint 1 ticket #8)
+# Failed login attempts before account is temporarily locked (15 min window).
+# Conservative default = 5. Tighten in prod if needed (e.g., 3).
+LOGIN_LOCKOUT_MAX_ATTEMPTS=5
+
 # Payment - SystemPay (BNP Paribas)
 SYSTEMPAY_SITE_ID=your-site-id
 SYSTEMPAY_CERTIFICATE_PROD=your-certificate

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -52,6 +52,12 @@ export class AuthService {
 
   private readonly googleClientSecret: string;
 
+  // ADR-043 Sprint 1 ticket #8 — login lockout (STRIDE 02-admin/03-sessions
+  // important #12). Window TTL is set in CacheService.incrementLoginAttempts
+  // (15 min). Threshold is read from env LOGIN_LOCKOUT_MAX_ATTEMPTS to allow
+  // tightening per environment without redeploy; defaults to a conservative 5.
+  private readonly maxLoginAttempts: number;
+
   constructor(
     private readonly jwtService: JwtService,
     private readonly userDataService: UserDataConsolidatedService,
@@ -65,8 +71,15 @@ export class AuthService {
     this.googleClient = this.googleClientId
       ? new OAuth2Client(this.googleClientId)
       : null;
+
+    const envMax = parseInt(
+      this.configService.get<string>('LOGIN_LOCKOUT_MAX_ATTEMPTS') || '5',
+      10,
+    );
+    this.maxLoginAttempts = Number.isFinite(envMax) && envMax > 0 ? envMax : 5;
+
     this.logger.log(
-      `AuthService initialized - Google Sign-In ${this.googleClientId ? 'enabled' : 'disabled (no GOOGLE_CLIENT_ID)'}`,
+      `AuthService initialized - Google Sign-In ${this.googleClientId ? 'enabled' : 'disabled (no GOOGLE_CLIENT_ID)'} - login lockout threshold ${this.maxLoginAttempts}/15min`,
     );
   }
 
@@ -77,6 +90,22 @@ export class AuthService {
     email: string,
     password: string,
   ): Promise<AuthUser | null> {
+    // Normalize email for lockout key — case-insensitive to avoid bypass via
+    // alternating capitalization (Test@x.com vs test@x.com).
+    const lockoutKey = (email || '').trim().toLowerCase();
+
+    // Lockout gate (STRIDE important #12) — fail fast before any DB lookup
+    // or password hash compute, so brute force can't even probe timing.
+    const attempts = await this.cacheService.getLoginAttempts(lockoutKey);
+    if (attempts >= this.maxLoginAttempts) {
+      this.logger.warn(
+        `Login lockout active for ${lockoutKey} (${attempts}/${this.maxLoginAttempts} attempts) — rejecting`,
+      );
+      throw new UnauthorizedException(
+        'Trop de tentatives. Compte temporairement verrouillé. Réessayez dans 15 minutes.',
+      );
+    }
+
     try {
       this.logger.debug(`Authenticating user: ${email}`);
 
@@ -85,6 +114,7 @@ export class AuthService {
 
       if (!resolved) {
         this.logger.warn(`User not found in any table: ${email}`);
+        await this.cacheService.incrementLoginAttempts(lockoutKey);
         return null;
       }
 
@@ -98,6 +128,7 @@ export class AuthService {
       );
       if (!isPasswordValid) {
         this.logger.warn(`Invalid password for user: ${email}`);
+        await this.cacheService.incrementLoginAttempts(lockoutKey);
         return null;
       }
 
@@ -151,8 +182,15 @@ export class AuthService {
       // Vérifier que l'utilisateur est actif
       if (!authUser.isActive) {
         this.logger.warn(`Inactive user tried to login: ${email}`);
+        // Inactive account is a real existing identity — count it as a
+        // failed attempt so attackers can't pivot to brute force the rest
+        // of the username space without consequence.
+        await this.cacheService.incrementLoginAttempts(lockoutKey);
         throw new UnauthorizedException('Compte désactivé');
       }
+
+      // Successful login resets the lockout counter for this identity.
+      await this.cacheService.clearLoginAttempts(lockoutKey);
 
       this.logger.log(
         `Authentication successful for ${email} (source: ${authSource}, admin: ${authUser.isAdmin})`,

--- a/backend/tests/unit/auth.service.test.ts
+++ b/backend/tests/unit/auth.service.test.ts
@@ -69,6 +69,10 @@ describe('AuthService', () => {
     set: jest.fn(),
     del: jest.fn(),
     delete: jest.fn(),
+    // ADR-043 Sprint 1 ticket #8 — login lockout helpers
+    getLoginAttempts: jest.fn(),
+    incrementLoginAttempts: jest.fn(),
+    clearLoginAttempts: jest.fn(),
   };
 
   const mockPasswordCrypto = {
@@ -96,6 +100,11 @@ describe('AuthService', () => {
     mockCacheService.set.mockResolvedValue(undefined);
     mockCacheService.del.mockResolvedValue(undefined);
     mockCacheService.delete.mockResolvedValue(undefined);
+
+    // Default: lockout helpers — 0 prior attempts (no lockout active)
+    mockCacheService.getLoginAttempts.mockResolvedValue(0);
+    mockCacheService.incrementLoginAttempts.mockResolvedValue(1);
+    mockCacheService.clearLoginAttempts.mockResolvedValue(undefined);
 
     // Default: upgradeHashIfNeeded resolves (async no-op)
     mockPasswordCrypto.upgradeHashIfNeeded.mockResolvedValue(false);
@@ -222,6 +231,75 @@ describe('AuthService', () => {
       'im10tech7legacy',
       expect.any(Function), // the update callback
     );
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // TEST 5b: lockout — counter increments on each failed login (wrong password)
+  // ADR-043 Sprint 1 ticket #8
+  // ═══════════════════════════════════════════════════════════════
+  it('authenticateUser() should increment login attempts on invalid password', async () => {
+    mockUserService.resolveUserByEmail.mockResolvedValue(mockResolved);
+    mockPasswordCrypto.validatePassword.mockResolvedValue({
+      isValid: false,
+      format: 'bcrypt',
+    });
+
+    await service.authenticateUser('Test@Example.com', 'wrongPassword');
+
+    // Expect lowercase normalized key (case-insensitive lockout)
+    expect(mockCacheService.incrementLoginAttempts).toHaveBeenCalledWith(
+      'test@example.com',
+    );
+    expect(mockCacheService.clearLoginAttempts).not.toHaveBeenCalled();
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // TEST 5c: lockout — counter increments on unknown user (anti-enumeration)
+  // ═══════════════════════════════════════════════════════════════
+  it('authenticateUser() should increment login attempts on unknown user (prevents enumeration)', async () => {
+    mockUserService.resolveUserByEmail.mockResolvedValue(null);
+
+    await service.authenticateUser('unknown@example.com', 'anyPassword');
+
+    expect(mockCacheService.incrementLoginAttempts).toHaveBeenCalledWith(
+      'unknown@example.com',
+    );
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // TEST 5d: lockout — counter clears on successful login
+  // ═══════════════════════════════════════════════════════════════
+  it('authenticateUser() should clear login attempts on successful login', async () => {
+    mockUserService.resolveUserByEmail.mockResolvedValue(mockResolved);
+    mockPasswordCrypto.validatePassword.mockResolvedValue({
+      isValid: true,
+      format: 'bcrypt',
+    });
+
+    await service.authenticateUser('test@example.com', 'correctPassword');
+
+    expect(mockCacheService.clearLoginAttempts).toHaveBeenCalledWith(
+      'test@example.com',
+    );
+    expect(mockCacheService.incrementLoginAttempts).not.toHaveBeenCalled();
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // TEST 5e: lockout — threshold reached → fail-fast UnauthorizedException
+  //          (no DB lookup, no password compute)
+  // ═══════════════════════════════════════════════════════════════
+  it('authenticateUser() should reject without DB lookup when lockout threshold reached', async () => {
+    // Default threshold = 5 (env LOGIN_LOCKOUT_MAX_ATTEMPTS unset)
+    mockCacheService.getLoginAttempts.mockResolvedValue(5);
+
+    await expect(
+      service.authenticateUser('test@example.com', 'anyPassword'),
+    ).rejects.toThrow(UnauthorizedException);
+
+    // Critical: fail-fast — no DB / hash compute / counter increment
+    expect(mockUserService.resolveUserByEmail).not.toHaveBeenCalled();
+    expect(mockPasswordCrypto.validatePassword).not.toHaveBeenCalled();
+    expect(mockCacheService.incrementLoginAttempts).not.toHaveBeenCalled();
   });
 
   // ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

ADR-043 Plan F Sprint 1 ticket #8 — login lockout après N tentatives (1j, source F0.2 STRIDE 02-admin/03-sessions important #12).

`CacheService` expose déjà les helpers ([cache.service.ts:237-255](backend/src/cache/cache.service.ts#L237-L255), TTL 15min) mais ils étaient **dead code — jamais wired** dans le flow auth. Brute force possible sans freinage. Cette PR wire les helpers existants + ajoute un fail-fast gate.

## Changes

- `backend/src/auth/auth.service.ts` :
  - `maxLoginAttempts` lu depuis env `LOGIN_LOCKOUT_MAX_ATTEMPTS` (défaut conservateur 5)
  - `lockoutKey = email.trim().toLowerCase()` — case-insensitive (anti-bypass `Test@x.com` vs `test@x.com`)
  - **Fail-fast gate** au début de `authenticateUser()` : si attempts ≥ threshold → `UnauthorizedException` AVANT DB lookup / hash compute (pas de timing leak, pas de charge DB sous brute force)
  - Increment sur 3 chemins fail (user not found, password invalide, compte inactif), clear sur succès complet
- `backend/.env.example` : `LOGIN_LOCKOUT_MAX_ATTEMPTS=5` documenté
- `backend/tests/unit/auth.service.test.ts` : 4 tests dédiés (5b/5c/5d/5e couvrant increment, anti-enumeration, clear, fail-fast)

## Properties

- **Anti-enumeration** : increment même sur user inconnu (attaquant ne peut pas distinguer email valide / invalide)
- **Anti-timing** : fail-fast gate AVANT `resolveUserByEmail` ou `validatePassword`
- **Read-only mode compat** (ADR-028 Option D) : CacheService no-op si Redis indisponible (`if (!redisReady) return 1`) → lockout dégradé silencieusement, ne bloque pas le flow
- **Configurable sans redéploy** : tighten en prod via `LOGIN_LOCKOUT_MAX_ATTEMPTS=3`

## Test plan

- [ ] CI verte : 4 nouveaux tests + 5 existants `authenticateUser` passent
- [ ] TypeScript build vert
- [ ] Pas de régression sur le flow login standard (test 1 « valid email + valid password » toujours vert)
- [ ] Post-merge en preprod : tester manuellement 5 tentatives échouées → 6e tentative avec bon password rejetée

## Refs

- ADR-043 Plan F Phase 1 cadre (vault PR #174)
- F0.2 STRIDE 02-admin/03-sessions important #12
- Sprint 1 cumul livré : #338 + #339 + #380 + #383 + #388 + cette PR = **6/9 tickets** (~5.25j sur 7.25j)
- ADR-043 promotion `proposed → accepted` : seuil 80% items livrés. 6/9 = 67%. #6 (rate limit paiement) restant pour atteindre 78%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)