### PR TITLE
fix(deps): unblock main build — declare @repo/seo-types as backend workspace dep

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -55,6 +55,7 @@
     "@repo/registry": "*",
     "@repo/seo-role-contracts": "*",
     "@repo/seo-roles": "*",
+    "@repo/seo-types": "*",
     "@sentry/nestjs": "^10.51.0",
     "@supabase/supabase-js": "^2.95.0",
     "@types/bull": "^4.10.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
         "@repo/registry": "*",
         "@repo/seo-role-contracts": "*",
         "@repo/seo-roles": "*",
+        "@repo/seo-types": "*",
         "@sentry/nestjs": "^10.51.0",
         "@supabase/supabase-js": "^2.95.0",
         "@types/bull": "^4.10.4",


### PR DESCRIPTION
## Summary — Main-build unblocker

main est rouge depuis **21+ heures** (2026-05-15 15:07 UTC → 2026-05-16 12:11 UTC, 10+ failed runs consécutifs). Cause : Docker buildx step échoue avec :

\`\`\`
@fafa/backend:build: src/modules/seo-monitoring/services/crux-alerter.service.ts(37,8):
  error TS2307: Cannot find module '@repo/seo-types' or its corresponding type declarations.
\`\`\`

3 fichiers backend importent `@repo/seo-types` (introduits par PRs #525 + #527 — feat(seo-crux) ADR-063 PR-4/PR-5) mais le workspace dep n'a jamais été ajouté à `backend/package.json`.

Dev local marche (workspace symlinks via Node fallback), Docker buildx (turbo --force + fresh npm ci) casse.

## Fix — one line

```diff
   "@repo/seo-role-contracts": "*",
   "@repo/seo-roles": "*",
+  "@repo/seo-types": "*",
```

Pattern identique aux 4 autres `@repo/*` deps existantes du backend.

## Test plan

- [x] `tsc --noEmit` PASS (0 erreurs, vs 3 TS2307 avant)
- [x] `require.resolve('@repo/seo-types')` retourne `packages/seo-types/dist/index.js`
- [ ] CI green
- [ ] Docker build PASS post-merge

## Scope

- Single fichier : `backend/package.json` + `package-lock.json`
- Zero code change
- Unblocks Phase 0/0.5 sitemap auth deploy + all other work blocked by main red

## Refs

- PR #525 (feat(seo-crux): alerter service pr-4 adr-063)
- PR #527 (feat(seo-crux): wiring final processor + endpoint admin pr-5 adr-063)
- First failed run : 25925217418 (2026-05-15 15:07 UTC)
- Failed run blocking sitemap auth : 25961530297 (2026-05-16 12:07 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)