### PR TITLE
fix(ci): build @repo/registry before Zod validation in registry-build.yml

### DIFF
--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build @repo/registry (dist required by Zod validation step)
+        run: npm run -w @repo/registry build
+
       - name: Run upstream audit producers (provide inputs for builders)
         run: npm run audit:inventory
 


### PR DESCRIPTION
## Summary

- Ajoute le step `npm run -w @repo/registry build` dans `registry-build.yml` avant le step "Validate outputs against @repo/registry Zod schemas"
- Aligne avec le pattern canon déjà utilisé par `registry-fresh.yml` et `registry-new-file-gate.yml`
- Sans ce build, `@repo/registry/dist/index.js` n'existe pas et l'import Node échoue avec `ERR_MODULE_NOT_FOUND`

## Why

Avec PR #501 (fix YAML), le workflow `registry-build.yml` s'exécute enfin réellement. Le run a immédiatement révélé un fail métier sous-jacent : `npm ci` installe les deps mais ne build pas les workspaces TypeScript locaux (`@repo/registry` compile via `tsc` dans son script `build`).

C'est le pattern canon adopté par les 2 autres workflows qui dépendent de `@repo/registry`. Sans alignement ici, `registry-build.yml` continue à fail (warn-only par design, mais brouille le signal pour le gate Phase 1 ADR-058).

## Test plan

- [x] Build local : `npm run -w @repo/registry build` → produit `packages/registry/dist/index.js` + `.d.ts` (vérifié)
- [x] YAML valide : `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/registry-build.yml'))"` (vérifié)
- [ ] CI verte sur cette PR → confirme que le workflow tourne maintenant au vert
- [ ] Merge → débloque un VRAI signal vert pour le compteur 7-14j observation Phase 1 ADR-058

## Chaîne

1. PR #501 (mergée) : workflow exécutable
2. **Cette PR** : workflow produit signal vert
3. (Plus tard) Vault : promotion ADR-058 `proposed → accepted` après 7-14j observation
4. (Plus tard) Vault : création ADR "Repository Contract System meta-model"
5. (Plus tard) Ouverture `feat/architecture-contract-v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)