### PR TITLE
chore(turbo): dev task depends on workspace builds (root-cause for missing dist/)

### DIFF
--- a/log.md
+++ b/log.md
@@ -777,3 +777,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/vehicles-strict-numeric-pipe`
 - **Décision** : chore(ownership): register backend/src/common/{pipes/params,schemas} (+1 other commit)
 - **Sortie** : PR #553 | commits 6f0030af8 08159f793
+
+## 2026-05-16 — chore/turbo-dev-depends-on-build (auto)
+
+- **Branche** : `chore/turbo-dev-depends-on-build`
+- **Décision** : chore(turbo): dev task depends on workspace builds
+- **Sortie** : PR #573 | commits 3c67dc79a

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
     "tasks": {
       "dev": {
         "cache": false,
-        "persistent": true
+        "persistent": true,
+        "dependsOn": ["^build"]
       },
       "build": {
         "outputs": ["dist/**", "build/**"],


### PR DESCRIPTION
## Problem

Without this 2-line change, Turbo runs `dev` on `@fafa/backend` and `@fafa/frontend` immediately even when the workspace deps they import (`@repo/database-types`, `@repo/seo-types`, `@repo/registry`) have no `dist/` directory yet.

That happens after :
- a fresh clone
- `npm run clean-node-modules`
- pulling a PR that touched `packages/`
- switching between branches with different package source

Symptom is always the same :

```
Error: Cannot find module '/opt/automecanik/app/node_modules/@repo/database-types/dist/index.js'
```

Every developer ends up running `npm -w @repo/database-types run build` by hand. That's the bricolage this PR removes.

## Fix

`turbo.json` :

```diff
   "dev": {
     "cache": false,
-    "persistent": true
+    "persistent": true,
+    "dependsOn": ["^build"]
   },
```

`build` / `typecheck` / `test` already declare `dependsOn: ["^build"]`. This aligns `dev` with the same canonical pattern.

## Cost

The very first cold `npm run dev` after a clone or a packages/ change now builds the workspace packages first (~3-5 s for the four packages combined). Every subsequent run hits Turbo's cache and is sub-second — same as `npm run build` already behaves.

## Test plan

- [x] `turbo run dev --dry-run` shows `^build` in the prerequisite graph
- [ ] Cold smoke : `npm run clean-node-modules && npm install && npm run dev` (backend boots clean, zero manual builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)