### PR TITLE
feat(seo-v9): wire R7_BRAND in ExecutionRouter (no bricolage)

### DIFF
--- a/backend/src/modules/admin/services/execution-router.service.test.ts
+++ b/backend/src/modules/admin/services/execution-router.service.test.ts
@@ -1,0 +1,370 @@
+/**
+ * ExecutionRouterService — R7_BRAND dispatch coverage.
+ *
+ * Strategy: mock SupabaseBaseService at module level (chainable client),
+ * mock ModuleRef to return our enricher stub, drive everything through the
+ * public `execute(req)` method so we cover the full flow:
+ *   normalizeRoleId → EXECUTION_REGISTRY lookup → resolveEnricher
+ *   → executeWithRetryBackoff → executeWithTimeout → dispatchSingle
+ *   → inferStatus → logExecution.
+ *
+ * Pattern inspired by tests/unit/rag-pipeline-hardening.test.ts.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// ── Mock SupabaseBaseService before imports ──
+//
+// Per-table chain so we can assert `auto_marque` was NOT queried for invalid
+// targetIds, even though `pieces_gamme` is always queried by `resolvePgAlias`
+// (pre-existing tech debt documented in the plan, out of scope for this PR).
+
+interface TableHandlers {
+  single?: () => Promise<any>;
+  maybeSingle?: () => Promise<any>;
+  insert?: (payload?: any) => Promise<any>;
+}
+
+const tableHandlers: Record<string, TableHandlers> = {};
+const calls: Record<
+  string,
+  { single: number; maybeSingle: number; insert: number }
+> = {};
+
+function setTable(name: string, handlers: TableHandlers): void {
+  tableHandlers[name] = handlers;
+}
+
+function callsFor(name: string) {
+  return calls[name] ?? { single: 0, maybeSingle: 0, insert: 0 };
+}
+
+function makeChainFor(table: string) {
+  const handlers = tableHandlers[table] ?? {};
+  const chain: Record<string, jest.Mock> = {};
+  chain.from = jest.fn().mockReturnValue(chain);
+  chain.select = jest.fn().mockReturnValue(chain);
+  chain.update = jest.fn().mockReturnValue(chain);
+  chain.eq = jest.fn().mockReturnValue(chain);
+  chain.in = jest.fn().mockReturnValue(chain);
+  chain.gte = jest.fn().mockReturnValue(chain);
+  chain.order = jest.fn().mockReturnValue(chain);
+  chain.limit = jest.fn().mockReturnValue(chain);
+  chain.insert = jest.fn().mockImplementation((payload?: any) => {
+    calls[table] = calls[table] ?? { single: 0, maybeSingle: 0, insert: 0 };
+    calls[table].insert += 1;
+    return (handlers.insert ?? (() => Promise.resolve({ error: null })))(
+      payload,
+    );
+  });
+  chain.maybeSingle = jest.fn().mockImplementation(() => {
+    calls[table] = calls[table] ?? { single: 0, maybeSingle: 0, insert: 0 };
+    calls[table].maybeSingle += 1;
+    return (handlers.maybeSingle ?? (() => Promise.resolve({ data: null })))();
+  });
+  chain.single = jest.fn().mockImplementation(() => {
+    calls[table] = calls[table] ?? { single: 0, maybeSingle: 0, insert: 0 };
+    calls[table].single += 1;
+    return (handlers.single ?? (() => Promise.resolve({ data: null })))();
+  });
+  return chain;
+}
+
+const mockClient = {
+  from: jest.fn().mockImplementation((table: string) => makeChainFor(table)),
+};
+
+jest.mock('@database/services/supabase-base.service', () => ({
+  SupabaseBaseService: class {
+    protected client: any = mockClient;
+    protected logger: any = {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    };
+    constructor(..._args: any[]) {}
+  },
+}));
+
+// Stub heavy enricher modules so importing ExecutionRouterService doesn't
+// trigger their constructors (irrelevant for routing tests).
+jest.mock('./buying-guide-enricher.service', () => ({
+  BuyingGuideEnricherService: class {},
+}));
+jest.mock('./conseil-enricher.service', () => ({
+  ConseilEnricherService: class {},
+}));
+jest.mock('./r2-enricher.service', () => ({
+  R2EnricherService: class {},
+}));
+jest.mock('./r8-vehicle-enricher.service', () => ({
+  R8VehicleEnricherService: class {},
+}));
+jest.mock('./r7-brand-enricher.service', () => ({
+  R7BrandEnricherService: class {},
+}));
+jest.mock('./r1-enricher.service', () => ({
+  R1EnricherService: class {},
+}));
+jest.mock('./r4-content-enricher.service', () => ({
+  R4ContentEnricherService: class {},
+}));
+jest.mock('../../seo/services/reference.service', () => ({
+  ReferenceService: class {},
+}));
+jest.mock('../../seo/validation/diagnostic.service', () => ({
+  DiagnosticService: class {},
+}));
+
+import { ExecutionRouterService } from './execution-router.service';
+import { EXECUTION_REGISTRY } from '../../../config/execution-registry.constants';
+import { RoleId } from '../../../config/role-ids';
+
+// ── Helpers ──
+
+function makeService(
+  enricherForRole: Record<string, any>,
+): ExecutionRouterService {
+  const moduleRef = {
+    get: jest.fn((cls: any) => {
+      // Match by class name string, since serviceClassMap stored class refs
+      const name = cls?.name ?? '';
+      return enricherForRole[name] ?? null;
+    }),
+  };
+  const config = {
+    get: jest.fn().mockReturnValue(''),
+    getOrThrow: jest.fn().mockReturnValue(''),
+  };
+  const flags = {} as any;
+  return new ExecutionRouterService(config as any, moduleRef as any, flags);
+}
+
+// ── Tests ──
+
+function resetMocks() {
+  for (const k of Object.keys(tableHandlers)) delete tableHandlers[k];
+  for (const k of Object.keys(calls)) delete calls[k];
+  mockClient.from.mockClear();
+  mockClient.from.mockImplementation((table: string) => makeChainFor(table));
+}
+
+const auto_marque_30 = {
+  marque_id: 30,
+  marque_alias: 'audi',
+  marque_name: 'Audi',
+};
+
+describe('ExecutionRouterService — R7_BRAND dispatch', () => {
+  beforeEach(resetMocks);
+
+  it('1. R7 success → status=success when enricher returns draft', async () => {
+    setTable('auto_marque', {
+      single: () => Promise.resolve({ data: auto_marque_30, error: null }),
+    });
+    const enrichSingle = jest.fn().mockResolvedValue({
+      status: 'draft',
+      seoDecision: 'PUBLISH',
+      diversityScore: 78,
+      warnings: [],
+      reasons: [],
+      pageKey: 'r7_brand_30',
+    });
+    const service = makeService({
+      R7BrandEnricherService: { enrichSingle },
+    });
+
+    const result = await service.execute({
+      roleId: 'R7_BRAND',
+      targetIds: ['30'],
+      dryRun: false,
+    });
+
+    expect(result.results[0].status).toBe('success');
+    expect(enrichSingle).toHaveBeenCalledWith(30); // number, not string
+    // mode reads from registry — never duplicate the magic value
+    expect(result.mode).toBe(
+      EXECUTION_REGISTRY[RoleId.R7_BRAND].defaultWriteMode,
+    );
+    expect(result.dryRun).toBe(false);
+    // auto_marque was queried (resolveMarqueId path)
+    expect(callsFor('auto_marque').single).toBeGreaterThanOrEqual(1);
+  });
+
+  it('2. R7 dryRun → preview returns existing page metadata', async () => {
+    setTable('auto_marque', {
+      single: () => Promise.resolve({ data: auto_marque_30, error: null }),
+    });
+    setTable('__seo_r7_pages', {
+      maybeSingle: () =>
+        Promise.resolve({
+          data: {
+            id: 1,
+            seo_decision: 'PUBLISH',
+            diversity_score: 82,
+            updated_at: '2026-04-01T00:00:00Z',
+          },
+          error: null,
+        }),
+    });
+    const enrichSingle = jest.fn();
+    const service = makeService({
+      R7BrandEnricherService: { enrichSingle },
+    });
+
+    const result = await service.execute({
+      roleId: 'R7_BRAND',
+      targetIds: ['30'],
+      dryRun: true,
+    });
+
+    expect(result.results[0].status).toBe('success');
+    const data = result.results[0].data as any;
+    expect(data.exists).toBe(true);
+    expect(data.status).toBe('ready');
+    expect(data.action).toContain('regenerate');
+    expect(data.currentDecision).toBe('PUBLISH');
+    expect(enrichSingle).not.toHaveBeenCalled();
+    expect(callsFor('__seo_r7_pages').maybeSingle).toBe(1);
+  });
+
+  it('3. R7 dryRun → preview returns "would create" when no page exists', async () => {
+    setTable('auto_marque', {
+      single: () =>
+        Promise.resolve({
+          data: { marque_id: 30, marque_alias: 'bmw', marque_name: 'BMW' },
+          error: null,
+        }),
+    });
+    setTable('__seo_r7_pages', {
+      maybeSingle: () => Promise.resolve({ data: null, error: null }),
+    });
+    const enrichSingle = jest.fn();
+    const service = makeService({
+      R7BrandEnricherService: { enrichSingle },
+    });
+
+    const result = await service.execute({
+      roleId: 'R7_BRAND',
+      targetIds: ['30'],
+      dryRun: true,
+    });
+
+    const data = result.results[0].data as any;
+    expect(data.exists).toBe(false);
+    expect(data.status).toBe('ready');
+    expect(data.action).toBe('would create R7 brand page');
+    expect(enrichSingle).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'abc',
+    '30abc',
+    ' 30',
+    '-1',
+    '+30',
+    '0x1E',
+    '',
+    '0', // passes regex but fails `marqueId <= 0`
+  ])(
+    '4. R7 invalid targetId %p → failed without auto_marque or enricher call',
+    async (targetId) => {
+      // No setTable for auto_marque — any call would fall back to `data:null`,
+      // but our assertion is that auto_marque is never queried at all.
+      const enrichSingle = jest.fn();
+      const service = makeService({
+        R7BrandEnricherService: { enrichSingle },
+      });
+
+      const result = await service.execute({
+        roleId: 'R7_BRAND',
+        targetIds: [targetId],
+        dryRun: false,
+      });
+
+      expect(result.results[0].status).toBe('failed');
+      const data = result.results[0].data as any;
+      expect(data.reason).toMatch(/Invalid or unknown/);
+      // The strict regex `/^\d+$/` and `<=0` guard short-circuit BEFORE
+      // any auto_marque SELECT — pieces_gamme is still hit by the
+      // pre-existing `resolvePgAlias` call (documented tech debt).
+      expect(callsFor('auto_marque').single).toBe(0);
+      expect(enrichSingle).not.toHaveBeenCalled();
+    },
+  );
+
+  it('5. R7 marque not found in auto_marque → failed', async () => {
+    setTable('auto_marque', {
+      single: () => Promise.resolve({ data: null, error: null }),
+    });
+    const enrichSingle = jest.fn();
+    const service = makeService({
+      R7BrandEnricherService: { enrichSingle },
+    });
+
+    const result = await service.execute({
+      roleId: 'R7_BRAND',
+      targetIds: ['999999'],
+      dryRun: false,
+    });
+
+    expect(result.results[0].status).toBe('failed');
+    const data = result.results[0].data as any;
+    expect(data.reason).toContain('999999');
+    expect(enrichSingle).not.toHaveBeenCalled();
+    expect(callsFor('auto_marque').single).toBe(1);
+  });
+
+  it('6. R7 enricher returns failed → propagate failed with reasons', async () => {
+    setTable('auto_marque', {
+      single: () => Promise.resolve({ data: auto_marque_30, error: null }),
+    });
+    const enrichSingle = jest.fn().mockResolvedValue({
+      status: 'failed',
+      seoDecision: 'REJECT',
+      diversityScore: 0,
+      warnings: ['boom'],
+      reasons: ['ENRICHMENT_FAILED'],
+      pageKey: 'r7_brand_30',
+    });
+    const service = makeService({
+      R7BrandEnricherService: { enrichSingle },
+    });
+
+    const result = await service.execute({
+      roleId: 'R7_BRAND',
+      targetIds: ['30'],
+      dryRun: false,
+    });
+
+    expect(result.results[0].status).toBe('failed');
+    const data = result.results[0].data as any;
+    expect(data.status).toBe('failed');
+    expect(data.reasons[0]).toBe('ENRICHMENT_FAILED');
+  });
+});
+
+describe('ExecutionRouterService — regression smoke', () => {
+  beforeEach(resetMocks);
+
+  it('7. R8_VEHICLE dispatch still works with numeric typeId after R7 wiring', async () => {
+    // pieces_gamme.single → null (resolvePgAlias returns null for typeId)
+    setTable('pieces_gamme', {
+      single: () => Promise.resolve({ data: null, error: null }),
+    });
+    const enrichSingle = jest.fn().mockResolvedValue({ ok: true });
+    const service = makeService({
+      R8VehicleEnricherService: { enrichSingle },
+    });
+
+    const result = await service.execute({
+      roleId: 'R8_VEHICLE',
+      targetIds: ['12345'],
+      dryRun: false,
+    });
+
+    expect(result.results[0].status).toBe('success');
+    expect(enrichSingle).toHaveBeenCalledWith(12345);
+  });
+});

--- a/backend/src/modules/admin/services/execution-router.service.ts
+++ b/backend/src/modules/admin/services/execution-router.service.ts
@@ -6,8 +6,8 @@
  *
  * Fixes applied:
  * - R4/R5: single-target dispatch instead of batch-all
- * - R7_BRAND: explicit "not implemented" error
- * - dryRun: supported for R1/R2/R3-conseil (preview without DB write)
+ * - R7_BRAND: dispatch to R7BrandEnricherService.enrichSingle(marqueId)
+ * - dryRun: supported for R1/R2/R3-conseil/R5/R7/R8 (preview without DB write)
  *
  * @see execution-registry.constants.ts
  */
