### PR TITLE
fix(lockfile): sync package-lock with frontend tiptap-ecosystem bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -588,7 +588,7 @@
         "@tiptap/extension-italic": "^3.23.1",
         "@tiptap/pm": "^3.23.1",
         "@tiptap/react": "^3.23.1",
-        "@tiptap/starter-kit": "^3.20.0",
+        "@tiptap/starter-kit": "^3.23.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -22795,7 +22795,9 @@
       }
     },
     "node_modules/linkifyjs": {
-      "version": "4.3.2",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "license": "MIT"
     },
     "node_modules/lint-staged": {


### PR DESCRIPTION
## Pourquoi

CI sur **main HEAD** (`2c619e78`, [Deploy run 25809368558](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25810391572)) + toutes les PR ouvertes échouent `npm ci` avec EUSAGE :

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json or npm-shrinkwrap.json are in sync.
npm error Invalid: lock file's linkifyjs@4.3.2 does not satisfy linkifyjs@4.3.3
```

**Root cause** : #444 (tiptap-ecosystem group bump du 2026-05-11) a mis à jour `frontend/package.json` (`@tiptap/starter-kit: "^3.20.0" → "^3.23.1"`) mais le `package-lock.json` qui a été committé contient encore :
- Le snapshot pré-bump du workspace `frontend` (`@tiptap/starter-kit: ^3.20.0`).
- La résolution transitive `linkifyjs@4.3.2` (la nouvelle version de tiptap requiert `linkifyjs@4.3.3`).

Le CI de #444 n'a pas attrapé le bug parce qu'à ce moment-là le lockfile correspondait encore à sa propre intermédiaire ; le décalage n'est devenu bloquant qu'après merge, quand `npm ci` sur d'autres branches a comparé l'état post-bump du registry vs le lockfile statique committé.

## Diff

```diff
- "@tiptap/starter-kit": "^3.20.0",
+ "@tiptap/starter-kit": "^3.23.1",   # frontend workspace snapshot dans le lockfile
...
- "version": "4.3.2",
+ "version": "4.3.3",                  # node_modules/linkifyjs
+ "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+ "integrity": "sha512-…"
```

**4 insertions / 2 deletions** dans `package-lock.json` uniquement. Aucun `package.json` modifié — ils étaient déjà corrects (post-#444), seul le snapshot lockfile était stale.

## Méthode

```bash
npm install --package-lock-only --ignore-scripts
```

Chirurgical — pas de réinstall global, pas de touche aux autres deps.

## Vérification

- `npm ci --dry-run` : ✅ exit 0 après le fix (`added 275, removed 1, changed 7`).
- Aucun fichier source modifié.
- Aucune migration touchée, aucun secret.

## Débloque

- **main Deploy workflow** — actuellement rouge à chaque push.
- **PR #459** (PR-3b prereq — validate-before-delete unreachable-aware) — bloquée par EUSAGE.
- Toutes les autres PRs ouvertes qui re-run leur CI.

→ Une fois mergée, les PRs en file (#459 → PR-3b-1 blog-metadata → cascade PR-3 du plan `/home/deploy/.claude/plans/pr-3-backend-nestjs-aware-deadcode.md`) reprennent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)