### PR TITLE
fix(seo): restore automatic sitemap regeneration via BullMQ (incident traffic-drop 2026-04-22)

### DIFF
--- a/audit-reports/seo-smoke/2026-05-13/PHASE-3-5-POST-MERGE-PLAYBOOK.md
+++ b/audit-reports/seo-smoke/2026-05-13/PHASE-3-5-POST-MERGE-PLAYBOOK.md
@@ -1,0 +1,263 @@
+# Phase 3.5 — Post-merge playbook (PR #487)
+
+> Use this immediately after `fix(seo): restore automatic sitemap regeneration via BullMQ` is merged on `main`. The goal is to minimize the Google re-crawl latency: trigger a controlled manual regeneration right after PROD deploy instead of waiting for the 03:00 UTC cron tick.
+
+---
+
+## 0. Prerequisites
+
+- PR #487 merged on `main` (CI green, reviewer approved).
+- You have `ssh` access to DEV (`46.224.118.55`) and PROD (`49.12.233.2`).
+- You have `CF_API_TOKEN` and the Cloudflare `ZONE_ID` for `automecanik.com`.
+- You have an admin session on `https://search.google.com/search-console` for `sc-domain:automecanik.com` (or the `https://www.automecanik.com/` property — pick the one configured in this codebase, cf. `GSC_SITE_URL`).
+
+---
+
+## 1. DEV deploy verification (~5 min after merge)
+
+```bash
+# Wait for the auto-deploy from `main` push to land on DEV.
+ssh root@46.224.118.55 'docker compose -p automecanik logs --since=10m backend' \
+  | grep -iE "sitemap.*nightly regeneration|seo-monitor.*scheduler" \
+  | head -10
+```
+
+**Expected log line** (proves the scheduler registered the repeatable job):
+
+```
+✅ Sitemap V10 nightly regeneration scheduled (cron="0 3 * * *" UTC)
+```
+
+If the line is absent:
+
+- Confirm the deploy actually landed: `ssh ... docker compose ps backend` shows recent `Up`.
+- Re-check `SEO_SITEMAP_CRON_ENABLED` is not set to `false` in the DEV env.
+- Look for boot errors: `ssh ... docker compose logs backend | grep -iE 'error|exception' | head`.
+
+---
+
+## 2. PROD tag deploy
+
+```bash
+git checkout main && git pull
+TAG="v2026.05.14-sitemap-cron"
+git tag "$TAG"
+git push origin "$TAG"
+
+# GitHub Actions runs deploy-prod.yml automatically. Watch:
+gh run watch --repo ak125/nestjs-remix-monorepo \
+  $(gh run list --workflow deploy-prod.yml --branch "$TAG" \
+     --json databaseId --jq '.[0].databaseId') --exit-status
+```
+
+Once green, verify on PROD:
+
+```bash
+ssh root@49.12.233.2 'docker compose -p automecanik logs --since=10m backend' \
+  | grep -iE "sitemap.*nightly regeneration|seo-monitor.*scheduler" \
+  | head -10
+```
+
+Same expected log line as DEV.
+
+---
+
+## 3. Immediate manual trigger (skip 03:00 UTC wait)
+
+```bash
+# PROD only — DEV is READ_ONLY so the processor short-circuits there.
+# RateLimitSitemap is 3 req/min, but we only need one call.
+curl -sS -X POST https://www.automecanik.com/api/sitemap/v10/generate-all \
+  -H 'Content-Type: application/json' \
+  -d '{}' | jq .
+```
+
+**Expected JSON** (truncated):
+
+```json
+{
+  "success": true,
+  "message": "All V10 sitemaps generated successfully",
+  "data": {
+    "totalUrls": 102395,
+    "totalFiles": 12,
+    "durationMs": 45000,
+    "buckets": [ ... ]
+  }
+}
+```
+
+If `success: false`, inspect bucket-level errors in `data.buckets[].error` and `data.hubResult.error`.
+
+---
+
+## 4. Sitemap freshness check
+
+```bash
+# Wait 60s for Cloudflare cache to potentially serve a stale copy, then bypass:
+curl -sL -H 'Cache-Control: no-cache' \
+  https://www.automecanik.com/sitemap.xml | head -20
+
+# Check ALL sub-sitemaps' lastmod are today's date:
+TODAY=$(date -u +%F)
+curl -sL https://www.automecanik.com/sitemap.xml \
+  | grep -oE '<loc>[^<]+</loc>' \
+  | sed 's|<loc>\(.*\)</loc>|\1|' \
+  | while read child; do
+      lm=$(curl -sL "$child" | head -3 | grep -oE 'lastmod>[0-9-]+' | head -1 | sed 's|lastmod>||')
+      printf "%-60s lastmod=%s\n" "$(basename $child)" "$lm"
+    done
+
+# Spot-check pieces-1.xml URL count is unchanged:
+curl -sL https://www.automecanik.com/sitemap-pieces-1.xml | grep -c '<loc>'
+# Expected: ~50000 (same as before; this PR doesn't modify URL inclusion)
+```
+
+If any `lastmod` ≠ today: rerun step 3 once. If still mismatched, investigate `sitemap-v10-xml.service.ts:75-77` and `__sitemap_p_link` row count.
+
+---
+
+## 5. Cloudflare cache purge — sitemap files only
+
+> **CRITICAL**: purge ONLY `/sitemap*.xml`. Do NOT purge `/pieces/*` — the HTML is healthy (cf. Phase −1 smoke-test), purging would needlessly hit our origin.
+
+```bash
+# Set these once:
+export CF_API_TOKEN="..."  # CloudflareAPI token with Zone.Cache.Purge perm
+export ZONE_ID="..."
+
+# Purge just the sitemap URLs we care about:
+curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/purge_cache" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "files": [
+      "https://www.automecanik.com/sitemap.xml",
+      "https://www.automecanik.com/sitemap-racine.xml",
+      "https://www.automecanik.com/sitemap-categories.xml",
+      "https://www.automecanik.com/sitemap-vehicules.xml",
+      "https://www.automecanik.com/sitemap-blog.xml",
+      "https://www.automecanik.com/sitemap-pages.xml",
+      "https://www.automecanik.com/sitemap-diagnostic.xml",
+      "https://www.automecanik.com/sitemap-reference.xml",
+      "https://www.automecanik.com/sitemap-brands.xml",
+      "https://www.automecanik.com/sitemap-pieces-1.xml",
+      "https://www.automecanik.com/sitemap-pieces-2.xml",
+      "https://www.automecanik.com/sitemap-pieces-3.xml"
+    ]
+  }' | jq .
+
+# Confirm the cache miss on next fetch:
+curl -sI https://www.automecanik.com/sitemap.xml | grep -i cf-cache-status
+# Expected: cf-cache-status: MISS (then HIT on second fetch — fresh content cached)
+```
+
+---
+
+## 6. GSC resubmit + URL Inspection (prioritized)
+
+### 6.a Resubmit the sitemap index
+
+In Google Search Console UI for the property: **Indexing → Sitemaps**, click `sitemap.xml`, then *"Demander une nouvelle indexation"* (request re-indexing) or remove + re-add. GSC processes within hours.
+
+### 6.b URL Inspection on top baseline URLs
+
+From `__seo_ga4_daily` baseline (top organic pieces, W17 reference). For each: GSC UI → **URL Inspection** → paste URL → *"Demander une indexation"*. Quota ~10/day per property.
+
+Priority list (auto-generated from baseline):
+
+```sql
+-- Run this on Supabase to get the current top-20 baseline URLs:
+SELECT 'https://www.automecanik.com' || page AS url, SUM(sessions) AS baseline_sessions
+FROM __seo_ga4_daily
+WHERE channel = 'organic search'
+  AND page LIKE '/pieces/%'
+  AND date BETWEEN '2026-04-13' AND '2026-04-26'
+GROUP BY page
+ORDER BY baseline_sessions DESC
+LIMIT 20;
+```
+
+---
+
+## 7. Monitor recovery (7–14 days)
+
+Daily check on the GA4 + GSC tables (both fed by the existing daily-fetch processor at 04:00 UTC):
+
+```sql
+-- Organic pieces sessions trend, last 21 days
+SELECT date,
+       SUM(sessions) FILTER (WHERE channel = 'organic search'
+                              AND page LIKE '/pieces/%') AS organic_pieces
+FROM __seo_ga4_daily
+WHERE date >= CURRENT_DATE - INTERVAL '21 days'
+GROUP BY date ORDER BY date;
+
+-- GSC pieces impressions trend, last 21 days
+SELECT date,
+       SUM(impressions) FILTER (WHERE page LIKE '%/pieces/%') AS pieces_impressions,
+       SUM(clicks)      FILTER (WHERE page LIKE '%/pieces/%') AS pieces_clicks
+FROM __seo_gsc_daily
+WHERE date >= CURRENT_DATE - INTERVAL '21 days'
+GROUP BY date ORDER BY date;
+```
+
+**Expected timeline**:
+
+- D+1 to D+3: Googlebot detects sitemap freshness change, recrawl rate increases.
+- D+3 to D+7: Impressions start recovering for previously deindexed `/pieces/*` URLs.
+- D+7 to D+14: Sessions follow. Target: return to W17 baseline (≈ 405 organic sessions/week on pieces).
+
+If no recovery at D+10: open Phase 4.A ticket (Freshness SLO + BullMQ healthcheck) and Phase 4.D (real `last_modified_at` per URL).
+
+---
+
+## 8. Tag this resolved in vault + memory
+
+```bash
+# 1. Append session log entry (skill `session-log` triggers on Stop hook, or invoke manually):
+echo "$(date -u +%F) | main | sitemap auto-regeneration restored (PR #487) + Phase 3.5 playbook executed" >> log.md
+
+# 2. Update memory if recovery is confirmed:
+cat > /home/deploy/.claude/projects/-opt-automecanik-app/memory/incident-traffic-drop-2026-04-22-resolved.md <<'EOF'
+---
+name: incident-traffic-drop-2026-04-22-resolved
+description: -40% organic /pieces/* W17→W19 caused by stale sitemap; resolved via BullMQ scheduler (PR #487)
+metadata:
+  type: project
+---
+
+Root cause: zero scheduler triggered sitemap regeneration → last manual run 2026-04-23 froze `<lastmod>` 21 days → Googlebot crawl budget eroded.
+
+Why: @nestjs/schedule v6 disabled in app.module.ts (conflict @nestjs/common v10) → all @Cron inert. No BullMQ job either.
+
+Fix: SitemapV10SchedulerService registers BullMQ repeatable on `seo-monitor` queue (PR #487), READ_ONLY gate at processor (ADR-028 Option D), 03:00 UTC daily. SitemapRegenerateProcessor delegates to SitemapV10Service.generateAll(). Manual trigger possible via existing POST /api/sitemap/v10/generate-all.
+
+Prevention: PR #488 adds CI guard that fails the build when @Cron is present while ScheduleModule is disabled (or annotate with INERT-OK-NO-SCHEDULER).
+
+How to apply: any incident with declining GSC impressions while HTML is clean → check sitemap freshness FIRST (curl /sitemap.xml | grep lastmod). Phase −1 playbook in `audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md`.
+
+Refs:
+- PR #487 (fix), PR #488 (prevention)
+- audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md (Phase -1 evidence)
+- audit-reports/seo-smoke/2026-05-13/PHASE-3-5-POST-MERGE-PLAYBOOK.md (this playbook)
+EOF
+```
+
+---
+
+## Rollback (if step 3 or step 4 reveals catastrophic regression)
+
+```bash
+# 1. Quick disable without revert:
+ssh root@49.12.233.2 'docker compose -p automecanik exec backend env SEO_SITEMAP_CRON_ENABLED=false'
+# Then redeploy to apply (or modify the docker-compose env and `docker compose up -d`).
+
+# 2. Full revert via PR (preferred — leaves audit trail):
+gh pr create --base main \
+  --head revert/sitemap-cron-fix \
+  --title "revert: sitemap cron auto-regeneration"
+gh pr merge <revert-pr> --auto --squash
+```
+
+No DB migration to roll back. The existing manual POST `/api/sitemap/v10/generate-all` keeps working as before.

