### PR TITLE
chore(cleanup): validate-before-delete unreachable-subtree aware (PR-3b prereq)

### DIFF
--- a/scripts/cleanup/validate-before-delete.sh
+++ b/scripts/cleanup/validate-before-delete.sh
@@ -110,7 +110,22 @@ done
 RUNTIME_JSON="$REPO_ROOT/audit/runtime-entrypoints.json"
 DYN_JSON="$REPO_ROOT/audit/dynamic-import-edges.json"
 if [[ -f "$RUNTIME_JSON" ]] && command -v node >/dev/null 2>&1; then
-  if node -e 'const j=require(process.argv[1]); process.exit((j.runtime_files||[]).includes(process.argv[2])?0:1)' "$RUNTIME_JSON" "$REL"; then
+  # The runtime_files list is broad and includes files of NestJS modules that
+  # are NOT reachable from app.module.ts (the entrypoints.nestjs_unreachable_modules
+  # list). For Step B drops of those subtrees, the runtime-entrypoint check must
+  # not blanket-reject — by definition, an unreachable module file is not runtime.
+  if node -e '
+    const j = require(process.argv[1]);
+    const rel = process.argv[2];
+    const runtime = j.runtime_files || [];
+    if (!runtime.includes(rel)) process.exit(1);
+    const unreachable = (j.entrypoints && j.entrypoints.nestjs_unreachable_modules) || [];
+    const subtreeDirs = unreachable
+      .filter((p) => p.startsWith("backend/src/modules/"))
+      .map((p) => p.replace(/[^/]+\.module\.ts$/, ""));
+    if (subtreeDirs.some((d) => rel.startsWith(d))) process.exit(1);
+    process.exit(0);
+  ' "$RUNTIME_JSON" "$REL"; then
     report_hit "[RUNTIME-ENTRYPOINT] '$REL' is listed in audit/runtime-entrypoints.json — DO NOT delete."
   fi
 fi


### PR DESCRIPTION
## Summary

- Plan §11.3 requires \`validate-before-delete.sh\` to say SAFE for every file targeted by Step B (PR-3b-*) drops.
- Step B targets files of NestJS modules in \`audit/runtime-entrypoints.json#entrypoints.nestjs_unreachable_modules\` (the 6 sous-arbres feature in plan §4).
- Current \`[RUNTIME-ENTRYPOINT]\` check tests \`j.runtime_files\` — the broad list of ALL DI-live files **including unreachable**. Result: every Step B candidate gets blanket-rejected. Plan §11.3 + §4 become mechanically contradictory.

## Empirical context

PR-3b-1 (blog-metadata canari) attempted today and rolled back per plan §12.8 after surfacing this gap. Triage artefact (locally produced, not committed) confirmed verdict \`dead_subtree\`: 3 backend files, 0 importer, 0 dynamic, 0 string-ref, 0 BullMQ, 0 real migration ref, 0 frontend consumer.

## Fix

- Runtime-entrypoint check stays in place for **reachable** files.
- For files in \`backend/src/modules/<subtree>/\` where \`<subtree>.module.ts\` is in \`nestjs_unreachable_modules\`, the check passes through (no hit). Semantics: unreachable ≠ runtime, by definition.
- \`marketing-matrix\` (only unreachable outside \`backend/src/modules/\`) intentionally excluded from subtree-dir derivation — allowlisted per plan §12.5, never a Step B target.

## Testing (4 scenarios)

| Scenario | Before | After |
|----------|--------|-------|
| \`blog-metadata.module.ts\` (Step B target) | BLOCKED on RUNTIME-ENTRYPOINT | passes (only KNOWLEDGE hit — auto-gen) |
| \`blog-metadata.controller.ts\` (Step B target) | BLOCKED on RUNTIME-ENTRYPOINT + NESTJS-DI | NESTJS-DI only (bottom-up signal, expected) |
| \`backend/src/app.module.ts\` (reachable + protected) | BLOCKED on NEVER-AUTO-DELETE + RUNTIME | BLOCKED on NEVER-AUTO-DELETE + RUNTIME (unchanged) |
| \`backend/src/modules/seo/.../seo-meta-registry.service.ts\` (reachable) | BLOCKED on RUNTIME-ENTRYPOINT | BLOCKED on RUNTIME-ENTRYPOINT (unchanged) |

## Scope

- 1 file: \`scripts/cleanup/validate-before-delete.sh\` (+16 −1)
- No change to \`audit/*.json\` (read-only consumer).
- No file drops, no source code change, no build/test/CI matrix change.
- Plan §10 compliant: no opportunistic cleanup.

## Test plan

- [ ] CI all green
- [ ] Post-merge: run \`bash scripts/cleanup/validate-before-delete.sh backend/src/modules/blog-metadata/blog-metadata.module.ts\` locally → no [RUNTIME-ENTRYPOINT] hit.
- [ ] PR-3b-1 (blog-metadata canari) opened next, scoped strictly per plan §4 + §11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)