### PR TITLE
fix(seo): require admin auth on SitemapV10 mutating endpoints

### DIFF
--- a/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
+++ b/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
@@ -11,7 +11,7 @@
  * - POST /api/sitemap/v10/ping             → Ping Google
  */
 
-import { Controller, Get, Post, Param, Logger } from '@nestjs/common';
+import { Controller, Get, Post, Param, Logger, UseGuards } from '@nestjs/common';
 import {
   SitemapV10Service,
   TemperatureBucket,
@@ -19,6 +19,21 @@ import {
 import { SitemapV10ScoringService } from '../services/sitemap-v10-scoring.service';
 import { SitemapV10HubsService } from '../services/sitemap-v10-hubs.service';
 import { RateLimitSitemap } from '../../../common/decorators/rate-limit.decorator';
+import { IsAdminGuard } from '@auth/is-admin.guard';
+
+/**
+ * 🔒 Sécurité — tous les endpoints qui MUTENT (POST regenerate / refresh / hubs /
+ * ping) sont protégés par `IsAdminGuard`. Avant la PR de hardening de 2026-05-14
+ * ces endpoints étaient publics avec un simple rate-limit 3/min — exploitable
+ * par un attaquant pour saturer disk/CPU (chaque generate-all consomme ~14 s CPU
+ * + écrit ~100 fichiers XML, jusqu'à ~250k URLs). Le rate-limit ne suffit pas
+ * (multi-IP). L'endpoint GET /stats reste public, c'est de la donnée déjà
+ * exposée via les fichiers XML eux-mêmes.
+ *
+ * Le scheduler BullMQ (SitemapV10SchedulerService, PR #487) appelle
+ * `SitemapV10Service.generateAll()` directement via DI — il ne passe pas par
+ * ce controller HTTP, donc le guard ne le bloque pas.
+ */
 
 @RateLimitSitemap() // 🛡️ 3 req/min - Sitemaps are memory-intensive
 @Controller('api/sitemap/v10')
@@ -35,6 +50,7 @@ export class SitemapV10Controller {
    * POST /api/sitemap/v10/generate-all
    * Génère tous les sitemaps par température
    */
+  @UseGuards(IsAdminGuard)
   @Post('generate-all')
   async generateAll(): Promise<{
     success: boolean;
@@ -98,6 +114,7 @@ export class SitemapV10Controller {
    * POST /api/sitemap/v10/generate/:bucket
    * Génère le sitemap d'un bucket spécifique
    */
+  @UseGuards(IsAdminGuard)
   @Post('generate/:bucket')
   async generateBucket(@Param('bucket') bucket: string): Promise<{
     success: boolean;
@@ -150,6 +167,7 @@ export class SitemapV10Controller {
    * POST /api/sitemap/v10/refresh-scores
    * Recalcule les scores de toutes les pages
    */
+  @UseGuards(IsAdminGuard)
   @Post('refresh-scores')
   async refreshScores(): Promise<{
     success: boolean;
@@ -192,6 +210,7 @@ export class SitemapV10Controller {
    * POST /api/sitemap/v10/generate-hubs
    * Génère les hubs de crawl (version legacy - non paginée)
    */
+  @UseGuards(IsAdminGuard)
   @Post('generate-hubs')
   async generateHubs(): Promise<{
     success: boolean;
@@ -250,6 +269,7 @@ export class SitemapV10Controller {
    * - hot/money.html (top 2k)
    * - risk/weak-cluster.html (pages à risque)
    */
+  @UseGuards(IsAdminGuard)
   @Post('generate-hubs-robust')
   async generateHubsRobust(): Promise<{
     success: boolean;
@@ -360,6 +380,7 @@ export class SitemapV10Controller {
    * POST /api/sitemap/v10/ping
    * Ping Google pour le sitemap index
    */
+  @UseGuards(IsAdminGuard)
   @Post('ping')
   async pingGoogle(): Promise<{
     success: boolean;
@@ -392,6 +413,7 @@ export class SitemapV10Controller {
    * POST /api/sitemap/v10/ping/:bucket
    * Ping Google pour un bucket spécifique
    */
+  @UseGuards(IsAdminGuard)
   @Post('ping/:bucket')
   async pingGoogleBucket(@Param('bucket') bucket: string): Promise<{
     success: boolean;

--- a/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
+++ b/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
@@ -11,7 +11,14 @@
  * - POST /api/sitemap/v10/ping             → Ping Google
  */
 
-import { Controller, Get, Post, Param, Logger, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Logger,
+  UseGuards,
+} from '@nestjs/common';
 import {
   SitemapV10Service,
   TemperatureBucket,


### PR DESCRIPTION
## Summary

Lock down the `POST` endpoints under `/api/sitemap/v10/*` behind `IsAdminGuard`. Before this PR they were reachable by any anonymous client (only protected by a 3 req/min rate-limit) — discovered after PR #487 when a `curl -X POST` from an external host successfully triggered a full 102k-URL regeneration.

## Why this matters

- `POST generate-all` runs `SitemapV10Service.generateAll()` end-to-end: ~14 s CPU, ~100 XML files, ~250 k URLs across hubs.
- Rate-limit is per-IP, so any attacker can distribute and saturate disk/CPU.
- Same surface also exposes `generate/:bucket`, `refresh-scores`, `generate-hubs(-robust)`, `ping`, `ping/:bucket` — all mutating.

`IsAdminGuard` is already the canonical guard for admin-only routes in this module (`DiagnosticController`, `SeoGeneratorController`, `ReferenceController`).

## Change

- One import: `import { IsAdminGuard } from '@auth/is-admin.guard';`
- `@UseGuards(IsAdminGuard)` added on each of the 7 `@Post(...)` decorators.
- Class-level comment explaining the lockdown rationale.
- `GET /api/sitemap/v10/stats` stays public (read-only, data already public via the XML files).

The BullMQ scheduler (`SitemapV10SchedulerService`, PR #487) calls `SitemapV10Service.generateAll()` directly via DI — it does NOT go through this controller, so the guard does not affect the nightly cron.

## Test plan

- [x] Compile pass (`@auth/*` alias OK in `backend/tsconfig.json`).
- [ ] CI green.
- [ ] DEV post-merge: `curl -X POST http://46.224.118.55:3200/api/sitemap/v10/generate-all` returns `403` (was `200` before).
- [ ] Admin UI on `/admin/gammes-seo` continues to trigger regeneration (session-authenticated).
- [ ] BullMQ scheduler keeps producing `lastmod=today` on `/sitemap-pieces-*.xml` (verified observable externally via `curl`).

## Rollback

Pure additive change (one import + one decorator per route). Revert PR is safe — no DB, no env, no data-fetching behavior touched.

```bash
gh pr create --base main --head revert/sitemap-admin-guard \
  --title "revert: sitemap admin guard"
gh pr merge <revert-pr> --auto --squash
```

## Refs

- PR #487 — incident-resolving fix that exposed the public-endpoint problem
- `backend/src/auth/is-admin.guard.ts` — guard implementation
- `backend/src/modules/seo/controllers/diagnostic.controller.ts:64` — canonical `@UseGuards(IsAdminGuard)` usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)