### PR TITLE
fix(sitemap): async-202 enqueue for v10/generate-all (fix CF 524 — issue #586)

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/controllers/admin-buying-guide-preview.controller.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/rm.module.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-17'
+last_scan: '2026-05-18'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
+++ b/backend/src/modules/seo/controllers/sitemap-v10.controller.ts
@@ -2,8 +2,8 @@
  * 🔥 CONTRÔLEUR SITEMAP V10 - ENDPOINTS TEMPÉRATURE
  *
  * Endpoints:
- * - POST /api/sitemap/v10/generate-all      → Génère tous les buckets
- * - POST /api/sitemap/v10/generate/:bucket  → Génère un bucket spécifique
+ * - POST /api/sitemap/v10/generate-all      → ASYNC : enqueue BullMQ job, returns 202 + jobId (since 2026-05-18, fix CF 524 timeout)
+ * - POST /api/sitemap/v10/generate/:bucket  → Génère un bucket spécifique (sync, single bucket fits CF timeout)
  * - POST /api/sitemap/v10/refresh-scores   → Recalcule les scores
  * - POST /api/sitemap/v10/generate-hubs    → Génère les hubs de crawl (legacy)
  * - POST /api/sitemap/v10/generate-hubs-robust → 🚀 Hubs paginés (max 5k/file)
@@ -11,13 +11,28 @@
  * - POST /api/sitemap/v10/ping             → Ping Google
  */
 
-import { Controller, Get, Post, Param, Logger } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Logger,
+  HttpCode,
+  HttpStatus,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
 import {
   SitemapV10Service,
   TemperatureBucket,
 } from '../services/sitemap-v10.service';
 import { SitemapV10ScoringService } from '../services/sitemap-v10-scoring.service';
 import { SitemapV10HubsService } from '../services/sitemap-v10-hubs.service';
+import {
+  SITEMAP_REGENERATE_JOB_NAME,
+  SitemapRegenerateJobData,
+} from '../services/sitemap-v10-scheduler.service';
 import { RateLimitSitemap } from '../../../common/decorators/rate-limit.decorator';
 
 @RateLimitSitemap() // 🛡️ 3 req/min - Sitemaps are memory-intensive
@@ -29,68 +44,87 @@ export class SitemapV10Controller {
     private readonly sitemapService: SitemapV10Service,
     private readonly scoringService: SitemapV10ScoringService,
     private readonly hubsService: SitemapV10HubsService,
+    @InjectQueue('seo-monitor') private readonly seoMonitorQueue: Queue,
   ) {}
 
   /**
    * POST /api/sitemap/v10/generate-all
-   * Génère tous les sitemaps par température
+   *
+   * Enqueues a BullMQ job to regenerate all temperature-bucket sitemaps.
+   * Returns 202 Accepted immediately — actual regeneration runs async in
+   * `SitemapRegenerateProcessor` on the `seo-monitor` queue.
+   *
+   * Why async (since 2026-05-18) : in-app sync path takes >100s on prod-scale
+   * data (102k URLs across 7 buckets + 113 hub files), exceeding the
+   * Cloudflare 100s origin timeout. The daily GH Actions cron
+   * (`.github/workflows/sitemap-daily-regen.yml`) was failing with CF 524
+   * since the workflow shipped (PR #565, 2026-05-17). See issue #586.
+   *
+   * Idempotence : deterministic jobId scoped to current UTC date
+   * (`sitemap-v10-api-YYYY-MM-DD`) — multiple same-day API triggers dedupe
+   * to a single BullMQ job. Distinct from the nightly scheduler's
+   * `sitemap-v10-nightly-regeneration` repeatable jobId (worst case = 2
+   * regens per day; the regeneration itself is idempotent).
+   *
+   * Tracking : observers can poll the `seo-monitor` BullMQ queue via
+   * existing Bull Board admin tooling or the scheduler heartbeat (Phase 7,
+   * PR #566).
    */
   @Post('generate-all')
+  @HttpCode(HttpStatus.ACCEPTED)
   async generateAll(): Promise<{
-    success: boolean;
+    success: true;
+    accepted: true;
     message: string;
-    data?: {
-      totalUrls: number;
-      totalFiles: number;
-      durationMs: number;
-      indexPath?: string;
-      buckets: Array<{
-        bucket: string;
-        success: boolean;
-        urlCount: number;
-        filesGenerated: number;
-        error?: string;
-      }>;
-      hubResult?: {
-        success: boolean;
-        totalUrls: number;
-        totalFiles: number;
-        error?: string;
-      };
+    data: {
+      jobId: string;
+      jobName: string;
+      triggeredBy: SitemapRegenerateJobData['triggeredBy'];
+      enqueuedAt: string;
     };
   }> {
-    this.logger.log('📝 POST /api/sitemap/v10/generate-all');
+    this.logger.log('📝 POST /api/sitemap/v10/generate-all (async enqueue)');
+
+    const today = new Date().toISOString().slice(0, 10);
+    const deterministicJobId = `sitemap-v10-api-${today}`;
+    const triggeredBy: SitemapRegenerateJobData['triggeredBy'] = 'api';
 
     try {
-      const result = await this.sitemapService.generateAll();
+      const job = await this.seoMonitorQueue.add(
+        SITEMAP_REGENERATE_JOB_NAME,
+        { triggeredBy } satisfies SitemapRegenerateJobData,
+        {
+          jobId: deterministicJobId,
+          removeOnComplete: 14,
+          removeOnFail: 30,
+          attempts: 2,
+          backoff: { type: 'exponential', delay: 60_000 },
+        },
+      );
+
+      this.logger.log(
+        `✅ Enqueued sitemap regeneration job ${job.id} (jobId=${deterministicJobId})`,
+      );
 
       return {
-        success: result.success,
-        message: result.success
-          ? 'All V10 sitemaps generated successfully'
-          : 'Some sitemaps failed to generate',
+        success: true,
+        accepted: true,
+        message:
+          'Sitemap regeneration enqueued (async). Processor runs on the seo-monitor BullMQ queue.',
         data: {
-          totalUrls: result.totalUrls,
-          totalFiles: result.totalFiles,
-          durationMs: result.totalDurationMs,
-          indexPath: result.indexPath,
-          buckets: result.results.map((r) => ({
-            bucket: r.bucket,
-            success: r.success,
-            urlCount: r.urlCount,
-            filesGenerated: r.filesGenerated,
-            error: r.error,
-          })),
-          hubResult: result.hubResult,
+          jobId: String(job.id ?? deterministicJobId),
+          jobName: SITEMAP_REGENERATE_JOB_NAME,
+          triggeredBy,
+          enqueuedAt: new Date().toISOString(),
         },
       };
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      this.logger.error(`Generate all failed: ${message}`);
-      return {
+      this.logger.error(`Failed to enqueue sitemap regeneration: ${message}`);
+      throw new ServiceUnavailableException({
         success: false,
-        message: `Generation failed: ${message}`,
-      };
+        message: `Failed to enqueue sitemap regeneration: ${message}`,
+      });
     }
   }
 

--- a/backend/tests/unit/sitemap-v10-controller.test.ts
+++ b/backend/tests/unit/sitemap-v10-controller.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression test : SitemapV10Controller.generateAll
+ *
+ * Pin the async-202 contract that fixes the Cloudflare 524 timeout on the
+ * daily sitemap regen cron (issue #586). The endpoint MUST enqueue a BullMQ
+ * job and return immediately — it MUST NOT call `sitemapService.generateAll()`
+ * synchronously (root cause of the >100s response time that tripped CF).
+ *
+ * Covers :
+ *   - `queue.add` invoked with the canonical job name + `triggeredBy: 'api'`
+ *   - Deterministic jobId `sitemap-v10-api-YYYY-MM-DD` for same-day dedup
+ *   - 202 Accepted shape (handled by `@HttpCode(HttpStatus.ACCEPTED)` decorator;
+ *     here we verify the response body shape only — HTTP status is enforced
+ *     by Nest at runtime, not in unit tests of the controller method)
+ *   - `sitemapService.generateAll()` is NEVER called from this endpoint
+ *   - Redis/BullMQ failure surfaces as `ServiceUnavailableException` (HTTP 503)
+ */
+
+import { ServiceUnavailableException } from '@nestjs/common';
+import { Queue } from 'bull';
+import { SitemapV10Controller } from '../../src/modules/seo/controllers/sitemap-v10.controller';
+import { SITEMAP_REGENERATE_JOB_NAME } from '../../src/modules/seo/services/sitemap-v10-scheduler.service';
+import { SitemapV10Service } from '../../src/modules/seo/services/sitemap-v10.service';
+import { SitemapV10ScoringService } from '../../src/modules/seo/services/sitemap-v10-scoring.service';
+import { SitemapV10HubsService } from '../../src/modules/seo/services/sitemap-v10-hubs.service';
+
+type AddedJob = { id: number | string };
+
+function makeQueueMock(addedJobId: number | string = 1234): jest.Mocked<Queue> {
+  return {
+    add: jest.fn().mockResolvedValue({ id: addedJobId } as AddedJob),
+  } as unknown as jest.Mocked<Queue>;
+}
+
+function makeSitemapServiceMock(): jest.Mocked<SitemapV10Service> {
+  return {
+    generateAll: jest.fn(),
+  } as unknown as jest.Mocked<SitemapV10Service>;
+}
+
+function buildController(overrides?: {
+  queue?: jest.Mocked<Queue>;
+  sitemapService?: jest.Mocked<SitemapV10Service>;
+}): {
+  controller: SitemapV10Controller;
+  queue: jest.Mocked<Queue>;
+  sitemapService: jest.Mocked<SitemapV10Service>;
+} {
+  const queue = overrides?.queue ?? makeQueueMock();
+  const sitemapService = overrides?.sitemapService ?? makeSitemapServiceMock();
+  const scoringService = {} as SitemapV10ScoringService;
+  const hubsService = {} as SitemapV10HubsService;
+
+  const controller = new SitemapV10Controller(
+    sitemapService,
+    scoringService,
+    hubsService,
+    queue,
+  );
+
+  return { controller, queue, sitemapService };
+}
+
+describe('SitemapV10Controller.generateAll (async-202 contract — fix CF 524)', () => {
+  it('enqueues a BullMQ job with triggeredBy="api" and SITEMAP_REGENERATE_JOB_NAME', async () => {
+    const { controller, queue } = buildController();
+
+    const response = await controller.generateAll();
+
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    const [jobName, jobData] = queue.add.mock.calls[0];
+    expect(jobName).toBe(SITEMAP_REGENERATE_JOB_NAME);
+    expect(jobData).toEqual({ triggeredBy: 'api' });
+    expect(response.success).toBe(true);
+    expect(response.accepted).toBe(true);
+    expect(response.data.triggeredBy).toBe('api');
+    expect(response.data.jobName).toBe(SITEMAP_REGENERATE_JOB_NAME);
+  });
+
+  it('uses a deterministic jobId scoped to the current UTC date for same-day dedup', async () => {
+    const { controller, queue } = buildController();
+    const expectedDate = new Date().toISOString().slice(0, 10);
+
+    await controller.generateAll();
+
+    const opts = queue.add.mock.calls[0][2] as { jobId?: string };
+    expect(opts.jobId).toBe(`sitemap-v10-api-${expectedDate}`);
+  });
+
+  it('configures retry policy (2 attempts, exponential 60s backoff, retention 14d/30f)', async () => {
+    const { controller, queue } = buildController();
+
+    await controller.generateAll();
+
+    const opts = queue.add.mock.calls[0][2] as {
+      attempts?: number;
+      backoff?: { type?: string; delay?: number };
+      removeOnComplete?: number;
+      removeOnFail?: number;
+    };
+    expect(opts.attempts).toBe(2);
+    expect(opts.backoff?.type).toBe('exponential');
+    expect(opts.backoff?.delay).toBe(60_000);
+    expect(opts.removeOnComplete).toBe(14);
+    expect(opts.removeOnFail).toBe(30);
+  });
+
+  it('NEVER calls sitemapService.generateAll() (root cause of CF 524)', async () => {
+    const { controller, sitemapService } = buildController();
+
+    await controller.generateAll();
+
+    expect(sitemapService.generateAll).not.toHaveBeenCalled();
+  });
+
+  it('returns the BullMQ job id in response data', async () => {
+    const { controller } = buildController({ queue: makeQueueMock(987654) });
+
+    const response = await controller.generateAll();
+
+    expect(response.data.jobId).toBe('987654');
+  });
+
+  it('falls back to the deterministic jobId when queue returns no id', async () => {
+    const queue = {
+      add: jest.fn().mockResolvedValue({ id: undefined }),
+    } as unknown as jest.Mocked<Queue>;
+    const { controller } = buildController({ queue });
+    const expectedDate = new Date().toISOString().slice(0, 10);
+
+    const response = await controller.generateAll();
+
+    expect(response.data.jobId).toBe(`sitemap-v10-api-${expectedDate}`);
+  });
+
+  it('throws ServiceUnavailableException (HTTP 503) when Redis/BullMQ is unavailable', async () => {
+    const queue = {
+      add: jest.fn().mockRejectedValue(new Error('ECONNREFUSED 127.0.0.1:6379')),
+    } as unknown as jest.Mocked<Queue>;
+    const { controller } = buildController({ queue });
+
+    await expect(controller.generateAll()).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the daily sitemap-regen cron failing with Cloudflare 524 origin timeouts since [PR #565](https://github.com/ak125/nestjs-remix-monorepo/pull/565) (Phase 6) shipped. Root cause: `POST /api/sitemap/v10/generate-all` synchronously called `SitemapV10Service.generateAll()` which takes >100s on prod-scale data (102k URLs + 113 hub files) — exceeded CF 100s origin timeout.

Closes #586 once merged.

## Root cause (empirical, posted on issue #586)

| Run | Conclusion | Reason |
|---|---|---|
| 26013618111 (2026-05-18 04:31 UTC) | ❌ failure | `curl: (22) error 524` — Cloudflare origin timeout |
| Local test (PR #565 description) | ≈ 15s | Cold-start + smaller dataset, fits CF timeout |
| Prod actual | >100s | 102k URLs + 113 hub files, exceeds CF 100s default |

## Fix (FinOps industry-standard async pattern, zero new infra)

The async infrastructure was **already shipped** :

- `SitemapRegenerateProcessor` on the `seo-monitor` BullMQ queue (PR #565)
- `SitemapV10SchedulerService.SitemapRegenerateJobData.triggeredBy` typed as `'scheduler' | 'api' | 'manual'` — the `'api'` branch was designed but never wired
- `SeoModule` already imports `WorkerModule` which exports `BullModule`
- Scheduler heartbeat for observability (PR #566)

Only the **controller method needed a one-line-equivalent refactor** : enqueue instead of awaiting `sitemapService.generateAll()`. Returns `HTTP 202 Accepted` in ~150ms.

## What changes (2 files, hand-edited)

### `backend/src/modules/seo/controllers/sitemap-v10.controller.ts`

- `generateAll()` : sync call → `seoMonitorQueue.add(SITEMAP_REGENERATE_JOB_NAME, { triggeredBy: 'api' }, { jobId: 'sitemap-v10-api-YYYY-MM-DD', ... })`
- `@HttpCode(HttpStatus.ACCEPTED)` decorator → returns 202 instead of 200
- Constructor : `@InjectQueue('seo-monitor') private readonly seoMonitorQueue: Queue`
- Response shape : `{ success: true, accepted: true, message, data: { jobId, jobName, triggeredBy: 'api', enqueuedAt } }`
- Redis/BullMQ failure → `ServiceUnavailableException` (HTTP 503) so consumers see real errors
- Other endpoints (`generate/:bucket`, `generate-hubs`, `refresh-scores`, `ping`, `stats`) unchanged — sync remains adequate at smaller scope

### `backend/tests/unit/sitemap-v10-controller.test.ts` (new)

7 unit tests pinning the async-202 contract :

1. `queue.add` invoked with `SITEMAP_REGENERATE_JOB_NAME` + `{ triggeredBy: 'api' }`
2. Deterministic jobId `sitemap-v10-api-YYYY-MM-DD` (same-day dedup)
3. Retry policy : 2 attempts, exponential 60s backoff, retention 14/30
4. **`sitemapService.generateAll()` is NEVER called from this endpoint** (root cause regression test)
5. BullMQ job id returned in response
6. Fallback to deterministic jobId when queue returns undefined id
7. `ServiceUnavailableException` on Redis/BullMQ unavailable

**Local test run** : `✓ 7 passed (12.7s)` — see file for details.

## Auto-generated noise in the diff

42 files in `.claude/knowledge/modules/*.md` got their `last_scan` date bumped from `2026-05-17` to `2026-05-18` by the pre-commit hook `scripts/knowledge/refresh-knowledge.py` (documented behaviour in monorepo CLAUDE.md). One-line change per file, no semantic content drift. The hook is the canonical refresh path — these would have been bumped by the next commit anyway.

## Idempotence + side effects

- **Same-day API triggers dedupe** via deterministic jobId
- **Nightly scheduler** keeps its own repeatable jobId (`sitemap-v10-nightly-regeneration`) — distinct namespace
- **Worst case** : 2 regens per day (scheduler at 03:00 UTC + API trigger at 03:00 UTC). Regen is idempotent (overwrites files). Acceptable for V1.
- **READ_ONLY mode** : already enforced at the processor level (ADR-028 Option D) — unchanged
- **Auth** : Phase 5 cutover (AnyOf guards) is orthogonal — will land in a separate PR

## Breaking change (acknowledged, low impact)

Response shape changes :

```diff
- HTTP 200 { success, message, data: { totalUrls, totalFiles, durationMs, buckets, hubResult } }
+ HTTP 202 { success: true, accepted: true, message, data: { jobId, jobName, triggeredBy, enqueuedAt } }
```

Only known consumer is `.github/workflows/sitemap-daily-regen.yml` which uses `curl -fsSL` and does **not parse the body** — operationally invisible. Admin tooling that depended on the sync result shape would need to poll the BullMQ queue via Bull Board (equivalent to nightly cron observability).

## Test plan (post-merge validation)

- [x] Local unit tests : 7/7 passing
- [x] Typecheck : no errors on changed files
- [x] Commit signed (G3)
- [ ] CI green on PR
- [ ] After merge : manual `gh workflow run sitemap-daily-regen.yml --repo ak125/nestjs-remix-monorepo` → expect green, ~150ms response, jobId in workflow logs
- [ ] Next cron run (2026-05-19 03:00 UTC) : expect green
- [ ] Sitemap freshness SLO endpoint (PR #492 if merged) confirms `<lastmod>` advances daily
- [ ] Close issue #586

## Why I'm NOT auto-merging

This touches a production-critical path (sitemap regen → SEO crawl budget). Even with CI green, this needs your eyes :

1. Confirm response-shape break is acceptable (no admin tooling I'm unaware of)
2. Decide if the 2-regens-per-day worst case is OK (alternative : align jobId with scheduler)
3. Validate the post-merge test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code) on deploy VPS worktree