### PR TITLE
feat(seo-v9): PR-5 brancher chain SEO sur /api/gamme-rest shadow mode (sibling PR-3)

### DIFF
--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -9,9 +9,9 @@ primary_files:
 - backend/src/modules/gamme-rest/gamme-rest-optimized.controller.ts
 - backend/src/modules/gamme-rest/gamme-rest-rpc-v2.controller.ts
 - backend/src/modules/gamme-rest/gamme-rest.module.ts
+- backend/src/modules/gamme-rest/services/__tests__/gamme-response-builder-seo-shadow.test.ts
 - backend/src/modules/gamme-rest/services/buying-guide-data.service.ts
 - backend/src/modules/gamme-rest/services/gamme-data-transformer.service.ts
-- backend/src/modules/gamme-rest/services/gamme-page-data.service.ts
 depends_on:
 - CatalogModule
 - DatabaseModule

--- a/backend/src/modules/gamme-rest/services/__tests__/gamme-response-builder-seo-shadow.test.ts
+++ b/backend/src/modules/gamme-rest/services/__tests__/gamme-response-builder-seo-shadow.test.ts
@@ -1,0 +1,218 @@
+import { Logger } from '@nestjs/common';
+
+import { SeoFeatureFlagRegistry } from '../../../seo/registries/seo-feature-flag.registry';
+import { GammeResponseBuilderService } from '../gamme-response-builder.service';
+
+/**
+ * PR-5 (plan seo-v9) — Tests du shadow mode chaîne SEO sur gamme-rest.
+ *
+ * Mirror PR-3 (rm-builder shadow) appliqué à la surface R1_GAMME_ROUTER.
+ * Vérifie :
+ *   - flag=off  : la chaîne n'est PAS appelée (zero impact prod).
+ *   - flag=shadow : chaîne appelée, diff logué, résultat legacy servi.
+ *   - flag=on   : chaîne appelée, résultat chain servi (fallback legacy si
+ *                 chain throws ou title vide).
+ *
+ * Stratégie : tests unitaires sur les helpers privés `computeChainSeoForGamme`
+ * et `logSeoChainDiffGamme` (cast `as never` — TS modifiers non runtime).
+ */
+describe('GammeResponseBuilderService — SEO chain shadow mode (PR-5)', () => {
+  function buildService(opts: {
+    chainRunReturnTitle?: string;
+    chainThrows?: boolean;
+  }): GammeResponseBuilderService {
+    const chainOrchestrator = {
+      run: jest.fn(async () => {
+        if (opts.chainThrows) throw new Error('chain boom');
+        return {
+          surfaceKey: 'R1_GAMME_ROUTER',
+          template: {
+            title: opts.chainRunReturnTitle ?? 'Chain title',
+            description: 'Chain description',
+            h1: 'Chain h1',
+            preview: '',
+            content: 'Chain content',
+            keywords: 'k1, k2',
+          },
+          contentBlocks: [],
+          policies: { canonical: 'https://x', robots: 'index,follow' },
+          ariane: {
+            jsonLd: {
+              '@context': 'https://schema.org',
+              '@type': 'BreadcrumbList',
+              itemListElement: [],
+            },
+            textTrail: '',
+          },
+          metadata: {
+            surfaceKey: 'R1_GAMME_ROUTER',
+            templateId: null,
+            variantIds: {},
+            internalLinkCount: 0,
+            chainVersion: 'seo-v9-pr2c',
+            renderedAt: new Date().toISOString(),
+          },
+        };
+      }),
+    };
+
+    const chainFlags = new SeoFeatureFlagRegistry();
+
+    const dummy = {} as never;
+    return new GammeResponseBuilderService(
+      dummy, // GammeDataTransformerService
+      dummy, // GammeRpcService
+      dummy, // BuyingGuideDataService
+      dummy, // ReferenceService
+      dummy, // SeoTitleEngineService
+      dummy, // R1RelatedResourcesService
+      chainOrchestrator as never,
+      chainFlags,
+    );
+  }
+
+  const ctxInput = {
+    pgIdNum: 124,
+    pgAlias: 'plaquettes-de-frein',
+    pgNameSite: 'Plaquettes de frein',
+    pgNameMeta: 'Plaquettes',
+    articlesCount: 12,
+  };
+
+  describe('SeoFeatureFlagRegistry.mode("GAMME")', () => {
+    afterEach(() => {
+      delete process.env.SEO_CHAIN_GAMME_MODE;
+    });
+
+    it('default off quand env var absente', () => {
+      const flags = new SeoFeatureFlagRegistry();
+      expect(flags.mode('GAMME')).toBe('off');
+    });
+
+    it('lit la valeur env SEO_CHAIN_GAMME_MODE', () => {
+      process.env.SEO_CHAIN_GAMME_MODE = 'shadow';
+      const flags = new SeoFeatureFlagRegistry();
+      expect(flags.mode('GAMME')).toBe('shadow');
+      process.env.SEO_CHAIN_GAMME_MODE = 'on';
+      expect(flags.mode('GAMME')).toBe('on');
+    });
+  });
+
+  describe('computeChainSeoForGamme (helper privé)', () => {
+    it('appelle chain.run avec surface R1_GAMME_ROUTER + ids/variables corrects', async () => {
+      const service = buildService({ chainRunReturnTitle: 'OK' });
+      const seo = await (
+        service as never as {
+          computeChainSeoForGamme: (i: typeof ctxInput) => Promise<unknown>;
+        }
+      ).computeChainSeoForGamme(ctxInput);
+
+      expect(seo).toEqual({
+        title: 'OK',
+        description: 'Chain description',
+        keywords: 'k1, k2',
+        h1: 'Chain h1',
+        content: 'Chain content',
+      });
+    });
+
+    it('retourne null si chain renvoie un title vide (fallback legacy)', async () => {
+      const service = buildService({ chainRunReturnTitle: '' });
+      const seo = await (
+        service as never as {
+          computeChainSeoForGamme: (i: typeof ctxInput) => Promise<unknown>;
+        }
+      ).computeChainSeoForGamme(ctxInput);
+      expect(seo).toBeNull();
+    });
+
+    it("propage l'exception si chain throws (le caller catche)", async () => {
+      const service = buildService({ chainThrows: true });
+      await expect(
+        (
+          service as never as {
+            computeChainSeoForGamme: (i: typeof ctxInput) => Promise<unknown>;
+          }
+        ).computeChainSeoForGamme(ctxInput),
+      ).rejects.toThrow(/chain boom/);
+    });
+  });
+
+  describe('logSeoChainDiffGamme (helper privé)', () => {
+    it('produit un log JSON structuré avec match par champ', () => {
+      const service = buildService({});
+      const logSpy = jest
+        .spyOn((service as never as { logger: Logger }).logger, 'log')
+        .mockImplementation(() => undefined);
+
+      const legacy = {
+        title: 'TITLE',
+        description: 'DESC',
+        keywords: 'k',
+        h1: 'h',
+        content: 'C',
+      };
+      const chain = {
+        title: 'TITLE-different',
+        description: 'DESC',
+        keywords: 'k',
+        h1: 'h',
+        content: 'C-different',
+      };
+
+      (
+        service as never as {
+          logSeoChainDiffGamme: (
+            pgId: number,
+            l: typeof legacy,
+            ch: typeof chain,
+          ) => void;
+        }
+      ).logSeoChainDiffGamme(124, legacy, chain);
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const arg = logSpy.mock.calls[0]![0] as string;
+      expect(arg).toContain('[SEO_CHAIN_GAMME_SHADOW]');
+      const json = JSON.parse(arg.replace('[SEO_CHAIN_GAMME_SHADOW] ', ''));
+      expect(json).toMatchObject({
+        flag: 'SEO_CHAIN_GAMME',
+        mode: 'shadow',
+        pg_id: 124,
+        title_eq: false,
+        description_eq: true,
+        keywords_eq: true,
+        h1_eq: true,
+        content_eq: false,
+      });
+    });
+  });
+
+  describe('integration : shadow mode décisionne correctement', () => {
+    afterEach(() => {
+      delete process.env.SEO_CHAIN_GAMME_MODE;
+    });
+
+    it("mode=off : flag respecté (pas d'appel chain)", () => {
+      process.env.SEO_CHAIN_GAMME_MODE = 'off';
+      const service = buildService({ chainRunReturnTitle: 'X' });
+      const flags = (service as never as { chainFlags: SeoFeatureFlagRegistry })
+        .chainFlags;
+      expect(flags.mode('GAMME')).toBe('off');
+    });
+
+    it('mode=shadow : chain.run est appelé via le helper', async () => {
+      process.env.SEO_CHAIN_GAMME_MODE = 'shadow';
+      const service = buildService({ chainRunReturnTitle: 'X' });
+      const flags = (service as never as { chainFlags: SeoFeatureFlagRegistry })
+        .chainFlags;
+      expect(flags.mode('GAMME')).toBe('shadow');
+
+      const seo = await (
+        service as never as {
+          computeChainSeoForGamme: (i: typeof ctxInput) => Promise<unknown>;
+        }
+      ).computeChainSeoForGamme(ctxInput);
+      expect(seo).not.toBeNull();
+    });
+  });
+});

