### PR TITLE
chore(cleanup): validate-before-delete http-route-caller aware (PR-3b prereq-2)

### DIFF
--- a/.claude/knowledge/ops/cleanup-targets.md
+++ b/.claude/knowledge/ops/cleanup-targets.md
@@ -42,13 +42,13 @@ Source d'évidence : [`audit/runtime-entrypoints.json#nestjs_unreachable_modules
 | `modules/upload/` | 10 | 2025-08-28 | **aucun** | `.claude/knowledge/modules/upload.md` | **clearly dead** — candidat delete |
 | `modules/agentic-engine/` | 14 | 2026-03-09 | **aucun** | knowledge note seule | **clearly dead** — candidat delete |
 | `modules/mcp-validation/` | **19** | 2026-01-26 | **aucun** | knowledge note seule | **clearly dead** — candidat delete (plus gros bucket) |
-| `modules/substitution/` | 6 | 2026-01-12 | **aucun** | knowledge note + ref `.claude/knowledge/integrations/parts-feed.md` | **likely dead** — vérifier le lien parts-feed avant delete |
+| `modules/substitution/` | 6 | 2026-01-12 | **aucun import statique** ; **mais** `@Controller('api/substitution') @Get('check')` consommé par `frontend/app/routes/pieces.$slug.tsx:206` (HTTP runtime — TS ne voit pas l'edge) | knowledge note + ref `.claude/knowledge/integrations/parts-feed.md` | **`http_live` — retention requise** (canari PR-3b-1 PR #466 closed 2026-05-13 ; le drop aurait cassé `/pieces/:slug` en prod). Allowlist via `validate-before-delete.sh` (le check `[HTTP-ROUTE-CALLER]` du prereq-2 fire automatiquement). |
 | `modules/knowledge-graph/` | 6 | 2025-12-30 | `app.module.ts` ligne 59 + 224 (**commentés** `DEV ONLY — Experimental`) | cette section, déjà flaggée backlog 2026-04-24 | `backlog — decision pending: delete vs promote` |
 | `modules/blog-metadata/` | 3 | 2025-10-04 | **aucun** | Section 3 (fusion candidate) | **refactor, pas delete** — fusion `→ blog/metadata/` |
 
 0 dynamic import edge vers aucun de ces 6 sous-arbres ([`audit/dynamic-import-edges.json`](../../../audit/dynamic-import-edges.json)). Aucun n'est dans `runtime-entrypoints.json#never_auto_delete_globs`. Toutes les conditions #0-#6 de `validate-before-delete.sh` à re-vérifier avant `git rm`.
 
-**Action recommandée** : 4 PRs séparées (`upload`, `agentic-engine`, `mcp-validation`, `substitution`), 1 par module, chacune passant par `validate-before-delete.sh` + `npm run build` ×2 + `npm test`. `knowledge-graph` reste en `decision pending` (delete vs restore) — choix humain. `blog-metadata` traité via Section 3 (fusion).
+**Action recommandée (révisée 2026-05-13 post-canari)** : 3 PRs séparées (`upload`, `agentic-engine`, `mcp-validation`), 1 par module, chacune passant par `validate-before-delete.sh` (prereq-2 = check `[HTTP-ROUTE-CALLER]` actif) + `npm run build` ×2 + `npm test`. `substitution` est sorti de la file Step B → `http_live` retention. `knowledge-graph` reste en `decision pending` (delete vs restore) — choix humain. `blog-metadata` traité via Section 3 (fusion). **Présomptions à vérifier avant drop** : `agentic-engine` apparaît partiellement vivant (`workers/processors/agentic.processor.ts` importe les services directement) → probable `partial`, pas `dead_subtree` ; `upload` a vraisemblablement un `@Controller` consommé par admin UI → vérifier `[HTTP-ROUTE-CALLER]`.
 
 ### Templates `.spec/templates/*.ts` orphans
 
@@ -134,7 +134,7 @@ Les cycles "acceptables" sont documentés ici comme **explicitement tolérés**.
 |---|---|---|---|---|
 | ~~1~~ | ~~Archiver les 76 `.js` backend racine~~ | — | — | **mostly done** (76 → 14, voir Section 1) |
 | ~~2~~ | ~~Fix phantom dep `file-type`~~ | — | — | **done** (déclaré en `dependencies`, voir Section 5) |
-| 3 | **PR-3 Step B** — delete 4 modules unreachable clearly-dead (`upload`, `agentic-engine`, `mcp-validation`, `substitution`) | Moyen (4 PRs, ≤1j chacune) | -49 fichiers, -4 sous-arbres orphelins | `backlog` |
+| 3 | **PR-3 Step B** — triage + delete-or-allowlist 3 modules unreachable (`upload`, `agentic-engine`, `mcp-validation`) ; `substitution` sorti (→ `http_live` allowlist post-canari 2026-05-13) | Moyen (3 PRs, ≤1j chacune) | 0-3 sous-arbres orphelins selon triage (estimation révisée : 1-2 vrai delete sur 3) | `backlog` |
 | 4 | Decider `knowledge-graph` (delete vs promote) | Faible (décision) puis Moyen (exécution) | -6 fichiers OU intent restauré | `backlog — decision pending` |
 | 5 | Fusion `blog-metadata/` → `blog/metadata/` | Faible (1h) | Supprime fragment artificiel | `backlog` |
 | 6 | **PR-4** Frontend Remix-aware — 187 candidats `frontend-shared` + 29 dup exports, par batch | Moyen-lourd (~3-4 PRs) | Cleanup du gros bucket | `backlog` (+ #158/#160 vieillissants) |

--- a/scripts/cleanup/validate-before-delete.sh
+++ b/scripts/cleanup/validate-before-delete.sh
@@ -173,6 +173,51 @@ if [[ -n "$STRING_HITS" ]]; then
   done <<< "$STRING_HITS"
 fi
 
+# ---- 4b. HTTP route callers (catch frontend HTTP edges that TS imports miss) ----
+# Lesson canari PR-3b-1 substitution (PR #466 closed 2026-05-13): a NestJS module can
+# be "unreachable from app.module.ts" yet still serve live HTTP traffic via a sibling
+# *.controller.ts that the frontend calls with `fetch('/api/...')`. TS does not see
+# this edge — build green, but 404 prod on every page hitting the route.
+#
+# For any file under `backend/src/modules/<subtree>/<dir>/...`, extract
+# `@Controller('<path>')` strings from `*.controller.ts` files in the subtree, then
+# grep that path across frontend/app, packages, scripts, e2e, tests. Any hit means
+# the subtree exposes a live HTTP edge — dropping any of its files breaks the route.
+#
+# Scope: only modules whose *.controller.ts uses a string-arg @Controller decorator.
+# `@Controller({ path: '...' })` object-form is not parsed (rare in this codebase).
+SUBTREE_DIR=""
+if [[ "$REL" =~ ^(backend/src/modules/[^/]+)/ ]]; then
+  SUBTREE_DIR="${BASH_REMATCH[1]}/"
+fi
+
+if [[ -n "$SUBTREE_DIR" && -d "$REPO_ROOT/$SUBTREE_DIR" ]]; then
+  # Extract route paths from @Controller('<path>') string-arg decorators in the subtree.
+  CONTROLLER_PATHS=$(grep -rhE "@Controller\s*\(\s*['\"\`]" "$REPO_ROOT/$SUBTREE_DIR" 2>/dev/null \
+    | sed -nE "s/.*@Controller\s*\(\s*['\"\`]([^'\"\`]+)['\"\`].*/\1/p" \
+    | sort -u || true)
+  if [[ -n "$CONTROLLER_PATHS" ]]; then
+    # Resolve the search dirs that actually exist (e2e/ and tests/ are optional).
+    HTTP_SEARCH_DIRS=()
+    for d in frontend/app packages scripts e2e tests; do
+      [[ -d "$REPO_ROOT/$d" ]] && HTTP_SEARCH_DIRS+=("$REPO_ROOT/$d")
+    done
+    if [[ ${#HTTP_SEARCH_DIRS[@]} -gt 0 ]]; then
+      while IFS= read -r ROUTE_PATH; do
+        [[ -z "$ROUTE_PATH" ]] && continue
+        ROUTE_HITS=$(grep -rln --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' --include='*.cjs' \
+          -F "$ROUTE_PATH" \
+          "${HTTP_SEARCH_DIRS[@]}" 2>/dev/null | grep -v "^$ABS$" || true)
+        if [[ -n "$ROUTE_HITS" ]]; then
+          while IFS= read -r f; do
+            report_hit "[HTTP-ROUTE-CALLER] @Controller('$ROUTE_PATH') consumed by: ${f#"$REPO_ROOT"/}"
+          done <<< "$ROUTE_HITS"
+        fi
+      done <<< "$CONTROLLER_PATHS"
+    fi
+  fi
+fi
+
 # ---- 5. CI / npm scripts / git hooks (path or basename in workflows, package.json, husky) ----
 CI_HITS=$(grep -rln \
   -e "$REL" -e "$BASENAME" \


### PR DESCRIPTION
**PR-3b prereq-2** — durcissement méthodologique post-canari échoué.

## Pourquoi

PR #466 (canari `substitution` drop) closed 2026-05-13 avant merge — la review auto a détecté que `@Controller('api/substitution') @Get('check')` était consommé en runtime par `frontend/app/routes/pieces.$slug.tsx:206` (`fetch('\${API_URL}/api/substitution/check?...')`). TS ne voit pas l'edge HTTP → build vert, mais 404 prod sur chaque `/pieces/:slug` (le fallback `.catch(() => null)` aurait mangé le signal silencieusement). Le triage initial `audit/unreachable-modules/substitution.md` avait omis ce check (`string_refs` grep scopé à `backend/src + .github + scripts + supabase/migrations`, **`frontend/app` excluded**).

→ Méthodologie à corriger : **tout sous-arbre contenant un `@Controller(...)` est `http_live` par défaut** jusqu'à preuve grep contraire sur l'intégralité des workspaces. Reposer le check sur la mémoire humaine = bricolage ; le mettre dans `validate-before-delete.sh` = robuste.

## Changements

### `scripts/cleanup/validate-before-delete.sh` (+45 lignes)

Nouvelle section 4b « HTTP route callers » :
- Pour chaque file under `backend/src/modules/<subtree>/`, extraire les `@Controller('<path>')` string-arg decorators du subtree (regex sur le subtree complet).
- Pour chaque `<path>`, grep le string en `-F` (fixed) à travers les dirs existants : `frontend/app`, `packages`, `scripts`, `e2e`, `tests`.
- Hit → report `[HTTP-ROUTE-CALLER] @Controller('<path>') consumed by: <file>`.

Pattern aligné sur PR #459 (unreachable-aware) : guard-rail file-internal, scope strict, pas de nouveau script.

### Tests empiriques (4 scénarios)

| Cas | Attendu | Résultat |
|---|---|---|
| `substitution.module.ts` | flag HTTP-ROUTE-CALLER vers `pieces.\$slug.tsx` | ✓ |
| `substitution.service.ts` (any subtree file) | idem (subtree expose une route) | ✓ |
| `cart-core.controller.ts` (live module) | 9 callers frontend (`api/cart`) | ✓ |
| `backend/src/types/order.types.ts` (hors subtree) | pas de fire (SUBTREE_DIR regex ne matche pas) | ✓ |

Limitation : seul `@Controller('<path>')` string-arg est parsé. La forme `@Controller({ path: '...' })` (rare ici) n'est pas couverte — documentée dans le commentaire de section.

### `.claude/knowledge/ops/cleanup-targets.md` (3 lignes touchées)

- Substitution row → `http_live — retention requise` avec lien canari et méthode d'allowlist auto via le nouveau check.
- « Action recommandée » → 3 PRs au lieu de 4 (substitution sorti de Step B).
- Priorisation item #3 → 3 modules, estimation révisée « 1-2 vrai delete sur 3 » (post-canari realism).

## Hors scope

- Aucun fichier backend touché.
- Aucune migration / RPC / table modifiée.
- Aucun build/test impacté.
- Pas de `[HTTP-ROUTE-CALLER]` flag ajouté à un module live (ils sont déjà BLOCKED par `[NEVER-AUTO-DELETE]` / `[RUNTIME-ENTRYPOINT]` / `[NESTJS-DI]` etc. — le nouveau check est purement additif sur les unreachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)