### PR TITLE
chore(ci): lighthouse-budget timings-only — post-cascade size-limit cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -963,9 +963,20 @@ jobs:
           retention-days: 7
 
   # ============================================
-  # Lighthouse Performance Audit (post-deploy)
+  # Lighthouse Performance Audit (post-deploy, observe-only)
   # ============================================
-
+  # SCOPE : observabilité timing synthétique sur serveur PREPROD réel après
+  # deploy main. **Non-bloquant** (cf. step "Lighthouse summary"). Catch les
+  # régressions de TTFB / cold start / CDN / gzip serveur qu'un bundle scan
+  # statique ne voit pas.
+  #
+  # **N'est PAS un PR gate** : l'anti-régression bundle PR est dans
+  # perf-gates.yml via size-limit sur frontend/.size-limit.json (déterministe,
+  # gzip, bloquant). Voir frontend/size-limit.README.md.
+  #
+  # Budgets de timing : frontend/lighthouse-budget.json (timings only depuis
+  # 2026-05-14 ; les resourceSizes/resourceCounts ont migré vers .size-limit.json
+  # — source de vérité unique pour les budgets bundle).
   lighthouse:
     name: 🔦 Lighthouse Performance Audit
     runs-on: [self-hosted, Linux, X64]

--- a/frontend/lighthouse-budget.README.md
+++ b/frontend/lighthouse-budget.README.md
@@ -1,89 +1,73 @@
-# `lighthouse-budget.json` — anti-régression baseline
+# `lighthouse-budget.json` — budgets timing post-deploy (observe-only)
 
-## Rôle
+## Rôle actuel (post-cascade size-limit 2026-05-14)
 
-Ce fichier est le budget Lighthouse appliqué par
-[`.github/workflows/perf-gates.yml`](../.github/workflows/perf-gates.yml).
-**Son seul rôle est de prévenir les régressions de performance**, pas
-d'imposer des objectifs aspirationnels.
+Ce fichier est consommé **uniquement** par le job `lighthouse:` post-deploy de [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) (ligne ~969). Il définit les seuils de timing (FCP/LCP/TTI/TBT/CLS) mesurés par Lighthouse-CI sur le **serveur PREPROD réel** (`localhost:3200` du runner self-hosted), **après deploy sur main**, en mode **observe-only / non-bloquant**.
 
