### PR TITLE
docs(ops): refresh cleanup-targets.md against PR-0a/0b deep-audit SoT

### DIFF
--- a/.claude/knowledge/ops/cleanup-targets.md
+++ b/.claude/knowledge/ops/cleanup-targets.md
@@ -2,18 +2,21 @@
 scope: Ops / Cleanup backlog
 audience: human + Claude
 sources:
-  - audit-reports/phase0-baseline.json
-  - npm run audit:knip
-  - npm run audit:madge
-last_scan: 2026-04-24
+  - audit/cleanup-plan-by-domain.md   # Phase 2 driver — séquence canon PR-2…PR-6 (PR-0b)
+  - audit/risk-register.md            # par domaine : surface / candidats / cycles / couverture / risque (PR-0b)
+  - audit/runtime-entrypoints.json    # zone never-auto-delete + nestjs_unreachable_modules (PR-0a)
+  - audit/dead-code-candidates.json   # 339 candidats high/med/low (PR-0a)
+  - audit/cycle-map.json              # 15 cycles (PR-0a)
+  - audit/db-usage-map.json           # 60 candidate-orphan tables / 141 candidate-orphan RPC (PR-0b)
+  - audit-reports/phase0-baseline.json # ratchet baseline (PR-1 audit-baseline = #267 en cours)
+last_scan: 2026-05-13
 ---
 
 # Cleanup Targets — Backlog structuré
 
