### PR TITLE
feat(db-contract): DB Contract V1 (PR-3a) — declarative read-only ownership + access surfaces

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,6 +25,7 @@ on:
       - "audit-reports/phase0-baseline.json"
       - ".github/workflows/audit.yml"
       - ".spec/00-canon/repository-registry/architecture.yaml"
+      - ".spec/00-canon/repository-registry/db.yaml"
       - ".dependency-cruiser.generated.cjs"
 
 permissions:
@@ -67,6 +68,13 @@ jobs:
       - name: 🏛️ Architecture contract — regenerate artifacts
         if: always()
         run: npm run architecture:build
+
+      - name: 🗄️ DB contract — regenerate IDE schema mirror (PR-3a)
+        # Mirror of architecture:build pattern. Pure regen — if Zod parse
+        # throws, that surfaces a real bug in db.yaml. No committed artifact
+        # in PR-3a; PR-3b will add the artifact + freshness gate.
+        if: always()
+        run: npm run db-contract:build
 
       # RATCHET DEADLINE — mechanical expiration via env var + date check.
       # After the deadline, the STEP fails visibly (red ✘ in the CI summary, ::error::

--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,4 @@ audit/registry/cache/
 # `npm run architecture:build` on every run. Not committed to avoid PR noise /
 # merge conflicts. Fresh checkouts: run the build once for IDE $schema resolution.
 .spec/00-canon/_schema/architecture.schema.json
+.spec/00-canon/_schema/db.schema.json

--- a/.spec/00-canon/repository-registry/architecture.yaml
+++ b/.spec/00-canon/repository-registry/architecture.yaml
@@ -19,9 +19,9 @@
 #    × runtime observability  → use OTel config / Sentry tags
 #    × queue/cache mapping    → use `runtime-topology.yaml` (PR-4)
 #    × SEO flows / role canon → use existing seo-role-contracts (PR-F SEO)
-#    × projection graph       → use `db.yaml` (PR-3)
+#    × projection graph       → see `db.yaml`
 #    × RAG flows              → use ADR-046 wiki-exports SoT
-#    × DB schema / RLS        → use `db.yaml` (PR-3)
+#    × DB schema / RLS        → see `db.yaml`
 #
 #  If you're tempted to add a section that isn't an architectural invariant —
 #  open a NEW contract file instead.

