### PR TITLE
chore(workers): align PageType on canon WorkerPageType (@repo/seo-roles)

### DIFF
--- a/backend/src/workers/types/content-refresh.types.ts
+++ b/backend/src/workers/types/content-refresh.types.ts
@@ -1,23 +1,11 @@
-import { RoleId } from '../../config/role-ids';
+import { RoleId, type WorkerPageType } from '../../config/role-ids';
 
-export type PageType =
-  | 'R1_pieces'
-  | 'R2_product'
-  | 'R3_conseils'
-  | 'R3_guide_howto'
-  | 'R4_reference'
-  | 'R5_diagnostic'
-  | 'R6_guide_achat'
-  | 'R7_brand'
-  | 'R8_vehicle';
-
-// NOTE : `PAGE_TYPE_TO_CANONICAL_ROLE` previously defined here was dead code
-// (zero importers across backend) AND diverged from the canonical mapping in
-// `backend/src/config/role-ids.ts` (`PAGE_TYPE_TO_ROLE`) on `R3_guide_howto` :
-// the dead copy mapped to R6_GUIDE_ACHAT, the canonical to R3_CONSEILS.
-// The canonical PAGE_TYPE_TO_ROLE is the single source of truth (now consumed
-// via `@repo/seo-roles` per PR-0A). If a PageType → RoleId conversion is needed
-// in worker code, import `pageTypeToRoleId` from the package.
+// PageType is the worker DB vocabulary kept for backwards-compat with
+// `__rag_content_refresh_log.page_type` and similar columns. Canon source =
+// `@repo/seo-roles` (re-exported via `backend/src/config/role-ids.ts`). For
+// PageType → RoleId conversion in worker code, import `pageTypeToRoleId` from
+// the package.
+export type PageType = WorkerPageType;
 
 /** Job data for gamme-based refresh (R1, R3, R4) */
 export interface ContentRefreshJobData {


### PR DESCRIPTION
## Summary

- Replace the in-file string-literal union `PageType` (9 literals) by `export type PageType = WorkerPageType` from `@repo/seo-roles`.
- The two definitions had identical literals — the duplicate triggered `no-restricted-syntax` ESLint errors flagged as *Legacy SEO role literal in OUTPUT context*.
- 11 consumers across `backend/src/config/*`, `backend/src/modules/admin/*` keep working — `PageType` stays an exported type alias.

## Why

ESLint cache invalidation on PR #422 surfaced 3 pre-existing errors on main:

```
backend/src/workers/types/content-refresh.types.ts:4,6,7
  ⚠️ Legacy SEO role literal in OUTPUT context.
  Use normalizeRoleId() / @repo/seo-roles canonical RoleId.
```

These errors block PR #422 ESLint check despite being unrelated to its diff. Fixing them via the canon (alias on the package's `WorkerPageType`) is the non-bricolage path : no `eslint-disable`, no path-based rule override, just align on the single source of truth (PR #312 / mémoire `seo-roles-canon-shipped-20260505`).

The local file already pointed to this canon explicitly in its previous note (line 19): *"now consumed via `@repo/seo-roles` per PR-0A"*.

## Verification

```bash
# 0 errors on the modified file
npx eslint backend/src/workers/types/content-refresh.types.ts
# exit 0

# Consumers still typecheck
npx tsc --noEmit -p backend
# exit 0
```

## Test plan

- [x] ESLint local on the file — 0 errors
- [x] TypeScript compile on backend — 0 errors
- [ ] CI ESLint job green
- [ ] CI Backend Tests green (no behavior change — type alias only)
- [ ] CI Deterministic gates green (no new exports/types)

## Unblocks

PR #422 (`feat/seo-v9-r8-meta-pool`) ESLint failure once rebased on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)