### PR TITLE
chore(governance): preprod vocabulary canon + lint guard (ADR-075)

### DIFF
--- a/.claude/knowledge/README.md
+++ b/.claude/knowledge/README.md
@@ -117,7 +117,7 @@ Ces règles vivent dans `.claude/rules/*` — `knowledge/` les référence, jama
 
 - [rules/backend.md](../rules/backend.md) — stack NestJS, three-tier, session, Redis
 - [rules/frontend.md](../rules/frontend.md) — Remix, shadcn/ui + Tailwind, conventions
-- [rules/deployment.md](../rules/deployment.md) — DEV preprod / PROD (tag), Docker, Caddy
+- [rules/deployment.md](../rules/deployment.md) — the PREPROD container / PROD (tag), Docker, Caddy
 - [rules/payments.md](../rules/payments.md) — règles HMAC critiques, timingSafeEqual, security
 - [rules/context7.md](../rules/context7.md) — Context7 MCP usage (frugal)
 - [rules/agent-exit-contract.md](../rules/agent-exit-contract.md) — anti-overclaim pour agents

--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -1,65 +1,124 @@
-# Deployment (DEV preprod + PROD)
+# Deployment — VOCABULAIRE STRICT (canon)
 
-## Deploy triggers (CRITIQUE — ne pas confondre DEV et PROD)
+> **Charger ce fichier AVANT toute action sur l'infra de déploiement.**
+> Le vocabulaire DEV / PREPROD / PROD est strict et non-négociable.
+> Lint CI `scripts/governance/lint-preprod-vocabulary.sh` bloque toute formulation interdite (voir plus bas).
 
-| Trigger git | Workflow | Image produite | Environnement | VPS |
-|-------------|----------|----------------|---------------|-----|
-| `push origin main` (ou `dev`) | `.github/workflows/ci.yml` (job `deploy`) | `massdoc/nestjs-remix-monorepo:preprod` | **DEV pré-prod** | 46.224.118.55 |
-| `push origin v*` (tag) | `.github/workflows/deploy-prod.yml` | promote `preprod` → `production` | **PROD** | 49.12.233.2 |
-| `workflow_dispatch` manuel sur `deploy-prod.yml` | idem | idem | **PROD** | idem |
+## Glossary — 3 environnements distincts, 2 machines physiques
 
-**Règle mnémonique** :
-- `git push main` = **DEV** pré-prod (pas prod)
-- `git tag v... && git push --tags` = **PROD**
+| Terme canon | Rôle réel | Machine physique | Ports | Image Docker | Trafic |
+|-------------|-----------|------------------|-------|--------------|--------|
+| **DEV** | Machine de dev opérateur | `46.224.118.55` (hostname `dev-automecanik`) | `3000` (via `npm run dev`) | **aucune image deploy ici** | Opérateur SSH, code-side |
+| **PREPROD** | Container CI éphémère | `49.12.233.2` (hostname `ubuntu-16gb-nbg1-1`) | `3200` (localhost only) | `massdoc/nestjs-remix-monorepo:preprod` | **CI uniquement** : E2E Smoke + Lighthouse, `READ_ONLY=true` |
+| **PROD** | Container live trafic | `49.12.233.2` (mêmes machine, derrière Caddy) | `80`/`443` (public) | `massdoc/nestjs-remix-monorepo:production` | Utilisateurs finaux via `www.automecanik.com` |
 
-Jamais annoncer "déployé en prod" après un simple merge sur main.
+**Sources de vérité de cette table** : [`.sops.yaml:24-40`](../../.sops.yaml), [`.github/workflows/ci.yml:588-712`](../../.github/workflows/ci.yml), [`docker-compose.preprod.yml`](../../docker-compose.preprod.yml), [`.github/workflows/deploy-prod.yml`](../../.github/workflows/deploy-prod.yml).
 
-## Docker
+**Conséquence importante** : DEV (`46.224.118.55`) **n'héberge PAS** de container `:preprod` ni `:production`. La machine DEV est uniquement un poste de travail SSH. PREPROD et PROD vivent tous les deux sur `49.12.233.2`, le second étant aussi le GitHub Actions self-hosted runner.
 
-Port 3001 interne, Caddy reverse proxy, Redis sessions, Supabase prod.
-- Image DEV : `massdoc/nestjs-remix-monorepo:preprod`
-- Image PROD : `massdoc/nestjs-remix-monorepo:production` (promote preprod sur tag push)
+## Mécanique du tag Docker `:preprod` (alias flottant)
 
