### PR TITLE
fix(docker): copy all internal packages in runner stage (anti-regression)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,10 +75,14 @@ COPY --chown=remix-api:nodejs --from=installer /app/frontend/build ./frontend/bu
 COPY --chown=remix-api:nodejs --from=installer /app/frontend/public ./frontend/public
 COPY --chown=remix-api:nodejs --from=installer /app/frontend/package.json ./frontend/package.json
 
-# Copier les packages internes nécessaires
-COPY --chown=remix-api:nodejs --from=installer /app/packages/design-tokens ./packages/design-tokens
-COPY --chown=remix-api:nodejs --from=installer /app/packages/database-types ./packages/database-types
-COPY --chown=remix-api:nodejs --from=installer /app/packages/seo-roles ./packages/seo-roles
+# Copier l'ensemble des packages internes (workspaces npm) en une seule étape :
+# le builder stage a fait `turbo run build`, donc chaque package/*/dist est prêt
+# et les symlinks node_modules/@repo|@fafa/* pointent vers packages/*. Cherry-pick
+# package par package ici cassait silencieusement le runtime à chaque nouveau
+# package interne (ex: @repo/seo-role-contracts ajouté par PR #399 → runtime crash
+# "Cannot find module" sur tous les deploys depuis 2026-05-08). Une COPY globale
+# élimine cette catégorie de régression.
+COPY --chown=remix-api:nodejs --from=installer /app/packages ./packages
 
 # 🛡️ RPC Safety Gate - Governance files
 # IMPORTANT: Copy to /app/backend/governance/ because start.sh does "cd backend"


### PR DESCRIPTION
## Summary

Fix structurel du Dockerfile qui débloque **8 deploys DEV preprod consécutifs en échec** depuis 2026-05-08 22:07.

**Cause racine** : depuis [PR #399](https://github.com/ak125/nestjs-remix-monorepo/pull/399) (PR-2a registries) qui a introduit \`@repo/seo-role-contracts\`, le runtime container plante au boot avec :
\`\`\`
Error: Cannot find module '@repo/seo-role-contracts'
❌ PREPROD health check failed after 2 minutes
\`\`\`

Le runner stage du Dockerfile faisait du cherry-pick package par package (3 lignes COPY pour \`design-tokens\` / \`database-types\` / \`seo-roles\`). Pattern fragile : chaque nouveau package interne ajouté par une PR ailleurs cassait silencieusement le deploy. Affecté : tous les commits main depuis le 2026-05-08 (#399, #404, #406, #407, #409, #410, #408 LCP R3, #415, #416).

## Fix

Remplacer 3 lignes cherry-pick par 1 ligne robuste :
\`\`\`diff
- COPY --from=installer /app/packages/design-tokens ./packages/design-tokens
- COPY --from=installer /app/packages/database-types ./packages/database-types
- COPY --from=installer /app/packages/seo-roles ./packages/seo-roles
+ COPY --from=installer /app/packages ./packages
\`\`\`

Le builder stage exécute déjà \`turbo run build --force\` qui produit \`packages/*/dist\` correctement. Les symlinks \`node_modules/@repo|@fafa/*\` pointent vers \`packages/*\` (npm workspaces, déjà copiés ligne 68 du Dockerfile).

## Test plan

- [ ] CI Backend Tests + TypeScript + ESLint vert (pas de modif code)
- [ ] **Deploy PREPROD passe** : health check OK sur \`46.224.118.55\` (vérification post-merge)
- [ ] Couvre les 5 packages prod : \`database-types\`, \`design-tokens\`, \`seo-role-contracts\`, \`seo-roles\`, \`seo-types\`

## Future-proof

Tout nouveau package interne (\`packages/X/\`) sera automatiquement inclus au runtime sans toucher au Dockerfile. Élimine cette catégorie de régression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)