### PR TITLE
fix(registry): complete dual-mode build to unblock backend boot

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -258,6 +258,11 @@ entries:
     owner: '@ak125/auth-team'
     sourceConfidence: medium
     risk: high
+  - glob: backend/src/types/registry-runtime.d.ts
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   - glob: backend/supabase/migrations/*seo_crux*
     domain: D3
     owner: '@ak125/seo-team'

--- a/backend/src/modules/seo-control-plane/services/criticality-loader.service.ts
+++ b/backend/src/modules/seo-control-plane/services/criticality-loader.service.ts
@@ -24,7 +24,7 @@ import {
   classifyRoute,
   type SeoCriticality,
   type TierId,
-} from '@repo/registry';
+} from '@repo/registry/runtime';
 
 /**
  * Resolution path : depuis backend/dist runtime, remonter à la racine repo

--- a/backend/src/types/registry-runtime.d.ts
+++ b/backend/src/types/registry-runtime.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Type shim for `@repo/registry/runtime` subpath.
+ *
+ * Background:
+ *   - `@repo/registry` is a hybrid-mode workspace package (ADR-058):
+ *     - default subpath `.` serves TS source (consumed by tsx scripts, no build prereq)
+ *     - `./runtime` subpath serves compiled `dist/` (consumed by NestJS compiled
+ *       backend for value imports like `SeoCriticalitySchema`, `classifyRoute`)
+ *
+ *   - Backend `tsconfig.json` inherits `moduleResolution: "Node"` from the
+ *     shared base. Legacy Node resolution does NOT honor `package.json#exports`
+ *     subpath conditions, so `tsc` cannot find `@repo/registry/runtime` and
+ *     emits TS2307.
+ *
+ *   - We cannot switch the backend to `moduleResolution: "bundler"` (requires
+ *     `module: ES2015+`, incompatible with the existing CJS emit pipeline)
+ *     nor `node16` (would require `.js` extensions on every relative import).
+ *
+ *   - This shim makes TypeScript resolve `@repo/registry/runtime` as if it
+ *     were the same module as `@repo/registry` (which it is, type-wise — both
+ *     subpaths expose `./src/index.ts` for types). At runtime, Node 16+ CJS
+ *     `require()` honors the `exports` map natively and routes to `dist/`.
+ *
+ * This file is the canonical compile-time bridge between legacy Node TS
+ * resolution and modern `exports`-aware subpath consumption.
+ */
+declare module '@repo/registry/runtime' {
+  export * from '@repo/registry';
+}

--- a/packages/registry/tsconfig.json
+++ b/packages/registry/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../typescript-config/base.json",
   "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "target": "ES2020",
     "lib": ["ES2020"],
     "skipLibCheck": true,
@@ -12,10 +12,14 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
     "noUnusedLocals": false,
     "noUnusedParameters": false
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Main backend currently crashes on boot:

```
SyntaxError: Unexpected identifier 'Status'
at packages/registry/src/index.ts:20
export { StatusSchema, type Status } from "./shared/status";
required by backend/dist/modules/seo-control-plane/services/criticality-loader.service.js
```

Cause : `@repo/registry` is hybrid-mode (default subpath = TS source, `./runtime` = compiled CJS) but only **half** of that design landed on main:

| Item | State on main | This PR |
|---|---|---|
| 1. `registry/package.json` adds `./runtime` subpath | ✅ landed (#519/#523) | — |
| 2. `registry/tsconfig.json` flipped to CJS emit | ❌ still `noEmit: true` → `dist/` never produced | ✅ flips |
| 3. `criticality-loader.service.ts` imports `@repo/registry/runtime` | ❌ still imports `@repo/registry` (root) → CJS `require()` resolves to `src/index.ts` → TS syntax crashes Node | ✅ fixes |
| 4. Backend shim for legacy `moduleResolution: Node` not honoring `exports` subpaths | ❌ missing | ✅ adds `backend/src/types/registry-runtime.d.ts` |

## Why a shim and not a `moduleResolution` change

Backend inherits `moduleResolution: Node` (legacy) from the shared base. Switching to:
- `bundler` requires `module: ES2015+` → breaks the existing CJS emit pipeline
- `node16`/`nodenext` requires `.js` extensions on every relative import → massive blast radius across `backend/src/**`

The shim is the surgical fix: TypeScript sees `@repo/registry/runtime` as identical to `@repo/registry` for type resolution; at runtime Node 16+ CJS `require()` natively honors the `exports` map and routes to `dist/index.js`.

## Test plan

- [x] `npm run build -w @repo/registry` produces `dist/index.js` (CJS) and `dist/index.d.ts`
- [x] `node -e "require('@repo/registry/runtime')"` returns 41 exports including `classifyRoute: function` and `SeoCriticalitySchema: object`
- [x] `tsc --build` in `backend/` : 0 errors (after building dependent workspace packages)
- [x] `ownership.yaml` declares the new `backend/src/types/registry-runtime.d.ts` (D15, low risk)
- [ ] Backend dev server boots past `[EnvValidation] All required environment variables present`

## Supersedes

#521 (`fix/registry-runtime-build`) had items 2 and 3 right but was missing item 4 (the shim), and the branch had diverged from main (ahead 4 / behind 5 with uncommitted WIP). Recommend closing #521 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)