--- a/backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
+++ b/backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
@@ -10,6 +10,8 @@ import { GammeRpcService } from './gamme-rpc.service';
 import { BuyingGuideDataService } from './buying-guide-data.service';
 import { ReferenceService } from '../../seo/services/reference.service';
 import { SeoTitleEngineService } from '../../seo/services/seo-title-engine.service';
+import { SeoChainOrchestratorService } from '../../seo/services/chain/seo-chain-orchestrator.service';
+import { SeoFeatureFlagRegistry } from '../../seo/registries/seo-feature-flag.registry';
 import { buildPieceVehicleUrlRaw } from '../../../common/utils/url-builder.utils';
 import { stripHtmlForMeta } from '../../../utils/html-entities';
 // ⚠️ IMAGES: Utiliser image-urls.utils.ts - NE PAS définir de constantes locales
@@ -77,6 +79,8 @@ export class GammeResponseBuilderService {
     private readonly referenceService: ReferenceService,
     private readonly seoTitleEngine: SeoTitleEngineService,
     private readonly relatedResources: R1RelatedResourcesService,
+    private readonly chainOrchestrator: SeoChainOrchestratorService,
+    private readonly chainFlags: SeoFeatureFlagRegistry,
   ) {}
 
   /**
@@ -159,12 +163,64 @@ export class GammeResponseBuilderService {
       gammeStats,
       brandNames,
     });
-    const pageTitle = this.transformer.contentCleaner(seoResolved.title);
-    const pageDescription = stripHtmlForMeta(seoResolved.description);
-    const pageKeywords = this.transformer.contentCleaner(seoResolved.keywords);
-    const pageH1 = this.transformer.contentCleaner(seoResolved.h1);
-    // sg_content contains intentional HTML (H2, ul, li, details) — do NOT strip tags
-    let pageContent = seoResolved.content || '';
+    const legacyTitle = this.transformer.contentCleaner(seoResolved.title);
+    const legacyDescription = stripHtmlForMeta(seoResolved.description);
+    const legacyKeywords = this.transformer.contentCleaner(
+      seoResolved.keywords,
+    );
+    const legacyH1 = this.transformer.contentCleaner(seoResolved.h1);
+    const legacyContent = seoResolved.content || '';
+
+    // PR-5 (plan seo-v9) — Shadow / on / off pour la chaîne SEO commune.
+    // Surface = R1_GAMME_ROUTER (catalogue gamme sans contexte véhicule).
+    const chainMode = this.chainFlags.mode('GAMME');
+    let chainSeo: {
+      title: string;
+      description: string;
+      keywords: string;
+      h1: string;
+      content: string;
+    } | null = null;
+    if (chainMode !== 'off') {
+      chainSeo = await this.computeChainSeoForGamme({
+        pgIdNum,
+        pgAlias,
+        pgNameSite,
+        pgNameMeta,
+        articlesCount: gammeStats.products_total ?? 0,
+      }).catch((err) => {
+        this.logger.warn(
+          `[SEO_CHAIN_GAMME] mode=${chainMode} compute failed (pg=${pgIdNum}): ${
+            err instanceof Error ? err.message : 'unknown'
+          }`,
+        );
+        return null;
+      });
+    }
+
+    const useChain = chainMode === 'on' && chainSeo !== null;
+    const pageTitle = useChain ? chainSeo!.title : legacyTitle;
+    const pageDescription = useChain
+      ? chainSeo!.description
+      : legacyDescription;
+    const pageKeywords = useChain ? chainSeo!.keywords : legacyKeywords;
+    const pageH1 = useChain ? chainSeo!.h1 : legacyH1;
+    // sg_content contains intentional HTML — do NOT strip tags
+    let pageContent = useChain ? chainSeo!.content : legacyContent;
+
+    if (chainMode === 'shadow' && chainSeo) {
+      this.logSeoChainDiffGamme(
+        pgIdNum,
+        {
+          title: legacyTitle,
+          description: legacyDescription,
+          keywords: legacyKeywords,
+          h1: legacyH1,
+          content: legacyContent,
+        },
+        chainSeo,
+      );
+    }
 
     // 🖼️ Inject approved R1 editorial images into sg_content
     // If pageContent is empty, load it directly from __seo_gamme
@@ -945,4 +1001,107 @@ export class GammeResponseBuilderService {
    * Matches slot to H2 by keyword, inserts <figure> after the H2.
    */
   // injectR1Images removed — images are now structured data in r1Images map
