### PR TITLE
fix(backend-dev): runtime tsconfig-paths safety net to eliminate tsc/tsc-alias race

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,3 +1,27 @@
+// Dev-only safety net : register tsconfig-paths before any other require().
+// PROD utilise tsc-alias pour réécrire les @alias en relatifs au build (single-shot,
+// race-free). En dev, `tsc --watch` et `tsc-alias --watch` tournent en parallèle ;
+// nodemon peut redémarrer node sur un dist/*.js fraîchement réécrit par tsc mais
+// pas encore traité par tsc-alias → MODULE_NOT_FOUND `@common/exceptions`.
+// La registration runtime ci-dessous patche le loader Node pour résoudre les
+// `@alias/*` résiduels, éliminant la race. Inactive en prod (tsc-alias a déjà fait
+// le travail au build, et tsconfig-paths reste en devDependencies).
+if (process.env.NODE_ENV !== 'production') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('tsconfig-paths').register({
+    baseUrl: __dirname,
+    paths: {
+      '@auth/*': ['auth/*'],
+      '@cache/*': ['cache/*'],
+      '@common/*': ['common/*'],
+      '@config/*': ['config/*'],
+      '@database/*': ['database/*'],
+      '@security/*': ['security/*'],
+      '@modules/*': ['modules/*'],
+    },
+  });
+}
+
 // Sentry MUST be imported first so its OpenTelemetry-based auto-instrumentation
 // can patch http/fs/express before any other module loads.
 // `instrument.ts` also runs `dotenv/config` internally — populating env vars


### PR DESCRIPTION
## Problème

`npm run dev` chaîne `tsc --watch` et `tsc-alias --watch` en parallèle. Quand un fichier `src/*.ts` change :

1. `tsc` rebuild `dist/*.js` avec `require(\"@common/...\")` (alias non-résolu)
2. nodemon détecte `dist/main.js` modifié, debounce 2s, redémarre node
3. `tsc-alias --watch` (chokidar) détecte aussi mais peut être plus lent
4. → `MODULE_NOT_FOUND` si node redémarre avant que tsc-alias finisse

Symptôme reproduit cette session (deux fois consécutives en éditant guard.ts) :

```
node:internal/modules/cjs/loader:1210
Error: Cannot find module '@common/exceptions'
Require stack:
- /opt/automecanik/app/backend/dist/config/app.config.js
- /opt/automecanik/app/backend/dist/config/csp.config.js
- /opt/automecanik/app/backend/dist/main.js
```

Workaround manuel jusqu'ici : `npx tsc-alias -p tsconfig.json` puis relance. Bricolage répétitif.

## Fix structurel

Registrer `tsconfig-paths` au runtime au top de `src/main.ts` (avant tout autre import). Le loader Node intercepte tout `require('@alias/...')` résiduel et résout via la path map.

`tsc-alias` reste actif (PROD build single-shot race-free), le runtime register est un **safety net dev-only**.

```ts
if (process.env.NODE_ENV !== 'production') {
  require('tsconfig-paths').register({
    baseUrl: __dirname,
    paths: {
      '@auth/*': ['auth/*'],
      '@cache/*': ['cache/*'],
      // ...7 alias backend canon
    },
  });
}
```

### Pourquoi conditionné `!= production`

- PROD Docker image : `tsc-alias` rewrite déjà fait au build, dist est clean. Pas besoin du register.
- `tsconfig-paths` reste en `devDependencies` → image PROD plus légère, zéro impact runtime.
- DEV : safety net actif, race tsc/tsc-alias éliminée.

### Pourquoi pas alternative

| Option | Pourquoi pas |
|--------|--------------|
| Augmenter `nodemon --delay 2000ms` à 5000ms | Bricolage : juste plus de tolérance, race toujours possible |
| Watcher custom dans wait-and-start.js qui grep-clean avant restart | Surface large, fragile, complique la stack |
| Migrer entièrement à tsconfig-paths runtime (PROD inclus) | Sortie de scope : tsc-alias en PROD est race-free + image plus lean |
| Remplacer tsc-alias par module-alias | Migration plus large, pas justifiée |
| **Cette PR — runtime safety net dev-only** | ✓ structurel ✓ scope minimal ✓ zero impact PROD ✓ pattern Node.js standard |

## Validation empirique

```
$ node -e \"require('tsconfig-paths').register({
    baseUrl: __dirname + '/dist',
    paths: { '@common/*': ['common/*'] }
  });
  const exc = require('@common/exceptions');
  console.log(Object.keys(exc));\"
[
  'DomainNotFoundException',
  'DomainValidationException',
  'BusinessRuleException',
  'DatabaseException',
  ...
]
```

Module résolu correctement via la path map runtime.

## Test plan

- [x] `npx tsc --build` compile sans erreur sur le fichier touché
- [x] `dist/main.js` émet le block register au top, AVANT `require(\"./instrument\")`
- [x] `tsc-alias` ne touche pas les literals dans `register({paths: {...}})` (correct — ce sont des strings, pas des require)
- [x] Test empirique : `require('@common/exceptions')` résout via runtime register
- [ ] CI verte (TS, ESLint, Backend Tests, Frontend Tests, gates)
- [ ] Smoke test post-merge : DEV preprod redéploie sans `MODULE_NOT_FOUND`
- [ ] Validation user : `npm run dev` ne crash plus sur édition src/*.ts

## Refs

- Crash logs cette session : 2× `[nodemon] starting node dist/main.js` → `Cannot find module '@common/exceptions'` après édition `src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts`
- `backend-ts-aliases.md` (memory) : 7 alias canon `@auth/@cache/@common/@config/@database/@security/@modules`
- `tsconfig-paths` ^4.2.0 déjà en devDependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)