### PR TITLE
feat(seo): add /api/admin/sitemap/scheduler-status diagnostic endpoint

### DIFF
--- a/backend/src/auth/admin-or-internal-key.guard.test.ts
+++ b/backend/src/auth/admin-or-internal-key.guard.test.ts
@@ -1,0 +1,89 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import { AdminOrInternalKeyGuard } from './admin-or-internal-key.guard';
+import { InternalApiKeyGuard } from './internal-api-key.guard';
+
+const VALID_KEY = 'test-internal-key-32bytes-aaaa';
+
+function makeContext(opts: {
+  user?: any;
+  headers?: Record<string, string>;
+}): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({
+        user: opts.user,
+        headers: opts.headers ?? {},
+        method: 'POST',
+        url: '/api/test',
+      }),
+    }),
+    getHandler: () => () => undefined,
+    getClass: () => class {},
+  } as unknown as ExecutionContext;
+}
+
+describe('AdminOrInternalKeyGuard', () => {
+  let guard: AdminOrInternalKeyGuard;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        AdminOrInternalKeyGuard,
+        InternalApiKeyGuard,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (k: string, def?: string) =>
+              k === 'INTERNAL_API_KEY' ? VALID_KEY : def,
+          },
+        },
+      ],
+    }).compile();
+    guard = moduleRef.get(AdminOrInternalKeyGuard);
+  });
+
+  describe('internal key path', () => {
+    it('accepts request with matching x-internal-key header', () => {
+      const ctx = makeContext({ headers: { 'x-internal-key': VALID_KEY } });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it('rejects request with mismatched x-internal-key (does NOT fall back to session)', () => {
+      const ctx = makeContext({
+        headers: { 'x-internal-key': 'wrong-key' },
+        user: { isAdmin: true, level: 7 },
+      });
+      expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+    });
+  });
+
+  describe('admin session path', () => {
+    it('accepts request with isAdmin=true', () => {
+      const ctx = makeContext({ user: { isAdmin: true, level: 0 } });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it('accepts request with numeric level >= 7', () => {
+      const ctx = makeContext({ user: { level: 7 } });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it('accepts request with string level >= 7 (legacy MD5 session)', () => {
+      const ctx = makeContext({ user: { level: '9' } });
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
+
+    it('rejects request with level < 7', () => {
+      const ctx = makeContext({ user: { level: 3, email: 'sales@x.com' } });
+      expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+
+    it('rejects anonymous request (no user, no header)', () => {
+      const ctx = makeContext({});
+      expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+    });
+  });
+});

--- a/backend/src/auth/admin-or-internal-key.guard.ts
+++ b/backend/src/auth/admin-or-internal-key.guard.ts
@@ -1,0 +1,48 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InternalApiKeyGuard } from './internal-api-key.guard';
+
+/**
+ * Composite guard that accepts EITHER an admin browser session OR a valid
+ * `X-Internal-Key` header. Useful for endpoints that must be reachable from
+ * both the admin UI (manual op) and an automated cron/CI (GitHub Action,
+ * internal script).
+ *
+ * When the header is present we delegate strict validation (timing-safe
+ * comparison + ForbiddenException on mismatch) to `InternalApiKeyGuard` so
+ * a misconfigured caller fails fast rather than silently falling back to
+ * session auth.
+ */
+@Injectable()
+export class AdminOrInternalKeyGuard implements CanActivate {
+  private readonly logger = new Logger(AdminOrInternalKeyGuard.name);
+
+  constructor(private readonly internalKeyGuard: InternalApiKeyGuard) {}
+
+  canActivate(context: ExecutionContext): boolean | Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    if (request.headers['x-internal-key']) {
+      return this.internalKeyGuard.canActivate(context);
+    }
+
+    const user = request.user;
+    const isAdmin =
+      user?.isAdmin === true || parseInt(String(user?.level || 0), 10) >= 7;
+
+    if (!isAdmin) {
+      this.logger.warn(
+        `Admin/internal access denied for ${user?.email || 'anonymous'} on ${request.method} ${request.url}`,
+      );
+      throw new UnauthorizedException(
+        'Admin session or X-Internal-Key required',
+      );
+    }
+    return true;
+  }
+}

--- a/backend/src/modules/seo/controllers/sitemap-delta.controller.ts
+++ b/backend/src/modules/seo/controllers/sitemap-delta.controller.ts
@@ -3,9 +3,17 @@
  * Endpoints pour gérer le diff journalier et sitemap-latest.xml
  */
 
-import { Controller, Get, Post, Param, Logger } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Logger,
+  UseGuards,
+} from '@nestjs/common';
 import { SitemapDeltaService } from '../services/sitemap-delta.service';
 import { RateLimitSitemap } from '../../../common/decorators/rate-limit.decorator';
+import { AdminOrInternalKeyGuard } from '../../../auth/admin-or-internal-key.guard';
 
 @RateLimitSitemap() // 🛡️ 3 req/min - Sitemaps are memory-intensive
 @Controller('sitemap-v2/delta')
@@ -88,6 +96,7 @@ export class SitemapDeltaController {
    * Déclencher manuellement la génération de sitemap-latest.xml
    */
   @Post('generate')
+  @UseGuards(AdminOrInternalKeyGuard)
   async triggerGeneration() {
     this.logger.log('🔄 Manual trigger: delta sitemap generation');
 
@@ -104,6 +113,7 @@ export class SitemapDeltaController {
    * Nettoyer les deltas expirés
    */
   @Post('cleanup')
+  @UseGuards(AdminOrInternalKeyGuard)
   async cleanupExpired() {
     this.logger.log('🧹 Manual trigger: cleanup expired deltas');
 

--- a/backend/src/modules/seo/controllers/sitemap-scheduler-diagnostic.controller.test.ts
+++ b/backend/src/modules/seo/controllers/sitemap-scheduler-diagnostic.controller.test.ts
@@ -1,0 +1,170 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getQueueToken } from '@nestjs/bull';
+import { SitemapSchedulerDiagnosticController } from './sitemap-scheduler-diagnostic.controller';
+import { SITEMAP_REGENERATE_JOB_ID } from '../services/sitemap-v10-scheduler.service';
+import { AdminOrInternalKeyGuard } from '../../../auth/admin-or-internal-key.guard';
+import { InternalApiKeyGuard } from '../../../auth/internal-api-key.guard';
+
+const FROZEN_NOW = new Date('2026-05-16T09:00:00.000Z');
+
+function makeQueueMock(opts: {
+  repeatable?: any[];
+  waiting?: number;
+  delayed?: number;
+  active?: number;
+  failed?: number;
+  completed?: number;
+  paused?: boolean;
+}) {
+  return {
+    getRepeatableJobs: jest.fn().mockResolvedValue(opts.repeatable ?? []),
+    getWaitingCount: jest.fn().mockResolvedValue(opts.waiting ?? 0),
+    getDelayedCount: jest.fn().mockResolvedValue(opts.delayed ?? 0),
+    getActiveCount: jest.fn().mockResolvedValue(opts.active ?? 0),
+    getFailedCount: jest.fn().mockResolvedValue(opts.failed ?? 0),
+    getCompletedCount: jest.fn().mockResolvedValue(opts.completed ?? 0),
+    isPaused: jest.fn().mockResolvedValue(opts.paused ?? false),
+  };
+}
+
+async function buildController(opts: {
+  envCronEnabled?: string;
+  envCron?: string;
+  queue: ReturnType<typeof makeQueueMock>;
+}) {
+  const moduleRef = await Test.createTestingModule({
+    controllers: [SitemapSchedulerDiagnosticController],
+    providers: [
+      { provide: getQueueToken('seo-monitor'), useValue: opts.queue },
+      {
+        provide: ConfigService,
+        useValue: {
+          get: (key: string, def?: string) => {
+            if (key === 'SEO_SITEMAP_CRON_ENABLED') return opts.envCronEnabled;
+            if (key === 'SEO_SITEMAP_CRON') return opts.envCron ?? def;
+            if (key === 'INTERNAL_API_KEY') return 'test-key';
+            return def;
+          },
+        },
+      },
+    ],
+  })
+    .overrideGuard(AdminOrInternalKeyGuard)
+    .useValue({ canActivate: () => true })
+    .overrideGuard(InternalApiKeyGuard)
+    .useValue({ canActivate: () => true })
+    .compile();
+  return moduleRef.get(SitemapSchedulerDiagnosticController);
+}
+
+describe('SitemapSchedulerDiagnosticController', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(FROZEN_NOW);
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reports healthy state when repeatable job is registered', async () => {
+    const queue = makeQueueMock({
+      repeatable: [
+        {
+          key: 'seo-monitor:sitemap-regenerate-all:::0 3 * * *',
+          name: 'sitemap-regenerate-all',
+          id: SITEMAP_REGENERATE_JOB_ID,
+          cron: '0 3 * * *',
+          tz: 'UTC',
+          next: new Date('2026-05-17T03:00:00.000Z').getTime(),
+        },
+      ],
+      delayed: 1,
+      completed: 2,
+    });
+    const ctrl = await buildController({ queue });
+
+    const result = await ctrl.getSchedulerStatus();
+
+    expect(result.schedulerConfigured).toBe(true);
+    expect(result.cron).toBe('0 3 * * *');
+    expect(result.cronEnvOverride).toBeNull();
+    expect(result.ourRepeatableFound).toBe(true);
+    expect(result.repeatableJobs).toHaveLength(1);
+    expect(result.repeatableJobs[0]).toMatchObject({
+      id: SITEMAP_REGENERATE_JOB_ID,
+      cron: '0 3 * * *',
+      tz: 'UTC',
+      next: '2026-05-17T03:00:00.000Z',
+    });
+    expect(result.counts).toEqual({
+      waiting: 0,
+      delayed: 1,
+      active: 0,
+      failed: 0,
+      completed: 2,
+      paused: false,
+    });
+    // Frozen now = 2026-05-16T09:00:00Z, last 03:00 UTC tick was today
+    expect(result.lastExpectedRunIso).toBe('2026-05-16T03:00:00.000Z');
+    expect(result.hoursSinceLastExpectedRun).toBe(6);
+  });
+
+  it('reports schedulerConfigured=false when SEO_SITEMAP_CRON_ENABLED=false', async () => {
+    const queue = makeQueueMock({});
+    const ctrl = await buildController({
+      envCronEnabled: 'false',
+      queue,
+    });
+
+    const result = await ctrl.getSchedulerStatus();
+
+    expect(result.schedulerConfigured).toBe(false);
+    expect(result.cronEnvOverride).toBe('false');
+    expect(result.ourRepeatableFound).toBe(false);
+  });
+
+  it('reports ourRepeatableFound=false when repeatable list lacks our jobId', async () => {
+    const queue = makeQueueMock({
+      repeatable: [
+        {
+          key: 'seo-monitor:other-job:::*/30 * * * *',
+          name: 'other-job',
+          id: 'other-job-id',
+          cron: '*/30 * * * *',
+          tz: 'UTC',
+          next: Date.now() + 60_000,
+        },
+      ],
+    });
+    const ctrl = await buildController({ queue });
+
+    const result = await ctrl.getSchedulerStatus();
+
+    expect(result.ourRepeatableFound).toBe(false);
+    expect(result.repeatableJobs).toHaveLength(1);
+    expect(result.repeatableJobs[0].id).toBe('other-job-id');
+  });
+
+  it('falls back to null lastExpectedRunIso for non-daily cron expressions', async () => {
+    const queue = makeQueueMock({});
+    const ctrl = await buildController({
+      envCron: '*/15 * * * *',
+      queue,
+    });
+
+    const result = await ctrl.getSchedulerStatus();
+
+    expect(result.cron).toBe('*/15 * * * *');
+    expect(result.lastExpectedRunIso).toBeNull();
+    expect(result.hoursSinceLastExpectedRun).toBeNull();
+  });
+
+  it('returns "now" as ISO timestamp', async () => {
+    const queue = makeQueueMock({});
+    const ctrl = await buildController({ queue });
+
+    const result = await ctrl.getSchedulerStatus();
+
+    expect(result.now).toBe(FROZEN_NOW.toISOString());
+  });
+});

--- a/backend/src/modules/seo/controllers/sitemap-scheduler-diagnostic.controller.ts
+++ b/backend/src/modules/seo/controllers/sitemap-scheduler-diagnostic.controller.ts
@@ -1,0 +1,172 @@
+/**
+ * Diagnostic endpoint for the BullMQ-backed sitemap regeneration scheduler.
+ *
+ * Lit l'état réel du job repeatable `sitemap-v10-nightly-regeneration` enregistré
+ * sur la queue `seo-monitor` et expose les compteurs Bull (waiting/delayed/active/
+ * failed/completed) ainsi que le timing prévu vs. observé. Pas d'effet de bord :
+ * lecture seule sur Redis via Bull.
+ *
+ * Cas d'usage : confirmer pourquoi le sitemap stagne en PROD malgré PR #487/488.
+ * Signature attendue d'un système sain :
+ *   - schedulerConfigured = true
+ *   - repeatableJobs contient une entrée avec key `…sitemap-regenerate-all…`
+ *   - delayed >= 1 (next run scheduled)
+ *   - completed > 0 si déployé depuis > 24h
+ *
+ * Signature attendue d'un système cassé :
+ *   - schedulerConfigured = false → env override (SEO_SITEMAP_CRON_ENABLED=false)
+ *   - repeatableJobs vide → onModuleInit n'a pas tourné OU configureRepeatableJob a throw
+ *   - delayed = 0 + repeatable absent → idem
+ *   - completed = 0 et lastExpectedRun > 24h dans le passé → worker ne consomme pas
+ *
+ * Garde : AdminOrInternalKeyGuard — session admin (humain en incident response)
+ * ou X-Internal-Key (script de monitoring).
+ */
+
+import { Controller, Get, Logger, UseGuards } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { ConfigService } from '@nestjs/config';
+import { Queue } from 'bull';
+import { AdminOrInternalKeyGuard } from '../../../auth/admin-or-internal-key.guard';
+import { SITEMAP_REGENERATE_JOB_ID } from '../services/sitemap-v10-scheduler.service';
+
+interface RepeatableJobInfo {
+  key: string;
+  name: string;
+  id: string | null;
+  cron: string | null;
+  tz: string | null;
+  next: string | null;
+}
+
+interface SchedulerStatusResponse {
+  now: string;
+  schedulerConfigured: boolean;
+  cron: string;
+  cronEnvOverride: string | null;
+  expectedJobId: string;
+  repeatableJobs: RepeatableJobInfo[];
+  ourRepeatableFound: boolean;
+  counts: {
+    waiting: number;
+    delayed: number;
+    active: number;
+    failed: number;
+    completed: number;
+    paused: boolean;
+  };
+  lastExpectedRunIso: string | null;
+  hoursSinceLastExpectedRun: number | null;
+}
+
+@Controller('api/admin/sitemap')
+@UseGuards(AdminOrInternalKeyGuard)
+export class SitemapSchedulerDiagnosticController {
+  private readonly logger = new Logger(
+    SitemapSchedulerDiagnosticController.name,
+  );
+
+  constructor(
+    @InjectQueue('seo-monitor') private readonly seoMonitorQueue: Queue,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Get('scheduler-status')
+  async getSchedulerStatus(): Promise<SchedulerStatusResponse> {
+    const cronEnvOverride =
+      this.configService.get<string>('SEO_SITEMAP_CRON_ENABLED') ?? null;
+    const cron = this.configService.get<string>(
+      'SEO_SITEMAP_CRON',
+      '0 3 * * *',
+    );
+    const schedulerConfigured = this.isEnabled(cronEnvOverride);
+
+    const [rawRepeatable, waiting, delayed, active, failed, completed, paused] =
+      await Promise.all([
+        this.seoMonitorQueue.getRepeatableJobs(),
+        this.seoMonitorQueue.getWaitingCount(),
+        this.seoMonitorQueue.getDelayedCount(),
+        this.seoMonitorQueue.getActiveCount(),
+        this.seoMonitorQueue.getFailedCount(),
+        this.seoMonitorQueue.getCompletedCount(),
+        this.seoMonitorQueue.isPaused(),
+      ]);
+
+    const repeatableJobs: RepeatableJobInfo[] = rawRepeatable.map((j) => ({
+      key: j.key,
+      name: j.name,
+      id: j.id ?? null,
+      cron: (j as { cron?: string }).cron ?? null,
+      tz: (j as { tz?: string }).tz ?? null,
+      next: j.next ? new Date(j.next).toISOString() : null,
+    }));
+
+    const ourRepeatableFound = repeatableJobs.some(
+      (j) => j.id === SITEMAP_REGENERATE_JOB_ID,
+    );
+
+    const lastExpectedRunIso = this.computeLastExpectedRun(cron);
+    const hoursSinceLastExpectedRun = lastExpectedRunIso
+      ? Math.round(
+          ((Date.now() - new Date(lastExpectedRunIso).getTime()) / 36e5) * 100,
+        ) / 100
+      : null;
+
+    return {
+      now: new Date().toISOString(),
+      schedulerConfigured,
+      cron,
+      cronEnvOverride,
+      expectedJobId: SITEMAP_REGENERATE_JOB_ID,
+      repeatableJobs,
+      ourRepeatableFound,
+      counts: { waiting, delayed, active, failed, completed, paused },
+      lastExpectedRunIso,
+      hoursSinceLastExpectedRun,
+    };
+  }
+
+  private isEnabled(override: string | null): boolean {
+    if (override === null) return true;
+    return override.toLowerCase() !== 'false' && override !== '0';
+  }
+
+  /**
+   * Compute the most recent past tick of a simple cron string (m h dom mon dow).
+   * Only supports the schedule we ship (`0 3 * * *` daily fixed-time). For other
+   * patterns returns null rather than guessing — keep diagnostic honest.
+   */
+  private computeLastExpectedRun(cron: string): string | null {
+    const parts = cron.trim().split(/\s+/);
+    if (parts.length !== 5) return null;
+    const [m, h, dom, mon, dow] = parts;
+    const isDaily =
+      /^\d+$/.test(m) &&
+      /^\d+$/.test(h) &&
+      dom === '*' &&
+      mon === '*' &&
+      dow === '*';
+    if (!isDaily) return null;
+
+    const minute = parseInt(m, 10);
+    const hour = parseInt(h, 10);
+    if (minute < 0 || minute > 59 || hour < 0 || hour > 23) return null;
+
+    const now = new Date();
+    const candidate = new Date(
+      Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate(),
+        hour,
+        minute,
+        0,
+        0,
+      ),
+    );
+    if (candidate.getTime() > now.getTime()) {
+      candidate.setUTCDate(candidate.getUTCDate() - 1);
+    }
+    return candidate.toISOString();
+  }
+}

--- a/backend/src/modules/seo/controllers/sitemap-streaming.controller.ts
+++ b/backend/src/modules/seo/controllers/sitemap-streaming.controller.ts
@@ -3,7 +3,14 @@
  * API simplifiée pour générer et servir les sitemaps compressés
  */
 
-import { Controller, Get, Post, Query, Logger } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Query,
+  Logger,
+  UseGuards,
+} from '@nestjs/common';
 import { SitemapStreamingService } from '../services/sitemap-streaming.service';
 import {
   StreamingGenerationResult,
@@ -12,6 +19,7 @@ import {
   StreamingConfig,
 } from '../interfaces/sitemap-streaming.interface';
 import { RateLimitSitemap } from '../../../common/decorators/rate-limit.decorator';
+import { AdminOrInternalKeyGuard } from '../../../auth/admin-or-internal-key.guard';
 
 @RateLimitSitemap() // 🛡️ 3 req/min - Sitemaps are memory-intensive
 @Controller('sitemap-v2/streaming')
@@ -33,6 +41,7 @@ export class SitemapStreamingController {
    * - dryRun: true | false (simulation sans écriture)
    */
   @Post('generate')
+  @UseGuards(AdminOrInternalKeyGuard)
   async generate(
     @Query('type') type?: string,
     @Query('forceRegeneration') forceRegeneration?: string,
@@ -124,6 +133,7 @@ export class SitemapStreamingController {
    * Nettoyer tous les fichiers sitemaps
    */
   @Post('cleanup')
+  @UseGuards(AdminOrInternalKeyGuard)
   async cleanup(): Promise<{
     success: boolean;
     message: string;

--- a/backend/src/modules/seo/controllers/sitemap-unified.controller.ts
+++ b/backend/src/modules/seo/controllers/sitemap-unified.controller.ts
@@ -7,9 +7,10 @@
  * → Redirige vers SitemapV10Service.generateAll()
  */
 
-import { Controller, Post, Get, Logger } from '@nestjs/common';
+import { Controller, Post, Get, Logger, UseGuards } from '@nestjs/common';
 import { SitemapV10Service } from '../services/sitemap-v10.service';
 import { RateLimitSitemap } from '../../../common/decorators/rate-limit.decorator';
+import { AdminOrInternalKeyGuard } from '../../../auth/admin-or-internal-key.guard';
 
 @RateLimitSitemap() // 🛡️ 3 req/min - Sitemaps are memory-intensive
 @Controller('api/sitemap')
@@ -29,6 +30,7 @@ export class SitemapUnifiedController {
    * - Temperature buckets (hot/stable/cold)
    */
   @Post('generate-all')
+  @UseGuards(AdminOrInternalKeyGuard)
   async generateAll(): Promise<{
     success: boolean;
     message: string;

--- a/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
+++ b/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
@@ -11,7 +11,14 @@
  * - POST /api/sitemap/v10/ping             → Ping Google
  */
 
-import { Controller, Get, Post, Param, Logger } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Logger,
+  UseGuards,
+} from '@nestjs/common';
 import {
   SitemapV10Service,
   TemperatureBucket,
@@ -19,7 +26,15 @@ import {
 import { SitemapV10ScoringService } from '../services/sitemap-v10-scoring.service';
 import { SitemapV10HubsService } from '../services/sitemap-v10-hubs.service';
 import { RateLimitSitemap } from '../../../common/decorators/rate-limit.decorator';
+import { AdminOrInternalKeyGuard } from '../../../auth/admin-or-internal-key.guard';
 
+/**
+ * Toutes les routes d'écriture (@Post) requièrent une session admin
+ * (cookie `connect.sid` + `level >= 7`) OU le header `X-Internal-Key` valide.
+ * Pré-fix 2026-05-16 ces endpoints étaient publics — un POST anonyme pouvait
+ * régénérer 102k URLs (15s CPU + écritures disque). Le rate-limit 3 req/min
+ * ne discriminait pas l'origine. Les @Get restent publics (stats lecture seule).
+ */
 @RateLimitSitemap() // 🛡️ 3 req/min - Sitemaps are memory-intensive
 @Controller('api/sitemap/v10')
 export class SitemapV10Controller {
@@ -36,6 +51,7 @@ export class SitemapV10Controller {
    * Génère tous les sitemaps par température
    */
   @Post('generate-all')
+  @UseGuards(AdminOrInternalKeyGuard)
   async generateAll(): Promise<{
     success: boolean;
     message: string;
@@ -99,6 +115,7 @@ export class SitemapV10Controller {
    * Génère le sitemap d'un bucket spécifique
    */
   @Post('generate/:bucket')
+  @UseGuards(AdminOrInternalKeyGuard)
   async generateBucket(@Param('bucket') bucket: string): Promise<{
     success: boolean;
     message: string;
@@ -151,6 +168,7 @@ export class SitemapV10Controller {
    * Recalcule les scores de toutes les pages
    */
   @Post('refresh-scores')
+  @UseGuards(AdminOrInternalKeyGuard)
   async refreshScores(): Promise<{
     success: boolean;
     message: string;
@@ -193,6 +211,7 @@ export class SitemapV10Controller {
    * Génère les hubs de crawl (version legacy - non paginée)
    */
   @Post('generate-hubs')
+  @UseGuards(AdminOrInternalKeyGuard)
   async generateHubs(): Promise<{
     success: boolean;
     message: string;
@@ -251,6 +270,7 @@ export class SitemapV10Controller {
    * - risk/weak-cluster.html (pages à risque)
    */
   @Post('generate-hubs-robust')
+  @UseGuards(AdminOrInternalKeyGuard)
   async generateHubsRobust(): Promise<{
     success: boolean;
     message: string;
@@ -361,6 +381,7 @@ export class SitemapV10Controller {
    * Ping Google pour le sitemap index
    */
   @Post('ping')
+  @UseGuards(AdminOrInternalKeyGuard)
   async pingGoogle(): Promise<{
     success: boolean;
     message: string;

--- a/backend/src/modules/seo/seo.module.ts
+++ b/backend/src/modules/seo/seo.module.ts
@@ -117,6 +117,7 @@ import { SitemapV10Controller } from './controllers/sitemap-v10.controller';
 import { SitemapUnifiedController } from './controllers/sitemap-unified.controller';
 import { SitemapStreamingController } from './controllers/sitemap-streaming.controller';
 import { SitemapDeltaController } from './controllers/sitemap-delta.controller';
+import { SitemapSchedulerDiagnosticController } from './controllers/sitemap-scheduler-diagnostic.controller';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // CONTROLEURS CONTENT (ex seo-content)
@@ -201,6 +202,7 @@ import { R2V2Module } from './r2/r2-v2.module';
     SitemapUnifiedController,
     SitemapStreamingController,
     SitemapDeltaController,
+    SitemapSchedulerDiagnosticController,
     // Content
     ReferenceController,
     DiagnosticController,


### PR DESCRIPTION
## Summary

Endpoint admin-only `GET /api/admin/sitemap/scheduler-status` qui expose l'état réel du job repeatable BullMQ `sitemap-v10-nightly-regeneration` sur la queue `seo-monitor`. Lecture seule sur Redis via bull — aucun effet de bord.

**Cas d'usage immédiat** : valider en PROD pourquoi le cron BullMQ sitemap ne fire pas depuis 2026-05-13 22:06 UTC malgré le deploy PR #487/488. Sans cet endpoint, le seul moyen de diagnostiquer est SSH PROD (qui m'a été refusé).

## Stacked on PR-A

Cette PR dépend du guard `AdminOrInternalKeyGuard` introduit par #550. Mergez **PR-A d'abord** puis rebase cette branche sur main.

## Response shape

` ` `json
{
  \"now\": \"2026-05-16T09:00:00.000Z\",
  \"schedulerConfigured\": true,
  \"cron\": \"0 3 * * *\",
  \"cronEnvOverride\": null,
  \"expectedJobId\": \"sitemap-v10-nightly-regeneration\",
  \"repeatableJobs\": [
    {
      \"key\": \"seo-monitor:sitemap-regenerate-all:::0 3 * * *\",
      \"name\": \"sitemap-regenerate-all\",
      \"id\": \"sitemap-v10-nightly-regeneration\",
      \"cron\": \"0 3 * * *\",
      \"tz\": \"UTC\",
      \"next\": \"2026-05-17T03:00:00.000Z\"
    }
  ],
  \"ourRepeatableFound\": true,
  \"counts\": { \"waiting\": 0, \"delayed\": 1, \"active\": 0, \"failed\": 0, \"completed\": 12, \"paused\": false },
  \"lastExpectedRunIso\": \"2026-05-16T03:00:00.000Z\",
  \"hoursSinceLastExpectedRun\": 6
}
` ` `

## Diagnostic matrix (PR-D will use this)

| Signal | Cause | Fix direction |
|--------|-------|---------------|
| `schedulerConfigured: false` | `SEO_SITEMAP_CRON_ENABLED=false` en PROD | Flip env var, restart |
| `repeatableJobs: []` | `onModuleInit` n'a pas tourné OU `configureRepeatableJob` a throw | Check logs au boot pour stacktrace |
| `ourRepeatableFound: false` (autre key présente) | Stale cron string registered, idempotence cassée | Force cleanup repeatable + redeploy |
| `completed: 0` ET `hoursSinceLastExpectedRun > 24` | Worker registered mais ne consume pas | Vérifier processor binding, queue isolation worker container |

## Test plan

- [x] `sitemap-scheduler-diagnostic.controller.test.ts` 5/5 PASS :
  - healthy state (jobId present, daily cron, last run 6h ago)
  - `SEO_SITEMAP_CRON_ENABLED=false` → schedulerConfigured false
  - other jobId present but not ours → ourRepeatableFound false
  - non-daily cron (\`*/15 * * * *\`) → lastExpectedRunIso null
  - `now` returned as ISO timestamp
- [x] `tsc --noEmit` PASS (0 errors)
- [ ] Post-merge PROD : `curl -H \"X-Internal-Key: \$INTERNAL_API_KEY\" https://www.automecanik.com/api/admin/sitemap/scheduler-status` → verdict instantané

## Security

- Endpoint gated par `AdminOrInternalKeyGuard` (PR-A). Accepte session admin OU `X-Internal-Key` valide.
- Expose : noms de jobs, cron strings, counters Bull. Aucune donnée utilisateur, aucun secret. Niveau "ops dashboard" — admin-only suffit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)