### PR TITLE
fix(seo-r2): ADR-068 — rename verdict review → review_required + REJECT scope strict

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-15'
+last_scan: '2026-05-16'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/backend/src/modules/seo/r2/dto/r2-enrich-single.dto.ts
+++ b/backend/src/modules/seo/r2/dto/r2-enrich-single.dto.ts
@@ -20,9 +20,15 @@ export interface R2EnrichSingleResponse {
   featureFlagEnabled: boolean;
   eligibility: {
     score: number;
-    // ADR-067 : pipeline ne peut émettre que ces 3 verdicts.
+    // ADR-067 + ADR-068 : pipeline ne peut émettre que ces 3 verdicts.
     // 'suppressed' reste un statut DB pour le path manual admin uniquement.
-    verdict: 'eligible' | 'review' | 'reject';
+    verdict: 'eligible' | 'review_required' | 'reject';
+    // ADR-068 : si verdict='reject', rejectReason DOIT être l'une des 4 raisons strict.
+    rejectReason?:
+      | 'productCount_under_2'
+      | 'data_invalid'
+      | 'url_impossible'
+      | 'compatibility_absent';
     reason: string;
     subscores: {
       motor: number;

--- a/backend/src/modules/seo/r2/schemas/r2-eligibility.schema.ts
+++ b/backend/src/modules/seo/r2/schemas/r2-eligibility.schema.ts
@@ -29,17 +29,37 @@ export type R2EligibilitySubscores = z.infer<
 
 // ── Verdict (decision tree output) ─────────────────────────────────────────────
 //
-// ADR-067 amendment (2026-05-15) : SUPPRESSED automatique INTERDIT.
-// Le pipeline ne peut émettre que 3 verdicts : eligible | review | reject.
+// ADR-067 (2026-05-15) : SUPPRESSED automatique INTERDIT.
+// ADR-068 (2026-05-16) : renommage 'review' → 'review_required' (cohérence canon
+// avec R2DecisionV2Enum.review_required). REJECT scope strict — 4 raisons UNIQUES
+// (productCount_under_2 / data_invalid / url_impossible / compatibility_absent).
+// Voir MEMORY feedback_no_auto_page_suppression_ever (canon-strict, 4 interdictions auto).
+//
+// Le pipeline ne peut émettre que 3 verdicts : eligible | review_required | reject.
 // SUPPRESSED reste un statut DB mais devient manual-only (admin override UI).
-// Voir MEMORY feedback_no_auto_page_suppression_ever.
 export const R2EligibilityVerdictEnum = z.enum([
   'eligible',
-  'review',
+  'review_required',
   'reject',
 ]);
 
 export type R2EligibilityVerdictKind = z.infer<typeof R2EligibilityVerdictEnum>;
+
+/**
+ * ADR-068 (2026-05-16) — REJECT scope strict : 4 raisons UNIQUES.
+ * Doit être aligné avec Rego policy `r2-content-write.rego` :
+ *   valid_reject_reasons := {productCount_under_2, data_invalid, url_impossible, compatibility_absent}
+ *
+ * PAS pour similarité forte (catalog overlap, semantic cosine) → verdict 'review_required'.
+ */
+export const R2RejectReasonEnum = z.enum([
+  'productCount_under_2',
+  'data_invalid',
+  'url_impossible',
+  'compatibility_absent',
+]);
+
+export type R2RejectReasonKind = z.infer<typeof R2RejectReasonEnum>;
 
 /**
  * Manual canonical target for admin SUPPRESSED override (ADR-067).
@@ -61,6 +81,9 @@ export const R2EligibilityVerdictSchema = z.object({
   eligibilityScore: z.number().min(0).max(100), // composite weighted
   subscores: R2EligibilitySubscoresSchema,
   verdict: R2EligibilityVerdictEnum,
+  // ADR-068 : si verdict='reject', rejectReason DOIT être l'une des 4 raisons strict.
+  // Undefined pour 'eligible' / 'review_required'.
+  rejectReason: R2RejectReasonEnum.optional(),
   reason: z.string(),
 });
 

--- a/backend/src/modules/seo/r2/services/__tests__/r2-eligibility.spec.ts
+++ b/backend/src/modules/seo/r2/services/__tests__/r2-eligibility.spec.ts
@@ -112,14 +112,16 @@ describe('R2EligibilityService', () => {
       searchVolumeFactor: 10,
     });
     expect(verdict.eligibilityScore).toBeLessThan(THRESHOLD_V1);
-    expect(verdict.verdict).toBe('review');
-    // No suppressedCanonicalTarget — ADR-067 forbids pipeline-emitted SUPPRESSED
-    expect(verdict.reason).toContain('REVIEW');
+    expect(verdict.verdict).toBe('review_required');
+    // ADR-068 : pas de rejectReason pour verdict review_required
+    expect(verdict.rejectReason).toBeUndefined();
+    expect(verdict.reason).toContain('REVIEW_REQUIRED');
   });
 
-  it('verdict enum never includes "suppressed" from pipeline (ADR-067)', () => {
+  it('verdict enum never includes "suppressed" / "review" from pipeline (ADR-067 + ADR-068)', () => {
     // Exhaustive sweep : with varying motor strength + productCount >= 2,
-    // verdict must always be in {eligible, review} (never suppressed)
+    // verdict must always be in {eligible, review_required} (never suppressed,
+    // never the legacy short "review" — ADR-068 renamed to review_required).
     const scenarios = [
       { hp: false, eng: false, prod: 5, sv: 0 },
       { hp: true, eng: false, prod: 10, sv: 30 },
@@ -144,11 +146,24 @@ describe('R2EligibilityService', () => {
         productCount: sc.prod,
         searchVolumeFactor: sc.sv,
       });
-      expect(['eligible', 'review']).toContain(verdict.verdict);
-      // Runtime safety check : enum guarantees no 'suppressed' at type level,
-      // but assert at runtime in case of upstream regression.
+      expect(['eligible', 'review_required']).toContain(verdict.verdict);
       expect(verdict.verdict as string).not.toBe('suppressed');
+      expect(verdict.verdict as string).not.toBe('review'); // ADR-068 renamed
     }
+  });
+
+  it('ADR-068 : reject verdict carries strict rejectReason (productCount_under_2)', () => {
+    const verdict = service.evaluate({
+      pgId: 100,
+      typeId: 12345,
+      motorDelta: { ...baseMotor, productCount: 0 },
+      commercialInputs: baseCommercialInputs,
+      productCount: 0,
+      searchVolumeFactor: 0,
+    });
+    expect(verdict.verdict).toBe('reject');
+    expect(verdict.rejectReason).toBe('productCount_under_2');
+    expect(verdict.reason).toContain('ADR-068');
   });
 
   it('exposes all 4 subscores in verdict', () => {

--- a/backend/src/modules/seo/r2/services/r2-eligibility.service.ts
+++ b/backend/src/modules/seo/r2/services/r2-eligibility.service.ts
@@ -65,14 +65,19 @@ export class R2EligibilityService {
    * persisting result in __seo_r2_eligibility_log.
    */
   evaluate(inputs: EligibilityRunInputs): R2EligibilityVerdict {
-    // Hard reject : productCount < 2 (legacy noindex rule preserved)
+    // ADR-068 (2026-05-16) — REJECT scope strict : 4 raisons UNIQUES.
+    // Cette branche couvre `productCount_under_2`. Les 3 autres raisons
+    // (data_invalid / url_impossible / compatibility_absent) sont détectées en
+    // amont par R2DataLoaderService (PR 2 V1.5) qui propage une erreur explicite
+    // au lieu d'invoquer evaluate().
     if (inputs.productCount < 2) {
       return {
         eligible: false,
         eligibilityScore: 0,
         subscores: { motor: 0, compat: 0, commercial: 0, crawl: 0 },
         verdict: 'reject',
-        reason: `productCount=${inputs.productCount} < 2 (noindex rule)`,
+        rejectReason: 'productCount_under_2',
+        reason: `ADR-068 REJECT scope strict : productCount=${inputs.productCount} < 2 (page invalide)`,
       };
     }
 
@@ -111,16 +116,17 @@ export class R2EligibilityService {
       };
     }
 
-    // ADR-067 (2026-05-15) : Below threshold + valid productCount → REVIEW
-    // (enrichment queue or human validation). Pipeline never emits SUPPRESSED.
-    // The admin can manually flip a REVIEW page to SUPPRESSED via UI later if
-    // a real duplicate is confirmed humanly (rare exception path).
+    // ADR-067 (2026-05-15) + ADR-068 (2026-05-16) : Below threshold + valid
+    // productCount → REVIEW_REQUIRED (enrichment queue or human validation).
+    // Pipeline never emits SUPPRESSED ni noindex auto ni canonical sibling auto.
+    // Page valide DOIT rester candidate INDEX (canonical self, sitemap include).
+    // Admin peut flipper REVIEW_REQUIRED → SUPPRESSED via UI uniquement.
     return {
       eligible: false,
       eligibilityScore: roundedScore,
       subscores,
-      verdict: 'review',
-      reason: `score=${roundedScore} < THRESHOLD_V1=${THRESHOLD_V1} — REVIEW queue (enrichment or human validation, ADR-067)`,
+      verdict: 'review_required',
+      reason: `score=${roundedScore} < THRESHOLD_V1=${THRESHOLD_V1} — REVIEW_REQUIRED queue (enrichissement/validation humaine, ADR-068)`,
     };
   }
 


### PR DESCRIPTION
## Summary

**Code fixup pour ADR-068** (vault commit `2c3ea84b`, merged 2026-05-16) — renforce ADR-067 :

- Renommage `verdict: 'review'` → `verdict: 'review_required'` (cohérence canon avec `R2DecisionV2Enum`)
- REJECT scope strict avec `rejectReason` structuré (4 raisons UNIQUES alignées Rego)
- Doctrine canon-strict : page valide DOIT rester candidate INDEX

## Doctrine ADR-068 (rappel)

4 actions auto **strictement INTERDITES** sur page valide (`productCount ≥ 2` + compat réelle) :
1. SUPPRESSION auto (déjà ADR-067)
2. DÉSINDEXATION auto (`decision='noindex_follow'`) — Rego deny NEW
3. CANONICALISATION auto vers sœur — Rego deny NEW
4. EXCLUSION SITEMAP auto — discipline runtime (PR 2 V1.5)

REJECT scope **strict** : 4 raisons UNIQUES uniquement (PAS pour similarité).

## Changements code

### Schemas

- `R2EligibilityVerdictEnum` : `['eligible', 'review', 'reject']` → **`['eligible', 'review_required', 'reject']`**
- `R2RejectReasonEnum` (NEW) : `['productCount_under_2', 'data_invalid', 'url_impossible', 'compatibility_absent']`
  Aligné avec Rego `valid_reject_reasons` set (vault ADR-068)
- `R2EligibilityVerdictSchema` : ajout `rejectReason?: R2RejectReasonEnum`

### Service

- `R2EligibilityService.evaluate()` :
  - Below threshold + productCount ≥ 2 → `verdict: 'review_required'` (était `'review'`)
  - productCount < 2 → `verdict: 'reject'` + `rejectReason: 'productCount_under_2'`
  - Reason mentionne `ADR-068 REJECT scope strict` + `REVIEW_REQUIRED queue`
- Les 3 autres raisons REJECT (`data_invalid` / `url_impossible` / `compatibility_absent`) sont émises **en amont** par `R2DataLoaderService` (PR 2 V1.5) — propage erreur explicite avant invocation `evaluate()`.

### DTO

- `R2EnrichSingleResponse.eligibility.verdict` : `'eligible' | 'review_required' | 'reject'`
- `R2EnrichSingleResponse.eligibility.rejectReason?` : optionnel, type union des 4 raisons strict

### Tests Jest

- Renommage tous `'review'` → `'review_required'`
- Test sweep ADR-067/068 : verdict in `{eligible, review_required}`, runtime check NOT `'suppressed'`, NOT `'review'` legacy
- Nouveau test ADR-068 : reject verdict porte `rejectReason: 'productCount_under_2'` + reason contient `'ADR-068'`

## Backward compat préservée

- `R2DecisionV2Enum` (DB) garde `'review_required'` (déjà aligné depuis ADR-066)
- `R2StatusV2Enum` (DB status row) garde `'review'` (status court inchangé)
- Migration : pas de DDL nécessaire
- Frontend canonical rendering : à valider en PR 2 V1.5 (canonical self pour INDEX et REVIEW_REQUIRED)

## Test plan

- [x] `backend tsc --build` → 0 errors
- [ ] CI : Backend Tests (Jest), TypeScript, ESLint, Migration Safety
- [x] Pre-commit hooks pass (lint-staged + refresh-knowledge auto-update `.claude/knowledge/modules/*.md` — normal)

## Self-review

1. ✅ **Doctrine alignment** : code reflète ADR-068 vault commit `2c3ea84b`
2. ✅ **Backward compat** : enum DB inchangé pour `review_required` (déjà aligné) et `suppressed` (manual path)
3. ✅ **Strict reject reasons** : 4 valeurs alignées avec Rego `valid_reject_reasons`
4. ✅ **Tests** : verdict enum runtime check (eligible/review_required only), reject avec rejectReason explicit
5. ✅ **Reason field** mentionne ADR-068 + REVIEW_REQUIRED rationale (audit-trail clarté)

## Self-review verdict: APPROVE

Fixup aligné vault doctrine ADR-068. Zéro page R2 v2 en prod. Pilote V1 post-merge sera sous doctrine canon-strict :
- INDEX
- REVIEW_REQUIRED (incl. sitemap, canonical self)
- REGENERATE
- REJECT (4 raisons UNIQUES, PAS pour similarité)

## Cross-refs

- Vault PR [ADR-068 merged](https://github.com/ak125/governance-vault/pull/283) (`2c3ea84b`)
- Cascade canon : ADR-066 (`8a92c49`) → ADR-067 (`74f45919`) → ADR-068 (`2c3ea84b`)
- Memory `feedback_no_auto_page_suppression_ever` (canon-strict 4 interdictions)
- Calibration empirique N=200 (Supabase MCP project `cxpojprgwgubzjyqzmoq`, 2026-05-15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)