### PR TITLE
feat(seo): sitemap freshness SLO endpoint + daily CI watchdog

### DIFF
--- a/.github/workflows/sitemap-freshness-slo.yml
+++ b/.github/workflows/sitemap-freshness-slo.yml
@@ -1,0 +1,50 @@
+name: 🛰️ Sitemap freshness SLO
+
+# Hits the public GET /api/sitemap/v10/freshness endpoint and fails if the
+# sitemap is older than the threshold OR if the BullMQ scheduler is no longer
+# registered. Prevents recurrence of the silent-stale class of bug that caused
+# the traffic-drop incident 2026-04-22 → 2026-05-13 (see PR #487).
+#
+# Schedule rationale:
+#  - Backend cron fires at 03:00 UTC (SitemapV10SchedulerService).
+#  - SEO daily-fetch cron fires at 04:00 UTC.
+#  - This SLO check fires at 06:00 UTC, leaving 3h margin for the regen to finish.
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # 06:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      url:
+        description: Freshness endpoint URL to probe
+        required: false
+        default: https://www.automecanik.com/api/sitemap/v10/freshness
+      warn_threshold_hours:
+        description: Max staleHours allowed before failing
+        required: false
+        default: '36'
+  pull_request:
+    paths:
+      - scripts/ci/check-sitemap-freshness.sh
+      - .github/workflows/sitemap-freshness-slo.yml
+      - backend/src/modules/seo/services/sitemap-v10-freshness.service.ts
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Probe and assert
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Make script executable
+        run: chmod +x scripts/ci/check-sitemap-freshness.sh
+
+      - name: Run freshness check
+        env:
+          SEO_FRESHNESS_URL: ${{ inputs.url || 'https://www.automecanik.com/api/sitemap/v10/freshness' }}
+          SEO_FRESHNESS_WARN_HOURS: ${{ inputs.warn_threshold_hours || '36' }}
+        run: ./scripts/ci/check-sitemap-freshness.sh

--- a/.github/workflows/sitemap-freshness-slo.yml
+++ b/.github/workflows/sitemap-freshness-slo.yml
@@ -23,11 +23,13 @@ on:
         description: Max staleHours allowed before failing
         required: false
         default: '36'
-  pull_request:
-    paths:
-      - scripts/ci/check-sitemap-freshness.sh
-      - .github/workflows/sitemap-freshness-slo.yml
-      - backend/src/modules/seo/services/sitemap-v10-freshness.service.ts
+
+# Note: this workflow used to also run on `pull_request` to validate the
+# script syntax. That was removed because the probe targets the deployed
+# PROD endpoint — pre-merge runs always 404 by design (the endpoint isn't
+# deployed yet) and were blocking the merge of the very PR that ships the
+# endpoint. The script is unit-coverable via the backend Jest suite +
+# manual `workflow_dispatch` after deploy.
 
 permissions:
   contents: read

--- a/.github/workflows/sitemap-freshness-slo.yml
+++ b/.github/workflows/sitemap-freshness-slo.yml
@@ -46,7 +46,36 @@ jobs:
         run: chmod +x scripts/ci/check-sitemap-freshness.sh
 
       - name: Run freshness check
+        id: probe
         env:
           SEO_FRESHNESS_URL: ${{ inputs.url || 'https://www.automecanik.com/api/sitemap/v10/freshness' }}
           SEO_FRESHNESS_WARN_HOURS: ${{ inputs.warn_threshold_hours || '36' }}
         run: ./scripts/ci/check-sitemap-freshness.sh
+
+      # Notify Sentry on failure so the existing alert rule (single-recipient
+      # email mirror, cf. memory `sentry-vps-bootstrap-20260506`) surfaces this
+      # in the user's mailbox without requiring a separate SMTP setup. Skipped
+      # silently if the SENTRY_DSN secret is not configured in the repo —
+      # ergo this workflow merges cleanly even before SENTRY_DSN is added.
+      - name: Notify Sentry (on failure)
+        if: failure() && env.SENTRY_DSN != ''
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          python3 -m pip install --quiet sentry-sdk
+          python3 - <<'PY'
+          import os, sentry_sdk
+          sentry_sdk.init(
+              dsn=os.environ['SENTRY_DSN'],
+              environment='production',
+              release='sitemap-freshness-watchdog',
+              traces_sample_rate=0.0,
+          )
+          sentry_sdk.set_tag('watchdog', 'sitemap-freshness-slo')
+          sentry_sdk.set_tag('workflow_run', os.environ.get('GITHUB_RUN_ID', ''))
+          sentry_sdk.capture_message(
+              'sitemap-freshness-slo watchdog FAILED — sitemap is stale or scheduler missing',
+              level='error',
+          )
+          sentry_sdk.flush(timeout=5)
+          PY

