### PR TITLE
chore(audit): harden audit tooling — argv-not-string-splice, stderr-as-evidence

### DIFF
--- a/scripts/audit/build-deep-inventory.js
+++ b/scripts/audit/build-deep-inventory.js
@@ -187,16 +187,28 @@ function lastModifiedMap() {
 
 function runJson(cmd, args, label) {
   log(`[build-deep-inventory] running ${label}…`);
-  let stdout;
+  // stderr is *evidence*, not noise: capture it, tee it to audit/cache/tool-<label>.stderr.log
+  // (gitignored, but published as a CI artefact), echo it to our own stderr, and fold it
+  // into the failure message. An audit pipeline that silently eats a tool's stderr can't be
+  // trusted to explain its own false positives / negatives.
+  const slug = label.replace(/[^A-Za-z0-9]+/g, '-').toLowerCase();
+  let stdout = '';
+  let stderr = '';
+  let failure = null;
   try {
-    stdout = execFileSync(cmd, args, { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 256 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] });
+    stdout = execFileSync(cmd, args, { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 256 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] });
   } catch (e) {
-    // many of these tools exit non-zero when they find issues — keep stdout
+    // many of these tools exit non-zero when they find issues — keep stdout/stderr
     stdout = (e.stdout || '').toString();
-    if (!stdout) die(`${label} produced no output (and failed): ${e.message}`);
+    stderr = (e.stderr || '').toString();
+    failure = e;
   }
+  try { fs.mkdirSync(CACHE_DIR, { recursive: true }); fs.writeFileSync(path.join(CACHE_DIR, `tool-${slug}.stderr.log`), stderr); } catch { /* best effort */ }
+  if (stderr.trim()) log(`[build-deep-inventory] ${label} stderr:\n${stderr.trimEnd()}`);
+  const tail = stderr.trim() ? `\n--- ${label} stderr ---\n${stderr.trimEnd()}` : '';
+  if (!stdout) die(`${label} produced no output${failure ? ` (exit ${failure.status ?? '?'}): ${failure.message}` : ''}${tail}`);
   try { return JSON.parse(stdout); }
-  catch (e) { die(`${label} did not return valid JSON: ${e.message}`); }
+  catch (e) { die(`${label} did not return valid JSON: ${e.message}${tail}`); }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/cleanup/validate-before-delete.sh
+++ b/scripts/cleanup/validate-before-delete.sh
@@ -104,15 +104,18 @@ for g in "${NEVER_AUTO_DELETE_GLOBS[@]}"; do
 done
 
 # ---- 0b / 2 / 3. audit/ artefacts cross-check (when present) ----
+# NB: the JSON path and $REL are passed to `node -e` via process.argv, never spliced
+# into the JS source — a path/basename containing a quote, backtick or ${...} must not
+# be able to alter the probe (this script gets run on arbitrary repo paths).
 RUNTIME_JSON="$REPO_ROOT/audit/runtime-entrypoints.json"
 DYN_JSON="$REPO_ROOT/audit/dynamic-import-edges.json"
 if [[ -f "$RUNTIME_JSON" ]] && command -v node >/dev/null 2>&1; then
-  if node -e "const j=require('$RUNTIME_JSON'); process.exit((j.runtime_files||[]).includes('$REL')?0:1)" 2>/dev/null; then
+  if node -e 'const j=require(process.argv[1]); process.exit((j.runtime_files||[]).includes(process.argv[2])?0:1)' "$RUNTIME_JSON" "$REL"; then
     report_hit "[RUNTIME-ENTRYPOINT] '$REL' is listed in audit/runtime-entrypoints.json — DO NOT delete."
   fi
 fi
 if [[ -f "$DYN_JSON" ]] && command -v node >/dev/null 2>&1; then
-  if node -e "const j=require('$DYN_JSON'); process.exit((j.edges||[]).some(e=>e.to==='$REL')?0:1)" 2>/dev/null; then
+  if node -e 'const j=require(process.argv[1]); process.exit((j.edges||[]).some((e)=>e.to===process.argv[2])?0:1)' "$DYN_JSON" "$REL"; then
     report_hit "[DYNAMIC-IMPORT] '$REL' is the target of a dynamic import (audit/dynamic-import-edges.json)."
   fi
 fi


### PR DESCRIPTION
Two small, tooling-only follow-ups from the #441/#447 review — no `backend/`/`frontend/` source, no behaviour change to the generated artefacts.

### 1. `scripts/cleanup/validate-before-delete.sh` — stop splicing into `node -e` source

The `audit/runtime-entrypoints.json` / `audit/dynamic-import-edges.json` cross-check probes built a `node -e "...require('$JSON')...includes('$REL')..."` string by interpolating `$REL` (and the JSON path) **into the JS source**. This script gets run on arbitrary repo paths; a path/basename containing `'`, `` ` `` or `${...}` could alter the probe. Both probes now pass the values as `process.argv[1]` / `process.argv[2]`:

```bash
node -e 'const j=require(process.argv[1]); process.exit((j.runtime_files||[]).includes(process.argv[2])?0:1)' "$RUNTIME_JSON" "$REL"
```

Verified: hostile `$REL` (`x') ; process.exit(99) ; //`) → exit 1 (not found), **not** 99; real entrypoint (`frontend/app/root.tsx`) → exit 0; `./validate-before-delete.sh frontend/app/root.tsx` still prints `[RUNTIME-ENTRYPOINT] … DO NOT delete`. `bash -n` clean.

### 2. `scripts/audit/build-deep-inventory.js` — `runJson` keeps tool stderr as evidence

`runJson()` ran `dependency-cruiser` / `knip` with `stdio: ['ignore', 'pipe', 'ignore']` — a tool that crashed or warned left **no trace** (`"<tool> produced no output"` and nothing else). For an audit-first system stderr *is* evidence. Now:
- `stdio: ['ignore', 'pipe', 'pipe']` — stderr captured (incl. on non-zero exit, via `e.stderr`);
- tee'd to `audit/cache/tool-<label>.stderr.log` (the `cache/` dir is gitignored but is exactly what a CI run would upload as an artefact);
- echoed to the generator's own stderr (visible in the run log);
- folded into the `die()` message on failure (`exit <code>` + the stderr tail).

`node --check` clean.

### Not done here (deliberate)
- The migration-parsing `confidence` cap (low/medium, never high) in `build-db-usage-map.js` stays as-is — that's the *correct* design for regex-only SQL parsing (PL/pgSQL bodies, `EXECUTE`, dynamic SQL, triggers, indirect RPCs, views, PostgREST, RLS policies all defeat high certainty without a real SQL AST + runtime traces). The map stays advisory / non-destructive / ADR-gated.
- The `audit:inventory:check` CI wiring (`.github/workflows/audit.yml`) remains PR-7's job — "once the map is stable".

🤖 Generated with [Claude Code](https://claude.com/claude-code)