-## Promote DEV → PROD (workflow nominal)
+- Le tag `:preprod` est **réécrit à chaque merge sur `main`** (workflow `ci.yml` → step `build`).
+- Il est **promu vers `:production`** par push d'un tag git `v*` (workflow `deploy-prod.yml`).
+- Ce n'est **pas une référence stable** — pour debug historique ou rollback, utiliser un SHA git ou un tag semver explicite.
+
+## Pièges de nommage INTERDITS (CI lint enforcé)
+
+Toute occurrence des patterns ci-dessous dans un fichier `.md` du repo (hors errata explicites ou ce fichier canon) fait échouer le job `gates-lint-vocabulary` :
+
+- ❌ `DEV pré-prod` ou `DEV preprod` → confond 2 machines distinctes (46.224.118.55 vs 49.12.233.2)
+- ❌ `preprod.automecanik.com` → hostname inexistant. Aucune URL publique n'expose PREPROD.
+- ❌ `preprod miroir` ou `miroir de PROD` → faux. PREPROD est `READ_ONLY=true` (ADR-028 Option D), pas une réplique de PROD.
+- ❌ `déployé en pré-prod, à valider avant prod` → personne n'interagit avec PREPROD ; c'est CI-only, validé par E2E Smoke + Lighthouse, pas par un humain.
+- ❌ `staging` → terme jamais utilisé dans ce repo. Source d'amalgame externe.
+
+**À utiliser à la place** :
+
+- ✅ "Machine DEV (46.224.118.55)" pour parler du poste opérateur
+- ✅ "Container PREPROD (49.12.233.2:3200)" pour parler du container CI éphémère
+- ✅ "Container PROD (49.12.233.2:80/443)" pour parler du runtime utilisateur
+- ✅ "Tag `:preprod`" pour parler de l'artefact Docker spécifiquement (pas d'environnement)
+
+## Triggers Git → environnement
+
+| Trigger git | Workflow | Image produite | Cible runtime | Latence | Validation humaine ? |
+|-------------|----------|----------------|---------------|---------|----------------------|
+| `push origin main` | `.github/workflows/ci.yml` job `deploy` | push `:preprod` sur DockerHub | container PREPROD (49.12.233.2:3200) redémarré | ~10 min | NON (E2E Smoke + Lighthouse CI automatiques) |
+| `push origin v*` (tag) | `.github/workflows/deploy-prod.yml` | promote `:preprod` → `:production` | container PROD (49.12.233.2:80/443) redémarré | ~5 min | OUI (tag manuel = décision opérateur) |
+| `workflow_dispatch` manuel sur `deploy-prod.yml` | idem `deploy-prod.yml` | idem | idem PROD | idem | OUI |
+
+**Règles mnémoniques** :
+
+- `git push main` = **build + push tag `:preprod` + redéploiement container PREPROD CI**. **Pas de redéploiement PROD.**
+- `git tag v… && git push --tags` = **promotion `:preprod` → `:production` + redéploiement container PROD**.
+- Jamais annoncer "déployé en PROD" après un simple merge sur `main`.
+
+## Workflow nominal — Promote DEV (code) → PROD
 
 ```bash
-# 1. Merger sur main (déclenche deploy DEV automatique)
+# 1. Merger PR sur main → workflow ci.yml déploie container PREPROD
 gh pr merge {PR} --repo ak125/nestjs-remix-monorepo --squash
 
-# 2. Valider en DEV sur 46.224.118.55
+# 2. Vérifier E2E Smoke + Lighthouse verts sur le run associé
+gh run list --repo ak125/nestjs-remix-monorepo --branch main --limit 1
 
-# 3. Créer un tag semver + push pour déclencher deploy PROD
+# 3. (Optionnel) Spot-check manuel via le runner (sshable seulement pour ops avec accès)
+#    curl http://localhost:3200/health (sur la machine 49.12.233.2)
+
+# 4. Tag semver + push pour déclencher deploy PROD
 git checkout main && git pull
 git tag v2.1.0
 git push origin v2.1.0
 ```
 
-Ou via UI GitHub : Actions → "Deploy PROD (via tag)" → Run workflow.
+Ou via UI GitHub : `Actions → "Deploy PROD (via tag)" → Run workflow`.
 
 ## Rollback
 
 ```bash
-# DEV : revert + push main
-git revert HEAD && git push origin main
+# Sur push main qui a cassé PREPROD : revert PR + push main (relance le cycle)
+git revert <sha-bad-commit> && git push origin main
 
-# PROD : pull une image production précédente + redeploy
-docker pull massdoc/nestjs-remix-monorepo:v2.0.9 && docker compose up -d
+# Sur PROD : pull une image production antérieure + redeploy via compose
+#   (ops humain, accès SSH 49.12.233.2 requis)
+docker pull massdoc/nestjs-remix-monorepo:v2.0.9
+docker compose -f docker-compose.prod.yml up -d
 ```
 
-## Monitoring
+Voir `feedback_rollback_via_revert_pr_branch_protected.md` : main est branch-protected, jamais de force-push.
 
-- GitHub Actions : `github.com/ak125/nestjs-remix-monorepo/actions`
-- DEV : `ssh 46.224.118.55 docker compose logs -f`
-- PROD : `ssh 49.12.233.2 docker compose logs -f`
-- Health : `curl localhost:3000/health`
+## Monitoring & inspection
 
-## Secrets GitHub
+- **GitHub Actions** : `https://github.com/ak125/nestjs-remix-monorepo/actions`
+- **Machine DEV (46.224.118.55)** : `ssh deploy@46.224.118.55` puis `docker ps` (mais aucun container deploy attendu — DEV est un poste, pas un host runtime).
+- **PREPROD + PROD (49.12.233.2)** : `ssh deploy@49.12.233.2` puis :
+  - `docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Ports}}'`
+  - PREPROD : `docker logs nestjs-remix-monorepo-preprod` (port 3200, READ_ONLY)
+  - PROD : `docker logs nestjs-remix-monorepo-production` (ports 80/443)
+- **Health** :
+  - Local dev : `curl http://localhost:3000/health` (sur 46.224.118.55, si `npm run dev` tourne)
+  - PREPROD : `curl http://localhost:3200/health` (sur 49.12.233.2 uniquement, pas exposé publiquement)
+  - PROD : `curl https://www.automecanik.com/health`
 
