### PR TITLE
refactor(seo-v9): retrofit rm-builder sur SeoShadowObservatory (ADR-055)

### DIFF
--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -12,7 +12,7 @@ primary_files:
 depends_on:
 - DatabaseModule
 - CatalogModule
-- SeoModule
+- SeoShadowObservatoryModule
 ---
 
 # Module Rm

--- a/backend/src/modules/rm/rm.module.ts
+++ b/backend/src/modules/rm/rm.module.ts
@@ -1,7 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { DatabaseModule } from '../../database/database.module';
 import { CatalogModule } from '../catalog/catalog.module';
-import { SeoModule } from '../seo/seo.module';
+import { SeoShadowObservatoryModule } from '../seo-shadow-observatory/seo-shadow-observatory.module';
 import { RmBuilderService } from './services/rm-builder.service';
 import { RmController } from './controllers/rm.controller';
 
@@ -41,7 +41,11 @@ import { RmController } from './controllers/rm.controller';
  * - rm_health
  */
 @Module({
-  imports: [DatabaseModule, CatalogModule, forwardRef(() => SeoModule)],
+  imports: [
+    DatabaseModule,
+    forwardRef(() => CatalogModule),
+    SeoShadowObservatoryModule, // Retrofit ADR-055 — shadow R1_GAMME_VEHICLE_ROUTER
+  ],
   providers: [RmBuilderService],
   controllers: [RmController],
   exports: [RmBuilderService],

--- a/backend/src/modules/rm/services/__tests__/rm-builder-seo-shadow.test.ts
+++ b/backend/src/modules/rm/services/__tests__/rm-builder-seo-shadow.test.ts
@@ -1,72 +1,24 @@
-import { Logger } from '@nestjs/common';
-
-import { SeoFeatureFlagRegistry } from '../../../seo/registries/seo-feature-flag.registry';
 import { RmBuilderService } from '../rm-builder.service';
+import type { SeoShadowObservatory } from '../../../seo-shadow-observatory/seo-shadow-observatory.service';
 
 /**
- * PR-3 (plan seo-v9) — Tests du shadow mode chaîne SEO sur rm-builder.
+ * Retrofit ADR-055 — rm-builder utilise maintenant `SeoShadowObservatory`
+ * au lieu de chain inline (ancien pattern PR-3).
  *
- * Vérifie :
- *   - flag=off  : la chaîne n'est PAS appelée (zero impact prod).
- *   - flag=shadow : la chaîne est appelée, diff logué, résultat legacy servi.
- *   - flag=on   : la chaîne est appelée, résultat chain servi (avec fallback
- *                 legacy si la chaîne échoue ou renvoie title vide).
- *
- * Stratégie : tests unitaires sur les helpers privés `computeChainSeoForRm`
- * et `logSeoChainDiff` (accès via `as never` cast — TS modifiers ne sont pas
- * runtime). Pas de boot complet du module — on injecte des stubs directs.
+ * Ce test vérifie le nouveau contrat :
+ *   - `fireShadowObservation(ctx, legacy)` appelle `observatory.observe()`
+ *     avec le bon `surface` (`R1_GAMME_VEHICLE_ROUTER`).
+ *   - Aucune mutation de `result.seo` (ADR-055 I3 — pas de branche `mode='on'`).
+ *   - `observe()` est appelé en sync (sans await — ADR-055 I2).
  */
-describe('RmBuilderService — SEO chain shadow mode (PR-3)', () => {
-  function buildService(opts: {
-    chainRunReturnTitle?: string;
-    chainThrows?: boolean;
-  }): RmBuilderService {
-    const chainOrchestrator = {
-      run: jest.fn(async () => {
-        if (opts.chainThrows) throw new Error('chain boom');
-        return {
-          surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
-          template: {
-            title: opts.chainRunReturnTitle ?? 'Chain title',
-            description: 'Chain description',
-            h1: 'Chain h1',
-            preview: 'Chain preview',
-            content: 'Chain content',
-            keywords: 'k',
-          },
-          contentBlocks: [],
-          policies: { canonical: 'https://x', robots: 'index,follow' },
-          ariane: {
-            jsonLd: {
-              '@context': 'https://schema.org',
-              '@type': 'BreadcrumbList',
-              itemListElement: [],
-            },
-            textTrail: '',
-          },
-          metadata: {
-            surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
-            templateId: null,
-            variantIds: {},
-            internalLinkCount: 0,
-            chainVersion: 'seo-v9-pr2c',
-            renderedAt: new Date().toISOString(),
-          },
-        };
-      }),
-    } as unknown as ConstructorParameters<typeof RmBuilderService>[3];
-
-    const chainFlags = new SeoFeatureFlagRegistry();
-
-    // Stubs minimaux : le test ne touche pas à cacheService / seoTemplateService /
-    // rpcGate. Les helpers testés ne les utilisent pas.
+describe('RmBuilderService — shadow via SeoShadowObservatory (retrofit ADR-055)', () => {
+  function buildService(observatory: { observe: jest.Mock }): RmBuilderService {
     const dummy = {} as never;
     return new RmBuilderService(
       dummy, // CacheService
       dummy, // SeoTemplateService
       dummy, // RpcGateService
-      chainOrchestrator,
-      chainFlags,
+      observatory as unknown as SeoShadowObservatory,
     );
   }
 
@@ -87,157 +39,122 @@ describe('RmBuilderService — SEO chain shadow mode (PR-3)', () => {
     power_ps: '90',
   };
 
-  describe('SeoFeatureFlagRegistry.mode("RM")', () => {
-    afterEach(() => {
-      delete process.env.SEO_CHAIN_RM_MODE;
-    });
+  const legacy = {
+    h1: 'Plaquettes Renault Clio',
+    title: 'Plaquettes Clio - Pieces auto',
+    description: 'Description legacy',
+    content: 'Contenu legacy',
+    preview: 'Preview legacy',
+  };
 
-    it('default off quand env var absente', () => {
-      const flags = new SeoFeatureFlagRegistry();
-      expect(flags.mode('RM')).toBe('off');
-    });
+  it('fireShadowObservation appelle observatory.observe avec surface R1_GAMME_VEHICLE_ROUTER', () => {
+    const observe = jest.fn();
+    const service = buildService({ observe });
 
-    it('lit la valeur env SEO_CHAIN_RM_MODE', () => {
-      process.env.SEO_CHAIN_RM_MODE = 'shadow';
-      const flags = new SeoFeatureFlagRegistry();
-      expect(flags.mode('RM')).toBe('shadow');
-      process.env.SEO_CHAIN_RM_MODE = 'on';
-      expect(flags.mode('RM')).toBe('on');
-    });
+    (
+      service as unknown as {
+        fireShadowObservation: (c: typeof ctx, l: typeof legacy) => void;
+      }
+    ).fireShadowObservation(ctx, legacy);
 
-    it('fallback off sur valeur invalide', () => {
-      process.env.SEO_CHAIN_RM_MODE = 'invalid_value';
-      const flags = new SeoFeatureFlagRegistry();
-      expect(flags.mode('RM')).toBe('off');
-    });
+    expect(observe).toHaveBeenCalledTimes(1);
+    const input = observe.mock.calls[0][0];
+    expect(input.surface).toBe('R1_GAMME_VEHICLE_ROUTER');
+    expect(input.entityId).toBe('124:12345');
+    expect(input.legacy.title).toBe(legacy.title);
+    expect(input.legacy.h1).toBe(legacy.h1);
+    expect(input.legacy.description).toBe(legacy.description);
+    expect(input.ids.pgId).toBe(124);
+    expect(input.ids.typeId).toBe(12345);
+    expect(input.ids.gammeAlias).toBe('plaquettes');
+    expect(input.vars.gamme).toBe('Plaquettes');
+    expect(input.vars.marque).toBe('Renault');
+    expect(input.vars.nbCh).toBe(90);
+    expect(input.vars.minPrice).toBe(25);
   });
 
-  describe('computeChainSeoForRm (helper privé)', () => {
-    it('appelle chain.run avec surface R1_GAMME_VEHICLE_ROUTER + ids/variables corrects', async () => {
-      const service = buildService({ chainRunReturnTitle: 'OK' });
-      const seo = await (
-        service as never as {
-          computeChainSeoForRm: (c: typeof ctx) => Promise<unknown>;
-        }
-      ).computeChainSeoForRm(ctx);
+  it('fireShadowObservation construit un requestUrl canonique R1', () => {
+    const observe = jest.fn();
+    const service = buildService({ observe });
 
-      expect(seo).toEqual({
-        h1: 'Chain h1',
-        title: 'OK',
-        description: 'Chain description',
-        content: 'Chain content',
-        preview: 'Chain preview',
-      });
-    });
+    (
+      service as unknown as {
+        fireShadowObservation: (c: typeof ctx, l: typeof legacy) => void;
+      }
+    ).fireShadowObservation(ctx, legacy);
 
-    it('retourne null si chain renvoie un title vide (fallback legacy)', async () => {
-      const service = buildService({ chainRunReturnTitle: '' });
-      const seo = await (
-        service as never as {
-          computeChainSeoForRm: (c: typeof ctx) => Promise<unknown>;
-        }
-      ).computeChainSeoForRm(ctx);
-      expect(seo).toBeNull();
-    });
-
-    it("propage l'exception si chain throws (le caller catche)", async () => {
-      const service = buildService({ chainThrows: true });
-      await expect(
-        (
-          service as never as {
-            computeChainSeoForRm: (c: typeof ctx) => Promise<unknown>;
-          }
-        ).computeChainSeoForRm(ctx),
-      ).rejects.toThrow(/chain boom/);
-    });
+    const input = observe.mock.calls[0][0];
+    expect(input.requestUrl).toBe(
+      'https://www.automecanik.com/pieces/plaquettes.renault.clio.1-5-dci.html',
+    );
   });
 
-  describe('logSeoChainDiff (helper privé)', () => {
-    it('produit un log JSON structuré avec match par champ', () => {
-      const service = buildService({});
-      const logSpy = jest
-        .spyOn((service as never as { logger: Logger }).logger, 'log')
-        .mockImplementation(() => undefined);
-
-      const legacy = {
-        h1: 'h',
-        title: 'TITLE',
-        description: 'DESC',
-        content: 'C',
-        preview: 'P',
-      };
-      const chain = {
-        h1: 'h',
-        title: 'TITLE-different',
-        description: 'DESC',
-        content: 'C-different',
-        preview: 'P',
-      };
-
-      (
-        service as never as {
-          logSeoChainDiff: (
-            c: typeof ctx,
-            l: typeof legacy,
-            ch: typeof chain,
-          ) => void;
-        }
-      ).logSeoChainDiff(ctx, legacy, chain);
-
-      expect(logSpy).toHaveBeenCalledTimes(1);
-      const arg = logSpy.mock.calls[0]![0] as string;
-      expect(arg).toContain('[SEO_CHAIN_RM_SHADOW]');
-      const json = JSON.parse(arg.replace('[SEO_CHAIN_RM_SHADOW] ', ''));
-      expect(json).toMatchObject({
-        flag: 'SEO_CHAIN_RM',
-        mode: 'shadow',
-        pg_id: 124,
-        type_id: 12345,
-        title_eq: false,
-        description_eq: true,
-        h1_eq: true,
-        content_eq: false,
-        preview_eq: true,
-      });
+  it('observe est synchrone (return immédiat — ADR-055 I2)', () => {
+    let observed = false;
+    const observe = jest.fn(() => {
+      observed = true;
     });
+    const service = buildService({ observe });
+
+    (
+      service as unknown as {
+        fireShadowObservation: (c: typeof ctx, l: typeof legacy) => void;
+      }
+    ).fireShadowObservation(ctx, legacy);
+
+    // Si l'API était async/awaitée, observed serait encore false ici.
+    expect(observed).toBe(true);
   });
 
-  describe('integration : shadow mode décisionne correctement', () => {
-    afterEach(() => {
-      delete process.env.SEO_CHAIN_RM_MODE;
-    });
+  it('legacy.canonical/robots/keywords sont null (rm-builder ne les calcule pas)', () => {
+    const observe = jest.fn();
+    const service = buildService({ observe });
 
-    it('mode=off : chain.run NE doit PAS être appelé', async () => {
-      process.env.SEO_CHAIN_RM_MODE = 'off';
-      const service = buildService({ chainRunReturnTitle: 'X' });
-      // Simulate the gate check that happens inside getPageCompleteV2.
-      const flags = (
-        service as never as {
-          chainFlags: SeoFeatureFlagRegistry;
-        }
-      ).chainFlags;
-      const mode = flags.mode('RM');
-      expect(mode).toBe('off');
-      // Si le code respecte cet invariant, computeChainSeoForRm n'est pas appelé.
-      // Verrouillé par la lecture de mode === 'off' dans getPageCompleteV2.
-    });
+    (
+      service as unknown as {
+        fireShadowObservation: (c: typeof ctx, l: typeof legacy) => void;
+      }
+    ).fireShadowObservation(ctx, legacy);
 
-    it('mode=shadow : chain.run est appelé', async () => {
-      process.env.SEO_CHAIN_RM_MODE = 'shadow';
-      const service = buildService({ chainRunReturnTitle: 'X' });
-      const flags = (
-        service as never as {
-          chainFlags: SeoFeatureFlagRegistry;
-        }
-      ).chainFlags;
-      expect(flags.mode('RM')).toBe('shadow');
+    const input = observe.mock.calls[0][0];
+    expect(input.legacy.canonical).toBeNull();
+    expect(input.legacy.robots).toBeNull();
+    expect(input.legacy.keywords).toBeNull();
+  });
 
-      const seo = await (
-        service as never as {
-          computeChainSeoForRm: (c: typeof ctx) => Promise<unknown>;
-        }
-      ).computeChainSeoForRm(ctx);
-      expect(seo).not.toBeNull();
-    });
+  it('power_ps absent → nbCh = 0 (no NaN propagé)', () => {
+    const observe = jest.fn();
+    const service = buildService({ observe });
+
+    (
+      service as unknown as {
+        fireShadowObservation: (c: typeof ctx, l: typeof legacy) => void;
+      }
+    ).fireShadowObservation({ ...ctx, power_ps: '' }, legacy);
+
+    const input = observe.mock.calls[0][0];
+    expect(input.vars.nbCh).toBe(0);
+  });
+
+  it('min_price/count absents → 0 (defaults)', () => {
+    const observe = jest.fn();
+    const service = buildService({ observe });
+
+    (
+      service as unknown as {
+        fireShadowObservation: (c: typeof ctx, l: typeof legacy) => void;
+      }
+    ).fireShadowObservation(
+      {
+        ...ctx,
+        min_price: undefined as unknown as number,
+        count: undefined as unknown as number,
+      },
+      legacy,
+    );
+
+    const input = observe.mock.calls[0][0];
+    expect(input.vars.minPrice).toBe(0);
+    expect(input.vars.articlesCount).toBe(0);
   });
 });

--- a/backend/src/modules/rm/services/rm-builder.service.ts
+++ b/backend/src/modules/rm/services/rm-builder.service.ts
@@ -7,8 +7,7 @@ import {
   type SeoContext,
   type SeoTemplates,
 } from '../../catalog/services/seo-template.service';
-import { SeoChainOrchestratorService } from '../../seo/services/chain/seo-chain-orchestrator.service';
-import { SeoFeatureFlagRegistry } from '../../seo/registries/seo-feature-flag.registry';
+import { SeoShadowObservatory } from '../../seo-shadow-observatory/seo-shadow-observatory.service';
 import {
   RmProduct,
   RmListing,
@@ -46,8 +45,7 @@ export class RmBuilderService extends SupabaseBaseService {
     private readonly cacheService: CacheService,
     private readonly seoTemplateService: SeoTemplateService,
     rpcGate: RpcGateService,
-    private readonly chainOrchestrator: SeoChainOrchestratorService,
-    private readonly chainFlags: SeoFeatureFlagRegistry,
+    private readonly shadowObservatory: SeoShadowObservatory,
   ) {
     super();
     this.rpcGate = rpcGate;
@@ -624,35 +622,12 @@ export class RmBuilderService extends SupabaseBaseService {
               preview: processed.preview,
             };
 
-            // PR-3 (plan seo-v9) — Shadow / on / off pour la chaîne SEO commune.
-            // off    : comportement legacy strictement préservé (default).
-            // shadow : exécute la chaîne en parallèle, log diff structuré, sert legacy.
-            // on     : sert la chaîne, fallback legacy si échec (résilience).
-            const chainMode = this.chainFlags.mode('RM');
-            let chainSeo: typeof legacySeo | null = null;
-            if (chainMode !== 'off') {
-              chainSeo = await this.computeChainSeoForRm(ctx).catch((err) => {
-                this.logger.warn(
-                  `[SEO_CHAIN_RM] mode=${chainMode} compute failed (pg=${ctx.pg_id}, type=${ctx.type_id}): ${
-                    err instanceof Error ? err.message : 'unknown'
-                  }`,
-                );
-                return null;
-              });
-            }
-
-            if (chainMode === 'on' && chainSeo) {
-              result.seo = chainSeo;
-              this.logger.debug(
-                `[SEO_CHAIN_RM] mode=on serving chain output (pg=${ctx.pg_id}, type=${ctx.type_id})`,
-              );
-            } else {
-              result.seo = legacySeo;
-            }
-
-            if (chainMode === 'shadow' && chainSeo) {
-              this.logSeoChainDiff(ctx, legacySeo, chainSeo);
-            }
+            // Retrofit ADR-055 — shadow observation via SeoShadowObservatoryModule (I1).
+            // Observatory.observe() est sync : retour immédiat, comparaison réelle
+            // dispatchée via setImmediate. Aucune mutation de result.seo possible
+            // depuis ce module (I3 — pas de branche mode === 'on').
+            result.seo = legacySeo;
+            this.fireShadowObservation(ctx, legacySeo);
           } catch (seoErr) {
             this.logger.warn(
               `SEO processing failed, fallback to raw: ${seoErr}`,
@@ -822,21 +797,44 @@ export class RmBuilderService extends SupabaseBaseService {
    * @returns le payload `seo` formaté comme la sortie `SeoTemplateService`,
    * ou `null` si la chaîne renvoie un title vide (fallback legacy).
    */
-  private async computeChainSeoForRm(ctx: SeoContext): Promise<{
-    h1: string;
-    title: string;
-    description: string;
-    content: string;
-    preview: string;
-  } | null> {
-    const baseUrl = process.env.SITE_URL ?? 'https://www.automecanik.com';
-
-    const out = await this.chainOrchestrator.run({
-      surfaceKey: 'R1_GAMME_VEHICLE_ROUTER',
-      pgId: ctx.pg_id,
-      typeId: ctx.type_id,
-      vehicleId: ctx.type_id,
-      variables: {
+  /**
+   * Fire-and-forget shadow observation R1 gamme×véhicule (retrofit ADR-055).
+   *
+   * NE PAS `await` cette méthode — `observe()` est sync par contrat (validé
+   * par `.ast-grep/rules/seo-shadow-no-await.yml`). La comparaison réelle
+   * court via `setImmediate` dans le module observatory.
+   */
+  private fireShadowObservation(
+    ctx: SeoContext,
+    legacy: {
+      h1: string;
+      title: string;
+      description: string;
+      content: string;
+      preview: string;
+    },
+  ): void {
+    this.shadowObservatory.observe({
+      surface: 'R1_GAMME_VEHICLE_ROUTER',
+      legacy: {
+        title: legacy.title,
+        description: legacy.description,
+        h1: legacy.h1,
+        content: legacy.content,
+        keywords: null,
+        canonical: null,
+        robots: null,
+      },
+      requestUrl: `https://www.automecanik.com/pieces/${ctx.gamme_alias}.${ctx.marque_alias}.${ctx.modele_alias}.${ctx.type_alias}.html`,
+      ids: {
+        pgId: ctx.pg_id,
+        typeId: ctx.type_id,
+        gammeAlias: ctx.gamme_alias,
+        marqueAlias: ctx.marque_alias,
+        modeleAlias: ctx.modele_alias,
+        typeAlias: ctx.type_alias,
+      },
+      vars: {
         gamme: ctx.gamme_name,
         gammeMeta: ctx.gamme_name,
         marque: ctx.marque_name,
@@ -846,73 +844,13 @@ export class RmBuilderService extends SupabaseBaseService {
         modeleMeta: ctx.modele_name,
         type: ctx.type_name,
         typeMeta: ctx.type_name,
-        annee: '',
         nbCh: Number.parseInt(ctx.power_ps ?? '0', 10) || 0,
-        carosserie: '',
-        fuel: '',
-        codeMoteur: '',
-        minPrice: ctx.min_price ?? undefined,
+        minPrice: ctx.min_price ?? 0,
         articlesCount: ctx.count ?? 0,
         gammeLevel: 1,
-        isTopGamme: false,
+        isTopGamme: 0,
       },
-      ids: {
-        gammeAlias: ctx.gamme_alias,
-        marqueAlias: ctx.marque_alias,
-        modeleAlias: ctx.modele_alias,
-        typeAlias: ctx.type_alias,
-      },
-      baseUrl,
-      breadcrumbs: [],
+      entityId: `${ctx.pg_id}:${ctx.type_id}`,
     });
-
-    if (!out.template.title) return null;
-
-    return {
-      h1: out.template.h1,
-      title: out.template.title,
-      description: out.template.description,
-      content: out.template.content,
-      preview: out.template.preview,
-    };
-  }
-
-  /**
-   * Log structuré de la divergence entre legacy SEO et chaîne SEO (mode shadow).
-   *
-   * Format : 1 ligne par champ avec match=true|false. Permet de quantifier
-   * facilement la divergence sur 1000 requêtes via `grep | jq` côté Sentry/log.
-   */
-  private logSeoChainDiff(
-    ctx: SeoContext,
-    legacy: {
-      h1: string;
-      title: string;
-      description: string;
-      content: string;
-      preview: string;
-    },
-    chain: {
-      h1: string;
-      title: string;
-      description: string;
-      content: string;
-      preview: string;
-    },
-  ): void {
-    const diff = {
-      flag: 'SEO_CHAIN_RM',
-      mode: 'shadow',
-      pg_id: ctx.pg_id,
-      type_id: ctx.type_id,
-      title_eq: legacy.title === chain.title,
-      description_eq: legacy.description === chain.description,
-      h1_eq: legacy.h1 === chain.h1,
-      content_eq: legacy.content === chain.content,
-      preview_eq: legacy.preview === chain.preview,
-      legacy_title_len: legacy.title.length,
-      chain_title_len: chain.title.length,
-    };
-    this.logger.log(`[SEO_CHAIN_RM_SHADOW] ${JSON.stringify(diff)}`);
   }
 }

--- a/backend/src/modules/seo-shadow-observatory/env.schema.ts
+++ b/backend/src/modules/seo-shadow-observatory/env.schema.ts
@@ -16,5 +16,6 @@ import { z } from 'zod';
 export const SeoShadowEnvSchema = z.object({
   SEO_CHAIN_R7_MODE: z.enum(['off', 'shadow', 'on']).default('off'),
   SEO_CHAIN_R8_MODE: z.enum(['off', 'shadow', 'on']).default('off'),
+  SEO_CHAIN_RM_MODE: z.enum(['off', 'shadow', 'on']).default('off'),
   SEO_CHAIN_SHADOW_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0.01),
 });

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts
@@ -117,6 +117,25 @@ export class SeoShadowChainRunner {
           brandId: numericOrUndefined(ids.brandId),
         };
 
+      case 'R1_GAMME_VEHICLE_ROUTER':
+        // Retrofit rm-builder : ids/vars depuis `SeoContext` (cf. rm-builder.service.ts:598).
+        return {
+          surfaceKey: surface,
+          pgId: numericOrZero(ids.pgId),
+          typeId: numericOrZero(ids.typeId),
+          vehicleId: numericOrUndefined(ids.typeId),
+          variables: variables as never,
+          ids: {
+            gammeAlias: String(ids.gammeAlias ?? ''),
+            marqueAlias: String(ids.marqueAlias ?? ''),
+            modeleAlias: String(ids.modeleAlias ?? ''),
+            typeAlias: String(ids.typeAlias ?? ''),
+          },
+          baseUrl: SeoShadowChainRunner.BASE_URL,
+          requestedUrl: requestUrl,
+          breadcrumbs: [],
+        };
+
       default:
         throw new SeoShadowSurfaceNotWiredError(surface);
     }
@@ -125,7 +144,9 @@ export class SeoShadowChainRunner {
 
 export class SeoShadowSurfaceNotWiredError extends Error {
   constructor(surface: SurfaceKey) {
-    super(`SeoShadowChainRunner: surface ${surface} non câblée (PR-6 = R7+R8)`);
+    super(
+      `SeoShadowChainRunner: surface ${surface} non câblée (R7+R8 PR-6, R1_GAMME_VEHICLE_ROUTER retrofit RM)`,
+    );
     this.name = 'SeoShadowSurfaceNotWiredError';
   }
 }

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-event-sink.service.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-event-sink.service.ts
@@ -20,6 +20,8 @@ import type { DiffResult } from './types';
 const SURFACE_SUBTYPE: Partial<Record<SurfaceKey, string>> = {
   R7_BRAND_HUB: 'seo.shadow.r7.divergence',
   R8_VEHICLE: 'seo.shadow.r8.divergence',
+  // Retrofit rm-builder : R1 gamme×véhicule (legacy `/api/rm/page-v2`).
+  R1_GAMME_VEHICLE_ROUTER: 'seo.shadow.r1_rm.divergence',
 };
 
 const TABLE = '__seo_event_log';

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.module.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.module.ts
@@ -54,19 +54,24 @@ export class SeoShadowObservatoryModule implements OnModuleInit {
     const env = SeoShadowEnvSchema.parse({
       SEO_CHAIN_R7_MODE: this.cfg.get<string>('SEO_CHAIN_R7_MODE'),
       SEO_CHAIN_R8_MODE: this.cfg.get<string>('SEO_CHAIN_R8_MODE'),
+      SEO_CHAIN_RM_MODE: this.cfg.get<string>('SEO_CHAIN_RM_MODE'),
       SEO_CHAIN_SHADOW_SAMPLE_RATE: this.cfg.get<string>(
         'SEO_CHAIN_SHADOW_SAMPLE_RATE',
       ),
     });
-    if (env.SEO_CHAIN_R7_MODE === 'on' || env.SEO_CHAIN_R8_MODE === 'on') {
+    if (
+      env.SEO_CHAIN_R7_MODE === 'on' ||
+      env.SEO_CHAIN_R8_MODE === 'on' ||
+      env.SEO_CHAIN_RM_MODE === 'on'
+    ) {
       throw new Error(
-        `[SEO_SHADOW_BOOT_GUARD] mode=on forbidden in PR-6 (no on-branch shipped). ` +
-          `Detected R7=${env.SEO_CHAIN_R7_MODE} R8=${env.SEO_CHAIN_R8_MODE}. ` +
-          `Flip mode=on requires ADR-054 sign-off + dedicated PR — see governance-vault.`,
+        `[SEO_SHADOW_BOOT_GUARD] mode=on forbidden (no on-branch shipped). ` +
+          `Detected R7=${env.SEO_CHAIN_R7_MODE} R8=${env.SEO_CHAIN_R8_MODE} RM=${env.SEO_CHAIN_RM_MODE}. ` +
+          `Flip mode=on requires ADR-055 sign-off + dedicated PR — see governance-vault.`,
       );
     }
     this.logger.log(
-      `[SEO_SHADOW] boot OK — R7=${env.SEO_CHAIN_R7_MODE} R8=${env.SEO_CHAIN_R8_MODE} sample_rate=${env.SEO_CHAIN_SHADOW_SAMPLE_RATE}`,
+      `[SEO_SHADOW] boot OK — R7=${env.SEO_CHAIN_R7_MODE} R8=${env.SEO_CHAIN_R8_MODE} RM=${env.SEO_CHAIN_RM_MODE} sample_rate=${env.SEO_CHAIN_SHADOW_SAMPLE_RATE}`,
     );
   }
 }

--- a/backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.service.ts
+++ b/backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.service.ts
@@ -20,12 +20,16 @@ import {
 } from './types';
 
 /**
- * Mapping `surface → flag` (clé `SeoFeatureFlagRegistry`). PR-6 = R7 + R8.
+ * Mapping `surface → flag` (clé `SeoFeatureFlagRegistry`).
  * Étendre quand une surface est wirée (cf. README onboarding checklist).
+ *
+ * PR-6 (initial) : R7 + R8.
+ * Retrofit rm-builder : R1_GAMME_VEHICLE_ROUTER (flag `RM`).
  */
 const SURFACE_TO_FLAG: Partial<Record<SurfaceKey, SeoChainFlagKey>> = {
   R7_BRAND_HUB: 'R7',
   R8_VEHICLE: 'R8',
+  R1_GAMME_VEHICLE_ROUTER: 'RM',
 };
 
 /**

--- a/backend/tests/unit/seo-shadow-event-sink.test.ts
+++ b/backend/tests/unit/seo-shadow-event-sink.test.ts
@@ -84,6 +84,16 @@ describe('SeoShadowEventSink', () => {
     );
   });
 
+  it('mappe R1_GAMME_VEHICLE_ROUTER → seo.shadow.r1_rm.divergence (retrofit ADR-055)', async () => {
+    const supa = buildSupabaseStub();
+    const sink = buildSink(supa);
+    await sink.write('R1_GAMME_VEHICLE_ROUTER', '124:12345', 'https://x.test/p', baseDiff);
+    const row = (supa.insert.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect((row.payload as Record<string, unknown>).subtype).toBe(
+      'seo.shadow.r1_rm.divergence',
+    );
+  });
+
   it('severity=info quand policyDivergence=false', async () => {
     const supa = buildSupabaseStub();
     const sink = buildSink(supa);


### PR DESCRIPTION
## Summary

Drop le shadow inline ad-hoc PR-3 (`await chainSeo` blocant + branche `mode === 'on'` mutant la réponse) au profit du pattern canon `SeoShadowObservatoryModule` formalisé par **[ADR-055](https://github.com/ak125/governance-vault/pull/243)** (vault PR mergée 2026-05-09).

## Conformité ADR-055

- **I1** : `SeoShadowObservatoryModule` = unique chemin canon shadow (était : shadow inline)
- **I2** : `observe()` sync + `setImmediate` (était : `await chainSeo` blocant)
- **I3** : Aucune branche `mode === 'on'` dans rm-builder (était : `if (chainMode === 'on') result.seo = chainSeo`)
- **I4** : Persistance `__seo_event_log` via observatory sink (était : `logger.log` ad-hoc)
- **I5** : Sampler déterministe sha1 via observatory (était : pas de sampler)

## Changes

### Observatory extension (R1_GAMME_VEHICLE_ROUTER nouvelle surface)

| Fichier | Ajout |
|---|---|
| `seo-shadow-observatory.service.ts` | `SURFACE_TO_FLAG` += `R1_GAMME_VEHICLE_ROUTER: 'RM'` |
| `seo-shadow-event-sink.service.ts` | `SURFACE_SUBTYPE` += `'seo.shadow.r1_rm.divergence'` |
| `seo-shadow-chain-runner.service.ts` | Nouvelle case `R1_GAMME_VEHICLE_ROUTER` dans `adaptInput()` (pgId, typeId, aliases) |
| `env.schema.ts` | Ajoute `SEO_CHAIN_RM_MODE` au Zod schema |
| `seo-shadow-observatory.module.ts` | Boot guard étendu pour bloquer `RM_MODE=on` |

### rm-builder.service.ts (refactor cœur)

**Drop** :
- `chainOrchestrator: SeoChainOrchestratorService` + `chainFlags: SeoFeatureFlagRegistry` du constructor
- Méthodes privées `computeChainSeoForRm` (-54 lignes) + `logSeoChainDiff` (-30 lignes)
- Bloc inline shadow lignes 627-655 : branche `mode === 'on'` + `await this.computeChainSeoForRm`

**Add** :
- `shadowObservatory: SeoShadowObservatory` injection
- `fireShadowObservation(ctx, legacySeo)` sync wrapper (40 lignes)
- `result.seo = legacySeo` (no mutation possible — I3)

### rm.module.ts

- Drop : `forwardRef(() => SeoModule)` (plus utilisé directement)
- Add : `SeoShadowObservatoryModule` import

### Tests

- `rm-builder-seo-shadow.test.ts` **réécrit** (6 cas) — vérifie surface `R1_GAMME_VEHICLE_ROUTER`, `entityId='${pg_id}:${type_id}'`, `requestUrl` canonique R1, sync API, defaults `nbCh/minPrice/articlesCount`.
- `seo-shadow-event-sink.test.ts` : +1 cas mapping R1.

## Validation

| Check | Résultat |
|---|---|
| `tsc --noEmit` | ✅ 0 erreur |
| `jest seo-shadow\|rm-builder` | ✅ **70 passed / 9 suites** |
| `ast-grep seo-shadow-no-await` | ✅ 0 violation |

## Test plan

- [x] tsc green
- [x] tests verts
- [x] ast-grep clean
- [ ] CI complet
- [ ] Merge sur main + activation preprod `SEO_CHAIN_RM_MODE=shadow` après vérification

## Suite (issues follow-up séparées)

1. **Retrofit PR-5 gamme-rest** : même anti-pattern (`await this.computeChainSeoForGamme(...)` + branche `mode === 'on'` dans `gamme-response-builder.service.ts`). Retrofit séparé pour limiter blast radius (gamme-rest sert plus de trafic que rm).
2. **R8 redirect logic backend-side** : reproduire `marque_alias-marque_id` redirect 301 pour lever skip canonical R8 (R-SEO ADR-055 §"R8 limite connue").

🤖 Generated with [Claude Code](https://claude.com/claude-code)