### PR TITLE
feat(seo-v9): PR-6 SeoShadowObservatory module + R7/R8 shadow (sibling PR-3/PR-5)

### DIFF
--- a/.ast-grep/rules/seo-shadow-no-await.yml
+++ b/.ast-grep/rules/seo-shadow-no-await.yml
@@ -1,0 +1,33 @@
+id: seo-shadow-no-await
+language: typescript
+severity: error
+message: |
+  Ne JAMAIS `await` un appel à `<...>.observe(...)` du `SeoShadowObservatory`.
+
+  L'API `observe()` est SYNCHRONE par contrat — elle valide l'input via Zod,
+  consulte le sampler/breaker, puis dispatche le travail réel via
+  `setImmediate(() => runComparison(...))`. La non-bloquance du chemin
+  réponse HTTP en dépend. Un `await` accidentel (a) annule le bénéfice du
+  setImmediate et (b) propage une erreur potentielle au caller — ce qui peut
+  faire crasher la requête HTTP servie en legacy intact.
+
+  Pattern correct :
+      this.shadowObservatory.observe({ surface: 'R7_BRAND_HUB', ... });
+      return brandPayload;
+
+  Pattern interdit :
+      await this.shadowObservatory.observe({ ... });   // ❌
+      void this.shadowObservatory.observe({ ... });    // ❌ (inutile, déjà sync)
+
+  Voir plan seo-v9 PR-6 §4.1 + §5.4b + ADR-054 (à ouvrir post-merge).
+files:
+  - backend/src/**/*.ts
+ignores:
+  - backend/src/**/*.spec.ts
+  - backend/src/**/*.e2e-spec.ts
+  - backend/src/**/test-*.ts
+rule:
+  any:
+    - pattern: await $X.shadowObservatory.observe($$$)
+    - pattern: await this.shadowObservatory.observe($$$)
+    - pattern: await $X.shadowObservatory.observe($$$).$M($$$)

--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -15,6 +15,7 @@ primary_files:
 depends_on:
 - ConfigModule
 - DatabaseModule
+- SeoShadowObservatoryModule
 - CatalogModule
 - CacheModule
 ---

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-08'
+last_scan: '2026-05-09'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/.github/workflows/seo-shadow-flag-guard.yml
+++ b/.github/workflows/seo-shadow-flag-guard.yml
@@ -1,0 +1,41 @@
+name: SEO shadow flag guard
+
+# Defense-in-depth (cf. plan seo-v9 PR-6 §5.4 + §4.7) :
+#   - Boot guard Zod refuse `mode=on` au démarrage NestJS.
+#   - Cette CI rule refuse qu'`SEO_CHAIN_R<n>_MODE=on` apparaisse dans la
+#     config commit (env files, docker-compose, autres workflows, secrets).
+#   - ADR-054 (à ouvrir post-merge) formalise le sign-off pour le flip futur.
+#
+# Les trois couches sont indépendantes — il faut trois modifications coordonnées
+# (code + ADR + ENV) pour activer `on` en prod.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  no-mode-on-in-config:
+    name: Refuser SEO_CHAIN_R*_MODE=on dans la config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan config files
+        run: |
+          set -e
+          echo "🔎 Recherche d'un flip mode=on commité accidentellement…"
+          # `|| true` : grep retourne 1 si pas de match — c'est le cas vouluo.
+          MATCHES=$(grep -RInE "SEO_CHAIN_R[0-9]+_MODE=on" \
+              .env* docker-compose*.y*ml .github/workflows/ secrets/ 2>/dev/null \
+              | grep -v ":[[:space:]]*#" || true)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::Flip mode=on détecté en config — interdit en PR-6 (cf. ADR-054 governance-vault)."
+            echo "$MATCHES"
+            exit 1
+          fi
+          echo "✅ Aucun flip mode=on en config."