-> "Start with a baseline performance budget. Measure your current
-> performance, then set budgets just above those values."
-> — [web.dev/performance-budgets-101](https://web.dev/articles/performance-budgets-101)
+> *"Non-blocking: violations signalees mais ne bloquent pas le pipeline."* — extrait du step summary du job.
 
-## Calibration courante
+**Ce n'est pas un PR gate.** Le gate PR vit dans [`.github/workflows/perf-gates.yml`](../.github/workflows/perf-gates.yml) qui appelle [size-limit](https://github.com/ai/size-limit) sur [`.size-limit.json`](./.size-limit.json) (budgets structurels gzip déterministes). Voir [`size-limit.README.md`](./size-limit.README.md) pour la philosophie complète.
 
-Mesures de référence prises sur CI run
-[`25178882039`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25178882039)
-(2026-04-30, après merge des 3 couches du plan TTI home : PR #227 warm
-cache families, PR #229 manualChunks app-level + Remix v3 future flags,
-PR #230 DI direct loader sans HTTP loopback) :
+## Pourquoi ne pas migrer ce job vers size-limit aussi ?
 
-| Métrique | Pic mesuré | Budget actuel | Headroom |
-|---|---:|---:|---:|
+Contexte différent :
+
+| Aspect | PR gate (size-limit) | PREPROD post-deploy (Lighthouse ici) |
+|--|--|--|
+| Quand | Sur chaque PR | Sur push main (1×/merge) |
+| Quoi | Bundle artefact statique | Serveur réel deployed |
+| Où | GitHub runner partagé | Self-hosted DEV VPS (port 3200) |
+| Mesure | Octets gzip sur disque | TTFB + render + parse + paint sur HTTP réel |
+| Bloque | Oui (`exit 1` sur dépassement) | Non (`> Non-blocking`) |
+| Catch | Bundle bloat | CDN / gzip serveur / cold start / SSL / Nest boot |
+| Valeur | Anti-régression structurelle | Sanity check post-deploy |
+
+Un size-limit en PREPROD donnerait les mêmes octets que sur PR (artefact identique). Pas de valeur ajoutée. Lighthouse PREPROD mesure des choses qu'un static scan ne peut pas voir.
+
+## Pourquoi seulement les timings (et pas `resourceSizes`/`resourceCounts`) ?
+
+Avant 2026-05-14 ce fichier portait aussi `resourceSizes` (script/stylesheet/total KB) et `resourceCounts` (script/stylesheet). Ces dimensions sont maintenant exprimées en gzip dans `frontend/.size-limit.json` (**source de vérité unique**). Les conserver ici dupliquait sans valeur (artefact identique sur PR et PREPROD).
+
+## Calibration courante des timings
+
+Mesures de référence prises sur CI run [`25178882039`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25178882039) (2026-04-30, après merge des 3 couches du plan TTI home — PR #227 warm cache, PR #229 manualChunks + v3 flags, PR #230 DI direct loader) :
+
+| Métrique | Pic mesuré | Budget | Headroom |
+|--|--:|--:|--:|
 | First Contentful Paint | 9 195 ms (pieces) | 10 200 ms | +11 % |
 | Largest Contentful Paint | 10 005 ms (pieces) | 11 100 ms | +11 % |
 | Time to Interactive | 10 922 ms (pieces) | 12 100 ms | +11 % |
 | Total Blocking Time | 125 ms (home) | 500 ms | enveloppe variance |
 | Cumulative Layout Shift | n/a | 0.25 | défaut Lighthouse |
-| Script size | 1 117 KB (pieces) | 1 250 KB | +12 % |
-| Stylesheet size | 354 KB | 400 KB | +13 % |
-| Total size | 1 590 KB (pieces) | 1 800 KB | +13 % |
-| Script count | 22 (pieces, constructeurs) | 30 | +36 % |
-| Stylesheet count | 3 (constructeurs) | 10 | enveloppe |
 
-URLs auditées : `/`, `/pieces/<long-slug>`, `/constructeurs/renault-140.html`.
-Le budget `path: "/*"` couvre les trois — calibré sur la **pire** valeur
-observée à travers les trois pages.
+URLs auditées (cf. `ci.yml` job `lighthouse:`) : `/`, `/search?q=plaquette`, `/pieces/catalogue`. Le budget `path: "/*"` couvre les trois — calibré sur la **pire** valeur observée.
 
 ### Trajectoire vs baseline pré-plan
 
-Pour mémoire, la baseline pré-plan (CI run
-[`25175348869`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25175348869),
-post-PR #224 exit-124 flake fix mais avant les 3 couches) :
+Pour mémoire, la baseline pré-plan (CI run [`25175348869`](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/25175348869)) :
 
-| Métrique | Avant plan | Après plan | Delta home (CI) |
-|---|---:|---:|---:|
+| Métrique | Avant plan | Après plan | Delta home |
+|--|--:|--:|--:|
 | FCP home | 10 766 ms | **2 712 ms** | **−75 %** |
 | LCP home | 11 527 ms | 3 312 ms | −71 % |
 | TTI home | 11 656 ms | 8 776 ms | −25 % |
-| Script count peak | 44 | **22** | −50 % |
-
-Le pic se déplace : la **home** est maintenant clean (FCP < 3 s), mais
-les pages `/pieces/<slug>` et `/constructeurs/<slug>.html` restent
-contraintes par leur propre latence loader (TTFB pieces 3 264 ms,
-constructeurs 416 ms). Couches futures (5/6 hors plan TTI home actuel)
-devront s'attaquer à ces routes.
 
 ## Comment évoluer
 
-1. **Tighten** dès qu'une PR ship une amélioration mesurable
-   (ex : nouveau lazy-loading, replacement d'une dep lourde, critical
-   CSS extraction). Mettre à jour ce README + le JSON dans le même
-   commit pour que la régression soit détectée.
-
-2. **Loosen jamais** sans justification écrite ici. Si une PR fait
-   monter une métrique, le bon réflexe est d'optimiser, pas de
-   relâcher le budget.
-
+1. **Tighten** dès qu'une PR ship une amélioration mesurable post-deploy (lazy-hydration, SSR streaming, critical CSS inline). Mettre à jour ce README + le JSON dans le même commit.
+2. **Loosen jamais** sans justification écrite ici. Si une métrique monte, optimiser, pas relâcher.
 3. **Rebaseliner** annuellement après campagnes de perf majeures.
+
+**Ne pas réintroduire** `resourceSizes` / `resourceCounts` ici — ces dimensions vivent dans `.size-limit.json` (source de vérité unique post-cascade 2026-05-14, cf. PR #508).
 
 ## Hors-scope du budget
 
-Le travail d'optimisation perf réel (réduction structurelle des
-bundles, critical CSS, lazy hydration, audit de dépendances lourdes
-comme recharts/tiptap/lucide) est tracké comme projet engineering
-séparé. Ce gate sert uniquement à empêcher les régressions pendant
-qu'on bosse l'optim.
+Le travail d'optimisation perf réel (réduction structurelle, critical CSS, lazy hydration, audit deps lourdes) est tracké comme projet engineering séparé. Ce check sert uniquement à surfacer des régressions de timing post-deploy en mode observe.
+
+**Vraie surveillance CWV utilisateurs réels** : à venir via ADR CrUX API + cron + alerting (chantier séparé).
 
 ## Historique
 
-- **2026-04-30 (rev 2)** : recalibration après merge des 3 couches du
-  plan TTI home (PR #227 warm cache, PR #229 manualChunks + v3 flags,
-  PR #230 DI direct loader). FCP home mesuré : 10 766 → 2 712 ms (−75 %).
-  Script count peak : 44 → 22 (−50 %). Budget resserré pour figer les
-  gains et détecter toute régression.
-- **2026-04-30 (rev 1)** : calibration initiale empirique post-fix
-  exit-124 (PR #224). Budgets précédents (script 400 KB, stylesheet
-  150 KB, TTI 6 s) étaient aspirationnels et n'avaient jamais
-  réellement tourné en CI à cause du flake. Premier baseline mesuré.
+- **2026-05-14 (rev 3, ce PR)** : retrait des `resourceSizes` / `resourceCounts` (dupliqués avec `.size-limit.json` post PR #506/#508 cascade). Scope clarifié : observe-only, PREPROD post-deploy uniquement. Plus utilisé par `perf-gates.yml` (PR gate) qui consomme `.size-limit.json` via [size-limit](https://github.com/ai/size-limit).
+- **2026-04-30 (rev 2)** : recalibration après merge des 3 couches du plan TTI home (PR #227 warm cache, PR #229 manualChunks + v3 flags, PR #230 DI direct loader). FCP home mesuré : 10 766 → 2 712 ms (−75 %). Script count peak : 44 → 22 (−50 %).
+- **2026-04-30 (rev 1)** : calibration initiale empirique post-fix exit-124 (PR #224). Budgets précédents étaient aspirationnels et n'avaient jamais réellement tourné en CI à cause du flake. Premier baseline mesuré.

--- a/frontend/lighthouse-budget.json
+++ b/frontend/lighthouse-budget.json
@@ -7,15 +7,6 @@
       { "metric": "interactive", "budget": 12100 },
       { "metric": "total-blocking-time", "budget": 500 },
       { "metric": "cumulative-layout-shift", "budget": 0.25 }
-    ],
-    "resourceSizes": [
-      { "resourceType": "script", "budget": 1250 },
-      { "resourceType": "stylesheet", "budget": 400 },
-      { "resourceType": "total", "budget": 1800 }
-    ],
-    "resourceCounts": [
-      { "resourceType": "script", "budget": 30 },
-      { "resourceType": "stylesheet", "budget": 10 }
     ]
   }
 ]

--- a/frontend/size-limit.README.md
+++ b/frontend/size-limit.README.md
@@ -83,4 +83,4 @@ size-limit ne supporte que `error` (exit code) — pas de niveau `warn`. C'est i
 ## Historique
 
 - **2026-05-14 (création, PR #507)** : adoption size-limit. Élimination du script custom `bundle-stats.mjs` (PR #506) et du bloc inline gzip de `ci.yml`. Source de vérité unique : `frontend/.size-limit.json`. Calibration empirique sur build commit `9797b488` (post PR #506 merge).
-- **Historique antérieur** : voir entrée correspondante dans `lighthouse-budget.README.md` (encore présent pour le job Lighthouse PREPROD non-bloquant `ci.yml`, à migrer dans un PR-suivi).
+- **Historique antérieur** : voir [`lighthouse-budget.README.md`](./lighthouse-budget.README.md) — fichier conservé exclusivement pour le job `lighthouse:` PREPROD post-deploy de `ci.yml` (observe-only, mesure timing synthétique sur serveur réel). Ne migre pas vers size-limit : contexte différent (artefact statique vs serveur deployed). Détails dans son README.


### PR DESCRIPTION
## Finition de la cascade size-limit

Suite à la cascade #504 → #506 → #508 qui a établi **`frontend/.size-limit.json`** comme source de vérité unique pour les budgets bundle (gzip), `frontend/lighthouse-budget.json` portait encore des dimensions dupliquées (`resourceSizes` et `resourceCounts`) qui ne sont plus utilisées :

| Dimension | Avant ce PR | Après ce PR |
|--|--|--|
| `resourceSizes` (script/css/total KB) | dans `lighthouse-budget.json` ET `.size-limit.json` | **`.size-limit.json` seul (gzip)** |
| `resourceCounts` (script/css count) | dans `lighthouse-budget.json` | **retiré** (pas utilisé ailleurs) |
| `timings` (FCP/LCP/TTI/TBT/CLS) | dans `lighthouse-budget.json` | **conservé ici** — utilisé par job PREPROD observe-only |

## Pourquoi garder `lighthouse-budget.json` (et ne pas tout supprimer)

Le job `lighthouse:` post-deploy de `ci.yml` (ligne ~969) mesure le **serveur PREPROD réel** (port 3200, self-hosted DEV VPS, après deploy main) en mode observe-only / non-bloquant. Ce contexte capture des choses qu'un static scan ne peut pas voir :

| Aspect | PR gate (size-limit) | PREPROD post-deploy (Lighthouse ici) |
|--|--|--|
| Quand | Sur chaque PR | Sur push main (1×/merge) |
| Quoi | Bundle artefact statique | Serveur réel deployed |
| Où | GitHub runner partagé | Self-hosted DEV VPS (port 3200) |
| Mesure | Octets gzip sur disque | TTFB + render + parse + paint sur HTTP réel |
| Bloque | Oui (`exit 1` sur dépassement) | Non (`> Non-blocking`) |
| Catch | Bundle bloat | CDN / gzip serveur / cold start / SSL / Nest boot |

Donc : pas de delete (perd l'observabilité TTFB/cold start), pas de migrate vers size-limit (redondant — même artefact que PR gate). Juste retrait des dimensions dupliquées.

## Changements

| Fichier | Action |
|--|--|
| `frontend/lighthouse-budget.json` | `-9 lignes` (resourceSizes + resourceCounts retirés) |
| `frontend/lighthouse-budget.README.md` | **réécrit** — scope clarifié, table comparative PR gate vs PREPROD, instruction "ne pas réintroduire resourceSizes ici" |
| `frontend/size-limit.README.md` | forward-pointer corrigé (était "à migrer dans un PR-suivi" → "scope différent, ne migre pas") |
| `.github/workflows/ci.yml` | commentaire scope au-dessus du job `lighthouse:` (observe-only, non-bloquant) |

Net : `+87 / -101 = -14 lignes`.

## Effet attendu

- **Source de vérité unique** pour les budgets bundle (`.size-limit.json`)
- **Zéro duplication** entre `lighthouse-budget.json` et `.size-limit.json`
- **Scope explicite** dans chaque README — plus de confusion possible sur "lequel est consommé par quoi"
- **Aucun changement runtime** : le job Lighthouse PREPROD continue exactement comme avant (timings-only étaient déjà sa raison d'être informationnelle)

## Hors scope (chantier séparé)

**ADR CWV monitoring PROD via CrUX API** — la vraie surveillance régression user-facing utilise les données field 28j de CrUX (ce que Google Search utilise pour le ranking). Synthétique CI = canary smoke, pas surveillance.

## Test plan

- [ ] CI verte sur cette PR (rien ne change runtime, juste cleanup de fichier statique)
- [ ] Sur le prochain push main, vérifier que le job `lighthouse:` PREPROD passe toujours (les timings sont toujours là)

🤖 Generated with [Claude Code](https://claude.com/claude-code)