### PR TITLE
chore(ci): guard against inert @Cron when ScheduleModule is disabled

### DIFF
--- a/.github/workflows/cron-schedulemodule-guard.yml
+++ b/.github/workflows/cron-schedulemodule-guard.yml
@@ -1,0 +1,38 @@
+name: 🕐 Cron / ScheduleModule guard
+
+# Prevent the regression that caused traffic-drop 2026-04-22 → 2026-05-13:
+# @nestjs/schedule was disabled in app.module.ts but @Cron decorators
+# remained in the codebase, silently inert (no error, no log).
+#
+# Cf. PR #487 (sitemap regeneration restoration via BullMQ).
+# Cf. audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md.
+
+on:
+  pull_request:
+    paths:
+      - "backend/src/**/*.ts"
+      - "scripts/ci/check-cron-needs-schedulemodule.sh"
+      - ".github/workflows/cron-schedulemodule-guard.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/src/**/*.ts"
+      - "scripts/ci/check-cron-needs-schedulemodule.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: Detect inert scheduling decorators
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Make guard script executable
+        run: chmod +x scripts/ci/check-cron-needs-schedulemodule.sh
+
+      - name: Run guard
+        run: ./scripts/ci/check-cron-needs-schedulemodule.sh

--- a/backend/src/modules/catalog/services/vehicle-filtered-catalog-v4-hybrid.service.ts
+++ b/backend/src/modules/catalog/services/vehicle-filtered-catalog-v4-hybrid.service.ts
@@ -764,6 +764,7 @@ export class VehicleFilteredCatalogV4HybridService
   /**
    * 🔄 PRÉ-CALCUL BACKGROUND DES VÉHICULES POPULAIRES
    */
