### PR TITLE
feat(ci): ESM package dist smoke test — categorical defense vs preprod regressions

### DIFF
--- a/.github/workflows/esm-package-smoke.yml
+++ b/.github/workflows/esm-package-smoke.yml
@@ -1,0 +1,105 @@
+name: 🧪 ESM Package Smoke
+
+# Catches the bug class that broke 10 consecutive `🚀 Deploy` runs on main
+# (resolved by PR #570, 2026-05-16): ESM-emitting workspace packages whose
+# dist cannot be loaded by Node 22 due to extensionless relative imports,
+# missing `"type": "module"`, or other runtime-only configuration drift.
+#
+# `tsc` (typecheck) and `eslint` (lint) cannot catch these because they are
+# emit-time / Node-resolver issues. Only a real dynamic `import()` does.
+#
+# Runs on every PR and main push that touches `packages/**` — fast (~2 min)
+# and decisive: any internal package declaring `"type": "module"` must load
+# its `dist/index.js` cleanly under the production Node version.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - '.github/workflows/esm-package-smoke.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - '.github/workflows/esm-package-smoke.yml'
+
+jobs:
+  esm-smoke:
+    name: 🧪 ESM dist dynamic import
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v4
+
+      - name: ⚙️ Setup Node 22 (matches Docker preprod image node:22-alpine)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: 📦 Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: 🏗️ Build all internal packages
+        run: npx turbo run build --filter='./packages/*'
+
+      - name: 🧪 Dynamic-import every ESM package's dist
+        run: |
+          set -uo pipefail
+          failed=()
+          smoked=0
+
+          for pkg_dir in packages/*/; do
+            pkg=$(basename "$pkg_dir")
+            pkg_json="${pkg_dir}package.json"
+            [ -f "$pkg_json" ] || continue
+
+            # Only smoke packages that declare themselves as ESM
+            if ! grep -qE '"type":[[:space:]]*"module"' "$pkg_json"; then
+              echo "⏭️  $pkg — not type:module, skipped"
+              continue
+            fi
+
+            entry="${pkg_dir}dist/index.js"
+            if [ ! -f "$entry" ]; then
+              echo "⚠️  $pkg — no dist/index.js after build, skipped"
+              continue
+            fi
+
+            echo ""
+            echo "🧪 $pkg → $entry"
+            if node --input-type=module -e "
+              import('./$entry').then(m => {
+                const keys = Object.keys(m).length;
+                if (keys === 0) throw new Error('zero exports');
+                console.log('  ✅ keys=' + keys);
+              }).catch(e => {
+                console.error('  ❌ ' + (e.code || e.message));
+                process.exit(1);
+              });
+            "; then
+              smoked=$((smoked + 1))
+            else
+              failed+=("$pkg")
+            fi
+          done
+
+          echo ""
+          echo "─── Summary ───"
+          echo "Smoked: $smoked package(s)"
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "❌ FAILED: ${failed[*]}"
+            echo ""
+            echo "Each failing package must load via:"
+            echo "  node --input-type=module -e \"import('./packages/<name>/dist/index.js')\""
+            echo ""
+            echo "Common causes:"
+            echo "  • Extensionless relative imports in src/ (require .js for NodeNext)"
+            echo "  • Missing \"type\": \"module\" when emitting ESM syntax"
+            echo "  • tsconfig moduleResolution still 'bundler' instead of 'NodeNext'"
+            exit 1
+          fi
+
+          echo "✅ All ESM packages load cleanly under Node 22"


### PR DESCRIPTION
## Summary

New standalone CI gate `🧪 ESM Package Smoke` that dynamically `import()`s every internal package's `dist/index.js` under Node 22 (matches `node:22-alpine` production image). **Categorical defense** against the bug class that broke 10 consecutive `🚀 Deploy` runs on main (resolved by [PR #570](https://github.com/ak125/nestjs-remix-monorepo/pull/570)).

**1 file, 105 lines** — pure shell + node, no new dependencies.

## Why this gate

The bug class (`ERR_MODULE_NOT_FOUND` on relative imports inside ESM packages) is **invisible** to every existing CI gate:

| Existing gate | Why it can't catch this |
|---------------|------------------------|
| `tsc` typecheck | bundler/classic moduleResolution tolerate extensionless imports |
| `eslint` | sees source, not emitted dist |
| backend Jest | mocks `@repo/database-types`, maps `@repo/seo-types` to source `.ts` — bypasses dist |
| frontend Vite | own resolver, doesn't exercise Node's ESM loader |
| `Deploy PREPROD` | catches it, but only **after merge**, 9 min into deploy |

Only a real `node --input-type=module -e "import(...)"` against the built dist under the production Node version exercises the actual ESM loader that crashes preprod boot.

## What it does

For every internal package whose `package.json` declares `"type": "module"`:
1. After `turbo run build`, locate `packages/<name>/dist/index.js`
2. Run `node --input-type=module -e "import('./<entry>').then(...)"` under Node 22
3. Pass if module loads with non-zero exports; fail otherwise

Today's coverage (verified locally):
- `@repo/database-types` (183 exports)
- `@repo/seo-types` (50 exports)
- `@fafa/design-tokens` (1 export — dual-package ESM entry)

Future ESM packages are picked up automatically via the `type: module` grep — no manual list to maintain.

## Cost

- **~2 min** added to PRs touching `packages/**` only (path-filtered, doesn't run on most PRs)
- Standalone workflow, easy to disable/rollback if flaky
- No new npm dependencies

## Out of scope (deliberate follow-ups)

- ESLint rule `import/extensions` for ESM packages — complementary edit-time defense, but tsc NodeNext already catches this at typecheck for the 2 NodeNext packages (diminishing returns)
- Backend tsconfig migration to NodeNext — sprint-scale, separate ADR (touches hundreds of internal imports)

## Test plan

- [x] Local dry-run: 3/3 ESM packages load successfully on Node 20.19.6
- [ ] PR CI green (this workflow's own first run will validate the workflow itself)
- [ ] Verify by introducing a deliberate extensionless import in a sandbox PR — gate must reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)