### PR TITLE
feat(seo): automate post-incident recovery monitoring (D+3 → D+14)

### DIFF
--- a/.github/workflows/seo-recovery-watchdog.yml
+++ b/.github/workflows/seo-recovery-watchdog.yml
@@ -1,0 +1,43 @@
+name: 🩺 SEO recovery watchdog
+
+# Probes GET /api/seo/monitor/recovery-status daily and fails if recovery
+# is stalled (status=degraded or failed). Automates the 7-14 day monitoring
+# window that follows PR #487 (sitemap regen restoration).
+#
+# Schedule rationale:
+#  - Backend daily-fetch cron fetches GSC at 04:00 UTC.
+#  - This watchdog fires at 07:00 UTC, giving the fetch 3h headroom.
+#
+# When to disable:
+#  - Once `status=recovered` has held for 7 consecutive days, comment out
+#    the schedule trigger or delete this workflow. Re-enable manually if
+#    a similar incident pattern reappears.
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # 07:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      url:
+        description: Recovery endpoint URL to probe
+        required: false
+        default: https://www.automecanik.com/api/seo/monitor/recovery-status
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Probe recovery status
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Make script executable
+        run: chmod +x scripts/ci/check-seo-recovery.sh
+
+      - name: Run watchdog
+        env:
+          SEO_RECOVERY_URL: ${{ inputs.url || 'https://www.automecanik.com/api/seo/monitor/recovery-status' }}
+        run: ./scripts/ci/check-seo-recovery.sh

--- a/.github/workflows/seo-recovery-watchdog.yml
+++ b/.github/workflows/seo-recovery-watchdog.yml
@@ -38,6 +38,34 @@ jobs:
         run: chmod +x scripts/ci/check-seo-recovery.sh
 
       - name: Run watchdog
+        id: probe
         env:
           SEO_RECOVERY_URL: ${{ inputs.url || 'https://www.automecanik.com/api/seo/monitor/recovery-status' }}
         run: ./scripts/ci/check-seo-recovery.sh
+
+      # Notify Sentry on failure so the existing alert rule (single-recipient
+      # email mirror, cf. memory `sentry-vps-bootstrap-20260506`) surfaces this
+      # in the user's mailbox without requiring a separate SMTP setup. Skipped
+      # silently if the SENTRY_DSN secret is not configured in the repo.
+      - name: Notify Sentry (on failure)
+        if: failure() && env.SENTRY_DSN != ''
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          python3 -m pip install --quiet sentry-sdk
+          python3 - <<'PY'
+          import os, sentry_sdk
+          sentry_sdk.init(
+              dsn=os.environ['SENTRY_DSN'],
+              environment='production',
+              release='seo-recovery-watchdog',
+              traces_sample_rate=0.0,
+          )
+          sentry_sdk.set_tag('watchdog', 'seo-recovery')
+          sentry_sdk.set_tag('workflow_run', os.environ.get('GITHUB_RUN_ID', ''))
+          sentry_sdk.capture_message(
+              'seo-recovery-watchdog FAILED — pieces impressions recovery stalled or below target',
+              level='error',
+          )
+          sentry_sdk.flush(timeout=5)
+          PY