--- a/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
+++ b/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
@@ -18,6 +18,10 @@ import {
 } from '../services/sitemap-v10.service';
 import { SitemapV10ScoringService } from '../services/sitemap-v10-scoring.service';
 import { SitemapV10HubsService } from '../services/sitemap-v10-hubs.service';
+import {
+  SitemapV10FreshnessService,
+  SitemapFreshnessReport,
+} from '../services/sitemap-v10-freshness.service';
 import { RateLimitSitemap } from '../../../common/decorators/rate-limit.decorator';
 
 @RateLimitSitemap() // 🛡️ 3 req/min - Sitemaps are memory-intensive
@@ -29,7 +33,21 @@ export class SitemapV10Controller {
     private readonly sitemapService: SitemapV10Service,
     private readonly scoringService: SitemapV10ScoringService,
     private readonly hubsService: SitemapV10HubsService,
+    private readonly freshnessService: SitemapV10FreshnessService,
   ) {}
+
+  /**
+   * GET /api/sitemap/v10/freshness
+   * Observable SLO source for sitemap freshness. Public read-only — surfaces
+   * fs mtime, parsed `<lastmod>`, BullMQ scheduler registration, and a
+   * boolean `isHealthy` against the `SEO_SITEMAP_FRESHNESS_WARN_HOURS`
+   * threshold (default 36h). Consumed by `scripts/ci/check-sitemap-freshness.sh`
+   * and the `sitemap-freshness-slo.yml` GH workflow that fires daily.
+   */
+  @Get('freshness')
+  async getFreshness(): Promise<SitemapFreshnessReport> {
+    return this.freshnessService.getFreshness();
+  }
 
   /**
    * POST /api/sitemap/v10/generate-all

--- a/backend/src/modules/seo/seo.module.ts
+++ b/backend/src/modules/seo/seo.module.ts
@@ -76,6 +76,7 @@ import { SitemapDeltaService } from './services/sitemap-delta.service';
 import { SitemapStreamingService } from './services/sitemap-streaming.service';
 import { SitemapV10SchedulerService } from './services/sitemap-v10-scheduler.service';
 import { SitemapRegenerateProcessor } from './processors/sitemap-regenerate.processor';
+import { SitemapV10FreshnessService } from './services/sitemap-v10-freshness.service';
 import { SitemapHygieneService } from './services/sitemap-hygiene.service';
 import { SitemapVehiclePiecesValidator } from './services/sitemap-vehicle-pieces-validator.service';
 
@@ -246,6 +247,8 @@ import { PageRoleValidationInterceptor } from './interceptors/page-role-validati
     // Régénération nocturne BullMQ (fix traffic-drop 2026-04-22 → 2026-05-13)
     SitemapV10SchedulerService,
     SitemapRegenerateProcessor,
+    // Freshness observability (Phase 4.A+C — fait suite à PR #487)
+    SitemapV10FreshnessService,
     // Content
     ReferenceService,
     DiagnosticService,

--- a/backend/src/modules/seo/services/sitemap-v10-freshness.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-freshness.service.ts
@@ -1,0 +1,143 @@
+/**
+ * SitemapV10FreshnessService — observable SLO source for sitemap freshness.
+ *
+ * Pourquoi ce service existe
+ * --------------------------
+ * Avant l'incident traffic-drop 2026-04-22 → 2026-05-13, on n'avait aucun
+ * moyen de savoir si le sitemap était stale (`<lastmod>` figé) avant que
+ * Google ne décide de réduire son crawl budget. La cause racine
+ * (`@nestjs/schedule` désactivé + zéro alternative) était silencieuse
+ * pendant 21 jours. Ce service expose la fraîcheur en données structurées
+ * qu'un check CI ou un dashboard peut consommer.
+ *
+ * Sources de vérité (par ordre de fiabilité)
+ * -------------------------------------------
+ * 1. `fs.stat(SITEMAP_OUTPUT_DIR/sitemap.xml)` — `mtime` = dernière écriture
+ *    physique. Source la plus fiable, ne dépend ni de Redis ni de DB.
+ * 2. Parsing du premier `<lastmod>` dans `sitemap.xml` — ce que Google voit
+ *    réellement. Source de vérité côté SEO.
+ * 3. BullMQ queue `seo-monitor` — présence du repeatable job
+ *    `sitemap-regenerate-all`. Source de vérité côté pipeline.
+ *
+ * Le service expose les 3 ; le verdict global (`isHealthy`, `staleHours`)
+ * est calculé à partir de la source 1 (filesystem), qui est aussi ce qui
+ * est servi sur le web.
+ */
+
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { getErrorMessage } from '@common/utils/error.utils';
+import { SITEMAP_REGENERATE_JOB_NAME } from './sitemap-v10-scheduler.service';
+
+export interface SitemapFreshnessReport {
+  /** ISO-8601 of `fs.stat(sitemap.xml).mtime`. null if file missing. */
+  fileLastModifiedAt: string | null;
+  /** ISO-8601 of the first `<lastmod>` parsed inside `sitemap.xml`. */
+  indexLastmod: string | null;
+  /** Hours between `fileLastModifiedAt` and now. null if file missing. */
+  staleHours: number | null;
+  /** True if the BullMQ repeatable job is registered (scheduler healthy). */
+  schedulerRegistered: boolean;
+  /** Absolute path of the file used as primary source. */
+  sitemapPath: string;
+  /** Whether `staleHours <= warnThresholdHours` (typically 36 h). */
+  isHealthy: boolean;
+  /** Threshold used for `isHealthy`, configurable via SEO_SITEMAP_FRESHNESS_WARN_HOURS. */
+  warnThresholdHours: number;
+  /** Optional explanation if `isHealthy` is false. */
+  reason?: string;
+}
+
+@Injectable()
+export class SitemapV10FreshnessService {
+  private readonly logger = new Logger(SitemapV10FreshnessService.name);
+  private readonly outputDir: string;
+  private readonly warnHours: number;
+
+  constructor(
+    private readonly configService: ConfigService,
+    @Optional()
+    @InjectQueue('seo-monitor')
+    private readonly seoMonitorQueue: Queue | null,
+  ) {
+    this.outputDir =
+      this.configService.get<string>('SITEMAP_OUTPUT_DIR') || '/var/www/sitemaps';
+    this.warnHours = parseInt(
+      this.configService.get<string>('SEO_SITEMAP_FRESHNESS_WARN_HOURS') || '36',
+      10,
+    );
+  }
+
+  async getFreshness(): Promise<SitemapFreshnessReport> {
+    const sitemapPath = path.join(this.outputDir, 'sitemap.xml');
+    const warnThresholdHours = this.warnHours;
+
+    let fileLastModifiedAt: string | null = null;
+    let staleHours: number | null = null;
+    let indexLastmod: string | null = null;
+    let reason: string | undefined;
+
+    try {
+      const stat = await fs.stat(sitemapPath);
+      fileLastModifiedAt = stat.mtime.toISOString();
+      staleHours = (Date.now() - stat.mtimeMs) / 3_600_000;
+    } catch (err) {
+      const message = getErrorMessage(err);
+      this.logger.warn(`fs.stat(${sitemapPath}) failed: ${message}`);
+      reason = `sitemap.xml unreadable (${message})`;
+    }
+
+    if (fileLastModifiedAt) {
+      try {
+        const xml = await fs.readFile(sitemapPath, 'utf8');
+        // Parse the FIRST <lastmod> in the index (cheapest reliable extraction).
+        const match = xml.match(/<lastmod>([^<]+)<\/lastmod>/);
+        indexLastmod = match ? match[1].trim() : null;
+      } catch (err) {
+        this.logger.warn(
+          `read sitemap.xml for lastmod failed: ${getErrorMessage(err)}`,
+        );
+      }
+    }
+
+    const schedulerRegistered = await this.checkSchedulerRegistered();
+
+    const isHealthy =
+      staleHours !== null && staleHours <= warnThresholdHours && fileLastModifiedAt !== null;
+    if (!isHealthy && !reason) {
+      if (staleHours === null) {
+        reason = 'sitemap.xml missing';
+      } else {
+        reason = `staleHours=${staleHours.toFixed(2)} > warnThresholdHours=${warnThresholdHours}`;
+      }
+    }
+
+    return {
+      fileLastModifiedAt,
+      indexLastmod,
+      staleHours: staleHours !== null ? Number(staleHours.toFixed(2)) : null,
+      schedulerRegistered,
+      sitemapPath,
+      isHealthy,
+      warnThresholdHours,
+      reason,
+    };
+  }
+
+  private async checkSchedulerRegistered(): Promise<boolean> {
+    if (!this.seoMonitorQueue) return false;
+    try {
+      const jobs = await this.seoMonitorQueue.getRepeatableJobs();
+      return jobs.some((j) => j.name === SITEMAP_REGENERATE_JOB_NAME);
+    } catch (err) {
+      this.logger.warn(
+        `getRepeatableJobs failed: ${getErrorMessage(err)} — assuming scheduler not registered`,
+      );
+      return false;
+    }
+  }
+}

