### PR TITLE
feat(auth): phase 3 — legacy internal-key guard with kill-switch + sentry

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -13,7 +13,9 @@ import { AdminSessionGuard } from './admin-session.guard';
 import { CookieSerializer } from './cookie-serializer';
 import { GithubOidcGuard } from './github-oidc.guard';
 import { GithubOidcService } from './github-oidc.service';
+import { InternalApiKeyGuard } from './internal-api-key.guard';
 import { IsAdminGuard } from './is-admin.guard';
+import { LegacyInternalKeyGuard } from './legacy-internal-key.guard';
 import { LocalAuthGuard } from './local-auth.guard';
 import { LocalStrategy } from './local.strategy';
 import { PermissionsService } from './permissions.service';
@@ -51,6 +53,8 @@ import { PermissionsGuard } from './guards/permissions.guard';
     GithubOidcService,
     AdminSessionGuard,
     GithubOidcGuard,
+    InternalApiKeyGuard,
+    LegacyInternalKeyGuard,
   ],
   exports: [
     AuthService,
@@ -59,6 +63,8 @@ import { PermissionsGuard } from './guards/permissions.guard';
     GithubOidcService,
     AdminSessionGuard,
     GithubOidcGuard,
+    InternalApiKeyGuard,
+    LegacyInternalKeyGuard,
   ],
 })
 export class AuthModule {}