--- a/.spec/00-canon/repository-registry/db.yaml
+++ b/.spec/00-canon/repository-registry/db.yaml
@@ -1,0 +1,127 @@
+# yaml-language-server: $schema=../_schema/db.schema.json
+# .spec/00-canon/repository-registry/db.yaml
+#
+# AutoMecanik monorepo — canonical DB contract V1 (PR-3a, ADR-058 follow-on,
+# ADR-062 conformant).
+#
+# The `# yaml-language-server:` directive above links this YAML to its
+# generated JSON Schema mirror for IDE validation. The schema file is
+# gitignored — run `npm run db-contract:build` after a fresh clone.
+#
+# ──────────────────────────────────────────────────────────────────────────────────
+#  DOCTRINE — read before adding anything to this file
+# ──────────────────────────────────────────────────────────────────────────────────
+#  This file holds DB OWNERSHIP & ACCESS SURFACE INVARIANTS ONLY.
+#
+#  Do NOT add to this file:
+#    × column schemas / DDL          → use migrations (backend/supabase/migrations/)
+#    × RLS policies                  → use migrations + ADR-021 pattern
+#    × deletePolicy state            → use `delete-policy.yaml`
+#    × rlsEnabled / row counts       → derived in `audit/registry/db.json`
+#    × RPC signatures                → use `audit/registry/rpc.json`
+#    × runtime access metrics        → OTel / Sentry
+#    × per-query observability       → out of contract scope
+#
+#  Loi A (ADR-062): this contract is NEVER derived from audit/registry/db.json.
+#  Loi B (ADR-062): the generated _schema/db.schema.json is read-only mirror.
+#
+#  V1 COVERAGE: a curated set of P0/P1 tables (≤ 20). Adding a table here is
+#  a deliberate governance act — table appears in db.yaml ⇔ a human committed
+#  to its access contract. Not exhaustive; PR-3c will audit real-vs-contract.
+#
+#  ENFORCEMENT TRAJECTORY:
+#    PR-3a (this file) — contract + Zod schema + generator. No enforcement.
+#    PR-3b             — committed artifact + freshness gate (warn-only, ratchet).
+#    PR-3c             — audit script: real Layer 1 access vs declared contract (report only).
+#    PR-3d             — ratchet on NEW access surfaces only (grandfather existing).
+# ──────────────────────────────────────────────────────────────────────────────────
+#
+# WORKFLOW
+# Edit this YAML → run `npm run db-contract:build` → commit ONLY the YAML.
+# The JSON schema mirror under _schema/ is gitignored.
+
+schemaVersion: "1.0.0"
+adr: ADR-058
+
+tables:
+  # ── D11 Commerce & Users (money path) ──
+  - name: public.__paybox_gate_log
+    domain: D11
+    owner: "@ak125/payments-team"
+    criticality: critical
+    allowed_access_surfaces: [backend, service_role]
+    forbidden_access_surfaces: [frontend, anon, authenticated]
+    notes: |
+      Payments HMAC gate audit log. ADR-021 vague 2a: REVOKE ALL anon,
+      authenticated; service_role grant via DO block idempotent.
+
+  - name: public.__write_audit_log
+    domain: D11
+    owner: "@ak125/payments-team"
+    criticality: critical
+    allowed_access_surfaces: [backend, service_role]
+    forbidden_access_surfaces: [frontend, anon, authenticated]
+    notes: |
+      Idempotency ledger for write operations on money path.
+
+  - name: public.__abandoned_cart_emails
+    domain: D11
+    owner: "@ak125/payments-team"
+    criticality: high
+    allowed_access_surfaces: [backend, worker, service_role]
+    forbidden_access_surfaces: [frontend, anon, authenticated]
+    notes: |
+      Cart recovery email queue. BullMQ worker consumer.
+
+  # ── D3 SEO & Sitemap (P0 read model, content surface) ──
+  - name: public.__seo_page
+    domain: D3
+    owner: "@ak125/seo-team"
+    criticality: critical
+    allowed_access_surfaces: [backend, rpc]
+    forbidden_access_surfaces: [frontend, anon, authenticated]
+    notes: |
+      Canonical SEO page metadata. Frontend reads via RPC (get_seo_page_*).
+      RLS state is intentionally not tracked here; see migrations and
+      audit/registry/db.json.
+
+  - name: public.__seo_keywords
+    domain: D3
+    owner: "@ak125/seo-team"
+    criticality: high
+    allowed_access_surfaces: [backend, rpc]
+    forbidden_access_surfaces: [frontend, anon, authenticated]
+    notes: |
+      V-Level classification keywords (T=keywords axis, ADR-027 derivative).
+
+  # ── D4 Vehicle / Compatibility (P0 TecDoc) ──
+  - name: public.__vehicles
+    domain: D4
+    owner: "@ak125/vehicle-team"
+    criticality: critical
+    allowed_access_surfaces: [backend, rpc]
+    forbidden_access_surfaces: [frontend, anon, authenticated]
+    notes: |
+      53,959 types (30,502 legacy + 23,457 remapped). Frontend reads via
+      cached RPC compat_*. Range 60000-83456 noindex.
+
+  # ── D1 Catalog Core (P0 75GB) ──
+  - name: public.pieces
+    domain: D1
+    owner: "@ak125/catalog-team"
+    criticality: critical
+    allowed_access_surfaces: [backend, rpc]
+    forbidden_access_surfaces: [frontend, anon, authenticated]
+    notes: |
+      Catalog core. Frontend reaches it strictly via cached RPC; never direct query.
+
+  # ── D7 Knowledge Graph & Diagnostic ──
+  - name: public.kg_nodes
+    domain: D7
+    owner: "@ak125"
+    criticality: high
+    allowed_access_surfaces: [backend, service_role]
+    forbidden_access_surfaces: [frontend, anon, authenticated]
+    notes: |
+      Knowledge graph nodes. RLS state is intentionally not tracked here;
+      see migrations and audit/registry/db.json.

--- a/log.md
+++ b/log.md
@@ -603,3 +603,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/db-contract-v1`
 - **Décision** : feat(db-contract): §2 add canon db.yaml — 8 P0/P1 tables (V1 minimal) (+1 other commit)
 - **Sortie** : PR aucune | commits 82a7cede 48330a0d
+
+## 2026-05-14 — feat/db-contract-v1 (auto)
+
+- **Branche** : `feat/db-contract-v1`
+- **Décision** : feat(db-contract): §6 size invariants + doctrine pointer cleanup (+6 other commits)
+- **Sortie** : PR #511 | commits 3a654957 f9aa65a7 e1bc4a24 c27b7035 106c0bb6 82a7cede 48330a0d

--- a/log.md
+++ b/log.md
@@ -597,3 +597,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/perf-gates-bundle-stats-no-lighthouse`
 - **Décision** : fix(perf-gates): use turbo build at root, not -w frontend (workspace deps) (+2 other commits)
 - **Sortie** : PR #506 | commits dbb88af1 d2f291a8 8b2dfd70
+
+## 2026-05-14 — feat/db-contract-v1 (auto)
+
+- **Branche** : `feat/db-contract-v1`
+- **Décision** : feat(db-contract): §2 add canon db.yaml — 8 P0/P1 tables (V1 minimal) (+1 other commit)
+- **Sortie** : PR aucune | commits 82a7cede 48330a0d

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "registry:check-new-files": "node scripts/registry/check-new-files.js",
     "architecture:build": "npm -w @repo/registry run build:architecture",
     "architecture:test": "tsx --test tests/registry/architecture-generator.test.ts",
