### PR TITLE
docs(audit): upload partial retention (option B, no drop) — PR-3b-2

### DIFF
--- a/.claude/knowledge/ops/cleanup-targets.md
+++ b/.claude/knowledge/ops/cleanup-targets.md
@@ -39,7 +39,7 @@ Source d'évidence : [`audit/runtime-entrypoints.json#nestjs_unreachable_modules
 
 | Module | Fichiers | 1er commit | Importeurs statiques | Doc humaine | Verdict |
 |---|---|---|---|---|---|
-| `modules/upload/` | 10 | 2025-08-28 | **aucun** | `.claude/knowledge/modules/upload.md` | **clearly dead** — candidat delete |
+| `modules/upload/` | 10 | 2025-08-28 | **aucun import direct du module** ; **mais** `SupabaseStorageService` (`services/supabase-storage.service.ts`) consommé par `rag-proxy/rag-proxy.module.ts` + `rag-proxy/services/rag-image-management.service.ts` | `.claude/knowledge/modules/upload.md` | **`partial` — retention requise** (PR-3b-2 doc 2026-05-13, option B). 0 drop : Step B canonique exige `clearly dead` module-entier ; un storage util vivant fait sortir upload du scope. Refactor préface (relocation `storage/` séparée) reste optionnelle hors-Step-B. Protection via `validate-before-delete.sh` (`[NESTJS-DI]`+`[IMPORT]` intra-sous-arbre fire automatiquement). |
 | `modules/agentic-engine/` | 14 | 2026-03-09 | **aucun** | knowledge note seule | **clearly dead** — candidat delete |
 | `modules/mcp-validation/` | **19** | 2026-01-26 | **aucun** | knowledge note seule | **clearly dead** — candidat delete (plus gros bucket) |
 | `modules/substitution/` | 6 | 2026-01-12 | **aucun import statique** ; **mais** `@Controller('api/substitution') @Get('check')` consommé par `frontend/app/routes/pieces.$slug.tsx:206` (HTTP runtime — TS ne voit pas l'edge) | knowledge note + ref `.claude/knowledge/integrations/parts-feed.md` | **`http_live` — retention requise** (canari PR-3b-1 PR #466 closed 2026-05-13 ; le drop aurait cassé `/pieces/:slug` en prod). Allowlist via `validate-before-delete.sh` (le check `[HTTP-ROUTE-CALLER]` du prereq-2 fire automatiquement). |
@@ -48,7 +48,9 @@ Source d'évidence : [`audit/runtime-entrypoints.json#nestjs_unreachable_modules
 
 0 dynamic import edge vers aucun de ces 6 sous-arbres ([`audit/dynamic-import-edges.json`](../../../audit/dynamic-import-edges.json)). Aucun n'est dans `runtime-entrypoints.json#never_auto_delete_globs`. Toutes les conditions #0-#6 de `validate-before-delete.sh` à re-vérifier avant `git rm`.
 
-**Action recommandée (révisée 2026-05-13 post-canari)** : 3 PRs séparées (`upload`, `agentic-engine`, `mcp-validation`), 1 par module, chacune passant par `validate-before-delete.sh` (prereq-2 = check `[HTTP-ROUTE-CALLER]` actif) + `npm run build` ×2 + `npm test`. `substitution` est sorti de la file Step B → `http_live` retention. `knowledge-graph` reste en `decision pending` (delete vs restore) — choix humain. `blog-metadata` traité via Section 3 (fusion). **Présomptions à vérifier avant drop** : `agentic-engine` apparaît partiellement vivant (`workers/processors/agentic.processor.ts` importe les services directement) → probable `partial`, pas `dead_subtree` ; `upload` a vraisemblablement un `@Controller` consommé par admin UI → vérifier `[HTTP-ROUTE-CALLER]`.
+**Action recommandée (révisée 2026-05-13 post-canari + arbitrage option B)** : seul `mcp-validation` reste candidat Step B `dead_subtree` à vérifier. `substitution` et `upload` sont sortis (verdict `http_live` / `partial` documenté retention, 0 drop). `agentic-engine` présomption forte `partial` (`workers/processors/agentic.processor.ts` importe `agentic-engine/services/*` directement) → vraisemblablement retention. `knowledge-graph` reste en `decision pending` (delete vs restore) — choix humain. `blog-metadata` traité via Section 3 (fusion).
+
+**Principe option B (no bricolage)** : un sous-arbre `partial` (un fichier vivant consommé externe) n'est pas un Step B canonique. Pas de drop file-by-file (sortirait du scope « delete module-entier clearly-dead »). Refactor préface (relocation des utilitaires vivants) reste une option future hors Step B, à arbitrer séparément.
 
 ### Templates `.spec/templates/*.ts` orphans
 
@@ -134,7 +136,7 @@ Les cycles "acceptables" sont documentés ici comme **explicitement tolérés**.
 |---|---|---|---|---|
 | ~~1~~ | ~~Archiver les 76 `.js` backend racine~~ | — | — | **mostly done** (76 → 14, voir Section 1) |
 | ~~2~~ | ~~Fix phantom dep `file-type`~~ | — | — | **done** (déclaré en `dependencies`, voir Section 5) |
-| 3 | **PR-3 Step B** — triage + delete-or-allowlist 3 modules unreachable (`upload`, `agentic-engine`, `mcp-validation`) ; `substitution` sorti (→ `http_live` allowlist post-canari 2026-05-13) | Moyen (3 PRs, ≤1j chacune) | 0-3 sous-arbres orphelins selon triage (estimation révisée : 1-2 vrai delete sur 3) | `backlog` |
+| 3 | **PR-3 Step B** — seul `mcp-validation` reste candidat `dead_subtree` plausible ; `upload` sorti (`partial` retention, PR-3b-2 doc 2026-05-13) ; `substitution` sorti (`http_live` retention, PR-3b prereq-2 2026-05-13) ; `agentic-engine` présomption `partial` (worker DI live) | Faible (1 PR au max, mcp-validation) | 0 à 17 fichiers selon triage | `backlog` |
 | 4 | Decider `knowledge-graph` (delete vs promote) | Faible (décision) puis Moyen (exécution) | -6 fichiers OU intent restauré | `backlog — decision pending` |
 | 5 | Fusion `blog-metadata/` → `blog/metadata/` | Faible (1h) | Supprime fragment artificiel | `backlog` |
 | 6 | **PR-4** Frontend Remix-aware — 187 candidats `frontend-shared` + 29 dup exports, par batch | Moyen-lourd (~3-4 PRs) | Cleanup du gros bucket | `backlog` (+ #158/#160 vieillissants) |

--- a/audit/unreachable-modules/upload.md
+++ b/audit/unreachable-modules/upload.md
@@ -1,0 +1,59 @@
+# Triage upload — retention (no drop)
+
+> Produit par **PR-3b-2 Step B** per plan `/home/deploy/.claude/plans/pr-3-backend-nestjs-aware-deadcode.md` §4 (matrice révisée post-canari `http_route_callers` #469).
+> Snapshot post-#459 + #469 sur main `156f02ac`.
+> **Option B retenue 2026-05-13** : pas de drop sur verdict `partial`, retention documentée (cf. substitution PR #469).
+
+## Faits (verdict matrice §4 plan)
+
+- **`nestjs_reachable_from_app_module`** : `false` (`runtime-entrypoints.json#nestjs_unreachable_modules`).
+- **`static_importers`** : `SupabaseStorageService` importé directement par 2 fichiers `rag-proxy/` :
+  - `backend/src/modules/rag-proxy/rag-proxy.module.ts:3` — `import { SupabaseStorageService } from '../upload/services/supabase-storage.service';`
+  - `backend/src/modules/rag-proxy/services/rag-image-management.service.ts:18` — idem
+  - `rag-proxy.module.ts:80` — registered as provider locally (comment historique : « registered locally to avoid UploadModule CACHE_MANAGER dep »).
+- **`dynamic_importers`** (`audit/dynamic-import-edges.json`) : `[]`.
+- **`string_refs`** : `[]` côté code routé.
+- **`bullmq_processors_referencing`** : `[]`.
+- **`http_route_callers`** (check du prereq-2) : flag levé sur substring `upload`, triage manuel = **0 vrai caller**. Les hits frontend (`uploads/...`, `/upload/constructeurs-automobiles/...`) sont des chemins d'assets statiques (Supabase Storage / PHP legacy), pas des fetches vers `@Controller('upload')` routes. Les 2 fetches réels du frontend ciblent `/api/admin/r1-image-prompts/...` (admin module, pas upload).
+- **`db_callsites`** + **`supabase_migrations_referencing`** : 0.
+
+## Verdict matrice plan §4
+
+| Constat | Verdict |
+|---|---|
+| `static_importers ≠ ∅` (`SupabaseStorageService` consommé par rag-proxy) **mais** `*.module.ts` reste unreached | **`partial`** |
+
+→ **verdict : `partial`** — retention requise (cf. arbitrage scope §"Décision" ci-dessous).
+
+## Décision (arbitrage option A vs B, 2026-05-13)
+
+**Option B retenue** : pas de drop sur verdict `partial`. Le scope Step B (cleanup-targets.md item #3) est strictement « delete modules **clearly-dead**, module-entier » — un sous-arbre `partial` (storage utilitaire consommé externe) ne fit pas. Une refactor préface (relocation `supabase-storage.service.ts` + `upload.dto.ts` → `backend/src/modules/storage/` ou `common/services/storage/`) serait un chantier séparé, non-Step-B.
+
+→ **Action** : zero drop. Upload reste tel quel. Le check `[HTTP-ROUTE-CALLER]` du prereq-2 (#469) + `[NESTJS-DI]` + `[IMPORT]` intra-sous-arbre via `validate-before-delete.sh` continueront à protéger les fichiers du sous-arbre contre tout `git rm` futur tant que `SupabaseStorageService` reste consommé.
+
+## Détail surface (pour traçabilité, sans action)
+
+| Fichier | Consommé externe ? |
+|---|---|
+| `upload.module.ts` | non (mais wire les services internes) |
+| `upload.controller.ts` | non (admin-only, 0 caller) |
+| `dto/index.ts` | non (barrel) |
+| `dto/upload.dto.ts` | indirectement (via `FileUploadResult` requis par `supabase-storage.service.ts`) |
+| `services/supabase-storage.service.ts` | **OUI — 5 hits rag-proxy** |
+| `services/image-processing.service.ts` | non |
+| `services/upload.service.ts` | non |
+| `services/file-validation.service.ts` | non |
+| `services/upload-analytics.service.ts` | non |
+| `services/upload-optimization.service.ts` | non |
+
+8 fichiers nominalement dead, mais aucun n'est droppé per option B. Toute future refactor du sous-arbre (relocation du storage utilitaire) ouvrira un nouveau triage hors Step B.
+
+## Knowledge
+
+`.claude/knowledge/modules/upload.md` conservée per convention `refresh-knowledge.py`.
+
+## Hors scope
+
+- **Aucune migration DB / RPC / table touchée** (plan §10).
+- **Aucun fichier code modifié** — c'est un PR purement documentaire.
+- Pas de mise à jour `audit/*.json` (rien dans l'inventaire ne change, l'audit re-scan donnerait le même résultat).


### PR DESCRIPTION
**PR-3b-2 — retention doc only**. Arbitrage scope option B retenu 2026-05-13 (cf. discussion post-PR #475 closed).

## Pourquoi

`cleanup-targets.md` item #3 cadre Step B comme « delete modules **clearly-dead**, module-entier ». Upload est empiriquement `partial` : `SupabaseStorageService` (`backend/src/modules/upload/services/supabase-storage.service.ts`) est consommé par `backend/src/modules/rag-proxy/{rag-proxy.module.ts, services/rag-image-management.service.ts}`. Un drop file-by-file pour cleaner un `partial` sortirait du scope Step B (cf. tentative PR #475 closed). 

**Option B retenue** : 0 drop, retention documentée. Même traitement que `substitution` (`http_live` retention en PR #469).

## Changements (pure doc)

- **`audit/unreachable-modules/upload.md`** — nouveau, artefact triage verdict `partial` + décision option B + détail surface (8 fichiers nominalement dead, 2 utilitaires consommés par rag-proxy).
- **`.claude/knowledge/ops/cleanup-targets.md`** :
  - Upload row : « clearly dead — candidat delete » → « **partial — retention requise** » avec doc des consommateurs rag-proxy.
  - « Action recommandée » : principe option B ajouté (no bricolage = pas de drop file-by-file sur `partial`).
  - Priorisation item #3 : seul `mcp-validation` reste candidat `dead_subtree` plausible ; `agentic-engine` présomption forte `partial`.

## Méthode (no bricolage)

- 0 fichier backend modifié.
- 0 migration / RPC / table touchée (plan §10).
- Le check `validate-before-delete.sh` (`NESTJS-DI` + `IMPORT` intra-sous-arbre via prereq-1 #459) continue de protéger les 8 fichiers nominalement dead contre tout `git rm` tant que `SupabaseStorageService` reste consommé. Le `[HTTP-ROUTE-CALLER]` (prereq-2 #469) renforce.

## Hors scope (refactor préface optionnelle)

Si on souhaite vraiment cleaner upload/, une PR séparée hors Step B pourrait :
1. Move `services/supabase-storage.service.ts` + `dto/upload.dto.ts` → `backend/src/modules/storage/`
2. Update les 2 imports de `rag-proxy`
3. Drop le reste de upload/ comme Step B canonique (`clearly_dead` après refactor)

À arbitrer séparément, hors ce chantier.

## Suite

- **PR-3b-3 agentic-engine** : présomption `partial` confirmée par grep (worker processor importe les services directement) → vraisemblablement aussi option B retention.
- **PR-3b-4 mcp-validation** : à triager, seul candidat `dead_subtree` plausible restant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)