### PR TITLE
fix(ci): unbreak registry-build.yml (YAML parse error on bare colon)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-13'
+last_scan: '2026-05-14'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -74,7 +74,7 @@ jobs:
           fi
           echo "✓ Deterministic across 2 runs"
 
-      - name: Run RPC parser fixture tests (V1-3 : 3 parse modes)
+      - name: "Run RPC parser fixture tests (V1-3: 3 parse modes)"
         run: npm run registry:test:rpc-parser
 
       - name: Validate outputs against @repo/registry Zod schemas


### PR DESCRIPTION
## Summary

- Fix `.github/workflows/registry-build.yml` ligne 77 : nom d'étape `Run RPC parser fixture tests (V1-3 : 3 parse modes)` cassait le parser YAML (colon nu interprété comme séparateur de mapping)
- Quote la string → workflow parsable → jobs créés → CI réelle exécutée
- Side-effect du pre-commit : 42 refresh `last_scan` dans `.claude/knowledge/modules/*.md` (script `refresh-knowledge.py` documenté dans CLAUDE.md, comportement nominal)

## Why it matters

Le workflow échoue en **0 seconde, 10 runs consécutifs** sur `main` depuis sa création (#457). GitHub Actions affiche "This run likely failed because of a workflow file issue" sans logs, ce qui masque qu'aucun job n'est jamais lancé. C'est l'un des blockers ouverts pour l'ouverture de PR sur `feat/architecture-contract-v1` (cf. note de session : *attendre stabilisation registry-build.yml avant ouverture PR*).

Validation locale :
```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/registry-build.yml'))"
# avant : ScannerError: mapping values are not allowed here
#   in ".github/workflows/registry-build.yml", line 77, column 50
# après : (no output → YAML valid)
```

Le workflow est `continue-on-error: true` (warn-only Phase 1 ADR-058) — donc même si la première exécution réelle révèle un fail métier, ça ne bloque pas main. Au contraire, ça permet enfin d'avoir un vrai signal.

## Test plan

- [ ] CI verte sur cette PR (le workflow tournera réellement pour la première fois)
- [ ] Merge → observer ≥3 runs verts consécutifs sur `main` avant de débloquer la suite (ADR-058 promotion + ouverture `feat/architecture-contract-v1`)
- [ ] Si red après merge : c'est un fail métier réel (Layer 1 builders), pas de syntax — gérer dans une PR séparée

🤖 Generated with [Claude Code](https://claude.com/claude-code)