### PR TITLE
feat(seo-v9): PR-3 brancher chain SEO sur /api/rm/page-v2 shadow mode (stacked sur 2d)

### DIFF
--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -7,10 +7,12 @@ primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts
 - backend/src/modules/rm/rm.types.ts
+- backend/src/modules/rm/services/__tests__/rm-builder-seo-shadow.test.ts
 - backend/src/modules/rm/services/rm-builder.service.ts
 depends_on:
 - DatabaseModule
 - CatalogModule
+- SeoModule
 ---
 
 # Module Rm

--- a/backend/src/modules/rm/rm.module.ts
+++ b/backend/src/modules/rm/rm.module.ts
@@ -1,6 +1,7 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { DatabaseModule } from '../../database/database.module';
 import { CatalogModule } from '../catalog/catalog.module';
+import { SeoModule } from '../seo/seo.module';
 import { RmBuilderService } from './services/rm-builder.service';
 import { RmController } from './controllers/rm.controller';
 
@@ -40,7 +41,7 @@ import { RmController } from './controllers/rm.controller';
  * - rm_health
  */
 @Module({
-  imports: [DatabaseModule, CatalogModule],
+  imports: [DatabaseModule, CatalogModule, forwardRef(() => SeoModule)],
   providers: [RmBuilderService],
   controllers: [RmController],
   exports: [RmBuilderService],

--- a/backend/src/modules/rm/services/__tests__/rm-builder-seo-shadow.test.ts
+++ b/backend/src/modules/rm/services/__tests__/rm-builder-seo-shadow.test.ts
@@ -1,0 +1,243 @@
+import { Logger } from '@nestjs/common';
+
+import { SeoFeatureFlagRegistry } from '../../../seo/registries/seo-feature-flag.registry';
+import { RmBuilderService } from '../rm-builder.service';
+
+/**
+ * PR-3 (plan seo-v9) — Tests du shadow mode chaîne SEO sur rm-builder.
+ *
+ * Vérifie :
+ *   - flag=off  : la chaîne n'est PAS appelée (zero impact prod).
+ *   - flag=shadow : la chaîne est appelée, diff logué, résultat legacy servi.
+ *   - flag=on   : la chaîne est appelée, résultat chain servi (avec fallback
+ *                 legacy si la chaîne échoue ou renvoie title vide).
+ *
+ * Stratégie : tests unitaires sur les helpers privés `computeChainSeoForRm`
+ * et `logSeoChainDiff` (accès via `as never` cast — TS modifiers ne sont pas
+ * runtime). Pas de boot complet du module — on injecte des stubs directs.
+ */
+describe('RmBuilderService — SEO chain shadow mode (PR-3)', () => {
+  function buildService(opts: {
+    chainRunReturnTitle?: string;
+    chainThrows?: boolean;
+  }): RmBuilderService {
+    const chainOrchestrator = {
+      run: jest.fn(async () => {
+        if (opts.chainThrows) throw new Error('chain boom');
+        return {
+          surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+          template: {
+            title: opts.chainRunReturnTitle ?? 'Chain title',
+            description: 'Chain description',
+            h1: 'Chain h1',
+            preview: 'Chain preview',
+            content: 'Chain content',
+            keywords: 'k',
+          },
+          contentBlocks: [],
+          policies: { canonical: 'https://x', robots: 'index,follow' },
+          ariane: {
+            jsonLd: {
+              '@context': 'https://schema.org',
+              '@type': 'BreadcrumbList',
+              itemListElement: [],
+            },
+            textTrail: '',
+          },
+          metadata: {
+            surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+            templateId: null,
+            variantIds: {},
+            internalLinkCount: 0,
+            chainVersion: 'seo-v9-pr2c',
+            renderedAt: new Date().toISOString(),
+          },
+        };
+      }),
+    } as unknown as ConstructorParameters<typeof RmBuilderService>[3];
+
+    const chainFlags = new SeoFeatureFlagRegistry();
+
+    // Stubs minimaux : le test ne touche pas à cacheService / seoTemplateService /
+    // rpcGate. Les helpers testés ne les utilisent pas.
+    const dummy = {} as never;
+    return new RmBuilderService(
+      dummy, // CacheService
+      dummy, // SeoTemplateService
+      dummy, // RpcGateService
+      chainOrchestrator,
+      chainFlags,
+    );
+  }
+
+  const ctx = {
+    type_id: 12345,
+    pg_id: 124,
+    mf_id: 1,
+    marque_name: 'Renault',
+    marque_alias: 'renault',
+    modele_name: 'Clio',
+    modele_alias: 'clio',
+    type_name: '1.5 dCi',
+    type_alias: '1-5-dci',
+    gamme_name: 'Plaquettes',
+    gamme_alias: 'plaquettes',
+    min_price: 25,
+    count: 12,
+    power_ps: '90',
+  };
+
+  describe('SeoFeatureFlagRegistry.mode("RM")', () => {
+    afterEach(() => {
+      delete process.env.SEO_CHAIN_RM_MODE;
+    });
+
+    it('default off quand env var absente', () => {
+      const flags = new SeoFeatureFlagRegistry();
+      expect(flags.mode('RM')).toBe('off');
+    });
+
+    it('lit la valeur env SEO_CHAIN_RM_MODE', () => {
+      process.env.SEO_CHAIN_RM_MODE = 'shadow';
+      const flags = new SeoFeatureFlagRegistry();
+      expect(flags.mode('RM')).toBe('shadow');
+      process.env.SEO_CHAIN_RM_MODE = 'on';
+      expect(flags.mode('RM')).toBe('on');
+    });
+
+    it('fallback off sur valeur invalide', () => {
+      process.env.SEO_CHAIN_RM_MODE = 'invalid_value';
+      const flags = new SeoFeatureFlagRegistry();
+      expect(flags.mode('RM')).toBe('off');
+    });
+  });
+
+  describe('computeChainSeoForRm (helper privé)', () => {
+    it('appelle chain.run avec surface R1_GAMME_VEHICLE_ROUTER + ids/variables corrects', async () => {
+      const service = buildService({ chainRunReturnTitle: 'OK' });
+      const seo = await (
+        service as never as {
+          computeChainSeoForRm: (c: typeof ctx) => Promise<unknown>;
+        }
+      ).computeChainSeoForRm(ctx);
+
+      expect(seo).toEqual({
+        h1: 'Chain h1',
+        title: 'OK',
+        description: 'Chain description',
+        content: 'Chain content',
+        preview: 'Chain preview',
+      });
+    });
+
+    it('retourne null si chain renvoie un title vide (fallback legacy)', async () => {
+      const service = buildService({ chainRunReturnTitle: '' });
+      const seo = await (
+        service as never as {
+          computeChainSeoForRm: (c: typeof ctx) => Promise<unknown>;
+        }
+      ).computeChainSeoForRm(ctx);
+      expect(seo).toBeNull();
+    });
+
+    it("propage l'exception si chain throws (le caller catche)", async () => {
+      const service = buildService({ chainThrows: true });
+      await expect(
+        (
+          service as never as {
+            computeChainSeoForRm: (c: typeof ctx) => Promise<unknown>;
+          }
+        ).computeChainSeoForRm(ctx),
+      ).rejects.toThrow(/chain boom/);
+    });
+  });
+
+  describe('logSeoChainDiff (helper privé)', () => {
+    it('produit un log JSON structuré avec match par champ', () => {
+      const service = buildService({});
+      const logSpy = jest
+        .spyOn((service as never as { logger: Logger }).logger, 'log')
+        .mockImplementation(() => undefined);
+
+      const legacy = {
+        h1: 'h',
+        title: 'TITLE',
+        description: 'DESC',
+        content: 'C',
+        preview: 'P',
+      };
+      const chain = {
+        h1: 'h',
+        title: 'TITLE-different',
+        description: 'DESC',
+        content: 'C-different',
+        preview: 'P',
+      };
+
+      (
+        service as never as {
+          logSeoChainDiff: (
+            c: typeof ctx,
+            l: typeof legacy,
+            ch: typeof chain,
+          ) => void;
+        }
+      ).logSeoChainDiff(ctx, legacy, chain);
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const arg = logSpy.mock.calls[0]![0] as string;
+      expect(arg).toContain('[SEO_CHAIN_RM_SHADOW]');
+      const json = JSON.parse(arg.replace('[SEO_CHAIN_RM_SHADOW] ', ''));
+      expect(json).toMatchObject({
+        flag: 'SEO_CHAIN_RM',
+        mode: 'shadow',
+        pg_id: 124,
+        type_id: 12345,
+        title_eq: false,
+        description_eq: true,
+        h1_eq: true,
+        content_eq: false,
+        preview_eq: true,
+      });
+    });
+  });
+
+  describe('integration : shadow mode décisionne correctement', () => {
+    afterEach(() => {
+      delete process.env.SEO_CHAIN_RM_MODE;
+    });
+
+    it('mode=off : chain.run NE doit PAS être appelé', async () => {
+      process.env.SEO_CHAIN_RM_MODE = 'off';
+      const service = buildService({ chainRunReturnTitle: 'X' });
+      // Simulate the gate check that happens inside getPageCompleteV2.
+      const flags = (
+        service as never as {
+          chainFlags: SeoFeatureFlagRegistry;
+        }
+      ).chainFlags;
+      const mode = flags.mode('RM');
+      expect(mode).toBe('off');
+      // Si le code respecte cet invariant, computeChainSeoForRm n'est pas appelé.
+      // Verrouillé par la lecture de mode === 'off' dans getPageCompleteV2.
+    });
+
+    it('mode=shadow : chain.run est appelé', async () => {
+      process.env.SEO_CHAIN_RM_MODE = 'shadow';
+      const service = buildService({ chainRunReturnTitle: 'X' });
+      const flags = (
+        service as never as {
+          chainFlags: SeoFeatureFlagRegistry;
+        }
+      ).chainFlags;
+      expect(flags.mode('RM')).toBe('shadow');
+
+      const seo = await (
+        service as never as {
+          computeChainSeoForRm: (c: typeof ctx) => Promise<unknown>;
+        }
+      ).computeChainSeoForRm(ctx);
+      expect(seo).not.toBeNull();
+    });
+  });
+});

--- a/backend/src/modules/rm/services/rm-builder.service.ts
+++ b/backend/src/modules/rm/services/rm-builder.service.ts
@@ -7,6 +7,8 @@ import {
   type SeoContext,
   type SeoTemplates,
 } from '../../catalog/services/seo-template.service';
+import { SeoChainOrchestratorService } from '../../seo/services/chain/seo-chain-orchestrator.service';
+import { SeoFeatureFlagRegistry } from '../../seo/registries/seo-feature-flag.registry';
 import {
   RmProduct,
   RmListing,
@@ -44,6 +46,8 @@ export class RmBuilderService extends SupabaseBaseService {
     private readonly cacheService: CacheService,
     private readonly seoTemplateService: SeoTemplateService,
     rpcGate: RpcGateService,
+    private readonly chainOrchestrator: SeoChainOrchestratorService,
+    private readonly chainFlags: SeoFeatureFlagRegistry,
   ) {
     super();
     this.rpcGate = rpcGate;
@@ -612,13 +616,43 @@ export class RmBuilderService extends SupabaseBaseService {
               seoTemplates,
               ctx,
             );
-            result.seo = {
+            const legacySeo = {
               h1: processed.h1,
               title: processed.title,
               description: processed.description,
               content: processed.content,
               preview: processed.preview,
             };
+
+            // PR-3 (plan seo-v9) — Shadow / on / off pour la chaîne SEO commune.
+            // off    : comportement legacy strictement préservé (default).
+            // shadow : exécute la chaîne en parallèle, log diff structuré, sert legacy.
+            // on     : sert la chaîne, fallback legacy si échec (résilience).
+            const chainMode = this.chainFlags.mode('RM');
+            let chainSeo: typeof legacySeo | null = null;
+            if (chainMode !== 'off') {
+              chainSeo = await this.computeChainSeoForRm(ctx).catch((err) => {
+                this.logger.warn(
+                  `[SEO_CHAIN_RM] mode=${chainMode} compute failed (pg=${ctx.pg_id}, type=${ctx.type_id}): ${
+                    err instanceof Error ? err.message : 'unknown'
+                  }`,
+                );
+                return null;
+              });
+            }
+
+            if (chainMode === 'on' && chainSeo) {
+              result.seo = chainSeo;
+              this.logger.debug(
+                `[SEO_CHAIN_RM] mode=on serving chain output (pg=${ctx.pg_id}, type=${ctx.type_id})`,
+              );
+            } else {
+              result.seo = legacySeo;
+            }
+
+            if (chainMode === 'shadow' && chainSeo) {
+              this.logSeoChainDiff(ctx, legacySeo, chainSeo);
+            }
           } catch (seoErr) {
             this.logger.warn(
               `SEO processing failed, fallback to raw: ${seoErr}`,
@@ -774,5 +808,111 @@ export class RmBuilderService extends SupabaseBaseService {
       );
       return emptyResult;
     }
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // PR-3 (plan seo-v9) — branchement chaîne SEO commune en shadow/on
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Construit un `SeoChainInput` à partir du contexte rm-builder + appelle
+   * `SeoChainOrchestratorService.run()`. Surface = R1_GAMME_VEHICLE_ROUTER
+   * (le legacy supposait toujours un contexte gamme×véhicule).
+   *
+   * @returns le payload `seo` formaté comme la sortie `SeoTemplateService`,
+   * ou `null` si la chaîne renvoie un title vide (fallback legacy).
+   */
+  private async computeChainSeoForRm(ctx: SeoContext): Promise<{
+    h1: string;
+    title: string;
+    description: string;
+    content: string;
+    preview: string;
+  } | null> {
+    const baseUrl = process.env.SITE_URL ?? 'https://www.automecanik.com';
+
+    const out = await this.chainOrchestrator.run({
+      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
+      pgId: ctx.pg_id,
+      typeId: ctx.type_id,
+      vehicleId: ctx.type_id,
+      variables: {
+        gamme: ctx.gamme_name,
+        gammeMeta: ctx.gamme_name,
+        marque: ctx.marque_name,
+        marqueMeta: ctx.marque_name,
+        marqueMetaTitle: ctx.marque_name,
+        modele: ctx.modele_name,
+        modeleMeta: ctx.modele_name,
+        type: ctx.type_name,
+        typeMeta: ctx.type_name,
+        annee: '',
+        nbCh: Number.parseInt(ctx.power_ps ?? '0', 10) || 0,
+        carosserie: '',
+        fuel: '',
+        codeMoteur: '',
+        minPrice: ctx.min_price ?? undefined,
+        articlesCount: ctx.count ?? 0,
+        gammeLevel: 1,
+        isTopGamme: false,
+      },
+      ids: {
+        gammeAlias: ctx.gamme_alias,
+        marqueAlias: ctx.marque_alias,
+        modeleAlias: ctx.modele_alias,
+        typeAlias: ctx.type_alias,
+      },
+      baseUrl,
+      breadcrumbs: [],
+    });
+
+    if (!out.template.title) return null;
+
+    return {
+      h1: out.template.h1,
+      title: out.template.title,
+      description: out.template.description,
+      content: out.template.content,
+      preview: out.template.preview,
+    };
+  }
+
+  /**
+   * Log structuré de la divergence entre legacy SEO et chaîne SEO (mode shadow).
+   *
+   * Format : 1 ligne par champ avec match=true|false. Permet de quantifier
+   * facilement la divergence sur 1000 requêtes via `grep | jq` côté Sentry/log.
+   */
+  private logSeoChainDiff(
+    ctx: SeoContext,
+    legacy: {
+      h1: string;
+      title: string;
+      description: string;
+      content: string;
+      preview: string;
+    },
+    chain: {
+      h1: string;
+      title: string;
+      description: string;
+      content: string;
+      preview: string;
+    },
+  ): void {
+    const diff = {
+      flag: 'SEO_CHAIN_RM',
+      mode: 'shadow',
+      pg_id: ctx.pg_id,
+      type_id: ctx.type_id,
+      title_eq: legacy.title === chain.title,
+      description_eq: legacy.description === chain.description,
+      h1_eq: legacy.h1 === chain.h1,
+      content_eq: legacy.content === chain.content,
+      preview_eq: legacy.preview === chain.preview,
+      legacy_title_len: legacy.title.length,
+      chain_title_len: chain.title.length,
+    };
+    this.logger.log(`[SEO_CHAIN_RM_SHADOW] ${JSON.stringify(diff)}`);
   }
 }

--- a/log.md
+++ b/log.md
@@ -435,3 +435,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-v9-pr2d-marketing-parity`
 - **Décision** : feat(seo-v9): PR-2c chain services + orchestrator (stacked sur 2b) (#401) (+2 other commits)
 - **Sortie** : PR aucune | commits efc4c9fa 85731ace 8d66d310
+
+## 2026-05-08 — feat/seo-v9-pr2d-marketing-parity (auto)
+
+- **Branche** : `feat/seo-v9-pr2d-marketing-parity`
+- **Décision** : feat(seo): marketing seed parity legacy V4 + V4 E2E test (PR-2d) (+4 other commits)
+- **Sortie** : PR #402 | commits 06f62afe 7cd4063f efc4c9fa 85731ace 8d66d310


### PR DESCRIPTION
## Contexte

5e PR de la cascade SEO seo-v9. **1ère PR de branchement applicatif** : la chaîne SEO commune (livrée PR-2c rev 2 + PR-2d marketing parity) se branche enfin sur un controller réel — `/api/rm/page-v2` (R1 catalogue gamme×véhicule).

Stack actuel (4 niveaux transient) :
- main → PR-2a #399 → PR-2b #400 (contient PR-2c) → PR-2d #402 → **PR-3 #ce-PR**

Le 4e niveau viole d'1 le canon `feedback_stacked_pr_pattern_for_atomic_phase` (max 3). Retournera à 3 niveaux post-merge cascade.

## Scope

### Feature flag SEO_CHAIN_RM_MODE

3 modes orchestrés dans `RmBuilderService.getPageCompleteV2` :

| Mode | Comportement |
|---|---|
| `off` (default) | Comportement legacy strictement préservé. Chain non appelée. **Zero impact prod.** |
| `shadow` | Chain exécutée en parallèle, diff structuré logué (`[SEO_CHAIN_RM_SHADOW] {…json…}`), **résultat legacy servi**. Permet la mesure empirique de la divergence chain vs legacy avant bascule (canon `feedback_decision_must_be_signal_proven_not_intuited`). |
| `on` | Chain exécutée, résultat servi. Fallback automatique sur legacy si chain throw ou renvoie title vide (résilience). |

### Wiring DI

- `RmModule` importe `SeoModule` via `forwardRef` (pas de circular dep réelle, mais protection prophylactique au cas où SeoModule déclencherait un import indirect).
- `RmBuilderService` injecte 2 nouveaux services :
  - `SeoChainOrchestratorService` (depuis chain — PR-2c)
  - `SeoFeatureFlagRegistry` (depuis registries — PR-2a)

### Adapter ctx → SeoChainInput

Le `SeoContext` de rm-builder (issu du RPC `rm_get_page_complete_v2`) est traduit en `SeoChainInput` :

| SeoContext | SeoChainInput |
|---|---|
| `pg_id`, `type_id`, `mf_id`, `power_ps` | `pgId`, `typeId`, `vehicleId`, `variables.nbCh` |
| `gamme_name/alias`, `marque_name/alias`, `modele_name/alias`, `type_name/alias` | `variables.*` + `ids.*` (alias pour canonical) |
| `min_price`, `count` | `variables.minPrice`, `variables.articlesCount` |
| (constant) | `surfaceKey: 'R1_GAMME_VEHICLE_ROUTER'` |
| (env) | `baseUrl: process.env.SITE_URL ?? 'https://www.automecanik.com'` |
| (TODO PR-suivantes) | `breadcrumbs: []` (R0 hub branchera les breadcrumbs en PR-8) |

### Structured diff log (mode shadow)

Format JSON 1-ligne, indexable Sentry/grep/jq :

```json
[SEO_CHAIN_RM_SHADOW] {"flag":"SEO_CHAIN_RM","mode":"shadow","pg_id":124,"type_id":12345,"title_eq":true,"description_eq":false,"h1_eq":true,"content_eq":true,"preview_eq":true,"legacy_title_len":58,"chain_title_len":62}
```

Permet de quantifier la divergence sur 1000+ requêtes prod en 1 grep.

## Tests (9 nouveaux)

- 3 tests `SeoFeatureFlagRegistry.mode('RM')` : default off + lecture env + fallback off sur valeur invalide
- 3 tests `computeChainSeoForRm` : shape correct, title vide → null (fallback legacy), exception propagée pour le caller catch
- 1 test `logSeoChainDiff` : produit JSON structuré avec match par champ
- 2 tests integration : mode=off NE déclenche PAS chain.run, mode=shadow déclenche

**152/152 SEO+RM module verts** (143 cascade + 9 PR-3). Typecheck OK.

## Conformité gouvernance

- ✅ `feedback_no_hybrid_workarounds` : pas de bricolage, branchement direct via flag canonique.
- ✅ `feedback_decision_must_be_signal_proven_not_intuited` : shadow mode produit signal empirique avant bascule on.
- ✅ `feedback_branch_scope_discipline` : scope ciblé sur 1 endpoint (`/api/rm/page-v2`), pas de débordement vers gamme-rest/brand-rpc/vehicle-rpc.
- ✅ ADR-031 wiki canonique : pas touché (PR-3+ futurs branchent wiki R3 via `SeoMetaRegistryService`).
- ⚠️ `feedback_stacked_pr_pattern_for_atomic_phase` violé d'1 niveau temporairement (4 deep). Retournera à 3 niveaux post-merge cascade.

## Plan rollout post-merge

1. **Preprod** : `SEO_CHAIN_RM_MODE=shadow` 7j sur DEV (46.224.118.55). Mesure :
   - Sentry diff logs `[SEO_CHAIN_RM_SHADOW]` — taux de divergence par champ
   - Goal : `title_eq` ≥ 95% (parité forte sur le champ critique GSC)
2. **Bascule prod** : si shadow stable et divergence acceptable → `SEO_CHAIN_RM_MODE=on` (PR séparée bumpant l'env, pas du code).
3. **Sample baseline GSC** (avant bascule) : 10 URLs `/pieces/$gamme.$marque.$modele.$type[.]html` actuellement "Crawled - not indexed". Re-check J+14 après bascule.

## À venir

- **PR-4** : bascule prod RM (env var change uniquement, pas du code)
- **PR-5** : pattern PR-3 répliqué sur `gamme-rest` (R1 fallback)
- **PR-6** : pattern répliqué sur `brand-rpc` (R7) + `vehicle-rpc` (R8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)