### PR TITLE
fix(frontend): scope Sentry browser reports to /assets/*.js via allowUrls

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-10'
+last_scan: '2026-05-11'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -95,6 +95,17 @@ const initObservability = async (): Promise<void> => {
     tracesSampleRate: 0.1,
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0,
+    // Ne remonter que les erreurs issues du JS qu'on a buildé (`/assets/*.js`).
+    // Drop le bruit des scripts inline injectés hors de notre code : beacon
+    // bot Cloudflare (`/cdn-cgi/challenge-platform/...` → `Cannot read
+    // properties of null (reading 'document')` quand une extension détache son
+    // iframe caché), extensions navigateur, tags tiers. `allowUrls` matche le
+    // filename de la dernière frame significative ; nos chunks sont tous sous
+    // `/assets/`, les erreurs des `<script>` inline ont pour filename l'URL de
+    // la page (.html) → filtrées. Géré par `eventFiltersIntegration` (default
+    // integration — l'array `integrations` ci-dessous fusionne avec les
+    // défauts, ne les remplace pas).
+    allowUrls: [/\/assets\//],
     integrations: [
       Sentry.browserTracingIntegration({
         useEffect,
@@ -131,11 +142,7 @@ const initObservability = async (): Promise<void> => {
 // page programmatically while measuring CLS, which would have falsely fired
 // the trigger during audits. Real users still get init on the first
 // click / key / touch — typically within the first second of engagement.
-const interactionEvents = [
-  "pointerdown",
-  "keydown",
-  "touchstart",
-] as const;
+const interactionEvents = ["pointerdown", "keydown", "touchstart"] as const;
 
 let initStarted = false;
 const triggerInit = (): void => {


### PR DESCRIPTION
## Pourquoi

Sentry (`automecanik-frontend-prod`) a alerté sur :

```
TypeError: Cannot read properties of null (reading 'document')
  at HTMLDocument.c (/constructeurs/renault-140/master-iii-140039/2-3-dci-fwd-77287.html:222:160)
  environment=production  browser=Chrome 147 / Windows  handled=yes  mechanism=generic
```

**Ce n'est pas un bug du code AutoMecanik.** La ligne 222 de cette page (vérifié par `curl` sur la prod) est le **beacon de détection de bots de Cloudflare**, injecté au niveau du CDN edge :

```js
<script nonce="...">(function(){function c(){var b=a.contentDocument||a.contentWindow.document;...}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;...document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);...}})();</script>
<!-- => window.__CF$cv$params + /cdn-cgi/challenge-platform/scripts/jsd/main.js -->
```

`c` est le handler `DOMContentLoaded` (d'où `HTMLDocument.c` dans la stack). Il lit `a.contentDocument || a.contentWindow.document` sur un iframe caché 1×1 ; quand une extension navigateur (ad-blocker / privacy / antivirus web) détache cet iframe, `a.contentWindow` devient `null` → `null.document` → l'exception exacte. La page fonctionne normalement — c'est du bruit télémétrique.

Ça remonte dans Sentry uniquement parce que `frontend/app/entry.client.tsx` installe un early `window.addEventListener("error", …)` qui bufferise l'erreur puis la rejoue via `Sentry.captureException()` après l'init lazy du SDK (d'où `handled: yes` / `mechanism: generic`). Le SDK n'avait aucun filtre `allowUrls`/`denyUrls`/`ignoreErrors`.

## Changement

Ajoute `allowUrls: [/\/assets\//]` au `Sentry.init()` navigateur dans `frontend/app/entry.client.tsx`. L'intégration par défaut `eventFiltersIntegration` ne transmet alors que les erreurs dont la stack provient du JS qu'on a buildé et shippé (tous nos chunks sont sous `/assets/`). Ça drop :

- le bruit du beacon Cloudflare (`/cdn-cgi/challenge-platform/...`),
- le bruit des extensions navigateur (`chrome-extension://…`),
- le bruit des `<script>` inline tiers,

tout en conservant **toutes** les vraies erreurs app (React, route modules, vendor chunks — tout est `/assets/`). Aucun changement au scrubbing PII (`beforeSend` / `sentryBeforeSend`) ni au SDK SSR (`entry.server.tsx`).

### Alternatives écartées

- `ignoreErrors: [/…reading 'document'…/]` — trop large (masquerait un vrai `foo.document` sur null dans notre code) ; `allowUrls` discrimine par origine du code, pas par message.
- Filtre signature dans `beforeSend` — plus de code, pas de signature *Cloudflare-spécifique* exploitable dans l'event capturé (le filename de la frame en erreur = l'URL de la page, pas `/cdn-cgi/`).
- Désactiver "Bot Fight Mode" / "JS Detections" côté dashboard Cloudflare — décision/changement infra hors monorepo.
- `Sentry.thirdPartyErrorFilterIntegration` — nécessiterait `@sentry/vite-plugin` + `applicationKey`, trop gros ; `allowUrls` couvre le besoin via une intégration déjà active.

## Vérification

- `npx turbo build --filter=@fafa/frontend` → OK.
- `tsc` (frontend) : **0 nouvelle erreur** introduite par ce diff. 12 erreurs pré-existantes sur `main` (`@repo/database-types` n'exporte plus `VehicleBrand`/`VehicleModel`/`VehicleType` en local — environnemental, résolu en CI via `npm ci` + build des packages). `entry.client.tsx` typecheck propre.
- `allowUrls?: Array<string | RegExp>` confirmé option top-level valide pour `@sentry/remix@10.51.0` (`@sentry/core` `options.d.ts` — comportement géré par `eventFiltersIntegration`, default integration ; l'array `integrations: [...]` actuel fusionne avec les défauts, ne les remplace pas).

Post-merge (DEV preprod auto sur 46.224.118.55) : smoke `/health` + chargement d'une page `/constructeurs/...`, vérifier que le SDK Sentry s'init toujours après interaction. Observation Sentry quelques jours : l'issue `056df0ab2c9c4b12865cb78da2ea002a` (+ variantes du beacon Cloudflare) ne reçoit plus d'events ; les vraies erreurs JS app continuent de remonter. **À faire manuellement** : résoudre/mute l'issue `056df0ab…` dans l'UI Sentry (le filtre arrête les futurs events, ne ferme pas l'issue existante).

> Note : 42 fichiers `.claude/knowledge/modules/*.md` apparaissent dans le diff — bump mécanique `last_scan: 2026-05-10 → 2026-05-11` ajouté par le hook pre-commit (`scripts/knowledge/refresh-knowledge.py`), pas une modification manuelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)