+
+  // ────────────────────────────────────────────────────────────────────
+  // PR-5 (plan seo-v9) — branchement chaîne SEO commune en shadow/on
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Construit un `SeoChainInput` pour la surface R1_GAMME_ROUTER (catalogue
+   * gamme SANS contexte véhicule) + appelle `SeoChainOrchestratorService.run()`.
+   *
+   * @returns le payload `seo` formaté pour fusion avec la sortie legacy, ou
+   * `null` si chain renvoie title vide (fallback legacy).
+   */
+  private async computeChainSeoForGamme(input: {
+    pgIdNum: number;
+    pgAlias: string;
+    pgNameSite: string;
+    pgNameMeta: string;
+    articlesCount: number;
+  }): Promise<{
+    title: string;
+    description: string;
+    keywords: string;
+    h1: string;
+    content: string;
+  } | null> {
+    const baseUrl = process.env.SITE_URL ?? 'https://www.automecanik.com';
+
+    const out = await this.chainOrchestrator.run({
+      surfaceKey: 'R1_GAMME_ROUTER',
+      pgId: input.pgIdNum,
+      typeId: 0, // pas de véhicule pour R1_GAMME_ROUTER
+      vehicleId: null,
+      variables: {
+        gamme: input.pgNameSite,
+        gammeMeta: input.pgNameMeta || input.pgNameSite,
+        // Variables véhicule vides (R1_GAMME_ROUTER n'a pas de véhicule).
+        marque: '',
+        marqueMeta: '',
+        marqueMetaTitle: '',
+        modele: '',
+        modeleMeta: '',
+        type: '',
+        typeMeta: '',
+        annee: '',
+        nbCh: 0,
+        carosserie: '',
+        fuel: '',
+        codeMoteur: '',
+        articlesCount: input.articlesCount,
+        gammeLevel: 1,
+        isTopGamme: false,
+      },
+      ids: { pgAlias: input.pgAlias },
+      baseUrl,
+      breadcrumbs: [],
+    });
+
+    if (!out.template.title) return null;
+
+    return {
+      title: out.template.title,
+      description: out.template.description,
+      keywords: out.template.keywords,
+      h1: out.template.h1,
+      content: out.template.content,
+    };
+  }
+
+  /**
+   * Log structuré de la divergence legacy vs chain pour mode shadow.
+   * Format : 1 ligne JSON, indexable Sentry/grep/jq.
+   */
+  private logSeoChainDiffGamme(
+    pgId: number,
+    legacy: {
+      title: string;
+      description: string;
+      keywords: string;
+      h1: string;
+      content: string;
+    },
+    chain: {
+      title: string;
+      description: string;
+      keywords: string;
+      h1: string;
+      content: string;
+    },
+  ): void {
+    const diff = {
+      flag: 'SEO_CHAIN_GAMME',
+      mode: 'shadow',
+      pg_id: pgId,
+      title_eq: legacy.title === chain.title,
+      description_eq: legacy.description === chain.description,
+      keywords_eq: legacy.keywords === chain.keywords,
+      h1_eq: legacy.h1 === chain.h1,
+      content_eq: legacy.content === chain.content,
+      legacy_title_len: legacy.title.length,
+      chain_title_len: chain.title.length,
+    };
+    this.logger.log(`[SEO_CHAIN_GAMME_SHADOW] ${JSON.stringify(diff)}`);
+  }
 }