--- a/backend/src/modules/seo-shadow-observatory/README.md
+++ b/backend/src/modules/seo-shadow-observatory/README.md
@@ -1,0 +1,192 @@
+# `SeoShadowObservatoryModule` — observabilité shadow réutilisable
+
+> **Statut** : livré dans PR-6 (seo-v9). Premier usage : R7 (`brand-rpc`) + R8 (`vehicle-rpc`).
+> **ADR vault associée** : `ADR-054 SEO Shadow Mode Architecture` (à ouvrir post-merge).
+> **Plan** : `home/.claude/plans/pr-6-r7-brand-rpc-fancy-blum.md`.
+
+## Vue d'ensemble
+
+Le module observe en **shadow** (audit silencieux, sans mutation) les divergences
+entre la sortie SEO **legacy** (RPC bake `__seo_marque` / `__seo_r8_pages` / etc.)
+et la sortie **chain** (`SeoChainOrchestratorService`, PR-2c). Les divergences
+sont :
+
+- **Persistées** dans `__seo_event_log` (`event_type='anomaly_detected'`,
+  `payload.subtype='seo.shadow.<r>.divergence'`) — queryable SQL.
+- **Émises sur Sentry** (level `warning`) lorsque `policy_divergence=true`
+  (canonical ou robots divergent).
+- **Hashées** (sha256 12 hex) — aucune URL canonical brute en log, cardinalité
+  maîtrisée.
+
+## Garanties
+
+| Garantie | Mécanisme |
+|---|---|
+| Chemin réponse non bloquant | `observe()` est sync ; le travail réel court via `setImmediate`. Lint ast-grep `.ast-grep/rules/seo-shadow-no-await.yml` interdit `await` sur l'API. |
+| Aucune mutation de la réponse | Le module n'expose **aucune** API qui modifie le payload servi. Aucune branche `mode === 'on'` dans le code livré. |
+| Sampler déterministe | `sha1(surface:entityId)` — même entité = même décision pour un sample-rate fixe. Reproductibilité tests. |
+| Boot guard `mode=on` | `onModuleInit` throw si `SEO_CHAIN_R*_MODE=on` détecté → container ne boot pas (PR-6 ne livre pas la branche on). |
+| Circuit breaker | > 50 timeouts/60s sur `SeoShadowChainRunner.compute()` → breaker ouvert, `observe()` skip silencieux. Empêche l'accumulation de `setImmediate` callbacks pendant un slowdown Supabase. |
+| Couplage minimal | Seul `SeoShadowChainRunner` importe `SeoModule`. Sampler / Normalizer / DiffEngine / Sink / PurgeCron sont purs. |
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  Caller (BrandRpcService, VehicleRpcService, futurs PR-8/12 R0/Blog)   │
+│      this.shadowObservatory.observe({...});  ← sync, return immédiat   │
+│      return legacyPayload;                                             │
+└──────────────────────────────────┬─────────────────────────────────────┘
+                                   │ setImmediate (vraie fire-and-forget)
+                                   ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│  SeoShadowObservatory (public)                                         │
+│   ├─ Zod parse input (fail-fast, no-op si invalide)                    │
+│   ├─ shouldObserve()  → SeoShadowSampler                               │
+│   ├─ isCircuitOpen()  → recentTimeouts                                 │
+│   └─ runComparison()                                                   │
+│        ├─ chainRunner.compute()  → SeoShadowChainRunner (timeout 2s)   │
+│        ├─ diffEngine.compare()   → SeoShadowDiffEngine (+ R8 skip)     │
+│        └─ sink.write()           → SeoShadowEventSink                  │
+└──────────────────────────────────┬─────────────────────────────────────┘
+                                   │
+                ┌──────────────────┴──────────────────┐
+                ▼                                     ▼
+        __seo_event_log JSONB                Sentry.captureMessage
+        (queryable SQL, retention 30j)       (warning, withScope)
+```
+
+## Comment lire les divergences (queries SQL types)
+
+```sql
+-- Bilan 7j par surface (décide go/no-go pour le flip mode=on futur)
+SELECT
+  payload->>'surface' AS surface,
+  count(*) FILTER (WHERE payload->>'policy_divergence' = 'true') AS policy_div,
+  count(*) AS total
+FROM __seo_event_log
+WHERE event_type = 'anomaly_detected'
+  AND payload->>'subtype' LIKE 'seo.shadow.%.divergence'
+  AND created_at > now() - interval '7 days'
+GROUP BY 1;
+
+-- Top 10 divergences canonical R7 (pour debug)
+SELECT
+  payload->>'entity_id'                AS brand_id,
+  entity_url,
+  payload->'diffs'                     AS field_diffs
+FROM __seo_event_log
+WHERE event_type = 'anomaly_detected'
+  AND payload->>'subtype' = 'seo.shadow.r7.divergence'
+  AND payload->>'policy_divergence' = 'true'
+ORDER BY created_at DESC
+LIMIT 10;
+```
+
+## Comment brancher un nouveau surface (checklist)
+
+Pour ajouter R0 (PR-8), Blog (PR-12), R3, etc. :
+
+1. **Vérifier le SurfaceKey** dans `@repo/seo-role-contracts/surface-keys` (déjà 16 surfaces déclarées).
+2. **Ajouter le slug** dans `SURFACE_SUBTYPE` de `seo-shadow-event-sink.service.ts` :
+   ```ts
+   const SURFACE_SUBTYPE: Partial<Record<SurfaceKey, string>> = {
+     R7_BRAND_HUB: 'seo.shadow.r7.divergence',
+     R8_VEHICLE: 'seo.shadow.r8.divergence',
+     R0_HOME: 'seo.shadow.r0.divergence',  // ← nouveau
+   };
+   ```
+3. **Mapper le flag** dans `SURFACE_TO_FLAG` de `seo-shadow-observatory.service.ts` :
+   ```ts
+   const SURFACE_TO_FLAG: Partial<Record<SurfaceKey, SeoChainFlagKey>> = {
+     R7_BRAND_HUB: 'R7',
+     R8_VEHICLE: 'R8',
+     R0_HOME: 'HOME',  // ← nouveau (flag déjà déclaré dans SeoFeatureFlagRegistry)
+   };
+   ```
+4. **Ajouter un cas** dans `SeoShadowChainRunner.adaptInput()` :
+   ```ts
+   case 'R0_HOME':
+     return {
+       surfaceKey: surface,
+       pgId: 0,
+       typeId: 0,
+       variables,
+       ids: { staticPath: '/' },
+       baseUrl: SeoShadowChainRunner.BASE_URL,
+       requestedUrl: requestUrl,
+       breadcrumbs: [],
+     };
+   ```
+5. **Si redirect logic frontend non reproduit** (cas R8) : ajouter le `skip` dans `SeoShadowDiffEngine.compareCanonical()` avec `skip_reason` documenté.
+6. **Brancher le caller** :
+   ```ts
+   this.shadowObservatory.observe({
+     surface: 'R0_HOME',
+     legacy: homePayload.seo,
+     requestUrl: req.url,
+     ids: { staticPath: '/' },
+     vars: { /* depuis le payload */ },
+     entityId: 'home',
+   });
+   ```
+7. **Tests** : ≥ 4 cas par surface (off, sample false, sample true OK, sample true throw) — voir `seo-shadow-observatory.test.ts` pour le pattern.
+8. **Mettre à jour ce README** avec l'entrée "Comment brancher" ci-dessus.
+
+## Bumping `schema_version`
+
+Si le format de `payload.diffs[*]` ou la structure générale change :
+
+1. Incrémenter `SeoShadowEventSink.SCHEMA_VERSION` (de `1` à `2`).
+2. Documenter le changelog dans ce README (section "Schema versions").
+3. L'ETL doit lire `payload->>'schema_version'` pour disambiguïser et appliquer
+   la bonne déserialisation.
+
+## Schema versions
+
+| Version | PR | Date | Changelog |
+|---|---|---|---|
+| 1 | PR-6 | 2026-05-08 | Format initial : `{schema_version, subtype, surface, entity_id, divergence_types[], policy_divergence, diffs[], observed_at}`. R7+R8 wirés. R8 canonical skip. |
+
+## Limites connues
+
+- **R8 canonical comparison désactivée** (`skip_reason: 'r8_frontend_redirect_logic_not_reproduced'`).
+  Le frontend Remix R8 applique un redirect 301 (`marque_alias-marque_id`) que le
+  backend ne reproduit pas. `policy_divergence` R8 reste piloté par `robots_eq`
+  uniquement. Issue follow-up à ouvrir post-merge pour reproduire le redirect.
+- **PR-3 (RM) et PR-5 (gamme-rest)** utilisent encore le pattern shadow inline
+  (`await chainSeo` bloquant + branche `mode === 'on'` exposée). Issue follow-up
+  pour retrofit sur ce module.
+- **`@Cron` décorateur** : `ScheduleModule` est désactivé dans le monorepo (cf.
+  `app.module.ts:150-153`). Le `SeoShadowPurgeCron.purgeOldEvents()` doit être
+  déclenché par crontab système + curl admin endpoint, ou ré-activer
+  ScheduleModule. Documenté dans la classe.
+
+## Cron purge `__seo_event_log`
+
+`SeoShadowPurgeCron.purgeOldEvents()` supprime quotidiennement les observations
+shadow > 30 jours. WHERE clause : `payload->>'subtype' LIKE 'seo.shadow.%.divergence'`.
+**Ne touche aucun autre consommateur** de `__seo_event_log`. Respecte
+`READ_ONLY=true` (gate au processor — cf. mémoire
+`feedback_readonly_gate_at_processor_not_scheduler`).
+
+## Defense-in-depth
+
+| Couche | Mécanisme |
+|---|---|
+| Zod env | `SEO_CHAIN_R*_MODE=tru` (typo) → boot fail. |
+| Boot guard | `mode=on` détecté → `throw` → container ne boot pas. |
+| CI guard | `.github/workflows/seo-shadow-flag-guard.yml` refuse `SEO_CHAIN_R*_MODE=on` dans `.env*` / `docker-compose*` / workflows / secrets. |
+| ADR | `ADR-054` (vault) formalise le sign-off pour le flip futur. |
+
+Trois modifications coordonnées (code + ADR + ENV) sont nécessaires pour activer
+`mode=on` en prod.
+
+## ENV vars
+
+| Variable | Default | Description |
+|---|---|---|
+| `SEO_CHAIN_R7_MODE` | `off` | `off` / `shadow` / `on`. PR-6 accepte uniquement `off` ou `shadow`. |
+| `SEO_CHAIN_R8_MODE` | `off` | Idem R7. |
+| `SEO_CHAIN_SHADOW_SAMPLE_RATE` | `0.01` | Taux d'échantillonnage \[0..1\]. **Conservateur en preprod** ; augmenter à `0.05` ou `0.1` après 24h si volume `__seo_event_log` soutenable. |
+| `READ_ONLY` | _absent_ | `true` → `SeoShadowPurgeCron` no-op (cohérent avec ADR-028 read-only hardening). |

--- a/backend/src/modules/seo-shadow-observatory/env.schema.ts
+++ b/backend/src/modules/seo-shadow-observatory/env.schema.ts
@@ -18,4 +18,3 @@ export const SeoShadowEnvSchema = z.object({
   SEO_CHAIN_R8_MODE: z.enum(['off', 'shadow', 'on']).default('off'),
   SEO_CHAIN_SHADOW_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0.01),
 });
-export type SeoShadowEnv = z.infer<typeof SeoShadowEnvSchema>;

--- a/backend/src/modules/seo-shadow-observatory/env.schema.ts
+++ b/backend/src/modules/seo-shadow-observatory/env.schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+/**
+ * Schema Zod des ENV vars consommées par le module observatory.
+ * Validé au démarrage (`onModuleInit` du module) — fail-fast sur valeur
+ * malformée (`SEO_CHAIN_R7_MODE=tru` → throw, container ne boot pas).
+ *
+ * Defense in depth (cf. plan PR-6 §4.7) :
+ *   - Zod refuse les valeurs malformées au démarrage.
+ *   - Boot guard `throw` refuse `mode=on` (PR-6 ne livre PAS la branche on).
+ *   - CI guard refuse `SEO_CHAIN_R*_MODE=on` dans la config commit.
+ *
+ * Default `SEO_CHAIN_SHADOW_SAMPLE_RATE=0.01` (1%) — démarrage conservateur,
+ * volume `__seo_event_log` inconnu sur cette nouvelle source.
+ */
+export const SeoShadowEnvSchema = z.object({
+  SEO_CHAIN_R7_MODE: z.enum(['off', 'shadow', 'on']).default('off'),
+  SEO_CHAIN_R8_MODE: z.enum(['off', 'shadow', 'on']).default('off'),
+  SEO_CHAIN_SHADOW_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0.01),
+});
+export type SeoShadowEnv = z.infer<typeof SeoShadowEnvSchema>;

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import type { SurfaceKey } from '@repo/seo-role-contracts';
+
+import { SeoChainOrchestratorService } from '@modules/seo/services/chain/seo-chain-orchestrator.service';
+
+import {
+  ChainSeoSnapshotSchema,
+  type ChainSeoSnapshot,
+  type ShadowObservationInput,
+} from './types';
+
+/**
+ * Erreur dédiée — permet à l'observatory de distinguer un timeout chaîne
+ * (compteur circuit breaker) d'une autre erreur (skip simple).
+ */
+export class SeoShadowChainTimeoutError extends Error {
+  constructor() {
+    super('SeoShadowChainRunner timeout');
+    this.name = 'SeoShadowChainTimeoutError';
+  }
+}
+
+/**
+ * Adaptateur **unique** entre le module observatory et le `SeoModule`.
+ *
+ * - Convertit l'input shadow (générique) en `SeoChainInput` (orchestrateur).
+ * - Applique un **timeout dur** (2s, cohérent timeouts RPC R7/R8) — sous
+ *   slowdown Supabase, on évite l'accumulation de `setImmediate` callbacks.
+ * - Valide la sortie via `ChainSeoSnapshotSchema` (output corrompu ⇒ throw,
+ *   pas de diff bizarre persisté en `__seo_event_log`).
+ *
+ * Sampler / Normalizer / DiffEngine / Sink **n'importent rien** de SeoModule —
+ * ils restent purs et testables en isolation.
+ *
+ * @see plan seo-v9 PR-6 §4.4
+ */
+@Injectable()
+export class SeoShadowChainRunner {
+  private readonly logger = new Logger(SeoShadowChainRunner.name);
+  private static readonly TIMEOUT_MS = 2_000;
+  private static readonly BASE_URL = 'https://www.automecanik.com';
+
+  constructor(private readonly orchestrator: SeoChainOrchestratorService) {}
+
+  async compute(input: ShadowObservationInput): Promise<ChainSeoSnapshot> {
+    let timer: NodeJS.Timeout | undefined;
+    const work = this.computeUnbounded(input);
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new SeoShadowChainTimeoutError()),
+        SeoShadowChainRunner.TIMEOUT_MS,
+      );
+    });
+    try {
+      return await Promise.race([work, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  private async computeUnbounded(
+    input: ShadowObservationInput,
+  ): Promise<ChainSeoSnapshot> {
+    const chainInput = this.adaptInput(input);
+    const out = await this.orchestrator.run(chainInput);
+    return ChainSeoSnapshotSchema.parse({
+      title: out.template.title ?? null,
+      description: out.template.description ?? null,
+      h1: out.template.h1 ?? null,
+      content: out.template.content ?? null,
+      keywords: out.template.keywords ?? null,
+      canonical: out.policies.canonical || null,
+      robots: out.policies.robots ?? null,
+    });
+  }
+
+  /**
+   * Map l'input générique observatory vers le shape canonique orchestrateur.
+   * Surface-specific extraction des `ids` / `pgId` / `typeId`.
+   */
+  private adaptInput(
+    input: ShadowObservationInput,
+  ): import('@modules/seo/services/chain/seo-chain-orchestrator.service').SeoChainInput {
+    const { surface, ids, vars, requestUrl } = input;
+    const variables = (vars ?? {}) as Record<string, string | number>;
+
+    switch (surface) {
+      case 'R7_BRAND_HUB':
+        return {
+          surfaceKey: surface,
+          pgId: 0,
+          typeId: 0,
+          variables: variables as never,
+          ids: { brandAlias: String(ids.brandAlias ?? '') },
+          baseUrl: SeoShadowChainRunner.BASE_URL,
+          requestedUrl: requestUrl,
+          breadcrumbs: [],
+          brandId: numericOrUndefined(ids.brandId),
+        };
+
+      case 'R8_VEHICLE':
+        return {
+          surfaceKey: surface,
+          pgId: 0,
+          typeId: numericOrZero(ids.typeId),
+          vehicleId: numericOrUndefined(ids.typeId),
+          variables: variables as never,
+          ids: {
+            brandAlias: String(ids.brandAlias ?? ''),
+            modeleAlias: String(ids.modeleAlias ?? ''),
+            typeAlias: String(ids.typeAlias ?? ''),
+          },
+          baseUrl: SeoShadowChainRunner.BASE_URL,
+          requestedUrl: requestUrl,
+          breadcrumbs: [],
+          brandId: numericOrUndefined(ids.brandId),
+        };
+
+      default:
+        throw new SeoShadowSurfaceNotWiredError(surface);
+    }
+  }
+}
+
+export class SeoShadowSurfaceNotWiredError extends Error {
+  constructor(surface: SurfaceKey) {
+    super(`SeoShadowChainRunner: surface ${surface} non câblée (PR-6 = R7+R8)`);
+    this.name = 'SeoShadowSurfaceNotWiredError';
+  }
+}
+
+function numericOrUndefined(v: unknown): number | undefined {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string') {
+    const n = Number.parseInt(v, 10);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}
+
+function numericOrZero(v: unknown): number {
+  return numericOrUndefined(v) ?? 0;
+}

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-diff-engine.service.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-diff-engine.service.ts
@@ -1,0 +1,188 @@
+import { createHash } from 'node:crypto';
+
+import { Injectable } from '@nestjs/common';
+
+import type { SurfaceKey } from '@repo/seo-role-contracts';
+
+import type {
+  ChainSeoSnapshot,
+  DiffResult,
+  FieldDiff,
+  LegacySeoSnapshot,
+} from './types';
+import { SeoShadowUrlNormalizer } from './seo-shadow-url-normalizer.service';
+
+const TEXT_FIELDS = [
+  'title',
+  'description',
+  'h1',
+  'content',
+  'keywords',
+] as const satisfies readonly FieldDiff['field'][];
+
+/**
+ * Compare un snapshot legacy ↔ chain et produit un diff field-level.
+ *
+ * Garanties :
+ *   - Aucune URL canonical brute en sortie — uniquement des hashes 12 hex
+ *     (cardinalité maîtrisée pour `__seo_event_log` + Loki).
+ *   - Normalisation canonical avant comparaison (cf. UrlNormalizer).
+ *   - **R8 canonical skip** : la frontend Remix R8 applique un redirect 301
+ *     (`marque_alias-marque_id` mismatch) que le backend ne reproduit pas
+ *     ; comparer les canonicals produirait une avalanche de faux positifs.
+ *     On marque `equal=null` + `skip_reason='r8_frontend_redirect_logic_not_reproduced'`.
+ *     `policy_divergence` R8 reste donc piloté par `robots_eq` uniquement.
+ *
+ * @see plan seo-v9 PR-6 §4.5 — limite connue R8.
+ */
+@Injectable()
+export class SeoShadowDiffEngine {
+  constructor(private readonly normalizer: SeoShadowUrlNormalizer) {}
+
+  compare(
+    legacy: LegacySeoSnapshot,
+    chain: ChainSeoSnapshot,
+    requestUrl: string,
+    surface: SurfaceKey,
+  ): DiffResult {
+    const diffs: FieldDiff[] = [];
+
+    for (const field of TEXT_FIELDS) {
+      diffs.push(this.compareText(field, legacy[field], chain[field]));
+    }
+
+    diffs.push(this.compareCanonical(surface, legacy, chain, requestUrl));
+    diffs.push(this.compareRobots(legacy.robots ?? null, chain.robots));
+
+    const divergenceTypes = diffs
+      .filter((d) => d.equal === false)
+      .map((d) => d.field);
+
+    const canonicalDiff = diffs.find((d) => d.field === 'canonical');
+    const robotsDiff = diffs.find((d) => d.field === 'robots');
+    const policyDivergence =
+      canonicalDiff?.equal === false || robotsDiff?.equal === false;
+
+    return {
+      diffs,
+      divergenceTypes,
+      policyDivergence,
+      summary: {
+        surface,
+        divergenceCount: divergenceTypes.length,
+        divergenceTypes,
+      },
+    };
+  }
+
+  private compareText(
+    field: (typeof TEXT_FIELDS)[number],
+    legacy: string | null | undefined,
+    chain: string | null,
+  ): FieldDiff {
+    const l = legacy ?? null;
+    const c = chain ?? null;
+    if (l === null && c === null) {
+      return {
+        field,
+        equal: null,
+        legacyHash: null,
+        chainHash: null,
+        legacyLen: null,
+        chainLen: null,
+      };
+    }
+    return {
+      field,
+      equal: l === c,
+      legacyHash: hash(l),
+      chainHash: hash(c),
+      legacyLen: l !== null ? l.length : null,
+      chainLen: c !== null ? c.length : null,
+    };
+  }
+
+  private compareCanonical(
+    surface: SurfaceKey,
+    legacy: LegacySeoSnapshot,
+    chain: ChainSeoSnapshot,
+    requestUrl: string,
+  ): FieldDiff {
+    if (surface === 'R8_VEHICLE') {
+      return {
+        field: 'canonical',
+        equal: null,
+        legacyHash: null,
+        chainHash: null,
+        legacyLen: null,
+        chainLen: null,
+        skip_reason: 'r8_frontend_redirect_logic_not_reproduced',
+      };
+    }
+    const legacyNorm = this.normalizer.reconstructLegacy(
+      legacy.canonical ?? null,
+      requestUrl,
+    );
+    const chainNorm = this.normalizer.normalize(chain.canonical);
+    if (legacyNorm === null && chainNorm === null) {
+      return {
+        field: 'canonical',
+        equal: null,
+        legacyHash: null,
+        chainHash: null,
+        legacyLen: null,
+        chainLen: null,
+      };
+    }
+    return {
+      field: 'canonical',
+      equal: legacyNorm === chainNorm,
+      legacyHash: hash(legacyNorm),
+      chainHash: hash(chainNorm),
+      legacyLen: legacyNorm !== null ? legacyNorm.length : null,
+      chainLen: chainNorm !== null ? chainNorm.length : null,
+    };
+  }
+
+  private compareRobots(
+    legacy: string | null,
+    chain: string | null,
+  ): FieldDiff {
+    if (legacy === null && chain === null) {
+      return {
+        field: 'robots',
+        equal: null,
+        legacyHash: null,
+        chainHash: null,
+        legacyLen: null,
+        chainLen: null,
+      };
+    }
+    if (legacy === null || chain === null) {
+      // Un seul côté absent — non comparable, pas de policy_divergence.
+      return {
+        field: 'robots',
+        equal: null,
+        legacyHash: hash(legacy),
+        chainHash: hash(chain),
+        legacyLen: legacy !== null ? legacy.length : null,
+        chainLen: chain !== null ? chain.length : null,
+      };
+    }
+    const lNorm = legacy.replace(/\s+/g, '').toLowerCase();
+    const cNorm = chain.replace(/\s+/g, '').toLowerCase();
+    return {
+      field: 'robots',
+      equal: lNorm === cNorm,
+      legacyHash: hash(legacy),
+      chainHash: hash(chain),
+      legacyLen: legacy.length,
+      chainLen: chain.length,
+    };
+  }
+}
+
+function hash(value: string | null): string | null {
+  if (value === null) return null;
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-event-sink.service.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-event-sink.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as Sentry from '@sentry/nestjs';
+import { SupabaseClient, createClient } from '@supabase/supabase-js';
+
+import { getEffectiveSupabaseKey } from '@common/utils';
+
+import type { SurfaceKey } from '@repo/seo-role-contracts';
+
+import type { DiffResult } from './types';
+
+/**
+ * Mapping `surface → subtype` figé (cf. plan §4.6 + §2bis Adjusted).
+ *
+ * IMPORTANT — décision §2bis : l'enum Postgres `seo_event_type` ne contient pas
+ * `seo.shadow.r*.divergence`. Plutôt qu'une migration ALTER TYPE, on utilise
+ * la valeur existante `'anomaly_detected'` (sémantiquement aligné — divergence
+ * shadow = anomalie observée) et on place le slug shadow dans `payload.subtype`.
+ */
+const SURFACE_SUBTYPE: Partial<Record<SurfaceKey, string>> = {
+  R7_BRAND_HUB: 'seo.shadow.r7.divergence',
+  R8_VEHICLE: 'seo.shadow.r8.divergence',
+};
+
+const TABLE = '__seo_event_log';
+const SCHEMA_VERSION = 1; // bump si format `payload.diffs[*]` change
+
+/** Mapping legacy event_log severity (notre 'warn'/'info') → seo_severity enum. */
+function mapSeverity(policyDivergence: boolean): 'medium' | 'info' {
+  return policyDivergence ? 'medium' : 'info';
+}
+
+/**
+ * Persiste les observations shadow dans `__seo_event_log` + envoie un event
+ * Sentry (warning level) sur `policy_divergence`.
+ *
+ * Garanties :
+ *   - Aucune URL canonical brute écrite — uniquement les hashes 12 hex via
+ *     `DiffResult.diffs[*].legacyHash/chainHash`.
+ *   - `Sentry.withScope` + `captureMessage` (vs breadcrumb seul) car
+ *     `setImmediate` détache du request scope HTTP — un breadcrumb orphelin
+ *     ne serait jamais attaché à un event.
+ *   - Si Supabase écrit en erreur → log error + propage (le caller gère).
+ *
+ * @see plan seo-v9 PR-6 §4.6
+ */
+@Injectable()
+export class SeoShadowEventSink {
+  private readonly logger = new Logger(SeoShadowEventSink.name);
+  private readonly supabase: SupabaseClient;
+
+  constructor(cfg: ConfigService) {
+    const url = cfg.get<string>('SUPABASE_URL') ?? '';
+    const key = getEffectiveSupabaseKey();
+    this.supabase = createClient(url, key, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  async write(
+    surface: SurfaceKey,
+    entityId: string,
+    requestUrl: string,
+    diff: DiffResult,
+  ): Promise<void> {
+    const subtype = SURFACE_SUBTYPE[surface];
+    if (!subtype) {
+      throw new Error(
+        `SeoShadowEventSink: surface ${surface} non mappée dans SURFACE_SUBTYPE`,
+      );
+    }
+    const severity = mapSeverity(diff.policyDivergence);
+
+    const { error } = await this.supabase.from(TABLE).insert({
+      event_type: 'anomaly_detected', // valeur enum existante (cf. §2bis Adjusted)
+      entity_url: requestUrl,
+      severity,
+      payload: {
+        schema_version: SCHEMA_VERSION,
+        subtype, // 'seo.shadow.r7.divergence' / 'seo.shadow.r8.divergence'
+        surface,
+        entity_id: entityId,
+        divergence_types: diff.divergenceTypes,
+        policy_divergence: diff.policyDivergence,
+        diffs: diff.diffs,
+        observed_at: new Date().toISOString(),
+      },
+    });
+    if (error) {
+      this.logger.error(
+        `[SEO_SHADOW] event_log insert failed (${subtype}): ${error.message}`,
+      );
+      throw new Error(`event_log insert failed: ${error.message}`);
+    }
+
+    if (diff.policyDivergence) {
+      // setImmediate détache du request scope Sentry → withScope + captureMessage.
+      Sentry.withScope((scope) => {
+        scope.setTag('seo.surface', surface);
+        scope.setTag('seo.policy_divergence', 'true');
+        scope.setTag('seo.shadow_subtype', subtype);
+        scope.setExtra('entity_id', entityId);
+        scope.setExtra('divergence_types', diff.divergenceTypes);
+        scope.setExtra('schema_version', SCHEMA_VERSION);
+        Sentry.captureMessage(
+          `[SEO_SHADOW][${surface}] policy_divergence entity_id=${entityId}`,
+          'warning',
+        );
+      });
+    }
+  }
+}

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.module.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.module.ts
@@ -1,0 +1,72 @@
+import { Logger, Module, OnModuleInit } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
+import { SeoModule } from '@modules/seo/seo.module';
+
+import { SeoShadowEnvSchema } from './env.schema';
+import { SeoShadowChainRunner } from './seo-shadow-chain-runner.service';
+import { SeoShadowDiffEngine } from './seo-shadow-diff-engine.service';
+import { SeoShadowEventSink } from './seo-shadow-event-sink.service';
+import { SeoShadowObservatory } from './seo-shadow-observatory.service';
+import { SeoShadowPurgeCron } from './seo-shadow-purge.cron';
+import { SeoShadowSampler } from './seo-shadow-sampler.service';
+import { SeoShadowUrlNormalizer } from './seo-shadow-url-normalizer.service';
+
+/**
+ * `SeoShadowObservatoryModule` — observabilité shadow réutilisable, dédiée.
+ *
+ * **Imports** :
+ *   - `SeoModule` — UNIQUEMENT pour `SeoChainOrchestratorService` +
+ *     `SeoFeatureFlagRegistry`. Seul `SeoShadowChainRunner` consomme ces
+ *     services. Sampler / Normalizer / DiffEngine / Sink restent purs.
+ *   - `ConfigModule` — pour `SeoShadowEnvSchema` (Zod) + `READ_ONLY` gate cron.
+ *
+ * **Exports** :
+ *   - `SeoShadowObservatory` — API publique (caller : R7/R8 services).
+ *   - `SeoShadowPurgeCron` — exposé pour potentiel admin endpoint trigger.
+ *
+ * **Boot guard** (`onModuleInit`) :
+ *   - Zod parse les ENV. `SEO_CHAIN_R7_MODE=tru` (typo) → throw, container ne boot pas.
+ *   - `mode=on` détecté → throw (PR-6 ne livre PAS la branche on ; flip
+ *     requiert ADR-054 sign-off + PR dédié).
+ *
+ * @see plan seo-v9 PR-6 §4.7
+ */
+@Module({
+  imports: [SeoModule, ConfigModule],
+  providers: [
+    SeoShadowObservatory,
+    SeoShadowSampler,
+    SeoShadowUrlNormalizer,
+    SeoShadowChainRunner,
+    SeoShadowDiffEngine,
+    SeoShadowEventSink,
+    SeoShadowPurgeCron,
+  ],
+  exports: [SeoShadowObservatory, SeoShadowPurgeCron],
+})
+export class SeoShadowObservatoryModule implements OnModuleInit {
+  private readonly logger = new Logger(SeoShadowObservatoryModule.name);
+
+  constructor(private readonly cfg: ConfigService) {}
+
+  onModuleInit(): void {
+    const env = SeoShadowEnvSchema.parse({
+      SEO_CHAIN_R7_MODE: this.cfg.get<string>('SEO_CHAIN_R7_MODE'),
+      SEO_CHAIN_R8_MODE: this.cfg.get<string>('SEO_CHAIN_R8_MODE'),
+      SEO_CHAIN_SHADOW_SAMPLE_RATE: this.cfg.get<string>(
+        'SEO_CHAIN_SHADOW_SAMPLE_RATE',
+      ),
+    });
+    if (env.SEO_CHAIN_R7_MODE === 'on' || env.SEO_CHAIN_R8_MODE === 'on') {
+      throw new Error(
+        `[SEO_SHADOW_BOOT_GUARD] mode=on forbidden in PR-6 (no on-branch shipped). ` +
+          `Detected R7=${env.SEO_CHAIN_R7_MODE} R8=${env.SEO_CHAIN_R8_MODE}. ` +
+          `Flip mode=on requires ADR-054 sign-off + dedicated PR — see governance-vault.`,
+      );
+    }
+    this.logger.log(
+      `[SEO_SHADOW] boot OK — R7=${env.SEO_CHAIN_R7_MODE} R8=${env.SEO_CHAIN_R8_MODE} sample_rate=${env.SEO_CHAIN_SHADOW_SAMPLE_RATE}`,
+    );
+  }
+}

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.service.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.service.ts
@@ -1,0 +1,131 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import {
+  SeoFeatureFlagRegistry,
+  type SeoChainFlagKey,
+} from '@modules/seo/registries/seo-feature-flag.registry';
+
+import type { SurfaceKey } from '@repo/seo-role-contracts';
+
+import { SeoShadowSampler } from './seo-shadow-sampler.service';
+import {
+  SeoShadowChainRunner,
+  SeoShadowChainTimeoutError,
+} from './seo-shadow-chain-runner.service';
+import { SeoShadowDiffEngine } from './seo-shadow-diff-engine.service';
+import { SeoShadowEventSink } from './seo-shadow-event-sink.service';
+import {
+  ShadowObservationInputSchema,
+  type ShadowObservationInput,
+} from './types';
+
+/**
+ * Mapping `surface → flag` (clé `SeoFeatureFlagRegistry`). PR-6 = R7 + R8.
+ * Étendre quand une surface est wirée (cf. README onboarding checklist).
+ */
+const SURFACE_TO_FLAG: Partial<Record<SurfaceKey, SeoChainFlagKey>> = {
+  R7_BRAND_HUB: 'R7',
+  R8_VEHICLE: 'R8',
+};
+
+/**
+ * Service public du module observatory.
+ *
+ * API : `observe(input)` — synchrone, return immédiat. La comparaison réelle
+ * est dispatchée via `setImmediate` (vraie fire-and-forget) ; le chemin
+ * réponse HTTP du caller n'attend RIEN.
+ *
+ * Garanties :
+ *   - Input invalide (Zod fail) → log + no-op, jamais de crash propagé.
+ *   - Mode `off` ou non-shadow → no-op silencieux.
+ *   - Sampler négatif → no-op silencieux.
+ *   - Circuit breaker ouvert (>50 timeouts/60s) → no-op silencieux.
+ *   - **Aucune branche `mode === 'on'`** dans le code — un flip ENV ne peut
+ *     pas activer la chaîne en prod. Boot guard + CI guard + ADR-054
+ *     formalisent le pré-requis pour le flip futur.
+ *
+ * @see plan seo-v9 PR-6 §4.1
+ */
+@Injectable()
+export class SeoShadowObservatory {
+  private readonly logger = new Logger(SeoShadowObservatory.name);
+  private static readonly TIMEOUT_WINDOW_MS = 60_000;
+  private static readonly TIMEOUT_THRESHOLD = 50;
+  private recentTimeouts: number[] = [];
+
+  constructor(
+    private readonly flags: SeoFeatureFlagRegistry,
+    private readonly sampler: SeoShadowSampler,
+    private readonly chainRunner: SeoShadowChainRunner,
+    private readonly diffEngine: SeoShadowDiffEngine,
+    private readonly sink: SeoShadowEventSink,
+  ) {}
+
+  /** Sync — return immédiat. La comparaison réelle court via `setImmediate`. */
+  observe(rawInput: unknown): void {
+    let input: ShadowObservationInput;
+    try {
+      input = ShadowObservationInputSchema.parse(rawInput);
+    } catch (err) {
+      this.logger.error(
+        `[SEO_SHADOW] invalid input: ${(err as Error).message}`,
+      );
+      return;
+    }
+
+    if (!this.shouldObserve(input)) return;
+    if (this.isCircuitOpen()) return;
+
+    setImmediate(() => {
+      void this.runComparison(input).catch((err: unknown) => {
+        const e = err as Error;
+        this.logger.error(
+          `[SEO_SHADOW][${input.surface}] runComparison threw: ${e?.message ?? String(err)}`,
+        );
+      });
+    });
+  }
+
+  private shouldObserve(input: ShadowObservationInput): boolean {
+    const flag = SURFACE_TO_FLAG[input.surface];
+    if (!flag) return false; // surface non câblée pour shadow
+    const mode = this.flags.mode(flag);
+    if (mode !== 'shadow') return false;
+    return this.sampler.shouldSample(input.surface, input.entityId);
+  }
+
+  private isCircuitOpen(): boolean {
+    const cutoff = Date.now() - SeoShadowObservatory.TIMEOUT_WINDOW_MS;
+    this.recentTimeouts = this.recentTimeouts.filter((t) => t > cutoff);
+    return this.recentTimeouts.length >= SeoShadowObservatory.TIMEOUT_THRESHOLD;
+  }
+
+  private async runComparison(input: ShadowObservationInput): Promise<void> {
+    let chain;
+    try {
+      chain = await this.chainRunner.compute(input);
+    } catch (err) {
+      if (err instanceof SeoShadowChainTimeoutError) {
+        this.recentTimeouts.push(Date.now());
+      }
+      throw err;
+    }
+    const diff = this.diffEngine.compare(
+      input.legacy,
+      chain,
+      input.requestUrl,
+      input.surface,
+    );
+    if (diff.policyDivergence) {
+      this.logger.warn(
+        `[SEO_SHADOW][${input.surface}] policy_divergence ${JSON.stringify(diff.summary)}`,
+      );
+    }
+    await this.sink.write(
+      input.surface,
+      input.entityId,
+      input.requestUrl,
+      diff,
+    );
+  }
+}

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-purge.cron.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-purge.cron.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseClient, createClient } from '@supabase/supabase-js';
+
+import { getEffectiveSupabaseKey } from '@common/utils';
+
+/**
+ * Purge quotidienne des observations shadow > 30 jours dans `__seo_event_log`.
+ *
+ * **Note ScheduleModule désactivé** dans le monorepo (conflit `@nestjs/schedule` v6
+ * vs `@nestjs/common` v10 — cf. `app.module.ts:150-153`). Cette classe expose
+ * `purgeOldEvents()` ; le déclenchement réel est fait :
+ *   - soit par crontab système + curl sur un endpoint admin (pattern actuel
+ *     pour les autres jobs SEO — cf. `quality-history-snapshot.service.ts`),
+ *   - soit automatiquement via le décorateur `@Cron` quand ScheduleModule
+ *     sera ré-activé.
+ *
+ * **Garanties** :
+ *   - `READ_ONLY=true` → no-op silencieux (gate au processor, **pas** au
+ *     scheduler — cf. mémoire `feedback_readonly_gate_at_processor_not_scheduler`).
+ *   - WHERE clause cible **strictement** `payload->>'subtype' LIKE 'seo.shadow.%.divergence'`
+ *     ; ne touche aucun autre consommateur de `__seo_event_log`.
+ *   - Cutoff = `now - 30 jours` (au-delà l'historique n'éclaire plus une décision).
+ *   - Échec Supabase loggué mais n'interrompt pas le scheduler — retentera
+ *     demain.
+ *
+ * @see plan seo-v9 PR-6 §5.4a
+ */
+@Injectable()
+export class SeoShadowPurgeCron {
+  private readonly logger = new Logger(SeoShadowPurgeCron.name);
+  private readonly supabase: SupabaseClient;
+  private static readonly RETENTION_DAYS = 30;
+  private static readonly TABLE = '__seo_event_log';
+
+  constructor(private readonly cfg: ConfigService) {
+    const url = cfg.get<string>('SUPABASE_URL') ?? '';
+    const key = getEffectiveSupabaseKey();
+    this.supabase = createClient(url, key, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  }
+
+  /**
+   * Méthode appelable manuellement (admin endpoint) ou par cron externe.
+   * Idempotente — exécutions multiples = même état final.
+   */
+  async purgeOldEvents(): Promise<{ deleted: number; skipped?: string }> {
+    if (this.cfg.get<string>('READ_ONLY') === 'true') {
+      this.logger.log('[SEO_SHADOW_PURGE] skipped — READ_ONLY=true');
+      return { deleted: 0, skipped: 'read_only' };
+    }
+    const cutoff = new Date(
+      Date.now() - SeoShadowPurgeCron.RETENTION_DAYS * 24 * 3600 * 1000,
+    );
+    const { data, error, count } = await this.supabase
+      .from(SeoShadowPurgeCron.TABLE)
+      .delete({ count: 'exact' })
+      .like('payload->>subtype', 'seo.shadow.%.divergence')
+      .lt('created_at', cutoff.toISOString())
+      .select('id');
+    if (error) {
+      this.logger.error(
+        `[SEO_SHADOW_PURGE] failed: ${error.message}`,
+        error.stack,
+      );
+      return { deleted: 0 };
+    }
+    const deleted = count ?? data?.length ?? 0;
+    this.logger.log(
+      `[SEO_SHADOW_PURGE] removed ${deleted} rows older than ${SeoShadowPurgeCron.RETENTION_DAYS}d`,
+    );
+    return { deleted };
+  }
+}

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-sampler.service.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-sampler.service.ts
@@ -1,0 +1,45 @@
+import { createHash } from 'node:crypto';
+
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Sampler déterministe pour `SeoShadowObservatory`.
+ *
+ * Hash sha1(`${surface}:${entityId}`) % 2^32 / 2^32 ∈ [0, 1[ comparé au taux
+ * d'échantillonnage. La même paire (surface, entityId) est **toujours** ou
+ * **jamais** échantillonnée pour un taux fixe — ça permet :
+ *   - Un diff reproductible en preprod (même URLs sont observées).
+ *   - Une couverture homogène quel que soit le trafic.
+ *   - Des tests stables sans `jest.spyOn(Math, 'random')`.
+ *
+ * Default conservateur : 1% (`0.01`). Volume `__seo_event_log` inconnu pour
+ * cette nouvelle source ; on commence bas, on évalue J+1 avant d'augmenter.
+ *
+ * @see plan seo-v9 PR-6 §4.2
+ */
+@Injectable()
+export class SeoShadowSampler {
+  private readonly rate: number;
+
+  constructor(cfg: ConfigService) {
+    const raw = cfg.get<string>('SEO_CHAIN_SHADOW_SAMPLE_RATE') ?? '0.01';
+    const parsed = Number.parseFloat(raw);
+    this.rate =
+      Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : 0.01;
+  }
+
+  /** Décide si l'observation doit être réalisée pour cette paire. */
+  shouldSample(surface: string, entityId: string): boolean {
+    if (this.rate <= 0) return false;
+    if (this.rate >= 1) return true;
+    const digest = createHash('sha1').update(`${surface}:${entityId}`).digest();
+    const bucket = digest.readUInt32BE(0) / 0xffffffff;
+    return bucket < this.rate;
+  }
+
+  /** Exposé pour observabilité (tests, audit logs). */
+  get sampleRate(): number {
+    return this.rate;
+  }
+}

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-url-normalizer.service.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-url-normalizer.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+
+const CANONICAL_HOST = 'www.automecanik.com';
+const CANONICAL_BASE = `https://${CANONICAL_HOST}`;
+
+/**
+ * Normalise les URLs canonical avant comparaison legacy↔chain.
+ *
+ * Sans normalisation, `https://www.automecanik.com/Foo/`
+ * et `https://www.automecanik.com/foo` produiraient `canonical_eq=false`
+ * → faux positifs en masse. La normalisation enforce :
+ *   - Protocole `https:`.
+ *   - Hostname canonique `www.automecanik.com`.
+ *   - Pathname lowercase + URI-decoded.
+ *   - Pas de trailing slash (sauf root `/`).
+ *   - Pas de query string ni fragment.
+ *
+ * @see plan seo-v9 PR-6 §4.3
+ */
+@Injectable()
+export class SeoShadowUrlNormalizer {
+  /** Retourne la forme canonique stricte ou `null` si l'URL est invalide. */
+  normalize(url: string | null | undefined): string | null {
+    if (!url) return null;
+    try {
+      const u = new URL(url, CANONICAL_BASE);
+      let path = decodeURI(u.pathname).toLowerCase();
+      if (path.length > 1 && path.endsWith('/')) {
+        path = path.slice(0, -1);
+      }
+      return `${CANONICAL_BASE}${path}`;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Pour les surfaces où le legacy ne bake pas le canonical backend-side
+   * (ex: R7 — frontend Remix dérive de `pathname`), on reconstruit la même
+   * valeur que produirait le frontend, à partir du `requestUrl`.
+   */
+  reconstructLegacy(
+    rpcCanonical: string | null | undefined,
+    requestUrl: string,
+  ): string | null {
+    return this.normalize(rpcCanonical) ?? this.normalize(requestUrl);
+  }
+}

--- a/backend/src/modules/seo-shadow-observatory/types.ts
+++ b/backend/src/modules/seo-shadow-observatory/types.ts
@@ -6,7 +6,7 @@ import { SurfaceKeySchema } from '@repo/seo-role-contracts';
  * Snapshot SEO comparable côté legacy (extrait du payload RPC R7/R8).
  * Tous les champs optionnels — un legacy minimaliste reste exploitable.
  */
-export const LegacySeoSnapshotSchema = z
+const LegacySeoSnapshotSchema = z
   .object({
     title: z.string().nullable().optional(),
     description: z.string().nullable().optional(),

--- a/backend/src/modules/seo-shadow-observatory/types.ts
+++ b/backend/src/modules/seo-shadow-observatory/types.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+
+import { SurfaceKeySchema } from '@repo/seo-role-contracts';
+
+/**
+ * Snapshot SEO comparable côté legacy (extrait du payload RPC R7/R8).
+ * Tous les champs optionnels — un legacy minimaliste reste exploitable.
+ */
+export const LegacySeoSnapshotSchema = z
+  .object({
+    title: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    h1: z.string().nullable().optional(),
+    content: z.string().nullable().optional(),
+    keywords: z.string().nullable().optional(),
+    canonical: z.string().nullable().optional(),
+    robots: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type LegacySeoSnapshot = z.infer<typeof LegacySeoSnapshotSchema>;
+
+/**
+ * Snapshot SEO côté chaîne (résultat normalisé après orchestrateur + canonical
+ * + indexability). Les `null` sont autorisés quand l'info n'est pas calculable.
+ */
+export const ChainSeoSnapshotSchema = z.object({
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  h1: z.string().nullable(),
+  content: z.string().nullable(),
+  keywords: z.string().nullable(),
+  canonical: z.string().nullable(),
+  robots: z.string().nullable(),
+});
+export type ChainSeoSnapshot = z.infer<typeof ChainSeoSnapshotSchema>;
+
+/**
+ * Input du `SeoShadowObservatory.observe()`. Validé Zod à chaque appel
+ * (fail-fast). Caller buggé → log + no-op, jamais de crash propagé.
+ */
+export const ShadowObservationInputSchema = z.object({
+  surface: SurfaceKeySchema,
+  legacy: LegacySeoSnapshotSchema,
+  requestUrl: z.string().min(1),
+  ids: z.record(z.union([z.string(), z.number()])),
+  vars: z.record(z.union([z.string(), z.number()])).optional(),
+  entityId: z.string().min(1),
+});
+export type ShadowObservationInput = z.infer<
+  typeof ShadowObservationInputSchema
+>;
+
+/**
+ * Diff structuré d'un champ SEO. `equal=null` = non comparable
+ * (ex: legacy.robots absent, ou skip explicite — cf. R8 canonical).
+ */
+export interface FieldDiff {
+  field:
+    | 'title'
+    | 'description'
+    | 'h1'
+    | 'content'
+    | 'keywords'
+    | 'canonical'
+    | 'robots';
+  equal: boolean | null;
+  legacyHash: string | null; // sha256 12 hex chars
+  chainHash: string | null;
+  legacyLen: number | null;
+  chainLen: number | null;
+  /** Renseigné si `equal=null` par décision explicite. */
+  skip_reason?: string;
+}
+
+/**
+ * Résultat global du diff pour une observation shadow. Persisté en
+ * `__seo_event_log.payload` (cf. SeoShadowEventSink).
+ */
+export interface DiffResult {
+  diffs: FieldDiff[];
+  /** Sous-ensemble de fields où `equal=false` (jamais `null`). */
+  divergenceTypes: string[];
+  /** True si canonical_eq=false OU robots_eq=false. */
+  policyDivergence: boolean;
+  /** Résumé compact pour log warn. */
+  summary: {
+    surface: string;
+    divergenceCount: number;
+    divergenceTypes: string[];
+  };
+}

--- a/backend/src/modules/vehicles/brands.controller.ts
+++ b/backend/src/modules/vehicles/brands.controller.ts
@@ -16,10 +16,12 @@ import {
   Body,
   Param,
   Query,
+  Req,
   Logger,
   ParseIntPipe,
   Header,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import { OperationFailedException } from '@common/exceptions';
 import { VehicleBrandsService } from './services/data/vehicle-brands.service';
 import { VehicleModelsService } from './services/data/vehicle-models.service';
@@ -395,12 +397,17 @@ export class BrandsController {
    * Utilisé par le loader frontend /constructeurs/{brand}.html
    */
   @Get(':id/page-data-rpc')
-  async getBrandPageDataRpc(@Param('id', ParseIntPipe) marqueId: number) {
+  async getBrandPageDataRpc(
+    @Param('id', ParseIntPipe) marqueId: number,
+    @Req() req: Request,
+  ) {
     this.logger.log(`⚡ GET /api/brands/${marqueId}/page-data-rpc`);
 
     try {
-      const result =
-        await this.brandRpcService.getBrandPageDataOptimized(marqueId);
+      const result = await this.brandRpcService.getBrandPageDataOptimized(
+        marqueId,
+        req.url,
+      );
 
       return {
         success: true,

--- a/backend/src/modules/vehicles/services/brand-rpc.service.ts
+++ b/backend/src/modules/vehicles/services/brand-rpc.service.ts
@@ -4,6 +4,8 @@ import { CacheService } from '@cache/cache.service';
 import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
 import { DatabaseException, ErrorCodes } from '@common/exceptions';
 
+import { SeoShadowObservatory } from '@modules/seo-shadow-observatory/seo-shadow-observatory.service';
+
 /**
  * 🚀 Service RPC optimisé pour les pages marques constructeurs
  *
@@ -34,6 +36,7 @@ export class BrandRpcService extends SupabaseBaseService {
   constructor(
     private readonly cacheService: CacheService,
     rpcGate: RpcGateService,
+    private readonly shadowObservatory: SeoShadowObservatory,
   ) {
     super();
     this.rpcGate = rpcGate;
@@ -47,9 +50,12 @@ export class BrandRpcService extends SupabaseBaseService {
   }
 
   /**
-   * ⚡ Récupère les données page marque avec cache
+   * ⚡ Récupère les données page marque avec cache.
+   *
+   * `requestUrl` optionnel — si fourni, déclenche une observation shadow
+   * (SeoShadowObservatory, PR-6). Sync, non-bloquant pour le chemin réponse.
    */
-  async getBrandPageDataOptimized(marqueId: number) {
+  async getBrandPageDataOptimized(marqueId: number, requestUrl?: string) {
     const startTime = performance.now();
     const cacheKey = this.getCacheKey(marqueId);
 
@@ -61,13 +67,15 @@ export class BrandRpcService extends SupabaseBaseService {
       this.logger.debug(
         `🎯 CACHE HIT brand ${marqueId} en ${cacheTime.toFixed(1)}ms`,
       );
-      return {
+      const result = {
         ...cached,
         _cache: {
           hit: true,
           time: cacheTime,
         },
       };
+      this.fireShadowObservation(marqueId, requestUrl, result);
+      return result;
     }
 
     // 2. Cache miss → Appel RPC
@@ -80,7 +88,52 @@ export class BrandRpcService extends SupabaseBaseService {
       this.logger.error(`Erreur cache brand ${marqueId}:`, err),
     );
 
+    this.fireShadowObservation(marqueId, requestUrl, result);
     return result;
+  }
+
+  /**
+   * Fire-and-forget shadow observation (PR-6).
+   *
+   * NE PAS `await` cette méthode — `observe()` est sync par contrat (validé
+   * par `.ast-grep/rules/seo-shadow-no-await.yml`). La comparaison réelle
+   * court via `setImmediate` dans le module observatory.
+   */
+  private fireShadowObservation(
+    marqueId: number,
+    requestUrl: string | undefined,
+    result: Record<string, unknown>,
+  ): void {
+    if (!requestUrl) return;
+    const brand =
+      (result['brand'] as Record<string, unknown> | undefined) ?? undefined;
+    const seo =
+      (result['seo'] as Record<string, unknown> | undefined) ?? undefined;
+    const brandAlias = String(brand?.['marque_alias'] ?? '');
+    const marqueName = String(brand?.['marque_name'] ?? '');
+    if (!brandAlias) return;
+    this.shadowObservatory.observe({
+      surface: 'R7_BRAND_HUB',
+      legacy: {
+        title: (seo?.['title'] as string | null | undefined) ?? null,
+        description:
+          (seo?.['description'] as string | null | undefined) ?? null,
+        h1: (seo?.['h1'] as string | null | undefined) ?? null,
+        content: (seo?.['content'] as string | null | undefined) ?? null,
+        keywords: (seo?.['keywords'] as string | null | undefined) ?? null,
+        canonical: (seo?.['canonical'] as string | null | undefined) ?? null,
+        robots: (seo?.['robots'] as string | null | undefined) ?? null,
+      },
+      requestUrl,
+      ids: {
+        brandId: marqueId,
+        brandAlias,
+      },
+      vars: {
+        VMarque: marqueName,
+      },
+      entityId: String(marqueId),
+    });
   }
 
   /**

--- a/backend/src/modules/vehicles/services/vehicle-rpc.service.ts
+++ b/backend/src/modules/vehicles/services/vehicle-rpc.service.ts
@@ -4,6 +4,8 @@ import { CacheService } from '@cache/cache.service';
 import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
 import { DomainNotFoundException, ErrorCodes } from '@common/exceptions';
 
+import { SeoShadowObservatory } from '@modules/seo-shadow-observatory/seo-shadow-observatory.service';
+
 /**
  * Service RPC pour les pages vehicule /constructeurs/{marque}/{modele}/{type}.html
  *
@@ -28,6 +30,7 @@ export class VehicleRpcService extends SupabaseBaseService {
   constructor(
     private readonly cacheService: CacheService,
     rpcGate: RpcGateService,
+    private readonly shadowObservatory: SeoShadowObservatory,
   ) {
     super();
     this.rpcGate = rpcGate;
@@ -39,8 +42,11 @@ export class VehicleRpcService extends SupabaseBaseService {
 
   /**
    * Récupère les données page véhicule. Redis L1 (1h) + DB cache-first.
+   *
+   * `requestUrl` optionnel — si fourni, déclenche une observation shadow
+   * (SeoShadowObservatory, PR-6). Sync, non-bloquant pour le chemin réponse.
    */
-  async getVehiclePageDataOptimized(typeId: number) {
+  async getVehiclePageDataOptimized(typeId: number, requestUrl?: string) {
     const startTime = performance.now();
     const cacheKey = this.getCacheKey(typeId);
 
@@ -48,10 +54,12 @@ export class VehicleRpcService extends SupabaseBaseService {
     const cached =
       await this.cacheService.get<Record<string, unknown>>(cacheKey);
     if (cached) {
-      return {
+      const result = {
         ...cached,
         _cache: { hit: true, time: performance.now() - startTime },
       };
+      this.fireShadowObservation(typeId, requestUrl, result);
+      return result;
     }
 
     // L2: table __vehicle_page_cache via get_vehicle_page_data_cached (rebuild si miss)
@@ -85,13 +93,69 @@ export class VehicleRpcService extends SupabaseBaseService {
         this.logger.warn(`L1 cache set failed for type ${typeId}: ${err}`),
       );
 
-    return {
+    const result = {
       ...data,
       _performance: {
         totalTime: performance.now() - startTime,
         cacheHit: false,
       },
     };
+    this.fireShadowObservation(typeId, requestUrl, result);
+    return result;
+  }
+
+  /**
+   * Fire-and-forget shadow observation R8 (PR-6).
+   *
+   * NE PAS `await` cette méthode — `observe()` est sync par contrat (validé
+   * par `.ast-grep/rules/seo-shadow-no-await.yml`). La comparaison réelle
+   * court via `setImmediate` dans le module observatory.
+   *
+   * Limite connue : R8 canonical comparison désactivée (frontend Remix
+   * applique un redirect 301 que le backend ne reproduit pas).
+   * `policy_divergence` R8 reste piloté par `robots_eq` uniquement.
+   */
+  private fireShadowObservation(
+    typeId: number,
+    requestUrl: string | undefined,
+    result: Record<string, unknown>,
+  ): void {
+    if (!requestUrl) return;
+    const vehicle =
+      (result['vehicle'] as Record<string, unknown> | undefined) ?? undefined;
+    const seo =
+      (result['seo'] as Record<string, unknown> | undefined) ?? undefined;
+    const brandAlias = String(vehicle?.['marque_alias'] ?? '');
+    const modeleAlias = String(vehicle?.['modele_alias'] ?? '');
+    const typeAlias = String(vehicle?.['type_alias'] ?? '');
+    if (!brandAlias || !modeleAlias || !typeAlias) return;
+    this.shadowObservatory.observe({
+      surface: 'R8_VEHICLE',
+      legacy: {
+        title: (seo?.['title'] as string | null | undefined) ?? null,
+        description:
+          (seo?.['description'] as string | null | undefined) ?? null,
+        h1: (seo?.['h1'] as string | null | undefined) ?? null,
+        content: (seo?.['content'] as string | null | undefined) ?? null,
+        keywords: (seo?.['keywords'] as string | null | undefined) ?? null,
+        canonical: (seo?.['canonical'] as string | null | undefined) ?? null,
+        robots: (seo?.['robots'] as string | null | undefined) ?? null,
+      },
+      requestUrl,
+      ids: {
+        brandId: Number(vehicle?.['marque_id'] ?? 0),
+        brandAlias,
+        modeleAlias,
+        typeAlias,
+        typeId,
+      },
+      vars: {
+        VMarque: String(vehicle?.['marque_name'] ?? ''),
+        VModele: String(vehicle?.['modele_name'] ?? ''),
+        VType: String(vehicle?.['type_name'] ?? ''),
+      },
+      entityId: String(typeId),
+    });
   }
 
   /**

--- a/backend/src/modules/vehicles/vehicles.controller.ts
+++ b/backend/src/modules/vehicles/vehicles.controller.ts
@@ -5,12 +5,13 @@ import {
   Query,
   Param,
   Body,
+  Req,
   Res,
   Logger,
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { DomainNotFoundException } from '@common/exceptions';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { VehiclesService } from './vehicles.service';
 import { VehiclePaginationDto } from './dto/vehicles.dto';
 import { VehicleBrandsService } from './services/data/vehicle-brands.service';
@@ -350,13 +351,18 @@ export class VehiclesController {
    * Utilisé par le loader frontend /constructeurs/.../type.html
    */
   @Get('types/:typeId/page-data-rpc')
-  async getVehiclePageDataRpc(@Param('typeId') typeId: string) {
+  async getVehiclePageDataRpc(
+    @Param('typeId') typeId: string,
+    @Req() req: Request,
+  ) {
     const typeIdNum = parseInt(typeId, 10);
     this.logger.log(`⚡ GET /api/vehicles/types/${typeIdNum}/page-data-rpc`);
 
     try {
-      const result =
-        await this.vehicleRpcService.getVehiclePageDataOptimized(typeIdNum);
+      const result = await this.vehicleRpcService.getVehiclePageDataOptimized(
+        typeIdNum,
+        req.url,
+      );
 
       // Overlay R8 enriched content (non-blocking, ~5ms)
       const r8Content = await this.vehicleRpcService.getR8Content(typeIdNum);

--- a/backend/src/modules/vehicles/vehicles.module.ts
+++ b/backend/src/modules/vehicles/vehicles.module.ts
@@ -58,10 +58,14 @@ import { BrandRpcService } from './services/brand-rpc.service';
 import { CatalogModule } from '../catalog/catalog.module';
 import { DatabaseModule } from '../../database/database.module';
 
+// PR-6 — observatory shadow R7/R8 (consommé par BrandRpcService + VehicleRpcService)
+import { SeoShadowObservatoryModule } from '../seo-shadow-observatory/seo-shadow-observatory.module';
+
 @Module({
   imports: [
     ConfigModule,
     DatabaseModule,
+    SeoShadowObservatoryModule, // PR-6 shadow observatory R7/R8
     forwardRef(() => CatalogModule), // 🔗 Pour le maillage interne (gammes populaires)
     CacheModule.registerAsync({
       inject: [ConfigService],

--- a/backend/tests/unit/seo-shadow-chain-runner.test.ts
+++ b/backend/tests/unit/seo-shadow-chain-runner.test.ts
@@ -1,0 +1,120 @@
+/**
+ * SeoShadowChainRunner — adaptateur unique vers SeoChainOrchestratorService
+ * + timeout 2s + Zod validation du output.
+ *
+ * @see backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts
+ */
+import {
+  SeoShadowChainRunner,
+  SeoShadowChainTimeoutError,
+  SeoShadowSurfaceNotWiredError,
+} from '../../src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service';
+import type { SeoChainOrchestratorService } from '../../src/modules/seo/services/chain/seo-chain-orchestrator.service';
+import type { ShadowObservationInput } from '../../src/modules/seo-shadow-observatory/types';
+
+function fakeOrchestratorOk() {
+  return {
+    run: jest.fn().mockResolvedValue({
+      surfaceKey: 'R7_BRAND_HUB',
+      template: {
+        title: 'A',
+        description: 'B',
+        h1: 'C',
+        preview: 'P',
+        content: 'D',
+        keywords: 'E',
+      },
+      contentBlocks: [],
+      policies: { canonical: 'https://www.automecanik.com/x', robots: 'index,follow', blockingReasons: [] },
+      ariane: { jsonLd: null, textTrail: null },
+      metadata: {},
+    }),
+  } as unknown as SeoChainOrchestratorService;
+}
+
+function r7Input(overrides: Partial<ShadowObservationInput> = {}): ShadowObservationInput {
+  return {
+    surface: 'R7_BRAND_HUB',
+    legacy: { title: 'A' },
+    requestUrl: 'https://www.automecanik.com/constructeurs/bmw.html',
+    ids: { brandId: 1, brandAlias: 'bmw' },
+    vars: { VMarque: 'BMW' },
+    entityId: '1',
+    ...overrides,
+  };
+}
+
+describe('SeoShadowChainRunner', () => {
+  it('compute success → ChainSeoSnapshot bien formé', async () => {
+    const runner = new SeoShadowChainRunner(fakeOrchestratorOk());
+    const out = await runner.compute(r7Input());
+    expect(out.title).toBe('A');
+    expect(out.canonical).toBe('https://www.automecanik.com/x');
+    expect(out.robots).toBe('index,follow');
+  });
+
+  it('R8 input → adapté avec ids brandAlias/modeleAlias/typeAlias', async () => {
+    const orchestrator = fakeOrchestratorOk();
+    const runner = new SeoShadowChainRunner(orchestrator);
+    await runner.compute(
+      r7Input({
+        surface: 'R8_VEHICLE',
+        ids: {
+          brandId: 1,
+          brandAlias: 'bmw',
+          modeleAlias: 'serie-3',
+          typeAlias: '320i',
+          typeId: 9876,
+        },
+      }),
+    );
+    const callInput = (orchestrator.run as jest.Mock).mock.calls[0][0];
+    expect(callInput.surfaceKey).toBe('R8_VEHICLE');
+    expect(callInput.typeId).toBe(9876);
+    expect(callInput.ids.brandAlias).toBe('bmw');
+    expect(callInput.ids.modeleAlias).toBe('serie-3');
+    expect(callInput.ids.typeAlias).toBe('320i');
+  });
+
+  it('orchestrator throw → propagé', async () => {
+    const orchestrator = {
+      run: jest.fn().mockRejectedValue(new Error('boom')),
+    } as unknown as SeoChainOrchestratorService;
+    const runner = new SeoShadowChainRunner(orchestrator);
+    await expect(runner.compute(r7Input())).rejects.toThrow(/boom/);
+  });
+
+  it('timeout 2s → throw SeoShadowChainTimeoutError', async () => {
+    jest.useFakeTimers();
+    const orchestrator = {
+      run: jest.fn().mockImplementation(() => new Promise(() => {})),
+    } as unknown as SeoChainOrchestratorService;
+    const runner = new SeoShadowChainRunner(orchestrator);
+    const promise = runner.compute(r7Input());
+    jest.advanceTimersByTime(2_001);
+    await expect(promise).rejects.toThrow(SeoShadowChainTimeoutError);
+    jest.useRealTimers();
+  });
+
+  it('output corrompu (type invalide) → Zod throw', async () => {
+    const orchestrator = {
+      run: jest.fn().mockResolvedValue({
+        surfaceKey: 'R7_BRAND_HUB',
+        template: { title: 42, description: 'B', h1: 'C', preview: '', content: '', keywords: '' },
+        contentBlocks: [],
+        policies: { canonical: '', robots: 'index,follow' },
+        ariane: {},
+        metadata: {},
+      }),
+    } as unknown as SeoChainOrchestratorService;
+    const runner = new SeoShadowChainRunner(orchestrator);
+    await expect(runner.compute(r7Input())).rejects.toBeDefined();
+  });
+
+  it('surface non câblée → throw SeoShadowSurfaceNotWiredError', async () => {
+    const runner = new SeoShadowChainRunner(fakeOrchestratorOk());
+    await expect(
+      runner.compute(r7Input({ surface: 'R0_HOME' })),
+    ).rejects.toThrow(SeoShadowSurfaceNotWiredError);
+  });
+});

--- a/backend/tests/unit/seo-shadow-diff-engine.test.ts
+++ b/backend/tests/unit/seo-shadow-diff-engine.test.ts
@@ -1,0 +1,155 @@
+/**
+ * SeoShadowDiffEngine — diff field-level legacy↔chain + R8 canonical skip.
+ *
+ * @see backend/src/modules/seo-shadow-observatory/seo-shadow-diff-engine.service.ts
+ */
+import { SeoShadowDiffEngine } from '../../src/modules/seo-shadow-observatory/seo-shadow-diff-engine.service';
+import { SeoShadowUrlNormalizer } from '../../src/modules/seo-shadow-observatory/seo-shadow-url-normalizer.service';
+import type {
+  ChainSeoSnapshot,
+  LegacySeoSnapshot,
+} from '../../src/modules/seo-shadow-observatory/types';
+
+const REQUEST_URL = 'https://www.automecanik.com/constructeurs/bmw.html';
+
+function legacy(overrides: Partial<LegacySeoSnapshot> = {}): LegacySeoSnapshot {
+  return {
+    title: 'Pièces BMW',
+    description: 'Catalogue BMW',
+    h1: 'BMW',
+    content: 'Lorem',
+    keywords: 'bmw,pieces',
+    canonical: REQUEST_URL,
+    robots: 'index,follow',
+    ...overrides,
+  };
+}
+
+function chain(overrides: Partial<ChainSeoSnapshot> = {}): ChainSeoSnapshot {
+  return {
+    title: 'Pièces BMW',
+    description: 'Catalogue BMW',
+    h1: 'BMW',
+    content: 'Lorem',
+    keywords: 'bmw,pieces',
+    canonical: REQUEST_URL,
+    robots: 'index,follow',
+    ...overrides,
+  };
+}
+
+describe('SeoShadowDiffEngine', () => {
+  let engine: SeoShadowDiffEngine;
+  beforeEach(() => {
+    engine = new SeoShadowDiffEngine(new SeoShadowUrlNormalizer());
+  });
+
+  it('tous champs égaux → divergenceTypes vide + policyDivergence false', () => {
+    const r = engine.compare(legacy(), chain(), REQUEST_URL, 'R7_BRAND_HUB');
+    expect(r.divergenceTypes).toEqual([]);
+    expect(r.policyDivergence).toBe(false);
+    expect(r.summary.divergenceCount).toBe(0);
+  });
+
+  it('title divergent → divergenceTypes contient title, mais policyDivergence false', () => {
+    const r = engine.compare(
+      legacy(),
+      chain({ title: 'Autre titre' }),
+      REQUEST_URL,
+      'R7_BRAND_HUB',
+    );
+    expect(r.divergenceTypes).toContain('title');
+    expect(r.policyDivergence).toBe(false);
+  });
+
+  it('canonical divergent (R7) → policyDivergence true', () => {
+    const r = engine.compare(
+      legacy({ canonical: REQUEST_URL }),
+      chain({ canonical: 'https://www.automecanik.com/constructeurs/audi.html' }),
+      REQUEST_URL,
+      'R7_BRAND_HUB',
+    );
+    expect(r.divergenceTypes).toContain('canonical');
+    expect(r.policyDivergence).toBe(true);
+  });
+
+  it('canonical normalisé identique malgré format différent', () => {
+    // legacy avec trailing slash + casse + http, chain forme normalisée
+    const r = engine.compare(
+      legacy({ canonical: 'http://www.automecanik.com/Constructeurs/BMW.html/' }),
+      chain({ canonical: 'https://www.automecanik.com/constructeurs/bmw.html' }),
+      REQUEST_URL,
+      'R7_BRAND_HUB',
+    );
+    const canonical = r.diffs.find((d) => d.field === 'canonical');
+    expect(canonical?.equal).toBe(true);
+    expect(r.policyDivergence).toBe(false);
+  });
+
+  it('R8_VEHICLE → canonical equal=null + skip_reason', () => {
+    const r = engine.compare(
+      legacy({ canonical: 'https://www.automecanik.com/A.html' }),
+      chain({ canonical: 'https://www.automecanik.com/B.html' }),
+      REQUEST_URL,
+      'R8_VEHICLE',
+    );
+    const canonical = r.diffs.find((d) => d.field === 'canonical');
+    expect(canonical?.equal).toBeNull();
+    expect(canonical?.skip_reason).toBe(
+      'r8_frontend_redirect_logic_not_reproduced',
+    );
+    expect(r.divergenceTypes).not.toContain('canonical');
+  });
+
+  it('R8_VEHICLE robots divergent → policyDivergence true (canonical skip ne masque pas robots)', () => {
+    const r = engine.compare(
+      legacy({ robots: 'index,follow' }),
+      chain({ robots: 'noindex,follow' }),
+      REQUEST_URL,
+      'R8_VEHICLE',
+    );
+    expect(r.divergenceTypes).toContain('robots');
+    expect(r.policyDivergence).toBe(true);
+  });
+
+  it('robots un seul côté → equal=null, pas de policyDivergence sur robots seul', () => {
+    const r = engine.compare(
+      legacy({ robots: null }),
+      chain({ robots: 'index,follow' }),
+      REQUEST_URL,
+      'R7_BRAND_HUB',
+    );
+    const robots = r.diffs.find((d) => d.field === 'robots');
+    expect(robots?.equal).toBeNull();
+  });
+
+  it('robots whitespace/case insensitive', () => {
+    const r = engine.compare(
+      legacy({ robots: 'INDEX, FOLLOW' }),
+      chain({ robots: 'index,follow' }),
+      REQUEST_URL,
+      'R7_BRAND_HUB',
+    );
+    const robots = r.diffs.find((d) => d.field === 'robots');
+    expect(robots?.equal).toBe(true);
+  });
+
+  it('hashes 12 hex chars présents quand champ présent', () => {
+    const r = engine.compare(legacy(), chain(), REQUEST_URL, 'R7_BRAND_HUB');
+    const title = r.diffs.find((d) => d.field === 'title');
+    expect(title?.legacyHash).toMatch(/^[0-9a-f]{12}$/);
+    expect(title?.chainHash).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it('summary contient surface + count + types', () => {
+    const r = engine.compare(
+      legacy(),
+      chain({ title: 'X', description: 'Y' }),
+      REQUEST_URL,
+      'R7_BRAND_HUB',
+    );
+    expect(r.summary.surface).toBe('R7_BRAND_HUB');
+    expect(r.summary.divergenceCount).toBe(2);
+    expect(r.summary.divergenceTypes.sort()).toEqual(['description', 'title']);
+  });
+});

--- a/backend/tests/unit/seo-shadow-event-sink.test.ts
+++ b/backend/tests/unit/seo-shadow-event-sink.test.ts
@@ -1,0 +1,130 @@
+/**
+ * SeoShadowEventSink — write `__seo_event_log` + Sentry withScope.
+ *
+ * @see backend/src/modules/seo-shadow-observatory/seo-shadow-event-sink.service.ts
+ */
+import { ConfigService } from '@nestjs/config';
+
+jest.mock('@sentry/nestjs', () => ({
+  withScope: jest.fn((fn: (s: { setTag: jest.Mock; setExtra: jest.Mock }) => void) =>
+    fn({ setTag: jest.fn(), setExtra: jest.fn() }),
+  ),
+  captureMessage: jest.fn(),
+}));
+
+import * as Sentry from '@sentry/nestjs';
+
+import { SeoShadowEventSink } from '../../src/modules/seo-shadow-observatory/seo-shadow-event-sink.service';
+import type { DiffResult } from '../../src/modules/seo-shadow-observatory/types';
+
+function buildSupabaseStub() {
+  const insert = jest.fn().mockResolvedValue({ error: null });
+  const from = jest.fn(() => ({ insert }));
+  return { from, insert };
+}
+
+function buildSink(supabaseStub: { from: jest.Mock }): SeoShadowEventSink {
+  const cfg = {
+    get: (k: string) => (k === 'SUPABASE_URL' ? 'http://x' : undefined),
+  } as unknown as ConfigService;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'fake';
+  const sink = new SeoShadowEventSink(cfg);
+  // @ts-expect-error swap supabase
+  sink['supabase'] = { from: supabaseStub.from };
+  return sink;
+}
+
+const baseDiff: DiffResult = {
+  diffs: [
+    {
+      field: 'title',
+      equal: true,
+      legacyHash: 'aaa',
+      chainHash: 'aaa',
+      legacyLen: 3,
+      chainLen: 3,
+    },
+  ],
+  divergenceTypes: [],
+  policyDivergence: false,
+  summary: {
+    surface: 'R7_BRAND_HUB',
+    divergenceCount: 0,
+    divergenceTypes: [],
+  },
+};
+
+describe('SeoShadowEventSink', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('insère event_type=anomaly_detected + payload.subtype=seo.shadow.r7.divergence (R7)', async () => {
+    const supa = buildSupabaseStub();
+    const sink = buildSink(supa);
+    await sink.write('R7_BRAND_HUB', '42', 'https://x.test/y', baseDiff);
+    expect(supa.from).toHaveBeenCalledWith('__seo_event_log');
+    expect(supa.insert).toHaveBeenCalledTimes(1);
+    const row = (supa.insert.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect(row.event_type).toBe('anomaly_detected');
+    expect((row.payload as Record<string, unknown>).subtype).toBe(
+      'seo.shadow.r7.divergence',
+    );
+    expect((row.payload as Record<string, unknown>).schema_version).toBe(1);
+    expect(row.entity_url).toBe('https://x.test/y');
+  });
+
+  it('mappe R8_VEHICLE → seo.shadow.r8.divergence', async () => {
+    const supa = buildSupabaseStub();
+    const sink = buildSink(supa);
+    await sink.write('R8_VEHICLE', '999', 'https://x.test/v', baseDiff);
+    const row = (supa.insert.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect((row.payload as Record<string, unknown>).subtype).toBe(
+      'seo.shadow.r8.divergence',
+    );
+  });
+
+  it('severity=info quand policyDivergence=false', async () => {
+    const supa = buildSupabaseStub();
+    const sink = buildSink(supa);
+    await sink.write('R7_BRAND_HUB', '1', 'https://x.test/', baseDiff);
+    const row = (supa.insert.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect(row.severity).toBe('info');
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('severity=medium + Sentry.withScope+captureMessage quand policyDivergence=true', async () => {
+    const supa = buildSupabaseStub();
+    const sink = buildSink(supa);
+    await sink.write('R7_BRAND_HUB', '7', 'https://x.test/', {
+      ...baseDiff,
+      policyDivergence: true,
+    });
+    const row = (supa.insert.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect(row.severity).toBe('medium');
+    expect(Sentry.withScope).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect((Sentry.captureMessage as jest.Mock).mock.calls[0][1]).toBe('warning');
+  });
+
+  it('surface non mappée → throw', async () => {
+    const supa = buildSupabaseStub();
+    const sink = buildSink(supa);
+    // R0_HOME est un SurfaceKey valide mais pas mappé dans SURFACE_SUBTYPE
+    // (PR-6 = R7+R8 only). Ajout futur quand R0 est wiré.
+    await expect(sink.write('R0_HOME', '1', 'https://x.test/', baseDiff))
+      .rejects.toThrow(/non mappée/);
+  });
+
+  it('Supabase error → throw', async () => {
+    const supa = {
+      from: jest.fn(() => ({
+        insert: jest.fn().mockResolvedValue({ error: { message: 'duplicate' } }),
+      })),
+    };
+    const sink = buildSink(supa);
+    await expect(
+      sink.write('R7_BRAND_HUB', '1', 'https://x.test/', baseDiff),
+    ).rejects.toThrow(/event_log insert failed/);
+  });
+});

--- a/backend/tests/unit/seo-shadow-observatory.test.ts
+++ b/backend/tests/unit/seo-shadow-observatory.test.ts
@@ -1,0 +1,195 @@
+/**
+ * SeoShadowObservatory — service public, sync API + circuit breaker.
+ *
+ * @see backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.service.ts
+ */
+import { ConfigService } from '@nestjs/config';
+
+import { SeoFeatureFlagRegistry } from '../../src/modules/seo/registries/seo-feature-flag.registry';
+import { SeoShadowObservatory } from '../../src/modules/seo-shadow-observatory/seo-shadow-observatory.service';
+import { SeoShadowSampler } from '../../src/modules/seo-shadow-observatory/seo-shadow-sampler.service';
+import {
+  SeoShadowChainRunner,
+  SeoShadowChainTimeoutError,
+} from '../../src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service';
+import { SeoShadowDiffEngine } from '../../src/modules/seo-shadow-observatory/seo-shadow-diff-engine.service';
+import { SeoShadowEventSink } from '../../src/modules/seo-shadow-observatory/seo-shadow-event-sink.service';
+import { SeoShadowUrlNormalizer } from '../../src/modules/seo-shadow-observatory/seo-shadow-url-normalizer.service';
+
+function flushImmediates(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function makeCfg(rate = '1', mode: 'off' | 'shadow' | 'on' = 'shadow'): ConfigService {
+  process.env.SEO_CHAIN_R7_MODE = mode;
+  process.env.SEO_CHAIN_SHADOW_SAMPLE_RATE = rate;
+  return {
+    get: (k: string) => process.env[k],
+  } as unknown as ConfigService;
+}
+
+function buildInput(overrides: Record<string, unknown> = {}) {
+  return {
+    surface: 'R7_BRAND_HUB' as const,
+    legacy: {
+      title: 'A',
+      description: 'B',
+      h1: 'C',
+      content: 'D',
+      keywords: 'E',
+      canonical: 'https://www.automecanik.com/x',
+      robots: 'index,follow',
+    },
+    requestUrl: 'https://www.automecanik.com/x',
+    ids: { brandId: 1, brandAlias: 'bmw' },
+    vars: { VMarque: 'BMW' },
+    entityId: '1',
+    ...overrides,
+  };
+}
+
+describe('SeoShadowObservatory', () => {
+  let cfg: ConfigService;
+  let flags: SeoFeatureFlagRegistry;
+  let sampler: SeoShadowSampler;
+  let chainRunner: SeoShadowChainRunner;
+  let diffEngine: SeoShadowDiffEngine;
+  let sink: SeoShadowEventSink;
+  let observatory: SeoShadowObservatory;
+
+  beforeEach(() => {
+    cfg = makeCfg('1', 'shadow');
+    flags = new SeoFeatureFlagRegistry();
+    sampler = new SeoShadowSampler(cfg);
+    chainRunner = {
+      compute: jest.fn().mockResolvedValue({
+        title: 'A',
+        description: 'B',
+        h1: 'C',
+        content: 'D',
+        keywords: 'E',
+        canonical: 'https://www.automecanik.com/x',
+        robots: 'index,follow',
+      }),
+    } as unknown as SeoShadowChainRunner;
+    diffEngine = new SeoShadowDiffEngine(new SeoShadowUrlNormalizer());
+    sink = { write: jest.fn().mockResolvedValue(undefined) } as unknown as SeoShadowEventSink;
+    observatory = new SeoShadowObservatory(
+      flags,
+      sampler,
+      chainRunner,
+      diffEngine,
+      sink,
+    );
+  });
+
+  afterEach(() => {
+    delete process.env.SEO_CHAIN_R7_MODE;
+    delete process.env.SEO_CHAIN_SHADOW_SAMPLE_RATE;
+    jest.restoreAllMocks();
+  });
+
+  it('mode=off → chainRunner non appelé, sink non appelé', async () => {
+    process.env.SEO_CHAIN_R7_MODE = 'off';
+    observatory.observe(buildInput());
+    await flushImmediates();
+    expect(chainRunner.compute).not.toHaveBeenCalled();
+    expect(sink.write).not.toHaveBeenCalled();
+  });
+
+  it('mode=on → chainRunner non appelé (PR-6 ne contient pas la branche on)', async () => {
+    process.env.SEO_CHAIN_R7_MODE = 'on';
+    observatory.observe(buildInput());
+    await flushImmediates();
+    expect(chainRunner.compute).not.toHaveBeenCalled();
+    expect(sink.write).not.toHaveBeenCalled();
+  });
+
+  it('mode=shadow + sample → chainRunner + sink appelés', async () => {
+    observatory.observe(buildInput());
+    await flushImmediates();
+    expect(chainRunner.compute).toHaveBeenCalledTimes(1);
+    expect(sink.write).toHaveBeenCalledTimes(1);
+  });
+
+  it('mode=shadow + sample rate 0 → chainRunner non appelé', async () => {
+    process.env.SEO_CHAIN_SHADOW_SAMPLE_RATE = '0';
+    sampler = new SeoShadowSampler(cfg);
+    observatory = new SeoShadowObservatory(
+      flags,
+      sampler,
+      chainRunner,
+      diffEngine,
+      sink,
+    );
+    observatory.observe(buildInput());
+    await flushImmediates();
+    expect(chainRunner.compute).not.toHaveBeenCalled();
+  });
+
+  it('observe() retourne SYNCHRONEMENT — chainRunner.compute pas encore lancé après return', () => {
+    let computeStarted = false;
+    (chainRunner.compute as jest.Mock).mockImplementation(async () => {
+      computeStarted = true;
+      return {
+        title: 'A',
+        description: 'B',
+        h1: 'C',
+        content: 'D',
+        keywords: 'E',
+        canonical: 'https://www.automecanik.com/x',
+        robots: 'index,follow',
+      };
+    });
+    observatory.observe(buildInput());
+    // Au retour synchrone, setImmediate n'a pas encore tiré.
+    expect(computeStarted).toBe(false);
+  });
+
+  it('input invalide Zod → log + no-op (pas de crash propagé)', async () => {
+    const errSpy = jest.spyOn((observatory as unknown as { logger: { error: () => void } }).logger, 'error').mockImplementation(() => {});
+    observatory.observe({ not: 'valid' });
+    await flushImmediates();
+    expect(errSpy).toHaveBeenCalled();
+    expect(chainRunner.compute).not.toHaveBeenCalled();
+  });
+
+  it('chainRunner throw non-timeout → sink non appelé, error loggée', async () => {
+    (chainRunner.compute as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+    const errSpy = jest.spyOn((observatory as unknown as { logger: { error: () => void } }).logger, 'error').mockImplementation(() => {});
+    observatory.observe(buildInput());
+    await flushImmediates();
+    await flushImmediates();
+    expect(sink.write).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('circuit breaker s’ouvre après 50 timeouts/min', async () => {
+    (chainRunner.compute as jest.Mock).mockRejectedValue(
+      new SeoShadowChainTimeoutError(),
+    );
+    jest.spyOn((observatory as unknown as { logger: { error: () => void } }).logger, 'error').mockImplementation(() => {});
+
+    // Empile 50 observations qui timeout
+    for (let i = 0; i < 50; i++) {
+      observatory.observe(buildInput({ entityId: `t-${i}` }));
+    }
+    // Laisse les setImmediate tirer
+    for (let i = 0; i < 60; i++) {
+      await flushImmediates();
+    }
+
+    // 51e tentative → breaker ouvert, chainRunner non appelé
+    const callsBefore = (chainRunner.compute as jest.Mock).mock.calls.length;
+    observatory.observe(buildInput({ entityId: 'after' }));
+    await flushImmediates();
+    const callsAfter = (chainRunner.compute as jest.Mock).mock.calls.length;
+    expect(callsAfter).toBe(callsBefore);
+  });
+
+  it('surface non câblée pour shadow (ex: R0_HOME) → no-op', async () => {
+    observatory.observe(buildInput({ surface: 'R0_HOME' }));
+    await flushImmediates();
+    expect(chainRunner.compute).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/unit/seo-shadow-purge.test.ts
+++ b/backend/tests/unit/seo-shadow-purge.test.ts
@@ -1,0 +1,102 @@
+/**
+ * SeoShadowPurgeCron — purge `__seo_event_log` 30j + READ_ONLY gate au processor.
+ *
+ * @see backend/src/modules/seo-shadow-observatory/seo-shadow-purge.cron.ts
+ */
+import { ConfigService } from '@nestjs/config';
+
+import { SeoShadowPurgeCron } from '../../src/modules/seo-shadow-observatory/seo-shadow-purge.cron';
+
+interface SupabaseSpy {
+  from: jest.Mock;
+  delete: jest.Mock;
+  like: jest.Mock;
+  lt: jest.Mock;
+  select: jest.Mock;
+  __lastFilter?: { table?: string; deleteCalled?: boolean; like?: [string, string]; lt?: [string, string] };
+}
+
+function buildSupabaseStub(returns: { data?: unknown; error?: unknown; count?: number }) {
+  const builder: SupabaseSpy = {
+    from: jest.fn(),
+    delete: jest.fn(),
+    like: jest.fn(),
+    lt: jest.fn(),
+    select: jest.fn(),
+    __lastFilter: {},
+  };
+  builder.from.mockImplementation((table: string) => {
+    builder.__lastFilter!.table = table;
+    return builder;
+  });
+  builder.delete.mockImplementation(() => {
+    builder.__lastFilter!.deleteCalled = true;
+    return builder;
+  });
+  builder.like.mockImplementation((col: string, pattern: string) => {
+    builder.__lastFilter!.like = [col, pattern];
+    return builder;
+  });
+  builder.lt.mockImplementation((col: string, value: string) => {
+    builder.__lastFilter!.lt = [col, value];
+    return builder;
+  });
+  builder.select.mockResolvedValue(returns);
+  return builder;
+}
+
+function buildCron(env: Record<string, string | undefined>, supabaseStub: SupabaseSpy): SeoShadowPurgeCron {
+  process.env = { ...process.env, ...env };
+  const cfg = {
+    get: <T = string>(key: string): T | undefined => env[key] as T | undefined,
+  } as unknown as ConfigService;
+  const cron = new SeoShadowPurgeCron(cfg);
+  // @ts-expect-error swap supabase client par notre stub
+  cron['supabase'] = { from: supabaseStub.from };
+  return cron;
+}
+
+describe('SeoShadowPurgeCron', () => {
+  it('READ_ONLY=true → no-op (pas de query DELETE émise)', async () => {
+    const supa = buildSupabaseStub({ data: [], error: null, count: 0 });
+    const cron = buildCron({ READ_ONLY: 'true', SUPABASE_URL: 'http://x' }, supa);
+    const result = await cron.purgeOldEvents();
+    expect(result).toEqual({ deleted: 0, skipped: 'read_only' });
+    expect(supa.from).not.toHaveBeenCalled();
+    expect(supa.delete).not.toHaveBeenCalled();
+  });
+
+  it('WHERE clause cible strictement seo.shadow.%.divergence', async () => {
+    const supa = buildSupabaseStub({ data: [{ id: '1' }, { id: '2' }], error: null, count: 2 });
+    const cron = buildCron({ SUPABASE_URL: 'http://x' }, supa);
+    await cron.purgeOldEvents();
+    expect(supa.__lastFilter?.like?.[0]).toBe('payload->>subtype');
+    expect(supa.__lastFilter?.like?.[1]).toBe('seo.shadow.%.divergence');
+  });
+
+  it('cible la table __seo_event_log', async () => {
+    const supa = buildSupabaseStub({ data: [], error: null, count: 0 });
+    const cron = buildCron({ SUPABASE_URL: 'http://x' }, supa);
+    await cron.purgeOldEvents();
+    expect(supa.__lastFilter?.table).toBe('__seo_event_log');
+  });
+
+  it('cutoff = now - 30 jours', async () => {
+    const FIXED_NOW = new Date('2026-06-01T12:00:00Z').getTime();
+    jest.spyOn(Date, 'now').mockReturnValue(FIXED_NOW);
+    const supa = buildSupabaseStub({ data: [], error: null, count: 0 });
+    const cron = buildCron({ SUPABASE_URL: 'http://x' }, supa);
+    await cron.purgeOldEvents();
+    const expectedCutoff = new Date(FIXED_NOW - 30 * 24 * 3600 * 1000).toISOString();
+    expect(supa.__lastFilter?.lt?.[0]).toBe('created_at');
+    expect(supa.__lastFilter?.lt?.[1]).toBe(expectedCutoff);
+    jest.restoreAllMocks();
+  });
+
+  it('Supabase error → log + return deleted=0 (pas d’exception)', async () => {
+    const supa = buildSupabaseStub({ data: null, error: { message: 'boom' }, count: null });
+    const cron = buildCron({ SUPABASE_URL: 'http://x' }, supa);
+    const result = await cron.purgeOldEvents();
+    expect(result).toEqual({ deleted: 0 });
+  });
+});

--- a/backend/tests/unit/seo-shadow-sampler.test.ts
+++ b/backend/tests/unit/seo-shadow-sampler.test.ts
@@ -1,0 +1,68 @@
+/**
+ * SeoShadowSampler — sampler déterministe (sha1-based bucket).
+ *
+ * @see backend/src/modules/seo-shadow-observatory/seo-shadow-sampler.service.ts
+ */
+import { ConfigService } from '@nestjs/config';
+
+import { SeoShadowSampler } from '../../src/modules/seo-shadow-observatory/seo-shadow-sampler.service';
+
+function makeSampler(rate: string | undefined): SeoShadowSampler {
+  const cfg = {
+    get: (key: string) =>
+      key === 'SEO_CHAIN_SHADOW_SAMPLE_RATE' ? rate : undefined,
+  } as unknown as ConfigService;
+  return new SeoShadowSampler(cfg);
+}
+
+describe('SeoShadowSampler', () => {
+  it('rate=0 → never samples', () => {
+    const s = makeSampler('0');
+    for (let i = 0; i < 1000; i++) {
+      expect(s.shouldSample('R7_BRAND_HUB', `brand-${i}`)).toBe(false);
+    }
+  });
+
+  it('rate=1 → always samples', () => {
+    const s = makeSampler('1');
+    for (let i = 0; i < 1000; i++) {
+      expect(s.shouldSample('R7_BRAND_HUB', `brand-${i}`)).toBe(true);
+    }
+  });
+
+  it('rate=0.5 → ~50% sur 10k itérations (tolérance ±3%)', () => {
+    const s = makeSampler('0.5');
+    let sampled = 0;
+    for (let i = 0; i < 10000; i++) {
+      if (s.shouldSample('R7_BRAND_HUB', `entity-${i}`)) sampled++;
+    }
+    expect(sampled).toBeGreaterThan(4700);
+    expect(sampled).toBeLessThan(5300);
+  });
+
+  it('déterminisme cross-call : même paire = même décision', () => {
+    const s = makeSampler('0.3');
+    for (let i = 0; i < 100; i++) {
+      const key = `entity-${i}`;
+      const first = s.shouldSample('R7_BRAND_HUB', key);
+      for (let j = 0; j < 5; j++) {
+        expect(s.shouldSample('R7_BRAND_HUB', key)).toBe(first);
+      }
+    }
+  });
+
+  it('env malformée → fallback 0.01 (cohérent avec default)', () => {
+    const s = makeSampler('not-a-number');
+    expect(s.sampleRate).toBe(0.01);
+  });
+
+  it('env hors bornes → fallback 0.01', () => {
+    expect(makeSampler('-0.5').sampleRate).toBe(0.01);
+    expect(makeSampler('1.5').sampleRate).toBe(0.01);
+  });
+
+  it('env absente → fallback 0.01', () => {
+    const s = makeSampler(undefined);
+    expect(s.sampleRate).toBe(0.01);
+  });
+});

--- a/backend/tests/unit/seo-shadow-url-normalizer.test.ts
+++ b/backend/tests/unit/seo-shadow-url-normalizer.test.ts
@@ -1,0 +1,91 @@
+/**
+ * SeoShadowUrlNormalizer — normalisation canonical (RFC 3986 + lowercase host).
+ *
+ * @see backend/src/modules/seo-shadow-observatory/seo-shadow-url-normalizer.service.ts
+ */
+import { SeoShadowUrlNormalizer } from '../../src/modules/seo-shadow-observatory/seo-shadow-url-normalizer.service';
+
+describe('SeoShadowUrlNormalizer', () => {
+  let n: SeoShadowUrlNormalizer;
+  beforeEach(() => {
+    n = new SeoShadowUrlNormalizer();
+  });
+
+  describe('normalize()', () => {
+    it('null/undefined/empty → null', () => {
+      expect(n.normalize(null)).toBeNull();
+      expect(n.normalize(undefined)).toBeNull();
+      expect(n.normalize('')).toBeNull();
+    });
+
+    it('drop trailing slash sauf root', () => {
+      expect(n.normalize('https://www.automecanik.com/foo/')).toBe(
+        'https://www.automecanik.com/foo',
+      );
+      expect(n.normalize('https://www.automecanik.com/')).toBe(
+        'https://www.automecanik.com/',
+      );
+    });
+
+    it('lowercase pathname', () => {
+      expect(n.normalize('https://www.automecanik.com/Constructeurs/BMW.html'))
+        .toBe('https://www.automecanik.com/constructeurs/bmw.html');
+    });
+
+    it('décode URI', () => {
+      expect(n.normalize('https://www.automecanik.com/foo%20bar')).toBe(
+        'https://www.automecanik.com/foo bar',
+      );
+    });
+
+    it('drop fragment et query', () => {
+      expect(n.normalize('https://www.automecanik.com/x?a=1&b=2#frag')).toBe(
+        'https://www.automecanik.com/x',
+      );
+    });
+
+    it('force hostname canonique', () => {
+      expect(n.normalize('https://staging.automecanik.com/x')).toBe(
+        'https://www.automecanik.com/x',
+      );
+    });
+
+    it('force protocol https', () => {
+      expect(n.normalize('http://www.automecanik.com/x')).toBe(
+        'https://www.automecanik.com/x',
+      );
+    });
+
+    it('idempotence sur sortie déjà normalisée', () => {
+      const url = 'https://www.automecanik.com/constructeurs/bmw.html';
+      expect(n.normalize(n.normalize(url))).toBe(url);
+    });
+
+    it('path-only relative → ancré sur base canonique', () => {
+      expect(n.normalize('/foo/bar')).toBe('https://www.automecanik.com/foo/bar');
+    });
+  });
+
+  describe('reconstructLegacy()', () => {
+    it('utilise rpcCanonical si présent', () => {
+      expect(
+        n.reconstructLegacy(
+          'https://www.automecanik.com/x/',
+          '/should-be-ignored',
+        ),
+      ).toBe('https://www.automecanik.com/x');
+    });
+
+    it('fallback sur requestUrl si rpcCanonical null', () => {
+      expect(
+        n.reconstructLegacy(null, 'https://www.automecanik.com/Constructeurs/Bmw.html'),
+      ).toBe('https://www.automecanik.com/constructeurs/bmw.html');
+    });
+
+    it('fallback sur requestUrl si rpcCanonical vide', () => {
+      expect(n.reconstructLegacy('', '/constructeurs/bmw.html')).toBe(
+        'https://www.automecanik.com/constructeurs/bmw.html',
+      );
+    });
+  });
+});

--- a/backend/tests/unit/vehicle-rpc.service.test.ts
+++ b/backend/tests/unit/vehicle-rpc.service.test.ts
@@ -33,6 +33,10 @@ describe('VehicleRpcService', () => {
     get: jest.fn((_key: string, defaultValue?: any) => defaultValue),
   };
 
+  const mockShadowObservatory = {
+    observe: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -42,6 +46,12 @@ describe('VehicleRpcService', () => {
         { provide: CacheService, useValue: mockCacheService },
         { provide: RpcGateService, useValue: mockRpcGate },
         { provide: ConfigService, useValue: mockConfigService },
+        {
+          provide: (await import(
+            '../../src/modules/seo-shadow-observatory/seo-shadow-observatory.service'
+          )).SeoShadowObservatory,
+          useValue: mockShadowObservatory,
+        },
       ],
     }).compile();
 

--- a/log.md
+++ b/log.md
@@ -489,3 +489,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-v9-pr2d-marketing-parity`
 - **Décision** : feat(seo): marketing seed parity legacy V4 + V4 E2E test (PR-2d) (+4 other commits)
 - **Sortie** : PR #402 | commits 06f62afe 7cd4063f efc4c9fa 85731ace 8d66d310
+
+## 2026-05-09 — pr6-clean (auto)
+
+- **Branche** : `pr6-clean`
+- **Décision** : fix(seo-v9): pr-6 update vehicle-rpc legacy test for shadowObservatory dep (+2 other commits)
+- **Sortie** : PR aucune | commits c4808beb a8df0f53 c230abd4


### PR DESCRIPTION
## Summary

- Crée `SeoShadowObservatoryModule` — infra observabilité shadow réutilisable, dédiée. Premier usage : R7 (`/api/brands/:id/page-data-rpc`) + R8 (`/api/vehicles/types/:typeId/page-data-rpc`).
- **0 mutation** de la réponse legacy ; `observe()` sync, `setImmediate` découple ; aucune branche `mode === 'on'` dans le code livré.
- 4 couches defense-in-depth contre flip accidentel : Zod env + boot guard `throw` + CI guard workflow + lint ast-grep.

## Architecture (cf. plan §3)

```
caller → observe() (sync) → setImmediate → chain runner (timeout 2s)
       → diff engine (R8 canonical skip) → sink (__seo_event_log + Sentry)
```

| Composant | Rôle | Couplage SeoModule |
|---|---|---|
| `SeoShadowObservatory` | Public API + Zod input + circuit breaker (>50 timeouts/60s) | aucun (utilise les sous-services) |
| `SeoShadowSampler` | sha1-based déterministe (default 1%) | aucun |
| `SeoShadowUrlNormalizer` | RFC normalize + reconstructLegacy R7 | aucun |
| `SeoShadowDiffEngine` | Diff field-level + R8 canonical skip | aucun |
| `SeoShadowChainRunner` | Adaptateur unique vers SeoChainOrchestratorService + timeout 2s + Zod output | **seul** import SeoModule |
| `SeoShadowEventSink` | `__seo_event_log` + Sentry withScope/captureMessage | SupabaseService + Sentry |
| `SeoShadowPurgeCron` | TTL 30j, READ_ONLY gate au processor | SupabaseService |

## §2bis schema verified — Adjusted

Probe Supabase MCP : table effective = `__seo_event_log` (pas `event_log`), colonne `payload` (pas `data`), enum `seo_event_type` figé sans `seo.shadow.*`. **Décision** : réutiliser `event_type='anomaly_detected'` + placer slug shadow dans `payload.subtype='seo.shadow.r7.divergence'` / `'seo.shadow.r8.divergence'`. Aucune migration DB requise.

## R8 canonical limite connue

Le frontend Remix R8 applique un redirect 301 (`marque_alias-marque_id` mismatch, [constructeurs.\$brand.\$model.\$type.tsx:317-330](https://github.com/ak125/nestjs-remix-monorepo/blob/main/frontend/app/routes/constructeurs.%24brand.%24model.%24type.tsx#L317-L330)) que le backend ne reproduit pas. Le `legacyCanonical` reconstruit backend ne reflète donc pas l'URL post-redirect que Google voit. **Skip explicite** dans `SeoShadowDiffEngine.compareCanonical()` : `equal=null` + `skip_reason='r8_frontend_redirect_logic_not_reproduced'`. R8 `policy_divergence` reste piloté par `robots_eq` uniquement. Issue follow-up à ouvrir post-merge pour reproduire le redirect backend-side.

## Defense-in-depth flip mode=on

| Couche | Mécanisme |
|---|---|
| Zod env | `SEO_CHAIN_R*_MODE=tru` (typo) → boot fail. |
| Boot guard | `mode=on` détecté → `throw` → container ne boot pas. PR-6 ne livre PAS la branche on. |
| CI guard | `seo-shadow-flag-guard.yml` refuse `=on` dans `.env*`/`docker-compose*`/workflows/secrets. |
| Lint ast-grep | `seo-shadow-no-await.yml` interdit `await observatory.observe()`. |
| ADR (post-merge) | `ADR-054 SEO Shadow Mode Architecture` (governance-vault). |

Trois modifications coordonnées (code+ADR+ENV) requises pour activer `on` en prod.

## Test plan

- [x] `tsc --noEmit` : ✅ 0 erreur
- [x] `npx jest seo-shadow` : ✅ 55 tests verts / 7 suites
- [x] `ast-grep scan seo-shadow-no-await` : ✅ 0 violation
- [x] CI guard `SEO_CHAIN_R*_MODE=on` : ✅ aucun match
- [ ] Preprod : `SEO_CHAIN_R7_MODE=shadow` + `SEO_CHAIN_R8_MODE=shadow` + `SEO_CHAIN_SHADOW_SAMPLE_RATE=0.01` 7j
- [ ] Bilan SQL post-7j (cf. README §"Comment lire les divergences")
- [ ] ADR-054 ouverte dans `governance-vault` (post-merge)

## Hors-scope

- ❌ Frontend Remix non touché.
- ❌ `seo-canonical.service.ts` / `seo-indexability-policy.service.ts` non touchés.
- ❌ RPC Postgres et tables `__seo_*` non touchés.
- ❌ PR-3 (RM) / PR-5 (gamme-rest) conservent leur shadow inline (issue follow-up retrofit sur ce module).
- ❌ Reproduire R8 frontend redirect logic backend (issue follow-up).

## Stacking

Base = `feat/seo-v9-pr2d-marketing-parity` (PR #402). Sibling de PR-3 (#403) et PR-5 (#404). Cascade naturelle au merge.

## Plan + ADR

- Plan : `home/.claude/plans/pr-6-r7-brand-rpc-fancy-blum.md` (4 itérations de revue utilisateur intégrées).
- ADR vault à ouvrir post-merge : `ADR-054 SEO Shadow Mode Architecture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)