### PR TITLE
docs(audit): generator determinism cross-Node evidence (W4)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -67,6 +67,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: high
+  - glob: audit-reports/**
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   - glob: audit/unreachable-modules/**
     domain: D15
     owner: '@ak125'

--- a/audit-reports/generator-determinism-2026-05-14.md
+++ b/audit-reports/generator-determinism-2026-05-14.md
@@ -1,0 +1,56 @@
+# Generator determinism cross-audit — 2026-05-14 (W4)
+
+> One-shot empirical audit of canon generator determinism across the Node
+> majors each generator claims to support. **Informational only — no CI
+> gate, no enforcement, no generator code change.** Follow-up decisions
+> (e.g. tightening `SUPPORTED_NODE_MAJORS`) belong in separate PRs.
+
+## Scope
+
+| Generator | Source | Output artifact | Claimed Node majors |
+|---|---|---|---|
+| `architecture:build` | `packages/registry/src/bin/build-architecture-artifacts.ts` (PR #507) | `.spec/00-canon/_schema/architecture.schema.json` | `22` |
+| `db-contract:build` | `packages/registry/src/bin/build-db-contract-artifacts.ts` (PR #511) | `.spec/00-canon/_schema/db.schema.json` | `20`, `22` |
+
+## Host metadata
+
+- Repo HEAD: `e56ebd34` (2026-05-14T15:06:23+02:00)
+- Branch: `chore/w4-generator-determinism-audit`
+- Docker version: `Docker version 29.1.2, build 890dcca`
+- Audit runner Node: `v20.19.6` (host)
+- `node:22-slim` digest: `node@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e`
+- `node:20-slim` digest: `node@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0`
+
+## Same-Node determinism (double-run SHA compare)
+
+| Generator | Node major | Run 1 SHA-256 (12) | Run 2 SHA-256 (12) | Same-Node determinism |
+|---|---|---|---|---|
+| architecture | 22 | b2077b43d654… | b2077b43d654… | ✓ deterministic |
+| db-contract | 20 | 28bc94dcc246… | 28bc94dcc246… | ✓ deterministic |
+| db-contract | 22 | 28bc94dcc246… | 28bc94dcc246… | ✓ deterministic |
+
+## Cross-Node-major byte-equality (per generator)
+
+| Generator | Node A | Node B | SHA-256 A (12) | SHA-256 B (12) | Cross-Node byte-equality |
+|---|---|---|---|---|---|
+| db-contract | 20 | 22 | 28bc94dcc246… | 28bc94dcc246… | ✓ byte-equal |
+
+## Conclusion
+
+Both generators are byte-deterministic on every Node major they claim to support. `architecture:build` reproduces byte-identical output across two consecutive Node 22 runs. `db-contract:build` reproduces byte-identical output on both Node 20 and Node 22 independently *and* produces the same artifact bytes across the two majors — the `SUPPORTED_NODE_MAJORS = ['20', '22']` claim is empirically validated. No divergence detected at any of the four observed pairs.
+
+## Recommendations (textual — no code change in this PR)
+
+- No generator change required. Leave `SUPPORTED_NODE_MAJORS` arrays as-is in both generators.
+- Before PR-3b commits `audit/registry/db-contract.generated.json`, re-run this script from the PR-3b branch and append the resulting SHAs as a new dated report under `audit-reports/`. The freshness gate PR-3b plans to introduce will diff *that* committed artifact against the regenerated one; a re-confirmation guards against silent CI baseline drift.
+- For every future canon generator added under `packages/registry/src/bin/` (RPC, runtime, workers, SEO surface, …), append its tuple to the `GENERATORS` array in `scripts/audit/check-generator-determinism.sh` and re-run W4 before merging that contract's PR. The audit script is the canonical "what's covered" registry for determinism evidence.
+- No promotion of W4 into a recurring CI gate. The audit is one-shot evidence; an ongoing gate is a different decision (out of W4 scope, would require its own ADR/plan).
+- If a future re-run surfaces a divergence (cross-Node ✘ or same-Node ✘), open a defect-fix PR named PR-W4b with the *minimum* fix (typically a 1-line tightening of `SUPPORTED_NODE_MAJORS`) — do not bundle it with anything else.
+
+## Reproduce
+
+```bash
+bash scripts/audit/check-generator-determinism.sh
+```
+
+The script is idempotent and safe to re-run; it only regenerates the gitignored `_schema/*.schema.json` mirrors on the host filesystem. Cost ~15s on a warm Docker layer cache (node:22-slim + node:20-slim already pulled).

--- a/scripts/audit/check-generator-determinism.sh
+++ b/scripts/audit/check-generator-determinism.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# scripts/audit/check-generator-determinism.sh
+#
+# W4 cross-Node generator determinism audit. One-shot, no CI gate.
+#
+# For each supported generator × supported Node major, runs the generator
+# twice and reports the SHA-256 of the output artifact. Also reports the
+# cross-Node-major byte-equality status where multiple majors are supported.
+#
+# Prints a markdown report on stdout suitable for paste into
+# audit-reports/generator-determinism-*.md.
+#
+# Exit status:
+#   0 always — W4 is informational. A divergence is reported in the table
+#              but does NOT fail the script. Decisions are deferred to a
+#              separate PR after human review.
+#
+# Reproduce:  bash scripts/audit/check-generator-determinism.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Configuration. To extend with a new generator, append a tuple:
+#   name|workspace_script|artifact_path|supported_node_majors_csv
+GENERATORS=(
+  "architecture|build:architecture|.spec/00-canon/_schema/architecture.schema.json|22"
+  "db-contract|build:db-contract|.spec/00-canon/_schema/db.schema.json|20,22"
+)
+
+# Run a single generator inside a node:<major>-slim container and emit the
+# sha256 of the produced artifact to stdout.
+#
+# Side effects:
+#   - regenerates `_schema/*.schema.json` mirrors (gitignored — safe to leave).
+#   - regenerates `.dependency-cruiser.generated.cjs` (COMMITTED). The audit
+#     restores it to its committed state at the end (see RESTORE_PATHS).
+#
+# The generators are pure JS (zod, zod-to-json-schema, js-yaml, tsx — no
+# native bindings), so a host-built node_modules works inside the
+# container regardless of Node major.
+run_in_node() {
+  local node_major="$1"
+  local workspace_script="$2"
+  local artifact_path="$3"
+
+  docker run --rm \
+    -v "$REPO_ROOT:/app" \
+    -w /app \
+    --entrypoint /bin/sh \
+    "node:${node_major}-slim" \
+    -c "npm --workspace=@repo/registry run --silent ${workspace_script} >/dev/null 2>&1 \
+        && sha256sum ${artifact_path} | awk '{print \$1}'" \
+    2>/dev/null
+}
+
+emit_table_header() {
+  cat <<'EOF'
+| Generator | Node major | Run 1 SHA-256 (12) | Run 2 SHA-256 (12) | Same-Node determinism |
+|---|---|---|---|---|
+EOF
+}
+
+emit_cross_node_header() {
+  cat <<'EOF'
+
+| Generator | Node A | Node B | SHA-256 A (12) | SHA-256 B (12) | Cross-Node byte-equality |
+|---|---|---|---|---|---|
+EOF
+}
+
+emit_row() {
+  local gen="$1"
+  local major="$2"
+  local sha1="$3"
+  local sha2="$4"
+  local same="$5"
+  printf '| %s | %s | %s… | %s… | %s |\n' \
+    "$gen" "$major" "${sha1:0:12}" "${sha2:0:12}" "$same"
+}
+
+emit_cross_row() {
+  local gen="$1"
+  local major_a="$2"
+  local major_b="$3"
+  local sha_a="$4"
+  local sha_b="$5"
+  local equal="$6"
+  printf '| %s | %s | %s | %s… | %s… | %s |\n' \
+    "$gen" "$major_a" "$major_b" "${sha_a:0:12}" "${sha_b:0:12}" "$equal"
+}
+
+# Map of "<generator>@<major>" → single-run sha (filled during pass 1, used
+# by the cross-Node section).
+declare -A SAMPLE_SHA
+
+echo "## Same-Node determinism (double-run SHA compare)"
+echo
+emit_table_header
+
+for entry in "${GENERATORS[@]}"; do
+  IFS='|' read -r name script artifact majors_csv <<<"$entry"
+  IFS=',' read -ra majors <<<"$majors_csv"
+  for major in "${majors[@]}"; do
+    sha1="$(run_in_node "$major" "$script" "$artifact")"
+    sha2="$(run_in_node "$major" "$script" "$artifact")"
+    if [[ "$sha1" == "$sha2" ]]; then
+      verdict="✓ deterministic"
+    else
+      verdict="✘ DIVERGENCE"
+    fi
+    SAMPLE_SHA["${name}@${major}"]="$sha1"
+    emit_row "$name" "$major" "$sha1" "$sha2" "$verdict"
+  done
+done
+
+echo
+echo "## Cross-Node-major byte-equality (per generator)"
+
+emit_cross_node_header
+
+for entry in "${GENERATORS[@]}"; do
+  IFS='|' read -r name script artifact majors_csv <<<"$entry"
+  IFS=',' read -ra majors <<<"$majors_csv"
+  if [[ "${#majors[@]}" -lt 2 ]]; then
+    continue
+  fi
+  # Compare all unordered pairs.
+  for ((i=0; i<${#majors[@]}-1; i++)); do
+    for ((j=i+1; j<${#majors[@]}; j++)); do
+      a="${majors[$i]}"
+      b="${majors[$j]}"
+      sha_a="${SAMPLE_SHA["${name}@${a}"]}"
+      sha_b="${SAMPLE_SHA["${name}@${b}"]}"
+      if [[ "$sha_a" == "$sha_b" ]]; then
+        verdict="✓ byte-equal"
+      else
+        verdict="✘ DIVERGENCE"
+      fi
+      emit_cross_row "$name" "$a" "$b" "$sha_a" "$sha_b" "$verdict"
+    done
+  done
+done
+
+# Restore committed generator outputs to their original state. The audit
+# is informational; the generator runs above are evidence collection, not
+# canonical regeneration. Restoring keeps `git status` clean after the
+# script and lets contributors run W4 without dirtying the working tree.
+RESTORE_PATHS=(
+  ".dependency-cruiser.generated.cjs"
+)
+for p in "${RESTORE_PATHS[@]}"; do
+  if [[ -e "$p" ]]; then
+    git checkout -- "$p" 2>/dev/null || true
+  fi
+done
+
+echo
+echo "## Reproduce"
+echo
+echo '```bash'
+echo "bash scripts/audit/check-generator-determinism.sh"
+echo '```'


### PR DESCRIPTION
**This PR is informational only.** No generator code changed, no CI gate added, no enforcement, no `SUPPORTED_NODE_MAJORS` modification. Decisions surfaced by the audit (if any) belong to follow-up PRs.

## What the audit found

| Generator | Node major | Same-Node | Cross-Node 20↔22 |
|---|---|---|---|
| `architecture:build` | 22 (only claim) | ✓ deterministic | n/a |
| `db-contract:build` | 20 | ✓ deterministic | ✓ byte-equal |
| `db-contract:build` | 22 | ✓ deterministic | ✓ byte-equal |

All four observed pairs green. `db-contract`'s claim `SUPPORTED_NODE_MAJORS = ['20', '22']` empirically validated via Docker (`node:22-slim` + `node:20-slim`).

## Files added

| File | Purpose |
|---|---|
| `scripts/audit/check-generator-determinism.sh` | Reusable audit runner. Single `GENERATORS` array; future contracts append one tuple to extend coverage. Restores committed generator outputs (e.g. `.dependency-cruiser.generated.cjs`) to leave `git status` clean. |
| `audit-reports/generator-determinism-2026-05-14.md` | Frozen evidence: scope, host metadata (Docker version + image digests + HEAD SHA), result tables, conclusion, recommendations (textual only — no code action). |

## Scope discipline (per execution GO)

- [x] zero edit to `packages/registry/src/bin/*.ts` (generators)
- [x] zero edit to `.github/workflows/*.yml` (no CI gate added)
- [x] zero edit to `package.json` (no new script/dep)
- [x] zero edit to `.spec/00-canon/repository-registry/*.yaml` **except** a 5-line ownership glob for `audit-reports/**` — required by the ADR-058 PR-G block-new gate (`.husky/pre-push` refused the push without it). Documented in commit `7fee360a`. Smallest possible registry-overlay change to unblock W4.
- [x] zero promotion of W4 into a recurring CI gate
- [x] zero hidden decision — recommendations are textual, any change lives in a separate PR

## Constraints honored

- ✅ Audit transversal PR-2 + PR-3a
- ✅ Docker Node 20/22 — both images pulled, both runs successful
- ✅ SHA-256 double-run compare per-major + cross-major
- ✅ Dated report frozen at HEAD `e56ebd34`
- ✅ No gate / no promotion / no hidden decision
- ✅ Idempotent script — repeated runs leave repo state clean (verified)

## Recommendations (textual, in the report)

1. Leave both generators untouched. `SUPPORTED_NODE_MAJORS` arrays stand as-is.
2. Before PR-3b commits `audit/registry/db-contract.generated.json`, re-run the script from the PR-3b branch and append the SHAs as a new dated report.
3. Every future canon generator must append a tuple to the script's `GENERATORS` array + re-run W4 before merging.
4. No promotion of W4 into a CI gate (one-shot evidence vs ongoing enforcement = different decisions).
5. Any discovered divergence opens its own minimal PR-W4b — no bundling.

## Sequence context

Per memory `repository-contract-series-canon-20260514.md`:
Contract (PR-2 #507, PR-3a #511) → validate (W3 #512) → **audit (this PR-W4)** → ratchet (PR-W3b, PR-3b) → enforce.

## Reproduce

\`\`\`bash
bash scripts/audit/check-generator-determinism.sh
\`\`\`

~15s on a warm Docker layer cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)