--- a/backend/src/modules/seo/controllers/seo-monitor.controller.ts
+++ b/backend/src/modules/seo/controllers/seo-monitor.controller.ts
@@ -14,10 +14,17 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { SeoMonitorSchedulerService } from '../../../workers/services/seo-monitor-scheduler.service';
+import {
+  SeoRecoveryMonitorService,
+  SeoRecoveryReport,
+} from '../services/seo-recovery-monitor.service';
 
 @Controller('api/seo/monitor')
 export class SeoMonitorController {
-  constructor(private readonly schedulerService: SeoMonitorSchedulerService) {}
+  constructor(
+    private readonly schedulerService: SeoMonitorSchedulerService,
+    private readonly recoveryMonitor: SeoRecoveryMonitorService,
+  ) {}
 
   /**
    * 📊 GET /api/seo/monitor/stats
@@ -31,6 +38,22 @@ export class SeoMonitorController {
       success: true,
       data: stats,
     };
+  }
+
+  /**
+   * 🩺 GET /api/seo/monitor/recovery-status
+   * Observable recovery report after the traffic-drop incident
+   * 2026-04-22 → 2026-05-13. Compares current-week GSC impressions
+   * on `/pieces/*` against the pre-incident W17 baseline and emits
+   * a `status` field consumed by the daily CI watchdog
+   * (.github/workflows/seo-recovery-watchdog.yml).
+   *
+   * Public read-only — same security profile as `/stats`. Configurable
+   * via SEO_RECOVERY_* env vars (see service docstring).
+   */
+  @Get('recovery-status')
+  async getRecoveryStatus(): Promise<SeoRecoveryReport> {
+    return this.recoveryMonitor.getReport();
   }
 
   /**

--- a/backend/src/modules/seo/seo.module.ts
+++ b/backend/src/modules/seo/seo.module.ts
@@ -58,6 +58,7 @@ import { RiskFlagsEngineService } from './services/risk-flags-engine.service';
 import { GooglebotDetectorService } from './services/googlebot-detector.service';
 import { KeywordsDashboardService } from './services/keywords-dashboard.service';
 import { LogIngestionService } from './services/log-ingestion.service';
+import { SeoRecoveryMonitorService } from './services/seo-recovery-monitor.service';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // SERVICES SITEMAP (ex seo-sitemap)
@@ -232,6 +233,7 @@ import { R2V2Module } from './r2/r2-v2.module';
     GooglebotDetectorService,
     KeywordsDashboardService,
     LogIngestionService,
+    SeoRecoveryMonitorService,
     // Sitemap
     SitemapV10XmlService,
     SitemapV10DataService,

--- a/backend/src/modules/seo/services/seo-recovery-monitor.service.ts
+++ b/backend/src/modules/seo/services/seo-recovery-monitor.service.ts
@@ -84,10 +84,7 @@ export class SeoRecoveryMonitorService extends SupabaseBaseService {
   }
 
   async getReport(): Promise<SeoRecoveryReport> {
-    const urlPattern = this.envStr(
-      'SEO_RECOVERY_URL_PATTERN',
-      '/pieces/%',
-    );
+    const urlPattern = this.envStr('SEO_RECOVERY_URL_PATTERN', '/pieces/%');
     const baselineFrom = this.envStr(
       'SEO_RECOVERY_BASELINE_FROM',
       '2026-04-13',
@@ -113,17 +110,28 @@ export class SeoRecoveryMonitorService extends SupabaseBaseService {
     const now = new Date();
     const dayOfWeek = (now.getUTCDay() + 6) % 7; // Mon=0, Sun=6
     const weekStart = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - dayOfWeek),
+      Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate() - dayOfWeek,
+      ),
     );
     const weekStartIso = weekStart.toISOString().slice(0, 10);
     const today = now.toISOString().slice(0, 10);
-    const current = await this.aggregateWindow(urlPattern, weekStartIso, today);
+    const current = await this.aggregateWindow(
+      urlPattern,
+      weekStartIso,
+      today,
+    );
 
     // 3. Verdict
-    const baselineDaily = baseline.weeklyImpressions / Math.max(baseline.days, 1);
+    const baselineDaily =
+      baseline.weeklyImpressions / Math.max(baseline.days, 1);
     const currentDaily = current.weeklyImpressions / Math.max(current.days, 1);
     const recoveryRatio =
-      baselineDaily > 0 ? Number((currentDaily / baselineDaily).toFixed(3)) : null;
+      baselineDaily > 0
+        ? Number((currentDaily / baselineDaily).toFixed(3))
+        : null;
 
     let status: RecoveryStatus;
     let message: string;
@@ -168,7 +176,7 @@ export class SeoRecoveryMonitorService extends SupabaseBaseService {
     };
   }
 
-  private async aggregateWindow(
+  protected async aggregateWindow(
     urlPattern: string,
     from: string,
     to: string,

--- a/backend/src/modules/seo/services/seo-recovery-monitor.service.ts
+++ b/backend/src/modules/seo/services/seo-recovery-monitor.service.ts
@@ -1,0 +1,223 @@
+/**
+ * SeoRecoveryMonitorService — observable recovery report after the
+ * traffic-drop incident 2026-04-22 → 2026-05-13.
+ *
+ * Pourquoi ce service existe
+ * --------------------------
+ * PR #487 a restauré la régénération automatique du sitemap. Reste à
+ * vérifier que Google re-crawl effectivement et que les impressions
+ * `/pieces/*` reviennent à leur baseline pré-incident (~3666/sem en W17).
+ * Sans automation, ce monitoring impose une requête SQL quotidienne
+ * pendant 14 jours. Ce service automatise : il calcule le ratio de
+ * recovery (impressions semaine en cours / baseline) et émet un verdict
+ * qu'un workflow GitHub Actions probe daily.
+ *
+ * Configuration (tous tunables via env, défauts ciblés sur l'incident actuel)
+ * --------------------------------------------------------------------------
+ *   SEO_RECOVERY_URL_PATTERN          (default '/pieces/%')
+ *   SEO_RECOVERY_BASELINE_FROM        (default '2026-04-13')
+ *   SEO_RECOVERY_BASELINE_TO          (default '2026-04-20')
+ *   SEO_RECOVERY_FIX_DATE             (default '2026-05-13' — PR #487 deploy)
+ *   SEO_RECOVERY_TARGET_RATIO         (default '0.80' — 80% baseline = OK)
+ *   SEO_RECOVERY_GRACE_DAYS           (default '3'  — fenêtre où on s'attend
+ *                                       à voir le rebond commencer)
+ *   SEO_RECOVERY_DEADLINE_DAYS        (default '14' — verdict définitif)
+ *
+ * Verdicts (`status` field)
+ * -------------------------
+ *   in_progress  — daysSinceFix < graceDays : trop tôt pour conclure
+ *   recovering   — graceDays ≤ days < deadline ET ratio ≥ target : OK
+ *   degraded     — graceDays ≤ days < deadline ET ratio < target : warn,
+ *                  pas encore fail
+ *   recovered    — ratio ≥ target ET days ≥ graceDays : succès clair
+ *   failed       — days ≥ deadline ET ratio < target : échec, ouvrir
+ *                  une nouvelle Phase −1 (cause différente du sitemap)
+ *   insufficient_data — pas assez de rows dans la semaine en cours (cron
+ *                       J-3 GSC pas encore arrivé, ou trop tôt après deploy)
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { getErrorMessage } from '@common/utils/error.utils';
+
+export type RecoveryStatus =
+  | 'in_progress'
+  | 'recovering'
+  | 'degraded'
+  | 'recovered'
+  | 'failed'
+  | 'insufficient_data';
+
+export interface SeoRecoveryReport {
+  fixDate: string;
+  daysSinceFix: number;
+  baselineWindow: { from: string; to: string };
+  baseline: {
+    weeklyImpressions: number;
+    weeklyClicks: number;
+    days: number;
+  };
+  current: {
+    weekStart: string;
+    weeklyImpressions: number;
+    weeklyClicks: number;
+    days: number;
+  };
+  recoveryRatio: number | null;
+  targetRatio: number;
+  graceDays: number;
+  deadlineDays: number;
+  status: RecoveryStatus;
+  /** Human-readable explanation surfaced in CI logs. */
+  message: string;
+}
+
+@Injectable()
+export class SeoRecoveryMonitorService extends SupabaseBaseService {
+  protected override readonly logger = new Logger(
+    SeoRecoveryMonitorService.name,
+  );
+
+  constructor(configService: ConfigService) {
+    super(configService);
+  }
+
+  async getReport(): Promise<SeoRecoveryReport> {
+    const urlPattern = this.envStr(
+      'SEO_RECOVERY_URL_PATTERN',
+      '/pieces/%',
+    );
+    const baselineFrom = this.envStr(
+      'SEO_RECOVERY_BASELINE_FROM',
+      '2026-04-13',
+    );
+    const baselineTo = this.envStr('SEO_RECOVERY_BASELINE_TO', '2026-04-20');
+    const fixDate = this.envStr('SEO_RECOVERY_FIX_DATE', '2026-05-13');
+    const targetRatio = this.envFloat('SEO_RECOVERY_TARGET_RATIO', 0.8);
+    const graceDays = this.envInt('SEO_RECOVERY_GRACE_DAYS', 3);
+    const deadlineDays = this.envInt('SEO_RECOVERY_DEADLINE_DAYS', 14);
+
+    const daysSinceFix = Math.floor(
+      (Date.now() - new Date(fixDate).getTime()) / 86_400_000,
+    );
+
+    // 1. Baseline (pre-incident week)
+    const baseline = await this.aggregateWindow(
+      urlPattern,
+      baselineFrom,
+      baselineTo,
+    );
+
+    // 2. Current week — use ISO week start (Monday)
+    const now = new Date();
+    const dayOfWeek = (now.getUTCDay() + 6) % 7; // Mon=0, Sun=6
+    const weekStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - dayOfWeek),
+    );
+    const weekStartIso = weekStart.toISOString().slice(0, 10);
+    const today = now.toISOString().slice(0, 10);
+    const current = await this.aggregateWindow(urlPattern, weekStartIso, today);
+
+    // 3. Verdict
+    const baselineDaily = baseline.weeklyImpressions / Math.max(baseline.days, 1);
+    const currentDaily = current.weeklyImpressions / Math.max(current.days, 1);
+    const recoveryRatio =
+      baselineDaily > 0 ? Number((currentDaily / baselineDaily).toFixed(3)) : null;
+
+    let status: RecoveryStatus;
+    let message: string;
+
+    if (current.days === 0) {
+      status = 'insufficient_data';
+      message = `No GSC rows in the current week (since ${weekStartIso}). GSC has a J-3 latency — wait for the daily-fetch cron.`;
+    } else if (daysSinceFix < graceDays) {
+      status = 'in_progress';
+      message = `D+${daysSinceFix} (grace ${graceDays}d) — too early to conclude. Ratio so far: ${recoveryRatio}.`;
+    } else if (recoveryRatio !== null && recoveryRatio >= targetRatio) {
+      status = 'recovered';
+      message = `D+${daysSinceFix}, ratio ${recoveryRatio} ≥ target ${targetRatio}. Recovery successful.`;
+    } else if (daysSinceFix >= deadlineDays) {
+      status = 'failed';
+      message = `D+${daysSinceFix} (deadline ${deadlineDays}d), ratio ${recoveryRatio} < target ${targetRatio}. Open a fresh Phase −1 — the cause is not (only) sitemap freshness.`;
+    } else if (recoveryRatio !== null && recoveryRatio >= targetRatio * 0.6) {
+      status = 'recovering';
+      message = `D+${daysSinceFix}, ratio ${recoveryRatio} on track toward target ${targetRatio}.`;
+    } else {
+      status = 'degraded';
+      message = `D+${daysSinceFix}, ratio ${recoveryRatio} stalled. Not yet a failure (deadline ${deadlineDays}d) but warrants attention.`;
+    }
+
+    return {
+      fixDate,
+      daysSinceFix,
+      baselineWindow: { from: baselineFrom, to: baselineTo },
+      baseline,
+      current: {
+        weekStart: weekStartIso,
+        weeklyImpressions: current.weeklyImpressions,
+        weeklyClicks: current.weeklyClicks,
+        days: current.days,
+      },
+      recoveryRatio,
+      targetRatio,
+      graceDays,
+      deadlineDays,
+      status,
+      message,
+    };
+  }
+
+  private async aggregateWindow(
+    urlPattern: string,
+    from: string,
+    to: string,
+  ): Promise<{ weeklyImpressions: number; weeklyClicks: number; days: number }> {
+    try {
+      const { data, error } = await this.supabase
+        .from('__seo_gsc_daily')
+        .select('date,impressions,clicks')
+        .like('page', `%${urlPattern.replace(/^\/|\/$/g, '')}%`)
+        .gte('date', from)
+        .lte('date', to);
+      if (error) {
+        this.logger.warn(`aggregateWindow query failed: ${error.message}`);
+        return { weeklyImpressions: 0, weeklyClicks: 0, days: 0 };
+      }
+      const rows = data ?? [];
+      const distinctDays = new Set(rows.map((r) => r.date as string)).size;
+      return {
+        weeklyImpressions: rows.reduce(
+          (s, r) => s + (Number(r.impressions) || 0),
+          0,
+        ),
+        weeklyClicks: rows.reduce((s, r) => s + (Number(r.clicks) || 0), 0),
+        days: distinctDays,
+      };
+    } catch (err) {
+      this.logger.warn(
+        `aggregateWindow threw: ${getErrorMessage(err)} — returning zeros`,
+      );
+      return { weeklyImpressions: 0, weeklyClicks: 0, days: 0 };
+    }
+  }
+
+  private envStr(key: string, fallback: string): string {
+    const v = this.configService.get<string>(key);
+    return v && v.length > 0 ? v : fallback;
+  }
+
+  private envInt(key: string, fallback: number): number {
+    const v = this.configService.get<string>(key);
+    if (!v) return fallback;
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) ? n : fallback;
+  }
+
+  private envFloat(key: string, fallback: number): number {
+    const v = this.configService.get<string>(key);
+    if (!v) return fallback;
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : fallback;
+  }
+}

