### PR TITLE
feat(canon-mirrors): pre-commit hook blocks manual edits (ADR-061 §3)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,39 @@
+# Block manual edits to canon mirrors (ADR-061 §3 — canon mirrors are READ-ONLY).
+# Canon mirrors (`.claude/canon-mirrors/<canon>.md` + workspaces) are synced by
+# cron VPS DEV (governance-vault/_scripts/cron-sync-canon-mirrors.sh). Manual edits
+# break the SoT contract — vault canon must remain the only source of truth.
+#
+# Le hook est self-consistent : il appelle `sync_canon_mirrors.py --check` qui
+# compare les fichiers staged à la distribution canon vault. Si match (cas cron :
+# le --write vient juste d'aligner), le check pass. Si manuel (différent du canon),
+# le check fail et le commit est bloqué.
+#
+# Tolérance : si vault inaccessible localement (`$GOVERNANCE_VAULT_PATH`),
+# warn-only (CI authoritatif).
+CANON_MIRRORS_CHANGED=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '(^|/)\.claude/canon-mirrors/.+\.md$' || true)
+if [ -n "$CANON_MIRRORS_CHANGED" ]; then
+  VAULT_PATH="${GOVERNANCE_VAULT_PATH:-/opt/automecanik/governance-vault}"
+  if [ ! -f "$VAULT_PATH/_scripts/sync_canon_mirrors.py" ]; then
+    echo "WARNING: canon-mirrors edits staged but vault sync script not found at $VAULT_PATH."
+    echo "Cannot verify locally — CI will run the authoritative check."
+  else
+    if ! python3 "$VAULT_PATH/_scripts/sync_canon_mirrors.py" --check --monorepo . >/dev/null 2>&1; then
+      echo ""
+      echo "ERROR (ADR-061 §3): canon-mirrors content drift detected vs vault canon."
+      echo ""
+      echo "Canon mirrors are READ-ONLY. Manual edits are forbidden."
+      echo "To update a canon, edit the vault source (ledger/rules/rules-*.md) and run:"
+      echo "  bash $VAULT_PATH/_scripts/cron-sync-canon-mirrors.sh"
+      echo ""
+      echo "Files staged:"
+      echo "$CANON_MIRRORS_CHANGED" | sed 's|^|  - |'
+      echo ""
+      echo "See https://github.com/ak125/governance-vault/blob/main/ledger/decisions/adr/ADR-061-workspace-governance.md §3"
+      exit 1
+    fi
+  fi
+fi
+
 # Block any staged file under app/.local/governance-vault/
 # (deprecated per ADR-015 — governance vault is at /opt/automecanik/governance-vault/)
 BLOCKED=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^\.local/governance-vault/' || true)

--- a/log.md
+++ b/log.md
@@ -561,3 +561,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/ci-workspace-invariants`
 - **Décision** : feat(ci): workspace mini-monorepo check (ADR-061 §6)
 - **Sortie** : PR aucune | commits 9331cadd
+
+## 2026-05-14 — feat/canon-mirrors-precommit-hook (auto)
+
+- **Branche** : `feat/canon-mirrors-precommit-hook`
+- **Décision** : feat(canon-mirrors): pre-commit hook blocks manual edits (ADR-061 §3)
+- **Sortie** : PR aucune | commits c725253e


### PR DESCRIPTION
**Étape 4 follow-up (côté monorepo)** — pre-commit hook anti-manuel-edit pour canon mirrors.

## Pourquoi

[ADR-061](https://github.com/ak125/governance-vault/blob/main/ledger/decisions/adr/ADR-061-workspace-governance.md) §3 codifie : les canon mirrors (\`.claude/canon-mirrors/*\` + workspaces) sont read-only, synchronisés par cron VPS DEV depuis le vault.

Jusqu'à présent : aucune garde mécanique → un agent peut éditer manuellement un mirror sans rien bloquer.

## Changement (1 fichier)

**\`.husky/pre-commit\`** — ajout d'un bloc en tête du hook.

Pattern self-consistent (no AUTO_SYNC bypass needed) :
- Détecte si des fichiers \`.claude/canon-mirrors/*.md\` sont stagés.
- Appelle \`governance-vault/_scripts/sync_canon_mirrors.py --check --monorepo .\`.
- Si match (cas cron auto-sync) → check exit 0, commit OK.
- Si diverge (édit manuel) → check exit 1, commit refusé avec message explicite.

Tolérance :
- Si vault inaccessible localement (\`\$GOVERNANCE_VAULT_PATH\`), warn-only (CI authoritatif).
- Env var configurable pour les dev machines avec layout custom.

## Dépendance

Le script \`sync_canon_mirrors.py\` est introduit par [governance-vault PR #268](https://github.com/ak125/governance-vault/pull/268). Avant merge de #268 : hook warn-only (script not found). Après merge : hook actif.

## Méthode (no bricolage)

- 0 duplication logique (delegue au script vault, single source of truth).
- 0 nouvelle convention (réutilise pattern \`BLOCKED=\$(git diff...)\` du hook existant).
- 0 dépendance ajoutée (python3 + bash déjà requis).
- Bloc en tête du hook → fast-fail avant les autres checks coûteux.

## Test

```bash
$ bash -n .husky/pre-commit
syntax OK
```

Test fonctionnel impossible avant merge vault #268 (le script n'existe pas encore localement). Validation Phase A se fera empiriquement sur VPS DEV après les 2 merges.

Source : \`/home/deploy/.claude/plans/sous-projets-downstream-restants-enchanted-shell.md\` étape 4 (livrable #2).