### PR TITLE
feat(seo-r2): r8 snapshot write side + outbox relay (adr-072 pr 2d-2)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -78,6 +78,7 @@
     "cron-parser": "^4.9.0",
     "eventemitter2": "^6.4.9",
     "express-session": "^1.17.3",
+    "fast-json-stable-stringify": "^2.1.0",
     "file-type": "^20.4.1",
     "google-auth-library": "^10.6.1",
     "googleapis": "^164.1.0",

--- a/backend/src/modules/seo/r2/queues/r8-enrichment.constants.ts
+++ b/backend/src/modules/seo/r2/queues/r8-enrichment.constants.ts
@@ -1,0 +1,48 @@
+/**
+ * ADR-072 PR 2D-2 — R8 Enrichment + Outbox Relay queue constants.
+ *
+ * Two BullMQ queues introduced :
+ *   - `r8-enrichment` : event-driven worker that materializes a R8 snapshot
+ *     (status `minimal` for PR 2D-2, `enriched` for PR 2H once KG/WIKI lands).
+ *   - `seo-outbox-relay` : repeatable poller that drains `__seo_outbox_event`
+ *     and dispatches to downstream queues (canon transactional outbox pattern).
+ *
+ * Concurrency canon :
+ *   - r8-enrichment : 5 workers (one per type_id, no cross-type dependency).
+ *   - seo-outbox-relay : 1 worker — single-writer claim via RPC
+ *     `__seo_outbox_claim_batch` (FOR UPDATE SKIP LOCKED). Multiple instances
+ *     stay safe because the RPC is atomic.
+ *
+ * Canon refs :
+ *   - MEMORY feedback_schedulemodule_disabled_use_bullmq : do not use @Cron.
+ *   - MEMORY feedback_no_long_polling_until_loops : poll cadence = job repeat,
+ *     never tight Bash loops.
+ */
+
+export const R8_ENRICHMENT_QUEUE_NAME = 'r8-enrichment';
+export const R8_ENRICHMENT_JOB_NAME = 'r8-enrich-type';
+export const R8_ENRICHMENT_CONCURRENCY = 5;
+
+export const SEO_OUTBOX_QUEUE_NAME = 'seo-outbox-relay';
+export const SEO_OUTBOX_RELAY_JOB_NAME = 'seo-outbox-relay-poll';
+export const SEO_OUTBOX_RELAY_INTERVAL_MS = 5_000;
+export const SEO_OUTBOX_RELAY_BATCH_SIZE = 100;
+
+/**
+ * Outbox event type → downstream BullMQ queue routing.
+ *
+ * For PR 2D-2 only `R8SnapshotUpdated` is wired (no consumer side-effect yet
+ * — the relay marks the event as published, downstream consumers ship in
+ * PR 2E / PR 2H). Future events join this table without changing the relay
+ * loop.
+ */
+export const OUTBOX_EVENT_ROUTING = {
+  R8SnapshotUpdated: R8_ENRICHMENT_QUEUE_NAME, // self-loop reserved; relay just marks published
+} as const;
+
+export type OutboxEventType = keyof typeof OUTBOX_EVENT_ROUTING;
+
+export interface R8EnrichmentJobData {
+  typeId: number;
+  reason: 'seed' | 'auto_type_changed' | 'manual' | 'event_R8SnapshotUpdated';
+}

--- a/backend/src/modules/seo/r2/queues/r8-enrichment.processor.ts
+++ b/backend/src/modules/seo/r2/queues/r8-enrichment.processor.ts
@@ -1,0 +1,210 @@
+/**
+ * ADR-072 PR 2D-2 — BullMQ processors for `r8-enrichment` and
+ * `seo-outbox-relay`.
+ *
+ * READ_ONLY gate (ADR-028 Option D, MEMORY
+ * `feedback_readonly_gate_at_processor_not_scheduler`) lives on each
+ * handler — the scheduler stays registered so the BullMQ wiring is observable
+ * even when no write is allowed.
+ */
+
+import { OnQueueError, OnQueueFailed, Process, Processor } from '@nestjs/bull';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Job, Queue } from 'bull';
+import { getAppConfig } from '../../../../config/app.config';
+import {
+  OutboxRelayService,
+  OutboxRelayPublisher,
+  OutboxRow,
+} from '../services/outbox-relay.service';
+import { R8ParentEnrichmentService } from '../services/r8-parent-enrichment.service';
+import {
+  R8_ENRICHMENT_JOB_NAME,
+  R8_ENRICHMENT_QUEUE_NAME,
+  R8EnrichmentJobData,
+  SEO_OUTBOX_QUEUE_NAME,
+  SEO_OUTBOX_RELAY_JOB_NAME,
+} from './r8-enrichment.constants';
+
+export interface R8EnrichmentJobResult {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  typeId: number;
+  skipped?: 'read_only' | 'invalid_payload';
+  versionSha?: string;
+  inserted?: boolean;
+  pagesPointerUpdated?: boolean;
+}
+
+@Processor(R8_ENRICHMENT_QUEUE_NAME)
+@Injectable()
+export class R8EnrichmentProcessor {
+  private readonly logger = new Logger(R8EnrichmentProcessor.name);
+  private readonly readOnly: boolean;
+
+  constructor(private readonly enrichment: R8ParentEnrichmentService) {
+    this.readOnly = getAppConfig().supabase.readOnly;
+  }
+
+  @Process({ name: R8_ENRICHMENT_JOB_NAME, concurrency: 5 })
+  async handleEnrichment(
+    job: Job<R8EnrichmentJobData>,
+  ): Promise<R8EnrichmentJobResult> {
+    const startedAtMs = Date.now();
+    const startedAt = new Date(startedAtMs).toISOString();
+    const payload = job.data;
+
+    if (!payload || !Number.isInteger(payload.typeId) || payload.typeId <= 0) {
+      this.logger.warn(
+        `r8-enrichment job ${job.id} dropped — invalid payload: ${JSON.stringify(payload)}`,
+      );
+      return {
+        startedAt,
+        finishedAt: new Date().toISOString(),
+        durationMs: Date.now() - startedAtMs,
+        typeId: payload?.typeId ?? 0,
+        skipped: 'invalid_payload',
+      };
+    }
+
+    if (this.readOnly) {
+      this.logger.log(
+        `[READ_ONLY] r8-enrichment job ${job.id} typeId=${payload.typeId} — skipped`,
+      );
+      return {
+        startedAt,
+        finishedAt: new Date().toISOString(),
+        durationMs: Date.now() - startedAtMs,
+        typeId: payload.typeId,
+        skipped: 'read_only',
+      };
+    }
+
+    const outcome = await this.enrichment.enrichTypeId(
+      payload.typeId,
+      payload.reason ?? 'manual',
+    );
+
+    return {
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      durationMs: Date.now() - startedAtMs,
+      typeId: payload.typeId,
+      versionSha: outcome?.versionSha,
+      inserted: outcome?.inserted,
+      pagesPointerUpdated: outcome?.pagesPointerUpdated,
+    };
+  }
+
+  @OnQueueError()
+  onError(error: Error): void {
+    this.logger.error(`r8-enrichment queue error: ${error.message}`);
+  }
+
+  @OnQueueFailed()
+  onFailed(job: Job<R8EnrichmentJobData>, err: Error): void {
+    this.logger.error(
+      `r8-enrichment job ${job.id} typeId=${job.data?.typeId} failed: ${err.message}`,
+    );
+  }
+}
+
+/**
+ * Outbox relay processor — single repeatable job that drains pending events.
+ *
+ * Concurrency stays at 1 (BullMQ default for one job per worker). Atomic claim
+ * via RPC protects against the rare case where two backend instances run the
+ * scheduler in parallel.
+ */
+@Processor(SEO_OUTBOX_QUEUE_NAME)
+@Injectable()
+export class OutboxRelayProcessor implements OutboxRelayPublisher {
+  private readonly logger = new Logger(OutboxRelayProcessor.name);
+  private readonly readOnly: boolean;
+
+  constructor(
+    private readonly relay: OutboxRelayService,
+    @InjectQueue(R8_ENRICHMENT_QUEUE_NAME)
+    private readonly r8EnrichmentQueue: Queue<R8EnrichmentJobData>,
+  ) {
+    this.readOnly = getAppConfig().supabase.readOnly;
+  }
+
+  @Process({ name: SEO_OUTBOX_RELAY_JOB_NAME, concurrency: 1 })
+  async handleRelay(): Promise<{
+    skipped?: 'read_only';
+    claimed: number;
+    published: number;
+    failed: number;
+    durationMs: number;
+  }> {
+    if (this.readOnly) {
+      return {
+        skipped: 'read_only',
+        claimed: 0,
+        published: 0,
+        failed: 0,
+        durationMs: 0,
+      };
+    }
+
+    const result = await this.relay.pollOnce({ publisher: this });
+    if (result.claimed > 0) {
+      this.logger.log(
+        `outbox relay tick — claimed=${result.claimed} published=${result.published} failed=${result.failed} duration=${result.durationMs}ms`,
+      );
+    }
+    return result;
+  }
+
+  async publish(
+    queueName: string,
+    eventType: string,
+    row: OutboxRow,
+  ): Promise<void> {
+    if (queueName === R8_ENRICHMENT_QUEUE_NAME) {
+      const typeId = this.extractTypeIdFromAggregateId(row.aggregate_id);
+      if (typeId === null) {
+        throw new Error(
+          `r8-enrichment publish skipped — aggregate_id "${row.aggregate_id}" not numeric`,
+        );
+      }
+      await this.r8EnrichmentQueue.add(
+        R8_ENRICHMENT_JOB_NAME,
+        { typeId, reason: 'event_R8SnapshotUpdated' },
+        {
+          removeOnComplete: 100,
+          removeOnFail: 50,
+          attempts: 3,
+          backoff: { type: 'exponential', delay: 2_000 },
+          jobId: `r8-${typeId}-${row.id}`, // idempotent enqueue
+        },
+      );
+      return;
+    }
+    throw new Error(`unrouted_queue:${queueName} for event_type=${eventType}`);
+  }
+
+  private extractTypeIdFromAggregateId(aggregateId: string): number | null {
+    const parsed = Number.parseInt(aggregateId, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return null;
+    }
+    if (String(parsed) !== aggregateId.trim()) {
+      return null;
+    }
+    return parsed;
+  }
+
+  @OnQueueError()
+  onError(error: Error): void {
+    this.logger.error(`outbox relay queue error: ${error.message}`);
+  }
+
+  @OnQueueFailed()
+  onFailed(job: Job, err: Error): void {
+    this.logger.error(`outbox relay job ${job.id} failed: ${err.message}`);
+  }
+}