-    "depcruise:integrity-test": "tsx --test tests/registry/depcruise-integrity.test.ts"
+    "depcruise:integrity-test": "tsx --test tests/registry/depcruise-integrity.test.ts",
+    "db-contract:build": "npm -w @repo/registry run build:db-contract"
   },
   "keywords": [],
   "author": "",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build:architecture": "tsx src/bin/build-architecture-artifacts.ts",
+    "build:db-contract": "tsx src/bin/build-db-contract-artifacts.ts",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts"
   },

--- a/packages/registry/src/__tests__/db-contract-size.test.ts
+++ b/packages/registry/src/__tests__/db-contract-size.test.ts
@@ -1,0 +1,44 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { load as parseYaml } from 'js-yaml';
+
+// Size invariants — bound the canon contract growth surface. These bounds
+// double-protect what DbContractSchema already enforces (via max(20) on
+// tables[]), and add file-LOC + top-level-key set checks that the Zod
+// schema cannot express on its own.
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const YAML_PATH = path.join(
+  REPO_ROOT,
+  '.spec/00-canon/repository-registry/db.yaml',
+);
+
+const raw = readFileSync(YAML_PATH, 'utf8');
+const doc = parseYaml(raw) as Record<string, unknown> & { tables: unknown[] };
+
+describe('db.yaml — size invariants', () => {
+  test('file is ≤ 300 LOC (anti-bloat budget for V1 minimal contract)', () => {
+    const lines = raw.split('\n').length;
+    assert.ok(
+      lines <= 300,
+      `db.yaml is ${lines} lines (budget: ≤ 300). Split additional rows into a follow-up PR + ADR.`,
+    );
+  });
+
+  test('has tables[].length ≤ 20 (V1 scope cap)', () => {
+    assert.ok(
+      doc.tables.length <= 20,
+      `db.yaml declares ${doc.tables.length} tables (cap: ≤ 20). Bump schemaVersion + open ADR before extending.`,
+    );
+  });
+
+  test('has exactly 3 top-level keys (anti-smuggling — V1 minimal)', () => {
+    assert.deepEqual(
+      Object.keys(doc).sort(),
+      ['adr', 'schemaVersion', 'tables'],
+      'unexpected top-level keys — V1 minimal allows only { schemaVersion, adr, tables }',
+    );
+  });
+});

