### PR TITLE
ci(migration-safety): replace squawk-action wrapper with direct binary (drop GitHub API write dep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,15 +519,30 @@ jobs:
             echo "files=$files" >> "$GITHUB_OUTPUT"
           fi
 
+      # Direct squawk binary invocation (industry-standard CI linter pattern :
+      # exit-code-driven, no third-party API side-effects). The previous
+      # `sbdchd/squawk-action@v2` wrapper called `upload-to-github`, which
+      # POSTs a PR comment and requires `pull-requests: write` — adding write
+      # scope to every pipeline just to render diagnostics is bricolage.
+      # Violations show up in the job log; squawk exits non-zero on violation,
+      # which fails the job. Same approach as eslint / tsc / ruff / clippy.
+      - name: Install squawk
+        if: steps.changed-sql.outputs.files != ''
+        env:
+          SQUAWK_VERSION: "2.52.1"
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/bin"
+          curl -fsSL \
+            "https://github.com/sbdchd/squawk/releases/download/v${SQUAWK_VERSION}/squawk-linux-x86_64" \
+            -o "$RUNNER_TEMP/bin/squawk"
+          chmod +x "$RUNNER_TEMP/bin/squawk"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/squawk" --version
+
       - name: Run squawk on changed migrations
         if: steps.changed-sql.outputs.files != ''
-        uses: sbdchd/squawk-action@v2
-        with:
-          files:              ${{ steps.changed-sql.outputs.files }}
-          version:            "2.52.1"
-          config:             ".squawk.toml"
-          fail-on-violations: true
-          # `files:` (explicit list from git diff) — `pattern:` is for static globs.
+        run: squawk --config .squawk.toml ${{ steps.changed-sql.outputs.files }}
 
   build:
     name: 🐳 build


### PR DESCRIPTION
## Pourquoi

PR #517 a introduit \`sbdchd/squawk-action@v2\` qui appelle \`squawk upload-to-github\` — un POST API sur \`POST /repos/:owner/:repo/issues/:number/comments\` pour rendre un PR comment avec les violations. Ce mode require \`pull-requests: write\` sur le workflow.

Symptômes en production :
- PR #520 (cf-analytics) : 403 sur \`upload-to-github\` malgré migration squawk-conform → patch ajoutant \`pull-requests: write\` au job
- PR #524 (runtime-logs) : 403 répété, même cause, même patch envisagé

**C'est du bricolage** : on grant write-scope GH API à chaque pipeline qui passe migration-safety juste pour rendre un commentaire diagnostique. Une linter CI doit communiquer **par exit code + log**, pas en mutating l'issue tracker.

## La bonne approche

Pattern industriel canonique (eslint, tsc, ruff, clippy, golangci-lint) :
1. Install le binaire pinné
2. Run le binaire sur les fichiers
3. Exit non-zero → job fail
4. Violations visibles dans le job log

Squawk supporte ça nativement : sans subcommand, \`squawk <files>\` lint et exit non-zero en cas de violation. La subcommand \`upload-to-github\` est un *opt-in* pour qui veut un comment PR — pas un requis.

## Diff

\`\`\`yaml
# AVANT
- name: Run squawk on changed migrations
  uses: sbdchd/squawk-action@v2
  with:
    fail-on-violations: true
    # …

# APRÈS
- name: Install squawk
  env:
    SQUAWK_VERSION: "2.52.1"
  run: |
    set -euo pipefail
    mkdir -p \"\$RUNNER_TEMP/bin\"
    curl -fsSL \\
      \"https://github.com/sbdchd/squawk/releases/download/v\${SQUAWK_VERSION}/squawk-linux-x86_64\" \\
      -o \"\$RUNNER_TEMP/bin/squawk\"
    chmod +x \"\$RUNNER_TEMP/bin/squawk\"
    echo \"\$RUNNER_TEMP/bin\" >> \"\$GITHUB_PATH\"

- name: Run squawk on changed migrations
  run: squawk --config .squawk.toml \${{ steps.changed-sql.outputs.files }}
\`\`\`

## Bénéfices

- Plus de \`pull-requests: write\` requis (workflow reste \`contents: read\`, least-privilege canon)
- Plus de 403 races avec l'API GitHub
- Same squawk binary, same \`.squawk.toml\`, same rules — seul le canal de sortie change
- Aligne migration-safety sur le pattern \`size-limit\`, \`eslint\`, \`tsc\` déjà adoptés dans ce CI

## Effet sur PRs en flight

- **PR #524** (PR-2A-3 runtime-logs) — rebase, le 403 disparaît
- **PR #520** (PR-2A-2 cf-analytics) — rebase, la permission band-aid devient inutile (peut être retirée)

## Trail

- ADR-064 SEO Production Control Plane (squawk gate origine)
- Memory : \`feedback_no_bricolage_escalate_to_industry_standard\`, \`feedback_two_pr_recovery_platform_for_ci_gate_replacement\`
- PR #517 (squawk introduction, à corriger)

## Test plan

- [ ] CI green sur cette PR
- [ ] Merge → PR #524 rebase → migration-safety green sans permission patch
- [ ] PR #520 rebase → idem

🤖 Generated with [Claude Code](https://claude.com/claude-code)