### PR TITLE
ci(workflows): migrate 3 routines from Claude Desktop to GH Actions

### DIFF
--- a/.github/scripts/closure-t48h-slo-digest.sh
+++ b/.github/scripts/closure-t48h-slo-digest.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# T+48h SLO digest — measure 9 signals 48h after the closure sequence
+# (2026-05-17), classify each as ✅/⛔/❓, write a digest body file, emit
+# GitHub Actions outputs.
+#
+# Called by .github/workflows/closure-t48h-slo-digest.yml. Requires gh CLI
+# with GH_TOKEN env var and REPO env var (owner/name).
+set -euo pipefail
+
+: "${GH_TOKEN:?missing}"
+: "${REPO:?missing}"
+
+NOW_UTC=$(date -u +%FT%TZ)
+OUT=$(mktemp)
+HOLD_COUNT=0
+UNKNOWN_COUNT=0
+
+push_status() {
+  local name="$1" status="$2" detail="$3"
+  echo "| $name | $status | $detail |" >> "$OUT"
+  case "$status" in
+    "⛔") HOLD_COUNT=$((HOLD_COUNT + 1)) ;;
+    "❓") UNKNOWN_COUNT=$((UNKNOWN_COUNT + 1)) ;;
+  esac
+}
+
+cat > "$OUT" <<EOF
+**Measurement time:** $NOW_UTC
+**Closure baseline:** issue #582 (T+0 digest from 2026-05-17)
+
+## 9-SLO matrix
+
+| Signal | Status | Evidence |
+|--------|--------|----------|
+EOF
+
+# ---- 1. Preprod (proxy via CI deploys on main) ----
+CI=$(gh run list --repo "$REPO" --branch main --workflow=ci.yml --limit 3 \
+  --json conclusion --jq '[.[] | .conclusion // "running"]')
+CI_FAILS=$(echo "$CI" | jq '[.[] | select(. == "failure")] | length')
+if [ "$CI_FAILS" -eq 0 ]; then
+  push_status "1. Preprod (proxy CI deploys)" "✅" "Last 3 main deploys: $CI"
+else
+  push_status "1. Preprod (proxy CI deploys)" "⛔" "Last 3 main deploys: $CI"
+fi
+
+# ---- 2. Sitemap freshness ----
+LM=$(curl -fsS -m 10 -I https://www.automecanik.com/sitemap.xml 2>/dev/null \
+  | grep -i '^last-modified:' \
+  | sed 's/[Ll]ast-[Mm]odified:[[:space:]]*//I; s/\r$//' \
+  || echo "")
+if [ -n "$LM" ]; then
+  AGE_HRS=$(( ( $(date -u +%s) - $(date -u -d "$LM" +%s) ) / 3600 ))
+  if [ "$AGE_HRS" -lt 26 ]; then
+    push_status "2. Sitemap freshness" "✅" "age=${AGE_HRS}h <26h"
+  else
+    push_status "2. Sitemap freshness" "⛔" "age=${AGE_HRS}h ≥26h"
+  fi
+else
+  push_status "2. Sitemap freshness" "❓" "Cannot fetch last-modified"
+fi
+
+# ---- 3. OIDC sitemap cron ----
+OIDC=$(gh run list --workflow=sitemap-daily-regen.yml --limit 2 --repo "$REPO" \
+  --json conclusion --jq '[.[] | .conclusion // "running"]')
+OIDC_OK=$(echo "$OIDC" | jq '[.[] | select(. == "success")] | length')
+OIDC_LEN=$(echo "$OIDC" | jq 'length')
+if [ "$OIDC_OK" -eq 2 ] && [ "$OIDC_LEN" -eq 2 ]; then
+  push_status "3. OIDC sitemap cron" "✅" "2/2 success: $OIDC"
+elif [ "$OIDC_LEN" -eq 0 ]; then
+  push_status "3. OIDC sitemap cron" "❓" "No runs found"
+else
+  push_status "3. OIDC sitemap cron" "⛔" "Got: $OIDC"
+fi
+
+# ---- 4. Heartbeat scheduler (code presence + CI green) ----
+HEARTBEAT_CODE=$(grep -rE 'worker:seo-monitor:heartbeat' backend/src/modules/seo/services/ 2>/dev/null | head -1 || echo "")
+if [ -n "$HEARTBEAT_CODE" ] && [ "$CI_FAILS" -eq 0 ]; then
+  push_status "4. Heartbeat scheduler" "✅" "Code present + CI deploys green"
+elif [ -z "$HEARTBEAT_CODE" ]; then
+  push_status "4. Heartbeat scheduler" "⛔" "Heartbeat code missing from main"
+else
+  push_status "4. Heartbeat scheduler" "❓" "Code present but CI not all green"
+fi
+
+# ---- 5. Audit baseline ----
+AUD=$(gh run list --workflow=audit.yml --limit 3 --repo "$REPO" --branch main \
+  --json conclusion --jq '[.[] | .conclusion // "running"]')
+AUD_FAILS=$(echo "$AUD" | jq '[.[] | select(. == "failure")] | length')
+if [ "$AUD_FAILS" -eq 0 ]; then
+  push_status "5. Audit baseline (main)" "✅" "Last 3: $AUD"
+else
+  push_status "5. Audit baseline (main)" "⛔" "Last 3: $AUD"
+fi
+
+# ---- 6. Dependency freshness gate ----
+DEP=$(gh run list --workflow=dependency-modernization-fresh.yml --limit 10 --repo "$REPO" \
+  --json conclusion,event --jq '[.[] | {c: .conclusion, e: .event}]')
+PUSH_OK=$(echo "$DEP" | jq '[.[] | select(.e == "push" and .c == "success")] | length')
+PUSH_FAIL=$(echo "$DEP" | jq '[.[] | select(.e == "push" and .c == "failure")] | length')
+if [ "$PUSH_OK" -gt 0 ] && [ "$PUSH_FAIL" -eq 0 ]; then
+  push_status "6. Dependency freshness gate" "✅" "Push: $PUSH_OK success / $PUSH_FAIL fail (Dependabot blocks expected)"
+elif [ "$PUSH_FAIL" -gt 0 ]; then
+  push_status "6. Dependency freshness gate" "⛔" "Push fails: $PUSH_FAIL"
+else
+  push_status "6. Dependency freshness gate" "❓" "No push events found"
+fi
+
+# ---- 7. Drift observatory ----
+DRF=$(gh run list --workflow=contract-drift-observatory.yml --limit 3 --repo "$REPO" --branch main \
+  --json conclusion --jq '[.[] | .conclusion // "running"]')
+DRF_FAILS=$(echo "$DRF" | jq '[.[] | select(. == "failure")] | length')
+if [ "$DRF_FAILS" -eq 0 ]; then
+  push_status "7. Drift observatory" "✅" "Last 3: $DRF"
+else
+  push_status "7. Drift observatory" "⛔" "Last 3: $DRF"
+fi
+
+# ---- 8. Synthetic crawler / sitemap freshness SLO ----
+SLO=$(gh run list --workflow=sitemap-freshness-slo.yml --limit 3 --repo "$REPO" \
+  --json conclusion --jq '[.[] | .conclusion // "running"]')
+SLO_LEN=$(echo "$SLO" | jq 'length')
+SLO_FAILS=$(echo "$SLO" | jq '[.[] | select(. == "failure")] | length')
+if [ "$SLO_LEN" -eq 0 ]; then
+  push_status "8. Synthetic crawler SLO" "❓" "No recent runs"
+elif [ "$SLO_FAILS" -eq 0 ]; then
+  push_status "8. Synthetic crawler SLO" "✅" "Last 3: $SLO"
+else
+  push_status "8. Synthetic crawler SLO" "⛔" "Last 3: $SLO"
+fi
+
+# ---- 9. GSC impressions (manual check required) ----
+push_status "9. GSC impressions /pieces/*" "❓" "Manual GSC dashboard check required"
+
+# ---- Verdict ----
+echo "" >> "$OUT"
+echo "## 🎯 Verdict" >> "$OUT"
+echo "" >> "$OUT"
+if [ "$HOLD_COUNT" -eq 0 ]; then
+  VERDICT="GO"
+  DEPS_STALE=0
+  if [ -f audit/dependencies/dependency-modernization-inventory.json ]; then
+    DEPS_STALE=$(jq '[.families[]? | select((.staleness_months? // 0) > 6)] | length' \
+      audit/dependencies/dependency-modernization-inventory.json 2>/dev/null || echo 0)
+  fi
+  if [ "$DEPS_STALE" -gt 0 ]; then
+    NEXT="📦 **PR-9b** — first typed batch upgrade (≤ 3 packages, scope strict). $DEPS_STALE families flagged stale >6 months."
+  else
+    NEXT="🧹 **PR-8b-2** — cleanup ≤ 5 files (canon \`feedback_deletion_governance_scaling_discipline\`)."
+  fi
+  echo "✅ **GO** — $UNKNOWN_COUNT UNKNOWN signal(s), 0 HOLD." >> "$OUT"
+  echo "" >> "$OUT"
+  echo "**Recommended next track:** $NEXT" >> "$OUT"
+  echo "" >> "$OUT"
+  echo "> Reminder: **JAMAIS PR-9b ET PR-8b-2 en parallèle** (canon \`feedback_evidence_before_perimeter_expansion\`)." >> "$OUT"
+else
+  VERDICT="HOLD"
+  echo "⛔ **HOLD** — $HOLD_COUNT signal(s) breached threshold. Mini-PR recovery scope only. Re-window 48h after fix." >> "$OUT"
+fi
+
+cat >> "$OUT" <<EOF
+
+---
+
+**References:**
+- T+0 baseline: #582
+- Merged PRs: #579 (PR-9a) #562 (auth phase 3) #565 (OIDC) #566 (heartbeat)
+- Workflow run: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$REPO}/actions/runs/${GITHUB_RUN_ID:-?}
+
+_Replaces Claude Desktop routine \`trig_01EGEoNa8u6DbEXs6KtuPoMJ\` (disabled 2026-05-17). This workflow can be deleted in a follow-up cleanup PR after this run fires._
+EOF
+
+{
+  echo "title=📊 Closure 2026-05-17 — T+48h SLO digest (verdict: $VERDICT)"
+  echo "body_path=$OUT"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/scripts/morning-health-digest.sh
+++ b/.github/scripts/morning-health-digest.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Morning health digest — collect 6 signals, classify, write digest body file,
+# emit GitHub Actions outputs.
+#
+# Called by .github/workflows/morning-health-digest.yml. Requires gh CLI with
+# GH_TOKEN env var and REPO env var (owner/name).
+set -euo pipefail
+
+: "${GH_TOKEN:?missing}"
+: "${REPO:?missing}"
+
+NOW_UTC=$(date -u +%FT%TZ)
+TODAY=$(date -u +%F)
+YESTERDAY=$(date -u -d 'yesterday' +%F)
+OUT=$(mktemp)
+STATUS_OVERALL="✅"
+
+# ---- Signal 1 — Sitemap freshness ----
+echo "## Signal 1 — Sitemap freshness (PROD)" >> "$OUT"
+LM=$(curl -fsS -m 10 -I https://www.automecanik.com/sitemap.xml 2>/dev/null \
+  | grep -i '^last-modified:' \
+  | sed 's/[Ll]ast-[Mm]odified:[[:space:]]*//I; s/\r$//' \
+  || echo "")
+if [ -n "$LM" ]; then
+  AGE_SEC=$(( $(date -u +%s) - $(date -u -d "$LM" +%s) ))
+  AGE_HRS=$(( AGE_SEC / 3600 ))
+  if [ "$AGE_HRS" -lt 26 ]; then
+    S="✅"
+  elif [ "$AGE_HRS" -lt 30 ]; then
+    S="⚠️"
+    [ "$STATUS_OVERALL" = "✅" ] && STATUS_OVERALL="⚠️"
+  else
+    S="⛔"
+    STATUS_OVERALL="⛔"
+  fi
+  echo "$S last-modified=\`$LM\` (age=${AGE_HRS}h, threshold <26h)" >> "$OUT"
+else
+  echo "❓ Could not fetch \`last-modified\`" >> "$OUT"
+fi
+echo "" >> "$OUT"
+
+# ---- Signal 2 — OIDC daily sitemap cron ----
+echo "## Signal 2 — OIDC daily sitemap cron" >> "$OUT"
+OIDC=$(gh run list --workflow=sitemap-daily-regen.yml --limit 2 --repo "$REPO" \
+  --json conclusion,createdAt \
+  --jq '.[] | "\(.createdAt[:19]) \(.conclusion // "running")"' 2>/dev/null || echo "")
+if [ -z "$OIDC" ]; then
+  echo "⚠️ No runs yet" >> "$OUT"
+  [ "$STATUS_OVERALL" = "✅" ] && STATUS_OVERALL="⚠️"
+else
+  echo '```' >> "$OUT"
+  echo "$OIDC" >> "$OUT"
+  echo '```' >> "$OUT"
+  if echo "$OIDC" | grep -q failure; then STATUS_OVERALL="⛔"; fi
+fi
+echo "" >> "$OUT"
+
+# ---- Signal 3 — CI deploys on main ----
+echo "## Signal 3 — CI deploys on main (last 3)" >> "$OUT"
+CI=$(gh run list --repo "$REPO" --branch main --workflow=ci.yml --limit 3 \
+  --json conclusion,createdAt,headSha \
+  --jq '.[] | "\(.createdAt[:19]) sha=\(.headSha[:7]) \(.conclusion // "running")"' 2>/dev/null || echo "")
+echo '```' >> "$OUT"
+echo "$CI" >> "$OUT"
+echo '```' >> "$OUT"
+if echo "$CI" | grep -q failure; then STATUS_OVERALL="⛔"; fi
+echo "" >> "$OUT"
+
+# ---- Signal 4 — Open PRs with failing checks ----
+echo "## Signal 4 — Open PRs with failing checks" >> "$OUT"
+FAILS=$(gh pr list --repo "$REPO" --state open --limit 60 \
+  --json number,title,headRefName,statusCheckRollup \
+  --jq '[.[] | {n: .number, t: (.title[:65]), head: .headRefName, failed: ([.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name] | unique)} | select((.failed | length) > 0)]' 2>/dev/null || echo "[]")
+DEPENDABOT=$(echo "$FAILS" | jq '[.[] | select(.head | startswith("dependabot/"))] | length')
+OTHER=$(echo "$FAILS" | jq '[.[] | select(.head | startswith("dependabot/") | not)] | length')
+echo "- Dependabot freshness-gate blocked: **$DEPENDABOT** (expected, PR-9a control plane)" >> "$OUT"
+echo "- Other failing PRs (actionable): **$OTHER**" >> "$OUT"
+if [ "$OTHER" -gt 0 ]; then
+  [ "$STATUS_OVERALL" = "✅" ] && STATUS_OVERALL="⚠️"
+  echo "" >> "$OUT"
+  echo "**Actionable:**" >> "$OUT"
+  echo "$FAILS" | jq -r '.[] | select(.head | startswith("dependabot/") | not) | "- #\(.n) \(.t) — failing: \(.failed | join(", "))"' >> "$OUT"
+fi
+echo "" >> "$OUT"
+
+# ---- Signal 5 — Audit + drift on main ----
+echo "## Signal 5 — Audit & drift workflows on main" >> "$OUT"
+AUD=$(gh run list --workflow=audit.yml --limit 3 --repo "$REPO" --branch main \
+  --json conclusion --jq '.[] | .conclusion // "running"' 2>/dev/null | tr '\n' ' ' || echo "")
+DRF=$(gh run list --workflow=contract-drift-observatory.yml --limit 3 --repo "$REPO" --branch main \
+  --json conclusion --jq '.[] | .conclusion // "running"' 2>/dev/null | tr '\n' ' ' || echo "")
+echo "- audit.yml (last 3): $AUD" >> "$OUT"
+echo "- contract-drift-observatory.yml (last 3): $DRF" >> "$OUT"
+if echo "$AUD $DRF" | grep -q failure; then STATUS_OVERALL="⛔"; fi
+echo "" >> "$OUT"
+
+# ---- Signal 6 — Yesterday's merges ----
+echo "## Signal 6 — PRs merged yesterday ($YESTERDAY)" >> "$OUT"
+MERGED=$(gh pr list --repo "$REPO" --state merged \
+  --search "merged:>=$YESTERDAY merged:<$TODAY" \
+  --json number,title,mergedAt \
+  --jq '.[] | "- #\(.number) \(.title[:70]) (\(.mergedAt[:16]))"' 2>/dev/null || echo "")
+if [ -z "$MERGED" ]; then
+  echo "_None._" >> "$OUT"
+else
+  echo "$MERGED" >> "$OUT"
+fi
+echo "" >> "$OUT"
+
+echo "---" >> "$OUT"
+echo "Run: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$REPO}/actions/runs/${GITHUB_RUN_ID:-?}" >> "$OUT"
+echo "Replaces Claude Desktop routine \`trig_017ywezN156yjiVW8BRVcYi6\` (disabled 2026-05-17)." >> "$OUT"
+
+{
+  echo "title=$STATUS_OVERALL Morning health digest — $TODAY"
+  echo "body_path=$OUT"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/scripts/weekly-pr-hygiene.sh
+++ b/.github/scripts/weekly-pr-hygiene.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Weekly PR hygiene digest — collect open PR inventory, classify, recommend
+# this week's focus, write a digest body file, and emit GitHub Actions outputs.
+#
+# Called by .github/workflows/weekly-pr-hygiene.yml. Requires gh CLI with
+# GH_TOKEN env var and REPO env var (owner/name).
+set -euo pipefail
+
+: "${GH_TOKEN:?missing}"
+: "${REPO:?missing}"
+
+TODAY=$(date -u +%F)
+WEEKNUM=$(date -u +%V)
+SEVEN_DAYS_AGO=$(date -u -d '7 days ago' +%F)
+LAST_MONDAY=$(date -u -d 'last Monday' +%F)
+OUT=$(mktemp)
+
+# ---- Measurement 1 — Stale PRs (≥ 7d inactive) ----
+STALE_RAW=$(gh pr list --repo "$REPO" --state open --limit 100 \
+  --json number,title,headRefName,updatedAt,isDraft \
+  --jq "[.[] | select(.updatedAt < \"$SEVEN_DAYS_AGO\")]")
+STALE_COUNT=$(echo "$STALE_RAW" | jq 'length')
+
+# ---- Measurement 2 — Conflicting PRs ----
+CONFLICT_RAW=$(gh pr list --repo "$REPO" --state open --limit 100 \
+  --json number,title,mergeStateStatus,headRefName \
+  --jq '[.[] | select(.mergeStateStatus == "DIRTY" or .mergeStateStatus == "CONFLICTING")]')
+CONFLICT_COUNT=$(echo "$CONFLICT_RAW" | jq 'length')
+
+# ---- Measurement 3 — Dependabot blockers (PR-9a freshness gate effect) ----
+DEPABOT_RAW=$(gh pr list --repo "$REPO" --state open --search 'head:dependabot' --limit 30 \
+  --json number,title,statusCheckRollup \
+  --jq '[.[] | select((.statusCheckRollup // []) | map(select(.conclusion == "FAILURE")) | length > 0)]')
+DEPABOT_COUNT=$(echo "$DEPABOT_RAW" | jq 'length')
+
+# ---- Measurement 4 — Last week's merged PRs ----
+MERGED_RAW=$(gh pr list --repo "$REPO" --state merged \
+  --search "merged:>=$LAST_MONDAY" --limit 50 \
+  --json number,title,mergedAt,additions,deletions)
+MERGED_COUNT=$(echo "$MERGED_RAW" | jq 'length')
+LOC_ADD=$(echo "$MERGED_RAW" | jq '[.[].additions] | add // 0')
+LOC_DEL=$(echo "$MERGED_RAW" | jq '[.[].deletions] | add // 0')
+
+# ---- Measurement 5 — Audit baseline state ----
+AUDIT_BASELINE_PRESENT="no"
+AUDIT_UNUSED_EXPORTS=""
+if [ -f audit-reports/phase0-baseline.json ]; then
+  AUDIT_BASELINE_PRESENT="yes"
+  AUDIT_UNUSED_EXPORTS=$(jq '.knip.unused_exports' audit-reports/phase0-baseline.json)
+fi
+AUDIT_RUNS=$(gh run list --workflow=audit.yml --limit 5 --repo "$REPO" --branch main \
+  --json conclusion --jq '[.[] | .conclusion // "running"]')
+AUDIT_FAILS=$(echo "$AUDIT_RUNS" | jq '[.[] | select(. == "failure")] | length')
+
+# ---- Decision tree ----
+if [ "$STALE_COUNT" -ge 10 ] && [ "$MERGED_COUNT" -lt 5 ]; then
+  FOCUS="🧹 Hygiene week — batch-close stale PRs"
+  ACTION1="Mirror the 2026-05-17 closure batch (audit-trail comments, branches preserved)."
+  ACTION2="Re-evaluate cascade PRs (seo-governance-control-plane / seo-projection)."
+  ACTION3="Skip new feature work until WIP < 20 open PRs."
+elif [ "$DEPABOT_COUNT" -ge 5 ]; then
+  FOCUS="📦 PR-9b first batch upgrade (scope ≤ 3 packages)"
+  ACTION1="Pick top 3 packages from audit/dependencies/dependency-modernization-inventory.json (longest gap-to-latest)."
+  ACTION2="Refresh inventory + bump packages in single PR (typed, with rollback drill)."
+  ACTION3="Verify Dependabot freshness gate unblocks after merge."
+elif [ "$AUDIT_FAILS" -gt 0 ]; then
+  FOCUS="🛠 Baseline recovery mini-PR"
+  ACTION1="Identify regression source via npm run audit:knip -- --reporter=symbols."
+  ACTION2="Fix at source (export visibility) or refresh baseline with audit-trail."
+  ACTION3="No new front until audit gates green again."
+elif [ "$CONFLICT_COUNT" -gt 0 ]; then
+  FOCUS="🔀 Rebase cascade (oldest stack first)"
+  ACTION1="Worktree per stack, rebase on main, push --force-with-lease."
+  ACTION2="Merge in cascade order: A1 → B → C → D → E."
+  ACTION3="Run audit:contract-drift-ratchet after each merge."
+else
+  FOCUS="🧪 PR-8b-2 cleanup (≤ 5 files)"
+  ACTION1="Pick next 5 candidates from audit/cleanup/inventory.json."
+  ACTION2="One PR with audit-trail, observation window 48h after merge."
+  ACTION3="No PR-9b or other new front in parallel (canon feedback_evidence_before_perimeter_expansion)."
+fi
+
+# ---- Assemble digest body (heredoc — safe inside .sh, not YAML) ----
+cat > "$OUT" <<EOF
+## 🎯 Recommendation — Week $WEEKNUM ($TODAY)
+
+**Focus:** $FOCUS
+
+1. $ACTION1
+2. $ACTION2
+3. $ACTION3
+
+> Canon \`feedback_evidence_before_perimeter_expansion\` — un seul front à la fois.
+
+---
+
+## 📊 Open PR inventory
+
+| Bucket | Count |
+|--------|-------|
+| Stale (≥ 7d inactive) | $STALE_COUNT |
+| Conflicting (DIRTY/CONFLICTING) | $CONFLICT_COUNT |
+| Dependabot blocked by freshness-gate | $DEPABOT_COUNT (expected, PR-9a control plane) |
+
+## 🪦 Stale PRs
+
+EOF
+
+if [ "$STALE_COUNT" -gt 0 ]; then
+  echo "$STALE_RAW" | jq -r '.[] | "- #\(.number) \(.title[:70]) — last updated \(.updatedAt[:10])\(if .isDraft then " _(draft)_" else "" end)"' >> "$OUT"
+else
+  echo "_None._" >> "$OUT"
+fi
+echo "" >> "$OUT"
+
+echo "## 🔀 Conflicting PRs" >> "$OUT"
+if [ "$CONFLICT_COUNT" -gt 0 ]; then
+  echo "$CONFLICT_RAW" | jq -r '.[] | "- #\(.number) \(.title[:70]) (\(.mergeStateStatus))"' >> "$OUT"
+else
+  echo "_None._" >> "$OUT"
+fi
+echo "" >> "$OUT"
+
+echo "## 📦 Dependabot blockers (PR-9a control plane effect — expected)" >> "$OUT"
+if [ "$DEPABOT_COUNT" -gt 0 ]; then
+  echo "$DEPABOT_RAW" | jq -r '.[] | "- #\(.number) \(.title[:70])"' | head -10 >> "$OUT"
+  if [ "$DEPABOT_COUNT" -gt 10 ]; then
+    REMAINING=$((DEPABOT_COUNT - 10))
+    echo "- _… and $REMAINING more._" >> "$OUT"
+  fi
+else
+  echo "_None._" >> "$OUT"
+fi
+echo "" >> "$OUT"
+
+cat >> "$OUT" <<EOF
+## 🚢 Last week's deliverables (since $LAST_MONDAY)
+
+- Merged: **$MERGED_COUNT PRs**
+- LoC: **+$LOC_ADD / -$LOC_DEL**
+
+## 🛡 Audit baseline
+
+- baseline file present: **$AUDIT_BASELINE_PRESENT**
+- knip.unused_exports baseline: **${AUDIT_UNUSED_EXPORTS:-?}**
+- audit.yml last 5 runs on main: $AUDIT_RUNS
+- failures: **$AUDIT_FAILS**
+
+---
+
+Run: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-$REPO}/actions/runs/${GITHUB_RUN_ID:-?}
+Replaces Claude Desktop routine \`trig_01N7BCAuPai8ZRwX88ytNU3i\` (disabled 2026-05-17).
+EOF
+
+# ---- Emit GitHub Actions outputs ----
+{
+  echo "title=📊 Weekly PR hygiene W$WEEKNUM — $TODAY ($FOCUS)"
+  echo "body_path=$OUT"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/.github/workflows/closure-t48h-slo-digest.yml
+++ b/.github/workflows/closure-t48h-slo-digest.yml
@@ -1,0 +1,74 @@
+name: 📊 Closure 2026-05-17 — T+48h SLO digest
+
+# One-shot SLO digest 48h after the closure sequence executed on 2026-05-17
+# (4 PRs merged: #562 #565 #566 #579 + 13 stales closed).
+#
+# Replaces Claude Desktop routine `trig_01EGEoNa8u6DbEXs6KtuPoMJ` (disabled
+# 2026-05-17). GitHub Actions has no native "run-once-at-date" trigger, so
+# we use a daily cron with a date guard. After 2026-05-19 fires successfully
+# this workflow file SHOULD BE DELETED in a follow-up cleanup PR.
+#
+# Cron: 17:30 UTC daily, guarded to fire only on 2026-05-19.
+# Target run: 2026-05-19T17:38Z (= 19:38 Europe/Paris).
+on:
+  schedule:
+    - cron: "30 17 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+  actions: read
+  contents: read
+
+concurrency:
+  group: closure-t48h-slo-digest
+  cancel-in-progress: false
+
+jobs:
+  date-guard:
+    name: Date guard (fire only on 2026-05-19)
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.guard.outputs.proceed }}
+    steps:
+      - name: Check date
+        id: guard
+        run: |
+          TODAY=$(date -u +%F)
+          if [ "$TODAY" = "2026-05-19" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "🛑 Skip — today is $TODAY, target is 2026-05-19."
+          fi
+
+  digest:
+    name: Measure 9 SLO + publish T+48h digest
+    needs: date-guard
+    if: needs.date-guard.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (shallow)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run T+48h SLO digest script
+        id: collect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: bash .github/scripts/closure-t48h-slo-digest.sh
+
+      - name: Create T+48h digest issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue create \
+            --repo "$REPO" \
+            --title "${{ steps.collect.outputs.title }}" \
+            --body-file "${{ steps.collect.outputs.body_path }}" \
+            --assignee ak125

--- a/.github/workflows/morning-health-digest.yml
+++ b/.github/workflows/morning-health-digest.yml
@@ -1,0 +1,51 @@
+name: 🌅 Morning health digest
+
+# Daily weekday digest published as a GitHub issue assigned to @ak125.
+# Owner (subscribed to repo) receives the email automatically.
+#
+# Replaces Claude Desktop routine `trig_017ywezN156yjiVW8BRVcYi6` (disabled
+# 2026-05-17) — self-hosted in repo, audit-trail via git history.
+#
+# Cron: 05:00 UTC = 07:00 Europe/Paris (CEST) on weekdays.
+on:
+  schedule:
+    - cron: "0 5 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  actions: read
+  contents: read
+
+concurrency:
+  group: morning-health-digest
+  cancel-in-progress: false
+
+jobs:
+  digest:
+    name: Collect signals + publish digest issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout (shallow)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run morning digest script
+        id: collect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: bash .github/scripts/morning-health-digest.sh
+
+      - name: Create digest issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue create \
+            --repo "$REPO" \
+            --title "${{ steps.collect.outputs.title }}" \
+            --body-file "${{ steps.collect.outputs.body_path }}" \
+            --assignee ak125

--- a/.github/workflows/weekly-pr-hygiene.yml
+++ b/.github/workflows/weekly-pr-hygiene.yml
@@ -1,0 +1,52 @@
+name: 📊 Weekly PR hygiene & sprint recommendation
+
+# Monday morning digest published as a GitHub issue assigned to @ak125.
+# Owner (subscribed to repo) receives the email automatically.
+#
+# Replaces Claude Desktop routine `trig_01N7BCAuPai8ZRwX88ytNU3i` (disabled
+# 2026-05-17) — self-hosted in repo, audit-trail via git history.
+#
+# Cron: 07:00 UTC Monday = 09:00 Europe/Paris (CEST).
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+  actions: read
+  contents: read
+
+concurrency:
+  group: weekly-pr-hygiene
+  cancel-in-progress: false
+
+jobs:
+  hygiene:
+    name: Inventory open PRs + recommend sprint focus
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (shallow)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run hygiene digest script
+        id: collect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: bash .github/scripts/weekly-pr-hygiene.sh
+
+      - name: Create hygiene digest issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue create \
+            --repo "$REPO" \
+            --title "${{ steps.collect.outputs.title }}" \
+            --body-file "${{ steps.collect.outputs.body_path }}" \
+            --assignee ak125

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -42,6 +42,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: medium
     risk: high
+  - glob: .github/scripts/**
+    domain: D13
+    owner: '@ak125'
+    sourceConfidence: medium
+    risk: high
   - glob: .github/workflows/agents-md-validation.yml
     domain: D15
     owner: '@ak125'


### PR DESCRIPTION
## Summary

Migrates 3 Claude Desktop routines (now `enabled=false`) to **self-hosted GitHub Actions workflows** in the repo. Owner still gets email notifications because each workflow creates a GitHub issue assigned to @ak125.

Why: keep automation in the repo (git audit-trail, no Claude Desktop dependency, reusable `workflow_dispatch` for manual runs).

## Migrated routines

| Routine ID (disabled) | New workflow | Cron | When |
|----------------------|--------------|------|------|
| `trig_017ywezN156yjiVW8BRVcYi6` | `.github/workflows/morning-health-digest.yml` | `0 5 * * 1-5` | Lun-Ven 07:00 Paris |
| `trig_01N7BCAuPai8ZRwX88ytNU3i` | `.github/workflows/weekly-pr-hygiene.yml` | `0 7 * * 1` | Lundi 09:00 Paris |
| `trig_01EGEoNa8u6DbEXs6KtuPoMJ` | `.github/workflows/closure-t48h-slo-digest.yml` | `30 17 * * *` (date-gated) | One-shot 2026-05-19 19:30 Paris |

## Structure

Each workflow delegates to a shell script under `.github/scripts/` so heredoc markdown bodies don't conflict with YAML block-scalar indentation. Scripts smoke-tested locally on 2026-05-17 (morning-digest produced a real digest with 19 actionable PRs identified — see manual run before push).

```
.github/
├── workflows/
│   ├── morning-health-digest.yml        (cron + checkout + script + issue)
│   ├── weekly-pr-hygiene.yml
│   └── closure-t48h-slo-digest.yml      (date-guard job + digest job)
└── scripts/
    ├── morning-health-digest.sh         (6 signals + status overall)
    ├── weekly-pr-hygiene.sh             (5 measurements + decision tree)
    └── closure-t48h-slo-digest.sh       (9-SLO matrix + verdict GO/HOLD)
```

## Follow-ups after merge

- After **2026-05-19 17:38 UTC** fires successfully, a follow-up PR should **delete `closure-t48h-slo-digest.yml` + `.sh`** (one-shot, no longer needed).
- The 3 Claude routines remain visible (but disabled) at https://claude.ai/code/routines — claude.ai API does not expose delete. User should remove them manually if desired.

## Test plan

- [x] YAML syntax validation (Python yaml.safe_load on all 3 workflows)
- [x] Shell syntax check (`bash -n` on all 3 scripts)
- [x] Local smoke test of `morning-health-digest.sh` against live repo — produced realistic digest with sitemap freshness ⛔ (33h), 19 actionable PRs, etc.
- [ ] Post-merge: trigger workflow_dispatch on `morning-health-digest.yml` to verify end-to-end issue creation
- [ ] Post-merge: verify scheduled run fires correctly at next cron tick

## Ownership

Added `.github/scripts/**` to `ownership.yaml` (D13/@ak125, same as workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)