### PR TITLE
fix(rag): RAG_L3_GUARD_ENFORCE explicit env to align guard with Phase 3B delivery state

### DIFF
--- a/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
+++ b/backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
@@ -5,19 +5,35 @@
  *
  * Au boot NestJS :
  *   1. Vérifie l'existence de `<RAG_KNOWLEDGE_PATH>/.last-sync.json` (manifest produit
- *      par le cron sync-wiki-exports-to-rag).
+ *      par le cron sync-wiki-exports-to-rag — livré par PR #369 / Phase 3B PR-P).
  *   2. Vérifie que ce manifest n'est pas obsolète (> 24h).
  *
- * En production réelle (NODE_ENV=production hors APP_ENV=preprod/READ_ONLY=true),
- * fail-fast si manifest absent ou obsolète : un L3 stale signale soit un cron
- * mort, soit une migration incomplète, et le service ne doit pas démarrer dans
- * cet état (mémoire incident-images-2026-04-11).
+ * Modes (matrice explicite) :
  *
- * En dev/preprod, soft-warn (le manifest peut ne pas exister tant que Phase 3B
- * PR-P n'a pas livré le sync canon).
+ * | NODE_ENV     | APP_ENV / READ_ONLY  | RAG_L3_GUARD_ENFORCE | Comportement |
+ * |--------------|----------------------|----------------------|--------------|
+ * | production   | (other)              | true                 | fail-fast    |
+ * | production   | preprod / true       | (any)                | soft-warn    |
+ * | production   | (other)              | false / unset        | soft-warn    |
+ * | non-prod     | (any)                | (any)                | soft-warn    |
  *
- * Bypass : `SKIP_RAG_BOOTSTRAP_GUARD=true` (escape hatch dev/CI). À documenter
- * dans tout usage en preprod si activé.
+ * `RAG_L3_GUARD_ENFORCE=true` est l'**opt-in explicite** activé seulement quand
+ * Phase 3B est entièrement livrée : (a) cron sync-wiki-exports-to-rag écrit le
+ * manifest sur DEV VPS (PR #369 mergée), et (b) le manifest est délivré sur
+ * PROD VPS via le mécanisme de mirror (git pull `automecanik-rag` ou équivalent
+ * vérifié sur 49.12.233.2). Tant que ces deux préconditions ne sont pas
+ * empiriquement validées, la guard reste informative (warn-only) y compris
+ * en prod — pour ne pas casser les deploys avant que sa dépendance soit live.
+ *
+ * Précédent : PR #356 (introduction guard) déclarait dans son body « Tant que
+ * Phase 3B non livrée, le bootstrap guard reste soft-warn en dev/preprod » —
+ * mais activait fail-fast en prod par défaut. Conséquence empirique :
+ * deploy-prod.yml du tag v2026.05.10-lcp-r3-cache (run 25636043816) a thrown
+ * « manifest absent » et bloqué le rollout R3 LCP cache (PR #408). Ce flag
+ * encode l'intention explicite de l'auteur en config plutôt qu'en assumption.
+ *
+ * Bypass d'urgence : `SKIP_RAG_BOOTSTRAP_GUARD=true` (escape hatch dev/CI,
+ * NE PAS utiliser en prod — sert à débloquer perf-gates en CI ou dev local).
  *
  * Performance : 1 fs.statSync local au boot, < 5ms. Synchrone (memory backend.md
  * "Aucun await d'I/O distante dans onModuleInit" — fs sync local OK).
@@ -47,16 +63,19 @@ export class RagKnowledgeBootstrapGuardService implements OnModuleInit {
     const manifestPath = path.join(ragDir, MANIFEST_FILENAME);
     const isReadOnlyPreprod =
       process.env.APP_ENV === 'preprod' || process.env.READ_ONLY === 'true';
+    const enforceFailFast = process.env.RAG_L3_GUARD_ENFORCE === 'true';
     const shouldFailFast =
-      process.env.NODE_ENV === 'production' && !isReadOnlyPreprod;
+      process.env.NODE_ENV === 'production' &&
+      !isReadOnlyPreprod &&
+      enforceFailFast;
 
     if (!fs.existsSync(manifestPath)) {
-      const msg = `[RagKnowledgeBootstrapGuard] manifest absent: ${manifestPath}. Le cron sync-wiki-exports-to-rag doit avoir produit ce fichier (Phase 3B PR-P du plan refondation R-stack).`;
+      const msg = `[RagKnowledgeBootstrapGuard] manifest absent: ${manifestPath}. Le cron sync-wiki-exports-to-rag doit avoir produit ce fichier (Phase 3B PR-P / PR #369).`;
       if (shouldFailFast) {
         throw new Error(msg);
       }
       this.logger.warn(
-        `${msg} (dev/preprod : soft-warn — Phase 3B livre le sync)`,
+        `${msg} (warn-only : RAG_L3_GUARD_ENFORCE absent ou Phase 3B pas encore activée)`,
       );
       return;
     }
@@ -69,7 +88,9 @@ export class RagKnowledgeBootstrapGuardService implements OnModuleInit {
       if (shouldFailFast) {
         throw new Error(msg);
       }
-      this.logger.warn(`${msg} (dev/preprod : soft-warn)`);
+      this.logger.warn(
+        `${msg} (warn-only : RAG_L3_GUARD_ENFORCE absent ou Phase 3B pas encore activée)`,
+      );
       return;
     }
 

--- a/backend/tests/unit/rag-knowledge-bootstrap.guard.test.ts
+++ b/backend/tests/unit/rag-knowledge-bootstrap.guard.test.ts
@@ -10,27 +10,50 @@ describe('RagKnowledgeBootstrapGuardService', () => {
     delete process.env.READ_ONLY;
     delete process.env.RAG_KNOWLEDGE_PATH;
     delete process.env.SKIP_RAG_BOOTSTRAP_GUARD;
+    delete process.env.RAG_L3_GUARD_ENFORCE;
   });
 
   afterAll(() => {
     process.env = originalEnv;
   });
 
-  it('fail-fasts in real production when the L3 manifest is absent', () => {
+  it('fail-fasts in production when manifest absent AND RAG_L3_GUARD_ENFORCE=true', () => {
     process.env.NODE_ENV = 'production';
-    process.env.RAG_KNOWLEDGE_PATH = '/tmp/automecanik-rag-missing-prod';
+    process.env.RAG_L3_GUARD_ENFORCE = 'true';
+    process.env.RAG_KNOWLEDGE_PATH = '/tmp/automecanik-rag-missing-enforced';
 
     expect(() => new RagKnowledgeBootstrapGuardService().onModuleInit()).toThrow(
       '[RagKnowledgeBootstrapGuard] manifest absent:',
     );
   });
 
-  it('soft-warns in READ_ONLY preprod when the L3 manifest is absent', () => {
+  it('soft-warns in production when manifest absent AND RAG_L3_GUARD_ENFORCE unset (Phase 3B pas livrée)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.RAG_KNOWLEDGE_PATH = '/tmp/automecanik-rag-missing-not-enforced';
+
+    expect(() =>
+      new RagKnowledgeBootstrapGuardService().onModuleInit(),
+    ).not.toThrow();
+  });
+
+  it('soft-warns in READ_ONLY preprod regardless of enforce flag', () => {
     process.env.NODE_ENV = 'production';
     process.env.APP_ENV = 'preprod';
     process.env.READ_ONLY = 'true';
+    process.env.RAG_L3_GUARD_ENFORCE = 'true';
     process.env.RAG_KNOWLEDGE_PATH =
       '/tmp/automecanik-rag-missing-readonly-preprod';
+
+    expect(() =>
+      new RagKnowledgeBootstrapGuardService().onModuleInit(),
+    ).not.toThrow();
+  });
+
+  it('skips entirely when SKIP_RAG_BOOTSTRAP_GUARD=true (escape hatch CI/dev)', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.RAG_L3_GUARD_ENFORCE = 'true';
+    process.env.SKIP_RAG_BOOTSTRAP_GUARD = 'true';
+    process.env.RAG_KNOWLEDGE_PATH = '/tmp/automecanik-rag-missing-skipped';
 
     expect(() =>
       new RagKnowledgeBootstrapGuardService().onModuleInit(),


### PR DESCRIPTION
## Problème

PR #356 (RagKnowledgeBootstrapGuard, MVP-0 PR-E) a introduit un fail-fast au boot NestJS qui throw si `/opt/automecanik/rag/knowledge/.last-sync.json` est absent en PROD. Le manifest est produit par le cron `sync-wiki-exports-to-rag` dont l'écriture est livrée par **PR #369** (Phase 3B PR-P), pas encore mergée.

**Design defect dans PR #356** : son body déclarait explicitement
> *« Tant que Phase 3B non livrée, le bootstrap guard reste soft-warn en dev/preprod »*

mais l'implémentation activait fail-fast en prod par défaut, sans toggle.

**Conséquence empirique** : deploy-prod.yml du tag `v2026.05.10-lcp-r3-cache` ([run 25636043816](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25636043816)) a thrown :
```
Error: [RagKnowledgeBootstrapGuard] manifest absent: /opt/automecanik/rag/knowledge/.last-sync.json
```
→ Health check failed × 5 → rollback → bloqué le rollout R3 LCP cache (PR #408 mergée mais pas livrée en PROD).

PROD reste sur l'image antérieure (le rollback `docker compose up` du previous a échoué cosmétiquement, mais le container existant tourne toujours). `curl https://www.automecanik.com` répond 200.

## Fix (no bricolage)

Encode l'intention auteur en **config explicite** plutôt qu'en assumption. Nouvelle var `RAG_L3_GUARD_ENFORCE` (default `false` = soft-warn even in PROD).

### Matrice après ce changement

| NODE_ENV     | APP_ENV / READ_ONLY  | RAG_L3_GUARD_ENFORCE | Comportement |
|--------------|----------------------|----------------------|--------------|
| production   | (other)              | `true`               | fail-fast    |
| production   | preprod / true       | (any)                | soft-warn    |
| production   | (other)              | `false` / unset      | soft-warn    |
| non-prod     | (any)                | (any)                | soft-warn    |

### Pourquoi cette approche

| Alternative | Pourquoi rejetée |
|-------------|------------------|
| `SKIP_RAG_BOOTSTRAP_GUARD=true` en compose (PR #433 fermée) | Bricolage : full bypass, masque aussi les vrais incidents stale futurs |
| Revert PR #356 entièrement | Trop large : la guard structure (filesystem 3-tier, husky, ast-grep) reste valide, seul le runtime fail-fast est prématuré |
| Distinguer absent vs stale (warn absent, throw stale) | Edge case : suppression manuelle du manifest in-flight → silent warn au lieu d'incident |
| Attendre PR #369 (PR-E.2) | Bloquée par lint pré-existant + behind main → délai indéterminé, et ne résout pas le problème côté PROD VPS mirror sync (autre dépendance) |
| **Cette PR — env opt-in `RAG_L3_GUARD_ENFORCE`** | ✓ encode intention auteur ✓ default safe ✓ pattern standard (cf. `RPC_GATE_MODE=enforce`) ✓ scope minimal (1 fichier code + 1 fichier test) ✓ activation explicite après preuve empirique |

## Activation prévue (follow-up séparée)

Cette PR ne change RIEN au comportement opérationnel actuel. Pour activer la fail-fast comme PR #356 l'avait prévu :

1. PR #369 mergée → DEV cron sync écrit manifest `/opt/automecanik/rag/knowledge/.last-sync.json`
2. Vérification empirique : mirror PROD VPS (49.12.233.2) reçoit le manifest via `git pull automecanik-rag` ou mécanisme équivalent
3. PR follow-up : `RAG_L3_GUARD_ENFORCE=true` dans `docker-compose.prod.yml`
4. Guard fail-fast PROD comme intended par PR #356

Cette séquence est explicitement documentée dans la docstring du guard.

## Test plan

- [x] Tests unitaires étendus 4 cas : enforce-true throw, enforce-unset warn, preprod soft-warn, SKIP escape hatch (`backend/tests/unit/rag-knowledge-bootstrap.guard.test.ts`)
- [x] Lint local OK (eslint sur le module)
- [ ] CI verte (TS, ESLint, Backend Tests, etc.)
- [ ] Merge → ci.yml rebuild image `:preprod`
- [ ] Tag `v2026.05.10-lcp-r3-cache-1` → deploy-prod.yml
- [ ] Container log : `[RagKnowledgeBootstrapGuard] manifest absent: ... (warn-only : RAG_L3_GUARD_ENFORCE absent ou Phase 3B pas encore activée)`
- [ ] `/health` → 200 sur 49.12.233.2
- [ ] PROD sert R3 LCP cache (TTL 600s, single-flight, web-vitals beacon)

## Refs

- PR #356 : guard introduction (ADR-046 § Layer L3) — fixait l'intention dans body, pas le code
- PR #408 : R3 LCP cache (mergée, le payload bloqué par cette régression)
- PR #369 : PR-E.2 manifest+cron canon (résolution permanente Phase 3B, en cours)
- PR #420 : précédent fix preprod soft-warn — même esprit, scope préprod uniquement
- PR #381 : précédent escape-hatch CI — escape hatch dev/CI, pas pour PROD

🤖 Generated with [Claude Code](https://claude.com/claude-code)