### PR TITLE
feat(seo/projection): read rpc + adapter (pr-7a)

### DIFF
--- a/backend/src/modules/seo/projection/__tests__/seo-projection-read.adapter.test.ts
+++ b/backend/src/modules/seo/projection/__tests__/seo-projection-read.adapter.test.ts
@@ -13,9 +13,7 @@ import {
   SeoProjectionReadAdapter,
 } from '../seo-projection-read.adapter';
 
-
 const ADAPTER_SRC = join(__dirname, '..', 'seo-projection-read.adapter.ts');
-
 
 // Test instance sans wiring DI (méthodes testées sont pures ou mockent supabase)
 function makeAdapter(rpcMock: jest.Mock): SeoProjectionReadAdapter {
@@ -24,14 +22,17 @@ function makeAdapter(rpcMock: jest.Mock): SeoProjectionReadAdapter {
   ) as SeoProjectionReadAdapter & { supabase: unknown };
   (adapter as unknown as { supabase: unknown }).supabase = { rpc: rpcMock };
   // Logger stub
-  (adapter as unknown as { readLogger: { warn: jest.Mock; error: jest.Mock; log: jest.Mock } }).readLogger = {
+  (
+    adapter as unknown as {
+      readLogger: { warn: jest.Mock; error: jest.Mock; log: jest.Mock };
+    }
+  ).readLogger = {
     warn: jest.fn(),
     error: jest.fn(),
     log: jest.fn(),
   };
   return adapter;
 }
-
 
 function validRpcPayload(overrides: Record<string, unknown> = {}): unknown {
   return {
@@ -61,7 +62,6 @@ function validRpcPayload(overrides: Record<string, unknown> = {}): unknown {
   };
 }
 
-
 // ────────────────────────────────────────────────────────────────────────────
 // Zod schema validation
 // ────────────────────────────────────────────────────────────────────────────
@@ -74,7 +74,11 @@ describe('ProjectionPayloadSchema', () => {
 
   it('rejects support entity_type', () => {
     const parsed = ProjectionPayloadSchema.safeParse(
-      validRpcPayload({ entity_id: 'support:retours', entity_type: 'support', slug: 'retours' }),
+      validRpcPayload({
+        entity_id: 'support:retours',
+        entity_type: 'support',
+        slug: 'retours',
+      }),
     );
     expect(parsed.success).toBe(false);
   });
@@ -94,7 +98,10 @@ describe('ProjectionPayloadSchema', () => {
   });
 
   it('rejects extra fields', () => {
-    const parsed = ProjectionPayloadSchema.safeParse({ ...(validRpcPayload() as object), extra: 'oops' });
+    const parsed = ProjectionPayloadSchema.safeParse({
+      ...(validRpcPayload() as object),
+      extra: 'oops',
+    });
     expect(parsed.success).toBe(false);
   });
 
@@ -115,14 +122,15 @@ describe('ProjectionPayloadSchema', () => {
   });
 });
 
-
 // ────────────────────────────────────────────────────────────────────────────
 // getActiveProjection behaviour
 // ────────────────────────────────────────────────────────────────────────────
 
 describe('SeoProjectionReadAdapter.getActiveProjection', () => {
   it('returns success for valid payload', async () => {
-    const rpc = jest.fn().mockResolvedValue({ data: validRpcPayload(), error: null });
+    const rpc = jest
+      .fn()
+      .mockResolvedValue({ data: validRpcPayload(), error: null });
     const adapter = makeAdapter(rpc);
     const result = await adapter.getActiveProjection('gamme:filtre-a-huile');
     expect(result.status).toBe('success');
@@ -181,9 +189,13 @@ describe('SeoProjectionReadAdapter.getActiveProjection', () => {
   });
 
   it('passes role filter to RPC when provided', async () => {
-    const rpc = jest.fn().mockResolvedValue({ data: validRpcPayload(), error: null });
+    const rpc = jest
+      .fn()
+      .mockResolvedValue({ data: validRpcPayload(), error: null });
     const adapter = makeAdapter(rpc);
-    await adapter.getActiveProjection('gamme:filtre-a-huile', { role: 'R3_CONSEILS' });
+    await adapter.getActiveProjection('gamme:filtre-a-huile', {
+      role: 'R3_CONSEILS',
+    });
     expect(rpc).toHaveBeenCalledWith('get_active_seo_projection', {
       p_entity_id: 'gamme:filtre-a-huile',
       p_role: 'R3_CONSEILS',
@@ -201,7 +213,6 @@ describe('SeoProjectionReadAdapter.getActiveProjection', () => {
   });
 });
 
-
 // ────────────────────────────────────────────────────────────────────────────
 // Architectural guards — adapter must use RPC, NEVER direct table SELECT
 // ────────────────────────────────────────────────────────────────────────────
@@ -212,14 +223,18 @@ describe('PR-7a architectural guards', () => {
   function codeOnly(text: string): string {
     return text
       .split('\n')
-      .filter((line) => !line.trim().startsWith('*') && !line.trim().startsWith('//'))
+      .filter(
+        (line) => !line.trim().startsWith('*') && !line.trim().startsWith('//'),
+      )
       .join('\n');
   }
 
   it('uses callRpc<T>() wrapper canonique (RPC Safety Gate)', () => {
     // RPC Safety Gate canon : ne JAMAIS appeler `.rpc()` direct sur supabase.
     // Tout passe par `this.callRpc<T>` (SupabaseBaseService wrapper).
-    expect(src).toMatch(/this\.callRpc<[^>]+>\(\s*['"]get_active_seo_projection['"]/);
+    expect(src).toMatch(
+      /this\.callRpc<[^>]+>\(\s*['"]get_active_seo_projection['"]/,
+    );
     expect(src).not.toMatch(/this\.supabase\.rpc\(/);
   });
 

--- a/backend/src/modules/seo/projection/__tests__/seo-projection-read.adapter.test.ts
+++ b/backend/src/modules/seo/projection/__tests__/seo-projection-read.adapter.test.ts
@@ -216,8 +216,11 @@ describe('PR-7a architectural guards', () => {
       .join('\n');
   }
 
-  it('uses .rpc() — RPC path canonique', () => {
-    expect(src).toMatch(/this\.supabase\.rpc\(['"]get_active_seo_projection['"]/);
+  it('uses callRpc<T>() wrapper canonique (RPC Safety Gate)', () => {
+    // RPC Safety Gate canon : ne JAMAIS appeler `.rpc()` direct sur supabase.
+    // Tout passe par `this.callRpc<T>` (SupabaseBaseService wrapper).
+    expect(src).toMatch(/this\.callRpc<[^>]+>\(\s*['"]get_active_seo_projection['"]/);
+    expect(src).not.toMatch(/this\.supabase\.rpc\(/);
   });
 
   it('NEVER calls .from() on projection tables directly (ADR-059 No Direct Page SQL)', () => {

--- a/backend/src/modules/seo/projection/__tests__/seo-projection-read.adapter.test.ts
+++ b/backend/src/modules/seo/projection/__tests__/seo-projection-read.adapter.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests SeoProjectionReadAdapter — validation entrée/sortie + garde-fou architectural.
+ *
+ * Garde-fou critique (ADR-059 §"No Direct Page SQL") :
+ *   L'adapter ne doit JAMAIS appeler `.from('__seo_entity_*')` ou
+ *   `.from('__seo_projection_*')` directement. Uniquement `.rpc(...)`.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  ProjectionPayloadSchema,
+  SeoProjectionReadAdapter,
+} from '../seo-projection-read.adapter';
+
+
+const ADAPTER_SRC = join(__dirname, '..', 'seo-projection-read.adapter.ts');
+
+
+// Test instance sans wiring DI (méthodes testées sont pures ou mockent supabase)
+function makeAdapter(rpcMock: jest.Mock): SeoProjectionReadAdapter {
+  const adapter = Object.create(
+    SeoProjectionReadAdapter.prototype,
+  ) as SeoProjectionReadAdapter & { supabase: unknown };
+  (adapter as unknown as { supabase: unknown }).supabase = { rpc: rpcMock };
+  // Logger stub
+  (adapter as unknown as { readLogger: { warn: jest.Mock; error: jest.Mock; log: jest.Mock } }).readLogger = {
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+  };
+  return adapter;
+}
+
+
+function validRpcPayload(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    entity_id: 'gamme:filtre-a-huile',
+    entity_type: 'gamme',
+    slug: 'filtre-a-huile',
+    projection_contract_version: '1.0.0',
+    facts: { material: 'cellulose', oem_compat: ['BMW', 'PSA'] },
+    blocks: [
+      {
+        role: 'R3_CONSEILS',
+        section: 'S2_DIAG',
+        content_md: 'Filtre à huile retient particules.',
+        content_hash: 'sha256:' + 'a'.repeat(64),
+      },
+    ],
+    sources: [
+      {
+        id: 'bosch_fad_2020',
+        type: 'specialist',
+        confidence_base: 0.85,
+        url: null,
+      },
+    ],
+    fetched_at: '2026-05-13T20:50:00+00:00',
+    ...overrides,
+  };
+}
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Zod schema validation
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('ProjectionPayloadSchema', () => {
+  it('accepts a valid payload', () => {
+    const parsed = ProjectionPayloadSchema.safeParse(validRpcPayload());
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects support entity_type', () => {
+    const parsed = ProjectionPayloadSchema.safeParse(
+      validRpcPayload({ entity_id: 'support:retours', entity_type: 'support', slug: 'retours' }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects plural entity_id', () => {
+    const parsed = ProjectionPayloadSchema.safeParse(
+      validRpcPayload({ entity_id: 'gammes:filtre-a-huile' }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects missing fields (additionalProperties strict)', () => {
+    const payload = validRpcPayload() as Record<string, unknown>;
+    delete payload.facts;
+    const parsed = ProjectionPayloadSchema.safeParse(payload);
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects extra fields', () => {
+    const parsed = ProjectionPayloadSchema.safeParse({ ...(validRpcPayload() as object), extra: 'oops' });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects invalid content_hash', () => {
+    const parsed = ProjectionPayloadSchema.safeParse(
+      validRpcPayload({
+        blocks: [
+          {
+            role: 'R3_CONSEILS',
+            section: null,
+            content_md: 'x',
+            content_hash: 'md5:deadbeef',
+          },
+        ],
+      }),
+    );
+    expect(parsed.success).toBe(false);
+  });
+});
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// getActiveProjection behaviour
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('SeoProjectionReadAdapter.getActiveProjection', () => {
+  it('returns success for valid payload', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: validRpcPayload(), error: null });
+    const adapter = makeAdapter(rpc);
+    const result = await adapter.getActiveProjection('gamme:filtre-a-huile');
+    expect(result.status).toBe('success');
+    expect(result.payload?.entity_id).toBe('gamme:filtre-a-huile');
+    expect(rpc).toHaveBeenCalledWith('get_active_seo_projection', {
+      p_entity_id: 'gamme:filtre-a-huile',
+      p_role: null,
+    });
+  });
+
+  it('returns empty when facts and blocks are empty', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: validRpcPayload({ facts: {}, blocks: [] }),
+      error: null,
+    });
+    const adapter = makeAdapter(rpc);
+    const result = await adapter.getActiveProjection('gamme:unknown-slug');
+    expect(result.status).toBe('empty');
+  });
+
+  it('returns rpc_failed when RPC errors', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'permission denied' },
+    });
+    const adapter = makeAdapter(rpc);
+    const result = await adapter.getActiveProjection('gamme:filtre-a-huile');
+    expect(result.status).toBe('rpc_failed');
+    expect(result.error).toContain('permission denied');
+  });
+
+  it('returns validation_failed for malformed payload', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: { not_a_valid: 'payload' },
+      error: null,
+    });
+    const adapter = makeAdapter(rpc);
+    const result = await adapter.getActiveProjection('gamme:filtre-a-huile');
+    expect(result.status).toBe('validation_failed');
+  });
+
+  it('refuses invalid entity_id before calling RPC', async () => {
+    const rpc = jest.fn();
+    const adapter = makeAdapter(rpc);
+    const result = await adapter.getActiveProjection('support:retours');
+    expect(result.status).toBe('validation_failed');
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('refuses plural entity_id before calling RPC', async () => {
+    const rpc = jest.fn();
+    const adapter = makeAdapter(rpc);
+    const result = await adapter.getActiveProjection('gammes:filtre-a-huile');
+    expect(result.status).toBe('validation_failed');
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('passes role filter to RPC when provided', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: validRpcPayload(), error: null });
+    const adapter = makeAdapter(rpc);
+    await adapter.getActiveProjection('gamme:filtre-a-huile', { role: 'R3_CONSEILS' });
+    expect(rpc).toHaveBeenCalledWith('get_active_seo_projection', {
+      p_entity_id: 'gamme:filtre-a-huile',
+      p_role: 'R3_CONSEILS',
+    });
+  });
+
+  it('refuses malformed role before calling RPC', async () => {
+    const rpc = jest.fn();
+    const adapter = makeAdapter(rpc);
+    const result = await adapter.getActiveProjection('gamme:filtre-a-huile', {
+      role: 'invalid-role',
+    });
+    expect(result.status).toBe('validation_failed');
+    expect(rpc).not.toHaveBeenCalled();
+  });
+});
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Architectural guards — adapter must use RPC, NEVER direct table SELECT
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('PR-7a architectural guards', () => {
+  const src = readFileSync(ADAPTER_SRC, 'utf-8');
+
+  function codeOnly(text: string): string {
+    return text
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('*') && !line.trim().startsWith('//'))
+      .join('\n');
+  }
+
+  it('uses .rpc() — RPC path canonique', () => {
+    expect(src).toMatch(/this\.supabase\.rpc\(['"]get_active_seo_projection['"]/);
+  });
+
+  it('NEVER calls .from() on projection tables directly (ADR-059 No Direct Page SQL)', () => {
+    const code = codeOnly(src);
+    const forbidden = [
+      ".from('__seo_entity_facts')",
+      ".from('__seo_entity_fact_versions')",
+      ".from('__seo_entity_sources')",
+      ".from('__seo_content_blocks')",
+      ".from('__seo_content_block_versions')",
+      ".from('__seo_projection_runs')",
+      ".from('__seo_projection_conflicts')",
+      '.from("__seo_entity_facts")',
+      '.from("__seo_entity_sources")',
+      '.from("__seo_content_blocks")',
+      '.from("__seo_projection_runs")',
+      '.from("__seo_projection_conflicts")',
+      ".from('mv_seo_entity_facts_current')",
+      ".from('mv_seo_content_blocks_current')",
+      '.from("mv_seo_entity_facts_current")',
+      '.from("mv_seo_content_blocks_current")',
+    ];
+    for (const needle of forbidden) {
+      expect(code).not.toContain(needle);
+    }
+  });
+
+  it('NEVER writes (no .insert/.update/.delete/.upsert)', () => {
+    const code = codeOnly(src);
+    expect(code).not.toMatch(/\.insert\(/);
+    expect(code).not.toMatch(/\.update\(/);
+    expect(code).not.toMatch(/\.delete\(/);
+    expect(code).not.toMatch(/\.upsert\(/);
+  });
+
+  it('NEVER imports LLM SDKs', () => {
+    const forbiddenImports = [
+      "from 'anthropic'",
+      "from '@anthropic-ai",
+      "from 'openai'",
+      "from 'groq-sdk'",
+      "from 'cohere-ai'",
+      "from 'mistralai'",
+      "from '@google/generative-ai'",
+    ];
+    for (const needle of forbiddenImports) {
+      expect(src).not.toContain(needle);
+    }
+  });
+
+  it('NEVER writes wiki canon (no automecanik-wiki path in code)', () => {
+    const code = codeOnly(src);
+    expect(code).not.toMatch(/automecanik-wiki/);
+    expect(code).not.toMatch(/\bgit\s+push\b/);
+  });
+
+  it('exposes ProjectionPayloadSchema strict (additionalProperties forbidden)', () => {
+    expect(src).toMatch(/\.strict\(\)/);
+  });
+
+  it('declares Logger (observability for rpc_failed cases)', () => {
+    expect(src).toMatch(/private readonly readLogger = new Logger/);
+  });
+});

--- a/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
+++ b/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
@@ -21,16 +21,20 @@ import { z } from 'zod';
 
 import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
 
-
 // ────────────────────────────────────────────────────────────────────────────
 // Zod schemas — strict validation du payload RPC
 // ────────────────────────────────────────────────────────────────────────────
 
 const EntityIdSchema = z
   .string()
-  .regex(/^(gamme|vehicle|constructeur|diagnostic):[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+  .regex(
+    /^(gamme|vehicle|constructeur|diagnostic):[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+  );
 
-const RoleSchema = z.string().regex(/^R[0-9]_[A-Z_]+$/).nullable();
+const RoleSchema = z
+  .string()
+  .regex(/^R[0-9]_[A-Z_]+$/)
+  .nullable();
 
 const SourceSchema = z
   .object({
@@ -64,7 +68,6 @@ export const ProjectionPayloadSchema = z
   .strict();
 
 export type ProjectionPayload = z.infer<typeof ProjectionPayloadSchema>;
-
 
 // ────────────────────────────────────────────────────────────────────────────
 // Adapter

--- a/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
+++ b/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
@@ -121,10 +121,14 @@ export class SeoProjectionReadAdapter extends SupabaseBaseService {
       }
     }
 
-    const { data, error } = await this.supabase.rpc('get_active_seo_projection', {
-      p_entity_id: entityId,
-      p_role: options.role ?? null,
-    });
+    // Uses canonical `callRpc<T>` wrapper (RPC Safety Gate). Never direct supabase.rpc.
+    const { data, error } = await this.callRpc<unknown>(
+      'get_active_seo_projection',
+      {
+        p_entity_id: entityId,
+        p_role: options.role ?? null,
+      },
+    );
 
     if (error) {
       this.readLogger.warn(

--- a/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
+++ b/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
@@ -1,0 +1,163 @@
+/**
+ * ADR-059 Phase B PR-7a — SeoProjectionReadAdapter.
+ *
+ * Seul point d'accès lecture autorisé pour la projection runtime SEO.
+ * **AUCUNE page R0-R8 ne lit `__seo_entity_*` directement** : tout passe
+ * par cet adapter qui invoque la RPC SECURITY DEFINER `get_active_seo_projection`.
+ *
+ * Garde-fous architecturaux (ADR-059 §"No Direct Page SQL") :
+ *  - Cet adapter est la SEULE surface autorisée pour lecture projection
+ *  - Aucun `.from('__seo_entity_*')` direct ici (uniquement `.rpc(...)`)
+ *  - Zod validation strict du payload retourné
+ *  - 0 LLM, 0 write DB, 0 wiki canon write
+ *
+ * Future enrichissement (PR-7b ou followup) :
+ *  - Cache Redis 5min advisory (lecture rapide pages)
+ *  - GrowthBook feature flag `seo_projection_read_v1` avec circuit breaker
+ *  - Fallback deterministic legacy si projection vide/RPC indisponible
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { z } from 'zod';
+
+import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Zod schemas — strict validation du payload RPC
+// ────────────────────────────────────────────────────────────────────────────
+
+const EntityIdSchema = z
+  .string()
+  .regex(/^(gamme|vehicle|constructeur|diagnostic):[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+
+const RoleSchema = z.string().regex(/^R[0-9]_[A-Z_]+$/).nullable();
+
+const SourceSchema = z
+  .object({
+    id: z.string().nullable(),
+    type: z.string().nullable(),
+    confidence_base: z.number().min(0).max(1).nullable(),
+    url: z.string().nullable(),
+  })
+  .strict();
+
+const BlockSchema = z
+  .object({
+    role: z.string(),
+    section: z.string().nullable(),
+    content_md: z.string(),
+    content_hash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  })
+  .strict();
+
+export const ProjectionPayloadSchema = z
+  .object({
+    entity_id: EntityIdSchema,
+    entity_type: z.enum(['gamme', 'vehicle', 'constructeur', 'diagnostic']),
+    slug: z.string(),
+    projection_contract_version: z.string().regex(/^\d+\.\d+\.\d+$/),
+    facts: z.record(z.string(), z.unknown()),
+    blocks: z.array(BlockSchema),
+    sources: z.array(SourceSchema),
+    fetched_at: z.string(),
+  })
+  .strict();
+
+export type ProjectionPayload = z.infer<typeof ProjectionPayloadSchema>;
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Adapter
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface GetActiveProjectionOptions {
+  /** Optional role filter (e.g. 'R3_CONSEILS'). NULL = all roles. */
+  role?: string | null;
+}
+
+export interface ProjectionReadResult {
+  status: 'success' | 'empty' | 'rpc_failed' | 'validation_failed';
+  payload: ProjectionPayload | null;
+  error: string | null;
+}
+
+@Injectable()
+export class SeoProjectionReadAdapter extends SupabaseBaseService {
+  private readonly readLogger = new Logger(SeoProjectionReadAdapter.name);
+
+  /**
+   * Lit la projection active pour une entité.
+   *
+   * @returns `ProjectionReadResult` typé. Status :
+   *  - `success` : payload non vide
+   *  - `empty` : projection inexistante (no facts + no blocks)
+   *  - `rpc_failed` : RPC erreur (DB indisponible, permission, etc.)
+   *  - `validation_failed` : payload retourné ne match pas le Zod schema (régression contract)
+   *
+   * Pour le caller (loader Remix / SSR) : `status==='success'` → render avec
+   * payload ; autre status → fallback legacy path (PR-7b).
+   */
+  async getActiveProjection(
+    entityId: string,
+    options: GetActiveProjectionOptions = {},
+  ): Promise<ProjectionReadResult> {
+    // Validate input avant RPC (defense en profondeur — la RPC valide aussi)
+    const idCheck = EntityIdSchema.safeParse(entityId);
+    if (!idCheck.success) {
+      return {
+        status: 'validation_failed',
+        payload: null,
+        error: `invalid entity_id: ${entityId} (${idCheck.error.issues[0]?.message})`,
+      };
+    }
+    if (options.role !== undefined && options.role !== null) {
+      const roleCheck = RoleSchema.safeParse(options.role);
+      if (!roleCheck.success) {
+        return {
+          status: 'validation_failed',
+          payload: null,
+          error: `invalid role: ${options.role}`,
+        };
+      }
+    }
+
+    const { data, error } = await this.supabase.rpc('get_active_seo_projection', {
+      p_entity_id: entityId,
+      p_role: options.role ?? null,
+    });
+
+    if (error) {
+      this.readLogger.warn(
+        `RPC get_active_seo_projection failed for ${entityId}: ${error.message}`,
+      );
+      return {
+        status: 'rpc_failed',
+        payload: null,
+        error: error.message,
+      };
+    }
+
+    const parsed = ProjectionPayloadSchema.safeParse(data);
+    if (!parsed.success) {
+      this.readLogger.error(
+        `RPC payload validation failed for ${entityId}: ${parsed.error.issues
+          .map((i) => i.message)
+          .join('; ')}`,
+      );
+      return {
+        status: 'validation_failed',
+        payload: null,
+        error: parsed.error.issues.map((i) => i.message).join('; '),
+      };
+    }
+
+    const payload = parsed.data;
+    const isEmpty =
+      Object.keys(payload.facts).length === 0 && payload.blocks.length === 0;
+    return {
+      status: isEmpty ? 'empty' : 'success',
+      payload,
+      error: null,
+    };
+  }
+}

--- a/backend/supabase/migrations/20260513204943_seo_projection_read_rpc.sql
+++ b/backend/supabase/migrations/20260513204943_seo_projection_read_rpc.sql
@@ -1,0 +1,111 @@
+-- ============================================================================
+-- ADR-059 SEO Runtime Projection — Phase B PR-7a (read RPC)
+--
+-- RPC unique pour lecture publique de la projection active.
+-- - SECURITY DEFINER : bypass RLS interne sur __seo_* tables (read-only)
+-- - Lit les 2 materialized views (mv_seo_entity_facts_current +
+--   mv_seo_content_blocks_current) + __seo_entity_sources
+-- - Returns JSONB shape compatible avec exports-seo.schema.json
+--
+-- Garde-fous SQL :
+-- - Validation pattern entity_id (singulier sans support)
+-- - EXCEPTION sur entity_id invalide
+-- - STABLE function (cacheable per Postgres)
+-- - Pas d'INSERT/UPDATE/DELETE
+-- - GRANT EXECUTE explicite (anon + authenticated + service_role)
+--
+-- Refs : ADR-059 vault PR #260, PR-6a tables, PR-6b workers.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION get_active_seo_projection(
+  p_entity_id text,
+  p_role text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_facts jsonb;
+  v_blocks jsonb;
+  v_sources jsonb;
+BEGIN
+  -- Validation pattern entity_id (singulier ADR-031, support exclu)
+  IF p_entity_id !~ '^(gamme|vehicle|constructeur|diagnostic):[a-z0-9][a-z0-9-]*[a-z0-9]$' THEN
+    RAISE EXCEPTION 'invalid entity_id pattern: %', p_entity_id
+      USING ERRCODE = '22023', HINT = 'expected <entity_type>:<slug-singular>, entity_type in {gamme,vehicle,constructeur,diagnostic}';
+  END IF;
+
+  -- Optional role filter validation
+  IF p_role IS NOT NULL AND p_role !~ '^R[0-9]_[A-Z_]+$' THEN
+    RAISE EXCEPTION 'invalid role pattern: %', p_role
+      USING ERRCODE = '22023', HINT = 'expected R<digit>_<UPPER_NAME>';
+  END IF;
+
+  -- Facts (key/value) depuis MV
+  SELECT COALESCE(jsonb_object_agg(fact_key, fact_value), '{}'::jsonb)
+  INTO v_facts
+  FROM mv_seo_entity_facts_current
+  WHERE entity_id = p_entity_id;
+
+  -- Blocks (role-aware) depuis MV
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'role', role,
+        'section', section,
+        'content_md', content_md,
+        'content_hash', content_hash
+      )
+      ORDER BY role, COALESCE(section, '')
+    ),
+    '[]'::jsonb
+  )
+  INTO v_blocks
+  FROM mv_seo_content_blocks_current
+  WHERE entity_id = p_entity_id
+    AND (p_role IS NULL OR role = p_role);
+
+  -- Sources (provenance)
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', source_id,
+        'type', source_type,
+        'confidence_base', confidence_base,
+        'url', url
+      )
+    ),
+    '[]'::jsonb
+  )
+  INTO v_sources
+  FROM __seo_entity_sources
+  WHERE entity_id = p_entity_id;
+
+  RETURN jsonb_build_object(
+    'entity_id', p_entity_id,
+    'entity_type', split_part(p_entity_id, ':', 1),
+    'slug', split_part(p_entity_id, ':', 2),
+    'projection_contract_version', '1.0.0',
+    'facts', v_facts,
+    'blocks', v_blocks,
+    'sources', v_sources,
+    'fetched_at', to_jsonb(now() AT TIME ZONE 'UTC')
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION get_active_seo_projection(text, text) IS
+  'ADR-059 PR-7a read RPC. SECURITY DEFINER bypass RLS interne. STABLE = cacheable. Returns JSONB shape compatible exports-seo.schema.json. Lit MVs (transitional acceleration). 0 INSERT/UPDATE/DELETE.';
+
+-- Permissions explicites (feedback_supabase_grant_explicit)
+REVOKE ALL ON FUNCTION get_active_seo_projection(text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_active_seo_projection(text, text) TO service_role;
+GRANT EXECUTE ON FUNCTION get_active_seo_projection(text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_active_seo_projection(text, text) TO anon;
+
+COMMIT;

--- a/log.md
+++ b/log.md
@@ -543,3 +543,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feature/seo-projection-read-rpc`
 - **Décision** : feat(seo/projection): read rpc + adapter (pr-7a)
 - **Sortie** : PR #485 | commits 603f4318
+
+## 2026-05-14 — feature/seo-projection-read-rpc (auto)
+
+- **Branche** : `feature/seo-projection-read-rpc`
+- **Décision** : fix(seo/projection): use callRpc<T> wrapper canonique (rpc safety gate) (+2 other commits)
+- **Sortie** : PR #485 | commits b90b4b81 7adea5b6 ceed0f0b

--- a/log.md
+++ b/log.md
@@ -538,8 +538,8 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Décision** : feat(registry): LLM entrypoint REPO_MAP.md + CLAUDE.md step 0 + cross-language hook (ADR-058 PR-F) (+8 other commits)
 - **Sortie** : PR #463 | commits 9ac2f75b 77d4b57a a1d79d5b 658018c4 66d9e64f b08d3e90 b281943b f067e9ec 0504fd38
 
-## 2026-05-13 — fix/seo-sitemap-auto-regeneration-cron (auto)
+## 2026-05-13 — feature/seo-projection-read-rpc (auto)
 
-- **Branche** : `fix/seo-sitemap-auto-regeneration-cron`
-- **Décision** : fix(seo): restore automatic sitemap regeneration via BullMQ repeatable job
-- **Sortie** : PR #487 | commits af70edb3
+- **Branche** : `feature/seo-projection-read-rpc`
+- **Décision** : feat(seo/projection): read rpc + adapter (pr-7a)
+- **Sortie** : PR #485 | commits 603f4318

--- a/tests/db/test_seo_projection_read_rpc.py
+++ b/tests/db/test_seo_projection_read_rpc.py
@@ -1,0 +1,113 @@
+"""
+Tests Python contractuels sur la migration RPC `get_active_seo_projection`.
+
+Vérifications statiques (sans connexion DB) :
+- SECURITY DEFINER présent
+- STABLE function (pas VOLATILE)
+- search_path forcé (anti-hijack)
+- Validation entity_id pattern
+- GRANT EXECUTE explicite
+- AUCUN INSERT/UPDATE/DELETE dans le body
+- Mention 'No Direct Page SQL' / cohérence ADR-059
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "backend"
+    / "supabase"
+    / "migrations"
+    / "20260513204943_seo_projection_read_rpc.sql"
+)
+
+
+@pytest.fixture(scope="module")
+def sql() -> str:
+    assert MIGRATION_PATH.exists(), f"migration missing: {MIGRATION_PATH}"
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def test_function_name_canonical(sql: str) -> None:
+    assert "FUNCTION get_active_seo_projection(" in sql
+
+
+def test_security_definer(sql: str) -> None:
+    assert "SECURITY DEFINER" in sql, "RPC must be SECURITY DEFINER (bypass RLS internal)"
+
+
+def test_stable_function(sql: str) -> None:
+    assert "\nSTABLE\n" in sql or " STABLE\n" in sql, "RPC must be STABLE (cacheable per Postgres)"
+
+
+def test_search_path_forced(sql: str) -> None:
+    assert "SET search_path = public" in sql, "search_path must be forced (anti-hijack)"
+
+
+def test_entity_id_pattern_validated(sql: str) -> None:
+    assert "RAISE EXCEPTION 'invalid entity_id pattern" in sql
+    # Singulier + support exclu dans la regex
+    assert "gamme|vehicle|constructeur|diagnostic" in sql
+    # Support pas dans la regex
+    assert "(gamme|vehicle|constructeur|diagnostic|support)" not in sql
+
+
+def test_role_pattern_validated(sql: str) -> None:
+    assert "invalid role pattern" in sql
+    assert "R[0-9]_[A-Z_]+" in sql
+
+
+def test_no_destructive_writes(sql: str) -> None:
+    # Comments OK, mais aucun INSERT/UPDATE/DELETE en statement
+    # Strip lines starting with -- (SQL comments)
+    code_only = "\n".join(
+        line for line in sql.splitlines() if not line.strip().startswith("--")
+    )
+    for needle in ("INSERT INTO ", "UPDATE __seo", "DELETE FROM ", "TRUNCATE ", "DROP "):
+        assert needle not in code_only.upper(), f"forbidden SQL '{needle}' must not appear in RPC body"
+
+
+def test_explicit_grants(sql: str) -> None:
+    assert "REVOKE ALL ON FUNCTION get_active_seo_projection" in sql
+    assert "GRANT EXECUTE ON FUNCTION get_active_seo_projection(text, text) TO service_role" in sql
+    assert "GRANT EXECUTE ON FUNCTION get_active_seo_projection(text, text) TO authenticated" in sql
+    assert "GRANT EXECUTE ON FUNCTION get_active_seo_projection(text, text) TO anon" in sql
+
+
+def test_returns_jsonb(sql: str) -> None:
+    assert "RETURNS jsonb" in sql
+
+
+def test_reads_materialized_views(sql: str) -> None:
+    """RPC consomme bien les MVs PR-6a (transitional acceleration)."""
+    assert "FROM mv_seo_entity_facts_current" in sql
+    assert "FROM mv_seo_content_blocks_current" in sql
+
+
+def test_reads_sources_table(sql: str) -> None:
+    assert "FROM __seo_entity_sources" in sql
+
+
+def test_projection_contract_version_in_output(sql: str) -> None:
+    """Le payload doit toujours indiquer projection_contract_version."""
+    assert "'projection_contract_version'" in sql
+    assert "'1.0.0'" in sql
+
+
+def test_transaction_wrapped(sql: str) -> None:
+    assert sql.strip().endswith("COMMIT;")
+    assert "BEGIN;" in sql
+
+
+def test_comment_references_adr_059(sql: str) -> None:
+    assert "ADR-059" in sql
+
+
+def test_no_function_returns_table_or_setof(sql: str) -> None:
+    """RPC retourne 1 seul JSONB (pas SETOF/TABLE) — simplifie cache + serialization."""
+    assert "RETURNS SETOF" not in sql
+    assert "RETURNS TABLE" not in sql


### PR DESCRIPTION
ADR-059 Phase B PR-7a — lecture canon projection via RPC SECURITY DEFINER + adapter NestJS.

**Verrou critique (ADR-059 No Direct Page SQL)** : pages lisent projection runtime via RPC/adapter, JAMAIS wiki ou `__seo_entity_*` direct.

## Scope

- Migration RPC `get_active_seo_projection(p_entity_id, p_role)`
- Adapter NestJS `SeoProjectionReadAdapter`
- Tests Python (15) + Jest (21) = **36/36 PASS**
- **AUCUN frontend Remix** (= PR-7b)
- **AUCUN GrowthBook** (= PR-7b)
- **AUCUN depcruise/ast-grep guards** (= PR-7b)
- **AUCUNE migration legacy** (= PR-7b)

## RPC garde-fous

- `SECURITY DEFINER` : bypass RLS interne (read-only sur `__seo_*`)
- `STABLE` : cacheable per Postgres
- `SET search_path = public` : anti-hijack
- Validation pattern `entity_id` (singulier ADR-031, **support exclu**) avec `RAISE EXCEPTION ERRCODE 22023`
- Validation pattern `role` (`R<digit>_<UPPER_NAME>`)
- Lit `mv_seo_entity_facts_current` + `mv_seo_content_blocks_current` + `__seo_entity_sources`
- Returns JSONB single (pas SETOF/TABLE)
- `REVOKE ALL PUBLIC` + `GRANT EXECUTE` explicite (service_role / authenticated / anon)

## Adapter garde-fous

- `ProjectionPayloadSchema` Zod strict (`additionalProperties: forbidden`)
- Status enum : `success` / `empty` / `rpc_failed` / `validation_failed`
- Defense en profondeur : valide `entity_id` + `role` AVANT appel RPC
- **AUCUN `.from()`** direct sur `__seo_*` ou `mv_seo_*` (forced RPC, 15 patterns négatifs)
- **AUCUN `.insert/.update/.delete/.upsert`** (read-only adapter)
- Logger pour observability `rpc_failed` (avant Sentry breadcrumbs PR-7b)

## Tests

Python contract (15) : function_name, SECURITY DEFINER, STABLE, search_path, entity_id pattern (support exclu), role pattern, no destructive SQL, explicit GRANTs, returns_jsonb, reads_MVs, projection_contract_version, BEGIN/COMMIT, ADR-059 reference, no SETOF/TABLE.

Jest adapter (21) : Zod accept/reject valid/support/plural/extra/invalid hash (6) ; getActiveProjection success/empty/rpc_failed/validation_failed (4) ; pre-RPC validation (3) ; role filter passed (1) ; architectural guards (7).

## Wiring module.ts

Sera fait en **post-merge PR-6b** (PR-6b #483 OPEN au moment de cette PR — création initiale du module).

## Hors scope PR-7a

- Loaders Remix R0-R8 + adapter consumption (= PR-7b)
- GrowthBook advisory rollout + circuit breaker (= PR-7b)
- depcruise + ast-grep guards frontend (= PR-7b)
- Migration progressive legacy → projection (= PR-7b)

## Refs

- ADR-059 vault PR #260 (accepted)
- PR-6a #481 (MVs lus par RPC)
- PR-6b #483 (workers écrivent ces tables)
- PR-6c-a #484 (replay) + PR-6c-b vault #261 MERGED (DRP runbook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)