### PR TITLE
chore(ci): wire @repo/registry contract tests into audit.yml (W3, warn-only)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -79,6 +79,32 @@ jobs:
       # RATCHET DEADLINE — mechanical expiration via env var + date check.
       # After the deadline, the STEP fails visibly (red ✘ in the CI summary, ::error::
       # in the log), but the WORKFLOW still passes because `continue-on-error: true` is
+      # V1. The visible failure is the social signal forcing PR-W3b to land. PR-W3b
+      # removes `continue-on-error: true` to make this gate workflow-blocking.
+      #
+      # TODO_REMOVE_IN: PR-W3b
+      #   - Delete `continue-on-error: true` below.
+      #   - Delete the `REGISTRY_TESTS_WARN_ONLY_UNTIL` env block.
+      #   - Delete the date-check `if` line in the run script.
+      #   Refusing this PR after the deadline means knowingly accepting permanent dead code.
+      - name: 📋 @repo/registry contract tests (architecture + db, warn-only)
+        if: always()
+        continue-on-error: true
+        env:
+          REGISTRY_TESTS_WARN_ONLY_UNTIL: "2026-06-15"
+        run: |
+          # 1) Mechanical ratchet — after the deadline, the step fails visibly.
+          if [ "$(date +%F)" \> "$REGISTRY_TESTS_WARN_ONLY_UNTIL" ]; then
+            echo "::error::warn-only deadline ($REGISTRY_TESTS_WARN_ONLY_UNTIL) expired — open PR-W3b to remove continue-on-error: true and make this gate workflow-blocking."
+            exit 2
+          fi
+
+          # 2) Run the workspace test suite (node:test via tsx).
+          npm -w @repo/registry test
+
+      # RATCHET DEADLINE — mechanical expiration via env var + date check.
+      # After the deadline, the STEP fails visibly (red ✘ in the CI summary, ::error::
+      # in the log), but the WORKFLOW still passes because `continue-on-error: true` is
       # V1. The visible failure is the social signal forcing PR-3b to land. PR-3b removes
       # `continue-on-error: true` to make this gate workflow-blocking.
       # ADRs/comments without auto-expiration always become permanent dead code; the


### PR DESCRIPTION
Wires the 79 test cases in `@repo/registry` into CI as a warn-only step in `audit.yml`. They currently pass locally but were not executed by any workflow since PR #507 — a Zod schema regression would slip past review.

Closes the test-execution gap for **PR-2 (architecture-contract, 5 cases)** and **PR-3a (db-contract, 22 cases)** plus pre-existing shared/entries/overlay schemas (~52 cases). No new contract, no new artifact, no enforcement.

## What this PR does

- Adds **one step** in `.github/workflows/audit.yml`, after `db-contract:build`, running `npm -w @repo/registry test`.
- `continue-on-error: true` — warn-only initial. Failures surface as red ✘ in the CI summary + `::error::` annotation, but do not block merge.
- Ratchet env `REGISTRY_TESTS_WARN_ONLY_UNTIL=2026-06-15` + `TODO_REMOVE_IN: PR-W3b` marker → soft gate cannot decay into permanent dead code.

## What this PR does NOT do

- ❌ No new contract (= contracts roadmap).
- ❌ No new artifact (= PR-3b).
- ❌ No hard-gate enforcement (= PR-W3b after observation).
- ❌ No change to the test files themselves — only wires what exists.

## Local verification

```
$ npm -w @repo/registry test
# tests 79 | suites 26 | pass 79 | fail 0 | duration_ms 480
```

## Constraints honored (per execution GO)

- [x] step AFTER `db-contract:build` (line 77 → new step at line 90)
- [x] `continue-on-error: true` visible (line 92)
- [x] `REGISTRY_TESTS_WARN_ONLY_UNTIL: "2026-06-15"` visible (line 94)
- [x] `TODO_REMOVE_IN: PR-W3b` present with 3-bullet promotion checklist (line 85)
- [x] tests themselves untouched (only audit.yml diff, +26 LOC)

## Sequence context

Per memory `repository-contract-series-canon-20260514.md`:
Contract (PR-2 #507, PR-3a #511) → **validate (this PR-W3)** → observe → audit → ratchet (PR-W3b) → enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)