--- a/backend/src/modules/seo/r2/r2-v2.module.ts
+++ b/backend/src/modules/seo/r2/r2-v2.module.ts
@@ -9,10 +9,20 @@
  * Wired into SeoModule (see backend/src/modules/seo/seo.module.ts).
  */
 
+import { BullModule } from '@nestjs/bull';
 import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../../../database/database.module';
 import { R1GammeCompletenessAuditController } from './r1-gamme-completeness-audit.controller';
 import { R2AdminPilotController } from './r2-admin-pilot.controller';
+import {
+  R8_ENRICHMENT_QUEUE_NAME,
+  SEO_OUTBOX_QUEUE_NAME,
+} from './queues/r8-enrichment.constants';
+import {
+  OutboxRelayProcessor,
+  R8EnrichmentProcessor,
+} from './queues/r8-enrichment.processor';
+import { OutboxRelayService } from './services/outbox-relay.service';
 import { R1GammeCompletenessAuditService } from './services/r1-gamme-completeness-audit.service';
 import { R2CatalogSignatureService } from './services/r2-catalog-signature.service';
 import { R2CommercialDistinctivenessService } from './services/r2-commercial-distinctiveness.service';
@@ -26,13 +36,22 @@ import {
 import { R2MotorDeltaService } from './services/r2-motor-delta.service';
 import { R2OpaEvaluatorService } from './services/r2-opa-evaluator.service';
 import { R2VehicleFamilyService } from './services/r2-vehicle-family.service';
+import { R8ParentEnrichmentService } from './services/r8-parent-enrichment.service';
+import { R8SnapshotSeedService } from './services/r8-snapshot-seed.service';
 import {
   R8SnapshotReaderService,
   R8_SNAPSHOT_CACHE_TOKEN,
 } from './services/r8-snapshot-reader.service';
+import { SeoOutboxRelaySchedulerService } from './services/seo-outbox-relay-scheduler.service';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [
+    DatabaseModule,
+    BullModule.registerQueue(
+      { name: R8_ENRICHMENT_QUEUE_NAME },
+      { name: SEO_OUTBOX_QUEUE_NAME },
+    ),
+  ],
   controllers: [R2AdminPilotController, R1GammeCompletenessAuditController],
   providers: [
     R1GammeCompletenessAuditService,
@@ -46,6 +65,12 @@ import {
     R2VehicleFamilyService,
     R2FeatureFlagService,
     R8SnapshotReaderService, // ADR-072 §3 R8 Vehicle Domain bounded context read-side
+    R8ParentEnrichmentService, // ADR-072 PR 2D-2 write side
+    R8SnapshotSeedService, // ADR-072 PR 2D-2 idempotent batch seed
+    OutboxRelayService, // ADR-072 PR 2D-2 transactional outbox relay
+    SeoOutboxRelaySchedulerService, // BullMQ repeatable scheduler
+    R8EnrichmentProcessor,
+    OutboxRelayProcessor,
     {
       // Redis provider stub — PR 2 V1.5 wires real Redis client (BullMQ Redis
       // reused). For PR 1 foundation, feature flag falls back to env var.
@@ -53,8 +78,8 @@ import {
       useValue: null,
     },
     {
-      // R8 snapshot cache provider (Redis L1) — null fallback pour PR 2D
-      // foundation (cache désactivé tant que pas branché). PR 2D-2 ou PR 2E
+      // R8 snapshot cache provider (Redis L1) — null fallback pour PR 2D-2
+      // (cache désactivé tant que BullMQ Redis pas branché ici). PR 2E
       // wire le vrai client Redis (BullMQ Redis réutilisé).
       provide: R8_SNAPSHOT_CACHE_TOKEN,
       useValue: null,
@@ -70,6 +95,9 @@ import {
     R2OpaEvaluatorService,
     R2FeatureFlagService,
     R8SnapshotReaderService,
+    R8ParentEnrichmentService,
+    R8SnapshotSeedService,
+    OutboxRelayService,
   ],
 })
 export class R2V2Module {}

--- a/backend/src/modules/seo/r2/services/__tests__/outbox-relay.test.ts
+++ b/backend/src/modules/seo/r2/services/__tests__/outbox-relay.test.ts
@@ -1,0 +1,174 @@
+/**
+ * ADR-072 PR 2D-2 — OutboxRelayService unit tests.
+ *
+ * Covers : empty claim short-circuit, RPC error short-circuit, route-and-publish
+ * happy path, unroutable event_type → requeue + attempts++, publisher throw →
+ * markFailed.
+ */
+
+import {
+  OutboxRelayPublisher,
+  OutboxRelayService,
+  OutboxRow,
+} from '../outbox-relay.service';
+
+const sampleOutboxRow: OutboxRow = {
+  id: 11,
+  aggregate_type: 'R8VehicleSnapshot',
+  aggregate_id: '12345',
+  event_type: 'R8SnapshotUpdated',
+  payload: { typeId: 12345 },
+  trace_id: null,
+  occurred_at: '2026-05-16T10:00:00Z',
+  attempts: 0,
+};
+
+interface RecordedPublish {
+  queue: string;
+  eventType: string;
+  row: OutboxRow;
+}
+
+function makePublisher(opts: { throwOn?: number } = {}): {
+  publisher: OutboxRelayPublisher;
+  published: RecordedPublish[];
+} {
+  const published: RecordedPublish[] = [];
+  const publisher: OutboxRelayPublisher = {
+    publish: async (queue, eventType, row) => {
+      if (opts.throwOn === row.id) {
+        throw new Error('queue down');
+      }
+      published.push({ queue, eventType, row });
+    },
+  };
+  return { publisher, published };
+}
+
+interface RecordedUpdate {
+  values: Record<string, unknown>;
+  where: Record<string, unknown>;
+}
+
+function makeFakeSupabase(opts: {
+  rpcRows?: OutboxRow[] | null;
+  rpcError?: { message: string };
+}) {
+  const updates: RecordedUpdate[] = [];
+  return {
+    supabase: {
+      rpc(name: string, _args: Record<string, unknown>) {
+        expect(name).toBe('__seo_outbox_claim_batch');
+        if (opts.rpcError) {
+          return Promise.resolve({ data: null, error: opts.rpcError });
+        }
+        return Promise.resolve({
+          data: opts.rpcRows ?? [],
+          error: null,
+        });
+      },
+      from(_table: string) {
+        return {
+          update(values: Record<string, unknown>) {
+            return {
+              eq(col: string, val: unknown) {
+                updates.push({ values, where: { [col]: val } });
+                return Promise.resolve({ data: null, error: null });
+              },
+            };
+          },
+        };
+      },
+    },
+    updates,
+  };
+}
+
+function createService(supabase: unknown): OutboxRelayService {
+  const svc = Object.create(OutboxRelayService.prototype) as OutboxRelayService;
+  (
+    svc as unknown as {
+      logger: { log: () => void; error: () => void; warn: () => void };
+    }
+  ).logger = { log: () => {}, error: () => {}, warn: () => {} };
+  (svc as unknown as { supabase: unknown }).supabase = supabase;
+  return svc;
+}
+
+describe('OutboxRelayService.pollOnce', () => {
+  it('short-circuits cleanly when no rows are claimed', async () => {
+    const { supabase, updates } = makeFakeSupabase({ rpcRows: [] });
+    const { publisher, published } = makePublisher();
+    const svc = createService(supabase);
+    const result = await svc.pollOnce({ publisher });
+
+    expect(result.claimed).toBe(0);
+    expect(result.published).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(updates).toHaveLength(0);
+    expect(published).toHaveLength(0);
+  });
+
+  it('returns zero counts when RPC errors out (no throw)', async () => {
+    const { supabase } = makeFakeSupabase({
+      rpcError: { message: 'tx timeout' },
+    });
+    const { publisher } = makePublisher();
+    const svc = createService(supabase);
+    const result = await svc.pollOnce({ publisher });
+
+    expect(result.claimed).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it('publishes routable events to r8-enrichment queue', async () => {
+    const { supabase, updates } = makeFakeSupabase({
+      rpcRows: [sampleOutboxRow],
+    });
+    const { publisher, published } = makePublisher();
+    const svc = createService(supabase);
+    const result = await svc.pollOnce({ publisher });
+
+    expect(result.claimed).toBe(1);
+    expect(result.published).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(published).toHaveLength(1);
+    expect(published[0].queue).toBe('r8-enrichment');
+    expect(published[0].eventType).toBe('R8SnapshotUpdated');
+    expect(updates).toHaveLength(0);
+  });
+
+  it('requeues unroutable events (resets published_at, increments attempts)', async () => {
+    const { supabase, updates } = makeFakeSupabase({
+      rpcRows: [{ ...sampleOutboxRow, event_type: 'UnknownEvent' }],
+    });
+    const { publisher, published } = makePublisher();
+    const svc = createService(supabase);
+    const result = await svc.pollOnce({ publisher });
+
+    expect(result.claimed).toBe(1);
+    expect(result.published).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(published).toHaveLength(0);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].values.published_at).toBeNull();
+    expect(updates[0].values.attempts).toBe(1);
+    expect(updates[0].values.last_error).toContain('unroutable_event_type');
+  });
+
+  it('marks failed when publisher throws (without reverting published_at)', async () => {
+    const { supabase, updates } = makeFakeSupabase({
+      rpcRows: [sampleOutboxRow],
+    });
+    const { publisher } = makePublisher({ throwOn: sampleOutboxRow.id });
+    const svc = createService(supabase);
+    const result = await svc.pollOnce({ publisher });
+
+    expect(result.claimed).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.published).toBe(0);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].values.last_error).toMatch(/queue down/);
+    expect(updates[0].values.published_at).toBeUndefined(); // not reverted
+  });
+});

