### PR TITLE
feat(db): migrations seo projection 7 tables + 2 mvs (pr-6a)

### DIFF
--- a/backend/supabase/migrations/20260513202231_seo_projection_tables.sql
+++ b/backend/supabase/migrations/20260513202231_seo_projection_tables.sql
@@ -1,0 +1,304 @@
+-- ============================================================================
+-- ADR-059 SEO Runtime Projection — Phase B PR-6a (migrations DB uniquement)
+-- 7 tables (pattern kg_v3 réutilisé) + 3 enums + indexes + RLS + GRANTs explicites
+--
+-- AUCUN worker, AUCUN runner, AUCUN replay : ces composants vivent dans
+-- PR-6b (workers BullMQ) et PR-6c (replay_projection.py + G1/G2).
+--
+-- Refs :
+--   - ADR-059 vault PR #260 (accepted 2026-05-13)
+--   - ADR-021 Database RLS Hardening Zero-Trust (RLS sur toutes nouvelles tables)
+--   - feedback_supabase_grant_explicit_for_new_projects (GRANTs explicites)
+--   - feedback_replay_sot_is_immutable_object_store (exports_snapshot_uri = SoT)
+--   - feedback_versions_complete_for_deterministic_replay (builder/pipeline/extractor/runner)
+-- ============================================================================
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Enums
+-- ────────────────────────────────────────────────────────────────────────────
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'seo_projection_version_status') THEN
+    CREATE TYPE seo_projection_version_status AS ENUM ('draft', 'active', 'deprecated');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'seo_projection_run_status') THEN
+    CREATE TYPE seo_projection_run_status AS ENUM (
+      'running', 'success', 'failed', 'aborted_contract_mismatch'
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'seo_projection_trigger_kind') THEN
+    CREATE TYPE seo_projection_trigger_kind AS ENUM ('cron', 'manual', 'replay');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'seo_projection_conflict_resolution') THEN
+    CREATE TYPE seo_projection_conflict_resolution AS ENUM ('pending', 'resolved', 'ignored');
+  END IF;
+END$$;
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. __seo_projection_runs : audit trail + versions complètes (replay determinism)
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS __seo_projection_runs (
+  id                          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  started_at                  timestamptz NOT NULL DEFAULT now(),
+  ended_at                    timestamptz,
+  status                      seo_projection_run_status NOT NULL DEFAULT 'running',
+  entities_processed          integer NOT NULL DEFAULT 0 CHECK (entities_processed >= 0),
+  conflicts_count             integer NOT NULL DEFAULT 0 CHECK (conflicts_count >= 0),
+
+  -- Versions complètes (replay determinism per ADR-059 §"Versions complètes")
+  projection_contract_version text NOT NULL CHECK (projection_contract_version ~ '^[0-9]+\.[0-9]+\.[0-9]+$'),
+  builder_version             text NOT NULL CHECK (builder_version ~ '^[0-9]+\.[0-9]+\.[0-9]+$'),
+  pipeline_version            text NOT NULL CHECK (pipeline_version ~ '^[0-9]+\.[0-9]+\.[0-9]+$'),
+  extractor_version           text NOT NULL CHECK (extractor_version ~ '^[0-9]+\.[0-9]+\.[0-9]+$'),
+  runner_version              text NOT NULL CHECK (runner_version ~ '^[0-9]+\.[0-9]+\.[0-9]+$'),
+
+  -- Snapshot replay SoT (object-store tar.zst immutable per PR-5b)
+  exports_snapshot_hash       text NOT NULL CHECK (exports_snapshot_hash ~ '^sha256:[a-f0-9]{64}$'),
+  exports_snapshot_uri        text NOT NULL,
+
+  -- Audit-only (NOT replay-authoritative — informational metadata)
+  wiki_commit_sha             text NOT NULL,
+
+  -- Trigger provenance + replay traceability
+  trigger_kind                seo_projection_trigger_kind NOT NULL DEFAULT 'cron',
+  replayed_from_run_id        uuid REFERENCES __seo_projection_runs(id) ON DELETE RESTRICT,
+
+  error_message               text
+);
+
+CREATE INDEX IF NOT EXISTS idx_seo_projection_runs_started_at
+  ON __seo_projection_runs (started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_projection_runs_status
+  ON __seo_projection_runs (status);
+CREATE INDEX IF NOT EXISTS idx_seo_projection_runs_trigger_kind
+  ON __seo_projection_runs (trigger_kind);
+CREATE INDEX IF NOT EXISTS idx_seo_projection_runs_replayed_from
+  ON __seo_projection_runs (replayed_from_run_id)
+  WHERE replayed_from_run_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_seo_projection_runs_exports_snapshot_hash
+  ON __seo_projection_runs (exports_snapshot_hash);
+
+COMMENT ON TABLE __seo_projection_runs IS
+  'ADR-059 §Versioning complet. 1 row par exécution runner. exports_snapshot_uri = replay SoT (tar.zst immutable object-store). wiki_commit_sha = informational-only audit metadata.';
+COMMENT ON COLUMN __seo_projection_runs.wiki_commit_sha IS
+  'INFORMATIONAL-ONLY audit. Replay SoT = exports_snapshot_uri (tar.zst). Anti git rewrite / force push.';
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. __seo_entity_fact_versions : versions historiques (kg_v3 pattern)
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS __seo_entity_fact_versions (
+  version_id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_id           text NOT NULL CHECK (entity_id ~ '^(gamme|vehicle|constructeur|diagnostic):[a-z0-9-]+$'),
+  fact_key            text NOT NULL CHECK (length(fact_key) BETWEEN 1 AND 200),
+  fact_value          jsonb NOT NULL,
+  source_id           text,
+
+  -- kg_v3 pattern
+  status              seo_projection_version_status NOT NULL DEFAULT 'draft',
+  valid_from          timestamptz NOT NULL DEFAULT now(),
+  valid_to            timestamptz,
+  source_type         text,
+  confidence_base     numeric(3,2) CHECK (confidence_base IS NULL OR (confidence_base >= 0 AND confidence_base <= 1)),
+  content_hash        text NOT NULL CHECK (content_hash ~ '^sha256:[a-f0-9]{64}$'),
+
+  -- Provenance
+  source_wiki_commit  text NOT NULL,
+  run_id              uuid NOT NULL REFERENCES __seo_projection_runs(id) ON DELETE RESTRICT,
+
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_seo_entity_fact_versions_entity_key
+  ON __seo_entity_fact_versions (entity_id, fact_key);
+CREATE INDEX IF NOT EXISTS idx_seo_entity_fact_versions_status
+  ON __seo_entity_fact_versions (status);
+CREATE INDEX IF NOT EXISTS idx_seo_entity_fact_versions_run
+  ON __seo_entity_fact_versions (run_id);
+CREATE INDEX IF NOT EXISTS idx_seo_entity_fact_versions_content_hash
+  ON __seo_entity_fact_versions (content_hash);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_seo_entity_fact_versions_entity_key_hash
+  ON __seo_entity_fact_versions (entity_id, fact_key, content_hash);
+
+COMMENT ON TABLE __seo_entity_fact_versions IS
+  'ADR-059 versions historiques. INSERT-only (jamais UPDATE, jamais DELETE — audit trail préservé). Rollback = UPDATE active_version_id sur __seo_entity_facts.';
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 3. __seo_entity_facts : current state pointer (active_version_id)
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS __seo_entity_facts (
+  entity_id           text NOT NULL CHECK (entity_id ~ '^(gamme|vehicle|constructeur|diagnostic):[a-z0-9-]+$'),
+  fact_key            text NOT NULL,
+  active_version_id   uuid REFERENCES __seo_entity_fact_versions(version_id) ON DELETE RESTRICT,
+  updated_at          timestamptz NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (entity_id, fact_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_seo_entity_facts_entity_id
+  ON __seo_entity_facts (entity_id);
+CREATE INDEX IF NOT EXISTS idx_seo_entity_facts_active_version
+  ON __seo_entity_facts (active_version_id);
+
+COMMENT ON TABLE __seo_entity_facts IS
+  'Current-state pointer per (entity_id, fact_key). active_version_id pointe vers __seo_entity_fact_versions. Rollback = UPDATE active_version_id, jamais DELETE.';
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 4. __seo_entity_sources : sources par entity
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS __seo_entity_sources (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_id       text NOT NULL CHECK (entity_id ~ '^(gamme|vehicle|constructeur|diagnostic):[a-z0-9-]+$'),
+  source_id       text NOT NULL,
+  source_type     text NOT NULL,
+  confidence_base numeric(3,2) CHECK (confidence_base IS NULL OR (confidence_base >= 0 AND confidence_base <= 1)),
+  url             text,
+  metadata        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  run_id          uuid REFERENCES __seo_projection_runs(id) ON DELETE RESTRICT,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_seo_entity_sources_entity
+  ON __seo_entity_sources (entity_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_seo_entity_sources_entity_source
+  ON __seo_entity_sources (entity_id, source_id);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 5. __seo_content_block_versions : versions historiques blocks
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS __seo_content_block_versions (
+  version_id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_id           text NOT NULL CHECK (entity_id ~ '^(gamme|vehicle|constructeur|diagnostic):[a-z0-9-]+$'),
+  role                text NOT NULL,
+  section             text,
+  content_md          text NOT NULL,
+
+  status              seo_projection_version_status NOT NULL DEFAULT 'draft',
+  valid_from          timestamptz NOT NULL DEFAULT now(),
+  valid_to            timestamptz,
+  content_hash        text NOT NULL CHECK (content_hash ~ '^sha256:[a-f0-9]{64}$'),
+
+  source_wiki_commit  text NOT NULL,
+  run_id              uuid NOT NULL REFERENCES __seo_projection_runs(id) ON DELETE RESTRICT,
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_seo_content_block_versions_entity_role
+  ON __seo_content_block_versions (entity_id, role);
+CREATE INDEX IF NOT EXISTS idx_seo_content_block_versions_status
+  ON __seo_content_block_versions (status);
+CREATE INDEX IF NOT EXISTS idx_seo_content_block_versions_run
+  ON __seo_content_block_versions (run_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_seo_content_block_versions_entity_role_hash
+  ON __seo_content_block_versions (entity_id, role, content_hash);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 6. __seo_content_blocks : current state pointer
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS __seo_content_blocks (
+  entity_id           text NOT NULL CHECK (entity_id ~ '^(gamme|vehicle|constructeur|diagnostic):[a-z0-9-]+$'),
+  role                text NOT NULL,
+  section             text,
+  active_version_id   uuid REFERENCES __seo_content_block_versions(version_id) ON DELETE RESTRICT,
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+-- COALESCE pour gérer section nullable (PG ne permet pas PK avec NULL)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_seo_content_blocks_entity_role_section
+  ON __seo_content_blocks (entity_id, role, COALESCE(section, ''));
+CREATE INDEX IF NOT EXISTS idx_seo_content_blocks_entity
+  ON __seo_content_blocks (entity_id);
+CREATE INDEX IF NOT EXISTS idx_seo_content_blocks_active_version
+  ON __seo_content_blocks (active_version_id);
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 7. __seo_projection_conflicts : conflits non auto-appliqués (review humaine)
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS __seo_projection_conflicts (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_id           text NOT NULL CHECK (entity_id ~ '^(gamme|vehicle|constructeur|diagnostic):[a-z0-9-]+$'),
+  fact_key            text,
+  block_key           text,  -- e.g. "R3_CONSEILS:S2_DIAG"
+  current_value       jsonb,
+  proposed_value      jsonb,
+  reason              text NOT NULL,
+  resolution          seo_projection_conflict_resolution NOT NULL DEFAULT 'pending',
+  resolved_at         timestamptz,
+  resolved_by         text,
+  resolution_notes    text,
+  run_id              uuid NOT NULL REFERENCES __seo_projection_runs(id) ON DELETE RESTRICT,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+
+  CHECK (fact_key IS NOT NULL OR block_key IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_seo_projection_conflicts_entity
+  ON __seo_projection_conflicts (entity_id);
+CREATE INDEX IF NOT EXISTS idx_seo_projection_conflicts_resolution
+  ON __seo_projection_conflicts (resolution);
+CREATE INDEX IF NOT EXISTS idx_seo_projection_conflicts_run
+  ON __seo_projection_conflicts (run_id);
+CREATE INDEX IF NOT EXISTS idx_seo_projection_conflicts_pending
+  ON __seo_projection_conflicts (created_at DESC)
+  WHERE resolution = 'pending';
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- RLS zero-trust (ADR-021)
+-- ────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE __seo_projection_runs        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE __seo_entity_facts           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE __seo_entity_fact_versions   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE __seo_entity_sources         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE __seo_content_blocks         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE __seo_content_block_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE __seo_projection_conflicts   ENABLE ROW LEVEL SECURITY;
+
+-- AUCUNE policy SELECT pour anon/authenticated par défaut.
+-- service_role bypass RLS (postgres role).
+-- Lecture publique passera EXCLUSIVEMENT par RPC SECURITY DEFINER (PR-7).
+-- Cohérent avec ADR-059 "No Direct Page SQL".
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- GRANTs explicites (feedback_supabase_grant_explicit_for_new_projects)
+-- ────────────────────────────────────────────────────────────────────────────
+
+REVOKE ALL ON __seo_projection_runs        FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON __seo_entity_facts           FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON __seo_entity_fact_versions   FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON __seo_entity_sources         FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON __seo_content_blocks         FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON __seo_content_block_versions FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON __seo_projection_conflicts   FROM PUBLIC, anon, authenticated;
+
+-- service_role : SELECT + INSERT + UPDATE (PAS DELETE — ADR-059 §Rollback dit "jamais DELETE")
+GRANT SELECT, INSERT, UPDATE ON __seo_projection_runs        TO service_role;
+GRANT SELECT, INSERT, UPDATE ON __seo_entity_facts           TO service_role;
+GRANT SELECT, INSERT, UPDATE ON __seo_entity_fact_versions   TO service_role;
+GRANT SELECT, INSERT, UPDATE ON __seo_entity_sources         TO service_role;
+GRANT SELECT, INSERT, UPDATE ON __seo_content_blocks         TO service_role;
+GRANT SELECT, INSERT, UPDATE ON __seo_content_block_versions TO service_role;
+GRANT SELECT, INSERT, UPDATE ON __seo_projection_conflicts   TO service_role;
+
+-- Sequences (gen_random_uuid n'utilise pas de séquence ; safe net si futurs ALTER)
+GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO service_role;
+
+COMMIT;

--- a/backend/supabase/migrations/20260513202232_seo_projection_materialized_views.sql
+++ b/backend/supabase/migrations/20260513202232_seo_projection_materialized_views.sql
@@ -1,0 +1,93 @@
+-- ============================================================================
+-- ADR-059 SEO Runtime Projection — Phase B PR-6a (MVs)
+--
+-- 2 materialized views pour accélération lecture pages R0-R8.
+--
+-- IMPORTANT (ADR-059 §"Known scalability limitation") :
+--   Ces MVs sont des STRUCTURES D'ACCÉLÉRATION TRANSITOIRES, **jamais**
+--   architecture définitive. Acceptable < ~100k entities. Au-delà,
+--   migration vers : tables current-state transactionnelles / incremental
+--   refresh / partitions par entity_type / event-driven read models.
+--
+-- IMPORTANT (ADR-059 §"Découplage write ↔ refresh") :
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY ne s'exécute JAMAIS dans la
+--   transaction d'écriture du runner. PR-6b implémente 2 queues BullMQ
+--   séparées (projection-write-queue + projection-refresh-queue).
+--
+-- Refs : ADR-059 vault PR #260 (accepted 2026-05-13).
+-- ============================================================================
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- mv_seo_entity_facts_current — facts actives par entity
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_seo_entity_facts_current AS
+SELECT
+  f.entity_id,
+  f.fact_key,
+  v.fact_value,
+  v.source_id,
+  v.source_type,
+  v.confidence_base,
+  v.content_hash,
+  v.valid_from,
+  v.valid_to,
+  f.updated_at
+FROM __seo_entity_facts f
+JOIN __seo_entity_fact_versions v
+  ON v.version_id = f.active_version_id
+WHERE v.status = 'active';
+
+-- UNIQUE index requis par REFRESH ... CONCURRENTLY
+CREATE UNIQUE INDEX IF NOT EXISTS uq_mv_seo_entity_facts_current
+  ON mv_seo_entity_facts_current (entity_id, fact_key);
+CREATE INDEX IF NOT EXISTS idx_mv_seo_entity_facts_current_entity
+  ON mv_seo_entity_facts_current (entity_id);
+
+COMMENT ON MATERIALIZED VIEW mv_seo_entity_facts_current IS
+  'ADR-059 transitional acceleration structure. REFRESH CONCURRENTLY only (never in write txn). Migration future si > 100k entities : current-state tables transactionnelles / incremental refresh / partitions / event-driven.';
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- mv_seo_content_blocks_current — blocks actifs par entity
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_seo_content_blocks_current AS
+SELECT
+  b.entity_id,
+  b.role,
+  b.section,
+  v.content_md,
+  v.content_hash,
+  v.valid_from,
+  v.valid_to,
+  b.updated_at
+FROM __seo_content_blocks b
+JOIN __seo_content_block_versions v
+  ON v.version_id = b.active_version_id
+WHERE v.status = 'active';
+
+-- UNIQUE index requis par REFRESH ... CONCURRENTLY (COALESCE pour section nullable)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_mv_seo_content_blocks_current
+  ON mv_seo_content_blocks_current (entity_id, role, COALESCE(section, ''));
+CREATE INDEX IF NOT EXISTS idx_mv_seo_content_blocks_current_entity
+  ON mv_seo_content_blocks_current (entity_id);
+
+COMMENT ON MATERIALIZED VIEW mv_seo_content_blocks_current IS
+  'ADR-059 transitional acceleration structure. REFRESH CONCURRENTLY only. Refresh worker = PR-6b projection-refresh-queue (debounce 5s, concurrency=1, single-flight).';
+
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Permissions MVs
+-- ────────────────────────────────────────────────────────────────────────────
+
+REVOKE ALL ON mv_seo_entity_facts_current   FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON mv_seo_content_blocks_current FROM PUBLIC, anon, authenticated;
+
+-- service_role : SELECT only (les MVs sont consommées via RPC PR-7 SECURITY DEFINER)
+GRANT SELECT ON mv_seo_entity_facts_current   TO service_role;
+GRANT SELECT ON mv_seo_content_blocks_current TO service_role;
+
+COMMIT;

--- a/log.md
+++ b/log.md
@@ -532,14 +532,20 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Décision** : feat(registry): canonical projection Layer 3 + freshness CI Phase 1 + 4 invariants (ADR-058 PR-E) (+6 other commits)
 - **Sortie** : PR #462 | commits a1d79d5b 658018c4 66d9e64f b08d3e90 b281943b f067e9ec 0504fd38
 
-## 2026-05-13 — feat/registry-pr-f-llm-entrypoint (auto)
+## 2026-05-13 — feat/registry-pr-d-canon-overlay (auto)
 
-- **Branche** : `feat/registry-pr-f-llm-entrypoint`
-- **Décision** : feat(registry): LLM entrypoint REPO_MAP.md + CLAUDE.md step 0 + cross-language hook (ADR-058 PR-F) (+8 other commits)
-- **Sortie** : PR #463 | commits 9ac2f75b 77d4b57a a1d79d5b 658018c4 66d9e64f b08d3e90 b281943b f067e9ec 0504fd38
+- **Branche** : `feat/registry-pr-d-canon-overlay`
+- **Décision** : Merge remote-tracking branch 'origin/main' into feat/registry-pr-d-canon-overlay (+8 other commits)
+- **Sortie** : PR #474 | commits 9f4c6a9b be6cd0d5 c13a0d1a 658018c4 66d9e64f b08d3e90 b281943b f067e9ec 0504fd38
 
-## 2026-05-13 — fix/seo-sitemap-auto-regeneration-cron (auto)
+## 2026-05-13 — feat/registry-pr-d-canon-overlay (auto)
 
-- **Branche** : `fix/seo-sitemap-auto-regeneration-cron`
-- **Décision** : fix(seo): restore automatic sitemap regeneration via BullMQ repeatable job
-- **Sortie** : PR #487 | commits af70edb3
+- **Branche** : `feat/registry-pr-d-canon-overlay`
+- **Décision** : chore(registry): rebuild canonical against new main (sync race fix) (+12 other commits)
+- **Sortie** : PR #474 | commits c901b065 ec17c941 2bc5f803 666d7f46 9f4c6a9b be6cd0d5 c13a0d1a 658018c4 66d9e64f b08d3e90 b281943b f067e9ec 0504fd38
+
+## 2026-05-13 — feature/seo-projection-db-migrations (auto)
+
+- **Branche** : `feature/seo-projection-db-migrations`
+- **Décision** : feat(db): migrations seo projection 7 tables + 2 mvs (pr-6a)
+- **Sortie** : PR #481 | commits b3eb5c69

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -1,0 +1,9 @@
+"""Permet à pytest de résoudre les imports depuis la racine app/."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/db/test_seo_projection_migrations.py
+++ b/tests/db/test_seo_projection_migrations.py
@@ -1,0 +1,269 @@
+"""
+Tests contractuels des migrations SEO projection (ADR-059 PR-6a).
+
+Approche : parse les fichiers SQL et vérifie le shape attendu (présence
+tables/MVs/colonnes/indexes/RLS/GRANTs). N'applique PAS les migrations
+(pas de connexion DB en CI — c'est le job de Supabase migrations en deploy).
+
+7 tables attendues :
+    __seo_projection_runs, __seo_entity_facts, __seo_entity_fact_versions,
+    __seo_entity_sources, __seo_content_blocks, __seo_content_block_versions,
+    __seo_projection_conflicts
+
+2 MVs attendues :
+    mv_seo_entity_facts_current, mv_seo_content_blocks_current
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "backend" / "supabase" / "migrations"
+
+
+@pytest.fixture(scope="module")
+def tables_sql() -> str:
+    path = MIGRATIONS_DIR / "20260513202231_seo_projection_tables.sql"
+    assert path.exists(), f"migration absente : {path}"
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def mvs_sql() -> str:
+    path = MIGRATIONS_DIR / "20260513202232_seo_projection_materialized_views.sql"
+    assert path.exists(), f"migration absente : {path}"
+    return path.read_text(encoding="utf-8")
+
+
+# ───────────────────────── 7 tables ─────────────────────────
+
+EXPECTED_TABLES = [
+    "__seo_projection_runs",
+    "__seo_entity_facts",
+    "__seo_entity_fact_versions",
+    "__seo_entity_sources",
+    "__seo_content_blocks",
+    "__seo_content_block_versions",
+    "__seo_projection_conflicts",
+]
+
+
+@pytest.mark.parametrize("table_name", EXPECTED_TABLES)
+def test_table_create_statement_present(tables_sql: str, table_name: str) -> None:
+    pattern = rf"CREATE TABLE IF NOT EXISTS\s+{re.escape(table_name)}\b"
+    assert re.search(pattern, tables_sql), f"missing CREATE TABLE for {table_name}"
+
+
+def test_exactly_seven_tables(tables_sql: str) -> None:
+    creates = re.findall(r"CREATE TABLE IF NOT EXISTS\s+(\w+)", tables_sql)
+    assert len(creates) == 7, f"expected 7 CREATE TABLE, got {len(creates)}: {creates}"
+    assert set(creates) == set(EXPECTED_TABLES)
+
+
+# ───────────────────────── 2 materialized views ─────────────────────────
+
+EXPECTED_MVS = ["mv_seo_entity_facts_current", "mv_seo_content_blocks_current"]
+
+
+@pytest.mark.parametrize("mv_name", EXPECTED_MVS)
+def test_mv_create_statement_present(mvs_sql: str, mv_name: str) -> None:
+    pattern = rf"CREATE MATERIALIZED VIEW IF NOT EXISTS\s+{re.escape(mv_name)}\b"
+    assert re.search(pattern, mvs_sql), f"missing CREATE MATERIALIZED VIEW for {mv_name}"
+
+
+def test_exactly_two_mvs(mvs_sql: str) -> None:
+    mvs = re.findall(r"CREATE MATERIALIZED VIEW IF NOT EXISTS\s+(\w+)", mvs_sql)
+    assert len(mvs) == 2
+    assert set(mvs) == set(EXPECTED_MVS)
+
+
+@pytest.mark.parametrize("mv_name", EXPECTED_MVS)
+def test_mv_has_unique_index_for_concurrent_refresh(mvs_sql: str, mv_name: str) -> None:
+    """REFRESH ... CONCURRENTLY exige un UNIQUE INDEX sur la MV."""
+    pattern = rf"CREATE UNIQUE INDEX[^;]+ON\s+{re.escape(mv_name)}\b"
+    assert re.search(pattern, mvs_sql), (
+        f"{mv_name} must have a UNIQUE INDEX to support REFRESH CONCURRENTLY"
+    )
+
+
+# ───────────────────────── Versions complètes (replay determinism) ───────────
+
+VERSION_FIELDS = [
+    "projection_contract_version",
+    "builder_version",
+    "pipeline_version",
+    "extractor_version",
+    "runner_version",
+    "exports_snapshot_hash",
+    "exports_snapshot_uri",
+    "wiki_commit_sha",
+    "trigger_kind",
+    "replayed_from_run_id",
+]
+
+
+@pytest.mark.parametrize("field", VERSION_FIELDS)
+def test_projection_runs_has_version_field(tables_sql: str, field: str) -> None:
+    """ADR-059 §Versioning complet — chaque version field doit être dans __seo_projection_runs."""
+    runs_block = _extract_table_block(tables_sql, "__seo_projection_runs")
+    assert field in runs_block, f"__seo_projection_runs missing column: {field}"
+
+
+def test_wiki_commit_authority_documented_as_informational(tables_sql: str) -> None:
+    """Anti-replay-bug : wiki_commit_sha doit être documenté informational-only."""
+    assert "INFORMATIONAL-ONLY" in tables_sql.upper()
+    assert "tar.zst" in tables_sql or "exports_snapshot" in tables_sql
+
+
+def test_exports_snapshot_hash_pattern_sha256(tables_sql: str) -> None:
+    """exports_snapshot_hash doit avoir un CHECK pattern ^sha256:[a-f0-9]{64}$."""
+    runs_block = _extract_table_block(tables_sql, "__seo_projection_runs")
+    assert "sha256" in runs_block
+    assert re.search(r"exports_snapshot_hash[^,]+sha256", runs_block)
+
+
+# ───────────────────────── kg_v3 pattern ─────────────────────────
+
+KG_V3_FIELDS_IN_VERSIONS = ["status", "valid_from", "valid_to", "source_type", "confidence_base", "content_hash"]
+
+
+@pytest.mark.parametrize("field", KG_V3_FIELDS_IN_VERSIONS)
+def test_fact_versions_has_kg_v3_field(tables_sql: str, field: str) -> None:
+    block = _extract_table_block(tables_sql, "__seo_entity_fact_versions")
+    assert field in block, f"__seo_entity_fact_versions missing kg_v3 field: {field}"
+
+
+def test_facts_table_has_active_version_id_fk(tables_sql: str) -> None:
+    block = _extract_table_block(tables_sql, "__seo_entity_facts")
+    assert "active_version_id" in block
+    assert "REFERENCES __seo_entity_fact_versions" in block
+
+
+def test_blocks_table_has_active_version_id_fk(tables_sql: str) -> None:
+    block = _extract_table_block(tables_sql, "__seo_content_blocks")
+    assert "active_version_id" in block
+    assert "REFERENCES __seo_content_block_versions" in block
+
+
+# ───────────────────────── RLS zero-trust ─────────────────────────
+
+@pytest.mark.parametrize("table_name", EXPECTED_TABLES)
+def test_rls_enabled_on_all_tables(tables_sql: str, table_name: str) -> None:
+    """ADR-021 : RLS activée sur toutes les nouvelles tables."""
+    pattern = rf"ALTER TABLE\s+{re.escape(table_name)}\s+ENABLE ROW LEVEL SECURITY"
+    assert re.search(pattern, tables_sql), f"RLS not enabled on {table_name}"
+
+
+def test_no_select_policy_for_anon_or_authenticated(tables_sql: str) -> None:
+    """Lecture publique doit passer par RPC SECURITY DEFINER (ADR-059 No Direct Page SQL)."""
+    # No CREATE POLICY granting SELECT to anon/authenticated should exist
+    bad_patterns = [
+        r"CREATE POLICY[^;]+TO\s+anon[^;]+SELECT",
+        r"CREATE POLICY[^;]+TO\s+authenticated[^;]+SELECT",
+    ]
+    for pat in bad_patterns:
+        assert not re.search(pat, tables_sql, re.IGNORECASE), (
+            f"forbidden SELECT policy for anon/authenticated: {pat}. "
+            "Reads MUST go through RPC SECURITY DEFINER (PR-7)."
+        )
+
+
+# ───────────────────────── GRANTs explicites ─────────────────────────
+
+@pytest.mark.parametrize("table_name", EXPECTED_TABLES)
+def test_explicit_revoke_for_anon_authenticated(tables_sql: str, table_name: str) -> None:
+    """feedback_supabase_grant_explicit : REVOKE ALL FROM anon/authenticated."""
+    pattern = rf"REVOKE ALL ON\s+{re.escape(table_name)}\b[^;]*FROM[^;]*(anon|authenticated)"
+    assert re.search(pattern, tables_sql), f"missing explicit REVOKE for {table_name}"
+
+
+@pytest.mark.parametrize("table_name", EXPECTED_TABLES)
+def test_grants_to_service_role_no_delete(tables_sql: str, table_name: str) -> None:
+    """service_role doit avoir SELECT/INSERT/UPDATE mais JAMAIS DELETE (ADR-059 audit trail)."""
+    pattern = rf"GRANT\s+SELECT,\s*INSERT,\s*UPDATE\s+ON\s+{re.escape(table_name)}\s+TO\s+service_role"
+    assert re.search(pattern, tables_sql), f"missing GRANT to service_role on {table_name}"
+
+
+def test_no_delete_grant_to_any_role(tables_sql: str) -> None:
+    """ADR-059 §Rollback : jamais DELETE, audit trail préservé."""
+    assert "GRANT DELETE" not in tables_sql.upper(), (
+        "ADR-059 forbids DELETE on projection tables (rollback = UPDATE active_version_id only)"
+    )
+
+
+# ───────────────────────── No destructive statements ─────────────────────────
+
+def test_no_drop_table_in_migrations(tables_sql: str, mvs_sql: str) -> None:
+    combined = tables_sql + "\n" + mvs_sql
+    assert not re.search(r"\bDROP TABLE\b", combined, re.IGNORECASE), (
+        "PR-6a migrations must not contain DROP TABLE"
+    )
+
+
+def test_no_truncate_in_migrations(tables_sql: str, mvs_sql: str) -> None:
+    combined = tables_sql + "\n" + mvs_sql
+    assert not re.search(r"\bTRUNCATE\b", combined, re.IGNORECASE)
+
+
+def test_no_delete_in_migrations(tables_sql: str, mvs_sql: str) -> None:
+    combined = tables_sql + "\n" + mvs_sql
+    # Allow ON DELETE RESTRICT (FK clause), forbid bare DELETE statements
+    bare_delete = re.search(r"^\s*DELETE\s+FROM\b", combined, re.IGNORECASE | re.MULTILINE)
+    assert bare_delete is None, "PR-6a must not contain DELETE FROM"
+
+
+def test_transactions_wrapped(tables_sql: str, mvs_sql: str) -> None:
+    """Chaque migration doit être dans BEGIN ... COMMIT pour atomicité."""
+    for sql, name in [(tables_sql, "tables"), (mvs_sql, "mvs")]:
+        assert re.search(r"^\s*BEGIN\s*;", sql, re.MULTILINE), f"{name} migration missing BEGIN"
+        assert re.search(r"^\s*COMMIT\s*;", sql, re.MULTILINE), f"{name} migration missing COMMIT"
+
+
+# ───────────────────────── Indexes critiques ─────────────────────────
+
+CRITICAL_INDEXES = [
+    "idx_seo_projection_runs_started_at",
+    "idx_seo_projection_runs_exports_snapshot_hash",
+    "idx_seo_entity_fact_versions_status",
+    "idx_seo_entity_fact_versions_run",
+    "idx_seo_content_block_versions_status",
+    "idx_seo_projection_conflicts_pending",
+]
+
+
+@pytest.mark.parametrize("index_name", CRITICAL_INDEXES)
+def test_critical_index_present(tables_sql: str, index_name: str) -> None:
+    assert index_name in tables_sql, f"critical index missing: {index_name}"
+
+
+# ───────────────────────── PR-6a scope strict (no worker/runner/replay) ─────
+
+def test_no_function_or_trigger_in_pr6a(tables_sql: str, mvs_sql: str) -> None:
+    """PR-6a = DDL pures. Functions/triggers = PR-6b/PR-7."""
+    combined = tables_sql + "\n" + mvs_sql
+    assert not re.search(r"CREATE\s+(OR\s+REPLACE\s+)?FUNCTION\b", combined, re.IGNORECASE), (
+        "PR-6a must not contain CREATE FUNCTION (= PR-6b workers / PR-7 RPC)"
+    )
+    assert not re.search(r"CREATE\s+TRIGGER\b", combined, re.IGNORECASE), (
+        "PR-6a must not contain CREATE TRIGGER (= PR-6b)"
+    )
+
+
+def test_no_insert_or_update_in_migrations(tables_sql: str, mvs_sql: str) -> None:
+    """PR-6a = pure DDL, no data manipulation."""
+    combined = tables_sql + "\n" + mvs_sql
+    assert not re.search(r"^\s*INSERT\s+INTO\b", combined, re.MULTILINE | re.IGNORECASE)
+    assert not re.search(r"^\s*UPDATE\s+\w+\s+SET\b", combined, re.MULTILINE | re.IGNORECASE)
+
+
+# ───────────────────────── Helpers ─────────────────────────
+
+def _extract_table_block(sql: str, table_name: str) -> str:
+    """Retourne le bloc CREATE TABLE ... ) pour une table donnée."""
+    pattern = rf"CREATE TABLE IF NOT EXISTS\s+{re.escape(table_name)}\s*\((.*?)\n\);"
+    match = re.search(pattern, sql, re.DOTALL)
+    assert match, f"could not extract table block for {table_name}"
+    return match.group(1)


### PR DESCRIPTION
ADR-059 Phase B PR-6a — migrations Supabase DDL only. 7 tables __seo_projection_* / __seo_entity_* (kg_v3 pattern) + 2 materialized views CONCURRENT REFRESH. AUCUN worker, AUCUN runner, AUCUN replay (= PR-6b + PR-6c).

Files: backend/supabase/migrations/20260513202231_seo_projection_tables.sql + 20260513202232_seo_projection_materialized_views.sql + tests/db/test_seo_projection_migrations.py (68 tests).

Garde-fous (68 tests PASS): RLS zero-trust ADR-021 sur 7 tables, AUCUNE policy SELECT anon/authenticated (lecture via RPC SECURITY DEFINER PR-7 — coherent No Direct Page SQL), REVOKE ALL explicite + GRANT SELECT/INSERT/UPDATE service_role (feedback_supabase_grant_explicit), AUCUN GRANT DELETE (rollback = UPDATE active_version_id), CHECK sha256/semver/entity_id pattern singulier, FK ON DELETE RESTRICT.

Scope strict PR-6a (testé): AUCUN CREATE FUNCTION/TRIGGER, AUCUN INSERT/UPDATE, AUCUN DROP/TRUNCATE/DELETE FROM, BEGIN/COMMIT atomic.

7 tables: __seo_projection_runs (audit + versions builder/pipeline/extractor/runner + exports_snapshot_uri replay SoT + wiki_commit_sha informational-only), __seo_entity_fact_versions (kg_v3), __seo_entity_facts (active_version_id FK), __seo_entity_sources, __seo_content_block_versions, __seo_content_blocks, __seo_projection_conflicts.

2 MVs transitional acceleration (jamais architecture definitive per ADR-059): mv_seo_entity_facts_current + mv_seo_content_blocks_current, chacune avec UNIQUE INDEX requis CONCURRENTLY.

Cette PR ne deploie pas — migrations commitees au repo, application via Supabase CLI standard.

Hors scope: PR-6b workers BullMQ, PR-6c replay_projection.py G1/G2, PR-7 RPC + pages + guards.

Refs: ADR-059 vault PR #260 accepted, ADR-021 RLS zero-trust, kg_v3 pattern migration 20260125.