### PR TITLE
feat(auth): Phase 1 — GithubOidcService with hardcoded invariants (claims validation only)

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { AuthPermissionsController } from './controllers/auth-permissions.contro
 import { AuthTokenController } from './controllers/auth-token.controller';
 import { ProfileController } from './profile.controller';
 import { CookieSerializer } from './cookie-serializer';
+import { GithubOidcService } from './github-oidc.service';
 import { IsAdminGuard } from './is-admin.guard';
 import { LocalAuthGuard } from './local-auth.guard';
 import { LocalStrategy } from './local.strategy';
@@ -45,7 +46,13 @@ import { PermissionsGuard } from './guards/permissions.guard';
     IsAdminGuard,
     PermissionsService,
     PermissionsGuard,
+    GithubOidcService,
   ],
-  exports: [AuthService, PermissionsService, PermissionsGuard],
+  exports: [
+    AuthService,
+    PermissionsService,
+    PermissionsGuard,
+    GithubOidcService,
+  ],
 })
 export class AuthModule {}

--- a/backend/src/auth/github-oidc.service.test.ts
+++ b/backend/src/auth/github-oidc.service.test.ts
@@ -1,0 +1,223 @@
+import { Test } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import {
+  SignJWT,
+  generateKeyPair,
+  exportJWK,
+  createLocalJWKSet,
+  type JWK,
+  type KeyLike,
+} from 'jose';
+
+import {
+  GithubOidcService,
+  type GithubOidcClaims,
+} from './github-oidc.service';
+
+// ───────────────────────────────────────────────────────────────────
+// Test fixtures
+// ───────────────────────────────────────────────────────────────────
+
+const KID = 'test-kid-1';
+
+const VALID_CLAIMS: Omit<GithubOidcClaims, 'iat' | 'exp' | 'iss' | 'aud'> = {
+  repository: GithubOidcService.REPOSITORY,
+  repository_owner: 'ak125',
+  event_name: 'schedule',
+  ref: 'refs/heads/main',
+  workflow: 'sitemap-daily-regen',
+  workflow_ref: GithubOidcService.ALLOWED_JOB_REFS[0],
+  job_workflow_ref: GithubOidcService.ALLOWED_JOB_REFS[0],
+  run_id: '12345',
+  run_number: '7',
+  run_attempt: '1',
+  actor: 'ak125',
+  sha: 'abc123def456',
+  sub: GithubOidcService.ALLOWED_SUBS[0],
+};
+
+async function setupKeysAndService(): Promise<{
+  privateKey: KeyLike;
+  service: GithubOidcService;
+}> {
+  const { publicKey, privateKey } = await generateKeyPair('RS256', {
+    extractable: true,
+  });
+  const jwk: JWK = await exportJWK(publicKey);
+  jwk.kid = KID;
+  jwk.alg = 'RS256';
+  jwk.use = 'sig';
+
+  const localJwks = createLocalJWKSet({ keys: [jwk] });
+
+  const moduleRef = await Test.createTestingModule({
+    providers: [GithubOidcService],
+  }).compile();
+
+  const service = moduleRef.get(GithubOidcService);
+  service.setJwksForTesting(localJwks);
+  return { privateKey, service };
+}
+
+async function signClaims(
+  privateKey: KeyLike,
+  overrides: Partial<typeof VALID_CLAIMS> = {},
+  opts: { exp?: string; nbf?: string; aud?: string } = {},
+): Promise<string> {
+  const claims = { ...VALID_CLAIMS, ...overrides };
+  let jwt = new SignJWT(claims as Record<string, unknown>)
+    .setProtectedHeader({ alg: 'RS256', kid: KID, typ: 'JWT' })
+    .setIssuer(GithubOidcService.ISSUER)
+    .setAudience(opts.aud ?? GithubOidcService.AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime(opts.exp ?? '10m')
+    .setJti(`jti-${Math.random()}`);
+  if (opts.nbf) jwt = jwt.setNotBefore(opts.nbf);
+  return jwt.sign(privateKey);
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Happy path
+// ───────────────────────────────────────────────────────────────────
+
+describe('GithubOidcService — validate() happy path', () => {
+  it('accepts a fully-conformant JWT and returns claims', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+    const token = await signClaims(privateKey);
+
+    const claims = await service.validate(token);
+
+    expect(claims.repository).toBe(GithubOidcService.REPOSITORY);
+    expect(claims.sub).toBe(GithubOidcService.ALLOWED_SUBS[0]);
+    expect(claims.event_name).toBe('schedule');
+    expect(claims.actor).toBe('ak125');
+  });
+
+  it('accepts workflow_dispatch event_name', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+    const token = await signClaims(privateKey, {
+      event_name: 'workflow_dispatch',
+    });
+
+    const claims = await service.validate(token);
+    expect(claims.event_name).toBe('workflow_dispatch');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────
+// Claim mismatches — fail-closed
+// ───────────────────────────────────────────────────────────────────
+
+describe('GithubOidcService — claim validation (5 pinned invariants)', () => {
+  it('rejects when repository claim mismatches', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+    const token = await signClaims(privateKey, { repository: 'evil/fork' });
+    await expect(service.validate(token)).rejects.toThrow(ForbiddenException);
+    await expect(service.validate(token)).rejects.toThrow(
+      /claim repository mismatch/,
+    );
+  });
+
+  it('rejects when event_name is not in allow-list', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+    const token = await signClaims(privateKey, { event_name: 'push' });
+    await expect(service.validate(token)).rejects.toThrow(
+      /claim event_name not allowed/,
+    );
+  });
+
+  it('rejects when ref is not refs/heads/main', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+    const token = await signClaims(privateKey, { ref: 'refs/heads/dev' });
+    await expect(service.validate(token)).rejects.toThrow(
+      /claim ref not allowed/,
+    );
+  });
+
+  it('rejects when job_workflow_ref points to a different workflow file', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+    const token = await signClaims(privateKey, {
+      job_workflow_ref:
+        'ak125/nestjs-remix-monorepo/.github/workflows/other.yml@refs/heads/main',
+    });
+    await expect(service.validate(token)).rejects.toThrow(
+      /claim job_workflow_ref not allowed/,
+    );
+  });
+
+  it('rejects when sub claim has unexpected format (defense in depth alongside job_workflow_ref)', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+    const token = await signClaims(privateKey, {
+      sub: 'repo:ak125/nestjs-remix-monorepo:ref:refs/heads/feature-branch',
+    });
+    await expect(service.validate(token)).rejects.toThrow(
+      /claim sub not allowed/,
+    );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────
+// Signature / time / audience — built-in jose checks
+// ───────────────────────────────────────────────────────────────────
+
+describe('GithubOidcService — jose built-in checks', () => {
+  it('rejects when audience claim is wrong', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+    const token = await signClaims(privateKey, {}, { aud: 'wrong-audience' });
+    await expect(service.validate(token)).rejects.toThrow();
+  });
+
+  it('rejects when exp is in the past (beyond clockTolerance)', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+    // Sign with already-past expiration. clockTolerance is 30s, so -60s is rejected.
+    const token = await signClaims(privateKey, {}, { exp: '-60s' });
+    await expect(service.validate(token)).rejects.toThrow();
+  });
+
+  it('rejects when signed by an untrusted key (wrong kid / no match in JWKS)', async () => {
+    const { service } = await setupKeysAndService();
+    // Generate a different key pair NOT in the local JWKS
+    const { privateKey: otherPrivate } = await generateKeyPair('RS256', {
+      extractable: true,
+    });
+    const token = await signClaims(otherPrivate);
+    await expect(service.validate(token)).rejects.toThrow();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────
+// Constants exposed for downstream Phase 2-5 consumers
+// ───────────────────────────────────────────────────────────────────
+
+describe('GithubOidcService — exposed constants (Phase 0.6 paradigm)', () => {
+  it('exposes ISSUER as a public static readonly', () => {
+    expect(GithubOidcService.ISSUER).toBe(
+      'https://token.actions.githubusercontent.com',
+    );
+  });
+
+  it('exposes AUDIENCE as a public static readonly', () => {
+    expect(GithubOidcService.AUDIENCE).toBe('automecanik-sitemap-regen');
+  });
+
+  it('exposes REPOSITORY as a public static readonly', () => {
+    expect(GithubOidcService.REPOSITORY).toBe('ak125/nestjs-remix-monorepo');
+  });
+
+  it('exposes ALLOWED_EVENTS as readonly array', () => {
+    expect(GithubOidcService.ALLOWED_EVENTS).toEqual([
+      'schedule',
+      'workflow_dispatch',
+    ]);
+  });
+
+  it('exposes ALLOWED_REFS, ALLOWED_JOB_REFS, ALLOWED_SUBS as readonly arrays', () => {
+    expect(GithubOidcService.ALLOWED_REFS).toEqual(['refs/heads/main']);
+    expect(GithubOidcService.ALLOWED_JOB_REFS).toHaveLength(1);
+    expect(GithubOidcService.ALLOWED_SUBS).toHaveLength(1);
+  });
+
+  it('exposes CLOCK_TOLERANCE_SECONDS = 30 (runner ↔ VPS clock drift budget)', () => {
+    expect(GithubOidcService.CLOCK_TOLERANCE_SECONDS).toBe(30);
+  });
+});

--- a/backend/src/auth/github-oidc.service.ts
+++ b/backend/src/auth/github-oidc.service.ts
@@ -1,0 +1,183 @@
+/**
+ * GithubOidcService — JWT validation for GitHub Actions OIDC tokens.
+ *
+ * Phase 1/11 of sitemap regen auth plan (`docs/superpowers/plans/2026-05-16-sitemap-regen-auth-impl.md`).
+ *
+ * **Paradigm (Phase 0.6)**: validation invariants are HARDCODED as `static readonly`
+ * class constants, NOT env vars. They don't change between deployments of this code
+ * — they're contractual invariants of "this codebase deploys here, uses this audience,
+ * accepts these workflow refs". Forks customize via source edit (versioned, reviewable).
+ *
+ * Cf. memory `feedback_hardcode_invariants_env_only_for_knobs`.
+ *
+ * **This phase (1) — claims validation only.** Phase 4 will extend with `jti`
+ * anti-replay (Redis SETNX dedicated DB 1). Phase 2-3 will wrap this service in
+ * `GithubOidcGuard` + `LegacyInternalKeyGuard` for controller-level usage.
+ *
+ * **Fail-closed**: any claim mismatch, signature failure, or JWKS unavailability
+ * throws an exception. No silent fallback. This is the "industry standard 2026"
+ * pattern for service-to-service auth (memory
+ * `feedback_oidc_federation_over_long_lived_bearer`).
+ */
+
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  OnModuleInit,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  createRemoteJWKSet,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+} from 'jose';
+
+export interface GithubOidcClaims extends JWTPayload {
+  repository: string;
+  repository_owner: string;
+  event_name: string;
+  ref: string;
+  workflow: string;
+  workflow_ref: string;
+  job_workflow_ref: string;
+  run_id: string;
+  run_number: string;
+  run_attempt: string;
+  actor: string;
+  sha: string;
+}
+
+@Injectable()
+export class GithubOidcService implements OnModuleInit {
+  private readonly logger = new Logger(GithubOidcService.name);
+
+  // ─────────────────────────────────────────────────────────────────
+  // Hardcoded invariants (Phase 0.6 paradigm — never env-overridable).
+  // To change for a legitimate fork: edit here, get PR review, redeploy.
+  // ─────────────────────────────────────────────────────────────────
+
+  /** GitHub Actions OIDC issuer — only valid value globally. */
+  static readonly ISSUER = 'https://token.actions.githubusercontent.com';
+
+  /** Audience claim — must match `core.getIDToken('automecanik-sitemap-regen')`. */
+  static readonly AUDIENCE = 'automecanik-sitemap-regen';
+
+  /** Repository claim — only this repo's workflows may auth. */
+  static readonly REPOSITORY = 'ak125/nestjs-remix-monorepo';
+
+  /** Event names accepted (cron + admin manual via GitHub UI workflow_dispatch). */
+  static readonly ALLOWED_EVENTS: readonly string[] = [
+    'schedule',
+    'workflow_dispatch',
+  ];
+
+  /** Refs accepted — main only. Feature branches don't get prod auth. */
+  static readonly ALLOWED_REFS: readonly string[] = ['refs/heads/main'];
+
+  /** Exact job_workflow_ref allowed — pins to a specific workflow file on main. */
+  static readonly ALLOWED_JOB_REFS: readonly string[] = [
+    'ak125/nestjs-remix-monorepo/.github/workflows/sitemap-daily-regen.yml@refs/heads/main',
+  ];
+
+  /** Sub claim format — defense in depth alongside job_workflow_ref. */
+  static readonly ALLOWED_SUBS: readonly string[] = [
+    'repo:ak125/nestjs-remix-monorepo:ref:refs/heads/main',
+  ];
+
+  /** Clock tolerance for exp/nbf/iat (runner ↔ PROD VPS time skew). */
+  static readonly CLOCK_TOLERANCE_SECONDS = 30;
+
+  // ─────────────────────────────────────────────────────────────────
+
+  /**
+   * JWKS resolver. Initialized in `onModuleInit` from the remote endpoint.
+   * Tests override via `setJwksForTesting()`.
+   */
+  protected jwks!: JWTVerifyGetKey;
+
+  onModuleInit(): void {
+    this.jwks = this.createJwks();
+  }
+
+  /**
+   * Factory hook — production uses `createRemoteJWKSet` against GitHub's JWKS
+   * endpoint. Tests override this method in a subclass (or use
+   * `setJwksForTesting`) to inject a local JWKS via `createLocalJWKSet`.
+   */
+  protected createJwks(): JWTVerifyGetKey {
+    return createRemoteJWKSet(
+      new URL(GithubOidcService.ISSUER + '/.well-known/jwks'),
+    );
+  }
+
+  /**
+   * Test seam — override the JWKS resolver post-init (vitest/jest unit tests).
+   * Production code MUST NOT call this.
+   */
+  setJwksForTesting(jwks: JWTVerifyGetKey): void {
+    this.jwks = jwks;
+  }
+
+  /**
+   * Validate a Bearer JWT from a GitHub Actions OIDC token.
+   * - Verifies signature, iss, aud, exp, nbf, iat (with clockTolerance).
+   * - Verifies all 5 pinned claims (repository, event_name, ref, job_workflow_ref, sub).
+   * - Audit-logs success.
+   * - Fail-closed: throws on any mismatch.
+   *
+   * Phase 4 will add `assertNotReplayed(payload)` here (Redis SETNX on jti).
+   */
+  async validate(token: string): Promise<GithubOidcClaims> {
+    const { payload } = await jwtVerify(token, this.jwks, {
+      issuer: GithubOidcService.ISSUER,
+      audience: GithubOidcService.AUDIENCE,
+      clockTolerance: GithubOidcService.CLOCK_TOLERANCE_SECONDS,
+    });
+    this.assertClaims(payload);
+    this.auditLog(payload);
+    return payload as GithubOidcClaims;
+  }
+
+  private assertClaims(p: JWTPayload): void {
+    if (p.repository !== GithubOidcService.REPOSITORY) {
+      throw new ForbiddenException('claim repository mismatch');
+    }
+    if (!GithubOidcService.ALLOWED_EVENTS.includes(p.event_name as string)) {
+      throw new ForbiddenException('claim event_name not allowed');
+    }
+    if (!GithubOidcService.ALLOWED_REFS.includes(p.ref as string)) {
+      throw new ForbiddenException('claim ref not allowed');
+    }
+    if (
+      !GithubOidcService.ALLOWED_JOB_REFS.includes(p.job_workflow_ref as string)
+    ) {
+      throw new ForbiddenException('claim job_workflow_ref not allowed');
+    }
+    if (!GithubOidcService.ALLOWED_SUBS.includes(p.sub as string)) {
+      throw new ForbiddenException('claim sub not allowed');
+    }
+  }
+
+  private auditLog(p: JWTPayload): void {
+    this.logger.log({
+      event: 'github_oidc_auth_success',
+      repository: p.repository,
+      workflow: p.workflow,
+      job_workflow_ref: p.job_workflow_ref,
+      event_name: p.event_name,
+      ref: p.ref,
+      sub: p.sub,
+      run_id: p.run_id,
+      run_attempt: p.run_attempt,
+      actor: p.actor,
+      sha: p.sha,
+      jti: p.jti,
+    });
+  }
+}
+
+// Suppress unused-import warning for UnauthorizedException — used in Phase 4
+// for the anti-replay path. Kept here so the Phase 4 PR diff is minimal.
+void UnauthorizedException;


### PR DESCRIPTION
## Summary

Phase 1/11 du plan sitemap regen auth — implémente `GithubOidcService` qui valide les JWTs OIDC émis par GitHub Actions, en appliquant le paradigme Phase 0.6 (#556) : **toutes les invariants hardcoded en code, jamais env-overridable**.

## Changes

- **`backend/src/auth/github-oidc.service.ts`** (NEW, 195 lignes) — service avec 8 constantes statiques :
  - `ISSUER`, `AUDIENCE`, `REPOSITORY`, `ALLOWED_EVENTS`, `ALLOWED_REFS`, `ALLOWED_JOB_REFS`, `ALLOWED_SUBS`, `CLOCK_TOLERANCE_SECONDS`
  - `validate(token)` : `jose.jwtVerify` → `assertClaims` (5 pinned) → `auditLog` structuré
  - Fail-closed sur n'importe quel mismatch (no fallback, throws)
- **`backend/src/auth/github-oidc.service.test.ts`** (NEW, 220 lignes) — 16 tests :
  - Happy path (schedule + workflow_dispatch)
  - 5 pinned claims rejetés sur mismatch (repository / event_name / ref / job_workflow_ref / sub)
  - jose built-ins (wrong audience, exp past beyond clockTolerance, untrusted key)
  - Exposed static constants assertions
- **`backend/src/auth/auth.module.ts`** — `GithubOidcService` ajouté aux providers + exports

## Test infrastructure

`jose.createLocalJWKSet` (pas de `nock` requis). Service expose `setJwksForTesting()` seam pour swap le JWKS resolver en unit tests.

## Out of scope (Phases suivantes)

- Anti-replay jti SETNX → Phase 4
- `GithubOidcGuard` Bearer wrapper → Phase 2
- `LegacyInternalKeyGuard` + Sentry telemetry → Phase 3
- `AnyOf` composite + controller migration → Phase 2-5
- Cron workflow + dispatch → Phase 6

## Test plan

- [x] tsc --noEmit PASS (0 erreurs)
- [x] jest 16/16 tests PASS
- [ ] CI green sur cette PR
- [ ] Post-merge : container boots, `GithubOidcService.onModuleInit()` réussit (JWKS fetch lazy à la première validation, pas au boot)

## Invariants respectés

1. ✅ No public endpoint regression (service registered mais non-consumé)
2. ✅ No auth fallback ambiguity (service atomique, validate-or-throw)
3. ✅ Fail-closed on JWKS failure (jose throws, propagated)
4. ✅ No Bull queue coupling (Phase 4 ajoutera Redis dédié pour anti-replay)

## Refs

- Plan : [`docs/superpowers/plans/2026-05-16-sitemap-regen-auth-impl.md`](docs/superpowers/plans/2026-05-16-sitemap-regen-auth-impl.md) (à venir dans une PR future)
- Phase 0.6 paradigm : PR #556 (`07eea5ae2`)
- Memory `feedback_hardcode_invariants_env_only_for_knobs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)