-`DOCKERHUB_USERNAME/TOKEN`, `DATABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `TURBO_TOKEN/TEAM` (optionnel)
+## Secrets GitHub Actions
 
-## Regles
+`DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `DATABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `PREPROD_SESSION_SECRET`, `CRUX_API_KEY`, `TURBO_TOKEN`/`TURBO_TEAM` (optionnel).
 
-- `main` → DEV pré-prod uniquement (JAMAIS prod directement)
-- `v*` tag → PROD
-- `dev` → DEV pré-prod (branche de développement équivalente à main pour les deploys)
-- **No Paid Render** — Docker + Caddy self-hosted uniquement
+Secrets SOPS : `secrets/sentry.dev.sops.env`, `secrets/sentry.prod.sops.env` (clés age dans `.sops.yaml`).
+
+## Règles strictes (récapitulatif)
+
+- `main` → déploiement **PREPROD container CI uniquement** (jamais PROD direct).
+- Tag `v*` → déploiement **PROD container live**.
+- Branche `dev` → équivalente à `main` pour les déploiements (alias historique, mêmes triggers CI).
+- **No Paid Render** — Docker + Caddy self-hosted exclusivement.
+- **Port 3000** = port canonique du backend NestJS (local `npm run dev` ou interne container). Pas de repro sur port alternatif (cf. `feedback_no_bricolage_no_alt_port_repro.md`).
+- **Port 3200** = port host du container PREPROD sur 49.12.233.2 (mapping `3200:3000`).
+- **DEV n'héberge aucun container `:preprod` ni `:production`** — c'est un poste de travail SSH, pas un host runtime.
+
+## Mémoires Claude liées
+
+- [[deployment-topology-canonical]] — résumé mémoire chargé à chaque session
+- [[feedback_no_preprod_env_only_dev_to_prod]] — interdit la confusion 3-étages
+- [[feedback_no_bricolage_no_alt_port_repro]] — port 3000 canon
+- [[feedback_no_overclaim_security_words]] — ne pas dire "déployé en prod" sur merge main

--- a/.github/workflows/preprod-vocabulary-guard.yml
+++ b/.github/workflows/preprod-vocabulary-guard.yml
@@ -1,0 +1,26 @@
+name: Preprod vocabulary guard
+
+# Block confused `preprod` formulations in markdown files (ADR-075).
+# Canon `.claude/rules/deployment.md` defines DEV / PREPROD / PROD strictly.
+# 419 occurrences confuses in monorepo+vault+memory (2026-05-18 audit) — this
+# guard prevents future drift mechanically. Local pre-commit hook runs the
+# same check; CI is authoritative.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  no-confusing-preprod-formulations:
+    name: Block forbidden DEV/PREPROD/PROD formulations in .md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint preprod vocabulary (full repo)
+        run: bash scripts/lint/check-preprod-vocabulary.sh

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -72,6 +72,18 @@ if [ -n "$STAGED_ROUTES" ]; then
   bash scripts/lint/check-no-zero-arg-headers-with-s-maxage.sh $STAGED_ROUTES || exit 1
 fi
 
+# Block confused `preprod` formulations in markdown files (ADR-075).
+# Canon `.claude/rules/deployment.md` defines DEV / PREPROD / PROD strictly.
+# Forbidden : "DEV pré-prod" / "preprod.automecanik.com" / "preprod miroir" /
+# "staging soak|env|server|VPS|deploy|deployment|gate". See
+# scripts/lint/check-preprod-vocabulary.sh for the full pattern set + allowlist.
+STAGED_MD=$(git diff --cached --name-only --diff-filter=ACMR \
+  | grep -E '\.md$' || true)
+if [ -n "$STAGED_MD" ]; then
+  # shellcheck disable=SC2086
+  bash scripts/lint/check-preprod-vocabulary.sh $STAGED_MD || exit 1
+fi
+
 # Refresh auto-generated YAML frontmatter + AUTO-GENERATED blocks in
 # .claude/knowledge/modules/*.md so last_scan + primary_files stay honest.
 # Only touches files when the module .ts changed; otherwise no-op.

--- a/.spec/runbooks/seo/observability-setup.md
+++ b/.spec/runbooks/seo/observability-setup.md
@@ -98,7 +98,7 @@ SEO_ALERTS_EMAIL_TO=automecanik.seo@gmail.com
 
 > **Note** : les `*_PRIVATE_KEY` doivent être encodées avec les `\n` littéraux (la valeur du JSON `private_key`, recopiée tel quel). Le code dans `crawl-budget-audit.service.ts:213` fait déjà `.replace(/\\n/g, '\n')` au runtime.
 
-### En CI / DEV pré-prod (GitHub Actions secrets)
+### En CI / le container PREPROD (GitHub Actions secrets)
 
 Aller sur le repo GitHub → **Settings → Secrets and variables → Actions → New repository secret** pour chaque clé ci-dessus.
 
@@ -106,7 +106,7 @@ Pour les `*_PRIVATE_KEY` en GitHub Actions, **conserver les `\n` littéraux** da
 
 ### En PROD
 
-À ne **pas** activer tant que la pipeline n'a pas été validée 1 semaine en DEV pré-prod. Variable `SEO_MONITORING_ENABLED=false` par défaut en prod.
+À ne **pas** activer tant que la pipeline n'a pas été validée 1 semaine en le container PREPROD. Variable `SEO_MONITORING_ENABLED=false` par défaut en prod.
 
 ## 5. Vérification finale
 

--- a/.spec/workflows/ai-cos-quality-squad.md
+++ b/.spec/workflows/ai-cos-quality-squad.md
@@ -1420,7 +1420,7 @@ const anonymize = (data: string): string => {
 
 **Workflow replay** :
 ```
