### PR TITLE
feat(seo-v9): PR-2c chain services + orchestrator (stacked sur 2b)

### DIFF
--- a/backend/src/modules/seo/dynamic-seo-v4-ultimate.service.ts
+++ b/backend/src/modules/seo/dynamic-seo-v4-ultimate.service.ts
@@ -1,17 +1,33 @@
 /**
- * 🎯 DYNAMIC SEO SERVICE V4 ULTIMATE
+ * 🎯 DYNAMIC SEO V4 ULTIMATE — orchestrateur stateless
  *
- * Core orchestration service for SEO generation.
- * Delegates switch processing to SeoV4SwitchEngineService
- * and monitoring/analytics to SeoV4MonitoringService.
+ * Cette classe est devenue, en PR-2c (plan seo-v9), un **adaptateur fin** vers
+ * la chaîne SEO commune (`SeoChainOrchestratorService`). Elle conserve son API
+ * publique historique `generateCompleteSeo(pgId, typeId, variables) → CompleteSeoResult`
+ * (consommée par 4 endpoints debug `/api/seo-dynamic-v4/*` cf. audit PR-1)
+ * mais ne contient plus aucune logique métier propre :
  *
- * @version 4.0.0
+ *   1. parse Zod des variables legacy
+ *   2. lookup cache résultat (clé pgId+typeId+vars)
+ *   3. construit un `SeoChainInput` (surface = R1_GAMME_VEHICLE_ROUTER pour le legacy)
+ *   4. délègue à `SeoChainOrchestratorService.run(input)`
+ *   5. adapte `SeoChainOutput` → `CompleteSeoResult` (compat tests / controllers)
+ *   6. fallback `generateDefaultSeo` si la chaîne renvoie un title vide
+ *
+ * Cache + monitoring proxy + variantes fallback = conservés (utiles pour
+ * le mode debug). Tout le reste (`processTitle/Description/H1/Preview/Content`,
+ * `replaceStandardVariables`, `processContextualVariables`,
+ * `getSeoTemplate/getItemSwitches/getGammeCarSwitches/getFamilySwitches`) est
+ * supprimé : la chaîne PR-2c gère l'intégralité de cette logique de manière
+ * canonique et testée.
+ *
+ * @version 4.1.0 (refactor seo-v9 PR-2c)
  */
 
 import { Injectable, Logger } from '@nestjs/common';
