### PR TITLE
fix(ci): restore prod-smoke checkout + node-22 setup (PR #510 regression)

### DIFF
--- a/.github/workflows/prod-smoke-tests.yml
+++ b/.github/workflows/prod-smoke-tests.yml
@@ -24,6 +24,20 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - name: ⬇️ Checkout repo
+        # Required by the long-tail step which executes
+        # `scripts/ci/sample-smoke-urls.ts`. PR #510 added that step without
+        # checkout/setup-node, breaking the workflow on every schedule since
+        # 2026-05-14.
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Setup Node.js 22
+        # Self-hosted runner has no node/npx in PATH by default. Matches the
+        # canonical pattern used by the other self-hosted jobs in ci.yml.
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: 🏥 Health endpoint
         id: health-check
         run: |


### PR DESCRIPTION
## Summary

- **Root cause**: PR #510 (commit dcde5629d, merged 2026-05-14) added a long-tail step that calls `npx -y tsx scripts/ci/sample-smoke-urls.ts` on the self-hosted runner without `actions/checkout` or `actions/setup-node`. The runner has no node/npx in PATH, so `npx` errors and `bash -e` aborts. Every later critical step is skipped, and the always-run summary renders ❌ FAIL for each one via `steps.<id>.outcome`.
- **Fix**: prepend `actions/checkout@v4` + `actions/setup-node@v6` (`node-version: 22`) at the top of the job. Matches the canonical pattern already in [ci.yml:900-910](.github/workflows/ci.yml#L900-L910) for self-hosted jobs.
- **Scope**: surgical, 14 lines added, 0 lines changed/removed.

## Impact since 2026-05-14

| Run | Date (UTC) | Conclusion |
|---|---|---|
| 25878064439 | 2026-05-14 18:31 | failure |
| 25893227072 | 2026-05-15 00:20 | failure |
| 25904970065 | 2026-05-15 06:59 | failure |
| 25917882737 | 2026-05-15 12:30 | failure |
| 25934504589 | 2026-05-15 18:27 | failure |
| 25947611102 | 2026-05-16 00:18 | failure |
| 25955247162 | 2026-05-16 06:41 | failure |

The only **real** failure was the Long-tail step itself; the cascade of ❌ in the summary was phantom (skipped steps reported by `steps.<id>.outcome != 'success'`).

PR #510 test-plan checkbox _"CI smoke v2 vert sur DEV (sample 150 URLs)"_ was not validated before merge → see `feedback_test_before_entering_plan_approval`.

## Test plan

- [ ] `actions/workflow_dispatch` on this branch passes (triggered after PR open)
- [ ] After merge, the next scheduled run (cron `0 */6 * * *`) is green
- [ ] Long-tail step samples ≥ 100 URLs and finishes within the 5-minute job timeout
- [ ] No phantom ❌ in the summary table

## Out of scope

- The `actions/upload-artifact@v4` Node 20 deprecation warning (informational, June 2 2026).
- A pre-commit/CI gate that would catch workflow regressions of this shape before merge — candidate follow-up after evidence (one occurrence so far).

🤖 Generated with [Claude Code](https://claude.com/claude-code)