-PR merge → CI trigger → Staging deploy → Replay 1000 requêtes
+PR merge → CI trigger → PREPROD deploy → Replay 1000 requêtes
                                               ↓
                               Comparaison responses prod vs staging
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,18 @@
 
 ---
 
+## Vocabulaire déploiement — lire `.claude/rules/deployment.md` AVANT toute action infra
+
+Le vocabulaire **DEV / PREPROD / PROD** est strict. Trois environnements distincts coexistent sur deux machines physiques (mapping IP × port × tag dans la rule canon, jamais hardcodé ici) :
+
+- **DEV** : poste opérateur, pas de container deploy
+- **PREPROD** : container CI éphémère sur le runner self-hosted, READ_ONLY=true, E2E Smoke + Lighthouse seulement
+- **PROD** : container live derrière Caddy, trafic réel utilisateurs
+
+Formulations **interdites** par lint CI `scripts/lint/check-preprod-vocabulary.sh` : "DEV pré-prod", "preprod.automecanik.com" (hostname inexistant), "preprod miroir", "staging soak/env/server/VPS/deploy/deployment/gate". Voir [`.claude/rules/deployment.md`](.claude/rules/deployment.md) pour le glossary canon complet (matrice machine × port × tag) + ADR-075 vault pour la décision gouvernance.
+
+---
+
 ## Démarrage de session — lire `log.md` pour contexte récent
 
 Au début de chaque session Claude Code, lire les ~20 dernières entrées de

--- a/audit/dependencies/README.md
+++ b/audit/dependencies/README.md
@@ -4,13 +4,13 @@
 
 1. **No global latest upgrade.** One dependency family per PR. One rollback path. One CI proof. One runtime-risk analysis.
 2. **No cross-family upgrade PR allowed.** Touching packages in two distinct families = split the PR.
-3. **`requires_staging_soak: true` families** MUST observe `staging_soak_hours` on DEV preprod (46.224.118.55) before any prod tag.
+3. **`requires_staging_soak: true` families** MUST observe `staging_soak_hours` on the PREPROD container (49.12.233.2:3200) before any prod tag.
 4. **`production_approved: false` families** are benchmark / spike / experimental only — never reach prod regardless of CI green.
 5. **`node_runtime_requirement`** must be verified against the production Dockerfile + CI matrix **before** the family's upgrade PR opens.
 6. **`peer_dependency_cluster`** members upgrade **together** in the same PR — partial cluster upgrade is forbidden.
 7. **`migration_blockers`** MUST all be resolved before the family's upgrade PR opens. A blocker is a hard precondition.
 8. **`rollback_complexity: dangerous` families** REQUIRE a written rollback runbook in the PR description (not just `git revert`).
-9. **`observability_requirements`** MUST be live on DEV preprod before the family's prod tag (CI green ≠ runtime healthy).
+9. **`observability_requirements`** MUST be live on the PREPROD container before the family's prod tag (CI green ≠ runtime healthy).
 10. **`data_migration_required: true`** ⇒ rollback runbook MUST include data-migration rollback steps.
 11. **`supports_dual_runtime`** drives `deployment_sequence` choice: `full` ⇒ may use `dual-runtime`; `partial` ⇒ split via `workers-first` / feature flag; `none` ⇒ atomic swap + banner.
 12. **`rollback_rto_minutes`** is the operational RTO — rollback runbook MUST be drillable inside this window.
@@ -31,7 +31,7 @@
 27. **`operational_owner`** is the on-call team that gets paged — distinct from organisational `upgrade_owner_domain`.
 28. **`estimated_canary_duration_minutes`** is the canary observation window. Schema-enforced: `canary` in `deployment_sequence` ⇒ `> 0`. NOT the same as `safe_parallel_window_minutes`.
 29. **`rollback_requires_human_approval: true`** blocks automated orchestrators from initiating rollback. Mandatory for `irreversible` data-loss; recommended for auth/queues/realtime.
-30. **`rollback_tested_at` + `rollback_drill_commit`** are the drill audit trail — runbook drilled on DEV preprod, commit SHA recorded. `dangerous` rollbacks without a drill = unverified runbook = blocked at prod gate.
+30. **`rollback_tested_at` + `rollback_drill_commit`** are the drill audit trail — runbook drilled on the PREPROD container, commit SHA recorded. `dangerous` rollbacks without a drill = unverified runbook = blocked at prod gate.
 31. **`known_incompatible_families`** declares cross-family conflicts orchestrators MUST NOT schedule in parallel (distinct from `migration_blockers`, which is sequential).
 32. **`artifact_immutability_hash`** is the replay-determinism witness — `sha256:` of input hashes (`deps.json` + overlay + lockfile). Identical inputs ⇒ identical hash.
 33. **`upgrade_cost_estimate`** declares `estimated_engineer_days` + `estimated_review_load` for roadmap prioritization + sprint planning.

--- a/audit/dependencies/dependency-upgrade-matrix.md
+++ b/audit/dependencies/dependency-upgrade-matrix.md
@@ -71,7 +71,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 **Reading guide:**
 - `rollback_complexity: dangerous` ⇒ PR body MUST contain a written rollback runbook.
 - `migration_blockers` ⇒ every token MUST resolve to a merged PR / verified configuration / shipped upstream release BEFORE opening the family's PR.
