### PR TITLE
fix(seo): allow quality history boot in read-only

### DIFF
--- a/backend/src/modules/seo-monitoring/controllers/quality-history.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/quality-history.controller.ts
@@ -29,6 +29,7 @@ import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
 import { AuthenticatedGuard } from '@auth/authenticated.guard';
 import { IsAdminGuard } from '@auth/is-admin.guard';
+import { getEffectiveSupabaseKey } from '@common/utils';
 import {
   QualityHistorySnapshotService,
   SnapshotKind,
@@ -45,7 +46,8 @@ export class QualityHistoryController {
     configService: ConfigService,
   ) {
     const url = configService.get<string>('SUPABASE_URL') || '';
-    const key = configService.get<string>('SUPABASE_SERVICE_ROLE_KEY') || '';
+    // ADR-028 Option D — fallback to ANON_KEY in read-only mode (RLS protects writes)
+    const key = getEffectiveSupabaseKey();
     if (!url || !key) {
       this.logger.warn(
         'QualityHistoryController: Supabase env missing — service will fail on first call',

--- a/backend/tests/unit/seo-monitoring/quality-history.controller.test.ts
+++ b/backend/tests/unit/seo-monitoring/quality-history.controller.test.ts
@@ -1,0 +1,47 @@
+import { ConfigService } from '@nestjs/config';
+import { createClient } from '@supabase/supabase-js';
+
+import { QualityHistoryController } from '../../../src/modules/seo-monitoring/controllers/quality-history.controller';
+import { QualityHistorySnapshotService } from '../../../src/modules/seo-monitoring/services/quality-history-snapshot.service';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ rpc: jest.fn(), from: jest.fn() })),
+}));
+
+describe('QualityHistoryController', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.SUPABASE_ANON_KEY;
+    delete process.env.READ_ONLY;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  function makeConfig(overrides: Record<string, string | undefined>) {
+    return {
+      get: <T = string>(key: string): T | undefined => overrides[key] as T,
+    } as unknown as ConfigService;
+  }
+
+  it('uses ANON_KEY when READ_ONLY=true and SERVICE_ROLE_KEY is absent', () => {
+    process.env.READ_ONLY = 'true';
+    process.env.SUPABASE_ANON_KEY = 'anon-key-xyz';
+
+    new QualityHistoryController(
+      {} as QualityHistorySnapshotService,
+      makeConfig({ SUPABASE_URL: 'https://supabase.test' }),
+    );
+
+    expect(createClient).toHaveBeenCalledWith(
+      'https://supabase.test',
+      'anon-key-xyz',
+      { auth: { persistSession: false, autoRefreshToken: false } },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Retrofit `QualityHistoryController` to use the canonical `getEffectiveSupabaseKey()` resolver.
- Allows `READ_ONLY=true` preprod to boot with `SUPABASE_ANON_KEY` when `SUPABASE_SERVICE_ROLE_KEY` is intentionally absent per ADR-028.
- Adds a regression test covering the read-only anon-key fallback for this controller.

## Context

Preprod deploy after #417 no longer failed on missing internal packages, but crashed during Nest boot with:

```text
Error: supabaseKey is required.
new QualityHistoryController (.../quality-history.controller.js)
```

Root cause: this controller still read `SUPABASE_SERVICE_ROLE_KEY` directly, while neighboring SEO monitoring services/controllers already use `getEffectiveSupabaseKey()`.

## Validation

- `git diff --check` OK
- Focused Jest could not be executed locally in the isolated worktree because the shared local dependency tree is missing `ts-jest`.
- Backend typecheck command reached project dependency gaps in the local shared dependency tree (`zod-to-json-schema`, `pdf-parse`), unrelated to this patch. CI should provide the clean signal.