### PR TITLE
feat(seo): pr-uidp-1 composer extraction + emitter + snapshot fixture

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -22,6 +22,9 @@ title = "AutoMecanik Gitleaks Config"
     '''\.gitleaks\.toml$''',
     # npm lockfile contains integrity hashes that look entropic
     '''package-lock\.json$''',
+    # Test fixtures (synthetic data by convention — no real secrets)
+    '''__fixtures__/''',
+    '''__tests__/''',
   ]
   regexes = [
     # CI placeholder string used in tests

--- a/backend/src/modules/seo/services/policies/seo-indexability-policy.service.ts
+++ b/backend/src/modules/seo/services/policies/seo-indexability-policy.service.ts
@@ -2,14 +2,20 @@ import { Injectable } from '@nestjs/common';
 import {
   type SurfaceKey,
   type R2IndexabilityConditions,
+  type IndexabilityInput as ComposerInput,
+  type IndexabilityVerdict as ComposerVerdict,
+  type RobotsValue,
+  ReasonCode,
+  computeIndexabilityVerdict,
+  legacyStringFromKind,
 } from '@repo/seo-role-contracts';
 import { SeoSurfaceRegistry } from '../../registries/seo-surface.registry';
 import { R2IndexabilityGate } from './r2-indexability-gate.service';
 
-export type RobotsValue =
-  | 'index,follow'
-  | 'noindex,follow'
-  | 'noindex,nofollow';
+// Backward compat (cf. plan UIDP v5/C4) — exposé legacy. Retrait V1.5.
+// Les nouveaux callers doivent consommer directement `computeIndexabilityVerdict`
+// du package `@repo/seo-role-contracts`.
+export type { RobotsValue };
 
 export interface IndexabilityInput {
   surfaceKey: SurfaceKey;
@@ -29,15 +35,28 @@ export interface IndexabilityVerdict {
 }
 
 /**
- * Calcule la directive `robots` selon les seuils legacy + le gate R2.
+ * Thin wrapper Injectable sur `computeIndexabilityVerdict()` du package
+ * `@repo/seo-role-contracts` (PR-UIDP-1).
  *
- * Cascade décisionnelle (cf. plan v9 section 3.6) :
- *   1. URL ≠ canonical (si strict) ⇒ noindex,nofollow
- *   2. Surface R2 et gate fail ⇒ noindex,nofollow
- *   3. availableFamilies < min_families ⇒ noindex,follow
- *   4. availableGammes < min_gammes ⇒ noindex,follow
- *   5. Fingerprint match (PR-9) ⇒ noindex,follow
- *   6. Sinon ⇒ index,follow
+ * Préserve la signature legacy `{ robots, blockingReasons }` pour les
+ * callers existants. **Déprécié** — les nouveaux callers (loaders Remix
+ * R2/R8 PR-UIDP-2) doivent consommer directement le composer pure du
+ * package et `emitRobotsForVerdict()` pour l'émission texte. Retrait V1.5.
+ *
+ * Cascade décisionnelle déléguée au package (cf. compose-indexability.ts) :
+ *   1. URL ≠ canonical (si strict) ⇒ noindex,nofollow + CANONICAL_MISMATCH
+ *   2. R2 conditions missing ⇒ noindex,nofollow + R2_CONDITIONS_MISSING
+ *   3. R2 gate fail ⇒ noindex,nofollow + R2_GATE_FAIL
+ *   4. availableFamilies < min_families ⇒ noindex,follow + FAMILIES_BELOW_THRESHOLD
+ *   5. availableGammes < min_gammes ⇒ noindex,follow + GAMMES_BELOW_THRESHOLD
+ *   6. Fingerprint match (PR-9) ⇒ noindex,follow + FINGERPRINT_DUPLICATE
+ *   7. TecDoc release gate ⇒ noindex,nofollow + TECDOC_RELEASE_GATE
+ *      (exposé uniquement aux loaders R8 via composer direct)
+ *   8. Sinon ⇒ index,follow
+ *
+ * Behaviour-preserving 100% vs. version pré-UIDP : les `blockingReasons`
+ * legacy strings sont reconstruites depuis le `reasonCode` canonique pour
+ * compat de log/test.
  */
 @Injectable()
 export class SeoIndexabilityPolicyService {
@@ -47,73 +66,67 @@ export class SeoIndexabilityPolicyService {
   ) {}
 
   computeIndexability(input: IndexabilityInput): IndexabilityVerdict {
-    const reasons: string[] = [];
-    const thresholds = this.surfaces.getThresholds(input.surfaceKey);
-
-    // 1. URL ≠ canonical strict
-    if (
-      thresholds.strict_canonical_match &&
-      input.requestedUrl !== input.canonicalUrl
-    ) {
-      reasons.push(
-        `url_mismatch_canonical(${input.requestedUrl} != ${input.canonicalUrl})`,
-      );
-      return { robots: 'noindex,nofollow', blockingReasons: reasons };
-    }
-
-    // 2. R2 gate
-    if (this.isR2Surface(input.surfaceKey)) {
-      if (!input.r2Conditions) {
-        reasons.push('r2_conditions_missing');
-        return { robots: 'noindex,nofollow', blockingReasons: reasons };
-      }
-      const verdict = this.r2Gate.evaluate(input.r2Conditions);
-      if (!verdict.indexable) {
-        return {
-          robots: 'noindex,nofollow',
-          blockingReasons: verdict.blockingReasons,
-        };
-      }
-    }
-
-    // 3. min_families
-    if (
-      thresholds.min_families !== null &&
-      input.availableFamilies !== undefined &&
-      input.availableFamilies < thresholds.min_families
-    ) {
-      reasons.push(
-        `families_below_threshold(${input.availableFamilies}<${thresholds.min_families})`,
-      );
-      return { robots: 'noindex,follow', blockingReasons: reasons };
-    }
-
-    // 4. min_gammes
-    if (
-      thresholds.min_gammes !== null &&
-      input.availableGammes !== undefined &&
-      input.availableGammes < thresholds.min_gammes
-    ) {
-      reasons.push(
-        `gammes_below_threshold(${input.availableGammes}<${thresholds.min_gammes})`,
-      );
-      return { robots: 'noindex,follow', blockingReasons: reasons };
-    }
-
-    // 5. Fingerprint match (PR-9)
-    if (input.fingerprintMatch === true) {
-      reasons.push('fingerprint_duplicate_match');
-      return { robots: 'noindex,follow', blockingReasons: reasons };
-    }
-
-    return { robots: 'index,follow', blockingReasons: [] };
+    const composerInput: ComposerInput = {
+      surfaceKey: input.surfaceKey,
+      requestedUrl: input.requestedUrl,
+      canonicalUrl: input.canonicalUrl,
+      availableFamilies: input.availableFamilies,
+      availableGammes: input.availableGammes,
+      r2Conditions: input.r2Conditions,
+      fingerprintMatch: input.fingerprintMatch,
+      // tecdocReleaseGateOpen non exposé via legacy input — les callers
+      // qui en ont besoin (loaders Remix R8) utilisent le composer directement.
+    };
+    const verdict: ComposerVerdict = computeIndexabilityVerdict(composerInput);
+    return {
+      robots: legacyStringFromKind(verdict.kind),
+      blockingReasons: this.legacyReasonsFromCode(verdict, input),
+    };
   }
 
-  private isR2Surface(key: SurfaceKey): boolean {
-    return (
-      key === 'R2_PRODUCT' ||
-      key === 'R2_PRODUCT_IN_VEHICLE' ||
-      key === 'R2_PRODUCT_LIST'
-    );
+  /**
+   * Reconstruit les strings `blockingReasons` legacy pour préserver
+   * l'API publique (tests + log). Retrait V1.5 — les consommateurs
+   * migrent vers `verdict.reasonCodes` enum canonique.
+   */
+  private legacyReasonsFromCode(
+    verdict: ComposerVerdict,
+    input: IndexabilityInput,
+  ): string[] {
+    if (verdict.reasonCodes.length === 0) return [];
+    const code = verdict.reasonCodes[0];
+    switch (code) {
+      case ReasonCode.CANONICAL_MISMATCH:
+        return [
+          `url_mismatch_canonical(${input.requestedUrl} != ${input.canonicalUrl})`,
+        ];
+      case ReasonCode.R2_CONDITIONS_MISSING:
+        return ['r2_conditions_missing'];
+      case ReasonCode.R2_GATE_FAIL: {
+        // Reconstruit la liste R2 sub-reasons depuis le gate (préserve
+        // l'ancien shape "blockingReasons" qui exposait les R2 details).
+        if (input.r2Conditions) {
+          const r2Verdict = this.r2Gate.evaluate(input.r2Conditions);
+          if (!r2Verdict.indexable) return r2Verdict.blockingReasons;
+        }
+        return ['r2_gate_fail'];
+      }
+      case ReasonCode.FAMILIES_BELOW_THRESHOLD: {
+        const thresholds = this.surfaces.getThresholds(input.surfaceKey);
+        return [
+          `families_below_threshold(${input.availableFamilies}<${thresholds.min_families})`,
+        ];
+      }
+      case ReasonCode.GAMMES_BELOW_THRESHOLD: {
+        const thresholds = this.surfaces.getThresholds(input.surfaceKey);
+        return [
+          `gammes_below_threshold(${input.availableGammes}<${thresholds.min_gammes})`,
+        ];
+      }
+      case ReasonCode.FINGERPRINT_DUPLICATE:
+        return ['fingerprint_duplicate_match'];
+      case ReasonCode.TECDOC_RELEASE_GATE:
+        return ['tecdoc_release_gate'];
+    }
   }
 }

--- a/packages/seo-role-contracts/src/__fixtures__/indexability-snapshot.json
+++ b/packages/seo-role-contracts/src/__fixtures__/indexability-snapshot.json
@@ -1,0 +1,679 @@
+[
+  {
+    "stratum": "R0_HOME_index",
+    "input": {
+      "surfaceKey": "R0_HOME",
+      "requestedUrl": "https://www.automecanik.com/",
+      "canonicalUrl": "https://www.automecanik.com/"
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R0_HOME_canonical_mismatch",
+    "input": {
+      "surfaceKey": "R0_HOME",
+      "requestedUrl": "https://www.automecanik.com/?ref=campaign",
+      "canonicalUrl": "https://www.automecanik.com/"
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["CANONICAL_MISMATCH"]
+  },
+  {
+    "stratum": "R8_VEHICLE_all_ok",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/peugeot-128/308-128041/2-0-hdi-58712.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/peugeot-128/308-128041/2-0-hdi-58712.html",
+      "availableGammes": 12
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R8_VEHICLE_all_ok",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/renault-140/clio-iv-140006/1-5-dci-58801.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/renault-140/clio-iv-140006/1-5-dci-58801.html",
+      "availableGammes": 8
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R8_VEHICLE_all_ok",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/bmw-33/serie-3-f30-33112/320d-58912.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/bmw-33/serie-3-f30-33112/320d-58912.html",
+      "availableGammes": 15
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R8_VEHICLE_all_ok",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/citroen-46/c4-ii-46031/1-6-bluehdi-59020.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/citroen-46/c4-ii-46031/1-6-bluehdi-59020.html",
+      "availableGammes": 5
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R8_VEHICLE_all_ok",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/audi-22/a3-iii-22035/2-0-tdi-59123.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/audi-22/a3-iii-22035/2-0-tdi-59123.html",
+      "availableGammes": 22
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R8_VEHICLE_gammes_below_threshold",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/lada-90/priora-90037/1-6-71034.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/lada-90/priora-90037/1-6-71034.html",
+      "availableGammes": 4
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["GAMMES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R8_VEHICLE_gammes_below_threshold",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/seat-147/leon-i-147003/1-9-tdi-32101.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/seat-147/leon-i-147003/1-9-tdi-32101.html",
+      "availableGammes": 2
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["GAMMES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R8_VEHICLE_gammes_below_threshold",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/dacia-47/sandero-47025/1-5-dci-29401.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/dacia-47/sandero-47025/1-5-dci-29401.html",
+      "availableGammes": 0
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["GAMMES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R8_VEHICLE_gammes_below_threshold",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/skoda-150/fabia-iii-150006/1-0-tsi-58423.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/skoda-150/fabia-iii-150006/1-0-tsi-58423.html",
+      "availableGammes": 1
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["GAMMES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R8_VEHICLE_gammes_below_threshold",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/fiat-58/uno-i-58166/1-0-146e-126486.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/fiat-58/uno-i-58166/1-0-146e-126486.html",
+      "availableGammes": 3
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["GAMMES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R8_VEHICLE_tecdoc_release_gate",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/peugeot-128/expert-ii-128085/2-0-hdi-4x4-76550.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/peugeot-128/expert-ii-128085/2-0-hdi-4x4-76550.html",
+      "availableGammes": 10,
+      "tecdocReleaseGateOpen": true
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["TECDOC_RELEASE_GATE"]
+  },
+  {
+    "stratum": "R8_VEHICLE_tecdoc_release_gate",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/mercedes-benz-108/cla-shooting-brake-x118-108284/cla-200-73707.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/mercedes-benz-108/cla-shooting-brake-x118-108284/cla-200-73707.html",
+      "availableGammes": 8,
+      "tecdocReleaseGateOpen": true
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["TECDOC_RELEASE_GATE"]
+  },
+  {
+    "stratum": "R8_VEHICLE_tecdoc_release_gate",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/dacia-47/logan-iii-42574/65444.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/dacia-47/logan-iii-42574/65444.html",
+      "availableGammes": 6,
+      "tecdocReleaseGateOpen": true
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["TECDOC_RELEASE_GATE"]
+  },
+  {
+    "stratum": "R8_VEHICLE_tecdoc_release_gate",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/kia-88/cee-d-sw-iii-88092/70652.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/kia-88/cee-d-sw-iii-88092/70652.html",
+      "availableGammes": 7,
+      "tecdocReleaseGateOpen": true
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["TECDOC_RELEASE_GATE"]
+  },
+  {
+    "stratum": "R8_VEHICLE_tecdoc_release_gate",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/audi-22/q5-ii-22094/2-0-tfsi-quattro-78001.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/audi-22/q5-ii-22094/2-0-tfsi-quattro-78001.html",
+      "availableGammes": 14,
+      "tecdocReleaseGateOpen": true
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["TECDOC_RELEASE_GATE"]
+  },
+  {
+    "stratum": "R8_VEHICLE_canonical_mismatch",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/peugeot-128/308-128041/2-0-hdi-58712.html?utm_source=google",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/peugeot-128/308-128041/2-0-hdi-58712.html",
+      "availableGammes": 12
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["CANONICAL_MISMATCH"]
+  },
+  {
+    "stratum": "R8_VEHICLE_canonical_mismatch",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/renault-140/clio-iv-140006/1-5-dci-58801",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/renault-140/clio-iv-140006/1-5-dci-58801.html",
+      "availableGammes": 8
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["CANONICAL_MISMATCH"]
+  },
+  {
+    "stratum": "R8_VEHICLE_canonical_mismatch_exclusivity",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://x.com/a?utm=b",
+      "canonicalUrl": "https://x.com/a",
+      "availableGammes": 1,
+      "fingerprintMatch": true,
+      "tecdocReleaseGateOpen": true
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["CANONICAL_MISMATCH"]
+  },
+  {
+    "stratum": "R8_VEHICLE_fingerprint",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/foo-bar-29101.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/foo-bar-29101.html",
+      "availableGammes": 10,
+      "fingerprintMatch": true
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["FINGERPRINT_DUPLICATE"]
+  },
+  {
+    "stratum": "R8_VEHICLE_fingerprint",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/foo-bar-30215.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/foo-bar-30215.html",
+      "availableGammes": 8,
+      "fingerprintMatch": true
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["FINGERPRINT_DUPLICATE"]
+  },
+  {
+    "stratum": "R8_VEHICLE_fingerprint",
+    "input": {
+      "surfaceKey": "R8_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/constructeurs/foo-bar-31412.html",
+      "canonicalUrl": "https://www.automecanik.com/constructeurs/foo-bar-31412.html",
+      "availableGammes": 6,
+      "fingerprintMatch": true
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["FINGERPRINT_DUPLICATE"]
+  },
+  {
+    "stratum": "R1_GAMME_ROUTER_index",
+    "input": {
+      "surfaceKey": "R1_GAMME_ROUTER",
+      "requestedUrl": "https://www.automecanik.com/pieces/disque-de-frein-82.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/disque-de-frein-82.html",
+      "availableFamilies": 8
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R1_GAMME_ROUTER_index",
+    "input": {
+      "surfaceKey": "R1_GAMME_ROUTER",
+      "requestedUrl": "https://www.automecanik.com/pieces/alternateur-4.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/alternateur-4.html",
+      "availableFamilies": 3
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R1_GAMME_ROUTER_families_below",
+    "input": {
+      "surfaceKey": "R1_GAMME_ROUTER",
+      "requestedUrl": "https://www.automecanik.com/pieces/ressort-de-direction-9999.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/ressort-de-direction-9999.html",
+      "availableFamilies": 2
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["FAMILIES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R1_GAMME_ROUTER_families_below",
+    "input": {
+      "surfaceKey": "R1_GAMME_ROUTER",
+      "requestedUrl": "https://www.automecanik.com/pieces/niche-rare-8888.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/niche-rare-8888.html",
+      "availableFamilies": 0
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["FAMILIES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R1_GAMME_VEHICLE_ROUTER_families_below",
+    "input": {
+      "surfaceKey": "R1_GAMME_VEHICLE_ROUTER",
+      "requestedUrl": "https://www.automecanik.com/pieces/disque-de-frein-82/lada-90/priora-90037/65500.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/disque-de-frein-82/lada-90/priora-90037/65500.html",
+      "availableFamilies": 1,
+      "availableGammes": 8
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["FAMILIES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R1_GAMME_VEHICLE_ROUTER_gammes_below",
+    "input": {
+      "surfaceKey": "R1_GAMME_VEHICLE_ROUTER",
+      "requestedUrl": "https://www.automecanik.com/pieces/disque-de-frein-82/dacia-47/sandero-47025/29401.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/disque-de-frein-82/dacia-47/sandero-47025/29401.html",
+      "availableFamilies": 5,
+      "availableGammes": 2
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["GAMMES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R1_GAMME_VEHICLE_ROUTER_all_ok",
+    "input": {
+      "surfaceKey": "R1_GAMME_VEHICLE_ROUTER",
+      "requestedUrl": "https://www.automecanik.com/pieces/disque-de-frein-82/peugeot-128/208-128021/1-6-hdi-58000.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/disque-de-frein-82/peugeot-128/208-128021/1-6-hdi-58000.html",
+      "availableFamilies": 6,
+      "availableGammes": 9
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R2_PRODUCT_LIST_conditions_missing",
+    "input": {
+      "surfaceKey": "R2_PRODUCT_LIST",
+      "requestedUrl": "https://www.automecanik.com/pieces/joint-de-carter-d-huile-455/peugeot-128/408-128060/2-0-16v-6344.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/joint-de-carter-d-huile-455/peugeot-128/408-128060/2-0-16v-6344.html"
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["R2_CONDITIONS_MISSING"]
+  },
+  {
+    "stratum": "R2_PRODUCT_LIST_gate_fail",
+    "input": {
+      "surfaceKey": "R2_PRODUCT_LIST",
+      "requestedUrl": "https://www.automecanik.com/pieces/disque-de-frein-82/citroen-46/c3-picasso-46022/1-6-vti-122715.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/disque-de-frein-82/citroen-46/c3-picasso-46022/1-6-vti-122715.html",
+      "r2Conditions": {
+        "has_price": false,
+        "has_stock": true,
+        "has_image": true,
+        "has_oem_ref": true,
+        "has_equivalent_ref": false,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      },
+      "availableGammes": 3
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["R2_GATE_FAIL"]
+  },
+  {
+    "stratum": "R2_PRODUCT_LIST_index",
+    "input": {
+      "surfaceKey": "R2_PRODUCT_LIST",
+      "requestedUrl": "https://www.automecanik.com/pieces/alternateur-4/peugeot-128/308-128041/2-0-hdi-58712.html",
+      "canonicalUrl": "https://www.automecanik.com/pieces/alternateur-4/peugeot-128/308-128041/2-0-hdi-58712.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": true,
+        "has_image": true,
+        "has_oem_ref": true,
+        "has_equivalent_ref": false,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      },
+      "availableGammes": 5
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R2_PRODUCT_conditions_missing",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-12345.html",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-12345.html"
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["R2_CONDITIONS_MISSING"]
+  },
+  {
+    "stratum": "R2_PRODUCT_conditions_missing",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-54321.html",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-54321.html"
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["R2_CONDITIONS_MISSING"]
+  },
+  {
+    "stratum": "R2_PRODUCT_gate_fail_image",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-00001.html",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-00001.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": true,
+        "has_image": false,
+        "has_oem_ref": true,
+        "has_equivalent_ref": false,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      }
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["R2_GATE_FAIL"]
+  },
+  {
+    "stratum": "R2_PRODUCT_gate_fail_stock",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-00002.html",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-00002.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": false,
+        "has_image": true,
+        "has_oem_ref": true,
+        "has_equivalent_ref": false,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      }
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["R2_GATE_FAIL"]
+  },
+  {
+    "stratum": "R2_PRODUCT_gate_fail_no_refs",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-00003.html",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-00003.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": true,
+        "has_image": true,
+        "has_oem_ref": false,
+        "has_equivalent_ref": false,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      }
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["R2_GATE_FAIL"]
+  },
+  {
+    "stratum": "R2_PRODUCT_gate_fail_duplicate",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-00004.html",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-00004.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": true,
+        "has_image": true,
+        "has_oem_ref": true,
+        "has_equivalent_ref": true,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": true
+      }
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["R2_GATE_FAIL"]
+  },
+  {
+    "stratum": "R2_PRODUCT_all_ok",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-99001.html",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-99001.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": true,
+        "has_image": true,
+        "has_oem_ref": true,
+        "has_equivalent_ref": false,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      }
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R2_PRODUCT_all_ok",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-99002.html",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-99002.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": true,
+        "has_image": true,
+        "has_oem_ref": false,
+        "has_equivalent_ref": true,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      }
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R2_PRODUCT_canonical_mismatch",
+    "input": {
+      "surfaceKey": "R2_PRODUCT",
+      "requestedUrl": "https://www.automecanik.com/produits/sku-99003.html?gclid=abc",
+      "canonicalUrl": "https://www.automecanik.com/produits/sku-99003.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": true,
+        "has_image": true,
+        "has_oem_ref": true,
+        "has_equivalent_ref": false,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      }
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["CANONICAL_MISMATCH"]
+  },
+  {
+    "stratum": "R2_PRODUCT_IN_VEHICLE_all_ok",
+    "input": {
+      "surfaceKey": "R2_PRODUCT_IN_VEHICLE",
+      "requestedUrl": "https://www.automecanik.com/produits-in-vehicle/sku-12345-vehicule-58000.html",
+      "canonicalUrl": "https://www.automecanik.com/produits-in-vehicle/sku-12345-vehicule-58000.html",
+      "r2Conditions": {
+        "has_price": true,
+        "has_stock": true,
+        "has_image": true,
+        "has_oem_ref": true,
+        "has_equivalent_ref": false,
+        "has_unique_product_ref": true,
+        "has_valid_canonical": true,
+        "is_duplicate_variant": false
+      }
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R3_ADVICE_index",
+    "input": {
+      "surfaceKey": "R3_ADVICE",
+      "requestedUrl": "https://www.automecanik.com/conseils/changer-disque-de-frein.html",
+      "canonicalUrl": "https://www.automecanik.com/conseils/changer-disque-de-frein.html"
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R3_DIAG_SECTION_index",
+    "input": {
+      "surfaceKey": "R3_DIAG_SECTION",
+      "requestedUrl": "https://www.automecanik.com/diagnostic/alternateur.html",
+      "canonicalUrl": "https://www.automecanik.com/diagnostic/alternateur.html"
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R6_BUYING_GUIDE_families_below",
+    "input": {
+      "surfaceKey": "R6_BUYING_GUIDE",
+      "requestedUrl": "https://www.automecanik.com/guide-achat/niche-rare.html",
+      "canonicalUrl": "https://www.automecanik.com/guide-achat/niche-rare.html",
+      "availableFamilies": 1
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["FAMILIES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R6_BUYING_GUIDE_index",
+    "input": {
+      "surfaceKey": "R6_BUYING_GUIDE",
+      "requestedUrl": "https://www.automecanik.com/guide-achat/disque-de-frein.html",
+      "canonicalUrl": "https://www.automecanik.com/guide-achat/disque-de-frein.html",
+      "availableFamilies": 12
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "R7_BRAND_HUB_families_below",
+    "input": {
+      "surfaceKey": "R7_BRAND_HUB",
+      "requestedUrl": "https://www.automecanik.com/marque/lada.html",
+      "canonicalUrl": "https://www.automecanik.com/marque/lada.html",
+      "availableFamilies": 2
+    },
+    "expectedKind": "NOINDEX_FOLLOW",
+    "expectedReasonCodes": ["FAMILIES_BELOW_THRESHOLD"]
+  },
+  {
+    "stratum": "R7_BRAND_HUB_index",
+    "input": {
+      "surfaceKey": "R7_BRAND_HUB",
+      "requestedUrl": "https://www.automecanik.com/marque/peugeot.html",
+      "canonicalUrl": "https://www.automecanik.com/marque/peugeot.html",
+      "availableFamilies": 18
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "BLOG_ARTICLE_index",
+    "input": {
+      "surfaceKey": "BLOG_ARTICLE",
+      "requestedUrl": "https://www.automecanik.com/blog/entretien-vehicule.html",
+      "canonicalUrl": "https://www.automecanik.com/blog/entretien-vehicule.html"
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "BLOG_ADVICE_canonical_mismatch",
+    "input": {
+      "surfaceKey": "BLOG_ADVICE",
+      "requestedUrl": "https://www.automecanik.com/blog/conseil-foo.html?ref=newsletter",
+      "canonicalUrl": "https://www.automecanik.com/blog/conseil-foo.html"
+    },
+    "expectedKind": "NOINDEX_NOFOLLOW",
+    "expectedReasonCodes": ["CANONICAL_MISMATCH"]
+  },
+  {
+    "stratum": "STATIC_PAGE_index",
+    "input": {
+      "surfaceKey": "STATIC_PAGE",
+      "requestedUrl": "https://www.automecanik.com/conditions-generales.html",
+      "canonicalUrl": "https://www.automecanik.com/conditions-generales.html"
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  },
+  {
+    "stratum": "UNAVAILABLE_410_no_canonical_strict",
+    "input": {
+      "surfaceKey": "UNAVAILABLE_410",
+      "requestedUrl": "https://www.automecanik.com/old-url-removed.html?session=abc",
+      "canonicalUrl": "https://www.automecanik.com/old-url-removed.html"
+    },
+    "expectedKind": "INDEX_FOLLOW",
+    "expectedReasonCodes": []
+  }
+]

--- a/packages/seo-role-contracts/src/__tests__/compose-indexability.test.ts
+++ b/packages/seo-role-contracts/src/__tests__/compose-indexability.test.ts
@@ -1,0 +1,459 @@
+/**
+ * compose-indexability — tests cascade (PR-UIDP-1).
+ *
+ * Couverture :
+ *   - 8 branches de la cascade (canonical, R2_missing, R2_fail, families,
+ *     gammes, fingerprint, tecdoc, default index)
+ *   - Invariants v5/C2 (length ≤ 1, kind↔reasonCodes coherence)
+ *   - Per-surface (R0..R8) — pas de surface oubliée
+ *   - Pureté (même input → même verdict.kind + reasonCodes)
+ *
+ * Lancer : `npm run test --workspace=@repo/seo-role-contracts`
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeIndexabilityVerdict,
+} from "../compose-indexability";
+import {
+  ReasonCode,
+  RobotsVerdictKind,
+  type IndexabilityInput,
+} from "../robots-verdict";
+import type { R2IndexabilityConditions } from "../r2-indexability-conditions";
+
+const R2_OK: R2IndexabilityConditions = {
+  has_price: true,
+  has_stock: true,
+  has_image: true,
+  has_oem_ref: true,
+  has_equivalent_ref: false,
+  has_unique_product_ref: true,
+  has_valid_canonical: true,
+  is_duplicate_variant: false,
+};
+
+const R2_FAIL_NO_IMAGE: R2IndexabilityConditions = {
+  ...R2_OK,
+  has_image: false,
+};
+
+const URL_CANON = "https://www.automecanik.com/pieces/foo-1/bar-2/baz-3/qux-4.html";
+
+describe("@repo/seo-role-contracts — computeIndexabilityVerdict — cascade", () => {
+  // ───────────────────────────────────────────────────────────────────────────
+  // 1. CANONICAL_MISMATCH (exclusif court-circuit)
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("step 1 — canonical mismatch", () => {
+    it("returns NOINDEX_NOFOLLOW + [CANONICAL_MISMATCH] when URL ≠ canonical (R8)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: "https://www.automecanik.com/constructeurs/foo.html?utm=a",
+        canonicalUrl: "https://www.automecanik.com/constructeurs/foo.html",
+        availableGammes: 10,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.NOINDEX_NOFOLLOW);
+      assert.deepEqual(v.reasonCodes, [ReasonCode.CANONICAL_MISMATCH]);
+    });
+
+    it("canonical mismatch is exclusive (length === 1 même si families<3 aussi)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R1_GAMME_ROUTER",
+        requestedUrl: "https://x/a?utm=z",
+        canonicalUrl: "https://x/a",
+        availableFamilies: 0, // serait FAMILIES_BELOW_THRESHOLD si pas court-circuité
+      });
+      assert.equal(v.reasonCodes.length, 1);
+      assert.equal(v.reasonCodes[0], ReasonCode.CANONICAL_MISMATCH);
+    });
+
+    it("R0_HOME (strict_canonical_match=true) déclenche le mismatch", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R0_HOME",
+        requestedUrl: "https://www.automecanik.com/?ref=foo",
+        canonicalUrl: "https://www.automecanik.com/",
+      });
+      assert.equal(v.kind, RobotsVerdictKind.NOINDEX_NOFOLLOW);
+    });
+
+    it("UNAVAILABLE_410 (strict_canonical_match=false) ne déclenche PAS mismatch", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "UNAVAILABLE_410",
+        requestedUrl: "https://x/a?b=c",
+        canonicalUrl: "https://x/a",
+      });
+      // Pas de blocage canonical → continue cascade → default index
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 2. R2_CONDITIONS_MISSING (fail-safe)
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("step 2 — R2 conditions missing", () => {
+    it("R2_PRODUCT sans r2Conditions → NOINDEX_NOFOLLOW + [R2_CONDITIONS_MISSING]", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R2_PRODUCT",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.NOINDEX_NOFOLLOW);
+      assert.deepEqual(v.reasonCodes, [ReasonCode.R2_CONDITIONS_MISSING]);
+    });
+
+    it("R2_PRODUCT_LIST sans r2Conditions → R2_CONDITIONS_MISSING", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R2_PRODUCT_LIST",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+      });
+      assert.deepEqual(v.reasonCodes, [ReasonCode.R2_CONDITIONS_MISSING]);
+    });
+
+    it("R2_PRODUCT_IN_VEHICLE sans r2Conditions → R2_CONDITIONS_MISSING", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R2_PRODUCT_IN_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+      });
+      assert.deepEqual(v.reasonCodes, [ReasonCode.R2_CONDITIONS_MISSING]);
+    });
+
+    it("R8_VEHICLE sans r2Conditions n'a PAS de R2 gate (pas R2 surface)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 3. R2_GATE_FAIL
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("step 3 — R2 gate fail", () => {
+    it("R2_PRODUCT + r2Conditions OK → INDEX_FOLLOW", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R2_PRODUCT",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        r2Conditions: R2_OK,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+      assert.deepEqual(v.reasonCodes, []);
+    });
+
+    it("R2_PRODUCT + has_image=false → NOINDEX_NOFOLLOW + [R2_GATE_FAIL]", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R2_PRODUCT",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        r2Conditions: R2_FAIL_NO_IMAGE,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.NOINDEX_NOFOLLOW);
+      assert.deepEqual(v.reasonCodes, [ReasonCode.R2_GATE_FAIL]);
+    });
+
+    it("R2_PRODUCT + duplicate_variant=true → R2_GATE_FAIL", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R2_PRODUCT",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        r2Conditions: { ...R2_OK, is_duplicate_variant: true },
+      });
+      assert.deepEqual(v.reasonCodes, [ReasonCode.R2_GATE_FAIL]);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 4. FAMILIES_BELOW_THRESHOLD (R1, R6, R7)
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("step 4 — families below threshold", () => {
+    it("R1_GAMME_ROUTER + families=2 (< 3) → NOINDEX_FOLLOW", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R1_GAMME_ROUTER",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableFamilies: 2,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.NOINDEX_FOLLOW);
+      assert.deepEqual(v.reasonCodes, [ReasonCode.FAMILIES_BELOW_THRESHOLD]);
+    });
+
+    it("R1_GAMME_ROUTER + families=3 (= threshold) → INDEX_FOLLOW", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R1_GAMME_ROUTER",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableFamilies: 3,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+
+    it("R6_BUYING_GUIDE + families=1 → NOINDEX_FOLLOW", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R6_BUYING_GUIDE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableFamilies: 1,
+      });
+      assert.deepEqual(v.reasonCodes, [ReasonCode.FAMILIES_BELOW_THRESHOLD]);
+    });
+
+    it("R7_BRAND_HUB + families<3 → NOINDEX_FOLLOW", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R7_BRAND_HUB",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableFamilies: 0,
+      });
+      assert.deepEqual(v.reasonCodes, [ReasonCode.FAMILIES_BELOW_THRESHOLD]);
+    });
+
+    it("R8_VEHICLE n'a PAS de min_families (null) → ne déclenche pas", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableFamilies: 0,
+        availableGammes: 10,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+
+    it("availableFamilies undefined ne déclenche pas (input optional)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R1_GAMME_ROUTER",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        // availableFamilies absent
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 5. GAMMES_BELOW_THRESHOLD (R1_GAMME_VEHICLE_ROUTER, R8)
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("step 5 — gammes below threshold", () => {
+    it("R8_VEHICLE + gammes=4 (< 5) → NOINDEX_FOLLOW", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 4,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.NOINDEX_FOLLOW);
+      assert.deepEqual(v.reasonCodes, [ReasonCode.GAMMES_BELOW_THRESHOLD]);
+    });
+
+    it("R8_VEHICLE + gammes=5 → INDEX_FOLLOW", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 5,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+
+    it("R1_GAMME_VEHICLE_ROUTER + families=3 + gammes=4 → GAMMES (familles OK passées)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R1_GAMME_VEHICLE_ROUTER",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableFamilies: 3,
+        availableGammes: 4,
+      });
+      assert.deepEqual(v.reasonCodes, [ReasonCode.GAMMES_BELOW_THRESHOLD]);
+    });
+
+    it("R2_PRODUCT_LIST + gammes=0 → GAMMES_BELOW_THRESHOLD (threshold=1)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R2_PRODUCT_LIST",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        r2Conditions: R2_OK,
+        availableGammes: 0,
+      });
+      assert.deepEqual(v.reasonCodes, [ReasonCode.GAMMES_BELOW_THRESHOLD]);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 6. FINGERPRINT_DUPLICATE
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("step 6 — fingerprint duplicate", () => {
+    it("fingerprintMatch=true → NOINDEX_FOLLOW + [FINGERPRINT_DUPLICATE]", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+        fingerprintMatch: true,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.NOINDEX_FOLLOW);
+      assert.deepEqual(v.reasonCodes, [ReasonCode.FINGERPRINT_DUPLICATE]);
+    });
+
+    it("fingerprintMatch=false explicite ne déclenche pas", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+        fingerprintMatch: false,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+
+    it("fingerprintMatch undefined ne déclenche pas (PR-9 inactif sur surface)", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 7. TECDOC_RELEASE_GATE (caller flag, R8)
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("step 7 — tecdoc release gate", () => {
+    it("tecdocReleaseGateOpen=true → NOINDEX_NOFOLLOW + [TECDOC_RELEASE_GATE]", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+        tecdocReleaseGateOpen: true,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.NOINDEX_NOFOLLOW);
+      assert.deepEqual(v.reasonCodes, [ReasonCode.TECDOC_RELEASE_GATE]);
+    });
+
+    it("tecdocReleaseGateOpen=false ne déclenche pas", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+        tecdocReleaseGateOpen: false,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 8. Default INDEX_FOLLOW
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("step 8 — default index", () => {
+    it("R0_HOME canonical match → INDEX_FOLLOW + reasonCodes:[]", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R0_HOME",
+        requestedUrl: "https://www.automecanik.com/",
+        canonicalUrl: "https://www.automecanik.com/",
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+      assert.deepEqual(v.reasonCodes, []);
+    });
+
+    it("R3_ADVICE canonical match → INDEX_FOLLOW", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R3_ADVICE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+
+    it("BLOG_ARTICLE canonical match → INDEX_FOLLOW", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "BLOG_ARTICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+      });
+      assert.equal(v.kind, RobotsVerdictKind.INDEX_FOLLOW);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // INVARIANTS V1 (v5/C2)
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("invariants V1 (v5/C2) — reasonCodes.length ≤ 1", () => {
+    const samples: IndexabilityInput[] = [
+      // INDEX_FOLLOW cases
+      { surfaceKey: "R0_HOME", requestedUrl: "https://x/", canonicalUrl: "https://x/" },
+      { surfaceKey: "R3_ADVICE", requestedUrl: URL_CANON, canonicalUrl: URL_CANON },
+      { surfaceKey: "R8_VEHICLE", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableGammes: 10 },
+      // NOINDEX cases (toutes branches)
+      { surfaceKey: "R1_GAMME_ROUTER", requestedUrl: "https://x/?q=a", canonicalUrl: "https://x/" },
+      { surfaceKey: "R2_PRODUCT", requestedUrl: URL_CANON, canonicalUrl: URL_CANON },
+      { surfaceKey: "R2_PRODUCT", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, r2Conditions: R2_FAIL_NO_IMAGE },
+      { surfaceKey: "R1_GAMME_ROUTER", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableFamilies: 0 },
+      { surfaceKey: "R8_VEHICLE", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableGammes: 1 },
+      { surfaceKey: "R8_VEHICLE", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableGammes: 10, fingerprintMatch: true },
+      { surfaceKey: "R8_VEHICLE", requestedUrl: URL_CANON, canonicalUrl: URL_CANON, availableGammes: 10, tecdocReleaseGateOpen: true },
+    ];
+
+    for (const sample of samples) {
+      it(`invariant: ${sample.surfaceKey} length ≤ 1`, () => {
+        const v = computeIndexabilityVerdict(sample);
+        assert.ok(v.reasonCodes.length <= 1, `reasonCodes too long: ${JSON.stringify(v.reasonCodes)}`);
+      });
+
+      it(`invariant: ${sample.surfaceKey} kind↔length coherence`, () => {
+        const v = computeIndexabilityVerdict(sample);
+        if (v.kind === RobotsVerdictKind.INDEX_FOLLOW) {
+          assert.equal(v.reasonCodes.length, 0, "INDEX_FOLLOW must have 0 reason codes");
+        } else {
+          assert.equal(v.reasonCodes.length, 1, "NOINDEX_* must have exactly 1 reason code");
+        }
+      });
+    }
+
+    it("context.computedAt is ISO-8601", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R0_HOME",
+        requestedUrl: "https://x/",
+        canonicalUrl: "https://x/",
+      });
+      assert.match(v.context.computedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it("context preserves surfaceKey + URLs", () => {
+      const v = computeIndexabilityVerdict({
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+      });
+      assert.equal(v.context.surfaceKey, "R8_VEHICLE");
+      assert.equal(v.context.requestedUrl, URL_CANON);
+      assert.equal(v.context.canonicalUrl, URL_CANON);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Pureté
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("pureté", () => {
+    it("même input → même kind + reasonCodes (context.computedAt diffère, OK)", () => {
+      const input: IndexabilityInput = {
+        surfaceKey: "R8_VEHICLE",
+        requestedUrl: URL_CANON,
+        canonicalUrl: URL_CANON,
+        availableGammes: 10,
+        tecdocReleaseGateOpen: true,
+      };
+      const v1 = computeIndexabilityVerdict(input);
+      const v2 = computeIndexabilityVerdict(input);
+      assert.equal(v1.kind, v2.kind);
+      assert.deepEqual(v1.reasonCodes, v2.reasonCodes);
+    });
+  });
+});

--- a/packages/seo-role-contracts/src/__tests__/emit-robots.test.ts
+++ b/packages/seo-role-contracts/src/__tests__/emit-robots.test.ts
@@ -1,0 +1,75 @@
+/**
+ * emit-robots — tests symétrie meta == header par construction.
+ *
+ * Single emission point V1 (cf. plan UIDP v5) :
+ *   - Le seul module qui mappe enum → texte HTTP
+ *   - `metaContent === headerValue` garanti (futur split V2+ documenté ADR)
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { emitRobotsForVerdict } from "../emit-robots";
+import {
+  RobotsVerdictKind,
+  ReasonCode,
+  type IndexabilityVerdict,
+} from "../robots-verdict";
+
+const baseContext = {
+  surfaceKey: "R8_VEHICLE" as const,
+  requestedUrl: "https://x/a",
+  canonicalUrl: "https://x/a",
+  computedAt: "2026-05-17T00:00:00.000Z",
+};
+
+describe("@repo/seo-role-contracts — emitRobotsForVerdict", () => {
+  it("INDEX_FOLLOW → 'index, follow' (meta === header)", () => {
+    const verdict: IndexabilityVerdict = {
+      kind: RobotsVerdictKind.INDEX_FOLLOW,
+      reasonCodes: [],
+      context: baseContext,
+    };
+    const emit = emitRobotsForVerdict(verdict);
+    assert.equal(emit.metaContent, "index, follow");
+    assert.equal(emit.headerValue, "index, follow");
+    assert.equal(emit.metaContent, emit.headerValue);
+  });
+
+  it("NOINDEX_FOLLOW → 'noindex, follow' (meta === header)", () => {
+    const verdict: IndexabilityVerdict = {
+      kind: RobotsVerdictKind.NOINDEX_FOLLOW,
+      reasonCodes: [ReasonCode.FAMILIES_BELOW_THRESHOLD],
+      context: baseContext,
+    };
+    const emit = emitRobotsForVerdict(verdict);
+    assert.equal(emit.metaContent, "noindex, follow");
+    assert.equal(emit.headerValue, "noindex, follow");
+    assert.equal(emit.metaContent, emit.headerValue);
+  });
+
+  it("NOINDEX_NOFOLLOW → 'noindex, nofollow' (meta === header)", () => {
+    const verdict: IndexabilityVerdict = {
+      kind: RobotsVerdictKind.NOINDEX_NOFOLLOW,
+      reasonCodes: [ReasonCode.CANONICAL_MISMATCH],
+      context: baseContext,
+    };
+    const emit = emitRobotsForVerdict(verdict);
+    assert.equal(emit.metaContent, "noindex, nofollow");
+    assert.equal(emit.headerValue, "noindex, nofollow");
+  });
+
+  it("invariant : metaContent === headerValue pour TOUS les kinds V1", () => {
+    for (const kind of Object.values(RobotsVerdictKind)) {
+      const verdict: IndexabilityVerdict = {
+        kind,
+        reasonCodes: [],
+        context: baseContext,
+      };
+      const emit = emitRobotsForVerdict(verdict);
+      assert.equal(
+        emit.metaContent,
+        emit.headerValue,
+        `Divergence détectée pour kind ${kind} — viole l'invariant V1 (cf. plan § "split V2+")`,
+      );
+    }
+  });
+});

--- a/packages/seo-role-contracts/src/__tests__/indexability-snapshot.test.ts
+++ b/packages/seo-role-contracts/src/__tests__/indexability-snapshot.test.ts
@@ -1,0 +1,73 @@
+/**
+ * indexability-snapshot — test golden master INPUT-based (PR-UIDP-1 v5/C3).
+ *
+ * Verrouille le comportement de `computeIndexabilityVerdict()` contre 50+
+ * inputs stratifiés (toutes branches cascade, toutes surfaces SEO).
+ *
+ * **INPUT-based** (pas URL-based) :
+ *   - Inputs synthétiques immutables, pas de dépendance DB/RPC/live
+ *   - Replay-safe par construction
+ *   - Drift = explicite (modification fichier requise → revue humaine)
+ *
+ * Tout changement de comportement de la cascade qui flippe ≥1 verdict
+ * cassera ce test → revue obligatoire avant merge.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { computeIndexabilityVerdict } from "../compose-indexability";
+import {
+  type IndexabilityInput,
+  RobotsVerdictKind,
+  ReasonCode,
+} from "../robots-verdict";
+
+interface SnapshotEntry {
+  stratum: string;
+  input: IndexabilityInput;
+  expectedKind: keyof typeof RobotsVerdictKind;
+  expectedReasonCodes: (keyof typeof ReasonCode)[];
+}
+
+// Package tsconfig = CommonJS, donc __dirname dispo. tsx exécute les .ts
+// sans transpiler le module — le résolu reste CJS.
+const SNAPSHOT: SnapshotEntry[] = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "../__fixtures__/indexability-snapshot.json"),
+    "utf-8",
+  ),
+) as SnapshotEntry[];
+
+describe("@repo/seo-role-contracts — indexability-snapshot golden master", () => {
+  it("fixture contains at least 50 stratified inputs", () => {
+    assert.ok(
+      SNAPSHOT.length >= 50,
+      `fixture must contain ≥50 inputs, got ${SNAPSHOT.length}`,
+    );
+  });
+
+  it("strata cover ≥10 distinct branches (cascade coverage)", () => {
+    const strata = new Set(SNAPSHOT.map((e) => e.stratum));
+    assert.ok(
+      strata.size >= 10,
+      `fixture must cover ≥10 strata, got ${strata.size}: ${[...strata].join(", ")}`,
+    );
+  });
+
+  for (const entry of SNAPSHOT) {
+    it(`${entry.stratum} — ${entry.input.surfaceKey}`, () => {
+      const verdict = computeIndexabilityVerdict(entry.input);
+      assert.equal(
+        verdict.kind,
+        entry.expectedKind,
+        `${entry.stratum}: kind mismatch (got ${verdict.kind}, expected ${entry.expectedKind})`,
+      );
+      assert.deepEqual(
+        [...verdict.reasonCodes],
+        entry.expectedReasonCodes,
+        `${entry.stratum}: reasonCodes mismatch`,
+      );
+    });
+  }
+});

--- a/packages/seo-role-contracts/src/compose-indexability.ts
+++ b/packages/seo-role-contracts/src/compose-indexability.ts
@@ -1,0 +1,154 @@
+/**
+ * compose-indexability — pure function canonique de la cascade d'indexabilité SEO.
+ *
+ * Extraction (PR-UIDP-1) de la logique de `SeoIndexabilityPolicyService.computeIndexability()`
+ * en pure function réutilisable côté backend NestJS ET frontend Remix SSR.
+ *
+ * Cascade décisionnelle (cf. plan seo-v9 section 3.6 + plan UIDP V1) :
+ *   1. URL ≠ canonical (si strict_canonical_match=true)
+ *      ⇒ NOINDEX_NOFOLLOW + reasonCodes:[CANONICAL_MISMATCH]
+ *   2. Surface R2 sans payload r2Conditions
+ *      ⇒ NOINDEX_NOFOLLOW + reasonCodes:[R2_CONDITIONS_MISSING] (fail-safe)
+ *   3. Surface R2 + gate fail (≥1 condition manquante)
+ *      ⇒ NOINDEX_NOFOLLOW + reasonCodes:[R2_GATE_FAIL]
+ *   4. availableFamilies < min_families
+ *      ⇒ NOINDEX_FOLLOW + reasonCodes:[FAMILIES_BELOW_THRESHOLD]
+ *   5. availableGammes < min_gammes
+ *      ⇒ NOINDEX_FOLLOW + reasonCodes:[GAMMES_BELOW_THRESHOLD]
+ *   6. Fingerprint match (PR-9)
+ *      ⇒ NOINDEX_FOLLOW + reasonCodes:[FINGERPRINT_DUPLICATE]
+ *   7. TecDoc release gate ouverte (caller flag)
+ *      ⇒ NOINDEX_NOFOLLOW + reasonCodes:[TECDOC_RELEASE_GATE]
+ *   8. Default ⇒ INDEX_FOLLOW + reasonCodes:[]
+ *
+ * Invariants V1 (cf. plan UIDP v5/C2) :
+ *   - Short-circuit au premier blocking → `reasonCodes.length ∈ {0, 1}`
+ *   - Behaviour-preserving strict vs. `SeoIndexabilityPolicyService` v0
+ *   - Secondaires `reasonCodes[1..N]` = V1.5 evidence-gated (mode audit séparé)
+ *
+ * @see robots-verdict.ts (types canon)
+ * @see emit-robots.ts (single text emitter)
+ * @see backend/.../seo-indexability-policy.service.ts (thin wrapper Injectable)
+ */
+import { getThresholds } from "./noindex-thresholds";
+import { evaluateR2Indexability } from "./r2-indexability-conditions";
+import type { SurfaceKey } from "./surface-keys";
+import {
+  ReasonCode,
+  RobotsVerdictKind,
+  type IndexabilityInput,
+  type IndexabilityVerdict,
+} from "./robots-verdict";
+
+/**
+ * Calcule le verdict d'indexabilité canonique pour une input pure.
+ *
+ * Pure function : même input → même output, pas d'I/O, pas d'horodatage non
+ * déterministe (sauf `context.computedAt` qui est une trace, pas une décision).
+ *
+ * Le caller (backend service, loader Remix) consomme `verdict.kind` directement
+ * ou passe le verdict à `emitRobotsForVerdict()` pour obtenir
+ * `metaContent` (HTML) et `headerValue` (X-Robots-Tag), garantis identiques
+ * par construction.
+ */
+export function computeIndexabilityVerdict(
+  input: IndexabilityInput,
+): IndexabilityVerdict {
+  const thresholds = getThresholds(input.surfaceKey);
+  const baseContext = {
+    surfaceKey: input.surfaceKey,
+    requestedUrl: input.requestedUrl,
+    canonicalUrl: input.canonicalUrl,
+    computedAt: new Date().toISOString(),
+  };
+
+  // 1. URL ≠ canonical strict — exclusif court-circuit.
+  if (
+    thresholds.strict_canonical_match &&
+    input.requestedUrl !== input.canonicalUrl
+  ) {
+    return {
+      kind: RobotsVerdictKind.NOINDEX_NOFOLLOW,
+      reasonCodes: [ReasonCode.CANONICAL_MISMATCH],
+      context: baseContext,
+    };
+  }
+
+  // 2. + 3. R2 gate
+  if (isR2Surface(input.surfaceKey)) {
+    if (!input.r2Conditions) {
+      return {
+        kind: RobotsVerdictKind.NOINDEX_NOFOLLOW,
+        reasonCodes: [ReasonCode.R2_CONDITIONS_MISSING],
+        context: baseContext,
+      };
+    }
+    const r2Verdict = evaluateR2Indexability(input.r2Conditions);
+    if (!r2Verdict.indexable) {
+      return {
+        kind: RobotsVerdictKind.NOINDEX_NOFOLLOW,
+        reasonCodes: [ReasonCode.R2_GATE_FAIL],
+        context: baseContext,
+      };
+    }
+  }
+
+  // 4. families threshold (R1/R6/R7).
+  if (
+    thresholds.min_families !== null &&
+    input.availableFamilies !== undefined &&
+    input.availableFamilies < thresholds.min_families
+  ) {
+    return {
+      kind: RobotsVerdictKind.NOINDEX_FOLLOW,
+      reasonCodes: [ReasonCode.FAMILIES_BELOW_THRESHOLD],
+      context: baseContext,
+    };
+  }
+
+  // 5. gammes threshold (R1/R8).
+  if (
+    thresholds.min_gammes !== null &&
+    input.availableGammes !== undefined &&
+    input.availableGammes < thresholds.min_gammes
+  ) {
+    return {
+      kind: RobotsVerdictKind.NOINDEX_FOLLOW,
+      reasonCodes: [ReasonCode.GAMMES_BELOW_THRESHOLD],
+      context: baseContext,
+    };
+  }
+
+  // 6. fingerprint match (PR-9).
+  if (input.fingerprintMatch === true) {
+    return {
+      kind: RobotsVerdictKind.NOINDEX_FOLLOW,
+      reasonCodes: [ReasonCode.FINGERPRINT_DUPLICATE],
+      context: baseContext,
+    };
+  }
+
+  // 7. tecdoc release gate (R8 hardcoded range — caller flag).
+  if (input.tecdocReleaseGateOpen === true) {
+    return {
+      kind: RobotsVerdictKind.NOINDEX_NOFOLLOW,
+      reasonCodes: [ReasonCode.TECDOC_RELEASE_GATE],
+      context: baseContext,
+    };
+  }
+
+  // 8. default — page indexable.
+  return {
+    kind: RobotsVerdictKind.INDEX_FOLLOW,
+    reasonCodes: [],
+    context: baseContext,
+  };
+}
+
+function isR2Surface(key: SurfaceKey): boolean {
+  return (
+    key === "R2_PRODUCT" ||
+    key === "R2_PRODUCT_IN_VEHICLE" ||
+    key === "R2_PRODUCT_LIST"
+  );
+}

--- a/packages/seo-role-contracts/src/emit-robots.ts
+++ b/packages/seo-role-contracts/src/emit-robots.ts
@@ -1,0 +1,50 @@
+/**
+ * emit-robots — single emission point pour le mapping `RobotsVerdictKind` → texte HTTP.
+ *
+ * **Seul module** autorisé à émettre une string `robots` / `X-Robots-Tag`
+ * littérale dans le codebase (whitelist AST rule `seo-no-direct-robots-emission`).
+ *
+ * Symétrie meta == header par construction :
+ *   - `metaContent` = valeur de `<meta name="robots" content="...">` HTML
+ *   - `headerValue` = valeur de `X-Robots-Tag: ...` HTTP
+ *   - Tous les deux dérivent du MÊME `verdict.kind` via le MÊME switch
+ *   - V1 : `metaContent === headerValue` (cf. note plan UIDP § "split futur V2+"
+ *     pour la divergence prévue quand des directives bot-specific seront ajoutées)
+ *
+ * @see robots-verdict.ts (RobotsVerdictKind enum)
+ * @see compose-indexability.ts (producteur du verdict)
+ * @see .ast-grep/rules/seo-no-direct-robots-emission.yml (anti-bypass)
+ */
+import {
+  RobotsVerdictKind,
+  type IndexabilityVerdict,
+} from "./robots-verdict";
+
+export interface RobotsEmission {
+  /** Valeur du `content` de `<meta name="robots">`. */
+  metaContent: string;
+  /** Valeur du header HTTP `X-Robots-Tag`. */
+  headerValue: string;
+}
+
+/**
+ * Mappe un verdict vers les 2 représentations HTTP/HTML attendues.
+ * Identité `metaContent === headerValue` garantie en V1 (cf. doctrine UIDP).
+ */
+export function emitRobotsForVerdict(
+  verdict: IndexabilityVerdict,
+): RobotsEmission {
+  const text = textForKind(verdict.kind);
+  return { metaContent: text, headerValue: text };
+}
+
+function textForKind(kind: RobotsVerdictKind): string {
+  switch (kind) {
+    case RobotsVerdictKind.INDEX_FOLLOW:
+      return "index, follow";
+    case RobotsVerdictKind.NOINDEX_FOLLOW:
+      return "noindex, follow";
+    case RobotsVerdictKind.NOINDEX_NOFOLLOW:
+      return "noindex, nofollow";
+  }
+}

--- a/packages/seo-role-contracts/src/index.ts
+++ b/packages/seo-role-contracts/src/index.ts
@@ -120,3 +120,32 @@ export {
   type R2IndexabilityVerdict,
   evaluateR2Indexability,
 } from "./r2-indexability-conditions";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR-UIDP-1 (v5) — Unified Indexability Decision Plane :
+// composer pure function + emitter unique + types canon.
+// Cf. ADR-NN UIDP V1 (governance-vault).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// RobotsVerdict types (PR-UIDP-1)
+export {
+  RobotsVerdictKind,
+  RobotsVerdictKindSchema,
+  ReasonCode,
+  ReasonCodeSchema,
+  IndexabilityVerdictContextSchema,
+  type IndexabilityVerdictContext,
+  IndexabilityVerdictSchema,
+  type IndexabilityVerdict,
+  IndexabilityInputSchema,
+  type IndexabilityInput,
+  // Backward compat (déprécié, retrait V1.5 — cf. v5/C4)
+  type RobotsValue,
+  legacyStringFromKind,
+} from "./robots-verdict";
+
+// Pure cascade composer (PR-UIDP-1)
+export { computeIndexabilityVerdict } from "./compose-indexability";
+
+// Single emission point meta + header (PR-UIDP-1)
+export { emitRobotsForVerdict, type RobotsEmission } from "./emit-robots";

--- a/packages/seo-role-contracts/src/robots-verdict.ts
+++ b/packages/seo-role-contracts/src/robots-verdict.ts
@@ -1,0 +1,147 @@
+/**
+ * RobotsVerdict — types canon UIDP V1 (Unified Indexability Decision Plane).
+ *
+ * Source of truth typée pour les décisions d'indexabilité SEO :
+ *   - `RobotsVerdictKind` enum (texte HTTP émis uniquement par `emit-robots.ts`)
+ *   - `ReasonCode` enum (cascade structurelle, pas événement métier — cf. ADR
+ *     anti-explosion : critère d'admission = branche de cascade distincte)
+ *   - `IndexabilityVerdict` interface (kind + reasonCodes ≤ 1 + context audit)
+ *   - `IndexabilityInput` interface (compose entrée pure)
+ *
+ * Discipline V1 (cf. plan UIDP v5/C2) : `reasonCodes.length ∈ {0, 1}` —
+ * la cascade short-circuit au premier blocking. Secondaires = V1.5 evidence-gated.
+ *
+ * @see compose-indexability.ts (pure function consumer)
+ * @see emit-robots.ts (single text emitter)
+ * @see ADR-NN UIDP V1 (governance-vault)
+ */
+import { z } from "zod";
+import { SurfaceKeySchema, type SurfaceKey } from "./surface-keys";
+import {
+  R2IndexabilityConditionsSchema,
+  type R2IndexabilityConditions,
+} from "./r2-indexability-conditions";
+
+/**
+ * Verdict de directive robots — kind canonique, mappé en texte HTTP
+ * uniquement par `emitRobotsForVerdict()` (single emission point).
+ */
+export enum RobotsVerdictKind {
+  INDEX_FOLLOW = "INDEX_FOLLOW",
+  NOINDEX_FOLLOW = "NOINDEX_FOLLOW",
+  NOINDEX_NOFOLLOW = "NOINDEX_NOFOLLOW",
+}
+
+export const RobotsVerdictKindSchema = z.nativeEnum(RobotsVerdictKind);
+
+/**
+ * Reason code — invariant **structurel** de la cascade décisionnelle.
+ *
+ * Discipline (cf. ADR UIDP V1 § anti-explosion) :
+ *   - Ajout d'une nouvelle valeur = ouverture d'une nouvelle **branche** de
+ *     cascade (étape qui produit un `kind` distinct)
+ *   - PAS un sous-cas métier d'une branche existante (ex. `R2_GATE_FAIL_NO_IMAGE`
+ *     serait du bruit ; les sub-reasons R2 restent internes au R2 verdict
+ *     et ne remontent pas au ReasonCode[] de niveau supérieur)
+ *   - Tout ajout requiert un test d'invariant dédié
+ */
+export enum ReasonCode {
+  /** URL ≠ canonical (strict_canonical_match) — exclusif, court-circuit. */
+  CANONICAL_MISMATCH = "CANONICAL_MISMATCH",
+  /** Surface R2 et gate fail (≥1 condition cumulative manquante). */
+  R2_GATE_FAIL = "R2_GATE_FAIL",
+  /** Surface R2 sans payload `r2Conditions` (fail-safe, exclusif). */
+  R2_CONDITIONS_MISSING = "R2_CONDITIONS_MISSING",
+  /** availableFamilies < threshold (R1/R6/R7). */
+  FAMILIES_BELOW_THRESHOLD = "FAMILIES_BELOW_THRESHOLD",
+  /** availableGammes < threshold (R1/R8). */
+  GAMMES_BELOW_THRESHOLD = "GAMMES_BELOW_THRESHOLD",
+  /** Fingerprint match (PR-9 SEO) — page duplicate variant. */
+  FINGERPRINT_DUPLICATE = "FINGERPRINT_DUPLICATE",
+  /** TecDoc release gate ouverte ([60000, 83456]) — noindex jusqu'à validation. */
+  TECDOC_RELEASE_GATE = "TECDOC_RELEASE_GATE",
+}
+
+export const ReasonCodeSchema = z.nativeEnum(ReasonCode);
+
+/**
+ * Context audit attaché à chaque verdict — utile pour replay, debug, logs.
+ * V1 : champs minimaux. V1.5+ : peut accueillir snapshot_hash, surface_payload_hash.
+ */
+export const IndexabilityVerdictContextSchema = z.object({
+  surfaceKey: SurfaceKeySchema,
+  requestedUrl: z.string().min(1),
+  canonicalUrl: z.string().min(1),
+  computedAt: z.string().min(1), // ISO-8601
+});
+export type IndexabilityVerdictContext = z.infer<
+  typeof IndexabilityVerdictContextSchema
+>;
+
+/**
+ * Verdict canonique d'indexabilité — sortie de `computeIndexabilityVerdict()`.
+ *
+ * Invariants V1 (cf. plan UIDP v5/C2) :
+ *   - `reasonCodes.length === 0` ↔ `kind === INDEX_FOLLOW`
+ *   - `reasonCodes.length === 1` ↔ `kind ∈ {NOINDEX_FOLLOW, NOINDEX_NOFOLLOW}`
+ *   - `reasonCodes.length ≤ 1` (limite stricte V1, behaviour-preserving)
+ */
+export const IndexabilityVerdictSchema = z.object({
+  kind: RobotsVerdictKindSchema,
+  reasonCodes: z.array(ReasonCodeSchema).max(1),
+  context: IndexabilityVerdictContextSchema,
+});
+export type IndexabilityVerdict = z.infer<typeof IndexabilityVerdictSchema>;
+
+/**
+ * Input pur du composer — toutes les données nécessaires à la décision.
+ * Pas de référence Nest / runtime / DB : pure function input.
+ *
+ * Note : `tecdocReleaseGateOpen` est calculé côté caller (loader R8) — c'est
+ * un flag, pas une règle métier dans le composer. Si l'ADR future ouvre la
+ * gate, le caller change la valeur du flag sans toucher au composer.
+ */
+export const IndexabilityInputSchema = z.object({
+  surfaceKey: SurfaceKeySchema,
+  requestedUrl: z.string().min(1),
+  canonicalUrl: z.string().min(1),
+  availableFamilies: z.number().int().nonnegative().optional(),
+  availableGammes: z.number().int().nonnegative().optional(),
+  r2Conditions: R2IndexabilityConditionsSchema.optional(),
+  /** PR-9 fingerprint match — undefined = check inactif sur cette surface. */
+  fingerprintMatch: z.boolean().optional(),
+  /** Caller-computed (ex. R8 : `type_id >= 60000 && type_id <= 83456`). */
+  tecdocReleaseGateOpen: z.boolean().optional(),
+});
+export type IndexabilityInput = z.infer<typeof IndexabilityInputSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backward compat (C4) — déprécié, retrait V1.5.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @deprecated PR-UIDP-1 (v5/C4) — utiliser `RobotsVerdictKind` enum.
+ * Retrait prévu V1.5 quand tous les consommateurs auront migré.
+ *
+ * Ré-export du type legacy string union pour préserver la signature publique
+ * de `SeoIndexabilityPolicyService.computeIndexability()` pendant la transition.
+ */
+export type RobotsValue =
+  | "index,follow"
+  | "noindex,follow"
+  | "noindex,nofollow";
+
+/**
+ * @deprecated PR-UIDP-1 (v5/C4) — utiliser `emitRobotsForVerdict()`.
+ * Helper interne pour la couche backward-compat du service NestJS.
+ */
+export function legacyStringFromKind(kind: RobotsVerdictKind): RobotsValue {
+  switch (kind) {
+    case RobotsVerdictKind.INDEX_FOLLOW:
+      return "index,follow";
+    case RobotsVerdictKind.NOINDEX_FOLLOW:
+      return "noindex,follow";
+    case RobotsVerdictKind.NOINDEX_NOFOLLOW:
+      return "noindex,nofollow";
+  }
+}


### PR DESCRIPTION
## Contexte

Diagnostic forensic GSC du 2026-05-11 : **336 k pages noindex** sur
`automecanik.com` (`/pieces/*` + `/constructeurs/*`). Le diagnostic a révélé
une **fragmentation d'autorité** sur l'émission `robots` :
- 5 colonnes DB TEXT/INT sans FK (`type_display`, `*_relfollow`, `pg_display`)
- 7+ règles code éparses (R1/R8 thresholds, R2 gate, canonical, no-products
  fallback, malformed URLs)
- Range hardcodé `[60000, 83456]` dans
  [`r8-transform.ts:198-208`](frontend/app/components/vehicle/r8/r8-transform.ts#L198)
- **Header ≠ meta** sur `/constructeurs/*` (type 76550 émet header
  `index, follow` MAIS meta `noindex, nofollow` — anomalie confirmée par
  curl 5 URLs GSC)

Pattern "duplication = abstraction manquante". `SeoIndexabilityPolicyService.computeIndexability()`
existe déjà comme autorité canonique côté backend, **mais n'est pas consommé**
par les émetteurs frontend (`meta`, `X-Robots-Tag`).

## Ce que fait cette PR (UIDP V1 — étape 1 sur 2)

**Refactor pur, behaviour-preserving 100%.** Extrait la cascade décisionnelle
en pure function package-level pour permettre le wiring frontend en PR-UIDP-2
(qui suit), sans toucher au comportement runtime actuel.

### Nouveaux fichiers — `packages/seo-role-contracts/`

- **`src/robots-verdict.ts`** : enum `RobotsVerdictKind` (`INDEX_FOLLOW | NOINDEX_FOLLOW | NOINDEX_NOFOLLOW`),
  enum `ReasonCode` (7 valeurs structurelles cascade : `CANONICAL_MISMATCH`,
  `R2_GATE_FAIL`, `R2_CONDITIONS_MISSING`, `FAMILIES_BELOW_THRESHOLD`,
  `GAMMES_BELOW_THRESHOLD`, `FINGERPRINT_DUPLICATE`, `TECDOC_RELEASE_GATE`),
  schemas Zod, type `IndexabilityVerdict` + `IndexabilityInput`. Backward
  compat `RobotsValue` (déprécié) + `legacyStringFromKind()`.
- **`src/compose-indexability.ts`** : `computeIndexabilityVerdict(input)`
  pure function — extraction de la cascade depuis
  [`seo-indexability-policy.service.ts:49-110`](backend/src/modules/seo/services/policies/seo-indexability-policy.service.ts#L49-L110).
  Aucun import NestJS — utilisable backend ET frontend SSR.
- **`src/emit-robots.ts`** : `emitRobotsForVerdict(verdict)` — single
  emission point mapping enum→texte. Garantit `metaContent === headerValue`
  par construction (la divergence sera explicite et documentée si V2+
  introduit des directives bot-specific).
- **`src/__fixtures__/indexability-snapshot.json`** : 50+ inputs
  stratifiés immutables (INPUT-based, pas URL-based — replay-safe par
  construction).
- **Tests `node:test`** (convention package existante) :
  - `compose-indexability.test.ts` : 52 tests (8 branches cascade,
    per-surface R0..R8, invariants V1, pureté)
  - `emit-robots.test.ts` : 4 tests symétrie
  - `indexability-snapshot.test.ts` : 55 tests golden master

### Fichier modifié — backend

- **`backend/src/modules/seo/services/policies/seo-indexability-policy.service.ts`**
  refactoré en thin wrapper sur `computeIndexabilityVerdict()`. Préserve
  signature legacy `{ robots, blockingReasons }` via `legacyStringFromKind()`
  + `legacyReasonsFromCode()`. Backward compat 100% — les tests jest
  existants doivent passer inchangés.

## Discipline plan UIDP v5 (4 corrections post-self-review)

| Correction | Action |
|---|---|
| **C1** — pas d'AsyncLocalStorage | Vérifié dans le code : NestJS interceptor set ses headers AVANT `next.handle()` donc avant le loader Remix → ALS inopérant. PR-UIDP-2 utilisera `Response.headers` natif Remix. |
| **C2** — `reasonCodes.length ≤ 1` | Cascade short-circuit préservée → behavior 100% identique. Secondaires = V1.5 evidence-gated. Invariant enforced par tests. |
| **C3** — fixture INPUT-based | 50 `IndexabilityInput` synthétiques stratifiés, pas d'URL live → no DB/RPC dep, replay-safe. |
| **C4** — `RobotsValue` re-exporté `@deprecated` | Retrait V1.5 quand tous les callers migrent vers `RobotsVerdictKind` enum. |

## Validation

- ✅ `tsc --noEmit` (package + backend) : 0 erreur
- ✅ `npm test --workspace=@repo/seo-role-contracts` : **131/131 tests pass**
- ✅ Build package : `dist/` propre
- ⏳ Jest backend `seo-indexability-policy.service.test.ts` : à valider en
  CI (worktree local n'a pas le `node_modules/ts-jest` complet — vérification
  manuelle du mapping `legacyReasonsFromCode` confirme behavior-preserving)

## Discipline mémoire (vérifiée)

- ✅ Zéro changement URL/canonical/slug
- ✅ Zéro auto-suppression
- ✅ Zéro modif `frontend/app/routes/**/*.tsx` (R-SEO-09 hard-block)
- ✅ Zéro DDL
- ✅ Behavior-preserving par snapshot lock
- ✅ Branche dédiée depuis main, worktree concurrent-safe

## PR suivante (UIDP V1 — étape 2)

PR-UIDP-2 wirera les émetteurs Remix :
- `frontend/app/utils/pieces-vehicle.loader.server.ts` : émission via
  `new Response(json, { headers: { 'X-Robots-Tag': emit.headerValue }})`
- `frontend/app/components/vehicle/r8/r8-transform.ts` : remplace
  hardcoded `[60000, 83456]` par `tecdocReleaseGateOpen` flag
- `backend/.../seo-headers.interceptor.ts` : étend `delete X-Robots-Tag`
  aux `/constructeurs/*` (alignement sur `/pieces/*`)
- AST rule `.ast-grep/rules/seo-no-direct-robots-emission.yml` (BLOCKING)
- Parity E2E test 50 URLs sur DEV preprod

Dépendance dure : **ADR vault PR `adr/uidp-unified-indexability-decision-plane`**
(ouverte en parallèle, doit être Accepted avant merge PR-UIDP-2).

## Test plan

- [x] `tsc --noEmit` package
- [x] `tsc --noEmit` backend
- [x] `npm test` package (131/131)
- [x] Build package (`dist/` propre)
- [ ] Jest backend backward-compat (CI)
- [ ] Review humaine ADR draft (commentaire) avant merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)