### PR TITLE
fix(canon): resync marketing-voice mirrors with vault v1.0.1 (ADR-038)

### DIFF
--- a/.claude/canon-mirrors/marketing-voice.md
+++ b/.claude/canon-mirrors/marketing-voice.md
@@ -3,7 +3,7 @@
 > **Source de vérité canonique** — règles obligatoires de voix de marque pour
 > tous les agents marketing (ADR-036) et toute campagne produite par le module
 > backend `marketing/`. Synchronisée vers monorepo via canon-publish.
-> **Version** : 1.0.0 | **Status** : `proposed` (à passer `accepted` après merge ADR-036)
+> **Version** : 1.0.0 | **Status** : `canon` (ratifié par ADR-038)
 
 Ce fichier est l'**unique source canonique** de la voix de marque marketing.
 Toute copie dans le monorepo (`.claude/canon-mirrors/marketing-voice.md`) est

--- a/scripts/ci/sync-marketing-voice-from-vault.sh
+++ b/scripts/ci/sync-marketing-voice-from-vault.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# sync-marketing-voice-from-vault.sh — fetch canon from governance-vault,
+# apply the canonical strip-frontmatter transform, and write both mirrors.
+#
+# Idempotent: safe to re-run. Verifies output sha256 against the vault's
+# distribution_sha256 BEFORE touching mirrors (fail-closed).
+#
+# Source of truth for the transform: governance-vault/_scripts/compute-canon-hashes.py
+# (FRONTMATTER_RE = r"^---\n.*?\n---\n*", DOTALL — strips frontmatter and all
+# trailing newlines after the closing fence).
+#
+# Pair this with scripts/ci/check-marketing-voice-hash.sh which validates the
+# result in CI (.github/workflows/marketing-voice-hash.yml).
+
+set -euo pipefail
+
+CANON_URL="https://raw.githubusercontent.com/ak125/governance-vault/main/ledger/rules/rules-marketing-voice.md"
+HASHES_URL="https://raw.githubusercontent.com/ak125/governance-vault/main/99-meta/canon-hashes.json"
+
+MIRRORS=(
+  ".claude/canon-mirrors/marketing-voice.md"
+  "workspaces/marketing/.claude/canon-mirrors/marketing-voice.md"
+)
+
+tmpdist=$(mktemp)
+trap 'rm -f "$tmpdist"' EXIT
+
+expected_sha=$(curl -fsSL "$HASHES_URL" | jq -r '.canons.marketing_voice.distribution_sha256')
+
+curl -fsSL "$CANON_URL" | python3 -c "
+import re, sys
+text = sys.stdin.read()
+sys.stdout.write(re.sub(r'^---\n.*?\n---\n*', '', text, count=1, flags=re.DOTALL))
+" > "$tmpdist"
+
+actual_sha=$(sha256sum "$tmpdist" | awk '{print $1}')
+
+if [[ "$actual_sha" != "$expected_sha" ]]; then
+  echo "ERROR: produced sha $actual_sha != vault distribution_sha256 $expected_sha" >&2
+  echo "       Possible vault state changed mid-fetch — re-run." >&2
+  exit 1
+fi
+
+for mirror in "${MIRRORS[@]}"; do
+  if [[ ! -d "$(dirname "$mirror")" ]]; then
+    echo "ERROR: mirror parent dir missing: $(dirname "$mirror")" >&2
+    exit 1
+  fi
+  cp "$tmpdist" "$mirror"
+  echo "OK $mirror updated (sha ${expected_sha:0:12}…)"
+done

--- a/workspaces/marketing/.claude/canon-mirrors/marketing-voice.md
+++ b/workspaces/marketing/.claude/canon-mirrors/marketing-voice.md
@@ -3,7 +3,7 @@
 > **Source de vérité canonique** — règles obligatoires de voix de marque pour
 > tous les agents marketing (ADR-036) et toute campagne produite par le module
 > backend `marketing/`. Synchronisée vers monorepo via canon-publish.
-> **Version** : 1.0.0 | **Status** : `proposed` (à passer `accepted` après merge ADR-036)
+> **Version** : 1.0.0 | **Status** : `canon` (ratifié par ADR-038)
 
 Ce fichier est l'**unique source canonique** de la voix de marque marketing.
 Toute copie dans le monorepo (`.claude/canon-mirrors/marketing-voice.md`) est


### PR DESCRIPTION
## Summary

- Workflow `marketing-voice-hash` était rouge : drift entre les mirrors locaux (sha `56ca202a…`, v1.0.0 / `status: proposed`) et le `distribution_sha256` du vault (`c5a7bfd0…`, v1.0.1 / `status: canon ratifié ADR-038`).
- Le vault a bumpé v1.0.0 → v1.0.1 mais sans propagation : `canon-publish.yml` côté vault ne surveille **pas** `rules-marketing-voice.md` et son matrix `dispatch` n'inclut pas ce monorepo. Gap architectural à corriger côté vault dans une PR séparée.
- Ce PR fait deux choses :
  1. **Resync immédiat** des deux mirrors avec le canon v1.0.1 du vault.
  2. Ajoute `scripts/ci/sync-marketing-voice-from-vault.sh` — script idempotent et réutilisable qui applique la transform canonique du vault (regex `^---\n.*?\n---\n*` DOTALL, identique à `governance-vault/_scripts/compute-canon-hashes.py`) et **fail-closed** si le sha produit ne matche pas `distribution_sha256`.

## Test plan

- [x] `bash scripts/ci/check-marketing-voice-hash.sh .claude/canon-mirrors/marketing-voice.md` → `OK matches vault distribution_sha256 (c5a7bfd096e0…)`
- [x] `bash scripts/ci/check-marketing-voice-hash.sh workspaces/marketing/.claude/canon-mirrors/marketing-voice.md` → idem
- [x] `sha256sum` des deux mirrors → `c5a7bfd096e00608b240c8f7ba4cb7c7e1a14090a3faf8f7c78b99d79a1a2b4e`
- [x] Idempotence : 2ᵉ run du sync ne change pas `git status` (même delta : 3 fichiers)
- [ ] Workflow `marketing-voice-hash.yml` vert sur les 2 jobs matrix dans cette PR
- [ ] Pas de régression sur les autres workflows (low blast radius — 3 fichiers, tous canon-mirror / scripts CI)

## Follow-up (HORS scope cette PR)

Ouvrir une PR côté `ak125/governance-vault` pour :
1. Étendre `canon-publish.yml` `paths:` avec `ledger/rules/rules-marketing-voice.md`.
2. Étendre la matrix `dispatch` avec `ak125/nestjs-remix-monorepo`.
3. (V2) faire que le dispatch ouvre automatiquement une PR de resync dans les consumers — sinon chaque bump canon redemande ce flow manuel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)