### PR TITLE
feat(seo-cp): pr-2a-2.5 cloudflare rum collector (web vitals edge ingestion)

### DIFF
--- a/.spec/00-canon/repo-map.md
+++ b/.spec/00-canon/repo-map.md
@@ -151,7 +151,7 @@ frontend/app/
 
 | Metrique | Valeur |
 |----------|--------|
-| Backend modules | 47 |
+| Backend modules | 48 |
 | Frontend routes | 233 |
 | Shared packages | 8 |
 | Docker configs | 10 |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -163,6 +163,22 @@ SEO_CP_CF_ANALYTICS_CRON=*/5 * * * *
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ZONE_ID=
 
+# PR-2A-2.5 — L1 Cloudflare RUM Collector (q-daily GraphQL Web Vitals ingest)
+# Source C' du SLO multi-source : edge-RUM utilisateur réel (LCP/CLS/INP p75)
+# complémentaire de cf-analytics (edge-server status codes).
+#
+# Default ENABLED=false → opt-in explicite (le scope du token doit inclure
+# Account.Analytics:Read, distinct de Zone:Cache Purge utilisé par les scripts ops).
+# Si CLOUDFLARE_ANALYTICS_TOKEN est défini, il prend précédence sur CLOUDFLARE_API_TOKEN
+# (séparation des privilèges + rotation indépendante de la cache-purge token).
+#
+# CLOUDFLARE_ACCOUNT_ID requis (rum* datasets sont account-scoped, pas zone-scoped).
+# Récupération : Cloudflare dashboard → sidebar droite "Account ID" (32 hex chars).
+SEO_CP_CF_RUM_ENABLED=false
+SEO_CP_CF_RUM_CRON=0 1 * * *
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_ANALYTICS_TOKEN=
+
 # ─────────────────────────────────────────────────────────────────────────────
 # L1 Runtime Logs Collector (PR-2A-3) — Source A du SLO multi-source.
 # Scan __error_logs LOADER_* sur fenêtre glissante 60min, agrège par bucket

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.processor.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.processor.ts
@@ -80,9 +80,6 @@ export class CfRumProcessor {
   @OnQueueFailed()
   onJobFailed(job: Job<CfRumJobData>, err: Error): void {
     if (job.name !== CF_RUM_JOB_NAME) return;
-    this.logger.error(
-      `cf-rum job ${job.id} failed: ${err.message}`,
-      err.stack,
-    );
+    this.logger.error(`cf-rum job ${job.id} failed: ${err.message}`, err.stack);
   }
 }

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.processor.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.processor.ts
@@ -1,0 +1,88 @@
+/**
+ * CfRumProcessor — BullMQ consumer du job `seo-cp-cf-rum-fetch`.
+ *
+ * ADR-064 PR-2A-2.5. Scheduled by `CfRumSchedulerService` (q-daily repeatable
+ * à 01:00 UTC). READ_ONLY gate au processor (cf. pattern canon — preprod miroir).
+ *
+ * Queue mutualisée `seo-crawler-monitor` (même que synthetic-crawler, cf-analytics,
+ * runtime-logs). Volume cf-rum = 1 job/jour, contention nulle.
+ */
+
+import { OnQueueError, OnQueueFailed, Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { getAppConfig } from '../../../../config/app.config';
+import { CfRumCollectorService } from './cf-rum.service';
+import {
+  CF_RUM_JOB_NAME,
+  CF_RUM_QUEUE_NAME,
+  type CfRumJobData,
+  type CfRumRunResult,
+} from './cf-rum.types';
+
+@Processor(CF_RUM_QUEUE_NAME)
+export class CfRumProcessor {
+  private readonly logger = new Logger(CfRumProcessor.name);
+  private readonly readOnly: boolean;
+  private lastQueueErrorLog = 0;
+
+  constructor(private readonly collector: CfRumCollectorService) {
+    this.readOnly = getAppConfig().supabase.readOnly;
+  }
+
+  @Process(CF_RUM_JOB_NAME)
+  async handle(job: Job<CfRumJobData>): Promise<CfRumRunResult> {
+    const startedAtMs = Date.now();
+    const triggeredBy = job.data?.triggeredBy ?? 'scheduler';
+
+    if (this.readOnly) {
+      this.logger.log(
+        `[READ_ONLY] Skipping cf-rum fetch (triggeredBy=${triggeredBy})`,
+      );
+      return {
+        run_id: 'read-only-skip',
+        started_at: new Date(startedAtMs).toISOString(),
+        finished_at: new Date().toISOString(),
+        duration_ms: Date.now() - startedAtMs,
+        triggered_by: triggeredBy,
+        bucket_date: '',
+        pageload_events: 0,
+        performance_events: 0,
+        rows_upserted: 0,
+        totals_period: {
+          visits: 0,
+          pageviews: 0,
+          lcp_p75_ms: null,
+          cls_p75_milli: null,
+          inp_p75_ms: null,
+        },
+        skipped: 'read_only',
+      };
+    }
+
+    return this.collector.run({
+      triggeredBy,
+      bucketDateOverride: job.data?.bucketDateOverride,
+    });
+  }
+
+  @OnQueueError()
+  onQueueError(err: Error): void {
+    const now = Date.now();
+    if (now - this.lastQueueErrorLog < 60_000) return;
+    this.lastQueueErrorLog = now;
+    this.logger.error(
+      `Queue error (${CF_RUM_QUEUE_NAME}): ${err.message}`,
+      err.stack,
+    );
+  }
+
+  @OnQueueFailed()
+  onJobFailed(job: Job<CfRumJobData>, err: Error): void {
+    if (job.name !== CF_RUM_JOB_NAME) return;
+    this.logger.error(
+      `cf-rum job ${job.id} failed: ${err.message}`,
+      err.stack,
+    );
+  }
+}

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.scheduler.service.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.scheduler.service.ts
@@ -1,0 +1,128 @@
+/**
+ * CfRumSchedulerService — BullMQ repeatable scheduler q-daily (01:00 UTC).
+ *
+ * ADR-064 §Architecture L1 — PR-2A-2.5.
+ *
+ * Cadence q-daily (≠ Q5min cf-analytics) :
+ *   - Web Vitals RUM buffered ~30 min après l'heure côté CF.
+ *   - ABR (Adaptive Bit Rate) ramène la résolution à 1 j pour fenêtres > 7 j.
+ *   - 1 run/jour à 01:00 UTC → capture le jour J-1 complet, marge de 1 h sur
+ *     le buffer.
+ *   - Polling plus fréquent gaspille le quota GraphQL et fournit du bruit
+ *     sur les faibles échantillons RUM (~710 visites/sem sur automecanik.com
+ *     d'après l'email CF du 17 mai).
+ *
+ * Volume : 1 job/jour × ~10 path_groups × 4 tiers = 40 rows/jour upsertées.
+ * Storage 90j négligeable (~3 600 rows max).
+ *
+ * `SEO_CP_CF_RUM_ENABLED=false` désactive le scheduler (kill switch).
+ * Default ENABLED=`false` → opt-in explicite par environnement (preprod-only
+ * jusqu'à validation du token Account.Analytics:Read + AccountID).
+ */
+
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { ConfigService } from '@nestjs/config';
+import { Queue } from 'bull';
+import { getErrorMessage } from '../../../../common/utils/error.utils';
+import {
+  CF_RUM_JOB_ID,
+  CF_RUM_JOB_NAME,
+  CF_RUM_QUEUE_NAME,
+  type CfRumJobData,
+} from './cf-rum.types';
+
+@Injectable()
+export class CfRumSchedulerService implements OnModuleInit {
+  private readonly logger = new Logger(CfRumSchedulerService.name);
+
+  constructor(
+    @InjectQueue(CF_RUM_QUEUE_NAME) private readonly queue: Queue,
+    private readonly configService: ConfigService,
+  ) {}
+
+  onModuleInit(): void {
+    if (!this.isEnabled()) {
+      this.logger.log(
+        'SEO_CP_CF_RUM_ENABLED=false — cf-rum scheduler skipped',
+      );
+      return;
+    }
+    void this.configureRepeatableJob();
+  }
+
+  private async configureRepeatableJob(): Promise<void> {
+    try {
+      await this.removeStaleRepeatableJob();
+
+      await this.queue.add(
+        CF_RUM_JOB_NAME,
+        { triggeredBy: 'scheduler' } satisfies CfRumJobData,
+        {
+          repeat: { cron: this.getCron(), tz: 'UTC' },
+          jobId: CF_RUM_JOB_ID,
+          // 1 run/jour → keep 30 completions (1 mois d'historique BullMQ).
+          removeOnComplete: 30,
+          removeOnFail: 30,
+          attempts: 2,
+          backoff: {
+            type: 'exponential',
+            delay: 60_000, // 1 min — RUM buffer côté CF rend un retry rapide inutile
+          },
+        },
+      );
+
+      this.logger.log(
+        `✅ cf-rum scheduled on queue "${CF_RUM_QUEUE_NAME}" (cron="${this.getCron()}" UTC)`,
+      );
+    } catch (err) {
+      this.logger.error(
+        '❌ Failed to configure cf-rum repeatable job',
+        getErrorMessage(err),
+      );
+    }
+  }
+
+  private async removeStaleRepeatableJob(): Promise<void> {
+    try {
+      const jobs = await this.queue.getRepeatableJobs();
+      for (const job of jobs) {
+        if (job.name === CF_RUM_JOB_NAME) {
+          await this.queue.removeRepeatableByKey(job.key);
+          this.logger.log(
+            `🗑️ Removed stale cf-rum repeatable job: ${job.key}`,
+          );
+        }
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Could not enumerate stale cf-rum jobs: ${getErrorMessage(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Default "0 1 * * *" UTC = 01:00 UTC chaque jour.
+   * Override via SEO_CP_CF_RUM_CRON.
+   *
+   * Rationale 01:00 UTC : RUM buffer CF ~30 min après l'heure → 00:30 UTC
+   * marge de 1 h. Conservative.
+   */
+  private getCron(): string {
+    return this.configService.get<string>(
+      'SEO_CP_CF_RUM_CRON',
+      '0 1 * * *',
+    );
+  }
+
+  /**
+   * Default disabled (opt-in explicite). Cohérent canon `feedback_check_secret_propagation_when_adding_fail_fast`
+   * — l'activation suppose AccountID + token scopé Account.Analytics:Read OK.
+   */
+  private isEnabled(): boolean {
+    const raw = this.configService.get<string>('SEO_CP_CF_RUM_ENABLED');
+    if (raw === undefined || raw === null) return false;
+    const v = raw.toLowerCase();
+    return v === 'true' || v === '1';
+  }
+}

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.scheduler.service.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.scheduler.service.ts
@@ -43,9 +43,7 @@ export class CfRumSchedulerService implements OnModuleInit {
 
   onModuleInit(): void {
     if (!this.isEnabled()) {
-      this.logger.log(
-        'SEO_CP_CF_RUM_ENABLED=false — cf-rum scheduler skipped',
-      );
+      this.logger.log('SEO_CP_CF_RUM_ENABLED=false — cf-rum scheduler skipped');
       return;
     }
     void this.configureRepeatableJob();
@@ -89,9 +87,7 @@ export class CfRumSchedulerService implements OnModuleInit {
       for (const job of jobs) {
         if (job.name === CF_RUM_JOB_NAME) {
           await this.queue.removeRepeatableByKey(job.key);
-          this.logger.log(
-            `🗑️ Removed stale cf-rum repeatable job: ${job.key}`,
-          );
+          this.logger.log(`🗑️ Removed stale cf-rum repeatable job: ${job.key}`);
         }
       }
     } catch (err) {
@@ -109,10 +105,7 @@ export class CfRumSchedulerService implements OnModuleInit {
    * marge de 1 h. Conservative.
    */
   private getCron(): string {
-    return this.configService.get<string>(
-      'SEO_CP_CF_RUM_CRON',
-      '0 1 * * *',
-    );
+    return this.configService.get<string>('SEO_CP_CF_RUM_CRON', '0 1 * * *');
   }
 
   /**

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.test.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.test.ts
@@ -1,10 +1,7 @@
 import type { ConfigService } from '@nestjs/config';
 import type { SeoCriticality } from '@repo/registry';
 import { CriticalityLoaderService } from '../../services/criticality-loader.service';
-import {
-  CfRumCollectorService,
-  normalizePathGroup,
-} from './cf-rum.service';
+import { CfRumCollectorService, normalizePathGroup } from './cf-rum.service';
 
 const VALID_CONFIG: SeoCriticality = {
   schemaVersion: '1.0.0',
@@ -100,50 +97,60 @@ function mockFetch(
   pageload: MockPageload[],
   performance: MockPerformance[],
 ): jest.Mock {
-  return jest.fn().mockImplementation(async (_url: string, init: RequestInit) => {
-    const body = JSON.parse(init.body as string) as { query: string };
-    const isPageload = body.query.includes('rumPageloadEventsAdaptiveGroups');
-    return {
-      ok: true,
-      status: 200,
-      text: async () => '',
-      json: async () => ({
-        data: {
-          viewer: {
-            accounts: [
-              isPageload
-                ? {
-                    rumPageloadEventsAdaptiveGroups: pageload.map((p) => ({
-                      dimensions: { date: p.date, requestPath: p.path },
-                      count: p.count,
-                      sum: { visits: p.visits ?? p.count },
-                    })),
-                  }
-                : {
-                    rumPerformanceEventsAdaptiveGroups: performance.map((p) => ({
-                      dimensions: { date: p.date, requestPath: p.path },
-                      count: p.count,
-                      quantiles: {
-                        performanceLargestContentfulPaintPathP50: p.lcpP50 ?? null,
-                        performanceLargestContentfulPaintPathP75: p.lcpP75 ?? null,
-                        performanceLargestContentfulPaintPathP95: p.lcpP95 ?? null,
-                        performanceCumulativeLayoutShiftP50: null,
-                        performanceCumulativeLayoutShiftP75: p.clsP75 ?? null,
-                        performanceCumulativeLayoutShiftP95: null,
-                        performanceInteractionToNextPaintP50: null,
-                        performanceInteractionToNextPaintP75: p.inpP75 ?? null,
-                        performanceInteractionToNextPaintP95: null,
-                        performanceFirstContentfulPaintP75: p.fcpP75 ?? null,
-                        performanceTimeToFirstByteP75: p.ttfbP75 ?? null,
-                      },
-                    })),
-                  },
-            ],
+  return jest
+    .fn()
+    .mockImplementation(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { query: string };
+      const isPageload = body.query.includes('rumPageloadEventsAdaptiveGroups');
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => ({
+          data: {
+            viewer: {
+              accounts: [
+                isPageload
+                  ? {
+                      rumPageloadEventsAdaptiveGroups: pageload.map((p) => ({
+                        dimensions: { date: p.date, requestPath: p.path },
+                        count: p.count,
+                        sum: { visits: p.visits ?? p.count },
+                      })),
+                    }
+                  : {
+                      rumPerformanceEventsAdaptiveGroups: performance.map(
+                        (p) => ({
+                          dimensions: { date: p.date, requestPath: p.path },
+                          count: p.count,
+                          quantiles: {
+                            performanceLargestContentfulPaintPathP50:
+                              p.lcpP50 ?? null,
+                            performanceLargestContentfulPaintPathP75:
+                              p.lcpP75 ?? null,
+                            performanceLargestContentfulPaintPathP95:
+                              p.lcpP95 ?? null,
+                            performanceCumulativeLayoutShiftP50: null,
+                            performanceCumulativeLayoutShiftP75:
+                              p.clsP75 ?? null,
+                            performanceCumulativeLayoutShiftP95: null,
+                            performanceInteractionToNextPaintP50: null,
+                            performanceInteractionToNextPaintP75:
+                              p.inpP75 ?? null,
+                            performanceInteractionToNextPaintP95: null,
+                            performanceFirstContentfulPaintP75:
+                              p.fcpP75 ?? null,
+                            performanceTimeToFirstByteP75: p.ttfbP75 ?? null,
+                          },
+                        }),
+                      ),
+                    },
+              ],
+            },
           },
-        },
-      }),
-    };
-  });
+        }),
+      };
+    });
 }
 
 describe('normalizePathGroup', () => {
@@ -225,15 +232,21 @@ describe('CfRumCollectorService', () => {
 
   it('prefers CLOUDFLARE_ANALYTICS_TOKEN over CLOUDFLARE_API_TOKEN when both set', async () => {
     let capturedAuth: string | undefined;
-    globalThis.fetch = jest.fn().mockImplementation(async (_url, init: RequestInit) => {
-      capturedAuth = (init.headers as Record<string, string>).Authorization;
-      return {
-        ok: true,
-        status: 200,
-        text: async () => '',
-        json: async () => ({ data: { viewer: { accounts: [{ rumPageloadEventsAdaptiveGroups: [] }] } } }),
-      };
-    }) as unknown as typeof globalThis.fetch;
+    globalThis.fetch = jest
+      .fn()
+      .mockImplementation(async (_url, init: RequestInit) => {
+        capturedAuth = (init.headers as Record<string, string>).Authorization;
+        return {
+          ok: true,
+          status: 200,
+          text: async () => '',
+          json: async () => ({
+            data: {
+              viewer: { accounts: [{ rumPageloadEventsAdaptiveGroups: [] }] },
+            },
+          }),
+        };
+      }) as unknown as typeof globalThis.fetch;
 
     const upsertSpy = jest.fn().mockResolvedValue({ error: null });
     const svc = buildSvc(
@@ -252,14 +265,38 @@ describe('CfRumCollectorService', () => {
   it('aggregates pageload + performance by tier × path_group, upserts to __seo_snapshot_cf_rum', async () => {
     globalThis.fetch = mockFetch(
       [
-        { date: '2026-05-16', path: '/pieces/foo-1.html', count: 100, visits: 80 },
-        { date: '2026-05-16', path: '/pieces/bar-2.html', count: 50, visits: 40 },
+        {
+          date: '2026-05-16',
+          path: '/pieces/foo-1.html',
+          count: 100,
+          visits: 80,
+        },
+        {
+          date: '2026-05-16',
+          path: '/pieces/bar-2.html',
+          count: 50,
+          visits: 40,
+        },
         { date: '2026-05-16', path: '/blog/post-x', count: 30, visits: 25 },
         { date: '2026-05-16', path: '/admin/dashboard', count: 10, visits: 5 },
       ],
       [
-        { date: '2026-05-16', path: '/pieces/foo-1.html', count: 100, lcpP75: 2100, clsP75: 0.087, inpP75: 180 },
-        { date: '2026-05-16', path: '/blog/post-x', count: 30, lcpP75: 1800, clsP75: 0.05, inpP75: 150 },
+        {
+          date: '2026-05-16',
+          path: '/pieces/foo-1.html',
+          count: 100,
+          lcpP75: 2100,
+          clsP75: 0.087,
+          inpP75: 180,
+        },
+        {
+          date: '2026-05-16',
+          path: '/blog/post-x',
+          count: 30,
+          lcpP75: 1800,
+          clsP75: 0.05,
+          inpP75: 150,
+        },
       ],
     ) as unknown as typeof globalThis.fetch;
 
@@ -338,42 +375,49 @@ describe('CfRumCollectorService', () => {
 
   it('persists volumes with null percentiles when performance query fails (non-fatal)', async () => {
     let call = 0;
-    globalThis.fetch = jest.fn().mockImplementation(async (_url, init: RequestInit) => {
-      call++;
-      const body = JSON.parse(init.body as string) as { query: string };
-      const isPageload = body.query.includes('rumPageloadEventsAdaptiveGroups');
-      if (isPageload) {
-        return {
-          ok: true,
-          status: 200,
-          text: async () => '',
-          json: async () => ({
-            data: {
-              viewer: {
-                accounts: [
-                  {
-                    rumPageloadEventsAdaptiveGroups: [
-                      {
-                        dimensions: { date: '2026-05-16', requestPath: '/pieces/x' },
-                        count: 42,
-                        sum: { visits: 30 },
-                      },
-                    ],
-                  },
-                ],
+    globalThis.fetch = jest
+      .fn()
+      .mockImplementation(async (_url, init: RequestInit) => {
+        call++;
+        const body = JSON.parse(init.body as string) as { query: string };
+        const isPageload = body.query.includes(
+          'rumPageloadEventsAdaptiveGroups',
+        );
+        if (isPageload) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => '',
+            json: async () => ({
+              data: {
+                viewer: {
+                  accounts: [
+                    {
+                      rumPageloadEventsAdaptiveGroups: [
+                        {
+                          dimensions: {
+                            date: '2026-05-16',
+                            requestPath: '/pieces/x',
+                          },
+                          count: 42,
+                          sum: { visits: 30 },
+                        },
+                      ],
+                    },
+                  ],
+                },
               },
-            },
-          }),
+            }),
+          };
+        }
+        // Performance query fails.
+        return {
+          ok: false,
+          status: 500,
+          text: async () => 'Schema mismatch',
+          json: async () => ({}),
         };
-      }
-      // Performance query fails.
-      return {
-        ok: false,
-        status: 500,
-        text: async () => 'Schema mismatch',
-        json: async () => ({}),
-      };
-    }) as unknown as typeof globalThis.fetch;
+      }) as unknown as typeof globalThis.fetch;
 
     const upsertSpy = jest.fn().mockResolvedValue({ error: null });
     const svc = buildSvc(
@@ -437,22 +481,26 @@ describe('CfRumCollectorService', () => {
   it('uses J-1 UTC as the default bucket date', async () => {
     // Stable mock: no data, just observe the date arg sent to CF.
     let capturedFrom: string | undefined;
-    globalThis.fetch = jest.fn().mockImplementation(async (_url, init: RequestInit) => {
-      const body = JSON.parse(init.body as string) as { variables: { from: string } };
-      capturedFrom = body.variables.from;
-      return {
-        ok: true,
-        status: 200,
-        text: async () => '',
-        json: async () => ({
-          data: {
-            viewer: {
-              accounts: [{ rumPageloadEventsAdaptiveGroups: [] }],
+    globalThis.fetch = jest
+      .fn()
+      .mockImplementation(async (_url, init: RequestInit) => {
+        const body = JSON.parse(init.body as string) as {
+          variables: { from: string };
+        };
+        capturedFrom = body.variables.from;
+        return {
+          ok: true,
+          status: 200,
+          text: async () => '',
+          json: async () => ({
+            data: {
+              viewer: {
+                accounts: [{ rumPageloadEventsAdaptiveGroups: [] }],
+              },
             },
-          },
-        }),
-      };
-    }) as unknown as typeof globalThis.fetch;
+          }),
+        };
+      }) as unknown as typeof globalThis.fetch;
 
     const upsertSpy = jest.fn().mockResolvedValue({ error: null });
     const svc = buildSvc(

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.test.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.test.ts
@@ -1,0 +1,474 @@
+import type { ConfigService } from '@nestjs/config';
+import type { SeoCriticality } from '@repo/registry';
+import { CriticalityLoaderService } from '../../services/criticality-loader.service';
+import {
+  CfRumCollectorService,
+  normalizePathGroup,
+} from './cf-rum.service';
+
+const VALID_CONFIG: SeoCriticality = {
+  schemaVersion: '1.0.0',
+  slo_window_minutes: 60,
+  tiers: {
+    tier0: {
+      slo: 0.997,
+      sampling_weight: 0.6,
+      alerting: {
+        breach_threshold_minutes: 5,
+        channel: 'pagerduty',
+        auto_issue: true,
+      },
+      routes: ['pieces/*'],
+    },
+    tier1: {
+      slo: 0.99,
+      sampling_weight: 0.3,
+      alerting: {
+        breach_threshold_minutes: 15,
+        channel: 'slack',
+        auto_issue: false,
+      },
+      routes: ['blog/*'],
+    },
+    tier2: {
+      slo: 0.98,
+      sampling_weight: 0.1,
+      alerting: {
+        breach_threshold_minutes: 60,
+        channel: 'log',
+        auto_issue: false,
+      },
+      routes: ['support/*'],
+    },
+  },
+  excluded: { routes: ['admin/*', 'api/*'] },
+  metadata: {
+    adr_reference: 'ADR-064',
+    introduced_in_pr: 'TBD',
+    last_review: '2026-05-17',
+    next_review_due: '2026-08-17',
+  },
+};
+
+function makeConfigService(
+  overrides: Record<string, string | number> = {},
+): ConfigService {
+  return {
+    get: (key: string, def?: unknown): unknown => overrides[key] ?? def,
+  } as unknown as ConfigService;
+}
+
+function buildSvc(
+  crit: CriticalityLoaderService,
+  cfg: ConfigService,
+  spyUpsert: jest.Mock,
+): CfRumCollectorService {
+  const svc = Object.create(
+    CfRumCollectorService.prototype,
+  ) as CfRumCollectorService;
+  Object.assign(svc, {
+    logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    criticality: crit,
+    cfg,
+    supabase: {
+      from: (_table: string) => ({ upsert: spyUpsert }),
+    },
+  });
+  return svc;
+}
+
+interface MockPageload {
+  date: string;
+  path: string;
+  count: number;
+  visits?: number;
+}
+interface MockPerformance {
+  date: string;
+  path: string;
+  count: number;
+  lcpP75?: number;
+  lcpP50?: number;
+  lcpP95?: number;
+  clsP75?: number;
+  inpP75?: number;
+  fcpP75?: number;
+  ttfbP75?: number;
+}
+
+function mockFetch(
+  pageload: MockPageload[],
+  performance: MockPerformance[],
+): jest.Mock {
+  return jest.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string) as { query: string };
+    const isPageload = body.query.includes('rumPageloadEventsAdaptiveGroups');
+    return {
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => ({
+        data: {
+          viewer: {
+            accounts: [
+              isPageload
+                ? {
+                    rumPageloadEventsAdaptiveGroups: pageload.map((p) => ({
+                      dimensions: { date: p.date, requestPath: p.path },
+                      count: p.count,
+                      sum: { visits: p.visits ?? p.count },
+                    })),
+                  }
+                : {
+                    rumPerformanceEventsAdaptiveGroups: performance.map((p) => ({
+                      dimensions: { date: p.date, requestPath: p.path },
+                      count: p.count,
+                      quantiles: {
+                        performanceLargestContentfulPaintPathP50: p.lcpP50 ?? null,
+                        performanceLargestContentfulPaintPathP75: p.lcpP75 ?? null,
+                        performanceLargestContentfulPaintPathP95: p.lcpP95 ?? null,
+                        performanceCumulativeLayoutShiftP50: null,
+                        performanceCumulativeLayoutShiftP75: p.clsP75 ?? null,
+                        performanceCumulativeLayoutShiftP95: null,
+                        performanceInteractionToNextPaintP50: null,
+                        performanceInteractionToNextPaintP75: p.inpP75 ?? null,
+                        performanceInteractionToNextPaintP95: null,
+                        performanceFirstContentfulPaintP75: p.fcpP75 ?? null,
+                        performanceTimeToFirstByteP75: p.ttfbP75 ?? null,
+                      },
+                    })),
+                  },
+            ],
+          },
+        },
+      }),
+    };
+  });
+}
+
+describe('normalizePathGroup', () => {
+  it('maps root path correctly', () => {
+    expect(normalizePathGroup('/')).toBe('/');
+    expect(normalizePathGroup('')).toBe('/');
+    expect(normalizePathGroup(null)).toBe('/');
+    expect(normalizePathGroup(undefined)).toBe('/');
+  });
+
+  it('extracts the first segment as a glob group', () => {
+    expect(normalizePathGroup('/pieces/foo-1.html')).toBe('/pieces/*');
+    expect(normalizePathGroup('/blog/post-x')).toBe('/blog/*');
+    expect(normalizePathGroup('/admin/dashboard')).toBe('/admin/*');
+    expect(normalizePathGroup('/support/contact')).toBe('/support/*');
+  });
+
+  it('handles deep paths by keeping only the first segment', () => {
+    expect(normalizePathGroup('/pieces/freins/disque-bmw-e90')).toBe(
+      '/pieces/*',
+    );
+    expect(normalizePathGroup('/pieces/123/abc/def')).toBe('/pieces/*');
+  });
+
+  it('strips query strings and fragments', () => {
+    expect(normalizePathGroup('/pieces/foo?utm=x')).toBe('/pieces/*');
+    expect(normalizePathGroup('/blog/post#section')).toBe('/blog/*');
+  });
+
+  it('falls back to /other for non-alphanumeric first segments', () => {
+    expect(normalizePathGroup('/%20space/foo')).toBe('/other');
+    expect(normalizePathGroup('/<script>/x')).toBe('/other');
+  });
+
+  it('handles valid char classes (letters, digits, hyphens, underscores, dots)', () => {
+    expect(normalizePathGroup('/api-v2/foo')).toBe('/api-v2/*');
+    expect(normalizePathGroup('/v1.0/foo')).toBe('/v1.0/*');
+    expect(normalizePathGroup('/my_section/foo')).toBe('/my_section/*');
+  });
+});
+
+describe('CfRumCollectorService', () => {
+  let crit: CriticalityLoaderService;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    crit = new CriticalityLoaderService();
+    crit.setConfigForTest(VALID_CONFIG);
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('skips when CLOUDFLARE token is missing (graceful)', async () => {
+    const upsertSpy = jest.fn().mockResolvedValue({ error: null });
+    const svc = buildSvc(
+      crit,
+      makeConfigService({ CLOUDFLARE_ACCOUNT_ID: 'acc-123' }),
+      upsertSpy,
+    );
+    const result = await svc.run({ triggeredBy: 'test' });
+    expect(result.skipped).toBe('no_token');
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips when CLOUDFLARE_ACCOUNT_ID is missing (graceful)', async () => {
+    const upsertSpy = jest.fn().mockResolvedValue({ error: null });
+    const svc = buildSvc(
+      crit,
+      makeConfigService({ CLOUDFLARE_API_TOKEN: 'tok-123' }),
+      upsertSpy,
+    );
+    const result = await svc.run({ triggeredBy: 'test' });
+    expect(result.skipped).toBe('no_account_id');
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('prefers CLOUDFLARE_ANALYTICS_TOKEN over CLOUDFLARE_API_TOKEN when both set', async () => {
+    let capturedAuth: string | undefined;
+    globalThis.fetch = jest.fn().mockImplementation(async (_url, init: RequestInit) => {
+      capturedAuth = (init.headers as Record<string, string>).Authorization;
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => ({ data: { viewer: { accounts: [{ rumPageloadEventsAdaptiveGroups: [] }] } } }),
+      };
+    }) as unknown as typeof globalThis.fetch;
+
+    const upsertSpy = jest.fn().mockResolvedValue({ error: null });
+    const svc = buildSvc(
+      crit,
+      makeConfigService({
+        CLOUDFLARE_API_TOKEN: 'old-token',
+        CLOUDFLARE_ANALYTICS_TOKEN: 'new-analytics-token',
+        CLOUDFLARE_ACCOUNT_ID: 'acc-123',
+      }),
+      upsertSpy,
+    );
+    await svc.run({ triggeredBy: 'test' });
+    expect(capturedAuth).toBe('Bearer new-analytics-token');
+  });
+
+  it('aggregates pageload + performance by tier × path_group, upserts to __seo_snapshot_cf_rum', async () => {
+    globalThis.fetch = mockFetch(
+      [
+        { date: '2026-05-16', path: '/pieces/foo-1.html', count: 100, visits: 80 },
+        { date: '2026-05-16', path: '/pieces/bar-2.html', count: 50, visits: 40 },
+        { date: '2026-05-16', path: '/blog/post-x', count: 30, visits: 25 },
+        { date: '2026-05-16', path: '/admin/dashboard', count: 10, visits: 5 },
+      ],
+      [
+        { date: '2026-05-16', path: '/pieces/foo-1.html', count: 100, lcpP75: 2100, clsP75: 0.087, inpP75: 180 },
+        { date: '2026-05-16', path: '/blog/post-x', count: 30, lcpP75: 1800, clsP75: 0.05, inpP75: 150 },
+      ],
+    ) as unknown as typeof globalThis.fetch;
+
+    const upsertSpy = jest.fn().mockResolvedValue({ error: null });
+    const svc = buildSvc(
+      crit,
+      makeConfigService({
+        CLOUDFLARE_API_TOKEN: 'tok',
+        CLOUDFLARE_ACCOUNT_ID: 'acc-123',
+      }),
+      upsertSpy,
+    );
+
+    const result = await svc.run({
+      triggeredBy: 'test',
+      bucketDateOverride: '2026-05-16',
+    });
+
+    expect(result.skipped).toBeUndefined();
+    expect(result.bucket_date).toBe('2026-05-16');
+    expect(result.pageload_events).toBe(4);
+    expect(result.performance_events).toBe(2);
+    expect(upsertSpy).toHaveBeenCalledTimes(1);
+
+    const rows = upsertSpy.mock.calls[0][0] as Array<{
+      tier: string;
+      path_group: string;
+      visit_count: number;
+      pageview_count: number;
+      lcp_p75_ms: number | null;
+      cls_p75_milli: number | null;
+    }>;
+
+    // Grand total : (tier='total', path_group='total') = tous pageloads sommés.
+    const grandTotal = rows.find(
+      (r) => r.tier === 'total' && r.path_group === 'total',
+    );
+    expect(grandTotal).toBeDefined();
+    expect(grandTotal?.pageview_count).toBe(190); // 100+50+30+10
+    expect(grandTotal?.visit_count).toBe(150); // 80+40+25+5
+
+    // (tier='total', path_group='/pieces/*') = total pieces.
+    const totalPieces = rows.find(
+      (r) => r.tier === 'total' && r.path_group === '/pieces/*',
+    );
+    expect(totalPieces?.pageview_count).toBe(150); // 100+50
+
+    // (tier='tier0', path_group='total') = total tier0 (= pieces).
+    const tier0Total = rows.find(
+      (r) => r.tier === 'tier0' && r.path_group === 'total',
+    );
+    expect(tier0Total?.pageview_count).toBe(150);
+
+    // (tier='tier0', path_group='/pieces/*') = drill-down complet.
+    const tier0Pieces = rows.find(
+      (r) => r.tier === 'tier0' && r.path_group === '/pieces/*',
+    );
+    expect(tier0Pieces?.pageview_count).toBe(150);
+    expect(tier0Pieces?.lcp_p75_ms).toBe(2100);
+    expect(tier0Pieces?.cls_p75_milli).toBe(87); // 0.087 * 1000
+
+    // admin/* est excluded → JAMAIS de row tier2 (admin n'est pas tier2 dans VALID_CONFIG).
+    // Mais admin contribue toujours aux rollups (total/total) et (total, /admin/*).
+    const totalAdmin = rows.find(
+      (r) => r.tier === 'total' && r.path_group === '/admin/*',
+    );
+    expect(totalAdmin?.pageview_count).toBe(10);
+
+    // tier1 = blog
+    const tier1Total = rows.find(
+      (r) => r.tier === 'tier1' && r.path_group === 'total',
+    );
+    expect(tier1Total?.pageview_count).toBe(30);
+    expect(tier1Total?.lcp_p75_ms).toBe(1800);
+  });
+
+  it('persists volumes with null percentiles when performance query fails (non-fatal)', async () => {
+    let call = 0;
+    globalThis.fetch = jest.fn().mockImplementation(async (_url, init: RequestInit) => {
+      call++;
+      const body = JSON.parse(init.body as string) as { query: string };
+      const isPageload = body.query.includes('rumPageloadEventsAdaptiveGroups');
+      if (isPageload) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => '',
+          json: async () => ({
+            data: {
+              viewer: {
+                accounts: [
+                  {
+                    rumPageloadEventsAdaptiveGroups: [
+                      {
+                        dimensions: { date: '2026-05-16', requestPath: '/pieces/x' },
+                        count: 42,
+                        sum: { visits: 30 },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          }),
+        };
+      }
+      // Performance query fails.
+      return {
+        ok: false,
+        status: 500,
+        text: async () => 'Schema mismatch',
+        json: async () => ({}),
+      };
+    }) as unknown as typeof globalThis.fetch;
+
+    const upsertSpy = jest.fn().mockResolvedValue({ error: null });
+    const svc = buildSvc(
+      crit,
+      makeConfigService({
+        CLOUDFLARE_API_TOKEN: 'tok',
+        CLOUDFLARE_ACCOUNT_ID: 'acc',
+      }),
+      upsertSpy,
+    );
+
+    const result = await svc.run({
+      triggeredBy: 'test',
+      bucketDateOverride: '2026-05-16',
+    });
+
+    // Volumes persisted, but perf events = 0 and percentiles null.
+    expect(result.skipped).toBeUndefined();
+    expect(result.pageload_events).toBe(1);
+    expect(result.performance_events).toBe(0);
+    expect(result.errorMessage).toMatch(/performance:/);
+    expect(upsertSpy).toHaveBeenCalledTimes(1);
+    expect(call).toBe(2); // both queries attempted
+
+    const rows = upsertSpy.mock.calls[0][0] as Array<{
+      tier: string;
+      path_group: string;
+      pageview_count: number;
+      lcp_p75_ms: number | null;
+    }>;
+    const tier0Pieces = rows.find(
+      (r) => r.tier === 'tier0' && r.path_group === '/pieces/*',
+    );
+    expect(tier0Pieces?.pageview_count).toBe(42);
+    expect(tier0Pieces?.lcp_p75_ms).toBeNull();
+  });
+
+  it('returns cf_api_error when pageload query (critical signal) fails', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'Unauthorized',
+      json: async () => ({}),
+    }) as unknown as typeof globalThis.fetch;
+
+    const upsertSpy = jest.fn().mockResolvedValue({ error: null });
+    const svc = buildSvc(
+      crit,
+      makeConfigService({
+        CLOUDFLARE_API_TOKEN: 'tok',
+        CLOUDFLARE_ACCOUNT_ID: 'acc',
+      }),
+      upsertSpy,
+    );
+
+    const result = await svc.run({ triggeredBy: 'test' });
+    expect(result.skipped).toBe('cf_api_error');
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('uses J-1 UTC as the default bucket date', async () => {
+    // Stable mock: no data, just observe the date arg sent to CF.
+    let capturedFrom: string | undefined;
+    globalThis.fetch = jest.fn().mockImplementation(async (_url, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { variables: { from: string } };
+      capturedFrom = body.variables.from;
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => ({
+          data: {
+            viewer: {
+              accounts: [{ rumPageloadEventsAdaptiveGroups: [] }],
+            },
+          },
+        }),
+      };
+    }) as unknown as typeof globalThis.fetch;
+
+    const upsertSpy = jest.fn().mockResolvedValue({ error: null });
+    const svc = buildSvc(
+      crit,
+      makeConfigService({
+        CLOUDFLARE_API_TOKEN: 'tok',
+        CLOUDFLARE_ACCOUNT_ID: 'acc',
+      }),
+      upsertSpy,
+    );
+
+    const result = await svc.run({ triggeredBy: 'test' });
+    const yesterday = new Date();
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    const expected = yesterday.toISOString().slice(0, 10);
+    expect(result.bucket_date).toBe(expected);
+    expect(capturedFrom).toBe(expected);
+  });
+});

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.ts
@@ -114,7 +114,7 @@ query SeoControlPlaneCfRumPerformance($accountTag: String!, $from: Date!, $to: D
 
 interface CfPageloadGroup {
   dimensions: {
-    date: string;          // 'YYYY-MM-DD'
+    date: string; // 'YYYY-MM-DD'
     requestPath: string | null;
   };
   count: number;
@@ -465,17 +465,50 @@ export class CfRumCollectorService extends SupabaseBaseService {
         const cell = this.ensureCell(out, t, pg);
         cell.samples += g.count;
         // Conservative aggregation : on garde le worst-case observed.
-        cell.lcp_p50_ms = maxNullable(cell.lcp_p50_ms, msToInt(q.performanceLargestContentfulPaintPathP50));
-        cell.lcp_p75_ms = maxNullable(cell.lcp_p75_ms, msToInt(q.performanceLargestContentfulPaintPathP75));
-        cell.lcp_p95_ms = maxNullable(cell.lcp_p95_ms, msToInt(q.performanceLargestContentfulPaintPathP95));
-        cell.cls_p50_milli = maxNullable(cell.cls_p50_milli, clsToMilli(q.performanceCumulativeLayoutShiftP50));
-        cell.cls_p75_milli = maxNullable(cell.cls_p75_milli, clsToMilli(q.performanceCumulativeLayoutShiftP75));
-        cell.cls_p95_milli = maxNullable(cell.cls_p95_milli, clsToMilli(q.performanceCumulativeLayoutShiftP95));
-        cell.inp_p50_ms = maxNullable(cell.inp_p50_ms, msToInt(q.performanceInteractionToNextPaintP50));
-        cell.inp_p75_ms = maxNullable(cell.inp_p75_ms, msToInt(q.performanceInteractionToNextPaintP75));
-        cell.inp_p95_ms = maxNullable(cell.inp_p95_ms, msToInt(q.performanceInteractionToNextPaintP95));
-        cell.fcp_p75_ms = maxNullable(cell.fcp_p75_ms, msToInt(q.performanceFirstContentfulPaintP75));
-        cell.ttfb_p75_ms = maxNullable(cell.ttfb_p75_ms, msToInt(q.performanceTimeToFirstByteP75));
+        cell.lcp_p50_ms = maxNullable(
+          cell.lcp_p50_ms,
+          msToInt(q.performanceLargestContentfulPaintPathP50),
+        );
+        cell.lcp_p75_ms = maxNullable(
+          cell.lcp_p75_ms,
+          msToInt(q.performanceLargestContentfulPaintPathP75),
+        );
+        cell.lcp_p95_ms = maxNullable(
+          cell.lcp_p95_ms,
+          msToInt(q.performanceLargestContentfulPaintPathP95),
+        );
+        cell.cls_p50_milli = maxNullable(
+          cell.cls_p50_milli,
+          clsToMilli(q.performanceCumulativeLayoutShiftP50),
+        );
+        cell.cls_p75_milli = maxNullable(
+          cell.cls_p75_milli,
+          clsToMilli(q.performanceCumulativeLayoutShiftP75),
+        );
+        cell.cls_p95_milli = maxNullable(
+          cell.cls_p95_milli,
+          clsToMilli(q.performanceCumulativeLayoutShiftP95),
+        );
+        cell.inp_p50_ms = maxNullable(
+          cell.inp_p50_ms,
+          msToInt(q.performanceInteractionToNextPaintP50),
+        );
+        cell.inp_p75_ms = maxNullable(
+          cell.inp_p75_ms,
+          msToInt(q.performanceInteractionToNextPaintP75),
+        );
+        cell.inp_p95_ms = maxNullable(
+          cell.inp_p95_ms,
+          msToInt(q.performanceInteractionToNextPaintP95),
+        );
+        cell.fcp_p75_ms = maxNullable(
+          cell.fcp_p75_ms,
+          msToInt(q.performanceFirstContentfulPaintP75),
+        );
+        cell.ttfb_p75_ms = maxNullable(
+          cell.ttfb_p75_ms,
+          msToInt(q.performanceTimeToFirstByteP75),
+        );
       }
     }
 
@@ -538,10 +571,7 @@ export class CfRumCollectorService extends SupabaseBaseService {
     if (error) throw new Error(`Supabase upsert error: ${error.message}`);
   }
 
-  private finalize(
-    r: CfRumRunResult,
-    startedAtMs: number,
-  ): CfRumRunResult {
+  private finalize(r: CfRumRunResult, startedAtMs: number): CfRumRunResult {
     r.finished_at = new Date().toISOString();
     r.duration_ms = Date.now() - startedAtMs;
     this.logger.log(

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.ts
@@ -1,0 +1,618 @@
+/**
+ * CfRumCollectorService — Layer 1 Collector (Cloudflare GraphQL RUM Web Vitals).
+ *
+ * ADR-064 §Architecture L1 — PR-2A-2.5. Lit l'API Cloudflare GraphQL Analytics
+ * account-scoped (`rumPageloadEventsAdaptiveGroups` + `rumPerformanceEventsAdaptiveGroups`)
+ * 1 fois/jour à 01:00 UTC (RUM buffered ~30 min après minuit, ABR favorise daily)
+ * et insère des snapshots agrégés par (jour, tier, path_group) dans
+ * `__seo_snapshot_cf_rum`.
+ *
+ * Pourquoi cette source complémentaire de cf-analytics (Source C) :
+ *   - cf-analytics = edge-server (status codes, cache, origin perf) → infra-perf
+ *   - cf-rum       = edge-RUM utilisateur réel (LCP/CLS/INP) → UX-perf
+ *
+ * Cadence q-daily (≠ Q5min cf-analytics) :
+ *   - RUM buffer ~30 min ; ABR ramène la résolution à 1 j pour fenêtres >7 j
+ *   - Q5min gaspillerait le quota GraphQL et fournirait du bruit sur faibles
+ *     échantillons RUM
+ *
+ * Discipline 4-layer : aucune lecture L2/L3, aucune écriture L4. Pure ingestion.
+ *
+ * Robustesse :
+ *   - 2 queries GraphQL séparées (pageload + performance) → si performance
+ *     échoue (schéma CF évolue), les visits/pageviews sont toujours upsertées
+ *     avec percentiles=null (canon `feedback_no_silent_skip_on_governance_critical_jobs`
+ *     — on log l'erreur mais on ne suppress pas la donnée volume).
+ *   - UPSERT idempotent sur (bucket_start, tier, path_group) — retry safe.
+ *   - Skip explicite si CLOUDFLARE_API_TOKEN ou CLOUDFLARE_ACCOUNT_ID manquant
+ *     (preprod fresh → graceful, surface dans le run result).
+ *
+ * @see feedback_seo_control_plane_layered_architecture
+ * @see feedback_slo_must_be_multi_source (source C' = edge-RUM)
+ * @see feedback_gsc_is_secondary_signal_only (CF RUM = monitoring primaire CWV)
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomUUID } from 'node:crypto';
+import { SupabaseBaseService } from '../../../../database/services/supabase-base.service';
+import { CriticalityLoaderService } from '../../services/criticality-loader.service';
+import {
+  PATH_GROUP_OTHER,
+  PATH_GROUP_TOTAL,
+  type CfRumJobData,
+  type CfRumRunResult,
+  type CfRumSnapshot,
+  type CfRumTierBucket,
+} from './cf-rum.types';
+
+const CF_GRAPHQL_ENDPOINT = 'https://api.cloudflare.com/client/v4/graphql';
+
+/**
+ * Pageload events query — visits, pageviews par jour × pagePath.
+ * Schéma CF GraphQL stable (publiquement documenté).
+ */
+const GRAPHQL_PAGELOAD_QUERY = `
+query SeoControlPlaneCfRumPageload($accountTag: String!, $from: Date!, $to: Date!) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      rumPageloadEventsAdaptiveGroups(
+        filter: { date_geq: $from, date_lt: $to }
+        limit: 10000
+        orderBy: [count_DESC]
+      ) {
+        dimensions {
+          date
+          requestPath
+        }
+        count
+        sum {
+          visits
+        }
+      }
+    }
+  }
+}`;
+
+/**
+ * Performance events query — Core Web Vitals percentiles par jour × pagePath.
+ * NOTE schéma : les noms exacts des champs `quantiles` peuvent évoluer côté CF.
+ * Si le schéma diverge, le service log l'erreur et continue avec les seules
+ * données pageload (visits/pageviews). Voir `fetchPerformance` ci-dessous.
+ */
+const GRAPHQL_PERFORMANCE_QUERY = `
+query SeoControlPlaneCfRumPerformance($accountTag: String!, $from: Date!, $to: Date!) {
+  viewer {
+    accounts(filter: { accountTag: $accountTag }) {
+      rumPerformanceEventsAdaptiveGroups(
+        filter: { date_geq: $from, date_lt: $to }
+        limit: 10000
+        orderBy: [count_DESC]
+      ) {
+        dimensions {
+          date
+          requestPath
+        }
+        count
+        quantiles {
+          performanceLargestContentfulPaintPathP50
+          performanceLargestContentfulPaintPathP75
+          performanceLargestContentfulPaintPathP95
+          performanceCumulativeLayoutShiftP50
+          performanceCumulativeLayoutShiftP75
+          performanceCumulativeLayoutShiftP95
+          performanceInteractionToNextPaintP50
+          performanceInteractionToNextPaintP75
+          performanceInteractionToNextPaintP95
+          performanceFirstContentfulPaintP75
+          performanceTimeToFirstByteP75
+        }
+      }
+    }
+  }
+}`;
+
+interface CfPageloadGroup {
+  dimensions: {
+    date: string;          // 'YYYY-MM-DD'
+    requestPath: string | null;
+  };
+  count: number;
+  sum: { visits: number };
+}
+
+interface CfPerformanceGroup {
+  dimensions: {
+    date: string;
+    requestPath: string | null;
+  };
+  count: number;
+  quantiles: {
+    performanceLargestContentfulPaintPathP50: number | null;
+    performanceLargestContentfulPaintPathP75: number | null;
+    performanceLargestContentfulPaintPathP95: number | null;
+    performanceCumulativeLayoutShiftP50: number | null;
+    performanceCumulativeLayoutShiftP75: number | null;
+    performanceCumulativeLayoutShiftP95: number | null;
+    performanceInteractionToNextPaintP50: number | null;
+    performanceInteractionToNextPaintP75: number | null;
+    performanceInteractionToNextPaintP95: number | null;
+    performanceFirstContentfulPaintP75: number | null;
+    performanceTimeToFirstByteP75: number | null;
+  };
+}
+
+interface CfGraphQLResponse<T> {
+  data?: {
+    viewer?: {
+      accounts?: Array<Record<string, T[]>>;
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+/** Normalise un pagePath en path_group (1er segment ou '/'). */
+export function normalizePathGroup(rawPath: string | null | undefined): string {
+  if (!rawPath || rawPath === '/' || rawPath === '') return '/';
+  const stripped = rawPath.split('?')[0].split('#')[0];
+  const segments = stripped.split('/').filter(Boolean);
+  if (segments.length === 0) return '/';
+  // Sécurité : segment vide ou suspect → fallback.
+  const first = segments[0];
+  if (!/^[a-z0-9._-]+$/i.test(first)) return PATH_GROUP_OTHER;
+  return `/${first}/*`;
+}
+
+/** Convertit un CLS float (0..1+ typique) en milli-entier pour stockage BIGINT. */
+function clsToMilli(cls: number | null | undefined): number | null {
+  if (cls === null || cls === undefined || !Number.isFinite(cls)) return null;
+  return Math.round(cls * 1000);
+}
+
+/** Convertit un float ms en entier ms ; null si non-fini. */
+function msToInt(ms: number | null | undefined): number | null {
+  if (ms === null || ms === undefined || !Number.isFinite(ms)) return null;
+  return Math.round(ms);
+}
+
+@Injectable()
+export class CfRumCollectorService extends SupabaseBaseService {
+  protected readonly logger = new Logger(CfRumCollectorService.name);
+  private readonly cfg: ConfigService;
+
+  constructor(
+    private readonly criticality: CriticalityLoaderService,
+    configService: ConfigService,
+  ) {
+    super(configService);
+    this.cfg = configService;
+  }
+
+  async run(job: CfRumJobData): Promise<CfRumRunResult> {
+    const startedAtMs = Date.now();
+    const runId = randomUUID();
+
+    // Fenêtre par défaut = jour UTC J-1 complet.
+    const bucketDate = job.bucketDateOverride ?? this.yesterdayUtc();
+    const fromDate = bucketDate;
+    const toDate = this.nextDayUtc(bucketDate);
+    const bucketStartIso = `${bucketDate}T00:00:00.000Z`;
+
+    const result: CfRumRunResult = {
+      run_id: runId,
+      started_at: new Date(startedAtMs).toISOString(),
+      finished_at: '',
+      duration_ms: 0,
+      triggered_by: job.triggeredBy,
+      bucket_date: bucketDate,
+      pageload_events: 0,
+      performance_events: 0,
+      rows_upserted: 0,
+      totals_period: {
+        visits: 0,
+        pageviews: 0,
+        lcp_p75_ms: null,
+        cls_p75_milli: null,
+        inp_p75_ms: null,
+      },
+    };
+
+    const token =
+      this.cfg.get<string>('CLOUDFLARE_ANALYTICS_TOKEN') ??
+      this.cfg.get<string>('CLOUDFLARE_API_TOKEN');
+    const accountTag = this.cfg.get<string>('CLOUDFLARE_ACCOUNT_ID');
+    if (!token) {
+      this.logger.warn(
+        'CLOUDFLARE_API_TOKEN/CLOUDFLARE_ANALYTICS_TOKEN missing — skipping cf-rum run',
+      );
+      result.skipped = 'no_token';
+      return this.finalize(result, startedAtMs);
+    }
+    if (!accountTag) {
+      this.logger.warn(
+        'CLOUDFLARE_ACCOUNT_ID missing — skipping cf-rum run (rum* datasets are account-scoped)',
+      );
+      result.skipped = 'no_account_id';
+      return this.finalize(result, startedAtMs);
+    }
+
+    this.logger.log(
+      `🌐 cf-rum run starting (run_id=${runId} bucket=${bucketDate} triggeredBy=${job.triggeredBy})`,
+    );
+
+    // 1) Pageload events — visits/pageviews. Échec ici = abort run (signal volume critique).
+    let pageloadGroups: CfPageloadGroup[];
+    try {
+      pageloadGroups = await this.fetchPageload(
+        token,
+        accountTag,
+        fromDate,
+        toDate,
+      );
+    } catch (err) {
+      this.logger.error(
+        `❌ CF GraphQL pageload fetch failed: ${this.errMsg(err)} — aborting run`,
+      );
+      result.skipped = 'cf_api_error';
+      result.errorMessage = this.errMsg(err);
+      return this.finalize(result, startedAtMs);
+    }
+    result.pageload_events = pageloadGroups.length;
+
+    // 2) Performance events — CWV percentiles. Échec ici = non-bloquant
+    //    (on persiste quand même les volumes avec percentiles=null).
+    let performanceGroups: CfPerformanceGroup[] = [];
+    try {
+      performanceGroups = await this.fetchPerformance(
+        token,
+        accountTag,
+        fromDate,
+        toDate,
+      );
+      result.performance_events = performanceGroups.length;
+    } catch (err) {
+      this.logger.warn(
+        `⚠️ CF GraphQL performance fetch failed (non-fatal — volumes still upserted): ${this.errMsg(err)}`,
+      );
+      result.errorMessage = `performance: ${this.errMsg(err)}`;
+    }
+
+    // 3) Agrégation cross-dataset par (tier, path_group).
+    const aggregated = this.aggregate(pageloadGroups, performanceGroups);
+
+    // 4) Build snapshots — flatten Map → rows.
+    const snapshots: CfRumSnapshot[] = [];
+    for (const [tier, byPath] of aggregated) {
+      for (const [pathGroup, agg] of byPath) {
+        snapshots.push({
+          bucket_start: bucketStartIso,
+          tier,
+          path_group: pathGroup,
+          visit_count: agg.visits,
+          pageview_count: agg.pageviews,
+          sample_count: agg.samples,
+          lcp_p50_ms: agg.lcp_p50_ms,
+          lcp_p75_ms: agg.lcp_p75_ms,
+          lcp_p95_ms: agg.lcp_p95_ms,
+          cls_p50_milli: agg.cls_p50_milli,
+          cls_p75_milli: agg.cls_p75_milli,
+          cls_p95_milli: agg.cls_p95_milli,
+          inp_p50_ms: agg.inp_p50_ms,
+          inp_p75_ms: agg.inp_p75_ms,
+          inp_p95_ms: agg.inp_p95_ms,
+          fcp_p75_ms: agg.fcp_p75_ms,
+          ttfb_p75_ms: agg.ttfb_p75_ms,
+          metrics_extra: {},
+          run_id: runId,
+          account_tag: accountTag,
+          fetched_at: new Date().toISOString(),
+        });
+      }
+    }
+
+    // 5) Totals period = rollup (tier='total', path_group='total').
+    const totalRow = snapshots.find(
+      (s) => s.tier === 'total' && s.path_group === PATH_GROUP_TOTAL,
+    );
+    if (totalRow) {
+      result.totals_period.visits = totalRow.visit_count;
+      result.totals_period.pageviews = totalRow.pageview_count;
+      result.totals_period.lcp_p75_ms = totalRow.lcp_p75_ms;
+      result.totals_period.cls_p75_milli = totalRow.cls_p75_milli;
+      result.totals_period.inp_p75_ms = totalRow.inp_p75_ms;
+    }
+
+    // 6) Persist.
+    try {
+      await this.persist(snapshots);
+      result.rows_upserted = snapshots.length;
+    } catch (err) {
+      this.logger.error(
+        `❌ persist failed (${snapshots.length} snapshots): ${this.errMsg(err)}`,
+      );
+      result.errorMessage = `${result.errorMessage ? `${result.errorMessage} | ` : ''}persist: ${this.errMsg(err)}`;
+    }
+
+    return this.finalize(result, startedAtMs);
+  }
+
+  // ── private ────────────────────────────────────────────────────────────────
+
+  private async fetchPageload(
+    token: string,
+    accountTag: string,
+    fromDate: string,
+    toDate: string,
+  ): Promise<CfPageloadGroup[]> {
+    const json = await this.graphqlRequest<CfPageloadGroup>(
+      token,
+      GRAPHQL_PAGELOAD_QUERY,
+      { accountTag, from: fromDate, to: toDate },
+    );
+    const groups =
+      json.data?.viewer?.accounts?.[0]?.rumPageloadEventsAdaptiveGroups;
+    if (!groups) {
+      throw new Error(
+        'CF GraphQL response missing rumPageloadEventsAdaptiveGroups',
+      );
+    }
+    return groups;
+  }
+
+  private async fetchPerformance(
+    token: string,
+    accountTag: string,
+    fromDate: string,
+    toDate: string,
+  ): Promise<CfPerformanceGroup[]> {
+    const json = await this.graphqlRequest<CfPerformanceGroup>(
+      token,
+      GRAPHQL_PERFORMANCE_QUERY,
+      { accountTag, from: fromDate, to: toDate },
+    );
+    const groups =
+      json.data?.viewer?.accounts?.[0]?.rumPerformanceEventsAdaptiveGroups;
+    if (!groups) {
+      throw new Error(
+        'CF GraphQL response missing rumPerformanceEventsAdaptiveGroups',
+      );
+    }
+    return groups;
+  }
+
+  private async graphqlRequest<T>(
+    token: string,
+    query: string,
+    variables: Record<string, string>,
+  ): Promise<CfGraphQLResponse<T>> {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 30_000);
+    try {
+      const res = await fetch(CF_GRAPHQL_ENDPOINT, {
+        method: 'POST',
+        signal: ctrl.signal,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, variables }),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `CF GraphQL HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`,
+        );
+      }
+      const json = (await res.json()) as CfGraphQLResponse<T>;
+      if (json.errors && json.errors.length > 0) {
+        throw new Error(
+          `CF GraphQL errors: ${json.errors.map((e) => e.message).join('; ')}`,
+        );
+      }
+      return json;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Agrège pageload + performance groups en (tier × path_group) → rollups.
+   *
+   * Pour chaque path raw :
+   *   - Tier déterminé par criticality.classify() : 'tier0'|'tier1'|'tier2'|'excluded'|null
+   *   - Path-group normalisé par normalizePathGroup() : '/pieces/*' etc.
+   *
+   * Lignes produites par path raw :
+   *   - (tier='total', path_group='total')     — grand total
+   *   - (tier=<X>,     path_group='total')     — total par tier (sauf 'excluded'/null)
+   *   - (tier='total', path_group=<G>)         — total par section
+   *   - (tier=<X>,     path_group=<G>)         — drill-down complet (sauf excluded)
+   *
+   * Pour les percentiles, on **prend le max p75 observé** sur les groups raw
+   * agrégés dans la même cellule. C'est conservateur (worst-case) et évite
+   * d'avoir à recalculer un percentile pondéré depuis des sous-percentiles
+   * (mathématiquement non-trivial sans la distribution complète).
+   *
+   * Cf. plan §Risques : si CF expose plus tard une API exposant l'histogramme
+   * brut, on pourra recalculer un vrai p75 pondéré côté Postgres.
+   */
+  private aggregate(
+    pageload: CfPageloadGroup[],
+    performance: CfPerformanceGroup[],
+  ): Map<CfRumTierBucket, Map<string, RumAggregate>> {
+    const out = new Map<CfRumTierBucket, Map<string, RumAggregate>>();
+
+    // 1) Volume (pageload).
+    for (const g of pageload) {
+      const path = g.dimensions.requestPath ?? '/';
+      const tier = this.tierOf(path);
+      const pathGroup = normalizePathGroup(path);
+
+      for (const [t, pg] of this.cellsFor(tier, pathGroup)) {
+        const cell = this.ensureCell(out, t, pg);
+        cell.pageviews += g.count;
+        cell.visits += g.sum.visits;
+      }
+    }
+
+    // 2) Web vitals (performance).
+    for (const g of performance) {
+      const path = g.dimensions.requestPath ?? '/';
+      const tier = this.tierOf(path);
+      const pathGroup = normalizePathGroup(path);
+      const q = g.quantiles;
+
+      for (const [t, pg] of this.cellsFor(tier, pathGroup)) {
+        const cell = this.ensureCell(out, t, pg);
+        cell.samples += g.count;
+        // Conservative aggregation : on garde le worst-case observed.
+        cell.lcp_p50_ms = maxNullable(cell.lcp_p50_ms, msToInt(q.performanceLargestContentfulPaintPathP50));
+        cell.lcp_p75_ms = maxNullable(cell.lcp_p75_ms, msToInt(q.performanceLargestContentfulPaintPathP75));
+        cell.lcp_p95_ms = maxNullable(cell.lcp_p95_ms, msToInt(q.performanceLargestContentfulPaintPathP95));
+        cell.cls_p50_milli = maxNullable(cell.cls_p50_milli, clsToMilli(q.performanceCumulativeLayoutShiftP50));
+        cell.cls_p75_milli = maxNullable(cell.cls_p75_milli, clsToMilli(q.performanceCumulativeLayoutShiftP75));
+        cell.cls_p95_milli = maxNullable(cell.cls_p95_milli, clsToMilli(q.performanceCumulativeLayoutShiftP95));
+        cell.inp_p50_ms = maxNullable(cell.inp_p50_ms, msToInt(q.performanceInteractionToNextPaintP50));
+        cell.inp_p75_ms = maxNullable(cell.inp_p75_ms, msToInt(q.performanceInteractionToNextPaintP75));
+        cell.inp_p95_ms = maxNullable(cell.inp_p95_ms, msToInt(q.performanceInteractionToNextPaintP95));
+        cell.fcp_p75_ms = maxNullable(cell.fcp_p75_ms, msToInt(q.performanceFirstContentfulPaintP75));
+        cell.ttfb_p75_ms = maxNullable(cell.ttfb_p75_ms, msToInt(q.performanceTimeToFirstByteP75));
+      }
+    }
+
+    return out;
+  }
+
+  /**
+   * Tier d'un path. Retourne 'total' sentinel pour 'excluded'/null (capté
+   * uniquement dans les cellules tier='total').
+   */
+  private tierOf(path: string): CfRumTierBucket | 'excluded' | null {
+    const t = this.criticality.classify(path);
+    return t;
+  }
+
+  /**
+   * Pour un (tier, pathGroup) donné, retourne les cellules de rollup à
+   * mettre à jour. Discipline :
+   *   - tier 'excluded' ou null → uniquement (total, total) + (total, pathGroup)
+   *   - tier 'tier0'|'tier1'|'tier2' → 4 cellules (total/total, total/pg, t/total, t/pg)
+   */
+  private cellsFor(
+    tier: CfRumTierBucket | 'excluded' | null,
+    pathGroup: string,
+  ): Array<[CfRumTierBucket, string]> {
+    const cells: Array<[CfRumTierBucket, string]> = [
+      ['total', PATH_GROUP_TOTAL],
+      ['total', pathGroup],
+    ];
+    if (tier === 'tier0' || tier === 'tier1' || tier === 'tier2') {
+      cells.push([tier, PATH_GROUP_TOTAL]);
+      cells.push([tier, pathGroup]);
+    }
+    return cells;
+  }
+
+  private ensureCell(
+    out: Map<CfRumTierBucket, Map<string, RumAggregate>>,
+    tier: CfRumTierBucket,
+    pathGroup: string,
+  ): RumAggregate {
+    let byPath = out.get(tier);
+    if (!byPath) {
+      byPath = new Map();
+      out.set(tier, byPath);
+    }
+    let cell = byPath.get(pathGroup);
+    if (!cell) {
+      cell = freshAggregate();
+      byPath.set(pathGroup, cell);
+    }
+    return cell;
+  }
+
+  private async persist(snapshots: CfRumSnapshot[]): Promise<void> {
+    if (snapshots.length === 0) return;
+    const { error } = await this.supabase
+      .from('__seo_snapshot_cf_rum')
+      .upsert(snapshots, { onConflict: 'bucket_start,tier,path_group' });
+    if (error) throw new Error(`Supabase upsert error: ${error.message}`);
+  }
+
+  private finalize(
+    r: CfRumRunResult,
+    startedAtMs: number,
+  ): CfRumRunResult {
+    r.finished_at = new Date().toISOString();
+    r.duration_ms = Date.now() - startedAtMs;
+    this.logger.log(
+      `✅ cf-rum run ${r.run_id} done in ${r.duration_ms}ms — ` +
+        `bucket=${r.bucket_date} pageload_events=${r.pageload_events} ` +
+        `perf_events=${r.performance_events} rows=${r.rows_upserted} ` +
+        `visits=${r.totals_period.visits} lcp_p75=${r.totals_period.lcp_p75_ms ?? 'null'}ms ` +
+        `cls_p75=${r.totals_period.cls_p75_milli ?? 'null'}/1000 ` +
+        `inp_p75=${r.totals_period.inp_p75_ms ?? 'null'}ms` +
+        (r.skipped ? ` [skipped: ${r.skipped}]` : ''),
+    );
+    return r;
+  }
+
+  private errMsg(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+  }
+
+  /** Retourne le jour UTC J-1 au format 'YYYY-MM-DD'. */
+  private yesterdayUtc(): string {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - 1);
+    return d.toISOString().slice(0, 10);
+  }
+
+  /** Retourne le lendemain (UTC) d'une date 'YYYY-MM-DD'. */
+  private nextDayUtc(date: string): string {
+    const d = new Date(`${date}T00:00:00Z`);
+    d.setUTCDate(d.getUTCDate() + 1);
+    return d.toISOString().slice(0, 10);
+  }
+}
+
+interface RumAggregate {
+  visits: number;
+  pageviews: number;
+  samples: number;
+  lcp_p50_ms: number | null;
+  lcp_p75_ms: number | null;
+  lcp_p95_ms: number | null;
+  cls_p50_milli: number | null;
+  cls_p75_milli: number | null;
+  cls_p95_milli: number | null;
+  inp_p50_ms: number | null;
+  inp_p75_ms: number | null;
+  inp_p95_ms: number | null;
+  fcp_p75_ms: number | null;
+  ttfb_p75_ms: number | null;
+}
+
+function freshAggregate(): RumAggregate {
+  return {
+    visits: 0,
+    pageviews: 0,
+    samples: 0,
+    lcp_p50_ms: null,
+    lcp_p75_ms: null,
+    lcp_p95_ms: null,
+    cls_p50_milli: null,
+    cls_p75_milli: null,
+    cls_p95_milli: null,
+    inp_p50_ms: null,
+    inp_p75_ms: null,
+    inp_p95_ms: null,
+    fcp_p75_ms: null,
+    ttfb_p75_ms: null,
+  };
+}
+
+function maxNullable(a: number | null, b: number | null): number | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return Math.max(a, b);
+}

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.types.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.types.ts
@@ -1,0 +1,98 @@
+/**
+ * Cloudflare RUM Collector — types & constants.
+ *
+ * ADR-064 §Architecture L1 — PR-2A-2.5 (Web Vitals edge-RUM).
+ *
+ * Une row par (bucket_start jour UTC, tier, path_group) dans __seo_snapshot_cf_rum.
+ *   - tier='total'        → rollup sans stratification criticality
+ *   - path_group='total'  → rollup sans stratification section
+ *   - (tier='total', path_group='total') = grand total quotidien (sanity baseline)
+ *
+ * Source GraphQL CF :
+ *   - rumPageloadEventsAdaptiveGroups → visits, pageviews (volume)
+ *   - rumPerformanceEventsAdaptiveGroups → LCP/CLS/INP/FCP/TTFB percentiles (UX)
+ *
+ * Discipline 4-layer : aucune lecture L2/L3, aucune écriture L4. Pure ingestion.
+ *
+ * @see feedback_seo_control_plane_layered_architecture
+ * @see feedback_slo_must_be_multi_source (source C' = edge-RUM utilisateur réel)
+ * @see feedback_gsc_is_secondary_signal_only (CF RUM = monitoring primaire CWV)
+ */
+
+import type { TierId } from '@repo/registry';
+
+export type CfRumTierBucket = TierId | 'total';
+export type CfRumTriggeredBy = 'scheduler' | 'manual' | 'test';
+
+/** Path-group sentinel pour le rollup grand total. */
+export const PATH_GROUP_TOTAL = 'total';
+/** Path-group fallback pour les paths non couverts par la normalisation. */
+export const PATH_GROUP_OTHER = '/other';
+
+export interface CfRumJobData {
+  triggeredBy: CfRumTriggeredBy;
+  /**
+   * Override de la fenêtre — par défaut le jour UTC précédent complet
+   * (00:00 UTC J-1 → 00:00 UTC J). Utile pour backfill manuel ou tests.
+   */
+  bucketDateOverride?: string; // 'YYYY-MM-DD' UTC
+}
+
+/** Row insérée dans __seo_snapshot_cf_rum. */
+export interface CfRumSnapshot {
+  bucket_start: string;          // ISO timestamp aligné minuit UTC du jour mesuré
+  tier: CfRumTierBucket;
+  path_group: string;            // '/pieces/*', '/blog/*', '/', '/other', 'total'
+
+  // Volume
+  visit_count: number;
+  pageview_count: number;
+  sample_count: number;
+
+  // Core Web Vitals (LCP/FCP/INP/TTFB en ms ; CLS × 1000 entier — voir migration)
+  lcp_p50_ms: number | null;
+  lcp_p75_ms: number | null;
+  lcp_p95_ms: number | null;
+  cls_p50_milli: number | null;
+  cls_p75_milli: number | null;
+  cls_p95_milli: number | null;
+  inp_p50_ms: number | null;
+  inp_p75_ms: number | null;
+  inp_p95_ms: number | null;
+  fcp_p75_ms: number | null;
+  ttfb_p75_ms: number | null;
+
+  // Breakdowns souples
+  metrics_extra: Record<string, unknown>;
+
+  // Audit-trail
+  run_id: string;
+  account_tag: string;
+  fetched_at: string;
+}
+
+export interface CfRumRunResult {
+  run_id: string;
+  started_at: string;
+  finished_at: string;
+  duration_ms: number;
+  triggered_by: CfRumTriggeredBy;
+  bucket_date: string;           // jour UTC mesuré ('YYYY-MM-DD')
+  pageload_events: number;       // nb de lignes GraphQL pageload reçues
+  performance_events: number;    // nb de lignes GraphQL performance reçues
+  rows_upserted: number;
+  totals_period: {
+    visits: number;
+    pageviews: number;
+    lcp_p75_ms: number | null;   // p75 LCP du rollup total/total
+    cls_p75_milli: number | null;
+    inp_p75_ms: number | null;
+  };
+  skipped?: 'read_only' | 'disabled' | 'no_token' | 'no_account_id' | 'cf_api_error';
+  errorMessage?: string;
+}
+
+export const CF_RUM_JOB_NAME = 'seo-cp-cf-rum-fetch';
+export const CF_RUM_JOB_ID = 'seo-cp-cf-rum-q-daily';
+/** Queue mutualisée L1 (cf. SYNTHETIC_QUEUE_NAME / CF_ANALYTICS_QUEUE_NAME). */
+export const CF_RUM_QUEUE_NAME = 'seo-crawler-monitor';

--- a/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.types.ts
+++ b/backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.types.ts
@@ -40,9 +40,9 @@ export interface CfRumJobData {
 
 /** Row insérée dans __seo_snapshot_cf_rum. */
 export interface CfRumSnapshot {
-  bucket_start: string;          // ISO timestamp aligné minuit UTC du jour mesuré
+  bucket_start: string; // ISO timestamp aligné minuit UTC du jour mesuré
   tier: CfRumTierBucket;
-  path_group: string;            // '/pieces/*', '/blog/*', '/', '/other', 'total'
+  path_group: string; // '/pieces/*', '/blog/*', '/', '/other', 'total'
 
   // Volume
   visit_count: number;
@@ -77,18 +77,23 @@ export interface CfRumRunResult {
   finished_at: string;
   duration_ms: number;
   triggered_by: CfRumTriggeredBy;
-  bucket_date: string;           // jour UTC mesuré ('YYYY-MM-DD')
-  pageload_events: number;       // nb de lignes GraphQL pageload reçues
-  performance_events: number;    // nb de lignes GraphQL performance reçues
+  bucket_date: string; // jour UTC mesuré ('YYYY-MM-DD')
+  pageload_events: number; // nb de lignes GraphQL pageload reçues
+  performance_events: number; // nb de lignes GraphQL performance reçues
   rows_upserted: number;
   totals_period: {
     visits: number;
     pageviews: number;
-    lcp_p75_ms: number | null;   // p75 LCP du rollup total/total
+    lcp_p75_ms: number | null; // p75 LCP du rollup total/total
     cls_p75_milli: number | null;
     inp_p75_ms: number | null;
   };
-  skipped?: 'read_only' | 'disabled' | 'no_token' | 'no_account_id' | 'cf_api_error';
+  skipped?:
+    | 'read_only'
+    | 'disabled'
+    | 'no_token'
+    | 'no_account_id'
+    | 'cf_api_error';
   errorMessage?: string;
 }
 

--- a/backend/src/modules/seo-control-plane/seo-control-plane.module.ts
+++ b/backend/src/modules/seo-control-plane/seo-control-plane.module.ts
@@ -5,7 +5,8 @@
  *   - L4 Governance binding : CriticalityLoaderService (lit seo-criticality.yaml)
  *   - L1 Collectors :
  *       • SyntheticCrawlerService — fetch + HTML probe (PR-2A-1, Source B)
- *       • CfAnalyticsCollectorService — Cloudflare GraphQL Analytics (PR-2A-2, Source C)
+ *       • CfAnalyticsCollectorService — Cloudflare GraphQL Analytics (PR-2A-2, Source C edge-server)
+ *       • CfRumCollectorService — Cloudflare GraphQL RUM Web Vitals (PR-2A-2.5, Source C' edge-RUM)
  *       • RuntimeLogsCollectorService — `__error_logs` query (PR-2A-3, Source A)
  *
  * Sous-PRs suivantes :
@@ -15,7 +16,7 @@
  *
  * Queue BullMQ partagée `seo-crawler-monitor` (NON mutualisée avec `seo-monitor`
  * pour éviter contention — cf. ADR-064 et feedback_schedulemodule_disabled_use_bullmq).
- * Mutualisation interne L1 OK : synthetic q15min + cf-analytics q5min + runtime-logs q5min = charge négligeable.
+ * Mutualisation interne L1 OK : synthetic q15min + cf-analytics q5min + runtime-logs q5min + cf-rum q-daily = charge négligeable.
  */
 
 import { Module } from '@nestjs/common';
@@ -29,6 +30,9 @@ import { SyntheticCrawlerSchedulerService } from './collectors/synthetic-crawler
 import { CfAnalyticsCollectorService } from './collectors/cf-analytics/cf-analytics.service';
 import { CfAnalyticsProcessor } from './collectors/cf-analytics/cf-analytics.processor';
 import { CfAnalyticsSchedulerService } from './collectors/cf-analytics/cf-analytics.scheduler.service';
+import { CfRumCollectorService } from './collectors/cf-rum/cf-rum.service';
+import { CfRumProcessor } from './collectors/cf-rum/cf-rum.processor';
+import { CfRumSchedulerService } from './collectors/cf-rum/cf-rum.scheduler.service';
 import { RuntimeLogsCollectorService } from './collectors/runtime-logs/runtime-logs.service';
 import { RuntimeLogsProcessor } from './collectors/runtime-logs/runtime-logs.processor';
 import { RuntimeLogsSchedulerService } from './collectors/runtime-logs/runtime-logs.scheduler.service';
@@ -46,10 +50,14 @@ import { SYNTHETIC_QUEUE_NAME } from './types';
     SyntheticCrawlerService,
     SyntheticCrawlerProcessor,
     SyntheticCrawlerSchedulerService,
-    // L1 — cf-analytics (PR-2A-2, Source C)
+    // L1 — cf-analytics (PR-2A-2, Source C edge-server)
     CfAnalyticsCollectorService,
     CfAnalyticsProcessor,
     CfAnalyticsSchedulerService,
+    // L1 — cf-rum (PR-2A-2.5, Source C' edge-RUM Web Vitals)
+    CfRumCollectorService,
+    CfRumProcessor,
+    CfRumSchedulerService,
     // L1 — runtime-logs (PR-2A-3, Source A)
     RuntimeLogsCollectorService,
     RuntimeLogsProcessor,

--- a/backend/supabase/migrations/20260517_seo_snapshot_cf_rum.sql
+++ b/backend/supabase/migrations/20260517_seo_snapshot_cf_rum.sql
@@ -1,0 +1,127 @@
+-- Migration : __seo_snapshot_cf_rum — L1 Collector edge-RUM Web Vitals
+-- ADR-064 SEO Production Control Plane, PR-2A-2.5 Cloudflare RUM Web Vitals.
+--
+-- Rôle : stocker les snapshots agrégés Cloudflare GraphQL `rumPerformanceEventsAdaptiveGroups`
+-- (LCP / CLS / INP / FCP / TTFB percentiles p50/p75/p95) + `rumPageloadEventsAdaptiveGroups`
+-- (visits / pageviews) par jour × tier × path_group. Lu par L2 SLO engine
+-- (Source C', edge-RUM utilisateur réel — complémentaire de la table edge-server
+-- __seo_snapshot_cf_analytics qui ne capture que les status codes et la perf origin).
+--
+-- Partitionnement quotidien (RANGE par bucket_start::date) :
+--   - INSERT 1x/jour à 01:00 UTC (RUM buffered ~30 min après minuit, ABR favorise daily).
+--   - Volume estimé : ~10 path_groups × 4 tiers × 1 bucket/jour = 40 rows/jour.
+--   - 90 jours × 40 = 3 600 rows max. Storage négligeable.
+--   - TTL 90 jours via DETACH + DROP, identique à __seo_snapshot_cf_analytics.
+--
+-- Cadence q-daily justifiée (≠ Q5min de cf-analytics) :
+--   - rumPerformanceEventsAdaptiveGroups buffer RUM ~30 min, ABR ramène la
+--     résolution à 1 jour pour fenêtres > 7 jours.
+--   - Une seule fenêtre 24 h/jour suffit pour un SLO p75 hebdo + corrélation
+--     traffic-drop J+1 (canon `feedback_gsc_is_secondary_signal_only` → CF RUM est
+--     la source primaire de monitoring Core Web Vitals, GSC secondaire à J+7).
+--
+-- Squawk conformance (ADR-064 squawk gate, PR #517) :
+--   - Pas de BEGIN/COMMIT explicites : Supabase migration tool wrappe déjà
+--     chaque .sql dans une transaction (`transaction-nesting` / `disallowed-statement`).
+--   - SET lock_timeout + SET statement_timeout pré-DDL (`require-timeout-settings`).
+--   - BIGINT pour les counters de latence (`prefer-bigint-over-int`).
+--   - CLS exprimé en `cls_p75_milli BIGINT` = CLS × 1000 (entier, pas de REAL/NUMERIC).
+--     Ex : CLS=0.087 → cls_p75_milli=87. Évite les pièges FP + reste lisible.
+
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+
+-- ── Parent table (partitioned) ───────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.__seo_snapshot_cf_rum (
+  id              BIGINT      GENERATED ALWAYS AS IDENTITY,
+  -- Aligned to midnight UTC of the day measured (daily granularity).
+  bucket_start    TIMESTAMPTZ NOT NULL,
+  tier            TEXT        NOT NULL CHECK (tier IN ('tier0', 'tier1', 'tier2', 'total')),
+  -- Path-group dimension : derived from URL by first-segment normalization.
+  -- 'total' = rollup across all paths (sanity baseline, equivalent to tier rollup).
+  path_group      TEXT        NOT NULL DEFAULT 'total',
+
+  -- ── Volume (rumPageloadEventsAdaptiveGroups) ───────────────────────────────
+  visit_count     BIGINT      NOT NULL DEFAULT 0 CHECK (visit_count >= 0),
+  pageview_count  BIGINT      NOT NULL DEFAULT 0 CHECK (pageview_count >= 0),
+  -- Nombre d'évènements RUM agrégés (utile pour pondérer les percentiles).
+  sample_count    BIGINT      NOT NULL DEFAULT 0 CHECK (sample_count >= 0),
+
+  -- ── Core Web Vitals percentiles (rumPerformanceEventsAdaptiveGroups) ──────
+  -- LCP / FCP / INP / TTFB : milliseconds, BIGINT (squawk prefer-bigint-over-int).
+  -- CLS : ratio × 1000 stocké en entier (cls_p75=87 = CLS 0.087). Voir squawk note.
+  lcp_p50_ms      BIGINT      NULL,
+  lcp_p75_ms      BIGINT      NULL,
+  lcp_p95_ms      BIGINT      NULL,
+  cls_p50_milli   BIGINT      NULL,
+  cls_p75_milli   BIGINT      NULL,
+  cls_p95_milli   BIGINT      NULL,
+  inp_p50_ms      BIGINT      NULL,
+  inp_p75_ms      BIGINT      NULL,
+  inp_p95_ms      BIGINT      NULL,
+  fcp_p75_ms      BIGINT      NULL,
+  ttfb_p75_ms     BIGINT      NULL,
+
+  -- ── Breakdowns souples (browsers, devices, countries) ─────────────────────
+  -- Volume contrôlé : ~10 paires KV par dimension, ~2 KB max. Cf.
+  -- feedback_table_split_vs_mega_jsonb (sub-10 KB JSONB sur <50 K rows = safe).
+  metrics_extra   JSONB       NOT NULL DEFAULT '{}'::jsonb,
+
+  -- ── Run-level audit-trail ─────────────────────────────────────────────────
+  run_id          UUID        NOT NULL,
+  account_tag     TEXT        NOT NULL,
+  fetched_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (id, bucket_start)
+)
+PARTITION BY RANGE (bucket_start);
+
+COMMENT ON TABLE public.__seo_snapshot_cf_rum IS
+  'PR-2A-2.5 ADR-064 — L1 Cloudflare RUM Web Vitals, daily buckets, partitioned daily, TTL 90j. Source edge-RUM (utilisateur réel) complémentaire de __seo_snapshot_cf_analytics (edge-server status codes).';
+
+-- ── Indexes (propagated to child partitions) ────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS idx_snap_cf_rum_bucket_tier
+  ON public.__seo_snapshot_cf_rum (bucket_start DESC, tier);
+
+CREATE INDEX IF NOT EXISTS idx_snap_cf_rum_run_id
+  ON public.__seo_snapshot_cf_rum (run_id);
+
+-- Anti-duplicate : (bucket_start, tier, path_group) unique. CF GraphQL est
+-- idempotent pour les buckets passés — UPSERT-on-conflict côté caller s'appuie
+-- sur cet index.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_snap_cf_rum_bucket_tier_path
+  ON public.__seo_snapshot_cf_rum (bucket_start, tier, path_group);
+
+-- ── Initial partitions (today + next 7 days) ────────────────────────────────
+-- Cron mensuel partagé (PR-2A-1.5 follow-up) crée J+30 / drop J-90.
+-- On pré-crée 8 partitions pour absorber le gap initial.
+
+DO $$
+DECLARE
+  d DATE := CURRENT_DATE;
+  next_d DATE;
+  part_name TEXT;
+BEGIN
+  FOR i IN 0..7 LOOP
+    next_d := d + INTERVAL '1 day';
+    part_name := '__seo_snapshot_cf_rum_p' || TO_CHAR(d, 'YYYYMMDD');
+    EXECUTE format(
+      'CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.__seo_snapshot_cf_rum FOR VALUES FROM (%L) TO (%L);',
+      part_name, d::TEXT, next_d::TEXT
+    );
+    d := next_d;
+  END LOOP;
+END $$;
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.__seo_snapshot_cf_rum ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role_all"
+  ON public.__seo_snapshot_cf_rum
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);

--- a/backend/supabase/migrations/20260517_seo_snapshot_cf_rum.sql
+++ b/backend/supabase/migrations/20260517_seo_snapshot_cf_rum.sql
@@ -81,16 +81,40 @@ COMMENT ON TABLE public.__seo_snapshot_cf_rum IS
   'PR-2A-2.5 ADR-064 — L1 Cloudflare RUM Web Vitals, daily buckets, partitioned daily, TTL 90j. Source edge-RUM (utilisateur réel) complémentaire de __seo_snapshot_cf_analytics (edge-server status codes).';
 
 -- ── Indexes (propagated to child partitions) ────────────────────────────────
+-- R2 (sql-governance-rules.md) : chaque CREATE INDEX justifié table+pattern+gain+RPC.
+-- Volume cible (cf. l'en-tête fichier) : ~40 rows/jour × 90 jours = ~3 600 rows max,
+-- partitionné quotidiennement, storage négligeable. Pas de seq-scan pénalisant sur
+-- une partition seule (~40 rows), mais le pruning + ordering ci-dessous évite
+-- les agrégations cross-partition coûteuses sur les fenêtres SLO 7j / 28j.
 
+-- INDEX: idx_snap_cf_rum_bucket_tier
+-- Table: public.__seo_snapshot_cf_rum (~3 600 rows max, storage négligeable)
+-- Pattern: WHERE bucket_start BETWEEN <a> AND <b> AND tier = '<tier>' ORDER BY bucket_start DESC
+--          (queries SLO L2 engine — p50/p75/p95 LCP/CLS/INP par tier sur fenêtre 7j/28j)
+-- Gain attendu: Seq Scan ~3 600 rows → Index Scan ~280 rows (1 tier × 7j × ~40 rows)
+-- RPC concernees: L2 SLO engine (ADR-064 PR-2B+, future) ; cf-rum.service.ts:535 indirect
 CREATE INDEX IF NOT EXISTS idx_snap_cf_rum_bucket_tier
   ON public.__seo_snapshot_cf_rum (bucket_start DESC, tier);
 
+-- INDEX: idx_snap_cf_rum_run_id
+-- Table: public.__seo_snapshot_cf_rum (~3 600 rows max, storage négligeable)
+-- Pattern: WHERE run_id = <uuid> — audit-trail lookup (rejouer / diagnostiquer un run
+--          collector spécifique, identifier les buckets manquants, debugging CF GraphQL)
+-- Gain attendu: Seq Scan ~3 600 rows → Index Scan ~40 rows (1 run = 10 paths × 4 tiers)
+-- RPC concernees: ops debugging via psql ; futur dashboard collector runs (ADR-064)
 CREATE INDEX IF NOT EXISTS idx_snap_cf_rum_run_id
   ON public.__seo_snapshot_cf_rum (run_id);
 
--- Anti-duplicate : (bucket_start, tier, path_group) unique. CF GraphQL est
--- idempotent pour les buckets passés — UPSERT-on-conflict côté caller s'appuie
--- sur cet index.
+-- INDEX: uniq_snap_cf_rum_bucket_tier_path (UNIQUE)
+-- Table: public.__seo_snapshot_cf_rum (~3 600 rows max, storage négligeable)
+-- Pattern: anti-duplicate gate pour UPSERT ON CONFLICT (bucket_start, tier, path_group)
+--          CF GraphQL rumPerformanceEventsAdaptiveGroups est idempotent sur les buckets
+--          passés (re-fetch même fenêtre renvoie les mêmes valeurs ABR-agrégées) — on
+--          se repose sur cet index pour absorber les retries cron sans dupliquer.
+-- Gain attendu: empêche le drift de cardinalité sur re-runs ; sans lui, chaque retry
+--               doublerait la table (~80 rows/jour × N retries) et casserait les p75.
+-- RPC concernees: backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.ts:537
+--                 (.upsert avec onConflict: 'bucket_start,tier,path_group')
 CREATE UNIQUE INDEX IF NOT EXISTS uniq_snap_cf_rum_bucket_tier_path
   ON public.__seo_snapshot_cf_rum (bucket_start, tier, path_group);
 

--- a/log.md
+++ b/log.md
@@ -795,3 +795,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/pr-7a-contract-drift-ratchet`
 - **Décision** : fix(ci): bypass npm banner in ratchet json output (workflow surgical fix) (+6 other commits)
 - **Sortie** : PR #545 | commits af746ad61 f539f83e4 48766b587 3402aee3f 347f4bcf5 0923c3217 18263e997
+
+## 2026-05-17 — feat/seo-cp-cf-rum-collector (auto)
+
+- **Branche** : `feat/seo-cp-cf-rum-collector`
+- **Décision** : feat(seo-cp): pr-2a-2.5 cloudflare rum collector (web vitals edge ingestion)
+- **Sortie** : PR #583 | commits 24fdf7367


### PR DESCRIPTION
## Summary

- **Nouveau L1 Collector** `CfRumCollectorService` ingère les Core Web Vitals (LCP/CLS/INP/FCP/TTFB) via Cloudflare GraphQL (`rumPerformanceEventsAdaptiveGroups` + `rumPageloadEventsAdaptiveGroups`) **1×/jour à 01:00 UTC** → table partitionnée `__seo_snapshot_cf_rum`.
- **Comble la colonne edge-RUM** dans la grille SLO multi-source (canon `feedback_slo_must_be_multi_source` : runtime + synthetic + edge + GSC) — les Web Vitals étaient déjà mesurés frontend mais envoyés à Sentry/GA4 (silos non queryables Supabase).
- **Complémentaire de `__seo_snapshot_cf_analytics`** : cette PR-2A-2 est edge-server (status codes, cache, origin perf), tandis que PR-2A-2.5 est edge-RUM utilisateur réel (UX-perf).

## Architecture (canon `feedback_seo_control_plane_layered_architecture`)

- Pattern 3-fichiers strict (service + scheduler + processor) **miroir exact** de `collectors/cf-analytics/*`
- Queue mutualisée `seo-crawler-monitor` (pas de nouvelle queue)
- READ_ONLY gate au processor
- UPSERT idempotent sur `(bucket_start, tier, path_group)`
- Stratification tier via `CriticalityLoaderService` (DI existante)
- `path_group` normalisé par 1er segment (`/pieces/*`, `/blog/*`, ...)
- **Default ENABLED=false** (opt-in explicite, scope token `Account.Analytics:Read`)

## Pourquoi maintenant (motivation business)

L'email Cloudflare Web Analytics hebdo du 17 mai expose :
- 710 visites (+24.56 %) sur automecanik.com
- p75 LCP/CLS/INP visibles mais **non persistés** côté Supabase
- Cadence J+1 (≠ GSC qui est J+2 à J+7 → `feedback_gsc_is_secondary_signal_only`)

Sans ce signal en SoT interne, l'incident `incident-traffic-drop-2026-04-22-sitemap-stale` n'aurait pas pu être corrélé à une régression CWV si elle s'était produite simultanément.

## Robustesse (industry-standard, pas de bricolage)

| Concern | Mitigation |
|---------|------------|
| Schéma CF GraphQL `rumPerformanceEventsAdaptiveGroups` évolue | Pageload + Performance queries **séparées** → volumes persistés avec `percentiles=null` si performance fail (canon `feedback_no_silent_skip_on_governance_critical_jobs`) |
| Mélange privilèges token | `CLOUDFLARE_ANALYTICS_TOKEN` séparable de `CLOUDFLARE_API_TOKEN` (zone:cache-purge) → rotation indépendante |
| Account-scoped vs zone-scoped | Nouveau `CLOUDFLARE_ACCOUNT_ID` (rum* datasets sont account-scoped) |
| ABR dégrade précision sur >7j | Cron daily → fenêtre 24 h, résolution max conservée |
| Partition manquante J+1 | DO block au boot crée J+0 à J+7 (idem cf-analytics migration) |
| Quota GraphQL CF | 2 requêtes/jour vs limite 300/5min = marge ×100 |

## Cadence q-daily justifiée (≠ Q5min cf-analytics)

- RUM buffered ~30 min après l'heure côté CF → 01:00 UTC = marge 1h
- ABR de Cloudflare ramène la résolution à 1 jour pour fenêtres > 7 j
- Q5min sur ~710 visites/sem fournirait du bruit (faibles échantillons RUM)
- 1 run/jour suffit pour SLO p75 hebdo + corrélation traffic-drop J+1

## Files changed (8)

- **NEW** `backend/supabase/migrations/20260517_seo_snapshot_cf_rum.sql` — table partitionnée + indexes + RLS + 8 partitions pré-créées
- **NEW** `backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.{types,service,scheduler.service,processor,service.test}.ts` (5 fichiers)
- **MOD** `backend/src/modules/seo-control-plane/seo-control-plane.module.ts` — register 3 providers
- **MOD** `backend/.env.example` — `SEO_CP_CF_RUM_ENABLED=false`, `SEO_CP_CF_RUM_CRON=0 1 * * *`, `CLOUDFLARE_ACCOUNT_ID=`, `CLOUDFLARE_ANALYTICS_TOKEN=`

## Tests (13/13 verts, +zero régression)

```
normalizePathGroup
  ✓ maps root path correctly
  ✓ extracts the first segment as a glob group
  ✓ handles deep paths by keeping only the first segment
  ✓ strips query strings and fragments
  ✓ falls back to /other for non-alphanumeric first segments
  ✓ handles valid char classes (letters, digits, hyphens, underscores, dots)

CfRumCollectorService
  ✓ skips when CLOUDFLARE token is missing (graceful)
  ✓ skips when CLOUDFLARE_ACCOUNT_ID is missing (graceful)
  ✓ prefers CLOUDFLARE_ANALYTICS_TOKEN over CLOUDFLARE_API_TOKEN when both set
  ✓ aggregates pageload + performance by tier × path_group, upserts to __seo_snapshot_cf_rum
  ✓ persists volumes with null percentiles when performance query fails (non-fatal)
  ✓ returns cf_api_error when pageload query (critical signal) fails
  ✓ uses J-1 UTC as the default bucket date
```

Sanity check croisé : 4 suites collectors / 26 tests passent (cf-rum + cf-analytics + runtime-logs + synthetic-crawler).

## Hors-scope explicite (V1.5/V2 — **PAS** implémenté ici)

Canon `feedback_v1_first_dont_build_ultimate_engine_too_early` + `feedback_evidence_before_perimeter_expansion` : V1.5+ uniquement après ≥ 7 jours d'évidence empirique en DEV.

- **V1.5** : `CfRumEvaluatorService` (L2) — alertes p75 LCP > 2.5s / CLS > 0.1 / INP > 200ms (seuils Google "Good")
- **V2** : `CfRumActionService` (L3) — auto cache-purge + warmup sur régression p75 LCP > 20% WoW tier0/tier1
- **V2+** : drill-down `pagePath` (vs `path_group`) — coûte plus de quota GraphQL, à activer si besoin prouvé

## Test plan (post-merge en DEV)

- [ ] Migration applique sans erreur — `SELECT COUNT(*) FROM __seo_snapshot_cf_rum;` retourne 0 (table créée, vide)
- [ ] Récupérer le `CLOUDFLARE_ACCOUNT_ID` via dashboard CF (sidebar droite, 32 hex chars) et l'injecter dans `.env` DEV
- [ ] Créer (ou réutiliser) un API token avec scope `Account → Account Analytics → Read`
- [ ] Set `SEO_CP_CF_RUM_ENABLED=true` en preprod uniquement
- [ ] T+24h : `SELECT bucket_start, tier, path_group, visit_count, lcp_p75_ms, cls_p75_milli, inp_p75_ms FROM __seo_snapshot_cf_rum ORDER BY bucket_start DESC LIMIT 20;` → ≥ 1 ligne pour J-1 UTC
- [ ] Vérifier logs backend : `docker compose logs backend | grep "seo-cp-cf-rum"` → 1 run/jour à 01:00 UTC
- [ ] Vérifier BullMQ repeatable : `redis-cli --scan --pattern "bull:seo-crawler-monitor:repeat:seo-cp-cf-rum-q-daily*"`
- [ ] Aucun secret en clair dans les logs (token redact dans logger CF custom)
- [ ] Idempotence : 2 runs successifs même jour → 0 nouvelles lignes (UPSERT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)