### PR TITLE
feat(seo): phase 7 — heartbeat scheduler observability

### DIFF
--- a/backend/src/modules/seo/services/sitemap-v10-scheduler.heartbeat.test.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-scheduler.heartbeat.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Phase 7 — heartbeat-specific tests for SitemapV10SchedulerService.
+ *
+ * Scope : verify that `writeHeartbeat()` writes a structured payload to
+ * Redis (via Bull queue.client SET command) with the correct key, value
+ * shape and TTL. Cleanup on `onModuleDestroy`. Does NOT test the BullMQ
+ * repeatable job scheduling (covered elsewhere / by integration).
+ */
+
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getQueueToken } from '@nestjs/bull';
+import {
+  SitemapV10SchedulerService,
+  HEARTBEAT_KEY_PREFIX,
+  HEARTBEAT_TTL_SECONDS,
+  type SitemapWorkerHeartbeat,
+} from './sitemap-v10-scheduler.service';
+
+const QUEUE_NAME = 'seo-monitor';
+
+function makeMockQueue(): {
+  add: jest.Mock;
+  getRepeatableJobs: jest.Mock;
+  removeRepeatableByKey: jest.Mock;
+  client: { set: jest.Mock; del: jest.Mock };
+} {
+  return {
+    add: jest.fn().mockResolvedValue(undefined),
+    getRepeatableJobs: jest.fn().mockResolvedValue([]),
+    removeRepeatableByKey: jest.fn().mockResolvedValue(undefined),
+    client: {
+      set: jest.fn().mockResolvedValue('OK'),
+      del: jest.fn().mockResolvedValue(1),
+    },
+  };
+}
+
+async function buildService(opts: {
+  cronEnabled?: string | undefined;
+  queue: ReturnType<typeof makeMockQueue>;
+}): Promise<SitemapV10SchedulerService> {
+  const env: Record<string, string | undefined> = {
+    SEO_SITEMAP_CRON_ENABLED: opts.cronEnabled,
+    SEO_SITEMAP_CRON: '0 3 * * *',
+  };
+  const moduleRef = await Test.createTestingModule({
+    providers: [
+      SitemapV10SchedulerService,
+      { provide: getQueueToken(QUEUE_NAME), useValue: opts.queue },
+      {
+        provide: ConfigService,
+        useValue: { get: (k: string, def?: string) => env[k] ?? def },
+      },
+    ],
+  }).compile();
+  return moduleRef.get(SitemapV10SchedulerService);
+}
+
+describe('SitemapV10SchedulerService — Phase 7 heartbeat', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('writes a structured heartbeat payload to Redis on onModuleInit', async () => {
+    const queue = makeMockQueue();
+    const service = await buildService({ queue });
+
+    service.onModuleInit();
+    // writeHeartbeat is called immediately (not awaited) — let microtasks flush
+    await new Promise((r) => setImmediate(r));
+
+    expect(queue.client.set).toHaveBeenCalledTimes(1);
+    const [key, value, exFlag, ttl] = queue.client.set.mock.calls[0];
+    expect(key).toMatch(new RegExp(`^${HEARTBEAT_KEY_PREFIX}\\d+$`));
+    expect(exFlag).toBe('EX');
+    expect(ttl).toBe(HEARTBEAT_TTL_SECONDS);
+
+    const payload: SitemapWorkerHeartbeat = JSON.parse(value as string);
+    expect(payload.pid).toBe(process.pid);
+    expect(typeof payload.hostname).toBe('string');
+    expect(payload.queue).toBe('seo-monitor');
+    expect(payload.bullVersion).toBe('4.16.5');
+    expect(typeof payload.startedAt).toBe('string');
+    expect(typeof payload.lastHeartbeatAt).toBe('string');
+    expect(payload.uptimeSec).toBeGreaterThanOrEqual(0);
+    await service.onModuleDestroy();
+  });
+
+  it('does NOT start heartbeat when SEO_SITEMAP_CRON_ENABLED=false', async () => {
+    const queue = makeMockQueue();
+    const service = await buildService({
+      cronEnabled: 'false',
+      queue,
+    });
+
+    service.onModuleInit();
+    await new Promise((r) => setImmediate(r));
+
+    expect(queue.client.set).not.toHaveBeenCalled();
+    expect(queue.add).not.toHaveBeenCalled();
+    await service.onModuleDestroy();
+  });
+
+  it('deletes the heartbeat key on onModuleDestroy', async () => {
+    const queue = makeMockQueue();
+    const service = await buildService({ queue });
+    service.onModuleInit();
+    await new Promise((r) => setImmediate(r));
+
+    await service.onModuleDestroy();
+
+    expect(queue.client.del).toHaveBeenCalledTimes(1);
+    expect(queue.client.del.mock.calls[0][0]).toMatch(
+      new RegExp(`^${HEARTBEAT_KEY_PREFIX}\\d+$`),
+    );
+  });
+
+  it('refreshes heartbeat on the interval tick', async () => {
+    jest.useFakeTimers();
+    const queue = makeMockQueue();
+    const service = await buildService({ queue });
+    service.onModuleInit();
+    await Promise.resolve(); // flush microtasks for the immediate write
+
+    // Advance 30s — should trigger one more write
+    jest.advanceTimersByTime(30_000);
+    await Promise.resolve();
+
+    // Initial write + 1 interval tick = at least 2 calls
+    expect(queue.client.set.mock.calls.length).toBeGreaterThanOrEqual(2);
+    await service.onModuleDestroy();
+  });
+
+  it('survives a Redis SET failure (logs warn, does not crash)', async () => {
+    const queue = makeMockQueue();
+    queue.client.set.mockRejectedValueOnce(new Error('redis down'));
+    const service = await buildService({ queue });
+
+    expect(() => service.onModuleInit()).not.toThrow();
+    await new Promise((r) => setImmediate(r));
+
+    // Subsequent ticks should still attempt to write (resilient).
+    expect(queue.client.set).toHaveBeenCalled();
+    await service.onModuleDestroy();
+  });
+});

