### PR TITLE
ci: scope RAG permissions audit and fix ast-grep runner

### DIFF
--- a/.github/workflows/rag-permissions-audit.yml
+++ b/.github/workflows/rag-permissions-audit.yml
@@ -13,10 +13,26 @@ on:
       - 'rag/knowledge/**'
       - 'scripts/rag-sync/**'
       - 'scripts/wiki/**'
+      - 'scripts/wiki-generators/**'
+      - 'scripts/wiki-exports/**'
+      - 'scripts/raw-downloaders/**'
+      - 'sgconfig.yml'
+      - '.ast-grep/rules/no-direct-rag-knowledge-write.yml'
+      - '.github/workflows/rag-permissions-audit.yml'
   push:
     branches:
       - main
       - dev
+    paths:
+      - 'rag/knowledge/**'
+      - 'scripts/rag-sync/**'
+      - 'scripts/wiki/**'
+      - 'scripts/wiki-generators/**'
+      - 'scripts/wiki-exports/**'
+      - 'scripts/raw-downloaders/**'
+      - 'sgconfig.yml'
+      - '.ast-grep/rules/no-direct-rag-knowledge-write.yml'
+      - '.github/workflows/rag-permissions-audit.yml'
 
 # Minimum scope: PR diff inspection + checkout (ADR-043 Sprint 1 ticket #7).
 permissions:
@@ -66,7 +82,7 @@ jobs:
 
       - name: Run ast-grep rule
         run: |
-          npx --yes @ast-grep/cli@latest scan \
+          npx --yes --package @ast-grep/cli@0.42.1 ast-grep scan \
             --config sgconfig.yml \
             --rule .ast-grep/rules/no-direct-rag-knowledge-write.yml || {
             code=$?


### PR DESCRIPTION
## Summary

Fix the `RAG L3 Permissions Audit` workflow that has been failing on every `main` push since it was introduced.

## Root cause

- The workflow ran on every push to `main`/`dev`, even when no RAG/script path changed.
- The PR trigger did not include the workflow file itself, `sgconfig.yml`, or the script folders scanned by the ast-grep rule.
- The command `npx --yes @ast-grep/cli@latest scan` is ambiguous because `@ast-grep/cli` exposes multiple bins (`sg`, `ast-grep`), producing `npm error could not determine executable to run`.

## Changes

- Add `push.paths` so the RAG audit only runs for relevant RAG/script/config changes.
- Expand `pull_request.paths` to include:
  - `scripts/wiki-generators/**`
  - `scripts/wiki-exports/**`
  - `scripts/raw-downloaders/**`
  - `sgconfig.yml`
  - `.ast-grep/rules/no-direct-rag-knowledge-write.yml`
  - `.github/workflows/rag-permissions-audit.yml`
- Replace the ambiguous npx call with an explicit pinned package + binary:

```bash
npx --yes --package @ast-grep/cli@0.42.1 ast-grep scan \
  --config sgconfig.yml \
  --rule .ast-grep/rules/no-direct-rag-knowledge-write.yml
```

## Validation

- `git diff --check` passed.
- Local command passed with exit 0:

```bash
npx --yes --package @ast-grep/cli@0.42.1 ast-grep scan --config sgconfig.yml --rule .ast-grep/rules/no-direct-rag-knowledge-write.yml
```

## Notes

The canonical `knowledge/**` protection still lives in the separate `ak125/automecanik-rag` repo (`d22-protected-paths`). This monorepo workflow remains useful as a generator/script guard, but should not pollute unrelated `main` pushes.