### PR TITLE
chore(seo-roles): PR-3b promote ast-grep `seo-no-bare-role-literal` warn → error (bare forms only)

### DIFF
--- a/.ast-grep/rules/seo-no-bare-role-literal.yml
+++ b/.ast-grep/rules/seo-no-bare-role-literal.yml
@@ -1,6 +1,6 @@
 id: seo-no-bare-role-literal
 language: typescript
-severity: warning
+severity: error
 message: |
   Bare SEO role literal in OUTPUT context. Use canonical full name
   (R3_CONSEILS, R6_GUIDE_ACHAT, R6_SUPPORT, etc.) or call normalizeRoleId()
@@ -11,14 +11,24 @@ message: |
   packages/seo-roles/README.md.
 
   If this is a legacy DB filter, test fixture, or mapping reference, add
-  the file to the `files` exclusion list below with a comment explaining why.
+  the file to the `ignores:` list below with a comment explaining why.
 note: |
   Replace  '"R3"'  with  PageRole.R3_CONSEILS  (frontend)
        or  RoleId.R3_CONSEILS  (backend)
        or  normalizeRoleId(input)  if input is dynamic.
 
-  PR-3a (this rule) is `severity: warning` initially. Promotion to `error`
-  happens in PR-3b after 7 days of clean observation.
+  PR-3a shipped this rule with `severity: warning` (observe-only,
+  commit 0a792dcc, 2026-05-05).
+  PR-3b 2026-05-14 promoted to `severity: error` after empirical
+  clean observation : `ast-grep scan` returned 0 findings on the full
+  corpus for the bare-form patterns below. No code change needed
+  beyond this severity flip.
+
+  Note : the eslint `no-restricted-syntax` selector that catches the
+  *suffixed* legacy forms (R3_BLOG, R6_BUYING_GUIDE, …) remains at
+  `warn` deliberately. Promoting it would surface 11 files with mixed
+  legitimate / debt patterns (canon-defining Zod enums, INPUT switch
+  handlers, legacy DTOs) — audit work tracked as separate PR-3c.
 files:
   # ── Apply to frontend + backend TypeScript ──
   - backend/src/**/*.ts


### PR DESCRIPTION
## Summary

Minimal scope : `.ast-grep/rules/seo-no-bare-role-literal.yml` severity `warning` → `error`. **1 file, +14/-4 lines**. ESLint untouched.

## Why minimal

The earlier multi-commit attempt (later force-pushed away) included an ESLint `'no-restricted-syntax': ['warn', …]` → `['error', …]` flip that proved to be bricolage in disguise :

1. The ESLint block conflates 2 unrelated concerns — Tailwind responsive utilities and SEO legacy literals — at the same severity. Flipping to `error` surfaced a false positive on attribute selectors inside Tailwind arbitrary-value classnames (`command.tsx:28`, the `[&_[cmdk-group]:not([hidden])_~...]` pattern). Patching the regex with `(?<!\[)` lookbehind was regex-on-regex bricolage.

2. Absorbing the suffixed legacy forms (`R3_BLOG / R6_BUYING_GUIDE / R3_guide / …`) into ast-grep so the ESLint regex selector could be retired surfaced **61 findings across 11 files** (canon-defining Zod enums, INPUT switch handlers, legacy DTOs). Each requires per-file legitimate-vs-debt audit before it can be exempted or migrated.

Both follow-up workstreams belong to a separate **PR-3c** (audit + architectural split), not to a 7-day-trigger lint promotion.

## What this PR does

- `.ast-grep/rules/seo-no-bare-role-literal.yml` — `severity: warning` → `severity: error`.
- Note section updated to record the empirical 0-findings baseline AND the deliberate deferral of the ESLint suffixed-form promotion.

That's the only change.

## Pre-flight empirical (canon `feedback_decision_must_be_signal_proven_not_intuited`)

```
$ node_modules/.bin/ast-grep scan \
    --rule .ast-grep/rules/seo-no-bare-role-literal.yml \
    frontend/app backend/src
# → 0 rule findings (exit 0)
```

## What this PR does NOT do (deferred to PR-3c)

- ❌ No ESLint `no-restricted-syntax` severity flip.
- ❌ No regex lookbehind hack for the responsive selector.
- ❌ No file exemptions added to ast-grep beyond the existing list.
- ❌ No absorption of suffixed legacy forms.
- ❌ No migration of the 11 files surfaced by the absorption probe.

## Test plan

- [x] ast-grep scan = 0 rule findings on full corpus (verified locally with pinned ast-grep@0.42.2)
- [ ] CI ast-grep job passes
- [ ] CI eslint job passes (unchanged from main)
- [ ] No regression in `__regression__/seo-role-canon-guard.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)