### PR TITLE
feat(seo-r2): r1 gamme completeness audit prerequisite (adr-070 pr 2c')

### DIFF
--- a/backend/src/modules/seo/r2/r1-gamme-completeness-audit.controller.ts
+++ b/backend/src/modules/seo/r2/r1-gamme-completeness-audit.controller.ts
@@ -1,0 +1,64 @@
+/**
+ * ADR-070 PR 2C' — R1 Gamme Completeness Audit Admin Controller
+ *
+ * Admin endpoint pour visualiser l'audit de complétude R1 prerequisite
+ * AVANT le pilote V1 R2 v2 :
+ *
+ *   GET /api/admin/seo/r1/gamme-completeness-audit?sampleLimit=50
+ *
+ * Returns aggregated counts + top N incomplete gammes (status missing/partial)
+ * pour relance manuelle de l'agent r1-keyword-planner (workspace seo-batch).
+ *
+ * Pilot V1 blocker : si > 30% gammes incomplètes → backfill R1 obligatoire
+ * AVANT compose R2 (sinon massif review_required reason r1_gamme_sections_empty).
+ *
+ * Security : @UseGuards(IsAdminGuard) — admin authenticated only.
+ *
+ * Cf canon `feedback_no_overclaim_security_words` : 2-layer (admin guard + Rego).
+ */
+
+import { Controller, Get, Query, UseGuards, Logger } from '@nestjs/common';
+import { IsAdminGuard } from '@auth/is-admin.guard';
+import {
+  R1GammeCompletenessAuditService,
+  R1GammeCompletenessAuditReport,
+} from './services/r1-gamme-completeness-audit.service';
+
+@Controller('api/admin/seo/r1')
+@UseGuards(IsAdminGuard)
+export class R1GammeCompletenessAuditController {
+  private readonly logger = new Logger(R1GammeCompletenessAuditController.name);
+
+  constructor(private readonly auditService: R1GammeCompletenessAuditService) {}
+
+  /**
+   * GET /api/admin/seo/r1/gamme-completeness-audit
+   *
+   * Query params :
+   *   - sampleLimit (optional, default 50, max 500) :
+   *     top N incomplete gammes à inclure dans rowsSample
+   *
+   * Use case : admin UI dashboard de pré-pilote V1 R2 v2.
+   * Si pilotV1Blocker=true, l'admin relance r1-keyword-planner agent via
+   * le workspace seo-batch pour les pg_ids listés dans rowsSample.
+   */
+  @Get('gamme-completeness-audit')
+  async audit(
+    @Query('sampleLimit') sampleLimitRaw?: string,
+  ): Promise<R1GammeCompletenessAuditReport> {
+    // Strict numeric parse (canon `feedback_strict_numeric_targetid_parsing`)
+    let sampleLimit = 50;
+    if (sampleLimitRaw !== undefined) {
+      if (!/^\d+$/.test(sampleLimitRaw)) {
+        // Invalid → fallback to default
+        this.logger.warn(
+          `Invalid sampleLimit query=${sampleLimitRaw}, falling back to 50`,
+        );
+      } else {
+        sampleLimit = Math.min(500, Math.max(1, Number(sampleLimitRaw)));
+      }
+    }
+
+    return this.auditService.auditCompleteness(sampleLimit);
+  }
+}

--- a/backend/src/modules/seo/r2/r2-v2.module.ts
+++ b/backend/src/modules/seo/r2/r2-v2.module.ts
@@ -11,7 +11,9 @@
 
 import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../../../database/database.module';
+import { R1GammeCompletenessAuditController } from './r1-gamme-completeness-audit.controller';
 import { R2AdminPilotController } from './r2-admin-pilot.controller';
+import { R1GammeCompletenessAuditService } from './services/r1-gamme-completeness-audit.service';
 import { R2CatalogSignatureService } from './services/r2-catalog-signature.service';
 import { R2CommercialDistinctivenessService } from './services/r2-commercial-distinctiveness.service';
 import { R2CompositionInputSnapshotService } from './services/r2-composition-input-snapshot.service';
@@ -27,8 +29,9 @@ import { R2VehicleFamilyService } from './services/r2-vehicle-family.service';
 
 @Module({
   imports: [DatabaseModule],
-  controllers: [R2AdminPilotController],
+  controllers: [R2AdminPilotController, R1GammeCompletenessAuditController],
   providers: [
+    R1GammeCompletenessAuditService,
     R2CatalogSignatureService,
     R2CommercialDistinctivenessService,
     R2CompositionInputSnapshotService,
@@ -46,6 +49,7 @@ import { R2VehicleFamilyService } from './services/r2-vehicle-family.service';
     },
   ],
   exports: [
+    R1GammeCompletenessAuditService,
     R2CatalogSignatureService,
     R2CommercialDistinctivenessService,
     R2CompositionService,

--- a/backend/src/modules/seo/r2/services/__tests__/r1-gamme-completeness-audit.test.ts
+++ b/backend/src/modules/seo/r2/services/__tests__/r1-gamme-completeness-audit.test.ts
@@ -1,0 +1,267 @@
+/**
+ * ADR-070 PR 2C' — R1 Gamme Completeness Audit Service tests
+ *
+ * Coverage strategy : mock Supabase client to control gammes + sections
+ * returned, verify status computation + pilotV1Blocker threshold.
+ *
+ * Note : we extend the service to expose a protected `supabase` via a mock,
+ * since the service inherits from `SupabaseBaseService`. The `auditCompleteness`
+ * pure logic (count + status + threshold) is the unit under test.
+ */
+
+import {
+  R1GammeCompletenessAuditService,
+  R1_CRITICAL_SECTIONS_DB,
+} from '../r1-gamme-completeness-audit.service';
+
+interface FakeGammeRow {
+  pg_id: number;
+  pg_alias: string | null;
+  pg_name: string | null;
+}
+
+interface FakeConseilRow {
+  sgc_pg_id: number;
+  sgc_section_type: string;
+  sgc_content: string;
+}
+
+function makeFakeSupabase(
+  gammes: FakeGammeRow[],
+  conseilSections: FakeConseilRow[],
+) {
+  return {
+    from(table: string) {
+      if (table === 'pieces_gamme') {
+        return {
+          select: (_cols: string) => ({
+            order: (_col: string) => ({
+              range: (from: number, to: number) => {
+                const slice = gammes.slice(from, to + 1);
+                return Promise.resolve({ data: slice, error: null });
+              },
+            }),
+          }),
+        };
+      }
+      if (table === '__seo_gamme_conseil') {
+        return {
+          select: (_cols: string) => ({
+            in: (_col: string, _values: string[]) => ({
+              not: (_field: string, _op: string, _val: unknown) => ({
+                range: (from: number, to: number) => {
+                  const slice = conseilSections.slice(from, to + 1);
+                  return Promise.resolve({ data: slice, error: null });
+                },
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  };
+}
+
+function createServiceWithFakeData(
+  gammes: FakeGammeRow[],
+  sections: FakeConseilRow[],
+): R1GammeCompletenessAuditService {
+  // Bypass SupabaseBaseService constructor (which validates env) by using
+  // Object.create(prototype) — same pattern as r2-composition-input-snapshot.spec.ts.
+  const svc = Object.create(
+    R1GammeCompletenessAuditService.prototype,
+  ) as R1GammeCompletenessAuditService;
+  // Inject logger stub (Logger is non-public in base, we set via cast).
+  (
+    svc as unknown as {
+      logger: { log: () => void; error: () => void; warn: () => void };
+    }
+  ).logger = {
+    log: () => {},
+    error: () => {},
+    warn: () => {},
+  };
+  // Inject fake supabase
+  (svc as unknown as { supabase: unknown }).supabase = makeFakeSupabase(
+    gammes,
+    sections,
+  );
+  return svc;
+}
+
+const fullContent = 'X'.repeat(50);
+
+describe('R1GammeCompletenessAuditService', () => {
+  it('returns status=complete when all 5 critical sections present with non-empty content', async () => {
+    const gammes: FakeGammeRow[] = [
+      { pg_id: 100, pg_alias: 'huile', pg_name: 'Huile' },
+    ];
+    const sections: FakeConseilRow[] = R1_CRITICAL_SECTIONS_DB.map((s) => ({
+      sgc_pg_id: 100,
+      sgc_section_type: s,
+      sgc_content: fullContent,
+    }));
+    const svc = createServiceWithFakeData(gammes, sections);
+
+    const report = await svc.auditCompleteness();
+
+    expect(report.totalGammes).toBe(1);
+    expect(report.completeCount).toBe(1);
+    expect(report.partialCount).toBe(0);
+    expect(report.missingCount).toBe(0);
+    expect(report.completePercent).toBe(100);
+    expect(report.pilotV1Blocker).toBe(false);
+  });
+
+  it('returns status=partial when 2/5 sections present', async () => {
+    const gammes: FakeGammeRow[] = [
+      { pg_id: 100, pg_alias: 'huile', pg_name: 'Huile' },
+    ];
+    const sections: FakeConseilRow[] = [
+      { sgc_pg_id: 100, sgc_section_type: 'S1', sgc_content: fullContent },
+      { sgc_pg_id: 100, sgc_section_type: 'S3', sgc_content: fullContent },
+    ];
+    const svc = createServiceWithFakeData(gammes, sections);
+
+    const report = await svc.auditCompleteness();
+
+    expect(report.partialCount).toBe(1);
+    expect(report.rowsSample[0].status).toBe('partial');
+    expect(report.rowsSample[0].sectionsPresentCount).toBe(2);
+    expect(report.rowsSample[0].sectionsPresent.S1).toBe(true);
+    expect(report.rowsSample[0].sectionsPresent.S3).toBe(true);
+    expect(report.rowsSample[0].sectionsPresent.S5).toBe(false);
+  });
+
+  it('returns status=missing when 0 sections + pilotV1Blocker=true if > 30% incomplete', async () => {
+    // 10 gammes : 5 missing, 5 complete → 50% incomplete → blocker
+    const gammes: FakeGammeRow[] = Array.from({ length: 10 }, (_, i) => ({
+      pg_id: 100 + i,
+      pg_alias: `gamme${i}`,
+      pg_name: `Gamme ${i}`,
+    }));
+    const sections: FakeConseilRow[] = [];
+    for (let i = 5; i < 10; i++) {
+      for (const s of R1_CRITICAL_SECTIONS_DB) {
+        sections.push({
+          sgc_pg_id: 100 + i,
+          sgc_section_type: s,
+          sgc_content: fullContent,
+        });
+      }
+    }
+    const svc = createServiceWithFakeData(gammes, sections);
+
+    const report = await svc.auditCompleteness();
+
+    expect(report.missingCount).toBe(5);
+    expect(report.completeCount).toBe(5);
+    expect(report.missingPercent).toBe(50);
+    expect(report.pilotV1Blocker).toBe(true);
+  });
+
+  it('ignores sections with whitespace-only or very short content (< 10 chars)', async () => {
+    const gammes: FakeGammeRow[] = [
+      { pg_id: 100, pg_alias: 'huile', pg_name: 'Huile' },
+    ];
+    const sections: FakeConseilRow[] = [
+      { sgc_pg_id: 100, sgc_section_type: 'S1', sgc_content: '   ' }, // whitespace
+      { sgc_pg_id: 100, sgc_section_type: 'S3', sgc_content: 'tooshort' }, // 8 chars
+      { sgc_pg_id: 100, sgc_section_type: 'S5', sgc_content: fullContent }, // valid
+    ];
+    const svc = createServiceWithFakeData(gammes, sections);
+
+    const report = await svc.auditCompleteness();
+
+    expect(report.rowsSample[0].sectionsPresentCount).toBe(1);
+    expect(report.rowsSample[0].sectionsPresent.S5).toBe(true);
+    expect(report.rowsSample[0].sectionsPresent.S1).toBe(false);
+    expect(report.rowsSample[0].sectionsPresent.S3).toBe(false);
+  });
+
+  it('pilotV1Blocker=false when exactly 30% incomplete (boundary)', async () => {
+    // 10 gammes : 3 missing, 7 complete → 30% incomplete (boundary, NOT > 30%)
+    const gammes: FakeGammeRow[] = Array.from({ length: 10 }, (_, i) => ({
+      pg_id: 100 + i,
+      pg_alias: `gamme${i}`,
+      pg_name: `Gamme ${i}`,
+    }));
+    const sections: FakeConseilRow[] = [];
+    for (let i = 3; i < 10; i++) {
+      for (const s of R1_CRITICAL_SECTIONS_DB) {
+        sections.push({
+          sgc_pg_id: 100 + i,
+          sgc_section_type: s,
+          sgc_content: fullContent,
+        });
+      }
+    }
+    const svc = createServiceWithFakeData(gammes, sections);
+
+    const report = await svc.auditCompleteness();
+
+    expect(report.missingCount).toBe(3);
+    expect(report.completeCount).toBe(7);
+    expect(report.missingPercent).toBe(30);
+    expect(report.pilotV1Blocker).toBe(false); // > 30%, not >=
+  });
+
+  it('rowsSample sorts missing before partial, then partial by count ascending', async () => {
+    const gammes: FakeGammeRow[] = [
+      { pg_id: 100, pg_alias: 'a', pg_name: 'a' },
+      { pg_id: 200, pg_alias: 'b', pg_name: 'b' },
+      { pg_id: 300, pg_alias: 'c', pg_name: 'c' },
+    ];
+    const sections: FakeConseilRow[] = [
+      // pg 100 : 4/5 (partial, count=4)
+      { sgc_pg_id: 100, sgc_section_type: 'S1', sgc_content: fullContent },
+      { sgc_pg_id: 100, sgc_section_type: 'S3', sgc_content: fullContent },
+      { sgc_pg_id: 100, sgc_section_type: 'S5', sgc_content: fullContent },
+      { sgc_pg_id: 100, sgc_section_type: 'S6', sgc_content: fullContent },
+      // pg 200 : 0/5 (missing)
+      // pg 300 : 2/5 (partial, count=2)
+      { sgc_pg_id: 300, sgc_section_type: 'S1', sgc_content: fullContent },
+      { sgc_pg_id: 300, sgc_section_type: 'S3', sgc_content: fullContent },
+    ];
+    const svc = createServiceWithFakeData(gammes, sections);
+
+    const report = await svc.auditCompleteness();
+
+    // Expected sort : pg_id=200 (missing) first, then pg_id=300 (partial count=2), then pg_id=100 (partial count=4)
+    expect(report.rowsSample[0].pgId).toBe(200);
+    expect(report.rowsSample[0].status).toBe('missing');
+    expect(report.rowsSample[1].pgId).toBe(300);
+    expect(report.rowsSample[1].sectionsPresentCount).toBe(2);
+    expect(report.rowsSample[2].pgId).toBe(100);
+    expect(report.rowsSample[2].sectionsPresentCount).toBe(4);
+  });
+
+  it('rowsSample respects partialMissingSampleLimit parameter', async () => {
+    const gammes: FakeGammeRow[] = Array.from({ length: 100 }, (_, i) => ({
+      pg_id: i + 1,
+      pg_alias: `g${i}`,
+      pg_name: `G${i}`,
+    }));
+    const sections: FakeConseilRow[] = [];
+    const svc = createServiceWithFakeData(gammes, sections);
+
+    const report = await svc.auditCompleteness(5);
+
+    expect(report.rowsSample.length).toBe(5);
+    expect(report.missingCount).toBe(100);
+  });
+
+  it('returns zero counts when no gammes exist', async () => {
+    const svc = createServiceWithFakeData([], []);
+
+    const report = await svc.auditCompleteness();
+
+    expect(report.totalGammes).toBe(0);
+    expect(report.completeCount).toBe(0);
+    expect(report.partialCount).toBe(0);
+    expect(report.missingCount).toBe(0);
+    expect(report.completePercent).toBe(0);
+    expect(report.pilotV1Blocker).toBe(false);
+  });
+});

--- a/backend/src/modules/seo/r2/services/r1-gamme-completeness-audit.service.ts
+++ b/backend/src/modules/seo/r2/services/r1-gamme-completeness-audit.service.ts
@@ -1,0 +1,282 @@
+/**
+ * ADR-070 PR 2C' — R1 Gamme Completeness Audit Service
+ *
+ * Audit prerequisite avant pilote V1 R2 v2 — identifie les gammes R1 dont
+ * les sections critiques (héritées telles quelles par R2) sont incomplètes.
+ *
+ * Canon ADR-070 §G (R8 + R1 prerequisite gates) :
+ *   - R1 gamme context obligatoire (CADRE) pour qu'une page R2 puisse être INDEX
+ *   - Sections critiques héritées par R2 : S_SELECTION_GUIDE, S_MISTAKES_AVOID,
+ *     S_FAQ_GAMME, S_TECHNICAL_CRITERIA, S_REASSURANCE_METIER
+ *   - Mapping conceptuel → DB `__seo_gamme_conseil.sgc_section_type` :
+ *       S1 (Fonction)             → contribue à S_TECHNICAL_CRITERIA / S_REASSURANCE
+ *       S2 (Quand changer)        → contribue à S_REASSURANCE_METIER
+ *       S3 (Comment choisir)      → S_SELECTION_GUIDE
+ *       S5 (Erreurs à éviter)     → S_MISTAKES_AVOID
+ *       S6 (Vérification finale)  → S_TECHNICAL_CRITERIA
+ *       S8 (FAQ)                  → S_FAQ_GAMME
+ *
+ * Une gamme est considérée :
+ *   - `complete`  : 5/5 sections critiques DB présentes (S1+S3+S5+S6+S8) avec sgc_content non-vide
+ *   - `partial`   : 1-4 sections critiques présentes (R2 compose retournera review_required reason r1_gamme_sections_empty)
+ *   - `missing`   : 0 section critique ou aucune row __seo_gamme_conseil pour ce pg_id
+ *
+ * Service READ-ONLY pur. Aucun write. La relance R1 keyword planner agent
+ * (workspace seo-batch `r1-keyword-planner`) reste human-triggered.
+ *
+ * Cf MEMORY feedback_verify_existing_first : agent r1-keyword-planner déjà
+ * référencé dans `backend/src/modules/agentic-engine/constants/agentic.constants.ts`
+ * (GOAL_REGISTRY.keyword_plan.agents).
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseBaseService } from '../../../../database/services/supabase-base.service';
+
+/**
+ * 5 sections DB critiques canon ADR-070 R1 prerequisite.
+ * Toute gamme avec ces 5 sections non-vides est considérée `complete`.
+ */
+export const R1_CRITICAL_SECTIONS_DB = [
+  'S1', // Fonction
+  'S3', // Comment choisir
+  'S5', // Erreurs à éviter
+  'S6', // Vérification finale
+  'S8', // FAQ
+] as const;
+
+export type R1CriticalSectionDb = (typeof R1_CRITICAL_SECTIONS_DB)[number];
+
+export type R1GammeCompletenessStatus = 'complete' | 'partial' | 'missing';
+
+export interface R1GammePerSectionPresence {
+  S1: boolean;
+  S3: boolean;
+  S5: boolean;
+  S6: boolean;
+  S8: boolean;
+}
+
+export interface R1GammeCompletenessRow {
+  pgId: number;
+  pgAlias: string | null;
+  pgName: string | null;
+  sectionsPresent: R1GammePerSectionPresence;
+  sectionsPresentCount: number;
+  status: R1GammeCompletenessStatus;
+}
+
+export interface R1GammeCompletenessAuditReport {
+  totalGammes: number;
+  completeCount: number;
+  partialCount: number;
+  missingCount: number;
+  completePercent: number;
+  partialPercent: number;
+  missingPercent: number;
+  /**
+   * Bloque pilote V1 si > 30% gammes ont sections critiques vides
+   * (canon ADR-070 §G, seuil empirique calibration à venir).
+   */
+  pilotV1Blocker: boolean;
+  rowsSample: R1GammeCompletenessRow[]; // limite top N partial/missing pour visualisation admin
+  generatedAt: string;
+}
+
+@Injectable()
+export class R1GammeCompletenessAuditService extends SupabaseBaseService {
+  protected readonly logger = new Logger(R1GammeCompletenessAuditService.name);
+
+  /**
+   * Seuil canon ADR-070 §G : si > 30% gammes ont sections critiques vides,
+   * pilote V1 bloqué (sinon ~30%+ pages R2 retournent review_required
+   * reason `r1_gamme_sections_empty` immédiatement).
+   */
+  static readonly PILOT_V1_BLOCKER_THRESHOLD_PERCENT = 30;
+
+  /**
+   * Génère le rapport d'audit complet. Pure read. Lit :
+   *   - `pieces_gamme` pour la liste totale des gammes (pg_id, pg_alias, pg_name)
+   *   - `__seo_gamme_conseil` pour les sections existantes par gamme
+   *
+   * Param `partialMissingSampleLimit` : top N gammes incomplètes à inclure
+   * dans `rowsSample` (par défaut 50 — visualisation admin).
+   */
+  async auditCompleteness(
+    partialMissingSampleLimit: number = 50,
+  ): Promise<R1GammeCompletenessAuditReport> {
+    const startedAt = Date.now();
+
+    // 1. Pull all gammes (parent set) — paginated to handle large catalogs
+    const gammes = await this.fetchAllGammes();
+
+    // 2. Pull sections present per pg_id from __seo_gamme_conseil
+    //    Only critical sections, only with non-empty content.
+    const sectionsByPgId = await this.fetchCriticalSectionsPresenceMap();
+
+    // 3. Compute per-gamme status
+    const rows: R1GammeCompletenessRow[] = gammes.map((gamme) => {
+      const present = sectionsByPgId.get(gamme.pgId) ?? this.emptyPresence();
+      const count = R1_CRITICAL_SECTIONS_DB.filter((s) => present[s]).length;
+      const status: R1GammeCompletenessStatus =
+        count === R1_CRITICAL_SECTIONS_DB.length
+          ? 'complete'
+          : count === 0
+            ? 'missing'
+            : 'partial';
+      return {
+        pgId: gamme.pgId,
+        pgAlias: gamme.pgAlias,
+        pgName: gamme.pgName,
+        sectionsPresent: present,
+        sectionsPresentCount: count,
+        status,
+      };
+    });
+
+    // 4. Aggregate counts
+    const completeCount = rows.filter((r) => r.status === 'complete').length;
+    const partialCount = rows.filter((r) => r.status === 'partial').length;
+    const missingCount = rows.filter((r) => r.status === 'missing').length;
+    const total = rows.length;
+    const incompletePercent =
+      total === 0 ? 0 : ((partialCount + missingCount) / total) * 100;
+
+    // 5. Sample top N incomplete (sorted: missing first, then partial by count ascending)
+    const incompleteSorted = rows
+      .filter((r) => r.status !== 'complete')
+      .sort((a, b) => {
+        if (a.status !== b.status) {
+          return a.status === 'missing' ? -1 : 1;
+        }
+        return a.sectionsPresentCount - b.sectionsPresentCount;
+      });
+
+    const report: R1GammeCompletenessAuditReport = {
+      totalGammes: total,
+      completeCount,
+      partialCount,
+      missingCount,
+      completePercent: total === 0 ? 0 : (completeCount / total) * 100,
+      partialPercent: total === 0 ? 0 : (partialCount / total) * 100,
+      missingPercent: total === 0 ? 0 : (missingCount / total) * 100,
+      pilotV1Blocker:
+        incompletePercent >
+        R1GammeCompletenessAuditService.PILOT_V1_BLOCKER_THRESHOLD_PERCENT,
+      rowsSample: incompleteSorted.slice(0, partialMissingSampleLimit),
+      generatedAt: new Date().toISOString(),
+    };
+
+    const durationMs = Date.now() - startedAt;
+    this.logger.log(
+      `R1 gamme completeness audit done in ${durationMs}ms : ` +
+        `${completeCount}/${total} complete, ${partialCount} partial, ${missingCount} missing — ` +
+        `pilotV1Blocker=${report.pilotV1Blocker}`,
+    );
+
+    return report;
+  }
+
+  /** Pull all rows from pieces_gamme (paginated chunks of 1000). */
+  private async fetchAllGammes(): Promise<
+    Array<{ pgId: number; pgAlias: string | null; pgName: string | null }>
+  > {
+    const all: Array<{
+      pgId: number;
+      pgAlias: string | null;
+      pgName: string | null;
+    }> = [];
+    const pageSize = 1000;
+    let from = 0;
+
+    for (;;) {
+      const { data, error } = await this.supabase
+        .from('pieces_gamme')
+        .select('pg_id, pg_alias, pg_name')
+        .order('pg_id')
+        .range(from, from + pageSize - 1);
+
+      if (error) {
+        this.logger.error(
+          `fetchAllGammes failed at offset ${from}: ${error.message}`,
+        );
+        break;
+      }
+      if (!data || data.length === 0) {
+        break;
+      }
+      for (const row of data) {
+        all.push({
+          pgId: Number(row.pg_id),
+          pgAlias: row.pg_alias ?? null,
+          pgName: row.pg_name ?? null,
+        });
+      }
+      if (data.length < pageSize) {
+        break;
+      }
+      from += pageSize;
+    }
+
+    return all;
+  }
+
+  /**
+   * Pull __seo_gamme_conseil rows for critical sections only (non-empty content).
+   * Returns map pgId → presence flags per section.
+   */
+  private async fetchCriticalSectionsPresenceMap(): Promise<
+    Map<number, R1GammePerSectionPresence>
+  > {
+    const map = new Map<number, R1GammePerSectionPresence>();
+    const pageSize = 1000;
+    let from = 0;
+
+    for (;;) {
+      const { data, error } = await this.supabase
+        .from('__seo_gamme_conseil')
+        .select('sgc_pg_id, sgc_section_type, sgc_content')
+        .in('sgc_section_type', [...R1_CRITICAL_SECTIONS_DB])
+        .not('sgc_content', 'is', null)
+        .range(from, from + pageSize - 1);
+
+      if (error) {
+        this.logger.error(
+          `fetchCriticalSectionsPresenceMap failed at offset ${from}: ${error.message}`,
+        );
+        break;
+      }
+      if (!data || data.length === 0) {
+        break;
+      }
+
+      for (const row of data) {
+        const pgId = Number(row.sgc_pg_id);
+        const sectionType = row.sgc_section_type as R1CriticalSectionDb;
+        const content = (row.sgc_content as string | null) ?? '';
+
+        // Treat whitespace-only or extremely short content as effectively missing.
+        if (content.trim().length < 10) {
+          continue;
+        }
+
+        let presence = map.get(pgId);
+        if (!presence) {
+          presence = this.emptyPresence();
+          map.set(pgId, presence);
+        }
+        presence[sectionType] = true;
+      }
+
+      if (data.length < pageSize) {
+        break;
+      }
+      from += pageSize;
+    }
+
+    return map;
+  }
+
+  private emptyPresence(): R1GammePerSectionPresence {
+    return { S1: false, S3: false, S5: false, S6: false, S8: false };
+  }
+}


### PR DESCRIPTION
## Summary

PR 2C' du chantier R2 v2 (canon Round 5+6+7+8 du plan local). Cette PR ajoute l'**audit prerequisite R1** avant le pilote V1, pour identifier les gammes dont les sections critiques (héritées telles quelles par R2 selon canon Round 7 ADR-070) sont incomplètes.

Sans cet audit, le pilote V1 R2 v2 retournerait massivement `review_required` reason `r1_gamme_sections_empty` (gate prerequisite Rego ADR-070 §G).

## Canon doctrinal

**ADR-070** (vault merged 2026-05-16, commit `410b17a`) — Round 7 dit :
> R1 sections **héritées telles quelles** par R2 : S_SELECTION_GUIDE, S_MISTAKES_AVOID, S_FAQ_GAMME, S_TECHNICAL_CRITERIA, S_REASSURANCE_METIER

**Mapping conceptuel canon** (R1 → DB `__seo_gamme_conseil.sgc_section_type`) :

| R2 section | DB section | Description |
|------------|------------|-------------|
| S_TECHNICAL_CRITERIA / S_REASSURANCE | **S1** | Fonction |
| S_SELECTION_GUIDE | **S3** | Comment choisir |
| S_MISTAKES_AVOID | **S5** | Erreurs à éviter |
| S_TECHNICAL_CRITERIA | **S6** | Vérification finale |
| S_FAQ_GAMME | **S8** | FAQ |

Une gamme est `complete` si les 5 sections DB (S1/S3/S5/S6/S8) sont présentes avec `sgc_content` non-vide (> 10 chars).

## Implémentation

### Service `R1GammeCompletenessAuditService` (READ-ONLY pur)

`backend/src/modules/seo/r2/services/r1-gamme-completeness-audit.service.ts`

- `auditCompleteness(sampleLimit=50)` → `R1GammeCompletenessAuditReport`
- Lit `pieces_gamme` (parent set, paginé 1000) + `__seo_gamme_conseil` (sections critiques filtered)
- Status par gamme : `complete` (5/5) | `partial` (1-4) | `missing` (0)
- **`pilotV1Blocker`** = `true` si `> 30%` gammes incomplètes (canon ADR-070 §G seuil empirique)
- `rowsSample` : top N gammes incomplètes, triées (missing first, partial par count ascending)

### Admin endpoint

`backend/src/modules/seo/r2/r1-gamme-completeness-audit.controller.ts`

- `GET /api/admin/seo/r1/gamme-completeness-audit?sampleLimit=50` (max 500)
- `@UseGuards(IsAdminGuard)` — admin authenticated only (2-layer security : admin guard + Rego)
- Strict numeric parsing (`/^\d+$/` AVANT `Number.parseInt`)

### Workflow backfill

Le service est read-only. La relance de l'agent `r1-keyword-planner` (workspace `seo-batch`, référencé dans `agentic.constants.ts` GOAL_REGISTRY) reste **human-triggered** :

1. Admin visualise dashboard via `GET /api/admin/seo/r1/gamme-completeness-audit`
2. Si `pilotV1Blocker=true` → admin extrait les `pg_ids` du `rowsSample`
3. Admin lance l'agent `r1-keyword-planner` via Claude Code workspace `seo-batch` sur les pg_ids ciblés
4. Re-run audit pour vérifier post-backfill

## Tests

```bash
$ jest src/modules/seo/r2/services/__tests__/r1-gamme-completeness-audit.test.ts
PASS: 8/8
```

Couverture :
- `complete` (5/5 sections)
- `partial` (2/5 sections)
- `missing` (0 sections) + `pilotV1Blocker=true` (50% incomplete)
- whitespace-only / short content (< 10 chars) ignored
- `pilotV1Blocker=false` boundary (exactement 30% incomplete, > 30% canon strict)
- `rowsSample` sort order (missing first, partial ascending)
- `sampleLimit` parameter respect
- Zero gammes edge case

## Test plan

- [x] Tests 8/8 pass via `jest src/modules/seo/r2/`
- [x] Service registered dans `R2V2Module` (providers + exports)
- [x] Controller registered dans `R2V2Module` (controllers)
- [x] Pattern `Object.create(prototype)` aligned avec `r2-composition-input-snapshot.spec.ts` (bypass SupabaseBaseService ctor env check)
- [ ] Admin UI dashboard (hors scope cette PR, intégré dans PR 2E pilote)
- [ ] Calibration seuil `PILOT_V1_BLOCKER_THRESHOLD_PERCENT` (initial 30%, à valider empiriquement post-merge)

## Suivi post-merge

Sequence canon finale (plan local) :

1. ✅ PR 2B Vault ADR-070 MERGED commit `410b17a` (96/96 OPA pass)
2. ✅ PR 2B' Vault ADR-072 MERGED commit `8ad4bf8a` (113/113 OPA pass)
3. ✅ **PR 2C' Mono R1 audit prerequisite** (cette PR)
4. PR 2D Mono R8 snapshot + initial seed ALL type_ids + migrations Round 8 (`__seo_r2_page_snapshot` + `__seo_outbox_event`)
5. PR 2H Mono Knowledge Graph L3 + Evidence Decay
6. PR 2E Mono R2DataLoader + Pilot sync 10 URLs + Frontend/Sitemap CQRS + MEASUREMENT GATE Round 6 + STOP par défaut

🤖 Generated with [Claude Code](https://claude.com/claude-code)