### PR TITLE
feat(seo): pr-b field authority registry (yaml canon + json projection)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-14'
+last_scan: '2026-05-15'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -82,6 +82,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: low
+  - glob: audit/registry/seo-field-authority.json
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/src/auth/**
     domain: D11
     owner: '@ak125/auth-team'

--- a/.spec/00-canon/repository-registry/seo-field-authority.yaml
+++ b/.spec/00-canon/repository-registry/seo-field-authority.yaml
@@ -1,0 +1,130 @@
+# .spec/00-canon/repository-registry/seo-field-authority.yaml
+#
+# Field Authority Registry for SEO content fields.
+# PR-B of the SEO Governance Control Plane plan
+# (/home/deploy/.claude/plans/lors-du-audite-seo-concurrent-swan.md §5 Phase B).
+#
+# Établit l'autorité canonique d'écriture par champ SEO. L'authorité vit ICI,
+# pas inventée à runtime — OPA (Phase C) l'applique, ne la définit pas.
+#
+# Consommé par (futur) :
+#   - PR-C OPA Write Gateway (NestJS-only sync middleware, bundle WASM lit le
+#     JSON projeté pour décider allow/deny avec contexte authority)
+#   - PR-E Recovery Rollout (écritures legacy_recovery doivent matcher
+#     authoritative_writers ET porter source_metadata.evidence_tier ∈ exact_match_*)
+#
+# Validation :
+#   - scripts/audit/validate-seo-field-authority.ts (--lenient par défaut en
+#     PR-B ; --strict activé seulement à partir de PR-C via CI, car le
+#     service h1-deterministic-builder n'existe qu'en Phase C)
+#   - npm run registry:validate (Zod global)
+#
+# Discipline 4-layer (ADR-058) : ce fichier appartient au Layer 2 overlay
+# manuel. Aucun composant runtime n'écrit ici — édition manuelle uniquement,
+# revue par owners @ak125/seo-team.
+#
+# Memory rules :
+#   - feedback_no_touch_meta_h1_if_optimized (STRICT) — règle source du chantier
+#   - feedback_deterministic_evidence_tiers_over_bayesian — enum strict
+#   - feedback_branch_scope_discipline — scope strict PR-B (h1 uniquement)
+#
+# Verdict empirique PR-A1 #532 (2026-05-15) qui motive le verrou :
+# H1 shifting / cross-gamme misassignment (pas LLM overwrite individuel) sur
+# 13 / 23 R1 audités. Cause probable : bulk update SQL avec mauvaise jointure.
+
+schemaVersion: "1.0.0"
+
+# ── Configuration globale ──────────────────────────────────────────────────────
+#
+# Source de l'autorité : ce fichier YAML. Le JSON dans audit/registry/ est une
+# projection générée par scripts/audit/build-seo-field-authority.ts — JAMAIS
+# édité à la main (sinon drift détecté par validate-seo-field-authority.ts).
+
+defaults:
+  # Durée par défaut du lock après écriture authoritative (Phase E + Phase C
+  # OPA policy lira ce default si lock_default_duration_days absent du field).
+  lock_default_duration_days: 90
+  # Cadence de revue annuelle d'un H1 lock = 365j (recadrer si SEO performance
+  # delta significatif vs baseline).
+  review_cadence_days: 365
+
+# ── Fields gouvernés ───────────────────────────────────────────────────────────
+#
+# PR-B scope strict : h1 uniquement. meta_title / meta_description / canonical /
+# robots / og:image sont des extensions naturelles (même schema) à introduire en
+# PR séparée une fois l'architecture h1 stabilisée (Phase D / Phase E shipped).
+
+fields:
+  - field_path: h1
+    description: |
+      H1 — Primary page heading. Critical pour topic relevance SEO.
+      Audit forensic PR-A1 #532 (verdict 2026-05-15 condition b) a révélé un
+      pattern systémique de H1 shifting (chaque R1 affiche le H1 d'une autre
+      gamme). Ce field devient gouverné pour empêcher toute récurrence.
+
+    # Rôles SEO concernés (cf. seo-batch agent matrix R1-R8).
+    # R1_ROUTER  = pages catalogue /pieces/{gamme}
+    # R3_CONSEILS = pages conseils sectionnelles
+    # R6_GUIDE_ACHAT = guides achat purchase guide
+    # R7_BRAND = pages marque /constructeurs/{brand}
+    # R8_VEHICLE = pages véhicule
+    roles: [R1_ROUTER, R3_CONSEILS, R6_GUIDE_ACHAT, R7_BRAND, R8_VEHICLE]
+
+    # Mapping field_path logique → colonnes physiques. Le gateway OPA (Phase C)
+    # utilise ce mapping pour cibler la bonne table/colonne selon le role_id
+    # du write event. role_filter='legacy_fallback' = base à utiliser quand
+    # aucun override role-spécifique n'existe.
+    physical_columns:
+      - table: __seo_r1_gamme_slots
+        column: r1s_h1_override
+        role_filter: R1_ROUTER
+      - table: __seo_gamme_purchase_guide
+        column: sgpg_h1_override
+        role_filter: R6_GUIDE_ACHAT
+      - table: __seo_gamme
+        column: sg_h1
+        role_filter: legacy_fallback
+      - table: __meta_tags_ariane
+        column: mta_h1
+        role_filter: R7_BRAND|R8_VEHICLE
+
+    # Writers autorisés (enum strict). Chaque kind a une référence service
+    # canonique (path NestJS dotted) ou un via= pour les origines non-service
+    # (admin-ui, recovery pipeline). Le validator --strict vérifie l'existence
+    # des paths service à partir de PR-C.
+    authoritative_writers:
+      - kind: deterministic_builder
+        service: backend.modules.seo.builders.h1-deterministic-builder
+        notes: |
+          Service à créer en Phase C (PR-C). Le validator est LENIENT en PR-B
+          et ne fail PAS sur l'absence ; passera STRICT à partir de PR-C.
+      - kind: human_curated
+        via: admin-ui
+        notes: Écritures depuis l'interface admin authentifiée IsAdminGuard.
+      - kind: legacy_recovery
+        via: seo-recovery-pipeline
+        notes: |
+          Réservé à Phase E (PR-E rollout). Une écriture legacy_recovery
+          doit obligatoirement porter source_metadata.evidence_tier ∈
+          {exact_match_snapshot, exact_match_event_log, exact_match_blog_advice,
+          exact_match_builder_template} pour passer l'OPA policy.
+
+    # Writers explicitement refusés. Le validator vérifie qu'au minimum
+    # llm_generated_direct est présent (canon enforcement).
+    denied_writers:
+      - kind: llm_generated_direct
+        notes: |
+          Toute écriture LLM directe (sans validation humaine ou builder
+          déterministe intermédiaire) est refusée. Aligné règle stricte
+          feedback_no_touch_meta_h1_if_optimized.
+
+    # Durée du lock après écriture autoritaire (override du defaults global).
+    lock_default_duration_days: 90
+    review_cadence_days: 365
+
+# ── Note d'extension future ────────────────────────────────────────────────────
+#
+# meta_title, meta_description, canonical_url, robots_meta, og_image suivent la
+# MÊME structure. Ils sont volontairement OMIS de PR-B pour scope strict — à
+# introduire en PR séparée une fois Phase C+E stabilisées et que l'architecture
+# h1 a fait ses preuves sur DEV. Voir plan §15 anti-scope-creep.

--- a/audit/registry/seo-field-authority.json
+++ b/audit/registry/seo-field-authority.json
@@ -1,0 +1,73 @@
+{
+  "$generated": {
+    "by": "scripts/audit/build-seo-field-authority.ts",
+    "from": ".spec/00-canon/repository-registry/seo-field-authority.yaml",
+    "note": "DO NOT EDIT BY HAND. Regenerate via `pnpm tsx scripts/audit/build-seo-field-authority.ts`.",
+    "schemaVersion": "1.0.0"
+  },
+  "defaults": {
+    "lock_default_duration_days": 90,
+    "review_cadence_days": 365
+  },
+  "fields": [
+    {
+      "authoritative_writers": [
+        {
+          "kind": "deterministic_builder",
+          "notes": "Service à créer en Phase C (PR-C). Le validator est LENIENT en PR-B\net ne fail PAS sur l'absence ; passera STRICT à partir de PR-C.\n",
+          "service": "backend.modules.seo.builders.h1-deterministic-builder"
+        },
+        {
+          "kind": "human_curated",
+          "notes": "Écritures depuis l'interface admin authentifiée IsAdminGuard.",
+          "via": "admin-ui"
+        },
+        {
+          "kind": "legacy_recovery",
+          "notes": "Réservé à Phase E (PR-E rollout). Une écriture legacy_recovery\ndoit obligatoirement porter source_metadata.evidence_tier ∈\n{exact_match_snapshot, exact_match_event_log, exact_match_blog_advice,\nexact_match_builder_template} pour passer l'OPA policy.\n",
+          "via": "seo-recovery-pipeline"
+        }
+      ],
+      "denied_writers": [
+        {
+          "kind": "llm_generated_direct",
+          "notes": "Toute écriture LLM directe (sans validation humaine ou builder\ndéterministe intermédiaire) est refusée. Aligné règle stricte\nfeedback_no_touch_meta_h1_if_optimized.\n"
+        }
+      ],
+      "description": "H1 — Primary page heading. Critical pour topic relevance SEO.\nAudit forensic PR-A1 #532 (verdict 2026-05-15 condition b) a révélé un\npattern systémique de H1 shifting (chaque R1 affiche le H1 d'une autre\ngamme). Ce field devient gouverné pour empêcher toute récurrence.\n",
+      "field_path": "h1",
+      "lock_default_duration_days": 90,
+      "physical_columns": [
+        {
+          "column": "r1s_h1_override",
+          "role_filter": "R1_ROUTER",
+          "table": "__seo_r1_gamme_slots"
+        },
+        {
+          "column": "sgpg_h1_override",
+          "role_filter": "R6_GUIDE_ACHAT",
+          "table": "__seo_gamme_purchase_guide"
+        },
+        {
+          "column": "sg_h1",
+          "role_filter": "legacy_fallback",
+          "table": "__seo_gamme"
+        },
+        {
+          "column": "mta_h1",
+          "role_filter": "R7_BRAND|R8_VEHICLE",
+          "table": "__meta_tags_ariane"
+        }
+      ],
+      "review_cadence_days": 365,
+      "roles": [
+        "R1_ROUTER",
+        "R3_CONSEILS",
+        "R6_GUIDE_ACHAT",
+        "R7_BRAND",
+        "R8_VEHICLE"
+      ]
+    }
+  ],
+  "schemaVersion": "1.0.0"
+}

--- a/scripts/audit/build-seo-field-authority.ts
+++ b/scripts/audit/build-seo-field-authority.ts
@@ -1,0 +1,148 @@
+/**
+ * PR-B — Generate `audit/registry/seo-field-authority.json` from the YAML canon.
+ *
+ * Deterministic projection : sorted keys, stable formatting, idempotent.
+ * The YAML in `.spec/00-canon/repository-registry/seo-field-authority.yaml`
+ * is the Source of Truth. The JSON output is a machine-readable projection
+ * for consumers (OPA bundle WASM, dashboards, audit queries).
+ *
+ * Usage:
+ *   pnpm tsx scripts/audit/build-seo-field-authority.ts
+ *   pnpm tsx scripts/audit/build-seo-field-authority.ts --check  # exit 1 if drift
+ *
+ * Plan : §5 Phase B Field Authority Registry
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const YAML_PATH = path.join(
+  REPO_ROOT,
+  '.spec/00-canon/repository-registry/seo-field-authority.yaml',
+);
+const JSON_PATH = path.join(REPO_ROOT, 'audit/registry/seo-field-authority.json');
+
+// ── Logging (diagnostic → stderr) ───────────────────────────────────────────
+
+function log(msg: string): void {
+  process.stderr.write(msg + '\n');
+}
+
+// ── Types (mirror the YAML schema, kept loose so the validator owns enforcement) ──
+
+interface PhysicalColumn {
+  table: string;
+  column: string;
+  role_filter?: string;
+}
+
+interface Writer {
+  kind: string;
+  service?: string;
+  via?: string;
+  notes?: string;
+}
+
+interface FieldEntry {
+  field_path: string;
+  description?: string;
+  roles: string[];
+  physical_columns: PhysicalColumn[];
+  authoritative_writers: Writer[];
+  denied_writers: Writer[];
+  lock_default_duration_days?: number;
+  review_cadence_days?: number;
+}
+
+interface AuthorityDoc {
+  schemaVersion: string;
+  defaults?: {
+    lock_default_duration_days?: number;
+    review_cadence_days?: number;
+  };
+  fields: FieldEntry[];
+}
+
+// ── Deterministic stringify (sorted keys, 2-space indent, trailing newline) ──
+
+function deterministicStringify(obj: unknown): string {
+  const sorted = sortObjectKeys(obj);
+  return JSON.stringify(sorted, null, 2) + '\n';
+}
+
+function sortObjectKeys(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(sortObjectKeys);
+  if (obj === null || typeof obj !== 'object') return obj;
+  const sorted: Record<string, unknown> = {};
+  for (const k of Object.keys(obj as Record<string, unknown>).sort()) {
+    sorted[k] = sortObjectKeys((obj as Record<string, unknown>)[k]);
+  }
+  return sorted;
+}
+
+// ── Build pipeline ──────────────────────────────────────────────────────────
+
+function buildJson(): { content: string; doc: AuthorityDoc } {
+  if (!fs.existsSync(YAML_PATH)) {
+    throw new Error(`YAML canon not found at ${YAML_PATH}`);
+  }
+  const raw = fs.readFileSync(YAML_PATH, 'utf8');
+  const doc = yaml.load(raw) as AuthorityDoc;
+
+  // Enrich with generation metadata. The metadata block is at the top of the
+  // JSON so consumers can detect staleness ; deterministic_hash captures only
+  // the meaningful YAML content (computed elsewhere by the validator's diff).
+  const enriched = {
+    $generated: {
+      from: '.spec/00-canon/repository-registry/seo-field-authority.yaml',
+      by: 'scripts/audit/build-seo-field-authority.ts',
+      schemaVersion: doc.schemaVersion,
+      note: 'DO NOT EDIT BY HAND. Regenerate via `pnpm tsx scripts/audit/build-seo-field-authority.ts`.',
+    },
+    ...doc,
+  };
+
+  return { content: deterministicStringify(enriched), doc };
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const checkMode = argv.includes('--check');
+
+  log(`▶ Reading YAML canon : ${path.relative(REPO_ROOT, YAML_PATH)}`);
+  const { content, doc } = buildJson();
+  log(`  schemaVersion=${doc.schemaVersion}`);
+  log(`  fields=${doc.fields.length} (${doc.fields.map((f) => f.field_path).join(', ')})`);
+
+  fs.mkdirSync(path.dirname(JSON_PATH), { recursive: true });
+  const relJson = path.relative(REPO_ROOT, JSON_PATH);
+
+  if (checkMode) {
+    if (!fs.existsSync(JSON_PATH)) {
+      process.stderr.write(`[FAIL] ${relJson} does not exist — run without --check to regenerate.\n`);
+      process.exit(1);
+    }
+    const existing = fs.readFileSync(JSON_PATH, 'utf8');
+    if (existing !== content) {
+      process.stderr.write(`[FAIL] ${relJson} is stale vs YAML canon — regenerate.\n`);
+      process.exit(1);
+    }
+    log(`✓ ${relJson} matches YAML canon`);
+    process.exit(0);
+  }
+
+  fs.writeFileSync(JSON_PATH, content, 'utf8');
+  log(`✓ Wrote ${relJson}`);
+}
+
+try {
+  main();
+} catch (err: unknown) {
+  const msg = err instanceof Error ? err.stack ?? err.message : String(err);
+  process.stderr.write(`[FATAL] ${msg}\n`);
+  process.exit(1);
+}

--- a/scripts/audit/validate-seo-field-authority.ts
+++ b/scripts/audit/validate-seo-field-authority.ts
@@ -1,0 +1,312 @@
+/**
+ * PR-B — Validate the SEO Field Authority Registry (YAML canon + JSON projection).
+ *
+ * Two modes :
+ *   --lenient (default in PR-B) : warn on missing service references, allow
+ *                                 forward declarations (e.g. h1-deterministic-builder
+ *                                 doesn't exist until Phase C).
+ *   --strict (PR-C+ via CI)     : every `authoritative_writers[].service` must
+ *                                 resolve to an existing file under backend/src/.
+ *                                 Fails CI if any reference is missing.
+ *
+ * Always-on checks (both modes) :
+ *   - YAML parses cleanly
+ *   - schemaVersion matches expected
+ *   - Each field has required keys (field_path, roles, physical_columns,
+ *     authoritative_writers, denied_writers)
+ *   - physical_columns is non-empty, each entry has table + column
+ *   - authoritative_writers contains at least one entry, kinds are valid enum
+ *   - denied_writers contains at least `llm_generated_direct` (canon enforcement)
+ *   - lock_default_duration_days > 0 (either inline or via defaults)
+ *   - JSON projection at audit/registry/seo-field-authority.json matches
+ *     `build-seo-field-authority.ts --check`
+ *
+ * Usage:
+ *   pnpm tsx scripts/audit/validate-seo-field-authority.ts
+ *   pnpm tsx scripts/audit/validate-seo-field-authority.ts --strict
+ *
+ * Exit codes :
+ *   0 — all checks pass (warnings allowed in lenient mode)
+ *   1 — hard error (always-on check failed, or strict mode missing service)
+ *
+ * Plan : §5 Phase B + §15 anti-scope-creep (no runtime NestJS code)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import * as yaml from 'js-yaml';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const YAML_PATH = path.join(
+  REPO_ROOT,
+  '.spec/00-canon/repository-registry/seo-field-authority.yaml',
+);
+const BACKEND_SRC = path.join(REPO_ROOT, 'backend/src');
+const BUILD_SCRIPT = path.join(__dirname, 'build-seo-field-authority.ts');
+
+const EXPECTED_SCHEMA_VERSION = '1.0.0';
+const ALLOWED_WRITER_KINDS = new Set([
+  'deterministic_builder',
+  'human_curated',
+  'human_validated_llm',
+  'legacy_recovery',
+  'llm_generated_direct',
+]);
+const REQUIRED_DENIED_KINDS = new Set(['llm_generated_direct']);
+
+// ── Logging ─────────────────────────────────────────────────────────────────
+
+const errors: string[] = [];
+const warnings: string[] = [];
+
+function fail(msg: string): void {
+  errors.push(msg);
+  process.stderr.write(`[FAIL] ${msg}\n`);
+}
+function warn(msg: string): void {
+  warnings.push(msg);
+  process.stderr.write(`[WARN] ${msg}\n`);
+}
+function info(msg: string): void {
+  process.stderr.write(`${msg}\n`);
+}
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface PhysicalColumn {
+  table?: unknown;
+  column?: unknown;
+  role_filter?: unknown;
+}
+
+interface Writer {
+  kind?: unknown;
+  service?: unknown;
+  via?: unknown;
+  notes?: unknown;
+}
+
+interface FieldEntry {
+  field_path?: unknown;
+  description?: unknown;
+  roles?: unknown;
+  physical_columns?: unknown;
+  authoritative_writers?: unknown;
+  denied_writers?: unknown;
+  lock_default_duration_days?: unknown;
+  review_cadence_days?: unknown;
+}
+
+interface AuthorityDoc {
+  schemaVersion?: unknown;
+  defaults?: {
+    lock_default_duration_days?: unknown;
+    review_cadence_days?: unknown;
+  };
+  fields?: unknown;
+}
+
+// ── Service path resolution (NestJS dotted → backend/src/ file path) ──────────
+//
+// 'backend.modules.seo.builders.h1-deterministic-builder' → looks for
+// backend/src/modules/seo/builders/h1-deterministic-builder.{service,}.ts
+
+function resolveServicePath(dotted: string): { exists: boolean; tried: string[] } {
+  // Strip leading 'backend.' if present (it's a canonical prefix)
+  const stripped = dotted.startsWith('backend.') ? dotted.slice('backend.'.length) : dotted;
+  const segments = stripped.split('.');
+  const filename = segments.pop()!;
+  const dir = path.join(BACKEND_SRC, ...segments);
+  const candidates = [
+    path.join(dir, `${filename}.service.ts`),
+    path.join(dir, `${filename}.ts`),
+    path.join(dir, filename, 'index.ts'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return { exists: true, tried: candidates };
+  }
+  return { exists: false, tried: candidates };
+}
+
+// ── Checks ──────────────────────────────────────────────────────────────────
+
+function checkPhysicalColumns(field_path: string, physicalColumns: unknown): void {
+  if (!Array.isArray(physicalColumns) || physicalColumns.length === 0) {
+    fail(`field "${field_path}" : physical_columns must be a non-empty array`);
+    return;
+  }
+  for (const [i, col] of physicalColumns.entries()) {
+    const c = col as PhysicalColumn;
+    if (typeof c.table !== 'string' || !c.table) {
+      fail(`field "${field_path}".physical_columns[${i}] : table missing/invalid`);
+    }
+    if (typeof c.column !== 'string' || !c.column) {
+      fail(`field "${field_path}".physical_columns[${i}] : column missing/invalid`);
+    }
+  }
+}
+
+function checkAuthoritativeWriters(
+  field_path: string,
+  writers: unknown,
+  strict: boolean,
+): void {
+  if (!Array.isArray(writers) || writers.length === 0) {
+    fail(`field "${field_path}" : authoritative_writers must be non-empty`);
+    return;
+  }
+  for (const [i, w] of writers.entries()) {
+    const writer = w as Writer;
+    if (typeof writer.kind !== 'string' || !ALLOWED_WRITER_KINDS.has(writer.kind)) {
+      fail(
+        `field "${field_path}".authoritative_writers[${i}] : kind invalid (got ${JSON.stringify(writer.kind)}, expected one of ${[...ALLOWED_WRITER_KINDS].join(', ')})`,
+      );
+      continue;
+    }
+    // A writer must reference either a service or a via origin.
+    const hasService = typeof writer.service === 'string' && writer.service.length > 0;
+    const hasVia = typeof writer.via === 'string' && writer.via.length > 0;
+    if (!hasService && !hasVia) {
+      fail(
+        `field "${field_path}".authoritative_writers[${i}] (kind=${writer.kind}) : must declare either 'service' or 'via'`,
+      );
+      continue;
+    }
+    if (hasService) {
+      const resolved = resolveServicePath(writer.service as string);
+      if (!resolved.exists) {
+        const msg = `field "${field_path}".authoritative_writers[${i}] (kind=${writer.kind}) : service "${String(writer.service)}" not found under backend/src/ (tried ${resolved.tried.map((p) => path.relative(REPO_ROOT, p)).join(', ')})`;
+        if (strict) {
+          fail(msg);
+        } else {
+          warn(`${msg} — lenient: PR-B accepts forward declaration, will fail in --strict (PR-C+)`);
+        }
+      }
+    }
+  }
+}
+
+function checkDeniedWriters(field_path: string, writers: unknown): void {
+  if (!Array.isArray(writers) || writers.length === 0) {
+    fail(`field "${field_path}" : denied_writers must be non-empty`);
+    return;
+  }
+  const kinds = new Set<string>();
+  for (const [i, w] of writers.entries()) {
+    const writer = w as Writer;
+    if (typeof writer.kind !== 'string' || !ALLOWED_WRITER_KINDS.has(writer.kind)) {
+      fail(
+        `field "${field_path}".denied_writers[${i}] : kind invalid (got ${JSON.stringify(writer.kind)})`,
+      );
+      continue;
+    }
+    kinds.add(writer.kind);
+  }
+  for (const required of REQUIRED_DENIED_KINDS) {
+    if (!kinds.has(required)) {
+      fail(
+        `field "${field_path}" : denied_writers must include "${required}" (canon enforcement, memory feedback_no_touch_meta_h1_if_optimized)`,
+      );
+    }
+  }
+}
+
+function checkLockDuration(
+  field_path: string,
+  field: FieldEntry,
+  doc: AuthorityDoc,
+): void {
+  const inline = field.lock_default_duration_days;
+  const fallback = doc.defaults?.lock_default_duration_days;
+  const value = typeof inline === 'number' ? inline : typeof fallback === 'number' ? fallback : null;
+  if (value === null) {
+    fail(`field "${field_path}" : no lock_default_duration_days (inline or defaults)`);
+    return;
+  }
+  if (value <= 0) {
+    fail(`field "${field_path}" : lock_default_duration_days must be > 0 (got ${value})`);
+  }
+}
+
+function checkField(field: FieldEntry, doc: AuthorityDoc, strict: boolean): void {
+  if (typeof field.field_path !== 'string' || !field.field_path) {
+    fail(`field entry has no field_path`);
+    return;
+  }
+  const fp = field.field_path;
+  if (!Array.isArray(field.roles) || field.roles.length === 0) {
+    fail(`field "${fp}" : roles must be a non-empty array`);
+  }
+  checkPhysicalColumns(fp, field.physical_columns);
+  checkAuthoritativeWriters(fp, field.authoritative_writers, strict);
+  checkDeniedWriters(fp, field.denied_writers);
+  checkLockDuration(fp, field, doc);
+}
+
+function checkJsonProjection(): void {
+  const result = spawnSync('npx', ['tsx', BUILD_SCRIPT, '--check'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    fail(
+      `JSON projection audit/registry/seo-field-authority.json is stale vs YAML canon. ` +
+        `Run \`pnpm tsx scripts/audit/build-seo-field-authority.ts\` to regenerate.\n` +
+        `--check output:\n${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const strict = argv.includes('--strict');
+  const mode = strict ? 'strict' : 'lenient';
+
+  info(`▶ Validating SEO Field Authority Registry (mode=${mode})`);
+
+  if (!fs.existsSync(YAML_PATH)) {
+    fail(`YAML canon not found at ${path.relative(REPO_ROOT, YAML_PATH)}`);
+    process.exit(1);
+  }
+
+  let doc: AuthorityDoc;
+  try {
+    doc = yaml.load(fs.readFileSync(YAML_PATH, 'utf8')) as AuthorityDoc;
+  } catch (err) {
+    fail(`YAML parse error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  if (doc.schemaVersion !== EXPECTED_SCHEMA_VERSION) {
+    fail(
+      `schemaVersion mismatch: expected "${EXPECTED_SCHEMA_VERSION}", got ${JSON.stringify(doc.schemaVersion)}`,
+    );
+  }
+
+  if (!Array.isArray(doc.fields) || doc.fields.length === 0) {
+    fail(`doc.fields must be a non-empty array`);
+    process.exit(1);
+  }
+
+  // Check each field.
+  for (const f of doc.fields) {
+    checkField(f as FieldEntry, doc, strict);
+  }
+
+  // Check JSON projection consistency (drift detection).
+  checkJsonProjection();
+
+  // Summary.
+  info('');
+  if (errors.length === 0) {
+    info(`✓ Validation passed (${warnings.length} warnings) in ${mode} mode`);
+    process.exit(0);
+  }
+  process.stderr.write(`✗ Validation failed : ${errors.length} errors, ${warnings.length} warnings\n`);
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

PR-B du plan **SEO Governance Control Plane** — Field Authority Registry.

Établit l'**autorité canonique d'écriture par champ SEO** AVANT que toute policy engine ne l'applique. L'authority vit dans ce fichier YAML, pas inventée à runtime — OPA (Phase C) l'appliquera, ne la définira pas.

Plan : `/home/deploy/.claude/plans/lors-du-audite-seo-concurrent-swan.md` §5 Phase B

## Scope strict (verrouillé)

- ✅ `h1` = field gouverné (1 seul field)
- ✅ Mapping logique → colonnes physiques (4 tables)
- ✅ `denied_writers: llm_generated_direct` (canon enforcement)
- ✅ `authoritative_writers`: `deterministic_builder`, `human_curated`, `legacy_recovery`
- ✅ Validator `--lenient` par défaut en PR-B (warn forward declarations)
- ✅ Validator `--strict` activé seulement à partir de PR-C via CI
- ❌ Aucun runtime NestJS, aucun OPA, aucun UPDATE H1
- ❌ Aucun autre field (meta_title, meta_description, etc.) — extensions futures

## Ships (5 fichiers)

### 1. `.spec/00-canon/repository-registry/seo-field-authority.yaml`

Source de vérité canon. Layer 2 overlay manuel (ADR-058). Édité main par owners `@ak125/seo-team`.

```yaml
schemaVersion: "1.0.0"
defaults:
  lock_default_duration_days: 90
  review_cadence_days: 365
fields:
  - field_path: h1
    roles: [R1_ROUTER, R3_CONSEILS, R6_GUIDE_ACHAT, R7_BRAND, R8_VEHICLE]
    physical_columns:
      - { table: __seo_r1_gamme_slots, column: r1s_h1_override, role_filter: R1_ROUTER }
      - { table: __seo_gamme_purchase_guide, column: sgpg_h1_override, role_filter: R6_GUIDE_ACHAT }
      - { table: __seo_gamme, column: sg_h1, role_filter: legacy_fallback }
      - { table: __meta_tags_ariane, column: mta_h1, role_filter: R7_BRAND|R8_VEHICLE }
    authoritative_writers:
      - kind: deterministic_builder
        service: backend.modules.seo.builders.h1-deterministic-builder
      - kind: human_curated
        via: admin-ui
      - kind: legacy_recovery
        via: seo-recovery-pipeline
    denied_writers:
      - kind: llm_generated_direct
```

### 2. `scripts/audit/build-seo-field-authority.ts`

Projection déterministe YAML → JSON (sorted keys, idempotent). Mode `--check` pour drift detection CI.

### 3. `scripts/audit/validate-seo-field-authority.ts`

- **`--lenient`** (défaut PR-B) : `WARN` sur `service` référencé absent dans `backend/src/`. Le service `h1-deterministic-builder` n'existe qu'en Phase C — la lenient mode accepte cette forward declaration.
- **`--strict`** (PR-C+ via CI) : `FAIL` si tout service authoritative manque. À activer à partir de PR-C (création du service réel).
- Always-on : YAML parse, schemaVersion match, required keys, `physical_columns` non-vide, `denied_writers ⊇ {llm_generated_direct}` (canon), `lock_default_duration_days > 0`, drift JSON vs YAML.

### 4. `audit/registry/seo-field-authority.json`

Projection générée. Bloc `\$generated` (from, by, schemaVersion, note DO NOT EDIT).

### 5. `.spec/00-canon/repository-registry/ownership.yaml`

Ajoute glob `audit/registry/seo-field-authority.json` (domain D3, owner `@ak125/seo-team`, risk medium).

## Test plan

- [x] `npx tsc --noEmit --strict` sur les 2 scripts → OK
- [x] `pnpm tsx build-seo-field-authority.ts` → JSON written, 1 field
- [x] `pnpm tsx validate-seo-field-authority.ts` (lenient) → **PASS** (1 warn forward declaration attendu)
- [x] `pnpm tsx validate-seo-field-authority.ts --strict` → **FAIL** (service absent — comportement attendu, sera GO en PR-C)
- [x] Drift test : JSON tampered → validator detects → restored → PASS
- [ ] Review humaine
- [ ] CI verte (registry-new-file-gate doit passer grâce aux globs déjà couverts)

## Pas dans cette PR

- ❌ Aucun service NestJS, aucun decorator `@SeoFieldGuard`, aucun module governance
- ❌ Aucun bundle OPA / Rego (Phase C dans vault PR séparée PR-V)
- ❌ Aucun UPDATE sur tables H1 prod
- ❌ Aucun autre field SEO (meta_title, meta_description, canonical, robots, og:image) — extensions futures même schema
- ❌ Aucun lien Zod runtime / mirror dans `packages/seo-types/`

## Memory rules

- `feedback_no_touch_meta_h1_if_optimized` (STRICT) — canon enforcement via `denied_writers ⊇ {llm_generated_direct}`
- `feedback_deterministic_evidence_tiers_over_bayesian` — enum CHECK strict
- `feedback_branch_scope_discipline` — scope strict h1, branche dédiée
- `feedback_verify_existing_first` — réutilise pattern existant `.spec/00-canon/repository-registry/`

## Prochaine étape

**PR-V** dans `ak125/governance-vault` : `policies/seo-content/h1-write.rego` + WASM build CI. Puis **PR-C** : OPA Write Gateway NestJS-only + refactor 4 enrichers + activation `--strict` validator dans CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)