### PR TITLE
fix(rag): soft-warn bootstrap guard in read-only preprod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,7 +755,7 @@ jobs:
           SESSION_SECRET=${SESSION_SECRET}
           READ_ONLY=true
           # ADR-055 shadow activation: collect real preprod evidence before any
-          # mode=on decision. `on` remains blocked by backend boot guard.
+          # mode=on decision. Literal on remains blocked by backend boot guard.
           SEO_CHAIN_R7_MODE=shadow
           SEO_CHAIN_R8_MODE=shadow
           SEO_CHAIN_RM_MODE=shadow

--- a/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
+++ b/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
@@ -8,9 +8,10 @@
  *      par le cron sync-wiki-exports-to-rag).
  *   2. Vérifie que ce manifest n'est pas obsolète (> 24h).
  *
- * En production (NODE_ENV=production), fail-fast si manifest absent ou obsolète :
- * un L3 stale signale soit un cron mort, soit une migration incomplète, et le
- * service ne doit pas démarrer dans cet état (mémoire incident-images-2026-04-11).
+ * En production réelle (NODE_ENV=production hors APP_ENV=preprod/READ_ONLY=true),
+ * fail-fast si manifest absent ou obsolète : un L3 stale signale soit un cron
+ * mort, soit une migration incomplète, et le service ne doit pas démarrer dans
+ * cet état (mémoire incident-images-2026-04-11).
  *
  * En dev/preprod, soft-warn (le manifest peut ne pas exister tant que Phase 3B
  * PR-P n'a pas livré le sync canon).
@@ -44,11 +45,14 @@ export class RagKnowledgeBootstrapGuardService implements OnModuleInit {
     const ragDir =
       process.env.RAG_KNOWLEDGE_PATH ?? '/opt/automecanik/rag/knowledge';
     const manifestPath = path.join(ragDir, MANIFEST_FILENAME);
-    const isProd = process.env.NODE_ENV === 'production';
+    const isReadOnlyPreprod =
+      process.env.APP_ENV === 'preprod' || process.env.READ_ONLY === 'true';
+    const shouldFailFast =
+      process.env.NODE_ENV === 'production' && !isReadOnlyPreprod;
 
     if (!fs.existsSync(manifestPath)) {
       const msg = `[RagKnowledgeBootstrapGuard] manifest absent: ${manifestPath}. Le cron sync-wiki-exports-to-rag doit avoir produit ce fichier (Phase 3B PR-P du plan refondation R-stack).`;
-      if (isProd) {
+      if (shouldFailFast) {
         throw new Error(msg);
       }
       this.logger.warn(
@@ -62,7 +66,7 @@ export class RagKnowledgeBootstrapGuardService implements OnModuleInit {
 
     if (ageHours > STALE_THRESHOLD_HOURS) {
       const msg = `[RagKnowledgeBootstrapGuard] manifest stale (age=${ageHours.toFixed(1)}h > ${STALE_THRESHOLD_HOURS}h). Le cron sync est probablement en panne — investiguer avant restart.`;
-      if (isProd) {
+      if (shouldFailFast) {
         throw new Error(msg);
       }
       this.logger.warn(`${msg} (dev/preprod : soft-warn)`);

--- a/backend/tests/unit/rag-knowledge-bootstrap.guard.test.ts
+++ b/backend/tests/unit/rag-knowledge-bootstrap.guard.test.ts
@@ -1,0 +1,39 @@
+import { RagKnowledgeBootstrapGuardService } from '../../src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard';
+
+describe('RagKnowledgeBootstrapGuardService', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.APP_ENV;
+    delete process.env.NODE_ENV;
+    delete process.env.READ_ONLY;
+    delete process.env.RAG_KNOWLEDGE_PATH;
+    delete process.env.SKIP_RAG_BOOTSTRAP_GUARD;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('fail-fasts in real production when the L3 manifest is absent', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.RAG_KNOWLEDGE_PATH = '/tmp/automecanik-rag-missing-prod';
+
+    expect(() => new RagKnowledgeBootstrapGuardService().onModuleInit()).toThrow(
+      '[RagKnowledgeBootstrapGuard] manifest absent:',
+    );
+  });
+
+  it('soft-warns in READ_ONLY preprod when the L3 manifest is absent', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.APP_ENV = 'preprod';
+    process.env.READ_ONLY = 'true';
+    process.env.RAG_KNOWLEDGE_PATH =
+      '/tmp/automecanik-rag-missing-readonly-preprod';
+
+    expect(() =>
+      new RagKnowledgeBootstrapGuardService().onModuleInit(),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Keep `RagKnowledgeBootstrapGuard` fail-fast for real production.
- Treat `APP_ENV=preprod` or `READ_ONLY=true` as soft-warn mode, matching the guard docs and ADR-028 preprod behavior.
- Add regression coverage for prod fail-fast vs read-only preprod soft-warn.
- Remove backticks around `on` in the preprod `.env` heredoc comment to avoid shell command substitution noise (`on: command not found`).

## Context

After #419 fixed the Supabase boot crash, the main preprod deploy reached the next blocker:

```text
Error: [RagKnowledgeBootstrapGuard] manifest absent: /opt/automecanik/rag/knowledge/.last-sync.json
```

The deploy workflow explicitly disables RAG in preprod via sentinel values:

```text
RAG_SERVICE_URL=http://disabled:8000
RAG_API_KEY=disabled-preprod-readonly
READ_ONLY=true
APP_ENV=preprod
```

But the guard only checked `NODE_ENV=production`; `docker-compose.preprod.yml` sets `NODE_ENV=production`, so preprod was accidentally receiving the strict prod policy despite the guard comment saying dev/preprod should soft-warn.

## Validation

- `git diff --check` OK
- Full CI expected to run the new Jest regression in `Backend Tests`