### PR TITLE
chore(canon): introduce pipelines + projections registries (ADR-058 prep)

### DIFF
--- a/.github/workflows/canon-registries-validate.yml
+++ b/.github/workflows/canon-registries-validate.yml
@@ -1,0 +1,42 @@
+name: canon-registries-validate
+
+on:
+  pull_request:
+    paths:
+      - ".spec/00-canon/repository-registry/**"
+      - "scripts/canon/validate-cross-references.py"
+      - ".github/workflows/canon-registries-validate.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".spec/00-canon/repository-registry/**"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install ajv-cli
+        run: npm install -g ajv-cli@5 ajv-formats@3
+      - name: Validate pipelines.registry.json
+        run: |
+          ajv validate \
+            -c ajv-formats \
+            -s .spec/00-canon/repository-registry/_schema/pipelines.registry.schema.json \
+            -d .spec/00-canon/repository-registry/pipelines.registry.json
+      - name: Validate projections.registry.json
+        run: |
+          ajv validate \
+            -c ajv-formats \
+            -s .spec/00-canon/repository-registry/_schema/projections.registry.schema.json \
+            -d .spec/00-canon/repository-registry/projections.registry.json
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate cross-references coherence
+        run: python3 scripts/canon/validate-cross-references.py

--- a/.spec/00-canon/pipeline-phases.md
+++ b/.spec/00-canon/pipeline-phases.md
@@ -306,3 +306,8 @@ Implementation : `DecisionTrace` (decisionId, decidedBy, decidedAt, pipelineVers
 | 1.5 | `rag-state.types.ts` (PHASE15_*) | `rag-contracts.types.ts` | `rag-normalization.service.ts` | `20260315_phase15_normalization.sql` |
 | 1.6 | `rag-state.types.ts` (PHASE16_*) | `rag-readiness.types.ts` | `rag-admissibility-gate.service.ts` | `20260316_phase16_admissibility_gate.sql` |
 | 2 | `rag-state.types.ts` (PHASE2_*) | `rag-exploitation.types.ts` | (a venir) | `20260317_phase2_exploitation.sql` |
+
+## Companions machine-readable
+
+- [`pipelines.registry.json`](repository-registry/pipelines.registry.json) — registry des pipelines content/SEO/RAG, statut `READY` / `PARTIAL` / `MISSING` par pipeline (6 pipelines tracked). Validé en CI par `pipelines.registry.schema.json` (ajv).
+- [`projections.registry.json`](repository-registry/projections.registry.json) — registry des projections runtime DB SEO (`seo_runtime_v1` status `PLANNED`). Validé en CI par `projections.registry.schema.json`. Cross-references bidirectionnelles avec `pipelines.registry.json` (`feeds_projection` ↔ `fed_by_pipeline`) vérifiées par `scripts/canon/validate-cross-references.py`. Réf ADR-058.

--- a/.spec/00-canon/repository-registry/_schema/pipelines.registry.schema.json
+++ b/.spec/00-canon/repository-registry/_schema/pipelines.registry.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ak125/nestjs-remix-monorepo/.spec/00-canon/repository-registry/_schema/pipelines.registry.schema.json",
+  "title": "Pipelines Registry Canon",
+  "description": "Registry machine-readable des pipelines content/SEO/RAG. Statut READY/PARTIAL/MISSING. Réf ADR-058.",
+  "type": "object",
+  "required": ["schema_version", "pipelines"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "schema_url": {
+      "type": "string"
+    },
+    "generated_at": {
+      "type": ["string", "null"]
+    },
+    "pipelines": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "from", "to", "kind", "status", "adr"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$"
+          },
+          "from": { "type": "string" },
+          "to": { "type": "string" },
+          "kind": {
+            "type": "string",
+            "enum": ["promotion", "filtered_view", "runtime_projection", "runtime_consumer"]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["READY", "PARTIAL", "MISSING"]
+          },
+          "scripts": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "gaps": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "entity_types_supported": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "entity_types_excluded": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "rule": { "type": "string" },
+          "feeds_projection": {
+            "type": "string",
+            "description": "Si kind=runtime_projection : référence un projection_id de projections.registry.json"
+          },
+          "owner_pr": { "type": "string" },
+          "adr": {
+            "type": "string",
+            "pattern": "^ADR-[0-9]{3}$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.spec/00-canon/repository-registry/_schema/projections.registry.schema.json
+++ b/.spec/00-canon/repository-registry/_schema/projections.registry.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ak125/nestjs-remix-monorepo/.spec/00-canon/repository-registry/_schema/projections.registry.schema.json",
+  "title": "Projections Registry Canon",
+  "description": "Registry machine-readable des projections runtime DB SEO. Réf ADR-058.",
+  "type": "object",
+  "required": ["schema_version", "projections"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "schema_url": { "type": "string" },
+    "generated_at": { "type": ["string", "null"] },
+    "projections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "projection_id",
+          "status",
+          "source",
+          "fed_by_pipeline",
+          "tables",
+          "projection_contract_version",
+          "adr"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "projection_id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*_v[0-9]+$"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["PLANNED", "SHADOW", "LIVE", "DEPRECATED"]
+          },
+          "source": { "type": "string" },
+          "fed_by_pipeline": {
+            "type": "string",
+            "description": "Doit référencer un pipeline.id présent dans pipelines.registry.json"
+          },
+          "tables": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "pattern": "^__[a-z_]+$" }
+          },
+          "materialized_views": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "runner": { "type": "string" },
+          "refresh_worker": { "type": "string" },
+          "rpc": { "type": "string" },
+          "consumers": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["R0_HOME", "R1_ROUTER", "R2_PRODUCT", "R3_CONSEILS", "R4_REFERENCE", "R6_GUIDE_ACHAT", "R7_BRAND", "R8_VEHICLE"]
+            }
+          },
+          "consumers_non_seo": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["rag", "support", "diagnostic_tool"]
+            }
+          },
+          "projection_contract_version": {
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          },
+          "rollout_flag": { "type": "string" },
+          "owner_pr": { "type": "string" },
+          "adr": {
+            "type": "string",
+            "pattern": "^ADR-[0-9]{3}$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.spec/00-canon/repository-registry/pipelines.registry.json
+++ b/.spec/00-canon/repository-registry/pipelines.registry.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "1.0.0",
+  "schema_url": "./_schema/pipelines.registry.schema.json",
+  "generated_at": null,
+  "pipelines": [
+    {
+      "id": "raw_to_wiki",
+      "from": "automecanik-raw/",
+      "to": "automecanik-wiki/proposals/",
+      "kind": "promotion",
+      "status": "PARTIAL",
+      "scripts": ["automecanik-wiki/_scripts/recycle-from-rag.py"],
+      "gaps": ["claim extraction structurée", "source_map typed Pydantic", "structured proposal renderer"],
+      "owner_pr": "PR-3a (monorepo orchestration) + PR-3b (wiki repo bridge)",
+      "adr": "ADR-058"
+    },
+    {
+      "id": "wiki_to_exports_rag",
+      "from": "automecanik-wiki/wiki/<entity_type>/",
+      "to": "automecanik-wiki/exports/rag/<entity_type>/*.md",
+      "kind": "filtered_view",
+      "status": "READY",
+      "scripts": [
+        "app/scripts/rag-sync/sync-wiki-exports-to-rag.py",
+        "app/scripts/cron/sync-rag-from-wiki.sh"
+      ],
+      "entity_types_supported": ["gamme", "vehicle", "constructeur", "support", "diagnostic"],
+      "adr": "ADR-031"
+    },
+    {
+      "id": "wiki_to_exports_seo",
+      "from": "automecanik-wiki/wiki/<entity_type_singular>/",
+      "to": "automecanik-wiki/exports/seo/<entity_type>/*.json",
+      "kind": "filtered_view",
+      "status": "MISSING",
+      "scripts": [],
+      "entity_types_supported": ["gamme", "vehicle", "constructeur", "diagnostic"],
+      "entity_types_excluded": ["support"],
+      "rule": "roles_allowed must be non-empty; entities without SEO RoleId must be routed to exports/support",
+      "owner_pr": "PR-5a",
+      "adr": "ADR-058"
+    },
+    {
+      "id": "wiki_to_exports_support",
+      "from": "automecanik-wiki/wiki/<entity_type_singular>/",
+      "to": "automecanik-wiki/exports/support/<entity_type>/*.json",
+      "kind": "filtered_view",
+      "status": "MISSING",
+      "scripts": [],
+      "entity_types_supported": ["support", "diagnostic (sans block R3 S2_DIAG)"],
+      "owner_pr": "followup-task (hors PR-0..7)",
+      "adr": "ADR-058"
+    },
+    {
+      "id": "exports_seo_to_db_projection",
+      "from": "automecanik-wiki/exports/seo/",
+      "to": "__seo_projection_*, __seo_entity_*",
+      "kind": "runtime_projection",
+      "status": "MISSING",
+      "scripts": [],
+      "feeds_projection": "seo_runtime_v1",
+      "owner_pr": "PR-6",
+      "adr": "ADR-058"
+    },
+    {
+      "id": "db_projection_to_pages",
+      "from": "__seo_entity_facts(active_version_id)",
+      "to": "frontend/app/routes/{pieces,gammes,marques,blog}.*",
+      "kind": "runtime_consumer",
+      "status": "PARTIAL",
+      "scripts": [],
+      "gaps": ["RPC get_active_seo_projection à créer", "loaders Remix lisent legacy"],
+      "owner_pr": "PR-7",
+      "adr": "ADR-058"
+    }
+  ]
+}

--- a/.spec/00-canon/repository-registry/projections.registry.json
+++ b/.spec/00-canon/repository-registry/projections.registry.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.0.0",
+  "schema_url": "./_schema/projections.registry.schema.json",
+  "generated_at": null,
+  "projections": [
+    {
+      "projection_id": "seo_runtime_v1",
+      "status": "PLANNED",
+      "source": "wiki/exports/seo/",
+      "fed_by_pipeline": "exports_seo_to_db_projection",
+      "tables": [
+        "__seo_projection_runs",
+        "__seo_entity_facts",
+        "__seo_entity_fact_versions",
+        "__seo_entity_sources",
+        "__seo_content_blocks",
+        "__seo_content_block_versions",
+        "__seo_projection_conflicts"
+      ],
+      "materialized_views": [
+        "mv_seo_entity_facts_current",
+        "mv_seo_content_blocks_current"
+      ],
+      "runner": "backend/src/modules/seo/projection/seo-projection-write.worker.ts",
+      "refresh_worker": "backend/src/modules/seo/projection/seo-projection-refresh.worker.ts",
+      "rpc": "get_active_seo_projection",
+      "consumers": [
+        "R3_CONSEILS",
+        "R4_REFERENCE",
+        "R6_GUIDE_ACHAT",
+        "R7_BRAND",
+        "R8_VEHICLE"
+      ],
+      "consumers_non_seo": [],
+      "projection_contract_version": "1.0.0",
+      "rollout_flag": "growthbook:seo_projection_read_v1",
+      "owner_pr": "PR-6",
+      "adr": "ADR-058"
+    }
+  ]
+}

--- a/scripts/canon/validate-cross-references.py
+++ b/scripts/canon/validate-cross-references.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Vérifie la cohérence bidirectionnelle entre pipelines.registry.json et
+projections.registry.json :
+
+  - Pour chaque pipeline.kind == "runtime_projection" avec feeds_projection,
+    la projection référencée doit exister dans projections.registry.json
+  - Pour chaque projection.fed_by_pipeline, le pipeline référencé doit exister
+    avec kind == "runtime_projection"
+
+Exit 0 si cohérent, 1 sinon. Réf ADR-058.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REGISTRY_DIR = Path(__file__).resolve().parents[2] / ".spec" / "00-canon" / "repository-registry"
+PIPELINES = REGISTRY_DIR / "pipelines.registry.json"
+PROJECTIONS = REGISTRY_DIR / "projections.registry.json"
+
+
+def main() -> int:
+    if not PIPELINES.exists():
+        print(f"FAIL: {PIPELINES} introuvable", file=sys.stderr)
+        return 1
+    if not PROJECTIONS.exists():
+        print(f"FAIL: {PROJECTIONS} introuvable", file=sys.stderr)
+        return 1
+
+    pipelines = json.loads(PIPELINES.read_text())["pipelines"]
+    projections = json.loads(PROJECTIONS.read_text())["projections"]
+
+    pipeline_ids = {p["id"] for p in pipelines}
+    projection_ids = {p["projection_id"] for p in projections}
+
+    errors: list[str] = []
+
+    for pipeline in pipelines:
+        feeds = pipeline.get("feeds_projection")
+        if feeds:
+            if pipeline.get("kind") != "runtime_projection":
+                errors.append(
+                    f"pipeline {pipeline['id']!r} has feeds_projection but kind="
+                    f"{pipeline.get('kind')!r} (expected runtime_projection)"
+                )
+            if feeds not in projection_ids:
+                errors.append(
+                    f"pipeline {pipeline['id']!r} feeds_projection={feeds!r} "
+                    f"but no matching projection_id in projections.registry.json"
+                )
+
+    for projection in projections:
+        fed_by = projection["fed_by_pipeline"]
+        if fed_by not in pipeline_ids:
+            errors.append(
+                f"projection {projection['projection_id']!r} fed_by_pipeline={fed_by!r} "
+                f"but no matching pipeline.id in pipelines.registry.json"
+            )
+        matching = next((p for p in pipelines if p["id"] == fed_by), None)
+        if matching and matching.get("kind") != "runtime_projection":
+            errors.append(
+                f"projection {projection['projection_id']!r} fed by "
+                f"pipeline {fed_by!r} with kind={matching.get('kind')!r} "
+                f"(expected runtime_projection)"
+            )
+        if matching and matching.get("feeds_projection") != projection["projection_id"]:
+            errors.append(
+                f"projection {projection['projection_id']!r} fed by {fed_by!r} but "
+                f"pipeline.feeds_projection={matching.get('feeds_projection')!r} "
+                f"(asymmetric cross-reference)"
+            )
+
+    if errors:
+        print("FAIL: cross-references inconsistent:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: {len(pipelines)} pipelines + {len(projections)} projections, "
+        f"cross-references bidirectionnels coherents."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Introduce 2 machine-readable canon registries dans `.spec/00-canon/repository-registry/` pour tracker pipelines content/SEO/RAG et projections runtime DB SEO.

## Files

- `pipelines.registry.json` — 6 pipelines tracked (statut READY/PARTIAL/MISSING)
- `projections.registry.json` — 1 projection PLANNED (`seo_runtime_v1`)
- `_schema/pipelines.registry.schema.json` (ajv-validable)
- `_schema/projections.registry.schema.json` (ajv-validable, enum RoleId canon R0..R8 sans R5)
- `scripts/canon/validate-cross-references.py` (vérifie `feeds_projection` ↔ `fed_by_pipeline` bidirectionnel)
- `.github/workflows/canon-registries-validate.yml` (CI : ajv + cross-ref)

## Cross-references bidirectionnelles

```
pipelines["exports_seo_to_db_projection"].feeds_projection == "seo_runtime_v1"
projections["seo_runtime_v1"].fed_by_pipeline == "exports_seo_to_db_projection"
```

Test local validate-cross-references.py : **OK 6 pipelines + 1 projections cohérents**.

## Test plan

- [ ] CI `canon-registries-validate` passe (ajv + Python cross-ref)
- [ ] `jq '.pipelines | length'` retourne `6`
- [ ] `jq '.projections | length'` retourne `1`
- [ ] `jq -e '.projections[0].status == "PLANNED"'` retourne `true`
- [ ] `jq -e '.projections[0].projection_id == "seo_runtime_v1"'` retourne `true`

## Refs

ADR-058 (proposed via vault PR-1, separate vault repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)