### PR TITLE
feat(seo-v9): R8 meta-variant pool — diversification meta_title + meta_description (PR-1)

### DIFF
--- a/backend/src/config/page-contract-r8.schema.ts
+++ b/backend/src/config/page-contract-r8.schema.ts
@@ -548,6 +548,26 @@ export type R8CatalogDelta = z.infer<typeof R8CatalogDeltaSchema>;
 
 // ── Governance Decision (central contract) ──────────────
 
+/**
+ * Map slot → srtp_id (uuid) du template pool sélectionné via SeoRoleTemplateSelector.
+ *
+ * PR-1 seo-v9 : 2 slots seulement (`meta_title`, `meta_description`).
+ * H1 reste produit par `buildR8H1()` (format optimisé avec années) — pas
+ * dans le pool. Élargir si PR-2 ajoute d'autres slots.
+ *
+ * `.partial().default({})` rend le contrat default-safe : pages historiques
+ * sans `variant_signature` (ou avec `{}` issu du `DEFAULT '{}'::jsonb` de la
+ * migration) passent le parse sans casser l'existant.
+ */
+export const R8VariantSignatureSchema = z
+  .object({
+    meta_title: z.string().uuid().nullable(),
+    meta_description: z.string().uuid().nullable(),
+  })
+  .partial()
+  .default({});
+export type R8VariantSignature = z.infer<typeof R8VariantSignatureSchema>;
+
 export const R8GovernanceDecisionSchema = z.object({
   decision: R8SeoDecisionSchema,
   sitemapIncluded: z.boolean(),
@@ -559,6 +579,8 @@ export const R8GovernanceDecisionSchema = z.object({
   scores: R8DiversityMetricsSchema,
   reasons: z.array(R8ReasonCodeSchema).default([]),
   warnings: z.array(z.string()).default([]),
+  /** Map slot → srtp_id (uuid) du template pool sélectionné. Default-safe : `{}` accepté pour pages historiques. */
+  variantSignature: R8VariantSignatureSchema,
 });
 export type R8GovernanceDecision = z.infer<typeof R8GovernanceDecisionSchema>;
 

--- a/backend/src/config/seo-variations.config.ts
+++ b/backend/src/config/seo-variations.config.ts
@@ -190,3 +190,31 @@ export function selectVariationWithIndex<T>(
   const index = (typeId + pgId + offset) % variations.length;
   return { value: variations[index], index };
 }
+
+/**
+ * Substitution de placeholders `{key}` dans un template SEO.
+ *
+ * Comportement strict adapté aux surfaces meta (title/h1/description) :
+ * - placeholder absent ou valeur vide/null/undefined → chaîne vide (pas de
+ *   `{key}` literal qui leakerait en GSC)
+ * - whitespace collapse (multi-espaces → 1 espace)
+ * - trim final
+ *
+ * @example
+ * renderSeoTemplate('Pièces {brand} {model}', { brand: 'Renault', model: '' })
+ *   // → 'Pièces Renault'
+ */
+export function renderSeoTemplate(
+  template: string,
+  placeholders: Record<string, string | number | null | undefined>,
+): string {
+  return template
+    .replace(/\{(\w+)\}/g, (_, key) => {
+      const value = placeholders[key];
+      return value === null || value === undefined || value === ''
+        ? ''
+        : String(value);
+    })
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
+++ b/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
@@ -287,9 +287,10 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
         vehicleId: typeId,
         pgId: 0,
       });
-      const [metaTitlePick, metaDescPick]: Array<
-        SeoRoleTemplatePickResult | null
-      > = await Promise.all([
+      const [
+        metaTitlePick,
+        metaDescPick,
+      ]: Array<SeoRoleTemplatePickResult | null> = await Promise.all([
         this.seoRoleTemplate.pick({
           role: 'R8_VEHICLE',
           slot: 'meta_title',

--- a/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
+++ b/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
@@ -33,6 +33,11 @@ import {
   SEO_R8_TRUST_SIGNAL_VARIATIONS,
   R8_SLOT_OFFSETS,
 } from '../../../config/seo-variations.config';
+import {
+  SeoRoleTemplateSelector,
+  type SeoRoleTemplatePickResult,
+} from '../../seo/services/chain/seo-role-template-selector.service';
+import type { R8VariantSignature } from '../../../config/page-contract-r8.schema';
 
 // ── Result ──
 
@@ -97,6 +102,15 @@ interface R8Neighbor {
   faq_signature: string;
   category_signature: string;
   diversity_score: number;
+  /**
+   * PR-1 seo-v9 R8 meta variant pool : map slot → srtp_id (uuid).
+   * Optionnel — pages historiques antérieures à PR-1 ont `{}` ou `null`.
+   * H1 non poolisé : `buildR8H1` reste source unique.
+   */
+  variant_signature?: {
+    meta_title?: string | null;
+    meta_description?: string | null;
+  } | null;
 }
 
 @Injectable()
@@ -111,6 +125,7 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
     configService: ConfigService,
     private readonly textUtils: EnricherTextUtils,
     private readonly vehicleRagGenerator: VehicleRagGeneratorService,
+    private readonly seoRoleTemplate: SeoRoleTemplateSelector,
     @Optional() private readonly writeGate?: ContentWriteGateService,
     @Optional() private readonly featureFlags?: FeatureFlagsService,
   ) {
@@ -243,7 +258,9 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
         neighbors,
       );
 
-      // Build H1 + meta
+      // H1 : reste produit par buildR8H1 (format optimisé avec plage d'années,
+      // déjà désambiguïsant). NON poolisé en PR-1 — pas de signal GSC démontré
+      // sur H1 spécifiquement.
       const h1 = buildR8H1({
         brand: v.brand_name || '',
         model: v.model_name || '',
@@ -252,16 +269,72 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
         yearFrom: v.year_from || '',
         yearTo: v.year_to || null,
       });
+
+      // Meta title + description : PR-1 seo-v9 R8 meta variant pool.
+      // Sélection via __seo_role_template_pool + SeoSwitchSelector (sha256 seed).
+      // Fallback synchrone vers les templates hardcodés si le pool est vide
+      // ou en erreur DB → no-regression (warning émis pour détection seed ratée).
+      const placeholders = {
+        brand: v.brand_name || '',
+        model: v.model_name || '',
+        type: v.type_name || '',
+        power: v.power_ps ?? '',
+        fuel: v.fuel || '',
+        year_from: v.year_from ?? '',
+        year_to: v.year_to ?? '',
+      };
+      const seedFor = (): { vehicleId: number; pgId: number } => ({
+        vehicleId: typeId,
+        pgId: 0,
+      });
+      const [metaTitlePick, metaDescPick]: Array<
+        SeoRoleTemplatePickResult | null
+      > = await Promise.all([
+        this.seoRoleTemplate.pick({
+          role: 'R8_VEHICLE',
+          slot: 'meta_title',
+          seed: seedFor(),
+          placeholders,
+        }),
+        this.seoRoleTemplate.pick({
+          role: 'R8_VEHICLE',
+          slot: 'meta_description',
+          seed: seedFor(),
+          placeholders,
+        }),
+      ]);
+
       const metaTitle =
+        metaTitlePick?.rendered ??
         `Pièces ${v.brand_name} ${v.model_name} ${v.type_name} ${v.power_ps}ch | AutoMecanik`.slice(
           0,
           75,
         );
       const metaDescription =
+        metaDescPick?.rendered ??
         `Catalogue complet de pièces auto pour ${h1}. ${families.length} familles de pièces compatibles. Livraison rapide.`.slice(
           0,
           170,
         );
+
+      // Warning structuré si fallback déclenché — détecte une seed migration ratée silencieuse
+      if (!metaTitlePick || !metaDescPick) {
+        const missing = [
+          !metaTitlePick ? 'meta_title' : null,
+          !metaDescPick ? 'meta_description' : null,
+        ]
+          .filter(Boolean)
+          .join(',');
+        this.logger.warn(
+          `[R8_META_POOL_FALLBACK] type_id=${typeId} missing_pool_slots=${missing}`,
+        );
+      }
+
+      const variantSignature: R8VariantSignature = {
+        meta_title: metaTitlePick?.id ?? null,
+        meta_description: metaDescPick?.id ?? null,
+      };
+
       const canonicalUrl = `/constructeurs/${(v.brand_alias || v.brand_name || '').toLowerCase()}/${(v.model_alias || v.model_name || '').toLowerCase()}/${typeId}.html`;
 
       // Full content
@@ -273,8 +346,23 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
       const metrics = this.computeMetrics(blocks, neighbors, families);
       const fingerprints = this.computeFingerprints(contentMain, blocks);
 
+      // ── 3.b META COLLISION (PR-1 seo-v9 R8 meta variant pool) ──
+      // Pénalise semanticSimilarityScore si ≥2 voisins partagent le même
+      // template `meta_title` ou `meta_description`. La pénalité (≤ -10) peut
+      // basculer le score sous le seuil `min_semantic_diversity=65` du gate
+      // → `LOW_SEMANTIC_DIVERSITY` reason naturellement émis. Pas de
+      // pénalité H1 (5 templates × 18 frères → ⌈18/5⌉=4 collisions
+      // mathématiquement inévitables, faux positifs garantis).
+      const metaCollisionWarnings = this.applyMetaCollisionPenalty(
+        metrics,
+        neighbors,
+        variantSignature,
+      );
+
       // ── 4. GATE ──
       const { decision, reasons, warnings } = this.gate(metrics, blocks);
+      // Merge des warnings collision avec ceux du gate
+      warnings.push(...metaCollisionWarnings);
       const sitemapRules = R8_SITEMAP_RULES[decision];
 
       // ── 5. WRITE DB ──
@@ -322,6 +410,7 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
         engineFamilyKey,
         decision,
         sitemapRules,
+        variantSignature,
       });
 
       if (!pageId) {
@@ -462,6 +551,8 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
 
   // ── Neighbors ──
 
+  // Sentinel : `R8Neighbor` augmenté avec `variant_signature` pour la
+  // détection de collision meta dans la fratrie (PR-1 seo-v9).
   private async fetchNeighbors(
     neighborFamilyKey: string,
     excludePageKey: string,
@@ -469,7 +560,7 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
     const { data, error } = await this.client
       .from(R8_TABLES.pages)
       .select(
-        'id, page_key, content_main, faq_signature, category_signature, diversity_score',
+        'id, page_key, content_main, faq_signature, category_signature, diversity_score, variant_signature',
       )
       .eq('neighbor_family_key', neighborFamilyKey)
       .neq('page_key', excludePageKey)
@@ -900,6 +991,64 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
     return createHash('sha256').update(text).digest('hex');
   }
 
+  // ── Meta collision penalty (PR-1 seo-v9 R8 meta variant pool) ──
+
+  /**
+   * Pour chaque slot meta sensible (`meta_title`, `meta_description`), compte
+   * les voisins de la fratrie (`neighbor_family_key`) qui partagent le même
+   * `srtp_id`. Si ≥ 2 collisions → pénalité de 5 pts sur
+   * `metrics.semanticSimilarityScore`. Les pénalités s'additionnent ; le score
+   * est plafonné à 0.
+   *
+   * Pas de pénalité H1 : pool 5 templates × 18 frères = ⌈18/5⌉=4 collisions
+   * inévitables (faux positifs garantis si pénalisé).
+   *
+   * @returns warnings texte à merger avec ceux du gate.
+   */
+  private applyMetaCollisionPenalty(
+    metrics: ReturnType<R8VehicleEnricherService['computeMetrics']>,
+    neighbors: R8Neighbor[],
+    variantSignature: R8VariantSignature,
+  ): string[] {
+    const warnings: string[] = [];
+
+    const sameMetaTitleCount = variantSignature.meta_title
+      ? neighbors.filter(
+          (n) =>
+            n.variant_signature?.meta_title === variantSignature.meta_title,
+        ).length
+      : 0;
+
+    const sameMetaDescCount = variantSignature.meta_description
+      ? neighbors.filter(
+          (n) =>
+            n.variant_signature?.meta_description ===
+            variantSignature.meta_description,
+        ).length
+      : 0;
+
+    if (sameMetaTitleCount >= 2) {
+      metrics.semanticSimilarityScore = Math.max(
+        0,
+        metrics.semanticSimilarityScore - 5,
+      );
+      warnings.push(
+        `META_TITLE_COLLISION_IN_FAMILY count=${sameMetaTitleCount}`,
+      );
+    }
+    if (sameMetaDescCount >= 2) {
+      metrics.semanticSimilarityScore = Math.max(
+        0,
+        metrics.semanticSimilarityScore - 5,
+      );
+      warnings.push(
+        `META_DESCRIPTION_COLLISION_IN_FAMILY count=${sameMetaDescCount}`,
+      );
+    }
+
+    return warnings;
+  }
+
   // ── Gate ──
 
   private gate(
@@ -987,6 +1136,7 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
     engineFamilyKey: string;
     decision: R8SeoDecision;
     sitemapRules: { sitemap: boolean; robots: string };
+    variantSignature: R8VariantSignature;
   }): Promise<string | null> {
     const v = params.vehicle;
     const row = {
@@ -1034,6 +1184,8 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
       robots_directive: params.sitemapRules.robots,
       published_at:
         params.decision === 'INDEX' ? new Date().toISOString() : null,
+      // PR-1 seo-v9 R8 meta variant pool : map slot -> srtp_id (uuid).
+      variant_signature: params.variantSignature,
     };
 
     // ── P1.5 v2.1: Route through WriteGate when enabled ──

--- a/backend/src/modules/seo/registries/__tests__/seo-variant-family.registry.test.ts
+++ b/backend/src/modules/seo/registries/__tests__/seo-variant-family.registry.test.ts
@@ -10,14 +10,15 @@ describe('SeoVariantFamilyRegistry', () => {
     registry = new SeoVariantFamilyRegistry();
   });
 
-  it('list() returns the 4 canonical variant families', () => {
+  it('list() returns the 5 canonical variant families (4 legacy switch + ROLE_TEMPLATE_POOL)', () => {
     const families = registry.list();
-    expect(families).toHaveLength(4);
+    expect(families).toHaveLength(5);
     expect(families).toEqual([
       'ITEM_SWITCH',
       'TYPE_SWITCH',
       'GAMME_CAR_SWITCH',
       'FAMILY_GAMME_CAR_SWITCH',
+      'ROLE_TEMPLATE_POOL',
     ] as VariantFamilyKey[]);
   });
 
@@ -30,6 +31,9 @@ describe('SeoVariantFamilyRegistry', () => {
     expect(registry.resolveTable('FAMILY_GAMME_CAR_SWITCH')).toBe(
       '__seo_family_gamme_car_switch',
     );
+    expect(registry.resolveTable('ROLE_TEMPLATE_POOL')).toBe(
+      '__seo_role_template_pool',
+    );
   });
 
   it('getConfig() exposes purpose + knownAliases', () => {
@@ -37,5 +41,19 @@ describe('SeoVariantFamilyRegistry', () => {
     expect(cfg.knownAliases).toEqual([1, 2, 3]);
     expect(cfg.purpose).toContain('R1');
     expect(cfg.table).toBe('__seo_item_switch');
+  });
+
+  it('ROLE_TEMPLATE_POOL exposes orderBy=srtp_order (slot-based, deterministic)', () => {
+    const cfg = registry.getConfig('ROLE_TEMPLATE_POOL');
+    expect(cfg.orderBy).toBe('srtp_order');
+    expect(cfg.knownAliases).toEqual([]);
+    expect(cfg.purpose).toContain('slot-based');
+  });
+
+  it('legacy switch families do NOT declare orderBy (compat preserved)', () => {
+    expect(registry.getConfig('ITEM_SWITCH').orderBy).toBeUndefined();
+    expect(registry.getConfig('TYPE_SWITCH').orderBy).toBeUndefined();
+    expect(registry.getConfig('GAMME_CAR_SWITCH').orderBy).toBeUndefined();
+    expect(registry.getConfig('FAMILY_GAMME_CAR_SWITCH').orderBy).toBeUndefined();
   });
 });

--- a/backend/src/modules/seo/registries/__tests__/seo-variant-family.registry.test.ts
+++ b/backend/src/modules/seo/registries/__tests__/seo-variant-family.registry.test.ts
@@ -54,6 +54,8 @@ describe('SeoVariantFamilyRegistry', () => {
     expect(registry.getConfig('ITEM_SWITCH').orderBy).toBeUndefined();
     expect(registry.getConfig('TYPE_SWITCH').orderBy).toBeUndefined();
     expect(registry.getConfig('GAMME_CAR_SWITCH').orderBy).toBeUndefined();
-    expect(registry.getConfig('FAMILY_GAMME_CAR_SWITCH').orderBy).toBeUndefined();
+    expect(
+      registry.getConfig('FAMILY_GAMME_CAR_SWITCH').orderBy,
+    ).toBeUndefined();
   });
 });

--- a/backend/src/modules/seo/registries/seo-variant-family.registry.ts
+++ b/backend/src/modules/seo/registries/seo-variant-family.registry.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
  *
  * Aligné sur l'audit PR-1 du plan `seo-v9` (inventaire DB seo_*).
  */
-export const VariantFamilyKeySchema = z.enum([
+const VariantFamilyKeySchema = z.enum([
   'ITEM_SWITCH', // __seo_item_switch (R1 catalogue, alias 1=title 2=descrip 3=h1)
   'TYPE_SWITCH', // __seo_type_switch (R8 véhicule, alias 1/2/10/11/12)
   'GAMME_CAR_SWITCH', // __seo_gamme_car_switch (variantes contenu gamme×véhicule)
@@ -16,7 +16,7 @@ export const VariantFamilyKeySchema = z.enum([
 ]);
 export type VariantFamilyKey = z.infer<typeof VariantFamilyKeySchema>;
 
-export interface VariantFamilyConfig {
+interface VariantFamilyConfig {
   table: string;
   /** Aliases observés en prod (cf. audit PR-1). */
   knownAliases: number[];

--- a/backend/src/modules/seo/registries/seo-variant-family.registry.ts
+++ b/backend/src/modules/seo/registries/seo-variant-family.registry.ts
@@ -12,6 +12,7 @@ export const VariantFamilyKeySchema = z.enum([
   'TYPE_SWITCH', // __seo_type_switch (R8 véhicule, alias 1/2/10/11/12)
   'GAMME_CAR_SWITCH', // __seo_gamme_car_switch (variantes contenu gamme×véhicule)
   'FAMILY_GAMME_CAR_SWITCH', // __seo_family_gamme_car_switch (variantes par famille)
+  'ROLE_TEMPLATE_POOL', // __seo_role_template_pool (slot-based, role × slot × lang)
 ]);
 export type VariantFamilyKey = z.infer<typeof VariantFamilyKeySchema>;
 
@@ -21,6 +22,12 @@ export interface VariantFamilyConfig {
   knownAliases: number[];
   /** Description fonctionnelle. */
   purpose: string;
+  /**
+   * Colonne SQL d'ordre stable. Quand présent, `SeoSwitchSelector.fetchVariants()`
+   * applique `.order(orderBy, asc)` pour rendre l'idx sha256 reproductible.
+   * Absent → ordre PG non déterministe (legacy switch tables sans contrainte).
+   */
+  orderBy?: string;
 }
 
 const VARIANT_FAMILIES: Record<VariantFamilyKey, VariantFamilyConfig> = {
@@ -43,6 +50,13 @@ const VARIANT_FAMILIES: Record<VariantFamilyKey, VariantFamilyConfig> = {
     table: '__seo_family_gamme_car_switch',
     knownAliases: [],
     purpose: 'Variantes par famille produit (mfId)',
+  },
+  ROLE_TEMPLATE_POOL: {
+    table: '__seo_role_template_pool',
+    knownAliases: [],
+    orderBy: 'srtp_order',
+    purpose:
+      'Pool slot-based (role × slot × lang). Différent du pattern alias-based des 4 familles legacy. Sélection via SeoSwitchSelector + seed sha256.',
   },
 };
 

--- a/backend/src/modules/seo/seo.module.ts
+++ b/backend/src/modules/seo/seo.module.ts
@@ -149,6 +149,7 @@ import { SeoTemplateRenderer } from './services/chain/seo-template-renderer.serv
 import { SeoInternalLinkingService as SeoChainInternalLinkingService } from './services/chain/seo-internal-linking.service';
 import { SeoContentBlockBuilder } from './services/chain/seo-content-block-builder.service';
 import { SeoChainOrchestratorService } from './services/chain/seo-chain-orchestrator.service';
+import { SeoRoleTemplateSelector } from './services/chain/seo-role-template-selector.service';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // INTERCEPTORS
@@ -263,6 +264,8 @@ import { PageRoleValidationInterceptor } from './interceptors/page-role-validati
     SeoChainInternalLinkingService,
     SeoContentBlockBuilder,
     SeoChainOrchestratorService,
+    // R8 meta variant pool (PR-1 seo-v9 R8 meta diversification)
+    SeoRoleTemplateSelector,
 
     // Interceptors globaux
     {
@@ -336,6 +339,8 @@ import { PageRoleValidationInterceptor } from './interceptors/page-role-validati
     SeoChainInternalLinkingService,
     SeoContentBlockBuilder,
     SeoChainOrchestratorService,
+    // R8 meta variant pool (PR-1 seo-v9 R8 meta diversification) — exporté pour AdminModule (R8VehicleEnricherService)
+    SeoRoleTemplateSelector,
   ],
 })
 export class SeoModule {

--- a/backend/src/modules/seo/services/chain/__tests__/r8-meta-distribution.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/r8-meta-distribution.test.ts
@@ -134,7 +134,7 @@ describe('R8VariantSignatureSchema (Zod ↔ DB consistency)', () => {
     expect((parsed as Record<string, unknown>).h1).toBeUndefined();
   });
 
-  it("R8GovernanceDecisionSchema inclut variantSignature", () => {
+  it('R8GovernanceDecisionSchema inclut variantSignature', () => {
     const shape = R8GovernanceDecisionSchema.shape;
     expect(shape.variantSignature).toBeDefined();
   });

--- a/backend/src/modules/seo/services/chain/__tests__/r8-meta-distribution.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/r8-meta-distribution.test.ts
@@ -1,0 +1,141 @@
+import { SeoSwitchSelector } from '../seo-switch-selector.service';
+import { SeoVariantFamilyRegistry } from '../../../registries/seo-variant-family.registry';
+import {
+  R8VariantSignatureSchema,
+  R8GovernanceDecisionSchema,
+} from '../../../../../config/page-contract-r8.schema';
+
+/**
+ * Distribution & cohérence pour le pool R8 meta (PR-1 seo-v9).
+ *
+ * Critère **principal** : `max(count_per_uuid) <= ⌈18 / N⌉` sur 18 type_ids
+ * fratrie Clio III. Pas seulement le nombre d'UUIDs distincts (un pool peut
+ * avoir tous les UUIDs vus mais avec un déséquilibre catastrophique).
+ *
+ * Validation des caps de longueur Zod ↔ sizing pool.
+ */
+describe('R8 meta distribution & Zod-DB consistency', () => {
+  const selector = new SeoSwitchSelector(new SeoVariantFamilyRegistry());
+
+  /**
+   * 18 type_ids hypothétiques d'une fratrie Renault Clio III (motorisations
+   * différentes du même brand+model+generation). En prod : query sur
+   * `__seo_r8_pages WHERE neighbor_family_key=...`.
+   */
+  const SIBLING_TYPE_IDS = [
+    9001, 9002, 9003, 9004, 9005, 9006, 9007, 9008, 9009, 9010, 9011, 9012,
+    9013, 9014, 9015, 9016, 9017, 9018,
+  ];
+
+  /**
+   * Compte les collisions d'index sur N templates pour un slot donné.
+   */
+  function countCollisionsPerIndex(slot: string, poolSize: number): number[] {
+    const counts = new Array<number>(poolSize).fill(0);
+    for (const typeId of SIBLING_TYPE_IDS) {
+      const idx = selector.computeSeedIndex(
+        {
+          surfaceKey: `R8_VEHICLE:${slot}`,
+          pgId: 0,
+          vehicleId: typeId,
+          alias: null,
+        },
+        poolSize,
+      );
+      counts[idx]++;
+    }
+    return counts;
+  }
+
+  // Bound empirique : sha256 sur 18 inputs n'est pas parfaitement uniforme
+  // (variance statistique). On tolère 2× la moyenne théorique ⌈18/N⌉ ce qui
+  // correspond à ~2σ pour 18 tirages. Le but : détecter la pathologie
+  // « tous les 18 sur le même UUID » (legacy hardcodé), pas l'idéal mathématique.
+  it('meta_title (N=7) : pas de pathologie — max collisions ≤ 2*⌈18/7⌉ = 6 ; pool effectivement utilisé', () => {
+    const counts = countCollisionsPerIndex('meta_title', 7);
+    const maxCount = Math.max(...counts);
+    expect(maxCount).toBeLessThanOrEqual(2 * Math.ceil(18 / 7)); // = 6
+    // Le pire cas autorisé (6) reste < 50% de 18 — diversification garantie.
+    expect(maxCount).toBeLessThan(18 / 2);
+    expect(counts.reduce((a, b) => a + b, 0)).toBe(18);
+  });
+
+  it('meta_description (N=11) : max collisions ≤ 2*⌈18/11⌉ = 4', () => {
+    const counts = countCollisionsPerIndex('meta_description', 11);
+    const maxCount = Math.max(...counts);
+    expect(maxCount).toBeLessThanOrEqual(2 * Math.ceil(18 / 11)); // = 4
+    expect(maxCount).toBeLessThan(18 / 2);
+    expect(counts.reduce((a, b) => a + b, 0)).toBe(18);
+  });
+
+  it('couverture pool meta_title : ≥4 UUIDs distincts utilisés (vs 1 en legacy)', () => {
+    const counts = countCollisionsPerIndex('meta_title', 7);
+    const distinctIndexes = counts.filter((c) => c > 0).length;
+    expect(distinctIndexes).toBeGreaterThanOrEqual(4);
+  });
+
+  it('couverture pool meta_description : ≥7 UUIDs distincts utilisés', () => {
+    const counts = countCollisionsPerIndex('meta_description', 11);
+    const distinctIndexes = counts.filter((c) => c > 0).length;
+    expect(distinctIndexes).toBeGreaterThanOrEqual(7);
+  });
+
+  it('le salage par slot rend les distributions indépendantes', () => {
+    const titleCounts = countCollisionsPerIndex('meta_title', 7);
+    const descCounts = countCollisionsPerIndex('meta_description', 7);
+    // Si pas de salage, mêmes inputs → mêmes index distribution sur même
+    // pool size. Avec salage par slot, les patterns doivent diverger.
+    expect(titleCounts).not.toEqual(descCounts);
+  });
+});
+
+describe('R8VariantSignatureSchema (Zod ↔ DB consistency)', () => {
+  it('default-safe : objet vide accepté pour pages historiques', () => {
+    expect(R8VariantSignatureSchema.parse({})).toEqual({});
+    expect(R8VariantSignatureSchema.parse(undefined)).toEqual({});
+  });
+
+  it('accepte null pour chaque slot (fallback déclenché)', () => {
+    const parsed = R8VariantSignatureSchema.parse({
+      meta_title: null,
+      meta_description: null,
+    });
+    expect(parsed.meta_title).toBeNull();
+    expect(parsed.meta_description).toBeNull();
+  });
+
+  it('accepte des UUIDs valides', () => {
+    const parsed = R8VariantSignatureSchema.parse({
+      meta_title: '11111111-1111-1111-1111-111111111111',
+      meta_description: '22222222-2222-2222-2222-222222222222',
+    });
+    expect(parsed.meta_title).toBe('11111111-1111-1111-1111-111111111111');
+  });
+
+  it('rejette les strings non-UUID', () => {
+    expect(() =>
+      R8VariantSignatureSchema.parse({ meta_title: 'not-a-uuid' }),
+    ).toThrow();
+  });
+
+  it('h1 explicitement absent du schéma (resté hors pool, géré par buildR8H1)', () => {
+    // Test comportemental : un h1 dans variantSignature n'est pas reconnu
+    // (extra key dropped par Zod ou rejeté selon le strictness). On vérifie
+    // que parse retourne un objet sans la clé `h1`.
+    const parsed = R8VariantSignatureSchema.parse({
+      meta_title: '11111111-1111-1111-1111-111111111111',
+      meta_description: '22222222-2222-2222-2222-222222222222',
+      // h1 n'est pas dans le schéma — Zod le drop par défaut (strip mode)
+    } as never);
+    expect(Object.keys(parsed).sort()).toEqual([
+      'meta_description',
+      'meta_title',
+    ]);
+    expect((parsed as Record<string, unknown>).h1).toBeUndefined();
+  });
+
+  it("R8GovernanceDecisionSchema inclut variantSignature", () => {
+    const shape = R8GovernanceDecisionSchema.shape;
+    expect(shape.variantSignature).toBeDefined();
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/seo-role-template-selector.service.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-role-template-selector.service.test.ts
@@ -1,0 +1,167 @@
+import {
+  SeoRoleTemplateSelector,
+  type SeoR8MetaSlot,
+} from '../seo-role-template-selector.service';
+import type { SeoSwitchSelector } from '../seo-switch-selector.service';
+
+/**
+ * Stub minimal de SeoSwitchSelector qui retourne une variant fixe (ou null
+ * pour tester le fallback). On capture aussi les inputs pour vérifier que
+ * le seed `surfaceKey` est bien salé par slot.
+ */
+function makeStubSwitchSelector(
+  variantToReturn: Record<string, unknown> | null,
+) {
+  const callLog: Array<{
+    family: string;
+    where: Record<string, unknown>;
+    seed: Record<string, unknown>;
+  }> = [];
+  return {
+    stub: {
+      pickVariant: async (input: {
+        family: string;
+        where: Record<string, unknown>;
+        seed: Record<string, unknown>;
+      }) => {
+        callLog.push({
+          family: input.family,
+          where: input.where,
+          seed: input.seed,
+        });
+        return variantToReturn;
+      },
+    } as unknown as SeoSwitchSelector,
+    callLog,
+  };
+}
+
+describe('SeoRoleTemplateSelector', () => {
+  it('renvoie {id, rendered} avec template substitué et tronqué à srtp_max_length', async () => {
+    const { stub } = makeStubSwitchSelector({
+      srtp_id: '11111111-1111-1111-1111-111111111111',
+      srtp_template:
+        'Pièces {brand} {model} {type} {power}ch — Catalogue compatible',
+      srtp_max_length: 75,
+    });
+    const selector = new SeoRoleTemplateSelector(stub);
+
+    const result = await selector.pick({
+      role: 'R8_VEHICLE',
+      slot: 'meta_title',
+      seed: { vehicleId: 12345 },
+      placeholders: {
+        brand: 'Renault',
+        model: 'Clio III',
+        type: '1.5 dCi',
+        power: '90',
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('11111111-1111-1111-1111-111111111111');
+    expect(result!.rendered).toBe(
+      'Pièces Renault Clio III 1.5 dCi 90ch — Catalogue compatible',
+    );
+    expect(result!.rendered.length).toBeLessThanOrEqual(75);
+  });
+
+  it('renvoie null si pickVariant retourne null (pool vide / erreur DB)', async () => {
+    const { stub } = makeStubSwitchSelector(null);
+    const selector = new SeoRoleTemplateSelector(stub);
+
+    const result = await selector.pick({
+      role: 'R8_VEHICLE',
+      slot: 'meta_title',
+      seed: { vehicleId: 999 },
+      placeholders: { brand: 'X' },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('renvoie null si srtp_template est null (type narrowing safety)', async () => {
+    const { stub } = makeStubSwitchSelector({
+      srtp_id: '11111111-1111-1111-1111-111111111111',
+      srtp_template: null, // ← guard explicite contre String(null)='"null"' literal
+      srtp_max_length: 75,
+    });
+    const selector = new SeoRoleTemplateSelector(stub);
+
+    const result = await selector.pick({
+      role: 'R8_VEHICLE',
+      slot: 'meta_title',
+      seed: { vehicleId: 12345 },
+      placeholders: { brand: 'Renault' },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('sale le surfaceKey par slot — entropie indépendante par slot', async () => {
+    const { stub, callLog } = makeStubSwitchSelector({
+      srtp_id: '00000000-0000-0000-0000-000000000000',
+      srtp_template: 'X',
+      srtp_max_length: null,
+    });
+    const selector = new SeoRoleTemplateSelector(stub);
+
+    const slots: SeoR8MetaSlot[] = ['meta_title', 'meta_description'];
+    for (const slot of slots) {
+      await selector.pick({
+        role: 'R8_VEHICLE',
+        slot,
+        seed: { vehicleId: 42 },
+        placeholders: {},
+      });
+    }
+
+    const surfaceKeys = callLog.map((c) => c.seed.surfaceKey);
+    expect(surfaceKeys).toEqual([
+      'R8_VEHICLE:meta_title',
+      'R8_VEHICLE:meta_description',
+    ]);
+    // Doivent être distincts pour entropie indépendante par slot
+    expect(new Set(surfaceKeys).size).toBe(2);
+  });
+
+  it('passe role=R8_VEHICLE et status=active dans le where', async () => {
+    const { stub, callLog } = makeStubSwitchSelector({
+      srtp_id: '00000000-0000-0000-0000-000000000000',
+      srtp_template: 'X',
+      srtp_max_length: null,
+    });
+    const selector = new SeoRoleTemplateSelector(stub);
+
+    await selector.pick({
+      role: 'R8_VEHICLE',
+      slot: 'meta_title',
+      seed: { vehicleId: 1 },
+      placeholders: {},
+    });
+
+    expect(callLog[0].where).toEqual({
+      srtp_role: 'R8_VEHICLE',
+      srtp_slot: 'meta_title',
+      srtp_lang: 'fr',
+      srtp_status: 'active',
+    });
+  });
+
+  it('respecte le cap srtp_max_length sur le rendu', async () => {
+    const { stub } = makeStubSwitchSelector({
+      srtp_id: '00000000-0000-0000-0000-000000000000',
+      srtp_template:
+        'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      srtp_max_length: 30,
+    });
+    const selector = new SeoRoleTemplateSelector(stub);
+    const result = await selector.pick({
+      role: 'R8_VEHICLE',
+      slot: 'meta_title',
+      seed: { vehicleId: 1 },
+      placeholders: {},
+    });
+    expect(result!.rendered.length).toBeLessThanOrEqual(30);
+  });
+});

--- a/backend/src/modules/seo/services/chain/__tests__/seo-switch-selector.service.order.test.ts
+++ b/backend/src/modules/seo/services/chain/__tests__/seo-switch-selector.service.order.test.ts
@@ -1,0 +1,86 @@
+import { SeoSwitchSelector } from '../seo-switch-selector.service';
+import { SeoVariantFamilyRegistry } from '../../../registries/seo-variant-family.registry';
+
+/**
+ * Vérifie que `SeoSwitchSelector.fetchVariants()` honore le champ `orderBy`
+ * exposé par `VariantFamilyConfig` quand il est présent (PR-1 seo-v9 R8 meta
+ * pool — la famille `ROLE_TEMPLATE_POOL` déclare `orderBy: 'srtp_order'`).
+ *
+ * Les 4 familles legacy (sans `orderBy`) ne doivent PAS appeler `.order()` —
+ * compat préservée.
+ */
+describe('SeoSwitchSelector.fetchVariants — orderBy', () => {
+  /**
+   * Builder mock minimal qui capture tous les appels chaînés. Renvoie
+   * `{ data: [], error: null }` au final.
+   */
+  function makeQueryBuilder() {
+    const calls: { method: string; args: unknown[] }[] = [];
+    const builder: Record<string, unknown> = {};
+    const proxy: Record<string, unknown> = new Proxy(builder, {
+      get(_target, prop) {
+        if (prop === 'then') {
+          // Awaitable : résout sur { data: [], error: null }
+          return (resolve: (v: { data: unknown[]; error: null }) => void) =>
+            resolve({ data: [], error: null });
+        }
+        return (...args: unknown[]) => {
+          calls.push({ method: String(prop), args });
+          return proxy;
+        };
+      },
+    });
+    return { proxy, calls };
+  }
+
+  /**
+   * Override du client supabase via Object.defineProperty (la propriété est
+   * `readonly` sur SupabaseBaseService).
+   */
+  function overrideSupabase(
+    selector: SeoSwitchSelector,
+    fakeClient: { from: (table: string) => unknown },
+  ) {
+    Object.defineProperty(selector, 'supabase', {
+      value: fakeClient,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  it('appelle .order(srtp_order, asc) quand la famille déclare orderBy', async () => {
+    const registry = new SeoVariantFamilyRegistry();
+    const selector = new SeoSwitchSelector(registry);
+
+    const { proxy, calls } = makeQueryBuilder();
+    overrideSupabase(selector, { from: () => proxy });
+
+    await selector.fetchVariants({
+      family: 'ROLE_TEMPLATE_POOL',
+      where: { srtp_role: 'R8_VEHICLE', srtp_slot: 'meta_title' },
+      seed: { surfaceKey: 'R8_VEHICLE:meta_title', pgId: 0, vehicleId: 12345 },
+    });
+
+    const orderCall = calls.find((c) => c.method === 'order');
+    expect(orderCall).toBeDefined();
+    expect(orderCall?.args[0]).toBe('srtp_order');
+    expect(orderCall?.args[1]).toEqual({ ascending: true });
+  });
+
+  it('n appelle PAS .order() pour les familles legacy sans orderBy', async () => {
+    const registry = new SeoVariantFamilyRegistry();
+    const selector = new SeoSwitchSelector(registry);
+
+    const { proxy, calls } = makeQueryBuilder();
+    overrideSupabase(selector, { from: () => proxy });
+
+    await selector.fetchVariants({
+      family: 'TYPE_SWITCH',
+      where: { sts_id: '12345' },
+      seed: { surfaceKey: 'R8_VEHICLE', pgId: 0, vehicleId: 12345 },
+    });
+
+    const orderCall = calls.find((c) => c.method === 'order');
+    expect(orderCall).toBeUndefined();
+  });
+});

--- a/backend/src/modules/seo/services/chain/seo-role-template-selector.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-role-template-selector.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { renderSeoTemplate } from '../../../../config/seo-variations.config';
+import { SeoSwitchSelector } from './seo-switch-selector.service';
+
+/**
+ * Slots R8 meta supportés en PR-1 (plan seo-v9 §3 — R8 meta-variant pool).
+ * Élargir lors de la PR-2 quand les blocs R8 (intro/highlight/...) migrent
+ * du système const TS vers le pool DB.
+ *
+ * H1 NON inclus : `buildR8H1` (r8-keyword-plan.constants.ts:854) produit déjà
+ * un format optimisé `${brand} ${model} ${type} ${power} ch (${years})` avec
+ * désambiguïsation par plage d'années — pas de besoin GSC démontré pour
+ * pooliser H1.
+ */
+export type SeoR8MetaSlot = 'meta_title' | 'meta_description';
+
+export interface SeoRoleTemplatePickInput {
+  /** PR-1 ne supporte que `R8_VEHICLE`. Élargir RoleId en PR-2. */
+  role: 'R8_VEHICLE';
+  slot: SeoR8MetaSlot;
+  /** Défaut `'fr'`. Multilangue déféré (la colonne `srtp_lang` est prête). */
+  lang?: string;
+  /** Inputs minimaux pour le seed sha256 (vehicleId stable, pgId=0 par défaut). */
+  seed: {
+    vehicleId: number;
+    pgId?: number;
+  };
+  /** Map de placeholders `{key}` → valeur (cf. `renderSeoTemplate`). */
+  placeholders: Record<string, string | number | null | undefined>;
+}
+
+export interface SeoRoleTemplatePickResult {
+  /** UUID de `__seo_role_template_pool.srtp_id` — persisté dans `variant_signature`. */
+  id: string;
+  /** Texte rendu après substitution + cap `srtp_max_length`. */
+  rendered: string;
+}
+
+/**
+ * Wrapper thin sur `SeoSwitchSelector.pickVariant()` qui sait :
+ * 1. construire le `where` clause `(role, slot, lang, status='active')`
+ * 2. saler le `surfaceKey` par slot (`R8_VEHICLE:meta_title` ...) — entropie
+ *    indépendante par slot (sinon 2 slots de même taille donneraient le même
+ *    idx pour un même `vehicleId`)
+ * 3. type-narrower les colonnes `srtp_template`/`srtp_id`/`srtp_max_length`
+ *    (le schéma TS Database peut autoriser `null` → guard explicite, sinon
+ *    `String(null)` leakerait `'null'` literal en GSC)
+ *
+ * Pas de cache : 1 SELECT par `pick()`. Ajout d'un cache mémoire (TTL 1h
+ * pattern `SeoMetaRegistryService`) prévu en follow-up post-merge si signal
+ * volume.
+ *
+ * @see plan seo-v9 §3 — pool DB-backed `__seo_role_template_pool`
+ * @see SeoSwitchSelector — seed canonique sha256 résistant TecDoc V2
+ */
+@Injectable()
+export class SeoRoleTemplateSelector {
+  private readonly logger = new Logger(SeoRoleTemplateSelector.name);
+
+  constructor(private readonly switchSelector: SeoSwitchSelector) {}
+
+  async pick(
+    input: SeoRoleTemplatePickInput,
+  ): Promise<SeoRoleTemplatePickResult | null> {
+    const lang = input.lang ?? 'fr';
+    const variant = await this.switchSelector.pickVariant({
+      family: 'ROLE_TEMPLATE_POOL',
+      where: {
+        srtp_role: input.role,
+        srtp_slot: input.slot,
+        srtp_lang: lang,
+        srtp_status: 'active',
+      },
+      seed: {
+        // surfaceKey UPPER_SNAKE aligné sur l'existant (R1_GAMME_ROUTER, R1_GAMME_VEHICLE_ROUTER).
+        // Salage par slot pour entropie indépendante.
+        surfaceKey: `${input.role}:${input.slot}`,
+        pgId: input.seed.pgId ?? 0,
+        vehicleId: input.seed.vehicleId,
+        alias: null,
+      },
+    });
+    if (!variant) {
+      return null;
+    }
+
+    // Type narrowing : pickVariant retourne `Record<string, unknown>`.
+    // Le schéma TS Database autorise `srtp_template` null → guard explicite.
+    const template = variant.srtp_template;
+    const id = variant.srtp_id;
+    if (typeof template !== 'string' || typeof id !== 'string') {
+      this.logger.warn(
+        `[SeoRoleTemplateSelector] variant invalide (role=${input.role} slot=${input.slot} lang=${lang}) : srtp_template ou srtp_id non-string`,
+      );
+      return null;
+    }
+
+    const rendered = renderSeoTemplate(template, input.placeholders);
+    const maxLen =
+      typeof variant.srtp_max_length === 'number'
+        ? variant.srtp_max_length
+        : null;
+    const finalText = maxLen ? rendered.slice(0, maxLen) : rendered;
+
+    return { id, rendered: finalText };
+  }
+}

--- a/backend/src/modules/seo/services/chain/seo-switch-selector.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-switch-selector.service.ts
@@ -15,7 +15,7 @@ import type { VariantFamilyKey } from '../../registries/seo-variant-family.regis
  * Ceci remplace le seed legacy `(typeId + pgId) % len` qui était sensible aux
  * renumérotations TecDoc V2 (cf. mémoire `tecdoc-integration`).
  */
-export interface SwitchSeedInput {
+interface SwitchSeedInput {
   surfaceKey: string;
   pgId: number;
   vehicleId?: number | null;
@@ -27,7 +27,7 @@ export interface SwitchVariant {
   [key: string]: unknown;
 }
 
-export interface PickVariantInput<TWhere extends Record<string, unknown>> {
+interface PickVariantInput<TWhere extends Record<string, unknown>> {
   family: VariantFamilyKey;
   /** Filtres SQL `eq()` (ex: `{ sgcs_pg_id: 124 }` ou `{ sis_pg_id: 124 }`). */
   where: TWhere;

--- a/backend/src/modules/seo/services/chain/seo-switch-selector.service.ts
+++ b/backend/src/modules/seo/services/chain/seo-switch-selector.service.ts
@@ -103,7 +103,8 @@ export class SeoSwitchSelector extends SupabaseBaseService {
   async fetchVariants<TWhere extends Record<string, unknown>>(
     input: PickVariantInput<TWhere>,
   ): Promise<SwitchVariant[]> {
-    const table = this.families.resolveTable(input.family);
+    const config = this.families.getConfig(input.family);
+    const table = config.table;
     let query = this.supabase.from(table).select('*');
 
     for (const [col, val] of Object.entries(input.where)) {
@@ -111,6 +112,11 @@ export class SeoSwitchSelector extends SupabaseBaseService {
     }
     if (input.aliasColumn && typeof input.alias === 'number') {
       query = query.eq(input.aliasColumn, input.alias);
+    }
+    // Ordre stable obligatoire pour l'idempotence du seed sha256.
+    // Les 4 familles legacy n'ont pas `orderBy` → comportement inchangé.
+    if (config.orderBy) {
+      query = query.order(config.orderBy, { ascending: true });
     }
 
     const { data, error } = await query;

--- a/backend/supabase/migrations/20260509_seo_role_template_pool_with_r8_meta_seed.sql
+++ b/backend/supabase/migrations/20260509_seo_role_template_pool_with_r8_meta_seed.sql
@@ -1,0 +1,123 @@
+-- =====================================================================
+-- Migration: SEO role × slot template pool + R8 meta seed (atomique)
+--
+-- PR-1 plan seo-v9 R8 meta diversification.
+--
+-- Cause GSC: meta_title / h1 / meta_description hardcodés en string
+-- templates dans r8-vehicle-enricher.service.ts:247-264 → 18 frères Clio III
+-- ne diffèrent que par 4 variables → quasi-clones structurels.
+--
+-- Cible : pool DB-backed consommé via SeoSwitchSelector du chain seo-v9
+-- (sha256 seed canonique surfaceKey:pgId:vehicleId:alias, résistant aux
+-- renumérotations TecDoc V2). Une seule famille `ROLE_TEMPLATE_POOL`
+-- ajoutée au SeoVariantFamilyRegistry, slot-based (pas alias-based).
+--
+-- Atomicité : DDL + seed dans la MÊME transaction. Si un INSERT plante
+-- (typo template), toute la migration roll-back — on n'aura pas une table
+-- vide forçant le fallback partout.
+--
+-- Pattern RLS aligné sur 20260422_enable_rls_internal_tables.sql.
+-- =====================================================================
+
+BEGIN;
+
+-- =====================================================================
+-- 1) Table __seo_role_template_pool
+-- =====================================================================
+
+CREATE TABLE public.__seo_role_template_pool (
+  srtp_id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  srtp_role         text NOT NULL,
+  srtp_slot         text NOT NULL,
+  srtp_template     text NOT NULL,
+  srtp_lang         text NOT NULL DEFAULT 'fr',
+  srtp_status       text NOT NULL DEFAULT 'active',
+  srtp_order        int  NOT NULL,
+  srtp_weight       numeric NOT NULL DEFAULT 1.0,
+  srtp_max_length   int,
+  srtp_created_at   timestamptz NOT NULL DEFAULT now(),
+  srtp_updated_at   timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT chk_srtp_status CHECK (srtp_status IN ('active', 'retired', 'draft'))
+);
+
+CREATE UNIQUE INDEX uq_srtp_role_slot_lang_order
+  ON public.__seo_role_template_pool (srtp_role, srtp_slot, srtp_lang, srtp_order);
+
+CREATE INDEX idx_srtp_active_lookup
+  ON public.__seo_role_template_pool (srtp_role, srtp_slot, srtp_lang)
+  WHERE srtp_status = 'active';
+
+COMMENT ON TABLE public.__seo_role_template_pool IS
+  'DB-backed deterministic SEO template pool by role x slot x lang. PR-1: used by R8 meta layer.';
+
+COMMENT ON COLUMN public.__seo_role_template_pool.srtp_order IS
+  'Ordre stable consomme par SeoSwitchSelector.fetchVariants() pour rendre l''idx sha256 reproductible.';
+
+COMMENT ON COLUMN public.__seo_role_template_pool.srtp_weight IS
+  'Reserve - non consomme par le selector courant. Hook futur pour weighted selection.';
+
+COMMENT ON COLUMN public.__seo_role_template_pool.srtp_max_length IS
+  'Cap dur applique apres render. Doit matcher les caps Zod du contrat (75/120/170 pour R8 meta).';
+
+-- =====================================================================
+-- 2) RLS / sécurité (pattern 20260422_enable_rls_internal_tables.sql)
+-- =====================================================================
+
+ALTER TABLE public.__seo_role_template_pool ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.__seo_role_template_pool FROM anon, authenticated;
+
+CREATE POLICY __seo_role_template_pool_service_role_all
+  ON public.__seo_role_template_pool
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- =====================================================================
+-- 3) Colonne variant_signature sur __seo_r8_pages
+-- =====================================================================
+
+ALTER TABLE public.__seo_r8_pages
+  ADD COLUMN IF NOT EXISTS variant_signature jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.__seo_r8_pages.variant_signature IS
+  'Map slot->srtp_id (uuid) du template pool selectionne. PR-1: meta_title/h1/meta_description.';
+
+-- =====================================================================
+-- 4) Seed R8 meta : 18 templates (7 meta_title + 11 meta_description)
+--    Convention placeholders {brand} {model} {type} {power} (alignee TS).
+--    Pas d'allegations stock/livraison/origine non garanties.
+--    ON CONFLICT DO NOTHING : idempotent (re-run safe).
+--
+--    H1 NON inclus : buildR8H1() (r8-keyword-plan.constants.ts:854) produit
+--    deja un format optimise avec plage d'annees → pas de pool h1 en PR-1.
+-- =====================================================================
+
+INSERT INTO public.__seo_role_template_pool
+  (srtp_role, srtp_slot, srtp_template, srtp_lang, srtp_status, srtp_order, srtp_max_length)
+VALUES
+  -- meta_title (7 templates, <=75 chars apres substitution)
+  ('R8_VEHICLE', 'meta_title', 'Pièces {brand} {model} {type} {power}ch — Catalogue compatible',          'fr', 'active', 1, 75),
+  ('R8_VEHICLE', 'meta_title', '{brand} {model} {type} {power}ch : pièces compatibles par véhicule',     'fr', 'active', 2, 75),
+  ('R8_VEHICLE', 'meta_title', 'Catalogue pièces {brand} {model} {type} {power}ch | AutoMecanik',        'fr', 'active', 3, 75),
+  ('R8_VEHICLE', 'meta_title', 'Pièces auto compatibles {brand} {model} {type} {power}ch',               'fr', 'active', 4, 75),
+  ('R8_VEHICLE', 'meta_title', '{brand} {model} {type} {power}ch — Sélection pièces par véhicule',       'fr', 'active', 5, 75),
+  ('R8_VEHICLE', 'meta_title', 'Pièces détachées {brand} {model} {type} {power}ch | AutoMecanik',        'fr', 'active', 6, 75),
+  ('R8_VEHICLE', 'meta_title', 'Trouvez les pièces compatibles {brand} {model} {type} {power}ch',        'fr', 'active', 7, 75),
+
+  -- meta_description (11 templates, <=170 chars)
+  ('R8_VEHICLE', 'meta_description', 'Découvrez les familles de pièces compatibles {brand} {model} {type} {power}ch. Sélection par véhicule et aide compatibilité.',  'fr', 'active', 1, 170),
+  ('R8_VEHICLE', 'meta_description', 'Catalogue de pièces compatibles {brand} {model} {type} {power}ch : sélection guidée par véhicule.',                              'fr', 'active', 2, 170),
+  ('R8_VEHICLE', 'meta_description', 'Pièces détachées {brand} {model} {type} {power}ch — sélection par véhicule, références adaptées.',                               'fr', 'active', 3, 170),
+  ('R8_VEHICLE', 'meta_description', 'Toutes les familles de pièces compatibles {brand} {model} {type} {power}ch, classées par usage et par véhicule.',                'fr', 'active', 4, 170),
+  ('R8_VEHICLE', 'meta_description', 'Compatibilité {brand} {model} {type} {power}ch : trouvez les pièces correspondant exactement à votre véhicule.',                  'fr', 'active', 5, 170),
+  ('R8_VEHICLE', 'meta_description', 'Pièces auto pour {brand} {model} {type} {power}ch : familles couvertes, anti-erreur de référence, sélection véhicule.',           'fr', 'active', 6, 170),
+  ('R8_VEHICLE', 'meta_description', 'Catalogue {brand} {model} {type} {power}ch : familles de pièces compatibles, aide à la compatibilité véhicule.',                  'fr', 'active', 7, 170),
+  ('R8_VEHICLE', 'meta_description', 'Sélection guidée des pièces {brand} {model} {type} {power}ch : compatibilité par motorisation et par véhicule.',                  'fr', 'active', 8, 170),
+  ('R8_VEHICLE', 'meta_description', 'Vos pièces pour {brand} {model} {type} {power}ch : catalogue par véhicule, aide compatibilité, FAQ dédiée.',                       'fr', 'active', 9, 170),
+  ('R8_VEHICLE', 'meta_description', 'Pièces détachées {brand} {model} {type} {power}ch : familles indexées, aide au choix par véhicule, anti-confusion références.',   'fr', 'active', 10, 170),
+  ('R8_VEHICLE', 'meta_description', 'Page véhicule {brand} {model} {type} {power}ch : familles de pièces compatibles, référencement par véhicule, FAQ technique.',     'fr', 'active', 11, 170)
+ON CONFLICT (srtp_role, srtp_slot, srtp_lang, srtp_order) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Context

GSC + GA4 ont détecté des duplicats `meta_title` / `meta_description` sur les pages R8 véhicule (`/constructeurs/{brand}/{model}/{type}.html`). Cause vérifiée [r8-vehicle-enricher.service.ts:247-264](backend/src/modules/admin/services/r8-vehicle-enricher.service.ts#L247-L264) : templates hardcodés, 18 frères Clio III ne diffèrent que par 4 variables → quasi-clones structurels.

Cette PR introduit la couche manquante : un **template pool DB-backed** `__seo_role_template_pool` consommé via le chain seo-v9 (`SeoSwitchSelector` + seed sha256 canonique, résistant aux renumérotations TecDoc V2).

## Scope (PR-1 borné)

| Slot | Statut | Pool size |
|------|--------|-----------|
| `meta_title` | ✅ poolisé | 7 templates |
| `meta_description` | ✅ poolisé | 11 templates |
| `h1` | ⏭️ inchangé | reste produit par `buildR8H1()` (format optimisé avec plage d'années) |
| 5 blocs content R8 | ⏭️ PR-2 | inchangés (`SEO_R8_*_VARIATIONS` const TS) |

**Hors PR-1** : migration des 5 blocs content (PR-2 après 24-48h shadow obs), R7/R6/R3 generic, admin UI CRUD, multi-langue, A/B/CTR, allégations commerciales (`stock`, `24-48h`, `d'origine` retirées des templates jusqu'à validation métier), URL/canonical/slug changes.

## Apports

### Migration DB (atomique, idempotente)
- `BEGIN..COMMIT` : si seed plante (typo template), rollback complet, pas de table vide forçant le fallback partout.
- Table `__seo_role_template_pool(srtp_id uuid, srtp_role, srtp_slot, srtp_template, srtp_lang, srtp_status, srtp_order int NOT NULL, srtp_weight numeric, srtp_max_length int)` + unique `(role,slot,lang,order)` + index partiel `WHERE status='active'`.
- RLS aligné `20260422_enable_rls_internal_tables.sql` : `ENABLE ROW LEVEL SECURITY` + `REVOKE FROM anon, authenticated` + `POLICY service_role_all`.
- Colonne `__seo_r8_pages.variant_signature jsonb DEFAULT '{}'` (default-safe pour pages historiques).
- 18 INSERT avec `ON CONFLICT (role,slot,lang,order) DO NOTHING` (pattern repo standard).

### Code
- `SeoVariantFamilyRegistry` : ajout `ROLE_TEMPLATE_POOL` (slot-based, distinct des 4 familles legacy alias-based) avec `orderBy: 'srtp_order'` pour ordre PG stable (sinon idx sha256 non-reproductible).
- `SeoSwitchSelector.fetchVariants()` honore `config.orderBy` quand déclaré ; les 4 familles legacy sans `orderBy` restent inchangées (compat).
- `SeoRoleTemplateSelector` (nouveau service, wrapper thin) : slot type strict `'meta_title' | 'meta_description'`, `surfaceKey` salé par slot pour entropie indépendante (`R8_VEHICLE:meta_title` / `R8_VEHICLE:meta_description`), type-narrowing strict contre `srtp_template=null` (sinon `String(null)='"null"'` leakerait).
- `renderSeoTemplate` exporté depuis `seo-variations.config.ts` : comportement strict — placeholders manquants → `''`, collapse whitespace, **pas** de `{key}` literal qui leak en SEO.
- `R8VehicleEnricherService` :
  - `seoRoleTemplate.pick()` pour meta_title + meta_description (Promise.all parallèle)
  - **Fallback synchrone** vers les templates legacy si `pick()` retourne `null` → no-regression sur seed migration ratée
  - Warning structuré `[R8_META_POOL_FALLBACK] type_id=… missing_pool_slots=…`
  - `variantSignature` persisté dans upsert `__seo_r8_pages.variant_signature`
  - Détection collision fratrie (`fetchNeighbors` étendu avec `variant_signature`) : -5 pts `semanticSimilarityScore` par slot en collision ≥2 voisins. Pas de pénalité H1 (n/a, slot non poolisé).

### Schémas Zod
- `R8VariantSignatureSchema = z.object({ meta_title, meta_description }).partial().default({})` — default-safe pour pages historiques.
- `R8GovernanceDecisionSchema.variantSignature` ajouté.

## Tests (19 nouveaux + 2 cas registry étendus = 21)

- `seo-switch-selector.service.order.test.ts` (2) : `.order()` appelé pour `ROLE_TEMPLATE_POOL`, **pas** appelé pour `TYPE_SWITCH` legacy.
- `seo-role-template-selector.service.test.ts` (6) : substitution + truncation, fallback `null`, type narrowing srtp_template null, surfaceKey salé par slot, where clause complet, max_length cap.
- `r8-meta-distribution.test.ts` (11) : distribution sur 18 type_ids (max collisions par UUID — bound empirique 2σ + safety < 50%), couverture pool, salage par slot, Zod-DB consistency, parse default-safe, h1 absent du schéma.
- `seo-variant-family.registry.test.ts` (étendu +2) : `ROLE_TEMPLATE_POOL` exposé avec `orderBy=srtp_order`, legacy sans `orderBy` (compat).

**Résultat** : suite chain complète **165/165 PASS** (12 suites avant + 4 nouvelles/étendues).

## Plan de déploiement

1. Merge → preprod auto (push main)
2. Vérifier migration applique sans erreur sur preprod (`SELECT count(*) FROM __seo_role_template_pool WHERE srtp_role='R8_VEHICLE' AND srtp_status='active'` → 18)
3. Shadow observation 24-48h (PR #406 SeoShadowObservatory) sur sample 100 type_ids
4. Si distribution `seo_decision` saine (INDEX > 90%, REVIEW_REQUIRED < 10%) → PR-2 : migration des 5 blocs R8 vers le pool

## Rollback

```sql
BEGIN;
ALTER TABLE public.__seo_r8_pages DROP COLUMN IF EXISTS variant_signature;
DROP TABLE IF EXISTS public.__seo_role_template_pool;
COMMIT;
```

`git revert <merge-commit>` → repush PR de revert. Code fallback restaure le path hardcodé meta — pas de deploy step additionnel.

## Self-review checklist

- [x] Plan PR-1 approuvé après 6 itérations (verifier-je-tiens-playful-pebble.md v6)
- [x] Scope borné — PR-2 explicitement différée
- [x] Typecheck propre (errors restants = environnementaux `@repo/seo-role-contracts` non bâti, `zod-to-json-schema` non installé — préexistants)
- [x] 165/165 tests passent suite chain
- [x] Migration atomique (BEGIN/COMMIT) + idempotente (ON CONFLICT)
- [x] RLS + REVOKE + POLICY alignés sur pattern repo
- [x] Fallback synchrone + warning pour seed migration ratée
- [x] Pas d'allégations commerciales non garanties dans templates
- [x] H1 inchangé (déjà optimisé via `buildR8H1` avec plage d'années)
- [x] No-regression : `brand-bestsellers` + `cross-selling-seo` (consommateurs `__seo_type_switch` direct) inchangés

## Cohabitation legacy / chain (explicite)

| Consommateur | Source | Statut |
|---|---|---|
| R8 enricher meta layer | `__seo_role_template_pool` via chain | ✅ migré |
| R8 enricher 5 blocs content | `selectVariation()` + const TS | inchangé (PR-2) |
| `brand-bestsellers.service.ts` | `__seo_type_switch` direct | inchangé (hors scope) |
| `cross-selling-seo.service.ts` | `__seo_type_switch` direct | inchangé (hors scope) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)