### PR TITLE
perf(ai-content): enable Anthropic prompt cache on system block

### DIFF
--- a/backend/src/modules/ai-content/providers/anthropic.provider.ts
+++ b/backend/src/modules/ai-content/providers/anthropic.provider.ts
@@ -133,7 +133,18 @@ export class AnthropicProvider implements AIProvider {
         model,
         max_tokens: options.maxTokens || 4096,
         temperature: options.temperature ?? 0.7,
-        system: systemPrompt,
+        // Prompt cache on the system block: identical system prompts across
+        // calls (templates, anti-hallucination rules, advisor escalation 2nd
+        // pass) are billed at ~0.1× after the first hit. Min-size threshold
+        // applies (Sonnet 4 / Opus 4 = 1024 tokens) — below it, the API
+        // silently skips caching, no error.
+        system: [
+          {
+            type: 'text',
+            text: systemPrompt,
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
         messages: [
           {
             role: 'user',


### PR DESCRIPTION
## Summary

- Active `cache_control: { type: 'ephemeral' }` sur le bloc `system` dans `AnthropicProvider.generateContentWithUsage()` (`backend/src/modules/ai-content/providers/anthropic.provider.ts:132`).
- Tous les system prompts (templates de `content-templates.ts`, bloc `antiHallucinationRules` 7 règles dans `seo-generator.service.ts`, 2ᵉ passe Advisor) étaient refacturés au prix plein à chaque appel.
- `cache_read_input_tokens` était déjà **lu** côté usage (l.158-159) mais **jamais alimenté** côté requête — le commentaire l.248 promettait `"preserves cache entry"` sans qu'aucun `cache_control` ne soit posé.

## Impact attendu

| Métrique | Avant | Après (cache warm) |
|---|---|---|
| Input tokens du system block | 100% facturé | ~10% facturé (cache read) |
| Advisor escalation 2ᵉ appel | full system refacturé | cache hit côté Opus |
| Erreur si system < 1024 tokens | n/a | API skip silencieux |

Mesure exacte = via les `cacheRead`/`cacheCreation` exposés dans `AiTokenUsage` (déjà loggués par `AiContentService`). PR-2 ajoutera le hit-rate au log explicite.

## Risques

- **Min-size threshold** : Sonnet 4 / Opus 4 = 1024 tokens. En dessous, l'API ignore le `cache_control` sans erreur.
- **TTL ephemeral** = 5 min. Au-delà, prochain hit recrée le cache (`cache_creation_input_tokens` facturé 1.25×). Templates persistants → effet net positif quasi garanti sur batch jobs.
- Aucun changement de comportement fonctionnel — même output, juste billing différent.

## Test plan

- [x] Typecheck `tsc --noEmit` clean sur `anthropic.provider.ts` (erreurs pré-existantes `@repo/database-types` non liées au patch).
- [ ] CI workflows `ci.yml` doivent passer (lint + build backend).
- [ ] Post-merge en DEV preprod : vérifier 1ʳᵉ requête `cacheCreation > 0`, suivantes `cacheRead > 0` via log `AiContentService`.
- [ ] PR-2 follow-up : exposer hit-rate `cacheRead / (cacheRead + input)` dans le log `Generated N chars`.

## Source

Diagnostic interactif `verifier surconsommation de token` — 3 hotspots identifiés (cache, max_tokens default 4096, advisor duplication). PR-1 traite le hotspot #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)