### PR TITLE
feat(ci): workspace mini-monorepo check (ADR-061 §6)

### DIFF
--- a/.github/workflows/monorepo-invariants.yml
+++ b/.github/workflows/monorepo-invariants.yml
@@ -1,0 +1,29 @@
+name: Monorepo Invariants
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'workspaces/**'
+      - 'scripts/check-workspace-mini-monorepo.sh'
+      - '.github/workflows/monorepo-invariants.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'workspaces/**'
+      - 'scripts/check-workspace-mini-monorepo.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  workspace-mini-monorepo:
+    name: "No Mini-Monorepo (ADR-061 §6)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check workspaces ne sont pas mini-monorepos
+        run: |
+          chmod +x scripts/check-workspace-mini-monorepo.sh
+          ./scripts/check-workspace-mini-monorepo.sh

--- a/log.md
+++ b/log.md
@@ -555,3 +555,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/registry-pr-g-block-new`
 - **Décision** : fix(check-new-files): sanitize argv ref + execFileSync (CodeQL injection guard) (+16 other commits)
 - **Sortie** : PR #482 | commits f0c6f729 b05435e8 3eb76950 5368dec1 0653d797 00fe3be6 60209305 5828f494 27d515d8 77d4b57a a1d79d5b 658018c4 66d9e64f b08d3e90 b281943b f067e9ec 0504fd38
+
+## 2026-05-14 — feat/ci-workspace-invariants (auto)
+
+- **Branche** : `feat/ci-workspace-invariants`
+- **Décision** : feat(ci): workspace mini-monorepo check (ADR-061 §6)
+- **Sortie** : PR aucune | commits 9331cadd

--- a/scripts/check-workspace-mini-monorepo.sh
+++ b/scripts/check-workspace-mini-monorepo.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# check-workspace-mini-monorepo.sh — ADR-061 §6 : anti-mini-monorepo workspace invariant
+#
+# Contexte : ADR-061 « Workspace Governance » (accepted 2026-05-13) codifie 7 invariants
+# dont l'invariant §6 : un workspace root (`workspaces/<domain>/`) ne doit JAMAIS contenir
+# de fichier ou répertoire qui en ferait un mini-monorepo (duplication code monorepo,
+# package.json local, build config, etc.).
+#
+# Patterns interdits au workspace root :
+#   - Fichiers : package.json, tsconfig.json, Dockerfile, Makefile, CHANGELOG.md,
+#                pnpm-workspace.yaml, turbo.json, lerna.json, nx.json
+#   - Répertoires : backend/, frontend/, packages/, node_modules/, dist/, build/
+#
+# Structure autorisée d'un workspace (§2 ADR-061) :
+#   workspaces/<domain>/
+#     ├── README.md      (obligatoire)
+#     ├── CLAUDE.md      (obligatoire)
+#     ├── AGENTS.md      (obligatoire)
+#     └── .claude/
+#         ├── settings.json
+#         ├── canon-mirrors/      (read-only, sync par cron VPS DEV)
+#         └── rules/
+#
+# Usage :
+#   ./scripts/check-workspace-mini-monorepo.sh [repo_root]
+#
+# Exit 0 : aucune violation
+# Exit 1 : mini-monorepo détecté (rapport stdout)
+# Exit 2 : erreur (repo root missing)
+
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+if [[ ! -d "$REPO_ROOT" ]]; then
+  echo "Error: repo root not found: $REPO_ROOT" >&2
+  exit 2
+fi
+
+cd "$REPO_ROOT"
+
+WORKSPACES_DIR="workspaces"
+
+if [[ ! -d "$WORKSPACES_DIR" ]]; then
+  echo "PASS: no $WORKSPACES_DIR/ directory, nothing to check (ADR-061 §6 N/A)"
+  exit 0
+fi
+
+FORBIDDEN_FILES=(
+  "package.json"
+  "tsconfig.json"
+  "Dockerfile"
+  "Makefile"
+  "CHANGELOG.md"
+  "pnpm-workspace.yaml"
+  "turbo.json"
+  "lerna.json"
+  "nx.json"
+)
+
+FORBIDDEN_DIRS=(
+  "backend"
+  "frontend"
+  "packages"
+  "node_modules"
+  "dist"
+  "build"
+)
+
+VIOLATIONS=()
+
+for workspace in "$WORKSPACES_DIR"/*/; do
+  [[ -d "$workspace" ]] || continue
+  ws_name="$(basename "$workspace")"
+
+  # Fichiers interdits au root du workspace
+  for forbidden in "${FORBIDDEN_FILES[@]}"; do
+    if [[ -f "$workspace$forbidden" ]]; then
+      VIOLATIONS+=("$workspace$forbidden — forbidden file (ADR-061 §6)")
+    fi
+  done
+
+  # Répertoires interdits au root du workspace (duplication code monorepo)
+  for forbidden_dir in "${FORBIDDEN_DIRS[@]}"; do
+    if [[ -d "$workspace$forbidden_dir" ]]; then
+      VIOLATIONS+=("$workspace$forbidden_dir/ — forbidden directory, mini-monorepo duplication (ADR-061 §6)")
+    fi
+  done
+done
+
+if [[ ${#VIOLATIONS[@]} -eq 0 ]]; then
+  WS_COUNT="$(find "$WORKSPACES_DIR" -maxdepth 1 -mindepth 1 -type d | wc -l)"
+  echo "PASS: 0 mini-monorepo violation in $WS_COUNT workspace(s) (ADR-061 §6 respected)"
+  exit 0
+fi
+
+echo "FAIL: ${#VIOLATIONS[@]} mini-monorepo violation(s) detected"
+echo ""
+for v in "${VIOLATIONS[@]}"; do
+  echo "  - $v"
+done
+echo ""
+echo "Voir ADR-061 §6 (Anti-Mini-Monorepo) pour la liste exhaustive des patterns interdits."
+echo "Un workspace doit rester pur métadonnées (README + CLAUDE + AGENTS + .claude/) — pas de duplication code, pas de build config."
+
+exit 1


### PR DESCRIPTION
**Étape 3 Part B du roadmap downstream** — second script CI invariants hardening : anti-mini-monorepo workspace.

## Pourquoi

[ADR-061](https://github.com/ak125/governance-vault/blob/main/ledger/decisions/adr/ADR-061-workspace-governance.md) §6 (accepted 2026-05-13) codifie : un workspace root ne doit JAMAIS devenir un mini-monorepo (duplication code, build config local, package.json local).

Pas de garde mécanique aujourd'hui — un agent pouvait créer `workspaces/marketing/package.json` + `workspaces/marketing/backend/` sans rien bloquer. Ce gate ferme la régression.

## Changements

1. **`scripts/check-workspace-mini-monorepo.sh`** (nouveau, ~90 lignes bash pur)
   - Fichiers interdits au workspace root : `package.json`, `tsconfig.json`, `Dockerfile`, `Makefile`, `CHANGELOG.md`, `pnpm-workspace.yaml`, `turbo.json`, `lerna.json`, `nx.json`
   - Répertoires interdits : `backend/`, `frontend/`, `packages/`, `node_modules/`, `dist/`, `build/` (duplication code monorepo)
   - Exit 0 si propre, exit 1 + liste violations stdout sinon

2. **`.github/workflows/monorepo-invariants.yml`** (nouveau, job bloquant)
   - Triggers : PR sur main + push main, paths-filtered (`workspaces/**` + script + workflow)
   - Permissions read-only

## Tests empiriques

\`\`\`
=== Test 1 : pass case (3 workspaces propres : marketing, seo-batch, wiki) ===
PASS: 0 mini-monorepo violation in 3 workspace(s) (ADR-061 §6 respected)

=== Test 2 : fail case (workspaces/seo-batch/package.json + workspaces/seo-batch/backend/) ===
FAIL: 2 mini-monorepo violation(s) detected
  - workspaces/seo-batch/package.json — forbidden file (ADR-061 §6)
  - workspaces/seo-batch/backend/ — forbidden directory, mini-monorepo duplication (ADR-061 §6)
Exit code: 1
\`\`\`

## Méthode (no bricolage)

- Aucune dépendance externe — bash pur, GNU find non requis.
- Trigger paths-filtered → CI ne tourne que si le scope concerné est touché (efficacité).
- Pattern aligné sur les workflows existants (read-only permissions, single job).
- Aucun changement de comportement runtime — guard CI uniquement.

## Compatibilité

État actuel main : `marketing/`, `seo-batch/`, `wiki/` workspaces — **tous passent** le check. Aucune migration requise.

Source : `/home/deploy/.claude/plans/sous-projets-downstream-restants-enchanted-shell.md` étape 3 Part B.