### PR TITLE
feat(registry): Dependency Governance Contract V1 (PR-D)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -87,6 +87,17 @@ jobs:
         if: always()
         run: npm run runtime-contract:build
 
+      - name: 📦 Dep governance — regenerate IDE schema mirror (PR-D)
+        # Mirror of runtime-contract:build pattern. Pure regen of
+        # .spec/00-canon/_schema/dep-governance.schema.json (gitignored).
+        # If Zod parse / cross-contract test fails, surfaces a real bug in
+        # dep-governance.yaml. No committed artifact; no freshness gate yet
+        # — V2 may add a license/version-policy contract + gate.
+        # The @repo/registry test step below (warn-only via PR-W3 #512) picks
+        # up the new dep-governance-contract.test.ts cases automatically.
+        if: always()
+        run: npm run dep-governance:build
+
       # RATCHET DEADLINE — mechanical expiration via env var + date check.
       # After the deadline, the STEP fails visibly (red ✘ in the CI summary, ::error::
       # in the log), but the WORKFLOW still passes because `continue-on-error: true` is

--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,4 @@ audit/registry/cache/
 .spec/00-canon/_schema/architecture.schema.json
 .spec/00-canon/_schema/db.schema.json
 .spec/00-canon/_schema/runtime-topology.schema.json
+.spec/00-canon/_schema/dep-governance.schema.json

--- a/.spec/00-canon/repository-registry/dep-governance.yaml
+++ b/.spec/00-canon/repository-registry/dep-governance.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=../_schema/dep-governance.schema.json
+# .spec/00-canon/repository-registry/dep-governance.yaml
+#
+# AutoMecanik monorepo — canonical dependency governance contract (PR-D, ADR-058 follow-on).
+#
+# The `# yaml-language-server:` directive above links this YAML to its generated
+# JSON Schema mirror for IDE validation (RedHat YAML extension / Helix LSP / etc.).
+# The path is RELATIVE so it resolves correctly in worktrees / sub-checkouts. The
+# schema file is gitignored — run `npm run dep-governance:build` after a fresh
+# clone to populate it.
+#
+# ──────────────────────────────────────────────────────────────────────────────────
+#  DOCTRINE — read before adding anything to this file
+# ──────────────────────────────────────────────────────────────────────────────────
+#  This file holds NPM DEPENDENCY CLASSIFICATION INVARIANTS ONLY. It is NOT a
+#  dumping ground.
+#
+#  Do NOT add to this file:
+#    × license restrictions / SPDX policy → use `license-policy.yaml` (canon roadmap)
+#    × version range hygiene / lockfile rules → use `version-policy.yaml` or renovate
+#    × CVE / vulnerability info → use `audit-ci` / `npm audit` output
+#    × workspace deps (@fafa/*, @repo/*) → see `architecture.yaml` boundaries
+#    × phantom-dep prevention (transitive imports declared) → use dependency-cruiser rule
+#    × cross-family forbidden imports → V2 cross-contract with architecture.yaml/ownership.yaml
+#    × runtime entrypoint metadata → see `runtime-topology.yaml`
+#    × DB tables / RLS → see `db.yaml`
+#    × extraction confidence / source classification → it lives in L1 (audit/registry/deps.json)
+#
+#  If you're tempted to add a section that isn't a DEPENDENCY CLASSIFICATION
+#  INVARIANT, open a NEW contract file instead.
+#
+#  FUTURE-SPLIT WARNING:
+#  If a section starts describing INSTANCE-LEVEL config (a specific package's
+#  pinned exact version, a CVE allowlist, a license exception) instead of
+#  CLASSIFICATION (which canonical family does this dep belong to, who owns it,
+#  which domain consumes it), STOP and create a dedicated contract file.
+# ──────────────────────────────────────────────────────────────────────────────────
+#
+# V1 COVERAGE: this contract protects ONE invariant —
+#   the **canonical classification of npm dependencies** by functional family,
+#   with stable ownership and primary consuming domain.
+#
+# It does NOT cover license enforcement, version-range hygiene, CVE policy,
+# workspace deps, phantom-dep prevention, or cross-family forbidden imports —
+# those are dedicated contracts / tools.
+#
+# L1 ALIGNMENT:
+#   `id` format = `npm:<name>@<version>` (matches Layer 1 audit/registry/deps.json
+#   produced by scripts/registry/build-deps-registry.js, 232 entries verified
+#   2026-05-14). Cross-contract test §4.2 verifies that every L2 id appears in
+#   L1 (subset, not equivalence).
+#
+# ID-NAME COHERENCE:
+#   `id` MUST encode `name`: stripping the `npm:` prefix and the `@version`
+#   suffix from `id` MUST equal the `name` field. Enforced by Zod superRefine.
+#
+# WORKFLOW
+#   Edit this YAML → run `npm run dep-governance:build` → commit ONLY the YAML.
+#   The JSON schema mirror at `.spec/00-canon/_schema/dep-governance.schema.json`
+#   is gitignored, regenerated at each build.
+
+schemaVersion: "1.0.0"
+adr: ADR-058
+
+dependencies:
+  # V1 STUB — single entry to prove schema integrity (test §4.1) and
+  # cross-contracts (§4.2 L1 / §4.3 domains / §4.4 ownership / §4.5 family).
+  # Will be enriched to ~30 sample entries (multi-family, multi-domain)
+  # in a follow-up commit within PR-D.
+  - id: "npm:zod@^3.25.76"
+    name: "zod"
+    family: validation
+    domain: D14                          # Gamme Aggregates (cross-cutting; zod used everywhere)
+    owner: "@ak125"
+    notes: "Universal runtime validation; used in every workspace + canon contracts."

--- a/.spec/00-canon/repository-registry/dep-governance.yaml
+++ b/.spec/00-canon/repository-registry/dep-governance.yaml
@@ -63,13 +63,166 @@ schemaVersion: "1.0.0"
 adr: ADR-058
 
 dependencies:
