### PR TITLE
fix(ci): canon-registries-validate ajv draft-07 compat

### DIFF
--- a/.github/workflows/canon-registries-validate.yml
+++ b/.github/workflows/canon-registries-validate.yml
@@ -21,17 +21,15 @@ jobs:
         with:
           node-version: "20"
       - name: Install ajv-cli
-        run: npm install -g ajv-cli@5 ajv-formats@3
+        run: npm install -g ajv-cli@5
       - name: Validate pipelines.registry.json
         run: |
           ajv validate \
-            -c ajv-formats \
             -s .spec/00-canon/repository-registry/_schema/pipelines.registry.schema.json \
             -d .spec/00-canon/repository-registry/pipelines.registry.json
       - name: Validate projections.registry.json
         run: |
           ajv validate \
-            -c ajv-formats \
             -s .spec/00-canon/repository-registry/_schema/projections.registry.schema.json \
             -d .spec/00-canon/repository-registry/projections.registry.json
       - name: Setup Python

--- a/.spec/00-canon/repository-registry/_schema/pipelines.registry.schema.json
+++ b/.spec/00-canon/repository-registry/_schema/pipelines.registry.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/ak125/nestjs-remix-monorepo/.spec/00-canon/repository-registry/_schema/pipelines.registry.schema.json",
   "title": "Pipelines Registry Canon",
   "description": "Registry machine-readable des pipelines content/SEO/RAG. Statut READY/PARTIAL/MISSING. Réf ADR-058.",

--- a/.spec/00-canon/repository-registry/_schema/projections.registry.schema.json
+++ b/.spec/00-canon/repository-registry/_schema/projections.registry.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/ak125/nestjs-remix-monorepo/.spec/00-canon/repository-registry/_schema/projections.registry.schema.json",
   "title": "Projections Registry Canon",
   "description": "Registry machine-readable des projections runtime DB SEO. Réf ADR-058.",


### PR DESCRIPTION
## Summary

Fix CI workflow `canon-registries-validate.yml` introduit dans #467 qui échouait avec :
\`\`\`
schema invalid: no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
\`\`\`

## Cause

\`ajv-cli@5\` ne supporte pas le draft 2020-12 par défaut. Le flag \`-c ajv-formats\` plante aussi avec require error dans le sandbox CI.

## Fix

- Les 2 schemas : \`\$schema\` → \`http://json-schema.org/draft-07/schema#\` (universel)
- Workflow : retire \`-c ajv-formats\` et \`ajv-formats@3\` install (pas utilisé)

## Test local

\`\`\`
$ npx ajv-cli@5 validate -s _schema/pipelines.registry.schema.json -d pipelines.registry.json
.spec/00-canon/repository-registry/pipelines.registry.json valid

$ npx ajv-cli@5 validate -s _schema/projections.registry.schema.json -d projections.registry.json
.spec/00-canon/repository-registry/projections.registry.json valid

$ python3 scripts/canon/validate-cross-references.py
OK: 6 pipelines + 1 projections, cross-references bidirectionnels coherents.
\`\`\`

## Refs

PR #467 (canon registries introduction, ADR-058 prep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)