--- a/backend/src/modules/seo/services/sitemap-v10-scheduler.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-scheduler.service.ts
@@ -32,22 +32,53 @@
  *   `.claude/rules/backend.md` § Non-blocking onModuleInit
  */
 
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { ConfigService } from '@nestjs/config';
 import { Queue } from 'bull';
+import * as os from 'node:os';
 import { getErrorMessage } from '@common/utils/error.utils';
 
 export const SITEMAP_REGENERATE_JOB_NAME = 'sitemap-regenerate-all';
 export const SITEMAP_REGENERATE_JOB_ID = 'sitemap-v10-nightly-regeneration';
+
+/**
+ * Redis key prefix for per-process worker heartbeats (Phase 7 observability).
+ * Format : `worker:seo-monitor:heartbeat:<pid>`. TTL = 60s sliding (refreshed
+ * every 30s). Co-located with Bull's DB 0 since this is queue worker
+ * observability, namespaced separately from `bull:*` keys.
+ */
+export const HEARTBEAT_KEY_PREFIX = 'worker:seo-monitor:heartbeat:';
+export const HEARTBEAT_INTERVAL_MS = 30_000;
+export const HEARTBEAT_TTL_SECONDS = 60;
+
+export interface SitemapWorkerHeartbeat {
+  pid: number;
+  hostname: string;
+  queue: string;
+  bullVersion: string;
+  startedAt: string;
+  lastHeartbeatAt: string;
+  uptimeSec: number;
+}
 
 export interface SitemapRegenerateJobData {
   triggeredBy: 'scheduler' | 'api' | 'manual';
 }
 
 @Injectable()
