### PR TITLE
feat(payments): rate limit callback endpoints 30/min/IP (Plan F Sprint 1 ticket #6)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -99,6 +99,17 @@ import { DiagnosticEngineModule } from './modules/diagnostic-engine/diagnostic-e
           ttl: 3600000, // 1 heure
           limit: 2000, // 2000 req/heure par IP
         },
+        {
+          // ADR-043 Sprint 1 ticket #6 — payment callbacks (STRIDE 01-paiement
+          // critique #2). Apply via @Throttle({ payment_callback: {...} }) on
+          // /api/paybox/callback + /api/payments/callback/cyberplus. Gateway IPN
+          // sends ~1-2 callbacks per transaction → 30/min/IP is generous for
+          // legitimate flow, tight for crypto-compute DoS. On 429, gateways
+          // retry idempotently (HMAC signature dedups).
+          name: 'payment_callback',
+          ttl: 60000, // 1 minute
+          limit: 30,
+        },
       ],
       // 🛡️ Skip internal calls (Remix SSR + Docker containers + Admin users)
       skipIf: (context) => {

--- a/backend/src/modules/payments/controllers/paybox-callback.controller.ts
+++ b/backend/src/modules/payments/controllers/paybox-callback.controller.ts
@@ -9,6 +9,7 @@ import {
   Res,
   Req,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { Request, Response } from 'express';
 import { PayboxService } from '../services/paybox.service';
 import { PaymentDataService } from '../repositories/payment-data.service';
@@ -41,7 +42,13 @@ export class PayboxCallbackController {
   /**
    * IPN - Instant Payment Notification
    * Appelé par Paybox pour notifier le résultat du paiement
+   *
+   * Rate limit: 30/min/IP via named throttler `payment_callback` (ADR-043
+   * Sprint 1 ticket #6, STRIDE 01-paiement critique #2). Generous for
+   * legitimate gateway IPN; tight for crypto-compute DoS. Gateway retries
+   * idempotently on 429 (HMAC signature dedups).
    */
+  @Throttle({ payment_callback: { limit: 30, ttl: 60000 } })
   @Post('callback')
   async handleCallback(
     @Query() query: Record<string, string>,

--- a/backend/src/modules/payments/controllers/payment-callback.controller.ts
+++ b/backend/src/modules/payments/controllers/payment-callback.controller.ts
@@ -7,6 +7,7 @@ import {
   Logger,
   BadRequestException,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { OperationFailedException } from '@common/exceptions';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { PaymentService } from '../services/payment.service';
@@ -38,7 +39,12 @@ export class PaymentCallbackController {
   /**
    * POST /api/payments/callback/cyberplus
    * Webhook Cyberplus/BNP Paribas
+   *
+   * Rate limit: 30/min/IP via named throttler `payment_callback` (ADR-043
+   * Sprint 1 ticket #6, STRIDE 01-paiement critique #2). Gateway retries
+   * idempotently on 429 (HMAC signature dedups).
    */
+  @Throttle({ payment_callback: { limit: 30, ttl: 60000 } })
   @Post('callback/cyberplus')
   @ApiOperation({
     summary: 'Callback Cyberplus pour notifications de paiement',


### PR DESCRIPTION
## Summary

ADR-043 Plan F Sprint 1 ticket #6 — rate limit sur callbacks paiement (1.5j, source F0.2 STRIDE 01-paiement **critique #2**).

`ThrottlerModule` global (15/sec + 100/min + 2000/hr par IP) couvre les abus volumiques, mais STRIDE souligne le risque **crypto-compute DoS** spécifique aux callbacks IPN : chaque requête force le serveur à vérifier la signature HMAC. Cette PR ajoute un throttler dédié `payment_callback` (30/min/IP) plus strict, additif aux throttlers existants.

## Changes

- [`backend/src/app.module.ts`](backend/src/app.module.ts) ThrottlerModule.forRoot() : ajout du named throttler `payment_callback` (30/min, ttl 60000ms).
- [`paybox-callback.controller.ts`](backend/src/modules/payments/controllers/paybox-callback.controller.ts) : import `Throttle` + `@Throttle({ payment_callback: ... })` sur `POST /api/paybox/callback`.
- [`payment-callback.controller.ts`](backend/src/modules/payments/controllers/payment-callback.controller.ts) : même pattern sur `POST /api/payments/callback/cyberplus`.

## Properties

- **Comportement legit gateway** : Paybox/SystemPay/BNP envoient ~1-2 IPN par transaction → 30/min largement au-dessus.
- **429 retry idempotent** : signature HMAC + `normalizeOrderId` + DB upsert by order_id → gateway peut retry sans double-traitement.
- **Skip internal calls** (Remix SSR, Docker bridge, admin level≥7) : inchangé, hérité du global `skipIf`.
- **Pas de migration DB** ni de nouveau secret CI.

## Hors scope (follow-up)

- **IP allowlist gateway** (`PAYMENT_GATEWAY_IP_ALLOWLIST`) : utile si un opérateur excède 30/min (improbable). Stub non ajouté sans besoin empirique.
- **Caddy `rate_limit` directive** (couche réseau) : orthogonal, à évaluer si defense-in-depth réseau confirmé.

## Test plan

- [ ] CI verte : 14/14 required gates SUCCESS
- [ ] Pas de régression sur les flows legit (test cyberplus-signature continue de passer)
- [ ] Post-merge en preprod : monitoring du compteur Throttler `payment_callback` ; aucune 429 attendue sur trafic réel

## Refs

- ADR-043 Plan F Phase 1 cadre (vault PR #174)
- F0.2 STRIDE 01-paiement critique #2
- Sprint 1 cumul livré : #338 + #339 + #380 + #383 + #388 + #389 + cette PR = **7/9 tickets** (~6.75j sur 7.25j)
- ADR-043 promotion `proposed → accepted` : seuil 80% items livrés. **7/9 = 78%** (très proche du seuil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)