@@ -23,6 +23,7 @@ import { BuyingGuideEnricherService } from '../services/buying-guide-enricher.se
 import { ConseilEnricherService } from '../services/conseil-enricher.service';
 import { R2EnricherService } from '../services/r2-enricher.service';
 import { R8VehicleEnricherService } from '../services/r8-vehicle-enricher.service';
+import { R7BrandEnricherService } from '../services/r7-brand-enricher.service';
 import { DiagnosticService } from '../../seo/validation/diagnostic.service';
 import { R1EnricherService } from '../services/r1-enricher.service';
 import { ReferenceService } from '../../seo/services/reference.service';
@@ -101,6 +102,9 @@ export class ExecutionRouterService extends SupabaseBaseService {
       R8VehicleEnricherService: R8VehicleEnricherService as unknown as new (
         ...args: unknown[]
       ) => unknown,
+      R7BrandEnricherService: R7BrandEnricherService as unknown as new (
+        ...args: unknown[]
+      ) => unknown,
       DiagnosticService: DiagnosticService as unknown as new (
         ...args: unknown[]
       ) => unknown,
@@ -132,29 +136,7 @@ export class ExecutionRouterService extends SupabaseBaseService {
       );
     }
 
-    // 2. R7_BRAND: not implemented in ExecutionRouter — skip gracefully
-    if (roleId === RoleId.R7_BRAND) {
-      this.logger.warn(
-        'R7_BRAND enricher not available in ExecutionRouter. Use /content-gen --r7 or r7-brand-execution agent.',
-      );
-      return {
-        roleId: request.roleId,
-        mode: 'blocked_no_write',
-        dryRun: request.dryRun ?? true,
-        totalTargets: request.targetIds.length,
-        results: request.targetIds.map((id) => ({
-          targetId: id,
-          status: 'skipped' as const,
-          data: {
-            reason:
-              'R7_BRAND enricher not implemented in pipeline. Use /content-gen --r7 or r7-brand-execution agent.',
-          },
-        })),
-        duration: Date.now() - start,
-      };
-    }
-
-    // 3. Lookup registry entry
+    // 2. Lookup registry entry
     const entry = EXECUTION_REGISTRY[roleId];
     if (!entry) {
       return this.errorResult(
@@ -238,8 +220,7 @@ export class ExecutionRouterService extends SupabaseBaseService {
     allowedModes: string[];
     timeoutMs: number;
   }> {
-    // Include R7 manually (not in registry but is a known role)
-    const registryRoles = Object.values(EXECUTION_REGISTRY).map((entry) => ({
+    return Object.values(EXECUTION_REGISTRY).map((entry) => ({
       roleId: entry.roleId,
       pageType: entry.pageType,
       enricherServiceKey: entry.enricherServiceKey,
@@ -247,17 +228,6 @@ export class ExecutionRouterService extends SupabaseBaseService {
       allowedModes: [...entry.allowedModes],
       timeoutMs: entry.stopPolicy.timeoutMs,
     }));
-
-    registryRoles.push({
-      roleId: RoleId.R7_BRAND,
-      pageType: 'R7_brand',
-      enricherServiceKey: 'not_implemented',
-      available: false,
-      allowedModes: [],
-      timeoutMs: 0,
-    });
-
-    return registryRoles;
   }
 
   // ── Private: dispatch per role ──
@@ -314,6 +284,27 @@ export class ExecutionRouterService extends SupabaseBaseService {
       case RoleId.R5_DIAGNOSTIC:
         // Single-target: generate diagnostics for one gamme only
         return this.dispatchR5Single(enricher, targetId, pgAlias, dryRun);
+
+      case RoleId.R7_BRAND: {
+        // R7 expects a marque_id (number), not a gamme pgId.
+        // Validation: strict numeric format + existence in auto_marque.
+        const resolved = await this.resolveMarqueId(targetId);
+        if (!resolved) {
+          return {
+            targetId,
+            status: 'failed',
+            reason: `Invalid or unknown marque_id: "${targetId}". R7_BRAND requires a numeric marque_id existing in auto_marque.`,
+          };
+        }
+        if (dryRun) {
+          return this.dryRunR7Preview(
+            targetId,
+            resolved.marqueId,
+            resolved.brand,
+          );
+        }
+        return enricher.enrichSingle!(resolved.marqueId);
+      }
 
       case RoleId.R8_VEHICLE: {
         // R8 expects a vehicle typeId, not a gamme pgId
@@ -771,6 +762,84 @@ export class ExecutionRouterService extends SupabaseBaseService {
     } catch {
       return null;
     }
+  }
+
+  // ── Private: resolve marque_id from targetId (R7_BRAND) ──
+
+  /**
+   * Strictly numeric `targetId` ⇒ `auto_marque` row.
+   *
+   * Rejects:
+   * - non-numeric formats: `"abc"`, `"30abc"`, `"+30"`, `"0x1E"`, `" 30"`, `""`
+   * - non-positive ids: `"0"`, `"-1"` (regex blocks `-1`; `<= 0` blocks `0`)
+   * - missing rows in `auto_marque`
+   *
+   * Note: `parseInt("30abc", 10) === 30` would silently inject — the strict
+   * regex `/^\d+$/` blocks that case.
+   */
+  private async resolveMarqueId(targetId: string): Promise<{
+    marqueId: number;
+    brand: { marque_alias: string; marque_name: string };
+  } | null> {
+    if (!/^\d+$/.test(targetId)) return null;
+
+    const marqueId = Number.parseInt(targetId, 10);
+    if (Number.isNaN(marqueId) || marqueId <= 0) return null;
+
+    try {
+      const { data } = await this.client
+        .from('auto_marque')
+        .select('marque_id, marque_alias, marque_name')
+        .eq('marque_id', marqueId)
+        .single();
+      if (!data) return null;
+      return {
+        marqueId,
+        brand: {
+          marque_alias: data.marque_alias ?? '',
+          marque_name: data.marque_name ?? '',
+        },
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Private: dryRun preview for R7_BRAND ──
+
+  /**
+   * Read-only preview: SELECT current `__seo_r7_pages` row state, no writes.
+   * Returns `status: 'ready'` so `inferStatus` maps to `'success'`.
+   */
+  private async dryRunR7Preview(
+    targetId: string,
+    marqueId: number,
+    brand: { marque_alias: string; marque_name: string },
+  ): Promise<unknown> {
+    const pageKey = `r7_brand_${marqueId}`;
+    const { data: existing } = await this.client
+      .from('__seo_r7_pages')
+      .select('id, seo_decision, diversity_score, updated_at')
+      .eq('page_key', pageKey)
+      .maybeSingle();
+
+    return {
+      targetId,
+      dryRun: true,
+      roleId: RoleId.R7_BRAND,
+      marqueId,
+      marqueAlias: brand.marque_alias,
+      marqueName: brand.marque_name,
+      pageKey,
+      exists: !!existing,
+      currentDecision: existing?.seo_decision ?? null,
+      currentScore: existing?.diversity_score ?? null,
+      lastUpdate: existing?.updated_at ?? null,
+      action: existing
+        ? 'would regenerate (page exists)'
+        : 'would create R7 brand page',
+      status: 'ready',
+    };
   }
 
   // ── Private: infer status from result ──

--- a/log.md
+++ b/log.md
@@ -495,3 +495,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `pr6-clean`
 - **Décision** : fix(seo-v9): pr-6 update vehicle-rpc legacy test for shadowObservatory dep (+2 other commits)
 - **Sortie** : PR aucune | commits c4808beb a8df0f53 c230abd4
+
+## 2026-05-09 — feat/seo-v9-r7-router-wire (auto)
+
+- **Branche** : `feat/seo-v9-r7-router-wire`
+- **Décision** : docs(seo-batch): unblock R7 step in seo-gamme-audit skill (+2 other commits)
+- **Sortie** : PR #418 | commits cd329235 b94d51eb 46778759

--- a/workspaces/seo-batch/.claude/skills/seo-gamme-audit/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/seo-gamme-audit/SKILL.md
@@ -187,8 +187,15 @@ FROM __rag_readiness WHERE pg_alias = '{pg_alias}'
 ORDER BY canonical_role;
 ```
 
-### Étape 7b — R7 brand coverage (si table existe)
-Pas de table `__seo_r7_*` actuellement. Reporter "R7 non implémenté" et passer.
+### Étape 7b — R7 brand coverage
+```sql
+SELECT
+  count(*) FILTER (WHERE seo_decision = 'PUBLISH') AS r7_published,
+  count(*) AS r7_total,
+  avg(diversity_score)::numeric(5,2) AS r7_avg_score
+FROM __seo_r7_pages;
+```
+Si `r7_published = 0` → "R7 brand pages: aucune publication active". Sinon, reporter `r7_total` + `r7_published` + `r7_avg_score`. R7 est désormais branché dans `ExecutionRouter` (rôle dispatché comme R1-R8).
 
 ### Étape 7c — R8 vehicle pages
 ```sql


### PR DESCRIPTION
## Summary

- Removes hardcoded `not implemented` skip for `R7_BRAND` in `ExecutionRouterService` and dispatches to `R7BrandEnricherService.enrichSingle(marqueId)` exactly like R8 (numeric `targetId`, inline `case`, dryRun preview by router not enricher).
- Adds `resolveMarqueId(targetId)` helper with **strict** `/^\d+$/` regex + `Number.parseInt` + `auto_marque` existence check (rejects `"abc"`, `"30abc"`, `" 30"`, `"+30"`, `"0x1E"`, `""`, `"0"`, `"-1"`, missing rows). Adds `dryRunR7Preview()` returning `status:'ready'` (compatible with existing `inferStatus` mapper).
- First spec for `ExecutionRouterService`: 14 tests pass — 6 R7 happy/edge cases + 8 parameterized invalid `targetId` rejections + 1 R8 smoke regression.
- Doc fix in `seo-gamme-audit/SKILL.md`: replace obsolete "R7 non implémenté" stub with a real SQL probe on `__seo_r7_pages`.

R7 is now reachable through the canonical `/api/admin/pipeline/execute` endpoint, with `__pipeline_chain_queue` logging, retry, timeout, and unified observability — same governance as R1-R8.

## Plan reference

`/home/deploy/.claude/plans/utiliser-meileure-approche-meilleure-quiet-quasar.md` (approved).

## Decisions

- **Inline `case` in `dispatchSingle`** (aligned R1-R8) over a new `R7ExecutionAdapter` class — adapter pattern would be a hybrid for one role only.
- **DryRun preview by router** (SELECT-only on `__seo_r7_pages` + `auto_marque`), not by modifying `enrichSingle(marqueId)` — that signature is consumed by `AdminR7BrandController` and `enrichBatch`. Aligned with R8 pattern.
- **No mapper class**: `inferStatus` already recognises `'draft' | 'failed' | 'skipped' | 'ready'`, no duplication.
- **Per-table chain mock** in spec: lets us assert `auto_marque` was NOT queried for invalid `targetId`s, while documenting that `pieces_gamme` is still hit by `resolvePgAlias` (pre-existing tech debt).

## Out of scope (explicit)

- ADR vault `R7 Brand Runtime Completion` — separate PR on `ak125/governance-vault` per ADR-015 / CLAUDE.md rule 1.
- Refactor `parseNumericTargetId` shared between R7 and R8 + skip `resolvePgAlias` for numeric-targetId roles. Pre-existing debt (R8 has the same issue), follow-up.
- `executeWithConcurrency` results-order bug (pre-existing, follow-up). For `enrichBatch` admin flows, keep the existing controller path until ordering is guaranteed.
- Mapping `R7EnrichResult.reasons[]` → `data.reason` for `extractDetailedError` — accepted fallback, aligned with R1/R2/R8.
- True dryRun inside the enricher (compose+score sans UPSERT) — current preview suffices, reconsider on empirical signal.

## Known tech debt documented in this PR

- `__pipeline_chain_queue.pcq_pg_id` reused as `marque_id` for R7 (R8 does the same with `typeId`). Field is a generic pipeline trace; renaming would impact every non-gamme role.
- `dispatchSingle` and `logExecution` each call `resolvePgAlias(targetId)` on `pieces_gamme` even for R7/R8 numeric ids → 2 unnecessary SELECTs per execution. Pre-existing.

## Test plan

- [x] `cd backend && NODE_OPTIONS="--max-old-space-size=8192" npx tsc --noEmit` → 0 errors.
- [x] `npx jest src/modules/admin/services/execution-router.service.test.ts` → 14/14 PASS.
- [ ] Smoke dryRun on dev: `curl -X POST .../api/admin/pipeline/execute -d '{"roleId":"R7_BRAND","targetIds":["30"],"dryRun":true}'` → `results[0].status==='success'`, `data.status==='ready'`, `data.dryRun===true`, `data.marqueAlias` defined, no write to `__seo_r7_pages`.
- [ ] Smoke real on dev: same with `dryRun:false`, then verify in DB: `SELECT page_key, seo_decision, diversity_score FROM __seo_r7_pages WHERE page_key='r7_brand_30'` → 1 row, `__seo_r7_page_versions` ≥1, `__seo_r7_fingerprints` 1.
- [ ] `curl .../api/admin/pipeline/roles | jq '.[] | select(.roleId=="R7_BRAND")'` → `available:true`, `enricherServiceKey:"R7BrandEnricherService"`, `timeoutMs:180000`.
- [ ] R8 smoke regression: `curl .../execute -d '{"roleId":"R8_VEHICLE","targetIds":["12345"],"dryRun":true}'` → identical to pre-PR behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)