### PR TITLE
chore(db): set ALTER DEFAULT PRIVILEGES before Supabase 2026-10-30 Data API change

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -534,6 +534,11 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: medium
+  - glob: backend/supabase/migrations/*default_privileges*
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: high
   - glob: docs/seo/audit-orders-cart-link.md
     domain: D8
     owner: '@ak125/admin-team'

--- a/backend/supabase/migrations/20260513_default_privileges_data_api_post_oct30.sql
+++ b/backend/supabase/migrations/20260513_default_privileges_data_api_post_oct30.sql
@@ -27,6 +27,13 @@
 --   - Memory: feedback_supabase_grant_explicit_for_new_projects.md
 -- =============================================================================
 
+-- Timeout settings required by squawk `require-timeout-settings` (canon
+-- monorepo-wide). ALTER DEFAULT PRIVILEGES is catalog-only (no row scan, no
+-- relation lock), so these timeouts are protective only — they cap pathological
+-- lock contention on `pg_default_acl` during catalog write.
+SET lock_timeout = '1s';
+SET statement_timeout = '5s';
+
 -- Tables: backend (NestJS via service_role) gets full DML by default.
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;

--- a/backend/supabase/migrations/20260513_default_privileges_data_api_post_oct30.sql
+++ b/backend/supabase/migrations/20260513_default_privileges_data_api_post_oct30.sql
@@ -1,0 +1,51 @@
+-- =============================================================================
+-- ALTER DEFAULT PRIVILEGES — Supabase Data API auto-expose deprecation
+-- =============================================================================
+--
+-- Context: Supabase deprecates the public schema auto-expose default.
+--   - 2026-05-30 : enforced on NEW projects only
+--   - 2026-10-30 : enforced on ALL EXISTING projects (this one included)
+--
+-- After 2026-10-30, every table created without an explicit GRANT will return
+-- PostgREST error 42501 to supabase.from() / supabase.rpc() callers.
+--
+-- This migration sets DEFAULT privileges for FUTURE objects in schema `public`
+-- so that the backend (service_role) keeps working transparently. Frontend
+-- exposure (anon / authenticated) is INTENTIONALLY left to per-table explicit
+-- GRANTs — forcing a security review (RLS + scope) at table creation time.
+--
+-- Function defaults are also left out on purpose: the codebase has ~217
+-- migrations following the explicit "GRANT EXECUTE ON FUNCTION ... TO ..."
+-- pattern. Keeping that discipline avoids auto-exposing SECURITY DEFINER
+-- helpers.
+--
+-- Idempotent: ALTER DEFAULT PRIVILEGES is replace-on-conflict semantics.
+-- Scope: schema `public` only. `_archive`, `kg_*`, etc. are NOT touched.
+--
+-- References:
+--   - https://supabase.com/blog/data-api-access-changes (newsletter 2026-05)
+--   - Memory: feedback_supabase_grant_explicit_for_new_projects.md
+-- =============================================================================
+
+-- Tables: backend (NestJS via service_role) gets full DML by default.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;
+
+-- Sequences: USAGE + SELECT so SERIAL / IDENTITY inserts work for service_role.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO service_role;
+
+-- DELIBERATELY OMITTED:
+--   * ON TABLES TO anon, authenticated     — force per-table GRANT + RLS review
+--   * ON FUNCTIONS TO any role             — keep explicit RPC exposure pattern
+--   * ON SCHEMAS                           — schema usage is handled at role level
+--
+-- Convention going forward (post 2026-10-30):
+--   Every new table / view / RPC exposed via the Data API MUST ship its
+--   migration with an explicit GRANT block, e.g.:
+--
+--     GRANT SELECT ON public.my_new_table TO anon, authenticated;
+--     ALTER TABLE public.my_new_table ENABLE ROW LEVEL SECURITY;
+--     CREATE POLICY "..." ON public.my_new_table FOR SELECT ...;
+--
+--     GRANT EXECUTE ON FUNCTION public.my_new_rpc(...) TO anon, authenticated, service_role;


### PR DESCRIPTION
## Summary

- Adds `backend/supabase/migrations/20260513_default_privileges_data_api_post_oct30.sql`
- Sets `ALTER DEFAULT PRIVILEGES IN SCHEMA public` for `service_role` (tables + sequences) so the backend keeps working transparently after the Supabase Data API enforcement
- **No grant for `anon` / `authenticated` by default** — every new table exposed to the frontend must ship its migration with an explicit `GRANT` + RLS review (keeps the current ~217-migration discipline)
- **No default for `FUNCTIONS`** — explicit `GRANT EXECUTE … TO …` pattern is preserved, avoids auto-exposing `SECURITY DEFINER` helpers

## Why now

Supabase newsletter (received 2026-05-13) confirms two enforcement waves:

| Date | Scope |
|------|-------|
| 2026-05-30 | Default OFF on **new projects** |
| **2026-10-30** | Enforced on **all existing projects** (PROD AutoMecanik included — 3 Data-API projects detected on the account) |

Without this migration, the first table created in `public` after 2026-10-30 will silently break `supabase.from('X').select()` with PostgREST error `42501`. Existing tables keep their grants (backward compat).

## Why this exact shape

- `service_role` default = backend NestJS unaffected
- `anon`/`authenticated` left explicit = forces RLS review at table creation (memory `feedback_supabase_grant_explicit_for_new_projects.md`)
- Idempotent — re-applying is a no-op
- Scope strictly `public` — `_archive`, `kg_*` and other internal schemas not touched

## Test plan

- [ ] CI green (lint, type-check, build)
- [ ] Apply on a dev branch / staging Supabase first; confirm `supabase.from()` + `supabase.rpc()` still work on existing tables
- [ ] Create a throw-away test table after migration, verify backend (service_role) can DML it without explicit grant
- [ ] Verify a new anon-exposed table without explicit grant returns `42501` — that's the desired guardrail
- [ ] Apply on PROD project ≥ 60 days before 2026-10-30 enforcement date

## Follow-ups (not in this PR)

- Lint rule / pre-commit check that every new migration creating a public table also ships a `GRANT` block (or a `-- anon-restricted` opt-out comment)
- Run **Security Advisor** in Supabase dashboard for the 3 detected Data-API projects to audit existing exposure
- Decide if the staging / dev-branch projects need the same migration applied manually (they may already be 2026-05-30 cohorts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)