--- a/backend/src/auth/legacy-internal-key.guard.test.ts
+++ b/backend/src/auth/legacy-internal-key.guard.test.ts
@@ -1,0 +1,135 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException, type ExecutionContext } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+import { LegacyInternalKeyGuard } from './legacy-internal-key.guard';
+import { InternalApiKeyGuard } from './internal-api-key.guard';
+
+jest.mock('@sentry/nestjs', () => ({
+  captureMessage: jest.fn(),
+}));
+
+function makeCtx(headers: Record<string, string>): {
+  ctx: ExecutionContext;
+  req: {
+    headers: Record<string, string>;
+    _authPath?: string;
+    method: string;
+    url: string;
+  };
+} {
+  const req = {
+    headers,
+    method: 'POST',
+    url: '/api/sitemap/v10/generate-all',
+  } as {
+    headers: Record<string, string>;
+    _authPath?: string;
+    method: string;
+    url: string;
+  };
+  const ctx = {
+    switchToHttp: () => ({ getRequest: () => req }),
+    getHandler: () => () => undefined,
+    getClass: () => class {},
+  } as unknown as ExecutionContext;
+  return { ctx, req };
+}
+
+describe('LegacyInternalKeyGuard', () => {
+  let guard: LegacyInternalKeyGuard;
+  let mockInternal: { canActivate: jest.Mock };
+  let envValues: Record<string, string | undefined>;
+
+  beforeEach(async () => {
+    (Sentry.captureMessage as jest.Mock).mockClear();
+    mockInternal = { canActivate: jest.fn() };
+    envValues = { SITEMAP_LEGACY_INTERNAL_KEY_ENABLED: 'true' };
+    const m = await Test.createTestingModule({
+      providers: [
+        LegacyInternalKeyGuard,
+        { provide: InternalApiKeyGuard, useValue: mockInternal },
+        {
+          provide: ConfigService,
+          useValue: { get: (k: string) => envValues[k] },
+        },
+      ],
+    }).compile();
+    guard = m.get(LegacyInternalKeyGuard);
+  });
+
+  it('rejects when X-Internal-Key header is absent', async () => {
+    const { ctx } = makeCtx({});
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow(
+      /x-internal-key header required/,
+    );
+    expect(mockInternal.canActivate).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects when kill-switch is OFF (env=false)', async () => {
+    envValues.SITEMAP_LEGACY_INTERNAL_KEY_ENABLED = 'false';
+    const { ctx, req } = makeCtx({ 'x-internal-key': 'somekey' });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(
+      /Legacy auth disabled/,
+    );
+    expect(mockInternal.canActivate).not.toHaveBeenCalled();
+    expect(req._authPath).toBeUndefined();
+  });
+
+  it('rejects when kill-switch is UNSET (any non-"true" value)', async () => {
+    delete envValues.SITEMAP_LEGACY_INTERNAL_KEY_ENABLED;
+    const { ctx } = makeCtx({ 'x-internal-key': 'somekey' });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(
+      /Legacy auth disabled/,
+    );
+  });
+
+  it('delegates to InternalApiKeyGuard when kill-switch=true and header present', async () => {
+    mockInternal.canActivate.mockResolvedValue(true);
+    const { ctx, req } = makeCtx({ 'x-internal-key': 'validkey' });
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+
+    expect(mockInternal.canActivate).toHaveBeenCalledWith(ctx);
+    expect(req._authPath).toBe('internal-key-legacy');
+  });
+
+  it('emits Sentry warning breadcrumb on accept (deprecation tracking)', async () => {
+    mockInternal.canActivate.mockResolvedValue(true);
+    const { ctx } = makeCtx({ 'x-internal-key': 'validkey' });
+
+    await guard.canActivate(ctx);
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'legacy_auth_used',
+      expect.objectContaining({
+        level: 'warning',
+        tags: expect.objectContaining({
+          endpoint: '/api/sitemap/v10/generate-all',
+          method: 'POST',
+          deprecation: 'PR-E',
+        }),
+      }),
+    );
+  });
+
+  it('does not emit Sentry when InternalApiKeyGuard rejects', async () => {
+    mockInternal.canActivate.mockResolvedValue(false);
+    const { ctx, req } = makeCtx({ 'x-internal-key': 'wrongkey' });
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(false);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    expect(req._authPath).toBeUndefined();
+  });
+
+  it('propagates InternalApiKeyGuard thrown error (fail-closed, no fallback)', async () => {
+    const err = new UnauthorizedException('invalid internal key');
+    mockInternal.canActivate.mockRejectedValue(err);
+    const { ctx } = makeCtx({ 'x-internal-key': 'wrongkey' });
+
+    await expect(guard.canActivate(ctx)).rejects.toBe(err);
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/auth/legacy-internal-key.guard.ts
+++ b/backend/src/auth/legacy-internal-key.guard.ts
@@ -1,0 +1,85 @@
+/**
+ * LegacyInternalKeyGuard — kill-switched wrapper for X-Internal-Key auth.
+ *
+ * Phase 3/11 of sitemap regen auth plan. Atomic guard composed with
+ * `AdminSessionGuard` + `GithubOidcGuard` via `AnyOf()` on sitemap write
+ * endpoints (Phase 5 cutover).
+ *
+ * **Transitional only** : retained behind a kill-switch env flag during the
+ * cutover window. Default behavior on Phase 5 deploy = `true` (legacy
+ * X-Internal-Key still accepted). After Phase 6 (GitHub Action OIDC cron
+ * proven for 7 days), flip env to `false` to disable. Phase 10 removes this
+ * file entirely.
+ *
+ * Logic :
+ *   1. If no `X-Internal-Key` header → throw (other AnyOf paths handle it).
+ *   2. If kill-switch `SITEMAP_LEGACY_INTERNAL_KEY_ENABLED !== 'true'` → throw.
+ *   3. Delegate to `InternalApiKeyGuard.canActivate(ctx)` (timing-safe match).
+ *   4. On accept : Sentry breadcrumb `legacy_auth_used` (level=warning, tag
+ *      `deprecation=PR-E`) for tracking deprecation usage in PROD.
+ *
+ * Sentry was confirmed as the monorepo's only observability stack (cf. memory
+ * `feedback_hardcode_invariants_env_only_for_knobs`). No Prometheus / metric
+ * exporter is wired ; `Sentry.captureMessage` is the canonical alert path.
+ *
+ * Writes `req._authPath = 'internal-key-legacy'` on success for audit
+ * middleware.
+ */
+
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as Sentry from '@sentry/nestjs';
+import { InternalApiKeyGuard } from './internal-api-key.guard';
+
+@Injectable()
+export class LegacyInternalKeyGuard implements CanActivate {
+  private readonly logger = new Logger(LegacyInternalKeyGuard.name);
+
+  constructor(
+    private readonly internal: InternalApiKeyGuard,
+    private readonly config: ConfigService,
+  ) {}
+
+  async canActivate(ctx: ExecutionContext): Promise<boolean> {
+    const req = ctx.switchToHttp().getRequest();
+
+    if (!req.headers?.['x-internal-key']) {
+      throw new UnauthorizedException('x-internal-key header required');
+    }
+
+    if (
+      this.config.get<string>('SITEMAP_LEGACY_INTERNAL_KEY_ENABLED') !== 'true'
+    ) {
+      this.logger.warn(
+        `X-Internal-Key disabled by kill-switch on ${req.method} ${req.url}`,
+      );
+      throw new UnauthorizedException('Legacy auth disabled — migrate to OIDC');
+    }
+
+    const accepted = await this.internal.canActivate(ctx);
+    if (accepted !== true) {
+      return false;
+    }
+
+    this.logger.warn(
+      `LEGACY auth path used on ${req.method} ${req.url} — migrate to OIDC`,
+    );
+    Sentry.captureMessage('legacy_auth_used', {
+      level: 'warning',
+      tags: {
+        endpoint: String(req.url),
+        method: String(req.method),
+        deprecation: 'PR-E',
+      },
+    });
+
+    req._authPath = 'internal-key-legacy';
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3/11 du plan sitemap regen auth — **stacked on PR #560** (Phase 2 atomic guards). Cette PR sera retargeted vers main une fois #560 mergé.

`LegacyInternalKeyGuard` = atomic wrapper transitoire pour X-Internal-Key auth, gated par `SITEMAP_LEGACY_INTERNAL_KEY_ENABLED` env. Sera retiré entirely en Phase 10.

## Why a transitional wrapper

Cutover plan :
- **Phase 5 deploy** : default `true` → legacy X-Internal-Key encore accepté (callers internes legacy ne cassent pas)
- **Phase 6 + 7d zero Sentry `legacy_auth_used`** : flip env à `false` (action ops humaine PROD VPS)
- **Phase 10** : retire `LegacyInternalKeyGuard` du `AnyOf(...)` + delete file

Atomic separation = retrait propre sans toucher OIDC/admin paths (cf. memory `feedback_separate_guard_per_auth_path`).

## New files

- `backend/src/auth/legacy-internal-key.guard.ts` (70 lignes)
- `backend/src/auth/legacy-internal-key.guard.test.ts` (135 lignes)

`AuthModule` providers + exports updated avec `InternalApiKeyGuard` + `LegacyInternalKeyGuard`.

## Sentry telemetry

Sur chaque accept via legacy path :
```ts
Sentry.captureMessage('legacy_auth_used', {
  level: 'warning',
  tags: {
    endpoint: req.url,
    method: req.method,
    deprecation: 'PR-E',
  },
});
```

Permet de monitorer en PROD si quelqu'un utilise encore le legacy path (devrait être zero une fois Phase 6 deployé + cron OIDC en place).

## Tests (7/7 PASS)

- rejects missing header
- rejects kill-switch off (env=false)
- rejects kill-switch unset (treated as off)
- delegates to InternalApiKeyGuard on accept
- Sentry captureMessage called with correct tags
- no Sentry on internal key reject (returns false)
- propagates InternalApiKeyGuard thrown error (fail-closed)

## Invariants

1. ✅ No public endpoint regression
2. ✅ No auth fallback ambiguity (atomic, AnyOf handles composition)
3. ✅ Fail-closed on kill-switch off (explicit reject, no silent bypass)
4. ✅ No Bull queue coupling

## Refs

- Phase 0.6 paradigm : PR #556
- Phase 2 atomic guards : PR #560 (stacked base of this PR)
- Memory `feedback_separate_guard_per_auth_path`
- Memory `feedback_hardcode_invariants_env_only_for_knobs` (Sentry as only observability stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)