--- a/packages/registry/src/__tests__/db-contract.test.ts
+++ b/packages/registry/src/__tests__/db-contract.test.ts
@@ -1,0 +1,157 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { load as parseYaml } from 'js-yaml';
+import { DbContractSchema, type DbContract } from '../canonical/db-contract';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Paths — db.yaml is loaded from the real canon location. These tests catch
+// drift between the schema and the actual committed contract. For pure
+// schema unit-tests (no YAML), see fixture-based cases below.
+// ──────────────────────────────────────────────────────────────────────────
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const YAML_PATH = path.join(
+  REPO_ROOT,
+  '.spec/00-canon/repository-registry/db.yaml',
+);
+const DOMAINS_YAML = path.join(
+  REPO_ROOT,
+  '.spec/00-canon/repository-registry/domains.yaml',
+);
+
+function loadRealContract(): DbContract {
+  const raw = readFileSync(YAML_PATH, 'utf8');
+  const parsed = parseYaml(raw);
+  return DbContractSchema.parse(parsed);
+}
+
+function loadRealDomainIds(): Set<string> {
+  // domains.yaml top-level shape: { schemaVersion, entries: [ { id, ... }, ... ] }
+  // (see .spec/00-canon/repository-registry/domains.yaml — Layer 2 overlay).
+  const raw = readFileSync(DOMAINS_YAML, 'utf8');
+  const doc = parseYaml(raw) as { entries: Array<{ id: string }> };
+  return new Set(doc.entries.map((e) => e.id));
+}
+
+// V1 MINIMAL fixture for negative-path tests. Mirrors architecture-contract
+// pattern: the fixture is the well-formed baseline; tampered copies trigger
+// the rejection paths.
+const validFixture = {
+  schemaVersion: '1.0.0',
+  adr: 'ADR-058',
+  tables: [
+    {
+      name: 'public.products',
+      domain: 'D1',
+      owner: '@org/team',
+      criticality: 'critical',
+      allowed_access_surfaces: ['backend', 'rpc'],
+      forbidden_access_surfaces: ['frontend', 'anon'],
+      notes: 'Example.',
+    },
+  ],
+};
+
+describe('DbContractSchema — round-trip on real db.yaml', () => {
+  test('the committed db.yaml parses through DbContractSchema', () => {
+    assert.doesNotThrow(() => loadRealContract());
+  });
+
+  test('the committed db.yaml has no duplicate table.name', () => {
+    const c = loadRealContract();
+    const names = c.tables.map((t) => t.name);
+    assert.equal(new Set(names).size, names.length);
+  });
+
+  test('each table allowed/forbidden surface pair is disjoint', () => {
+    const c = loadRealContract();
+    for (const t of c.tables) {
+      const overlap = t.allowed_access_surfaces.filter((s) =>
+        t.forbidden_access_surfaces.includes(s),
+      );
+      assert.deepEqual(overlap, [], `overlap detected on "${t.name}": ${overlap.join(', ')}`);
+    }
+  });
+});
+
+describe('DbContractSchema — fixture-based negative paths', () => {
+  test('accepts the well-formed fixture', () => {
+    assert.doesNotThrow(() => DbContractSchema.parse(validFixture));
+  });
+
+  test('rejects unknown top-level fields (.strict() — V1 anti-dumping-ground)', () => {
+    const bad = { ...validFixture, sneakyExtra: 42 };
+    assert.throws(() => DbContractSchema.parse(bad));
+  });
+
+  test('rejects unknown per-table fields (.strict() — anti-smuggling)', () => {
+    const bad = {
+      ...validFixture,
+      tables: [{ ...validFixture.tables[0], rlsEnabled: true }],
+    };
+    assert.throws(() => DbContractSchema.parse(bad));
+  });
+});
+
+describe('DbContractSchema — cross-contract (ADR-062 §Cross-contract deps)', () => {
+  test('every db.yaml table.domain exists in domains.yaml', () => {
+    const c = loadRealContract();
+    const known = loadRealDomainIds();
+    for (const t of c.tables) {
+      assert.ok(
+        known.has(t.domain),
+        `db.yaml references unknown domain "${t.domain}" on table "${t.name}" — add it to domains.yaml first`,
+      );
+    }
+  });
+
+  test('rejects UNKNOWN domain in db.yaml (canon SoT must be explicit)', () => {
+    const bad = {
+      ...validFixture,
+      tables: [{ ...validFixture.tables[0], domain: 'UNKNOWN' }],
+    };
+    assert.throws(
+      () => DbContractSchema.parse(bad),
+      /UNKNOWN is forbidden in canon SoT/,
+    );
+  });
+});
+
+describe('DbContractSchema — anti-parallel-truth (ADR-062 Loi B)', () => {
+  // db.yaml must NOT redeclare facts that live in another canon source:
+  //   - rlsEnabled / row policies → migrations + audit/registry/db.json
+  //   - deletePolicy             → delete-policy.yaml
+  //   - rowCount / size metrics  → audit/registry/db.json
+  // Two angles, on purpose:
+  //   1. Structural-key visitor — catches any nested key matching the banned
+  //      pattern at any depth, even if values would happen to be empty.
+  //   2. Serialized body scan (excluding `notes`) — catches the pattern in
+  //      structural string VALUES too (e.g. an enum literal sneaking in).
+  // `notes` strings are stripped before the serialized scan to allow narrative
+  // pointers ("service_role grant via DO block …") without false positives.
+  const BANNED = /(rls[A-Z_]?enabled|deletePolicy|rowCount|policy)/i;
+
+  test('committed contract has no banned facts as structural keys (any depth)', () => {
+    const c = loadRealContract();
+    const visitKeys = (node: unknown): string[] => {
+      if (node === null || typeof node !== 'object') return [];
+      const obj = node as Record<string, unknown>;
+      return Object.keys(obj).flatMap((k) => [k, ...visitKeys(obj[k])]);
+    };
+    const offending = visitKeys(c).filter((k) => BANNED.test(k));
+    assert.deepEqual(offending, [], `parallel-truth leak (keys): ${offending.join(', ')}`);
+  });
+
+  test('committed contract serialized body (notes stripped) contains no banned tokens', () => {
+    const c = loadRealContract();
+    const structural = {
+      ...c,
+      tables: c.tables.map(({ notes: _notes, ...rest }) => rest),
+    };
+    assert.ok(
+      !BANNED.test(JSON.stringify(structural)),
+      'parallel-truth leak in structural body — see test header for canon rationale',
+    );
+  });
+});

--- a/packages/registry/src/__tests__/db-contract.test.ts
+++ b/packages/registry/src/__tests__/db-contract.test.ts
@@ -94,6 +94,83 @@ describe('DbContractSchema — fixture-based negative paths', () => {
   });
 });
 
