### PR TITLE
refactor(ai-content): make maxTokens required, drop magic 4096 fallback (stacked on #455)

### DIFF
--- a/backend/src/modules/ai-content/ai-content.service.ts
+++ b/backend/src/modules/ai-content/ai-content.service.ts
@@ -155,7 +155,7 @@ export class AiContentService {
   private async executeWithFailover(
     systemPrompt: string,
     userPrompt: string,
-    options: { temperature?: number; maxTokens?: number },
+    options: { temperature?: number; maxTokens: number },
   ): Promise<{
     content: string;
     usage: AiTokenUsage | null;

--- a/backend/src/modules/ai-content/providers/anthropic.provider.ts
+++ b/backend/src/modules/ai-content/providers/anthropic.provider.ts
@@ -21,7 +21,14 @@ export interface AiTokenUsage {
 
 export interface AiProviderOptions {
   temperature?: number;
-  maxTokens?: number;
+  /**
+   * Required output-token budget per call. Callers must declare an explicit
+   * budget — there is no implicit default. Anthropic bills reserved capacity,
+   * so a silent fallback would either truncate (too low) or over-bill (too
+   * high). DTO layer enforces a Zod `.default(500)` upstream, so internal
+   * callers always have a number to pass.
+   */
+  maxTokens: number;
   model?: string;
 }
 
@@ -131,7 +138,7 @@ export class AnthropicProvider implements AIProvider {
 
       const message = await this.client.messages.create({
         model,
-        max_tokens: options.maxTokens || 4096,
+        max_tokens: options.maxTokens,
         temperature: options.temperature ?? 0.7,
         // Prompt cache on the system block: identical system prompts across
         // calls (templates, anti-hallucination rules, advisor escalation 2nd


### PR DESCRIPTION
## Summary

Stacked on #455 → #453 → main. Cascade-merges naturally.

The `max_tokens: options.maxTokens || 4096` fallback in `AnthropicProvider.generateContentWithUsage()` was **dead code masking a missing contract**:

- DTO Zod schema: `maxLength: z.number().min(50).max(5000).optional().default(500)` → output type is always `number`.
- Every internal caller (5 services + 2 controller helpers) passes a `maxLength` (200 / 500 / 2000 / 2200 / V-Level computed).
- The `|| 4096` could only trigger if a future caller built `AiProviderOptions` directly and forgot the field — silent over-billing on Anthropic's reserved-capacity model.

## The canonical fix (no bricolage)

| Layer | Before | After |
|---|---|---|
| `AiProviderOptions.maxTokens` | `number?` | `number` (required) |
| `executeWithFailover` options | `maxTokens?: number` | `maxTokens: number` |
| `messages.create` | `options.maxTokens \|\| 4096` | `options.maxTokens` |

Future callers can no longer forget the budget — TypeScript fails at compile time. The Zod default at the DTO boundary remains the single source of truth for "what should I bill if the user didn't say".

## Risk

**None for current callers** — audit:

| Caller | maxLength passed | Source |
|---|---|---|
| `seo-generator.service.ts:245` | yes (V-Level via `getMaxTokens`) | runtime computed |
| `buying-guide-seo-draft.service.ts:153` | yes (2000) | constant |
| `buying-guide-seo-draft.service.ts:245` | yes (200) | constant |
| `conseil-enricher.service.ts:2582` | yes (200) | constant |
| `multi-channel-copywriter.service.ts:101` | yes (2200 fallback or template) | constant |
| `generateProductDescription` | yes (lengthMap[length]) | computed |
| `generateSEOMeta` | yes (200) | constant |
| `ai-content.controller.ts` HTTP DTO | Zod `default(500)` | DTO |

Every path resolves to a `number` before reaching the provider. The interface tightening is purely defensive.

## Test plan

- [x] Typecheck `tsc --noEmit` — no new TS errors (pre-existing `@repo/database-types` errors filtered, unrelated).
- [ ] CI green (lint + build + tests).
- [ ] Once #455 + #453 merge: this PR auto-rebases on main, then merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)