### PR TITLE
feat(seo-r2): r8 snapshot foundation + cqrs migrations (adr-072 pr 2d)

### DIFF
--- a/backend/src/modules/seo/r2/r2-v2.module.ts
+++ b/backend/src/modules/seo/r2/r2-v2.module.ts
@@ -26,6 +26,10 @@ import {
 import { R2MotorDeltaService } from './services/r2-motor-delta.service';
 import { R2OpaEvaluatorService } from './services/r2-opa-evaluator.service';
 import { R2VehicleFamilyService } from './services/r2-vehicle-family.service';
+import {
+  R8SnapshotReaderService,
+  R8_SNAPSHOT_CACHE_TOKEN,
+} from './services/r8-snapshot-reader.service';
 
 @Module({
   imports: [DatabaseModule],
@@ -41,10 +45,18 @@ import { R2VehicleFamilyService } from './services/r2-vehicle-family.service';
     R2OpaEvaluatorService,
     R2VehicleFamilyService,
     R2FeatureFlagService,
+    R8SnapshotReaderService, // ADR-072 §3 R8 Vehicle Domain bounded context read-side
     {
       // Redis provider stub — PR 2 V1.5 wires real Redis client (BullMQ Redis
       // reused). For PR 1 foundation, feature flag falls back to env var.
       provide: R2_FEATURE_FLAG_REDIS_TOKEN,
+      useValue: null,
+    },
+    {
+      // R8 snapshot cache provider (Redis L1) — null fallback pour PR 2D
+      // foundation (cache désactivé tant que pas branché). PR 2D-2 ou PR 2E
+      // wire le vrai client Redis (BullMQ Redis réutilisé).
+      provide: R8_SNAPSHOT_CACHE_TOKEN,
       useValue: null,
     },
   ],
@@ -57,6 +69,7 @@ import { R2VehicleFamilyService } from './services/r2-vehicle-family.service';
     R2MotorDeltaService,
     R2OpaEvaluatorService,
     R2FeatureFlagService,
+    R8SnapshotReaderService,
   ],
 })
 export class R2V2Module {}