+describe('DbContractSchema — field-level negative paths', () => {
+  // Pin the regex semantics on each primitive sub-schema so future tightening
+  // (e.g. forbidding `_` in owner names) cannot silently weaken the contract.
+  // Mirrors the discipline already present in architecture-contract.test.ts.
+  const mut = (patch: Partial<typeof validFixture.tables[0]>) => ({
+    ...validFixture,
+    tables: [{ ...validFixture.tables[0], ...patch }],
+  });
+
+  test('rejects schemaVersion outside semver X.Y.Z', () => {
+    for (const v of ['v1', '1.0', '1.0.0-rc.1', '1.0.0.0', 'latest']) {
+      assert.throws(
+        () => DbContractSchema.parse({ ...validFixture, schemaVersion: v }),
+        new RegExp('schemaVersion'),
+        `expected "${v}" to be rejected`,
+      );
+    }
+  });
+
+  test('rejects adr that does not match ADR-NNN', () => {
+    for (const a of ['ADR-58', 'adr-058', 'ADR058', 'ADR-', 'XX-001']) {
+      assert.throws(
+        () => DbContractSchema.parse({ ...validFixture, adr: a }),
+        /adr/i,
+        `expected "${a}" to be rejected`,
+      );
+    }
+  });
+
+  test('rejects owner missing @, uppercase, or with extra slashes', () => {
+    for (const o of ['org/team', '@Org/Team', '@a/b/c', '@', 'no-prefix']) {
+      assert.throws(
+        () => DbContractSchema.parse(mut({ owner: o as never })),
+        /owner/i,
+        `expected "${o}" to be rejected`,
+      );
+    }
+  });
+
+  test('rejects table name without schema, with leading dot, or uppercase', () => {
+    for (const n of ['products', '.products', 'public.', 'Public.products', 'public..products']) {
+      assert.throws(
+        () => DbContractSchema.parse(mut({ name: n })),
+        /table name/i,
+        `expected "${n}" to be rejected`,
+      );
+    }
+  });
+
+  test('rejects criticality outside the enum', () => {
+    for (const c of ['low', 'medium', 'P0', '']) {
+      assert.throws(
+        () => DbContractSchema.parse(mut({ criticality: c as never })),
+        `expected criticality "${c}" to be rejected`,
+      );
+    }
+  });
+
+  test('rejects empty allowed/forbidden surface arrays (min(1))', () => {
+    assert.throws(() => DbContractSchema.parse(mut({ allowed_access_surfaces: [] as never })));
+    assert.throws(() => DbContractSchema.parse(mut({ forbidden_access_surfaces: [] as never })));
+  });
+
+  test('rejects tables: [] (min(1)) and tables.length > 20 (max(20))', () => {
+    assert.throws(() => DbContractSchema.parse({ ...validFixture, tables: [] }));
+    const tooMany = Array.from({ length: 21 }, (_, i) => ({
+      ...validFixture.tables[0],
+      name: `public.t_${i}`,
+    }));
+    assert.throws(() => DbContractSchema.parse({ ...validFixture, tables: tooMany }));
+  });
+
+  test('rejects notes longer than 500 chars', () => {
+    assert.throws(() => DbContractSchema.parse(mut({ notes: 'x'.repeat(501) })));
+  });
+});
+
 describe('DbContractSchema — cross-contract (ADR-062 §Cross-contract deps)', () => {
   test('every db.yaml table.domain exists in domains.yaml', () => {
     const c = loadRealContract();
@@ -123,6 +200,11 @@ describe('DbContractSchema — anti-parallel-truth (ADR-062 Loi B)', () => {
   //   - rlsEnabled / row policies → migrations + audit/registry/db.json
   //   - deletePolicy             → delete-policy.yaml
   //   - rowCount / size metrics  → audit/registry/db.json
+  //   - row security              → migrations (ADR-021)
+  // Postgres ecosystem favors snake_case, so the regex must catch both
+  // styles (rowCount + row_count, rlsEnabled + rls_enabled, etc.). The
+  // sentinel test below pins positive hits so future edits stay honest.
+  //
   // Two angles, on purpose:
   //   1. Structural-key visitor — catches any nested key matching the banned
   //      pattern at any depth, even if values would happen to be empty.
@@ -130,7 +212,27 @@ describe('DbContractSchema — anti-parallel-truth (ADR-062 Loi B)', () => {
   //      structural string VALUES too (e.g. an enum literal sneaking in).
   // `notes` strings are stripped before the serialized scan to allow narrative
   // pointers ("service_role grant via DO block …") without false positives.
-  const BANNED = /(rls[A-Z_]?enabled|deletePolicy|rowCount|policy)/i;
+  const BANNED =
+    /(rls[_A-Z]?enabled|delete[_A-Z]?policy|row[_A-Z]?count|polic(?:y|ies)|row[_A-Z]?security)/i;
+
+  test('regex sentinel: BANNED catches both camelCase and snake_case spellings', () => {
+    const positives = [
+      'rlsEnabled', 'rls_enabled', 'RLS_enabled',
+      'rowCount', 'row_count', 'ROW_COUNT',
+      'deletePolicy', 'delete_policy',
+      'policy', 'policies',
+      'rowSecurity', 'row_security',
+    ];
+    const negatives = [
+      'service_role', 'grant', 'updated_at', 'enabled_at', 'delete_button',
+    ];
+    for (const p of positives) {
+      assert.ok(BANNED.test(p), `expected BANNED to match "${p}"`);
+    }
+    for (const n of negatives) {
+      assert.ok(!BANNED.test(n), `expected BANNED NOT to match "${n}"`);
+    }
+  });
 
   test('committed contract has no banned facts as structural keys (any depth)', () => {
     const c = loadRealContract();

--- a/packages/registry/src/bin/build-db-contract-artifacts.ts
+++ b/packages/registry/src/bin/build-db-contract-artifacts.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { load as parseYaml } from 'js-yaml';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import {
+  DbContractSchema,
+  type DbContract,
+} from '../canonical/db-contract';
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const YAML_PATH = path.join(
+  REPO_ROOT,
+  '.spec/00-canon/repository-registry/db.yaml',
+);
+const SCHEMA_OUT = path.join(
+  REPO_ROOT,
+  '.spec/00-canon/_schema/db.schema.json',
+);
+
+// Modern CLI pattern: pure logic throws, shell boundary catches in main()'s try/catch.
+class DbContractBuildError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'DbContractBuildError';
+  }
+}
+
+function fail(msg: string): never {
+  throw new DbContractBuildError(msg);
+}
+
+// Supported Node majors. This generator uses pure JSON.stringify (ECMA-262 stable)
+// over zodToJsonSchema()'s deterministic output — no util.inspect() dependency,
+// so output is byte-identical across 20.x and 22.x. Extend after re-running
+// determinism on any new major (Node 24+ should be re-verified).
+const SUPPORTED_NODE_MAJORS = ['20', '22'];
+
+{
+  const currentMajor = process.versions.node.split('.')[0];
+  if (!SUPPORTED_NODE_MAJORS.includes(currentMajor)) {
+    console.error(
+      `[db-contract:build] ABORT — Node ${process.version} unsupported. ` +
+        `Supported majors: v${SUPPORTED_NODE_MAJORS.join(', v')}.x. ` +
+        `Use nvm/volta to switch, or extend SUPPORTED_NODE_MAJORS after re-running determinism tests.`,
+    );
+    process.exit(2);
+  }
+}
+
+// Runtime version guard for zod compatibility with zod-to-json-schema.
+{
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const zodPkg = require('zod/package.json') as { version: string };
+  if (!zodPkg.version.startsWith('3.')) {
+    console.error(
+      `[db-contract:build] ABORT — zod v${zodPkg.version} unsupported (expected 3.x). ` +
+        'See packages/registry/package.json runtime deps.',
+    );
+    process.exit(2);
+  }
+}
+
+function loadContract(): { contract: DbContract; yamlSha256: string } {
+  const raw = readFileSync(YAML_PATH, 'utf8');
+  const yamlSha256 = createHash('sha256').update(raw).digest('hex');
+  const parsed = parseYaml(raw);
+  // Hardening: js-yaml will happily return a string, an array, or null for malformed
+  // / multi-document / scalar-rooted YAMLs.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    fail(
+      `db.yaml root must be a single object map, got ${
+        parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed
+      }. Check for accidental document separators ("---") or stray top-level lists.`,
+    );
+  }
+  const result = DbContractSchema.safeParse(parsed);
+  if (!result.success) {
+    const lines = ['db contract does not match schema:'];
+    for (const issue of result.error.issues) {
+      const where = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+      lines.push(`  • ${where}: ${issue.message}`);
+    }
+    fail(lines.join('\n'));
+  }
+  return { contract: result.data, yamlSha256 };
+}
+
+function emitJsonSchema(yamlSha256: string, tableCount: number): string {
+  const schema = zodToJsonSchema(DbContractSchema, {
+    name: 'DbContract',
+    target: 'jsonSchema7',
+  });
+  // Forensic markers — make audit/origin self-evident from the artifact alone.
+  // Stored under $comment (JSON Schema 7 reserved key, ignored by validators).
+  const enriched = {
+    $comment: [
+      'AUTO-GENERATED — DO NOT EDIT. Source: .spec/00-canon/repository-registry/db.yaml',
+      `sourceSha256: ${yamlSha256}`,
+      `generator: @repo/registry bin "build-db-contract-artifacts"`,
+      `nodeMajor: ${SUPPORTED_NODE_MAJORS.join('|')}`,
+      `tableCount: ${tableCount}`,
+      'regenerate: npm run db-contract:build',
+    ].join(' | '),
+    ...schema,
+  };
+  return JSON.stringify(enriched, null, 2) + '\n';
+}
+
+function main(): void {
+  // 1. Load + schema validation (throws DbContractBuildError on malformed YAML).
+  const { contract, yamlSha256 } = loadContract();
+
+  // 2. Pure compute of artifacts (no IO).
+  const schemaJson = emitJsonSchema(yamlSha256, contract.tables.length);
+
+  // 3. IO writes (the ONLY place in the bin that touches the filesystem).
+  mkdirSync(path.dirname(SCHEMA_OUT), { recursive: true });
+  writeFileSync(SCHEMA_OUT, schemaJson, 'utf8');
+
+  console.log(
+    `[db-contract:build] OK — emitted ${path.relative(REPO_ROOT, SCHEMA_OUT)} (${contract.tables.length} tables, source SHA-256: ${yamlSha256.slice(0, 12)}…)`,
+  );
+}
+
+// Shell boundary: catch the typed error here and only here.
+try {
+  main();
+} catch (e) {
+  if (e instanceof DbContractBuildError) {
+    console.error(`[db-contract:build] ERROR — ${e.message}`);
+  } else {
+    console.error('[db-contract:build] UNEXPECTED ERROR —', e);
+  }
+  process.exit(1);
+}

--- a/packages/registry/src/canonical/db-contract.ts
+++ b/packages/registry/src/canonical/db-contract.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import { DomainIdSchema } from '../shared/domain';
+
+// V1 MINIMAL — 3 top-level fields only: schemaVersion, adr, tables[].
+// Everything else (column DDL, RLS state, deletePolicy, RPC signatures,
+// row counts, runtime metrics) belongs elsewhere — see db.yaml doctrine.
+// One file = one invariant kind. Adding fields here = ADR + schemaVersion bump.
+
+const SemverSchema = z
+  .string()
+  .regex(/^\d+\.\d+\.\d+$/, 'schemaVersion must be semver (X.Y.Z)');
+
+const AdrIdSchema = z
+  .string()
+  .regex(/^ADR-\d{3,}$/, 'adr must be ADR-NNN');
+
+// Reuse the canonical DomainIdSchema (D1..D15 + UNKNOWN) but reject UNKNOWN
+// in db.yaml: this file is a human-edited canon SoT — domains MUST be
+// explicit. UNKNOWN is only a Layer 1 auto-classification escape hatch.
+const ContractDomainSchema = DomainIdSchema.refine(
+  (d) => d !== 'UNKNOWN',
+  { message: 'db.yaml domains must be explicit (D1..D15) — UNKNOWN is forbidden in canon SoT' },
+);
+
+const OwnerSchema = z
+  .string()
+  .regex(/^@[a-z0-9-]+(\/[a-z0-9-]+)?$/, 'owner must be @org or @org/team');
+
+// Table name in `schema.name` form (Postgres lowercase; underscores allowed,
+// leading underscore allowed for private tables like __seo_page).
+const TableNameSchema = z
+  .string()
+  .regex(/^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*$/, 'table name must be schema.name (lowercase)');
+
+const AccessSurfaceSchema = z.enum([
+  'backend',
+  'rpc',
+  'frontend',
+  'anon',
+  'authenticated',
+  'service_role',
+  'edge_function',
+  'worker',
+]);
+
+const CriticalitySchema = z.enum(['critical', 'high', 'normal']);
+
+const TableSchema = z
+  .object({
+    name: TableNameSchema,
+    domain: ContractDomainSchema,
+    owner: OwnerSchema,
+    criticality: CriticalitySchema,
+    allowed_access_surfaces: z.array(AccessSurfaceSchema).min(1).max(8),
+    forbidden_access_surfaces: z.array(AccessSurfaceSchema).min(1).max(8),
+    notes: z.string().max(500).optional(),
+  })
+  .strict()
+  .superRefine((t, ctx) => {
+    const overlap = t.allowed_access_surfaces.filter((s) =>
+      t.forbidden_access_surfaces.includes(s),
+    );
+    if (overlap.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `allowed_access_surfaces and forbidden_access_surfaces overlap on "${t.name}": ${[...new Set(overlap)].join(', ')}`,
+        path: ['allowed_access_surfaces'],
+      });
+    }
+  });
+
+export const DbContractSchema = z
+  .object({
+    schemaVersion: SemverSchema,
+    adr: AdrIdSchema,
+    tables: z.array(TableSchema).min(1).max(20),
+  })
+  .strict()
+  .superRefine((c, ctx) => {
+    const names = c.tables.map((t) => t.name);
+    const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+    if (dupes.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate table.name: ${[...new Set(dupes)].join(', ')}`,
+        path: ['tables'],
+      });
+    }
+  });
+
+export type DbContract = z.infer<typeof DbContractSchema>;
+export {
+  TableSchema,
+  AccessSurfaceSchema,
+  CriticalitySchema,
+  OwnerSchema,
+  TableNameSchema,
+};

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -91,3 +91,14 @@ export {
   LayerSchema,
   type ArchitectureContract,
 } from "./canonical/architecture-contract";
+
+// ── DB contract (PR-3a) ──
+export {
+  DbContractSchema,
+  TableSchema,
+  AccessSurfaceSchema,
+  CriticalitySchema,
+  OwnerSchema,
+  TableNameSchema,
+  type DbContract,
+} from "./canonical/db-contract";


### PR DESCRIPTION
This PR introduces a read-only DB Contract V1. It documents critical database ownership and allowed access surfaces. It does not change SQL, RLS, runtime behavior, or production access paths.

## 6-commit recap (ADR-062 §1..§6 pattern, mirror of PR #507)

| § | Commit | What |
|---|--------|------|
| §1 | `48330a0d` | Zod `DbContractSchema` V4-minimal strict — 3 top-level fields. Reuses canonical `DomainIdSchema` (D1..D15) and refines out `UNKNOWN` for canon SoT |
| §2 | `82a7cede` | Canon `db.yaml` — 8 P0/P1 tables (D11 money path, D3 SEO, D4 vehicles, D1 catalog, D7 KG). Doctrine header lists 7 explicit out-of-scope items |
| §3 | `c27b7035` | Generator + npm scripts (`db-contract:build` root / `build:db-contract` workspace) + schema mirror gitignore. Mirrors `build-architecture-artifacts.ts` exactly |
| §4 | `e1bc4a24` | 10 integrity tests via `node:test` — round-trip on real YAML, fixture negatives, cross-contract domain check, anti-parallel-truth (keys + serialized) |
| §5 | `f9aa65a7` | CI hookup in `audit.yml` (sibling of `architecture:build`, no continue-on-error, no new freshness gate) |
| §6 | `3a654957` | Size invariants test (3 cases) + architecture.yaml doctrine pointer cleanup (`use db.yaml (PR-3)` → `see db.yaml`) |

Total: 13 tests pass locally (10 integrity + 3 size). Generator deterministic.

## ADR-062 conformity (9 concepts + 2 Lois)

- [x] **Contract** — `db.yaml` is human-edited SoT
- [x] **Generator** — deterministic, SHA-256 verified
- [x] **Derived artifact** — `_schema/db.schema.json` gitignored, regenerable
- [x] **Enforcement engine** — Zod round-trip + cross-link to `domains.yaml`
- [x] **Freshness gate** — explicitly deferred to PR-3b (doctrine header)
- [x] **Ratchet** — explicitly deferred to PR-3b/3c/3d (doctrine header)
- [x] **Ownership** — parent glob `.spec/00-canon/repository-registry/**` covers db.yaml (no duplicate entry — Loi B)
- [x] **Semver** — `schemaVersion: "1.0.0"` (initial release pinned)
- [x] **Anti-parallel-truth** — no `rlsEnabled`/`deletePolicy`/`rowCount` in db.yaml (tested at key-level and serialized-body level)
- [x] **Loi A** — contract not derived from `audit/registry/db.json`
- [x] **Loi B** — generated artifact gitignored

## Out of scope (deliberately deferred)

| Item | Where | When |
|---|---|---|
| `audit/registry/db-contract.generated.json` committed | PR-3b | After ≥ 3 green CI runs on main |
| Freshness gate in `registry-fresh.yml` (warn-only, ratchet) | PR-3b | Same |
| Audit script real-access vs contract (report only) | PR-3c | After PR-3b ratchet ticks |
| Ratchet on **new** access surfaces only | PR-3d | After PR-3c reports N=10 clean merges |
| SQL migration / RLS policy change | **Never in this series** | Separate ADR-021 follow-ons |
| Runtime guard / ast-grep block | **Never in this series** | Separate ADR + sunset path |

## Implementation deviations from approved plan (transparent)

1. **Test runner**: `node:test` via `tsx --test` (the existing `@repo/registry` runner). The plan said vitest — vitest is not installed in this workspace; node:test is the established pattern.
2. **Schema reuse**: `DomainIdSchema` imported from `shared/domain` (anti parallel-truth) instead of redefining the regex.
3. **Script naming**: `db-contract:build` root + `build:db-contract` workspace — mirrors the exact PR #507 pattern (`architecture:build` / `build:architecture`).
4. **CI placement**: step added to `audit.yml` (sibling of `architecture:build`), not to `registry-build.yml`. Aligns with PR #507's placement: contract generators (Layer 2 overlay regen) live in audit.yml; `registry-build.yml` is reserved for Layer 1 auto-inventory builders.
5. **ownership.yaml**: NOT amended. The existing parent glob `.spec/00-canon/repository-registry/**` already covers db.yaml. Adding a specific entry would create a parallel-truth (Loi B).
6. **Test count**: 13 vs plan's 11 (added explicit UNKNOWN-domain rejection + split round-trip into per-invariant cases for sharper failure messages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)