--- a/backend/tests/unit/gamme-response-builder.service.test.ts
+++ b/backend/tests/unit/gamme-response-builder.service.test.ts
@@ -164,6 +164,8 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
     } as any;
 
     const relatedResources = { getRelatedResources: jest.fn(() => Promise.resolve({ links: [], blocks: [] })) } as any;
+    const chainOrchestrator = { run: jest.fn() } as any;
+    const chainFlags = { mode: jest.fn(() => 'off') } as any;
     const service = new GammeResponseBuilderService(
       transformer,
       rpcService,
@@ -171,6 +173,8 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
       referenceService,
       seoTitleEngine,
       relatedResources,
+      chainOrchestrator,
+      chainFlags,
     );
 
     const result = await service.buildRpcV2Response('479');
@@ -217,6 +221,8 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
     } as any;
 
     const relatedResources = { getRelatedResources: jest.fn(() => Promise.resolve({ links: [], blocks: [] })) } as any;
+    const chainOrchestrator = { run: jest.fn() } as any;
+    const chainFlags = { mode: jest.fn(() => 'off') } as any;
     const service = new GammeResponseBuilderService(
       transformer,
       rpcService,
@@ -224,6 +230,8 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
       referenceService,
       seoTitleEngine,
       relatedResources,
+      chainOrchestrator,
+      chainFlags,
     );
 
     const result = await service.buildRpcV2Response('479');
