### PR TITLE
fix(seo-r2): ADR-067 — remove auto SUPPRESSED verdict from pipeline

### DIFF
--- a/backend/src/modules/seo/r2/dto/r2-enrich-single.dto.ts
+++ b/backend/src/modules/seo/r2/dto/r2-enrich-single.dto.ts
@@ -20,7 +20,9 @@ export interface R2EnrichSingleResponse {
   featureFlagEnabled: boolean;
   eligibility: {
     score: number;
-    verdict: 'eligible' | 'suppressed' | 'reject';
+    // ADR-067 : pipeline ne peut émettre que ces 3 verdicts.
+    // 'suppressed' reste un statut DB pour le path manual admin uniquement.
+    verdict: 'eligible' | 'review' | 'reject';
     reason: string;
     subscores: {
       motor: number;
@@ -28,7 +30,6 @@ export interface R2EnrichSingleResponse {
       commercial: number;
       crawl: number;
     };
-    suppressedCanonicalTypeId?: number;
   };
   warning?: string;
   timestamp: string;

--- a/backend/src/modules/seo/r2/schemas/r2-eligibility.schema.ts
+++ b/backend/src/modules/seo/r2/schemas/r2-eligibility.schema.ts
@@ -28,27 +28,31 @@ export type R2EligibilitySubscores = z.infer<
 >;
 
 // ── Verdict (decision tree output) ─────────────────────────────────────────────
-
+//
+// ADR-067 amendment (2026-05-15) : SUPPRESSED automatique INTERDIT.
+// Le pipeline ne peut émettre que 3 verdicts : eligible | review | reject.
+// SUPPRESSED reste un statut DB mais devient manual-only (admin override UI).
+// Voir MEMORY feedback_no_auto_page_suppression_ever.
 export const R2EligibilityVerdictEnum = z.enum([
   'eligible',
-  'suppressed',
+  'review',
   'reject',
 ]);
 
 export type R2EligibilityVerdictKind = z.infer<typeof R2EligibilityVerdictEnum>;
 
 /**
- * Sibling target for SUPPRESSED canonical decision (cf ADR-066 + MEMORY
- * feedback_seo_suppressed_canonical_decision).
+ * Manual canonical target for admin SUPPRESSED override (ADR-067).
+ * Le pipeline ne produit jamais cette valeur — admin UI uniquement
+ * (via review queue flip). Conservé schema-side pour le path manual
+ * et l'audit-trail des décisions humaines.
  */
-export const SuppressedCanonicalTargetSchema = z.object({
+export const ManualCanonicalTargetSchema = z.object({
   typeId: z.number().int().positive(),
   pgId: z.number().int().positive(),
 });
 
-export type SuppressedCanonicalTarget = z.infer<
-  typeof SuppressedCanonicalTargetSchema
->;
+export type ManualCanonicalTarget = z.infer<typeof ManualCanonicalTargetSchema>;
 
 // ── Full verdict (consumed by R2EligibilityService) ────────────────────────────
 
@@ -58,7 +62,6 @@ export const R2EligibilityVerdictSchema = z.object({
   subscores: R2EligibilitySubscoresSchema,
   verdict: R2EligibilityVerdictEnum,
   reason: z.string(),
-  suppressedCanonicalTarget: SuppressedCanonicalTargetSchema.optional(),
 });
 
 export type R2EligibilityVerdict = z.infer<typeof R2EligibilityVerdictSchema>;
@@ -73,7 +76,9 @@ export const R2EligibilityLogRowSchema = z.object({
   eligibilityScore: z.number().min(0).max(100),
   subscores: R2EligibilitySubscoresSchema,
   verdict: R2EligibilityVerdictEnum,
-  suppressedTarget: z.number().int().positive().nullable().optional(),
+  // ADR-067 : pipeline n'émet jamais SUPPRESSED. Kept nullable for legacy rows
+  // and for the manual admin path (review queue → suppressed flip).
+  manualCanonicalTarget: z.number().int().positive().nullable().optional(),
   reason: z.string().nullable().optional(),
   evaluatedAt: z.date().optional(), // server default NOW()
 });

--- a/backend/src/modules/seo/r2/services/__tests__/r2-eligibility.spec.ts
+++ b/backend/src/modules/seo/r2/services/__tests__/r2-eligibility.spec.ts
@@ -61,8 +61,6 @@ describe('R2EligibilityService', () => {
       commercialInputs: baseCommercialInputs,
       productCount: 1,
       searchVolumeFactor: 50,
-      hasCanonicalSiblingIndex: true,
-      siblingCanonicalTarget: { typeId: 67890, pgId: 100 },
     });
     expect(verdict.verdict).toBe('reject');
     expect(verdict.eligibilityScore).toBe(0);
@@ -77,15 +75,16 @@ describe('R2EligibilityService', () => {
       commercialInputs: baseCommercialInputs,
       productCount: 50,
       searchVolumeFactor: 70,
-      hasCanonicalSiblingIndex: false,
     });
     expect(verdict.eligibilityScore).toBeGreaterThanOrEqual(THRESHOLD_V1);
     expect(verdict.verdict).toBe('eligible');
     expect(verdict.eligible).toBe(true);
   });
 
-  it('returns suppressed when below threshold AND canonical sibling exists', () => {
-    // Make motor very weak (no deltas at all) + low commercial distinctness
+  // ADR-067 (2026-05-15) — SUPPRESSED automatique INTERDIT.
+  // Pipeline below threshold + productCount >= 2 → REVIEW (jamais SUPPRESSED).
+  // Le path SUPPRESSED reste manual-only (admin UI override).
+  it('returns review when below threshold AND productCount >= 2 (ADR-067 no auto suppressed)', () => {
     const weakMotor: MotorDelta = {
       ...baseMotor,
       hasPowerDelta: false,
@@ -111,48 +110,45 @@ describe('R2EligibilityService', () => {
       commercialInputs: weakCommercialInputs,
       productCount: 3,
       searchVolumeFactor: 10,
-      hasCanonicalSiblingIndex: true,
-      siblingCanonicalTarget: { typeId: 67890, pgId: 100 },
     });
     expect(verdict.eligibilityScore).toBeLessThan(THRESHOLD_V1);
-    expect(verdict.verdict).toBe('suppressed');
-    expect(verdict.suppressedCanonicalTarget).toEqual({
-      typeId: 67890,
-      pgId: 100,
-    });
+    expect(verdict.verdict).toBe('review');
+    // No suppressedCanonicalTarget — ADR-067 forbids pipeline-emitted SUPPRESSED
+    expect(verdict.reason).toContain('REVIEW');
   });
 
-  it('returns reject when below threshold AND no canonical sibling', () => {
-    const weakMotor: MotorDelta = {
-      ...baseMotor,
-      hasPowerDelta: false,
-      hasEngineDelta: false,
-      hasPeriodDelta: false,
-      hasFuelDelta: false,
-      hasBodyDelta: false,
-      uniqueProductFamilies: [],
-      productCount: 3,
-    };
-    const weakCommercialInputs = {
-      ...baseCommercialInputs,
-      targetFamilies: baseCommercialInputs.clusterFamilies,
-      targetOemRefs: baseCommercialInputs.clusterOemRefs,
-      targetSuppliers: baseCommercialInputs.clusterSuppliers,
-      targetMedianPriceCents: baseCommercialInputs.clusterMedianPriceCents,
-      targetCompatScope: baseCommercialInputs.clusterCompatScope,
-    };
-    const verdict = service.evaluate({
-      pgId: 100,
-      typeId: 12345,
-      motorDelta: weakMotor,
-      commercialInputs: weakCommercialInputs,
-      productCount: 3,
-      searchVolumeFactor: 10,
-      hasCanonicalSiblingIndex: false,
-    });
-    expect(verdict.eligibilityScore).toBeLessThan(THRESHOLD_V1);
-    expect(verdict.verdict).toBe('reject');
-    expect(verdict.suppressedCanonicalTarget).toBeUndefined();
+  it('verdict enum never includes "suppressed" from pipeline (ADR-067)', () => {
+    // Exhaustive sweep : with varying motor strength + productCount >= 2,
+    // verdict must always be in {eligible, review} (never suppressed)
+    const scenarios = [
+      { hp: false, eng: false, prod: 5, sv: 0 },
+      { hp: true, eng: false, prod: 10, sv: 30 },
+      { hp: true, eng: true, prod: 200, sv: 90 },
+      { hp: false, eng: true, prod: 3, sv: 100 },
+    ];
+    for (const sc of scenarios) {
+      const motor: MotorDelta = {
+        ...baseMotor,
+        hasPowerDelta: sc.hp,
+        hasEngineDelta: sc.eng,
+        hasPeriodDelta: false,
+        hasFuelDelta: false,
+        hasBodyDelta: false,
+        productCount: sc.prod,
+      };
+      const verdict = service.evaluate({
+        pgId: 100,
+        typeId: 12345,
+        motorDelta: motor,
+        commercialInputs: baseCommercialInputs,
+        productCount: sc.prod,
+        searchVolumeFactor: sc.sv,
+      });
+      expect(['eligible', 'review']).toContain(verdict.verdict);
+      // Runtime safety check : enum guarantees no 'suppressed' at type level,
+      // but assert at runtime in case of upstream regression.
+      expect(verdict.verdict as string).not.toBe('suppressed');
+    }
   });
 
   it('exposes all 4 subscores in verdict', () => {
@@ -163,7 +159,6 @@ describe('R2EligibilityService', () => {
       commercialInputs: baseCommercialInputs,
       productCount: 50,
       searchVolumeFactor: 60,
-      hasCanonicalSiblingIndex: false,
     });
     expect(verdict.subscores.motor).toBeGreaterThanOrEqual(0);
     expect(verdict.subscores.motor).toBeLessThanOrEqual(100);

--- a/backend/src/modules/seo/r2/services/r2-eligibility.service.ts
+++ b/backend/src/modules/seo/r2/services/r2-eligibility.service.ts
@@ -26,13 +26,20 @@ import type { MotorDelta } from '../schemas/r2-composition.schema';
 import type {
   R2EligibilitySubscores,
   R2EligibilityVerdict,
-  SuppressedCanonicalTarget,
 } from '../schemas/r2-eligibility.schema';
 import {
   R2CommercialDistinctivenessService,
   type CommercialInputs,
 } from './r2-commercial-distinctiveness.service';
 
+/**
+ * ADR-067 (2026-05-15) : pipeline ne peut émettre que 3 verdicts —
+ * eligible | review | reject. SUPPRESSED reste manual-only (admin UI).
+ *
+ * Plus de `hasCanonicalSiblingIndex` ni `siblingCanonicalTarget` ici :
+ * la décision SUPPRESSED humaine se fait dans la review queue après
+ * que le pipeline a émis `review`, jamais avant.
+ */
 export interface EligibilityRunInputs {
   pgId: number;
   typeId: number;
@@ -40,8 +47,6 @@ export interface EligibilityRunInputs {
   commercialInputs: CommercialInputs;
   productCount: number;
   searchVolumeFactor: number; // log-normalized 0-100 (V-Level or GSC clicks proxy)
-  hasCanonicalSiblingIndex: boolean; // diversity service preview
-  siblingCanonicalTarget?: SuppressedCanonicalTarget;
 }
 
 @Injectable()
@@ -106,24 +111,16 @@ export class R2EligibilityService {
       };
     }
 
-    // Below threshold : SUPPRESSED if canonical sibling fiable, REJECT otherwise.
-    if (inputs.hasCanonicalSiblingIndex && inputs.siblingCanonicalTarget) {
-      return {
-        eligible: false,
-        eligibilityScore: roundedScore,
-        subscores,
-        verdict: 'suppressed',
-        suppressedCanonicalTarget: inputs.siblingCanonicalTarget,
-        reason: `score=${roundedScore} < ${THRESHOLD_V1}, canonical sibling type_id=${inputs.siblingCanonicalTarget.typeId}`,
-      };
-    }
-
+    // ADR-067 (2026-05-15) : Below threshold + valid productCount → REVIEW
+    // (enrichment queue or human validation). Pipeline never emits SUPPRESSED.
+    // The admin can manually flip a REVIEW page to SUPPRESSED via UI later if
+    // a real duplicate is confirmed humanly (rare exception path).
     return {
       eligible: false,
       eligibilityScore: roundedScore,
       subscores,
-      verdict: 'reject',
-      reason: `score=${roundedScore} < ${THRESHOLD_V1}, no canonical sibling fiable`,
+      verdict: 'review',
+      reason: `score=${roundedScore} < THRESHOLD_V1=${THRESHOLD_V1} — REVIEW queue (enrichment or human validation, ADR-067)`,
     };
   }
 


### PR DESCRIPTION
## Summary

**Code fixup pour ADR-067** (vault commit `74f45919`, merged 2026-05-15) — retire le path SUPPRESSED automatique du pipeline R2 v2.

## Doctrine (rappel)

ADR-067 amende ADR-066 : `SUPPRESSED automatique` est **strictement INTERDIT**. Compatibilité pièce prime sur similarité texte. Calibration empirique N=200 prod a révélé 58% des G2 candidats SUPPRESSED auto — inacceptable.

| Aspect | Avant (ADR-066) | Après (ADR-067) |
|--------|-----------------|-----------------|
| Pipeline verdict enum | `'eligible' \| 'suppressed' \| 'reject'` | **`'eligible' \| 'review' \| 'reject'`** |
| Below threshold + sibling | `verdict: 'suppressed'` | **`verdict: 'review'`** (enrichissement queue) |
| Below threshold + no sibling | `verdict: 'reject'` | **`verdict: 'review'`** (productCount ≥ 2) |
| productCount < 2 | `verdict: 'reject'` | **`verdict: 'reject'`** (page invalide) |
| SUPPRESSED status DB | conservé (auto + manual) | **conservé (manual-only)** |

## Changements code

### Schemas (`backend/src/modules/seo/r2/schemas/r2-eligibility.schema.ts`)

- `R2EligibilityVerdictEnum` : `['eligible', 'suppressed', 'reject']` → `['eligible', 'review', 'reject']`
- `SuppressedCanonicalTargetSchema` → `ManualCanonicalTargetSchema` (renommé, manual-only)
- `R2EligibilityVerdict.suppressedCanonicalTarget` field retiré (pipeline ne produit jamais cette valeur)
- `R2EligibilityLogRow.suppressedTarget` → `manualCanonicalTarget` (nullable, pour audit-trail des flips manuels)

### Service (`r2-eligibility.service.ts`)

- `EligibilityRunInputs` : retiré `hasCanonicalSiblingIndex` + `siblingCanonicalTarget` (paramètres devenus inutiles — pipeline n'émet plus SUPPRESSED)
- `evaluate()` : below threshold + productCount ≥ 2 → `verdict: 'review'` (was `'suppressed'` conditional)
- Reason mentionne ADR-067 + REVIEW queue rationale

### DTO (`r2-enrich-single.dto.ts`)

- `R2EnrichSingleResponse.eligibility.verdict` : `'eligible' | 'suppressed' | 'reject'` → `'eligible' | 'review' | 'reject'`
- `suppressedCanonicalTypeId?` retiré

### Tests Jest (`r2-eligibility.spec.ts`)

- Test `'returns suppressed when below threshold AND canonical sibling exists'` → `'returns review when below threshold AND productCount >= 2 (ADR-067 no auto suppressed)'`
- Test `'returns reject when below threshold AND no canonical sibling'` **retiré** (case plus possible avec nouvelle matrice — toujours REVIEW si productCount valide)
- **Nouveau test exhaustif** `'verdict enum never includes "suppressed" from pipeline (ADR-067)'` qui sweep 4 scénarios motor strength × productCount et vérifie verdict ∈ {eligible, review} + runtime assertion `not 'suppressed'`
- Tous inputs `hasCanonicalSiblingIndex` / `siblingCanonicalTarget` retirés des autres tests (params disparus)

## Backward compat préservée

- **`R2DecisionV2Enum`** garde `'suppressed'` (Rego + DB compat pour le path manual admin via human_curated)
- **`R2ContentContractV2Schema` superRefine** invariants SUPPRESSED conservés (canonical_target_type_id non-null, sitemapEligible=false) — valables pour pipeline rejeté ET path manual
- Migration `__seo_r2_pages` status enum garde 'suppressed' (aucune DDL nécessaire)
- Rego `r2-content-write.rego` (vault commit `74f45919`) :
  - `pipeline_generated → suppressed` désormais `deny` (avec reason ADR-067)
  - `human_curated → suppressed` autorisé avec invariants canonical anti-chain

## Test plan

- [x] `backend tsc --build` → 0 errors
- [x] Local file edits squawk-clean (no SQL changes)
- [x] Pre-commit hooks pass (lint-staged)
- [ ] CI run : Backend Tests (Jest), TypeScript, ESLint, Migration Safety, etc.

## Self-review

1. ✅ **Doctrine alignment** : code reflète ADR-067 vault commit `74f45919`
2. ✅ **Backward compat** : enum DB `suppressed` conservé pour path manual admin
3. ✅ **Tests** : test sweep exhaustif vérifie verdict enum runtime
4. ✅ **Scope strict** : fixup uniquement, zéro nouveau feature
5. ✅ **Pas de migration DDL** : enum `suppressed` reste dans status/decision check constraints (manual path)
6. ✅ **Reason field** mentionne ADR-067 + REVIEW queue rationale (audit-trail clarté)

## Self-review verdict: APPROVE

Fixup chirurgical aligné avec vault doctrine ADR-067. Zéro page R2 v2 en prod (PR 1 mergée 2026-05-15T17:39, pas encore activé feature flag), donc zéro impact migration. Pilote V1 post-merge sera sous nouvelle doctrine.

## Cross-refs

- Vault PR #282 [ADR-067 merged](https://github.com/ak125/governance-vault/pull/282) (commit `74f45919`)
- ADR-066 (vault commit `8a92c49`, amended)
- Memoires monorepo : `feedback_no_auto_page_suppression_ever` (STRICT NEW), `feedback_seo_suppressed_canonical_decision` (superseded), `feedback_canonical_chain_prevention` (amended manual-only), `feedback_seo_catalog_signature_before_text_diversity` (amended REVIEW+enrichissement)
- Calibration empirique N=200 (Supabase MCP project `cxpojprgwgubzjyqzmoq`, 2026-05-15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)