### PR TITLE
ci: enable SEO shadow modes in preprod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -754,6 +754,11 @@ jobs:
           SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
           SESSION_SECRET=${SESSION_SECRET}
           READ_ONLY=true
+          # ADR-055 shadow activation: collect real preprod evidence before any
+          # mode=on decision. `on` remains blocked by backend boot guard.
+          SEO_CHAIN_R7_MODE=shadow
+          SEO_CHAIN_R8_MODE=shadow
+          SEO_CHAIN_RM_MODE=shadow
           REDIS_URL=redis://redis-preprod:6379
           APP_URL=http://localhost:3200
           # RAG service disabled in preprod (4 rag-proxy services use


### PR DESCRIPTION
## Summary

Enable ADR-055 shadow observation in the PREPROD deploy by adding the three canonical env flags to the generated `.env`:

- `SEO_CHAIN_R7_MODE=shadow`
- `SEO_CHAIN_R8_MODE=shadow`
- `SEO_CHAIN_RM_MODE=shadow`

This keeps `mode=on` blocked by the existing backend boot guard while allowing preprod to collect real evidence.

## Tracking

- Closes/feeds #411 after merge + deploy evidence.
- Follow-up SQL baseline remains tracked in #414.

## Validation

- Diff verified locally: only `.github/workflows/ci.yml` changed.
- Flag names cross-checked against `backend/src/modules/seo-shadow-observatory/env.schema.ts` and boot log usage.

## Post-merge checks

- PREPROD deploy boots.
- Backend logs include `[SEO_SHADOW] boot OK` with R7/R8/RM set to `shadow`.
- Sentry receives a real shadow signal.
- `__seo_event_log` contains at least one relevant row.