### PR TITLE
feat(seo): phase 6 — GitHub Action OIDC daily sitemap regen workflow

### DIFF
--- a/.github/workflows/sitemap-daily-regen.yml
+++ b/.github/workflows/sitemap-daily-regen.yml
@@ -1,0 +1,84 @@
+name: sitemap-daily-regen
+
+# Phase 6/11 of sitemap regen auth plan
+# (docs/superpowers/specs/2026-05-16-sitemap-regen-auth-design.md).
+#
+# Daily regeneration of /pieces/* sitemaps via the PROD backend endpoint
+# `POST /api/sitemap/v10/generate-all`. Authenticated via GitHub Actions
+# OIDC federation (zero long-lived secret) — the workflow exchanges its
+# OIDC token for an audience-scoped JWT (Phase 1 GithubOidcService accepts
+# only `automecanik-sitemap-regen`).
+#
+# Triggered by :
+#   - `schedule` cron at 03:00 UTC daily (creux trafic FR ~05:00 Paris)
+#   - `workflow_dispatch` for admin manual regen without SSH/console
+#
+# Until Phase 5 (controller cutover) ships AND PROD deploys it, the endpoint
+# remains publicly accessible — the cron fires harmlessly and regenerates
+# sitemap. Once Phase 5 deploys, the endpoint requires
+# AnyOf(AdminSessionGuard, GithubOidcGuard, LegacyInternalKeyGuard) and this
+# workflow's Bearer JWT satisfies GithubOidcGuard.
+
+on:
+  schedule:
+    # 03:00 UTC daily = ~05:00 Paris (creux trafic, avant ingest GSC 04:00)
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # REQUIRED — issues the OIDC token via core.getIDToken
+  contents: read    # minimal — fork cannot modify the workflow file itself
+  issues: write     # for the failure-notification step (auto-create issue)
+
+concurrency:
+  group: sitemap-daily-regen
+  cancel-in-progress: false   # Queue manual dispatch behind scheduled run
+
+jobs:
+  regen:
+    name: Trigger sitemap regen via OIDC
+    runs-on: ubuntu-latest
+    timeout-minutes: 15   # peak observed: 102k URLs + 113 hub files ≈ 15s
+
+    steps:
+      - name: Issue GitHub OIDC token (audience = automecanik-sitemap-regen)
+        id: oidc
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const token = await core.getIDToken('automecanik-sitemap-regen');
+            core.setSecret(token);
+            core.setOutput('token', token);
+
+      - name: POST /api/sitemap/v10/generate-all on PROD
+        run: |
+          curl -fsSL -X POST \
+            --max-time 600 \
+            --retry 2 --retry-delay 10 \
+            --retry-connrefused \
+            -H "Authorization: Bearer ${{ steps.oidc.outputs.token }}" \
+            -H "User-Agent: AutoMecanikSitemapRegen/1.0 (+https://github.com/${{ github.repository }})" \
+            https://www.automecanik.com/api/sitemap/v10/generate-all
+
+      - name: Notify on failure (open GitHub issue)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const today = new Date().toISOString().slice(0, 10);
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Sitemap regen failed - ${today}`,
+              labels: ['incident-sitemap-cron'],
+              body: [
+                `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                ``,
+                `**Event**: ${context.eventName}`,
+                `**Actor**: ${context.actor}`,
+                `**SHA**: ${context.sha}`,
+                ``,
+                `Investigate via diagnostic endpoint (Phase 8) once shipped :`,
+                `\`curl -H "X-Internal-Key: $KEY" https://www.automecanik.com/api/admin/sitemap/scheduler-status\``,
+              ].join('\n'),
+            });


### PR DESCRIPTION
## Summary

Phase 6/11 — `.github/workflows/sitemap-daily-regen.yml` : cron quotidien 03:00 UTC + `workflow_dispatch` admin. OIDC token avec audience `automecanik-sitemap-regen` (hardcoded dans `GithubOidcService` Phase 1). Zéro long-lived secret.

## Indépendant des autres phases

Cette PR ne dépend ni de Phase 5 (controller cutover) ni de Phase 7/8 (heartbeat / diagnostic). Le workflow peut shipper en premier — il tournera harmlessly tant que Phase 5 n'est pas déployé (l'endpoint est public actuellement, le cron fire OK et régénère le sitemap = comportement souhaité pour fixer le sitemap-stale incident).

Une fois Phase 5 deployé, le Bearer JWT passe via `GithubOidcGuard` (validation 5 claims + jti anti-replay Phase 4).

## Safeguards

- `permissions: id-token: write` (REQUIRED OIDC), `contents: read` (minimal), `issues: write` (failure notify)
- `concurrency.group: sitemap-daily-regen`, `cancel-in-progress: false` — queue manual dispatch derrière cron (pas kill)
- `timeout-minutes: 15` (peak 102k URLs observed ≈ 15s)
- `curl --max-time 600 --retry 2 --retry-delay 10 --retry-connrefused`
- `failure()` step ouvre auto-issue labelée `incident-sitemap-cron`

## Test plan

- [x] YAML syntax valide
- [ ] Post-merge : `workflow_dispatch` manual via GitHub UI Actions tab → green run
- [ ] `curl -sI https://www.automecanik.com/sitemap.xml | grep last-modified` → today's date
- [ ] Daily cron fires automatiquement 03:00 UTC le lendemain
- [ ] Failure simulation (intentionally bad token) → auto-issue created

## Invariants

1. ✅ No public endpoint regression
2. ✅ No auth fallback ambiguity (Bearer JWT is the only path used by this workflow)
3. ✅ Fail-closed on JWKS failure (backend GithubOidcService throws → curl gets 4xx/5xx)
4. ✅ No Bull queue coupling

## Refs

- Phase 0.6 hardcoding paradigm : PR #556
- Phase 1 GithubOidcService : PR #559
- Phase 4 anti-replay (open) : PR #563
- Phase 5 controller cutover (next) : pending PR
- Memory `feedback_oidc_federation_over_long_lived_bearer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)