### PR TITLE
feat(seo-v9): PR-2d marketing seed parity legacy V4 + V4 E2E test (stacked sur 2b)

### DIFF
--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -4,6 +4,7 @@ sources:
 - backend/src/modules/seo
 last_scan: '2026-05-08'
 primary_files:
+- backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts
 - backend/src/modules/seo/config/sitemap.config.ts
 - backend/src/modules/seo/constants/seo-templates.constants.ts
@@ -11,7 +12,6 @@ primary_files:
 - backend/src/modules/seo/controllers/keywords-dashboard.controller.ts
 - backend/src/modules/seo/controllers/r2-page.controller.ts
 - backend/src/modules/seo/controllers/reference.controller.ts
-- backend/src/modules/seo/controllers/robots-txt.controller.ts
 depends_on:
 - ConfigModule
 - DatabaseModule

--- a/backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
+++ b/backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
@@ -1,0 +1,200 @@
+import { DynamicSeoV4UltimateService } from '../dynamic-seo-v4-ultimate.service';
+import { SeoSurfaceRegistry } from '../registries/seo-surface.registry';
+import { SeoVariantFamilyRegistry } from '../registries/seo-variant-family.registry';
+import { R2IndexabilityGate } from '../services/policies/r2-indexability-gate.service';
+import { SeoCanonicalService } from '../services/policies/seo-canonical.service';
+import { SeoIndexabilityPolicyService } from '../services/policies/seo-indexability-policy.service';
+import { SeoArianeBreadcrumbService } from '../services/chain/seo-ariane-breadcrumb.service';
+import { SeoChainOrchestratorService } from '../services/chain/seo-chain-orchestrator.service';
+import { SeoContentBlockBuilder } from '../services/chain/seo-content-block-builder.service';
+import { SeoInternalLinkingService } from '../services/chain/seo-internal-linking.service';
+import { SeoSwitchSelector } from '../services/chain/seo-switch-selector.service';
+import { SeoTemplateRenderer } from '../services/chain/seo-template-renderer.service';
+import { SeoV4MonitoringService } from '../services/seo-v4-monitoring.service';
+
+/**
+ * PR-2d — Test E2E V4 → chain delegation.
+ *
+ * Verrouille le contrat de l'adaptateur `DynamicSeoV4UltimateService` après
+ * le refactor PR-2c rev 2 :
+ *   - generateCompleteSeo(pgId, typeId, vars) appelle bien la chaîne
+ *   - le retour est un `CompleteSeoResult` valide (shape inchangée vs legacy)
+ *   - le fallback `generateDefaultSeo` se déclenche si template absent
+ *   - le cache résultat se comporte correctement (HIT après MISS)
+ */
+describe('DynamicSeoV4UltimateService → chain delegation (PR-2d E2E)', () => {
+  function buildV4(opts: { templateRow: Record<string, unknown> | null }) {
+    const renderer = new SeoTemplateRenderer();
+    const switchSelector = new SeoSwitchSelector(
+      new SeoVariantFamilyRegistry(),
+    );
+    const linking = new SeoInternalLinkingService();
+
+    Object.defineProperty(renderer, 'supabase', {
+      value: {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: opts.templateRow,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      },
+      configurable: true,
+    });
+
+    Object.defineProperty(switchSelector, 'supabase', {
+      value: {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                async then(resolve: (v: unknown) => void) {
+                  resolve({ data: [], error: null });
+                },
+              }),
+              async then(resolve: (v: unknown) => void) {
+                resolve({ data: [], error: null });
+              },
+            }),
+          }),
+        }),
+      },
+      configurable: true,
+    });
+
+    Object.defineProperty(linking, 'supabase', {
+      value: {
+        from: () => ({
+          select: () => ({
+            in: async () => ({ data: [], error: null }),
+          }),
+        }),
+      },
+      configurable: true,
+    });
+
+    const surfaces = new SeoSurfaceRegistry();
+    const orchestrator = new SeoChainOrchestratorService(
+      surfaces,
+      renderer,
+      switchSelector,
+      linking,
+      new SeoArianeBreadcrumbService(),
+      new SeoCanonicalService(),
+      new SeoIndexabilityPolicyService(surfaces, new R2IndexabilityGate()),
+      new SeoContentBlockBuilder(),
+    );
+
+    // SeoV4MonitoringService nécessite Supabase pour ses méthodes audit/metrics,
+    // mais aucun test ici ne les invoque → on crée un stub minimal.
+    const monitoring = Object.create(
+      SeoV4MonitoringService.prototype,
+    ) as SeoV4MonitoringService;
+
+    return new DynamicSeoV4UltimateService(orchestrator, monitoring);
+  }
+
+  const baseVars = {
+    gamme: 'Plaquettes',
+    gammeMeta: 'Plaquettes de frein',
+    marque: 'Renault',
+    marqueMeta: 'Renault',
+    marqueMetaTitle: 'Renault',
+    modele: 'Clio',
+    modeleMeta: 'Clio IV',
+    type: '1.5 dCi 90',
+    typeMeta: '1.5 dCi 90',
+    annee: '2015',
+    nbCh: 90,
+    carosserie: 'berline',
+    fuel: 'diesel',
+    codeMoteur: 'K9K',
+    minPrice: 25,
+    articlesCount: 12,
+    gammeLevel: 1,
+    isTopGamme: false,
+  };
+
+  it('renvoie un CompleteSeoResult valide quand la chaîne hydrate un template', async () => {
+    const v4 = buildV4({
+      templateRow: {
+        sgc_id: 124,
+        sgc_title: '#Gamme# pour #VMarque# #VModele# #VType#',
+        sgc_descrip: 'Description #PrixPasCher# #MinPrice#',
+        sgc_h1: '<h1>#Gamme#</h1>',
+        sgc_preview: 'Aperçu #Gamme#',
+        sgc_content: '<p>Découvrez nos pièces</p>',
+      },
+    });
+
+    const result = await v4.generateCompleteSeo(124, 12345, baseVars);
+
+    // Shape legacy CompleteSeoResult préservée (compat 4 endpoints debug).
+    expect(result).toMatchObject({
+      title: expect.any(String),
+      description: expect.any(String),
+      h1: expect.any(String),
+      preview: expect.any(String),
+      content: expect.any(String),
+      keywords: expect.any(String),
+      metadata: {
+        templatesUsed: expect.arrayContaining([expect.any(String)]),
+        switchesProcessed: expect.any(Number),
+        variablesReplaced: expect.any(Number),
+        processingTime: expect.any(Number),
+        cacheHit: false,
+        version: 'seo-v9-pr2c',
+      },
+    });
+
+    expect(result.title).toContain('Plaquettes de frein');
+    expect(result.description).toContain('à partir de 25€');
+    expect(result.metadata.templatesUsed[0]).toBe(
+      'R1_GAMME_VEHICLE_ROUTER:124',
+    );
+  });
+
+  it('utilise le fallback `generateDefaultSeo` si template DB absent', async () => {
+    const v4 = buildV4({ templateRow: null });
+
+    const result = await v4.generateCompleteSeo(0, 0, baseVars);
+
+    expect(result.metadata.templatesUsed).toContain('default_fallback');
+    expect(result.metadata.version).toMatch(/4\.1\.0-/);
+    // Le fallback produit un title programmatique avec marque + modèle.
+    expect(result.title).toContain('Renault');
+    expect(result.title).toContain('Clio');
+  });
+
+  it('cache résultat : 2e appel identique → cacheHit=true', async () => {
+    const v4 = buildV4({
+      templateRow: {
+        sgc_id: 1,
+        sgc_title: '#Gamme#',
+      },
+    });
+
+    const r1 = await v4.generateCompleteSeo(1, 1, baseVars);
+    const r2 = await v4.generateCompleteSeo(1, 1, baseVars);
+
+    expect(r1.metadata.cacheHit).toBe(false);
+    expect(r2.metadata.cacheHit).toBe(true);
+    expect(r2.title).toBe(r1.title);
+  });
+
+  it('invalidateCache vide le cache', async () => {
+    const v4 = buildV4({
+      templateRow: { sgc_id: 1, sgc_title: '#Gamme#' },
+    });
+
+    await v4.generateCompleteSeo(1, 1, baseVars);
+    v4.invalidateCache();
+    const r2 = await v4.generateCompleteSeo(1, 1, baseVars);
+
+    expect(r2.metadata.cacheHit).toBe(false);
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/__snapshots__/seo-chain-orchestrator.service.test.ts.snap
+++ b/backend/src/modules/seo/services/chain/__tests__/__snapshots__/seo-chain-orchestrator.service.test.ts.snap
@@ -88,7 +88,7 @@ exports[`SeoChainOrchestratorService Snapshot freeze contrat output (Étape 6 pl
   "surfaceKey": "R1_GAMME_VEHICLE_ROUTER",
   "template": {
     "content": "<p>dans la catégorie <b>Freinage</b></p>",
-    "description": "Description économique",
+    "description": "Description à prix discount",
     "h1": "<h1><b>Plaquettes</b></h1>",
     "keywords": "Plaquettes de frein, Renault, Clio IV, 1.5 dCi 90, 90 ch, 2015, berline, diesel, K9K",
     "preview": "Aperçu Plaquettes de frein",

--- a/backend/src/modules/seo/services/chain/__tests__/seo-chain-marketing-parity.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-chain-marketing-parity.test.ts
@@ -1,0 +1,259 @@
+import { SeoSurfaceRegistry } from '../../../registries/seo-surface.registry';
+import { SeoVariantFamilyRegistry } from '../../../registries/seo-variant-family.registry';
+import { R2IndexabilityGate } from '../../policies/r2-indexability-gate.service';
+import { SeoCanonicalService } from '../../policies/seo-canonical.service';
+import { SeoIndexabilityPolicyService } from '../../policies/seo-indexability-policy.service';
+import { SeoArianeBreadcrumbService } from '../seo-ariane-breadcrumb.service';
+import { SeoChainOrchestratorService } from '../seo-chain-orchestrator.service';
+import { SeoContentBlockBuilder } from '../seo-content-block-builder.service';
+import { SeoInternalLinkingService } from '../seo-internal-linking.service';
+import { SeoSwitchSelector } from '../seo-switch-selector.service';
+import { SeoTemplateRenderer } from '../seo-template-renderer.service';
+import { PRIX_PAS_CHER, VOUS_PROPOSE } from '../../../seo-v4.types';
+
+/**
+ * PR-2d — Marketing seed parity : title / description / content reçoivent
+ * 3 seeds distincts pour `#PrixPasCher#` (cf. legacy PHP `processTitle` /
+ * `processDescription` / `processContent`). Sans cela, toutes les sections
+ * d'une page sortent le MÊME prix → régression duplicate content.
+ *
+ * Ce test verrouille la parité orchestrator → legacy V4.
+ */
+describe('SeoChainOrchestrator — marketing seed parity (PR-2d)', () => {
+  function build(opts: {
+    template: Record<string, unknown>;
+  }): SeoChainOrchestratorService {
+    const renderer = new SeoTemplateRenderer();
+    const switchSelector = new SeoSwitchSelector(
+      new SeoVariantFamilyRegistry(),
+    );
+    const linking = new SeoInternalLinkingService();
+
+    Object.defineProperty(renderer, 'supabase', {
+      value: {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: opts.template, error: null }),
+            }),
+          }),
+        }),
+      },
+      configurable: true,
+    });
+
+    Object.defineProperty(switchSelector, 'supabase', {
+      value: {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                async then(resolve: (v: unknown) => void) {
+                  resolve({ data: [], error: null });
+                },
+              }),
+              async then(resolve: (v: unknown) => void) {
+                resolve({ data: [], error: null });
+              },
+            }),
+          }),
+        }),
+      },
+      configurable: true,
+    });
+
+    Object.defineProperty(linking, 'supabase', {
+      value: {
+        from: () => ({
+          select: () => ({
+            in: async () => ({ data: [], error: null }),
+          }),
+        }),
+      },
+      configurable: true,
+    });
+
+    const surfaces = new SeoSurfaceRegistry();
+    return new SeoChainOrchestratorService(
+      surfaces,
+      renderer,
+      switchSelector,
+      linking,
+      new SeoArianeBreadcrumbService(),
+      new SeoCanonicalService(),
+      new SeoIndexabilityPolicyService(surfaces, new R2IndexabilityGate()),
+      new SeoContentBlockBuilder(),
+    );
+  }
+
+  const baseVars = {
+    gamme: 'Plaquettes',
+    gammeMeta: 'Plaquettes',
+    marque: 'Renault',
+    marqueMeta: 'Renault',
+    marqueMetaTitle: 'Renault',
+    modele: 'Clio',
+    modeleMeta: 'Clio IV',
+    type: '1.5 dCi',
+    typeMeta: '1.5 dCi',
+    annee: '2015',
+    nbCh: 90,
+    carosserie: 'berline',
+    fuel: 'diesel',
+    codeMoteur: 'K9K',
+    articlesCount: 10,
+    gammeLevel: 1,
+    isTopGamme: false,
+  };
+
+  it('title et description ont des seeds #PrixPasCher# distincts (parité legacy V4)', async () => {
+    const orch = build({
+      template: {
+        sgc_id: 999,
+        sgc_title: 'Achetez nos pièces #PrixPasCher#',
+        sgc_descrip: 'Découvrez nos pièces #PrixPasCher#',
+        sgc_h1: '<h1>H1</h1>',
+        sgc_content: 'Contenu #PrixPasCher#',
+      },
+    });
+
+    const out = await orch.run({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      pgId: 124,
+      typeId: 12345,
+      vehicleId: 12345,
+      variables: baseVars,
+      ids: {
+        gammeAlias: 'g',
+        marqueAlias: 'm',
+        modeleAlias: 'mod',
+        typeAlias: 't',
+      },
+      baseUrl: 'https://www.automecanik.com',
+      breadcrumbs: [{ name: 'a', url: 'https://www.automecanik.com/' }],
+    });
+
+    const extract = (s: string) => {
+      // Trouve laquelle des 16 variantes a été interpolée.
+      for (const v of PRIX_PAS_CHER) if (s.includes(v)) return v;
+      return null;
+    };
+
+    const titlePrix = extract(out.template.title);
+    const descPrix = extract(out.template.description);
+    const contentPrix = extract(out.template.content);
+
+    // 3 valeurs trouvées (les marqueurs ont bien été remplacés).
+    expect(titlePrix).not.toBeNull();
+    expect(descPrix).not.toBeNull();
+    expect(contentPrix).not.toBeNull();
+
+    // Au moins 2 valeurs distinctes parmi les 3 (parité legacy : pgId+typeId+1
+    // vs pgId+typeId vs typeId — 3 seeds différents → variantes différentes
+    // sauf collision modulo accidentelle).
+    const distinct = new Set([titlePrix, descPrix, contentPrix]);
+    expect(distinct.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reproduit exactement les seeds legacy : title=(pgId%100)+1+typeId, descrip=(pgId%100)+typeId, content=typeId', async () => {
+    const orch = build({
+      template: {
+        sgc_id: 1,
+        sgc_title: '#PrixPasCher#',
+        sgc_descrip: '#PrixPasCher#',
+        sgc_content: '#PrixPasCher#',
+      },
+    });
+
+    const pgId = 10;
+    const typeId = 5;
+
+    const out = await orch.run({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      pgId,
+      typeId,
+      vehicleId: typeId,
+      variables: baseVars,
+      ids: {
+        gammeAlias: 'g',
+        marqueAlias: 'm',
+        modeleAlias: 'mod',
+        typeAlias: 't',
+      },
+      baseUrl: 'https://www.automecanik.com',
+      breadcrumbs: [{ name: 'a', url: 'https://www.automecanik.com/' }],
+    });
+
+    // Legacy V4 formulas (cleanContent strippe les balises mais préserve le
+    // texte du PrixPasCher, donc on peut comparer directement).
+    const expectedTitle =
+      PRIX_PAS_CHER[((pgId % 100) + 1 + typeId) % PRIX_PAS_CHER.length]!;
+    const expectedDesc =
+      PRIX_PAS_CHER[((pgId % 100) + typeId) % PRIX_PAS_CHER.length]!;
+    const expectedContent = PRIX_PAS_CHER[typeId % PRIX_PAS_CHER.length]!;
+
+    expect(out.template.title).toBe(expectedTitle);
+    expect(out.template.description).toBe(expectedDesc);
+    expect(out.template.content).toBe(expectedContent);
+  });
+
+  it('content reçoit la même seed VousPropose que content legacy (typeId%len)', async () => {
+    const orch = build({
+      template: {
+        sgc_id: 1,
+        sgc_content: '#VousPropose#',
+      },
+    });
+
+    const typeId = 7;
+    const out = await orch.run({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      pgId: 1,
+      typeId,
+      vehicleId: typeId,
+      variables: baseVars,
+      ids: {
+        gammeAlias: 'g',
+        marqueAlias: 'm',
+        modeleAlias: 'mod',
+        typeAlias: 't',
+      },
+      baseUrl: 'https://www.automecanik.com',
+      breadcrumbs: [{ name: 'a', url: 'https://www.automecanik.com/' }],
+    });
+
+    expect(out.template.content).toBe(
+      VOUS_PROPOSE[typeId % VOUS_PROPOSE.length]!,
+    );
+  });
+
+  it("h1 et preview reçoivent seed neutre (legacy n'utilisait pas de #PrixPasCher# sur ces champs)", async () => {
+    const orch = build({
+      template: {
+        sgc_id: 1,
+        sgc_h1: '#PrixPasCher#',
+        sgc_preview: '#PrixPasCher#',
+      },
+    });
+
+    const out = await orch.run({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      pgId: 50,
+      typeId: 100,
+      vehicleId: 100,
+      variables: baseVars,
+      ids: {
+        gammeAlias: 'g',
+        marqueAlias: 'm',
+        modeleAlias: 'mod',
+        typeAlias: 't',
+      },
+      baseUrl: 'https://www.automecanik.com',
+      breadcrumbs: [{ name: 'a', url: 'https://www.automecanik.com/' }],
+    });
+
+    // seed=0 → première variante de la liste.
+    expect(out.template.h1).toBe(PRIX_PAS_CHER[0]);
+    expect(out.template.preview).toBe(PRIX_PAS_CHER[0]);
+  });
+});

