### PR TITLE
feat(auth): phase 4 — jti anti-replay via dedicated redis db 1

### DIFF
--- a/backend/src/auth/github-oidc.service.test.ts
+++ b/backend/src/auth/github-oidc.service.test.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
-import { ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import {
   SignJWT,
   generateKeyPair,
@@ -8,6 +9,7 @@ import {
   type JWK,
   type KeyLike,
 } from 'jose';
+import IORedisMock from 'ioredis-mock';
 
 import {
   GithubOidcService,
@@ -39,6 +41,7 @@ const VALID_CLAIMS: Omit<GithubOidcClaims, 'iat' | 'exp' | 'iss' | 'aud'> = {
 async function setupKeysAndService(): Promise<{
   privateKey: KeyLike;
   service: GithubOidcService;
+  redis: InstanceType<typeof IORedisMock>;
 }> {
   const { publicKey, privateKey } = await generateKeyPair('RS256', {
     extractable: true,
@@ -49,14 +52,25 @@ async function setupKeysAndService(): Promise<{
   jwk.use = 'sig';
 
   const localJwks = createLocalJWKSet({ keys: [jwk] });
+  const redis = new IORedisMock();
+  // ioredis-mock shares an in-memory store globally across instances by
+  // default; flush to isolate state per test (avoids cross-test jti pollution).
+  await redis.flushall();
 
   const moduleRef = await Test.createTestingModule({
-    providers: [GithubOidcService],
+    providers: [
+      GithubOidcService,
+      {
+        provide: ConfigService,
+        useValue: { get: () => undefined },
+      },
+    ],
   }).compile();
 
   const service = moduleRef.get(GithubOidcService);
   service.setJwksForTesting(localJwks);
-  return { privateKey, service };
+  service.setRedisForTesting(redis as unknown as never);
+  return { privateKey, service, redis };
 }
 
 async function signClaims(
@@ -219,5 +233,86 @@ describe('GithubOidcService — exposed constants (Phase 0.6 paradigm)', () => {
 
   it('exposes CLOCK_TOLERANCE_SECONDS = 30 (runner ↔ VPS clock drift budget)', () => {
     expect(GithubOidcService.CLOCK_TOLERANCE_SECONDS).toBe(30);
+  });
+
+  it('exposes REDIS_DB_INDEX = 1 (isolation from Bull DB 0)', () => {
+    expect(GithubOidcService.REDIS_DB_INDEX).toBe(1);
+  });
+
+  it('exposes REDIS_JTI_PREFIX = "oidc:jti:" (namespace separation from Bull)', () => {
+    expect(GithubOidcService.REDIS_JTI_PREFIX).toBe('oidc:jti:');
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────
+// Anti-replay (Phase 4) — jti uniqueness via Redis SETNX
+// ───────────────────────────────────────────────────────────────────
+
+describe('GithubOidcService — anti-replay (Phase 4)', () => {
+  it('accepts a fresh jti and stores it in Redis', async () => {
+    const { privateKey, service, redis } = await setupKeysAndService();
+    const token = await signClaims(privateKey);
+
+    await expect(service.validate(token)).resolves.toBeDefined();
+
+    // Redis should now contain an oidc:jti:* key
+    const keys = await redis.keys('oidc:jti:*');
+    expect(keys.length).toBe(1);
+  });
+
+  it('rejects a replay of the same jti', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+
+    // Sign two tokens with the SAME jti (manually via SignJWT to control jti)
+    const sharedJti = `jti-replay-${Math.random()}`;
+    const signer = (jti: string) =>
+      new SignJWT({ ...VALID_CLAIMS })
+        .setProtectedHeader({ alg: 'RS256', kid: KID, typ: 'JWT' })
+        .setIssuer(GithubOidcService.ISSUER)
+        .setAudience(GithubOidcService.AUDIENCE)
+        .setIssuedAt()
+        .setExpirationTime('10m')
+        .setJti(jti)
+        .sign(privateKey);
+
+    const t1 = await signer(sharedJti);
+    const t2 = await signer(sharedJti);
+
+    await expect(service.validate(t1)).resolves.toBeDefined();
+    await expect(service.validate(t2)).rejects.toThrow(UnauthorizedException);
+    await expect(service.validate(t2)).rejects.toThrow(/token already used/);
+  });
+
+  it('rejects when jti claim is absent', async () => {
+    const { privateKey, service } = await setupKeysAndService();
+
+    const tokenWithoutJti = await new SignJWT({ ...VALID_CLAIMS })
+      .setProtectedHeader({ alg: 'RS256', kid: KID, typ: 'JWT' })
+      .setIssuer(GithubOidcService.ISSUER)
+      .setAudience(GithubOidcService.AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime('10m')
+      .sign(privateKey);
+
+    await expect(service.validate(tokenWithoutJti)).rejects.toThrow(
+      UnauthorizedException,
+    );
+    await expect(service.validate(tokenWithoutJti)).rejects.toThrow(
+      /missing jti claim/,
+    );
+  });
+
+  it('stores jti with TTL >= (exp - now) + 60s', async () => {
+    const { privateKey, service, redis } = await setupKeysAndService();
+    const token = await signClaims(privateKey, {}, { exp: '10m' });
+
+    await service.validate(token);
+
+    const keys = await redis.keys('oidc:jti:*');
+    expect(keys.length).toBe(1);
+    const ttl = await redis.ttl(keys[0]);
+    // 10m token + 60s safety = ~660s. Floor 60s in code. Allow generous bounds.
+    expect(ttl).toBeGreaterThanOrEqual(60);
+    expect(ttl).toBeLessThanOrEqual(700);
   });
 });

--- a/backend/src/auth/github-oidc.service.ts
+++ b/backend/src/auth/github-oidc.service.ts
@@ -24,15 +24,19 @@ import {
   ForbiddenException,
   Injectable,
   Logger,
+  OnModuleDestroy,
   OnModuleInit,
   UnauthorizedException,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as Sentry from '@sentry/nestjs';
 import {
   createRemoteJWKSet,
   jwtVerify,
   type JWTPayload,
   type JWTVerifyGetKey,
 } from 'jose';
+import Redis from 'ioredis';
 
 export interface GithubOidcClaims extends JWTPayload {
   repository: string;
@@ -50,8 +54,10 @@ export interface GithubOidcClaims extends JWTPayload {
 }
 
 @Injectable()
-export class GithubOidcService implements OnModuleInit {
+export class GithubOidcService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(GithubOidcService.name);
+
+  constructor(private readonly config: ConfigService) {}
 
   // ─────────────────────────────────────────────────────────────────
   // Hardcoded invariants (Phase 0.6 paradigm — never env-overridable).
@@ -89,6 +95,18 @@ export class GithubOidcService implements OnModuleInit {
   /** Clock tolerance for exp/nbf/iat (runner ↔ PROD VPS time skew). */
   static readonly CLOCK_TOLERANCE_SECONDS = 30;
 
+  /**
+   * Redis DB index for jti anti-replay store. Isolated from Bull (DB 0).
+   * Hardcoded per Phase 0.6 paradigm — invariant by convention.
+   */
+  static readonly REDIS_DB_INDEX = 1;
+
+  /**
+   * Redis key prefix for jti anti-replay records.
+   * Namespace separation from Bull's `bull:*` keys.
+   */
+  static readonly REDIS_JTI_PREFIX = 'oidc:jti:';
+
   // ─────────────────────────────────────────────────────────────────
 
   /**
@@ -97,8 +115,24 @@ export class GithubOidcService implements OnModuleInit {
    */
   protected jwks!: JWTVerifyGetKey;
 
+  /**
+   * Dedicated Redis client for anti-replay (Phase 4) — separate connection
+   * from Bull's queue.client (DB 0). Lazy-connect, max 3 retries per command.
+   * Tests override via `setRedisForTesting()`.
+   */
+  protected redis!: Redis;
+
   onModuleInit(): void {
     this.jwks = this.createJwks();
+    if (!this.redis) {
+      this.redis = this.createRedis();
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.redis) {
+      await this.redis.quit().catch(() => undefined);
+    }
   }
 
   /**
@@ -113,6 +147,22 @@ export class GithubOidcService implements OnModuleInit {
   }
 
   /**
+   * Factory hook for Redis — production opens a dedicated connection to the
+   * anti-replay DB. Tests override via `setRedisForTesting()` with an
+   * ioredis-mock instance.
+   */
+  protected createRedis(): Redis {
+    return new Redis({
+      host: this.config.get<string>('REDIS_HOST', 'localhost'),
+      port: parseInt(this.config.get<string>('REDIS_PORT', '6379'), 10),
+      password: this.config.get<string>('REDIS_PASSWORD') || undefined,
+      db: GithubOidcService.REDIS_DB_INDEX,
+      lazyConnect: true,
+      maxRetriesPerRequest: 3,
+    });
+  }
+
+  /**
    * Test seam — override the JWKS resolver post-init (vitest/jest unit tests).
    * Production code MUST NOT call this.
    */
@@ -121,13 +171,21 @@ export class GithubOidcService implements OnModuleInit {
   }
 
   /**
+   * Test seam — override the Redis client post-init (vitest/jest unit tests).
+   * Pass an ioredis-mock instance or a similar mock.
+   * Production code MUST NOT call this.
+   */
+  setRedisForTesting(redis: Redis): void {
+    this.redis = redis;
+  }
+
+  /**
    * Validate a Bearer JWT from a GitHub Actions OIDC token.
    * - Verifies signature, iss, aud, exp, nbf, iat (with clockTolerance).
    * - Verifies all 5 pinned claims (repository, event_name, ref, job_workflow_ref, sub).
+   * - Asserts jti has not been seen before (Phase 4 anti-replay via Redis SETNX).
    * - Audit-logs success.
-   * - Fail-closed: throws on any mismatch.
-   *
-   * Phase 4 will add `assertNotReplayed(payload)` here (Redis SETNX on jti).
+   * - Fail-closed: throws on any mismatch / replay / Redis unavailability.
    */
   async validate(token: string): Promise<GithubOidcClaims> {
     const { payload } = await jwtVerify(token, this.jwks, {
@@ -136,8 +194,44 @@ export class GithubOidcService implements OnModuleInit {
       clockTolerance: GithubOidcService.CLOCK_TOLERANCE_SECONDS,
     });
     this.assertClaims(payload);
+    await this.assertNotReplayed(payload);
     this.auditLog(payload);
     return payload as GithubOidcClaims;
+  }
+
+  /**
+   * Anti-replay : SETNX `oidc:jti:<jti>` with TTL = (exp - now) + 60s safety.
+   * Returns successfully if the key was created (first time we see this jti).
+   * Throws UnauthorizedException if the key already exists (replay detected).
+   *
+   * Fail-closed : if jti claim is absent or Redis is unavailable, throws. We
+   * never silently accept a token without anti-replay verification.
+   */
+  private async assertNotReplayed(p: JWTPayload): Promise<void> {
+    if (!p.jti) {
+      throw new UnauthorizedException('missing jti claim');
+    }
+
+    const expMs = (p.exp ?? 0) * 1000;
+    const remainingSec = Math.max(60, (expMs - Date.now()) / 1000);
+    const ttlSec = Math.ceil(remainingSec + 60);
+    const key = GithubOidcService.REDIS_JTI_PREFIX + String(p.jti);
+
+    const result = await this.redis.set(key, '1', 'EX', ttlSec, 'NX');
+
+    if (result !== 'OK') {
+      this.logger.error(
+        `Token replay detected: jti=${p.jti} repo=${p.repository}`,
+      );
+      Sentry.captureMessage('oidc_token_replay', {
+        level: 'error',
+        tags: {
+          jti: String(p.jti),
+          repository: String(p.repository),
+        },
+      });
+      throw new UnauthorizedException('token already used');
+    }
   }
 
   private assertClaims(p: JWTPayload): void {
@@ -177,7 +271,3 @@ export class GithubOidcService implements OnModuleInit {
     });
   }
 }
-
-// Suppress unused-import warning for UnauthorizedException — used in Phase 4
-// for the anti-replay path. Kept here so the Phase 4 PR diff is minimal.
-void UnauthorizedException;


### PR DESCRIPTION
## Summary

Phase 4/11 du plan sitemap regen auth. **Indépendant** des Phase 2 (PR #560) et Phase 3 (PR #562) — extends `GithubOidcService` shipped en Phase 1 (#559, mergé).

## Anti-replay design

Sur chaque `validate(token)` :
1. `jose.jwtVerify` (signature + iss + aud + exp + nbf + iat)
2. `assertClaims` (5 pinned invariants Phase 0.6)
3. **NEW** : `assertNotReplayed(payload)`
   - Throws si `jti` claim absent
   - `SETNX oidc:jti:<jti>` avec TTL = `(exp - now) + 60s` safety
   - Si SETNX retourne null (key existait) → `Sentry.captureMessage('oidc_token_replay')` + `UnauthorizedException`
4. `auditLog` (succès)

## Redis isolation

- DB 1 dédiée (hardcoded `REDIS_DB_INDEX = 1`) → isolation from Bull's DB 0
- Préfixe `oidc:jti:` (hardcoded `REDIS_JTI_PREFIX`) → namespace separation
- Connexion dédiée (`new Redis({ db: 1, lazyConnect: true, maxRetriesPerRequest: 3 })`)
- `onModuleDestroy` cleanup

## Hardcoded vs env

| Constant | Type | Reason |
|----------|------|--------|
| `REDIS_DB_INDEX = 1` | static readonly | Invariant by convention (Bull = 0, anti-replay = 1) |
| `REDIS_JTI_PREFIX = 'oidc:jti:'` | static readonly | Invariant namespace |
| `REDIS_HOST/PORT/PASSWORD` | env via ConfigService | True knobs (env-specific infra) |

Cf. memory `feedback_hardcode_invariants_env_only_for_knobs`.

## Tests (22/22 PASS)

4 new tests :
- accepts a fresh jti and stores it in Redis
- rejects a replay of the same jti
- rejects when jti claim is absent
- stores jti with TTL >= (exp - now) + 60s

+ 2 new constants assertions (REDIS_DB_INDEX, REDIS_JTI_PREFIX)

Test infra : `ioredis-mock` (already installed in Phase 0). `flushall()` per test for isolation (mock has global store by default).

## Invariants

1. ✅ No public endpoint regression
2. ✅ No auth fallback ambiguity (atomic anti-replay step in validate)
3. ✅ **Fail-closed on Redis failure** — if SETNX throws (Redis down), exception propagates → endpoint returns 503-equiv, no silent bypass
4. ✅ No Bull queue coupling (DB 1 dedicated, separate connection)

## Refs

- Phase 1 base : PR #559 (`340913e98`)
- Phase 0.6 paradigm : PR #556
- Memory `feedback_oidc_federation_over_long_lived_bearer`
- Memory `feedback_hardcode_invariants_env_only_for_knobs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)