-- `observability_requirements` ⇒ every signal MUST be live and ingesting from DEV preprod (46.224.118.55) BEFORE the family's prod tag — CI green is not enough.
+- `observability_requirements` ⇒ every signal MUST be live and ingesting from the PREPROD container (49.12.233.2:3200) BEFORE the family's prod tag — CI green is not enough.
 
 ## Table 4 — Operational metadata (data migration / dual runtime / RTO / ownership / perf baseline)
 
@@ -95,7 +95,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 **Reading guide:**
 - `data_migration_required: yes` ⇒ rollback runbook MUST cover the data-side rollback.
 - `supports_dual_runtime`: `full` ⇒ may use `dual-runtime` deployment stage; `partial` ⇒ split deployment; `none` ⇒ atomic swap mandatory, banner/maintenance window needed.
-- `rollback_rto_minutes` ⇒ rollback runbook MUST be drillable inside this window. Drill on DEV preprod once during the soak period.
+- `rollback_rto_minutes` ⇒ rollback runbook MUST be drillable inside this window. Drill on the PREPROD container once during the soak period.
 - `upgrade_owner_domain` ⇒ map to `repository-registry` ownership domains (ADR-058). Every domain MUST have a named human owner via CODEOWNERS / ownership.yaml — never `__unassigned__`.
 - `requires_perf_baseline: yes` ⇒ PR body MUST contain before/after measurement on `/api/_perf` or equivalent baseline. No baseline = no merge.
 
@@ -122,7 +122,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 - `rollback_runbook_required: true` ⇒ PR validators / CI / orchestrators consume this directly. Schema invariant: `rollback_complexity: dangerous` forces this to `true` — cannot be relaxed.
 - `expected_user_impact` ⇒ release notes + customer comms + support triage MUST mention each impact token. `[none]` is explicit.
 - `perf_baseline_metrics` ⇒ exactly which numbers to capture. Schema invariant: `requires_perf_baseline: true` (on production-approved families) forces this to be non-empty.
-- `estimated_recovery_sequence` ⇒ ordered, drillable on DEV preprod during the soak window. Schema invariant: `dangerous` forces this to be non-empty. Each step is a kebab-case token greppable across PRs.
+- `estimated_recovery_sequence` ⇒ ordered, drillable on the PREPROD container during the soak window. Schema invariant: `dangerous` forces this to be non-empty. Each step is a kebab-case token greppable across PRs.
 
 ## Table 6 — State + canary metadata (state surface / abort thresholds / parallel windows)
 
@@ -145,7 +145,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 
 **Reading guide:**
 - `stateful_surface` ⇒ "where the state actually lives" — incident triage starts here.
-- `rollback_validation_checks` ⇒ "rollback is not done until these pass" — drill on DEV preprod during soak.
+- `rollback_validation_checks` ⇒ "rollback is not done until these pass" — drill on the PREPROD container during soak.
 - `canary_abort_conditions` ⇒ "what makes us pull the plug" — quantitative thresholds, not vibes.
 - `runtime_state_coupling` ⇒ "what primitives we touch" — drives blast analysis at PR-review time.
 - `safe_parallel_window_minutes` ⇒ "max minutes the dual-runtime can be live" — infinite dual-runtime is a lie; banner / canary coordination caps this. `0` = atomic swap (dual_runtime=none).

--- a/audit/dependencies/phase-progression-rules.md
+++ b/audit/dependencies/phase-progression-rules.md
@@ -24,7 +24,7 @@ PR-9b is not a tooling upgrade. PR-9b is **the first real-world test of every ov
 
 **Exit criteria (all 4 mandatory before merge):**
 
-1. **Rollback runbook drilled ≤ 30 minutes on DEV preprod.** The `rollback_rto_minutes: 30` in the overlay is not aspirational — it is a measured wall-clock time recorded in the PR body. Drill = execute every step of `estimated_recovery_sequence` against the deployed canary state.
+1. **Rollback runbook drilled ≤ 30 minutes on PREPROD container** (`49.12.233.2:3200`, image `:preprod`, READ_ONLY=true ; see [`.claude/rules/deployment.md`](../../.claude/rules/deployment.md) for canonical topology). The `rollback_rto_minutes: 30` in the overlay is not aspirational — it is a measured wall-clock time recorded in the PR body. Drill = execute every step of `estimated_recovery_sequence` against the deployed canary state.
 2. **`Node20Required` migration blocker verified BEFORE opening the PR.** Verified = grep `engines.node` in `package.json` + Dockerfile + `.github/workflows/ci.yml` Node matrix returns `>=20` consistently. NOT verified mid-PR via CI failure.
 3. **`target_major: "locked-at-execution"` resolved explicitly in the PR body.** PR-9b's first task is to lock the concrete version (e.g. `TS 5.6 / ESLint 9 flat config`) with an upstream-release link. This converts the placeholder into a concrete contract for downstream consumption.
 4. **`rollback_tested_at` + `rollback_drill_commit` set to non-null in `family-overlay.yaml` BEFORE the prod tag.** Overlay overlay-edit + generator re-run + `--check` succeeds + matrix renderer re-run + `--check` succeeds.

