### PR TITLE
feat(seo/projection): frontend wiring + rollout + guards (pr-7b)

### DIFF
--- a/.ast-grep/rules/frontend-no-direct-seo-table.yml
+++ b/.ast-grep/rules/frontend-no-direct-seo-table.yml
@@ -1,0 +1,26 @@
+id: frontend-no-direct-seo-table
+language: TypeScript
+severity: error
+message: |
+  ADR-059 §"No Direct Page SQL" : les loaders Remix ne doivent JAMAIS
+  appeler `.from('__seo_*')` ou `.from('mv_seo_*')` directement.
+  Tout passe par `fetchActiveProjection()` (frontend/app/services/seo/projection-read.client.ts)
+  qui fetch le backend HTTP endpoint via l'adapter PR-7a.
+note: |
+  Si vous voyez ce message en CI, c'est qu'un loader Remix tente un
+  SELECT direct sur les tables de projection ou les MVs. Refactor pour
+  passer par le client HTTP : `import { fetchActiveProjection } from '~/services/seo/projection-read.client'`.
+files:
+  - frontend/app/**/*.ts
+  - frontend/app/**/*.tsx
+rule:
+  any:
+    - pattern: $X.from('__seo_entity_facts')
+    - pattern: $X.from('__seo_entity_fact_versions')
+    - pattern: $X.from('__seo_entity_sources')
+    - pattern: $X.from('__seo_content_blocks')
+    - pattern: $X.from('__seo_content_block_versions')
+    - pattern: $X.from('__seo_projection_runs')
+    - pattern: $X.from('__seo_projection_conflicts')
+    - pattern: $X.from('mv_seo_entity_facts_current')
+    - pattern: $X.from('mv_seo_content_blocks_current')

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -63,6 +63,17 @@ module.exports = {
       to: { path: '^backend/src/' },
     },
     {
+      name: 'frontend-not-to-seo-projection-supabase-direct',
+      severity: 'error',
+      comment:
+        'ADR-059 §"No Direct Page SQL" — frontend ne doit JAMAIS importer @supabase/* dans des fichiers qui touchent à la projection SEO. Lecture exclusivement via frontend/app/services/seo/projection-read.client.ts qui fetch le backend HTTP endpoint /api/seo-projection/:entity_id. Tables __seo_entity_*, mv_seo_*, __seo_projection_* ne doivent JAMAIS être adressées directement depuis Remix loaders.',
+      from: {
+        path: '^frontend/app/(routes|services/seo|services/projection|services/api).*',
+        pathNot: 'services/seo/projection-read\\.client\\.ts$',
+      },
+      to: { path: '^node_modules/@supabase/' },
+    },
+    {
       name: 'backend-not-to-frontend',
       severity: 'error',
       comment:

--- a/.github/workflows/seo-projection-frontend-guards.yml
+++ b/.github/workflows/seo-projection-frontend-guards.yml
@@ -1,0 +1,50 @@
+name: seo-projection-frontend-guards
+
+# ADR-059 §"No Direct Page SQL" — enforce mécaniquement que les loaders
+# Remix ne touchent JAMAIS __seo_entity_* / mv_seo_* / __seo_projection_*.
+# Lecture exclusivement via fetchActiveProjection() (HTTP vers backend adapter).
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/app/**'
+      - 'backend/src/modules/seo/projection/**'
+      - '.ast-grep/rules/frontend-no-direct-seo-table.yml'
+      - '.dependency-cruiser.cjs'
+      - '.github/workflows/seo-projection-frontend-guards.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/app/**'
+      - '.ast-grep/rules/frontend-no-direct-seo-table.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  ast-grep:
+    name: ast-grep frontend-no-direct-seo-table
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ast-grep
+        run: npm install -g @ast-grep/cli
+      - name: Scan frontend for direct SEO table access
+        run: |
+          ast-grep scan --config sgconfig.yml --rule .ast-grep/rules/frontend-no-direct-seo-table.yml frontend/
+
+  depcruise:
+    name: depcruise frontend-not-to-seo-projection-supabase-direct
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install deps
+        run: npm ci --ignore-scripts
+      - name: Run dependency-cruiser on frontend
+        run: |
+          npx depcruise --config .dependency-cruiser.cjs frontend/app/ \
+            --output-type err-long \
+            || (echo "::error::depcruise violation — see ADR-059 §No Direct Page SQL"; exit 1)

--- a/backend/src/modules/seo/projection/__tests__/seo-projection-read.controller.test.ts
+++ b/backend/src/modules/seo/projection/__tests__/seo-projection-read.controller.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests SeoProjectionReadController — HTTP endpoint surface stable.
+ */
+import { BadRequestException } from '@nestjs/common';
+
+import { SeoProjectionReadController } from '../seo-projection-read.controller';
+
+
+function makeAdapter(getResult: jest.Mock) {
+  return { getActiveProjection: getResult } as unknown as Parameters<
+    typeof SeoProjectionReadController.prototype.getActive
+  > extends never
+    ? never
+    : ConstructorParameters<typeof SeoProjectionReadController>[0];
+}
+
+
+function makeController(adapterMock: ReturnType<typeof makeAdapter>): SeoProjectionReadController {
+  const c = new SeoProjectionReadController(adapterMock);
+  (c as unknown as { readLogger: { warn: jest.Mock; error: jest.Mock; log: jest.Mock } }).readLogger = {
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+  };
+  return c;
+}
+
+
+describe('SeoProjectionReadController', () => {
+  it('rejects empty entity_id with BadRequest', async () => {
+    const adapter = makeAdapter(jest.fn());
+    const ctrl = makeController(adapter);
+    await expect(ctrl.getActive('')).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('delegates to adapter with role=null when role omitted', async () => {
+    const getResult = jest.fn().mockResolvedValue({
+      status: 'success',
+      payload: { entity_id: 'gamme:x' },
+      error: null,
+    });
+    const adapter = makeAdapter(getResult);
+    const ctrl = makeController(adapter);
+    await ctrl.getActive('gamme:filtre-a-huile');
+    expect(getResult).toHaveBeenCalledWith('gamme:filtre-a-huile', { role: null });
+  });
+
+  it('passes role filter when provided', async () => {
+    const getResult = jest.fn().mockResolvedValue({
+      status: 'success',
+      payload: null,
+      error: null,
+    });
+    const adapter = makeAdapter(getResult);
+    const ctrl = makeController(adapter);
+    await ctrl.getActive('gamme:filtre-a-huile', 'R3_CONSEILS');
+    expect(getResult).toHaveBeenCalledWith('gamme:filtre-a-huile', { role: 'R3_CONSEILS' });
+  });
+
+  it('returns adapter result unchanged (status enum forwarded)', async () => {
+    const expected = { status: 'empty' as const, payload: null, error: null };
+    const adapter = makeAdapter(jest.fn().mockResolvedValue(expected));
+    const ctrl = makeController(adapter);
+    const result = await ctrl.getActive('gamme:filtre-a-huile');
+    expect(result).toEqual(expected);
+  });
+
+  it('forwards rpc_failed status with logger warn', async () => {
+    const adapter = makeAdapter(
+      jest.fn().mockResolvedValue({
+        status: 'rpc_failed',
+        payload: null,
+        error: 'permission denied',
+      }),
+    );
+    const ctrl = makeController(adapter);
+    const result = await ctrl.getActive('gamme:filtre-a-huile');
+    expect(result.status).toBe('rpc_failed');
+  });
+});

--- a/backend/src/modules/seo/projection/__tests__/seo-projection-read.controller.test.ts
+++ b/backend/src/modules/seo/projection/__tests__/seo-projection-read.controller.test.ts
@@ -5,7 +5,6 @@ import { BadRequestException } from '@nestjs/common';
 
 import { SeoProjectionReadController } from '../seo-projection-read.controller';
 
-
 function makeAdapter(getResult: jest.Mock) {
   return { getActiveProjection: getResult } as unknown as Parameters<
     typeof SeoProjectionReadController.prototype.getActive
@@ -14,10 +13,15 @@ function makeAdapter(getResult: jest.Mock) {
     : ConstructorParameters<typeof SeoProjectionReadController>[0];
 }
 
-
-function makeController(adapterMock: ReturnType<typeof makeAdapter>): SeoProjectionReadController {
+function makeController(
+  adapterMock: ReturnType<typeof makeAdapter>,
+): SeoProjectionReadController {
   const c = new SeoProjectionReadController(adapterMock);
-  (c as unknown as { readLogger: { warn: jest.Mock; error: jest.Mock; log: jest.Mock } }).readLogger = {
+  (
+    c as unknown as {
+      readLogger: { warn: jest.Mock; error: jest.Mock; log: jest.Mock };
+    }
+  ).readLogger = {
     warn: jest.fn(),
     error: jest.fn(),
     log: jest.fn(),
@@ -25,12 +29,13 @@ function makeController(adapterMock: ReturnType<typeof makeAdapter>): SeoProject
   return c;
 }
 
-
 describe('SeoProjectionReadController', () => {
   it('rejects empty entity_id with BadRequest', async () => {
     const adapter = makeAdapter(jest.fn());
     const ctrl = makeController(adapter);
-    await expect(ctrl.getActive('')).rejects.toBeInstanceOf(BadRequestException);
+    await expect(ctrl.getActive('')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
   });
 
   it('delegates to adapter with role=null when role omitted', async () => {
@@ -42,7 +47,9 @@ describe('SeoProjectionReadController', () => {
     const adapter = makeAdapter(getResult);
     const ctrl = makeController(adapter);
     await ctrl.getActive('gamme:filtre-a-huile');
-    expect(getResult).toHaveBeenCalledWith('gamme:filtre-a-huile', { role: null });
+    expect(getResult).toHaveBeenCalledWith('gamme:filtre-a-huile', {
+      role: null,
+    });
   });
 
   it('passes role filter when provided', async () => {
@@ -54,7 +61,9 @@ describe('SeoProjectionReadController', () => {
     const adapter = makeAdapter(getResult);
     const ctrl = makeController(adapter);
     await ctrl.getActive('gamme:filtre-a-huile', 'R3_CONSEILS');
-    expect(getResult).toHaveBeenCalledWith('gamme:filtre-a-huile', { role: 'R3_CONSEILS' });
+    expect(getResult).toHaveBeenCalledWith('gamme:filtre-a-huile', {
+      role: 'R3_CONSEILS',
+    });
   });
 
   it('returns adapter result unchanged (status enum forwarded)', async () => {

--- a/backend/src/modules/seo/projection/__tests__/seo-projection-rollout.service.test.ts
+++ b/backend/src/modules/seo/projection/__tests__/seo-projection-rollout.service.test.ts
@@ -15,21 +15,22 @@ import {
   SeoProjectionRolloutService,
 } from '../seo-projection-rollout.service';
 
-
 const SERVICE_SRC = join(__dirname, '..', 'seo-projection-rollout.service.ts');
-
 
 function makeService(): SeoProjectionRolloutService {
   const svc = new SeoProjectionRolloutService();
   // Logger stub (avoid Nest DI for unit tests)
-  (svc as unknown as { rolloutLogger: { warn: jest.Mock; error: jest.Mock; log: jest.Mock } }).rolloutLogger = {
+  (
+    svc as unknown as {
+      rolloutLogger: { warn: jest.Mock; error: jest.Mock; log: jest.Mock };
+    }
+  ).rolloutLogger = {
     warn: jest.fn(),
     error: jest.fn(),
     log: jest.fn(),
   };
   return svc;
 }
-
 
 describe('SeoProjectionRolloutService — advisory-only contract', () => {
   it('FALLBACK_DEFAULT_FLAG_VALUE is false (legacy path)', () => {
@@ -104,7 +105,6 @@ describe('SeoProjectionRolloutService — advisory-only contract', () => {
   });
 });
 
-
 describe('PR-7b architectural guards (rollout service)', () => {
   const src = readFileSync(SERVICE_SRC, 'utf-8');
 
@@ -122,7 +122,12 @@ describe('PR-7b architectural guards (rollout service)', () => {
   });
 
   it('NEVER imports LLM SDKs', () => {
-    const forbidden = ["from 'anthropic'", "from '@anthropic-ai", "from 'openai'", "from 'groq-sdk'"];
+    const forbidden = [
+      "from 'anthropic'",
+      "from '@anthropic-ai",
+      "from 'openai'",
+      "from 'groq-sdk'",
+    ];
     for (const needle of forbidden) {
       expect(src).not.toContain(needle);
     }

--- a/backend/src/modules/seo/projection/__tests__/seo-projection-rollout.service.test.ts
+++ b/backend/src/modules/seo/projection/__tests__/seo-projection-rollout.service.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests SeoProjectionRolloutService — advisory-only, circuit breaker, fallback.
+ *
+ * Garde-fous critiques (ADR-059) :
+ *  - Runtime ne bloque JAMAIS sur lookup feature flag
+ *  - Default deterministic = false (legacy path)
+ *  - Circuit breaker : 3 failures → open 60s
+ *  - Cache 5min advisory
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  FALLBACK_DEFAULT_FLAG_VALUE,
+  SeoProjectionRolloutService,
+} from '../seo-projection-rollout.service';
+
+
+const SERVICE_SRC = join(__dirname, '..', 'seo-projection-rollout.service.ts');
+
+
+function makeService(): SeoProjectionRolloutService {
+  const svc = new SeoProjectionRolloutService();
+  // Logger stub (avoid Nest DI for unit tests)
+  (svc as unknown as { rolloutLogger: { warn: jest.Mock; error: jest.Mock; log: jest.Mock } }).rolloutLogger = {
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+  };
+  return svc;
+}
+
+
+describe('SeoProjectionRolloutService — advisory-only contract', () => {
+  it('FALLBACK_DEFAULT_FLAG_VALUE is false (legacy path)', () => {
+    expect(FALLBACK_DEFAULT_FLAG_VALUE).toBe(false);
+  });
+
+  it('returns default=false when no lookup configured', async () => {
+    const svc = makeService();
+    const decision = await svc.getRolloutDecision();
+    expect(decision.enabled).toBe(false);
+    expect(decision.source).toBe('default');
+  });
+
+  it('returns live value when lookup succeeds', async () => {
+    const svc = makeService();
+    svc.setLookup(async () => true);
+    const decision = await svc.getRolloutDecision();
+    expect(decision.enabled).toBe(true);
+    expect(decision.source).toBe('live');
+  });
+
+  it('uses cache when lookup fails but cache fresh', async () => {
+    const svc = makeService();
+    let succeed = true;
+    svc.setLookup(async () => {
+      if (succeed) return true;
+      throw new Error('GrowthBook down');
+    });
+    // First call : cache populated with true
+    await svc.getRolloutDecision();
+    succeed = false;
+    const decision = await svc.getRolloutDecision();
+    expect(decision.enabled).toBe(true);
+    expect(decision.source).toBe('cache');
+    expect(decision.last_error).toMatch(/GrowthBook down/);
+  });
+
+  it('falls back to default=false when lookup fails and no cache', async () => {
+    const svc = makeService();
+    svc.setLookup(async () => {
+      throw new Error('GrowthBook unavailable');
+    });
+    const decision = await svc.getRolloutDecision();
+    expect(decision.enabled).toBe(false);
+    expect(decision.source).toBe('default');
+    expect(decision.last_error).toMatch(/GrowthBook unavailable/);
+  });
+
+  it('opens circuit breaker after 3 consecutive failures', async () => {
+    const svc = makeService();
+    svc.setLookup(async () => {
+      throw new Error('persistent failure');
+    });
+    for (let i = 0; i < 3; i++) {
+      await svc.getRolloutDecision();
+    }
+    // 4th call : circuit OPEN, should not call lookup
+    const lookupSpy = jest.fn(async () => true);
+    svc.setLookup(lookupSpy);
+    const decision = await svc.getRolloutDecision();
+    expect(lookupSpy).not.toHaveBeenCalled();
+    expect(decision.source).toBe('circuit_open');
+    expect(decision.enabled).toBe(false); // no fresh cache → default
+  });
+
+  it('NEVER throws even if lookup throws synchronously', async () => {
+    const svc = makeService();
+    svc.setLookup((() => {
+      throw new Error('sync throw');
+    }) as never);
+    await expect(svc.getRolloutDecision()).resolves.toBeDefined();
+  });
+});
+
+
+describe('PR-7b architectural guards (rollout service)', () => {
+  const src = readFileSync(SERVICE_SRC, 'utf-8');
+
+  it('declares deterministic fallback default false', () => {
+    expect(src).toMatch(/FALLBACK_DEFAULT_FLAG_VALUE\s*=\s*false/);
+  });
+
+  it('has circuit breaker constants (anti runtime-critical dependency)', () => {
+    expect(src).toMatch(/CIRCUIT_FAIL_THRESHOLD/);
+    expect(src).toMatch(/CIRCUIT_OPEN_DURATION_MS/);
+  });
+
+  it('has 5min cache TTL per ADR-059', () => {
+    expect(src).toMatch(/CACHE_TTL_MS\s*=\s*5\s*\*\s*60_000/);
+  });
+
+  it('NEVER imports LLM SDKs', () => {
+    const forbidden = ["from 'anthropic'", "from '@anthropic-ai", "from 'openai'", "from 'groq-sdk'"];
+    for (const needle of forbidden) {
+      expect(src).not.toContain(needle);
+    }
+  });
+
+  it('NEVER imports Supabase JS (advisory service must not touch DB)', () => {
+    expect(src).not.toMatch(/from '@supabase\/supabase-js'/);
+    expect(src).not.toMatch(/SupabaseClient/);
+  });
+});

--- a/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
+++ b/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
@@ -21,16 +21,20 @@ import { z } from 'zod';
 
 import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
 
-
 // ────────────────────────────────────────────────────────────────────────────
 // Zod schemas — strict validation du payload RPC
 // ────────────────────────────────────────────────────────────────────────────
 
 const EntityIdSchema = z
   .string()
-  .regex(/^(gamme|vehicle|constructeur|diagnostic):[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+  .regex(
+    /^(gamme|vehicle|constructeur|diagnostic):[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+  );
 
-const RoleSchema = z.string().regex(/^R[0-9]_[A-Z_]+$/).nullable();
+const RoleSchema = z
+  .string()
+  .regex(/^R[0-9]_[A-Z_]+$/)
+  .nullable();
 
 const SourceSchema = z
   .object({
@@ -64,7 +68,6 @@ export const ProjectionPayloadSchema = z
   .strict();
 
 export type ProjectionPayload = z.infer<typeof ProjectionPayloadSchema>;
-
 
 // ────────────────────────────────────────────────────────────────────────────
 // Adapter

--- a/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
+++ b/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
@@ -121,10 +121,14 @@ export class SeoProjectionReadAdapter extends SupabaseBaseService {
       }
     }
 
-    const { data, error } = await this.supabase.rpc('get_active_seo_projection', {
-      p_entity_id: entityId,
-      p_role: options.role ?? null,
-    });
+    // Uses canonical `callRpc<T>` wrapper (RPC Safety Gate). Never direct supabase.rpc.
+    const { data, error } = await this.callRpc<unknown>(
+      'get_active_seo_projection',
+      {
+        p_entity_id: entityId,
+        p_role: options.role ?? null,
+      },
+    );
 
     if (error) {
       this.readLogger.warn(

--- a/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
+++ b/backend/src/modules/seo/projection/seo-projection-read.adapter.ts
@@ -1,0 +1,163 @@
+/**
+ * ADR-059 Phase B PR-7a — SeoProjectionReadAdapter.
+ *
+ * Seul point d'accès lecture autorisé pour la projection runtime SEO.
+ * **AUCUNE page R0-R8 ne lit `__seo_entity_*` directement** : tout passe
+ * par cet adapter qui invoque la RPC SECURITY DEFINER `get_active_seo_projection`.
+ *
+ * Garde-fous architecturaux (ADR-059 §"No Direct Page SQL") :
+ *  - Cet adapter est la SEULE surface autorisée pour lecture projection
+ *  - Aucun `.from('__seo_entity_*')` direct ici (uniquement `.rpc(...)`)
+ *  - Zod validation strict du payload retourné
+ *  - 0 LLM, 0 write DB, 0 wiki canon write
+ *
+ * Future enrichissement (PR-7b ou followup) :
+ *  - Cache Redis 5min advisory (lecture rapide pages)
+ *  - GrowthBook feature flag `seo_projection_read_v1` avec circuit breaker
+ *  - Fallback deterministic legacy si projection vide/RPC indisponible
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { z } from 'zod';
+
+import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Zod schemas — strict validation du payload RPC
+// ────────────────────────────────────────────────────────────────────────────
+
+const EntityIdSchema = z
+  .string()
+  .regex(/^(gamme|vehicle|constructeur|diagnostic):[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+
+const RoleSchema = z.string().regex(/^R[0-9]_[A-Z_]+$/).nullable();
+
+const SourceSchema = z
+  .object({
+    id: z.string().nullable(),
+    type: z.string().nullable(),
+    confidence_base: z.number().min(0).max(1).nullable(),
+    url: z.string().nullable(),
+  })
+  .strict();
+
+const BlockSchema = z
+  .object({
+    role: z.string(),
+    section: z.string().nullable(),
+    content_md: z.string(),
+    content_hash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  })
+  .strict();
+
+export const ProjectionPayloadSchema = z
+  .object({
+    entity_id: EntityIdSchema,
+    entity_type: z.enum(['gamme', 'vehicle', 'constructeur', 'diagnostic']),
+    slug: z.string(),
+    projection_contract_version: z.string().regex(/^\d+\.\d+\.\d+$/),
+    facts: z.record(z.string(), z.unknown()),
+    blocks: z.array(BlockSchema),
+    sources: z.array(SourceSchema),
+    fetched_at: z.string(),
+  })
+  .strict();
+
+export type ProjectionPayload = z.infer<typeof ProjectionPayloadSchema>;
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Adapter
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface GetActiveProjectionOptions {
+  /** Optional role filter (e.g. 'R3_CONSEILS'). NULL = all roles. */
+  role?: string | null;
+}
+
+export interface ProjectionReadResult {
+  status: 'success' | 'empty' | 'rpc_failed' | 'validation_failed';
+  payload: ProjectionPayload | null;
+  error: string | null;
+}
+
+@Injectable()
+export class SeoProjectionReadAdapter extends SupabaseBaseService {
+  private readonly readLogger = new Logger(SeoProjectionReadAdapter.name);
+
+  /**
+   * Lit la projection active pour une entité.
+   *
+   * @returns `ProjectionReadResult` typé. Status :
+   *  - `success` : payload non vide
+   *  - `empty` : projection inexistante (no facts + no blocks)
+   *  - `rpc_failed` : RPC erreur (DB indisponible, permission, etc.)
+   *  - `validation_failed` : payload retourné ne match pas le Zod schema (régression contract)
+   *
+   * Pour le caller (loader Remix / SSR) : `status==='success'` → render avec
+   * payload ; autre status → fallback legacy path (PR-7b).
+   */
+  async getActiveProjection(
+    entityId: string,
+    options: GetActiveProjectionOptions = {},
+  ): Promise<ProjectionReadResult> {
+    // Validate input avant RPC (defense en profondeur — la RPC valide aussi)
+    const idCheck = EntityIdSchema.safeParse(entityId);
+    if (!idCheck.success) {
+      return {
+        status: 'validation_failed',
+        payload: null,
+        error: `invalid entity_id: ${entityId} (${idCheck.error.issues[0]?.message})`,
+      };
+    }
+    if (options.role !== undefined && options.role !== null) {
+      const roleCheck = RoleSchema.safeParse(options.role);
+      if (!roleCheck.success) {
+        return {
+          status: 'validation_failed',
+          payload: null,
+          error: `invalid role: ${options.role}`,
+        };
+      }
+    }
+
+    const { data, error } = await this.supabase.rpc('get_active_seo_projection', {
+      p_entity_id: entityId,
+      p_role: options.role ?? null,
+    });
+
+    if (error) {
+      this.readLogger.warn(
+        `RPC get_active_seo_projection failed for ${entityId}: ${error.message}`,
+      );
+      return {
+        status: 'rpc_failed',
+        payload: null,
+        error: error.message,
+      };
+    }
+
+    const parsed = ProjectionPayloadSchema.safeParse(data);
+    if (!parsed.success) {
+      this.readLogger.error(
+        `RPC payload validation failed for ${entityId}: ${parsed.error.issues
+          .map((i) => i.message)
+          .join('; ')}`,
+      );
+      return {
+        status: 'validation_failed',
+        payload: null,
+        error: parsed.error.issues.map((i) => i.message).join('; '),
+      };
+    }
+
+    const payload = parsed.data;
+    const isEmpty =
+      Object.keys(payload.facts).length === 0 && payload.blocks.length === 0;
+    return {
+      status: isEmpty ? 'empty' : 'success',
+      payload,
+      error: null,
+    };
+  }
+}

--- a/backend/src/modules/seo/projection/seo-projection-read.controller.ts
+++ b/backend/src/modules/seo/projection/seo-projection-read.controller.ts
@@ -26,7 +26,6 @@ import {
 
 import { SeoProjectionReadAdapter } from './seo-projection-read.adapter';
 
-
 @Controller('api/seo-projection')
 export class SeoProjectionReadController {
   private readonly readLogger = new Logger(SeoProjectionReadController.name);

--- a/backend/src/modules/seo/projection/seo-projection-read.controller.ts
+++ b/backend/src/modules/seo/projection/seo-projection-read.controller.ts
@@ -1,0 +1,70 @@
+/**
+ * ADR-059 Phase B PR-7b — SeoProjectionReadController.
+ *
+ * Endpoint HTTP minimal exposant l'adapter lecture vers Remix.
+ *
+ * **Garde-fous architecturaux** :
+ *  - GET-only (aucun mutation endpoint ici)
+ *  - Lit via `SeoProjectionReadAdapter` uniquement (qui consomme la RPC SECURITY DEFINER)
+ *  - JAMAIS d'accès direct `.from('__seo_*')` ou `.from('mv_seo_*')` ici
+ *  - Status response refléte le `ProjectionReadResult.status` enum (success / empty /
+ *    rpc_failed / validation_failed) → le caller (loader Remix) peut décider
+ *    fallback legacy ou pas
+ *  - Pas de cache au niveau controller (cache RPC PostgreSQL STABLE suffit
+ *    pour Phase B initiale ; cache Redis applicatif éventuel = PR followup)
+ *
+ * Path canonique : `GET /api/seo-projection/:entity_id` (avec query `?role=R3_CONSEILS`).
+ */
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Logger,
+  Param,
+  Query,
+} from '@nestjs/common';
+
+import { SeoProjectionReadAdapter } from './seo-projection-read.adapter';
+
+
+@Controller('api/seo-projection')
+export class SeoProjectionReadController {
+  private readonly readLogger = new Logger(SeoProjectionReadController.name);
+
+  constructor(private readonly adapter: SeoProjectionReadAdapter) {}
+
+  /**
+   * Récupère la projection active pour une entité.
+   *
+   * Response shape :
+   * ```
+   * {
+   *   status: 'success' | 'empty' | 'rpc_failed' | 'validation_failed',
+   *   payload: ProjectionPayload | null,
+   *   error: string | null
+   * }
+   * ```
+   *
+   * HTTP semantics :
+   *  - 200 quel que soit le status (le caller traite avec son fallback)
+   *  - 400 sur entity_id mal formé (validation pré-RPC)
+   */
+  @Get(':entity_id')
+  async getActive(
+    @Param('entity_id') entityId: string,
+    @Query('role') role?: string,
+  ) {
+    if (!entityId || typeof entityId !== 'string') {
+      throw new BadRequestException('entity_id required');
+    }
+    const result = await this.adapter.getActiveProjection(entityId, {
+      role: role ?? null,
+    });
+    if (result.status === 'rpc_failed') {
+      this.readLogger.warn(
+        `RPC failed for ${entityId}: ${result.error ?? 'unknown'}`,
+      );
+    }
+    return result;
+  }
+}

--- a/backend/src/modules/seo/projection/seo-projection-rollout.service.ts
+++ b/backend/src/modules/seo/projection/seo-projection-rollout.service.ts
@@ -18,7 +18,6 @@
  */
 import { Injectable, Logger } from '@nestjs/common';
 
-
 // ────────────────────────────────────────────────────────────────────────────
 // Circuit breaker (anti runtime-critical dependency)
 // ────────────────────────────────────────────────────────────────────────────
@@ -30,14 +29,12 @@ const CACHE_TTL_MS = 5 * 60_000; // 5 min — per ADR-059 §"GrowthBook advisory
 export const FALLBACK_DEFAULT_FLAG_VALUE = false;
 export const FLAG_NAME = 'seo_projection_read_v1';
 
-
 type CircuitState = 'closed' | 'open';
 
 interface CachedFlag {
   value: boolean;
   fetched_at: number;
 }
-
 
 export interface RolloutDecision {
   /** Effective value to use at call site. */
@@ -48,13 +45,11 @@ export interface RolloutDecision {
   last_error: string | null;
 }
 
-
 /**
  * Pluggable lookup function : remplaçable par un vrai GrowthBook client SDK
  * en DI ou PR followup. Doit retourner un boolean ou throw.
  */
 export type FlagLookupFn = (flagName: string) => Promise<boolean>;
-
 
 @Injectable()
 export class SeoProjectionRolloutService {

--- a/backend/src/modules/seo/projection/seo-projection-rollout.service.ts
+++ b/backend/src/modules/seo/projection/seo-projection-rollout.service.ts
@@ -1,0 +1,163 @@
+/**
+ * ADR-059 Phase B PR-7b — SeoProjectionRolloutService.
+ *
+ * Lecture du feature flag `seo_projection_read_v1` pour % rollout.
+ *
+ * **Advisory-only (ADR-059 §"GrowthBook advisory-only, never runtime-critical")** :
+ *   - Runtime ne bloque JAMAIS sur lookup feature flag
+ *   - Safe fallback : last cached state (Redis-like in-memory snapshot < 5min)
+ *   - If cache expired : deterministic default = `false` (legacy path)
+ *   - Circuit breaker : 3 failures → open 60s → bypass GrowthBook + return default
+ *
+ * 0 modification page Remix obligatoire — c'est l'appelant qui décide
+ * d'utiliser ce service comme advisory toggle.
+ *
+ * Pour PR-7b initial : implémentation autonome (pas de dep GrowthBook SDK
+ * obligatoire). Le client GrowthBook réel pourra être branché via DI dans
+ * un PR followup quand l'instance self-hosted sera deployée.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Circuit breaker (anti runtime-critical dependency)
+// ────────────────────────────────────────────────────────────────────────────
+
+const CIRCUIT_FAIL_THRESHOLD = 3;
+const CIRCUIT_OPEN_DURATION_MS = 60_000;
+const CACHE_TTL_MS = 5 * 60_000; // 5 min — per ADR-059 §"GrowthBook advisory-only"
+
+export const FALLBACK_DEFAULT_FLAG_VALUE = false;
+export const FLAG_NAME = 'seo_projection_read_v1';
+
+
+type CircuitState = 'closed' | 'open';
+
+interface CachedFlag {
+  value: boolean;
+  fetched_at: number;
+}
+
+
+export interface RolloutDecision {
+  /** Effective value to use at call site. */
+  enabled: boolean;
+  /** Provenance for observability + tests. */
+  source: 'live' | 'cache' | 'circuit_open' | 'default';
+  /** Last error if any (null on success). */
+  last_error: string | null;
+}
+
+
+/**
+ * Pluggable lookup function : remplaçable par un vrai GrowthBook client SDK
+ * en DI ou PR followup. Doit retourner un boolean ou throw.
+ */
+export type FlagLookupFn = (flagName: string) => Promise<boolean>;
+
+
+@Injectable()
+export class SeoProjectionRolloutService {
+  private readonly rolloutLogger = new Logger(SeoProjectionRolloutService.name);
+
+  private failureCount = 0;
+  private circuitState: CircuitState = 'closed';
+  private circuitOpenedAt = 0;
+  private cache: CachedFlag | null = null;
+
+  /**
+   * Lookup function injection. Default = throws (caller MUST inject a real
+   * lookup via setLookup or DI). Sans lookup, fallback systematic.
+   */
+  private lookup: FlagLookupFn | null = null;
+
+  setLookup(fn: FlagLookupFn): void {
+    this.lookup = fn;
+  }
+
+  /**
+   * Lit la décision rollout pour le flag canonique.
+   *
+   * **JAMAIS bloquant** : retourne en moins de quelques ms même si GrowthBook
+   * unavailable. Cohérent ADR-059 §"Pages ne bloquent jamais sur lookup".
+   */
+  async getRolloutDecision(): Promise<RolloutDecision> {
+    // ── Circuit OPEN : bypass entirely
+    if (this.circuitState === 'open') {
+      if (Date.now() - this.circuitOpenedAt < CIRCUIT_OPEN_DURATION_MS) {
+        return {
+          enabled: this.cacheFresh()
+            ? (this.cache as CachedFlag).value
+            : FALLBACK_DEFAULT_FLAG_VALUE,
+          source: this.cacheFresh() ? 'cache' : 'circuit_open',
+          last_error: 'circuit_breaker_open',
+        };
+      }
+      // Probe : try once after window
+      this.circuitState = 'closed';
+      this.failureCount = 0;
+    }
+
+    // ── No lookup configured → deterministic default
+    if (!this.lookup) {
+      return {
+        enabled: this.cacheFresh()
+          ? (this.cache as CachedFlag).value
+          : FALLBACK_DEFAULT_FLAG_VALUE,
+        source: this.cacheFresh() ? 'cache' : 'default',
+        last_error: null,
+      };
+    }
+
+    // ── Live lookup
+    try {
+      const value = await this.lookup(FLAG_NAME);
+      this.cache = { value, fetched_at: Date.now() };
+      this.failureCount = 0;
+      return { enabled: value, source: 'live', last_error: null };
+    } catch (err) {
+      const message = (err as Error).message;
+      this.rolloutLogger.warn(
+        `GrowthBook lookup failed (${this.failureCount + 1}/${CIRCUIT_FAIL_THRESHOLD}): ${message}`,
+      );
+      this.failureCount += 1;
+      if (this.failureCount >= CIRCUIT_FAIL_THRESHOLD) {
+        this.circuitState = 'open';
+        this.circuitOpenedAt = Date.now();
+        this.rolloutLogger.error(
+          `GrowthBook circuit breaker OPEN for ${CIRCUIT_OPEN_DURATION_MS}ms. Pages will use cache OR legacy default.`,
+        );
+      }
+      if (this.cacheFresh()) {
+        return {
+          enabled: (this.cache as CachedFlag).value,
+          source: 'cache',
+          last_error: message,
+        };
+      }
+      return {
+        enabled: FALLBACK_DEFAULT_FLAG_VALUE,
+        source: 'default',
+        last_error: message,
+      };
+    }
+  }
+
+  /** Test helpers — read internal state without exposing in production API. */
+  getCircuitState(): CircuitState {
+    return this.circuitState;
+  }
+
+  resetForTests(): void {
+    this.failureCount = 0;
+    this.circuitState = 'closed';
+    this.circuitOpenedAt = 0;
+    this.cache = null;
+    this.lookup = null;
+  }
+
+  private cacheFresh(): boolean {
+    if (!this.cache) return false;
+    return Date.now() - this.cache.fetched_at < CACHE_TTL_MS;
+  }
+}

--- a/frontend/app/services/seo/projection-read.client.test.ts
+++ b/frontend/app/services/seo/projection-read.client.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests Remix client projection-read.
+ *
+ * Verifie le contract critique : JAMAIS de throw, JAMAIS de blocage,
+ * fallback null sur toute erreur (network / timeout / 4xx / 5xx / payload invalide).
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  fetchActiveProjection,
+  logShadowDrift,
+  ProjectionPayloadSchema,
+} from './projection-read.client';
+
+
+const CLIENT_SRC = join(__dirname, 'projection-read.client.ts');
+
+
+function validPayload(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    entity_id: 'gamme:filtre-a-huile',
+    entity_type: 'gamme',
+    slug: 'filtre-a-huile',
+    projection_contract_version: '1.0.0',
+    facts: { material: 'cellulose' },
+    blocks: [
+      {
+        role: 'R3_CONSEILS',
+        section: null,
+        content_md: 'body',
+        content_hash: 'sha256:' + 'a'.repeat(64),
+      },
+    ],
+    sources: [],
+    fetched_at: '2026-05-13T20:00:00Z',
+    ...overrides,
+  };
+}
+
+
+function mockFetch(response: { ok: boolean; status?: number; body: unknown }): typeof fetch {
+  return (async () => ({
+    ok: response.ok,
+    status: response.status ?? (response.ok ? 200 : 500),
+    json: async () => response.body,
+  })) as unknown as typeof fetch;
+}
+
+
+describe('fetchActiveProjection — contract', () => {
+  it('returns payload on success', async () => {
+    const f = mockFetch({
+      ok: true,
+      body: { status: 'success', payload: validPayload(), error: null },
+    });
+    const result = await fetchActiveProjection('gamme:filtre-a-huile', { fetchImpl: f });
+    expect(result?.entity_id).toBe('gamme:filtre-a-huile');
+  });
+
+  it('returns null on status=empty', async () => {
+    const f = mockFetch({
+      ok: true,
+      body: { status: 'empty', payload: null, error: null },
+    });
+    expect(await fetchActiveProjection('gamme:unknown', { fetchImpl: f })).toBeNull();
+  });
+
+  it('returns null on status=rpc_failed (backend GrowthBook down equivalent)', async () => {
+    const f = mockFetch({
+      ok: true,
+      body: { status: 'rpc_failed', payload: null, error: 'down' },
+    });
+    expect(await fetchActiveProjection('gamme:filtre-a-huile', { fetchImpl: f })).toBeNull();
+  });
+
+  it('returns null on 4xx', async () => {
+    const f = mockFetch({ ok: false, status: 400, body: {} });
+    expect(await fetchActiveProjection('gamme:filtre-a-huile', { fetchImpl: f })).toBeNull();
+  });
+
+  it('returns null on 5xx', async () => {
+    const f = mockFetch({ ok: false, status: 503, body: {} });
+    expect(await fetchActiveProjection('gamme:filtre-a-huile', { fetchImpl: f })).toBeNull();
+  });
+
+  it('returns null on malformed payload (Zod validation fails)', async () => {
+    const f = mockFetch({
+      ok: true,
+      body: { status: 'success', payload: { invalid: 'shape' }, error: null },
+    });
+    expect(await fetchActiveProjection('gamme:filtre-a-huile', { fetchImpl: f })).toBeNull();
+  });
+
+  it('returns null on network error (fetch throws)', async () => {
+    const f = (async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+    expect(await fetchActiveProjection('gamme:filtre-a-huile', { fetchImpl: f })).toBeNull();
+  });
+
+  it('returns null on invalid entity_id (defense en profondeur)', async () => {
+    const f = mockFetch({
+      ok: true,
+      body: { status: 'success', payload: validPayload(), error: null },
+    });
+    expect(await fetchActiveProjection('support:retours', { fetchImpl: f })).toBeNull();
+    expect(await fetchActiveProjection('gammes:filtre-a-huile', { fetchImpl: f })).toBeNull();
+  });
+
+  it('NEVER throws (contract architectural)', async () => {
+    const f = (async () => {
+      throw new Error('catastrophic');
+    }) as unknown as typeof fetch;
+    await expect(fetchActiveProjection('gamme:x', { fetchImpl: f })).resolves.toBeNull();
+  });
+
+  it('passes role query param when provided', async () => {
+    let capturedUrl = '';
+    const f = (async (input: string) => {
+      capturedUrl = input;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'success', payload: validPayload(), error: null }),
+      };
+    }) as unknown as typeof fetch;
+    await fetchActiveProjection('gamme:filtre-a-huile', {
+      fetchImpl: f,
+      role: 'R3_CONSEILS',
+      apiBaseUrl: 'http://backend',
+    });
+    expect(capturedUrl).toContain('role=R3_CONSEILS');
+    expect(capturedUrl).toContain('/api/seo-projection/');
+  });
+});
+
+
+describe('ProjectionPayloadSchema Zod (frontend mirror)', () => {
+  it('accepts valid payload', () => {
+    expect(ProjectionPayloadSchema.safeParse(validPayload()).success).toBe(true);
+  });
+
+  it('rejects support entity_type', () => {
+    expect(
+      ProjectionPayloadSchema.safeParse(
+        validPayload({
+          entity_id: 'support:retours',
+          entity_type: 'support',
+          slug: 'retours',
+        }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it('rejects extra fields', () => {
+    expect(
+      ProjectionPayloadSchema.safeParse({ ...(validPayload() as object), extra: 'oops' }).success,
+    ).toBe(false);
+  });
+});
+
+
+describe('logShadowDrift', () => {
+  it('emits JSON line with seo_projection_shadow_drift event', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    logShadowDrift('gamme:x', { content_hash: 'sha256:abc' }, { content_hash: 'sha256:def' });
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('seo_projection_shadow_drift'));
+    const arg = spy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(arg);
+    expect(parsed.entity_id).toBe('gamme:x');
+    expect(parsed.has_projection).toBe(true);
+    expect(parsed.has_legacy).toBe(true);
+    spy.mockRestore();
+  });
+});
+
+
+describe('PR-7b architectural guards (frontend client)', () => {
+  const src = readFileSync(CLIENT_SRC, 'utf-8');
+
+  it('NEVER imports Supabase JS (frontend client must HTTP only)', () => {
+    expect(src).not.toMatch(/from '@supabase\/supabase-js'/);
+    expect(src).not.toMatch(/createClient\(/);
+  });
+
+  it('NEVER imports LLM SDKs', () => {
+    const forbidden = ["from 'anthropic'", "from 'openai'", "from 'groq-sdk'"];
+    for (const needle of forbidden) {
+      expect(src).not.toContain(needle);
+    }
+  });
+
+  it('NEVER references __seo_entity_ or mv_seo_ table names', () => {
+    // Strip comments+docstrings : keep code only
+    const code = src
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('*') && !line.trim().startsWith('//'))
+      .join('\n');
+    expect(code).not.toMatch(/__seo_entity_/);
+    expect(code).not.toMatch(/__seo_projection_/);
+    expect(code).not.toMatch(/mv_seo_/);
+  });
+
+  it('uses fetch HTTP (not Supabase rpc)', () => {
+    expect(src).toMatch(/fetchImpl\s*\(/);
+    expect(src).not.toMatch(/\.rpc\(/);
+  });
+});
+
+
+// Vitest globals fallback
+declare const vi: typeof import('vitest').vi;

--- a/frontend/app/services/seo/projection-read.client.ts
+++ b/frontend/app/services/seo/projection-read.client.ts
@@ -1,0 +1,193 @@
+/**
+ * ADR-059 Phase B PR-7b — Remix client lecture projection runtime SEO.
+ *
+ * **Verrou architectural critique (ADR-059 §"No Direct Page SQL")** :
+ * Ce client est la SEULE surface autorisée pour lecture projection depuis
+ * les loaders Remix. AUCUN loader ne doit faire de SELECT direct sur
+ * `__seo_entity_*`, `__seo_projection_*` ou `mv_seo_*` (depcruise + ast-grep
+ * guards enforce statiquement).
+ *
+ * Garde-fous runtime :
+ *  - Fetch HTTP vers backend NestJS (timeout strict 2s par défaut)
+ *  - Fallback deterministic : si fetch fail OU status !== 'success',
+ *    retourne `null` → caller doit utiliser le legacy path
+ *  - JAMAIS de throw : le caller ne doit JAMAIS rester bloqué
+ *  - Zod validate côté Remix (defense en profondeur : backend déjà valide)
+ *  - Shadow drift logging (advisory) côté caller
+ *
+ * Aucune dépendance LLM, aucune dépendance Supabase JS direct côté frontend.
+ */
+import { z } from 'zod';
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Zod schemas (mirror du backend ProjectionPayloadSchema)
+// ────────────────────────────────────────────────────────────────────────────
+
+const EntityIdSchema = z
+  .string()
+  .regex(/^(gamme|vehicle|constructeur|diagnostic):[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+
+const BlockSchema = z
+  .object({
+    role: z.string(),
+    section: z.string().nullable(),
+    content_md: z.string(),
+    content_hash: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  })
+  .strict();
+
+const SourceSchema = z
+  .object({
+    id: z.string().nullable(),
+    type: z.string().nullable(),
+    confidence_base: z.number().min(0).max(1).nullable(),
+    url: z.string().nullable(),
+  })
+  .strict();
+
+export const ProjectionPayloadSchema = z
+  .object({
+    entity_id: EntityIdSchema,
+    entity_type: z.enum(['gamme', 'vehicle', 'constructeur', 'diagnostic']),
+    slug: z.string(),
+    projection_contract_version: z.string().regex(/^\d+\.\d+\.\d+$/),
+    facts: z.record(z.string(), z.unknown()),
+    blocks: z.array(BlockSchema),
+    sources: z.array(SourceSchema),
+    fetched_at: z.string(),
+  })
+  .strict();
+
+export type ProjectionPayload = z.infer<typeof ProjectionPayloadSchema>;
+
+const BackendResponseSchema = z
+  .object({
+    status: z.enum(['success', 'empty', 'rpc_failed', 'validation_failed']),
+    payload: ProjectionPayloadSchema.nullable(),
+    error: z.string().nullable(),
+  })
+  .strict();
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Client
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface FetchProjectionOptions {
+  /** Optional role filter (e.g. 'R3_CONSEILS'). */
+  role?: string | null;
+  /** Backend base URL (default: process.env.API_URL or http://localhost:3000). */
+  apiBaseUrl?: string;
+  /** Fetch timeout ms (default 2000). */
+  timeoutMs?: number;
+  /** Optional pre-configured fetch impl for tests / SSR injection. */
+  fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_API_BASE_URL =
+  typeof process !== 'undefined' && process.env.API_URL
+    ? process.env.API_URL
+    : 'http://localhost:3000';
+
+
+/**
+ * Récupère la projection active depuis le backend.
+ *
+ * Contract :
+ *  - Returns `ProjectionPayload` si projection trouvée et payload valide
+ *  - Returns `null` dans TOUS les autres cas (empty / rpc_failed /
+ *    validation_failed / fetch error / timeout)
+ *  - JAMAIS de throw : caller utilise le fallback legacy si null
+ *
+ * Le caller DOIT logguer (`logShadowDrift`) la différence projection vs
+ * legacy en shadow mode si applicable.
+ */
+export async function fetchActiveProjection(
+  entityId: string,
+  options: FetchProjectionOptions = {},
+): Promise<ProjectionPayload | null> {
+  const idCheck = EntityIdSchema.safeParse(entityId);
+  if (!idCheck.success) {
+    // Defense en profondeur : entity_id mal formé côté caller → null safe
+    return null;
+  }
+
+  const apiBaseUrl = options.apiBaseUrl ?? DEFAULT_API_BASE_URL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const url = new URL(
+    `${apiBaseUrl.replace(/\/$/, '')}/api/seo-projection/${encodeURIComponent(entityId)}`,
+  );
+  if (options.role) {
+    url.searchParams.set('role', options.role);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      // 4xx/5xx → fallback legacy
+      return null;
+    }
+    const body = await res.json();
+    const parsed = BackendResponseSchema.safeParse(body);
+    if (!parsed.success) {
+      return null;
+    }
+    if (parsed.data.status !== 'success' || !parsed.data.payload) {
+      return null;
+    }
+    return parsed.data.payload;
+  } catch {
+    // Network / timeout / abort → fallback legacy
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+
+// ────────────────────────────────────────────────────────────────────────────
+// Shadow drift logging (advisory)
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface ShadowDriftLog {
+  entity_id: string;
+  has_projection: boolean;
+  has_legacy: boolean;
+  projection_content_hash: string | null;
+  legacy_content_hash: string | null;
+  ts: string;
+}
+
+/**
+ * Logger advisory pour comparer projection vs legacy en shadow mode.
+ *
+ * Émet une ligne JSON sur stdout (capté par journald en SSR Remix). Pas
+ * d'écriture DB, pas de blocage runtime. Le caller appelle ce helper après
+ * fetchActiveProjection() + lecture legacy en parallèle.
+ */
+export function logShadowDrift(
+  entityId: string,
+  projection: { content_hash: string | null } | null,
+  legacy: { content_hash: string | null } | null,
+): void {
+  const log: ShadowDriftLog = {
+    entity_id: entityId,
+    has_projection: projection != null,
+    has_legacy: legacy != null,
+    projection_content_hash: projection?.content_hash ?? null,
+    legacy_content_hash: legacy?.content_hash ?? null,
+    ts: new Date().toISOString(),
+  };
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify({ event: 'seo_projection_shadow_drift', ...log }));
+}

--- a/log.md
+++ b/log.md
@@ -543,3 +543,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feature/seo-projection-frontend-wiring`
 - **Décision** : feat(seo/projection): frontend wiring + rollout + guards (pr-7b)
 - **Sortie** : PR #486 | commits bc3cc401
+
+## 2026-05-14 — feature/seo-projection-frontend-wiring (auto)
+
+- **Branche** : `feature/seo-projection-frontend-wiring`
+- **Décision** : fix(seo/projection): use callRpc<T> wrapper canonique (rpc safety gate) (+2 other commits)
+- **Sortie** : PR #486 | commits 85953658 b440cebb 701a1fad

--- a/log.md
+++ b/log.md
@@ -538,8 +538,8 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Décision** : feat(registry): LLM entrypoint REPO_MAP.md + CLAUDE.md step 0 + cross-language hook (ADR-058 PR-F) (+8 other commits)
 - **Sortie** : PR #463 | commits 9ac2f75b 77d4b57a a1d79d5b 658018c4 66d9e64f b08d3e90 b281943b f067e9ec 0504fd38
 
-## 2026-05-13 — fix/seo-sitemap-auto-regeneration-cron (auto)
+## 2026-05-13 — feature/seo-projection-frontend-wiring (auto)
 
-- **Branche** : `fix/seo-sitemap-auto-regeneration-cron`
-- **Décision** : fix(seo): restore automatic sitemap regeneration via BullMQ repeatable job
-- **Sortie** : PR #487 | commits af70edb3
+- **Branche** : `feature/seo-projection-frontend-wiring`
+- **Décision** : feat(seo/projection): frontend wiring + rollout + guards (pr-7b)
+- **Sortie** : PR #486 | commits bc3cc401


### PR DESCRIPTION
ADR-059 Phase B **PR-7b** (dernière PR Phase B). Branche Remix frontend sur backend HTTP endpoint (consomme adapter PR-7a + RPC SECURITY DEFINER PR-7a).

**Critère final atteint** : Pages R0-R8 peuvent lire projection active, mais **restent safe** si projection / GrowthBook / RPC échoue.

## Composants

- backend `SeoProjectionRolloutService` : GrowthBook advisory + circuit breaker (3 fails → open 60s) + cache 5min + fallback default `false`
- backend `SeoProjectionReadController` : `GET /api/seo-projection/:entity_id` + `?role=`
- frontend `projection-read.client.ts` : fetch HTTP timeout 2s, **JAMAIS throw**, fallback `null` sur toute erreur
- frontend `logShadowDrift` advisory projection vs legacy
- depcruise rule `frontend-not-to-seo-projection-supabase-direct` (error)
- ast-grep rule `frontend-no-direct-seo-table.yml` (error, 9 patterns)
- CI workflow `seo-projection-frontend-guards`

## Garde-fous (testés statiquement + runtime)

| # | Garde-fou | Test |
|---|---|---|
| 1 | Frontend JAMAIS throw | 9 tests : empty / rpc_failed / 4xx / 5xx / malformed / network / invalid entity_id / catastrophic |
| 2 | Frontend JAMAIS `@supabase/supabase-js` ou `createClient` | Test statique |
| 3 | Frontend JAMAIS référence `__seo_entity_` / `mv_seo_` dans code | Code-only scan |
| 4 | Frontend utilise `fetchImpl` HTTP, JAMAIS `.rpc` Supabase direct | Test statique |
| 5 | Rollout circuit breaker 3 fails → open 60s | Test integration |
| 6 | Rollout cache 5min canon ADR-059 | Test statique |
| 7 | Rollout fallback default `false` deterministic | Test integration |
| 8 | Rollout JAMAIS throw même sur sync throw | Test integration |
| 9 | AUCUN import LLM tous composants | Tests statiques per fichier |
| 10 | depcruise interdit `@supabase` frontend (sauf client) | Rule severity=error |
| 11 | ast-grep interdit `.from()` sur 9 tables `__seo_*`/`mv_seo_*` | Rule severity=error |

## Tests

- Backend Jest : **17 PASS** (rollout 12 + controller 5)
- Frontend Vitest : **17 tests** (fetchActiveProjection contract + Zod schema + logShadowDrift + architectural guards)

## Note merge

L'adapter PR-7a est inclus dans cette branche pour auto-suffisance des tests. Merge idempotent avec PR-7a #485 (même contenu fichier).

## Verrou architectural final posé

`projection read path != canon authority`. Pages lisent une projection runtime via HTTP/adapter, **JAMAIS** le wiki directement, **JAMAIS** les tables `__seo_entity_*` directement.

## Hors scope PR-7b (futur followup)

- Wiring effectif des loaders Remix R0-R8 (`pieces.$slug.tsx`, `gammes.*`) avec consumption `fetchActiveProjection` + shadow drift
- Deployment GrowthBook self-hosted Docker (instance VPS DEV)
- Migration progressive legacy → projection avec % rollout 1→10→50→100

## Refs

- ADR-059 vault PR #260 (accepted)
- PR-6a #481 (DB tables) — PR-6b #483 (workers) — PR-6c-a #484 (replay) — PR-6c-b vault #261 (DRP) — PR-7a #485 (RPC + adapter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)