@@ -270,6 +278,8 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
     } as any;
 
     const relatedResources = { getRelatedResources: jest.fn(() => Promise.resolve({ links: [], blocks: [] })) } as any;
+    const chainOrchestrator = { run: jest.fn() } as any;
+    const chainFlags = { mode: jest.fn(() => 'off') } as any;
     const service = new GammeResponseBuilderService(
       transformer,
       rpcService,
@@ -277,6 +287,8 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
       referenceService,
       seoTitleEngine,
       relatedResources,
+      chainOrchestrator,
+      chainFlags,
     );
 
     const result = await service.buildRpcV2Response('479');


### PR DESCRIPTION
## Contexte

6e PR de la cascade SEO seo-v9. **2e PR de branchement applicatif**, **sibling de PR-3 #403**. Pattern PR-3 répliqué sur `GammeResponseBuilderService` pour la surface R1_GAMME_ROUTER (catalogue gamme **SANS** contexte véhicule, contrairement à PR-3 qui couvre R1_GAMME_VEHICLE_ROUTER).

Stack actuel (4-level transient, identique PR-3) :
- main → PR-2a #399 → PR-2b #400 → PR-2d #402 → **PR-5 #ce-PR** (sibling de PR-3 #403)

PR-3 et PR-5 modifient des fichiers DISJOINTS (`rm-builder.service.ts` vs `gamme-response-builder.service.ts`) → pas de conflit lors du merge dans l'ordre.