--- a/backend/src/modules/seo/services/chain/seo-chain-orchestrator.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-chain-orchestrator.service.ts
@@ -268,6 +268,7 @@ export class SeoChainOrchestratorService {
         (templateRow[colA] ?? templateRow[colB] ?? '') as string,
       );
       if (!raw) continue;
+      const seeds = this.legacyMarketingSeeds(field, input.pgId, input.typeId);
       out[field as keyof SeoChainTemplateData] = this.renderer.applyVariables({
         surfaceKey: input.surfaceKey,
         templateText: raw,
@@ -276,10 +277,52 @@ export class SeoChainOrchestratorService {
         typeId: input.typeId,
         useMeta,
         minPriceFormat: field === 'description' ? 'descrip' : 'title',
+        prixPasCherSeed: seeds.prixPasCher,
+        vousProposeSeed: seeds.vousPropose,
       });
     }
 
     return out;
+  }
+
+  /**
+   * Reproduit les seeds `#PrixPasCher#` / `#VousPropose#` legacy V4 PHP,
+   * qui variaient PAR CHAMP pour donner de la diversité lexicale au rendu :
+   *
+   *   title       : `((pgId % 100) + 1 + typeId) % len`
+   *   description : `((pgId % 100) + typeId) % len`
+   *   content     : `typeId % len`
+   *   h1 / preview: pas de marqueur prix legacy → seed neutre `0`
+   *
+   * Sans cette parité, toutes les sections d'une page sortent le MÊME
+   * `#PrixPasCher#` (régression de duplicate content vs legacy).
+   *
+   * @see plan seo-v9 §1.2 pilier 4 « marqueurs marketing »
+   * @see legacy `dynamic-seo-v4-ultimate.service.ts` (avant refactor PR-2c rev 2)
+   */
+  private legacyMarketingSeeds(
+    field: string,
+    pgId: number,
+    typeId: number,
+  ): { prixPasCher: number; vousPropose: number } {
+    switch (field) {
+      case 'title':
+        return {
+          prixPasCher: (pgId % 100) + 1 + typeId,
+          vousPropose: typeId,
+        };
+      case 'description':
+        return {
+          prixPasCher: (pgId % 100) + typeId,
+          vousPropose: typeId,
+        };
+      case 'content':
+        return { prixPasCher: typeId, vousPropose: typeId };
+      case 'h1':
+      case 'preview':
+      default:
+        return { prixPasCher: 0, vousPropose: 0 };
+    }
   }
 
   private buildKeywords(v: TemplateVariables): string {

--- a/log.md
+++ b/log.md
@@ -429,3 +429,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-v9-pr2c-renderer-switch`
 - **Décision** : refactor(seo): v4 delegates to chain orchestrator (PR-2c rev 2) (+5 other commits)
 - **Sortie** : PR #401 | commits 79c32c9c 93c63ffe d4278b8e c02a31d2 85731ace 8d66d310
+
+## 2026-05-08 — feat/seo-v9-pr2d-marketing-parity (auto)
+
+- **Branche** : `feat/seo-v9-pr2d-marketing-parity`
+- **Décision** : feat(seo-v9): PR-2c chain services + orchestrator (stacked sur 2b) (#401) (+2 other commits)
+- **Sortie** : PR aucune | commits efc4c9fa 85731ace 8d66d310


### PR DESCRIPTION
## Contexte

4e PR de la cascade SEO seo-v9. PR-2c a été squash-mergé dans la branche PR-2b (#400) à 19:04 UTC. Cette PR-2d se stacke directement sur `feat/seo-v9-pr2b-policies` (qui contient maintenant tout le travail PR-2c rev 2).

## Scope

### 1. Marketing seed parity (régression silencieuse rattrapée)

Le refactor PR-2c rev 2 (V4 → chain) avait gommé une subtilité du legacy V4 : `processTitle`/`processDescription`/`processContent` utilisaient des **3 seeds différents** pour `#PrixPasCher#`, donnant de la diversité lexicale au rendu. Sans ça, toutes les sections d'une page sortent le même prix → régression duplicate content potentielle visible par Google.

Parité reproduite (`SeoChainOrchestratorService.legacyMarketingSeeds`) :

| Champ | Seed legacy V4 | Reproduit ✅ |
|---|---|---|
| title | `((pgId % 100) + 1 + typeId) % len` | ✅ |
| description | `((pgId % 100) + typeId) % len` | ✅ |
| content | `typeId % len` (idem `#VousPropose#`) | ✅ |
| h1, preview | seed neutre `0` (legacy n'utilisait pas) | ✅ |

### 2. Tests PR-2d (8 nouveaux)

**4 tests `seo-chain-marketing-parity.test.ts`** :
- title/description avec `#PrixPasCher#` produisent des variantes distinctes
- reproduction exacte des 3 formules legacy
- `#VousPropose#` content seed = `typeId % len`
- h1/preview reçoivent seed neutre

**4 tests E2E `dynamic-seo-v4-via-chain.test.ts`** (premier test pour V4) :
- `V4.generateCompleteSeo` renvoie un `CompleteSeoResult` valide (shape inchangée pour les 4 endpoints debug `/api/seo-dynamic-v4/*`)
- Fallback `generateDefaultSeo` se déclenche si template DB absent
- Cache HIT au 2e appel identique
- `invalidateCache` vide le cache

### 3. Snapshot orchestrator R1_GAMME_VEHICLE_ROUTER mis à jour

La description sort désormais `"à prix discount"` (seed `(pgId%100)+typeId`) au lieu de `"économique"` (ancien seed unique). Changement délibéré aligné parité legacy — ce snapshot était PRÉCISÉMENT ce qu'on cherchait à corriger.

## Cumul tests

- **143/143 SEO module verts** (vs 132 PR-2c rev 2, +11 tests)
  - Marketing parity : 4 tests
  - V4 E2E : 4 tests
  - Snapshot R1 mis à jour (+1 description "à prix discount")
- **Typecheck OK**

## Conformité gouvernance

- ✅ `feedback_no_hybrid_workarounds` : pas de bricolage, on reproduit la formule legacy exacte plutôt que d'inventer.
- ✅ `feedback_perf_migration_must_honor_contract` : migration SQL→NestJS doit honorer le contrat. Cette PR rattrape le contrat marketing.
- ✅ Pattern `legacyMarketingSeeds` documenté avec référence au legacy PHP (audit trail conservé).
- ✅ Stacked PR pattern (`feedback_stacked_pr_pattern_for_atomic_phase`) : 3 niveaux (main → 2a → 2b → 2d), respecté grâce au merge PR-2c → 2b qui a libéré le slot.

## À venir

- **PR-3+** : branchement applicatif sur les 4 services réels (`rm-builder`, `gamme-rest`, `brand-rpc`, `vehicle-rpc`) via `SeoChainOrchestratorService.run()` derrière feature flag `SEO_CHAIN_<surface>_MODE=shadow|on`.
- **PR-7** : remplace stub `SeoInternalLinkingService` par MV `seo_internal_link_candidates`. Contrat `LinkResolutionResult` stable → 0 changement caller.
- **PR-10** : drop `SeoV4SwitchEngineService` (déjà `@deprecated` depuis PR-2c rev 2).

## Test plan

- [x] 4 tests marketing parity verts
- [x] 4 tests V4 E2E verts
- [x] 143/143 SEO module total
- [x] Typecheck `npm run typecheck` — OK
- [ ] CI lint + jest — à valider
- [ ] Review fonctionnelle stacked

🤖 Generated with [Claude Code](https://claude.com/claude-code)