--- a/backend/tests/unit/seo-recovery-monitor.test.ts
+++ b/backend/tests/unit/seo-recovery-monitor.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression test : SeoRecoveryMonitorService.getReport()
+ *
+ * Pins the verdict matrix consumed by the daily watchdog
+ * (.github/workflows/seo-recovery-watchdog.yml + scripts/ci/check-seo-recovery.sh).
+ */
+
+import { ConfigService } from '@nestjs/config';
+import { SeoRecoveryMonitorService } from '../../src/modules/seo/services/seo-recovery-monitor.service';
+
+type GscRow = { date: string; impressions: number; clicks: number };
+
+function makeConfig(env: Record<string, string | undefined> = {}): ConfigService {
+  return {
+    get: jest.fn((key: string) => env[key]),
+  } as unknown as ConfigService;
+}
+
+/**
+ * Subclass the service so we can drive the Supabase query results in tests
+ * without touching the real `SupabaseBaseService` constructor. Cleaner than
+ * mocking the supabase client tree.
+ */
+class TestableRecoveryService extends SeoRecoveryMonitorService {
+  baselineRows: GscRow[] = [];
+  currentRows: GscRow[] = [];
+  calls: Array<{ from: string; to: string }> = [];
+
+  constructor(config: ConfigService) {
+    // Bypass `super()` which reads SUPABASE_URL/KEY and would create a client.
+    // We only need the typed shape; the protected `aggregateWindow` is what we override.
+    super(config);
+  }
+
+  // @ts-expect-error override private to control test data
+  protected async aggregateWindow(
+    _urlPattern: string,
+    from: string,
+    to: string,
+  ): Promise<{ weeklyImpressions: number; weeklyClicks: number; days: number }> {
+    this.calls.push({ from, to });
+    const rows = this.calls.length === 1 ? this.baselineRows : this.currentRows;
+    const days = new Set(rows.map((r) => r.date)).size;
+    return {
+      weeklyImpressions: rows.reduce((s, r) => s + r.impressions, 0),
+      weeklyClicks: rows.reduce((s, r) => s + r.clicks, 0),
+      days,
+    };
+  }
+}
+
+const ONE_DAY_MS = 86_400_000;
+
+describe('SeoRecoveryMonitorService.getReport', () => {
+  let dateNowSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    if (dateNowSpy) dateNowSpy.mockRestore();
+  });
+
+  function freezeNow(iso: string): void {
+    const t = new Date(iso).getTime();
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(t);
+  }
+
+  it('returns status=in_progress within graceDays of fix', async () => {
+    freezeNow('2026-05-15T10:00:00Z'); // D+2 since fix 2026-05-13
+    const svc = new TestableRecoveryService(makeConfig());
+    svc.baselineRows = Array.from({ length: 7 }, (_, i) => ({
+      date: `2026-04-${13 + i}`,
+      impressions: 500,
+      clicks: 2,
+    })); // 3500 over 7d baseline
+    svc.currentRows = [
+      { date: '2026-05-11', impressions: 300, clicks: 1 },
+      { date: '2026-05-12', impressions: 320, clicks: 1 },
+    ];
+
+    const report = await svc.getReport();
+
+    expect(report.status).toBe('in_progress');
+    expect(report.daysSinceFix).toBe(2);
+    expect(report.message).toMatch(/too early/i);
+  });
+
+  it('returns status=recovered when daily ratio ≥ targetRatio past graceDays', async () => {
+    freezeNow('2026-05-21T10:00:00Z'); // D+8 since fix
+    const svc = new TestableRecoveryService(makeConfig());
+    svc.baselineRows = Array.from({ length: 7 }, (_, i) => ({
+      date: `2026-04-${13 + i}`,
+      impressions: 500,
+      clicks: 2,
+    })); // baseline daily = 500
+    svc.currentRows = [
+      { date: '2026-05-18', impressions: 420, clicks: 2 },
+      { date: '2026-05-19', impressions: 440, clicks: 2 },
+      { date: '2026-05-20', impressions: 480, clicks: 3 },
+    ]; // current daily ~ 446 → ratio 0.89
+
+    const report = await svc.getReport();
+
+    expect(report.status).toBe('recovered');
+    expect(report.recoveryRatio).not.toBeNull();
+    expect(report.recoveryRatio).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it('returns status=degraded between graceDays and deadlineDays when ratio low', async () => {
+    freezeNow('2026-05-20T10:00:00Z'); // D+7 since fix
+    const svc = new TestableRecoveryService(makeConfig());
+    svc.baselineRows = Array.from({ length: 7 }, (_, i) => ({
+      date: `2026-04-${13 + i}`,
+      impressions: 500,
+      clicks: 2,
+    }));
+    svc.currentRows = [
+      { date: '2026-05-18', impressions: 100, clicks: 0 },
+      { date: '2026-05-19', impressions: 80, clicks: 0 },
+    ]; // ratio ~ 0.18
+
+    const report = await svc.getReport();
+
+    expect(report.status).toBe('degraded');
+    expect(report.recoveryRatio).toBeLessThan(report.targetRatio);
+  });
+
+  it('returns status=failed past deadlineDays when ratio still below target', async () => {
+    freezeNow('2026-05-29T10:00:00Z'); // D+16 since fix
+    const svc = new TestableRecoveryService(makeConfig());
+    svc.baselineRows = Array.from({ length: 7 }, (_, i) => ({
+      date: `2026-04-${13 + i}`,
+      impressions: 500,
+      clicks: 2,
+    }));
+    svc.currentRows = [
+      { date: '2026-05-25', impressions: 150, clicks: 0 },
+      { date: '2026-05-26', impressions: 200, clicks: 0 },
+    ];
+
+    const report = await svc.getReport();
+
+    expect(report.status).toBe('failed');
+    expect(report.daysSinceFix).toBeGreaterThanOrEqual(report.deadlineDays);
+  });
+
+  it('returns status=insufficient_data when current week has no rows', async () => {
+    freezeNow('2026-05-25T10:00:00Z');
+    const svc = new TestableRecoveryService(makeConfig());
+    svc.baselineRows = Array.from({ length: 7 }, (_, i) => ({
+      date: `2026-04-${13 + i}`,
+      impressions: 500,
+      clicks: 2,
+    }));
+    svc.currentRows = []; // GSC J-3 latency not caught up
+
+    const report = await svc.getReport();
+
+    expect(report.status).toBe('insufficient_data');
+    expect(report.message).toMatch(/no gsc rows/i);
+  });
+
+  it('honors env overrides for target ratio and deadlines', async () => {
+    freezeNow('2026-05-20T10:00:00Z'); // D+7
+    const svc = new TestableRecoveryService(
+      makeConfig({
+        SEO_RECOVERY_TARGET_RATIO: '0.95',
+        SEO_RECOVERY_GRACE_DAYS: '1',
+        SEO_RECOVERY_DEADLINE_DAYS: '5',
+      }),
+    );
+    svc.baselineRows = [{ date: '2026-04-13', impressions: 100, clicks: 1 }];
+    svc.currentRows = [{ date: '2026-05-18', impressions: 90, clicks: 1 }]; // ratio 0.9
+
+    const report = await svc.getReport();
+
+    expect(report.targetRatio).toBe(0.95);
+    expect(report.graceDays).toBe(1);
+    expect(report.deadlineDays).toBe(5);
+    // ratio 0.9 < 0.95 target AND days (7) >= deadline (5) → failed
+    expect(report.status).toBe('failed');
+  });
+});