-  # V1 STUB — single entry to prove schema integrity (test §4.1) and
-  # cross-contracts (§4.2 L1 / §4.3 domains / §4.4 ownership / §4.5 family).
-  # Will be enriched to ~30 sample entries (multi-family, multi-domain)
-  # in a follow-up commit within PR-D.
+  # V1 SAMPLE — 26 npm deps from L1 audit/registry/deps.json (226 npm total),
+  # selected so ALL 7 cross-contract tests pass (§4.1-§4.7).
+  # Selection criteria:
+  #   - Status LIVE only
+  #   - Source = npm (workspace deps out of V1 scope — covered by architecture.yaml)
+  #   - Name matches a heuristic family rule (regex-based dispatch)
+  #   - Owner = @ak125 (universal default; granular per-team owners V2)
+  # Diversification: 11 of 14 families covered (3 per family where possible).
+  #
+  # V1 GAPS — families RESERVED (no representative dep, intentional):
+  #   - vehicle  : TecDoc-equivs not yet extracted as deps
+  #   - payments : paybox/systempay are HTTP-only integrations, no SDK dep
+  #   - other    : escape hatch only, no permanent residents
+  # Test §4.5 RESERVED_V1 array documents this.
+
+  # ── auth (3 entries — D11) ──
+  - id: "npm:bcrypt@^6.0.0"
+    name: "bcrypt"
+    family: auth
+    domain: D11
+    owner: "@ak125"
+  - id: "npm:passport-jwt@^4.0.1"
+    name: "passport-jwt"
+    family: auth
+    domain: D11
+    owner: "@ak125"
+  - id: "npm:passport-local@^1.0.0"
+    name: "passport-local"
+    family: auth
+    domain: D11
+    owner: "@ak125"
+
+  # ── backend-platform (3 entries — D14) ──
+  - id: "npm:@nestjs/bull@^10.2.3"
+    name: "@nestjs/bull"
+    family: backend-platform
+    domain: D14
+    owner: "@ak125"
+  - id: "npm:@nestjs/bullmq@^11.0.4"
+    name: "@nestjs/bullmq"
+    family: backend-platform
+    domain: D14
+    owner: "@ak125"
+  - id: "npm:@nestjs/cache-manager@^2.3.0"
+    name: "@nestjs/cache-manager"
+    family: backend-platform
+    domain: D14
+    owner: "@ak125"
+
+  # ── build-tooling (2 entries — D13) ──
+  - id: "npm:tsx@^4.20.6"
+    name: "tsx"
+    family: build-tooling
+    domain: D13
+    owner: "@ak125"
+    notes: "Backend version of tsx; root has @^4.7.0 (different version range)."
+  - id: "npm:turbo@^2.9.12"
+    name: "turbo"
+    family: build-tooling
+    domain: D13
+    owner: "@ak125"
+
+  # ── db (1 entry — D1) ──
+  - id: "npm:@supabase/supabase-js@^2.95.0"
+    name: "@supabase/supabase-js"
+    family: db
+    domain: D1
+    owner: "@ak125"
+
+  # ── dev-tooling (3 entries — D13) ──
+  - id: "npm:@types/bcrypt@^6.0.0"
+    name: "@types/bcrypt"
+    family: dev-tooling
+    domain: D13
+    owner: "@ak125"
+  - id: "npm:@types/bcryptjs@^2.4.6"
+    name: "@types/bcryptjs"
+    family: dev-tooling
+    domain: D13
+    owner: "@ak125"
+  - id: "npm:@types/body-parser@^1.19.5"
+    name: "@types/body-parser"
+    family: dev-tooling
+    domain: D13
+    owner: "@ak125"
+
+  # ── frontend-ui (3 entries — D8) ──
+  - id: "npm:@radix-ui/react-accordion@^1.2.12"
+    name: "@radix-ui/react-accordion"
+    family: frontend-ui
+    domain: D8
+    owner: "@ak125"
+  - id: "npm:@radix-ui/react-avatar@^1.1.11"
+    name: "@radix-ui/react-avatar"
+    family: frontend-ui
+    domain: D8
+    owner: "@ak125"
+  - id: "npm:@radix-ui/react-collapsible@^1.1.12"
+    name: "@radix-ui/react-collapsible"
+    family: frontend-ui
+    domain: D8
+    owner: "@ak125"
+
+  # ── observability (3 entries — D10) ──
+  - id: "npm:@sentry/nestjs@^10.51.0"
+    name: "@sentry/nestjs"
+    family: observability
+    domain: D10
+    owner: "@ak125"
+  - id: "npm:@sentry/remix@^10.51.0"
+    name: "@sentry/remix"
+    family: observability
+    domain: D10
+    owner: "@ak125"
+  - id: "npm:pino-pretty@^13.1.3"
+    name: "pino-pretty"
+    family: observability
+    domain: D10
+    owner: "@ak125"
+
+  # ── rag (2 entries — D6) ──
+  - id: "npm:@anthropic-ai/sdk@^0.71.0"
+    name: "@anthropic-ai/sdk"
+    family: rag
+    domain: D6
+    owner: "@ak125"
+  - id: "npm:openai@^4.104.0"
+    name: "openai"
+    family: rag
+    domain: D6
+    owner: "@ak125"
+
+  # ── seo (1 entry — D3) ──
+  - id: "npm:meilisearch@^0.52.0"
+    name: "meilisearch"
+    family: seo
+    domain: D3
+    owner: "@ak125"
+
+  # ── testing (3 entries — D13) ──
+  - id: "npm:@axe-core/playwright@^4.11.3"
+    name: "@axe-core/playwright"
+    family: testing
+    domain: D13
+    owner: "@ak125"
+  - id: "npm:@testing-library/jest-dom@^6.6.3"
+    name: "@testing-library/jest-dom"
+    family: testing
+    domain: D13
+    owner: "@ak125"
+  - id: "npm:@testing-library/react@^16.3.0"
+    name: "@testing-library/react"
+    family: testing
+    domain: D13
+    owner: "@ak125"
+
+  # ── validation (1 entry — D14) ──
   - id: "npm:zod@^3.25.76"
     name: "zod"
     family: validation
-    domain: D14                          # Gamme Aggregates (cross-cutting; zod used everywhere)
+    domain: D14
     owner: "@ak125"
     notes: "Universal runtime validation; used in every workspace + canon contracts."

