### PR TITLE
chore(packages): include *.tsbuildinfo in clean scripts (prevent stale-skip class)

### DIFF
--- a/packages/database-types/package.json
+++ b/packages/database-types/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist *.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "generate:types": "echo 'Run: supabase gen types typescript --project-id YOUR_PROJECT_ID > src/types.ts'",
     "generate:zod": "tsx scripts/generate-zod-schemas.ts"

--- a/packages/seo-role-contracts/package.json
+++ b/packages/seo-role-contracts/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist *.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts"
   },

--- a/packages/seo-roles/package.json
+++ b/packages/seo-roles/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist *.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts"
   },

--- a/packages/seo-types/package.json
+++ b/packages/seo-types/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist *.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts"
   },


### PR DESCRIPTION
## Bug class identifiée

4 packages composite ont un script `clean` qui supprime `dist/` mais **laisse `tsconfig.tsbuildinfo` orphelin**. Quand quelqu'un (manuellement, IDE, partial git op) supprime `dist/` sans toucher au tsbuildinfo :

1. `tsc --build` lit le tsbuildinfo, dit \"déjà à jour\"
2. Skip silencieux de l'emit
3. `dist/` reste vide
4. Consommateur runtime crash : `MODULE_NOT_FOUND .../dist/index.js`

**Reproductible empiriquement** cette session sur `@repo/seo-role-contracts` :
```
[nodemon] starting node dist/main.js
[Nest] LOG [EnvValidation] All required environment variables present
Error: Cannot find module '/.../node_modules/@repo/seo-role-contracts/dist/index.js'
    at /.../tsconfig-paths/lib/register.js:103:40
```

## Fix

| Package | Avant | Après |
|---------|-------|-------|
| database-types | `rm -rf dist` | `rm -rf dist *.tsbuildinfo` |
| seo-role-contracts | `rm -rf dist` | `rm -rf dist *.tsbuildinfo` |
| seo-roles | `rm -rf dist` | `rm -rf dist *.tsbuildinfo` |
| seo-types | `rm -rf dist` | `rm -rf dist *.tsbuildinfo` |

Le glob `*.tsbuildinfo` (vs `tsconfig.tsbuildinfo` strict) couvre futurs `tsconfig.build.tsbuildinfo`, `tsconfig.test.tsbuildinfo`, etc. sans modification ultérieure.

## Pourquoi pas d'autre alternative

| Option | Pourquoi pas |
|--------|--------------|
| `tsc --build --clean` | Ne supprime pas les sous-dossiers dist vides + dépendance tsc |
| `prebuild` defensive (vérifier dist avant tsc) | Complexité dans 4 fichiers pour cas hypothétiques externes — fixer la source du bug suffit |
| Migrer `build` à `tsc --build --force` | Perd le bénéfice incremental |
| Gitignore packages/*/dist + supprimer trackés | Scope large (70+ fichiers tracked) — séparé si souhaité |

## Observation collatérale (hors scope, à adresser séparément)

3 des 4 packages ont leur `dist/` committé en git (anti-pattern) :
- `packages/database-types/dist/`: 60 fichiers tracked
- `packages/seo-roles/dist/`: 52 fichiers tracked
- `packages/seo-types/dist/`: 24 fichiers tracked
- `packages/seo-role-contracts/dist/`: NON tracked (le plus récent, PR #372)

C'est pour ça que `seo-role-contracts` était le seul à manifester le bug : sans dist en git, il fallait que le build le génère, et le build skippait à cause du tsbuildinfo orphelin. Les 3 autres packages ont leur dist garanti par le checkout — bug masqué.

À adresser si souhaité dans une PR séparée :
1. Ajouter `packages/*/dist/` au `.gitignore` racine
2. `git rm -rf --cached packages/{database-types,seo-roles,seo-types}/dist`
3. CI doit alors faire `npm run build` avant tout test/typecheck (probablement déjà le cas via turbo)

## Test plan

- [x] `clean` modifié sur les 4 packages
- [x] Reproduit le bug initial : `cd packages/seo-role-contracts && rm -rf dist && tsc --build` → skip silencieux
- [x] Avec le fix : `cd packages/seo-role-contracts && npm run clean && tsc --build` → rebuild complet
- [ ] CI verte (typecheck, lint, tests)

## Refs

- Crash log de cette session : `Cannot find module '/.../seo-role-contracts/dist/index.js'`
- Memory `backend-ts-aliases.md` : workspace packages canon
- ADR-046 § L1.5 (seo-role-contracts SoT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)