--- a/backend/tests/unit/seo-recovery-monitor.test.ts
+++ b/backend/tests/unit/seo-recovery-monitor.test.ts
@@ -32,7 +32,6 @@ class TestableRecoveryService extends SeoRecoveryMonitorService {
     super(config);
   }
 
-  // @ts-expect-error override private to control test data
   protected async aggregateWindow(
     _urlPattern: string,
     from: string,

--- a/scripts/ci/check-seo-recovery.sh
+++ b/scripts/ci/check-seo-recovery.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SEO recovery watchdog.
+#
+# Probes GET /api/seo/monitor/recovery-status and fails if the post-incident
+# recovery is stalled. Triggered daily by .github/workflows/seo-recovery-watchdog.yml
+# starting D+3 after the PR #487 deploy.
+#
+# Exit codes:
+#   0 — status in {recovered, recovering, in_progress, insufficient_data}
+#   1 — status in {degraded, failed} OR endpoint unreachable
+#
+# Usage:
+#   ./check-seo-recovery.sh [URL]
+# Default URL = $SEO_RECOVERY_URL or https://www.automecanik.com/api/seo/monitor/recovery-status
+
+set -euo pipefail
+
+URL="${1:-${SEO_RECOVERY_URL:-https://www.automecanik.com/api/seo/monitor/recovery-status}}"
+
+echo "🩺 Probing SEO recovery: $URL"
+echo ""
+
+RESPONSE="$(mktemp)"
+trap 'rm -f "$RESPONSE"' EXIT
+
+HTTP_CODE=$(curl -sS -L --max-time 30 -o "$RESPONSE" -w "%{http_code}" "$URL" || echo "000")
+
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "❌ Endpoint returned HTTP $HTTP_CODE (expected 200)."
+  echo ""
+  head -c 500 "$RESPONSE"; echo ""
+  exit 1
+fi
+
+# Pretty-print for CI log
+python3 -m json.tool < "$RESPONSE" || cat "$RESPONSE"
+echo ""
+
+STATUS=$(python3 -c "
+import json
+with open('$RESPONSE') as f:
+    d = json.load(f)
+print(d.get('status') or 'unknown')
+")
+MESSAGE=$(python3 -c "
+import json
+with open('$RESPONSE') as f:
+    d = json.load(f)
+print(d.get('message') or '')
+")
+
+echo "Verdict: $STATUS"
+echo "  $MESSAGE"
+echo ""
+
+case "$STATUS" in
+  recovered)
+    echo "✅ Recovery complete — disable this workflow once stable for a week."
+    exit 0
+    ;;
+  recovering|in_progress|insufficient_data)
+    echo "✅ Healthy progression — no action."
+    exit 0
+    ;;
+  degraded)
+    echo "⚠️  Recovery STALLED (not yet past deadline). Manual review recommended:"
+    echo "   1. GSC Coverage report — any new errors on /pieces/* ?"
+    echo "   2. Sitemap freshness endpoint — still serving today's <lastmod> ?"
+    echo "   3. Top URLs (audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md) — re-submit via URL Inspection ?"
+    exit 1
+    ;;
+  failed)
+    echo "❌ Recovery FAILED past deadline. Open a fresh Phase −1 investigation."
+    echo "   The sitemap fix alone was not sufficient — the cause is elsewhere."
+    exit 1
+    ;;
+  *)
+    echo "❓ Unknown status '$STATUS' — inspect raw JSON above."
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Automates the 7–14 day monitoring window that follows PR #487 (sitemap regen restoration). Replaces the manual "run this SQL query every day" loop with a public endpoint + a daily-scheduled GitHub workflow that surfaces a clear verdict on whether GSC impressions on `/pieces/*` are climbing back to the W17 baseline.