--- a/audit-reports/dep-governance-v1-coverage-2026-05-14.md
+++ b/audit-reports/dep-governance-v1-coverage-2026-05-14.md
@@ -1,0 +1,137 @@
+# Dependency Governance Contract V1 — Coverage Report (PR-D)
+
+> Generated 2026-05-14 during PR-D implementation.
+> Mirror of `runtime-contract-v1-coverage-2026-05-14.md` (PR-5 #519) evidence pattern.
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| L1 entries (`audit/registry/deps.json`) | **232** total (226 npm + 6 workspace) |
+| V1 canon sample (`dep-governance.yaml`) | **26 npm deps** (≈ 11.5 % of npm L1) |
+| Soft threshold (test §4.6) | < 500 |
+| Schema sanity cap (Zod `.max()`) | 2000 |
+| Cross-contract tests passing | 7/7 (19/19 test cases) |
+| Determinism (test §4.7) | byte-identical across runs |
+| Families covered | 11 of 14 (3 RESERVED V1) |
+
+## L1 source distribution (232 entries, verified 2026-05-14)
+
+```
+npm      : 226 (97.4 %)
+workspace:   6 ( 2.6 %)
+github   :   0
+git      :   0
+```
+
+PR-D V1 scope = **npm only** (workspace deps are covered by architecture.yaml boundaries).
+
+## Family classification (V1 sample — 26 entries / 14 families)
+
+| Family | Count V1 | Domain | Status |
+|---|---|---|---|
+| `auth`              | 3 | D11 | ✅ covered |
+| `backend-platform`  | 3 | D14 | ✅ covered |
+| `build-tooling`     | 2 | D13 | ✅ covered |
+| `db`                | 1 | D1  | ✅ covered |
+| `dev-tooling`       | 3 | D13 | ✅ covered |
+| `frontend-ui`       | 3 | D8  | ✅ covered |
+| `observability`     | 3 | D10 | ✅ covered |
+| `rag`               | 2 | D6  | ✅ covered |
+| `seo`               | 1 | D3  | ✅ covered |
+| `testing`           | 3 | D13 | ✅ covered |
+| `validation`        | 1 | D14 | ✅ covered |
+| `vehicle`           | 0 | D4  | 🔒 RESERVED V1 (TecDoc-equivs not yet extracted) |
+| `payments`          | 0 | D11 | 🔒 RESERVED V1 (paybox/systempay HTTP-only) |
+| `other`             | 0 | —   | 🔒 RESERVED V1 (escape hatch only, no permanent residents) |
+
+Test §4.5 RESERVED_V1 array enforces this — adding a `vehicle` or `payments` dep V1.5 requires updating both YAML + RESERVED_V1 simultaneously.
+
+## V1 selection methodology
+
+Heuristic regex-based dispatch from package name → family + domain:
+
+```
+^bcrypt|^passport|^jose|^jsonwebtoken         → auth / D11
+^@nestjs/|^express|^reflect-metadata|^rxjs    → backend-platform / D14
+^@supabase|^postgres|^pg|^drizzle             → db / D1
+^zod|^ajv|^joi                                → validation / D14
+^@anthropic-ai/|^openai|^@qdrant              → rag / D6
+^@sentry|^pino|^opentelemetry                 → observability / D10
+^react|^@remix-run|^@radix-ui|^tailwindcss    → frontend-ui / D8
+^typescript|^prettier|^eslint|^husky|^@types/ → dev-tooling / D13
+^vite|^turbo|^tsx|^esbuild                    → build-tooling / D13
+^vitest|^@testing-library|^playwright         → testing / D13
+^meilisearch                                  → seo / D3
+```
+
+Where multiple deps match per family, the script picks up to 3 (alphabetically). Owner = `@ak125` universal default for V1.
+
+## Cross-contract test summary (19 cases passing)
+
+| Test | Status | What it enforces |
+|---|---|---|
+| §4.1 schema integrity (12 sub-tests) | ✅ | Zod parse OK + 10 negative paths (extra fields rejected, malformed id/name/owner/family rejected, UNKNOWN domain rejected, id-name mismatch rejected, duplicate id/name rejected) |
+| §4.2 cross-contract L1 | ✅ | Every contract `id` exists in `audit/registry/deps.json` |
+| §4.3 cross-contract domains.yaml | ✅ | Every `domain` is declared in domains.yaml |
+| §4.4 cross-contract ownership.yaml | ✅ | Every `owner` appears as `owner:` in ownership.yaml entries |
+| §4.5 family enum coverage | ✅ | Every non-reserved FamilyIdSchema value used by ≥ 1 dep |
+| §4.6 size warning | ✅ | `dependencies.length=26` < 500 soft threshold |
+| §4.7 determinism | ✅ | Two consecutive `npm run dep-governance:build` produce byte-identical schema.json |
+
+## Anti-parallel-truth checklist (canon §46 Loi B)
+
+- ✅ `FamilyIdSchema` — NEW shared at `packages/registry/src/shared/family.ts` (the ONLY new shared schema in PR-D)
+- ✅ `DomainIdSchema` REUSED from `shared/domain.ts` + `.refine()` to forbid UNKNOWN in canon
+- ✅ `OwnerIdSchema` REUSED from `shared/owner.ts` (created in PR-5 #519)
+- ✅ L1 `DepEntrySchema` shape consulted to align id format (`npm:<name>@<version>`)
+- ✅ Inline regex for DepIdSchema accepts SemVer-range chars (verified all 226 npm L1 ids fit)
+- ✅ 7 L1 fields explicitly omitted: source, version, workspaces, declaredIn, status, sourceConfidence, per-entry schemaVersion (extraction concerns, not invariants)
+
+## Scope discipline (PR-D V1 explicitly OUT)
+
+- License enforcement → `license-policy.yaml` + license-checker tool (V2 candidate)
+- Version range hygiene (^ vs exact) → `version-policy.yaml` or renovate (V2 candidate)
+- CVE / vulnerability scanning → `audit-ci` / `npm audit` output (existing tools, not in canon)
+- Workspace deps (@fafa/*, @repo/*) → architecture.yaml boundaries (already covered)
+- Phantom-dep prevention (transitive imports declared) → dependency-cruiser rule (V2)
+- Cross-family forbidden imports (e.g., backend-platform must not import frontend-ui) → V2 cross-contract with architecture.yaml + ownership.yaml
+
+## Files shipped in PR-D
+
+| Path | LOC | Role |
+|---|---|---|
+| `packages/registry/src/shared/family.ts` | 47 | NEW shared FamilyIdSchema |
+| `packages/registry/src/canonical/dep-governance-contract.ts` | 110 | L3 Zod schema |
+| `packages/registry/src/__tests__/dep-governance-contract.test.ts` | 320 | 19 test cases |
+| `packages/registry/src/bin/build-dep-governance-artifacts.ts` | 110 | L3 generator |
+| `.spec/00-canon/repository-registry/dep-governance.yaml` | 230 | L2 canon YAML |
+| `audit-reports/dep-governance-v1-coverage-2026-05-14.md` | 130 | This file |
+| `.github/workflows/audit.yml` (+1 step) | +11 | CI hookup |
+| `.gitignore` (+1 line) | +1 | dep-governance.schema.json gitignored |
+| `packages/registry/package.json` (+1 script) | +1 | build:dep-governance |
+| `package.json` (+1 script) | +1 | dep-governance:build delegation |
+| `packages/registry/src/index.ts` (+1 export) | +1 | FamilyIdSchema exported |
+
+## V2 roadmap
+
+Preconditions (mirror PR-3b §52-57 / PR-5b in canon):
+1. PR-D merged + ≥ 3 green `audit.yml` runs on main with `dep-governance:build` step.
+2. No flaky test on `dep-governance-contract.test.ts`.
+3. ≥ 1 contributor PR has touched `dep-governance.yaml` correctly.
+4. Explicit V2 cadrage + new ADR if scope changes.
+
+V2 candidate enrichments:
+- Add `vehicle` and `payments` deps if/when SDKs are introduced.
+- Extend V1 sample from 26 → ~80 entries (still well under 500 soft threshold).
+- Per-team owners (replace universal `@ak125` with `@ak125/auth-team`, `@ak125/seo-team`, etc.).
+- Cross-family forbidden imports (V2 cross-contract).
+- License field (V2 contract or separate license-policy.yaml).
+
+## Refs
+
+- PR-D plan : `/home/deploy/.claude/plans/dependency-governance-contract-v1-2026-05-14.md`
+- Canon series : `repository-contract-series-canon-20260514.md`
+- PR-2 #507 (architecture V1) + PR-3a #511 (db V1) + PR-5 #519 (runtime V1)
+- PR-W3 #512 (registry tests warn-only) + PR-W4 #513 (generator determinism evidence)
+- ADR-058 (Repository Contract System)

--- a/log.md
+++ b/log.md
@@ -645,3 +645,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-cp-synthetic-crawler`
 - **Décision** : fix(seo-cp): add -- APPROVED: comments to DROP statements (CI migration safety gate) (+4 other commits)
 - **Sortie** : PR #516 | commits b2489e5e d8002a36 824d0dfc 7e84c3ee dba46e79
+
+## 2026-05-14 — feat/dep-governance-v1-clean (auto)
+
+- **Branche** : `feat/dep-governance-v1-clean`
+- **Décision** : feat(registry): dep governance contract V1 scaffold + 14 test cases (PR-D §1+§2+§4) (+1 other commit)
+- **Sortie** : PR aucune | commits 640377c1 21cbb039

--- a/log.md
+++ b/log.md
@@ -651,3 +651,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/dep-governance-v1-clean`
 - **Décision** : feat(registry): dep governance contract V1 scaffold + 14 test cases (PR-D §1+§2+§4) (+1 other commit)
 - **Sortie** : PR aucune | commits 640377c1 21cbb039
+
+## 2026-05-14 — feat/dep-governance-v1-clean (auto)
+
+- **Branche** : `feat/dep-governance-v1-clean`
+- **Décision** : feat(registry): dep governance generator + npm scripts (PR-D §3+§5) (+3 other commits)
+- **Sortie** : PR aucune | commits 0496d5b4 17ab0348 640377c1 21cbb039

--- a/log.md
+++ b/log.md
@@ -646,14 +646,26 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Décision** : fix(seo-cp): add -- APPROVED: comments to DROP statements (CI migration safety gate) (+4 other commits)
 - **Sortie** : PR #516 | commits b2489e5e d8002a36 824d0dfc 7e84c3ee dba46e79
 
-## 2026-05-14 — feat/dep-governance-v1-clean (auto)
+## 2026-05-14 — feat/adr-063-cwv-ingestion-v2 (auto)
 
-- **Branche** : `feat/dep-governance-v1-clean`
-- **Décision** : feat(registry): dep governance contract V1 scaffold + 14 test cases (PR-D §1+§2+§4) (+1 other commit)
-- **Sortie** : PR aucune | commits 640377c1 21cbb039
+- **Branche** : `feat/adr-063-cwv-ingestion-v2`
+- **Décision** : fix(seo-crux): prettier formatting + jest transformIgnore for @repo/seo-types (+1 other commit)
+- **Sortie** : PR #518 | commits ea602630 dd75d842
 
-## 2026-05-14 — feat/dep-governance-v1-clean (auto)
+## 2026-05-14 — feat/adr-063-cwv-ingestion-v2 (auto)
 
-- **Branche** : `feat/dep-governance-v1-clean`
-- **Décision** : feat(registry): dep governance generator + npm scripts (PR-D §3+§5) (+3 other commits)
-- **Sortie** : PR aucune | commits 0496d5b4 17ab0348 640377c1 21cbb039
+- **Branche** : `feat/adr-063-cwv-ingestion-v2`
+- **Décision** : fix(seo-crux): jest moduleNameMapper for @repo/seo-types workspace symlink (+3 other commits)
+- **Sortie** : PR #518 | commits f03a0252 26c34086 ea602630 dd75d842
+
+## 2026-05-14 — feat/adr-063-cwv-ingestion-v2 (auto)
+
+- **Branche** : `feat/adr-063-cwv-ingestion-v2`
+- **Décision** : test(seo-crux): skip fake-timer retry+circuit-breaker tests (CI timeout) (+5 other commits)
+- **Sortie** : PR #518 | commits f07a4990 44181f8c f03a0252 26c34086 ea602630 dd75d842
+
+## 2026-05-14 — feat/adr-063-cwv-ingestion-v2 (auto)
+
+- **Branche** : `feat/adr-063-cwv-ingestion-v2`
+- **Décision** : test(seo-crux): minimize to sync-only coverage (3 tests) (+7 other commits)
+- **Sortie** : PR #518 | commits 08142888 e5c6864b f07a4990 44181f8c f03a0252 26c34086 ea602630 dd75d842

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "architecture:test": "tsx --test tests/registry/architecture-generator.test.ts",
     "depcruise:integrity-test": "tsx --test tests/registry/depcruise-integrity.test.ts",
     "db-contract:build": "npm -w @repo/registry run build:db-contract",
-    "runtime-contract:build": "npm -w @repo/registry run build:runtime-contract"
+    "runtime-contract:build": "npm -w @repo/registry run build:runtime-contract",
+    "dep-governance:build": "npm -w @repo/registry run build:dep-governance"
   },
   "keywords": [],
   "author": "",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -13,6 +13,7 @@
     "build:architecture": "tsx src/bin/build-architecture-artifacts.ts",
     "build:db-contract": "tsx src/bin/build-db-contract-artifacts.ts",
     "build:runtime-contract": "tsx src/bin/build-runtime-contract-artifacts.ts",
+    "build:dep-governance": "tsx src/bin/build-dep-governance-artifacts.ts",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test src/**/*.test.ts"
   },

--- a/packages/registry/src/__tests__/dep-governance-contract.test.ts
+++ b/packages/registry/src/__tests__/dep-governance-contract.test.ts
@@ -1,0 +1,352 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { load as parseYaml } from "js-yaml";
+import {
+  DepGovernanceContractSchema,
+  type DepGovernanceContract,
+} from "../canonical/dep-governance-contract";
+import { FamilyIdSchema } from "../shared/family";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tests for dep-governance.yaml — Repository Contract V1 (PR-D).
+// Mirrors runtime-contract.test.ts pattern. node:test via tsx --test.
+//
+// 8+ test cases:
+//   §4.1  schema integrity (positive + negatives)
+//   §4.2  cross-contract L1 deps.json id match
+//   §4.3  cross-contract domains.yaml
+//   §4.4  cross-contract ownership.yaml owner FK
+//   §4.5  family enum coverage (every family declared in schema is used OR documented as reserved)
+//   §4.6  size warning soft threshold (entries.length < 500)
+//   §4.7  determinism (build twice, byte-identical)
+// ──────────────────────────────────────────────────────────────────────────
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const YAML_PATH = path.join(
+  REPO_ROOT,
+  ".spec/00-canon/repository-registry/dep-governance.yaml",
+);
+
+function loadRealContract(): DepGovernanceContract {
+  const raw = readFileSync(YAML_PATH, "utf8");
+  const parsed = parseYaml(raw);
+  return DepGovernanceContractSchema.parse(parsed);
+}
+
+// V1 MINIMAL fixture for negative-path tests.
+const validFixture = {
+  schemaVersion: "1.0.0",
+  adr: "ADR-058",
+  dependencies: [
+    {
+      id: "npm:zod@^3.25.76",
+      name: "zod",
+      family: "validation",
+      domain: "D14",
+      owner: "@ak125",
+    },
+  ],
+};
+
+describe("§4.1 schema integrity — real dep-governance.yaml", () => {
+  test("parses and validates", () => {
+    const contract = loadRealContract();
+    assert.equal(contract.schemaVersion, "1.0.0");
+    assert.match(contract.adr, /^ADR-\d{3,}$/);
+    assert.ok(
+      contract.dependencies.length >= 1,
+      "must declare at least 1 dependency",
+    );
+    assert.ok(
+      contract.dependencies.length <= 2000,
+      `dependencies.length=${contract.dependencies.length} exceeds sanity cap 2000`,
+    );
+  });
+
+  test("every entry has the 5 required fields (id, name, family, domain, owner)", () => {
+    const contract = loadRealContract();
+    for (const dep of contract.dependencies) {
+      assert.ok(dep.id, "missing id");
+      assert.ok(dep.name, "missing name");
+      assert.ok(dep.family, "missing family");
+      assert.ok(dep.domain, "missing domain");
+      assert.ok(dep.owner, "missing owner");
+    }
+  });
+});
+
+describe("§4.1 schema integrity — fixture-based negative paths", () => {
+  test("rejects extra top-level field (.strict() at root)", () => {
+    const tampered = { ...validFixture, extra: "smuggled" };
+    assert.equal(DepGovernanceContractSchema.safeParse(tampered).success, false);
+  });
+
+  test("rejects extra field on dep entry (.strict() at entry level)", () => {
+    const tampered = {
+      ...validFixture,
+      dependencies: [
+        { ...validFixture.dependencies[0], license: "MIT" },
+      ],
+    };
+    const result = DepGovernanceContractSchema.safeParse(tampered);
+    assert.equal(result.success, false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join("\n");
+      assert.match(messages, /license|unrecognized|extra/i);
+    }
+  });
+
+  test("rejects domain UNKNOWN (canon SoT must be explicit)", () => {
+    const tampered = {
+      ...validFixture,
+      dependencies: [{ ...validFixture.dependencies[0], domain: "UNKNOWN" }],
+    };
+    assert.equal(DepGovernanceContractSchema.safeParse(tampered).success, false);
+  });
+
+  test("rejects family not in canonical enum", () => {
+    const tampered = {
+      ...validFixture,
+      dependencies: [{ ...validFixture.dependencies[0], family: "frontend" }], // typo: should be frontend-ui
+    };
+    assert.equal(DepGovernanceContractSchema.safeParse(tampered).success, false);
+  });
+
+  test("rejects owner not matching @org or @org/team", () => {
+    const tampered = {
+      ...validFixture,
+      dependencies: [{ ...validFixture.dependencies[0], owner: "ak125" }],
+    };
+    assert.equal(DepGovernanceContractSchema.safeParse(tampered).success, false);
+  });
+
+  test("rejects id format not matching npm:<name>@<version>", () => {
+    const tampered = {
+      ...validFixture,
+      dependencies: [
+        { ...validFixture.dependencies[0], id: "zod@3.25.76" },
+      ],
+    };
+    assert.equal(DepGovernanceContractSchema.safeParse(tampered).success, false);
+  });
+
+  test("rejects id-name mismatch (id decodes to different name than name field)", () => {
+    const tampered = {
+      ...validFixture,
+      dependencies: [
+        {
+          ...validFixture.dependencies[0],
+          id: "npm:other-package@1.0.0",
+          name: "zod",
+        },
+      ],
+    };
+    const result = DepGovernanceContractSchema.safeParse(tampered);
+    assert.equal(result.success, false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join("\n");
+      assert.match(messages, /id-name mismatch/);
+    }
+  });
+
+  test("rejects duplicate dependency.id", () => {
+    const tampered = {
+      ...validFixture,
+      dependencies: [
+        validFixture.dependencies[0],
+        validFixture.dependencies[0],
+      ],
+    };
+    const result = DepGovernanceContractSchema.safeParse(tampered);
+    assert.equal(result.success, false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join("\n");
+      assert.match(messages, /Duplicate dependency.id/);
+    }
+  });
+
+  test("rejects duplicate dependency.name (different versions same package)", () => {
+    const tampered = {
+      ...validFixture,
+      dependencies: [
+        validFixture.dependencies[0],
+        { ...validFixture.dependencies[0], id: "npm:zod@^4.0.0" },
+      ],
+    };
+    const result = DepGovernanceContractSchema.safeParse(tampered);
+    assert.equal(result.success, false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message).join("\n");
+      assert.match(messages, /Duplicate dependency.name/);
+    }
+  });
+
+  test("accepts valid fixture (positive control)", () => {
+    assert.equal(DepGovernanceContractSchema.safeParse(validFixture).success, true);
+  });
+});
+
+describe("§4.2 cross-contract L1 — every contract id exists in audit/registry/deps.json", () => {
+  const L1_PATH = path.join(REPO_ROOT, "audit/registry/deps.json");
+
+  test("loads L1 deps registry", () => {
+    const raw = readFileSync(L1_PATH, "utf8");
+    const doc = JSON.parse(raw) as { entries: Array<{ id: string }> };
+    assert.ok(Array.isArray(doc.entries));
+    assert.ok(doc.entries.length > 0);
+  });
+
+  test("every contract dependency.id appears in L1 deps.json (subset)", () => {
+    const contract = loadRealContract();
+    const raw = readFileSync(L1_PATH, "utf8");
+    const l1 = JSON.parse(raw) as { entries: Array<{ id: string }> };
+    const l1Ids = new Set(l1.entries.map((e) => e.id));
+
+    const missing: string[] = [];
+    for (const dep of contract.dependencies) {
+      if (!l1Ids.has(dep.id)) missing.push(dep.id);
+    }
+
+    assert.equal(
+      missing.length,
+      0,
+      `${missing.length} contract deps NOT found in L1 deps.json: ${missing.slice(0, 5).join(", ")}${missing.length > 5 ? "…" : ""}. ` +
+        "Either the YAML drifted (version bumped in package.json) or L1 builder needs to re-run.",
+    );
+  });
+});
+
+describe("§4.3 cross-contract domains.yaml — every entry.domain is declared", () => {
+  const DOMAINS_PATH = path.join(
+    REPO_ROOT,
+    ".spec/00-canon/repository-registry/domains.yaml",
+  );
+
+  function loadDomainIds(): Set<string> {
+    const raw = readFileSync(DOMAINS_PATH, "utf8");
+    const doc = parseYaml(raw) as { entries: Array<{ id: string }> };
+    return new Set(doc.entries.map((e) => e.id));
+  }
+
+  test("every contract dependency.domain matches a domains.yaml entry id", () => {
+    const contract = loadRealContract();
+    const declaredDomains = loadDomainIds();
+
+    const unknown: string[] = [];
+    for (const dep of contract.dependencies) {
+      if (!declaredDomains.has(dep.domain)) {
+        unknown.push(`${dep.id} → domain=${dep.domain}`);
+      }
+    }
+
+    assert.equal(
+      unknown.length,
+      0,
+      `${unknown.length} deps reference undeclared domains: ${unknown.slice(0, 5).join(", ")}${unknown.length > 5 ? "…" : ""}`,
+    );
+  });
+});
+
+describe("§4.4 cross-contract ownership.yaml — owner FK enforcement", () => {
+  const OWNERSHIP_PATH = path.join(
+    REPO_ROOT,
+    ".spec/00-canon/repository-registry/ownership.yaml",
+  );
+
+  test("every contract dependency.owner appears as owner: in ownership.yaml entries", () => {
+    const contract = loadRealContract();
+    const raw = readFileSync(OWNERSHIP_PATH, "utf8");
+    const doc = parseYaml(raw) as { entries: Array<{ owner: string }> };
+    const declaredOwners = new Set(doc.entries.map((e) => e.owner));
+
+    const unknown: string[] = [];
+    for (const dep of contract.dependencies) {
+      if (!declaredOwners.has(dep.owner)) {
+        unknown.push(`${dep.id} → owner=${dep.owner}`);
+      }
+    }
+
+    assert.equal(
+      unknown.length,
+      0,
+      `${unknown.length} deps reference owners not declared in ownership.yaml: ${unknown.slice(0, 5).join(", ")}${unknown.length > 5 ? "…" : ""}. ` +
+        "OwnerIdSchema regex is permissive — this test is the runtime FK.",
+    );
+  });
+});
+
+describe("§4.5 family enum coverage — every family declared SHOULD be used", () => {
+  // Soft assertion: each family in FamilyIdSchema enum should be used by at least
+  // 1 dep, OR be documented as reserved (V1 may have unused families intentionally).
+  // This test surfaces dead enum values for V1.5 cleanup conversation, NOT a hard fail.
+  const RESERVED_V1: ReadonlyArray<string> = [
+    "vehicle",     // reserved — TecDoc-equivs not yet extracted
+    "payments",    // V1 may not have direct payment SDK if paybox is HTTP-only
+  ];
+
+  test("every non-reserved family in FamilyIdSchema is used by at least 1 dep", () => {
+    const contract = loadRealContract();
+    const usedFamilies = new Set(contract.dependencies.map((d) => d.family));
+    const allFamilies = FamilyIdSchema.options;
+
+    const unused = allFamilies.filter(
+      (f) => !usedFamilies.has(f) && !RESERVED_V1.includes(f),
+    );
+
+    assert.equal(
+      unused.length,
+      0,
+      `${unused.length} families declared but unused (and not reserved): ${unused.join(", ")}. ` +
+        "Either add at least one V1 dep with this family, or document as reserved in RESERVED_V1 array.",
+    );
+  });
+});
+
+describe("§4.6 size warning — soft threshold for ratchet conversation", () => {
+  const SOFT_THRESHOLD = 500;
+
+  test(`dependencies.length < ${SOFT_THRESHOLD} (operational threshold, not schema limit)`, () => {
+    const contract = loadRealContract();
+    assert.ok(
+      contract.dependencies.length < SOFT_THRESHOLD,
+      `dep-governance.yaml has ${contract.dependencies.length} dependencies (soft threshold: < ${SOFT_THRESHOLD}). ` +
+        "Soft threshold reached. Ratchet decision needed — bump threshold OR split " +
+        "dep-governance.yaml into per-family files (canon doctrine warns against monolithic dumps). " +
+        "Do NOT raise the Zod .max(2000) as a substitute.",
+    );
+  });
+});
+
+describe("§4.7 determinism — generator output is byte-identical across runs", () => {
+  const { execSync } = require("node:child_process");
+  const { createHash } = require("node:crypto");
+  const SCHEMA_OUT = path.join(
+    REPO_ROOT,
+    ".spec/00-canon/_schema/dep-governance.schema.json",
+  );
+
+  test("two consecutive builds produce the same schema.json bytes", () => {
+    execSync("npm run dep-governance:build", {
+      cwd: REPO_ROOT,
+      stdio: "pipe",
+    });
+    const first = readFileSync(SCHEMA_OUT);
+    const firstSha = createHash("sha256").update(first).digest("hex");
+
+    execSync("npm run dep-governance:build", {
+      cwd: REPO_ROOT,
+      stdio: "pipe",
+    });
+    const second = readFileSync(SCHEMA_OUT);
+    const secondSha = createHash("sha256").update(second).digest("hex");
+
+    assert.equal(
+      firstSha,
+      secondSha,
+      `Determinism broken: ${firstSha.slice(0, 12)} ≠ ${secondSha.slice(0, 12)}. ` +
+        "Mirror runtime-contract pattern.",
+    );
+  });
+});

--- a/packages/registry/src/__tests__/dep-governance-contract.test.ts
+++ b/packages/registry/src/__tests__/dep-governance-contract.test.ts
@@ -282,8 +282,9 @@ describe("§4.5 family enum coverage — every family declared SHOULD be used", 
   // 1 dep, OR be documented as reserved (V1 may have unused families intentionally).
   // This test surfaces dead enum values for V1.5 cleanup conversation, NOT a hard fail.
   const RESERVED_V1: ReadonlyArray<string> = [
-    "vehicle",     // reserved — TecDoc-equivs not yet extracted
-    "payments",    // V1 may not have direct payment SDK if paybox is HTTP-only
+    "vehicle",     // reserved — TecDoc-equivs not yet extracted as deps
+    "payments",    // paybox/systempay are HTTP-only integrations (no SDK dep V1)
+    "other",       // escape hatch only — no permanent residents per doctrine
   ];
 
   test("every non-reserved family in FamilyIdSchema is used by at least 1 dep", () => {

--- a/packages/registry/src/bin/build-dep-governance-artifacts.ts
+++ b/packages/registry/src/bin/build-dep-governance-artifacts.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { load as parseYaml } from "js-yaml";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import {
+  DepGovernanceContractSchema,
+  type DepGovernanceContract,
+} from "../canonical/dep-governance-contract";
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const YAML_PATH = path.join(
+  REPO_ROOT,
+  ".spec/00-canon/repository-registry/dep-governance.yaml",
+);
+const SCHEMA_OUT = path.join(
+  REPO_ROOT,
+  ".spec/00-canon/_schema/dep-governance.schema.json",
+);
+
+class DepGovernanceBuildError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "DepGovernanceBuildError";
+  }
+}
+
+function fail(msg: string): never {
+  throw new DepGovernanceBuildError(msg);
+}
+
+const SUPPORTED_NODE_MAJORS = ["20", "22"];
+
+{
+  const currentMajor = process.versions.node.split(".")[0];
+  if (!SUPPORTED_NODE_MAJORS.includes(currentMajor)) {
+    console.error(
+      `[dep-governance:build] ABORT — Node ${process.version} unsupported. ` +
+        `Supported majors: v${SUPPORTED_NODE_MAJORS.join(", v")}.x.`,
+    );
+    process.exit(2);
+  }
+}
+
+{
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const zodPkg = require("zod/package.json") as { version: string };
+  if (!zodPkg.version.startsWith("3.")) {
+    console.error(
+      `[dep-governance:build] ABORT — zod v${zodPkg.version} unsupported (expected 3.x).`,
+    );
+    process.exit(2);
+  }
+}
+
+function loadContract(): { contract: DepGovernanceContract; yamlSha256: string } {
+  const raw = readFileSync(YAML_PATH, "utf8");
+  const yamlSha256 = createHash("sha256").update(raw).digest("hex");
+  const parsed = parseYaml(raw);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    fail(
+      `dep-governance.yaml root must be a single object map, got ${
+        parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed
+      }.`,
+    );
+  }
+  const result = DepGovernanceContractSchema.safeParse(parsed);
+  if (!result.success) {
+    const lines = ["dep-governance contract does not match schema:"];
+    for (const issue of result.error.issues) {
+      const where = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+      lines.push(`  • ${where}: ${issue.message}`);
+    }
+    fail(lines.join("\n"));
+  }
+  return { contract: result.data, yamlSha256 };
+}
+
+function emitJsonSchema(yamlSha256: string, depCount: number): string {
+  const schema = zodToJsonSchema(DepGovernanceContractSchema, {
+    name: "DepGovernanceContract",
+    target: "jsonSchema7",
+  });
+  const enriched = {
+    $comment: [
+      "AUTO-GENERATED — DO NOT EDIT. Source: .spec/00-canon/repository-registry/dep-governance.yaml",
+      `sourceSha256: ${yamlSha256}`,
+      'generator: @repo/registry bin "build-dep-governance-artifacts"',
+      `nodeMajor: ${SUPPORTED_NODE_MAJORS.join("|")}`,
+      `dependencyCount: ${depCount}`,
+      "regenerate: npm run dep-governance:build",
+    ].join(" | "),
+    ...schema,
+  };
+  return JSON.stringify(enriched, null, 2) + "\n";
+}
+
+function main(): void {
+  const { contract, yamlSha256 } = loadContract();
+  const schemaJson = emitJsonSchema(yamlSha256, contract.dependencies.length);
+  mkdirSync(path.dirname(SCHEMA_OUT), { recursive: true });
+  writeFileSync(SCHEMA_OUT, schemaJson, "utf8");
+  console.log(
+    `[dep-governance:build] OK — emitted ${path.relative(REPO_ROOT, SCHEMA_OUT)} (${contract.dependencies.length} deps, source SHA-256: ${yamlSha256.slice(0, 12)}…)`,
+  );
+}
+
+try {
+  main();
+} catch (e) {
+  if (e instanceof DepGovernanceBuildError) {
+    console.error(`[dep-governance:build] ERROR — ${e.message}`);
+  } else {
+    console.error("[dep-governance:build] UNEXPECTED ERROR —", e);
+  }
+  process.exit(1);
+}

--- a/packages/registry/src/canonical/dep-governance-contract.ts
+++ b/packages/registry/src/canonical/dep-governance-contract.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import { DomainIdSchema } from "../shared/domain";
+import { OwnerIdSchema } from "../shared/owner";
+import { FamilyIdSchema } from "../shared/family";
+
+// V1 MINIMAL — 3 top-level fields only: schemaVersion, adr, dependencies[].
+// Everything else (license restrictions, version constraints, CVE info,
+// workspace deps, phantom-dep detection, cross-family forbidden imports)
+// belongs elsewhere — see dep-governance.yaml doctrine.
+//
+// Anti-parallel-truth (canon §46 Loi B):
+//   - family : reused from shared/family.ts (NEW shared in PR-D, 14 values)
+//   - domain : reused from shared/domain.ts (D1..D15, then refined to forbid UNKNOWN)
+//   - owner  : reused from shared/owner.ts (CodeOwners-style)
+//   - id     : aligned with L1 entries/dep-entry.ts format `npm:<name>@<version>`
+//
+// L2 ⊆ L1 + overlay:
+//   - L2 fields { id, name } are a subset of L1 DepEntry.
+//   - L2 adds 3 governance overlay fields { family, domain, owner } that L1
+//     cannot auto-extract (governance attribution).
+//   - L1 fields explicitly omitted from L2: source, version, workspaces,
+//     declaredIn, status, sourceConfidence, schemaVersion (per-entry) — these
+//     are extraction/runtime concerns, not invariants of governance.
+
+const SemverSchema = z
+  .string()
+  .regex(/^\d+\.\d+\.\d+$/, "schemaVersion must be semver (X.Y.Z)");
+
+const AdrIdSchema = z
+  .string()
+  .regex(/^ADR-\d{3,}$/, "adr must be ADR-NNN");
+
+// Reuse DomainIdSchema (D1..D15 + UNKNOWN) but reject UNKNOWN: this file is
+// a human-edited canon SoT — domains MUST be explicit. Mirror db-contract.ts:20
+// + runtime-contract.ts.
+const ContractDomainSchema = DomainIdSchema.refine(
+  (d) => d !== "UNKNOWN",
+  {
+    message:
+      "dep-governance.yaml domains must be explicit (D1..D15) — UNKNOWN is forbidden in canon SoT",
+  },
+);
+
+// L1 id format = `npm:<name>@<version>` (verified on audit/registry/deps.json
+// 232 entries). Strict format match enables cross-contract test §4.2.
+const DepIdSchema = z
+  .string()
+  .regex(
+    /^npm:[@a-zA-Z0-9._/-]+@[\w.\-+]+$/,
+    "id must be `npm:<name>@<version>` (matches L1 audit/registry/deps.json format)",
+  );
+
+const DepNameSchema = z
+  .string()
+  .regex(
+    /^[@a-zA-Z0-9._/-]+$/,
+    "name must be a valid npm package name (scoped or unscoped)",
+  );
+
+const DepGovernanceEntrySchema = z
+  .object({
+    id: DepIdSchema,
+    name: DepNameSchema,
+    family: FamilyIdSchema,         // canonical family classification (NEW)
+    domain: ContractDomainSchema,   // primary consuming domain (D1..D15)
+    owner: OwnerIdSchema,           // CodeOwners-style FK, runtime check via test §4.4b
+    notes: z.string().max(300).optional(),  // free-text rationale, e.g. "used by paybox-callback only"
+  })
+  .strict()
+  .superRefine((entry, ctx) => {
+    // id format must encode name: `npm:<name>@<version>` ⇒ stripped name matches `name` field.
+    const idName = entry.id.replace(/^npm:/, "").replace(/@[^@]+$/, "");
+    if (idName !== entry.name) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `id-name mismatch: id="${entry.id}" decodes name="${idName}" but name field is "${entry.name}"`,
+        path: ["id"],
+      });
+    }
+  });
+
+export const DepGovernanceContractSchema = z
+  .object({
+    schemaVersion: SemverSchema,
+    adr: AdrIdSchema,
+    // .max(2000) is a SANITY CAP only (defends against accidental import of
+    // a 50k file). The operational soft threshold (~500) is enforced by the
+    // size-warning test (§4.6) — that's where ratchet conversations happen.
+    dependencies: z.array(DepGovernanceEntrySchema).min(1).max(2000),
+  })
+  .strict()
+  .superRefine((c, ctx) => {
+    const ids = c.dependencies.map((d) => d.id);
+    const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
+    if (dupes.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate dependency.id: ${[...new Set(dupes)].join(", ")}`,
+        path: ["dependencies"],
+      });
+    }
+    const names = c.dependencies.map((d) => d.name);
+    const nameDupes = names.filter((n, i) => names.indexOf(n) !== i);
+    if (nameDupes.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate dependency.name (different versions same package — choose one): ${[...new Set(nameDupes)].join(", ")}`,
+        path: ["dependencies"],
+      });
+    }
+  });
+
+export type DepGovernanceContract = z.infer<typeof DepGovernanceContractSchema>;
+export type DepGovernanceEntry = z.infer<typeof DepGovernanceEntrySchema>;
+
+export {
+  DepGovernanceEntrySchema,
+  DepIdSchema,
+  DepNameSchema,
+  ContractDomainSchema,
+};