-> Source des chiffres : Phase 0 baseline capturée 2026-04-24 sur commit
-> `c18cd233`. Taux de faux positifs réel mesuré : **15-20 %** (pas 60-70 %
-> comme initialement suspecté — le plugin knip `nest` et `remix` sont
-> actifs et font leur job sur la majorité des classes DI / routes).
+> **SoT à jour pour les chiffres et la séquence des PRs : [`audit/cleanup-plan-by-domain.md`](../../../audit/cleanup-plan-by-domain.md) + [`audit/risk-register.md`](../../../audit/risk-register.md)** (générés par `npm run audit:inventory` depuis PR-0a/0b mergés 2026-05-11). Ce doc garde : (a) les **statuts PR par cluster** (in-progress / done / wontfix), (b) les **procédures batch** locales, (c) les **décisions humaines** (fusion vs delete, *decision pending*), (d) l'**historique** des cleanup-waves. Il ne duplique plus les chiffres bruts — les sections numériques pointent vers `audit/*.json`.
+>
+> Snapshot 2026-05-13 (post-#441/#447/#448, commit `cd3dea5c`) : **339 dead-code candidates** (high 23 / med 222 / low 94) · **15 cycles** · **41 duplicate exports** · **82 `no-deep-module-access` violations** · DB : 60 candidate-orphan tables (`low`) + 141 candidate-orphan RPC (`medium`). Taux de faux positifs ~15-20 % comme observé en 2026-04-24 — knip + plugin Nest auto-activé (`@nestjs/*` détecté) + plugin Remix font leur job sur les classes DI / routes.
 
 ## Légende des statuses
 
@@ -24,24 +27,28 @@ last_scan: 2026-04-24
 
 ## Section 1 — Obsolètes évidents
 
-### Scripts `.js` à la racine `backend/` (76 fichiers)
+### Scripts `.js` à la racine `backend/` — ~~76~~ → **14 fichiers** (wave largement attaquée)
 
-Script de dev / migration / debug laissés en place. Aucune référence runtime ni import.
+État 2026-05-13 : `git ls-files 'backend/*.js' 'backend/*.mjs'` → **14** (vs 76 en 2026-04-24). 0 `check-*.js` / 0 `deploy-rpc-*.js` / 0 `populate|assign|debug|fix-*.js` restants — les 3 patterns originaux sont **vidés**. Status : `mostly done` — re-checker les 14 résiduels au prochain pass.
 
-| Pattern | Count | Exemples | Status |
-|---|---|---|---|
-| `backend/check-*.js` | ~25 | `check-bmw-data.js`, `check-cgc-data.js`, `check-clio-structure.js`, `check-db-stats.js`, `check-display-types.js`, `check-models.js`, `check-pieces-gamme-columns.js`, `check-supabase-tables.mjs`, `check-tables.js`, `check-type-9040.js`, `check-type-id.js`, `check-type-modele-link.js`, `check-v2-duplicates.js`, `check-v3-candidates.js`, `check-vlevel.js`, `check-volumes.js`, `check-function-exists.js`, `check-9040-usage.js`, `check-bestsellers-data.js`, `check-tables-columns.js` | `backlog` |
-| `backend/deploy-rpc-*.js` | ~12 | `deploy-oem-refs-rpc.js`, `deploy-rpc-bestsellers.js`, `deploy-rpc-function.js`, `deploy-rpc-function-v2.js` (+ v3/v4/v5/v6) | `backlog` |
-| `backend/populate-*.js`, `backend/assign-*.js`, `backend/debug-*.js`, `backend/fix-*.js` | ~15 | `populate-clio3-pilot.js`, `assign-v4-fixed.js`, `debug-v4.js`, `fetch-trends-volumes.js`, `analyze-options.js`, `analyze_gammes_structure.js` | `backlog` |
+**Procédure** (toujours valable pour le résidu et tout futur dump scripts à la racine) : `./scripts/cleanup/validate-before-delete.sh backend/<file>.js` puis `git rm`. Par batch de 10-15.
 
-**Procédure** : `./scripts/cleanup/validate-before-delete.sh backend/<file>.js` puis `git rm`. Par batch de 10-15 pour review fluide. Ouvrir 3-4 PRs.
+### Modules NestJS unreachable — drill-down 2026-05-13
 
-### Module `backend/src/modules/knowledge-graph/` (5 fichiers)
+Source d'évidence : [`audit/runtime-entrypoints.json#nestjs_unreachable_modules`](../../../audit/runtime-entrypoints.json) (la BFS DI depuis `app.module.ts`/`worker.module.ts` ne les atteint pas) + grep statique d'importeurs sur `backend/src/**`. **39 candidats sur les 339 totaux** sont concentrés dans ces 6 sous-arbres.
 
-- Import commenté dans `backend/src/app.module.ts` → module jamais chargé en runtime
-- Tous fichiers flaggés unused par knip
-- **Action à décider** : `delete` (si l'intention a été abandonnée) ou `promote` (restaurer l'import + ajouter tests)
-- Status : `backlog — decision pending`
+| Module | Fichiers | 1er commit | Importeurs statiques | Doc humaine | Verdict |
+|---|---|---|---|---|---|
+| `modules/upload/` | 10 | 2025-08-28 | **aucun** | `.claude/knowledge/modules/upload.md` | **clearly dead** — candidat delete |
+| `modules/agentic-engine/` | 14 | 2026-03-09 | **aucun** | knowledge note seule | **clearly dead** — candidat delete |
+| `modules/mcp-validation/` | **19** | 2026-01-26 | **aucun** | knowledge note seule | **clearly dead** — candidat delete (plus gros bucket) |
+| `modules/substitution/` | 6 | 2026-01-12 | **aucun** | knowledge note + ref `.claude/knowledge/integrations/parts-feed.md` | **likely dead** — vérifier le lien parts-feed avant delete |
+| `modules/knowledge-graph/` | 6 | 2025-12-30 | `app.module.ts` ligne 59 + 224 (**commentés** `DEV ONLY — Experimental`) | cette section, déjà flaggée backlog 2026-04-24 | `backlog — decision pending: delete vs promote` |
+| `modules/blog-metadata/` | 3 | 2025-10-04 | **aucun** | Section 3 (fusion candidate) | **refactor, pas delete** — fusion `→ blog/metadata/` |
+
+0 dynamic import edge vers aucun de ces 6 sous-arbres ([`audit/dynamic-import-edges.json`](../../../audit/dynamic-import-edges.json)). Aucun n'est dans `runtime-entrypoints.json#never_auto_delete_globs`. Toutes les conditions #0-#6 de `validate-before-delete.sh` à re-vérifier avant `git rm`.
+
+**Action recommandée** : 4 PRs séparées (`upload`, `agentic-engine`, `mcp-validation`, `substitution`), 1 par module, chacune passant par `validate-before-delete.sh` + `npm run build` ×2 + `npm test`. `knowledge-graph` reste en `decision pending` (delete vs restore) — choix humain. `blog-metadata` traité via Section 3 (fusion).
 
 ### Templates `.spec/templates/*.ts` orphans
 
@@ -49,28 +56,23 @@ Script de dev / migration / debug laissés en place. Aucune référence runtime 
 - Tous flaggés unused
 - Status : `backlog — vérifier si référencés par un générateur (scripts/generate-specs.sh)`
 
-## Section 2 — Dead frontend components (147 fichiers `.tsx`)
+## Section 2 — Dead frontend components — voir PR-4 du plan canon
 
-**Tous dans `frontend/app/components/`** — aucun sous `app/routes/` (plugin remix OK).
-Chaque sous-dossier est une **PR batch** candidate.
+État 2026-05-13 : **187 candidats `frontend-shared`** (high 7 / med 148 / low 32) + **29 duplicate exports** dans ce cluster — le plus gros bucket du repo. Tous dans `frontend/app/{components,hooks,utils,services}/` — **aucun sous `app/routes/`** (plugin Remix OK).
 
-| Sous-dossier | ~Count | Note |
-|---|---|---|
-| `components/admin/` | ~25 | Dashboards / gestion internes — valider si tous les écrans admin sont encore utilisés |
-| `components/cart/` | ~10 | `AddToCartButton`, `CartIcon`, `CartItem` — certains peuvent être d'anciennes versions avant refonte |
-| `components/catalog/` | ~15 | `FilterAccordion`, `PiecesCatalogGrid`, `PurchaseGuide`, `ProductCatalog` — vérifier les intents R2 / R4 live |
-| `components/constructeurs/` | ~10 | `BrandHero` + variants — pages R7 brand |
-| `components/account/` | ~5 | `UserShipmentTracking` etc. — flow customer |
-| `components/blog/` | ~8 | Mis en place puis remplacé |
-| `components/vehicle/r8/sections/` | ~5 | Visibles sur git status récent (créées en parallèle d'autres PRs) — **vérifier activement** avant delete |
-| autres | ~70 | Répartis entre `common/`, `diagnostic/`, `seo/`, `navigation/`, `layout/` |
+Le détail (sous-dossier × count × note) et la séquence batch sont maintenant dans **PR-4** de [`audit/cleanup-plan-by-domain.md`](../../../audit/cleanup-plan-by-domain.md) (Step B = delete confirmé-orphan par batch ~30-40 → PR-4a / PR-4b / PR-4c ; Step C = collapse les 29 duplicate exports). Ne pas dupliquer les chiffres ici — re-générer via `npm run audit:inventory` avant chaque batch.
 
-**Procédure batch** par sous-dossier :
+**Procédure batch** par sous-dossier (inchangée) :
 1. `ls frontend/app/components/<subdir>/*.tsx` → liste
-2. Pour chaque : `validate-before-delete.sh <path>`
+2. Pour chaque : `validate-before-delete.sh <path>` + grep manuel (basename, dynamic import, Remix `useLoaderData` indirection)
 3. Supprimer les SAFE, documenter les BLOCKED
-4. `npm run build` (Remix build catch les refs hiérarchiques)
-5. PR ciblée "chore(cleanup): remove unused components in `<subdir>/`"
+4. **Supprimer aussi les `*.test.tsx` co-localisés**
+5. `npm run build` ×2 + `npm test` (Remix build catch les refs hiérarchiques)
+6. PR ciblée "chore(cleanup): remove unused components in `<subdir>/`"
+
+Statuts PR connus (à compléter quand mergent) :
+- #158 — `chore(cleanup): remove 3 dead search components (batch 2)` — `in-progress-pr#158` (OPEN depuis 2026-04, vieillissant)
+- #160 — `chore(cleanup): remove 4 dead forms components (batch 3)` — `in-progress-pr#160` (idem)
 
 ## Section 3 — Fusion candidates
 
@@ -83,9 +85,9 @@ Chaque sous-dossier est une **PR batch** candidate.
 
 Fusions = PR **plus lourdes** que simple delete (nécessitent update des imports côté consumers). Faire séparément des cleanup "simple delete".
 
-## Section 4 — Cycles (17 au total)
+## Section 4 — Cycles (**15** au total, ~~17~~)
 
-Classification tirée de `npm run audit:madge` + inspection code.
+État 2026-05-13 : [`audit/cycle-map.json`](../../../audit/cycle-map.json) en compte **15** (vs 17 estimés en 2026-04-24 — 2 cycles fortuits ont été résolus depuis). Liste exhaustive : voir le JSON ; classification humaine ci-dessous toujours valable. Séquence d'attaque dans PR-5 du plan canon ([`audit/cleanup-plan-by-domain.md`](../../../audit/cleanup-plan-by-domain.md) §PR-5).
 
 ### Fortuits (résolus par 1 inversion d'import, voir playbook)
 
@@ -117,29 +119,33 @@ Classification tirée de `npm run audit:madge` + inspection code.
 Les cycles "acceptables" sont documentés ici comme **explicitement tolérés**.
 À re-évaluer si une nouvelle règle `no-circular` strict s'active côté CI.
 
-## Section 5 — Dependency-cruiser violations (148 warnings)
+## Section 5 — Dependency-cruiser violations
 
-Breakdown exact disponible via `npm run audit:depcruise 2>&1 | tail -100`. Principales catégories :
+État 2026-05-13 : breakdown précis dans [`audit/module-boundaries.json`](../../../audit/module-boundaries.json) (`cross_domain_edges` + `deep_access_violations`). Principales catégories :
 
-- `no-circular` — duplicates des 17 cycles (chacun appelé plusieurs fois selon l'entry point)
-- `no-orphans` — fichiers sans dépendants visibles (overlap partiel avec knip unused)
-- `no-deep-module-access` — imports cross-modules directs (targets de refactor "module barrels")
-- `no-non-package-json` — 1 seul hit : `file-type` importé par `upload/services/file-validation.service.ts` sans entrée package.json → **phantom dep**, à corriger rapidement (`npm i -D file-type` ou retirer l'import).
+- `no-circular` — duplicates des **15** cycles (chacun appelé plusieurs fois selon l'entry point) → voir Section 4 + PR-5.
+- `no-orphans` — fichiers sans dépendants visibles (overlap partiel avec knip unused) → ils alimentent `audit/dead-code-candidates.json` (PR-3/PR-4).
+- `no-deep-module-access` — **82 violations** : `admin` 32, `blog` 23, `gamme-rest` 5, `vehicles` 5, `seo` 4, `cart`/`orders`/`rag-proxy` 2 each, autres 1 → cible PR-6 (barrels, surface publique).
+- ~~`no-non-package-json` — phantom dep `file-type`~~ → **RÉSOLU** : `backend/package.json` déclare `"file-type": "^20.4.1"` en `dependencies` (toujours importé par `upload/services/file-validation.service.ts:11`, mais le module `upload/` est lui-même candidat à la suppression, cf. Section 1).
 
-## Priorisation recommandée
+## Priorisation recommandée — état 2026-05-13
 
-| Ordre | Action | Effort | Gain |
-|---|---|---|---|
-| 1 | Archiver les 76 `.js` backend racine | Faible (2h) | Gros volume éliminé, 0 risque |
-| 2 | Fix phantom dep `file-type` | Très faible (15 min) | Promouvoir `no-non-package-json` à `error` |
-| 3 | Delete 147 .tsx components par batch de sous-dossiers | Moyen (1j itératif) | Nettoie le frontend, signal/bruit gagné |
-| 4 | Fusion `blog-metadata/` → `blog/metadata/` | Faible (1h) | Supprime fragment artificiel |
-| 5 | Fusion `customers/` DTO → `users/dto/` | Très faible (30 min) | Idem |
-| 6 | Résoudre 3 cycles fortuits (voir playbook) | Moyen (3h total) | -3 cycles, gain clarté |
-| 7 | Fusion `seo-logs/` → `seo/` | Moyen | Consolidation logique |
-| 8 | Split `admin/` god-module | Lourd, ADR requis | Long terme |
-| 9 | Refactor cycles structurels rag-proxy / auth↔users | Lourd | Long terme, casse cycle restants |
+| Ordre | Action | Effort | Gain | Statut |
+|---|---|---|---|---|
+| ~~1~~ | ~~Archiver les 76 `.js` backend racine~~ | — | — | **mostly done** (76 → 14, voir Section 1) |
+| ~~2~~ | ~~Fix phantom dep `file-type`~~ | — | — | **done** (déclaré en `dependencies`, voir Section 5) |
+| 3 | **PR-3 Step B** — delete 4 modules unreachable clearly-dead (`upload`, `agentic-engine`, `mcp-validation`, `substitution`) | Moyen (4 PRs, ≤1j chacune) | -49 fichiers, -4 sous-arbres orphelins | `backlog` |
+| 4 | Decider `knowledge-graph` (delete vs promote) | Faible (décision) puis Moyen (exécution) | -6 fichiers OU intent restauré | `backlog — decision pending` |
+| 5 | Fusion `blog-metadata/` → `blog/metadata/` | Faible (1h) | Supprime fragment artificiel | `backlog` |
+| 6 | **PR-4** Frontend Remix-aware — 187 candidats `frontend-shared` + 29 dup exports, par batch | Moyen-lourd (~3-4 PRs) | Cleanup du gros bucket | `backlog` (+ #158/#160 vieillissants) |
+| 7 | Fusion `customers/` DTO → `users/dto/` | Très faible (30 min) | Cohérence | `backlog` |
+| 8 | **PR-5a** — cycles fortuits (`root↔useRootData`, config-types cluster, rag-proxy×3) | Moyen (3h total) | -7 cycles, gain clarté | `backlog` |
+| 9 | Fusion `seo-logs/` → `seo/` | Moyen | Consolidation logique | `backlog` |
+| 10 | **PR-5b** — cycles intra-module orchestrateur-workers + promotion `no-circular warn→error` | Lourd | -8 cycles restants, gate strict | `backlog` |
+| 11 | **PR-6** — 82 `no-deep-module-access` violations (admin 32 + blog 23 prioritaires) + barrels + promotion `warn→error` | Lourd | Frontière modules nette | `backlog` |
+| 12 | Split `admin/` god-module | Lourd, ADR requis | Long terme | `backlog — ADR à rédiger` |
+| 13 | DB surface (141 RPC + 60 tables candidats) | Lourd, hors monorepo | Vault ADR + RPC Gate, jamais code PR ici | `backlog — vault track` |
 
 ---
 
-_Mettre à jour ce doc à chaque PR cleanup mergée (status column). Mettre à jour `audit-reports/phase0-baseline.json` parallèlement._
+_Mettre à jour ce doc à chaque PR cleanup mergée (column Statut). Pour les chiffres : ne JAMAIS éditer à la main — `npm run audit:inventory` régénère `audit/*.json`. Pour le baseline ratchet : `npm run audit:baseline:refresh` (manuel, maintainer-only — cf. PR #267)._


### PR DESCRIPTION
Doc-only refresh of `.claude/knowledge/ops/cleanup-targets.md` (last_scan was 2026-04-24, commit `c18cd233`). Aligns the backlog doc with today's verifiable numbers from `audit/*` (post-#441/#447/#448, commit `cd3dea5c`), and adds the per-module evidence the doc was missing. **No code touched, no behaviour change.**

### Stale numbers reconciled

| Claim (2026-04-24) | Reality (2026-05-13) | Evidence |
|---|---|---|
| 76 `.js` à la racine `backend/` | **14** (wave largement shippée — 0 `check-*`, 0 `deploy-rpc-*`, 0 `populate\|assign\|debug\|fix-*`) | `git ls-files 'backend/*.js' 'backend/*.mjs'` |
| `knowledge-graph/` = 5 fichiers | **6 fichiers**, import dans `app.module.ts` confirmé commenté lignes 59 + 224 (`DEV ONLY — Experimental`) | grep direct |
| 17 cycles | **15** (2 fortuits résolus depuis) | [`audit/cycle-map.json#count`](../audit/cycle-map.json) |
| `file-type` phantom dep | **résolu** — déclaré en `backend/package.json` `"dependencies": { "file-type": "^20.4.1" }`. Toujours importé par `upload/services/file-validation.service.ts:11`, mais `upload/` est lui-même candidat à la suppression. | `package.json` |
| 147 dead components | **187 candidats `frontend-shared`** (high 7 / med 148 / low 32) + 29 dup exports | [`audit/risk-register.md`](../audit/risk-register.md) |

### Nouveau contenu — evidence-based

**Section 1 "Modules NestJS unreachable — drill-down 2026-05-13"** : la table des 6 sous-arbres flaggés par `runtime-entrypoints.json#nestjs_unreachable_modules` avec verdict par module :

| Module | Fichiers | Importeurs statiques | Verdict |
|---|---|---|---|
| `upload/` | 10 | aucun | clearly dead |
| `agentic-engine/` | 14 | aucun | clearly dead |
| `mcp-validation/` | 19 | aucun | clearly dead (plus gros bucket) |
| `substitution/` | 6 | aucun (mais ref dans `.claude/knowledge/integrations/parts-feed.md`) | likely dead — vérifier parts-feed |
| `knowledge-graph/` | 6 | `app.module.ts` commenté | `decision pending` (delete vs promote) |
| `blog-metadata/` | 3 | aucun | fusion `→ blog/metadata/` (déjà Section 3) |

Grep direct + `audit/dynamic-import-edges.json` (0 dynamic edge vers ces sous-arbres) + aucun dans `runtime-entrypoints.json#never_auto_delete_globs`. **Conditions #0-#6 de `validate-before-delete.sh` à re-vérifier avant tout `git rm` ; PR-3 Step B donc faisable en 4 PRs séparées (`upload`, `agentic-engine`, `mcp-validation`, `substitution`).**

### Frontmatter

`sources:` réaligné sur les artefacts `audit/*` (nouveau SoT depuis PR-0a/0b mergés) + `audit-reports/phase0-baseline.json` pour le ratchet (PR-1 = #267, en cours). `last_scan: 2026-04-24 → 2026-05-13`.

### Priorisation

| Ordre | Action | Statut |
|---|---|---|
| ~~1~~ | ~~Archiver les 76 `.js` backend racine~~ | **mostly done** |
| ~~2~~ | ~~Fix phantom dep `file-type`~~ | **done** |
| 3 | PR-3 Step B — delete les 4 modules unreachable clearly-dead | `backlog` |
| 4 | Décider `knowledge-graph` (delete vs promote) | `backlog — decision pending` |
| 5 | Fusion `blog-metadata/` → `blog/metadata/` | `backlog` |
| 6 | PR-4 frontend Remix-aware (187 candidats) | `backlog` (+ #158/#160 vieillissants) |
| 7-13 | … (fusions, cycles PR-5a/5b, boundaries PR-6, admin split, DB surface) | `backlog` |

### Non touché (par discipline de scope)

- Sections "Templates `.spec/templates/*.ts` orphans", "Fusion candidates" tableau Section 3, classification humaine des cycles (Section 4 fortuits / structurels / acceptables) — sont des **décisions humaines**, préservées telles quelles.
- Les chiffres détaillés du bucket frontend (sous-dossiers × count) — supprimés ici, déjà dans `audit/cleanup-plan-by-domain.md` PR-4. Ne pas dupliquer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)