## What it does

- **Endpoint** `GET /api/seo/monitor/recovery-status` (public read-only) returns a single JSON with the verdict and the numbers behind it.
- **Watchdog** runs daily at **07:00 UTC** (3 h after the GSC daily-fetch). Exits non-zero on `degraded` / `failed` so the workflow surfaces a red dot in the Actions tab.
- **Six possible verdicts**:
  - `in_progress` — D < 3 days since fix, too early
  - `recovering` — heading toward target
  - `recovered` — ratio ≥ 80 % baseline (success)
  - `degraded` — stalled but still inside the 14-day deadline (warn)
  - `failed` — D ≥ 14 and still below target (open a fresh Phase −1)
  - `insufficient_data` — GSC J-3 latency, current week empty

## Configuration (all env-tunable)

Default values are aligned with the current incident; adjust if reused later.

| Var | Default |
|-----|---------|
| `SEO_RECOVERY_URL_PATTERN` | `/pieces/%` |
| `SEO_RECOVERY_BASELINE_FROM` | `2026-04-13` |
| `SEO_RECOVERY_BASELINE_TO` | `2026-04-20` |
| `SEO_RECOVERY_FIX_DATE` | `2026-05-13` |
| `SEO_RECOVERY_TARGET_RATIO` | `0.80` |
| `SEO_RECOVERY_GRACE_DAYS` | `3` |
| `SEO_RECOVERY_DEADLINE_DAYS` | `14` |

