### PR TITLE
feat(blog): R3 cache + single-flight + web-vitals (LCP fix mobile)

### DIFF
--- a/backend/src/modules/blog/services/r3-guide.service.test.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.test.ts
@@ -1,12 +1,12 @@
 /**
  * R3GuideService — cache, single-flight (anti-stampede), invalidation tests.
  *
- * Plan: /home/deploy/.claude/plans/automecanik-com-confidentialit-condition-greedy-harp.md (PR-A)
- *
- * Couvre les 3 invariants critiques du cache R3 :
+ * Couvre les invariants critiques du cache R3 :
  *   - TTL respecté (régression test seconds vs ms)
- *   - Single-flight : N appels concurrents => 1 seul `computeLegacyPayload`
+ *   - Single-flight : N appels concurrents ⇒ 1 seul `computeLegacyPayload`
  *   - Invalidation event-driven (`@OnEvent('article.published'|'article.updated')`)
+ *   - Cache write best-effort : `cacheService.set` qui throw ne masque pas le payload
+ *   - `onArticleChanged` log warn quand le payload n'a pas de pg_alias
  *
  * Pas d'I/O réseau ; mocks minimaux. CacheService est mocké via une Map
  * en mémoire avec TTL relatif émulé (Date.now()).
@@ -239,14 +239,48 @@ describe('R3GuideService — cache + single-flight + invalidation (PR-A)', () =>
       expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(2);
     });
 
-    it('onArticleChanged is a no-op when payload omits pg_alias', async () => {
+    it('onArticleChanged skips invalidation and warns when payload omits pg_alias', async () => {
       const { service, cache } = await buildService();
       const delSpy = jest.spyOn(cache, 'del');
+      const warnSpy = jest
+        .spyOn(service['logger'], 'warn')
+        .mockImplementation(() => undefined);
 
       await service.onArticleChanged(undefined);
       await service.onArticleChanged({});
 
       expect(delSpy).not.toHaveBeenCalled();
+      // Both bad payloads must be flagged so an operator can spot a broken
+      // emitter contract (silent invalidation = stale cache up to TTL).
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('cache write resilience (best-effort)', () => {
+    it('returns the computed payload even when cacheService.set throws', async () => {
+      const { service, cache, dataService } = await buildService();
+
+      // Simule un Redis blip pendant le SET (ECONNRESET, OOM, WRONGTYPE…).
+      // Le compute Supabase a réussi : 9 round-trips OK, on ne doit pas
+      // dégrader N coalesced callers en 500 alors que la donnée est en main.
+      jest
+        .spyOn(cache, 'set')
+        .mockRejectedValueOnce(new Error('redis ECONNRESET'));
+
+      const result = await service.getR3GuidePayload(PG_ALIAS);
+
+      expect(result).not.toBeNull();
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(1);
+    });
+
+    it('next call after a set failure recomputes (cache stayed empty)', async () => {
+      const { service, cache, dataService } = await buildService();
+      jest.spyOn(cache, 'set').mockRejectedValueOnce(new Error('redis blip'));
+
+      await service.getR3GuidePayload(PG_ALIAS); // miss + set fails
+      await service.getR3GuidePayload(PG_ALIAS); // cache empty → recompute
+
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/backend/src/modules/blog/services/r3-guide.service.test.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.test.ts
@@ -1,0 +1,252 @@
+/**
+ * R3GuideService — cache, single-flight (anti-stampede), invalidation tests.
+ *
+ * Plan: /home/deploy/.claude/plans/automecanik-com-confidentialit-condition-greedy-harp.md (PR-A)
+ *
+ * Couvre les 3 invariants critiques du cache R3 :
+ *   - TTL respecté (régression test seconds vs ms)
+ *   - Single-flight : N appels concurrents => 1 seul `computeLegacyPayload`
+ *   - Invalidation event-driven (`@OnEvent('article.published'|'article.updated')`)
+ *
+ * Pas d'I/O réseau ; mocks minimaux. CacheService est mocké via une Map
+ * en mémoire avec TTL relatif émulé (Date.now()).
+ */
+
+import { Test, type TestingModule } from '@nestjs/testing';
+import { CacheService } from '../../../cache/cache.service';
+import { BlogArticleDataService } from './blog-article-data.service';
+import { BlogSeoService } from './blog-seo.service';
+import { BlogArticleRelationService } from './blog-article-relation.service';
+import { InternalLinkingService } from '../../seo/internal-linking.service';
+import { R3GuideService } from './r3-guide.service';
+
+interface CacheEntry {
+  value: unknown;
+  expiresAt: number;
+}
+
+/**
+ * In-memory CacheService stub. TTL en secondes (cohérent avec ioredis SETEX).
+ * Resté minimal : juste ce qu'il faut pour valider get/set/del + expiration.
+ */
+class InMemoryCacheServiceStub {
+  private readonly store = new Map<string, CacheEntry>();
+
+  async get<T>(key: string): Promise<T | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value as T;
+  }
+
+  async set<T>(key: string, value: T, ttl: number): Promise<void> {
+    this.store.set(key, { value, expiresAt: Date.now() + ttl * 1000 });
+  }
+
+  async del(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+const PG_ALIAS = 'emetteur-d-embrayage';
+const PG_ID = 124;
+
+const articleStub = {
+  legacy_id: 999,
+  slug: PG_ALIAS,
+  title: 'Émetteur d’embrayage',
+  h1: 'Émetteur d’embrayage',
+  excerpt: 'Excerpt',
+  publishedAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  keywords: [],
+  viewsCount: 0,
+  featuredImage: null,
+  tags: [],
+  cta_link: null,
+  cta_anchor: null,
+  sections: [],
+  seo_data: null,
+};
+
+const gammeDataStub = { pg_id: PG_ID, pg_alias: PG_ALIAS };
+
+function makeMocks() {
+  const dataService = {
+    getArticleByGamme: jest
+      .fn()
+      .mockResolvedValue({ article: articleStub, gammeData: gammeDataStub }),
+    getRelatedArticles: jest.fn().mockResolvedValue([]),
+    getAdjacentArticles: jest
+      .fn()
+      .mockResolvedValue({ previous: null, next: null }),
+  };
+  const seoService = {
+    getGammeConseil: jest.fn().mockResolvedValue([]),
+    getSeoItemSwitches: jest.fn().mockResolvedValue([]),
+    getSeoBrief: jest.fn().mockResolvedValue(null),
+    hasPublishedR6Guide: jest.fn().mockResolvedValue(false),
+    getApprovedImages: jest.fn().mockResolvedValue([]),
+  };
+  const relationService = {
+    getCompatibleVehicles: jest.fn().mockResolvedValue([]),
+  };
+  const internalLinkingService = {
+    processLinkGamme: jest.fn().mockImplementation(async (s: string) => s),
+  };
+  return { dataService, seoService, relationService, internalLinkingService };
+}
+
+async function buildService(): Promise<{
+  service: R3GuideService;
+  cache: InMemoryCacheServiceStub;
+  dataService: ReturnType<typeof makeMocks>['dataService'];
+}> {
+  const cache = new InMemoryCacheServiceStub();
+  const mocks = makeMocks();
+
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    providers: [
+      R3GuideService,
+      { provide: CacheService, useValue: cache },
+      { provide: BlogArticleDataService, useValue: mocks.dataService },
+      { provide: BlogSeoService, useValue: mocks.seoService },
+      { provide: BlogArticleRelationService, useValue: mocks.relationService },
+      {
+        provide: InternalLinkingService,
+        useValue: mocks.internalLinkingService,
+      },
+    ],
+  }).compile();
+
+  const service = moduleRef.get(R3GuideService);
+  return { service, cache, dataService: mocks.dataService };
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('R3GuideService — cache + single-flight + invalidation (PR-A)', () => {
+  describe('cache hit / miss', () => {
+    it('first call computes; second call returns cached payload without recomputing', async () => {
+      const { service, dataService } = await buildService();
+
+      const first = await service.getR3GuidePayload(PG_ALIAS);
+      const second = await service.getR3GuidePayload(PG_ALIAS);
+
+      expect(first).not.toBeNull();
+      expect(second).toBe(first);
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null + skips cache write when no article matches the gamme', async () => {
+      const { service, cache, dataService } = await buildService();
+      dataService.getArticleByGamme.mockResolvedValueOnce({
+        article: null,
+        gammeData: null,
+      });
+
+      const result = await service.getR3GuidePayload('inconnu');
+
+      expect(result).toBeNull();
+      expect(await cache.get('r3-guide:v1:inconnu')).toBeNull();
+    });
+  });
+
+  describe('TTL régression (seconds vs ms)', () => {
+    it('respects a short TTL injected via setCacheTtlForTest', async () => {
+      const { service, dataService } = await buildService();
+      // 100 ms exprimé en secondes (0.1) — couvre le piège v4 (s) vs v5 (ms).
+      // Si l'unité interne dérive vers ms, la 2e expiration ne se produira pas
+      // dans les 200 ms et le test échouera.
+      service.setCacheTtlForTest(0.1);
+
+      await service.getR3GuidePayload(PG_ALIAS); // miss → compute #1
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(1);
+
+      await service.getR3GuidePayload(PG_ALIAS); // hit
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(1);
+
+      await sleep(150); // wait past TTL
+
+      await service.getR3GuidePayload(PG_ALIAS); // expired → compute #2
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('single-flight (anti-stampede)', () => {
+    it('coalesces 20 concurrent misses into a single computeLegacyPayload call', async () => {
+      const { service, dataService } = await buildService();
+
+      // Force computeLegacyPayload to take ~50 ms so concurrents land on inflight.
+      let resolveCompute: (value: unknown) => void = () => undefined;
+      const computePromise = new Promise((resolve) => {
+        resolveCompute = resolve;
+      });
+      dataService.getArticleByGamme.mockImplementationOnce(async () => {
+        await computePromise;
+        return { article: articleStub, gammeData: gammeDataStub };
+      });
+
+      const concurrent = Array.from({ length: 20 }, () =>
+        service.getR3GuidePayload(PG_ALIAS),
+      );
+
+      // Let microtasks queue, then release the compute.
+      await sleep(10);
+      resolveCompute(undefined);
+
+      const results = await Promise.all(concurrent);
+
+      expect(results).toHaveLength(20);
+      expect(results.every((r) => r === results[0])).toBe(true);
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears inflight entry on error so subsequent calls retry', async () => {
+      const { service, dataService } = await buildService();
+      dataService.getArticleByGamme
+        .mockRejectedValueOnce(new Error('transient supabase'))
+        .mockResolvedValueOnce({
+          article: articleStub,
+          gammeData: gammeDataStub,
+        });
+
+      await expect(service.getR3GuidePayload(PG_ALIAS)).rejects.toThrow(
+        'transient supabase',
+      );
+
+      // After a rejection, the inflight Map must be cleaned. Next call must
+      // hit the dataService a second time, not stay stuck on the failed Promise.
+      const recovered = await service.getR3GuidePayload(PG_ALIAS);
+      expect(recovered).not.toBeNull();
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('invalidation events', () => {
+    it('onArticleChanged deletes the cached key so next call recomputes', async () => {
+      const { service, dataService } = await buildService();
+
+      await service.getR3GuidePayload(PG_ALIAS); // populate cache
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(1);
+
+      await service.onArticleChanged({ pg_alias: PG_ALIAS });
+
+      await service.getR3GuidePayload(PG_ALIAS); // must recompute
+      expect(dataService.getArticleByGamme).toHaveBeenCalledTimes(2);
+    });
+
+    it('onArticleChanged is a no-op when payload omits pg_alias', async () => {
+      const { service, cache } = await buildService();
+      const delSpy = jest.spyOn(cache, 'del');
+
+      await service.onArticleChanged(undefined);
+      await service.onArticleChanged({});
+
+      expect(delSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/blog/services/r3-guide.service.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.ts
@@ -2,9 +2,17 @@
  * R3GuideService — Page engine orchestrator for R3 conseil guide pages.
  * Single method composes 5 existing services into one typed R3GuidePayload.
  * Replaces 5 separate HTTP calls from the Remix route.
+ *
+ * Cache layer (PR-A 2026-05-09) :
+ *   - Redis cache via CacheService (TTL secondes)
+ *   - Single-flight via inflight Map (anti-stampede)
+ *   - Invalidation event-driven via @OnEvent('article.published'|'article.updated')
+ *   - Instrumentation hit/miss/coalesced/duration via Logger structuré
  */
 
 import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { CacheService } from '../../../cache/cache.service';
 import { BlogArticleDataService } from './blog-article-data.service';
 import { BlogSeoService } from './blog-seo.service';
 import { BlogArticleRelationService } from './blog-article-relation.service';
@@ -26,11 +34,32 @@ import {
 import { PRIX_PAS_CHER } from '../../seo/seo-v4.types';
 import { InternalLinkingService } from '../../seo/internal-linking.service';
 
+/** Cache key prefix versionnée — bump v1→v2 invalide tous les payloads. */
+const R3_CACHE_PREFIX = 'r3-guide:v1:';
+
+/** TTL fresh window (seconds) — CacheService utilise ioredis SETEX en secondes. */
+const R3_CACHE_TTL_SECONDS = 30 * 60;
+
 @Injectable()
 export class R3GuideService {
   private readonly logger = new Logger(R3GuideService.name);
 
+  /**
+   * Single-flight in-memory dedup. N requêtes concurrentes en cache miss
+   * sur la même clé partagent un seul compute (1 round-trip Supabase × 9
+   * sources, pas 20). Multi-instance : dedup local par replica ; le store
+   * Redis partagé visibilise le résultat aux autres replicas après écriture.
+   */
+  private readonly inflight = new Map<
+    string,
+    Promise<R3GuidePayload | null>
+  >();
+
+  /** Tunable for tests — production code uses default. */
+  private cacheTtlSeconds: number = R3_CACHE_TTL_SECONDS;
+
   constructor(
+    private readonly cacheService: CacheService,
     private readonly dataService: BlogArticleDataService,
     private readonly seoService: BlogSeoService,
     private readonly relationService: BlogArticleRelationService,
@@ -38,10 +67,88 @@ export class R3GuideService {
   ) {}
 
   /**
-   * Build the complete R3 Guide payload for a given pg_alias.
-   * Returns null if no article is found for the gamme.
+   * Tests-only override — never call from production code.
+   * Allows TTL régression tests with short windows (~100 ms) without
+   * sleeping for 30 minutes.
+   */
+  setCacheTtlForTest(ttlSeconds: number): void {
+    this.cacheTtlSeconds = ttlSeconds;
+  }
+
+  /**
+   * Public entry — Redis cache + single-flight + invalidation events.
+   *   1. Cache hit → return immediately (TTFB ~10-50 ms via Redis)
+   *   2. Cache miss + inflight → coalesce on the running Promise
+   *   3. Cache miss + no inflight → compute, store, dedup concurrent callers
    */
   async getR3GuidePayload(pg_alias: string): Promise<R3GuidePayload | null> {
+    const cacheKey = `${R3_CACHE_PREFIX}${pg_alias}`;
+    const startedAt = Date.now();
+
+    const cached =
+      await this.cacheService.get<R3GuidePayload | null>(cacheKey);
+    if (cached !== null) {
+      this.logger.debug(
+        `[r3-cache] hit key=${cacheKey} duration_ms=${Date.now() - startedAt}`,
+      );
+      return cached;
+    }
+
+    const existing = this.inflight.get(cacheKey);
+    if (existing) {
+      this.logger.debug(`[r3-cache] coalesced key=${cacheKey}`);
+      return existing;
+    }
+
+    const promise = (async () => {
+      const computeStart = Date.now();
+      try {
+        const payload = await this.computeLegacyPayload(pg_alias);
+        if (payload !== null) {
+          await this.cacheService.set(cacheKey, payload, this.cacheTtlSeconds);
+        }
+        this.logger.log(
+          `[r3-cache] miss key=${cacheKey} duration_ms=${Date.now() - computeStart} cached=${payload !== null}`,
+        );
+        return payload;
+      } catch (err) {
+        this.logger.error(
+          `[r3-cache] miss-error key=${cacheKey} duration_ms=${Date.now() - computeStart}`,
+          err instanceof Error ? err.stack : String(err),
+        );
+        throw err;
+      } finally {
+        this.inflight.delete(cacheKey);
+      }
+    })();
+
+    this.inflight.set(cacheKey, promise);
+    return promise;
+  }
+
+  /**
+   * Invalidate the cached payload when an article is published/updated.
+   * Wire emitters in admin endpoints: `eventEmitter.emit('article.published', { pg_alias })`.
+   * If no event is wired, cache falls back to TTL expiration only.
+   */
+  @OnEvent('article.published')
+  @OnEvent('article.updated')
+  async onArticleChanged(payload: { pg_alias?: string } | undefined) {
+    const pg_alias = payload?.pg_alias;
+    if (!pg_alias) return;
+    const cacheKey = `${R3_CACHE_PREFIX}${pg_alias}`;
+    await this.cacheService.del(cacheKey);
+    this.logger.log(`[r3-cache] invalidated key=${cacheKey} on article event`);
+  }
+
+  /**
+   * Original implementation extracted intact — composes 9 Supabase round-trips.
+   * Structural debt to be addressed in a separate plan
+   * (R3GuideService fanout reduction via PostgreSQL RPC).
+   */
+  private async computeLegacyPayload(
+    pg_alias: string,
+  ): Promise<R3GuidePayload | null> {
     // Step 1 — Resolve article by gamme (blocking)
     const { article, gammeData } =
       await this.dataService.getArticleByGamme(pg_alias);

--- a/backend/src/modules/blog/services/r3-guide.service.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.ts
@@ -3,8 +3,8 @@
  * Single method composes 5 existing services into one typed R3GuidePayload.
  * Replaces 5 separate HTTP calls from the Remix route.
  *
- * Cache layer (PR-A 2026-05-09) :
- *   - Redis cache via CacheService (TTL secondes)
+ * Cache layer:
+ *   - Redis cache via CacheService (TTL en secondes)
  *   - Single-flight via inflight Map (anti-stampede)
  *   - Invalidation event-driven via @OnEvent('article.published'|'article.updated')
  *   - Instrumentation hit/miss/coalesced/duration via Logger structuré
@@ -64,9 +64,14 @@ export class R3GuideService {
   ) {}
 
   /**
-   * Tests-only override — never call from production code.
-   * Allows TTL régression tests with short windows (~100 ms) without
-   * sleeping for 30 minutes.
+   * Tests-only override — production code MUST NOT call this.
+   *
+   * `CacheService.set` calls `redisClient.setex(key, ttl, ...)` which expects
+   * an INTEGER number of seconds. Sub-second TTLs (e.g. `0.1`) only work when
+   * the underlying CacheService is stubbed — calling this with a non-integer
+   * against the real Redis would raise `ERR value is not an integer`.
+   *
+   * @internal Reserved for unit tests to avoid 30-minute sleeps.
    */
   setCacheTtlForTest(ttlSeconds: number): void {
     this.cacheTtlSeconds = ttlSeconds;
@@ -74,9 +79,13 @@ export class R3GuideService {
 
   /**
    * Public entry — Redis cache + single-flight + invalidation events.
-   *   1. Cache hit → return immediately (TTFB ~10-50 ms via Redis)
+   *   1. Cache hit → return immediately (no Supabase round-trip)
    *   2. Cache miss + inflight → coalesce on the running Promise
    *   3. Cache miss + no inflight → compute, store, dedup concurrent callers
+   *
+   * Negative results (article not found / `null`) are NOT cached —
+   * recomputed each call, by design. Trade-off: 404 storms re-execute the
+   * 9-fanout, but cached null risks delaying legitimate publishes.
    */
   async getR3GuidePayload(pg_alias: string): Promise<R3GuidePayload | null> {
     const cacheKey = `${R3_CACHE_PREFIX}${pg_alias}`;
@@ -101,7 +110,21 @@ export class R3GuideService {
       try {
         const payload = await this.computeLegacyPayload(pg_alias);
         if (payload !== null) {
-          await this.cacheService.set(cacheKey, payload, this.cacheTtlSeconds);
+          // Cache write is best-effort: a Redis blip must not 500 a request
+          // that already has a valid payload in hand. Inconsistent with
+          // CacheService.set rethrow semantics; isolate the failure here.
+          try {
+            await this.cacheService.set(
+              cacheKey,
+              payload,
+              this.cacheTtlSeconds,
+            );
+          } catch (cacheErr) {
+            this.logger.error(
+              `[r3-cache] set-failed key=${cacheKey} — payload returned uncached`,
+              cacheErr instanceof Error ? cacheErr.stack : String(cacheErr),
+            );
+          }
         }
         this.logger.log(
           `[r3-cache] miss key=${cacheKey} duration_ms=${Date.now() - computeStart} cached=${payload !== null}`,
@@ -131,7 +154,14 @@ export class R3GuideService {
   @OnEvent('article.updated')
   async onArticleChanged(payload: { pg_alias?: string } | undefined) {
     const pg_alias = payload?.pg_alias;
-    if (!pg_alias) return;
+    if (!pg_alias) {
+      // Loud no-op : a malformed event leaves the cache stale until TTL.
+      // Log so an operator can spot a broken emitter contract.
+      this.logger.warn(
+        `[r3-cache] article event received without pg_alias — invalidation skipped (payload=${JSON.stringify(payload)})`,
+      );
+      return;
+    }
     const cacheKey = `${R3_CACHE_PREFIX}${pg_alias}`;
     await this.cacheService.del(cacheKey);
     this.logger.log(`[r3-cache] invalidated key=${cacheKey} on article event`);

--- a/backend/src/modules/blog/services/r3-guide.service.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.ts
@@ -50,10 +50,7 @@ export class R3GuideService {
    * sources, pas 20). Multi-instance : dedup local par replica ; le store
    * Redis partagé visibilise le résultat aux autres replicas après écriture.
    */
-  private readonly inflight = new Map<
-    string,
-    Promise<R3GuidePayload | null>
-  >();
+  private readonly inflight = new Map<string, Promise<R3GuidePayload | null>>();
 
   /** Tunable for tests — production code uses default. */
   private cacheTtlSeconds: number = R3_CACHE_TTL_SECONDS;
@@ -85,8 +82,7 @@ export class R3GuideService {
     const cacheKey = `${R3_CACHE_PREFIX}${pg_alias}`;
     const startedAt = Date.now();
 
-    const cached =
-      await this.cacheService.get<R3GuidePayload | null>(cacheKey);
+    const cached = await this.cacheService.get<R3GuidePayload | null>(cacheKey);
     if (cached !== null) {
       this.logger.debug(
         `[r3-cache] hit key=${cacheKey} duration_ms=${Date.now() - startedAt}`,

--- a/docs/perf/r3-lcp-baseline-2026-05-09.md
+++ b/docs/perf/r3-lcp-baseline-2026-05-09.md
@@ -2,7 +2,7 @@
 
 > Date mesure : 2026-05-09
 > Branche : `feat/lcp-r3-conseils-fix`
-> Plan : `/home/deploy/.claude/plans/automecanik-com-confidentialit-condition-greedy-harp.md`
+> PR : [#408](https://github.com/ak125/nestjs-remix-monorepo/pull/408)
 
 ## Contexte
 

--- a/docs/perf/r3-lcp-baseline-2026-05-09.md
+++ b/docs/perf/r3-lcp-baseline-2026-05-09.md
@@ -1,0 +1,61 @@
+# R3 LCP Baseline — `/blog-pieces-auto/conseils/*`
+
+> Date mesure : 2026-05-09
+> Branche : `feat/lcp-r3-conseils-fix`
+> Plan : `/home/deploy/.claude/plans/automecanik-com-confidentialit-condition-greedy-harp.md`
+
+## Contexte
+
+Signal GSC CWV mobile : 50 URLs en LCP > 4 s (zone "Médiocre"), groupe `/blog-pieces-auto/conseils/*`. Plan d'action : Phase 0 mesure baseline → PR-A cache + single-flight → PR-A.1 instrumentation → PR-C web-vitals lib → décision PR-B image conditionnelle.
+
+## Baseline TTFB API backend (prod)
+
+Endpoint : `GET https://www.automecanik.com/api/r3-guide/$pg_alias`
+
+5 URLs sample × 3 runs (cold/warm mix prod) :
+
+| URL | run 1 | run 2 | run 3 |
+|---|---|---|---|
+| emetteur-d-embrayage | 607 ms | 489 ms | 526 ms |
+| support-moteur | 469 ms | 507 ms | 827 ms |
+| capteur-abs | 526 ms | 495 ms | 951 ms |
+| corps-papillon | 558 ms | 500 ms | 524 ms |
+| cable-d-embrayage | 526 ms | 475 ms | 494 ms |
+
+**Statistiques** (15 mesures) :
+- p50 ≈ 510 ms
+- p75 ≈ 560 ms
+- p95 ≈ 820 ms
+- p99 ≈ 950 ms
+- min = 469 ms / max = 951 ms
+
+Cohérent avec l'hypothèse : 9 round-trips Supabase REST cumulés (1 query bloquante + Promise.all 7 + 1 séquentielle), 500-1000 ms TTFB attendu.
+
+## LCP node mobile (à compléter post-mesure WPT/DevTools)
+
+- Méthode utilisée : _à remplir_ (WebPageTest Moto G4 / Chrome DevTools / Sentry)
+- Sample : 5 URLs ci-dessus
+- LCP node identifié : _à remplir_ (`<h1>` HeroBlog / `<img>` featuredImage / autre)
+- LCP p75 mesuré : _à remplir_
+- Décision PR-B (image responsive WebP) : _à remplir_ (skip si `<h1>` = LCP, go si `<img>`)
+
+## Cibles post-PR-A
+
+- TTFB p95 cache-hit < 200 ms (vs 820 ms baseline)
+- Hit ratio > 85 % sur 1h prod (50 URLs cohorte)
+- Stampede test : 20 requêtes parallèles → 1 seul appel `computeLegacyPayload`
+- TTL régression test : passe avec TTL court 100 ms + setTimeout 150 ms
+- LCP field p75 (post-PR-C web-vitals lib) ≤ 3,2 s sample
+
+## Cibles post-PR-B (si déclenchée)
+
+- LCP field p75 ≤ 2,5 s sample
+- featuredImage poids servi mobile p75 < 80 KB
+- Pas de double-fetch image dans waterfall
+
+## Validation finale
+
+GSC CWV report `/blog-pieces-auto/conseils/*` mobile :
+- J0 (déploiement) : "Médiocre", LCP p75 ~4,0 s, 50 URLs
+- J+14 : sortie attendue de "Médiocre" → "Améliorer"
+- J+28 : cible "Bon" (LCP groupe < 2,5 s)

--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -4,12 +4,13 @@
  * For more information, see https://remix.run/file-conventions/entry.client
  */
 
-import * as Sentry from "@sentry/remix";
 import { useLocation, useMatches, RemixBrowser } from "@remix-run/react";
+import * as Sentry from "@sentry/remix";
 import { startTransition, useEffect } from "react";
 import { hydrateRoot } from "react-dom/client";
-import { logger } from "~/utils/logger";
 import { sentryBeforeSend } from "~/utils/analytics-sanitize";
+import { logger } from "~/utils/logger";
+import { reportWebVitals } from "~/utils/web-vitals.client";
 
 // Sentry browser SDK — DSN injected at SSR time via `window.ENV.VITE_SENTRY_DSN`
 // (see root.tsx loader). When the DSN is absent, all Sentry calls are no-ops.
@@ -63,4 +64,7 @@ startTransition(() => {
       }
     },
   });
+  // Field Web Vitals reporter — pousse LCP/INP/CLS/FCP/TTFB vers
+  // Sentry.metrics (si dispo) → GA4 → console. Voir ~/utils/web-vitals.client.
+  reportWebVitals();
 });

--- a/frontend/app/utils/web-vitals.client.ts
+++ b/frontend/app/utils/web-vitals.client.ts
@@ -1,0 +1,116 @@
+/**
+ * web-vitals.client — Field Web Vitals reporter (LCP, INP, CLS, FCP, TTFB).
+ *
+ * Plan: /home/deploy/.claude/plans/automecanik-com-confidentialit-condition-greedy-harp.md (PR-C)
+ *
+ * Pousse chaque Web Vital vers (par ordre de priorité) :
+ *   1. Sentry.metrics.distribution (si l'API existe dans la version SDK installée)
+ *   2. window.gtag (GA4) - déjà câblé via root.tsx, RGPD consent géré
+ *   3. console.info (toujours, pour debug + Sentry breadcrumbs)
+ *
+ * Aucun appel n'est inventé : `Sentry.metrics?.distribution` est testé runtime
+ * avant usage. Si la lib n'expose pas cette API (build minimal, version sans
+ * Metrics, DSN absent → init noop), on tombe sur le fallback GA4/console
+ * sans planter.
+ */
+
+import * as Sentry from '@sentry/remix';
+import { onLCP, onCLS, onINP, onFCP, onTTFB, type Metric } from 'web-vitals';
+
+interface SentryMetricsDistribution {
+  (
+    name: string,
+    value: number,
+    options?: { unit?: string; tags?: Record<string, string> },
+  ): void;
+}
+
+interface SentryMetricsApi {
+  distribution?: SentryMetricsDistribution;
+}
+
+interface SentryWithMetrics {
+  metrics?: SentryMetricsApi;
+}
+
+interface GtagWindow {
+  gtag?: (
+    command: 'event',
+    eventName: string,
+    params: Record<string, unknown>,
+  ) => void;
+}
+
+function reportToSentry(metric: Metric): boolean {
+  // Vérification runtime : ne pas inventer l'API. Si Sentry est noop (DSN
+  // absent) ou build sans Metrics, on échoue silencieusement.
+  const sentry = Sentry as unknown as SentryWithMetrics;
+  if (typeof sentry.metrics?.distribution !== 'function') return false;
+
+  try {
+    sentry.metrics.distribution(`web_vital.${metric.name.toLowerCase()}`, metric.value, {
+      unit: 'millisecond',
+      tags: {
+        rating: metric.rating,
+        navigation_type: metric.navigationType ?? 'unknown',
+      },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function reportToGtag(metric: Metric): boolean {
+  const gtag = (window as GtagWindow).gtag;
+  if (typeof gtag !== 'function') return false;
+
+  try {
+    gtag('event', 'web_vitals', {
+      metric_name: metric.name,
+      metric_value: Math.round(metric.value),
+      metric_rating: metric.rating,
+      metric_id: metric.id,
+      navigation_type: metric.navigationType,
+      page_path:
+        typeof window !== 'undefined' ? window.location.pathname : '',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function reportToConsole(metric: Metric): void {
+  // Toujours appelé : utile pour debug local + capturé en breadcrumb par Sentry
+  // si `Sentry.init` capture les console (default v10 = true via integrations).
+  // eslint-disable-next-line no-console
+  console.info('[web-vitals]', {
+    name: metric.name,
+    value: Math.round(metric.value),
+    rating: metric.rating,
+    id: metric.id,
+    path: typeof window !== 'undefined' ? window.location.pathname : '',
+  });
+}
+
+function dispatchMetric(metric: Metric) {
+  // Try Sentry first, then GA4. Console always fires.
+  reportToSentry(metric);
+  reportToGtag(metric);
+  reportToConsole(metric);
+}
+
+/**
+ * Démarre le reporter Web Vitals. À appeler une seule fois après hydratation.
+ * Safe à no-op côté SSR (les `on*` callbacks ne fire qu'au browser).
+ */
+export function reportWebVitals(): void {
+  if (typeof window === 'undefined') return;
+
+  onLCP(dispatchMetric);
+  onCLS(dispatchMetric);
+  onINP(dispatchMetric);
+  onFCP(dispatchMetric);
+  onTTFB(dispatchMetric);
+}

--- a/frontend/app/utils/web-vitals.client.ts
+++ b/frontend/app/utils/web-vitals.client.ts
@@ -1,9 +1,7 @@
 /**
  * web-vitals.client — Field Web Vitals reporter (LCP, INP, CLS, FCP, TTFB).
  *
- * Plan: /home/deploy/.claude/plans/automecanik-com-confidentialit-condition-greedy-harp.md (PR-C)
- *
- * Pousse chaque Web Vital vers (par ordre de priorité) :
+ * Pousse chaque Web Vital vers, en cascade :
  *   1. Sentry.metrics.distribution (si l'API existe dans la version SDK installée)
  *   2. window.gtag (GA4) - déjà câblé via root.tsx, RGPD consent géré
  *   3. console.info (toujours, pour debug + Sentry breadcrumbs)
@@ -11,7 +9,9 @@
  * Aucun appel n'est inventé : `Sentry.metrics?.distribution` est testé runtime
  * avant usage. Si la lib n'expose pas cette API (build minimal, version sans
  * Metrics, DSN absent → init noop), on tombe sur le fallback GA4/console
- * sans planter.
+ * sans planter. Le dispatch entier est aussi wrappé en try/catch : un reporter
+ * passif ne doit jamais corrompre l'app (extension navigateur qui hook
+ * `console`, CMP qui mock `gtag`, etc.).
  */
 
 import * as Sentry from '@sentry/remix';
@@ -95,10 +95,13 @@ function reportToConsole(metric: Metric): void {
 }
 
 function dispatchMetric(metric: Metric) {
-  // Try Sentry first, then GA4. Console always fires.
-  reportToSentry(metric);
-  reportToGtag(metric);
-  reportToConsole(metric);
+  try {
+    reportToSentry(metric);
+    reportToGtag(metric);
+    reportToConsole(metric);
+  } catch {
+    // Reporter passif — ne jamais propager dans une callback PerformanceObserver.
+  }
 }
 
 /**

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
+    "web-vitals": "^4.2.4",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -606,6 +606,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
+        "web-vitals": "^4.2.4",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -34208,6 +34209,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",


### PR DESCRIPTION
## Summary

Fix LCP > 4 s mobile sur 50 URLs `/blog-pieces-auto/conseils/*` (signal GSC CWV "Médiocre").

- **PR-A** : cache `R3GuidePayload` via `CacheService` (Redis SETEX, TTL 30 min). `inflight Map` single-flight maison anti-stampede + invalidation event-driven `@OnEvent('article.*')`. Logger structuré `[r3-cache] hit|miss|coalesced|invalidated`.
- **PR-C minimal** : `web-vitals@^4` lib + sink défensif Sentry v10 → GA4 → console. Vérifie runtime `Sentry.metrics?.distribution` avant appel (pas d'API inventée).
- **Phase 0** : baseline TTFB documentée (5 URLs × 3 runs prod, p50=510 ms p95=820 ms).

Refonte structurelle RPC consolidation (9 round-trips Supabase → 1 RPC) **reportée en plan séparé** : signal GSC actif → priorité au gain rapide reliable. Cache single-flight + invalidation + tests TTL/stampede ≠ bricolage.

Plan complet : `~/.claude/plans/automecanik-com-confidentialit-condition-greedy-harp.md`

## Test plan

- [x] Tests Jest : 7/7 verts (`r3-guide.service.test.ts`)
  - cache hit/miss, TTL régression seconds vs ms, single-flight 20 concurrent → 1 compute, error recovery, invalidation event
- [x] Backend `tsc --noEmit` : exit 0
- [x] Frontend `tsc --noEmit` : exit 0
- [ ] Vérification preprod `SEO_CHAIN_RM_MODE` : N/A (PR ne touche pas la chain SEO seo-v9)
- [ ] Mesure TTFB post-déploiement : `curl -w "%{time_starttransfer}"` sur 5 URLs sample → cible p95 cache-hit < 200 ms
- [ ] Field LCP via `web-vitals` lib en prod 7j → décision PR-B image conditionnelle si LCP > 2,5 s p75
- [ ] Suivi GSC CWV 28j : groupe `/blog-pieces-auto/conseils/*` mobile sortie de "Médiocre"

## Hors scope

- RPC consolidation `get_r3_guide_payload` (plan séparé)
- PR-B image responsive WebP `<picture>` : conditionnelle, dépend du LCP node Phase 0 (WPT/DevTools manuels)
- Caddy edge cache : pas une 3e couche avant preuve de besoin
- AVIF : seulement si gain poids mesuré > 20-25% vs WebP

🤖 Generated with [Claude Code](https://claude.com/claude-code)