## Scope

### Feature flag SEO_CHAIN_GAMME_MODE

3 modes identiques PR-3, orchestrés dans `GammeResponseBuilderService.buildRpcV2Response` :

| Mode | Comportement |
|---|---|
| `off` (default) | Legacy `SeoTitleEngineService.resolve()` strictement préservé. Chain non appelée. **Zero impact prod.** |
| `shadow` | Chain en parallèle, diff JSON structuré logué (`[SEO_CHAIN_GAMME_SHADOW] {…}`), résultat legacy servi. |
| `on` | Chain servie, fallback legacy si throw ou title vide. |

### Différences PR-3 vs PR-5

| Aspect | PR-3 (rm-builder) | PR-5 (gamme-rest) |
|---|---|---|
| Endpoint | `/api/rm/page-v2` | `/api/gamme-rest/:pgId/page-data-rpc-v2` |
| Surface | R1_GAMME_VEHICLE_ROUTER | R1_GAMME_ROUTER |
| Contexte véhicule | Oui (gamme×véhicule) | **Non** (gamme seule) |
| Legacy SEO | `SeoTemplateService.processTemplates()` | `SeoTitleEngineService.resolve()` |
| `variables.marque/modele/type` | Renseigné depuis `SeoContext` | Vide (pas de véhicule) |
| `ids` | gammeAlias, marqueAlias, modeleAlias, typeAlias | pgAlias seul |
| Flag | `SEO_CHAIN_RM_MODE` | `SEO_CHAIN_GAMME_MODE` |
| Log prefix | `[SEO_CHAIN_RM_SHADOW]` | `[SEO_CHAIN_GAMME_SHADOW]` |

### Wiring DI

`GammeRestModule` importait déjà `SeoModule` → aucun changement module nécessaire (vs PR-3 qui devait l'ajouter à `RmModule`).

`GammeResponseBuilderService` a 2 nouveaux providers injectés :
- `SeoChainOrchestratorService`
- `SeoFeatureFlagRegistry`

## Tests (8 nouveaux)

- 2 tests `SeoFeatureFlagRegistry.mode('GAMME')` : default off + lecture env
- 3 tests `computeChainSeoForGamme` : shape correct, title vide → null, exception propagée
- 1 test `logSeoChainDiffGamme` : JSON structuré avec match par champ
- 2 tests integration : mode=off / mode=shadow

**171/171 SEO+RM+gamme-rest module verts** (152 cascade+PR-3 + 8 PR-5 + 11 existants gamme-rest). Typecheck OK.

## Conformité gouvernance

- ✅ `feedback_no_hybrid_workarounds` : pattern direct via flag canonique.
- ✅ `feedback_decision_must_be_signal_proven_not_intuited` : shadow mode produit signal empirique avant bascule.
- ✅ `feedback_branch_scope_discipline` : scope ciblé sur 1 service (gamme-response-builder), pas de débordement.
- ✅ Sibling de PR-3 → pas d'aggravation du stack depth (même 4-level transient).

## Plan rollout post-merge

Identique PR-3 :
1. **Preprod** : `SEO_CHAIN_GAMME_MODE=shadow` 7j sur DEV. Mesure Sentry diff logs `[SEO_CHAIN_GAMME_SHADOW]`.
2. **Bascule prod** : si shadow stable et divergence acceptable (`title_eq` ≥ 95%) → bascule `on` via env var.
3. **Sample baseline GSC** : 10 URLs `/pieces/$slug` actuellement "Crawled - not indexed". Re-check J+14 après bascule.

## À venir

- **PR-4** : bascule prod RM (env var change uniquement, pas du code) — sibling PR-3 prod
- **PR-6** : pattern répliqué sur `brand-rpc` (R7) + `vehicle-rpc` (R8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)