### PR TITLE
perf(frontend): lazy-load Sentry browser SDK post-hydration

### DIFF
--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -4,23 +4,80 @@
  * For more information, see https://remix.run/file-conventions/entry.client
  */
 
-import { useLocation, useMatches, RemixBrowser } from "@remix-run/react";
-import * as Sentry from "@sentry/remix";
-import { startTransition, useEffect } from "react";
+import { RemixBrowser } from "@remix-run/react";
+import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
-import { sentryBeforeSend } from "~/utils/analytics-sanitize";
 import { logger } from "~/utils/logger";
 import { reportWebVitals } from "~/utils/web-vitals.client";
 
-// Sentry browser SDK — DSN injected at SSR time via `window.ENV.VITE_SENTRY_DSN`
-// (see root.tsx loader). When the DSN is absent, all Sentry calls are no-ops.
-const dsn =
-  (typeof window !== "undefined" &&
-    (window as unknown as { ENV?: { VITE_SENTRY_DSN?: string } }).ENV
-      ?.VITE_SENTRY_DSN) ||
-  undefined;
+// Service worker cleanup — sync, no Sentry dep
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.getRegistrations().then(function (registrations) {
+    for (const registration of registrations) {
+      registration.unregister().then(function (boolean) {
+        logger.log("Service Worker désenregistré:", boolean);
+      });
+    }
+  });
+}
 