--- a/audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md
+++ b/audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md
@@ -1,0 +1,123 @@
+# Phase −1 Smoke-Test Report — Traffic Drop Investigation
+
+**Date** : 2026-05-13
+**Operator** : Investigation Phase −1 (HTTP smoke-test + robots/WAF + GSC quick-check)
+**Plan ref** : `/home/deploy/.claude/plans/verifier-pourquoi-le-trafic-binary-mist.md`
+
+---
+
+## Verdict Phase −1
+
+**H1 RLS direct, H1bis Security invoker chains, et fallback silencieux `r2_conditions_missing` → TOUS RÉFUTÉS sur PROD pour le périmètre observé.**
+
+PROD `www.automecanik.com` sert ses pages baseline pieces correctement : `index, follow`, canonical OK, prix/stock présents, HTML 200-477 Ko, aucune divergence Googlebot desktop / mobile / humain. La cascade noindex hypothétique du `seo-indexability-policy.service.ts:66-68` n'est pas active sur ces URLs.
+
+**La baisse −40 % organic est réelle mais ce N'EST PAS la racine identifiée par les hypothèses H1/H1bis du plan v3.**
+
+## Cause-racine probable après Phase −1
+
+**Désindexation Google active sur `/pieces/*`** confirmée par GSC, mécanisme externe ou en amont du rendu HTML actuel :
+
+1. **Sitemap stale depuis 2026-04-23** (drapeau rouge fort) — tous les sub-sitemaps ont `<lastmod>2026-04-23</lastmod>` figé sur la date exacte de l'incident, soit 21 jours sans régénération
+2. **Désindexation passée déjà actée** — les pages purgées le 22-23/04 (PR #135 + #136) ont été retirées de l'index Google et l'effet long-tail continue à éroder les impressions
+3. **Cause externe Google possible** — algo update 22-24 avril 2026, AI Overviews steal, ou pénalité qualité non identifiée
+
+Confiance verdict : **~75 %** (matrice Phase 1 du plan : "Zéro hit significatif + service_role + HTML normal + impressions ↓ = H2 sitemap ou cause externe Google")
+
+## Détail des étapes exécutées
+
+### −1.A — Smoke-test HTTP multi-UA (5 URLs top baseline organic)
+
+URLs testées (extraites de `__seo_ga4_daily` channel='organic search' W16-W17) :
+- `/pieces/cardan-13/renault-140/kangoo-ii-140023/1-5-dci-23465.html` (5 sessions baseline)
+- `/pieces/courroie-d-accessoire-10.html` (5 sessions, R1 catalogue)
+- `/pieces/plaquette-de-frein-402/renault-140/megane-iii-140049/1-5-dci-77310.html` (5)
+- `/pieces/plaquette-de-frein-402/mercedes-benz-108/classe-a-w169-108033/a-180-cdi-2-0-18264.html` (4)
+- `/pieces/courroie-d-accessoire-10/peugeot-128/301-128023/1-2-vti-58768.html` (3)
+
+Pour chaque URL × {Googlebot Desktop, Googlebot Smartphone, Human}, archive complète des HTML + headers dans `audit-reports/seo-smoke/2026-05-13/`.
+
+Résultat agrégé (5/5 URLs, 3/3 UA) :
+- `HTTP/2 200` partout
+- `<meta name="robots" content="index, follow"/>` ✅
+- Canonical correcte (pointe vers self) ✅
+- Titre + prix présents (ex : "à partir de 47.00€") ✅
+- `"availability":"https://schema.org/InStock"` (structured data) ✅
+- HTML 200-477 Ko (taille normale, pas dégradée)
+- Diff Googlebot desktop / mobile / humain = **identique** (aucun cloaking)
+- Cache Cloudflare : MISS premier hit, HIT ensuite (normal)
+
+### −1.D — Robots.txt + WAF
+
+- `robots.txt` PROD propre : aucun `Disallow: /pieces/` ni règle UA-restricted pour Googlebot
+- Modification PHP→migration aujourd'hui 2026-05-13 (mentionnée in-file) — **après l'incident**, donc pas la cause
+- WAF Cloudflare : `cf-cache-status: HIT/MISS` normal, aucun `cf-mitigated`, pas de 403/503/CAPTCHA pour Googlebot
+- Sitemap index `/sitemap.xml` :
+  - 11 sub-sitemaps référencés
+  - 3 sub-sitemaps pieces : **50 000 + 50 000 + 2 395 = 102 395 URLs** → pas amputé
+  - **TOUS** les sub-sitemaps ont `<lastmod>2026-04-23</lastmod>` figé → drapeau rouge stale 21 jours
+
+### −1.E — Googlebot Smartphone (mobile-first)
+
+Inclus dans −1.A. **Aucune divergence desktop vs mobile** sur les 5 URLs : même HTML, même taille, même robots, même canonical, même structured data. Mobile-first indexing pas en cause directe.
+
+### −1.B — GSC quick-check (`__seo_gsc_daily`)
+
+Trend hebdo (cf. tableau dans le rapport principal) :
+
+- **`pieces`** : impressions −40 % (3 666 → 2 183), clicks −72 % (18 → 5), CTR −53 % (0.49 → 0.23), position +3 (34 → 37) **W17 → W19**
+- **`blog`** : impressions stable (4-5K/sem), clicks/position stables
+- **`constructeurs`** : impressions stable (~900-1100/sem), clicks faibles oscillants
+- **`home`** : volumes très faibles (36-73 imp/sem) mais CTR élevé (8-15 %), stable
+
+Section `pieces` isolée → baisse spécifique à cette surface, pas un effet global domaine.
+
+## Comparaison GA4 vs GSC W17 → W19
+
+| Métrique | Source | W17 | W19 | Δ |
+|----------|--------|-----|-----|---|
+| sessions organic pieces | GA4 | 405 | 214 (×7/6) | **−47 %** |
+| clicks pieces | GSC | 18 | 5 | **−72 %** |
+| impressions pieces | GSC | 3 666 | 2 183 | **−40 %** |
+| CTR pieces | GSC | 0.49 % | 0.23 % | **−53 %** |
+| position pieces | GSC | 34.16 | 36.94 | **+3 places** |
+
+Les chutes GA4 et GSC convergent. **Le tracking GA4 n'est pas cassé** (H5 réfutée) — c'est bien une vraie désindexation Google.
+
+## Branchement Phase 3 — Fix racine ciblé
+
+Skip Phase 0 (obs-fix) et Phase 1 (script versionné) en bloc bloquant — la racine est externe au verdict noindex. Néanmoins :
+
+- **Phase 0 reste pertinent comme corrective d'observabilité** (incident parallèle) pour futurs incidents R2 silencieux — à programmer mais hors chemin critique
+- **Phase 1 script reste utile** comme outil reproductible pour mesurer l'effet de tout fix futur
+
+**Actions Phase 3 prioritaires (ordre)** :
+
+1. **Investiguer pourquoi le sitemap est figé à 2026-04-23** :
+   - Auditer `SitemapV2Service`, jobs BullMQ `sitemap:*`, cron de régénération
+   - Vérifier état dernière exécution réussie / failed
+   - Si PR #136 (purge orphans) a cassé le job → réparer + re-trigger
+2. **Régénérer le sitemap manuellement** une fois la cause sitemap identifiée
+3. **GSC URL Inspection** pour 10-20 URLs baseline top organic — forcer re-crawl prioritaire (quota ~10/jour user)
+4. **Surveiller `__seo_gsc_daily.pieces` impressions** sur 7 j post-fix sitemap (ETA rétablissement crawl Google ~7-14 j)
+
+## Fichiers archivés
+
+```
+audit-reports/seo-smoke/2026-05-13/
+├── PHASE-MINUS-1-REPORT.md (ce fichier)
+├── robots.txt + robots.txt.headers
+├── sitemap.xml
+├── googlebot-desktop-* (.html + .headers) × 5 URLs
+├── googlebot-mobile-* (.html + .headers) × 5 URLs
+└── human-* (.html + .headers) × 5 URLs
+```
+
+15 paires HTML+headers + 1 robots + 1 sitemap + ce rapport = 33 fichiers, preuve reviewable pour post-mortem.
+
+## Mémoires à actualiser (post-investigation)
+
+- `seo-v9-cascade-state-20260508.md` est **obsolète** — PRs #398/#399/#400 sont MERGED, pas drafts
+- Créer mémoire `incident-traffic-drop-2026-04-22-resolved-sitemap-stale.md` post-fix
+- Créer mémoire `feedback_smoke_test_http_before_obs_fix.md` — pattern Phase −1 confirmé efficace (15 min pour trancher H1/H1bis)
+- Hypothèses H1/H1bis réfutées contredisent la conclusion intuitive initiale → leçon de discipline empirique

--- a/backend/src/modules/seo/processors/sitemap-regenerate.processor.ts
+++ b/backend/src/modules/seo/processors/sitemap-regenerate.processor.ts
@@ -1,0 +1,136 @@
+/**
+ * SitemapRegenerateProcessor — consume du job `sitemap-regenerate-all`.
+ *
+ * Scheduled by `SitemapV10SchedulerService` (BullMQ repeatable, 03:00 UTC).
+ * Delegate `SitemapV10Service.generateAll()` qui régénère tous les buckets
+ * (racine, categories, vehicules, blog, pages, diagnostic, reference, brands,
+ * pieces-1..N, hubs). Aucun changement de comportement métier — uniquement
+ * fraîcheur du `<lastmod>` (suit la date de génération côté
+ * `sitemap-v10-xml.service.ts:75-77`).
+ *
+ * READ_ONLY gate ici (pas au scheduler) — mémoire
+ * `feedback_readonly_gate_at_processor_not_scheduler.md` et pattern
+ * `SeoDailyFetchProcessor`. Preprod miroir prod doit pouvoir valider le
+ * wiring BullMQ sans exécuter la génération qui écrit des fichiers.
+ */
+
+import { OnQueueError, OnQueueFailed, Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { getAppConfig } from '../../../config/app.config';
+import { getErrorMessage } from '../../../common/utils/error.utils';
+import { SitemapV10Service } from '../services/sitemap-v10.service';
+import {
+  SITEMAP_REGENERATE_JOB_NAME,
+  SitemapRegenerateJobData,
+} from '../services/sitemap-v10-scheduler.service';
+
+export interface SitemapRegenerateResult {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  triggeredBy: SitemapRegenerateJobData['triggeredBy'];
+  success: boolean;
+  skipped?: 'read_only';
+  totalUrls?: number;
+  totalFiles?: number;
+  indexPath?: string;
+  errorMessage?: string;
+}
+
+@Processor('seo-monitor')
+export class SitemapRegenerateProcessor {
+  private readonly logger = new Logger(SitemapRegenerateProcessor.name);
+  private readonly readOnly: boolean;
+  private lastQueueErrorLog = 0;
+
+  constructor(private readonly sitemapService: SitemapV10Service) {
+    this.readOnly = getAppConfig().supabase.readOnly;
+  }
+
+  @Process(SITEMAP_REGENERATE_JOB_NAME)
+  async handleRegenerate(
+    job: Job<SitemapRegenerateJobData>,
+  ): Promise<SitemapRegenerateResult> {
+    const startedAtMs = Date.now();
+    const startedAtIso = new Date(startedAtMs).toISOString();
+    const triggeredBy = job.data?.triggeredBy ?? 'scheduler';
+
+    // ADR-028 Option D — READ_ONLY gate au processor.
+    // Le scheduler reste enregistré pour valider le wiring BullMQ en preprod
+    // miroir prod, mais le handler court-circuite sans écrire de fichiers.
+    if (this.readOnly) {
+      this.logger.log(
+        `[READ_ONLY] Skipping sitemap regeneration (triggeredBy=${triggeredBy})`,
+      );
+      return {
+        startedAt: startedAtIso,
+        finishedAt: new Date().toISOString(),
+        durationMs: Date.now() - startedAtMs,
+        triggeredBy,
+        success: true,
+        skipped: 'read_only',
+      };
+    }
+
+    this.logger.log(
+      `🌙 Sitemap V10 regeneration starting (triggeredBy=${triggeredBy})`,
+    );
+
+    try {
+      const result = await this.sitemapService.generateAll();
+      const durationMs = Date.now() - startedAtMs;
+
+      const log = result.success
+        ? this.logger.log.bind(this.logger)
+        : this.logger.error.bind(this.logger);
+      log(
+        `${result.success ? '✅' : '❌'} Sitemap V10 regeneration done in ${durationMs}ms — ` +
+          `${result.totalUrls} URLs across ${result.totalFiles} files`,
+      );
+
+      return {
+        startedAt: startedAtIso,
+        finishedAt: new Date().toISOString(),
+        durationMs,
+        triggeredBy,
+        success: result.success,
+        totalUrls: result.totalUrls,
+        totalFiles: result.totalFiles,
+        indexPath: result.indexPath,
+      };
+    } catch (err) {
+      const message = getErrorMessage(err);
+      this.logger.error(
+        `❌ Sitemap V10 regeneration threw: ${message}`,
+        err instanceof Error ? err.stack : String(err),
+      );
+      return {
+        startedAt: startedAtIso,
+        finishedAt: new Date().toISOString(),
+        durationMs: Date.now() - startedAtMs,
+        triggeredBy,
+        success: false,
+        errorMessage: message,
+      };
+    }
+  }
+
+  @OnQueueError()
+  onQueueError(err: Error): void {
+    // Throttle to once per minute to avoid log spam if Redis flaps
+    const now = Date.now();
+    if (now - this.lastQueueErrorLog < 60_000) return;
+    this.lastQueueErrorLog = now;
+    this.logger.error(`Queue error (seo-monitor): ${err.message}`, err.stack);
+  }
+
+  @OnQueueFailed()
+  onJobFailed(job: Job<SitemapRegenerateJobData>, err: Error): void {
+    if (job.name !== SITEMAP_REGENERATE_JOB_NAME) return;
+    this.logger.error(
+      `Sitemap regeneration job ${job.id} failed: ${err.message}`,
+      err.stack,
+    );
+  }
+}

--- a/backend/src/modules/seo/seo.module.ts
+++ b/backend/src/modules/seo/seo.module.ts
@@ -74,6 +74,8 @@ import { HubsVehicleService } from './services/sitemap-v10-hubs-vehicle.service'
 import { SitemapV10ScoringService } from './services/sitemap-v10-scoring.service';
 import { SitemapDeltaService } from './services/sitemap-delta.service';
 import { SitemapStreamingService } from './services/sitemap-streaming.service';
+import { SitemapV10SchedulerService } from './services/sitemap-v10-scheduler.service';
+import { SitemapRegenerateProcessor } from './processors/sitemap-regenerate.processor';
 import { SitemapHygieneService } from './services/sitemap-hygiene.service';
 import { SitemapVehiclePiecesValidator } from './services/sitemap-vehicle-pieces-validator.service';
 
@@ -241,6 +243,9 @@ import { PageRoleValidationInterceptor } from './interceptors/page-role-validati
     SitemapStreamingService,
     SitemapHygieneService,
     SitemapVehiclePiecesValidator,
+    // Régénération nocturne BullMQ (fix traffic-drop 2026-04-22 → 2026-05-13)
+    SitemapV10SchedulerService,
+    SitemapRegenerateProcessor,
     // Content
     ReferenceService,
     DiagnosticService,

--- a/backend/src/modules/seo/services/sitemap-v10-scheduler.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-scheduler.service.ts
@@ -1,0 +1,145 @@
+/**
+ * Sitemap V10 — régénération automatique nocturne via BullMQ.
+ *
+ * Pourquoi ce service existe
+ * --------------------------
+ * Avant ce fix, la génération des sitemaps n'avait AUCUN déclencheur
+ * automatique : `SitemapV10Service.generateAll()` n'était appelable que
+ * manuellement via `POST /api/sitemap/v10/generate-all`. La dernière
+ * régénération manuelle datait du 2026-04-23 (post PR #135 — filtre
+ * TecDoc orphans). Conséquence : `<lastmod>2026-04-23</lastmod>` figé
+ * pendant 21 jours sur ~102 000 URLs `/pieces/*`, signal de site stagnant
+ * pour Googlebot → érosion progressive du crawl budget → −40 % impressions
+ * `/pieces/*` GSC entre W17 et W19 (cf. `audit-reports/seo-smoke/2026-05-13/`).
+ *
+ * Pourquoi BullMQ et pas `@Cron`
+ * ------------------------------
+ * Le `ScheduleModule` de `@nestjs/schedule` est désactivé monorepo
+ * (cf. app.module.ts:10, conflit version `@nestjs/common@^10` ×
+ * `@nestjs/schedule@^6`). Tous les `@Cron` du codebase sont inertes.
+ * Le pattern canonique du monorepo est BullMQ avec repeatable jobs
+ * (cf. `SeoMonitorSchedulerService`, `AbandonedCartService:58`).
+ *
+ * Garde-fous
+ * ----------
+ * - Job repeatable BullMQ avec `jobId` stable → pas de doublon
+ * - Nettoyage des anciens jobs au boot (pattern repeated dans
+ *   `SeoMonitorSchedulerService.cleanOldRepeatableJobs`)
+ * - READ_ONLY gate au processor (mémoire
+ *   `feedback_readonly_gate_at_processor_not_scheduler.md`)
+ * - `SEO_SITEMAP_CRON_ENABLED=false` désactive l'enregistrement
+ * - `onModuleInit` non-bloquant (`void` + fire-and-forget), pattern canon
+ *   `.claude/rules/backend.md` § Non-blocking onModuleInit
+ */
+
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { ConfigService } from '@nestjs/config';
+import { Queue } from 'bull';
+import { getErrorMessage } from '@common/utils/error.utils';
+
+export const SITEMAP_REGENERATE_JOB_NAME = 'sitemap-regenerate-all';
+export const SITEMAP_REGENERATE_JOB_ID = 'sitemap-v10-nightly-regeneration';
+
+export interface SitemapRegenerateJobData {
+  triggeredBy: 'scheduler' | 'api' | 'manual';
+}
+
+@Injectable()
+export class SitemapV10SchedulerService implements OnModuleInit {
+  private readonly logger = new Logger(SitemapV10SchedulerService.name);
+
+  constructor(
+    @InjectQueue('seo-monitor') private readonly seoMonitorQueue: Queue,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Init non-bloquant — fire-and-forget. Pattern canon backend.md.
+   * Bloquer ici stallerait `app.listen()` (cf. PR #224 / run 25166916535).
+   */
+  onModuleInit(): void {
+    if (!this.isEnabled()) {
+      this.logger.log(
+        'SEO_SITEMAP_CRON_ENABLED=false — sitemap regeneration scheduler skipped',
+      );
+      return;
+    }
+    void this.configureRepeatableJob();
+  }
+
+  private async configureRepeatableJob(): Promise<void> {
+    try {
+      await this.removeStaleRepeatableJob();
+
+      await this.seoMonitorQueue.add(
+        SITEMAP_REGENERATE_JOB_NAME,
+        {
+          triggeredBy: 'scheduler',
+        } satisfies SitemapRegenerateJobData,
+        {
+          repeat: {
+            cron: this.getCron(),
+            tz: 'UTC',
+          },
+          jobId: SITEMAP_REGENERATE_JOB_ID,
+          removeOnComplete: 14, // 2 semaines d'historique
+          removeOnFail: 30,
+          attempts: 2,
+          backoff: {
+            type: 'exponential',
+            delay: 60_000, // 1 min puis 2 min
+          },
+        },
+      );
+
+      this.logger.log(
+        `✅ Sitemap V10 nightly regeneration scheduled (cron="${this.getCron()}" UTC)`,
+      );
+    } catch (err) {
+      this.logger.error(
+        '❌ Failed to configure sitemap regeneration repeatable job',
+        getErrorMessage(err),
+      );
+    }
+  }
+
+  /**
+   * Idempotence : supprime l'ancien repeatable job avant de le réinsérer
+   * (sinon BullMQ stocke les anciens cron strings au redeploy).
+   */
+  private async removeStaleRepeatableJob(): Promise<void> {
+    try {
+      const jobs = await this.seoMonitorQueue.getRepeatableJobs();
+      for (const job of jobs) {
+        if (job.name === SITEMAP_REGENERATE_JOB_NAME) {
+          await this.seoMonitorQueue.removeRepeatableByKey(job.key);
+          this.logger.log(
+            `🗑️ Removed stale sitemap repeatable job: ${job.key}`,
+          );
+        }
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Could not enumerate stale sitemap jobs: ${getErrorMessage(err)}`,
+      );
+    }
+  }
+
+  /**
+   * 03:00 UTC = ~05:00 Paris, creux trafic FR, AVANT le job daily-fetch
+   * (04:00 UTC GSC/GA4) pour que sitemap soit frais avant l'ingestion KPI.
+   */
+  private getCron(): string {
+    return this.configService.get<string>(
+      'SEO_SITEMAP_CRON',
+      '0 3 * * *',
+    );
+  }
+
+  private isEnabled(): boolean {
+    const raw = this.configService.get<string>('SEO_SITEMAP_CRON_ENABLED');
+    if (raw === undefined || raw === null) return true;
+    return raw.toLowerCase() !== 'false' && raw !== '0';
+  }
+}

--- a/backend/src/modules/seo/services/sitemap-v10-scheduler.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-scheduler.service.ts
@@ -131,10 +131,7 @@ export class SitemapV10SchedulerService implements OnModuleInit {
    * (04:00 UTC GSC/GA4) pour que sitemap soit frais avant l'ingestion KPI.
    */
   private getCron(): string {
-    return this.configService.get<string>(
-      'SEO_SITEMAP_CRON',
-      '0 3 * * *',
-    );
+    return this.configService.get<string>('SEO_SITEMAP_CRON', '0 3 * * *');
   }
 
   private isEnabled(): boolean {

--- a/backend/tests/unit/sitemap-v10-scheduler.test.ts
+++ b/backend/tests/unit/sitemap-v10-scheduler.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression test : SitemapV10SchedulerService
+ *
+ * Pin l'invariant racine de l'incident traffic-drop 2026-04-22 → 2026-05-13 :
+ * un job repeatable BullMQ DOIT être enregistré au boot pour régénérer les
+ * sitemaps (lastmod sinon figé sur la dernière génération manuelle).
+ *
+ * Couvre :
+ *   - `onModuleInit` enregistre exactement un repeatable job
+ *   - `SEO_SITEMAP_CRON_ENABLED=false` désactive l'enregistrement
+ *   - Anciens jobs avec même nom sont supprimés avant ré-enregistrement
+ *   - Cron par défaut = '0 3 * * *' UTC
+ *   - Override via `SEO_SITEMAP_CRON` env var
+ */
+
+import { ConfigService } from '@nestjs/config';
+import { Queue } from 'bull';
+import {
+  SITEMAP_REGENERATE_JOB_ID,
+  SITEMAP_REGENERATE_JOB_NAME,
+  SitemapV10SchedulerService,
+} from '../../src/modules/seo/services/sitemap-v10-scheduler.service';
+
+function makeQueueMock(): jest.Mocked<Queue> {
+  return {
+    add: jest.fn().mockResolvedValue(undefined),
+    getRepeatableJobs: jest.fn().mockResolvedValue([]),
+    removeRepeatableByKey: jest.fn().mockResolvedValue(undefined),
+  } as unknown as jest.Mocked<Queue>;
+}
+
+function makeConfig(env: Record<string, string | undefined>): ConfigService {
+  return {
+    get: jest.fn((key: string, defaultValue?: string) => {
+      const v = env[key];
+      return v !== undefined ? v : defaultValue;
+    }),
+  } as unknown as ConfigService;
+}
+
+async function flushFireAndForget(): Promise<void> {
+  // Le service appelle `void this.configureRepeatableJob()` depuis
+  // onModuleInit (pattern non-bloquant canonique). On laisse la microtask
+  // se résoudre avant d'inspecter les mocks.
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('SitemapV10SchedulerService', () => {
+  it('registers exactly one repeatable job with default cron at 03:00 UTC', async () => {
+    const queue = makeQueueMock();
+    const config = makeConfig({});
+    const service = new SitemapV10SchedulerService(queue, config);
+
+    service.onModuleInit();
+    await flushFireAndForget();
+
+    expect(queue.getRepeatableJobs).toHaveBeenCalledTimes(1);
+    expect(queue.add).toHaveBeenCalledTimes(1);
+
+    const [jobName, jobData, jobOpts] = queue.add.mock.calls[0];
+    expect(jobName).toBe(SITEMAP_REGENERATE_JOB_NAME);
+    expect(jobData).toEqual({ triggeredBy: 'scheduler' });
+    expect(jobOpts).toMatchObject({
+      jobId: SITEMAP_REGENERATE_JOB_ID,
+      repeat: { cron: '0 3 * * *', tz: 'UTC' },
+    });
+  });
+
+  it('honors SEO_SITEMAP_CRON env override', async () => {
+    const queue = makeQueueMock();
+    const config = makeConfig({ SEO_SITEMAP_CRON: '15 2 * * *' });
+    const service = new SitemapV10SchedulerService(queue, config);
+
+    service.onModuleInit();
+    await flushFireAndForget();
+
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    const [, , jobOpts] = queue.add.mock.calls[0];
+    expect(jobOpts).toMatchObject({
+      repeat: { cron: '15 2 * * *', tz: 'UTC' },
+    });
+  });
+
+  it('skips registration when SEO_SITEMAP_CRON_ENABLED=false', async () => {
+    const queue = makeQueueMock();
+    const config = makeConfig({ SEO_SITEMAP_CRON_ENABLED: 'false' });
+    const service = new SitemapV10SchedulerService(queue, config);
+
+    service.onModuleInit();
+    await flushFireAndForget();
+
+    expect(queue.getRepeatableJobs).not.toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('removes stale sitemap repeatable jobs before re-registering', async () => {
+    const queue = makeQueueMock();
+    queue.getRepeatableJobs.mockResolvedValue([
+      // Stale entry from previous deploy
+      { name: SITEMAP_REGENERATE_JOB_NAME, key: 'stale::key::1' },
+      // Foreign entry — must NOT be removed
+      { name: 'daily-fetch', key: 'foreign::key::2' },
+    ] as Awaited<ReturnType<Queue['getRepeatableJobs']>>);
+
+    const service = new SitemapV10SchedulerService(queue, makeConfig({}));
+    service.onModuleInit();
+    await flushFireAndForget();
+
+    expect(queue.removeRepeatableByKey).toHaveBeenCalledTimes(1);
+    expect(queue.removeRepeatableByKey).toHaveBeenCalledWith('stale::key::1');
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when stale job enumeration fails (defensive)', async () => {
+    const queue = makeQueueMock();
+    queue.getRepeatableJobs.mockRejectedValue(new Error('redis down'));
+
+    const service = new SitemapV10SchedulerService(queue, makeConfig({}));
+    expect(() => service.onModuleInit()).not.toThrow();
+    await flushFireAndForget();
+
+    // Erreur d'enumeration ne doit pas bloquer l'enregistrement du nouveau job
+    expect(queue.add).toHaveBeenCalledTimes(1);
+  });
+});

--- a/log.md
+++ b/log.md
@@ -537,3 +537,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/registry-pr-f-llm-entrypoint`
 - **Décision** : feat(registry): LLM entrypoint REPO_MAP.md + CLAUDE.md step 0 + cross-language hook (ADR-058 PR-F) (+8 other commits)
 - **Sortie** : PR #463 | commits 9ac2f75b 77d4b57a a1d79d5b 658018c4 66d9e64f b08d3e90 b281943b f067e9ec 0504fd38
+
+## 2026-05-13 — fix/seo-sitemap-auto-regeneration-cron (auto)
+
+- **Branche** : `fix/seo-sitemap-auto-regeneration-cron`
+- **Décision** : fix(seo): restore automatic sitemap regeneration via BullMQ repeatable job
+- **Sortie** : PR #487 | commits af70edb3


### PR DESCRIPTION
## Summary

Restore automatic nightly regeneration of the `/sitemap*.xml` files. The previous flow had **no scheduler at all** — the sitemap was regenerated only when someone POSTed `/api/sitemap/v10/generate-all` manually. The last manual trigger was 2026-04-23 (post PR #135). Result: `<lastmod>2026-04-23</lastmod>` frozen on ~102 000 `/pieces/*` URLs for 21 days, signalling a stagnant site to Googlebot.

## Root cause for traffic-drop 2026-04-22 → 2026-05-13

Phase −1 smoke-test (`audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md`) refuted the initial hypotheses (RLS rupture, security invoker chain, silent `r2_conditions_missing` fallback). All 5 baseline `/pieces/*` URLs serve **clean HTML** (200, `index,follow`, canonical OK, price/stock present, no cloaking) to Googlebot Desktop, Googlebot Smartphone and humans.

GSC confirms a **real Google-side desindexation** isolated to the `pieces` section:

| pieces | clicks | impressions | CTR % | position |
|--------|--------|-------------|-------|----------|
| W17 (2026-04-20) | 18 | 3 666 | 0.49 | 34.16 |
| W19 (2026-05-04) | **5** | **2 183** | **0.23** | 36.94 |
| Δ | −72 % | **−40 %** | −53 % | +3 |

`blog`, `constructeurs`, `home` are stable → cause is `pieces` specific.

Diagnostic chain:

1. No `@Cron` anywhere in `backend/src/modules/seo/` for sitemap regeneration.
2. `@nestjs/schedule@^6.0.1` is disabled in `app.module.ts:10` (conflict with `@nestjs/common@^10`) — every `@Cron` in the codebase is **inert**.
3. `sitemap-delta.service.ts:339` has a TODO comment "À appeler depuis un Cron Job NestJS @Cron" never implemented.
4. The monorepo's canonical pattern for scheduled jobs is BullMQ repeatable, e.g. `SeoMonitorSchedulerService` and `AbandonedCartService:58`.
5. `sitemap-v10-xml.service.ts:75-77` falls back to `new Date()` whenever the source row has no `last_modified_at` — and `__sitemap_p_link` has no date column → every URL inherits the date of the run.
6. Combined: a single manual run freezes the entire sitemap at one date until somebody POSTs again.

## Fix

| File | Purpose |
|------|---------|
| `backend/src/modules/seo/services/sitemap-v10-scheduler.service.ts` (new) | Registers one BullMQ repeatable job (`sitemap-regenerate-all`) on the existing `seo-monitor` queue at `0 3 * * *` UTC by default. Idempotent (removes same-name stale entries first), non-blocking `onModuleInit`, disabled by `SEO_SITEMAP_CRON_ENABLED=false`. |
| `backend/src/modules/seo/processors/sitemap-regenerate.processor.ts` (new) | Consumes the job, delegates to `SitemapV10Service.generateAll()`. READ_ONLY gate at the processor (ADR-028 Option D, memory `feedback_readonly_gate_at_processor_not_scheduler.md`). |
| `backend/src/modules/seo/seo.module.ts` (+5 lines) | Wires the scheduler + processor as providers. `WorkerModule` is already imported, so `seo-monitor` queue is reachable via `@InjectQueue`. |
| `backend/tests/unit/sitemap-v10-scheduler.test.ts` (new) | Pins: exactly one repeatable job is added, override via env, disable via env, stale-job cleanup is scoped to same `name`, defensive handling of Redis enumeration failures. |

**Zero change to SEO verdict logic.** No new policy, no robots/canonical mutation, no DB migration, no new env required (defaults are safe). Existing `/api/sitemap/v10/generate-all` POST endpoint remains usable as the manual trigger.

## Why BullMQ, not `@Cron`

`ScheduleModule.forRoot()` is commented out in `app.module.ts:10` and `:153` because of the version conflict above. Re-enabling it would require either upgrading `@nestjs/common` to v11 or downgrading `@nestjs/schedule` to v4 — both are out of scope for this fix and risky on a perf-sensitive deploy path. BullMQ already powers `SeoMonitorSchedulerService`, `AbandonedCartService:58`, `SeoDailyFetchProcessor` — we reuse the proven plumbing.

## Tunables

- `SEO_SITEMAP_CRON` (default `'0 3 * * *'`) — cron string, UTC
- `SEO_SITEMAP_CRON_ENABLED` (default unset = enabled; `false`/`0` disables registration only — does not affect manual POSTs)

## Test plan

- [x] Unit tests pass locally (`sitemap-v10-scheduler.test.ts` — 5 cases).
- [ ] CI green on this branch.
- [ ] After merge → DEV preprod deploy: confirm log `✅ Sitemap V10 nightly regeneration scheduled (cron="0 3 * * *" UTC)` at boot.
- [ ] After PROD tag deploy: confirm log line on `49.12.233.2`, then within 24h verify `https://www.automecanik.com/sitemap-pieces-1.xml` shows `<lastmod>$(date -u +%F)</lastmod>`.
- [ ] Cloudflare purge for `/sitemap*.xml` after the first cron run (manual step in Phase 3.5).
- [ ] Resubmit sitemap in Google Search Console + URL Inspection on 10–20 top-baseline `/pieces/*` URLs.

## Rollback

```bash
# 1. Revert via PR (branch is protected, no direct push)
gh pr create --base main --head revert/<sha> --title "revert: sitemap cron"
gh pr merge <revert-pr> --auto --squash
# 2. (Optional) Disable without revert
#    Set SEO_SITEMAP_CRON_ENABLED=false in env, redeploy.
```

No DB migration, no destructive operation; the revert is purely additive cleanup.

## Refs

- [audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md](https://github.com/ak125/nestjs-remix-monorepo/blob/fix/seo-sitemap-auto-regeneration-cron/audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md)
- PR #135 — TecDoc orphan filter (last manual sitemap regeneration date)
- PR #136 — migration N2 archive_purge (DELETE commented, never applied)
- `backend/src/modules/seo/services/sitemap-v10-xml.service.ts:75-77` — the `lastmod` fallback
- `.claude/rules/backend.md` § Non-blocking `onModuleInit`
- Memory `feedback_readonly_gate_at_processor_not_scheduler.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)