--- a/backend/src/modules/seo/r2/services/__tests__/r8-parent-enrichment.test.ts
+++ b/backend/src/modules/seo/r2/services/__tests__/r8-parent-enrichment.test.ts
@@ -1,0 +1,334 @@
+/**
+ * ADR-072 PR 2D-2 — R8ParentEnrichmentService unit tests.
+ *
+ * Coverage :
+ *   1. Pure builder : disambiguation signature shape + deterministic sibling
+ *      ordering.
+ *   2. computeVersionSha is deterministic (same input → same sha) and changes
+ *      when any field changes.
+ *   3. enrichTypeId routes to RPC __seo_r8_publish_snapshot and surfaces the
+ *      idempotent outcome (`inserted=false` when RPC reports a reuse).
+ *   4. enrichTypeId throws on RPC error so the BullMQ processor surfaces the
+ *      failure to its retry policy.
+ *   5. Cache best-effort : invalidate failure does not bubble up.
+ *
+ * Pattern Object.create(prototype) pour bypass SupabaseBaseService ctor env
+ * check (canon r8-snapshot-reader.test.ts).
+ */
+
+import {
+  R8EnrichmentOutcome,
+  R8ParentEnrichmentService,
+} from '../r8-parent-enrichment.service';
+import { R8SnapshotCacheClient } from '../r8-snapshot-reader.service';
+
+const sampleAutoTypeRow = {
+  type_id: '12345',
+  type_marque_id: '40',
+  type_modele_id: '512',
+  type_power_ps: '88',
+  type_power_kw: '65',
+  type_year_from: '2010',
+  type_year_to: '2014',
+  type_month_from: '1',
+  type_month_to: '12',
+  type_body: '3/5 portes',
+  type_fuel: 'diesel',
+  type_engine: 'K9K 770',
+  type_liter: '1.5',
+  type_alias: 'clio-iii-1.5-dci',
+};
+
+const sampleSibling = {
+  ...sampleAutoTypeRow,
+  type_id: '99999',
+  type_power_ps: '90',
+};
+
+interface RpcInvocation {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+interface UpdateRecord {
+  table: string;
+  values: Record<string, unknown>;
+  where: Record<string, unknown>;
+}
+
+function makeFakeSupabase(opts: {
+  parent?: typeof sampleAutoTypeRow | null;
+  siblings?: (typeof sampleAutoTypeRow)[];
+  brandSlug?: string | null;
+  modelSlug?: string | null;
+  rpcResponse?: { data: unknown; error: { message: string } | null };
+}) {
+  const invocations: RpcInvocation[] = [];
+  const updates: UpdateRecord[] = [];
+
+  const supabase = {
+    from(table: string) {
+      return {
+        select(_cols: string) {
+          const builder: any = {
+            _eqFilters: {} as Record<string, unknown>,
+            _neqFilters: {} as Record<string, unknown>,
+            eq(col: string, value: unknown) {
+              this._eqFilters[col] = value;
+              return this;
+            },
+            neq(col: string, value: unknown) {
+              this._neqFilters[col] = value;
+              return this;
+            },
+            limit(_n: number) {
+              return this;
+            },
+            maybeSingle: async () => {
+              if (table === 'auto_type') {
+                return { data: opts.parent ?? null, error: null };
+              }
+              if (table === 'auto_marque') {
+                return opts.brandSlug !== undefined
+                  ? { data: { marque_alias: opts.brandSlug }, error: null }
+                  : { data: null, error: null };
+              }
+              if (table === 'auto_modele') {
+                return opts.modelSlug !== undefined
+                  ? { data: { modele_alias: opts.modelSlug }, error: null }
+                  : { data: null, error: null };
+              }
+              return { data: null, error: null };
+            },
+            then(
+              resolve: (value: { data: unknown; error: null }) => unknown,
+              reject?: (reason: unknown) => unknown,
+            ) {
+              if (table === 'auto_type') {
+                resolve({ data: opts.siblings ?? [], error: null });
+                return;
+              }
+              resolve({ data: [], error: null });
+              return reject; // unused, satisfy TS
+            },
+          };
+          return builder;
+        },
+        update(values: Record<string, unknown>) {
+          return {
+            eq(col: string, val: unknown) {
+              updates.push({ table, values, where: { [col]: val } });
+              return Promise.resolve({ data: null, error: null });
+            },
+          };
+        },
+      };
+    },
+    rpc(name: string, args: Record<string, unknown>) {
+      invocations.push({ name, args });
+      return Promise.resolve(
+        opts.rpcResponse ?? {
+          data: [
+            {
+              snapshot_id: 7,
+              inserted: true,
+              pages_pointer_updated: true,
+              outbox_event_id: 11,
+            },
+          ],
+          error: null,
+        },
+      );
+    },
+  };
+
+  return { supabase, invocations, updates };
+}
+
+function createService(
+  supabase: unknown,
+  cache?: R8SnapshotCacheClient,
+): R8ParentEnrichmentService {
+  const svc = Object.create(
+    R8ParentEnrichmentService.prototype,
+  ) as R8ParentEnrichmentService;
+  (
+    svc as unknown as {
+      logger: { log: () => void; error: () => void; warn: () => void };
+    }
+  ).logger = { log: () => {}, error: () => {}, warn: () => {} };
+  (svc as unknown as { supabase: unknown }).supabase = supabase;
+  (svc as unknown as { cache: R8SnapshotCacheClient | undefined }).cache =
+    cache;
+  return svc;
+}
+
+describe('R8ParentEnrichmentService', () => {
+  describe('buildDisambiguationSignature', () => {
+    it('sorts siblings by typeId for deterministic hashing', () => {
+      const svc = createService({});
+      const parent = { ...sampleAutoTypeRow, type_id: '12345' };
+      const s1 = { ...sampleAutoTypeRow, type_id: '99' };
+      const s2 = { ...sampleAutoTypeRow, type_id: '42' };
+      const s3 = { ...sampleAutoTypeRow, type_id: '12345' }; // self, must be filtered
+
+      const signature = svc.buildDisambiguationSignature(
+        parent,
+        'renault',
+        'clio-iii',
+        [s1, s2, s3],
+      );
+
+      expect(signature.siblings.map((s) => s.typeId)).toEqual([42, 99]);
+    });
+
+    it('returns null for blank string columns', () => {
+      const svc = createService({});
+      const parent = {
+        ...sampleAutoTypeRow,
+        type_body: '   ',
+        type_engine: '',
+        type_fuel: null,
+      };
+      const signature = svc.buildDisambiguationSignature(
+        parent,
+        'renault',
+        'clio-iii',
+        [],
+      );
+      expect(signature.bodyType).toBeNull();
+      expect(signature.engineCode).toBeNull();
+      expect(signature.fuelType).toBeNull();
+    });
+
+    it('throws on non-numeric type_id', () => {
+      const svc = createService({});
+      const parent = { ...sampleAutoTypeRow, type_id: 'abc' };
+      expect(() =>
+        svc.buildDisambiguationSignature(parent, 'renault', 'clio', []),
+      ).toThrow(/Non-numeric type_id/);
+    });
+  });
+
+  describe('computeVersionSha', () => {
+    it('is deterministic for identical input', () => {
+      const svc = createService({});
+      const signature = svc.buildDisambiguationSignature(
+        sampleAutoTypeRow,
+        'renault',
+        'clio-iii',
+        [sampleSibling],
+      );
+      const a = svc.computeVersionSha(signature);
+      const b = svc.computeVersionSha(signature);
+      expect(a).toBe(b);
+      expect(a).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('changes when any payload field changes', () => {
+      const svc = createService({});
+      const base = svc.buildDisambiguationSignature(
+        sampleAutoTypeRow,
+        'renault',
+        'clio-iii',
+        [],
+      );
+      const tweaked = svc.buildDisambiguationSignature(
+        { ...sampleAutoTypeRow, type_power_ps: '120' },
+        'renault',
+        'clio-iii',
+        [],
+      );
+      expect(svc.computeVersionSha(base)).not.toBe(
+        svc.computeVersionSha(tweaked),
+      );
+    });
+  });
+
+  describe('enrichTypeId', () => {
+    it('calls __seo_r8_publish_snapshot and returns outcome', async () => {
+      const { supabase, invocations } = makeFakeSupabase({
+        parent: sampleAutoTypeRow,
+        siblings: [sampleSibling],
+        brandSlug: 'renault',
+        modelSlug: 'clio-iii',
+      });
+      const svc = createService(supabase);
+      const outcome = (await svc.enrichTypeId(
+        12345,
+        'unit-test',
+      )) as R8EnrichmentOutcome;
+
+      expect(outcome.typeId).toBe(12345);
+      expect(outcome.snapshotId).toBe(7);
+      expect(outcome.inserted).toBe(true);
+      expect(outcome.pagesPointerUpdated).toBe(true);
+      expect(outcome.outboxEventId).toBe(11);
+      expect(outcome.versionSha).toMatch(/^[0-9a-f]{64}$/);
+      expect(invocations).toHaveLength(1);
+      expect(invocations[0].name).toBe('__seo_r8_publish_snapshot');
+      expect(invocations[0].args.p_type_id).toBe(12345);
+      expect(invocations[0].args.p_enrichment_status).toBe('minimal');
+      expect(invocations[0].args.p_event_reason).toBe('unit-test');
+    });
+
+    it('surfaces inserted=false when RPC reports an idempotent reuse', async () => {
+      const { supabase } = makeFakeSupabase({
+        parent: sampleAutoTypeRow,
+        rpcResponse: {
+          data: [
+            {
+              snapshot_id: 9,
+              inserted: false,
+              pages_pointer_updated: false,
+              outbox_event_id: 21,
+            },
+          ],
+          error: null,
+        },
+      });
+      const svc = createService(supabase);
+      const outcome = await svc.enrichTypeId(12345);
+      expect(outcome?.inserted).toBe(false);
+      expect(outcome?.pagesPointerUpdated).toBe(false);
+    });
+
+    it('returns null when auto_type row missing (no RPC call)', async () => {
+      const { supabase, invocations } = makeFakeSupabase({ parent: null });
+      const svc = createService(supabase);
+      const outcome = await svc.enrichTypeId(12345);
+      expect(outcome).toBeNull();
+      expect(invocations).toHaveLength(0);
+    });
+
+    it('throws when RPC reports an error so BullMQ retries kick in', async () => {
+      const { supabase } = makeFakeSupabase({
+        parent: sampleAutoTypeRow,
+        rpcResponse: { data: null, error: { message: 'unique violation' } },
+      });
+      const svc = createService(supabase);
+      await expect(svc.enrichTypeId(12345)).rejects.toThrow(
+        /r8_publish_snapshot_failed/,
+      );
+    });
+
+    it('rejects invalid typeId', async () => {
+      const svc = createService({});
+      await expect(svc.enrichTypeId(0)).rejects.toThrow(/Invalid typeId/);
+      await expect(svc.enrichTypeId(-1)).rejects.toThrow(/Invalid typeId/);
+    });
+
+    it('best-effort cache invalidation never bubbles', async () => {
+      const { supabase } = makeFakeSupabase({ parent: sampleAutoTypeRow });
+      const cache: R8SnapshotCacheClient = {
+        get: async () => null,
+        setEx: async () => {},
+        del: async () => {
+          throw new Error('redis down');
+        },
+      };
+      const svc = createService(supabase, cache);
+      await expect(svc.enrichTypeId(12345)).resolves.toBeTruthy();
+    });
+  });
+});

--- a/backend/src/modules/seo/r2/services/__tests__/r8-snapshot-seed.test.ts
+++ b/backend/src/modules/seo/r2/services/__tests__/r8-snapshot-seed.test.ts
@@ -1,0 +1,182 @@
+/**
+ * ADR-072 PR 2D-2 — R8SnapshotSeedService unit tests.
+ *
+ * Covers : batch loop pagination, idempotent counters, resumable cursor,
+ * failure handling (one row throws → counted in totalFailed, loop continues),
+ * dryRun (no writes).
+ */
+
+import {
+  R8SnapshotSeedService,
+  SeedRunOptions,
+} from '../r8-snapshot-seed.service';
+import { R8ParentEnrichmentService } from '../r8-parent-enrichment.service';
+
+interface FakeEnrichmentCall {
+  typeId: number;
+  reason: string;
+}
+
+function makeEnrichment(
+  behavior: (
+    typeId: number,
+  ) => { inserted: boolean; snapshotId: number } | null | Error,
+): { svc: R8ParentEnrichmentService; calls: FakeEnrichmentCall[] } {
+  const calls: FakeEnrichmentCall[] = [];
+  const svc = {
+    async enrichTypeId(typeId: number, reason: string) {
+      calls.push({ typeId, reason });
+      const outcome = behavior(typeId);
+      if (outcome instanceof Error) {
+        throw outcome;
+      }
+      if (outcome === null) {
+        return null;
+      }
+      return {
+        typeId,
+        versionSha: 'a'.repeat(64),
+        snapshotId: outcome.snapshotId,
+        inserted: outcome.inserted,
+        pagesPointerUpdated: true,
+        outboxEventId: 1,
+      };
+    },
+  } as unknown as R8ParentEnrichmentService;
+  return { svc, calls };
+}
+
+function makeSupabaseWithBatches(batches: string[][]) {
+  let index = 0;
+  return {
+    from(_table: string) {
+      return {
+        select(_cols: string) {
+          const builder: any = {
+            gte(_col: string, _value: string) {
+              return this;
+            },
+            order(_col: string, _opts: unknown) {
+              return this;
+            },
+            limit(_n: number) {
+              return this;
+            },
+            then(
+              resolve: (value: {
+                data: { type_id: string }[];
+                error: null;
+              }) => unknown,
+            ) {
+              const data = (batches[index] ?? []).map((id) => ({
+                type_id: id,
+              }));
+              index += 1;
+              resolve({ data, error: null });
+            },
+          };
+          return builder;
+        },
+      };
+    },
+  };
+}
+
+function createService(
+  enrichment: R8ParentEnrichmentService,
+  supabase: unknown,
+): R8SnapshotSeedService {
+  const svc = Object.create(
+    R8SnapshotSeedService.prototype,
+  ) as R8SnapshotSeedService;
+  (
+    svc as unknown as {
+      logger: { log: () => void; error: () => void; warn: () => void };
+    }
+  ).logger = { log: () => {}, error: () => {}, warn: () => {} };
+  (svc as unknown as { supabase: unknown }).supabase = supabase;
+  (svc as unknown as { enrichment: R8ParentEnrichmentService }).enrichment =
+    enrichment;
+  return svc;
+}
+
+describe('R8SnapshotSeedService', () => {
+  it('iterates all batches and counts inserted vs already-present', async () => {
+    const { svc: enrichment, calls } = makeEnrichment((typeId) => ({
+      inserted: typeId % 2 === 0,
+      snapshotId: typeId,
+    }));
+    const supabase = makeSupabaseWithBatches([
+      ['10', '11', '12'],
+      ['13', '14'],
+      [],
+    ]);
+    const svc = createService(enrichment, supabase);
+    const report = await svc.run({ batchSize: 3 });
+
+    expect(report.totalScanned).toBe(5);
+    expect(report.totalSeeded).toBe(3); // 10, 12, 14 inserted
+    expect(report.totalAlreadyPresent).toBe(2); // 11, 13 idempotent
+    expect(report.totalFailed).toBe(0);
+    expect(report.lastTypeIdProcessed).toBe(14);
+    expect(calls.map((c) => c.typeId)).toEqual([10, 11, 12, 13, 14]);
+    expect(new Set(calls.map((c) => c.reason))).toEqual(new Set(['seed']));
+  });
+
+  it('counts a failing typeId in totalFailed and keeps going', async () => {
+    const { svc: enrichment } = makeEnrichment((typeId) => {
+      if (typeId === 11) {
+        return new Error('rpc timeout');
+      }
+      return { inserted: true, snapshotId: typeId };
+    });
+    const supabase = makeSupabaseWithBatches([['10', '11', '12'], []]);
+    const svc = createService(enrichment, supabase);
+    const report = await svc.run();
+
+    expect(report.totalScanned).toBe(3);
+    expect(report.totalSeeded).toBe(2);
+    expect(report.totalFailed).toBe(1);
+  });
+
+  it('respects dryRun (no enrichment calls)', async () => {
+    const { svc: enrichment, calls } = makeEnrichment(() => ({
+      inserted: true,
+      snapshotId: 1,
+    }));
+    const supabase = makeSupabaseWithBatches([['10', '11'], []]);
+    const svc = createService(enrichment, supabase);
+    const report = await svc.run({ dryRun: true });
+
+    expect(report.totalScanned).toBe(2);
+    expect(report.totalSeeded).toBe(0);
+    expect(calls).toHaveLength(0);
+    expect(report.dryRun).toBe(true);
+  });
+
+  it('honors maxBatches safety cap', async () => {
+    const { svc: enrichment } = makeEnrichment(() => ({
+      inserted: true,
+      snapshotId: 1,
+    }));
+    const supabase = makeSupabaseWithBatches([['10'], ['11'], ['12']]);
+    const svc = createService(enrichment, supabase);
+    const options: SeedRunOptions = { batchSize: 1, maxBatches: 2 };
+    const report = await svc.run(options);
+
+    expect(report.totalScanned).toBe(2);
+  });
+
+  it('counts non-numeric type_ids as skipped', async () => {
+    const { svc: enrichment } = makeEnrichment(() => ({
+      inserted: true,
+      snapshotId: 1,
+    }));
+    const supabase = makeSupabaseWithBatches([['10', 'abc', '0'], []]);
+    const svc = createService(enrichment, supabase);
+    const report = await svc.run();
+
+    expect(report.totalScanned).toBe(1);
+    expect(report.totalSkipped).toBe(2); // 'abc' invalid, '0' invalid
+  });
+});

--- a/backend/src/modules/seo/r2/services/outbox-relay.service.ts
+++ b/backend/src/modules/seo/r2/services/outbox-relay.service.ts
@@ -1,0 +1,155 @@
+/**
+ * ADR-072 PR 2D-2 — Transactional Outbox Relay.
+ *
+ * Drains `__seo_outbox_event` in batches and routes each pending event to its
+ * downstream BullMQ queue (canon transactional outbox pattern :
+ * Confluent / Microservices.io).
+ *
+ * Atomic claim is delegated to the RPC `__seo_outbox_claim_batch` which uses
+ * `FOR UPDATE SKIP LOCKED` and flips `published_at` in a single transaction.
+ * That makes concurrent relay workers safe even though we target concurrency 1.
+ *
+ * READ_ONLY gate (ADR-028 Option D / MEMORY
+ * `feedback_readonly_gate_at_processor_not_scheduler`) is enforced inside the
+ * processor that calls `pollOnce()`, not here.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseBaseService } from '../../../../database/services/supabase-base.service';
+import {
+  OUTBOX_EVENT_ROUTING,
+  OutboxEventType,
+  SEO_OUTBOX_RELAY_BATCH_SIZE,
+} from '../queues/r8-enrichment.constants';
+
+export interface OutboxRow {
+  id: number;
+  aggregate_type: string;
+  aggregate_id: string;
+  event_type: string;
+  payload: Record<string, unknown>;
+  trace_id: string | null;
+  occurred_at: string;
+  attempts: number;
+}
+
+export interface OutboxRelayPublisher {
+  /**
+   * Push an event downstream. Implementations live in the BullMQ processor /
+   * controllers — kept as an interface so the service stays testable in unit
+   * scope (no @InjectQueue in this layer).
+   */
+  publish(queueName: string, eventType: string, row: OutboxRow): Promise<void>;
+}
+
+export interface OutboxRelayResult {
+  claimed: number;
+  published: number;
+  failed: number;
+  durationMs: number;
+}
+
+export interface OutboxRelayOptions {
+  batchSize?: number;
+  publisher: OutboxRelayPublisher;
+}
+
+@Injectable()
+export class OutboxRelayService extends SupabaseBaseService {
+  protected readonly logger = new Logger(OutboxRelayService.name);
+
+  async pollOnce(options: OutboxRelayOptions): Promise<OutboxRelayResult> {
+    const startedAt = Date.now();
+    const limit = Math.max(1, options.batchSize ?? SEO_OUTBOX_RELAY_BATCH_SIZE);
+
+    const { data, error } = await this.supabase.rpc(
+      '__seo_outbox_claim_batch',
+      { p_limit: limit },
+    );
+
+    if (error) {
+      this.logger.error(`__seo_outbox_claim_batch failed: ${error.message}`);
+      return {
+        claimed: 0,
+        published: 0,
+        failed: 0,
+        durationMs: Date.now() - startedAt,
+      };
+    }
+
+    const rows = (data ?? []) as OutboxRow[];
+    if (rows.length === 0) {
+      return {
+        claimed: 0,
+        published: 0,
+        failed: 0,
+        durationMs: Date.now() - startedAt,
+      };
+    }
+
+    let published = 0;
+    let failed = 0;
+
+    for (const row of rows) {
+      const queueName = this.routeEvent(row.event_type);
+      if (!queueName) {
+        // Unknown event type — leave attempts counter to grow so the row stays
+        // visible. RPC already flipped published_at to NOW(); revert it so the
+        // event can be reclaimed once a route is registered.
+        await this.requeueUnroutable(row);
+        failed += 1;
+        continue;
+      }
+
+      try {
+        await options.publisher.publish(queueName, row.event_type, row);
+        published += 1;
+      } catch (e) {
+        failed += 1;
+        await this.markFailed(row.id, (e as Error).message);
+      }
+    }
+
+    return {
+      claimed: rows.length,
+      published,
+      failed,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  private routeEvent(eventType: string): string | null {
+    if (eventType in OUTBOX_EVENT_ROUTING) {
+      return OUTBOX_EVENT_ROUTING[eventType as OutboxEventType];
+    }
+    return null;
+  }
+
+  private async requeueUnroutable(row: OutboxRow): Promise<void> {
+    const { error } = await this.supabase
+      .from('__seo_outbox_event')
+      .update({
+        published_at: null,
+        attempts: row.attempts + 1,
+        last_error: `unroutable_event_type:${row.event_type}`,
+      })
+      .eq('id', row.id);
+    if (error) {
+      this.logger.error(
+        `requeueUnroutable(id=${row.id}) failed: ${error.message}`,
+      );
+    }
+  }
+
+  private async markFailed(id: number, message: string): Promise<void> {
+    const { error } = await this.supabase
+      .from('__seo_outbox_event')
+      .update({
+        last_error: message.slice(0, 1000),
+      })
+      .eq('id', id);
+    if (error) {
+      this.logger.error(`markFailed(id=${id}) failed: ${error.message}`);
+    }
+  }
+}

--- a/backend/src/modules/seo/r2/services/outbox-relay.service.ts
+++ b/backend/src/modules/seo/r2/services/outbox-relay.service.ts
@@ -62,7 +62,8 @@ export class OutboxRelayService extends SupabaseBaseService {
     const startedAt = Date.now();
     const limit = Math.max(1, options.batchSize ?? SEO_OUTBOX_RELAY_BATCH_SIZE);
 
-    const { data, error } = await this.supabase.rpc(
+    // 🛡️ RPC Safety Gate — worker context (no `source: 'api'`).
+    const { data, error } = await this.callRpc<OutboxRow[]>(
       '__seo_outbox_claim_batch',
       { p_limit: limit },
     );
@@ -77,7 +78,7 @@ export class OutboxRelayService extends SupabaseBaseService {
       };
     }
 
-    const rows = (data ?? []) as OutboxRow[];
+    const rows = data ?? [];
     if (rows.length === 0) {
       return {
         claimed: 0,

--- a/backend/src/modules/seo/r2/services/r8-parent-enrichment.service.ts
+++ b/backend/src/modules/seo/r2/services/r8-parent-enrichment.service.ts
@@ -50,6 +50,13 @@ export interface R8EnrichmentOutcome {
   outboxEventId: number | null; // null only when RPC reuses an event row
 }
 
+interface PublishSnapshotRow {
+  snapshot_id: number;
+  inserted: boolean;
+  pages_pointer_updated: boolean;
+  outbox_event_id: number;
+}
+
 interface AutoTypeRow {
   type_id: string;
   type_marque_id: string | null;
@@ -169,7 +176,11 @@ export class R8ParentEnrichmentService extends SupabaseBaseService {
 
     // Canonical write path : RPC wraps INSERT snapshot + UPDATE pages pointer
     // + INSERT outbox event in a single SQL transaction.
-    const { data, error } = await this.supabase.rpc(
+    //
+    // 🛡️ RPC Safety Gate — callRpc routes via SupabaseBaseService.callRpc so
+    // governance allowlist / deny rules apply. Worker context (no `source:
+    // 'api'`) skips allowlist enforcement but still records the call.
+    const { data, error } = await this.callRpc<PublishSnapshotRow[]>(
       '__seo_r8_publish_snapshot',
       {
         p_type_id: typeId,
@@ -189,7 +200,9 @@ export class R8ParentEnrichmentService extends SupabaseBaseService {
     }
 
     // RPC returns a single row : { snapshot_id, inserted, pages_pointer_updated, outbox_event_id }
-    const row = Array.isArray(data) ? data[0] : data;
+    const row = Array.isArray(data)
+      ? data[0]
+      : (data as PublishSnapshotRow | null);
     if (!row || typeof row.snapshot_id !== 'number') {
       this.logger.error(
         `enrichTypeId(${typeId}) RPC returned malformed payload: ${JSON.stringify(data)}`,

--- a/backend/src/modules/seo/r2/services/r8-parent-enrichment.service.ts
+++ b/backend/src/modules/seo/r2/services/r8-parent-enrichment.service.ts
@@ -1,0 +1,318 @@
+/**
+ * ADR-072 PR 2D-2 — R8 Parent Enrichment Service (write side).
+ *
+ * Materializes one row of `__seo_r8_snapshot_store` for a given `type_id` and
+ * repoints `__seo_r8_pages.current_snapshot_id` to it atomically, then writes
+ * the `R8SnapshotUpdated` integration event into `__seo_outbox_event`
+ * (transactional outbox canon).
+ *
+ * Scope strict PR 2D-2 :
+ *   - Status `minimal` only — siblings derived from `auto_type` rows sharing
+ *     `type_modele_id` + `type_engine`. No WIKI evidence, no LLM enrichment.
+ *   - `enriched` / `stale` / `failed` transitions ship in PR 2H (KG + WIKI).
+ *
+ * Idempotency canon :
+ *   - `version_sha = sha256(canonical(disambiguation_signature))` via
+ *     `fast-json-stable-stringify` (MEMORY
+ *     feedback_deterministic_input_hash_canonical_json).
+ *   - INSERT collides on UNIQUE(version_sha) → existing snapshot reused, no
+ *     duplicate row. Re-running the seed for a stable `auto_type` row is a
+ *     no-op (re-points pages pointer if already correct = same UPDATE).
+ *
+ * Race-safety :
+ *   - The 3 writes (snapshot INSERT, pages UPDATE, outbox INSERT) are done via
+ *     RPC `__seo_r8_publish_snapshot` (PR 2D-2 migration) which wraps them in
+ *     a single SQL transaction. JS-side fallback below logs and aborts on
+ *     partial writes — RPC is the canonical path.
+ */
+
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'node:crypto';
+import stringify from 'fast-json-stable-stringify';
+import { SupabaseBaseService } from '../../../../database/services/supabase-base.service';
+import {
+  R8DisambiguationSignature,
+  R8DisambiguationSignatureSchema,
+  R8SiblingEntry,
+} from '../schemas/r8-snapshot.schema';
+import {
+  R8_SNAPSHOT_CACHE_TOKEN,
+  R8SnapshotCacheClient,
+} from './r8-snapshot-reader.service';
+
+export interface R8EnrichmentOutcome {
+  typeId: number;
+  versionSha: string;
+  snapshotId: number;
+  inserted: boolean; // false = idempotent hit (existing snapshot reused)
+  pagesPointerUpdated: boolean;
+  outboxEventId: number | null; // null only when RPC reuses an event row
+}
+
+interface AutoTypeRow {
+  type_id: string;
+  type_marque_id: string | null;
+  type_modele_id: string | null;
+  type_power_ps: string | null;
+  type_power_kw: string | null;
+  type_year_from: string | null;
+  type_year_to: string | null;
+  type_month_from: string | null;
+  type_month_to: string | null;
+  type_body: string | null;
+  type_fuel: string | null;
+  type_engine: string | null;
+  type_liter: string | null;
+  type_alias: string | null;
+}
+
+const PARSE_INT_RE = /^-?\d+$/;
+
+@Injectable()
+export class R8ParentEnrichmentService extends SupabaseBaseService {
+  protected readonly logger = new Logger(R8ParentEnrichmentService.name);
+
+  constructor(
+    @Optional() configService?: ConfigService,
+    @Optional()
+    @Inject(R8_SNAPSHOT_CACHE_TOKEN)
+    private readonly cache?: R8SnapshotCacheClient | null,
+  ) {
+    super(configService);
+  }
+
+  /**
+   * Read-side helpers exposed for tests and the seed job.
+   * Pure function : deterministic given the auto_type row + siblings.
+   */
+  buildDisambiguationSignature(
+    parent: AutoTypeRow,
+    brandSlug: string,
+    modelSlug: string,
+    siblings: AutoTypeRow[],
+    autoTypeUpdatedAt?: string,
+  ): R8DisambiguationSignature {
+    const signature: R8DisambiguationSignature = {
+      typeId: this.parseIntStrict(parent.type_id),
+      brandSlug,
+      modelSlug,
+      powerHp: this.parseIntNullable(parent.type_power_ps),
+      yearsFrom: this.parseIntNullable(parent.type_year_from),
+      yearsTo: this.parseIntNullable(parent.type_year_to),
+      bodyType: this.nullIfBlank(parent.type_body),
+      fuelType: this.nullIfBlank(parent.type_fuel),
+      engineCode: this.nullIfBlank(parent.type_engine),
+      // Euro norm is not present on auto_type — PR 2H joins KG/WIKI.
+      euroNorm: null,
+      literage: this.nullIfBlank(parent.type_liter),
+      siblings: siblings
+        .filter((s) => s.type_id !== parent.type_id)
+        .map(
+          (s): R8SiblingEntry => ({
+            typeId: this.parseIntStrict(s.type_id),
+            powerHp: this.parseIntNullable(s.type_power_ps),
+            yearsFrom: this.parseIntNullable(s.type_year_from),
+            yearsTo: this.parseIntNullable(s.type_year_to),
+            bodyType: this.nullIfBlank(s.type_body),
+            engineCode: this.nullIfBlank(s.type_engine),
+          }),
+        )
+        .sort((a, b) => a.typeId - b.typeId), // deterministic order → stable sha
+      sourceLineage: autoTypeUpdatedAt
+        ? { autoTypeUpdatedAt, wikiEvidenceIds: [], llmModel: undefined }
+        : undefined,
+    };
+
+    // Validate before hashing — catches schema drift at the boundary.
+    return R8DisambiguationSignatureSchema.parse(signature);
+  }
+
+  /**
+   * Deterministic content hash. Same signature → same sha → idempotent INSERT.
+   * Uses `fast-json-stable-stringify` (sorted keys) per MEMORY canon.
+   */
+  computeVersionSha(signature: R8DisambiguationSignature): string {
+    const canonical = stringify(signature);
+    return createHash('sha256').update(canonical).digest('hex');
+  }
+
+  /**
+   * Materialize the minimal R8 snapshot for `typeId`. Idempotent and safe to
+   * call from the seed loop, the BullMQ processor, or admin tools.
+   */
+  async enrichTypeId(
+    typeId: number,
+    reason: string = 'minimal-seed',
+  ): Promise<R8EnrichmentOutcome | null> {
+    if (!Number.isInteger(typeId) || typeId <= 0) {
+      throw new Error(`Invalid typeId: ${typeId}`);
+    }
+
+    const parent = await this.fetchAutoTypeRow(typeId);
+    if (!parent) {
+      this.logger.warn(
+        `enrichTypeId(${typeId}) — auto_type row missing, skipping`,
+      );
+      return null;
+    }
+
+    const { brandSlug, modelSlug } = await this.fetchBrandModelSlugs(parent);
+    const siblings = await this.fetchSiblings(parent);
+    const signature = this.buildDisambiguationSignature(
+      parent,
+      brandSlug,
+      modelSlug,
+      siblings,
+    );
+    const versionSha = this.computeVersionSha(signature);
+
+    // Canonical write path : RPC wraps INSERT snapshot + UPDATE pages pointer
+    // + INSERT outbox event in a single SQL transaction.
+    const { data, error } = await this.supabase.rpc(
+      '__seo_r8_publish_snapshot',
+      {
+        p_type_id: typeId,
+        p_version_sha: versionSha,
+        p_disambiguation_signature: signature,
+        p_enrichment_status: 'minimal',
+        p_source_lineage: null,
+        p_event_reason: reason,
+      },
+    );
+
+    if (error) {
+      this.logger.error(
+        `enrichTypeId(${typeId}) RPC __seo_r8_publish_snapshot failed: ${error.message}`,
+      );
+      throw new Error(`r8_publish_snapshot_failed: ${error.message}`);
+    }
+
+    // RPC returns a single row : { snapshot_id, inserted, pages_pointer_updated, outbox_event_id }
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row || typeof row.snapshot_id !== 'number') {
+      this.logger.error(
+        `enrichTypeId(${typeId}) RPC returned malformed payload: ${JSON.stringify(data)}`,
+      );
+      throw new Error('r8_publish_snapshot_invalid_response');
+    }
+
+    // Invalidate Redis L1 (best-effort) so the reader picks up the new pointer.
+    await this.invalidateCache(typeId);
+
+    return {
+      typeId,
+      versionSha,
+      snapshotId: row.snapshot_id,
+      inserted: row.inserted === true,
+      pagesPointerUpdated: row.pages_pointer_updated === true,
+      outboxEventId:
+        typeof row.outbox_event_id === 'number' ? row.outbox_event_id : null,
+    };
+  }
+
+  private async fetchAutoTypeRow(typeId: number): Promise<AutoTypeRow | null> {
+    const { data, error } = await this.supabase
+      .from('auto_type')
+      .select(
+        'type_id, type_marque_id, type_modele_id, type_power_ps, type_power_kw, type_year_from, type_year_to, type_month_from, type_month_to, type_body, type_fuel, type_engine, type_liter, type_alias',
+      )
+      .eq('type_id', String(typeId))
+      .maybeSingle();
+
+    if (error) {
+      this.logger.error(`fetchAutoTypeRow(${typeId}) failed: ${error.message}`);
+      return null;
+    }
+    return (data as AutoTypeRow | null) ?? null;
+  }
+
+  private async fetchSiblings(parent: AutoTypeRow): Promise<AutoTypeRow[]> {
+    if (!parent.type_modele_id) {
+      return [];
+    }
+    let query = this.supabase
+      .from('auto_type')
+      .select(
+        'type_id, type_marque_id, type_modele_id, type_power_ps, type_power_kw, type_year_from, type_year_to, type_month_from, type_month_to, type_body, type_fuel, type_engine, type_liter, type_alias',
+      )
+      .eq('type_modele_id', parent.type_modele_id)
+      .neq('type_id', parent.type_id)
+      .limit(50);
+
+    // Engine code grouping is the canonical sibling discriminator (canon
+    // ADR-070 §C). When the parent has none we keep all model siblings — the
+    // S_SIBLING_TABLE downstream still benefits from the listing.
+    if (parent.type_engine && parent.type_engine.trim().length > 0) {
+      query = query.eq('type_engine', parent.type_engine);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      this.logger.warn(
+        `fetchSiblings(${parent.type_id}) failed: ${error.message} — empty list`,
+      );
+      return [];
+    }
+    return (data as AutoTypeRow[] | null) ?? [];
+  }
+
+  private async fetchBrandModelSlugs(
+    parent: AutoTypeRow,
+  ): Promise<{ brandSlug: string; modelSlug: string }> {
+    if (!parent.type_marque_id || !parent.type_modele_id) {
+      return { brandSlug: 'unknown', modelSlug: 'unknown' };
+    }
+    const [brand, model] = await Promise.all([
+      this.supabase
+        .from('auto_marque')
+        .select('marque_alias')
+        .eq('marque_id', parent.type_marque_id)
+        .maybeSingle(),
+      this.supabase
+        .from('auto_modele')
+        .select('modele_alias')
+        .eq('modele_id', parent.type_modele_id)
+        .maybeSingle(),
+    ]);
+    return {
+      brandSlug: (brand.data?.marque_alias as string | undefined) ?? 'unknown',
+      modelSlug: (model.data?.modele_alias as string | undefined) ?? 'unknown',
+    };
+  }
+
+  private async invalidateCache(typeId: number): Promise<void> {
+    if (!this.cache) {
+      return;
+    }
+    try {
+      await this.cache.del(`r8:snapshot:${typeId}`);
+    } catch (e) {
+      this.logger.warn(
+        `invalidateCache(${typeId}) failed: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  private parseIntStrict(value: string): number {
+    if (!PARSE_INT_RE.test(value)) {
+      throw new Error(`Non-numeric type_id: ${value}`);
+    }
+    return Number.parseInt(value, 10);
+  }
+
+  private parseIntNullable(value: string | null): number | null {
+    if (value === null || !PARSE_INT_RE.test(value)) {
+      return null;
+    }
+    return Number.parseInt(value, 10);
+  }
+
+  private nullIfBlank(value: string | null): string | null {
+    if (value === null) {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? null : trimmed;
+  }
+}

--- a/backend/src/modules/seo/r2/services/r8-snapshot-seed.service.ts
+++ b/backend/src/modules/seo/r2/services/r8-snapshot-seed.service.ts
@@ -1,0 +1,157 @@
+/**
+ * ADR-072 PR 2D-2 — R8 snapshot seed job (idempotent batch).
+ *
+ * Walks `auto_type` once and ensures `__seo_r8_snapshot_store` has at least a
+ * `minimal` row for every `type_id` (gate SQL `snapshots >= auto_types` canon
+ * MEMORY project-r2-v2-canon-sequence-202605).
+ *
+ * Resumable & idempotent : relies on `__seo_r8_snapshot_store.version_sha`
+ * UNIQUE constraint — re-running the seed never duplicates rows. Optionally
+ * the job can be invoked with a `sinceTypeId` cursor to restart from a known
+ * point after a crash.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseBaseService } from '../../../../database/services/supabase-base.service';
+import { R8ParentEnrichmentService } from './r8-parent-enrichment.service';
+
+export interface SeedRunOptions {
+  batchSize?: number;
+  sinceTypeId?: number; // inclusive lower bound for resume
+  maxBatches?: number; // safety cap (default unlimited)
+  dryRun?: boolean; // count only, no writes
+}
+
+export interface SeedRunReport {
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  totalScanned: number;
+  totalSeeded: number;
+  totalAlreadyPresent: number;
+  totalSkipped: number;
+  totalFailed: number;
+  lastTypeIdProcessed: number | null;
+  dryRun: boolean;
+}
+
+const DEFAULT_BATCH_SIZE = 200;
+
+@Injectable()
+export class R8SnapshotSeedService extends SupabaseBaseService {
+  protected readonly logger = new Logger(R8SnapshotSeedService.name);
+
+  constructor(private readonly enrichment: R8ParentEnrichmentService) {
+    super();
+  }
+
+  async run(options: SeedRunOptions = {}): Promise<SeedRunReport> {
+    const startedAtMs = Date.now();
+    const startedAt = new Date(startedAtMs).toISOString();
+    const batchSize = Math.max(1, options.batchSize ?? DEFAULT_BATCH_SIZE);
+    const dryRun = options.dryRun === true;
+
+    let cursor = Math.max(0, options.sinceTypeId ?? 0);
+    let totalScanned = 0;
+    let totalSeeded = 0;
+    let totalAlreadyPresent = 0;
+    let totalSkipped = 0;
+    let totalFailed = 0;
+    let lastTypeIdProcessed: number | null = null;
+    let batchesRun = 0;
+
+    this.logger.log(
+      `R8 seed run start — batchSize=${batchSize}, sinceTypeId=${cursor}, dryRun=${dryRun}`,
+    );
+
+    while (true) {
+      if (
+        options.maxBatches !== undefined &&
+        batchesRun >= options.maxBatches
+      ) {
+        this.logger.log(
+          `R8 seed reached maxBatches=${options.maxBatches}, stopping`,
+        );
+        break;
+      }
+      const batch = await this.fetchBatch(cursor, batchSize);
+      if (batch.length === 0) {
+        break;
+      }
+      batchesRun += 1;
+
+      for (const typeIdStr of batch) {
+        const typeId = Number.parseInt(typeIdStr, 10);
+        if (!Number.isFinite(typeId) || typeId <= 0) {
+          totalSkipped += 1;
+          continue;
+        }
+        totalScanned += 1;
+        lastTypeIdProcessed = typeId;
+        cursor = typeId + 1;
+
+        if (dryRun) {
+          continue;
+        }
+
+        try {
+          const outcome = await this.enrichment.enrichTypeId(typeId, 'seed');
+          if (!outcome) {
+            totalSkipped += 1;
+            continue;
+          }
+          if (outcome.inserted) {
+            totalSeeded += 1;
+          } else {
+            totalAlreadyPresent += 1;
+          }
+        } catch (e) {
+          totalFailed += 1;
+          this.logger.warn(
+            `seed typeId=${typeId} failed (continuing): ${(e as Error).message}`,
+          );
+        }
+      }
+
+      // Soft yield — let other I/O proceed between batches.
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+
+    const finishedAtMs = Date.now();
+    const report: SeedRunReport = {
+      startedAt,
+      finishedAt: new Date(finishedAtMs).toISOString(),
+      durationMs: finishedAtMs - startedAtMs,
+      totalScanned,
+      totalSeeded,
+      totalAlreadyPresent,
+      totalSkipped,
+      totalFailed,
+      lastTypeIdProcessed,
+      dryRun,
+    };
+
+    this.logger.log(
+      `R8 seed done — scanned=${totalScanned} seeded=${totalSeeded} already=${totalAlreadyPresent} skipped=${totalSkipped} failed=${totalFailed} duration=${report.durationMs}ms`,
+    );
+
+    return report;
+  }
+
+  private async fetchBatch(cursor: number, limit: number): Promise<string[]> {
+    const { data, error } = await this.supabase
+      .from('auto_type')
+      .select('type_id')
+      .gte('type_id', String(cursor))
+      .order('type_id', { ascending: true })
+      .limit(limit);
+
+    if (error) {
+      this.logger.error(
+        `fetchBatch(cursor=${cursor}) failed: ${error.message}`,
+      );
+      throw new Error(`seed_fetch_batch_failed: ${error.message}`);
+    }
+    return (data ?? []).map((row) => String(row.type_id));
+  }
+}

--- a/backend/src/modules/seo/r2/services/seo-outbox-relay-scheduler.service.ts
+++ b/backend/src/modules/seo/r2/services/seo-outbox-relay-scheduler.service.ts
@@ -1,0 +1,59 @@
+/**
+ * ADR-072 PR 2D-2 — BullMQ scheduler for the outbox relay.
+ *
+ * Single repeatable job (interval `SEO_OUTBOX_RELAY_INTERVAL_MS`) that pokes
+ * the relay processor. SchedulerModule (`@Cron`) is disabled monorepo-wide
+ * (MEMORY `feedback_schedulemodule_disabled_use_bullmq`) — BullMQ is the canon.
+ *
+ * Non-blocking `onModuleInit` per MEMORY backend.md : we enqueue the repeatable
+ * job in a fire-and-forget warmer.
+ */
+
+import { InjectQueue } from '@nestjs/bull';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Queue } from 'bull';
+import {
+  SEO_OUTBOX_QUEUE_NAME,
+  SEO_OUTBOX_RELAY_INTERVAL_MS,
+  SEO_OUTBOX_RELAY_JOB_NAME,
+} from '../queues/r8-enrichment.constants';
+
+@Injectable()
+export class SeoOutboxRelaySchedulerService implements OnModuleInit {
+  private readonly logger = new Logger(SeoOutboxRelaySchedulerService.name);
+
+  constructor(
+    @InjectQueue(SEO_OUTBOX_QUEUE_NAME)
+    private readonly queue: Queue,
+  ) {}
+
+  onModuleInit(): void {
+    this.logger.log(
+      `🚀 Init SeoOutboxRelayScheduler — repeatable every ${SEO_OUTBOX_RELAY_INTERVAL_MS}ms (warm-up deferred)`,
+    );
+    void this.scheduleRepeatableJob();
+  }
+
+  private async scheduleRepeatableJob(): Promise<void> {
+    try {
+      // Idempotent : Bull dedupes repeatable definitions by name + cron/every.
+      await this.queue.add(
+        SEO_OUTBOX_RELAY_JOB_NAME,
+        {},
+        {
+          repeat: { every: SEO_OUTBOX_RELAY_INTERVAL_MS },
+          removeOnComplete: 50,
+          removeOnFail: 25,
+          jobId: 'seo-outbox-relay-tick',
+        },
+      );
+      this.logger.log(
+        `Outbox relay scheduled every ${SEO_OUTBOX_RELAY_INTERVAL_MS}ms`,
+      );
+    } catch (e) {
+      this.logger.error(
+        `Failed to schedule outbox relay: ${(e as Error).message}`,
+      );
+    }
+  }
+}

--- a/backend/supabase/migrations/20260517_seo_r2_v2_outbox_relay_rpc.down.sql
+++ b/backend/supabase/migrations/20260517_seo_r2_v2_outbox_relay_rpc.down.sql
@@ -1,0 +1,8 @@
+-- ADR-072 PR 2D-2 — Down migration : drop RPC helpers added in
+-- 20260517_seo_r2_v2_outbox_relay_rpc.sql. Tables themselves stay (owned by
+-- 20260516_seo_r2_v2_cqrs_snapshot.sql).
+
+DROP FUNCTION IF EXISTS public.__seo_outbox_claim_batch(INTEGER);
+DROP FUNCTION IF EXISTS public.__seo_r8_publish_snapshot(
+  BIGINT, TEXT, JSONB, TEXT, JSONB, TEXT
+);

--- a/backend/supabase/migrations/20260517_seo_r2_v2_outbox_relay_rpc.sql
+++ b/backend/supabase/migrations/20260517_seo_r2_v2_outbox_relay_rpc.sql
@@ -1,0 +1,199 @@
+-- squawk-ignore-file prefer-text-field
+-- squawk-ignore-file prefer-bigint-over-int
+--
+-- Rationale (ADR-072 PR 2D-2) :
+--   Both rules fire on PL/pgSQL function definitions where the parameter list
+--   reuses native PostgreSQL identifiers (TEXT, INT). The functions only own
+--   their parameters — no new persistent columns are introduced, so the
+--   project-wide TEXT/BIGINT canon (MEMORY vehicle-ops anti-patterns) does
+--   not apply.
+--
+-- =============================================================================
+-- ADR-072 — RPC helpers : __seo_r8_publish_snapshot + __seo_outbox_claim_batch
+-- =============================================================================
+--
+-- Two atomic SQL helpers consumed by PR 2D-2 services :
+--
+--   1. __seo_r8_publish_snapshot      — INSERT snapshot + UPDATE pages pointer
+--                                       + INSERT outbox event in one tx.
+--                                       Idempotent on UNIQUE(version_sha).
+--   2. __seo_outbox_claim_batch       — FOR UPDATE SKIP LOCKED claim of N
+--                                       pending events. Flips published_at to
+--                                       NOW() and returns the rows so the
+--                                       relay can push them to BullMQ.
+--
+-- Canon : Confluent Kafka outbox pattern, Microservices.io transactional
+-- outbox, Vercel ISR background regen.
+-- =============================================================================
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+-- =============================================================================
+-- 1. __seo_r8_publish_snapshot
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.__seo_r8_publish_snapshot(
+  p_type_id                  BIGINT,
+  p_version_sha              TEXT,
+  p_disambiguation_signature JSONB,
+  p_enrichment_status        TEXT,
+  p_source_lineage           JSONB,
+  p_event_reason             TEXT
+) RETURNS TABLE (
+  snapshot_id            BIGINT,
+  inserted               BOOLEAN,
+  pages_pointer_updated  BOOLEAN,
+  outbox_event_id        BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_snapshot_id      BIGINT;
+  v_inserted         BOOLEAN := false;
+  v_pages_updated    BOOLEAN := false;
+  v_event_id         BIGINT;
+BEGIN
+  -- 1) Snapshot INSERT — idempotent on UNIQUE(version_sha).
+  INSERT INTO public.__seo_r8_snapshot_store (
+    type_id,
+    version_sha,
+    disambiguation_signature,
+    enrichment_status,
+    source_lineage
+  ) VALUES (
+    p_type_id,
+    p_version_sha,
+    p_disambiguation_signature,
+    p_enrichment_status,
+    p_source_lineage
+  )
+  ON CONFLICT (version_sha) DO NOTHING
+  RETURNING id INTO v_snapshot_id;
+
+  IF v_snapshot_id IS NOT NULL THEN
+    v_inserted := true;
+  ELSE
+    SELECT id INTO v_snapshot_id
+    FROM public.__seo_r8_snapshot_store
+    WHERE version_sha = p_version_sha;
+  END IF;
+
+  IF v_snapshot_id IS NULL THEN
+    RAISE EXCEPTION
+      'r8_publish_snapshot_lookup_failed for version_sha=%', p_version_sha;
+  END IF;
+
+  -- 2) Pages pointer UPDATE — INSERT if row missing (idempotent).
+  --    We avoid ON CONFLICT here because __seo_r8_pages may have a different
+  --    UNIQUE shape across environments; rely on the type_id check instead.
+  WITH updated AS (
+    UPDATE public.__seo_r8_pages
+    SET current_snapshot_id = v_snapshot_id
+    WHERE type_id = p_type_id
+      AND (current_snapshot_id IS DISTINCT FROM v_snapshot_id)
+    RETURNING id
+  )
+  SELECT EXISTS (SELECT 1 FROM updated) INTO v_pages_updated;
+
+  -- 3) Outbox event INSERT. We always emit, even on idempotent snapshot
+  --    re-runs, so downstream consumers can observe the trigger source.
+  INSERT INTO public.__seo_outbox_event (
+    aggregate_type,
+    aggregate_id,
+    event_type,
+    payload,
+    occurred_at
+  ) VALUES (
+    'R8VehicleSnapshot',
+    p_type_id::TEXT,
+    'R8SnapshotUpdated',
+    jsonb_build_object(
+      'typeId', p_type_id,
+      'versionSha', p_version_sha,
+      'enrichmentStatus', p_enrichment_status,
+      'reason', p_event_reason,
+      'snapshotInserted', v_inserted,
+      'pagesPointerUpdated', v_pages_updated
+    ),
+    NOW()
+  )
+  RETURNING id INTO v_event_id;
+
+  RETURN QUERY SELECT v_snapshot_id, v_inserted, v_pages_updated, v_event_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.__seo_r8_publish_snapshot IS
+  'ADR-072 PR 2D-2 — atomic publish of a R8 snapshot version : INSERT __seo_r8_snapshot_store ON CONFLICT(version_sha) DO NOTHING, repoint __seo_r8_pages.current_snapshot_id, INSERT __seo_outbox_event R8SnapshotUpdated. SECURITY DEFINER so service_role calls inherit table privileges without granting INSERT on outbox to broader roles.';
+
+REVOKE ALL ON FUNCTION public.__seo_r8_publish_snapshot(
+  BIGINT, TEXT, JSONB, TEXT, JSONB, TEXT
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.__seo_r8_publish_snapshot(
+  BIGINT, TEXT, JSONB, TEXT, JSONB, TEXT
+) TO service_role;
+
+-- =============================================================================
+-- 2. __seo_outbox_claim_batch
+-- =============================================================================
+--
+-- Atomic FOR UPDATE SKIP LOCKED claim. Marks published_at = NOW() and returns
+-- the rows so the BullMQ relay can dispatch them to downstream queues.
+-- Concurrent relay workers are safe : each call claims a disjoint set.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.__seo_outbox_claim_batch(
+  p_limit INTEGER
+) RETURNS TABLE (
+  id              BIGINT,
+  aggregate_type  TEXT,
+  aggregate_id    TEXT,
+  event_type      TEXT,
+  payload         JSONB,
+  trace_id        TEXT,
+  occurred_at     TIMESTAMPTZ,
+  attempts        BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_limit INTEGER := GREATEST(1, LEAST(p_limit, 500));
+BEGIN
+  RETURN QUERY
+  WITH claimed AS (
+    SELECT e.id
+    FROM public.__seo_outbox_event e
+    WHERE e.published_at IS NULL
+    ORDER BY e.occurred_at ASC
+    FOR UPDATE SKIP LOCKED
+    LIMIT v_limit
+  ),
+  updated AS (
+    UPDATE public.__seo_outbox_event evt
+    SET published_at = NOW()
+    FROM claimed
+    WHERE evt.id = claimed.id
+    RETURNING
+      evt.id,
+      evt.aggregate_type,
+      evt.aggregate_id,
+      evt.event_type,
+      evt.payload,
+      evt.trace_id,
+      evt.occurred_at,
+      evt.attempts
+  )
+  SELECT * FROM updated;
+END;
+$$;
+
+COMMENT ON FUNCTION public.__seo_outbox_claim_batch IS
+  'ADR-072 PR 2D-2 — atomic FOR UPDATE SKIP LOCKED claim of pending outbox rows. Flips published_at to NOW() and returns the claimed rows. Safe under concurrent BullMQ relay workers; concurrency target is 1 but multi-instance backend pods stay correct.';
+
+REVOKE ALL ON FUNCTION public.__seo_outbox_claim_batch(INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.__seo_outbox_claim_batch(INTEGER) TO service_role;


### PR DESCRIPTION
## Summary

Materializes the R8 Vehicle Domain write path so the gate SQL `__seo_r8_snapshot_store >= auto_type` can pass before PR 2E (canon MEMORY `project-r2-v2-canon-sequence-202605`).

Strict scope: code + RPC migration only. Migration is NOT auto-applied. Seed job is NOT auto-executed. Both stay manual until `R2_V2_ENABLED` flips.

## What ships

- **R8ParentEnrichmentService** — deterministic disambiguation signature (`fast-json-stable-stringify` + sha256), atomic RPC `__seo_r8_publish_snapshot` (INSERT snapshot + UPDATE pages pointer + INSERT outbox event in one tx). Status pinned to `minimal`; `enriched`/`stale`/`failed` ship in PR 2H.
- **R8SnapshotSeedService** — resumable idempotent batch loop over `auto_type`. Counters: scanned / seeded / already-present / skipped / failed. dryRun supported.
- **OutboxRelayService + scheduler** — repeatable BullMQ tick every 5s. Drains via RPC `__seo_outbox_claim_batch` (FOR UPDATE SKIP LOCKED). Routes to downstream queues; unroutable events requeue with `attempts++`.
- **BullMQ wiring** — queues `r8-enrichment` (concurrency 5) + `seo-outbox-relay` (concurrency 1). READ_ONLY gate at the processor (canon `feedback_readonly_gate_at_processor_not_scheduler`).
- **Migration 20260517_seo_r2_v2_outbox_relay_rpc.sql** — 2 SECURITY DEFINER RPCs, GRANT `service_role` only, REVOKE PUBLIC. Tables themselves are owned by PR #558 migration.

## Out of scope (deferred)

- R2 compose pipeline → **PR 2E**
- Knowledge Graph + R2 evidence decay → **PR 2H**
- Sitemap V10 CQRS update → **PR 2E**
- Frontend Remix CQRS read → **PR 2E**
- OTel SDK setup → verify-existing-first canon (revisit start of PR 2E)
- Cache Redis L1 wire-up → null fallback retained, real client in PR 2E (BullMQ Redis reused)

## Production impact

**None until manual gestures.** Merge → DEV port 3000 code only. PROD deploy requires separate `git tag v*`. Migration application + seed execution remain operator-driven via Supabase MCP. R2 v2 pipeline stays dormant under `R2_V2_ENABLED=false` (canon `R2FeatureFlagService`).

## Test plan

- [x] Backend prettier --check pass
- [x] ESLint pass (0 errors, 2 minor `no-explicit-any` warnings in tests, accepted)
- [x] TypeScript --noEmit pass
- [x] Jest 21/21 (3 suites: r8-parent-enrichment, r8-snapshot-seed, outbox-relay)
- [ ] CI ⬣ ESLint
- [ ] CI ʦ TypeScript
- [ ] CI 🧪 Backend Tests
- [ ] CI Migration Safety
- [ ] CI Registry Layer 1 builders (warn-only)

## After merge (manual, separate GO)

1. `supabase` MCP → apply migration `20260517_seo_r2_v2_outbox_relay_rpc.sql` on canon Supabase project.
2. Admin endpoint or one-shot script → run `R8SnapshotSeedService.run({})` once.
3. Verify gate SQL `SELECT (SELECT COUNT(*) FROM __seo_r8_snapshot_store) AS snapshots, (SELECT COUNT(*) FROM auto_type) AS auto_types;` → `snapshots >= auto_types`.
4. Only then proceed to PR 2H (KG) → PR 2E (R2DataLoader + pilot V1 + measurement gate).

## Self-review verdict: APPROVE

- ✅ Scope strict respecté (zero R2 compose / KG / Sitemap / Frontend / OTel)
- ✅ Idempotent end-to-end (UNIQUE version_sha + RPC atomic + outbox `published_at`)
- ✅ READ_ONLY gate au processor (mémoire canon)
- ✅ Concurrency policy alignée (5 enrichment, 1 relay) — mémoire `feedback_seo_cluster_serialization_concurrency` n'impose 1 que par cluster_key R2 compose, hors scope ici
- ✅ Determinism : `fast-json-stable-stringify` + sibling sort
- ✅ Tests couvrent : pure fn determinism, idempotent counters, RPC error propagation, outbox state machine
- ✅ Anti-overclaim : zero `100% safe`, gate SQL n'est PAS prouvé pass par cette PR (geste opérationnel séparé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)