### PR TITLE
chore(auth): Phase 0.5 hotfix — propagate OIDC env vars to DEV preprod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,6 +659,22 @@ jobs:
           RAG_API_KEY=disabled-preprod-readonly
           # ADR-063 — CrUX API key (optional, blank-allowed = graceful degrade)
           CRUX_API_KEY=${CRUX_API_KEY}
+          # BEGIN sitemap-oidc-auth
+          # GitHub OIDC federation for sitemap regen (Phase 0.5 — propagates
+          # config from compose ${VAR} refs to runtime). Cf. spec
+          # docs/superpowers/specs/2026-05-16-sitemap-regen-auth-design.md.
+          # Values are non-sensitive (allowlists, audience) — overridable via
+          # GitHub Actions Variables (vars.X) but kept as literals here so
+          # DEV preprod boots correctly even before any var is set in UI.
+          GITHUB_OIDC_AUDIENCE=${GITHUB_OIDC_AUDIENCE:-automecanik-sitemap-regen}
+          GITHUB_OIDC_REPOSITORY=${GITHUB_OIDC_REPOSITORY:-ak125/nestjs-remix-monorepo}
+          GITHUB_OIDC_ALLOWED_EVENTS=${GITHUB_OIDC_ALLOWED_EVENTS:-schedule,workflow_dispatch}
+          GITHUB_OIDC_ALLOWED_REFS=${GITHUB_OIDC_ALLOWED_REFS:-refs/heads/main}
+          GITHUB_OIDC_ALLOWED_JOB_REFS=${GITHUB_OIDC_ALLOWED_JOB_REFS:-ak125/nestjs-remix-monorepo/.github/workflows/sitemap-daily-regen.yml@refs/heads/main}
+          GITHUB_OIDC_ALLOWED_SUBS=${GITHUB_OIDC_ALLOWED_SUBS:-repo:ak125/nestjs-remix-monorepo:ref:refs/heads/main}
+          REDIS_OIDC_DB_INDEX=${REDIS_OIDC_DB_INDEX:-1}
+          SITEMAP_LEGACY_INTERNAL_KEY_ENABLED=${SITEMAP_LEGACY_INTERNAL_KEY_ENABLED:-true}
+          # END sitemap-oidc-auth
           EOF
 
           cd $PREPROD_DIR


### PR DESCRIPTION
## Summary

