### PR TITLE
feat(seo-crux): wiring final processor + endpoint admin (pr-5 adr-063)

### DIFF
--- a/backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
@@ -230,6 +230,62 @@ export class SeoMonitoringController {
     return { from: dateFrom, to: dateTo, rows: data ?? [] };
   }
 
+  /**
+   * Read CrUX field history (ADR-063).
+   * Returns weekly p75 LCP/INP/CLS/TTFB/FCP rows from `__seo_crux_field_history`.
+   *
+   * Query params (mutually exclusive origin XOR url) :
+   *  - days       : lookback window in days (default 180)
+   *  - origin     : origin URL (default https://www.automecanik.com)
+   *  - url        : URL-level lookup (origin-level if omitted)
+   *  - formFactor : PHONE (default) | DESKTOP | TABLET | ALL_FORM_FACTORS
+   */
+  @Get('timeseries/crux')
+  async timeseriesCrux(
+    @Query('days') days?: string,
+    @Query('origin') origin?: string,
+    @Query('url') url?: string,
+    @Query('formFactor') formFactor?: string,
+  ) {
+    const dayCount = Math.min(parseInt(days ?? '180', 10) || 180, 365);
+    const dateTo = new Date().toISOString().slice(0, 10);
+    const dateFrom = new Date(Date.now() - dayCount * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const ff = (formFactor ?? 'PHONE').toUpperCase();
+    const originResolved = origin ?? 'https://www.automecanik.com';
+
+    let query = this.supabase
+      .from('__seo_crux_field_history')
+      .select(
+        'origin, url, form_factor, collection_period_start_date, collection_period_end_date, p75_lcp_ms, p75_inp_ms, p75_cls, p75_ttfb_ms, p75_fcp_ms, fetched_at, source_api',
+      )
+      .gte('collection_period_end_date', dateFrom)
+      .lte('collection_period_end_date', dateTo)
+      .eq('form_factor', ff)
+      .eq('origin', originResolved);
+
+    if (url) {
+      query = query.eq('url', url);
+    } else {
+      query = query.is('url', null);
+    }
+
+    const { data, error } = await query
+      .order('collection_period_end_date', { ascending: false })
+      .limit(500);
+    if (error) return { error: error.message, rows: [] };
+
+    return {
+      from: dateFrom,
+      to: dateTo,
+      origin: originResolved,
+      url: url ?? null,
+      form_factor: ff,
+      rows: data ?? [],
+    };
+  }
+
   @Get('runs')
   async runs(@Query('limit') limit?: string) {
     const max = Math.min(parseInt(limit ?? '50', 10), 500);

--- a/backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts
+++ b/backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts
@@ -20,11 +20,13 @@ import { Job } from 'bull';
 import { getAppConfig } from '../../../config/app.config';
 import { getErrorMessage } from '../../../common/utils/error.utils';
 import { AdminJobHealthService } from '../../admin/services/admin-job-health.service';
+import { CruxAlerterService } from '../services/crux-alerter.service';
+import { CruxFieldFetcherService } from '../services/crux-field-fetcher.service';
 import { Ga4DailyFetcherService } from '../services/ga4-daily-fetcher.service';
 import { GscDailyFetcherService } from '../services/gsc-daily-fetcher.service';
 import { GscLinksFetcherService } from '../services/gsc-links-fetcher.service';
 
-export type DailyFetchTask = 'all' | 'gsc' | 'ga4' | 'gsc_links';
+export type DailyFetchTask = 'all' | 'gsc' | 'ga4' | 'gsc_links' | 'crux';
 
 export interface SeoDailyFetchJobData {
   /** Date à fetcher au format ISO (YYYY-MM-DD). Si absent, J-3 par défaut (latence GSC/GA4). */
@@ -43,7 +45,7 @@ export interface SeoDailyFetchJobData {
 }
 
 export interface SeoDailyFetchPerSourceResult {
-  source: 'gsc' | 'ga4' | 'gsc_links';
+  source: 'gsc' | 'ga4' | 'gsc_links' | 'crux';
   status: 'ok' | 'skipped' | 'failed';
   rowsInserted: number;
   durationSeconds: number;
@@ -71,6 +73,8 @@ export class SeoDailyFetchProcessor {
     private readonly gscFetcher: GscDailyFetcherService,
     private readonly ga4Fetcher: Ga4DailyFetcherService,
     private readonly gscLinksFetcher: GscLinksFetcherService,
+    private readonly cruxFetcher: CruxFieldFetcherService,
+    private readonly cruxAlerter: CruxAlerterService,
     private readonly jobHealth: AdminJobHealthService,
   ) {
     this.readOnly = getAppConfig().supabase.readOnly;
@@ -107,7 +111,7 @@ export class SeoDailyFetchProcessor {
 
     const perSource: SeoDailyFetchPerSourceResult[] = [];
     const tasks =
-      task === 'all' ? (['gsc', 'ga4', 'gsc_links'] as const) : [task];
+      task === 'all' ? (['gsc', 'ga4', 'gsc_links', 'crux'] as const) : [task];
 
     let progressBase = 0;
     const progressStep = Math.floor(100 / tasks.length);
@@ -150,6 +154,35 @@ export class SeoDailyFetchProcessor {
           ) {
             status = 'skipped';
             message = r.warnings.join(',');
+          }
+        } else if (t === 'crux') {
+          // ADR-063 — CrUX field ingestion + alerting daily
+          const r = await this.cruxFetcher.fetchAndPersist({});
+          rowsInserted = r.rowsInserted;
+          if (r.warnings.includes('crux_client_unavailable')) {
+            status = 'skipped';
+            message = 'crux_client_unavailable';
+          } else {
+            // Trigger alerter on latest period (origin + URLs)
+            const evalResult = await this.cruxAlerter.runDailyEvaluation();
+            const noteParts: string[] = [];
+            if (evalResult.evaluated > 0) {
+              noteParts.push(`evaluated=${evalResult.evaluated}`);
+            }
+            if (
+              evalResult.emittedOpen +
+                evalResult.emittedStillOpen +
+                evalResult.emittedResolved >
+              0
+            ) {
+              noteParts.push(
+                `alerts=open:${evalResult.emittedOpen}/still:${evalResult.emittedStillOpen}/resolved:${evalResult.emittedResolved}`,
+              );
+            }
+            if (evalResult.errors.length > 0) {
+              noteParts.push(`errors=${evalResult.errors.length}`);
+            }
+            message = noteParts.join(' ');
           }
         }
 

--- a/backend/src/modules/seo-monitoring/services/crux-alerter.service.ts
+++ b/backend/src/modules/seo-monitoring/services/crux-alerter.service.ts
@@ -261,6 +261,236 @@ export class CruxAlerterService {
   }
 
   /**
+   * Daily orchestration entry point (PR-5).
+   *
+   * Queries the latest period from `__seo_crux_field_history`, applies
+   * detectors A (absolute, all rows) + B (Δ%, origin-level rows only),
+   * transitions state, and emits alerts.
+   *
+   * Returns a per-run summary. Errors caught per-row to avoid one bad row
+   * blocking the rest.
+   */
+  async runDailyEvaluation(): Promise<AlerterRunResult> {
+    const result: AlerterRunResult = {
+      evaluated: 0,
+      emittedOpen: 0,
+      emittedStillOpen: 0,
+      emittedResolved: 0,
+      errors: [],
+    };
+
+    // Step 1 — Fetch latest collection period rows (origin + URLs)
+    const { data: latestRows, error: latestErr } = await this.supabase
+      .from('__seo_crux_field_history')
+      .select(
+        'origin, url, form_factor, collection_period_end_date, p75_lcp_ms, p75_inp_ms, p75_cls',
+      )
+      .order('collection_period_end_date', { ascending: false })
+      .limit(1000);
+
+    if (latestErr) {
+      result.errors.push(`latest rows query failed: ${latestErr.message}`);
+      return result;
+    }
+    if (!latestRows || latestRows.length === 0) {
+      return result;
+    }
+
+    // Group by (origin, url, form_factor) and keep only the most recent period per group
+    const latestByGroup = new Map<
+      string,
+      {
+        origin: string;
+        url: string | null;
+        form_factor: CruxFormFactor;
+        p75_lcp_ms: number | null;
+        p75_inp_ms: number | null;
+        p75_cls: number | null;
+        end_date: string;
+      }
+    >();
+    for (const row of latestRows as Array<{
+      origin: string;
+      url: string | null;
+      form_factor: CruxFormFactor;
+      collection_period_end_date: string;
+      p75_lcp_ms: number | null;
+      p75_inp_ms: number | null;
+      p75_cls: number | null;
+    }>) {
+      const key = `${row.origin}|${row.url ?? ''}|${row.form_factor}`;
+      if (!latestByGroup.has(key)) {
+        latestByGroup.set(key, {
+          origin: row.origin,
+          url: row.url,
+          form_factor: row.form_factor,
+          p75_lcp_ms: row.p75_lcp_ms,
+          p75_inp_ms: row.p75_inp_ms,
+          p75_cls: row.p75_cls,
+          end_date: row.collection_period_end_date,
+        });
+      }
+    }
+
+    // Step 2 — For each group, evaluate detectors
+    const metricKeys: CruxMetricKey[] = ['lcp', 'inp', 'cls'];
+
+    for (const group of latestByGroup.values()) {
+      for (const metric of metricKeys) {
+        const value = this.getMetricValue(group, metric);
+        if (value === null) continue;
+        result.evaluated++;
+
+        try {
+          // Detector A (absolute) — all rows
+          const sevA = this.evaluateAbsolute(metric, value);
+
+          // Detector B (delta) — origin-level only (V1)
+          let sevB: CruxAlertSeverity | null = null;
+          let baselineMedian: number | null = null;
+          let deltaPct: number | null = null;
+          if (group.url === null) {
+            const baseline = await this.fetchBaseline(
+              group.origin,
+              group.form_factor,
+              metric,
+              group.end_date,
+            );
+            const eval2 = this.evaluateDelta(metric, value, baseline);
+            sevB = eval2.severity;
+            baselineMedian = eval2.baselineMedian;
+            deltaPct = eval2.deltaPct;
+          }
+
+          // Pick the more severe of the two detectors (CRIT > WARN > null)
+          const sev = this.pickWorseSeverity(sevA, sevB);
+          const detector: CruxAlertDetector =
+            sev !== null && sev === sevB ? 'delta' : 'absolute';
+
+          // Load existing state for transition decision
+          const existing = await this.loadExistingState(
+            group.origin,
+            group.url,
+            group.form_factor,
+            metric,
+          );
+          const newState = this.transitionState(existing, sev);
+          if (newState === null) continue;
+
+          await this.emitAlert({
+            origin: group.origin,
+            url: group.url,
+            form_factor: group.form_factor,
+            metric,
+            detector,
+            severity: sev ?? existing?.severity ?? 'WARN',
+            state: newState,
+            observedValue: value,
+            baselineMedian,
+            deltaPct,
+          });
+
+          if (newState === 'OPEN') result.emittedOpen++;
+          else if (newState === 'STILL_OPEN') result.emittedStillOpen++;
+          else if (newState === 'RESOLVED') result.emittedResolved++;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          result.errors.push(
+            `eval ${group.origin}|${group.url ?? ''}|${group.form_factor}|${metric}: ${msg}`,
+          );
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /** Extract the appropriate metric value from a row. */
+  private getMetricValue(
+    row: {
+      p75_lcp_ms: number | null;
+      p75_inp_ms: number | null;
+      p75_cls: number | null;
+    },
+    metric: CruxMetricKey,
+  ): number | null {
+    if (metric === 'lcp') return row.p75_lcp_ms;
+    if (metric === 'inp') return row.p75_inp_ms;
+    if (metric === 'cls') return row.p75_cls;
+    return null;
+  }
+
+  /** Pick the more severe of two severities (CRIT > WARN > null). */
+  private pickWorseSeverity(
+    a: CruxAlertSeverity | null,
+    b: CruxAlertSeverity | null,
+  ): CruxAlertSeverity | null {
+    if (a === 'CRIT' || b === 'CRIT') return 'CRIT';
+    if (a === 'WARN' || b === 'WARN') return 'WARN';
+    return null;
+  }
+
+  /** Fetch trailing-4 baseline values for delta detector. */
+  private async fetchBaseline(
+    origin: string,
+    form_factor: CruxFormFactor,
+    metric: CruxMetricKey,
+    excludeEndDate: string,
+  ): Promise<number[]> {
+    const column =
+      metric === 'lcp'
+        ? 'p75_lcp_ms'
+        : metric === 'inp'
+          ? 'p75_inp_ms'
+          : 'p75_cls';
+    const { data, error } = await this.supabase
+      .from('__seo_crux_field_history')
+      .select(`${column}, collection_period_end_date`)
+      .eq('origin', origin)
+      .is('url', null)
+      .eq('form_factor', form_factor)
+      .lt('collection_period_end_date', excludeEndDate)
+      .order('collection_period_end_date', { ascending: false })
+      .limit(DELTA_BASELINE_PERIODS);
+    if (error || !data) return [];
+    return (data as Array<Record<string, unknown>>)
+      .map((r) => r[column])
+      .filter((v): v is number => typeof v === 'number');
+  }
+
+  /** Load existing alert state for a target. */
+  private async loadExistingState(
+    origin: string,
+    url: string | null,
+    form_factor: CruxFormFactor,
+    metric: CruxMetricKey,
+  ): Promise<{
+    state: CruxAlertState;
+    severity: CruxAlertSeverity;
+    lastEmittedAt: Date;
+  } | null> {
+    const { data, error } = await this.supabase
+      .from('__seo_crux_alert_state')
+      .select('state, severity, last_emitted_at')
+      .eq('origin', origin)
+      .eq('url_key', url ?? '')
+      .eq('form_factor', form_factor)
+      .eq('metric', metric)
+      .maybeSingle();
+    if (error || !data) return null;
+    const row = data as {
+      state: CruxAlertState;
+      severity: CruxAlertSeverity;
+      last_emitted_at: string;
+    };
+    return {
+      state: row.state,
+      severity: row.severity,
+      lastEmittedAt: new Date(row.last_emitted_at),
+    };
+  }
+
+  /**
    * Upsert into `__seo_crux_alert_state`. PK conflict on
    * (origin, url_key, form_factor, metric) → UPDATE.
    * `url_key` generated server-side, omitted from payload.


### PR DESCRIPTION
## Summary

Dernier livrable monorepo pour **[ADR-063](https://github.com/ak125/governance-vault/blob/main/ledger/decisions/adr/ADR-063-cwv-monitoring-prod-crux-api.md)** — CWV Monitoring PROD via CrUX API.

Connecte les services PR-3/PR-4 au runtime BullMQ et expose l'API admin. CrUX field monitoring **devient actif** côté backend dès cette PR mergée (mais reste graceful-degrade si \`CRUX_API_KEY\` env vide).

## Processor wiring

\`seo-daily-fetch.processor.ts\` :
- Ajoute \`'crux'\` à \`DailyFetchTask\` + \`SeoDailyFetchPerSourceResult.source\`
- Inject \`CruxFieldFetcherService\` + \`CruxAlerterService\` constructor
- Task \`'all'\` lance désormais \`['gsc', 'ga4', 'gsc_links', 'crux']\`
- Branch \`'crux'\` :
  1. \`cruxFetcher.fetchAndPersist()\` → ingestion CrUX field
  2. Si pas \`crux_client_unavailable\` → \`cruxAlerter.runDailyEvaluation()\`
  3. Message agrégé \`evaluated=N alerts=open:X/still:Y/resolved:Z errors=K\`

**ADR-028 Option D READ_ONLY gate** au processor : court-circuite tout le job sans appel API/DB en preprod miroir prod.

## Alerter orchestration (\`runDailyEvaluation\`)

\`crux-alerter.service.ts\` — nouvelle méthode async :

1. Query latest \`collection_period_end_date\` par (origin, url, form_factor) depuis \`__seo_crux_field_history\` (limit 1000)
2. Pour chaque metric (\`lcp\`, \`inp\`, \`cls\`) :
   - **Detector A** absolu — toutes lignes (Google Web Vitals thresholds)
   - **Detector B** Δ% — origin-level uniquement (V1, \`url === null\`)
     - \`fetchBaseline\` trailing-4 periods du même metric
     - \`evaluateDelta\` retourne severity + baselineMedian + deltaPct
   - \`pickWorseSeverity(A, B)\` = CRIT > WARN > null
   - \`loadExistingState\` → row \`__seo_crux_alert_state\` ou null
   - \`transitionState\` → next state ou null (no-op anti-spam)
   - \`emitAlert\` si transition non-null
3. Retourne \`AlerterRunResult { evaluated, emittedOpen, emittedStillOpen, emittedResolved, errors[] }\`

## Endpoint admin

\`GET /api/admin/seo-monitoring/timeseries/crux\` :
- Query params : \`days\` (default 180, max 365), \`origin\` (default automecanik), \`url\` (origin-level si omis), \`formFactor\` (default PHONE)
- Returns \`{ from, to, origin, url, form_factor, rows[] }\` avec colonnes complètes p75 LCP/INP/CLS/TTFB/FCP + source_api
- Garde : RLS authenticated + \`IsAdminGuard\` global sur \`/api/admin/seo-monitoring/*\`

## Hors scope V1 (follow-up séparés)

- Sinks réels Slack webhook / Sentry SDK / Prometheus counter dans \`emitAlert\` (V1 = log local + persist DB)
- Backoff sticky 404 state column dans \`__seo_crux_alert_state\` (V1 = computed à chaque run)
- Cron déclenchement séparé pour CrUX uniquement (V1 = part of \`seo-daily-fetch\` task='all', réutilise cron 04:00 UTC existant)
- Extension \`/cron/health\` avec \`last_crux_run_at\` (V1 = readable via \`/runs\` endpoint filtré sur \`event_type='crux_fetch_run'\`)

## Test plan

- [x] Backend typecheck \`npx tsc --noEmit\` ✅ 0 erreur
- [x] Service est appelable depuis processor (DI résolu)
- [x] Endpoint admin compile + RLS authenticated
- [ ] CI : ESLint, TypeScript, Backend Tests, Migration Safety, Block-new registry
- [ ] Validation preprod DEV 7j : déployer → trigger manuel \`seo-daily-fetch\` task='all' → vérifier \`__seo_crux_field_history\` populated + \`__seo_event_log payload->>source='crux'\`
- [ ] Validation PROD 14j silencieux avant promotion ADR-063 status final \`accepted\` complet

## Refs

- **ADR-063** Accepted 2026-05-14 — vault PR #271 + #272 (\`dbfb016\` + \`3c6d6a9\`)
- **PR-2** #514 \`8bf0c037\` — fondations DB + types + env
- **PR-3** #518 \`58e1e18\` — ingestion (CruxApiClient + CruxFieldFetcherService)
- **PR-4** #525 \`2968335\` — alerting (CruxAlerterService détecteurs + state machine)
- **PR-5** (cette PR) — wiring final
- **Plan** : \`.claude/plans/adr-cwv-monitoring-prod-wobbly-swan.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)