-export class SitemapV10SchedulerService implements OnModuleInit {
+export class SitemapV10SchedulerService
+  implements OnModuleInit, OnModuleDestroy
+{
   private readonly logger = new Logger(SitemapV10SchedulerService.name);
+  private readonly heartbeatKey = `${HEARTBEAT_KEY_PREFIX}${process.pid}`;
+  private readonly startedAt = new Date();
+  private heartbeatTimer?: NodeJS.Timeout;
 
   constructor(
     @InjectQueue('seo-monitor') private readonly seoMonitorQueue: Queue,
@@ -57,6 +88,11 @@ export class SitemapV10SchedulerService implements OnModuleInit {
   /**
    * Init non-bloquant — fire-and-forget. Pattern canon backend.md.
    * Bloquer ici stallerait `app.listen()` (cf. PR #224 / run 25166916535).
+   *
+   * Phase 7 : starts the per-process heartbeat (Redis SET with TTL 60s
+   * refreshed every 30s) so the diagnostic endpoint (Phase 8) can detect
+   * worker liveness without depending on bull's `getWorkers()` (not in
+   * @types/bull v4.10.4).
    */
   onModuleInit(): void {
     if (!this.isEnabled()) {
@@ -65,7 +101,85 @@ export class SitemapV10SchedulerService implements OnModuleInit {
       );
       return;
     }
+    this.logger.log({
+      event: 'sitemap_scheduler_worker_online',
+      pid: process.pid,
+      hostname: os.hostname(),
+      queue: 'seo-monitor',
+      cron: this.getCron(),
+      timezone: 'UTC',
+      startedAt: this.startedAt.toISOString(),
+    });
     void this.configureRepeatableJob();
+    this.heartbeatTimer = setInterval(
+      () => void this.writeHeartbeat(),
+      HEARTBEAT_INTERVAL_MS,
+    );
+    void this.writeHeartbeat();
+  }
+
+  /**
+   * Phase 7 : symmetric shutdown — stop the interval, delete heartbeat key,
+   * emit lifecycle log. Permits the diagnostic endpoint to observe a clean
+   * worker shutdown vs a crash (silent disappearance of heartbeat key after
+   * TTL expiry).
+   */
+  async onModuleDestroy(): Promise<void> {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = undefined;
+    }
+    const uptimeSec = Math.floor(
+      (Date.now() - this.startedAt.getTime()) / 1000,
+    );
+    this.logger.log({
+      event: 'sitemap_scheduler_worker_offline',
+      pid: process.pid,
+      hostname: os.hostname(),
+      queue: 'seo-monitor',
+      uptimeSec,
+      reason: 'shutdown',
+    });
+    try {
+      await this.seoMonitorQueue.client.del(this.heartbeatKey);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to delete heartbeat key on shutdown: ${getErrorMessage(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Write the current process's heartbeat to Redis. Idempotent + cheap
+   * (~1ms intra-VPS) — re-written every HEARTBEAT_INTERVAL_MS to refresh
+   * the TTL. If the worker crashes, the key expires after
+   * HEARTBEAT_TTL_SECONDS, disappearing from the diagnostic endpoint.
+   *
+   * Failure is non-fatal : logs a warning, does not crash the scheduler.
+   * The next interval tick will retry. The diagnostic endpoint will simply
+   * see a stale heartbeat (timestamp gap) or absent key.
+   */
+  private async writeHeartbeat(): Promise<void> {
+    const now = new Date();
+    const payload: SitemapWorkerHeartbeat = {
+      pid: process.pid,
+      hostname: os.hostname(),
+      queue: 'seo-monitor',
+      bullVersion: '4.16.5',
+      startedAt: this.startedAt.toISOString(),
+      lastHeartbeatAt: now.toISOString(),
+      uptimeSec: Math.floor((now.getTime() - this.startedAt.getTime()) / 1000),
+    };
+    try {
+      await this.seoMonitorQueue.client.set(
+        this.heartbeatKey,
+        JSON.stringify(payload),
+        'EX',
+        HEARTBEAT_TTL_SECONDS,
+      );
+    } catch (err) {
+      this.logger.warn(`Heartbeat write failed: ${getErrorMessage(err)}`);
+    }
   }
 
   private async configureRepeatableJob(): Promise<void> {


### PR DESCRIPTION
## Summary

Phase 7/11 — `SitemapV10SchedulerService` écrit un heartbeat per-process à Redis (DB 0 via Bull's queue.client, namespace `worker:seo-monitor:heartbeat:<pid>`). TTL 60s sliding, refresh 30s. Permet à Phase 8 (diagnostic endpoint) de détecter worker liveness sans dépendre de bull's `getWorkers()` (absent de `@types/bull` v4.10.4).

**Indépendant** des phases OIDC (1-6). Modifie un service existant scheduler.

## Payload heartbeat

```ts
{
  pid: number,
  hostname: string,
  queue: 'seo-monitor',
  bullVersion: '4.16.5',
  startedAt: ISO,
  lastHeartbeatAt: ISO,
  uptimeSec: number,
}
```

## Lifecycle

- **onModuleInit** : log structuré `sitemap_scheduler_worker_online`, setInterval(30s), immediate first write
- **onModuleDestroy** : clearInterval, log `sitemap_scheduler_worker_offline` avec uptimeSec, DEL heartbeat key
- **Resilient** : Redis SET failures logged WARN, scheduler ne crash pas. Diagnostic endpoint verra une stale heartbeat (TTL expire après 60s) → signal worker mort.

## Tests (5/5 PASS)

- writes structured payload on init
- skips heartbeat when SEO_SITEMAP_CRON_ENABLED=false
- deletes heartbeat key on shutdown
- refreshes on interval tick (fake timer)
- survives Redis SET failure (resilient, logs warn)

## New exports for Phase 8

- `HEARTBEAT_KEY_PREFIX = 'worker:seo-monitor:heartbeat:'`
- `HEARTBEAT_INTERVAL_MS = 30_000`
- `HEARTBEAT_TTL_SECONDS = 60`
- `SitemapWorkerHeartbeat` type

## Invariants

1. ✅ No public endpoint regression (no controller change)
2. ✅ No auth fallback ambiguity
3. ✅ Fail-closed on Redis failure → scheduler logs WARN, diagnostic endpoint sees missing/stale heartbeat
4. ⚠️ Bull queue coupling : heartbeat ON Bull's Redis client (DB 0). Intentional — heartbeat IS queue observability. Distinct from anti-replay (Phase 4 DB 1 dedicated).

## Refs

- Spec : `docs/superpowers/specs/2026-05-16-sitemap-regen-auth-design.md` (not yet on main, will ship with Phase 1+ PRs)
- Phase 8 (next) : diagnostic endpoint consumes `worker:seo-monitor:heartbeat:*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)