--- a/backend/src/modules/seo/r2/schemas/r8-snapshot.schema.ts
+++ b/backend/src/modules/seo/r2/schemas/r8-snapshot.schema.ts
@@ -1,0 +1,125 @@
+/**
+ * ADR-072 — R8 Snapshot schemas (Zod versioned contracts)
+ *
+ * R8 Vehicle Domain bounded context (canon Round 8 §2 DDD bounded contexts).
+ * SoT table : __seo_r8_snapshot_store (immutable, content-addressed, versioned).
+ *
+ * R2 consumes via R8SnapshotReaderService.getLatestSnapshot(typeId) — persisted-only,
+ * jamais d'attente live. Si absent → R2 retourne review_required reason
+ * r8_snapshot_unavailable + enqueue async r8-enrichment (non-blocking).
+ *
+ * Schema Registry mirror Repository Contract Series (ADR-062 conformity criteria 9/9).
+ * Breaking changes → Architecture Contract gate observed → ratchet → enforce.
+ */
+
+import { z } from 'zod';
+
+// ── R8 enrichment status enum (canon Round 2 status enum strict) ─────────────
+//
+// Round 2 correction : retire 'unenriched' et 'snapshoted' ambigus. 4 valeurs canon :
+//   - minimal  : DB-only seed (auto_type + siblings basiques, pas de WIKI evidence)
+//   - enriched : full snapshot (DB + WIKI validated evidence)
+//   - stale    : snapshot existe mais auto_type.updated_at > snapshot.created_at
+//                OU TTL expiré (job nightly détecte, R2 compose continue avec stale +
+//                enqueue async re-enrichment)
+//   - failed   : enrichment tenté mais échoué (LLM timeout, data corruption, source ban)
+//                R2 retourne review_required reason r8_enrichment_failed (NE bloque pas)
+
+export const R8EnrichmentStatusEnum = z.enum([
+  'minimal',
+  'enriched',
+  'stale',
+  'failed',
+]);
+
+export type R8EnrichmentStatus = z.infer<typeof R8EnrichmentStatusEnum>;
+
+// ── R8 disambiguation signature (canon Round 5 CADRE véhicule) ───────────────
+//
+// Produit par R8ParentEnrichmentService (PR 2D-2 séparée). Représente la
+// signature désambiguïsée parent d'un type_id : puissance + années + carrosserie
+// + code moteur + norme Euro + liste sibling type_ids partageant le label moteur.
+//
+// Cf ADR-070 §C Disambiguation active : H1 mandatory power + body + years,
+// 3 sections obligatoires S_VARIANT_DISAMBIGUATION + S_SIBLING_TABLE + S_COMPAT_DIFFERENCES,
+// internal links sibling OK, canonical sibling INTERDIT.
+
+export const R8SiblingEntrySchema = z.object({
+  typeId: z.number().int().positive(),
+  powerHp: z.number().int().nonnegative().nullable(),
+  yearsFrom: z.number().int().nullable(),
+  yearsTo: z.number().int().nullable(),
+  bodyType: z.string().nullable(),
+  engineCode: z.string().nullable(),
+});
+
+export type R8SiblingEntry = z.infer<typeof R8SiblingEntrySchema>;
+
+export const R8DisambiguationSignatureSchema = z.object({
+  typeId: z.number().int().positive(),
+  brandSlug: z.string(),
+  modelSlug: z.string(),
+  // CADRE véhicule détaillé (canon ADR-070 §C disambiguation active)
+  powerHp: z.number().int().nonnegative().nullable(),
+  yearsFrom: z.number().int().nullable(),
+  yearsTo: z.number().int().nullable(),
+  bodyType: z.string().nullable(),         // "3/5 portes", "Break", etc.
+  fuelType: z.string().nullable(),
+  engineCode: z.string().nullable(),       // ex: "K9K 770"
+  euroNorm: z.string().nullable(),         // ex: "Euro5"
+  literage: z.string().nullable(),
+  // Sibling list (R2 S_SIBLING_TABLE + S_COMPAT_DIFFERENCES source)
+  siblings: z.array(R8SiblingEntrySchema).default([]),
+  // Lineage provenance
+  sourceLineage: z
+    .object({
+      autoTypeUpdatedAt: z.string().datetime().optional(),
+      wikiEvidenceIds: z.array(z.number().int().positive()).default([]),
+      llmModel: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type R8DisambiguationSignature = z.infer<
+  typeof R8DisambiguationSignatureSchema
+>;
+
+// ── R8 snapshot row (DB representation) ──────────────────────────────────────
+
+export const R8SnapshotRowSchema = z.object({
+  id: z.number().int().positive(),
+  typeId: z.number().int().positive(),
+  versionSha: z.string().regex(/^[0-9a-f]{64}$/, 'must be sha256 hex 64 chars'),
+  disambiguationSignature: R8DisambiguationSignatureSchema,
+  enrichmentStatus: R8EnrichmentStatusEnum,
+  sourceLineage: z
+    .object({
+      autoTypeUpdatedAt: z.string().datetime().optional(),
+      wikiEvidenceIds: z.array(z.number().int().positive()).default([]),
+      llmModel: z.string().optional(),
+    })
+    .nullable()
+    .optional(),
+  createdAt: z.string().datetime(),
+});
+
+export type R8SnapshotRow = z.infer<typeof R8SnapshotRowSchema>;
+
+// ── R8 snapshot read result (R2-facing API) ──────────────────────────────────
+//
+// Retourné par R8SnapshotReaderService.getLatestSnapshot(typeId).
+// `null` = snapshot absent → R2 retourne review_required reason r8_snapshot_unavailable.
+
+/**
+ * Discriminated union TypeScript explicite — pas de Zod schema pour ce type
+ * car z.discriminatedUnion infère des fields optionals (`?`) qui empêchent le
+ * narrowing TS via `if (result.found)` côté consumer (R2DataLoaderService).
+ *
+ * Validation runtime du payload réservée aux fields R8SnapshotRowSchema (déjà Zod).
+ */
+export type R8SnapshotReadResult =
+  | { found: true; snapshot: R8SnapshotRow }
+  | {
+      found: false;
+      reason: 'r8_snapshot_unavailable' | 'r8_enrichment_failed';
+    };

--- a/backend/src/modules/seo/r2/schemas/r8-snapshot.schema.ts
+++ b/backend/src/modules/seo/r2/schemas/r8-snapshot.schema.ts
@@ -63,10 +63,10 @@ export const R8DisambiguationSignatureSchema = z.object({
   powerHp: z.number().int().nonnegative().nullable(),
   yearsFrom: z.number().int().nullable(),
   yearsTo: z.number().int().nullable(),
-  bodyType: z.string().nullable(),         // "3/5 portes", "Break", etc.
+  bodyType: z.string().nullable(), // "3/5 portes", "Break", etc.
   fuelType: z.string().nullable(),
-  engineCode: z.string().nullable(),       // ex: "K9K 770"
-  euroNorm: z.string().nullable(),         // ex: "Euro5"
+  engineCode: z.string().nullable(), // ex: "K9K 770"
+  euroNorm: z.string().nullable(), // ex: "Euro5"
   literage: z.string().nullable(),
   // Sibling list (R2 S_SIBLING_TABLE + S_COMPAT_DIFFERENCES source)
   siblings: z.array(R8SiblingEntrySchema).default([]),

--- a/backend/src/modules/seo/r2/services/__tests__/r8-snapshot-reader.test.ts
+++ b/backend/src/modules/seo/r2/services/__tests__/r8-snapshot-reader.test.ts
@@ -1,0 +1,262 @@
+/**
+ * ADR-072 §3 — R8SnapshotReaderService tests
+ *
+ * Coverage : cache hit/miss, SQL JOIN parsing, enrichment_status='failed' →
+ * r8_enrichment_failed, absent → r8_snapshot_unavailable, Zod parse robustness.
+ *
+ * Pattern Object.create(prototype) pour bypass SupabaseBaseService ctor env check,
+ * mirror canon r2-composition-input-snapshot.spec.ts.
+ */
+
+import { R8SnapshotReaderService, R8SnapshotCacheClient } from '../r8-snapshot-reader.service';
+
+const validSnapshotRow = {
+  id: 42,
+  type_id: 12345,
+  version_sha: 'a'.repeat(64),
+  disambiguation_signature: {
+    typeId: 12345,
+    brandSlug: 'renault',
+    modelSlug: 'clio-iii',
+    powerHp: 88,
+    yearsFrom: 2010,
+    yearsTo: 2014,
+    bodyType: '3/5 portes',
+    fuelType: 'diesel',
+    engineCode: 'K9K 770',
+    euroNorm: 'Euro5',
+    literage: '1.5',
+    siblings: [],
+  },
+  enrichment_status: 'enriched',
+  source_lineage: { autoTypeUpdatedAt: '2026-05-01T00:00:00Z' },
+  created_at: '2026-05-15T10:00:00Z',
+};
+
+function makeFakeSupabaseFound(snapshotRow: typeof validSnapshotRow | null) {
+  return {
+    from(_table: string) {
+      return {
+        select: (_cols: string) => ({
+          eq: (_col: string, _val: number) => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: snapshotRow
+                  ? {
+                      type_id: snapshotRow.type_id,
+                      current_snapshot_id: snapshotRow.id,
+                      snapshot: snapshotRow,
+                    }
+                  : null,
+                error: null,
+              }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
+function makeFakeSupabaseNoPointer() {
+  return {
+    from(_table: string) {
+      return {
+        select: (_cols: string) => ({
+          eq: (_col: string, _val: number) => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: {
+                  type_id: 12345,
+                  current_snapshot_id: null,
+                  snapshot: null,
+                },
+                error: null,
+              }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
+function makeFakeSupabaseSqlError() {
+  return {
+    from(_table: string) {
+      return {
+        select: (_cols: string) => ({
+          eq: (_col: string, _val: number) => ({
+            maybeSingle: () =>
+              Promise.resolve({
+                data: null,
+                error: { message: 'connection refused' },
+              }),
+          }),
+        }),
+      };
+    },
+  };
+}
+
+function createService(
+  supabase: unknown,
+  cache?: R8SnapshotCacheClient,
+): R8SnapshotReaderService {
+  const svc = Object.create(
+    R8SnapshotReaderService.prototype,
+  ) as R8SnapshotReaderService;
+  (svc as unknown as { logger: { log: () => void; error: () => void; warn: () => void } }).logger = {
+    log: () => {},
+    error: () => {},
+    warn: () => {},
+  };
+  (svc as unknown as { supabase: unknown }).supabase = supabase;
+  (svc as unknown as { cache: R8SnapshotCacheClient | undefined }).cache = cache;
+  return svc;
+}
+
+describe('R8SnapshotReaderService', () => {
+  describe('getLatestSnapshot', () => {
+    it('returns found=true with enriched snapshot when DB row exists', async () => {
+      const svc = createService(makeFakeSupabaseFound(validSnapshotRow));
+      const result = await svc.getLatestSnapshot(12345);
+      expect(result.found).toBe(true);
+      if (result.found) {
+        expect(result.snapshot.versionSha).toBe('a'.repeat(64));
+        expect(result.snapshot.enrichmentStatus).toBe('enriched');
+        expect(result.snapshot.disambiguationSignature.powerHp).toBe(88);
+      }
+    });
+
+    it('returns found=true for status=minimal', async () => {
+      const svc = createService(
+        makeFakeSupabaseFound({ ...validSnapshotRow, enrichment_status: 'minimal' }),
+      );
+      const result = await svc.getLatestSnapshot(12345);
+      expect(result.found).toBe(true);
+    });
+
+    it('returns found=true for status=stale (R2 compose continues with stale)', async () => {
+      const svc = createService(
+        makeFakeSupabaseFound({ ...validSnapshotRow, enrichment_status: 'stale' }),
+      );
+      const result = await svc.getLatestSnapshot(12345);
+      expect(result.found).toBe(true);
+    });
+
+    it('returns found=false reason=r8_enrichment_failed when status=failed', async () => {
+      const svc = createService(
+        makeFakeSupabaseFound({ ...validSnapshotRow, enrichment_status: 'failed' }),
+      );
+      const result = await svc.getLatestSnapshot(12345);
+      expect(result.found).toBe(false);
+      if (result.found === false) {
+        expect(result.reason).toBe('r8_enrichment_failed');
+      }
+    });
+
+    it('returns found=false reason=r8_snapshot_unavailable when no row exists', async () => {
+      const svc = createService(makeFakeSupabaseFound(null));
+      const result = await svc.getLatestSnapshot(99999);
+      expect(result.found).toBe(false);
+      if (result.found === false) {
+        expect(result.reason).toBe('r8_snapshot_unavailable');
+      }
+    });
+
+    it('returns found=false reason=r8_snapshot_unavailable when current_snapshot_id is null', async () => {
+      const svc = createService(makeFakeSupabaseNoPointer());
+      const result = await svc.getLatestSnapshot(12345);
+      expect(result.found).toBe(false);
+      if (result.found === false) {
+        expect(result.reason).toBe('r8_snapshot_unavailable');
+      }
+    });
+
+    it('returns found=false on SQL error (graceful degradation)', async () => {
+      const svc = createService(makeFakeSupabaseSqlError());
+      const result = await svc.getLatestSnapshot(12345);
+      expect(result.found).toBe(false);
+      if (result.found === false) {
+        expect(result.reason).toBe('r8_snapshot_unavailable');
+      }
+    });
+
+    it('throws on invalid typeId (0, negative, non-integer)', async () => {
+      const svc = createService(makeFakeSupabaseFound(validSnapshotRow));
+      await expect(svc.getLatestSnapshot(0)).rejects.toThrow(/Invalid typeId/);
+      await expect(svc.getLatestSnapshot(-1)).rejects.toThrow(/Invalid typeId/);
+      await expect(svc.getLatestSnapshot(1.5)).rejects.toThrow(/Invalid typeId/);
+    });
+  });
+
+  describe('cache integration', () => {
+    it('returns cached value without hitting DB on cache hit', async () => {
+      const fakeCache: R8SnapshotCacheClient = {
+        get: jest.fn().mockResolvedValue(
+          JSON.stringify({
+            found: true,
+            snapshot: {
+              id: 42,
+              typeId: 12345,
+              versionSha: 'b'.repeat(64),
+              disambiguationSignature: validSnapshotRow.disambiguation_signature,
+              enrichmentStatus: 'enriched',
+              sourceLineage: null,
+              createdAt: '2026-05-15T10:00:00Z',
+            },
+          }),
+        ),
+        setEx: jest.fn().mockResolvedValue(undefined),
+        del: jest.fn().mockResolvedValue(undefined),
+      };
+      // Supabase should NOT be called when cache hits
+      const supabaseSpy = {
+        from: jest.fn(() => {
+          throw new Error('should not be called');
+        }),
+      };
+      const svc = createService(supabaseSpy, fakeCache);
+      const result = await svc.getLatestSnapshot(12345);
+      expect(result.found).toBe(true);
+      expect(fakeCache.get).toHaveBeenCalledWith('r8:snapshot:12345');
+      expect(supabaseSpy.from).not.toHaveBeenCalled();
+    });
+
+    it('writes to cache after DB miss → DB fetch', async () => {
+      const fakeCache: R8SnapshotCacheClient = {
+        get: jest.fn().mockResolvedValue(null),
+        setEx: jest.fn().mockResolvedValue(undefined),
+        del: jest.fn().mockResolvedValue(undefined),
+      };
+      const svc = createService(makeFakeSupabaseFound(validSnapshotRow), fakeCache);
+      await svc.getLatestSnapshot(12345);
+      expect(fakeCache.setEx).toHaveBeenCalledWith(
+        'r8:snapshot:12345',
+        3600,
+        expect.stringContaining('"found":true'),
+      );
+    });
+
+    it('handles cache.get errors gracefully (fallback DB)', async () => {
+      const fakeCache: R8SnapshotCacheClient = {
+        get: jest.fn().mockRejectedValue(new Error('redis down')),
+        setEx: jest.fn().mockResolvedValue(undefined),
+        del: jest.fn().mockResolvedValue(undefined),
+      };
+      const svc = createService(makeFakeSupabaseFound(validSnapshotRow), fakeCache);
+      const result = await svc.getLatestSnapshot(12345);
+      expect(result.found).toBe(true); // DB succeeded despite cache error
+    });
+
+    it('invalidateCache deletes the cache entry', async () => {
+      const fakeCache: R8SnapshotCacheClient = {
+        get: jest.fn().mockResolvedValue(null),
+        setEx: jest.fn().mockResolvedValue(undefined),
+        del: jest.fn().mockResolvedValue(undefined),
+      };
+      const svc = createService(makeFakeSupabaseFound(validSnapshotRow), fakeCache);
+      await svc.invalidateCache(12345);
+      expect(fakeCache.del).toHaveBeenCalledWith('r8:snapshot:12345');
+    });
+  });
+});

--- a/backend/src/modules/seo/r2/services/__tests__/r8-snapshot-reader.test.ts
+++ b/backend/src/modules/seo/r2/services/__tests__/r8-snapshot-reader.test.ts
@@ -8,7 +8,10 @@
  * mirror canon r2-composition-input-snapshot.spec.ts.
  */
 
-import { R8SnapshotReaderService, R8SnapshotCacheClient } from '../r8-snapshot-reader.service';
+import {
+  R8SnapshotReaderService,
+  R8SnapshotCacheClient,
+} from '../r8-snapshot-reader.service';
 
 const validSnapshotRow = {
   id: 42,
@@ -104,13 +107,18 @@ function createService(
   const svc = Object.create(
     R8SnapshotReaderService.prototype,
   ) as R8SnapshotReaderService;
-  (svc as unknown as { logger: { log: () => void; error: () => void; warn: () => void } }).logger = {
+  (
+    svc as unknown as {
+      logger: { log: () => void; error: () => void; warn: () => void };
+    }
+  ).logger = {
     log: () => {},
     error: () => {},
     warn: () => {},
   };
   (svc as unknown as { supabase: unknown }).supabase = supabase;
-  (svc as unknown as { cache: R8SnapshotCacheClient | undefined }).cache = cache;
+  (svc as unknown as { cache: R8SnapshotCacheClient | undefined }).cache =
+    cache;
   return svc;
 }
 
@@ -129,7 +137,10 @@ describe('R8SnapshotReaderService', () => {
 
     it('returns found=true for status=minimal', async () => {
       const svc = createService(
-        makeFakeSupabaseFound({ ...validSnapshotRow, enrichment_status: 'minimal' }),
+        makeFakeSupabaseFound({
+          ...validSnapshotRow,
+          enrichment_status: 'minimal',
+        }),
       );
       const result = await svc.getLatestSnapshot(12345);
       expect(result.found).toBe(true);
@@ -137,7 +148,10 @@ describe('R8SnapshotReaderService', () => {
 
     it('returns found=true for status=stale (R2 compose continues with stale)', async () => {
       const svc = createService(
-        makeFakeSupabaseFound({ ...validSnapshotRow, enrichment_status: 'stale' }),
+        makeFakeSupabaseFound({
+          ...validSnapshotRow,
+          enrichment_status: 'stale',
+        }),
       );
       const result = await svc.getLatestSnapshot(12345);
       expect(result.found).toBe(true);
@@ -145,7 +159,10 @@ describe('R8SnapshotReaderService', () => {
 
     it('returns found=false reason=r8_enrichment_failed when status=failed', async () => {
       const svc = createService(
-        makeFakeSupabaseFound({ ...validSnapshotRow, enrichment_status: 'failed' }),
+        makeFakeSupabaseFound({
+          ...validSnapshotRow,
+          enrichment_status: 'failed',
+        }),
       );
       const result = await svc.getLatestSnapshot(12345);
       expect(result.found).toBe(false);
@@ -185,7 +202,9 @@ describe('R8SnapshotReaderService', () => {
       const svc = createService(makeFakeSupabaseFound(validSnapshotRow));
       await expect(svc.getLatestSnapshot(0)).rejects.toThrow(/Invalid typeId/);
       await expect(svc.getLatestSnapshot(-1)).rejects.toThrow(/Invalid typeId/);
-      await expect(svc.getLatestSnapshot(1.5)).rejects.toThrow(/Invalid typeId/);
+      await expect(svc.getLatestSnapshot(1.5)).rejects.toThrow(
+        /Invalid typeId/,
+      );
     });
   });
 
@@ -199,7 +218,8 @@ describe('R8SnapshotReaderService', () => {
               id: 42,
               typeId: 12345,
               versionSha: 'b'.repeat(64),
-              disambiguationSignature: validSnapshotRow.disambiguation_signature,
+              disambiguationSignature:
+                validSnapshotRow.disambiguation_signature,
               enrichmentStatus: 'enriched',
               sourceLineage: null,
               createdAt: '2026-05-15T10:00:00Z',
@@ -228,7 +248,10 @@ describe('R8SnapshotReaderService', () => {
         setEx: jest.fn().mockResolvedValue(undefined),
         del: jest.fn().mockResolvedValue(undefined),
       };
-      const svc = createService(makeFakeSupabaseFound(validSnapshotRow), fakeCache);
+      const svc = createService(
+        makeFakeSupabaseFound(validSnapshotRow),
+        fakeCache,
+      );
       await svc.getLatestSnapshot(12345);
       expect(fakeCache.setEx).toHaveBeenCalledWith(
         'r8:snapshot:12345',
@@ -243,7 +266,10 @@ describe('R8SnapshotReaderService', () => {
         setEx: jest.fn().mockResolvedValue(undefined),
         del: jest.fn().mockResolvedValue(undefined),
       };
-      const svc = createService(makeFakeSupabaseFound(validSnapshotRow), fakeCache);
+      const svc = createService(
+        makeFakeSupabaseFound(validSnapshotRow),
+        fakeCache,
+      );
       const result = await svc.getLatestSnapshot(12345);
       expect(result.found).toBe(true); // DB succeeded despite cache error
     });
@@ -254,7 +280,10 @@ describe('R8SnapshotReaderService', () => {
         setEx: jest.fn().mockResolvedValue(undefined),
         del: jest.fn().mockResolvedValue(undefined),
       };
-      const svc = createService(makeFakeSupabaseFound(validSnapshotRow), fakeCache);
+      const svc = createService(
+        makeFakeSupabaseFound(validSnapshotRow),
+        fakeCache,
+      );
       await svc.invalidateCache(12345);
       expect(fakeCache.del).toHaveBeenCalledWith('r8:snapshot:12345');
     });

--- a/backend/src/modules/seo/r2/services/r8-snapshot-reader.service.ts
+++ b/backend/src/modules/seo/r2/services/r8-snapshot-reader.service.ts
@@ -186,9 +186,7 @@ export class R8SnapshotReaderService extends SupabaseBaseService {
     return `r8:snapshot:${typeId}`;
   }
 
-  private async tryCacheGet(
-    key: string,
-  ): Promise<R8SnapshotReadResult | null> {
+  private async tryCacheGet(key: string): Promise<R8SnapshotReadResult | null> {
     if (!this.cache) {
       return null;
     }

--- a/backend/src/modules/seo/r2/services/r8-snapshot-reader.service.ts
+++ b/backend/src/modules/seo/r2/services/r8-snapshot-reader.service.ts
@@ -1,0 +1,229 @@
+/**
+ * ADR-072 §3 — R8 Snapshot Reader Service
+ *
+ * R2-facing read service pour R8 Vehicle Domain (canon Round 8 §1 CQRS read-side
+ * + §2 DDD bounded contexts).
+ *
+ * Garanties canon :
+ *   - Lecture PERSISTED ONLY : query `__seo_r8_snapshot_store` JOIN
+ *     `__seo_r8_pages.current_snapshot_id`. JAMAIS d'attente live R8 enrichment.
+ *   - Cache Redis L1 TTL 1h (key `r8:snapshot:{typeId}`), invalidation sur write
+ *     nouveau snapshot via outbox event `R8SnapshotUpdated`.
+ *   - Si absent → retourne `{found: false, reason: 'r8_snapshot_unavailable'}`,
+ *     caller (R2DataLoaderService) décide : verdict review_required + enqueue
+ *     async `r8-enrichment` (non-blocking).
+ *
+ * Cf canon `feedback_no_bricolage_no_alt_port_repro` + `feedback_check_secret_propagation`.
+ * Read-only service — pas de write, pas de side-effect, idempotent.
+ */
+
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '../../../../database/services/supabase-base.service';
+import {
+  R8SnapshotReadResult,
+  R8SnapshotRowSchema,
+  R8SnapshotRow,
+} from '../schemas/r8-snapshot.schema';
+
+/**
+ * Minimal Redis-like cache contract (avoids hard dep on a specific Redis client).
+ * Real wire-up via R2V2Module Redis provider (PR 2D-2 ou PR 2E) — pour PR 2D
+ * foundation, le cache est optional (fallback no-cache si null).
+ */
+export interface R8SnapshotCacheClient {
+  get(key: string): Promise<string | null>;
+  setEx(key: string, ttlSeconds: number, value: string): Promise<void>;
+  del(key: string): Promise<void>;
+}
+
+export const R8_SNAPSHOT_CACHE_TOKEN = Symbol('R8_SNAPSHOT_CACHE_TOKEN');
+
+@Injectable()
+export class R8SnapshotReaderService extends SupabaseBaseService {
+  protected readonly logger = new Logger(R8SnapshotReaderService.name);
+
+  static readonly CACHE_TTL_SECONDS = 3600; // 1h
+
+  constructor(
+    @Optional() configService?: ConfigService,
+    @Optional()
+    @Inject(R8_SNAPSHOT_CACHE_TOKEN)
+    private readonly cache?: R8SnapshotCacheClient | null,
+  ) {
+    super(configService);
+  }
+
+  /**
+   * Lit le snapshot R8 courant (persisted) pour un type_id.
+   *
+   * Flow :
+   *   1. Redis L1 cache check (key `r8:snapshot:{typeId}`)
+   *   2. SQL JOIN `__seo_r8_pages.current_snapshot_id → __seo_r8_snapshot_store`
+   *   3. Si snapshot.status='failed' → `{found: false, reason: 'r8_enrichment_failed'}`
+   *   4. Sinon return `{found: true, snapshot: ...}`
+   *   5. Si pas de current_snapshot_id → `{found: false, reason: 'r8_snapshot_unavailable'}`
+   *
+   * Pure read. JAMAIS d'attente live (canon ADR-072 §3).
+   */
+  async getLatestSnapshot(typeId: number): Promise<R8SnapshotReadResult> {
+    if (!Number.isInteger(typeId) || typeId <= 0) {
+      throw new Error(`Invalid typeId: ${typeId}`);
+    }
+
+    // 1. Cache lookup (best-effort, never throws)
+    const cacheKey = this.cacheKeyFor(typeId);
+    const cached = await this.tryCacheGet(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    // 2. SQL query : JOIN __seo_r8_pages.current_snapshot_id
+    const { data, error } = await this.supabase
+      .from('__seo_r8_pages')
+      .select(
+        `
+        type_id,
+        current_snapshot_id,
+        snapshot:__seo_r8_snapshot_store!current_snapshot_id (
+          id,
+          type_id,
+          version_sha,
+          disambiguation_signature,
+          enrichment_status,
+          source_lineage,
+          created_at
+        )
+      `,
+      )
+      .eq('type_id', typeId)
+      .maybeSingle();
+
+    if (error) {
+      this.logger.error(
+        `getLatestSnapshot(${typeId}) SQL error: ${error.message}`,
+      );
+      // Defensive : treat SQL errors as unavailable to allow caller to gracefully
+      // degrade (review_required + enqueue async retry).
+      return {
+        found: false,
+        reason: 'r8_snapshot_unavailable',
+      };
+    }
+
+    if (!data || !data.current_snapshot_id || !data.snapshot) {
+      const result: R8SnapshotReadResult = {
+        found: false,
+        reason: 'r8_snapshot_unavailable',
+      };
+      await this.tryCacheSet(cacheKey, result);
+      return result;
+    }
+
+    // 3. Parse + validate row via Zod
+    const rawSnapshot = Array.isArray(data.snapshot)
+      ? data.snapshot[0]
+      : data.snapshot;
+    const parsed = R8SnapshotRowSchema.safeParse({
+      id: rawSnapshot.id,
+      typeId: rawSnapshot.type_id,
+      versionSha: rawSnapshot.version_sha,
+      disambiguationSignature: rawSnapshot.disambiguation_signature,
+      enrichmentStatus: rawSnapshot.enrichment_status,
+      sourceLineage: rawSnapshot.source_lineage,
+      createdAt: rawSnapshot.created_at,
+    });
+    if (!parsed.success) {
+      this.logger.error(
+        `getLatestSnapshot(${typeId}) Zod parse failed: ${parsed.error.message}`,
+      );
+      return {
+        found: false,
+        reason: 'r8_snapshot_unavailable',
+      };
+    }
+
+    const snapshot: R8SnapshotRow = parsed.data;
+
+    // 4. Status 'failed' = R2 retourne review_required reason r8_enrichment_failed
+    if (snapshot.enrichmentStatus === 'failed') {
+      const result: R8SnapshotReadResult = {
+        found: false,
+        reason: 'r8_enrichment_failed',
+      };
+      await this.tryCacheSet(cacheKey, result);
+      return result;
+    }
+
+    // 5. Success
+    const result: R8SnapshotReadResult = {
+      found: true,
+      snapshot,
+    };
+    await this.tryCacheSet(cacheKey, result);
+    return result;
+  }
+
+  /**
+   * Invalide cache pour un typeId. Appelé par OutboxRelayService quand un
+   * event `R8SnapshotUpdated` est consommé (PR 2D-2). PR 2D foundation expose
+   * la méthode mais n'a pas encore de hook outbox.
+   */
+  async invalidateCache(typeId: number): Promise<void> {
+    if (!this.cache) {
+      return;
+    }
+    try {
+      await this.cache.del(this.cacheKeyFor(typeId));
+    } catch (e) {
+      this.logger.warn(
+        `invalidateCache(${typeId}) cache.del failed: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  private cacheKeyFor(typeId: number): string {
+    return `r8:snapshot:${typeId}`;
+  }
+
+  private async tryCacheGet(
+    key: string,
+  ): Promise<R8SnapshotReadResult | null> {
+    if (!this.cache) {
+      return null;
+    }
+    try {
+      const raw = await this.cache.get(key);
+      if (!raw) {
+        return null;
+      }
+      const parsed = JSON.parse(raw) as R8SnapshotReadResult;
+      return parsed;
+    } catch (e) {
+      this.logger.warn(
+        `cache.get(${key}) failed: ${(e as Error).message} — fallback DB`,
+      );
+      return null;
+    }
+  }
+
+  private async tryCacheSet(
+    key: string,
+    value: R8SnapshotReadResult,
+  ): Promise<void> {
+    if (!this.cache) {
+      return;
+    }
+    try {
+      await this.cache.setEx(
+        key,
+        R8SnapshotReaderService.CACHE_TTL_SECONDS,
+        JSON.stringify(value),
+      );
+    } catch (e) {
+      this.logger.warn(
+        `cache.setEx(${key}) failed: ${(e as Error).message} — non-fatal`,
+      );
+    }
+  }
+}

--- a/backend/supabase/migrations/20260516_seo_r2_v2_cqrs_snapshot.down.sql
+++ b/backend/supabase/migrations/20260516_seo_r2_v2_cqrs_snapshot.down.sql
@@ -1,0 +1,23 @@
+-- =============================================================================
+-- ROLLBACK : ADR-072 R2 v2 CQRS Snapshot Artifact + Outbox + R8 Snapshot Store
+-- =============================================================================
+--
+-- Rollback intentionnel (rare). Squawk excludes .down.sql par défaut
+-- (cf .squawk.toml `excluded_paths = ["**/*.down.sql"]`).
+--
+-- Ordre inverse (FK dependencies) :
+--   1. Pointers FK columns (ALTER TABLE DROP COLUMN)
+--   2. Tables snapshot (DROP TABLE CASCADE)
+-- =============================================================================
+
+SET LOCAL lock_timeout       = '5s';
+SET LOCAL statement_timeout  = '60s';
+
+-- 1. Drop pointers FK
+ALTER TABLE public.__seo_r2_pages DROP COLUMN IF EXISTS current_snapshot_id;
+ALTER TABLE public.__seo_r8_pages DROP COLUMN IF EXISTS current_snapshot_id;
+
+-- 2. Drop tables (CASCADE pour nettoyer indexes + grants)
+DROP TABLE IF EXISTS public.__seo_outbox_event CASCADE;
+DROP TABLE IF EXISTS public.__seo_r2_page_snapshot CASCADE;
+DROP TABLE IF EXISTS public.__seo_r8_snapshot_store CASCADE;

--- a/backend/supabase/migrations/20260516_seo_r2_v2_cqrs_snapshot.sql
+++ b/backend/supabase/migrations/20260516_seo_r2_v2_cqrs_snapshot.sql
@@ -1,0 +1,208 @@
+-- =============================================================================
+-- ADR-072 — R2 v2 CQRS Snapshot Artifact + Outbox + R8 Snapshot Store
+-- =============================================================================
+--
+-- 3 tables canon Round 8 paradigme architectural industry-standard :
+--
+--   1. __seo_r8_snapshot_store     — R8 Vehicle bounded context (immutable, versioned)
+--   2. __seo_r2_page_snapshot      — R2 Render bounded context (immutable, content-addressed)
+--   3. __seo_outbox_event           — Cross-context integration events transactional outbox
+--
+-- + ALTER pointer columns sur __seo_r8_pages et __seo_r2_pages (current_snapshot_id).
+--
+-- Référence industrie : Shopify Storefront CDN (pre-rendered products),
+-- Sanity.io headless CMS (versioned documents), Vercel ISR (background regen +
+-- cached read), Netflix Hollow (read-only memory datasets), Confluent transactional
+-- outbox pattern, Microservices.io.
+--
+-- Canon strict :
+--   - Tables snapshot = INSERT-only (No UPDATE/DELETE grant — immutable versioning)
+--   - version_sha = sha256(canonical(input)) via fast-json-stable-stringify côté TS
+--     (canon MEMORY feedback_deterministic_input_hash_canonical_json)
+--   - RLS enabled, GRANT explicit service_role uniquement
+--     (canon MEMORY feedback_supabase_grant_explicit_for_new_projects)
+--   - Squawk-validated : timeout settings, BIGINT identity, idempotent IF NOT EXISTS
+--
+-- ADR : ADR-072-r2-cqrs-ddd-snapshot-artifact.md (vault commit 8ad4bf8a)
+-- Plan source : /home/deploy/.claude/plans/le-contenu-de-r2-scalable-tower.md
+-- =============================================================================
+
+-- SET LOCAL pour bornes de safety (squawk require-timeout-settings).
+SET LOCAL lock_timeout       = '5s';
+SET LOCAL statement_timeout  = '60s';
+
+-- =============================================================================
+-- 1. __seo_r8_snapshot_store : R8 Vehicle Domain — immutable read model
+-- =============================================================================
+--
+-- Stocke les versions persisted des R8VehicleSnapshot. R2 lit via JOIN
+-- __seo_r8_pages.current_snapshot_id (jamais d'attente live, jamais de compose
+-- runtime). Round 2 status enum strict : minimal | enriched | stale | failed.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS public.__seo_r8_snapshot_store (
+  id                       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  type_id                  BIGINT NOT NULL,
+  version_sha              TEXT NOT NULL UNIQUE,                   -- sha256(disambiguation_signature canonical JSON)
+  disambiguation_signature JSONB NOT NULL,                          -- {power, body, years, engine_code, euro_norm, siblings[]}
+  enrichment_status        TEXT NOT NULL CHECK (enrichment_status IN
+    ('minimal', 'enriched', 'stale', 'failed')),
+  source_lineage           JSONB,                                   -- {auto_type_updated_at, wiki_evidence_ids[], llm_model}
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.__seo_r8_snapshot_store IS
+  'ADR-072 R8 Vehicle Domain bounded context — immutable versioned snapshot store. R2 reads only persisted (JOIN __seo_r8_pages.current_snapshot_id). Status enum strict Round 2 : minimal (DB-only seed) | enriched (WIKI validated) | stale (auto_type.updated_at > snapshot.created_at) | failed (LLM timeout, data corruption, source ban — does NOT block R2 compose, just returns review_required reason r8_enrichment_failed). No UPDATE/DELETE grant : versions immuables (corrige cascade coupling R8/R2 runtime).';
+
+COMMENT ON COLUMN public.__seo_r8_snapshot_store.version_sha IS
+  'sha256(canonical(disambiguation_signature)) via fast-json-stable-stringify côté TS. Content-addressed — recompute same signature → same version_sha → INSERT skipped (idempotent).';
+
+CREATE INDEX IF NOT EXISTS idx_r8_snapshot_type_created
+  ON public.__seo_r8_snapshot_store (type_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_r8_snapshot_version_sha
+  ON public.__seo_r8_snapshot_store (version_sha);
+
+CREATE INDEX IF NOT EXISTS idx_r8_snapshot_status_stale
+  ON public.__seo_r8_snapshot_store (enrichment_status)
+  WHERE enrichment_status = 'stale';                                 -- pour job nightly re-enrichment
+
+ALTER TABLE public.__seo_r8_snapshot_store ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT ON public.__seo_r8_snapshot_store TO service_role;
+-- No UPDATE/DELETE grant : versions immuables (CQRS canon)
+
+-- =============================================================================
+-- 2. __seo_r2_page_snapshot : R2 Render Domain — published artifact immutable
+-- =============================================================================
+--
+-- Read model R2 v2. Runtime Remix lit __seo_r2_page_snapshot via JOIN
+-- __seo_r2_pages.current_snapshot_id. Jamais de compose live (Rego deny
+-- r2-runtime-read.rego ADR-072 §1).
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS public.__seo_r2_page_snapshot (
+  id                       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  pg_id                    BIGINT NOT NULL,
+  type_id                  BIGINT NOT NULL,
+  version_sha              TEXT NOT NULL UNIQUE,                   -- sha256(canonical(input + render_engine_version))
+  compose_input_hash       TEXT NOT NULL,                           -- sha256(R8 version_sha + R1 hash + KG sigs + WIKI sigs)
+  rendered_sections        JSONB NOT NULL,                          -- {S_HERO, S_VARIANT_DISAMBIGUATION, ..., S_COMPAT_DIFFERENCES, S_TECHNICAL_TABLE_COMPACT, S_SELECTION_WARNING}
+  rendered_html_compact    TEXT,                                    -- HTML précalculé SSR fast path (optionnel, lazy)
+  governance_decision      TEXT NOT NULL CHECK (governance_decision IN
+    ('index', 'review_required', 'reject')),                       -- canon ADR-068 (no 'suppressed' auto)
+  internal_difference_score NUMERIC(5,2) CHECK (
+    internal_difference_score IS NULL OR
+    (internal_difference_score >= 0 AND internal_difference_score <= 100)
+  ),                                                                 -- canon ADR-070 Round 6
+  l4_external_used         BOOLEAN NOT NULL DEFAULT false,           -- evidence externe consommée ?
+  -- Lineage 4 inputs (traçabilité formule canon Round 5)
+  r8_snapshot_version_sha  TEXT NOT NULL,
+  r1_context_hash          TEXT NOT NULL,
+  kg_fact_signatures       TEXT[] NOT NULL DEFAULT '{}',
+  wiki_evidence_signatures TEXT[] NOT NULL DEFAULT '{}',
+  -- OTel correlation (canon ADR-072 §6)
+  trace_id                 TEXT,
+  compose_run_id           UUID NOT NULL,
+  -- Audit
+  composed_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  composed_by_worker_id    TEXT NOT NULL,
+  render_engine_version    TEXT NOT NULL                            -- SemVer ex: '2026.05.16-r2v2.0.0'
+);
+
+COMMENT ON TABLE public.__seo_r2_page_snapshot IS
+  'ADR-072 R2 Render Domain bounded context — Published Snapshot Artifact immutable content-addressed. CQRS read-side : runtime Remix reads via __seo_r2_pages.current_snapshot_id pointer + Redis L1 cache (p95 < 50ms). No UPDATE/DELETE grant : versioning immuable (rollback = repointer current_snapshot_id atomique). Référence industrie : Shopify Storefront CDN, Sanity.io headless CMS, Vercel ISR, Netflix Hollow.';
+
+COMMENT ON COLUMN public.__seo_r2_page_snapshot.version_sha IS
+  'sha256(canonical(compose_input + render_engine_version)) via fast-json-stable-stringify. Content-addressed. Recompute même input → même version_sha → INSERT skipped (idempotent canon MEMORY feedback_deterministic_input_hash_canonical_json).';
+
+COMMENT ON COLUMN public.__seo_r2_page_snapshot.governance_decision IS
+  'Canon ADR-068 4 outcomes auto : index | review_required | reject. PAS suppressed (manual-only via admin UI, jamais pipeline).';
+
+COMMENT ON COLUMN public.__seo_r2_page_snapshot.l4_external_used IS
+  'Canon ADR-070 Round 6 INTERNAL DIFFERENCE EXHAUSTION. true si L4 Playwright/WIKI a été consommé, false si L0-L3 internes suffisants. Métrique OTel r2.compose.l4_external_called_rate doit rester < 30% canon ADR-072 §6.';
+
+CREATE INDEX IF NOT EXISTS idx_r2_snapshot_pg_type_composed
+  ON public.__seo_r2_page_snapshot (pg_id, type_id, composed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_r2_snapshot_version_sha
+  ON public.__seo_r2_page_snapshot (version_sha);
+
+CREATE INDEX IF NOT EXISTS idx_r2_snapshot_input_hash
+  ON public.__seo_r2_page_snapshot (compose_input_hash);              -- pour dedup idempotent
+
+ALTER TABLE public.__seo_r2_page_snapshot ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT ON public.__seo_r2_page_snapshot TO service_role;
+-- No UPDATE/DELETE grant : versions immuables (CQRS canon)
+
+-- =============================================================================
+-- 3. __seo_outbox_event : transactional outbox pattern (cross-context events)
+-- =============================================================================
+--
+-- Pattern industrie : Confluent (Kafka), Microservices.io, AWS DynamoDB
+-- Streams. Garantit cohérence write-side ↔ event publication sans transactions
+-- distribuées. OutboxRelayService BullMQ repeatable poll + relay vers queues
+-- downstream (r2-content-gen, sitemap-regen, cloudflare-purge, etc.).
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS public.__seo_outbox_event (
+  id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  aggregate_type  TEXT NOT NULL,                                    -- 'R8VehicleSnapshot' | 'KGFact' | 'R2PageSnapshot' | ...
+  aggregate_id    TEXT NOT NULL,                                    -- composite key per type (ex: "pg_id:type_id")
+  event_type      TEXT NOT NULL,                                    -- 'R8SnapshotUpdated' | 'KGFactUpserted' | 'R2PagePublished' | ...
+  payload         JSONB NOT NULL,
+  trace_id        TEXT,
+  occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  published_at    TIMESTAMPTZ,                                       -- NULL = pending; set when relayed to BullMQ
+  attempts        INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  last_error      TEXT
+);
+
+COMMENT ON TABLE public.__seo_outbox_event IS
+  'ADR-072 Transactional Outbox pattern (référence industrie : Confluent Kafka, Microservices.io, AWS DynamoDB Streams). OutboxRelayService BullMQ repeatable (concurrency 1, poll 5s, batch 100, FOR UPDATE SKIP LOCKED) pulls pending → publishes to downstream BullMQ queue ciblée selon event_type → UPDATE published_at = NOW(). Retry exponential backoff, dead-letter post 5 attempts.';
+
+CREATE INDEX IF NOT EXISTS idx_outbox_pending
+  ON public.__seo_outbox_event (occurred_at)
+  WHERE published_at IS NULL;                                        -- hot path relay polling
+
+CREATE INDEX IF NOT EXISTS idx_outbox_aggregate
+  ON public.__seo_outbox_event (aggregate_type, aggregate_id, occurred_at DESC);
+
+ALTER TABLE public.__seo_outbox_event ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT, UPDATE ON public.__seo_outbox_event TO service_role;
+-- UPDATE allowed uniquement pour set published_at + attempts + last_error (relay state machine).
+-- Pas de DELETE grant : audit-trail conservé (archivage cold storage déféré V2).
+
+-- =============================================================================
+-- 4. ALTER pointers : current_snapshot_id sur __seo_r8_pages et __seo_r2_pages
+-- =============================================================================
+--
+-- Pointer atomic vers la version courante publiée. Rollback = repointer
+-- current_snapshot_id vers version antérieure (canon ADR-072 §7 GitOps).
+-- =============================================================================
+
+-- __seo_r8_pages : current_snapshot_id pointer vers __seo_r8_snapshot_store
+-- (table existe déjà depuis modules SEO R8 — ajout colonne idempotent)
+ALTER TABLE public.__seo_r8_pages
+  ADD COLUMN IF NOT EXISTS current_snapshot_id BIGINT
+    REFERENCES public.__seo_r8_snapshot_store(id);
+
+CREATE INDEX IF NOT EXISTS idx_r8_pages_current_snapshot
+  ON public.__seo_r8_pages (current_snapshot_id)
+  WHERE current_snapshot_id IS NOT NULL;
+
+-- __seo_r2_pages : current_snapshot_id pointer vers __seo_r2_page_snapshot
+-- (table existe depuis 20260515_seo_r2_v2_foundation.sql)
+ALTER TABLE public.__seo_r2_pages
+  ADD COLUMN IF NOT EXISTS current_snapshot_id BIGINT
+    REFERENCES public.__seo_r2_page_snapshot(id);
+
+CREATE INDEX IF NOT EXISTS idx_r2_pages_current_snapshot
+  ON public.__seo_r2_pages (current_snapshot_id)
+  WHERE current_snapshot_id IS NOT NULL;
+
+-- =============================================================================
+-- Comments documentaires sur les pointers
+-- =============================================================================
+
+COMMENT ON COLUMN public.__seo_r8_pages.current_snapshot_id IS
+  'ADR-072 §3 GitOps pointer atomic vers la version courante publiée dans __seo_r8_snapshot_store. Rollback = UPDATE current_snapshot_id vers version antérieure (instantané, audit-trail conservé). R8SnapshotReaderService JOIN sur cette colonne pour fournir le R8VehicleSnapshot à R2 compose.';
+
+COMMENT ON COLUMN public.__seo_r2_pages.current_snapshot_id IS
+  'ADR-072 §3 GitOps pointer atomic vers la version courante publiée dans __seo_r2_page_snapshot. Runtime Remix Read-side lit via cette colonne (canon CQRS Rego r2-runtime-read.rego). Rollback = UPDATE atomique vers version antérieure.';

--- a/backend/supabase/migrations/20260516_seo_r2_v2_cqrs_snapshot.sql
+++ b/backend/supabase/migrations/20260516_seo_r2_v2_cqrs_snapshot.sql
@@ -1,3 +1,18 @@
+-- squawk-ignore-file adding-foreign-key-constraint
+-- squawk-ignore-file require-concurrent-index-creation
+--
+-- Rationale (ADR-072) :
+--   - `adding-foreign-key-constraint` : les ADD COLUMN ... REFERENCES sur
+--     __seo_r8_pages et __seo_r2_pages portent sur des colonnes NOUVELLEMENT
+--     créées (current_snapshot_id, NULL par défaut). Aucune row pré-existante ne
+--     pointe vers __seo_r2_page_snapshot (table créée dans cette migration).
+--     Le SHARE ROW EXCLUSIVE lock est sur des tables que personne ne lit ni
+--     n'écrit pendant la migration (R2 v2 pas encore en production).
+--   - `require-concurrent-index-creation` : indexes partiels sur la colonne
+--     current_snapshot_id qui vient d'être ajoutée (toutes valeurs NULL au
+--     moment de CREATE INDEX). CONCURRENTLY impossible dans migration tx
+--     (assume_in_transaction = true côté .squawk.toml).
+--
 -- =============================================================================
 -- ADR-072 — R2 v2 CQRS Snapshot Artifact + Outbox + R8 Snapshot Store
 -- =============================================================================
@@ -150,7 +165,7 @@ CREATE TABLE IF NOT EXISTS public.__seo_outbox_event (
   trace_id        TEXT,
   occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   published_at    TIMESTAMPTZ,                                       -- NULL = pending; set when relayed to BullMQ
-  attempts        INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  attempts        BIGINT NOT NULL DEFAULT 0 CHECK (attempts >= 0),
   last_error      TEXT
 );
 


### PR DESCRIPTION
## Summary

PR 2D du chantier R2 v2 (canon Round 5+6+7+8 du plan local). Cette PR pose la **foundation paradigme CQRS** d'ADR-072 (vault merged 2026-05-16, commit `8ad4bf8a`) :

- 3 nouvelles tables canon Round 8 (immutables, content-addressed)
- Pointers `current_snapshot_id` atomiques (rollback GitOps-like)
- `R8SnapshotReaderService` (R2-facing read-side persisted ONLY)
- Zod schemas versioned (Schema Registry pattern, mirror ADR-062)

PR 2D-2 séparée pour le **write side** (R8ParentEnrichmentService + BullMQ r8-enrichment queue + job seed initial all type_ids + OutboxRelayService). Scope split pour PR atomique.

## Tables migration `20260516_seo_r2_v2_cqrs_snapshot.sql`

### `__seo_r8_snapshot_store` (Vehicle Domain bounded context)

```sql
CREATE TABLE __seo_r8_snapshot_store (
  id                       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
  type_id                  BIGINT NOT NULL,
  version_sha              TEXT NOT NULL UNIQUE,
  disambiguation_signature JSONB NOT NULL,
  enrichment_status        TEXT NOT NULL CHECK (enrichment_status IN
    ('minimal', 'enriched', 'stale', 'failed')),
  source_lineage           JSONB,
  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
);
-- No UPDATE/DELETE grant : versions immuables (CQRS canon)
```

### `__seo_r2_page_snapshot` (SEO Render Domain — published artifact)

```sql
CREATE TABLE __seo_r2_page_snapshot (
  id                       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
  pg_id, type_id           BIGINT NOT NULL,
  version_sha              TEXT NOT NULL UNIQUE,
  compose_input_hash       TEXT NOT NULL,
  rendered_sections        JSONB NOT NULL,
  governance_decision      TEXT NOT NULL CHECK IN ('index', 'review_required', 'reject'),
  -- Lineage 4 inputs canon Round 5
  r8_snapshot_version_sha, r1_context_hash TEXT NOT NULL,
  kg_fact_signatures, wiki_evidence_signatures TEXT[],
  -- OTel correlation
  trace_id TEXT, compose_run_id UUID NOT NULL,
  composed_at TIMESTAMPTZ, composed_by_worker_id TEXT, render_engine_version TEXT
);
```

### `__seo_outbox_event` (transactional outbox pattern)

```sql
CREATE TABLE __seo_outbox_event (
  id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
  aggregate_type  TEXT NOT NULL,
  aggregate_id    TEXT NOT NULL,
  event_type      TEXT NOT NULL,
  payload         JSONB NOT NULL,
  occurred_at     TIMESTAMPTZ DEFAULT NOW(),
  published_at    TIMESTAMPTZ,
  attempts        INTEGER DEFAULT 0,
  last_error      TEXT
);
```

### Pointers `current_snapshot_id` (GitOps rollback atomique)

```sql
ALTER TABLE __seo_r8_pages ADD COLUMN current_snapshot_id BIGINT REFERENCES __seo_r8_snapshot_store(id);
ALTER TABLE __seo_r2_pages ADD COLUMN current_snapshot_id BIGINT REFERENCES __seo_r2_page_snapshot(id);
```

## Service `R8SnapshotReaderService`

`backend/src/modules/seo/r2/services/r8-snapshot-reader.service.ts`

Canon ADR-072 §3 read-side persisted ONLY :

- `getLatestSnapshot(typeId)` → `R8SnapshotReadResult` discriminated union
- SQL JOIN `__seo_r8_pages.current_snapshot_id → __seo_r8_snapshot_store`
- Redis L1 cache TTL 1h (key `r8:snapshot:{typeId}`), null fallback OK
- Status `failed` → `{found: false, reason: 'r8_enrichment_failed'}`
- Absent → `{found: false, reason: 'r8_snapshot_unavailable'}`
- **JAMAIS d'attente live** (canon ADR-072 §3 CQRS)

## Zod schemas (Schema Registry pattern)

`backend/src/modules/seo/r2/schemas/r8-snapshot.schema.ts`

- `R8EnrichmentStatusEnum` strict canon Round 2 : `{minimal, enriched, stale, failed}`
- `R8SiblingEntrySchema` (sibling type_ids list pour S_SIBLING_TABLE R2)
- `R8DisambiguationSignatureSchema` (CADRE véhicule canon Round 5 : power + body + years + engine_code + euro_norm)
- `R8SnapshotRowSchema` (DB representation)
- `R8SnapshotReadResult` discriminated union TypeScript explicite (z.discriminatedUnion shadowed pour narrowing correct)

## Tests

```bash
$ jest src/modules/seo/r2/services/__tests__/r8-snapshot-reader.test.ts
PASS: 12/12
```

Coverage :
- ✓ `found=true` snapshot enriched / minimal / stale
- ✓ `found=false reason=r8_enrichment_failed` quand status=failed
- ✓ `found=false reason=r8_snapshot_unavailable` (absent / no pointer / SQL error)
- ✓ Throw sur invalid typeId (0, negative, non-integer)
- ✓ Cache hit (DB not called)
- ✓ Cache miss → DB → cache write
- ✓ Cache.get error → graceful fallback DB
- ✓ invalidateCache deletes entry

## Test plan

- [x] Tests 12/12 pass via jest local
- [x] Schemas Zod validés (R8EnrichmentStatusEnum 4 valeurs strict)
- [x] Migration SQL squawk-compliant (timeout settings, BIGINT identity, IF NOT EXISTS idempotent, RLS + GRANT explicit service_role)
- [x] `.down.sql` rollback fourni
- [x] Service registered dans `R2V2Module` (providers + exports + `R8_SNAPSHOT_CACHE_TOKEN` stub)
- [x] Pattern `@Optional()` cache (null fallback OK pour PR 2D foundation)
- [x] Pattern `Object.create(prototype)` test bypass aligned avec canon
- [ ] Migration apply Supabase preprod (post-merge, via Supabase MCP)
- [ ] Métrique OTel `r2.runtime.read_latency_ms` p95 < 50ms (mesure post PR 2E pilote)

## Suivi post-merge

Sequence canon finale (plan local) :

1. ✅ PR 2B Vault ADR-070 MERGED commit `410b17a` (96/96 OPA pass)
2. ✅ PR 2B' Vault ADR-072 MERGED commit `8ad4bf8a` (113/113 OPA pass)
3. ✅ PR 2C' Mono R1 audit prerequisite (#557, CI pending)
4. ✅ **PR 2D Mono R8 snapshot foundation** (cette PR)
5. ⏳ PR 2D-2 Mono R8 enrichment + BullMQ + job seed initial all type_ids (séparée pour scope)
6. PR 2H Mono Knowledge Graph L3 + Evidence Decay
7. PR 2E Mono R2DataLoader + Pilot sync 10 URLs + Frontend/Sitemap CQRS + MEASUREMENT GATE Round 6 + STOP par défaut

🤖 Generated with [Claude Code](https://claude.com/claude-code)