Phase 0.5/11 — **ultra-scoped hotfix** : `.github/workflows/ci.yml` heredoc seul. Phase 0 (#552 merged 2026-05-16 11:42 UTC) a ajouté les interpolation refs `${VAR}` aux compose files, **mais** la source des vars sur DEV preprod est le `.env` régénéré in-place par `ci.yml` lignes 638-662 — qui ne contient pas les 8 nouvelles vars OIDC.

Sans ce fix : le container DEV preprod booterait avec valeurs undefined dès que Phase 1 (GithubOidcService) consomme `GITHUB_OIDC_REPOSITORY` etc. → fail-closed sur `assertClaims`.

## Changes

Single file : [`.github/workflows/ci.yml:661`](.github/workflows/ci.yml#L661). Ajout d'un bloc marqué dans le heredoc :

```bash
# BEGIN sitemap-oidc-auth
GITHUB_OIDC_AUDIENCE=${GITHUB_OIDC_AUDIENCE:-automecanik-sitemap-regen}
GITHUB_OIDC_REPOSITORY=${GITHUB_OIDC_REPOSITORY:-ak125/nestjs-remix-monorepo}
GITHUB_OIDC_ALLOWED_EVENTS=${GITHUB_OIDC_ALLOWED_EVENTS:-schedule,workflow_dispatch}
GITHUB_OIDC_ALLOWED_REFS=${GITHUB_OIDC_ALLOWED_REFS:-refs/heads/main}
GITHUB_OIDC_ALLOWED_JOB_REFS=${GITHUB_OIDC_ALLOWED_JOB_REFS:-ak125/nestjs-remix-monorepo/.github/workflows/sitemap-daily-regen.yml@refs/heads/main}
GITHUB_OIDC_ALLOWED_SUBS=${GITHUB_OIDC_ALLOWED_SUBS:-repo:ak125/nestjs-remix-monorepo:ref:refs/heads/main}
REDIS_OIDC_DB_INDEX=${REDIS_OIDC_DB_INDEX:-1}
SITEMAP_LEGACY_INTERNAL_KEY_ENABLED=${SITEMAP_LEGACY_INTERNAL_KEY_ENABLED:-true}
# END sitemap-oidc-auth
```

## Design choices

1. **Marked block** `# BEGIN sitemap-oidc-auth` / `# END sitemap-oidc-auth` → permet ops idempotents sur PROD VPS `~/production/.env` via `sed -i '/^# BEGIN sitemap-oidc-auth/,/^# END sitemap-oidc-auth/d'`. Mirror exact du pattern adopté pour le bloc PROD ops.

2. **Defaults literals avec override `${VAR:-default}`** :
   - Sans GitHub Variable set → utilise le default literal (spec-conformant)
   - Avec Variable set en UI → override pris en compte
   - Pas de GitHub **Secrets** pour ces 8 vars : ce sont des allowlists/config, pas des credentials (cf. principle ops-config-vs-secrets)

3. **Non-sensible** : tous les 8 noms et valeurs apparaissent en clair dans le spec doc committed publiquement. Mettre en secrets = mauvaise concept hierarchy.

## Scope strict

- ✅ `.github/workflows/ci.yml` only (1 fichier)
- ✅ Zero backend code
- ✅ Zero compose change
- ✅ Zero runtime behavior change (vars consommées à Phase 1+, pas avant)

## Invariants respectés

1. ✅ No public endpoint regression (rien touché côté HTTP)
2. ✅ No auth fallback ambiguity (pas de guard code)
3. ✅ Fail-closed on JWKS failure (pas applicable Phase 0.5)
4. ✅ No Bull queue coupling with anti-replay Redis (DB 1 dédiée via env)

## Test plan

- [x] YAML syntax valide (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`)
- [ ] CI green sur cette PR
- [ ] Post-merge : vérification automatique au prochain deploy DEV preprod via :
  ```bash
  ssh deploy@<dev-vps> 'docker compose -f ~/preprod/docker-compose.preprod.yml exec backend env | grep -cE "GITHUB_OIDC|REDIS_OIDC|SITEMAP_LEGACY"'
  # Expected: 8
  ```

## PROD VPS action (séparée, non-bloquante pour ce PR)

Pour PROD (49.12.233.2), action ops manuelle inévitable (SSH PROD inaccessible depuis l'environnement de cette session). À exécuter depuis votre workstation locale avec votre clé SSH PROD :

```bash
ssh deploy@49.12.233.2 'sed -i "/^# BEGIN sitemap-oidc-auth/,/^# END sitemap-oidc-auth/d" ~/production/.env && cat >> ~/production/.env << "EOF"
# BEGIN sitemap-oidc-auth
GITHUB_OIDC_AUDIENCE=automecanik-sitemap-regen
GITHUB_OIDC_REPOSITORY=ak125/nestjs-remix-monorepo
GITHUB_OIDC_ALLOWED_EVENTS=schedule,workflow_dispatch
GITHUB_OIDC_ALLOWED_REFS=refs/heads/main
GITHUB_OIDC_ALLOWED_JOB_REFS=ak125/nestjs-remix-monorepo/.github/workflows/sitemap-daily-regen.yml@refs/heads/main
GITHUB_OIDC_ALLOWED_SUBS=repo:ak125/nestjs-remix-monorepo:ref:refs/heads/main
REDIS_OIDC_DB_INDEX=1
SITEMAP_LEGACY_INTERNAL_KEY_ENABLED=true
# END sitemap-oidc-auth
EOF'
```

Idempotent : sed delete le bloc existant s'il y en a, puis ré-écrit propre. Pas de doublons même en re-exécution.

## Refs

- Spec : [`docs/superpowers/specs/2026-05-16-sitemap-regen-auth-design.md`](docs/superpowers/specs/2026-05-16-sitemap-regen-auth-design.md)
- Plan : [`docs/superpowers/plans/2026-05-16-sitemap-regen-auth-impl.md`](docs/superpowers/plans/2026-05-16-sitemap-regen-auth-impl.md)
- Phase 0 base : #552 (merged commit `a2196f8a7`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)