### PR TITLE
perf(backend): register compression middleware BEFORE useStaticAssets

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -25,8 +25,10 @@ import session from 'express-session';
 import Redis from 'ioredis';
 import passport from 'passport';
 import { urlencoded, json } from 'body-parser';
+import compression from 'compression';
 import cors from 'cors';
 import crypto from 'crypto';
+import helmet from 'helmet';
 
 const redisStoreFactory = RedisStore(session);
 
@@ -138,6 +140,22 @@ async function bootstrap() {
     );
     logger.log('Middleware de session initialisé');
 
+    // Compression middleware MUST be registered BEFORE useStaticAssets : Express
+    // applies middlewares in registration order, and the static-asset handler
+    // streams files directly without consulting downstream middleware. With
+    // compression registered after, every JS / CSS / font under /assets/* was
+    // served uncompressed (transferSize ≈ resourceSize on Lighthouse audits,
+    // see issue diagnosed in PRs #421 / #424 / #426 — none of those PRs moved
+    // script.size on the main Lighthouse run because compression was never
+    // applied to the static bundle).
+    app.use(
+      compression({
+        level: 6, // Bon équilibre vitesse/taille (défaut=6, max=9)
+        threshold: 1024, // Ne pas compresser les réponses < 1KB
+      }),
+    );
+    logger.log('Compression middleware enabled (level=6, threshold=1024)');
+
     expressApp.useStaticAssets(getPublicDir(), {
       immutable: true,
       maxAge: '1y',
@@ -183,32 +201,17 @@ async function bootstrap() {
       next();
     });
 
-    try {
-      // Import dynamique pour éviter d alourdir le build si non nécessaire
-      const helmet = (await import('helmet')).default;
-      const compression = (await import('compression')).default;
-
-      // Compression AVANT Helmet — pour que toutes les réponses soient compressées
-      // Note: Brotli géré côté Caddy en production (meilleur ratio, 15-20% vs gzip)
-      app.use(
-        compression({
-          level: 6, // Bon équilibre vitesse/taille (défaut=6, max=9)
-          threshold: 1024, // Ne pas compresser les réponses < 1KB
-        }),
-      );
-
-      // Helmet avec nonce dynamique par requête (voir config/csp.config.ts)
-      const isDev = process.env.NODE_ENV !== 'production';
-      app.use((req: any, res: any, next: any) => {
-        helmet({
-          contentSecurityPolicy: {
-            directives: buildCSPDirectives(isDev, res.locals.cspNonce),
-          },
-        })(req, res, next);
-      });
-    } catch (e) {
-      logger.warn({ err: e }, 'Helmet/compression non chargés');
-    }
+    // Helmet avec nonce dynamique par requête (voir config/csp.config.ts).
+    // Compression a été déplacée plus haut (avant useStaticAssets) — elle ne
+    // peut plus rester optionnelle vu son impact perf empirique mesuré.
+    const isDev = process.env.NODE_ENV !== 'production';
+    app.use((req: any, res: any, next: any) => {
+      helmet({
+        contentSecurityPolicy: {
+          directives: buildCSPDirectives(isDev, res.locals.cspNonce),
+        },
+      })(req, res, next);
+    });
 
     // CORS sécurisé - restreint en production
     const corsOrigin = process.env.CORS_ORIGIN?.split(',').map((s) => s.trim());


### PR DESCRIPTION
## Summary

Move Express `compression` middleware registration **before** `useStaticAssets()` in [backend/src/main.ts](backend/src/main.ts), and hoist the import to static (drop the silent try/catch). 1 file modified, +29/-26.

## Why — empirical root cause

Three previous perf PRs (#421 lazy Sentry, #424 trigger interaction, #426 Vite modulePreload exclude) **moved zero bytes** on the main Lighthouse audit :

| Metric | Pre #421 | Post #421 | Post #424 | Post #426 | Budget |
|---|---|---|---|---|---|
| script.size | 1483711 | 1524500 | 1524786 | **1524735** | 1280000 |
| total.size | — | 1982700 | 1982955 | **1982936** | 1843200 |
| interactive | — | 12325 | 12756 | **12736** | 12100 |

Diagnostic on the Lighthouse report from commit `f83d7b24` ([report HTML](https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1778417515113-62268.report.html)) revealed that **every JS chunk is served uncompressed** :

```
chunk                              transferSize  resourceSize  compressed
sentry-vendor-B_AznZeM.js                481539        481209          NO
react-vendor-4B2Xfegj.js                 301135        300805          NO
app-core-BwtU4YLM.js                     165087        164757          NO
radix-vendor-IoGVFYB7.js                  98047         97718          NO
lucide-vendor-hXLnwgp2.js                 64929         64601          NO
```

Cause : `expressApp.useStaticAssets()` was registered at [main.ts:141](backend/src/main.ts#L141), **before** the `compression` middleware at [main.ts:193](backend/src/main.ts#L193). Express applies middlewares in registration order and the static-asset handler streams files directly without consulting downstream middleware — so every `/assets/*` bypassed compression entirely.

The Vite-side fixes (lazy chunking, dynamic imports, modulePreload filtering) couldn't move the needle because the bytes were ALL transferred uncompressed regardless.

## Fix

```ts
// BEFORE (broken — compression registered AFTER static assets)
expressApp.useStaticAssets(getPublicDir(), { ... });   // line 141
// ... 50 lines of session/passport/CSP setup ...
try {
  const compression = (await import('compression')).default;
  app.use(compression({ level: 6, threshold: 1024 }));  // line 193 — too late
} catch (e) { logger.warn(...); }

// AFTER
import compression from 'compression';                  // static, mandatory
import helmet from 'helmet';                            // static, mandatory

// ...
app.use(compression({ level: 6, threshold: 1024 }));    // line 156, BEFORE static
expressApp.useStaticAssets(getPublicDir(), { ... });    // line 162
```

Bonus : drops the silent `try/catch` around `compression`/`helmet` imports — these are critical infra middlewares, not optional. Failure to load should fail loud, not silently degrade perf.

## Expected post-merge

| Metric | Current main | Expected | Budget | Verdict |
|---|---|---|---|---|
| script.size | 1525 KB | ~520 KB (gzip ~3x) | 1280 KB | ✅ |
| total.size | 1983 KB | ~700 KB | 1843 KB | ✅ |
| interactive | 12.7 s | ~10.5 s | 12.1 s | ✅ |
| FCP / LCP | already OK | preserved | preserved | ✅ |

## Verification

```bash
npx tsc --noEmit -p backend  # exit 0
npx eslint backend/src/main.ts  # exit 0 (13 unrelated `any` warnings preserved)
```

## Test plan

- [ ] CI ESLint / TypeScript / Backend Tests / Frontend Tests all green
- [ ] Deploy run completes (compression import is now static, can't silently fail)
- [ ] Post-merge Lighthouse main run — all 3 metrics under budget
- [ ] Manual smoke test : `curl -H 'Accept-Encoding: gzip' http://localhost:3200/assets/sentry-vendor-*.js -I` should return `Content-Encoding: gzip`

## Unblocks

PR #422 (`feat/seo-v9-r8-meta-pool`) CWV check on rebase post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)