--- a/packages/registry/src/canonical/dep-governance-contract.ts
+++ b/packages/registry/src/canonical/dep-governance-contract.ts
@@ -43,10 +43,15 @@ const ContractDomainSchema = DomainIdSchema.refine(
 
 // L1 id format = `npm:<name>@<version>` (verified on audit/registry/deps.json
 // 232 entries). Strict format match enables cross-contract test §4.2.
+//
+// Version part accepts SemVer-range chars: `^`, `~`, `>=`, `<=`, `>`, `<`,
+// digits, dots, hyphens (prerelease), plus signs (build metadata), letters
+// (alpha/beta/rc tags). The `*` wildcard belongs to workspace: ids only and
+// is intentionally rejected here (PR-D V1 scope = npm only, not workspace).
 const DepIdSchema = z
   .string()
   .regex(
-    /^npm:[@a-zA-Z0-9._/-]+@[\w.\-+]+$/,
+    /^npm:[@a-zA-Z0-9._/-]+@[\^~><=a-zA-Z0-9._\-+]+$/,
     "id must be `npm:<name>@<version>` (matches L1 audit/registry/deps.json format)",
   );
 

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -28,6 +28,7 @@ export { RiskSchema, type Risk } from "./shared/risk";
 export { DeletePolicySchema, type DeletePolicy } from "./shared/delete-policy";
 export { DerivedFromSchema, type DerivedFrom } from "./shared/derived-from";
 export { OwnerIdSchema, type OwnerId } from "./shared/owner";
+export { FamilyIdSchema, type FamilyId } from "./shared/family";
 
 // ── Layer 1 entries (auto-generated) ──
 export { FileEntrySchema, type FileEntry } from "./entries/file-entry";

--- a/packages/registry/src/shared/family.ts
+++ b/packages/registry/src/shared/family.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+/**
+ * Canonical family classification for npm dependencies, used by
+ * `dep-governance.yaml` (PR-D, Repository Contract series) to attribute
+ * each npm package to a single functional bucket.
+ *
+ * Taxonomy rationale (V1):
+ *   - Where possible, mirror the existing `domains.yaml` D1..D15 boundaries
+ *     (auth ↔ D11, seo ↔ D3, rag ↔ D6, observability ↔ D10, etc.) so that
+ *     cross-contract validation between dep-governance and ownership.yaml
+ *     stays semantically aligned.
+ *   - Add transverse families that have no domain home (`dev-tooling`,
+ *     `build-tooling`, `testing`) — these are infrastructural, not
+ *     domain-specific.
+ *   - `other` is the explicit escape hatch for unclassifiables — every use
+ *     should be a flag for V1.5 enrichment, not a permanent home.
+ *
+ * V1 cap: 14 values. V1.5 may add new families WITHOUT a schema-version bump
+ * (Zod enums extend additively). Removing or renaming a value REQUIRES
+ * schemaVersion bump + ADR.
+ *
+ * Anti-parallel-truth (canon §46 Loi B): every contract that classifies
+ * npm deps MUST import this schema, never declare an inline enum.
+ *
+ * @see [[feedback_verify_shared_schemas_before_inventing_zod]]
+ * @see [[repository-contract-series-canon-20260514]] §46 Loi B
+ */
+export const FamilyIdSchema = z.enum([
+  "auth",              // bcrypt, passport, jose, jwt — D11 subset
+  "payments",          // paybox SDK, systempay, stripe-equivs — D11 subset
+  "seo",               // schema-org libs, sitemap generators — D3
+  "rag",               // anthropic-sdk, qdrant client, openai SDK — D6
+  "vehicle",           // (reserved — TecDoc-equivs if/when extracted) — D4
+  "frontend-ui",       // react, @remix-run/*, @radix-ui/*, tailwindcss — D8
+  "backend-platform",  // @nestjs/*, express, fastify-equivs — D14
+  "db",                // @supabase/*, postgres, drizzle — D1+D14
+  "validation",        // zod, ajv, joi, yup — D14 transverse
+  "observability",     // @sentry/*, pino, opentelemetry — D10
+  "dev-tooling",       // typescript, prettier, eslint*, husky, lint-staged
+  "build-tooling",     // vite, turbo, tsx, esbuild, rollup, swc
+  "testing",           // vitest, @testing-library/*, playwright, supertest
+  "other",             // escape hatch — flag for V1.5 enrichment
+]);
+
+export type FamilyId = z.infer<typeof FamilyIdSchema>;


### PR DESCRIPTION
## Why

**Real Repository Contract V1 for npm dependency governance** — replacing the contested historic "PR-4" (commits `9797b488` etc. were dead-code cleanup batches, not a contract).

Mirror exact pattern of PR-2 #507 (architecture V1) + PR-3a #511 (db V1) + PR-5 #519 (runtime V1) — atomic §1..§6, mirror canon `repository-contract-series-canon-20260514` §31.

This PR fills the gap identified during PR-5 plan exploration: zero family classification existed in `audit/registry/deps.json` (232 entries, only `source` enum npm/workspace/github/git, no functional grouping).

## What

**L2+L3 atomic for npm dependency family classification** (NO L4 enforcement):

- **§1 Zod schema strict** (`DepGovernanceContractSchema`). REUSE-ONLY policy:
  - `FamilyIdSchema` NEW shared (`shared/family.ts`, 14 values aligned with D1..D15 + 3 transverse)
  - `DomainIdSchema` reused from `shared/domain.ts` + `.refine()` (UNKNOWN forbidden in canon)
  - `OwnerIdSchema` reused from `shared/owner.ts` (created in PR-5 #519)
  - L1 `DepEntrySchema` shape consulted to align id format `npm:<name>@<version>`
  - `source`, `version`, `workspaces`, `declaredIn`, `status`, `sourceConfidence`, per-entry `schemaVersion` **intentionally omitted** — extraction concerns, not invariants
- **§2 Canonical YAML** (`dep-governance.yaml`, 230 lines). Full doctrine header (~50 lines) with 8 explicit "Do NOT add" redirects (license-policy.yaml, version-policy.yaml, audit-ci, architecture.yaml boundaries, depcruise rules, V2 cross-family forbidden imports, runtime-topology.yaml, db.yaml).
- **§3 Deterministic generator** (`build-dep-governance-artifacts.ts`). Mirror exact `build-runtime-contract-artifacts.ts`. Empirically verified byte-identical (SHA-256 stable).
- **§4 Tests: 19 cases**:
  - §4.1 schema integrity (12 cases: positive + 10 negatives — extra fields, malformed id/name/owner/family, UNKNOWN domain, id-name mismatch, dup id/name)
  - §4.2 cross-contract L1 (every contract id ∈ `audit/registry/deps.json`)
  - §4.3 cross-contract domains.yaml
  - §4.4 cross-contract ownership.yaml owner FK
  - §4.5 family enum coverage (every non-reserved family used by ≥ 1 dep)
  - §4.6 size warning soft threshold (entries.length < 500)
  - §4.7 determinism (exec build twice, SHA-256 stable)
- **§5 CI hookup in audit.yml** — new step `📦 Dep governance — regenerate IDE schema mirror` sibling of `runtime-contract:build`. The existing `📋 @repo/registry contract tests` step (PR-W3 #512, warn-only until 2026-06-15) automatically picks up new tests.
- **§6 Size invariants** — `.max(2000)` Zod sanity cap (NOT operational limit) + soft threshold 500 enforced separately in test §4.6. `.strict()` at all levels.

**V1 coverage**: 26 sample npm deps across 11 of 14 families (full breakdown in `audit-reports/dep-governance-v1-coverage-2026-05-14.md`).

## V1 RESERVED families (intentional)

3 families declared in schema but unused V1 — documented in test §4.5 RESERVED_V1 array:
- `vehicle` — TecDoc-equivs not yet extracted as deps
- `payments` — paybox/systempay are HTTP-only integrations (no SDK dep V1)
- `other` — escape hatch only, no permanent residents per doctrine

## Anti-parallel-truth audit (canon §46 Loi B)

- ✅ 3 shared schemas REUSED (DomainIdSchema, OwnerIdSchema, L1 DepEntrySchema shape)
- ✅ 1 NEW shared schema created (`FamilyIdSchema` at `shared/family.ts`)
- ✅ 0 inline enums for family/domain/owner
- ✅ 7 L1 fields explicitly omitted with documented rationale

## Out of scope (V2 candidates)

- License enforcement → `license-policy.yaml` + license-checker tool
- Version range hygiene (^ vs exact) → `version-policy.yaml` or renovate
- CVE / vulnerability scanning → `audit-ci` / `npm audit` (existing tools)
- Workspace deps (@fafa/*, @repo/*) → architecture.yaml boundaries (already covered)
- Phantom-dep prevention → dependency-cruiser rule
- Cross-family forbidden imports → V2 cross-contract with architecture.yaml + ownership.yaml
- Per-team owners (V1 uses `@ak125` universal default)

## Test plan

- [x] `npm run dep-governance:build` → exit 0 (26 deps, deterministic)
- [x] `npm -w @repo/registry exec -- tsx --test src/__tests__/dep-governance-contract.test.ts` → 19/19 pass
- [x] `npm -w @repo/registry run typecheck` → exit 0
- [x] Generator determinism (re-run + `git diff --exit-code`) → exit 0
- [ ] CI `audit.yml` green on this PR (awaiting CI)

## Refs

- ADR-058 (Repository Contract System)
- Canon: `repository-contract-series-canon-20260514.md`
- PR-2 #507, PR-3a #511, PR-5 #519 — pattern reused
- PR-W3 #512 (registry tests warn-only) + PR-W4 #513 (generator determinism evidence)
- Plan: `/home/deploy/.claude/plans/dependency-governance-contract-v1-2026-05-14.md`
- Coverage evidence: `audit-reports/dep-governance-v1-coverage-2026-05-14.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)