-if (dsn) {
+// Early error buffer — captures errors fired between hydration and the lazy
+// Sentry init below. Replayed once Sentry is loaded so no error is lost during
+// the ~1.5-2s window before requestIdleCallback fires.
+type BufferedEvent =
+  | { kind: "error"; ev: ErrorEvent }
+  | { kind: "rejection"; ev: PromiseRejectionEvent };
+const errorBuffer: BufferedEvent[] = [];
+const onError = (ev: ErrorEvent) => errorBuffer.push({ kind: "error", ev });
+const onRejection = (ev: PromiseRejectionEvent) =>
+  errorBuffer.push({ kind: "rejection", ev });
+window.addEventListener("error", onError);
+window.addEventListener("unhandledrejection", onRejection);
+
+startTransition(() => {
+  hydrateRoot(document, <RemixBrowser />, {
+    onRecoverableError(error) {
+      if (error instanceof Error) {
+        console.warn("[Hydration]", error.message);
+      } else {
+        console.error("Recoverable error:", error);
+      }
+    },
+  });
+  // Web Vitals observers attached early — `web-vitals` v4 uses
+  // PerformanceObserver buffered:true so LCP/FCP candidates that already
+  // fired are still observed. Sentry pipe is wired up later via
+  // setSentryInstance() from initObservability().
+  reportWebVitals();
+});
+
+// Lazy observability init — defers ~100-150 KB of Sentry SDK off the
+// critical path. Fires after first idle frame with hard 2s timeout
+// (covers backgrounded tabs).
+const initObservability = async (): Promise<void> => {
+  const dsn = (window as unknown as { ENV?: { VITE_SENTRY_DSN?: string } }).ENV
+    ?.VITE_SENTRY_DSN;
+  if (!dsn) {
+    window.removeEventListener("error", onError);
+    window.removeEventListener("unhandledrejection", onRejection);
+    errorBuffer.length = 0;
+    return;
+  }
+
+  const [
+    Sentry,
+    { sentryBeforeSend },
+    { setSentryInstance },
+    { useEffect },
+    { useLocation, useMatches },
+  ] = await Promise.all([
+    import("@sentry/remix"),
+    import("~/utils/analytics-sanitize"),
+    import("~/utils/web-vitals.client"),
+    import("react"),
+    import("@remix-run/react"),
+  ]);
+
   Sentry.init({
     dsn,
     environment:
@@ -41,30 +98,37 @@ if (dsn) {
     // Cf. `~/utils/analytics-sanitize`.
     beforeSend: (event) => sentryBeforeSend(event),
   });
-}
 
-// Nettoyage des service workers existants
-if ("serviceWorker" in navigator) {
-  navigator.serviceWorker.getRegistrations().then(function (registrations) {
-    for (let registration of registrations) {
-      registration.unregister().then(function (boolean) {
-        logger.log("Service Worker désenregistré:", boolean);
-      });
-    }
-  });
-}
+  setSentryInstance(Sentry);
 
-startTransition(() => {
-  hydrateRoot(document, <RemixBrowser />, {
-    onRecoverableError(error) {
-      if (error instanceof Error) {
-        console.warn("[Hydration]", error.message);
+  // Replay any errors buffered during hydration → idle gap, then detach
+  for (const item of errorBuffer) {
+    try {
+      if (item.kind === "error") {
+        Sentry.captureException(item.ev.error ?? item.ev.message);
       } else {
-        console.error("Recoverable error:", error);
+        Sentry.captureException(item.ev.reason);
       }
-    },
+    } catch {
+      // Reporter passif — ne jamais propager
+    }
+  }
+  errorBuffer.length = 0;
+  window.removeEventListener("error", onError);
+  window.removeEventListener("unhandledrejection", onRejection);
+};
+
+interface IdleWindow {
+  requestIdleCallback?: (
+    cb: IdleRequestCallback,
+    opts?: IdleRequestOptions,
+  ) => number;
+}
+const idleWin = window as unknown as IdleWindow;
+if (typeof idleWin.requestIdleCallback === "function") {
+  idleWin.requestIdleCallback(() => void initObservability(), {
+    timeout: 2000,
   });
-  // Field Web Vitals reporter — pousse LCP/INP/CLS/FCP/TTFB vers
-  // Sentry.metrics (si dispo) → GA4 → console. Voir ~/utils/web-vitals.client.
-  reportWebVitals();
-});
+} else {
+  setTimeout(() => void initObservability(), 1500);
+}

--- a/frontend/app/utils/web-vitals.client.ts
+++ b/frontend/app/utils/web-vitals.client.ts
@@ -14,8 +14,7 @@
  * `console`, CMP qui mock `gtag`, etc.).
  */
 
-import * as Sentry from '@sentry/remix';
-import { onLCP, onCLS, onINP, onFCP, onTTFB, type Metric } from 'web-vitals';
+import { onLCP, onCLS, onINP, onFCP, onTTFB, type Metric } from "web-vitals";
 
 interface SentryMetricsDistribution {
   (
@@ -33,9 +32,22 @@ interface SentryWithMetrics {
   metrics?: SentryMetricsApi;
 }
 
+// Sentry instance is bound here by entry.client.tsx after lazy load
+// (post-hydration idle). Until then `_sentry` is null and reportToSentry()
+// short-circuits to GA4 + console without error.
+let _sentry: SentryWithMetrics | null = null;
+
+/**
+ * Bind the lazy-loaded Sentry instance to the web-vitals reporter.
+ * Called once from entry.client.tsx after `Sentry.init()` succeeds.
+ */
+export function setSentryInstance(s: unknown): void {
+  _sentry = s as SentryWithMetrics;
+}
+
 interface GtagWindow {
   gtag?: (
-    command: 'event',
+    command: "event",
     eventName: string,
     params: Record<string, unknown>,
   ) => void;
@@ -43,18 +55,23 @@ interface GtagWindow {
 
 function reportToSentry(metric: Metric): boolean {
   // Vérification runtime : ne pas inventer l'API. Si Sentry est noop (DSN
-  // absent) ou build sans Metrics, on échoue silencieusement.
-  const sentry = Sentry as unknown as SentryWithMetrics;
-  if (typeof sentry.metrics?.distribution !== 'function') return false;
+  // absent), pas encore chargé (idle pas encore fired), ou build sans Metrics,
+  // on échoue silencieusement.
+  const sentry = _sentry;
+  if (typeof sentry?.metrics?.distribution !== "function") return false;
 
   try {
-    sentry.metrics.distribution(`web_vital.${metric.name.toLowerCase()}`, metric.value, {
-      unit: 'millisecond',
-      tags: {
-        rating: metric.rating,
-        navigation_type: metric.navigationType ?? 'unknown',
+    sentry.metrics.distribution(
+      `web_vital.${metric.name.toLowerCase()}`,
+      metric.value,
+      {
+        unit: "millisecond",
+        tags: {
+          rating: metric.rating,
+          navigation_type: metric.navigationType ?? "unknown",
+        },
       },
-    });
+    );
     return true;
   } catch {
     return false;
@@ -63,17 +80,16 @@ function reportToSentry(metric: Metric): boolean {
 
 function reportToGtag(metric: Metric): boolean {
   const gtag = (window as GtagWindow).gtag;
-  if (typeof gtag !== 'function') return false;
+  if (typeof gtag !== "function") return false;
 
   try {
-    gtag('event', 'web_vitals', {
+    gtag("event", "web_vitals", {
       metric_name: metric.name,
       metric_value: Math.round(metric.value),
       metric_rating: metric.rating,
       metric_id: metric.id,
       navigation_type: metric.navigationType,
-      page_path:
-        typeof window !== 'undefined' ? window.location.pathname : '',
+      page_path: typeof window !== "undefined" ? window.location.pathname : "",
     });
     return true;
   } catch {
@@ -85,12 +101,12 @@ function reportToConsole(metric: Metric): void {
   // Toujours appelé : utile pour debug local + capturé en breadcrumb par Sentry
   // si `Sentry.init` capture les console (default v10 = true via integrations).
   // eslint-disable-next-line no-console
-  console.info('[web-vitals]', {
+  console.info("[web-vitals]", {
     name: metric.name,
     value: Math.round(metric.value),
     rating: metric.rating,
     id: metric.id,
-    path: typeof window !== 'undefined' ? window.location.pathname : '',
+    path: typeof window !== "undefined" ? window.location.pathname : "",
   });
 }
 
@@ -109,7 +125,7 @@ function dispatchMetric(metric: Metric) {
  * Safe à no-op côté SSR (les `on*` callbacks ne fire qu'au browser).
  */
 export function reportWebVitals(): void {
-  if (typeof window === 'undefined') return;
+  if (typeof window === "undefined") return;
 
   onLCP(dispatchMetric);
   onCLS(dispatchMetric);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -37,6 +37,12 @@ export default defineConfig({
 				manualChunks(id) {
 					// ─── Vendor chunks (node_modules) ────────────────────
 					if (id.includes('node_modules')) {
+						// Sentry SDK — loaded asynchronously post-hydration via dynamic
+						// import in entry.client.tsx. Isolated chunk avoids capture by
+						// later /react/ or /react-dom/ rules (e.g. transitive @sentry/react).
+						if (id.includes('/@sentry/')) {
+							return 'sentry-vendor';
+						}
 						// React core — stable, long-term cached
 						if (id.includes('/react-dom/') || id.includes('/react/') || id.includes('/scheduler/')) {
 							return 'react-vendor';


### PR DESCRIPTION
## Summary

- **Cause racine** (CI #2357 fail Lighthouse) : `@sentry/remix@^10.51.0` introduit en #324 (2026-05-06) est importé top-level dans [entry.client.tsx:8](frontend/app/entry.client.tsx#L8) et [web-vitals.client.ts:17](frontend/app/utils/web-vitals.client.ts#L17), ce qui embarque ~159 KB gzip de SDK Sentry sur le critical path de toutes les pages.
- **Fix** : dynamic import de `@sentry/remix` à l'intérieur de `initObservability()`, déclenché par `requestIdleCallback({ timeout: 2000 })` après `hydrateRoot()`. Aucun re-chunking cosmétique, aucun changement structurel Remix.
- **Préservation observabilité** : `browserTracingIntegration` conservée (réattachée post-idle, première transaction page-load manquée mais navigations client-side tracées). Early error buffer (`window.error` + `unhandledrejection`) capture les erreurs entre hydration et idle, replay via `Sentry.captureException` au moment de l'init.

## Mesures empiriques (build local `ANALYZE=true npm run build`)

| Métrique CI                         | Avant      | Après         | Budget    | Statut |
|------------------------------------|-----------|---------------|---------|--------|
| `react-vendor` gzip                 | 244 KB    | **94 KB**     | 100 KB  | ✅     |
| Initial Load gzip (4-pattern CI)    | 283 KB    | **134 KB**    | 200 KB  | ✅     |
| `sentry-vendor` gzip (NEW chunk)    | n/a       | 159 KB (lazy) | n/a     | hors critical path |

Lighthouse `script.size`, FCP `/search`, TTI `/search` à valider sur le run CI de cette PR.

## Trade-off acté

`browserTracingIntegration` est attachée post-idle, donc la transaction du **first page-load** n'est pas tracée par Sentry Performance. Toutes les navigations client-side ultérieures sont tracées normalement. Décision validée avec @ak125 (option « keep par sécurité »).

## Test plan

- [x] `npx tsc --noEmit` ✅
- [x] Build local `ANALYZE=true npm run build` — `sentry-vendor` chunk créé, `react-vendor` 244→94 KB gzip ✅
- [x] Calcul Initial Load CI metric local : 134 KB ✅
- [ ] Run CI complet (job `📦 Bundle Size Report` + `🔦 Lighthouse Performance Audit`) — à observer
- [ ] Smoke test runtime : DevTools Network panel → `sentry-vendor-*.js` chargé après `entry.client-*.js`/`root-*.js` avec `Initiator: requestIdleCallback`
- [ ] Smoke test runtime : `throw new Error("test")` console immédiat post-load → erreur capturée par Sentry après idle (via `errorBuffer` replay)

## Risques résiduels

1. **Erreurs purement console-only** entre 0 et ~1.5-2 s post-hydration sans event `error`/`unhandledrejection` ne sont pas captées (déjà le cas pré-PR — `console.error` n'est pas listened sans Sentry).
2. **Page backgroundée** : `requestIdleCallback({ timeout: 2000 })` force l'init dans 2 s même hors-focus.
3. **First page-load Sentry transaction perdue** (acté avec user — voir trade-off ci-dessus).
4. **`@sentry/replay`** : si la lib reste bundle-included malgré `replaysSessionSampleRate: 0`, gain réduit. Mitigation possible en PR follow-up : passer à `@sentry/browser` minimal (~40-50 KB additionnels).

## Plan complet

[plans/skip-to-content-ak125-snappy-eagle.md](https://github.com/ak125/nestjs-remix-monorepo/blob/perf/lazy-sentry-bundle-reduction/.claude/plans/skip-to-content-ak125-snappy-eagle.md) (interne au worktree, pas dans le repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)