+  // INERT-OK-NO-SCHEDULER — TODO: migrer vers BullMQ repeatable, cf. PR #487
   @Cron('0 */6 * * *') // Toutes les 6 heures
   async precomputePopularCatalogs(): Promise<void> {
     this.logger.log('🔄 [PRECOMPUTE] Début pré-calcul véhicules populaires...');

--- a/backend/src/modules/orders/services/order-cleanup.service.ts
+++ b/backend/src/modules/orders/services/order-cleanup.service.ts
@@ -20,6 +20,7 @@ export class OrderCleanupService extends SupabaseBaseService {
    * Toutes les 15 min : marquer les processing orphelins comme failed.
    * Conditionné à order_id IS NULL + updated_at < 15 min (inactivité réelle).
    */
+  // INERT-OK-NO-SCHEDULER — TODO: migrer vers BullMQ (queue `seo-monitor` ou nouvelle), cf. PR #487
   @Cron('0 */15 * * * *')
   async cleanupOrphanProcessing(): Promise<void> {
     try {
@@ -53,6 +54,7 @@ export class OrderCleanupService extends SupabaseBaseService {
   /**
    * Toutes les heures : purger les idempotency keys et resume tokens expirés.
    */
+  // INERT-OK-NO-SCHEDULER — TODO: migrer vers BullMQ (queue `seo-monitor` ou nouvelle), cf. PR #487
   @Cron(CronExpression.EVERY_HOUR)
   async purgeExpired(): Promise<void> {
     try {

--- a/scripts/ci/check-cron-needs-schedulemodule.sh
+++ b/scripts/ci/check-cron-needs-schedulemodule.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Guard : detect inert `@Cron` decorators when ScheduleModule is disabled.
+#
+# Pourquoi ce guard existe
+# ------------------------
+# Le 2026-04-22 → 2026-05-13, `@nestjs/schedule@^6` a été désactivé dans
+# `backend/src/app.module.ts` (conflit `@nestjs/common@^10`), rendant tous
+# les `@Cron` du codebase silencieusement inertes. Conséquence directe :
+# le sitemap n'était plus régénéré, `<lastmod>` figé 21 jours, −40 %
+# impressions GSC `/pieces/*`. Cf. PR #487 et
+# `audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md`.
+#
+# Règle
+# -----
+# Si `app.module.ts` ne contient PAS `ScheduleModule.forRoot()` actif
+# (non commenté), alors AUCUN `@Cron(` ou `@Interval(` ou `@Timeout(`
+# ne doit subsister dans `backend/src` — il faut migrer vers BullMQ
+# (pattern canonique : SeoMonitorSchedulerService, SitemapV10SchedulerService).
+#
+# Exemptions
+# ----------
+# `@Cron` dans des commentaires (// @Cron, /* @Cron */, ou tagué TODO/désactivé)
+# sont tolérés s'ils sont accompagnés explicitement du marqueur
+# `INERT-OK-NO-SCHEDULER` sur la même ligne ou juste au-dessus.
+#
+# Exit 0 si propre, 1 si violation.
+
+set -euo pipefail
+
+APP_MODULE="backend/src/app.module.ts"
+SCAN_DIR="backend/src"
+
+if [ ! -f "$APP_MODULE" ]; then
+  echo "❌ $APP_MODULE introuvable — la racine du repo est-elle correcte ?"
+  exit 2
+fi
+
+# Détecte si ScheduleModule.forRoot() est ACTIF (non commenté).
+# Un import commenté `// import { ScheduleModule } …` et un
+# `// ScheduleModule.forRoot()` sont considérés inactifs.
+SCHEDULE_ACTIVE=0
+if grep -E '^[[:space:]]*ScheduleModule\.forRoot\(\)' "$APP_MODULE" > /dev/null; then
+  SCHEDULE_ACTIVE=1
+fi
+
+if [ "$SCHEDULE_ACTIVE" -eq 1 ]; then
+  echo "✅ ScheduleModule.forRoot() actif — @Cron decorators sont fonctionnels."
+  exit 0
+fi
+
+echo "⚠️  ScheduleModule.forRoot() est désactivé / absent dans $APP_MODULE."
+echo "   Recherche des @Cron / @Interval / @Timeout actifs (potentiellement inertes)…"
+
+# Cherche les usages actifs (non commentés) des décorateurs scheduling.
+# Une ligne commence par espaces puis `@Cron(` (ou Interval/Timeout) — pas dans
+# un commentaire `//` ou `*`.
+VIOLATIONS_FILE="$(mktemp)"
+trap 'rm -f "$VIOLATIONS_FILE"' EXIT
+
+# grep -n donne le n° de ligne. On filtre :
+# - lignes qui commencent par espaces optionnels puis @Cron|@Interval|@Timeout
+# - on exclut les lignes commentées (commence par // ou *)
+# - on exclut les lignes qui mentionnent l'exemption INERT-OK-NO-SCHEDULER
+grep -RIn \
+  --include='*.ts' \
+  --exclude-dir=node_modules \
+  --exclude-dir=dist \
+  -E '^[[:space:]]*@(Cron|Interval|Timeout)\(' \
+  "$SCAN_DIR" 2>/dev/null \
+  | grep -v 'INERT-OK-NO-SCHEDULER' \
+  > "$VIOLATIONS_FILE" || true
+
+# Filtrer aussi les lignes où le @Cron est dans un commentaire de bloc /* … */
+# Si la ligne précédente ou le contexte amont est // INERT-OK-NO-SCHEDULER, exempter.
+# Approche simple : si la ligne au-dessus contient INERT-OK-NO-SCHEDULER, retirer.
+FILTERED_FILE="$(mktemp)"
+trap 'rm -f "$VIOLATIONS_FILE" "$FILTERED_FILE"' EXIT
+
+while IFS=: read -r file lineno _; do
+  prev=$((lineno - 1))
+  if [ "$prev" -gt 0 ] && sed -n "${prev}p" "$file" 2>/dev/null | grep -q 'INERT-OK-NO-SCHEDULER'; then
+    continue
+  fi
+  echo "${file}:${lineno}" >> "$FILTERED_FILE"
+done < "$VIOLATIONS_FILE"
+
+VIOLATIONS=$(wc -l < "$FILTERED_FILE" | tr -d ' ')
+
+if [ "$VIOLATIONS" -eq 0 ]; then
+  echo "✅ Aucun @Cron actif détecté pendant que ScheduleModule est inactif."
+  exit 0
+fi
+
+echo ""
+echo "❌ $VIOLATIONS occurrence(s) de @Cron / @Interval / @Timeout actives DÉTECTÉES"
+echo "   alors que ScheduleModule.forRoot() est désactivé :"
+echo ""
+while read -r entry; do
+  file="${entry%:*}"
+  line="${entry##*:}"
+  echo "   $file:$line"
+  sed -n "${line}p" "$file" 2>/dev/null | sed 's/^/      /'
+done < "$FILTERED_FILE"
+echo ""
+echo "Options pour corriger :"
+echo "  1. Migrer le job vers BullMQ repeatable (pattern canonique du monorepo)."
+echo "     Cf. SeoMonitorSchedulerService, SitemapV10SchedulerService (PR #487)."
+echo "  2. Réactiver ScheduleModule.forRoot() dans backend/src/app.module.ts"
+echo "     après avoir résolu le conflit de versions @nestjs/{schedule,common}."
+echo "  3. Si le décorateur est intentionnellement inerte (debug / TODO),"
+echo "     ajouter un commentaire \`// INERT-OK-NO-SCHEDULER\` sur la ligne juste"
+echo "     au-dessus pour exempter."
+echo ""
+echo "Référence : audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md"
+exit 1


### PR DESCRIPTION
## Summary

Add a CI guard that fails the build when `@Cron` / `@Interval` / `@Timeout` decorators are present in `backend/src` while `ScheduleModule.forRoot()` is disabled in `app.module.ts`. Prevents recurrence of the 2026-04-22 → 2026-05-13 traffic-drop incident where every `@Cron` in the codebase was silently inert.

## Why

PR #487 root-caused the SEO traffic drop to a structural class of bug: `@nestjs/schedule@^6` was commented out in `app.module.ts:10` and `:153` (conflict with `@nestjs/common@^10`) but `@Cron` decorators remained throughout `backend/src`, producing zero log, zero error, and zero side-effect — invisible for 21 days. Result: sitemap `<lastmod>` frozen on 2026-04-23, Googlebot crawl budget eroded, `-40 %` impressions on `/pieces/*`.

This guard catches it at PR time so the next contributor cannot reintroduce the same trap.

## How it works

- `scripts/ci/check-cron-needs-schedulemodule.sh` parses `app.module.ts`:
  - If a non-commented `ScheduleModule.forRoot()` is present → exits 0 (no-op).
  - Otherwise, greps for active `@Cron` / `@Interval` / `@Timeout` in `backend/src/**/*.ts`. Any hit not exempted blocks the run.
- Exemption: `// INERT-OK-NO-SCHEDULER` on the line immediately above the decorator. Use it for intentionally inert TODOs (e.g. legacy code awaiting BullMQ migration).
- Workflow `cron-schedulemodule-guard.yml` runs on PR + push to main.

## Pre-existing inert decorators (annotated, not migrated here)

Three locations were already inert before this PR; they are annotated with `INERT-OK-NO-SCHEDULER` and a TODO to migrate to BullMQ (as PR #487 does for the sitemap):

| File | Line | What |
|------|------|------|
| `backend/src/modules/orders/services/order-cleanup.service.ts` | 23 | Orphan processing cleanup (was every 15 min) |
| `backend/src/modules/orders/services/order-cleanup.service.ts` | 56 | Expired tokens purge (was hourly) |
| `backend/src/modules/catalog/services/vehicle-filtered-catalog-v4-hybrid.service.ts` | 767 | Popular vehicles precompute (was every 6 h) |

Each warrants its own follow-up PR to migrate to BullMQ repeatable jobs on the `seo-monitor` queue (or a new dedicated queue). Out of scope for this guard PR — see PR #487 for the canonical pattern.

## Test plan

- [x] Script runs locally and exits 0 once the 3 pre-existing decorators are annotated.
- [x] Removing one annotation locally re-triggers exit 1 with a clear diagnostic.
- [ ] CI green on this branch.

## Rollback

```bash
gh pr create --base main --head revert/<sha> --title "revert: cron guard"
gh pr merge <revert-pr> --auto --squash
```

Pure additive change; no DB migration, no env, no runtime behavior change. The 3 annotation lines could be removed individually if a contributor decides not to migrate that particular job.

## Refs

- PR #487 — sitemap regeneration BullMQ restoration (the incident that motivated this guard)
- `audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md` — Phase −1 investigation
- `backend/src/app.module.ts:10`, `:153` — where `ScheduleModule` is currently disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)