--- a/backend/src/modules/seo/services/sitemap-v10-freshness.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-freshness.service.ts
@@ -65,9 +65,11 @@ export class SitemapV10FreshnessService {
     private readonly seoMonitorQueue: Queue | null,
   ) {
     this.outputDir =
-      this.configService.get<string>('SITEMAP_OUTPUT_DIR') || '/var/www/sitemaps';
+      this.configService.get<string>('SITEMAP_OUTPUT_DIR') ||
+      '/var/www/sitemaps';
     this.warnHours = parseInt(
-      this.configService.get<string>('SEO_SITEMAP_FRESHNESS_WARN_HOURS') || '36',
+      this.configService.get<string>('SEO_SITEMAP_FRESHNESS_WARN_HOURS') ||
+        '36',
       10,
     );
   }
@@ -107,7 +109,9 @@ export class SitemapV10FreshnessService {
     const schedulerRegistered = await this.checkSchedulerRegistered();
 
     const isHealthy =
-      staleHours !== null && staleHours <= warnThresholdHours && fileLastModifiedAt !== null;
+      staleHours !== null &&
+      staleHours <= warnThresholdHours &&
+      fileLastModifiedAt !== null;
     if (!isHealthy && !reason) {
       if (staleHours === null) {
         reason = 'sitemap.xml missing';

--- a/backend/tests/unit/sitemap-v10-freshness.test.ts
+++ b/backend/tests/unit/sitemap-v10-freshness.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression test : SitemapV10FreshnessService.getFreshness()
+ *
+ * Pins the contract used by the CI freshness check
+ * (scripts/ci/check-sitemap-freshness.sh + .github/workflows/sitemap-freshness-slo.yml).
+ *
+ * Covers:
+ *   - File present, fresh → isHealthy=true
+ *   - File present, stale (> threshold) → isHealthy=false, reason set
+ *   - File missing → isHealthy=false, reason set
+ *   - Scheduler registered detected via BullMQ getRepeatableJobs
+ *   - Scheduler not registered when queue absent or job missing
+ */
+
+import { ConfigService } from '@nestjs/config';
+import { Queue } from 'bull';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { SitemapV10FreshnessService } from '../../src/modules/seo/services/sitemap-v10-freshness.service';
+import { SITEMAP_REGENERATE_JOB_NAME } from '../../src/modules/seo/services/sitemap-v10-scheduler.service';
+
+function makeConfig(env: Record<string, string | undefined>): ConfigService {
+  return {
+    get: jest.fn((key: string) => env[key]),
+  } as unknown as ConfigService;
+}
+
+function makeQueue(jobs: Array<{ name: string; key: string }> | Error): Queue {
+  return {
+    getRepeatableJobs: jest.fn(
+      jobs instanceof Error
+        ? () => Promise.reject(jobs)
+        : () => Promise.resolve(jobs as Awaited<ReturnType<Queue['getRepeatableJobs']>>),
+    ),
+  } as unknown as Queue;
+}
+
+const FRESH_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap-pieces-1.xml</loc>
+    <lastmod>2026-05-14</lastmod>
+  </sitemap>
+</sitemapindex>`;
+
+async function writeSitemap(dir: string, content: string, ageHours: number): Promise<void> {
+  const filePath = path.join(dir, 'sitemap.xml');
+  await fs.writeFile(filePath, content, 'utf8');
+  const mtime = new Date(Date.now() - ageHours * 3_600_000);
+  await fs.utimes(filePath, mtime, mtime);
+}
+
+describe('SitemapV10FreshnessService', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sitemap-freshness-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reports isHealthy=true when sitemap is fresh and scheduler registered', async () => {
+    await writeSitemap(tmpDir, FRESH_XML, 1); // 1h old
+    const service = new SitemapV10FreshnessService(
+      makeConfig({ SITEMAP_OUTPUT_DIR: tmpDir }),
+      makeQueue([{ name: SITEMAP_REGENERATE_JOB_NAME, key: 'k1' }]),
+    );
+
+    const report = await service.getFreshness();
+
+    expect(report.isHealthy).toBe(true);
+    expect(report.staleHours).toBeLessThan(2);
+    expect(report.fileLastModifiedAt).not.toBeNull();
+    expect(report.indexLastmod).toBe('2026-05-14');
+    expect(report.schedulerRegistered).toBe(true);
+    expect(report.warnThresholdHours).toBe(36);
+    expect(report.reason).toBeUndefined();
+  });
+
+  it('reports isHealthy=false when sitemap is older than threshold', async () => {
+    await writeSitemap(tmpDir, FRESH_XML, 50); // 50h old, default threshold 36h
+    const service = new SitemapV10FreshnessService(
+      makeConfig({ SITEMAP_OUTPUT_DIR: tmpDir }),
+      makeQueue([{ name: SITEMAP_REGENERATE_JOB_NAME, key: 'k1' }]),
+    );
+
+    const report = await service.getFreshness();
+
+    expect(report.isHealthy).toBe(false);
+    expect(report.staleHours).toBeGreaterThan(36);
+    expect(report.reason).toMatch(/staleHours/);
+  });
+
+  it('honors SEO_SITEMAP_FRESHNESS_WARN_HOURS env override', async () => {
+    await writeSitemap(tmpDir, FRESH_XML, 10); // 10h old
+    const service = new SitemapV10FreshnessService(
+      makeConfig({
+        SITEMAP_OUTPUT_DIR: tmpDir,
+        SEO_SITEMAP_FRESHNESS_WARN_HOURS: '6',
+      }),
+      makeQueue([{ name: SITEMAP_REGENERATE_JOB_NAME, key: 'k1' }]),
+    );
+
+    const report = await service.getFreshness();
+
+    expect(report.warnThresholdHours).toBe(6);
+    expect(report.isHealthy).toBe(false);
+    expect(report.reason).toMatch(/staleHours/);
+  });
+
+  it('reports isHealthy=false when sitemap.xml is missing', async () => {
+    const service = new SitemapV10FreshnessService(
+      makeConfig({ SITEMAP_OUTPUT_DIR: tmpDir }),
+      makeQueue([{ name: SITEMAP_REGENERATE_JOB_NAME, key: 'k1' }]),
+    );
+
+    const report = await service.getFreshness();
+
+    expect(report.isHealthy).toBe(false);
+    expect(report.staleHours).toBeNull();
+    expect(report.fileLastModifiedAt).toBeNull();
+    expect(report.indexLastmod).toBeNull();
+    expect(report.reason).toMatch(/unreadable|missing/);
+  });
+
+  it('reports schedulerRegistered=false when job not in repeatable list', async () => {
+    await writeSitemap(tmpDir, FRESH_XML, 1);
+    const service = new SitemapV10FreshnessService(
+      makeConfig({ SITEMAP_OUTPUT_DIR: tmpDir }),
+      makeQueue([{ name: 'other-job', key: 'k1' }]),
+    );
+
+    const report = await service.getFreshness();
+
+    expect(report.schedulerRegistered).toBe(false);
+    // The fs healthiness is independent of the scheduler check
+    expect(report.isHealthy).toBe(true);
+  });
+
+  it('does not throw when BullMQ getRepeatableJobs fails (defensive)', async () => {
+    await writeSitemap(tmpDir, FRESH_XML, 1);
+    const service = new SitemapV10FreshnessService(
+      makeConfig({ SITEMAP_OUTPUT_DIR: tmpDir }),
+      makeQueue(new Error('redis down')),
+    );
+
+    const report = await service.getFreshness();
+
+    expect(report.schedulerRegistered).toBe(false);
+    expect(report.isHealthy).toBe(true);
+  });
+
+  it('reports schedulerRegistered=false when queue is null (optional injection)', async () => {
+    await writeSitemap(tmpDir, FRESH_XML, 1);
+    const service = new SitemapV10FreshnessService(
+      makeConfig({ SITEMAP_OUTPUT_DIR: tmpDir }),
+      null,
+    );
+
+    const report = await service.getFreshness();
+
+    expect(report.schedulerRegistered).toBe(false);
+  });
+});

--- a/scripts/ci/check-sitemap-freshness.sh
+++ b/scripts/ci/check-sitemap-freshness.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Sitemap freshness SLO check.
+#
+# Pourquoi ce check existe
+# ------------------------
+# Incident traffic-drop 2026-04-22 → 2026-05-13 : <lastmod> du sitemap
+# figé pendant 21 jours (cron générateur silencieusement inerte). Aucun
+# moyen de détecter avant que GSC montre la dégradation impressions.
+# Ce check appelle l'endpoint /api/sitemap/v10/freshness (PR ouvrant
+# l'observabilité) et fail si la dernière régénération est trop ancienne.
+#
+# Usage
+# -----
+#   ./check-sitemap-freshness.sh [URL] [warnThresholdHours]
+#
+# Defaults:
+#   URL = $SEO_FRESHNESS_URL ou https://www.automecanik.com/api/sitemap/v10/freshness
+#   warnThresholdHours = $SEO_FRESHNESS_WARN_HOURS ou 36
+#
+# Exit codes:
+#   0 — sitemap fresh, scheduler enregistré
+#   1 — sitemap stale OU scheduler absent OU endpoint inaccessible
+
+set -euo pipefail
+
+URL="${1:-${SEO_FRESHNESS_URL:-https://www.automecanik.com/api/sitemap/v10/freshness}}"
+WARN_THRESHOLD_HOURS="${2:-${SEO_FRESHNESS_WARN_HOURS:-36}}"
+
+echo "🛰️  Checking sitemap freshness: $URL"
+echo "   Threshold: ${WARN_THRESHOLD_HOURS}h"
+echo ""
+
+RESPONSE="$(mktemp)"
+trap 'rm -f "$RESPONSE"' EXIT
+
+HTTP_CODE=$(curl -sS -L --max-time 30 -o "$RESPONSE" -w "%{http_code}" "$URL" || echo "000")
+
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "❌ Endpoint returned HTTP $HTTP_CODE (expected 200)."
+  echo ""
+  echo "Body (first 500 bytes):"
+  head -c 500 "$RESPONSE"
+  echo ""
+  exit 1
+fi
+
+# Pretty-print the JSON for the CI log
+if command -v python3 >/dev/null 2>&1; then
+  python3 -m json.tool < "$RESPONSE" || cat "$RESPONSE"
+elif command -v jq >/dev/null 2>&1; then
+  jq . < "$RESPONSE"
+else
+  cat "$RESPONSE"
+fi
+echo ""
+
+# Extract verdict — keep parsing minimal to avoid jq dependency in CI
+IS_HEALTHY=$(python3 -c "
+import json, sys
+with open('$RESPONSE') as f:
+    d = json.load(f)
+print('true' if d.get('isHealthy') is True else 'false')
+")
+STALE_HOURS=$(python3 -c "
+import json
+with open('$RESPONSE') as f:
+    d = json.load(f)
+print(d.get('staleHours') if d.get('staleHours') is not None else 'null')
+")
+SCHEDULER_REGISTERED=$(python3 -c "
+import json
+with open('$RESPONSE') as f:
+    d = json.load(f)
+print('true' if d.get('schedulerRegistered') is True else 'false')
+")
+REASON=$(python3 -c "
+import json
+with open('$RESPONSE') as f:
+    d = json.load(f)
+print(d.get('reason') or '')
+")
+
+echo "Summary:"
+echo "  staleHours: $STALE_HOURS (threshold ${WARN_THRESHOLD_HOURS}h)"
+echo "  schedulerRegistered: $SCHEDULER_REGISTERED"
+echo "  isHealthy: $IS_HEALTHY"
+if [ -n "$REASON" ]; then
+  echo "  reason: $REASON"
+fi
+echo ""
+
+EXIT=0
+if [ "$IS_HEALTHY" != "true" ]; then
+  echo "❌ Sitemap freshness UNHEALTHY"
+  EXIT=1
+fi
+if [ "$SCHEDULER_REGISTERED" != "true" ]; then
+  echo "⚠️  BullMQ scheduler 'sitemap-regenerate-all' is NOT registered."
+  echo "   The fs file may still be fresh from a manual POST, but auto-regen is broken."
+  EXIT=1
+fi
+
+if [ "$EXIT" -eq 0 ]; then
+  echo "✅ Sitemap freshness OK"
+fi
+exit "$EXIT"


### PR DESCRIPTION
## Summary

Add observability that would have caught the traffic-drop incident **2026-04-22 → 2026-05-13** within ~24h instead of 21 days. New public read-only `GET /api/sitemap/v10/freshness` endpoint exposes:

- `fileLastModifiedAt` — `fs.stat(sitemap.xml).mtime` (what was actually written)
- `indexLastmod` — first `<lastmod>` parsed inside `sitemap.xml` (what Google sees)
- `schedulerRegistered` — BullMQ repeatable-job presence (pipeline-side truth)
- `isHealthy` — derived boolean against `SEO_SITEMAP_FRESHNESS_WARN_HOURS` (default 36h)

A scheduled GH workflow probes the endpoint daily at 06:00 UTC (3h after the 03:00 nightly regen) and fails if the verdict is unhealthy.

## What changes

| File | Why |
|------|-----|
| `backend/src/modules/seo/services/sitemap-v10-freshness.service.ts` (new) | Service exposing 3 independent signals; primary verdict from filesystem mtime |
| `backend/src/modules/seo/controllers/sitemap-v10.controller.ts` | `GET /freshness` endpoint, public read-only (mirror of `GET /stats`) |
| `backend/src/modules/seo/seo.module.ts` | DI wiring |
| `scripts/ci/check-sitemap-freshness.sh` (new, executable) | Probes the endpoint, fails exit 1 on unhealthy. No `jq` dependency |
| `.github/workflows/sitemap-freshness-slo.yml` (new) | Daily 06:00 UTC schedule + `workflow_dispatch` + PR-touch trigger |
| `backend/tests/unit/sitemap-v10-freshness.test.ts` (new) | 7 cases: fresh/stale/env-override/missing-file/scheduler-missing/Redis-down/null-queue |

## Why these three signals (not just `<lastmod>`)

`<lastmod>` alone tells you what was published. Filesystem mtime tells you when. BullMQ presence tells you whether the next regeneration will happen. The incident root cause was all three pointing different directions: a stale `<lastmod>`, a recent file (regenerated once manually), and a missing scheduler. Catching any one in isolation would have flagged the problem.

## Behavior change

Zero for existing endpoints. New endpoint is additive and public read-only — same security profile as the existing `GET /stats`. Backend boots identically when `SITEMAP_OUTPUT_DIR` is missing; the service just returns `isHealthy=false` with a useful reason.

## Test plan

- [x] tsc / eslint pass.
- [x] Local smoke-test of the script against current PROD (which doesn't have the endpoint yet): correctly returns exit 1 with HTTP 404 message, exactly as designed.
- [ ] CI green on this branch.
- [ ] Post-merge: trigger `sitemap-freshness-slo` workflow via `workflow_dispatch` against PROD to validate `isHealthy=true`.
- [ ] Next 06:00 UTC scheduled run is green.

## Rollback

Pure additive (one service, one endpoint, one script, one workflow, one test file). Revert is safe — `git revert <merge-sha>` removes everything cleanly. The nightly regen pipeline from PR #487 is unaffected.

## Refs

- PR #487 — incident fix (the bug this SLO will catch in the future)
- PR #488 — recurrence guard (`@Cron` + `ScheduleModule` mismatch)
- PR #490 — admin guard on mutating sitemap endpoints
- PR #491 — preprod sitemap volume mount
- `audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md` — root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📧 Email notifications via Sentry (added in commit above)

When the watchdog fails (`degraded` or `failed`), the workflow now emits a Sentry event tagged `watchdog=...`. Sentry's existing single-recipient alert rule (cf. memory `sentry-vps-bootstrap-20260506`) mirrors any production-environment error event to email — so the user gets a mailbox alert without needing a separate SMTP setup.

**Requires** `SENTRY_DSN` secret in repo settings:
- `gh secret set SENTRY_DSN --repo ak125/nestjs-remix-monorepo --body "$(your prod DSN)"`
- Or via UI: https://github.com/ak125/nestjs-remix-monorepo/settings/secrets/actions

The Sentry step is gated by `if: failure() && env.SENTRY_DSN != ''` so this PR merges cleanly even if the secret is not yet set — emails just won't fire until you add it.
