### PR TITLE
chore(audit): refresh baseline post OIDC phase 1+2 merges (unblock 4 in-flight PRs)

### DIFF
--- a/audit-reports/phase0-baseline.json
+++ b/audit-reports/phase0-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "captured_at": "2026-05-13",
-  "captured_on_commit": "b762890a",
+  "captured_at": "2026-05-16",
+  "captured_on_commit": "95403c7d3",
   "thresholds": {
     "unused_files_delta": 5,
     "unused_exports_delta": 10,
@@ -15,12 +15,12 @@
     "ast_grep_errors_delta": 0
   },
   "knip": {
-    "unused_files": 342,
-    "unused_exports": 228,
-    "unused_types": 370,
+    "unused_files": 328,
+    "unused_exports": 238,
+    "unused_types": 214,
     "unused_dependencies": 4,
     "unused_dev_dependencies": 4,
-    "unlisted_dependencies": 38,
+    "unlisted_dependencies": 37,
     "unlisted_binaries": 5,
     "duplicate_exports": 41
   },
@@ -30,11 +30,11 @@
     "frontend_cycles": 1
   },
   "depcruise": {
-    "violations": 148,
+    "violations": 144,
     "errors": 0,
     "modules_cruised": 2101,
     "dependencies_cruised": 8425,
-    "warnings": 148
+    "warnings": 144
   },
   "ast_grep": {
     "warnings": 0,


### PR DESCRIPTION
## Summary

Refresh `audit-reports/phase0-baseline.json` after PR #559 (Phase 1 GithubOidcService) and PR #560 (Phase 2 atomic guards) merged into main. Those 2 PRs added ~10 new exports that knip sees as 'unused' until Phase 5 cutover wires them up — triggering false-positive regression on the 4 in-flight PRs (#562, #563, #565, #566).

Single-line escape hatch documented in CI workflow output : "if the regression is intentional, refresh the baseline via `npm run audit:baseline:refresh`".

## Deltas

```
knip.unused_files     342 → 328  (−14, improved)
knip.unused_exports   228 → 238  (+10, threshold caught up to current)
knip.unused_types     370 → 214  (−156, improved)
knip.unlisted_deps     38 →  37  (−1)
depcruise.violations  148 → 144  (−4, improved)
```

The +10 jump in unused_exports = the 10 OIDC-related exports added by Phase 1+2 (GithubOidcService, GithubOidcClaims, AdminSessionGuard, GithubOidcGuard, AnyOf, plus 2 in tests). They become "used" once Phase 5 wires them into the 4 sitemap controllers.

## Verification

Once merged + the 4 PRs rebase onto main, baseline gate should pass for all (each adds 1-3 new exports vs new baseline of 238 → well under threshold +10).

## Unblocks

- #562 Phase 3 LegacyInternalKeyGuard
- #563 Phase 4 jti anti-replay
- #565 Phase 6 GitHub Action OIDC workflow (no exports added but baseline gate failed due to stale main state)
- #566 Phase 7 Heartbeat observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)