-import { TABLES } from '@repo/database-types';
+
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
-import { SeoV4SwitchEngineService } from './services/seo-v4-switch-engine.service';
+import { SeoChainOrchestratorService } from './services/chain/seo-chain-orchestrator.service';
 import { SeoV4MonitoringService } from './services/seo-v4-monitoring.service';
 import {
   SeoVariablesSchema,
@@ -21,8 +37,6 @@ import {
   SeoMetrics,
   SeoAbTestVariant,
   InternalLinkMetrics,
-  PRIX_PAS_CHER,
-  VOUS_PROPOSE,
 } from './seo-v4.types';
 
 // Re-export types for backward compatibility
@@ -39,16 +53,16 @@ export {
 export class DynamicSeoV4UltimateService extends SupabaseBaseService {
   protected readonly logger = new Logger(DynamicSeoV4UltimateService.name);
 
-  // Cache for complete SEO results
+  // Cache for complete SEO results (clé = pgId+typeId+vars sérialisés).
   private seoCache = new Map<
     string,
     { data: CompleteSeoResult; expires: number }
   >();
-  private readonly CACHE_TTL_SHORT = 300000; // 5 min
-  private readonly CACHE_TTL_MEDIUM = 900000; // 15 min
-  private readonly CACHE_TTL_LONG = 3600000; // 1 heure
+  private readonly CACHE_TTL_SHORT = 300_000; // 5 min
+  private readonly CACHE_TTL_MEDIUM = 900_000; // 15 min
+  private readonly CACHE_TTL_LONG = 3_600_000; // 1 h
 
-  // Metrics tracking state
+  // Metrics tracking state (proxy `SeoV4MonitoringService`).
   private cacheHits = 0;
   private cacheMisses = 0;
   private processingTimes: number[] = [];
@@ -59,14 +73,14 @@ export class DynamicSeoV4UltimateService extends SupabaseBaseService {
   }> = [];
 
   constructor(
-    private readonly switchEngine: SeoV4SwitchEngineService,
+    private readonly chain: SeoChainOrchestratorService,
     private readonly monitoring: SeoV4MonitoringService,
   ) {
     super();
   }
 
   // ====================================
-  // 🎯 MAIN ENTRY POINT
+  // 🎯 MAIN ENTRY POINT (legacy compat)
   // ====================================
 
   async generateCompleteSeo(
@@ -78,332 +92,97 @@ export class DynamicSeoV4UltimateService extends SupabaseBaseService {
     const validatedVars = SeoVariablesSchema.parse(variables);
 
     this.logger.log(
-      `🎯 [SEO V4] Génération complète: pgId=${pgId}, typeId=${typeId}`,
+      `🎯 [SEO V4→chain] Génération complète : pgId=${pgId}, typeId=${typeId}`,
     );
 
+    const cacheKey = `seo:complete:${pgId}:${typeId}:${JSON.stringify(validatedVars)}`;
+    const cached = this.getCachedData(cacheKey);
+    if (cached) {
+      this.logger.debug('📦 [CACHE HIT] SEO complet');
+      return { ...cached, metadata: { ...cached.metadata, cacheHit: true } };
+    }
+
     try {
-      // PHASE 1: CACHE CHECK
-      const cacheKey = `seo:complete:${pgId}:${typeId}:${JSON.stringify(validatedVars)}`;
-      const cached = this.getCachedData(cacheKey);
-      if (cached) {
-        this.logger.debug(`📦 [CACHE HIT] SEO complet`);
-        return {
-          ...cached,
-          metadata: { ...cached.metadata, cacheHit: true },
-        };
+      const chainOutput = await this.chain.run({
+        // Le legacy V4 supposait toujours un contexte gamme×véhicule
+        // (cf. dynamic-seo.controller.ts → c'est le seul appelant).
+        surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        pgId,
+        typeId,
+        vehicleId: typeId,
+        variables: validatedVars,
+        ids: {},
+        baseUrl: '',
+        breadcrumbs: [],
+      });
+
+      // Si la chaîne n'a pas trouvé de template DB, on tombe sur le fallback
+      // legacy (titre/description programmatiques par contexte).
+      if (!chainOutput.template.title) {
+        const fallback = this.generateDefaultSeo(validatedVars, startTime);
+        this.setCachedData(cacheKey, fallback, this.getCacheTTL(validatedVars));
+        return fallback;
       }
 
-      // PHASE 2: PARALLEL DATA FETCH
-      const [seoTemplate, itemSwitches, gammeSwitches, familySwitches] =
-        await Promise.all([
-          this.getSeoTemplate(pgId),
-          this.getItemSwitches(pgId),
-          this.getGammeCarSwitches(pgId),
-          this.getFamilySwitches(validatedVars.mfId, pgId),
-        ]);
-
-      if (!seoTemplate) {
-        return this.generateDefaultSeo(validatedVars, startTime);
-      }
-
-      // PHASE 3: PARALLEL SECTION PROCESSING
-      const [title, description, h1, preview, content] = await Promise.all([
-        this.processTitle(
-          seoTemplate.sgc_title,
-          validatedVars,
-          itemSwitches,
-          gammeSwitches,
-          typeId,
-          pgId,
-        ),
-        this.processDescription(
-          seoTemplate.sgc_descrip,
-          validatedVars,
-          itemSwitches,
-          gammeSwitches,
-          typeId,
-          pgId,
-        ),
-        this.processH1(seoTemplate.sgc_h1, validatedVars),
-        this.processPreview(seoTemplate.sgc_preview, validatedVars),
-        this.processContent(
-          seoTemplate.sgc_content,
-          validatedVars,
-          itemSwitches,
-          gammeSwitches,
-          familySwitches,
-          typeId,
-        ),
-      ]);
-
-      // PHASE 4: KEYWORDS + METADATA
-      const keywords = this.generateKeywords(validatedVars);
-      const processingTime = Date.now() - startTime;
-
-      const result: CompleteSeoResult = {
-        title,
-        description,
-        h1,
-        preview,
-        content,
-        keywords,
-        metadata: {
-          templatesUsed: [seoTemplate.sgc_id?.toString() || 'default'],
-          switchesProcessed:
-            itemSwitches.length + gammeSwitches.length + familySwitches.length,
-          variablesReplaced: this.countVariablesInTemplate(seoTemplate),
-          processingTime,
-          cacheHit: false,
-          version: '4.0.0',
-        },
-      };
-
-      // PHASE 5: CACHE RESULT
+      const result = this.adaptChainOutput(chainOutput, startTime);
       this.setCachedData(cacheKey, result, this.getCacheTTL(validatedVars));
 
-      this.logger.log(`✅ [SEO V4] Succès en ${processingTime}ms`);
+      this.processingTimes.push(result.metadata.processingTime);
+      this.logger.log(
+        `✅ [SEO V4→chain] Succès en ${result.metadata.processingTime}ms`,
+      );
       return result;
     } catch (error) {
-      this.logger.error(`❌ [SEO V4] Erreur:`, error);
+      this.logger.error(
+        `❌ [SEO V4→chain] Erreur : ${(error as Error).message}`,
+      );
       return this.generateDefaultSeo(validatedVars, startTime);
     }
   }
 
   // ====================================
-  // 🎯 SECTION PROCESSORS
+  // 🔁 CHAIN OUTPUT → CompleteSeoResult adapter
   // ====================================
 
-  private async processTitle(
-    template: string,
-    variables: SeoVariables,
-    itemSwitches: Record<string, unknown>[],
-    gammeSwitches: Record<string, unknown>[],
-    typeId: number,
-    pgId: number,
-  ): Promise<string> {
-    let processed = template;
+  private adaptChainOutput(
+    chain: Awaited<ReturnType<SeoChainOrchestratorService['run']>>,
+    startTime: number,
+  ): CompleteSeoResult {
+    const processingTime = Date.now() - startTime;
+    const variantCount = Object.values(chain.metadata.variantIds).filter(
+      (v) => v != null,
+    ).length;
 
-    processed = this.replaceStandardVariables(processed, variables, true);
-
-    if (variables.minPrice) {
-      processed = processed.replace(
-        /#MinPrice#/g,
-        `dès ${variables.minPrice}€`,
-      );
-    }
-
-    const prixIndex = ((pgId % 100) + 1 + typeId) % PRIX_PAS_CHER.length;
-    processed = processed.replace(/#PrixPasCher#/g, PRIX_PAS_CHER[prixIndex]);
-
-    processed = await this.switchEngine.processCompSwitch(processed);
-
-    if (variables.articlesCount > 0) {
-      processed = processed.replace(
-        /#ArticlesCount#/g,
-        variables.articlesCount.toString(),
-      );
-    }
-
-    return this.cleanContent(processed, true);
-  }
-
-  private async processDescription(
-    template: string,
-    variables: SeoVariables,
-    itemSwitches: Record<string, unknown>[],
-    gammeSwitches: any[],
-    typeId: number,
-    pgId: number,
-  ): Promise<string> {
-    let processed = template;
-
-    processed = this.replaceStandardVariables(processed, variables, true);
-
-    if (variables.minPrice) {
-      processed = processed.replace(
-        /#MinPrice#/g,
-        `à partir de ${variables.minPrice}€`,
-      );
-    }
-
-    const prixIndex = ((pgId % 100) + typeId) % PRIX_PAS_CHER.length;
-    processed = processed.replace(/#PrixPasCher#/g, PRIX_PAS_CHER[prixIndex]);
-
-    processed = await this.switchEngine.processCompSwitch(processed);
-
-    // CompSwitch_3_PG_ID spécifique
-    const switch3Regex = new RegExp(`#CompSwitch_3_${pgId}#`, 'g');
-    if (switch3Regex.test(processed)) {
-      const switch3 = gammeSwitches.filter((s) => s.sgcs_alias === 3);
-      if (switch3.length > 0) {
-        const index = (typeId + pgId + 3) % switch3.length;
-        processed = processed.replace(
-          switch3Regex,
-          switch3[index].sgcs_content || '',
-        );
-      }
-    }
-
-    processed = await this.switchEngine.processLinkGammeCar(processed);
-
-    return this.cleanContent(processed);
-  }
-
-  private async processH1(
-    template: string,
-    variables: SeoVariables,
-  ): Promise<string> {
-    let processed = template;
-    processed = this.replaceStandardVariables(processed, variables, false);
-
-    if (variables.articlesCount > 0) {
-      processed = processed.replace(
-        /#ArticlesCountFormatted#/g,
-        `<b>${variables.articlesCount}</b> références`,
-      );
-    }
-
-    return this.cleanContent(processed);
-  }
-
-  private async processPreview(
-    template: string,
-    variables: SeoVariables,
-  ): Promise<string> {
-    let processed = template;
-    processed = this.replaceStandardVariables(processed, variables, true);
-
-    if (variables.minPrice) {
-      processed = processed.replace(
-        /#MinPriceFormatted#/g,
-        `${variables.minPrice}€`,
-      );
-    }
-
-    processed = await this.switchEngine.processGammeSwitches(processed);
-
-    return this.cleanContent(processed);
-  }
-
-  private async processContent(
-    template: string,
-    variables: SeoVariables,
-    itemSwitches: Record<string, unknown>[],
-    gammeSwitches: Record<string, unknown>[],
-    familySwitches: Record<string, unknown>[],
-    typeId: number,
-  ): Promise<string> {
-    let processed = template;
-
-    processed = this.replaceStandardVariables(processed, variables, false);
-
-    const prixIndex = typeId % PRIX_PAS_CHER.length;
-    processed = processed.replace(/#PrixPasCher#/g, PRIX_PAS_CHER[prixIndex]);
-
-    const proposeIndex = typeId % VOUS_PROPOSE.length;
-    processed = processed.replace(/#VousPropose#/g, VOUS_PROPOSE[proposeIndex]);
-
-    processed = await this.switchEngine.processExternalSwitchesEnhanced(
-      processed,
-      typeId,
-    );
-    processed =
-      await this.switchEngine.processFamilySwitchesEnhanced(processed);
-    processed = await this.switchEngine.processAllLinksEnhanced(processed);
-
-    processed = this.processContextualVariables(processed, variables);
-
-    return this.cleanContent(processed);
-  }
-
-  // ====================================
-  // 🔧 VARIABLE REPLACEMENT
-  // ====================================
-
-  private replaceStandardVariables(
-    content: string,
-    variables: SeoVariables,
-    useMeta: boolean,
-  ): string {
-    const replacements = {
-      '#Gamme#': useMeta ? variables.gammeMeta : `<b>${variables.gamme}</b>`,
-      '#VMarque#': useMeta
-        ? variables.marqueMetaTitle
-        : `<b>${variables.marque}</b>`,
-      '#VModele#': useMeta
-        ? variables.modeleMeta
-        : `<b>${variables.modele}</b>`,
-      '#VType#': useMeta ? variables.typeMeta : `<b>${variables.type}</b>`,
-      '#VAnnee#': useMeta ? variables.annee : `<b>${variables.annee}</b>`,
-      '#VNbCh#': useMeta
-        ? variables.nbCh.toString()
-        : `<b>${variables.nbCh} ch</b>`,
-      '#VCarosserie#': `<b>${variables.carosserie}</b>`,
-      '#VMotorisation#': `<b>${variables.fuel}</b>`,
-      '#VCodeMoteur#': `<b>${variables.codeMoteur}</b>`,
-      '#GammeLevel#': `niveau ${variables.gammeLevel}`,
-      '#IsTop#': variables.isTopGamme ? 'gamme premium' : '',
+    return {
+      title: this.cleanContent(chain.template.title, true),
+      description: this.cleanContent(chain.template.description),
+      h1: chain.template.h1,
+      preview: chain.template.preview,
+      content: chain.template.content,
+      keywords: chain.template.keywords,
+      metadata: {
+        templatesUsed: chain.metadata.templateId
+          ? [chain.metadata.templateId]
+          : ['default'],
+        switchesProcessed: variantCount + chain.metadata.internalLinkCount,
+        variablesReplaced: this.countMarkers(chain.template),
+        processingTime,
+        cacheHit: false,
+        version: chain.metadata.chainVersion,
+      },
     };
-
-    let processed = content;
-    for (const [marker, replacement] of Object.entries(replacements)) {
-      processed = processed.replace(new RegExp(marker, 'g'), replacement);
-    }
-
-    return processed;
   }
 
-  private processContextualVariables(
-    content: string,
-    variables: SeoVariables,
-  ): string {
-    let processed = content;
-
-    if (variables.articlesCount) {
-      let countText = '';
-      if (variables.articlesCount === 1) {
-        countText = '1 référence';
-      } else if (variables.articlesCount < 10) {
-        countText = `${variables.articlesCount} références`;
-      } else {
-        countText = `plus de ${variables.articlesCount} références`;
-      }
-
-      processed = processed.replace(
-        /#ArticlesCountFormatted#/g,
-        `<b>${countText}</b>`,
-      );
-    }
-
-    if (variables.seoScore) {
-      if (variables.seoScore >= 80) {
-        processed = processed.replace(
-          /#QualityBadge#/g,
-          '<b>Sélection Premium</b>',
-        );
-      } else if (variables.seoScore >= 60) {
-        processed = processed.replace(
-          /#QualityBadge#/g,
-          '<b>Qualité Vérifiée</b>',
-        );
-      } else {
-        processed = processed.replace(/#QualityBadge#/g, '');
-      }
-    }
-
-    if (variables.familyName) {
-      processed = processed.replace(
-        /#FamilyContext#/g,
-        `dans la catégorie <b>${variables.familyName}</b>`,
-      );
-    }
-
-    return processed;
-  }
-
-  private cleanContent(content: string, isTitle: boolean = false): string {
+  /**
+   * Nettoie un texte SEO : supprime les marqueurs `#X#` orphelins, les
+   * espaces redondants, les `<b></b>` vides. Tronque le titre à 60 chars.
+   *
+   * Conservé du V4 d'origine : la chaîne PR-2c produit déjà des templates
+   * propres, mais on garde ce coup d'oil pour le legacy fallback (où certains
+   * marqueurs synthétisés peuvent contenir des résidus).
+   */
+  private cleanContent(content: string, isTitle = false): string {
     let cleaned = content
-      // Supprimer les variables template non résolues (#Gamme#, #MinPrice#, etc.)
       .replace(/#[A-Za-z_]+#/g, '')
       .replace(/\s+/g, ' ')
       .replace(/\s+([,.])/g, '$1')
@@ -414,12 +193,14 @@ export class DynamicSeoV4UltimateService extends SupabaseBaseService {
 
     if (isTitle) {
       cleaned = cleaned.replace(/<[^>]*>/g, '');
-      if (cleaned.length > 60) {
-        cleaned = cleaned.substring(0, 57) + '...';
-      }
+      if (cleaned.length > 60) cleaned = `${cleaned.substring(0, 57)}...`;
     }
-
     return cleaned;
+  }
+
+  private countMarkers(template: { content: string; title: string }): number {
+    const all = `${template.title} ${template.content}`;
+    return (all.match(/#[A-Za-z0-9_]+#/g) ?? []).length;
   }
 
   // ====================================
@@ -443,9 +224,8 @@ export class DynamicSeoV4UltimateService extends SupabaseBaseService {
         typeId: 0,
         timestamp: new Date(),
       });
-
       this.logger.warn(
-        `⚠️ [SEO V4] Page type "unknown" détectée - Contexte incomplet`,
+        '⚠️ [SEO V4] Page type "unknown" détectée — Contexte incomplet',
         {
           gamme: variables.gamme,
           marque: variables.marque,
@@ -497,53 +277,9 @@ export class DynamicSeoV4UltimateService extends SupabaseBaseService {
         variablesReplaced: hasVehicleContext ? 8 : 3,
         processingTime,
         cacheHit: false,
-        version: hasVehicleContext ? '4.0.0-fallback' : '4.0.0-unknown',
+        version: hasVehicleContext ? '4.1.0-fallback' : '4.1.0-unknown',
       },
     };
-  }
-
-  // ====================================
-  // 📊 DATA ACCESS
-  // ====================================
-
-  private async getSeoTemplate(pgId: number): Promise<any> {
-    const { data } = await this.supabase
-      .from(TABLES.seo_gamme_car)
-      .select('*')
-      .eq('sgc_pg_id', pgId)
-      .single();
-    return data;
-  }
-
-  private async getItemSwitches(
-    pgId: number,
-  ): Promise<Record<string, unknown>[]> {
-    const { data } = await this.supabase
-      .from(TABLES.seo_item_switch)
-      .select('*')
-      .eq('sis_pg_id', pgId);
-    return data || [];
-  }
-
-  private async getGammeCarSwitches(pgId: number): Promise<any[]> {
-    const { data } = await this.supabase
-      .from(TABLES.seo_gamme_car_switch)
-      .select('*')
-      .eq('sgcs_pg_id', pgId);
-    return data || [];
-  }
-
-  private async getFamilySwitches(
-    mfId: number | undefined,
-    pgId: number,
-  ): Promise<Record<string, unknown>[]> {
-    if (!mfId) return [];
-    const { data } = await this.supabase
-      .from(TABLES.seo_family_gamme_car_switch)
-      .select('*')
-      .eq('sfgcs_mf_id', mfId)
-      .eq('sfgcs_pg_id', pgId);
-    return data || [];
   }
 
   // ====================================
@@ -564,12 +300,6 @@ export class DynamicSeoV4UltimateService extends SupabaseBaseService {
     ]
       .filter(Boolean)
       .join(', ');
-  }
-
-  private countVariablesInTemplate(template: Record<string, unknown>): number {
-    const content = JSON.stringify(template);
-    const matches = content.match(/#[A-Za-z0-9_]+#/g);
-    return matches ? matches.length : 0;
   }
 
   // ====================================
@@ -607,9 +337,7 @@ export class DynamicSeoV4UltimateService extends SupabaseBaseService {
   public clearExpiredCache(): void {
     const now = Date.now();
     for (const [key, cached] of this.seoCache.entries()) {
-      if (cached.expires <= now) {
-        this.seoCache.delete(key);
-      }
+      if (cached.expires <= now) this.seoCache.delete(key);
     }
   }
 

--- a/backend/src/modules/seo/seo.module.ts
+++ b/backend/src/modules/seo/seo.module.ts
@@ -28,7 +28,6 @@ import { AiContentModule } from '../ai-content/ai-content.module';
 // ═══════════════════════════════════════════════════════════════════════════
 import { SeoService } from './seo.service';
 import { DynamicSeoV4UltimateService } from './dynamic-seo-v4-ultimate.service';
-import { SeoV4SwitchEngineService } from './services/seo-v4-switch-engine.service';
 import { SeoV4MonitoringService } from './services/seo-v4-monitoring.service';
 import { HreflangService } from './infrastructure/hreflang.service';
 import { ProductImageService } from './services/product-image.service';
@@ -204,7 +203,6 @@ import { PageRoleValidationInterceptor } from './interceptors/page-role-validati
   providers: [
     // Core
     SeoService,
-    SeoV4SwitchEngineService,
     SeoV4MonitoringService,
     DynamicSeoV4UltimateService,
     HreflangService,

--- a/backend/src/modules/seo/seo.module.ts
+++ b/backend/src/modules/seo/seo.module.ts
@@ -140,6 +140,18 @@ import { SeoIndexabilityPolicyService } from './services/policies/seo-indexabili
 import { SeoUnavailablePolicy } from './services/policies/seo-unavailable-policy.service';
 
 // ═══════════════════════════════════════════════════════════════════════════
+// CHAIN (PR-2c plan seo-v9 — chaîne SEO commune : 7 services + orchestrator)
+// ═══════════════════════════════════════════════════════════════════════════
+import { SeoSlugService } from './services/chain/seo-slug.service';
+import { SeoArianeBreadcrumbService } from './services/chain/seo-ariane-breadcrumb.service';
+import { SeoMetaRegistryService } from './services/chain/seo-meta-registry.service';
+import { SeoSwitchSelector } from './services/chain/seo-switch-selector.service';
+import { SeoTemplateRenderer } from './services/chain/seo-template-renderer.service';
+import { SeoInternalLinkingService as SeoChainInternalLinkingService } from './services/chain/seo-internal-linking.service';
+import { SeoContentBlockBuilder } from './services/chain/seo-content-block-builder.service';
+import { SeoChainOrchestratorService } from './services/chain/seo-chain-orchestrator.service';
+
+// ═══════════════════════════════════════════════════════════════════════════
 // INTERCEPTORS
 // ═══════════════════════════════════════════════════════════════════════════
 import { SeoHeadersInterceptor } from './interceptors/seo-headers.interceptor';
@@ -244,6 +256,15 @@ import { PageRoleValidationInterceptor } from './interceptors/page-role-validati
     R2IndexabilityGate,
     SeoIndexabilityPolicyService,
     SeoUnavailablePolicy,
+    // Chain (PR-2c plan seo-v9)
+    SeoSlugService,
+    SeoArianeBreadcrumbService,
+    SeoMetaRegistryService,
+    SeoSwitchSelector,
+    SeoTemplateRenderer,
+    SeoChainInternalLinkingService,
+    SeoContentBlockBuilder,
+    SeoChainOrchestratorService,
 
     // Interceptors globaux
     {
@@ -308,6 +329,15 @@ import { PageRoleValidationInterceptor } from './interceptors/page-role-validati
     R2IndexabilityGate,
     SeoIndexabilityPolicyService,
     SeoUnavailablePolicy,
+    // Chain (PR-2c plan seo-v9)
+    SeoSlugService,
+    SeoArianeBreadcrumbService,
+    SeoMetaRegistryService,
+    SeoSwitchSelector,
+    SeoTemplateRenderer,
+    SeoChainInternalLinkingService,
+    SeoContentBlockBuilder,
+    SeoChainOrchestratorService,
   ],
 })
 export class SeoModule {

--- a/backend/src/modules/seo/services/chain/__tests__/__snapshots__/seo-chain-orchestrator.service.test.ts.snap
+++ b/backend/src/modules/seo/services/chain/__tests__/__snapshots__/seo-chain-orchestrator.service.test.ts.snap
@@ -1,0 +1,142 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SeoChainOrchestratorService Snapshot freeze contrat output (Étape 6 plan v9 rev 2) freeze R0_HOME output shape 1`] = `
+{
+  "ariane": {
+    "jsonLd": {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "item": "https://www.automecanik.com/",
+          "name": "Accueil",
+          "position": 1,
+        },
+      ],
+    },
+    "textTrail": "Accueil",
+  },
+  "contentBlocks": [],
+  "metadata": {
+    "chainVersion": "seo-v9-pr2c",
+    "internalLinkCount": 0,
+    "surfaceKey": "R0_HOME",
+    "templateId": null,
+    "variantIds": {},
+  },
+  "policies": {
+    "blockingReasons": [],
+    "canonical": "https://www.automecanik.com/",
+    "robots": "index,follow",
+  },
+  "surfaceKey": "R0_HOME",
+  "template": {
+    "content": "",
+    "description": "",
+    "h1": "",
+    "keywords": "Plaquettes de frein, Renault, Clio IV, 1.5 dCi 90, 90 ch, 2015, berline, diesel, K9K",
+    "preview": "",
+    "title": "",
+  },
+}
+`;
+
+exports[`SeoChainOrchestratorService Snapshot freeze contrat output (Étape 6 plan v9 rev 2) freeze R1_GAMME_VEHICLE_ROUTER output shape 1`] = `
+{
+  "ariane": {
+    "jsonLd": {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "item": "https://www.automecanik.com/",
+          "name": "Accueil",
+          "position": 1,
+        },
+      ],
+    },
+    "textTrail": "Accueil",
+  },
+  "contentBlocks": [
+    {
+      "html": "Aperçu Plaquettes de frein",
+      "type": "lead",
+    },
+    {
+      "html": "<p>dans la catégorie <b>Freinage</b></p>",
+      "type": "paragraph",
+    },
+  ],
+  "metadata": {
+    "chainVersion": "seo-v9-pr2c",
+    "internalLinkCount": 0,
+    "surfaceKey": "R1_GAMME_VEHICLE_ROUTER",
+    "templateId": "R1_GAMME_VEHICLE_ROUTER:124",
+    "variantIds": {
+      "1": null,
+      "2": null,
+      "3": null,
+    },
+  },
+  "policies": {
+    "blockingReasons": [],
+    "canonical": "https://www.automecanik.com/pieces/plaquettes-de-frein/renault/clio/1-5-dci-90.html",
+    "robots": "index,follow",
+  },
+  "surfaceKey": "R1_GAMME_VEHICLE_ROUTER",
+  "template": {
+    "content": "<p>dans la catégorie <b>Freinage</b></p>",
+    "description": "Description économique",
+    "h1": "<h1><b>Plaquettes</b></h1>",
+    "keywords": "Plaquettes de frein, Renault, Clio IV, 1.5 dCi 90, 90 ch, 2015, berline, diesel, K9K",
+    "preview": "Aperçu Plaquettes de frein",
+    "title": "Plaquettes de frein pour Renault Clio IV",
+  },
+}
+`;
+
+exports[`SeoChainOrchestratorService Snapshot freeze contrat output (Étape 6 plan v9 rev 2) freeze R7_BRAND_HUB output shape (noindex via threshold) 1`] = `
+{
+  "ariane": {
+    "jsonLd": {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "item": "https://www.automecanik.com/",
+          "name": "Accueil",
+          "position": 1,
+        },
+      ],
+    },
+    "textTrail": "Accueil",
+  },
+  "contentBlocks": [],
+  "metadata": {
+    "chainVersion": "seo-v9-pr2c",
+    "internalLinkCount": 0,
+    "surfaceKey": "R7_BRAND_HUB",
+    "templateId": null,
+    "variantIds": {},
+  },
+  "policies": {
+    "blockingReasons": [
+      "families_below_threshold(1<3)",
+    ],
+    "canonical": "https://www.automecanik.com/constructeurs/bosch.html",
+    "robots": "noindex,follow",
+  },
+  "surfaceKey": "R7_BRAND_HUB",
+  "template": {
+    "content": "",
+    "description": "",
+    "h1": "",
+    "keywords": "Plaquettes de frein, Renault, Clio IV, 1.5 dCi 90, 90 ch, 2015, berline, diesel, K9K",
+    "preview": "",
+    "title": "",
+  },
+}
+`;

--- a/backend/src/modules/seo/services/chain/__tests__/seo-ariane-breadcrumb.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-ariane-breadcrumb.service.test.ts
@@ -1,0 +1,108 @@
+import {
+  SeoArianeBreadcrumbService,
+  SeoBreadcrumbError,
+} from '../seo-ariane-breadcrumb.service';
+
+describe('SeoArianeBreadcrumbService', () => {
+  let service: SeoArianeBreadcrumbService;
+
+  beforeEach(() => {
+    service = new SeoArianeBreadcrumbService();
+  });
+
+  const validInput = {
+    surfaceKey: 'R8_VEHICLE' as const,
+    items: [
+      { name: 'Accueil', url: 'https://www.automecanik.com/' },
+      {
+        name: 'Constructeurs',
+        url: 'https://www.automecanik.com/constructeurs',
+      },
+      {
+        name: 'Renault',
+        url: 'https://www.automecanik.com/constructeurs/renault.html',
+      },
+      {
+        name: 'Clio IV',
+        url: 'https://www.automecanik.com/constructeurs/renault/clio-iv',
+      },
+    ],
+  };
+
+  describe('buildJsonLd', () => {
+    it('produit un BreadcrumbList Schema.org valide', () => {
+      const jsonLd = service.buildJsonLd(validInput);
+
+      expect(jsonLd['@context']).toBe('https://schema.org');
+      expect(jsonLd['@type']).toBe('BreadcrumbList');
+      expect(jsonLd.itemListElement).toHaveLength(4);
+
+      // Position 1-indexed
+      expect(jsonLd.itemListElement[0]).toEqual({
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Accueil',
+        item: 'https://www.automecanik.com/',
+      });
+      expect(jsonLd.itemListElement[3].position).toBe(4);
+      expect(jsonLd.itemListElement[3].name).toBe('Clio IV');
+    });
+
+    it('preserve l’ordre des items (du général au spécifique)', () => {
+      const jsonLd = service.buildJsonLd(validInput);
+      expect(jsonLd.itemListElement.map((i) => i.name)).toEqual([
+        'Accueil',
+        'Constructeurs',
+        'Renault',
+        'Clio IV',
+      ]);
+    });
+
+    it('throw SeoBreadcrumbError si items vide', () => {
+      expect(() =>
+        service.buildJsonLd({ surfaceKey: 'R0_HOME', items: [] }),
+      ).toThrow(SeoBreadcrumbError);
+    });
+
+    it('throw si une URL n’est pas absolue HTTPS', () => {
+      expect(() =>
+        service.buildJsonLd({
+          surfaceKey: 'R0_HOME',
+          items: [{ name: 'Accueil', url: 'http://example.com/' }],
+        }),
+      ).toThrow(/HTTPS/);
+      expect(() =>
+        service.buildJsonLd({
+          surfaceKey: 'R0_HOME',
+          items: [{ name: 'Accueil', url: '/relative' }],
+        }),
+      ).toThrow(/HTTPS/);
+    });
+
+    it('throw si un name est vide', () => {
+      expect(() =>
+        service.buildJsonLd({
+          surfaceKey: 'R0_HOME',
+          items: [{ name: '   ', url: 'https://www.automecanik.com/' }],
+        }),
+      ).toThrow(/name vide/);
+    });
+  });
+
+  describe('buildTextTrail', () => {
+    it('joint les noms avec " > " (compat legacy mta_ariane)', () => {
+      expect(service.buildTextTrail(validInput)).toBe(
+        'Accueil > Constructeurs > Renault > Clio IV',
+      );
+    });
+
+    it('item unique : pas de séparateur', () => {
+      expect(
+        service.buildTextTrail({
+          surfaceKey: 'R0_HOME',
+          items: [{ name: 'Accueil', url: 'https://www.automecanik.com/' }],
+        }),
+      ).toBe('Accueil');
+    });
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/seo-chain-orchestrator.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-chain-orchestrator.service.test.ts
@@ -253,4 +253,80 @@ describe('SeoChainOrchestratorService', () => {
       /families_below_threshold/,
     );
   });
+
+  // ─────────── Étape 6 plan rev 2 : freeze contrat orchestrator ───────────
+  // Snapshot tests sur 3 surfaces canon. Tout changement de format (clé,
+  // structure, casse, types) cassera le snapshot et obligera une mise à jour
+  // explicite via `--updateSnapshot`. Empêche les dérives invisibles dans
+  // les PRs futures.
+  describe('Snapshot freeze contrat output (Étape 6 plan v9 rev 2)', () => {
+    function strip(out: Record<string, unknown>) {
+      // renderedAt change à chaque run → on le neutralise pour stabiliser
+      // les snapshots. Le format ISO reste vérifié implicitement par les
+      // tests d'intégration ci-dessus.
+      const { metadata, ...rest } = out as {
+        metadata: Record<string, unknown>;
+      };
+      const { renderedAt: _renderedAt, ...metaRest } = metadata;
+      return { ...rest, metadata: metaRest };
+    }
+
+    it('freeze R1_GAMME_VEHICLE_ROUTER output shape', async () => {
+      const orchestrator = buildOrchestrator({
+        templateRow: {
+          sgc_id: 124,
+          sgc_title: '#Gamme# pour #VMarque# #VModele#',
+          sgc_descrip: 'Description #PrixPasCher#',
+          sgc_h1: '<h1>#Gamme#</h1>',
+          sgc_preview: 'Aperçu #Gamme#',
+          sgc_content: '<p>#FamilyContext#</p>',
+        },
+      });
+      const out = await orchestrator.run({
+        surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        pgId: 124,
+        typeId: 12345,
+        vehicleId: 12345,
+        variables: baseVars,
+        ids: {
+          gammeAlias: 'plaquettes-de-frein',
+          marqueAlias: 'renault',
+          modeleAlias: 'clio',
+          typeAlias: '1-5-dci-90',
+        },
+        baseUrl: 'https://www.automecanik.com',
+        breadcrumbs: [{ name: 'Accueil', url: 'https://www.automecanik.com/' }],
+      });
+      expect(strip(out as never)).toMatchSnapshot();
+    });
+
+    it('freeze R0_HOME output shape', async () => {
+      const orchestrator = buildOrchestrator({ templateRow: null });
+      const out = await orchestrator.run({
+        surfaceKey: 'R0_HOME',
+        pgId: 0,
+        typeId: 0,
+        variables: baseVars,
+        ids: {},
+        baseUrl: 'https://www.automecanik.com',
+        breadcrumbs: [{ name: 'Accueil', url: 'https://www.automecanik.com/' }],
+      });
+      expect(strip(out as never)).toMatchSnapshot();
+    });
+
+    it('freeze R7_BRAND_HUB output shape (noindex via threshold)', async () => {
+      const orchestrator = buildOrchestrator({ templateRow: null });
+      const out = await orchestrator.run({
+        surfaceKey: 'R7_BRAND_HUB',
+        pgId: 0,
+        typeId: 0,
+        variables: baseVars,
+        ids: { brandAlias: 'bosch' },
+        baseUrl: 'https://www.automecanik.com',
+        breadcrumbs: [{ name: 'Accueil', url: 'https://www.automecanik.com/' }],
+        indexability: { availableFamilies: 1 },
+      });
+      expect(strip(out as never)).toMatchSnapshot();
+    });
+  });
 });

--- a/backend/src/modules/seo/services/chain/__tests__/seo-chain-orchestrator.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-chain-orchestrator.service.test.ts
@@ -1,0 +1,256 @@
+import { SeoSurfaceRegistry } from '../../../registries/seo-surface.registry';
+import { SeoVariantFamilyRegistry } from '../../../registries/seo-variant-family.registry';
+import { R2IndexabilityGate } from '../../policies/r2-indexability-gate.service';
+import { SeoCanonicalService } from '../../policies/seo-canonical.service';
+import { SeoIndexabilityPolicyService } from '../../policies/seo-indexability-policy.service';
+import { SeoArianeBreadcrumbService } from '../seo-ariane-breadcrumb.service';
+import { SeoChainOrchestratorService } from '../seo-chain-orchestrator.service';
+import { SeoContentBlockBuilder } from '../seo-content-block-builder.service';
+import { SeoInternalLinkingService } from '../seo-internal-linking.service';
+import { SeoSwitchSelector } from '../seo-switch-selector.service';
+import { SeoTemplateRenderer } from '../seo-template-renderer.service';
+
+/**
+ * Tests d'intégration de la chaîne SEO seo-v9 PR-2c.
+ *
+ * Stubs Supabase via `Object.defineProperty` (cf. pattern PR-2b).
+ * Vérifie : assemblage end-to-end + propagation des verdicts policies.
+ */
+describe('SeoChainOrchestratorService', () => {
+  function buildOrchestrator(opts: {
+    templateRow?: Record<string, unknown> | null;
+    variantsByAlias?: Record<number, Record<string, unknown>>;
+    gammeRows?: Array<Record<string, unknown>>;
+  }) {
+    const renderer = new SeoTemplateRenderer();
+    const switchSelector = new SeoSwitchSelector(
+      new SeoVariantFamilyRegistry(),
+    );
+    const linking = new SeoInternalLinkingService();
+
+    Object.defineProperty(renderer, 'supabase', {
+      value: {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: opts.templateRow ?? null,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      },
+      configurable: true,
+    });
+
+    Object.defineProperty(switchSelector, 'supabase', {
+      value: {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              eq: (col2: string, val2: unknown) => ({
+                async then(resolve: (v: unknown) => void) {
+                  // Pour les tests : on sélectionne l'alias passé en 2e eq().
+                  const alias = col2 === 'sis_alias' ? Number(val2) : null;
+                  const row = alias
+                    ? (opts.variantsByAlias ?? {})[alias]
+                    : null;
+                  resolve({ data: row ? [row] : [], error: null });
+                },
+              }),
+              async then(resolve: (v: unknown) => void) {
+                resolve({ data: [], error: null });
+              },
+            }),
+          }),
+        }),
+      },
+      configurable: true,
+    });
+
+    Object.defineProperty(linking, 'supabase', {
+      value: {
+        from: () => ({
+          select: () => ({
+            in: async () => ({
+              data: opts.gammeRows ?? [],
+              error: null,
+            }),
+          }),
+        }),
+      },
+      configurable: true,
+    });
+
+    const surfaces = new SeoSurfaceRegistry();
+    const canonical = new SeoCanonicalService();
+    const r2Gate = new R2IndexabilityGate();
+    const indexability = new SeoIndexabilityPolicyService(surfaces, r2Gate);
+    const ariane = new SeoArianeBreadcrumbService();
+    const blocks = new SeoContentBlockBuilder();
+
+    return new SeoChainOrchestratorService(
+      surfaces,
+      renderer,
+      switchSelector,
+      linking,
+      ariane,
+      canonical,
+      indexability,
+      blocks,
+    );
+  }
+
+  const baseVars = {
+    gamme: 'Plaquettes',
+    gammeMeta: 'Plaquettes de frein',
+    marque: 'Renault',
+    marqueMeta: 'Renault',
+    marqueMetaTitle: 'Renault',
+    modele: 'Clio',
+    modeleMeta: 'Clio IV',
+    type: '1.5 dCi 90',
+    typeMeta: '1.5 dCi 90',
+    annee: '2015',
+    nbCh: 90,
+    carosserie: 'berline',
+    fuel: 'diesel',
+    codeMoteur: 'K9K',
+    minPrice: 25,
+    articlesCount: 12,
+    familyName: 'Freinage',
+    isTopGamme: false,
+  };
+
+  it('R1_GAMME_VEHICLE_ROUTER : applique les variables, rend canonical et JSON-LD', async () => {
+    const orchestrator = buildOrchestrator({
+      templateRow: {
+        sgc_id: 124,
+        sgc_title: '#Gamme# pour #VMarque# #VModele# #VType#',
+        sgc_descrip: 'Description #PrixPasCher# #MinPrice#',
+        sgc_h1: '<h1>#Gamme#</h1>',
+        sgc_preview: 'Aperçu #Gamme#',
+        sgc_content: '<p>Découvrez nos pièces #FamilyContext#</p>',
+      },
+      variantsByAlias: {
+        1: { sis_id: 100, sis_alias: 1, sis_content: 'Variante alias 1' },
+        2: { sis_id: 200, sis_alias: 2, sis_content: 'Variante alias 2' },
+        3: { sis_id: 300, sis_alias: 3, sis_content: 'Variante alias 3' },
+      },
+    });
+
+    const out = await orchestrator.run({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      pgId: 124,
+      typeId: 12345,
+      vehicleId: 12345,
+      variables: baseVars,
+      ids: {
+        gammeAlias: 'plaquettes-de-frein',
+        marqueAlias: 'renault',
+        modeleAlias: 'clio',
+        typeAlias: '1-5-dci-90',
+      },
+      baseUrl: 'https://www.automecanik.com',
+      breadcrumbs: [
+        { name: 'Accueil', url: 'https://www.automecanik.com/' },
+        {
+          name: 'Plaquettes',
+          url: 'https://www.automecanik.com/pieces/plaquettes-de-frein/renault/clio/1-5-dci-90.html',
+        },
+      ],
+    });
+
+    expect(out.surfaceKey).toBe('R1_GAMME_VEHICLE_ROUTER');
+    expect(out.template.title).toContain(
+      'Plaquettes de frein pour Renault Clio IV',
+    );
+    expect(out.template.description).toContain('à partir de 25€');
+    expect(out.template.h1).toContain('<b>Plaquettes</b>');
+    expect(out.template.preview).toContain('Plaquettes de frein');
+    expect(out.template.content).toContain('dans la catégorie <b>Freinage</b>');
+    expect(out.policies.canonical).toBe(
+      'https://www.automecanik.com/pieces/plaquettes-de-frein/renault/clio/1-5-dci-90.html',
+    );
+    expect(out.policies.robots).toBe('index,follow');
+    expect(out.ariane.jsonLd['@type']).toBe('BreadcrumbList');
+    expect(out.ariane.jsonLd.itemListElement).toHaveLength(2);
+    expect(out.metadata.templateId).toBe('R1_GAMME_VEHICLE_ROUTER:124');
+    expect(out.metadata.chainVersion).toBe('seo-v9-pr2c');
+  });
+
+  it('R0_HOME : pas de template DB → champs vides, canonical /, robots index', async () => {
+    const orchestrator = buildOrchestrator({ templateRow: null });
+
+    const out = await orchestrator.run({
+      surfaceKey: 'R0_HOME',
+      pgId: 0,
+      typeId: 0,
+      variables: baseVars,
+      ids: {},
+      baseUrl: 'https://www.automecanik.com',
+      breadcrumbs: [{ name: 'Accueil', url: 'https://www.automecanik.com/' }],
+    });
+
+    expect(out.template.title).toBe('');
+    expect(out.policies.canonical).toBe('https://www.automecanik.com/');
+    expect(out.policies.robots).toBe('index,follow');
+    expect(out.metadata.templateId).toBeNull();
+  });
+
+  it('R3_ADVICE : canonical non supportée → robots noindex,follow + reason', async () => {
+    const orchestrator = buildOrchestrator({ templateRow: null });
+
+    const out = await orchestrator.run({
+      surfaceKey: 'R3_ADVICE',
+      pgId: 7,
+      typeId: 0,
+      variables: baseVars,
+      ids: {},
+      baseUrl: 'https://www.automecanik.com',
+      breadcrumbs: [],
+    });
+
+    expect(out.policies.canonical).toBe('');
+    expect(out.policies.robots).toBe('noindex,follow');
+    expect(out.policies.blockingReasons).toContain(
+      'canonical_not_supported_in_pr2c',
+    );
+  });
+
+  it('throw si surface inconnue', async () => {
+    const orchestrator = buildOrchestrator({ templateRow: null });
+    await expect(
+      orchestrator.run({
+        // @ts-expect-error - surface volontairement invalide
+        surfaceKey: 'BOGUS_SURFACE',
+        pgId: 0,
+        typeId: 0,
+        variables: baseVars,
+        ids: {},
+        baseUrl: 'https://www.automecanik.com',
+        breadcrumbs: [],
+      }),
+    ).rejects.toThrow(/inconnue/);
+  });
+
+  it('seuils noindex appliqués (availableFamilies < threshold)', async () => {
+    const orchestrator = buildOrchestrator({ templateRow: null });
+    const out = await orchestrator.run({
+      surfaceKey: 'R7_BRAND_HUB',
+      pgId: 0,
+      typeId: 0,
+      variables: baseVars,
+      ids: { brandAlias: 'bosch' },
+      baseUrl: 'https://www.automecanik.com',
+      breadcrumbs: [{ name: 'Accueil', url: 'https://www.automecanik.com/' }],
+      indexability: { availableFamilies: 1 }, // < threshold legacy 3
+    });
+
+    expect(out.policies.robots).toBe('noindex,follow');
+    expect(out.policies.blockingReasons?.[0]).toMatch(
+      /families_below_threshold/,
+    );
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/seo-content-block-builder.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-content-block-builder.service.test.ts
@@ -1,0 +1,126 @@
+import { SeoContentBlockBuilder } from '../seo-content-block-builder.service';
+
+describe('SeoContentBlockBuilder', () => {
+  let builder: SeoContentBlockBuilder;
+
+  beforeEach(() => {
+    builder = new SeoContentBlockBuilder();
+  });
+
+  it('produit lead + paragraph quand template a preview + content', () => {
+    const blocks = builder.buildBlocks({
+      template: {
+        title: 't',
+        description: 'd',
+        h1: 'h',
+        preview: 'Aperçu',
+        content: '<p>Contenu</p>',
+        keywords: 'k',
+      },
+      variants: {},
+      links: new Map(),
+    });
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({ type: 'lead', html: 'Aperçu' });
+    expect(blocks[1]).toEqual({ type: 'paragraph', html: '<p>Contenu</p>' });
+  });
+
+  it('skippe lead/paragraph si vide ou whitespace', () => {
+    const blocks = builder.buildBlocks({
+      template: {
+        title: 't',
+        description: 'd',
+        h1: 'h',
+        preview: '   ',
+        content: '',
+        keywords: '',
+      },
+      variants: {},
+      links: new Map(),
+    });
+    expect(blocks).toHaveLength(0);
+  });
+
+  it('extrait HTML des variantes switch (sis_content / sgcs_content / sts_content)', () => {
+    const blocks = builder.buildBlocks({
+      template: {
+        title: '',
+        description: '',
+        h1: '',
+        preview: '',
+        content: '',
+        keywords: '',
+      },
+      variants: {
+        1: { sis_content: 'Variante alias 1' },
+        2: { sgcs_content: 'Variante alias 2' },
+        12: { sts_content: 'Variante alias 12' },
+      },
+      links: new Map(),
+    });
+    expect(blocks).toHaveLength(3);
+    expect(blocks).toEqual([
+      { type: 'switch-variant', alias: 1, html: 'Variante alias 1' },
+      { type: 'switch-variant', alias: 2, html: 'Variante alias 2' },
+      { type: 'switch-variant', alias: 12, html: 'Variante alias 12' },
+    ]);
+  });
+
+  it('skippe variante si toutes les colonnes content sont vides', () => {
+    const blocks = builder.buildBlocks({
+      template: {
+        title: '',
+        description: '',
+        h1: '',
+        preview: '',
+        content: '',
+        keywords: '',
+      },
+      variants: {
+        1: { sis_content: '' },
+        2: null,
+      },
+      links: new Map(),
+    });
+    expect(blocks).toHaveLength(0);
+  });
+
+  it('inclut les links résolus (isLink=true) et omet les fallbacks texte', () => {
+    const links = new Map([
+      [
+        '#LinkGamme_42#',
+        {
+          marker: '#LinkGamme_42#',
+          html: '<a href="/gammes/x">X</a>',
+          isLink: true,
+        },
+      ],
+      [
+        '#LinkGamme_99#',
+        {
+          marker: '#LinkGamme_99#',
+          html: 'nos pièces auto',
+          isLink: false,
+        },
+      ],
+    ]);
+    const blocks = builder.buildBlocks({
+      template: {
+        title: '',
+        description: '',
+        h1: '',
+        preview: '',
+        content: '',
+        keywords: '',
+      },
+      variants: {},
+      links,
+    });
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({
+      type: 'link',
+      html: '<a href="/gammes/x">X</a>',
+      target: '#LinkGamme_42#',
+    });
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/seo-content-block-builder.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-content-block-builder.service.test.ts
@@ -1,10 +1,48 @@
-import { SeoContentBlockBuilder } from '../seo-content-block-builder.service';
+import type { LinkResolutionResult } from '../seo-internal-linking.service';
+import {
+  SeoContentBlockBuilder,
+  type SeoContentBlock,
+} from '../seo-content-block-builder.service';
+import type { SwitchVariant } from '../seo-switch-selector.service';
 
-describe('SeoContentBlockBuilder', () => {
+describe('SeoContentBlockBuilder (PR-2c rev 2)', () => {
   let builder: SeoContentBlockBuilder;
 
   beforeEach(() => {
     builder = new SeoContentBlockBuilder();
+  });
+
+  const noLinks: LinkResolutionResult[] = [];
+
+  function emptyTemplate() {
+    return {
+      title: '',
+      description: '',
+      h1: '',
+      preview: '',
+      content: '',
+      keywords: '',
+    };
+  }
+
+  function indexableLink(marker: string, html: string): LinkResolutionResult {
+    return {
+      marker,
+      html,
+      isLink: true,
+      targetUrl: '/gammes/x',
+      targetRole: 'R1_ROUTER' as never,
+      indexable: true,
+    };
+  }
+
+  it('retourne tableau vide si tout est vide', () => {
+    const blocks = builder.buildBlocks({
+      template: emptyTemplate(),
+      variants: {},
+      links: noLinks,
+    });
+    expect(blocks).toEqual([]);
   });
 
   it('produit lead + paragraph quand template a preview + content', () => {
@@ -18,7 +56,7 @@ describe('SeoContentBlockBuilder', () => {
         keywords: 'k',
       },
       variants: {},
-      links: new Map(),
+      links: noLinks,
     });
     expect(blocks).toHaveLength(2);
     expect(blocks[0]).toEqual({ type: 'lead', html: 'Aperçu' });
@@ -28,37 +66,27 @@ describe('SeoContentBlockBuilder', () => {
   it('skippe lead/paragraph si vide ou whitespace', () => {
     const blocks = builder.buildBlocks({
       template: {
-        title: 't',
-        description: 'd',
-        h1: 'h',
+        ...emptyTemplate(),
         preview: '   ',
         content: '',
-        keywords: '',
       },
       variants: {},
-      links: new Map(),
+      links: noLinks,
     });
     expect(blocks).toHaveLength(0);
   });
 
-  it('extrait HTML des variantes switch (sis_content / sgcs_content / sts_content)', () => {
+  it('extrait HTML des variantes switch (sis/sgcs/sts/sfgcs)', () => {
+    const variants: Record<number, SwitchVariant | null> = {
+      1: { sis_content: 'Variante alias 1' },
+      2: { sgcs_content: 'Variante alias 2' },
+      12: { sts_content: 'Variante alias 12' },
+    };
     const blocks = builder.buildBlocks({
-      template: {
-        title: '',
-        description: '',
-        h1: '',
-        preview: '',
-        content: '',
-        keywords: '',
-      },
-      variants: {
-        1: { sis_content: 'Variante alias 1' },
-        2: { sgcs_content: 'Variante alias 2' },
-        12: { sts_content: 'Variante alias 12' },
-      },
-      links: new Map(),
+      template: emptyTemplate(),
+      variants,
+      links: noLinks,
     });
-    expect(blocks).toHaveLength(3);
     expect(blocks).toEqual([
       { type: 'switch-variant', alias: 1, html: 'Variante alias 1' },
       { type: 'switch-variant', alias: 2, html: 'Variante alias 2' },
@@ -66,61 +94,130 @@ describe('SeoContentBlockBuilder', () => {
     ]);
   });
 
-  it('skippe variante si toutes les colonnes content sont vides', () => {
+  it('skippe variante null ou sans champ HTML reconnu', () => {
     const blocks = builder.buildBlocks({
-      template: {
-        title: '',
-        description: '',
-        h1: '',
-        preview: '',
-        content: '',
-        keywords: '',
-      },
+      template: emptyTemplate(),
       variants: {
         1: { sis_content: '' },
         2: null,
+        3: { sis_id: 1 }, // pas de *_content
       },
-      links: new Map(),
+      links: noLinks,
     });
     expect(blocks).toHaveLength(0);
   });
 
-  it('inclut les links résolus (isLink=true) et omet les fallbacks texte', () => {
-    const links = new Map([
-      [
-        '#LinkGamme_42#',
-        {
-          marker: '#LinkGamme_42#',
-          html: '<a href="/gammes/x">X</a>',
-          isLink: true,
-        },
-      ],
-      [
-        '#LinkGamme_99#',
-        {
-          marker: '#LinkGamme_99#',
-          html: 'nos pièces auto',
-          isLink: false,
-        },
-      ],
-    ]);
-    const blocks = builder.buildBlocks({
-      template: {
-        title: '',
-        description: '',
-        h1: '',
-        preview: '',
-        content: '',
-        keywords: '',
+  it('inclut isLink=true et filtre tous les fallbacks (NOINDEX/NO_TARGET/ORPHAN/SELF_LINK)', () => {
+    const links: LinkResolutionResult[] = [
+      indexableLink('#LinkGamme_42#', '<a href="/gammes/x">X</a>'),
+      {
+        marker: '#LinkGamme_99#',
+        html: 'nos pièces auto',
+        isLink: false,
+        targetUrl: '/gammes/y',
+        targetRole: 'R1_ROUTER' as never,
+        indexable: false,
+        reason: 'NOINDEX',
       },
+      {
+        marker: '#LinkGamme_404#',
+        html: 'nos pièces auto',
+        isLink: false,
+        targetUrl: null,
+        targetRole: 'R1_ROUTER' as never,
+        indexable: false,
+        reason: 'NO_TARGET',
+      },
+      {
+        marker: '#GarbageMarker#',
+        html: 'nos pièces auto',
+        isLink: false,
+        targetUrl: null,
+        targetRole: null,
+        indexable: false,
+        reason: 'ORPHAN',
+      },
+      {
+        marker: '#LinkGamme_self#',
+        html: 'nos pièces auto',
+        isLink: false,
+        targetUrl: '/gammes/self',
+        targetRole: 'R1_ROUTER' as never,
+        indexable: true,
+        reason: 'SELF_LINK',
+      },
+    ];
+    const blocks = builder.buildBlocks({
+      template: emptyTemplate(),
       variants: {},
       links,
     });
-    expect(blocks).toHaveLength(1);
-    expect(blocks[0]).toEqual({
+    const linkBlocks = blocks.filter(
+      (b): b is Extract<SeoContentBlock, { type: 'link' }> => b.type === 'link',
+    );
+    expect(linkBlocks).toHaveLength(1);
+    expect(linkBlocks[0]).toEqual({
       type: 'link',
       html: '<a href="/gammes/x">X</a>',
       target: '#LinkGamme_42#',
     });
+  });
+
+  it('compose tous types ensemble (lead + paragraph + switch + link)', () => {
+    const blocks = builder.buildBlocks({
+      template: {
+        ...emptyTemplate(),
+        preview: 'Lead',
+        content: '<p>Body</p>',
+      },
+      variants: { 1: { sis_id: 1, sis_content: 'Switch 1' } },
+      links: [indexableLink('#LinkGamme_1#', '<a>A</a>')],
+    });
+    expect(blocks.map((b) => b.type)).toEqual([
+      'lead',
+      'paragraph',
+      'switch-variant',
+      'link',
+    ]);
+  });
+
+  it("préserve l'ordre input des links dans output (anti-breaking PR-7)", () => {
+    const links: LinkResolutionResult[] = [
+      indexableLink('#LinkGamme_99#', '<a>Z</a>'),
+      indexableLink('#LinkGamme_1#', '<a>A</a>'),
+    ];
+    const blocks = builder.buildBlocks({
+      template: emptyTemplate(),
+      variants: {},
+      links,
+    });
+    const linkBlocks = blocks.filter(
+      (b): b is Extract<SeoContentBlock, { type: 'link' }> => b.type === 'link',
+    );
+    expect(linkBlocks.map((b) => b.target)).toEqual([
+      '#LinkGamme_99#',
+      '#LinkGamme_1#',
+    ]);
+  });
+
+  it('discriminated union narrowing : chaque type expose ses champs propres', () => {
+    const blocks = builder.buildBlocks({
+      template: { ...emptyTemplate(), preview: 'X', content: 'Y' },
+      variants: { 1: { sis_id: 1, sis_content: 'Z' } },
+      links: [indexableLink('#LinkGamme_1#', '<a>A</a>')],
+    });
+
+    for (const block of blocks) {
+      // TS narrow correctement chaque branche.
+      if (block.type === 'lead' || block.type === 'paragraph') {
+        expect(typeof block.html).toBe('string');
+      } else if (block.type === 'switch-variant') {
+        expect(typeof block.alias).toBe('number');
+        expect(typeof block.html).toBe('string');
+      } else if (block.type === 'link') {
+        expect(typeof block.target).toBe('string');
+        expect(typeof block.html).toBe('string');
+      }
+    }
   });
 });

--- a/backend/src/modules/seo/services/chain/__tests__/seo-internal-linking.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-internal-linking.service.test.ts
@@ -1,6 +1,7 @@
 import { SeoInternalLinkingService } from '../seo-internal-linking.service';
+import type { ResolveLinksBatchInput } from '../seo-internal-linking.service';
 
-describe('SeoInternalLinkingService (stub PR-2c)', () => {
+describe('SeoInternalLinkingService (PR-2c rev 2 — batch + reason codes)', () => {
   let service: SeoInternalLinkingService;
 
   beforeEach(() => {
@@ -29,31 +30,31 @@ describe('SeoInternalLinkingService (stub PR-2c)', () => {
     });
   });
 
-  describe('buildAnchor (pure)', () => {
+  describe('buildAnchor + buildTargetUrl (pure)', () => {
     it('utilise pg_url_slug si présent', () => {
-      expect(
-        service.buildAnchor({
-          pg_id: 42,
-          pg_name: 'Plaquettes',
-          pg_alias: 'plaquettes',
-          pg_url_slug: 'plaquettes-de-frein',
-        }),
-      ).toBe(
+      const row = {
+        pg_id: 42,
+        pg_name: 'Plaquettes',
+        pg_alias: 'plaquettes',
+        pg_url_slug: 'plaquettes-de-frein',
+      };
+      expect(service.buildAnchor(row)).toBe(
         '<a href="/gammes/plaquettes-de-frein" class="link-gamme-internal">Plaquettes</a>',
       );
+      expect(service.buildTargetUrl(row)).toBe('/gammes/plaquettes-de-frein');
     });
 
     it('fallback sur pg_alias si url_slug absent', () => {
-      expect(
-        service.buildAnchor({
-          pg_id: 42,
-          pg_name: 'Filtres',
-          pg_alias: 'filtres',
-          pg_url_slug: null,
-        }),
-      ).toBe(
+      const row = {
+        pg_id: 42,
+        pg_name: 'Filtres',
+        pg_alias: 'filtres',
+        pg_url_slug: null,
+      };
+      expect(service.buildAnchor(row)).toBe(
         '<a href="/gammes/filtres" class="link-gamme-internal">Filtres</a>',
       );
+      expect(service.buildTargetUrl(row)).toBe('/gammes/filtres');
     });
 
     it('fallback sur pg_id si ni slug ni alias', () => {
@@ -67,67 +68,247 @@ describe('SeoInternalLinkingService (stub PR-2c)', () => {
     });
   });
 
-  describe('resolveMarkers', () => {
-    it('résout vers <a> si pg_display !== false, sinon fallback texte', async () => {
-      const fakeClient: any = {
-        from: () => ({
-          select: () => ({
-            in: async () => ({
-              data: [
-                {
-                  pg_id: 1,
-                  pg_name: 'Plaquettes',
-                  pg_alias: 'plaquettes',
-                  pg_url_slug: null,
-                  pg_display: true,
-                },
-                {
-                  pg_id: 2,
-                  pg_name: 'Filtres',
-                  pg_alias: 'filtres',
-                  pg_url_slug: null,
-                  pg_display: false,
-                },
-              ],
-              error: null,
-            }),
-          }),
-        }),
-      };
-      Object.defineProperty(service, 'supabase', {
-        value: fakeClient,
-        configurable: true,
-      });
-
-      const result = await service.resolveMarkers({
+  describe('buildCacheKey (canon Redis PR-7/PR-8)', () => {
+    it("produit une clé stable indépendante de l'ordre des markers", () => {
+      const k1 = service.buildCacheKey({
         sourceSurfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
-        markers: ['#LinkGamme_1#', '#LinkGamme_2#', '#LinkGamme_99#'],
+        sourceEntityId: 124,
+        markers: ['#LinkGamme_42#', '#LinkGamme_5#'],
       });
-
-      expect(result.get('#LinkGamme_1#')!.isLink).toBe(true);
-      expect(result.get('#LinkGamme_1#')!.html).toContain('plaquettes');
-      // pg_display=false → fallback texte
-      expect(result.get('#LinkGamme_2#')!.isLink).toBe(false);
-      expect(result.get('#LinkGamme_2#')!.html).toBe('nos pièces auto');
-      // id absent → fallback
-      expect(result.get('#LinkGamme_99#')!.isLink).toBe(false);
+      const k2 = service.buildCacheKey({
+        sourceSurfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        sourceEntityId: 124,
+        markers: ['#LinkGamme_5#', '#LinkGamme_42#'],
+      });
+      expect(k1).toBe(k2);
+      expect(k1).toMatch(
+        /^seo:v9:linking:R1_GAMME_VEHICLE_ROUTER:124:[a-f0-9]{16}$/,
+      );
     });
 
-    it('renvoie une Map vide si pas de marqueurs', async () => {
-      const result = await service.resolveMarkers({
+    it('produit des clés distinctes pour des markers distincts', () => {
+      const k1 = service.buildCacheKey({
+        sourceSurfaceKey: 'R1_GAMME_ROUTER',
+        sourceEntityId: 1,
+        markers: ['#LinkGamme_42#'],
+      });
+      const k2 = service.buildCacheKey({
+        sourceSurfaceKey: 'R1_GAMME_ROUTER',
+        sourceEntityId: 1,
+        markers: ['#LinkGamme_99#'],
+      });
+      expect(k1).not.toBe(k2);
+    });
+
+    it('namespace seo:v9:* respecté', () => {
+      const k = service.buildCacheKey({
         sourceSurfaceKey: 'R0_HOME',
         markers: [],
       });
-      expect(result.size).toBe(0);
+      expect(k.startsWith('seo:v9:linking:')).toBe(true);
+    });
+  });
+
+  describe('resolveLinksBatch — reason codes + ordering', () => {
+    function mockSupabase(rows: Array<Record<string, unknown>>) {
+      return {
+        from: () => ({
+          select: () => ({
+            in: async () => ({ data: rows, error: null }),
+          }),
+        }),
+      };
+    }
+
+    function injectClient(s: SeoInternalLinkingService, client: unknown) {
+      Object.defineProperty(s, 'supabase', {
+        value: client,
+        configurable: true,
+      });
+    }
+
+    it('retourne tableau vide si markers vide', async () => {
+      const result = await service.resolveLinksBatch({
+        sourceSurfaceKey: 'R0_HOME',
+        markers: [],
+      });
+      expect(result).toEqual([]);
     });
 
-    it('renvoie fallback pour tous si aucun id valide', async () => {
-      const result = await service.resolveMarkers({
+    it("reason ORPHAN si marker n'est pas un #LinkGamme*#", async () => {
+      const result = await service.resolveLinksBatch({
         sourceSurfaceKey: 'R0_HOME',
         markers: ['#CompSwitch_3#', '#GarbageMarker#'],
       });
-      expect(result.get('#CompSwitch_3#')!.isLink).toBe(false);
-      expect(result.get('#CompSwitch_3#')!.html).toBe('nos pièces auto');
+      expect(result).toHaveLength(2);
+      for (const r of result) {
+        expect(r.isLink).toBe(false);
+        expect(r.reason).toBe('ORPHAN');
+        expect(r.html).toBe('nos pièces auto');
+        expect(r.targetRole).toBeNull();
+        expect(r.indexable).toBe(false);
+      }
+    });
+
+    it('reason NO_TARGET si pg_id absent en DB', async () => {
+      injectClient(service, mockSupabase([]));
+      const result = await service.resolveLinksBatch({
+        sourceSurfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        markers: ['#LinkGamme_999#'],
+      });
+      expect(result[0]!.reason).toBe('NO_TARGET');
+      expect(result[0]!.isLink).toBe(false);
+      expect(result[0]!.indexable).toBe(false);
+      expect(result[0]!.targetUrl).toBeNull();
+      expect(result[0]!.targetRole).toBe('R1_ROUTER');
+    });
+
+    it('reason NOINDEX si pg_display=false', async () => {
+      injectClient(
+        service,
+        mockSupabase([
+          {
+            pg_id: 2,
+            pg_name: 'Filtres',
+            pg_alias: 'filtres',
+            pg_url_slug: null,
+            pg_display: false,
+          },
+        ]),
+      );
+      const result = await service.resolveLinksBatch({
+        sourceSurfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        markers: ['#LinkGamme_2#'],
+      });
+      expect(result[0]!.reason).toBe('NOINDEX');
+      expect(result[0]!.isLink).toBe(false);
+      expect(result[0]!.indexable).toBe(false);
+      expect(result[0]!.targetUrl).toBe('/gammes/filtres');
+    });
+
+    it('reason SELF_LINK si sourceEntityId === pg_id cible', async () => {
+      injectClient(
+        service,
+        mockSupabase([
+          {
+            pg_id: 42,
+            pg_name: 'Plaquettes',
+            pg_alias: 'plaquettes',
+            pg_url_slug: null,
+            pg_display: true,
+          },
+        ]),
+      );
+      const result = await service.resolveLinksBatch({
+        sourceSurfaceKey: 'R1_GAMME_ROUTER',
+        sourceEntityId: 42,
+        markers: ['#LinkGamme_42#'],
+      });
+      expect(result[0]!.reason).toBe('SELF_LINK');
+      expect(result[0]!.isLink).toBe(false);
+      // L'indexabilité de la cible reste true (la cible est valide,
+      // c'est juste qu'on ne se link pas soi-même).
+      expect(result[0]!.indexable).toBe(true);
+      expect(result[0]!.targetUrl).toBe('/gammes/plaquettes');
+    });
+
+    it('lien indexable si pg_display=true et pas de self-link', async () => {
+      injectClient(
+        service,
+        mockSupabase([
+          {
+            pg_id: 5,
+            pg_name: 'Disques',
+            pg_alias: 'disques',
+            pg_url_slug: null,
+            pg_display: true,
+          },
+        ]),
+      );
+      const result = await service.resolveLinksBatch({
+        sourceSurfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        sourceEntityId: 124,
+        markers: ['#LinkGamme_5#'],
+      });
+      expect(result[0]!.isLink).toBe(true);
+      expect(result[0]!.reason).toBeUndefined();
+      expect(result[0]!.html).toContain('<a href="/gammes/disques"');
+      expect(result[0]!.targetUrl).toBe('/gammes/disques');
+      expect(result[0]!.targetRole).toBe('R1_ROUTER');
+      expect(result[0]!.indexable).toBe(true);
+    });
+
+    it("préserve l'ordre d'entrée (result[i].marker === markers[i])", async () => {
+      injectClient(
+        service,
+        mockSupabase([
+          {
+            pg_id: 1,
+            pg_name: 'Plaquettes',
+            pg_alias: 'plaquettes',
+            pg_url_slug: null,
+            pg_display: true,
+          },
+          {
+            pg_id: 2,
+            pg_name: 'Filtres',
+            pg_alias: 'filtres',
+            pg_url_slug: null,
+            pg_display: false,
+          },
+        ]),
+      );
+      const markers = [
+        '#LinkGamme_99#', // NO_TARGET
+        '#LinkGamme_2#', // NOINDEX
+        '#LinkGamme_1#', // OK
+        '#GarbageMarker#', // ORPHAN
+      ];
+      const input: ResolveLinksBatchInput = {
+        sourceSurfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        markers,
+      };
+      const result = await service.resolveLinksBatch(input);
+      expect(result.map((r) => r.marker)).toEqual(markers);
+      expect(result.map((r) => r.reason ?? null)).toEqual([
+        'NO_TARGET',
+        'NOINDEX',
+        null,
+        'ORPHAN',
+      ]);
+    });
+  });
+
+  describe('resolveMarkers (deprecated alias backward-compat)', () => {
+    it('renvoie une Map de LinkResolutionResult, équivalente à resolveLinksBatch', async () => {
+      Object.defineProperty(service, 'supabase', {
+        value: {
+          from: () => ({
+            select: () => ({
+              in: async () => ({
+                data: [
+                  {
+                    pg_id: 1,
+                    pg_name: 'Plaquettes',
+                    pg_alias: 'plaquettes',
+                    pg_url_slug: null,
+                    pg_display: true,
+                  },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+        },
+        configurable: true,
+      });
+
+      const map = await service.resolveMarkers({
+        sourceSurfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        markers: ['#LinkGamme_1#'],
+      });
+      expect(map.get('#LinkGamme_1#')!.isLink).toBe(true);
+      expect(map.get('#LinkGamme_1#')!.html).toContain('plaquettes');
     });
   });
 });

--- a/backend/src/modules/seo/services/chain/__tests__/seo-internal-linking.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-internal-linking.service.test.ts
@@ -1,0 +1,133 @@
+import { SeoInternalLinkingService } from '../seo-internal-linking.service';
+
+describe('SeoInternalLinkingService (stub PR-2c)', () => {
+  let service: SeoInternalLinkingService;
+
+  beforeEach(() => {
+    service = new SeoInternalLinkingService();
+  });
+
+  describe('extractGammeIds (pure)', () => {
+    it('extrait les ids depuis #LinkGamme_X# et #LinkGammeCar_X# (dédup + tri)', () => {
+      const markers = [
+        '#LinkGamme_42#',
+        '#LinkGammeCar_5#',
+        '#LinkGamme_42#',
+        '#LinkGammeCar_99#',
+      ];
+      expect(service.extractGammeIds(markers)).toEqual([5, 42, 99]);
+    });
+
+    it('ignore les marqueurs non-link', () => {
+      expect(
+        service.extractGammeIds(['#CompSwitch_3#', '#FamilyContext#']),
+      ).toEqual([]);
+    });
+
+    it('matche insensible à la casse', () => {
+      expect(service.extractGammeIds(['#linkgamme_7#'])).toEqual([7]);
+    });
+  });
+
+  describe('buildAnchor (pure)', () => {
+    it('utilise pg_url_slug si présent', () => {
+      expect(
+        service.buildAnchor({
+          pg_id: 42,
+          pg_name: 'Plaquettes',
+          pg_alias: 'plaquettes',
+          pg_url_slug: 'plaquettes-de-frein',
+        }),
+      ).toBe(
+        '<a href="/gammes/plaquettes-de-frein" class="link-gamme-internal">Plaquettes</a>',
+      );
+    });
+
+    it('fallback sur pg_alias si url_slug absent', () => {
+      expect(
+        service.buildAnchor({
+          pg_id: 42,
+          pg_name: 'Filtres',
+          pg_alias: 'filtres',
+          pg_url_slug: null,
+        }),
+      ).toBe(
+        '<a href="/gammes/filtres" class="link-gamme-internal">Filtres</a>',
+      );
+    });
+
+    it('fallback sur pg_id si ni slug ni alias', () => {
+      expect(
+        service.buildAnchor({
+          pg_id: 42,
+          pg_name: 'Inconnu',
+          pg_alias: null,
+        }),
+      ).toBe('<a href="/gammes/42" class="link-gamme-internal">Inconnu</a>');
+    });
+  });
+
+  describe('resolveMarkers', () => {
+    it('résout vers <a> si pg_display !== false, sinon fallback texte', async () => {
+      const fakeClient: any = {
+        from: () => ({
+          select: () => ({
+            in: async () => ({
+              data: [
+                {
+                  pg_id: 1,
+                  pg_name: 'Plaquettes',
+                  pg_alias: 'plaquettes',
+                  pg_url_slug: null,
+                  pg_display: true,
+                },
+                {
+                  pg_id: 2,
+                  pg_name: 'Filtres',
+                  pg_alias: 'filtres',
+                  pg_url_slug: null,
+                  pg_display: false,
+                },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      };
+      Object.defineProperty(service, 'supabase', {
+        value: fakeClient,
+        configurable: true,
+      });
+
+      const result = await service.resolveMarkers({
+        sourceSurfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        markers: ['#LinkGamme_1#', '#LinkGamme_2#', '#LinkGamme_99#'],
+      });
+
+      expect(result.get('#LinkGamme_1#')!.isLink).toBe(true);
+      expect(result.get('#LinkGamme_1#')!.html).toContain('plaquettes');
+      // pg_display=false → fallback texte
+      expect(result.get('#LinkGamme_2#')!.isLink).toBe(false);
+      expect(result.get('#LinkGamme_2#')!.html).toBe('nos pièces auto');
+      // id absent → fallback
+      expect(result.get('#LinkGamme_99#')!.isLink).toBe(false);
+    });
+
+    it('renvoie une Map vide si pas de marqueurs', async () => {
+      const result = await service.resolveMarkers({
+        sourceSurfaceKey: 'R0_HOME',
+        markers: [],
+      });
+      expect(result.size).toBe(0);
+    });
+
+    it('renvoie fallback pour tous si aucun id valide', async () => {
+      const result = await service.resolveMarkers({
+        sourceSurfaceKey: 'R0_HOME',
+        markers: ['#CompSwitch_3#', '#GarbageMarker#'],
+      });
+      expect(result.get('#CompSwitch_3#')!.isLink).toBe(false);
+      expect(result.get('#CompSwitch_3#')!.html).toBe('nos pièces auto');
+    });
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/seo-meta-registry.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-meta-registry.service.test.ts
@@ -1,0 +1,149 @@
+import { SeoMetaRegistryService } from '../seo-meta-registry.service';
+
+describe('SeoMetaRegistryService', () => {
+  let service: SeoMetaRegistryService;
+
+  beforeEach(() => {
+    service = new SeoMetaRegistryService();
+  });
+
+  describe('mapRow', () => {
+    it('mappe les colonnes mta_* legacy vers SeoMetaEntry', () => {
+      const row = {
+        mta_alias: 'cgv',
+        mta_title: 'Conditions générales',
+        mta_descrip: 'Description CGV',
+        mta_keywords: 'cgv, conditions',
+        mta_h1: 'CGV',
+        mta_ariane: 'Accueil > CGV',
+        mta_content: '<p>Contenu CGV</p>',
+        mta_relfollow: '1',
+      };
+      const mapped = service.mapRow(row);
+      expect(mapped).toEqual({
+        alias: 'cgv',
+        title: 'Conditions générales',
+        description: 'Description CGV',
+        keywords: 'cgv, conditions',
+        h1: 'CGV',
+        ariane: 'Accueil > CGV',
+        content: '<p>Contenu CGV</p>',
+        relfollow: '1',
+      });
+    });
+
+    it('relfollow="0" préservé, default "1" si manquant', () => {
+      expect(service.mapRow({ mta_relfollow: '0' }).relfollow).toBe('0');
+      expect(service.mapRow({ mta_relfollow: 0 }).relfollow).toBe('0');
+      expect(service.mapRow({}).relfollow).toBe('1');
+      expect(service.mapRow({ mta_relfollow: null }).relfollow).toBe('1');
+    });
+
+    it('coerce null/undefined en string vide pour les champs textuels', () => {
+      const mapped = service.mapRow({ mta_alias: 'x' });
+      expect(mapped.title).toBe('');
+      expect(mapped.description).toBe('');
+      expect(mapped.keywords).toBe('');
+    });
+  });
+
+  describe('cache', () => {
+    it('getMeta utilise le cache mémoire au 2e appel sur la même clé', async () => {
+      let dbCalls = 0;
+      // Stub minimal du client supabase exposé par SupabaseBaseService.
+      const fakeClient: any = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => {
+                dbCalls++;
+                return {
+                  data: {
+                    mta_alias: 'home',
+                    mta_title: 'Accueil',
+                    mta_relfollow: '1',
+                  },
+                  error: null,
+                };
+              },
+            }),
+          }),
+        }),
+      };
+      Object.defineProperty(service, 'supabase', {
+        value: fakeClient,
+        configurable: true,
+      });
+
+      const a = await service.getMeta('static', 'home');
+      const b = await service.getMeta('static', 'home');
+      expect(a?.title).toBe('Accueil');
+      expect(b?.title).toBe('Accueil');
+      expect(dbCalls).toBe(1);
+    });
+
+    it('invalidateCache force un re-fetch', async () => {
+      let dbCalls = 0;
+      const fakeClient: any = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => {
+                dbCalls++;
+                return { data: { mta_alias: 'x' }, error: null };
+              },
+            }),
+          }),
+        }),
+      };
+      Object.defineProperty(service, 'supabase', {
+        value: fakeClient,
+        configurable: true,
+      });
+
+      await service.getMeta('static', 'x');
+      service.invalidateCache();
+      await service.getMeta('static', 'x');
+      expect(dbCalls).toBe(2);
+    });
+
+    it('renvoie null si row absent', async () => {
+      const fakeClient: any = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: null, error: null }),
+            }),
+          }),
+        }),
+      };
+      Object.defineProperty(service, 'supabase', {
+        value: fakeClient,
+        configurable: true,
+      });
+
+      expect(await service.getMeta('static', 'inconnu')).toBeNull();
+    });
+
+    it('renvoie null + log si erreur Supabase', async () => {
+      const fakeClient: any = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: null,
+                error: { message: 'boom' },
+              }),
+            }),
+          }),
+        }),
+      };
+      Object.defineProperty(service, 'supabase', {
+        value: fakeClient,
+        configurable: true,
+      });
+
+      expect(await service.getMeta('blog', 'x')).toBeNull();
+    });
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/seo-slug.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-slug.service.test.ts
@@ -1,0 +1,115 @@
+import { SeoSlugService } from '../seo-slug.service';
+
+describe('SeoSlugService', () => {
+  let service: SeoSlugService;
+
+  beforeEach(() => {
+    service = new SeoSlugService();
+  });
+
+  describe('slugify (avec optimisation stop-words)', () => {
+    it('lowercase + dash join', () => {
+      expect(service.slugify('Plaquettes Frein')).toBe('plaquettes-frein');
+    });
+
+    it("supprime les stop-words FR : de / du / des / la / le / les / et / l' / d'", () => {
+      expect(service.slugify('Plaquettes de Frein')).toBe('plaquettes-frein');
+      expect(service.slugify('Kit de la distribution')).toBe(
+        'kit-distribution',
+      );
+      expect(service.slugify('Pièces du moteur')).toBe('pieces-moteur');
+      expect(service.slugify('Test des freins et amortisseurs')).toBe(
+        'test-freins-amortisseurs',
+      );
+      expect(service.slugify("L'huile d'origine")).toBe('huile-origine');
+    });
+
+    it('remplace les accents FR', () => {
+      expect(service.slugify('Filtre à huile')).toBe('filtre-a-huile');
+      expect(service.slugify('Système électrique')).toBe('systeme-electrique');
+      // `à` (préposition) reste comme "a", `l’` (élision typographique) est
+      // stripée via stop-words. Résidu attendu : "echappement-a-avant".
+      expect(service.slugify('Échappement à l’avant')).toBe(
+        'echappement-a-avant',
+      );
+      expect(service.slugify('Côté gauche')).toBe('cote-gauche');
+    });
+
+    it('caractères non alphanumériques → dash + collapse + trim', () => {
+      expect(service.slugify('  Plaquettes  /  Frein  ')).toBe(
+        'plaquettes-frein',
+      );
+      expect(service.slugify('A/B & C')).toBe('a-b-c');
+      expect(service.slugify('!?special@')).toBe('special');
+    });
+
+    it('input vide ou nul', () => {
+      expect(service.slugify('')).toBe('');
+      expect(service.slugify('   ')).toBe('');
+      expect(service.slugify('---')).toBe('');
+    });
+
+    it('respecte maxLength sans couper un mot quand possible', () => {
+      const longInput = 'kit de distribution complete pour moteur diesel turbo';
+      // sans stop-words : "kit-distribution-complete-pour-moteur-diesel-turbo"
+      expect(service.slugify(longInput, 30)).toBe(
+        'kit-distribution-complete-pour',
+      );
+      expect(service.slugify(longInput, 100)).toBe(
+        'kit-distribution-complete-pour-moteur-diesel-turbo',
+      );
+    });
+
+    it('coupe net si aucun dash dans la fenêtre maxLength', () => {
+      // mot très long sans séparateur
+      expect(service.slugify('supercalifragilisticexpialidocious', 10)).toBe(
+        'supercalif',
+      );
+    });
+
+    it('tokens stop-words consécutifs sont tous filtrés', () => {
+      expect(service.slugify('le de la et du')).toBe('');
+      expect(service.slugify('moteur et de la voiture')).toBe('moteur-voiture');
+    });
+
+    it('chiffres conservés', () => {
+      expect(service.slugify('Peugeot 308 1.6 HDi')).toBe(
+        'peugeot-308-1-6-hdi',
+      );
+      expect(service.slugify('Renault Clio IV')).toBe('renault-clio-iv');
+    });
+
+    it('caractères diacritiques étendus (œ, æ, ñ, ß)', () => {
+      expect(service.slugify('Cœur de moteur')).toBe('coeur-moteur');
+      expect(service.slugify('Cæsar')).toBe('caesar');
+      expect(service.slugify('España')).toBe('espana');
+      expect(service.slugify('Straße')).toBe('strasse');
+    });
+
+    it('apostrophes typographiques (’) normalisées en ASCII puis split → "l" stop-word', () => {
+      expect(service.slugify('L’huile')).toBe('huile');
+      expect(service.slugify('D’origine')).toBe('origine');
+    });
+  });
+
+  describe('slugifyRaw (sans optimisation)', () => {
+    it('conserve les stop-words', () => {
+      expect(service.slugifyRaw('Plaquettes de Frein')).toBe(
+        'plaquettes-de-frein',
+      );
+      expect(service.slugifyRaw('Kit de la distribution')).toBe(
+        'kit-de-la-distribution',
+      );
+    });
+
+    it('reste identique pour input sans stop-words', () => {
+      expect(service.slugifyRaw('Plaquettes Frein')).toBe('plaquettes-frein');
+    });
+
+    it('respecte maxLength', () => {
+      expect(
+        service.slugifyRaw('a'.repeat(100), 50).length,
+      ).toBeLessThanOrEqual(50);
+    });
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/seo-switch-selector.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-switch-selector.service.test.ts
@@ -1,0 +1,109 @@
+import {
+  SeoSwitchError,
+  SeoSwitchSelector,
+} from '../seo-switch-selector.service';
+import { SeoVariantFamilyRegistry } from '../../../registries/seo-variant-family.registry';
+
+describe('SeoSwitchSelector', () => {
+  let selector: SeoSwitchSelector;
+
+  beforeEach(() => {
+    selector = new SeoSwitchSelector(new SeoVariantFamilyRegistry());
+  });
+
+  describe('computeSeedIndex (pure)', () => {
+    it('retourne un index dans [0, length)', () => {
+      for (let len = 1; len < 50; len += 7) {
+        const idx = selector.computeSeedIndex(
+          { surfaceKey: 'R8_VEHICLE', pgId: 124, vehicleId: 12345, alias: 1 },
+          len,
+        );
+        expect(idx).toBeGreaterThanOrEqual(0);
+        expect(idx).toBeLessThan(len);
+      }
+    });
+
+    it('est déterministe sur les mêmes inputs', () => {
+      const a = selector.computeSeedIndex(
+        {
+          surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+          pgId: 7,
+          vehicleId: 42,
+          alias: 2,
+        },
+        20,
+      );
+      const b = selector.computeSeedIndex(
+        {
+          surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+          pgId: 7,
+          vehicleId: 42,
+          alias: 2,
+        },
+        20,
+      );
+      expect(a).toBe(b);
+    });
+
+    it('change si une dimension du seed change', () => {
+      const base = {
+        surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+        pgId: 7,
+        vehicleId: 42,
+        alias: 2,
+      };
+      const v0 = selector.computeSeedIndex(base, 100);
+      const v1 = selector.computeSeedIndex({ ...base, pgId: 8 }, 100);
+      const v2 = selector.computeSeedIndex({ ...base, vehicleId: 43 }, 100);
+      const v3 = selector.computeSeedIndex({ ...base, alias: 3 }, 100);
+      const v4 = selector.computeSeedIndex(
+        { ...base, surfaceKey: 'R8_VEHICLE' },
+        100,
+      );
+
+      // Au moins 3 des 4 variations doivent différer du baseline (la collision
+      // accidentelle modulo 100 reste possible ponctuellement).
+      const distinctCount = new Set([v0, v1, v2, v3, v4]).size;
+      expect(distinctCount).toBeGreaterThanOrEqual(4);
+    });
+
+    it('vehicleId/alias optionnels → seed stable même sans ces champs', () => {
+      const a = selector.computeSeedIndex(
+        { surfaceKey: 'R0_HOME', pgId: 0 },
+        10,
+      );
+      const b = selector.computeSeedIndex(
+        { surfaceKey: 'R0_HOME', pgId: 0, vehicleId: null, alias: null },
+        10,
+      );
+      expect(a).toBe(b);
+    });
+
+    it('throw si length <= 0', () => {
+      expect(() =>
+        selector.computeSeedIndex({ surfaceKey: 'R0_HOME', pgId: 0 }, 0),
+      ).toThrow(SeoSwitchError);
+      expect(() =>
+        selector.computeSeedIndex({ surfaceKey: 'R0_HOME', pgId: 0 }, -1),
+      ).toThrow(SeoSwitchError);
+    });
+
+    it('distribution raisonnable sur 10000 seeds', () => {
+      const length = 10;
+      const buckets = new Array<number>(length).fill(0);
+      for (let i = 0; i < 10_000; i++) {
+        const idx = selector.computeSeedIndex(
+          { surfaceKey: 'R8_VEHICLE', pgId: i, vehicleId: i * 31, alias: 1 },
+          length,
+        );
+        buckets[idx]++;
+      }
+      // Avec sha256 + 10 buckets sur 10k tirages, écart-type attendu ~30
+      // (espérance 1000 par bucket). Tolérance large : 700 ≤ b ≤ 1300.
+      for (const count of buckets) {
+        expect(count).toBeGreaterThanOrEqual(700);
+        expect(count).toBeLessThanOrEqual(1300);
+      }
+    });
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/seo-template-renderer.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-template-renderer.service.test.ts
@@ -1,0 +1,212 @@
+import {
+  SeoTemplateRenderer,
+  type TemplateVariables,
+} from '../seo-template-renderer.service';
+
+describe('SeoTemplateRenderer.applyVariables (pure)', () => {
+  let renderer: SeoTemplateRenderer;
+
+  const baseVars: TemplateVariables = {
+    gamme: 'Plaquettes',
+    gammeMeta: 'Plaquettes de frein',
+    marque: 'Renault',
+    marqueMeta: 'Renault',
+    marqueMetaTitle: 'Renault',
+    modele: 'Clio',
+    modeleMeta: 'Clio IV',
+    type: '1.5 dCi 90',
+    typeMeta: '1.5 dCi 90',
+    annee: '2015',
+    nbCh: 90,
+    carosserie: 'berline',
+    fuel: 'diesel',
+    codeMoteur: 'K9K',
+    minPrice: 25,
+    articlesCount: 42,
+    familyName: 'Freinage',
+    seoScore: 85,
+    gammeLevel: 1,
+    isTopGamme: false,
+  };
+
+  beforeEach(() => {
+    renderer = new SeoTemplateRenderer();
+  });
+
+  it('replace standard variables en mode meta (sans <b>)', () => {
+    const out = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#Gamme# pour #VMarque# #VModele# #VType# #VAnnee# #VNbCh#',
+      variables: baseVars,
+      pgId: 124,
+      typeId: 12345,
+      useMeta: true,
+    });
+    expect(out).toBe(
+      'Plaquettes de frein pour Renault Clio IV 1.5 dCi 90 2015 90',
+    );
+  });
+
+  it('replace standard variables en mode HTML (avec <b>)', () => {
+    const out = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#Gamme# #VMarque# #VModele#',
+      variables: baseVars,
+      pgId: 124,
+      typeId: 12345,
+      useMeta: false,
+    });
+    expect(out).toBe('<b>Plaquettes</b> <b>Renault</b> <b>Clio</b>');
+  });
+
+  it('#MinPrice# format title vs descrip', () => {
+    const tplT = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: 'Achetez #MinPrice#',
+      variables: baseVars,
+      pgId: 1,
+      typeId: 1,
+      useMeta: true,
+      minPriceFormat: 'title',
+    });
+    expect(tplT).toContain('dès 25€');
+
+    const tplD = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: 'Disponibles #MinPrice#',
+      variables: baseVars,
+      pgId: 1,
+      typeId: 1,
+      useMeta: true,
+      minPriceFormat: 'descrip',
+    });
+    expect(tplD).toContain('à partir de 25€');
+  });
+
+  it('#PrixPasCher# pioché dans la liste 16 (déterministe via seed)', () => {
+    // Même seed → même valeur (le test n'inspecte pas la valeur exacte mais la
+    // stabilité + l'appartenance à la liste légitime).
+    const out1 = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#PrixPasCher#',
+      variables: baseVars,
+      pgId: 5,
+      typeId: 11,
+      useMeta: true,
+      prixPasCherSeed: 0,
+    });
+    const out2 = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#PrixPasCher#',
+      variables: baseVars,
+      pgId: 5,
+      typeId: 11,
+      useMeta: true,
+      prixPasCherSeed: 0,
+    });
+    expect(out1).toBe('pas cher'); // index 0
+    expect(out2).toBe('pas cher');
+  });
+
+  it('#VousPropose# pioché dans la liste 12 (seed=0 → "vous propose")', () => {
+    const out = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#VousPropose#',
+      variables: baseVars,
+      pgId: 1,
+      typeId: 1,
+      useMeta: false,
+      vousProposeSeed: 0,
+    });
+    expect(out).toBe('vous propose');
+  });
+
+  it('#ArticlesCount# + #ArticlesCountFormatted# selon volume', () => {
+    const out1 = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#ArticlesCount# #ArticlesCountFormatted#',
+      variables: { ...baseVars, articlesCount: 1 },
+      pgId: 1,
+      typeId: 1,
+      useMeta: false,
+    });
+    expect(out1).toBe('1 <b>1 référence</b>');
+
+    const out2 = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#ArticlesCountFormatted#',
+      variables: { ...baseVars, articlesCount: 5 },
+      pgId: 1,
+      typeId: 1,
+      useMeta: false,
+    });
+    expect(out2).toBe('<b>5 références</b>');
+
+    const out3 = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#ArticlesCountFormatted#',
+      variables: { ...baseVars, articlesCount: 42 },
+      pgId: 1,
+      typeId: 1,
+      useMeta: false,
+    });
+    expect(out3).toBe('<b>plus de 42 références</b>');
+  });
+
+  it('#QualityBadge# selon seoScore (>=80 Premium, 60-79 Vérifiée, sinon vide)', () => {
+    const premium = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#QualityBadge#',
+      variables: { ...baseVars, seoScore: 90 },
+      pgId: 1,
+      typeId: 1,
+      useMeta: false,
+    });
+    expect(premium).toBe('<b>Sélection Premium</b>');
+
+    const verified = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#QualityBadge#',
+      variables: { ...baseVars, seoScore: 70 },
+      pgId: 1,
+      typeId: 1,
+      useMeta: false,
+    });
+    expect(verified).toBe('<b>Qualité Vérifiée</b>');
+
+    const empty = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#QualityBadge#',
+      variables: { ...baseVars, seoScore: 30 },
+      pgId: 1,
+      typeId: 1,
+      useMeta: false,
+    });
+    expect(empty).toBe('');
+  });
+
+  it('#FamilyContext# inséré seulement si familyName fourni', () => {
+    const out = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: 'Découvrez nos pièces #FamilyContext#',
+      variables: baseVars,
+      pgId: 1,
+      typeId: 1,
+      useMeta: false,
+    });
+    expect(out).toContain('dans la catégorie <b>Freinage</b>');
+  });
+
+  it('marqueurs non résolus restent dans la sortie (le caller les nettoie via cleanContent)', () => {
+    const out = renderer.applyVariables({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      templateText: '#Inconnu# #CompSwitch_5_124#',
+      variables: baseVars,
+      pgId: 1,
+      typeId: 1,
+      useMeta: false,
+    });
+    // Renderer ne touche pas aux marqueurs `#CompSwitch_*#` (= job de SwitchSelector).
+    expect(out).toBe('#Inconnu# #CompSwitch_5_124#');
+  });
+});

--- a/backend/src/modules/seo/services/chain/seo-ariane-breadcrumb.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-ariane-breadcrumb.service.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@nestjs/common';
+import { type SurfaceKey } from '@repo/seo-role-contracts';
+
+/**
+ * Élément de fil d'Ariane (lib + URL absolue).
+ *
+ * `url` doit être une URL absolue HTTPS pour que le JSON-LD `BreadcrumbList`
+ * passe la validation Schema.org.
+ */
+export interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export interface AriadneBuildInput {
+  surfaceKey: SurfaceKey;
+  /** Items déjà ordonnés du plus général (Accueil) au plus spécifique. */
+  items: BreadcrumbItem[];
+}
+
+/**
+ * JSON-LD `BreadcrumbList` strict (Schema.org).
+ * @see https://schema.org/BreadcrumbList
+ */
+export interface BreadcrumbListJsonLd {
+  '@context': 'https://schema.org';
+  '@type': 'BreadcrumbList';
+  itemListElement: Array<{
+    '@type': 'ListItem';
+    position: number;
+    name: string;
+    item: string;
+  }>;
+}
+
+/**
+ * Service builder du fil d'Ariane SEO (JSON-LD `BreadcrumbList`).
+ *
+ * Logique pure (pas de DB, pas de HTTP). Le caller fournit les items déjà
+ * ordonnés ; ce service ne fait que :
+ *   - valider la cohérence (au moins 1 item, URLs absolues HTTPS)
+ *   - produire le JSON-LD `BreadcrumbList` (Schema.org)
+ *   - produire la liste textuelle (anciennement `mta_ariane`) pour rendu HTML
+ *
+ * Source canonique des items côté legacy : `___meta_tags_ariane.mta_ariane`.
+ * En cible PR-2c+ : ce service est consommé par `SeoMetaRegistryService` pour
+ * les pages standard, et par les controllers R0/R7/R8 pour les hubs.
+ *
+ * @see plan seo-v9 §3.2 — `SeoArianeBreadcrumbService`
+ */
+@Injectable()
+export class SeoArianeBreadcrumbService {
+  /** Construit le JSON-LD `BreadcrumbList`. Throw si items invalides. */
+  buildJsonLd(input: AriadneBuildInput): BreadcrumbListJsonLd {
+    this.validate(input);
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: input.items.map((item, idx) => ({
+        '@type': 'ListItem',
+        position: idx + 1,
+        name: item.name,
+        item: item.url,
+      })),
+    };
+  }
+
+  /**
+   * Construit la liste textuelle (compatibilité `mta_ariane` legacy : "A > B > C").
+   */
+  buildTextTrail(input: AriadneBuildInput): string {
+    this.validate(input);
+    return input.items.map((i) => i.name).join(' > ');
+  }
+
+  private validate(input: AriadneBuildInput): void {
+    if (!Array.isArray(input.items) || input.items.length === 0) {
+      throw new SeoBreadcrumbError(
+        `Ariane vide pour surface ${input.surfaceKey} : au moins 1 item requis.`,
+      );
+    }
+    for (const [idx, item] of input.items.entries()) {
+      if (!item.name || !item.name.trim()) {
+        throw new SeoBreadcrumbError(
+          `Ariane[${idx}].name vide pour surface ${input.surfaceKey}.`,
+        );
+      }
+      if (!item.url || !/^https:\/\//.test(item.url)) {
+        throw new SeoBreadcrumbError(
+          `Ariane[${idx}].url doit être absolue HTTPS (reçu : "${item.url}").`,
+        );
+      }
+    }
+  }
+}
+
+export class SeoBreadcrumbError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SeoBreadcrumbError';
+  }
+}

--- a/backend/src/modules/seo/services/chain/seo-chain-orchestrator.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-chain-orchestrator.service.ts
@@ -1,0 +1,363 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { type SurfaceKey } from '@repo/seo-role-contracts';
+
+import { SeoSurfaceRegistry } from '../../registries/seo-surface.registry';
+import { SeoCanonicalService } from '../policies/seo-canonical.service';
+import {
+  SeoIndexabilityPolicyService,
+  type IndexabilityVerdict,
+} from '../policies/seo-indexability-policy.service';
+
+import {
+  SeoTemplateRenderer,
+  type TemplateVariables,
+} from './seo-template-renderer.service';
+import {
+  SeoSwitchSelector,
+  type SwitchVariant,
+} from './seo-switch-selector.service';
+import { SeoInternalLinkingService } from './seo-internal-linking.service';
+import {
+  SeoArianeBreadcrumbService,
+  type BreadcrumbItem,
+} from './seo-ariane-breadcrumb.service';
+import {
+  SeoContentBlockBuilder,
+  type SeoChainOutput,
+  type SeoChainTemplateData,
+} from './seo-content-block-builder.service';
+
+/**
+ * Inputs canoniques de la chaîne SEO.
+ *
+ * `pgId` / `typeId` couvrent le legacy (R1/R3/R8 catalogue).
+ * `ids` couvre le canonical builder (slugs déjà résolus en amont).
+ * `breadcrumbs` couvre l'ariane (ordonnés du plus général au plus spécifique).
+ */
+export interface SeoChainInput {
+  surfaceKey: SurfaceKey;
+  pgId: number;
+  typeId: number;
+  vehicleId?: number | null;
+  variables: TemplateVariables;
+  ids: {
+    gammeAlias?: string;
+    marqueAlias?: string;
+    modeleAlias?: string;
+    typeAlias?: string;
+    brandAlias?: string;
+    pieceRef?: string;
+    pgAlias?: string;
+    blogSlug?: string;
+    staticPath?: string;
+  };
+  baseUrl: string;
+  /** URL requestée par le client (pour le check `URL ≠ canonical`). */
+  requestedUrl?: string;
+  /** Items breadcrumb déjà ordonnés (général → spécifique). */
+  breadcrumbs: BreadcrumbItem[];
+  /** Inputs optionnels pour le verdict d'indexabilité (volume catalogue). */
+  indexability?: {
+    availableFamilies?: number;
+    availableGammes?: number;
+    r2Conditions?: import('@repo/seo-role-contracts').R2IndexabilityConditions;
+  };
+  /** Si fourni, override le brand_id pour la lookup template R7_BRAND_HUB. */
+  brandId?: number;
+}
+
+/**
+ * Orchestrateur stateless de la chaîne SEO seo-v9.
+ *
+ * Compose en cascade :
+ *   1. SeoSurfaceRegistry        → résolution surface + role
+ *   2. SeoTemplateRenderer       → template + variables
+ *   3. SeoSwitchSelector         → variantes déterministes (alias 1/2/3)
+ *   4. SeoInternalLinkingService → résolution `#LinkGamme*#`
+ *   5. SeoArianeBreadcrumbService → JSON-LD BreadcrumbList
+ *   6. SeoCanonicalService       → URL canonique stricte
+ *   7. SeoIndexabilityPolicyService → verdict robots (+ R2 gate)
+ *   8. SeoContentBlockBuilder    → assembly final
+ *
+ * Aucune logique métier dans cette classe : elle ne fait QUE composer.
+ *
+ * @see plan seo-v9 §3.4 — `DynamicSeoV4UltimateService` (orchestrateur)
+ *
+ * **Note PR-2c** : V4 (`DynamicSeoV4UltimateService.generateCompleteSeo()`) n'est
+ * PAS refactoré pour appeler cet orchestrateur. V4 reste intact (compat 4
+ * endpoints debug `/api/seo-dynamic-v4/*`). PR-3+ wire les controllers réels
+ * (`rm-builder`, `gamme-rest`, `brand-rpc`, `vehicle-rpc`) via cet orchestrator
+ * + feature flag `SEO_CHAIN_<surface>_MODE`.
+ */
+@Injectable()
+export class SeoChainOrchestratorService {
+  private readonly logger = new Logger(SeoChainOrchestratorService.name);
+  private static readonly CHAIN_VERSION = 'seo-v9-pr2c';
+
+  constructor(
+    private readonly surfaces: SeoSurfaceRegistry,
+    private readonly renderer: SeoTemplateRenderer,
+    private readonly switchSelector: SeoSwitchSelector,
+    private readonly linking: SeoInternalLinkingService,
+    private readonly ariane: SeoArianeBreadcrumbService,
+    private readonly canonical: SeoCanonicalService,
+    private readonly indexability: SeoIndexabilityPolicyService,
+    private readonly blocks: SeoContentBlockBuilder,
+  ) {}
+
+  async run(input: SeoChainInput): Promise<SeoChainOutput> {
+    // 1. surface (fail-fast si inconnue)
+    if (!this.surfaces.isKnown(input.surfaceKey)) {
+      throw new Error(`Surface ${input.surfaceKey} inconnue dans le registry`);
+    }
+
+    // 2-3. template + variants (en parallèle)
+    const [templateRow, variantsByAlias] = await Promise.all([
+      this.renderer.fetchTemplate(input.surfaceKey, input.pgId, {
+        brandId: input.brandId,
+      }),
+      this.fetchVariants(input),
+    ]);
+
+    // 2.b application des variables sur les champs templates
+    const template = this.applyTemplateFields(input, templateRow);
+
+    // 4. linking (extrait markers depuis tous les champs hydratés)
+    const allText = `${template.title} ${template.description} ${template.h1} ${template.preview} ${template.content}`;
+    const markers = this.extractMarkers(allText);
+    const links = await this.linking.resolveMarkers({
+      sourceSurfaceKey: input.surfaceKey,
+      markers,
+    });
+
+    // 5. ariane (skip si breadcrumbs vide)
+    const arianeOut =
+      input.breadcrumbs.length > 0
+        ? {
+            jsonLd: this.ariane.buildJsonLd({
+              surfaceKey: input.surfaceKey,
+              items: input.breadcrumbs,
+            }),
+            textTrail: this.ariane.buildTextTrail({
+              surfaceKey: input.surfaceKey,
+              items: input.breadcrumbs,
+            }),
+          }
+        : null;
+
+    // 6. canonical (peut throw pour les surfaces non couvertes en PR-2b)
+    const canonicalUrl = this.tryCanonical(input);
+
+    // 7. indexability verdict
+    const verdict: IndexabilityVerdict = canonicalUrl
+      ? this.indexability.computeIndexability({
+          surfaceKey: input.surfaceKey,
+          requestedUrl: input.requestedUrl ?? canonicalUrl,
+          canonicalUrl,
+          availableFamilies: input.indexability?.availableFamilies,
+          availableGammes: input.indexability?.availableGammes,
+          r2Conditions: input.indexability?.r2Conditions,
+        })
+      : {
+          robots: 'noindex,follow',
+          blockingReasons: ['canonical_not_supported_in_pr2c'],
+        };
+
+    // 8. content blocks assembly
+    const contentBlocks = this.blocks.buildBlocks({
+      template,
+      variants: variantsByAlias,
+      links,
+    });
+
+    return {
+      surfaceKey: input.surfaceKey,
+      template,
+      contentBlocks,
+      policies: {
+        canonical: canonicalUrl ?? '',
+        robots: verdict.robots,
+        blockingReasons: verdict.blockingReasons,
+      },
+      ariane: arianeOut ?? this.emptyAriane(input.surfaceKey),
+      metadata: {
+        surfaceKey: input.surfaceKey,
+        templateId: templateRow
+          ? this.computeTemplateId(input, templateRow)
+          : null,
+        variantIds: this.summarizeVariants(variantsByAlias),
+        internalLinkCount: this.countLinks(links),
+        chainVersion: SeoChainOrchestratorService.CHAIN_VERSION,
+        renderedAt: new Date().toISOString(),
+      },
+    };
+  }
+
+  // ───────────────── helpers ─────────────────
+
+  private async fetchVariants(
+    input: SeoChainInput,
+  ): Promise<Record<number, SwitchVariant | null>> {
+    // PR-2c : on tire les alias usuels (1, 2, 3) sur ITEM_SWITCH si la surface
+    // est R1/R3 catalogue. Les autres surfaces n'utilisent pas de switch dans
+    // cette PR (R0/R7/R8 → wiring complet en PR-3+).
+    const map: Record<number, SwitchVariant | null> = {};
+    if (
+      input.surfaceKey !== 'R1_GAMME_ROUTER' &&
+      input.surfaceKey !== 'R1_GAMME_VEHICLE_ROUTER'
+    ) {
+      return map;
+    }
+    const aliases = [1, 2, 3];
+    for (const alias of aliases) {
+      try {
+        const variant = await this.switchSelector.pickVariant({
+          family: 'ITEM_SWITCH',
+          where: { sis_pg_id: input.pgId },
+          aliasColumn: 'sis_alias',
+          alias,
+          seed: {
+            surfaceKey: input.surfaceKey,
+            pgId: input.pgId,
+            vehicleId: input.vehicleId ?? input.typeId,
+            alias,
+          },
+        });
+        map[alias] = variant;
+      } catch (e) {
+        this.logger.warn(
+          `[SeoChainOrchestrator] pickVariant alias ${alias} échec : ${(e as Error).message}`,
+        );
+        map[alias] = null;
+      }
+    }
+    return map;
+  }
+
+  private applyTemplateFields(
+    input: SeoChainInput,
+    templateRow: Record<string, unknown> | null,
+  ): SeoChainTemplateData {
+    const candidates: Record<string, [string, string, boolean]> = {
+      title: ['sgc_title', 'sg_title', true],
+      description: ['sgc_descrip', 'sg_descrip', true],
+      h1: ['sgc_h1', 'sg_h1', false],
+      preview: ['sgc_preview', 'sg_preview', true],
+      content: ['sgc_content', 'sg_content', false],
+    } as Record<string, [string, string, boolean]>;
+
+    const out: SeoChainTemplateData = {
+      title: '',
+      description: '',
+      h1: '',
+      preview: '',
+      content: '',
+      keywords: this.buildKeywords(input.variables),
+    };
+
+    if (!templateRow) return out;
+
+    for (const [field, [colA, colB, useMeta]] of Object.entries(candidates)) {
+      const raw = String(
+        (templateRow[colA] ?? templateRow[colB] ?? '') as string,
+      );
+      if (!raw) continue;
+      out[field as keyof SeoChainTemplateData] = this.renderer.applyVariables({
+        surfaceKey: input.surfaceKey,
+        templateText: raw,
+        variables: input.variables,
+        pgId: input.pgId,
+        typeId: input.typeId,
+        useMeta,
+        minPriceFormat: field === 'description' ? 'descrip' : 'title',
+      });
+    }
+
+    return out;
+  }
+
+  private buildKeywords(v: TemplateVariables): string {
+    return [
+      v.gammeMeta,
+      v.marqueMeta,
+      v.modeleMeta,
+      v.typeMeta,
+      v.nbCh ? `${v.nbCh} ch` : '',
+      v.annee,
+      v.carosserie,
+      v.fuel,
+      v.codeMoteur,
+    ]
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  private extractMarkers(text: string): string[] {
+    const set = new Set<string>();
+    const re = /#LinkGamme(?:Car)?_\d+#/gi;
+    for (const m of text.match(re) ?? []) set.add(m);
+    return [...set];
+  }
+
+  private tryCanonical(input: SeoChainInput): string | null {
+    try {
+      return this.canonical.computeCanonical({
+        surfaceKey: input.surfaceKey,
+        ids: input.ids,
+        baseUrl: input.baseUrl,
+      });
+    } catch {
+      // Surfaces non couvertes en PR-2b (R3, R6, R2_LIST, …) : on ne casse pas
+      // la chaîne, on renvoie null. Le verdict robots applique son default.
+      return null;
+    }
+  }
+
+  private computeTemplateId(
+    input: SeoChainInput,
+    row: Record<string, unknown>,
+  ): string {
+    const idVal = row.sgc_id ?? row.sg_id ?? row.sm_id ?? input.pgId;
+    return `${input.surfaceKey}:${String(idVal)}`;
+  }
+
+  private summarizeVariants(
+    variants: Record<number, SwitchVariant | null>,
+  ): Record<string, string | number | null> {
+    const out: Record<string, string | number | null> = {};
+    for (const [alias, variant] of Object.entries(variants)) {
+      if (!variant) {
+        out[alias] = null;
+        continue;
+      }
+      const id =
+        (variant.sis_id as string | number | undefined) ??
+        (variant.sgcs_id as string | number | undefined) ??
+        (variant.sts_id as string | number | undefined) ??
+        null;
+      out[alias] = id ?? null;
+    }
+    return out;
+  }
+
+  private countLinks(links: Map<string, { isLink: boolean }>): number {
+    let n = 0;
+    for (const link of links.values()) if (link.isLink) n++;
+    return n;
+  }
+
+  private emptyAriane(_surfaceKey: SurfaceKey): SeoChainOutput['ariane'] {
+    return {
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [],
+      },
+      textTrail: '',
+    } as SeoChainOutput['ariane'];
+  }
+}
+
+// Re-export indexability verdict shape for convenience.
+export type { IndexabilityVerdict };

--- a/backend/src/modules/seo/services/chain/seo-chain-orchestrator.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-chain-orchestrator.service.ts
@@ -17,7 +17,10 @@ import {
   SeoSwitchSelector,
   type SwitchVariant,
 } from './seo-switch-selector.service';
-import { SeoInternalLinkingService } from './seo-internal-linking.service';
+import {
+  SeoInternalLinkingService,
+  type LinkResolutionResult,
+} from './seo-internal-linking.service';
 import {
   SeoArianeBreadcrumbService,
   type BreadcrumbItem,
@@ -84,11 +87,11 @@ export interface SeoChainInput {
  *
  * @see plan seo-v9 §3.4 — `DynamicSeoV4UltimateService` (orchestrateur)
  *
- * **Note PR-2c** : V4 (`DynamicSeoV4UltimateService.generateCompleteSeo()`) n'est
- * PAS refactoré pour appeler cet orchestrateur. V4 reste intact (compat 4
- * endpoints debug `/api/seo-dynamic-v4/*`). PR-3+ wire les controllers réels
- * (`rm-builder`, `gamme-rest`, `brand-rpc`, `vehicle-rpc`) via cet orchestrator
- * + feature flag `SEO_CHAIN_<surface>_MODE`.
+ * **Note PR-2c** : V4 (`DynamicSeoV4UltimateService.generateCompleteSeo()`) **EST**
+ * refactoré pour déléguer à cet orchestrateur (compat 4 endpoints debug
+ * `/api/seo-dynamic-v4/*` préservée via adapter). PR-3+ wire les controllers
+ * réels (`rm-builder`, `gamme-rest`, `brand-rpc`, `vehicle-rpc`) directement sur
+ * `SeoChainOrchestratorService.run()` + feature flag `SEO_CHAIN_<surface>_MODE`.
  */
 @Injectable()
 export class SeoChainOrchestratorService {
@@ -126,8 +129,10 @@ export class SeoChainOrchestratorService {
     // 4. linking (extrait markers depuis tous les champs hydratés)
     const allText = `${template.title} ${template.description} ${template.h1} ${template.preview} ${template.content}`;
     const markers = this.extractMarkers(allText);
-    const links = await this.linking.resolveMarkers({
+    const links = await this.linking.resolveLinksBatch({
       sourceSurfaceKey: input.surfaceKey,
+      sourceEntityId: input.pgId,
+      vehicleId: input.vehicleId,
       markers,
     });
 
@@ -341,9 +346,9 @@ export class SeoChainOrchestratorService {
     return out;
   }
 
-  private countLinks(links: Map<string, { isLink: boolean }>): number {
+  private countLinks(links: LinkResolutionResult[]): number {
     let n = 0;
-    for (const link of links.values()) if (link.isLink) n++;
+    for (const link of links) if (link.isLink) n++;
     return n;
   }
 

--- a/backend/src/modules/seo/services/chain/seo-content-block-builder.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-content-block-builder.service.ts
@@ -1,0 +1,142 @@
+import { Injectable } from '@nestjs/common';
+
+import { type SurfaceKey } from '@repo/seo-role-contracts';
+
+import type { ResolvedLink } from './seo-internal-linking.service';
+import type { BreadcrumbListJsonLd } from './seo-ariane-breadcrumb.service';
+import type { SwitchVariant } from './seo-switch-selector.service';
+
+/**
+ * Bloc de contenu structuré (équivalent moderne de la concaténation HTML PHP).
+ *
+ * Chaque bloc a un `type` discriminé (lead / paragraph / link / fact-list /
+ * cta) qui peut être rendu différemment côté Remix selon la surface.
+ */
+export type SeoContentBlock =
+  | { type: 'lead'; html: string }
+  | { type: 'paragraph'; html: string }
+  | { type: 'fact-list'; items: Array<{ label: string; value: string }> }
+  | { type: 'cta'; html: string; anchor?: string }
+  | { type: 'switch-variant'; alias: number; html: string }
+  | { type: 'link'; html: string; target: string };
+
+export interface SeoChainTemplateData {
+  /** Champs déjà hydratés (variables remplacées, switches résolus). */
+  title: string;
+  description: string;
+  h1: string;
+  preview: string;
+  content: string;
+  /** Mots-clés pré-calculés en amont (caller). */
+  keywords: string;
+}
+
+export interface SeoChainPolicies {
+  canonical: string;
+  robots: string;
+  /** Raisons éventuelles d'un noindex (vide si index,follow). */
+  blockingReasons?: string[];
+}
+
+export interface SeoChainAriadne {
+  jsonLd: BreadcrumbListJsonLd;
+  textTrail: string;
+}
+
+export interface SeoChainMetadata {
+  /** Surface effective (R0_HOME, R1_GAMME_VEHICLE_ROUTER, …). */
+  surfaceKey: SurfaceKey;
+  /** Identifiant du template choisi (ex: `__seo_gamme_car:124`). */
+  templateId: string | null;
+  /** Pour audit/fingerprint : ids des variantes switch sélectionnées. */
+  variantIds: Record<string, string | number | null>;
+  /** Liens internes résolus (count). */
+  internalLinkCount: number;
+  /** Version de la chaîne (utile pour les logs et le diff shadow). */
+  chainVersion: string;
+  renderedAt: string;
+}
+
+/**
+ * Output canonique de la chaîne SEO (consommé par les contrôleurs PR-3+).
+ *
+ * Structure exhaustive : tout ce dont un controller a besoin pour répondre
+ * `<title>`, `<meta>`, `<link rel="canonical">`, JSON-LD, et le rendu HTML
+ * de la page (via `contentBlocks`).
+ */
+export interface SeoChainOutput {
+  surfaceKey: SurfaceKey;
+  template: SeoChainTemplateData;
+  contentBlocks: SeoContentBlock[];
+  policies: SeoChainPolicies;
+  ariane: SeoChainAriadne;
+  metadata: SeoChainMetadata;
+}
+
+export interface BuildBlocksInput {
+  template: SeoChainTemplateData;
+  /** Variantes switch sélectionnées (par alias → ligne brute). */
+  variants: Record<number, SwitchVariant | null>;
+  /** Liens internes résolus (issu de `SeoInternalLinkingService`). */
+  links: Map<string, ResolvedLink>;
+}
+
+/**
+ * Service d'assemblage des `contentBlocks` à partir des autres briques de la
+ * chaîne SEO. Logique pure (pas de DB, pas de HTTP).
+ *
+ * @see plan seo-v9 §3.1 — `SeoContentBlockBuilder`
+ */
+@Injectable()
+export class SeoContentBlockBuilder {
+  buildBlocks(input: BuildBlocksInput): SeoContentBlock[] {
+    const blocks: SeoContentBlock[] = [];
+
+    if (input.template.preview && input.template.preview.trim()) {
+      blocks.push({ type: 'lead', html: input.template.preview });
+    }
+
+    if (input.template.content && input.template.content.trim()) {
+      blocks.push({ type: 'paragraph', html: input.template.content });
+    }
+
+    for (const [alias, variant] of Object.entries(input.variants)) {
+      if (!variant) continue;
+      const html = this.extractVariantHtml(variant);
+      if (html) {
+        blocks.push({
+          type: 'switch-variant',
+          alias: Number.parseInt(alias, 10),
+          html,
+        });
+      }
+    }
+
+    for (const link of input.links.values()) {
+      if (link.isLink) {
+        blocks.push({ type: 'link', html: link.html, target: link.marker });
+      }
+    }
+
+    return blocks;
+  }
+
+  /**
+   * Extrait le champ HTML pertinent d'une ligne switch brute. Les schémas
+   * varient (`sis_content`, `sgcs_content`, `sts_content`, …) — on tente
+   * dans l'ordre.
+   */
+  private extractVariantHtml(variant: SwitchVariant): string {
+    const candidates = [
+      'sis_content',
+      'sgcs_content',
+      'sfgcs_content',
+      'sts_content',
+    ];
+    for (const key of candidates) {
+      const value = variant[key];
+      if (typeof value === 'string' && value.trim()) return value;
+    }
+    return '';
+  }
+}

--- a/backend/src/modules/seo/services/chain/seo-content-block-builder.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-content-block-builder.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { type SurfaceKey } from '@repo/seo-role-contracts';
 
-import type { ResolvedLink } from './seo-internal-linking.service';
+import type { LinkResolutionResult } from './seo-internal-linking.service';
 import type { BreadcrumbListJsonLd } from './seo-ariane-breadcrumb.service';
 import type { SwitchVariant } from './seo-switch-selector.service';
 
@@ -77,8 +77,11 @@ export interface BuildBlocksInput {
   template: SeoChainTemplateData;
   /** Variantes switch sélectionnées (par alias → ligne brute). */
   variants: Record<number, SwitchVariant | null>;
-  /** Liens internes résolus (issu de `SeoInternalLinkingService`). */
-  links: Map<string, ResolvedLink>;
+  /**
+   * Liens internes résolus (ordering préservé depuis `resolveLinksBatch`).
+   * Issu de `SeoInternalLinkingService.resolveLinksBatch`.
+   */
+  links: LinkResolutionResult[];
 }
 
 /**
@@ -112,7 +115,7 @@ export class SeoContentBlockBuilder {
       }
     }
 
-    for (const link of input.links.values()) {
+    for (const link of input.links) {
       if (link.isLink) {
         blocks.push({ type: 'link', html: link.html, target: link.marker });
       }

--- a/backend/src/modules/seo/services/chain/seo-internal-linking.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-internal-linking.service.ts
@@ -1,0 +1,155 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { TABLES } from '@repo/database-types';
+import { type SurfaceKey } from '@repo/seo-role-contracts';
+
+export interface MarkerLookupInput {
+  /** Surface qui PORTE le marqueur (ex: page R1 contenant `#LinkGamme_42#`). */
+  sourceSurfaceKey: SurfaceKey;
+  /** Markers brut détectés dans le template (ex: `['#LinkGamme_42#', '#LinkGammeCar_5#']`). */
+  markers: string[];
+}
+
+export interface ResolvedLink {
+  /** Marker original. */
+  marker: string;
+  /** HTML du lien si la cible a un contenu valide, sinon fallback texte. */
+  html: string;
+  /** True si on a généré un vrai `<a>`, false si fallback texte. */
+  isLink: boolean;
+}
+
+interface GammeRow {
+  pg_id: number;
+  pg_name: string;
+  pg_alias: string | null;
+  pg_url_slug?: string | null;
+  pg_display?: boolean | null;
+}
+
+/**
+ * STUB de résolution des marqueurs `#LinkGamme_X#` / `#LinkGammeCar_X#`
+ * (linking interne SEO, marqueurs legacy `meta.conf.php`).
+ *
+ * Stratégie PR-2c :
+ *   - **lookup direct** par pg_id sur `pieces_gamme` (1 query par batch).
+ *   - lien créé seulement si `pg_display = true` (gate `allowed=true` legacy).
+ *   - fallback texte sinon (jamais de lien cassé vers une gamme désactivée).
+ *
+ * **PR-7 cible** : remplace ce stub par lookup pré-calculé sur la MV
+ * `seo_internal_link_candidates` (gain ~5-10× sur TTFB R1/R7/R8) — cf.
+ * plan seo-v9 §3.7.
+ *
+ * @see plan seo-v9 §3.1 — `SeoInternalLinkingService` (stub PR-2c → MV PR-7)
+ */
+@Injectable()
+export class SeoInternalLinkingService extends SupabaseBaseService {
+  protected readonly logger = new Logger(SeoInternalLinkingService.name);
+
+  /** Texte fallback si la gamme cible est inactive ou inconnue. */
+  private static readonly FALLBACK_TEXT = 'nos pièces auto';
+
+  /**
+   * Extrait les pg_id distincts depuis une liste de marqueurs.
+   * Pure : testable sans DB.
+   *
+   * Reconnaît : `#LinkGamme_<id>#`, `#LinkGammeCar_<id>#` (insensible à la casse).
+   */
+  extractGammeIds(markers: string[]): number[] {
+    const ids = new Set<number>();
+    const re = /#LinkGamme(?:Car)?_(\d+)#/i;
+    for (const marker of markers) {
+      const m = re.exec(marker);
+      if (m) ids.add(Number.parseInt(m[1]!, 10));
+    }
+    return [...ids].sort((a, b) => a - b);
+  }
+
+  /**
+   * Construit l'anchor `<a>` à partir d'une ligne `pieces_gamme` validée.
+   * Pure : testable sans DB.
+   */
+  buildAnchor(row: GammeRow): string {
+    const slug = row.pg_url_slug || row.pg_alias || String(row.pg_id);
+    return `<a href="/gammes/${slug}" class="link-gamme-internal">${row.pg_name}</a>`;
+  }
+
+  /** Texte fallback exposé pour cohérence avec le caller. */
+  fallbackText(): string {
+    return SeoInternalLinkingService.FALLBACK_TEXT;
+  }
+
+  /**
+   * Résout tous les marqueurs en batch (1 query Supabase quel que soit le
+   * nombre de marqueurs). Cache mémoire 1h par pg_id pour atténuer les hits
+   * répétés en attendant PR-7.
+   *
+   * @returns une Map `marker → ResolvedLink` (avec fallback si gamme inactive
+   * ou inconnue).
+   */
+  async resolveMarkers(
+    input: MarkerLookupInput,
+  ): Promise<Map<string, ResolvedLink>> {
+    const result = new Map<string, ResolvedLink>();
+    if (!input.markers.length) return result;
+
+    const ids = this.extractGammeIds(input.markers);
+    if (!ids.length) {
+      for (const marker of input.markers) {
+        result.set(marker, {
+          marker,
+          html: SeoInternalLinkingService.FALLBACK_TEXT,
+          isLink: false,
+        });
+      }
+      return result;
+    }
+
+    const rowsById = await this.loadGammes(ids);
+
+    for (const marker of input.markers) {
+      const idMatch = /#LinkGamme(?:Car)?_(\d+)#/i.exec(marker);
+      if (!idMatch) {
+        result.set(marker, {
+          marker,
+          html: SeoInternalLinkingService.FALLBACK_TEXT,
+          isLink: false,
+        });
+        continue;
+      }
+      const id = Number.parseInt(idMatch[1]!, 10);
+      const row = rowsById.get(id);
+      if (row && row.pg_display !== false) {
+        result.set(marker, {
+          marker,
+          html: this.buildAnchor(row),
+          isLink: true,
+        });
+      } else {
+        result.set(marker, {
+          marker,
+          html: SeoInternalLinkingService.FALLBACK_TEXT,
+          isLink: false,
+        });
+      }
+    }
+    return result;
+  }
+
+  private async loadGammes(ids: number[]): Promise<Map<number, GammeRow>> {
+    const { data, error } = await this.supabase
+      .from(TABLES.pieces_gamme)
+      .select('pg_id, pg_name, pg_alias, pg_url_slug, pg_display')
+      .in('pg_id', ids);
+
+    const rows = (data ?? []) as GammeRow[];
+    if (error) {
+      this.logger.error(
+        `[SeoInternalLinkingService] erreur fetch pieces_gamme: ${error.message}`,
+      );
+    }
+
+    return new Map(rows.map((r) => [r.pg_id, r]));
+  }
+}

--- a/backend/src/modules/seo/services/chain/seo-internal-linking.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-internal-linking.service.ts
@@ -1,23 +1,75 @@
+import { createHash } from 'node:crypto';
+
 import { Injectable, Logger } from '@nestjs/common';
 
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { TABLES } from '@repo/database-types';
-import { type SurfaceKey } from '@repo/seo-role-contracts';
+import { type SurfaceKey, SURFACE_TO_ROLE } from '@repo/seo-role-contracts';
+import { type RoleId } from '@repo/seo-roles';
 
-export interface MarkerLookupInput {
-  /** Surface qui PORTE le marqueur (ex: page R1 contenant `#LinkGamme_42#`). */
-  sourceSurfaceKey: SurfaceKey;
-  /** Markers brut détectés dans le template (ex: `['#LinkGamme_42#', '#LinkGammeCar_5#']`). */
-  markers: string[];
-}
+/**
+ * Raison structurée pour laquelle un marqueur n'a pas généré de lien indexable.
+ *
+ * Énumération stable consommée par PR-3+ (controllers shadow mode), PR-7
+ * (lookup MV `seo_internal_link_candidates`), PR-9 (fingerprint duplicate
+ * gate). Toute extension passe par ajout — pas de retypage breaking.
+ */
+export type LinkResolutionReason =
+  | 'NO_TARGET'
+  | 'NOINDEX'
+  | 'CANONICAL_MISMATCH'
+  | 'FORBIDDEN_ROLE'
+  | 'SELF_LINK'
+  | 'ORPHAN';
 
-export interface ResolvedLink {
-  /** Marker original. */
+/**
+ * Résultat canonique de résolution d'un marqueur de lien interne.
+ *
+ * Contrat stable — l'implémentation interne (stub direct PR-2c → MV PR-7)
+ * peut évoluer sans casser les consommateurs (orchestrator, builder,
+ * controllers shadow).
+ *
+ * @see plan seo-v9 §3.1 + §6 verrous techniques rev 2 (anti-breaking PR-7)
+ */
+export interface LinkResolutionResult {
+  /** Marqueur original (ex: `#LinkGamme_42#`). */
   marker: string;
-  /** HTML du lien si la cible a un contenu valide, sinon fallback texte. */
+  /** HTML `<a>` si lien indexable, fallback texte sinon. */
   html: string;
   /** True si on a généré un vrai `<a>`, false si fallback texte. */
   isLink: boolean;
+  /** URL absolue de la cible si résolue (sinon `null`). */
+  targetUrl: string | null;
+  /** Rôle SEO canonique de la cible (issu de `SURFACE_TO_ROLE`). */
+  targetRole: RoleId | null;
+  /** True si la cible serait actuellement indexable (`pg_display=true`). */
+  indexable: boolean;
+  /** Raison structurée du fallback (absente si `isLink=true`). */
+  reason?: LinkResolutionReason;
+}
+
+/**
+ * Inputs canoniques de la résolution batch.
+ *
+ * `markers[]` est obligatoire ; les autres champs servent à PR-7+ (cache
+ * key canonique, détection self-link, lookup MV pré-calculée).
+ */
+export interface ResolveLinksBatchInput {
+  /** Surface qui PORTE le marqueur (page R1 contenant `#LinkGamme_42#`). */
+  sourceSurfaceKey: SurfaceKey;
+  /** Markers brut détectés dans le template. */
+  markers: string[];
+  /**
+   * Identifiant de la source (pg_id, brand_id, type_id selon surface). Sert
+   * à la clé de cache canonique et au check `SELF_LINK` (PR-7+).
+   */
+  sourceEntityId?: string | number;
+  /** Contexte véhicule pour les surfaces R1_GAMME_VEHICLE_ROUTER / R8_VEHICLE. */
+  vehicleId?: number | null;
+  /** Contexte gamme parente (utile pour disambiguer une marque-gamme). */
+  gammeId?: number | null;
+  /** Locale (FR par défaut). */
+  locale?: string;
 }
 
 interface GammeRow {
@@ -29,19 +81,25 @@ interface GammeRow {
 }
 
 /**
- * STUB de résolution des marqueurs `#LinkGamme_X#` / `#LinkGammeCar_X#`
- * (linking interne SEO, marqueurs legacy `meta.conf.php`).
+ * Service de résolution batch des marqueurs `#LinkGamme_X#` /
+ * `#LinkGammeCar_X#` (linking interne SEO, marqueurs legacy `meta.conf.php`).
  *
- * Stratégie PR-2c :
- *   - **lookup direct** par pg_id sur `pieces_gamme` (1 query par batch).
- *   - lien créé seulement si `pg_display = true` (gate `allowed=true` legacy).
- *   - fallback texte sinon (jamais de lien cassé vers une gamme désactivée).
+ * **Stratégie PR-2c (stub interne, contrat stable)** :
+ *   - 1 query Supabase batch (`IN (...)` sur les pg_id distincts).
+ *   - Lien créé seulement si `pg_display=true` (gate `allowed=true` legacy).
+ *   - Fallback texte sinon (jamais de lien cassé vers gamme désactivée).
  *
- * **PR-7 cible** : remplace ce stub par lookup pré-calculé sur la MV
- * `seo_internal_link_candidates` (gain ~5-10× sur TTFB R1/R7/R8) — cf.
- * plan seo-v9 §3.7.
+ * **PR-7 cible** : remplace ce stub par lookup MV pré-calculé
+ * `seo_internal_link_candidates` (gain ~5-10× sur TTFB R1/R7/R8). Le
+ * contrat `resolveLinksBatch(...) → LinkResolutionResult[]` reste stable.
  *
- * @see plan seo-v9 §3.1 — `SeoInternalLinkingService` (stub PR-2c → MV PR-7)
+ * **Canon clé Redis** (PR-7/PR-8) :
+ *   `seo:v9:linking:${surface}:${sourceEntityId}:${markerHash}`
+ *   - TTL : 3600s (1h)
+ *   - Invalidation : cron daily refresh + event `seo.target_indexability_changed`
+ *   - Namespace : `seo:v9:*` (toutes les clés du moteur SEO v9)
+ *
+ * @see plan seo-v9 §3.1 + §6 verrous rev 2 — `SeoInternalLinkingService`
  */
 @Injectable()
 export class SeoInternalLinkingService extends SupabaseBaseService {
@@ -54,7 +112,8 @@ export class SeoInternalLinkingService extends SupabaseBaseService {
    * Extrait les pg_id distincts depuis une liste de marqueurs.
    * Pure : testable sans DB.
    *
-   * Reconnaît : `#LinkGamme_<id>#`, `#LinkGammeCar_<id>#` (insensible à la casse).
+   * Reconnaît : `#LinkGamme_<id>#`, `#LinkGammeCar_<id>#` (insensible à la
+   * casse).
    */
   extractGammeIds(markers: string[]): number[] {
     const ids = new Set<number>();
@@ -75,66 +134,170 @@ export class SeoInternalLinkingService extends SupabaseBaseService {
     return `<a href="/gammes/${slug}" class="link-gamme-internal">${row.pg_name}</a>`;
   }
 
+  /**
+   * URL cible absolue (sans le host — résolue à `https://example.com/gammes/...`
+   * côté caller via `baseUrl`). Pure : testable sans DB.
+   */
+  buildTargetUrl(row: GammeRow): string {
+    const slug = row.pg_url_slug || row.pg_alias || String(row.pg_id);
+    return `/gammes/${slug}`;
+  }
+
   /** Texte fallback exposé pour cohérence avec le caller. */
   fallbackText(): string {
     return SeoInternalLinkingService.FALLBACK_TEXT;
   }
 
   /**
-   * Résout tous les marqueurs en batch (1 query Supabase quel que soit le
-   * nombre de marqueurs). Cache mémoire 1h par pg_id pour atténuer les hits
-   * répétés en attendant PR-7.
+   * Hash canonique des marqueurs pour la clé de cache (PR-7/PR-8). Trie
+   * les markers pour stabiliser la clé indépendamment de l'ordre d'appel.
    *
-   * @returns une Map `marker → ResolvedLink` (avec fallback si gamme inactive
-   * ou inconnue).
+   * Pure : testable sans DB.
    */
-  async resolveMarkers(
-    input: MarkerLookupInput,
-  ): Promise<Map<string, ResolvedLink>> {
-    const result = new Map<string, ResolvedLink>();
-    if (!input.markers.length) return result;
+  buildCacheKey(input: ResolveLinksBatchInput): string {
+    const sortedMarkers = [...new Set(input.markers)].sort();
+    const markerHash = createHash('sha1')
+      .update(sortedMarkers.join('|'))
+      .digest('hex')
+      .slice(0, 16);
+    const entity = input.sourceEntityId ?? '';
+    return `seo:v9:linking:${input.sourceSurfaceKey}:${entity}:${markerHash}`;
+  }
+
+  /**
+   * Résout tous les marqueurs en batch (1 query Supabase quel que soit le
+   * nombre de marqueurs distincts).
+   *
+   * Préserve l'ordre d'entrée : `result[i].marker === input.markers[i]`.
+   *
+   * @see {@link LinkResolutionResult} pour le contrat stable
+   */
+  async resolveLinksBatch(
+    input: ResolveLinksBatchInput,
+  ): Promise<LinkResolutionResult[]> {
+    if (input.markers.length === 0) return [];
 
     const ids = this.extractGammeIds(input.markers);
-    if (!ids.length) {
-      for (const marker of input.markers) {
-        result.set(marker, {
-          marker,
-          html: SeoInternalLinkingService.FALLBACK_TEXT,
-          isLink: false,
-        });
-      }
-      return result;
+
+    // Aucun id valide dans les markers : tous orphans.
+    if (ids.length === 0) {
+      return input.markers.map((marker) =>
+        this.buildOrphanResult(marker, input.sourceSurfaceKey),
+      );
     }
 
     const rowsById = await this.loadGammes(ids);
 
-    for (const marker of input.markers) {
+    return input.markers.map((marker) => {
       const idMatch = /#LinkGamme(?:Car)?_(\d+)#/i.exec(marker);
       if (!idMatch) {
-        result.set(marker, {
-          marker,
-          html: SeoInternalLinkingService.FALLBACK_TEXT,
-          isLink: false,
-        });
-        continue;
+        return this.buildOrphanResult(marker, input.sourceSurfaceKey);
       }
+
       const id = Number.parseInt(idMatch[1]!, 10);
       const row = rowsById.get(id);
-      if (row && row.pg_display !== false) {
-        result.set(marker, {
+
+      // Cible inexistante en base.
+      if (!row) {
+        return this.buildFallbackResult({
           marker,
-          html: this.buildAnchor(row),
-          isLink: true,
-        });
-      } else {
-        result.set(marker, {
-          marker,
-          html: SeoInternalLinkingService.FALLBACK_TEXT,
-          isLink: false,
+          surface: input.sourceSurfaceKey,
+          reason: 'NO_TARGET',
+          indexable: false,
+          targetUrl: null,
         });
       }
-    }
-    return result;
+
+      // Cible désactivée éditorialement.
+      if (row.pg_display === false) {
+        return this.buildFallbackResult({
+          marker,
+          surface: input.sourceSurfaceKey,
+          reason: 'NOINDEX',
+          indexable: false,
+          targetUrl: this.buildTargetUrl(row),
+        });
+      }
+
+      // Self-link : pg_id source === pg_id target.
+      if (
+        input.sourceEntityId != null &&
+        String(input.sourceEntityId) === String(row.pg_id)
+      ) {
+        return this.buildFallbackResult({
+          marker,
+          surface: input.sourceSurfaceKey,
+          reason: 'SELF_LINK',
+          indexable: true,
+          targetUrl: this.buildTargetUrl(row),
+        });
+      }
+
+      // Cible valide → lien indexable.
+      return {
+        marker,
+        html: this.buildAnchor(row),
+        isLink: true,
+        targetUrl: this.buildTargetUrl(row),
+        targetRole: this.resolveTargetRole(input.sourceSurfaceKey),
+        indexable: true,
+      };
+    });
+  }
+
+  /**
+   * @deprecated PR-2c stub — utilisez `resolveLinksBatch(input)`. Retourne
+   * une `Map<string, LinkResolutionResult>` pour transition douce des
+   * consommateurs existants. Sera supprimé en PR-3 quand orchestrator +
+   * builder consomment l'array.
+   */
+  async resolveMarkers(input: {
+    sourceSurfaceKey: SurfaceKey;
+    markers: string[];
+  }): Promise<Map<string, LinkResolutionResult>> {
+    const results = await this.resolveLinksBatch({
+      sourceSurfaceKey: input.sourceSurfaceKey,
+      markers: input.markers,
+    });
+    return new Map(results.map((r) => [r.marker, r]));
+  }
+
+  // ───────────────── private — pure builders ─────────────────
+
+  private buildOrphanResult(
+    marker: string,
+    surface: SurfaceKey,
+  ): LinkResolutionResult {
+    return this.buildFallbackResult({
+      marker,
+      surface,
+      reason: 'ORPHAN',
+      indexable: false,
+      targetUrl: null,
+    });
+  }
+
+  private buildFallbackResult(args: {
+    marker: string;
+    surface: SurfaceKey;
+    reason: LinkResolutionReason;
+    indexable: boolean;
+    targetUrl: string | null;
+  }): LinkResolutionResult {
+    return {
+      marker: args.marker,
+      html: SeoInternalLinkingService.FALLBACK_TEXT,
+      isLink: false,
+      targetUrl: args.targetUrl,
+      targetRole:
+        args.reason === 'ORPHAN' ? null : this.resolveTargetRole(args.surface),
+      indexable: args.indexable,
+      reason: args.reason,
+    };
+  }
+
+  private resolveTargetRole(surface: SurfaceKey): RoleId | null {
+    return SURFACE_TO_ROLE[surface] ?? null;
   }
 
   private async loadGammes(ids: number[]): Promise<Map<number, GammeRow>> {
@@ -143,13 +306,27 @@ export class SeoInternalLinkingService extends SupabaseBaseService {
       .select('pg_id, pg_name, pg_alias, pg_url_slug, pg_display')
       .in('pg_id', ids);
 
-    const rows = (data ?? []) as GammeRow[];
     if (error) {
       this.logger.error(
         `[SeoInternalLinkingService] erreur fetch pieces_gamme: ${error.message}`,
       );
+      return new Map();
     }
 
+    const rows = (data ?? []) as GammeRow[];
     return new Map(rows.map((r) => [r.pg_id, r]));
   }
 }
+
+/**
+ * @deprecated Alias backward-compat. Utilisez `LinkResolutionResult`.
+ */
+export type ResolvedLink = LinkResolutionResult;
+
+/**
+ * @deprecated Alias backward-compat. Utilisez `ResolveLinksBatchInput`.
+ */
+export type MarkerLookupInput = Pick<
+  ResolveLinksBatchInput,
+  'sourceSurfaceKey' | 'markers'
+>;

--- a/backend/src/modules/seo/services/chain/seo-meta-registry.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-meta-registry.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { TABLES } from '@repo/database-types';
+
+/**
+ * Entrée meta canonique commune aux pages standard (`___meta_tags_ariane`)
+ * et au blog (`__blog_meta_tags_ariane`).
+ *
+ * Les colonnes `mta_*` sont identiques dans les deux tables (cf. audit PR-1
+ * volet 1 et plan seo-v9 §1.3.A).
+ */
+export interface SeoMetaEntry {
+  alias: string;
+  title: string;
+  description: string;
+  keywords: string;
+  h1: string;
+  ariane: string;
+  content: string;
+  /** `1` = follow, `0` = nofollow (legacy). */
+  relfollow: '0' | '1';
+}
+
+/**
+ * Catalogue des registres meta legacy. Aligné sur l'audit PR-1.
+ */
+export type SeoMetaCatalog = 'static' | 'blog';
+
+const CATALOG_TABLE: Record<SeoMetaCatalog, string> = {
+  static: TABLES.meta_tags_ariane,
+  blog: TABLES.blog_meta_tags_ariane,
+};
+
+interface CacheEntry {
+  data: SeoMetaEntry | null;
+  expires: number;
+}
+
+/**
+ * Service de lecture des meta legacy (`___meta_tags_ariane` 5 rows pour les
+ * pages standard, `__blog_meta_tags_ariane` 5 rows pour le blog).
+ *
+ * Cache en mémoire 1h (suffisant : ces tables ne changent quasi jamais).
+ * Pas de Redis : le cache est déjà partagé par worker, et les volumes (5 rows
+ * × 2 catalogues) sont triviaux. Si besoin d'invalidation manuelle :
+ * `invalidateCache()`.
+ *
+ * @see plan seo-v9 §3.2 — `SeoMetaRegistryService`
+ * @see legacy PHP `meta.conf.php` (chargement metas standard + breadcrumbs)
+ */
+@Injectable()
+export class SeoMetaRegistryService extends SupabaseBaseService {
+  protected readonly logger = new Logger(SeoMetaRegistryService.name);
+
+  private readonly CACHE_TTL_MS = 3_600_000;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  /**
+   * Récupère un registre meta par alias.
+   *
+   * @returns l'entrée meta si trouvée, sinon `null`. Pas de throw — le caller
+   * décide du fallback (souvent : meta SEO programmatique pour la page).
+   */
+  async getMeta(
+    catalog: SeoMetaCatalog,
+    alias: string,
+  ): Promise<SeoMetaEntry | null> {
+    const cacheKey = `${catalog}:${alias}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expires > Date.now()) return cached.data;
+
+    const table = CATALOG_TABLE[catalog];
+    const { data, error } = await this.supabase
+      .from(table)
+      .select(
+        'mta_alias, mta_title, mta_descrip, mta_keywords, mta_h1, mta_ariane, mta_content, mta_relfollow',
+      )
+      .eq('mta_alias', alias)
+      .maybeSingle();
+
+    if (error) {
+      this.logger.error(
+        `[SeoMetaRegistryService] erreur fetch ${table}.${alias}: ${error.message}`,
+      );
+      return null;
+    }
+
+    const entry = data ? this.mapRow(data) : null;
+    this.cache.set(cacheKey, {
+      data: entry,
+      expires: Date.now() + this.CACHE_TTL_MS,
+    });
+    return entry;
+  }
+
+  /**
+   * Mapping pure ligne SQL → `SeoMetaEntry`. Exposé pour testabilité (les
+   * tests peuvent l'appeler directement avec une row fake sans hit la DB).
+   */
+  mapRow(row: Record<string, unknown>): SeoMetaEntry {
+    const relfollow = String(row.mta_relfollow ?? '1') === '0' ? '0' : '1';
+    return {
+      alias: String(row.mta_alias ?? ''),
+      title: String(row.mta_title ?? ''),
+      description: String(row.mta_descrip ?? ''),
+      keywords: String(row.mta_keywords ?? ''),
+      h1: String(row.mta_h1 ?? ''),
+      ariane: String(row.mta_ariane ?? ''),
+      content: String(row.mta_content ?? ''),
+      relfollow,
+    };
+  }
+
+  invalidateCache(): void {
+    this.cache.clear();
+  }
+}

--- a/backend/src/modules/seo/services/chain/seo-slug.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-slug.service.ts
@@ -1,0 +1,142 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Service de génération de slugs SEO.
+ *
+ * Reproduit la logique legacy PHP `url_title_optimizer` :
+ *   1. lowercase
+ *   2. remplace accents (é→e, è→e, à→a, ç→c, etc.)
+ *   3. supprime les stop-words `de / du / des / la / les / et`
+ *   4. caractères non `[a-z0-9-]` → `-`
+ *   5. collapse les `-` consécutifs
+ *   6. strip leading/trailing `-`
+ *   7. tronque à `maxLength` (défaut 80, sans couper un mot quand possible)
+ *
+ * Logique pure — aucune DB, aucun HTTP. Testée par golden tests sur 50+ URLs
+ * legacy de référence (cf. `seo-slug.service.test.ts`).
+ *
+ * @see plan seo-v9 §3.2 — `SeoSlugService` (PR-2c)
+ */
+@Injectable()
+export class SeoSlugService {
+  private static readonly STOP_WORDS = new Set([
+    'de',
+    'du',
+    'des',
+    'la',
+    'le',
+    'les',
+    'et',
+    // Résidus d'élision après split de l'apostrophe : "l'huile" → ["l", "huile"]
+    'l',
+    'd',
+  ]);
+
+  private static readonly ACCENT_MAP: Record<string, string> = {
+    à: 'a',
+    á: 'a',
+    â: 'a',
+    ã: 'a',
+    ä: 'a',
+    å: 'a',
+    ç: 'c',
+    è: 'e',
+    é: 'e',
+    ê: 'e',
+    ë: 'e',
+    ì: 'i',
+    í: 'i',
+    î: 'i',
+    ï: 'i',
+    ñ: 'n',
+    ò: 'o',
+    ó: 'o',
+    ô: 'o',
+    õ: 'o',
+    ö: 'o',
+    ù: 'u',
+    ú: 'u',
+    û: 'u',
+    ü: 'u',
+    ý: 'y',
+    ÿ: 'y',
+    ß: 'ss',
+    œ: 'oe',
+    æ: 'ae',
+  };
+
+  /**
+   * Slugify un libellé (titre gamme, marque, modèle, etc.) avec optimisation SEO
+   * (suppression stop-words). Voir `slugifyRaw` pour conserver les stop-words.
+   *
+   * Note : la troncature `maxLength` est appliquée APRÈS le filtrage stop-words
+   * (sinon on perdrait des mots utiles à cause de tokens "de/du/..." qui auraient
+   * été comptés dans la fenêtre).
+   */
+  slugify(input: string, maxLength = 80): string {
+    const raw = this.slugifyRaw(input, Number.MAX_SAFE_INTEGER);
+    return this.applyOptimization(raw, maxLength);
+  }
+
+  /**
+   * Slugify "brut" : conserve les stop-words. Utile pour produire des URLs
+   * fidèles à un libellé exact (ex: titre d'article blog).
+   */
+  slugifyRaw(input: string, maxLength = 80): string {
+    if (!input) return '';
+
+    // Normalise les guillemets/apostrophes typographiques vers ASCII pour
+    // garantir une détection cohérente des élisions (l’huile = l'huile).
+    const normalized = input.toLowerCase().replace(/[‘’‚‛]/g, "'");
+
+    const accentless = this.stripAccents(normalized);
+
+    const slug = accentless
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+
+    return this.truncate(slug, maxLength);
+  }
+
+  /**
+   * Applique l'optimisation SEO sur un slug déjà normalisé : supprime les
+   * stop-words `de / du / des / la / les / et / l' / d'`.
+   */
+  private applyOptimization(slug: string, maxLength: number): string {
+    if (!slug) return '';
+
+    const filtered = slug
+      .split('-')
+      .filter((token) => token && !SeoSlugService.STOP_WORDS.has(token))
+      .join('-');
+
+    return this.truncate(filtered, maxLength);
+  }
+
+  private stripAccents(input: string): string {
+    let out = '';
+    for (const ch of input) {
+      out += SeoSlugService.ACCENT_MAP[ch] ?? ch;
+    }
+    return out;
+  }
+
+  /**
+   * Tronque sans couper un mot quand possible :
+   *   - si la coupe tombe pile sur une frontière de mot (`slug[maxLength] === '-'`),
+   *     on garde la fenêtre exacte ;
+   *   - sinon on revient au dernier `-` < `maxLength` ;
+   *   - sinon (un seul "mot" très long) on coupe net.
+   */
+  private truncate(slug: string, maxLength: number): string {
+    if (slug.length <= maxLength) return slug;
+
+    if (slug.charAt(maxLength) === '-') return slug.slice(0, maxLength);
+
+    const head = slug.slice(0, maxLength);
+    const lastDash = head.lastIndexOf('-');
+    if (lastDash > 0) return head.slice(0, lastDash);
+    return head;
+  }
+}

--- a/backend/src/modules/seo/services/chain/seo-switch-selector.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-switch-selector.service.ts
@@ -1,0 +1,132 @@
+import { createHash } from 'node:crypto';
+
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+
+import { SeoVariantFamilyRegistry } from '../../registries/seo-variant-family.registry';
+import type { VariantFamilyKey } from '../../registries/seo-variant-family.registry';
+
+/**
+ * Inputs servant à dériver le seed canonique d'un tirage de variante switch.
+ *
+ * Le seed est un sha256 stable sur la concaténation `surfaceKey:pgId:vehicleId:alias`,
+ * pris sur les 8 premiers hex caractères puis modulo la taille du jeu de variantes.
+ *
+ * Ceci remplace le seed legacy `(typeId + pgId) % len` qui était sensible aux
+ * renumérotations TecDoc V2 (cf. mémoire `tecdoc-integration`).
+ */
+export interface SwitchSeedInput {
+  surfaceKey: string;
+  pgId: number;
+  vehicleId?: number | null;
+  alias?: number | null;
+}
+
+/** Variante générique côté caller (renvoie la ligne brute de la table switch). */
+export interface SwitchVariant {
+  [key: string]: unknown;
+}
+
+export interface PickVariantInput<TWhere extends Record<string, unknown>> {
+  family: VariantFamilyKey;
+  /** Filtres SQL `eq()` (ex: `{ sgcs_pg_id: 124 }` ou `{ sis_pg_id: 124 }`). */
+  where: TWhere;
+  /** Filtre additionnel sur la colonne `*_alias` (selon la famille). */
+  aliasColumn?: string;
+  alias?: number;
+  seed: SwitchSeedInput;
+}
+
+/**
+ * Sélectionne une variante déterministe dans une famille `__seo_*_switch`.
+ *
+ * Consulte `SeoVariantFamilyRegistry` pour résoudre la table cible, lit les
+ * lignes filtrées (`where` + `alias` optionnel), puis applique le seed canonique
+ * sha256 pour choisir l'index modulo le nombre de variantes.
+ *
+ * Logique d'index (pure, testable sans DB) : `computeSeedIndex(seed, length)`.
+ *
+ * @see plan seo-v9 §3.5 — Seed canonique stable
+ * @see seo-v4-switch-engine.service.ts (legacy à déprécier post PR-2c)
+ */
+@Injectable()
+export class SeoSwitchSelector extends SupabaseBaseService {
+  protected readonly logger = new Logger(SeoSwitchSelector.name);
+
+  constructor(private readonly families: SeoVariantFamilyRegistry) {
+    super();
+  }
+
+  /**
+   * Calcule l'index déterministe pour un seed donné parmi `length` candidats.
+   *
+   * Pure : aucune DB, testable directement.
+   *
+   * Algorithme :
+   *   1. concatène `surfaceKey:pgId:vehicleId:alias` (vehicleId/alias optionnels → '')
+   *   2. sha256 hex
+   *   3. `parseInt(first8hex, 16) % length`
+   */
+  computeSeedIndex(seed: SwitchSeedInput, length: number): number {
+    if (length <= 0) {
+      throw new SeoSwitchError(`length doit être > 0 (reçu ${length})`);
+    }
+    const seedKey = [
+      seed.surfaceKey,
+      seed.pgId,
+      seed.vehicleId ?? '',
+      seed.alias ?? '',
+    ].join(':');
+    const hex = createHash('sha256').update(seedKey).digest('hex');
+    return parseInt(hex.slice(0, 8), 16) % length;
+  }
+
+  /**
+   * Tire une variante depuis la table switch résolue par la famille.
+   *
+   * @returns la variante choisie, ou `null` si aucune ligne ne match.
+   */
+  async pickVariant<TWhere extends Record<string, unknown>>(
+    input: PickVariantInput<TWhere>,
+  ): Promise<SwitchVariant | null> {
+    const variants = await this.fetchVariants(input);
+    if (variants.length === 0) return null;
+
+    const idx = this.computeSeedIndex(input.seed, variants.length);
+    return variants[idx];
+  }
+
+  /**
+   * Tire toutes les variantes correspondant aux critères, sans sélection.
+   * Utile pour les enchaînements (`processCompSwitch` qui itère sur tous les pgId).
+   */
+  async fetchVariants<TWhere extends Record<string, unknown>>(
+    input: PickVariantInput<TWhere>,
+  ): Promise<SwitchVariant[]> {
+    const table = this.families.resolveTable(input.family);
+    let query = this.supabase.from(table).select('*');
+
+    for (const [col, val] of Object.entries(input.where)) {
+      query = query.eq(col, val);
+    }
+    if (input.aliasColumn && typeof input.alias === 'number') {
+      query = query.eq(input.aliasColumn, input.alias);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      this.logger.error(
+        `[SeoSwitchSelector] erreur fetch ${table} : ${error.message}`,
+      );
+      return [];
+    }
+    return (data ?? []) as SwitchVariant[];
+  }
+}
+
+export class SeoSwitchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SeoSwitchError';
+  }
+}

--- a/backend/src/modules/seo/services/chain/seo-template-renderer.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-template-renderer.service.ts
@@ -1,0 +1,251 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { TABLES } from '@repo/database-types';
+import { type SurfaceKey } from '@repo/seo-role-contracts';
+
+import { PRIX_PAS_CHER, VOUS_PROPOSE } from '../../seo-v4.types';
+
+/**
+ * Variables métier injectables dans les templates SEO.
+ *
+ * Aligné sur les marqueurs `#X#` legacy PHP : `meta.conf.php` + `sql.conf.php`
+ * (cf. plan seo-v9 §1.2 pilier 4 « marqueurs métier + marketing »).
+ *
+ * `useMeta=true` (titre/description/preview) → variantes texte sans `<b>`.
+ * `useMeta=false` (h1/content) → variantes typographiées avec `<b>`.
+ */
+export interface TemplateVariables {
+  gamme: string;
+  gammeMeta: string;
+  marque: string;
+  marqueMeta: string;
+  marqueMetaTitle: string;
+  modele: string;
+  modeleMeta: string;
+  type: string;
+  typeMeta: string;
+  annee: string;
+  nbCh: number;
+  carosserie: string;
+  fuel: string;
+  codeMoteur: string;
+  /** Variables marketing legacy (PHP `$PrixPasCher[]` / `$VousPropose[]`). */
+  minPrice?: number;
+  articlesCount?: number;
+  familyName?: string;
+  seoScore?: number;
+  gammeLevel?: number;
+  isTopGamme?: boolean;
+}
+
+export interface RenderTemplateInput {
+  surfaceKey: SurfaceKey;
+  /** Champ libre du template legacy (`sgc_title` / `sgc_descrip` / etc.). */
+  templateText: string;
+  variables: TemplateVariables;
+  /** Pour les marqueurs déterministes (`#PrixPasCher#` modulo). */
+  pgId: number;
+  typeId: number;
+  /** `true` pour les champs sans HTML (title / preview / description). */
+  useMeta: boolean;
+  /** Si fourni, override l'index `PrixPasCher` (utile pour tests). */
+  prixPasCherSeed?: number;
+  /** Si fourni, override l'index `VousPropose`. */
+  vousProposeSeed?: number;
+  /** Format à utiliser pour `#MinPrice#` ('title' = "dès Xe", 'descrip' = "à partir de Xe"). */
+  minPriceFormat?: 'title' | 'descrip';
+}
+
+/**
+ * Service de rendu des templates SEO legacy (`__seo_*` tables).
+ *
+ * Responsabilités :
+ *   1. **applyVariables** (pure) — interpolation `#Marker#` → valeur depuis
+ *      `TemplateVariables`. Gère les variantes meta vs HTML (gras `<b>`).
+ *      Identique à `replaceStandardVariables` legacy V4 mais isolée et testable.
+ *   2. **fetchTemplate** (DB) — lit la ligne template canonique depuis la table
+ *      résolue par la surface (`__seo_gamme_car` pour R1_GAMME_VEHICLE_ROUTER,
+ *      `__seo_gamme` pour R1_GAMME_ROUTER, `__seo_marque` pour R7_BRAND_HUB).
+ *      R2_PRODUCT n'a pas de table : `fetchTemplate` retourne `null`, le caller
+ *      doit alors utiliser le mode concat programmatique (PR-11 différé).
+ *
+ * @see plan seo-v9 §3.1 — `SeoTemplateRenderer`
+ */
+@Injectable()
+export class SeoTemplateRenderer extends SupabaseBaseService {
+  protected readonly logger = new Logger(SeoTemplateRenderer.name);
+
+  /**
+   * Applique les variables métier sur un template texte. Logique pure : pas de DB.
+   *
+   * Inclut les marqueurs marketing déterministes (`#PrixPasCher#`,
+   * `#VousPropose#`, `#MinPrice#`) ainsi que les variables contextuelles
+   * (`#ArticlesCount#`, `#FamilyContext#`, `#QualityBadge#`).
+   *
+   * Le caller reste responsable d'appeler ensuite `SeoSwitchSelector` pour
+   * résoudre `#CompSwitch_*#` et `SeoInternalLinkingService` pour `#LinkGamme*#`.
+   */
+  applyVariables(input: RenderTemplateInput): string {
+    let out = input.templateText;
+    out = this.replaceStandardVariables(out, input.variables, input.useMeta);
+    out = this.replaceMarketingMarkers(out, input);
+    out = this.replaceContextualMarkers(out, input.variables);
+    return out;
+  }
+
+  /**
+   * Lit la ligne template canonique pour une surface (table résolue côté
+   * service — pas via registry car les schémas de colonnes diffèrent).
+   *
+   * @returns la ligne brute Supabase, ou `null` si non trouvée / non
+   * supportée pour la surface.
+   */
+  async fetchTemplate(
+    surfaceKey: SurfaceKey,
+    pgId: number,
+    extra?: { brandId?: number },
+  ): Promise<Record<string, unknown> | null> {
+    const cfg = this.resolveTemplateConfig(surfaceKey);
+    if (!cfg) return null;
+
+    const filterCol = cfg.filterColumn;
+    const filterVal = filterCol === 'sm_marque_id' ? extra?.brandId : pgId;
+    if (filterVal == null) return null;
+
+    const { data, error } = await this.supabase
+      .from(cfg.table)
+      .select('*')
+      .eq(filterCol, filterVal)
+      .maybeSingle();
+
+    if (error) {
+      this.logger.error(
+        `[SeoTemplateRenderer] fetchTemplate ${cfg.table}.${filterCol}=${filterVal}: ${error.message}`,
+      );
+      return null;
+    }
+    return data ?? null;
+  }
+
+  /**
+   * Mapping surface → table legacy. Surfaces sans template DB (R0_HOME,
+   * R2_PRODUCT*, blog géré par `SeoMetaRegistryService`, etc.) renvoient null.
+   */
+  private resolveTemplateConfig(
+    surfaceKey: SurfaceKey,
+  ): { table: string; filterColumn: string } | null {
+    switch (surfaceKey) {
+      case 'R1_GAMME_ROUTER':
+        return { table: TABLES.seo_gamme, filterColumn: 'sg_pg_id' };
+      case 'R1_GAMME_VEHICLE_ROUTER':
+        return { table: TABLES.seo_gamme_car, filterColumn: 'sgc_pg_id' };
+      case 'R7_BRAND_HUB':
+        return { table: '__seo_marque', filterColumn: 'sm_marque_id' };
+      default:
+        return null;
+    }
+  }
+
+  // ───────────────── private — pure substitutions ─────────────────
+
+  private replaceStandardVariables(
+    content: string,
+    v: TemplateVariables,
+    useMeta: boolean,
+  ): string {
+    const replacements: Record<string, string> = {
+      '#Gamme#': useMeta ? v.gammeMeta : `<b>${v.gamme}</b>`,
+      '#VMarque#': useMeta ? v.marqueMetaTitle : `<b>${v.marque}</b>`,
+      '#VModele#': useMeta ? v.modeleMeta : `<b>${v.modele}</b>`,
+      '#VType#': useMeta ? v.typeMeta : `<b>${v.type}</b>`,
+      '#VAnnee#': useMeta ? v.annee : `<b>${v.annee}</b>`,
+      '#VNbCh#': useMeta ? String(v.nbCh) : `<b>${v.nbCh} ch</b>`,
+      '#VCarosserie#': `<b>${v.carosserie}</b>`,
+      '#VMotorisation#': `<b>${v.fuel}</b>`,
+      '#VCodeMoteur#': `<b>${v.codeMoteur}</b>`,
+      '#GammeLevel#': v.gammeLevel ? `niveau ${v.gammeLevel}` : '',
+      '#IsTop#': v.isTopGamme ? 'gamme premium' : '',
+    };
+
+    let out = content;
+    for (const [marker, value] of Object.entries(replacements)) {
+      out = out.split(marker).join(value);
+    }
+    return out;
+  }
+
+  private replaceMarketingMarkers(
+    content: string,
+    input: RenderTemplateInput,
+  ): string {
+    let out = content;
+
+    // #MinPrice# (deux formats selon contexte)
+    if (input.variables.minPrice != null) {
+      const formatted =
+        input.minPriceFormat === 'descrip'
+          ? `à partir de ${input.variables.minPrice}€`
+          : input.minPriceFormat === 'title'
+            ? `dès ${input.variables.minPrice}€`
+            : `dès ${input.variables.minPrice}€`;
+      out = out.split('#MinPrice#').join(formatted);
+      out = out
+        .split('#MinPriceFormatted#')
+        .join(`${input.variables.minPrice}€`);
+    }
+
+    // #PrixPasCher# (16 variantes, seed déterministe)
+    const prixIdx =
+      (input.prixPasCherSeed ?? input.pgId + input.typeId) %
+      PRIX_PAS_CHER.length;
+    out = out.split('#PrixPasCher#').join(PRIX_PAS_CHER[prixIdx]);
+
+    // #VousPropose# (12 variantes)
+    const vpIdx = (input.vousProposeSeed ?? input.typeId) % VOUS_PROPOSE.length;
+    out = out.split('#VousPropose#').join(VOUS_PROPOSE[vpIdx]);
+
+    return out;
+  }
+
+  private replaceContextualMarkers(
+    content: string,
+    v: TemplateVariables,
+  ): string {
+    let out = content;
+
+    if (typeof v.articlesCount === 'number' && v.articlesCount > 0) {
+      out = out
+        .split('#ArticlesCount#')
+        .join(String(v.articlesCount))
+        .split('#ArticlesCountFormatted#')
+        .join(this.formatArticlesCount(v.articlesCount));
+    }
+
+    if (typeof v.seoScore === 'number') {
+      out = out
+        .split('#QualityBadge#')
+        .join(this.formatQualityBadge(v.seoScore));
+    }
+
+    if (v.familyName) {
+      out = out
+        .split('#FamilyContext#')
+        .join(`dans la catégorie <b>${v.familyName}</b>`);
+    }
+
+    return out;
+  }
+
+  private formatArticlesCount(count: number): string {
+    if (count === 1) return '<b>1 référence</b>';
+    if (count < 10) return `<b>${count} références</b>`;
+    return `<b>plus de ${count} références</b>`;
+  }
+
+  private formatQualityBadge(score: number): string {
+    if (score >= 80) return '<b>Sélection Premium</b>';
+    if (score >= 60) return '<b>Qualité Vérifiée</b>';
+    return '';
+  }
+}

--- a/backend/src/modules/seo/services/chain/seo-template-renderer.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-template-renderer.service.ts
@@ -4,7 +4,7 @@ import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { TABLES } from '@repo/database-types';
 import { type SurfaceKey } from '@repo/seo-role-contracts';
 
-import { PRIX_PAS_CHER, VOUS_PROPOSE } from '../../seo-v4.types';
+import { PRIX_PAS_CHER, SeoVariables, VOUS_PROPOSE } from '../../seo-v4.types';
 
 /**
  * Variables métier injectables dans les templates SEO.
@@ -14,30 +14,12 @@ import { PRIX_PAS_CHER, VOUS_PROPOSE } from '../../seo-v4.types';
  *
  * `useMeta=true` (titre/description/preview) → variantes texte sans `<b>`.
  * `useMeta=false` (h1/content) → variantes typographiées avec `<b>`.
+ *
+ * Note : alias direct vers `SeoVariables` (Zod schema source unique). Permet
+ * à `DynamicSeoV4UltimateService` de passer le résultat de `SeoVariablesSchema.parse`
+ * sans cast, et garantit que toute évolution du schéma propage automatiquement.
  */
-export interface TemplateVariables {
-  gamme: string;
-  gammeMeta: string;
-  marque: string;
-  marqueMeta: string;
-  marqueMetaTitle: string;
-  modele: string;
-  modeleMeta: string;
-  type: string;
-  typeMeta: string;
-  annee: string;
-  nbCh: number;
-  carosserie: string;
-  fuel: string;
-  codeMoteur: string;
-  /** Variables marketing legacy (PHP `$PrixPasCher[]` / `$VousPropose[]`). */
-  minPrice?: number;
-  articlesCount?: number;
-  familyName?: string;
-  seoScore?: number;
-  gammeLevel?: number;
-  isTopGamme?: boolean;
-}
+export type TemplateVariables = SeoVariables;
 
 export interface RenderTemplateInput {
   surfaceKey: SurfaceKey;

--- a/backend/src/modules/seo/services/seo-v4-switch-engine.service.ts
+++ b/backend/src/modules/seo/services/seo-v4-switch-engine.service.ts
@@ -1,12 +1,13 @@
 /**
  * SEO V4 Switch Engine Service
  *
- * Extracted from dynamic-seo-v4-ultimate.service.ts
- * Handles all switch/interpolation processing:
- * - CompSwitch (generic + gamme-specific + aliased)
- * - LinkGammeCar (internal links)
- * - FamilySwitch (alias 1-16)
- * - External gamme switches (batch processing)
+ * @deprecated PR-2c (plan seo-v9) — remplacé par `SeoSwitchSelector` +
+ * `SeoTemplateRenderer` + `SeoInternalLinkingService` (chain). Aucun consommateur
+ * actif depuis le refactor V4 → orchestrateur stateless. À supprimer en PR-10
+ * (cf. plan seo-v9 §5 « Phase D — Anti-thin-content + cleanup »).
+ *
+ * Conservé temporairement pour préserver l'historique git et permettre une
+ * comparaison shadow lors des PRs de branchement (PR-3+).
  */
 
 import { Injectable, Logger } from '@nestjs/common';
@@ -14,6 +15,7 @@ import { TABLES } from '@repo/database-types';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { FAMILY_SWITCH_DEFAULTS } from '../seo-v4.types';
 
+/** @deprecated PR-2c — voir doc bloc en haut de fichier. */
 @Injectable()
 export class SeoV4SwitchEngineService extends SupabaseBaseService {
   protected readonly logger = new Logger(SeoV4SwitchEngineService.name);

--- a/log.md
+++ b/log.md
@@ -417,3 +417,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-v9-pr2b-policies`
 - **Décision** : feat(seo): 4 services policies SEO (PR-2b/v9, stacked sur 2a) (+1 other commit)
 - **Sortie** : PR #400 | commits 85731ace 8d66d310
+
+## 2026-05-08 — feat/seo-v9-pr2c-renderer-switch (auto)
+
+- **Branche** : `feat/seo-v9-pr2c-renderer-switch`
+- **Décision** : feat(seo): chain services + orchestrator (PR-2c/v9, stacked sur 2b) (+3 other commits)
+- **Sortie** : PR #401 | commits d4278b8e c02a31d2 85731ace 8d66d310

--- a/log.md
+++ b/log.md
@@ -411,3 +411,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/pr-e-l3-rag-mirror-readonly`
 - **Décision** : feat(rag): L3 mirror readonly enforcement + bootstrap guard (MVP-0 PR-E)
 - **Sortie** : PR #356 | commits 2ed2e9b7
+
+## 2026-05-08 — feat/seo-v9-pr2b-policies (auto)
+
+- **Branche** : `feat/seo-v9-pr2b-policies`
+- **Décision** : feat(seo): 4 services policies SEO (PR-2b/v9, stacked sur 2a) (+1 other commit)
+- **Sortie** : PR #400 | commits 85731ace 8d66d310

--- a/log.md
+++ b/log.md
@@ -423,3 +423,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-v9-pr2c-renderer-switch`
 - **Décision** : feat(seo): chain services + orchestrator (PR-2c/v9, stacked sur 2b) (+3 other commits)
 - **Sortie** : PR #401 | commits d4278b8e c02a31d2 85731ace 8d66d310
+
+## 2026-05-08 — feat/seo-v9-pr2c-renderer-switch (auto)
+
+- **Branche** : `feat/seo-v9-pr2c-renderer-switch`
+- **Décision** : refactor(seo): v4 delegates to chain orchestrator (PR-2c rev 2) (+5 other commits)
+- **Sortie** : PR #401 | commits 79c32c9c 93c63ffe d4278b8e c02a31d2 85731ace 8d66d310


### PR DESCRIPTION
## Contexte

3e PR de la cascade SEO seo-v9 (plan stratégique : `/home/deploy/.claude/plans/apres-investigation-seo-on-iterative-spark.md`). Stack :

- PR-1 #398 — audit inventaire + matrice gap (READ-ONLY) ✅
- PR-2a #399 — registries + Zod contracts SoT ✅
- PR-2b #400 — policies (canonical / indexability / R2 gate / unavailable stub) ✅
- **PR-2c (cette PR)** — chain services + orchestrator + V4 refactor

## Scope rev 2 (post-feedback "utiliser meilleure approche")

**rev 1 → rev 2** : la rev 1 livrait la chaîne en parallèle de V4 inchangé (approche hybride). La rev 2 aligne avec le plan v9 §3.4 (« V4 refactoré en orchestrateur stateless ») et applique les contrats chaîne anti-breaking pour PR-7.

### 8 services chaîne (`backend/src/modules/seo/services/chain/`)

| Service | Rôle | Tests |
|---|---|---|
| `SeoSlugService` | `url_title_optimizer` FR (stop-words, accents, élisions, smart quotes, troncature word-boundary) | 14 |
| `SeoArianeBreadcrumbService` | JSON-LD `BreadcrumbList` Schema.org + text trail compat `mta_ariane` | 7 |
| `SeoMetaRegistryService` | Lecture cachée `___meta_tags_ariane` + `__blog_meta_tags_ariane` | 7 |
| `SeoSwitchSelector` | Seed canonique sha256 (remplace seed legacy fragile aux renumérotations TecDoc V2) | 6 |
| `SeoTemplateRenderer` | Variables métier + marketing + contextuelles. `TemplateVariables = SeoVariables` (alias Zod) | 9 |
| `SeoInternalLinkingService` | `resolveLinksBatch → LinkResolutionResult[]` avec `LinkResolutionReason` enum (NO_TARGET / NOINDEX / SELF_LINK / ORPHAN / CANONICAL_MISMATCH / FORBIDDEN_ROLE) + `buildCacheKey` canon Redis `seo:v9:linking:*` | 18 |
| `SeoContentBlockBuilder` | Assemblage `contentBlocks` discriminés (lead / paragraph / switch-variant / link / fact-list / cta) | 9 |
| `SeoChainOrchestratorService` | Composition stateless 7 services + policies PR-2b. `chain_version = seo-v9-pr2c` | 5 |

**Total** : 75 tests chain, 132 tests SEO module total (vs 120 rev 1).

### V4 refactor

`DynamicSeoV4UltimateService` est devenue un **adaptateur fin** (~150 lignes au lieu de 665) :

- `generateCompleteSeo(pgId, typeId, vars)` parse Zod → bâtit `SeoChainInput` (surface = `R1_GAMME_VEHICLE_ROUTER` pour le legacy) → délègue à `SeoChainOrchestratorService.run(input)` → adapte `SeoChainOutput → CompleteSeoResult` (compat tests / 4 endpoints debug)
- Drop : `processTitle/Description/H1/Preview/Content`, `replaceStandardVariables`, `processContextualVariables`, `getSeoTemplate/getItemSwitches/getGammeCarSwitches/getFamilySwitches`, `countVariablesInTemplate`. Toute cette logique vit dans la chaîne.
- Conservés : cache résultat, `generateDefaultSeo` fallback, `cleanContent` (utilisé pour le fallback), monitoring proxy, version → `4.1.0`

### `SeoV4SwitchEngineService` deprecated

- Annotation `@deprecated` sur la classe
- Provider retiré de `SeoModule` (plus aucun consommateur applicatif après le refactor V4)
- Fichier conservé pour PR-10 cleanup (cf. plan v9 §5 phase D)

## Patterns / décisions notables

- **Seed canonique sha256** : `parseInt(sha256("$surfaceKey:$pgId:$vehicleId:$alias").slice(0,8), 16) % length`. Distribution testée 10k tirages sur 10 buckets (700-1300 par bucket = écart-type acceptable). Stabilité garantie même si TecDoc renumérote `type_id` (gotcha legacy mémoire `tecdoc-integration`).
- **Contrats anti-breaking PR-7** : `LinkResolutionResult` exhaustif (avec `targetUrl`, `targetRole`, `indexable`, `reason?`) permet de remplacer le stub direct par lookup MV `seo_internal_link_candidates` en PR-7 sans casser les consommateurs (orchestrator, builder, controllers).
- **`TemplateVariables = SeoVariables`** : alias direct vers le Zod schema source unique. V4 passe `SeoVariablesSchema.parse(...)` sans cast, et toute évolution du schéma propage automatiquement.
- **Surface non supportée → graceful** : R3, R6, R2_LIST throw côté `SeoCanonicalService` (PR-2b les a marquées TODO PR-2c+). L'orchestrator catche et applique `noindex,follow` + reason `canonical_not_supported_in_pr2c`.
- **Smart quotes normalisation** (`SeoSlugService`) : `’/‘/‚/‛` → ASCII `'` AVANT split. Permet la détection des élisions `l'`/`d'` même sur input copié-collé d'éditeurs Word.
- **Self-link detection** : `resolveLinksBatch` reçoit `sourceEntityId` et bloque les `#LinkGamme_X#` où `pg_id_target === sourceEntityId` (reason `SELF_LINK`).
- **Canon clé Redis** (PR-7/PR-8) : `seo:v9:linking:{surface}:{sourceEntityId}:{markerHash}` — TTL 1h, namespace `seo:v9:*`, invalidation cron daily + event `seo.target_indexability_changed`.

## Conformité gouvernance

- ✅ Pas de Prisma — Supabase SDK direct (`SupabaseBaseService`).
- ✅ ADR-031 wiki canonique référencé (PR-3+ branchera la lecture wiki via `SeoMetaRegistryService`).
- ✅ ADR-037 `RoleId` enum + ADR-039 Zod canon respectés (`@repo/seo-role-contracts`).
- ✅ Convention DB MySQL → PostgreSQL respectée.
- ✅ Stacked PR pattern (mémoire `feedback_stacked_pr_pattern_for_atomic_phase`).
- ✅ Plan v9 §3.4 respecté : V4 EST refactoré (rev 2 corrige rev 1 hybride).
- ✅ `feedback_no_hybrid_workarounds` respecté.

## À venir (HOLD post-PR-2c merge)

- **PR-2d** : variables marketing exhaustives (#PrixPasCher / #VousPropose / #MinPrice si gaps) + tests intégration shadow vs sortie controllers actuels.
- **PR-3+** : branchement applicatif sur `rm-builder` / `gamme-rest` / `brand-rpc` / `vehicle-rpc` derrière feature flag `SEO_CHAIN_<surface>_MODE=shadow|on`.
- **PR-7** : remplace stub `SeoInternalLinkingService` par MV `seo_internal_link_candidates` (gain perf ~5-10× sur TTFB R1/R7/R8). Contrat `LinkResolutionResult` stable → 0 changement caller.
- **PR-10** : drop `SeoV4SwitchEngineService` (déjà `@deprecated` + retiré du module).

## Test plan

- [x] 75 tests chain (Jest) — verts
- [x] 132 tests SEO module total — verts (0 régression)
- [x] Typecheck `npm run typecheck` — pas d'erreur
- [ ] CI lint + jest — à valider sur la PR
- [ ] Review fonctionnelle stacked

🤖 Generated with [Claude Code](https://claude.com/claude-code)