### PR TITLE
feat(observatory): emit full sorted orphans list in contract-health.json

### DIFF
--- a/scripts/audit/build-drift-dashboard.test.ts
+++ b/scripts/audit/build-drift-dashboard.test.ts
@@ -1,5 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildDashboard } from "./build-drift-dashboard.ts";
@@ -72,6 +74,56 @@ test("ownership gap detection: no orphans for files that match globs", async () 
   const r = await buildDashboard({ repoRoot: FIXTURE_OK });
   assert.equal(r.json.ownership.gapCount, 0);
   assert.deepEqual(r.json.ownership.sample, []);
+  assert.deepEqual(r.json.ownership.orphans, []);
+});
+
+test("ownership gap detection: full orphans list emitted, sorted, >10 entries", async () => {
+  // Synthetic repo: 12 files where only 2 match the glob. Verifies that the
+  // returned `orphans` array is the FULL list (not truncated like `sample`),
+  // is sorted, and that `sample` is its first-10 prefix.
+  const root = mkdtempSync(join(tmpdir(), "drift-orphans-"));
+  mkdirSync(join(root, ".spec/00-canon/repository-registry"), { recursive: true });
+  mkdirSync(join(root, "audit/registry"), { recursive: true });
+
+  writeFileSync(
+    join(root, ".spec/00-canon/repository-registry/ownership.yaml"),
+    "schemaVersion: 1.0.0\nentries:\n  - glob: backend/**\n    domain: D1\n    owner: x\n    sourceConfidence: high\n    risk: low\n",
+    "utf8",
+  );
+
+  const orphanPaths = [
+    "orphan-z.ts",
+    "orphan-a.ts",
+    "orphan-m.ts",
+    "orphan-c.ts",
+    "orphan-b.ts",
+    "orphan-d.ts",
+    "orphan-e.ts",
+    "orphan-f.ts",
+    "orphan-g.ts",
+    "orphan-h.ts",
+    "orphan-i.ts",
+    "orphan-j.ts",
+  ];
+  const ownedPaths = ["backend/src/owned-1.ts", "backend/src/owned-2.ts"];
+  const allPaths = [...orphanPaths, ...ownedPaths];
+  writeFileSync(
+    join(root, "audit/registry/files.json"),
+    JSON.stringify({
+      entries: allPaths.map((p) => ({ path: p, id: p, owner: null, domain: null })),
+    }),
+    "utf8",
+  );
+
+  const r = await buildDashboard({ repoRoot: root });
+  const sortedOrphans = orphanPaths.slice().sort();
+  assert.equal(r.json.ownership.gapCount, orphanPaths.length);
+  assert.deepEqual(r.json.ownership.orphans, sortedOrphans);
+  assert.deepEqual(r.json.ownership.sample, sortedOrphans.slice(0, 10));
+  assert.ok(
+    r.json.ownership.orphans.length >= r.json.ownership.sample.length,
+    "orphans must be at least as long as sample",
+  );
 });
 
 test("canonical fingerprint: sotFingerprint surfaced, stale=false when sections non-empty", async () => {

--- a/scripts/audit/build-drift-dashboard.ts
+++ b/scripts/audit/build-drift-dashboard.ts
@@ -107,7 +107,7 @@ export interface DashboardJson {
     };
     depCruiserGenerated: { mtime: string | null; ageHours: number | null };
   };
-  ownership: { gapCount: number; sample: string[] };
+  ownership: { gapCount: number; sample: string[]; orphans: string[] };
   coverage: Record<string, unknown>;
 }
 
@@ -278,7 +278,7 @@ function signal2_fingerprint(
 
 function signal3_ownership(
   repoRoot: string,
-): { gapCount: number; sample: string[] } {
+): { gapCount: number; sample: string[]; orphans: string[] } {
   const ownershipPath = join(
     repoRoot,
     ".spec/00-canon/repository-registry/ownership.yaml",
@@ -289,7 +289,7 @@ function signal3_ownership(
   try {
     yamlText = readFileSync(ownershipPath, "utf8");
   } catch {
-    return { gapCount: 0, sample: [] };
+    return { gapCount: 0, sample: [], orphans: [] };
   }
   const overlay: any = yamlLoad(yamlText);
   const entries: any[] = Array.isArray(overlay?.entries) ? overlay.entries : [];
@@ -299,7 +299,7 @@ function signal3_ownership(
   try {
     filesParsed = JSON.parse(readFileSync(filesPath, "utf8"));
   } catch {
-    return { gapCount: 0, sample: [] };
+    return { gapCount: 0, sample: [], orphans: [] };
   }
   const fileEntries: any[] = Array.isArray(filesParsed?.entries)
     ? filesParsed.entries
@@ -312,7 +312,12 @@ function signal3_ownership(
     const matched = micromatch.isMatch(p, globs, { dot: true });
     if (!matched) orphans.push(p);
   }
-  return { gapCount: orphans.length, sample: orphans.slice(0, 10) };
+  const sortedOrphans = orphans.slice().sort();
+  return {
+    gapCount: sortedOrphans.length,
+    sample: sortedOrphans.slice(0, 10),
+    orphans: sortedOrphans,
+  };
 }
 
 function signal4to6_coverage(


### PR DESCRIPTION
## Summary

Precursor for PR-7 (Contract Drift Ratchet) per ADR-058 §23 `observe → ratchet → enforce`.

PR-6 (#540) surfaced ownership gaps as `{ gapCount, sample (first 10) }` — sufficient for the dashboard markdown, but insufficient for downstream consumers that need set-difference semantics (the ratchet computes `current_findings − baseline_findings`).

This PR adds an explicit `orphans: string[]` field carrying the **full sorted** list. `sample` remains `orphans.slice(0, 10)` for markdown rendering.

## Scope

- 1 source file (`scripts/audit/build-drift-dashboard.ts`) — 4 lines of structural change (type + return shape).
- 1 test file (`scripts/audit/build-drift-dashboard.test.ts`) — 1 augmented assertion + 1 new test using a synthetic >10-orphans repo to verify the full list, sort order, and `sample` prefix relationship.

## Verification

- All 7 dashboard tests pass locally.
- Live run against current repo: `gapCount: 538`, `orphans.length: 538`, sorted alphabetically (first `.dependency-cruiser.cjs`, last `services/remotion-renderer/src/types/contract.ts`).

## Why a separate PR (and not bundled in PR-7)

Keeps the dashboard contract change atomic and single-purpose. PR-7 then stays strictly scoped to its 3 canonical files (baseline + comparator + workflow) without touching PR-6's source.

## No behavior change for warn-only observer

The observer still always exits 0; the markdown is identical; only the JSON output grows one field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)