### PR TITLE
docs(audit): align safe-delete + baseline notes with ratchet pr-1 + pr-2

### DIFF
--- a/.claude/knowledge/ops/safe-delete-procedure.md
+++ b/.claude/knowledge/ops/safe-delete-procedure.md
@@ -70,12 +70,15 @@ Les PRs de cleanup doivent :
 - **Regrouper par cohérence** (ex : tout `frontend/app/components/admin/` dans 1 PR, pas mélanger avec `/cart/`)
 - **Ne pas régresser la baseline** : le CI `audit.yml` lance `audit:baseline` qui bloque si les counts régressent au-delà des seuils.
 
-Après merge d'une PR cleanup, le mainteneur refresh la baseline :
+Après merge d'une PR cleanup, le mainteneur refresh la baseline en une commande (PR #267) :
 ```bash
-npm run audit:baseline:json > /tmp/current.json
-# Merge manually the "current" numbers into audit-reports/phase0-baseline.json
-git commit -m "chore(baseline): refresh after #XXX cleanup"
+npm run audit:baseline:refresh
+git commit -am "chore(baseline): refresh after #XXX cleanup"
 ```
+
+Le refresh ré-exécute les quatre audits, écrit atomiquement la baseline, et préserve `thresholds` / `notes` / `version` plus les sous-champs que les parsers n'extraient pas. Garde `ensureDepsInstalled()` : refuse de tourner si `node_modules/{knip,madge,dependency-cruiser,@ast-grep/cli}` manque — lance `npm ci` d'abord.
+
+Depuis PR #449, le refresh affiche aussi un **warning stderr** listant toute métrique dont le `+delta` dépasse son seuil avant d'écrire — `Ctrl-C` si la régression est accidentelle, sinon le maintainer "banque" volontairement les nouveaux counts.
 
 ## Limites honnêtes de `validate-before-delete.sh`
 

--- a/audit-reports/phase0-baseline.json
+++ b/audit-reports/phase0-baseline.json
@@ -45,6 +45,7 @@
     "ast_grep_errors_delta = 0 means any new blocking rule violation fails CI immediately.",
     "cycles_delta = 0 because any new cycle indicates coupling going the wrong direction.",
     "unused_files tolerates +5 to accommodate genuinely new files (e.g. new controller) that knip hasn't yet traced transitively.",
-    "After each cleanup PR merges, refresh this baseline via `npm run audit:baseline:refresh` and commit the new counts."
+    "After each cleanup PR merges, refresh this baseline via `npm run audit:baseline:refresh` and commit the new counts.",
+    "Since PR #449, --refresh prints a stderr warning listing any metric whose +delta exceeds threshold before writing — Ctrl-C if unintentional."
   ]
 }


### PR DESCRIPTION
## Summary

Closes the doc-truth gap after the audit-baseline ratchet series landed on main as commit [`56cd52c6`](https://github.com/ak125/nestjs-remix-monorepo/commit/56cd52c6) :
- [PR #267](https://github.com/ak125/nestjs-remix-monorepo/pull/267) — `audit:baseline:refresh` script + atomic write + `ensureDepsInstalled()` guard covering all comparator modes
- [PR #449](https://github.com/ak125/nestjs-remix-monorepo/pull/449) — stderr warning listing any metric whose `+delta` exceeds threshold before refresh writes

The two docs touched still referenced the **pre-ratchet** workflow (hand-merging numbers from `audit:baseline:json` into the JSON). This PR aligns them with reality. **Pure docs change, zero impact on tooling behavior or CI gate counts.**

## Changes

### `.claude/knowledge/ops/safe-delete-procedure.md` (lines 73-77)

**Before** :
```bash
npm run audit:baseline:json > /tmp/current.json
# Merge manually the "current" numbers into audit-reports/phase0-baseline.json
git commit -m "chore(baseline): refresh after #XXX cleanup"
```

**After** :
```bash
npm run audit:baseline:refresh
git commit -am "chore(baseline): refresh after #XXX cleanup"
```

Plus two short paragraphs explaining (a) what `--refresh` preserves and the `ensureDepsInstalled()` guard requirement, (b) the PR #449 stderr regression warning and how to react to it.

### `audit-reports/phase0-baseline.json` — `notes[]`

Appends one entry :

> *"Since PR #449, --refresh prints a stderr warning listing any metric whose +delta exceeds threshold before writing — Ctrl-C if unintentional."*

The `notes` field is informational only — `computeDelta()` never reads it, so this diff is invisible to the `🛡️ Deterministic gates` job.

## Why this is its own (third) PR rather than amended into #267 / #449

#267 and #449 are already merged. This is the loop-closing follow-up that lets a maintainer reading `safe-delete-procedure.md` or `phase0-baseline.json` today learn the actual current workflow instead of the pre-ratchet recipe. Done as a separate PR for a clean audit trail.

## Test plan

- [x] `jq -e '.notes | length' audit-reports/phase0-baseline.json` → 6 (was 5), JSON valid
- [x] No `scripts/`, no `package.json`, no `audit-compare-baseline.js` touched — comparator behavior unchanged
- [ ] CI checks pass (no code paths exercised — only the audit gate runs against current counts, and `notes` are ignored by `computeDelta`)

## Out of scope (future PRs in the series)

- `--force` flag required when regressions detected (warn → block escalation)
- Progressive warn → error promotion on stable metrics (waits for empirical signal — see memory `audit-baseline-ratchet-pr3-prep-20260513.md`)
- Auto-cron CI refresh — **deliberately rejected**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