## Files

| File | Why |
|------|-----|
| `backend/src/modules/seo/services/seo-recovery-monitor.service.ts` | Queries `__seo_gsc_daily`, computes ratio, picks verdict |
| `backend/src/modules/seo/controllers/seo-monitor.controller.ts` | `GET /api/seo/monitor/recovery-status` endpoint |
| `backend/src/modules/seo/seo.module.ts` | DI wiring |
| `scripts/ci/check-seo-recovery.sh` | Probes + parses verdict (python3, no `jq`) |
| `.github/workflows/seo-recovery-watchdog.yml` | Daily 07:00 UTC + `workflow_dispatch` |
| `backend/tests/unit/seo-recovery-monitor.test.ts` | 6 verdict-transition cases |

## Test plan

- [x] tsc / eslint pass.
- [x] Local smoke-test of the script against current PROD: HTTP 404 as expected (endpoint not deployed yet), script exits 1 with a clear error.
- [ ] CI green on this branch.
- [ ] Post-merge + DEV/PROD deploy: `workflow_dispatch` should return `status=insufficient_data` initially (GSC J-3 latency).
- [ ] D+3 → D+14: daily scheduled run transitions through `in_progress` → `recovering` → `recovered`.

## When to disable

Once `status=recovered` has held for 7 consecutive days, comment out the `schedule:` trigger. Re-enable manually if a similar incident pattern reappears.

## Rollback

Pure additive (one service, one endpoint, one script, one workflow, one test file). Revert is safe — no DB, no env required, no behavior change on existing endpoints.

## Refs

- PR #487 — sitemap regen restoration (the fix this monitors)
- PR #492 — sitemap freshness SLO (the freshness side of the same incident)
- `audit-reports/seo-smoke/2026-05-13/PHASE-MINUS-1-REPORT.md` — root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📧 Email notifications via Sentry (added in commit above)

When the watchdog fails (`degraded` or `failed`), the workflow now emits a Sentry event tagged `watchdog=...`. Sentry's existing single-recipient alert rule (cf. memory `sentry-vps-bootstrap-20260506`) mirrors any production-environment error event to email — so the user gets a mailbox alert without needing a separate SMTP setup.

**Requires** `SENTRY_DSN` secret in repo settings:
- `gh secret set SENTRY_DSN --repo ak125/nestjs-remix-monorepo --body "$(your prod DSN)"`
- Or via UI: https://github.com/ak125/nestjs-remix-monorepo/settings/secrets/actions

The Sentry step is gated by `if: failure() && env.SENTRY_DSN != ''` so this PR merges cleanly even if the secret is not yet set — emails just won't fire until you add it.