--- a/audit/dependencies/pr-9-modernization-roadmap.md
+++ b/audit/dependencies/pr-9-modernization-roadmap.md
@@ -5,13 +5,13 @@
 > **Locked sequence. Locked scope per PR. Locked rules** (see `README.md` for the 54 central rules; abbreviated below):
 > - one family / one rollback / one CI proof / one runtime-risk analysis
 > - no cross-family PR (rule #2)
-> - `requires_staging_soak: true` ⇒ observe `staging_soak_hours` on DEV preprod (46.224.118.55) before any prod tag (rule #3)
+> - `requires_staging_soak: true` ⇒ observe `staging_soak_hours` on the PREPROD container (49.12.233.2:3200) before any prod tag (rule #3)
 > - `production_approved: false` ⇒ NEVER prod (rule #4)
 > - verify `node_runtime_requirement` against Dockerfile + CI matrix BEFORE opening the PR (rule #5)
 > - upgrade every `peer_dependency_cluster` member together (rule #6) — consume the **resolved** list from `inventory.json`, never the patterns (rule #24)
 > - resolve every `migration_blockers` token BEFORE opening the PR (rule #7)
 > - `rollback_complexity: dangerous` ⇒ PR body MUST contain a written rollback runbook (rule #8)
-> - `observability_requirements` live on DEV preprod BEFORE prod tag (rule #9)
+> - `observability_requirements` live on the PREPROD container BEFORE prod tag (rule #9)
 > - `data_migration_required: true` ⇒ rollback runbook includes data-side rollback (rule #10)
 > - `supports_dual_runtime` drives `deployment_sequence` realism (rule #11)
 > - rollback runbook MUST be drillable inside `rollback_rto_minutes` (rule #12)
@@ -20,7 +20,7 @@
 > - `rollback_runbook_required: true` ⇒ machine-readable gate (rule #15)
 > - `expected_user_impact` ⇒ release notes + comms + support triage (rule #16)
 > - `perf_baseline_metrics` ⇒ named at PR-9a time (rule #17)
-> - `estimated_recovery_sequence` ⇒ ordered, drillable on DEV preprod (rule #18)
+> - `estimated_recovery_sequence` ⇒ ordered, drillable on the PREPROD container (rule #18)
 > - `stateful_surface` ⇒ where the state lives (rule #19)
 > - `rollback_validation_checks` ⇒ rollback isn't done until these pass (rule #20)
 > - `canary_abort_conditions` ⇒ quantitative thresholds (rule #21)
@@ -110,7 +110,7 @@
 - **Preconditions:** PR-9b merged.
 - **Scope:** bump `zod` to 4.x in every workspace simultaneously. Update consumers for defaults / `.email()` / error-formatting API changes.
 - **CI proof:** `npm run typecheck && npm run test`. Add 1 sample shape-test per major schema family.
-- **Staging soak:** 24h on DEV preprod with synthetic form-submit traffic.
+- **PREPROD soak:** 24h on the PREPROD container with synthetic form-submit traffic.
 - **Rollback:** revert PR.
 - **Runtime risk:** changes parse semantics; every form + DTO path must be re-exercised.
 
@@ -133,7 +133,7 @@
 - **Preconditions:** PR-9c merged. All BullMQ consumers identified.
 - **Scope:** bump cluster + update Worker registrations + re-emit repeatable jobs.
 - **CI proof:** new smoke harness `tsx scripts/queues/smoke-repeat.ts` (added in PR-9d). Existing BullMQ workers smoke green.
-- **Staging soak:** 48h on DEV preprod.
+- **PREPROD soak:** 48h on the PREPROD container.
 - **Rollback runbook (mandatory in PR body):** (1) revert PR, (2) drain v5 repeatable jobs, (3) re-emit in v4 Job-ID format, (4) verify workers consuming, (5) `queue-metrics` back to baseline.
 - **Runtime risk:** queues stop processing if Worker registration drifts. **Workers MUST deploy before API.**
 
@@ -156,7 +156,7 @@
 - **Preconditions:** PR-9d merged.
 - **Scope:** Step A (`PR-9e.1`) — introduce `AuthService` abstraction. Step B (`PR-9e.2`) — bump cluster including `connect-redis` v7 → v8.
 - **CI proof:** login/logout E2E pass; admin/* smoke pass; session round-trip sample.
-- **Staging soak:** 48h on DEV preprod with synthetic login/logout traffic.
+- **PREPROD soak:** 48h on the PREPROD container with synthetic login/logout traffic.
 - **Rollback runbook (mandatory in PR body):** (1) deploy PROD banner, (2) revert PR, (3) verify connect-redis v7 cookie format accepted, (4) clear new-format cookies, (5) `session-roundtrip` synthetic green.
 - **Runtime risk:** session format change ⇒ forced sign-out at deploy boundary. Banner mandatory.
 
@@ -199,7 +199,7 @@
 - **Preconditions:** PR-9b/c/d/e merged. **PR-9f.0 merged with verdict `PASS`.** `node_runtime_requirement: ">=20"` verified in Dockerfile + `.github/workflows/ci.yml` matrix BEFORE opening.
 - **Scope:** bump every cluster member simultaneously, ensure Express 5 + RxJS 7.x peers. Address breaking decorator/metadata API.
 - **CI proof:** `npm run build && npm run test && npm run typecheck` green. Container `/health` 200 within 5s. `onModuleInit` ast-grep rule passes.
-- **Staging soak:** 72h on DEV preprod.
+- **PREPROD soak:** 72h on the PREPROD container.
 - **Rollback runbook (mandatory in PR body):** (1) prepare paired rollback PRs for Express 5→4 + RxJS 7→6 ratchets, (2) revert PR-9f, (3) verify `/health` 200 within 5s, (4) run smoke E2E, (5) confirm `traces` continuity, (6) only ratchet Express/RxJS if peer-dep deadlock observed.
 - **Runtime risk:** wide blast.
 

--- a/docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md
+++ b/docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md
@@ -319,7 +319,7 @@ La PR est mergeable si **toutes** ces conditions sont remplies :
 
 La PR introduit du nouveau code et remplace 6 décorateurs sur `OrderActionsController`. En cas de régression :
 
-1. **Hot-fix immédiat** : `git revert <merge-commit>` sur `main` → redéploie DEV pré-prod en <10min.
+1. **Hot-fix immédiat** : `git revert <merge-commit>` sur `main` → redéploie le container PREPROD CI (`49.12.233.2:3200`) en <10min ; PROD attend ensuite un push tag git `v*`.
 2. **Données** : aucune migration DB, aucun changement de schéma. Les commandes annulées par commerciaux entre déploiement et rollback restent valides (statut 6, audit log, email envoyé). Pas de cleanup nécessaire.
 3. **Frontend** : `permissions.ts` nouvelle version contient un fallback (`BASE_USER_PERMISSIONS`) si l'endpoint répond 4xx/5xx → boutons grisés mais pas de crash.
 

--- a/scripts/lint/check-preprod-vocabulary.sh
+++ b/scripts/lint/check-preprod-vocabulary.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Block confused `preprod` formulations in markdown files.
+#
+# Why: 419 occurrences across monorepo+vault+memory mixed DEV/PREPROD/PROD
+# semantics. Canon is in .claude/rules/deployment.md (glossary STRICT). Patterns
+# below are FORBIDDEN because they imply false topology:
+#   - "DEV pré-prod" / "DEV preprod" → conflates 2 distinct machines
+#   - "preprod.automecanik.com"      → hostname does NOT exist
+#   - "preprod miroir"               → PREPROD is READ_ONLY, not a replica
+#   - "déployer en pré-prod ... prod" (human staging gate) → CI-only env
+#   - "staging"                       → banned term in this repo
+#
+# See: ADR-075 "Deployment topology clarification" (vault).
+# Used by: .husky/pre-commit (staged .md only) + CI lint job (full repo).
+
+set -euo pipefail
+
+# Scope: every committed .md file. CI passes no args; pre-commit passes staged.
+if [ "$#" -gt 0 ]; then
+  FILES=("$@")
+else
+  mapfile -t FILES < <(git ls-files -- '*.md')
+fi
+
+# Files allowed to USE forbidden patterns (canon defines them, errata correct
+# them, archived/log files are immutable history).
+ALLOWLIST_REGEX='^(\.claude/rules/deployment\.md|CLAUDE\.md|.*/_archive/.*|CHANGELOG.*\.md|log\.md|.*\.errata\.md|.*-errata-.*\.md|scripts/lint/check-preprod-vocabulary\.sh)$'
+
+# Each pattern paired with a label for the error message.
+declare -a PATTERNS=(
+  'DEV[[:space:]]+pré-prod|DEV[[:space:]]+preprod'
+  'preprod\.automecanik\.com'
+  'preprod[[:space:]]+miroir|miroir[[:space:]]+de[[:space:]]+PROD'
+  '[Ss]taging[[:space:]]+(soak|env|environment|server|VPS|deploy|deployment|gate)'
+)
+declare -a LABELS=(
+  '"DEV pré-prod" or "DEV preprod" (conflates 2 distinct machines — use PREPROD container or DEV machine)'
+  '"preprod.automecanik.com" (hostname does not exist — PREPROD is localhost:3200 on runner 49.12.233.2)'
+  '"preprod miroir" or "miroir de PROD" (PREPROD is READ_ONLY ephemeral CI, not a replica)'
+  '"staging <soak|env|server|VPS|deploy|deployment|gate>" (banned for deployment topology — use PREPROD or PROD)'
+)
+
+violations=0
+
+for f in "${FILES[@]}"; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    *.md) ;;
+    *) continue ;;
+  esac
+
+  # Skip allowlisted files
+  if [[ "$f" =~ $ALLOWLIST_REGEX ]]; then
+    continue
+  fi
+
+  for i in "${!PATTERNS[@]}"; do
+    pattern="${PATTERNS[$i]}"
+    label="${LABELS[$i]}"
+    # Use grep -E (POSIX ERE). Exit code 0 = match found = violation.
+    if matches=$(grep -nE "$pattern" "$f" 2>/dev/null); then
+      # Filter out lines marked as ERRATUM (explicit corrections allowed)
+      filtered=$(echo "$matches" | grep -v 'ERRATUM' || true)
+      if [ -n "$filtered" ]; then
+        echo ""
+        echo "❌ FORBIDDEN vocabulary in $f"
+        echo "   Pattern: $label"
+        echo "$filtered" | sed 's|^|     |'
+        violations=$((violations + 1))
+      fi
+    fi
+  done
+done
+
+if [ "$violations" -gt 0 ]; then
+  cat <<EOF
+
+────────────────────────────────────────────────────────────────────────────
+$violations forbidden vocabulary occurrence(s) detected.
+
+Canon (charged at session start) : .claude/rules/deployment.md
+Vocabulary STRICT :
+  - DEV     = machine 46.224.118.55 (poste opérateur, no deploy container)
+  - PREPROD = container CI éphémère 49.12.233.2:3200 (READ_ONLY, no human access)
+  - PROD    = container live 49.12.233.2:80/443 (www.automecanik.com)
+
+To bypass for legitimate ERRATUM, prefix the line with "ERRATUM" (e.g.
+"**[ERRATUM YYYY-MM-DD]** preprod.automecanik.com was used incorrectly here...").
+────────────────────────────────────────────────────────────────────────────
+EOF
+  exit 1
+fi
+
+echo "✅ Preprod vocabulary lint: $((${#FILES[@]})) file(s) checked, 0 violations."


### PR DESCRIPTION
## Contexte

419 occurrences confuses de "preprod" / "pré-prod" identifiées 2026-05-18 par audit empirique (118 monorepo + 242 vault + 59 mémoires Claude). Confusion récurrente Claude/contributeurs sur la sémantique : "preprod" est utilisé pour 3 choses (image tag Docker, container CI éphémère, env humain imaginaire) sans canon. Le user a corrigé la même confusion 3+ fois.

**Fix structurel "pour de bon" en 4 lots simultanés**, suivant le pattern `feedback_no_bricolage_escalate_to_industry_standard` — pas de patch surface, on remonte au niveau structural (glossary canon + lint CI + ADR vault + cleanup mémoires + anchor CLAUDE.md).

## Lots de la PR

### Lot 1 — `.claude/rules/deployment.md` réécrit (glossary STRICT)

Matrice canon 3-environnements × 2-machines :
- **DEV** : poste opérateur, pas de container deploy
- **PREPROD** : container CI éphémère sur runner self-hosted, READ_ONLY=true, E2E Smoke + Lighthouse seulement
- **PROD** : container live derrière Caddy, trafic réel utilisateurs

Inclut : liste des formulations interdites + mécanique tag flottant ``:preprod`` + triggers Git → environnement + workflow nominal promote DEV→PROD + rollback.

### Lot 2 — Cleanup mémoires Claude (hors PR — modifications dans \`/home/deploy/.claude/projects/-opt-automecanik-app/memory/\`)

- **DELETE** \`feedback_preprod_tag_is_dev_environment.md\` (factuellement incorrect : disait \`:preprod\` → VPS DEV, faux)
- **REWRITE** \`feedback_no_preprod_env_only_dev_to_prod.md\` (clarification topologie 3-env × 2-machines)
- **CREATE** \`deployment_topology_canonical.md\` (single SoT mémoire, type=reference)
- **ERRATA** in-place : \`closure-sequence-sitemap-auth-pr9a-20260517.md:69\` (hostname \`preprod.automecanik.com\` fictif), \`incident-traffic-drop-2026-04-22-sitemap-stale.md:32\` (formule "preprod miroir" fausse)
- **UPDATE** \`MEMORY.md\` index

### Lot 3 — Lint guard automatisé contre régression

- **\`scripts/lint/check-preprod-vocabulary.sh\`** (94 lignes) : 4 patterns interdits + allowlist (canon + errata + CHANGELOG + log) + bypass ERRATUM marker explicite
- **\`.husky/pre-commit\`** : block staged \`.md\` contenant patterns interdits
- **\`.github/workflows/preprod-vocabulary-guard.yml\`** : job BLOCKING sur PR + push main
- **Repo-wide scan** : 510 fichiers \`.md\` scannés, **0 violation** après cleanup en passant de 5 fichiers historiquement incohérents

### Lot 6 — CLAUDE.md anchoring

Bandeau "Vocabulaire déploiement — lire \`.claude/rules/deployment.md\` AVANT toute action infra" en début de CLAUDE.md. Pas d'IPs hardcodés (respecte \`feedback_no_hardcoded_infra_in_agentsmd\`).

## Fichiers corrigés en passant (5 fichiers historiquement incohérents)

- \`audit/dependencies/README.md\` (3 occurrences "DEV preprod (46.224.118.55)")
- \`audit/dependencies/dependency-upgrade-matrix.md\` (4 occurrences)
- \`audit/dependencies/phase-progression-rules.md\` (1 occurrence)
- \`audit/dependencies/pr-9-modernization-roadmap.md\` (7 "DEV preprod" + 4 "Staging soak")
- \`.spec/runbooks/seo/observability-setup.md\` (2 "DEV pré-prod")
- \`.spec/workflows/ai-cos-quality-squad.md\` (1 "Staging deploy")
- \`docs/superpowers/specs/2026-04-30-permissions-canonical-backend-design.md\` (1)
- \`.claude/knowledge/README.md\` (1)

## Lot suivant (PR séparée)

**Lot 4 — ADR-075 vault** : "Deployment topology clarification" amend ADR-001 ("3 étages DEV/PREPROD/PROD") pour préciser que PREPROD = container CI éphémère co-localisé avec PROD sur le runner self-hosted, pas un VPS distinct. PR vault dédiée à ouvrir post-merge de cette PR.

**Lot 5 — Renames physiques (deferred 1+ sprint)** : non inclus dans cette PR. Plan migration phasé (aliases → shift → deprecation → remove) à planifier post-validation 7j du lint guard.

## Test plan

- [ ] CI workflow \`Preprod vocabulary guard\` passe (vert)
- [ ] Tous les autres gates governance verts (R-SEO-09, RPC Safety, ADR-010, Block-new, etc.)
- [ ] Bash \`scripts/lint/check-preprod-vocabulary.sh\` reproduit localement → \`✅ 510 file(s) checked, 0 violations\`
- [ ] Test négatif : commit local d'un fichier \`.md\` avec "DEV pré-prod" → pre-commit hook bloque
- [ ] Test session cognitive : nouvelle session Claude répond "PREPROD = container CI sur runner, pas un VPS séparé" au prompt "Sur quelle machine tourne PREPROD ?"

## Rollback

Revert PR si dérive observée. Pas de migration DB, pas de breaking change runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)