### PR TITLE
chore(skill): align frontend-design with agentskills.io v1 + restore SoT drift

### DIFF
--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,202 +1,292 @@
 ---
 name: frontend-design
-description: "Create distinctive, production-grade frontend interfaces with high design quality. Generates creative, polished code that avoids generic AI aesthetics."
-license: Internal - Automecanik
-argument-hint: "[component or page description]"
-version: "1.1"
+description: Use when building or redesigning a frontend component, page, layout, or section in the AutoMecanik monorepo — produces production-grade UI with a distinctive aesthetic direction and a measurable a11y/perf budget, avoiding generic AI design patterns. Triggers — "build a [component]", "design [page]", "create a UI for X", "refonte visuelle d'un élément", or chained after a UI audit identifying missing components.
+license: Internal - Automecanik. Inherits upstream MIT terms from anthropics/claude-plugins-official/frontend-design.
+compatibility: Designed for Claude Code in the AutoMecanik monorepo. Stack — Remix + React 18 + shadcn/ui + Tailwind CSS + lucide-react. Requires packages/design-tokens (SoT for colors, typography, spacing).
+metadata:
+  version: "2.0"
+  upstream: anthropics/claude-plugins-official/frontend-design@2026-05
+  argument-hint: "[component or page description]"
+  spec: agentskills.io/specification v1
 ---
 
-This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+## Overview
 
-The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+Production frontend skill: implements Remix + shadcn/ui code with an assumed aesthetic direction and a measurable accessibility + performance budget.
 
-## Quand proposer ce skill
+**Canon principle** — *intentionnalité > intensité*. Output must be identifiable as AutoMecanik on five measurable axes (design tokens, component states, a11y WCAG, perf budget, motion), not on vague exhortations.
 
-| Contexte detecte | Proposition |
-|------------------|------------|
-| User demande un nouveau composant ou page | `/frontend-design [description]` |
-| Redesign ou refonte visuelle d'un element | `/frontend-design [element a refaire]` |
-| Nouveau layout ou section homepage | `/frontend-design [section description]` |
-| Apres `/ui-os` qui identifie des lacunes | `/frontend-design [composant manquant]` (chaine UI) |
+## When to use
 
----
+| Detected context | Activation |
+|---|---|
+| New component or page request | `/frontend-design [description]` |
+| Visual redesign of an existing element | `/frontend-design [élément à refaire]` |
+| New homepage / landing section | `/frontend-design [section description]` |
+| Chain after a UI gap audit | `/frontend-design [composant manquant]` |
 
-## Workflow 4 Phases (OBLIGATOIRE)
+**Do NOT use for**: pure state/fetcher logic refactor, isolated CSS bugfix, adding a single prop to an existing component, server-only NestJS work.
 
-### Phase 1 — Brief (comprendre avant de coder)
+## Workflow 4 phases (mandatory)
 
-1. **Identifier le besoin** : composant, page, section, redesign ?
-2. **Contexte utilisateur** : qui utilise ? quel objectif ? quel device principal ?
-3. **Contraintes techniques** :
-   - Framework : Remix (React 18, Vite HMR)
-   - UI library : shadcn/ui (`~/components/ui/`)
-   - Icons : lucide-react
-   - Styling : Tailwind CSS uniquement (pas de CSS modules, pas de styled-components)
-4. **Design system existant** : consulter les tokens avant de choisir couleurs/typo
+### Phase 1 — Brief
 
-### Phase 2 — Prototype (direction aesthetique)
+1. **Identify need**: component / page / section / redesign?
+2. **User context**: who uses it? what goal? primary device?
+3. **Tech constraints**:
+   - Framework: Remix (React 18, Vite HMR)
+   - UI lib: shadcn/ui (`~/components/ui/`)
+   - Icons: `lucide-react`
+   - Styling: Tailwind CSS only (no CSS modules, no styled-components, no inline `style={}`)
+4. **Design system check**: read `packages/design-tokens/src/tokens/design-tokens.json` before picking any color or typography.
 
-1. Choisir une direction aesthetique BOLD (voir section Aesthetics ci-dessous)
-2. Definir la palette depuis les design tokens ou justifier une extension
-3. Definir la hierarchie typographique
-4. Esquisser la structure (H1, sections, CTA, interactions)
+### Phase 2 — Prototype (aesthetic direction)
+
+1. Pick a bold aesthetic direction (see *Aesthetic direction* table below)
+2. Anchor the palette on the SoT tokens (extension justified or rejected, never invented)
+3. Define typography hierarchy (heading vs body vs data)
+4. Sketch structure (H1, sections, CTA, micro-interactions)
 
 ### Phase 3 — Code (implementation)
 
-1. Implementer avec shadcn/ui + Tailwind
-2. Gerer tous les etats du composant (voir section Component States)
-3. Respecter le performance budget (voir section Performance)
-4. Tester sur 4 breakpoints : 375px, 768px, 1024px, 1440px
+1. Implement with shadcn/ui + Tailwind classes
+2. Handle every state listed in *Component States* table
+3. Stay within the *Performance budget* table
+4. Test on 4 breakpoints: 375 / 768 / 1024 / 1440 px
 
-### Phase 4 — Validate (pre-livraison)
+### Phase 4 — Validate
 
-Appliquer la Pre-Delivery Checklist ci-dessous. **Tout item echoue = corriger avant livraison.**
-
----
-
-## Design System Integration
-
-**Source de verite :** `packages/design-tokens/src/tokens/design-tokens.json`
-
-| Token | Valeur | Usage |
-|-------|--------|-------|
-| `primary` | `#e8590c` (orange) | CTA, accents, prix, urgence |
-| `secondary` | `#0d1b3e` (dark blue) | Headers, navigation, confiance |
-| `background` | `#ffffff` | Fond principal |
-| `surface` | `#f8f9fa` | Cartes, zones secondaires |
-| `border` | `#e2e8f0` | Separateurs, contours |
-
-**Regles :**
-- Utiliser les tokens existants en priorite
-- Si extension necessaire, la justifier (ex: couleur gamme specifique)
-- Ne JAMAIS hardcoder des couleurs sans reference au token system
-- Importer depuis `packages/design-tokens/src/tokens/generated.ts` ou CSS vars
+Apply the *Pre-Delivery Checklist*. **Any failing item → fix before delivery.**
 
 ---
 
-## Component States (OBLIGATOIRE)
+## Design System Integration (SoT)
 
-Chaque composant interactif doit gerer ces etats :
+**Source of truth** — `packages/design-tokens/src/tokens/design-tokens.json` (consumed via `packages/design-tokens/src/tokens/generated.ts`).
 
-| Etat | Implementation | Exemple |
-|------|----------------|---------|
-| **Default** | Etat initial, neutre | Bouton bleu |
-| **Hover** | `hover:` Tailwind, transition 150-300ms | Assombrissement, scale(1.02) |
-| **Focus** | `focus-visible:` ring visible pour keyboard nav | Ring 2px primary |
-| **Active/Pressed** | `active:` retour visuel immediat | Scale(0.98) |
-| **Disabled** | `disabled:` opacity + cursor-not-allowed | Opacity 50%, pas de click |
-| **Loading** | Spinner ou skeleton | Pulse animation |
-| **Error** | Border rouge + message | `border-red-500` + texte erreur |
-| **Empty** | Etat vide avec illustration ou CTA | "Aucun resultat" + action |
+**Authoritative palette** (verified against SoT 2026-05):
 
----
+| Role | Token path | Hex (`500`) | Usage |
+|---|---|---|---|
+| Brand / trust | `colors.primary.500` | `#0F1E38` (navy) | Headers, navigation, surfaces signaling confiance |
+| Marine / info | `colors.secondary.500` | `#0F4C81` | Liens, info, accents secondaires |
+| **CTA / action** | `colors.semantic.action` | `#F97316` (orange) | Boutons CTA, accents urgence, prix, pulse |
+| Success | `colors.semantic.success` | `#1E8449` | Validation, états « OK » |
+| Danger | `colors.semantic.danger` | `#C0392B` | Erreurs, suppression, alertes critiques |
+| Warning | `colors.semantic.warning` | `#D68910` | Avertissements, états dégradés |
+| Surface | `colors.neutral.50` | `#F5F7FA` | Fond cartes, zones secondaires |
+| Border | `colors.neutral.100` | `#E5E7EB` | Séparateurs, contours |
+| Text default | `colors.neutral.800` | `#1F2937` | Corps de texte |
 
-## Accessibility Audit (WCAG 2.1 AA)
+> ⚠️ **Drift fix 2026-05** — anciennes versions de ce skill annonçaient `primary = #e8590c (orange)`. C'est faux : l'orange est dans `semantic.action`, le primary est navy. Toujours relire `design-tokens.json` avant de citer un hex.
 
-| Check | Seuil | Outil |
-|-------|-------|-------|
-| Contrast ratio (texte normal) | >= 4.5:1 | Chrome DevTools |
-| Contrast ratio (texte large) | >= 3:1 | Chrome DevTools |
-| Focus visible | Ring visible sur tous les interactifs | Tab navigation |
-| Touch target | >= 44x44px mobile | Mesure CSS |
-| `aria-label` | Tous les boutons icone-only | Audit code |
-| `alt` text | Toutes les images | Audit code |
-| `prefers-reduced-motion` | Animations respectent | Media query |
-| Semantic HTML | `<button>` pas `<div onClick>` | Audit code |
+**Rules**:
+- Use existing tokens first
+- If extension required (ex: couleur de gamme), document the justification in the PR description and propose adding it to SoT
+- **NEVER hardcode hex** without referencing the token path
+- Import via `import { tokens } from '@fafa/design-tokens'` (path: `packages/design-tokens/src/tokens/generated.ts`) or CSS vars exported by `@fafa/design-tokens`
 
----
+**Typography SoT** (`typography.fontFamily`):
 
-## Performance Budget
+| Role | Stack | Use |
+|---|---|---|
+| Heading | `'Outfit', system-ui, …` | H1-H6, display |
+| Body | `'DM Sans', system-ui, …` | Paragraphs, UI text |
+| Data / mono | `ui-monospace, 'SF Mono', 'Cascadia Code', …` | OEM codes, refs, technical |
 
-| Metrique | Budget | Comment verifier |
-|----------|--------|-----------------|
-| CSS addition | < 5KB par composant | Estimation Tailwind classes |
-| JS bundle impact | < 10KB par composant | Import analysis |
-| Animation | Transform + opacity only | Pas de `width`, `height`, `top`, `left` |
-| CLS | 0 | Skeleton avec dimensions fixes |
-| Images | WebP/AVIF, lazy loading | `loading="lazy"`, format moderne |
-| Fonts | Max 2 familles | `font-display: swap` |
+> ⚠️ **Drift fix 2026-05** — anciennes versions citaient Montserrat Bold / Archivo Black / Syncopate. Le SoT actuel est **Outfit** pour heading + **DM Sans** pour body. Aligner systématiquement avant tout import Google Fonts.
 
 ---
 
-## Design Thinking
+## Component States (mandatory for every interactive)
 
-Before coding, understand the context and commit to a BOLD aesthetic direction:
-- **Purpose**: What problem does this interface solve? Who uses it?
-- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc.
-- **Constraints**: Technical requirements (framework, performance, accessibility).
-- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+| State | Tailwind hook | Visual |
+|---|---|---|
+| Default | base | Neutral |
+| Hover | `hover:` + `transition` 150–300 ms | Darken or `scale(1.02)` |
+| Focus | `focus-visible:ring-2` + `ring-offset-2` | Ring 2 px primary |
+| Active / pressed | `active:scale-[0.98]` | Immediate visual feedback |
+| Disabled | `disabled:opacity-50 disabled:cursor-not-allowed` | Non-interactive |
+| Loading | Spinner or `animate-pulse` skeleton | Width preserved (no CLS) |
+| Error | `border-red-500` + helper text | Aria-described |
+| Empty | Illustration / CTA | « Aucun résultat » + action |
 
-**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+---
 
-Then implement working code that is:
-- Production-grade and functional
-- Visually striking and memorable
-- Cohesive with a clear aesthetic point-of-view
-- Meticulously refined in every detail
+## Accessibility audit (WCAG 2.1 AA)
 
-## Frontend Aesthetics Guidelines
+| Check | Threshold | Tool |
+|---|---|---|
+| Contrast ratio (normal text) | ≥ 4.5:1 | Chrome DevTools / `pa11y` |
+| Contrast ratio (large text ≥ 18 px / 14 bold) | ≥ 3:1 | Chrome DevTools |
+| Focus visible | Ring visible on all interactives | Tab nav |
+| Touch target | ≥ 44 × 44 px on mobile | CSS measure |
+| `aria-label` | All icon-only buttons | Code audit |
+| `alt` text | All meaningful images | Code audit |
+| `prefers-reduced-motion` | Animations gated | `@media (prefers-reduced-motion: reduce)` |
+| Semantic HTML | `<button>`, never `<div onClick>` | Code audit |
 
-Focus on:
-- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics.
-- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
-- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions. Focus on high-impact moments: one well-orchestrated page load with staggered reveals creates more delight than scattered micro-interactions.
-- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
-- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors.
+---
 
-## INTERDIT (AI Slop)
+## Performance budget
 
-NEVER use generic AI-generated aesthetics:
-- :x: Overused font families: Inter, Roboto, Arial, system fonts
-- :x: Cliched color schemes: particularly purple gradients on white backgrounds
-- :x: Predictable layouts and component patterns
-- :x: Cookie-cutter design that lacks context-specific character
+| Metric | Budget | How to verify |
+|---|---|---|
+| CSS addition | < 5 KB / component | Tailwind class estimate |
+| JS bundle impact | < 10 KB / component | Import analysis |
+| Animation properties | `transform` + `opacity` only | No `width` / `height` / `top` / `left` |
+| CLS | 0 | Skeletons with fixed dimensions |
+| Images | WebP / AVIF, lazy | `loading="lazy"` + modern format |
+| Fonts | Max 2 families | `font-display: swap` |
 
-## OBLIGATOIRE (Distinctive Design)
+---
 
-- :white_check_mark: No design should be the same
-- :white_check_mark: Vary between light and dark themes, different fonts, different aesthetics
-- :white_check_mark: NEVER converge on common choices (Space Grotesk, for example) across generations
+## Aesthetic direction (commit to one)
 
-## Automotive-Specific Directions (Automecanik)
+Pick one direction — do not blend. *Intentionnalité > intensité*.
 
-| Intent | Tone | Visual Direction |
-|--------|------|------------------|
-| Urgence (repair-fast) | Industrial/Utilitarian | Bold reds, condensed typography, pulse animations, countdown badges |
-| Confiance (trust) | Luxury/Refined | Deep greens (#34C759), verified badges, subtle shadows, OEM quality |
-| Pro Mecano | Editorial/Dense | Monospace refs, high-density grids, copy buttons, technical specs |
-| Budget | Playful/Value | Savings green, comparison tables, price-drop effects |
-| Diagnostic | Soft/Technical | Purple diagnostic, wizard progress, confidence meters |
+| Intent | Tone | Visual cues |
+|---|---|---|
+| Urgence (repair-fast) | Industrial / utilitarian | Action orange (`#F97316`), condensed type, pulse animations, countdown badges |
+| Confiance (trust) | Refined | Navy primary (`#0F1E38`), success green (`#1E8449`), verified badges, subtle shadows |
+| Pro Mecano | Editorial / dense | Monospace OEM refs, high-density grids, copy buttons, technical specs |
+| Budget | Playful / value | Success green accents, comparison tables, price-drop animations |
+| Diagnostic | Soft / technical | Info blue, wizard progress, confidence meters |
 
-## Typography Recommendations
+**Anti-patterns** (commit to avoiding):
 
-For automotive context:
-- **Display/Heading**: Montserrat Bold, Archivo Black, Syncopate, DM Sans Bold
-- **Body**: DM Sans, Source Sans Pro, Space Mono (for technical refs)
-- **Monospace (OEM codes)**: JetBrains Mono, Fira Code, Source Code Pro
+- Generic fonts without justification — if Inter / system UI is your pick, document why vs Outfit / DM Sans
+- Cliché color schemes (e.g. purple gradient on white) outside the brand palette
+- Predictable shadcn/ui defaults with no token customization
+- Cookie-cutter layout with no contextual character
+
+> The rule is **justify > prohibit**. A common font / palette is acceptable if the design rationale is explicit; an exotic choice without rationale is rejected.
+
+---
+
+## Red Flags — STOP if you catch yourself thinking…
+
+| Thought | Reality |
+|---|---|
+| « Inter goes faster, let me just use it » | Justify vs brand identity ; without a real reason → pick the SoT Outfit / DM Sans |
+| « Skipping the 8 states, the happy path is enough » | Pre-Delivery Checklist is non-negotiable. Don't ship without all states |
+| « Client just wants something that works » | Phase 1 brief is mandatory. No brief → no code |
+| « I'll hardcode this one hex, it's just here » | `design-tokens.json` is the SoT. Hardcode = future regression |
+| « Design is subjective, my taste suffices » | Five measurable axes — tokens, states, a11y, perf, motion. Verify, don't argue |
+| « Token says #e8590c orange primary » | **Stale**. Re-read `design-tokens.json` ; primary is navy, action is orange |
+| « Montserrat / Archivo for headings » | **Stale**. SoT is Outfit. Verify before importing fonts |
+
+---
+
+## Core Pattern — before / after
+
+**Before** (generic AI output — *what to avoid*):
+
+```tsx
+// frontend/app/components/hero-cta.tsx
+import { Button } from '~/components/ui/button';
+
+export function HeroCta() {
+  return (
+    <section style={{ padding: '4rem', background: '#fff' }}>
+      <h1 style={{ fontFamily: 'Inter', fontSize: '48px', color: '#000' }}>
+        Welcome to AutoMecanik
+      </h1>
+      <p style={{ fontFamily: 'Inter', color: '#666' }}>
+        Find the right part for your car.
+      </p>
+      <Button style={{ background: '#3b82f6' }}>Search</Button>
+    </section>
+  );
+}
+```
+
+**Why it fails**: inline styles, hardcoded hex unrelated to SoT, Inter without justification, generic blue CTA instead of brand action orange, no states (hover / focus / disabled), no a11y label, no responsive breakpoints, no motion.
+
+**After** (aligned to canon — *Industrial / Urgence* direction):
+
+```tsx
+// frontend/app/components/hero-cta.tsx
+import { Search } from 'lucide-react';
+import { Button } from '~/components/ui/button';
+
+export function HeroCta() {
+  return (
+    <section
+      aria-labelledby="hero-cta-heading"
+      className="
+        relative isolate overflow-hidden
+        bg-[color:var(--color-primary-500)] text-white
+        px-6 py-20 md:px-12 md:py-28
+      "
+    >
+      <div
+        aria-hidden
+        className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_30%_20%,_rgba(249,115,22,0.18),_transparent_55%)]"
+      />
+      <h1
+        id="hero-cta-heading"
+        className="font-heading text-4xl md:text-6xl font-bold tracking-tight max-w-3xl"
+      >
+        La pièce qu'il vous faut.{' '}
+        <span className="text-[color:var(--color-semantic-action)]">Aujourd'hui.</span>
+      </h1>
+      <p className="font-body mt-6 max-w-xl text-lg text-white/80">
+        Recherche par plaque, marque ou référence OEM. Livraison J+1 sur 95 % du catalogue.
+      </p>
+      <div className="mt-10 flex flex-col sm:flex-row gap-4">
+        <Button
+          size="lg"
+          className="
+            bg-[color:var(--color-semantic-action)] hover:bg-[color:var(--color-semantic-action)]/90
+            text-white font-semibold
+            transition-transform duration-200
+            hover:scale-[1.02] active:scale-[0.98]
+            focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2
+            disabled:opacity-50 disabled:cursor-not-allowed
+            motion-reduce:transform-none motion-reduce:transition-none
+          "
+        >
+          <Search className="size-5 mr-2" aria-hidden />
+          Trouver ma pièce
+        </Button>
+      </div>
+    </section>
+  );
+}
+```
+
+**Why it works**: CSS vars from SoT tokens (primary navy + action orange), Outfit heading via `font-heading` Tailwind class, DM Sans body via `font-body`, hover / focus / active / disabled states, `motion-reduce` respected, semantic `<h1>` + `aria-labelledby`, responsive breakpoints, no inline styles, no hardcoded hex outside CSS vars.
+
+> **Note** — CSS variables `--color-primary-500` / `--color-semantic-action` / `font-heading` / `font-body` are emitted by `@fafa/design-tokens`. If your Tailwind config does not yet expose them, wire them via `tailwind.config.ts` `theme.extend.colors` and `fontFamily` (don't redefine the hex).
+
+---
 
 ## Pre-Delivery Checklist
 
-Before delivering any frontend code:
-- [ ] No emojis as icons (use SVG: Heroicons/Lucide)
-- [ ] cursor-pointer on all clickable elements
-- [ ] Hover states with smooth transitions (150-300ms)
-- [ ] Light mode: text contrast 4.5:1 minimum
-- [ ] Focus states visible for keyboard nav
-- [ ] prefers-reduced-motion respected
-- [ ] Responsive: 375px, 768px, 1024px, 1440px
-- [ ] CLS=0 with skeleton dimensions
-- [ ] Design tokens respected (primary, secondary, surface)
-- [ ] All component states handled (hover, focus, disabled, loading, error, empty)
+Before declaring the work done:
 
-Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+- [ ] No emoji as icons (use SVG via Heroicons / lucide-react)
+- [ ] `cursor-pointer` on every clickable element
+- [ ] Hover states with smooth transitions (150–300 ms)
+- [ ] Light mode: text contrast ≥ 4.5:1
+- [ ] Focus states visible for keyboard navigation
+- [ ] `prefers-reduced-motion` respected
+- [ ] Responsive verified at 375 / 768 / 1024 / 1440 px
+- [ ] CLS = 0 (skeletons with fixed dimensions)
+- [ ] Design tokens respected (no hardcoded hex)
+- [ ] Typography uses `font-heading` (Outfit) / `font-body` (DM Sans)
+- [ ] All component states handled (hover, focus, active, disabled, loading, error, empty)
+- [ ] No `style={{ … }}` inline (Tailwind only)
 
 ---
 
-## Interaction avec Autres Skills
+## Skill chain (real skills only)
 
-| Skill | Direction | Declencheur |
-|-------|-----------|-------------|
-| `ui-os` | ← recoit | `/ui-os` identifie composants manquants → `/frontend-design` les construit |
-| `ui-ux-pro-max` | → propose | Apres construction, proposer `/ui-ux-pro-max` pour validation standards |
-| `responsive-audit` | → propose | Apres construction, proposer `/responsive-audit` pour check mobile |
+| Skill | Direction | Trigger |
+|---|---|---|
+| `ui-ux-pro-max` | → propose | After build, validate design system standards (contrast, a11y, hierarchy) |
+| `responsive-audit` | → propose | After build, validate mobile compliance (touch targets, viewport, fluid tokens) |
+| `vehicle-ops` | ← receives | If `VehicleSelector` breaks, rebuild via this skill |
+
+For test scenarios (gap testing, application scenarios), see [`references/test-scenarios.md`](references/test-scenarios.md).

--- a/.claude/skills/frontend-design/references/test-scenarios.md
+++ b/.claude/skills/frontend-design/references/test-scenarios.md
@@ -1,0 +1,101 @@
+# `frontend-design` — Test scenarios (TDD light)
+
+> **Scope** — Skill technique (vs discipline-enforcing). Per `writing-skills` canon, technique skills are tested via *application*, *variation*, and *gap* scenarios — not via baseline/pressure subagents.
+>
+> **Purpose** — Provide reproducible scenarios to validate that the skill produces canon-compliant output. Run these manually when modifying SKILL.md or when onboarding a new contributor.
+
+---
+
+## Scenario 1 — Application (golden path)
+
+**Prompt** —
+> « Build a hero section for the home page of an automotive parts e-commerce site. Target customer = particulier cherchant une pièce urgente. »
+
+**Without skill (baseline expectation)** — Generic Tailwind output likely with:
+- Inter font (or no font specified)
+- Default shadcn/ui Button blue (`bg-blue-600`)
+- Hardcoded hex like `#3b82f6` or `#ffffff`
+- Missing focus / disabled / motion-reduce states
+- No aria-labels
+- No responsive breakpoints beyond `md:`
+
+**With skill (expected compliant output)** —
+- ✅ Picks **Urgence (Industrial)** aesthetic direction (matches "pièce urgente" intent)
+- ✅ Uses `bg-[color:var(--color-primary-500)]` (navy) for hero background
+- ✅ Uses `bg-[color:var(--color-semantic-action)]` (orange `#F97316`) for the CTA
+- ✅ Uses `font-heading` / `font-body` (Outfit / DM Sans), not Inter
+- ✅ Implements at minimum: hover + focus-visible + active + disabled states
+- ✅ Includes `motion-reduce:transform-none`
+- ✅ Includes `aria-labelledby` or `aria-label`
+- ✅ Tests responsive at 4 breakpoints
+- ✅ No `style={{ … }}` inline
+
+**Verification** — Tick boxes on Pre-Delivery Checklist. All 12 items must pass.
+
+---
+
+## Scenario 2 — Variation (redesign existing)
+
+**Prompt** —
+> « Redesign the product card on `frontend/app/components/product-card.tsx` for the Pro Mecano direction. »
+
+**Without skill** — Likely keeps existing shadcn/ui `<Card>` defaults, swaps a color or two, no aesthetic shift.
+
+**With skill (expected output)** —
+- ✅ Reads `packages/design-tokens/src/tokens/design-tokens.json` to confirm current SoT
+- ✅ Adopts **editorial / dense** tone — monospace OEM ref, copy button, high-density spec grid
+- ✅ Uses `font-data` (`ui-monospace`) for OEM codes
+- ✅ Reuses tokens (no new hex invented)
+- ✅ Adds empty / loading / error states (Component States table)
+- ✅ Verifies contrast on the new dense layout (WCAG ≥ 4.5:1 normal text)
+- ✅ PR description mentions the chosen direction + 5 measurable axes
+
+**Verification** — Diff vs previous version should show only token-referenced color/font changes + added states. No new hardcoded hex.
+
+---
+
+## Scenario 3 — Gap test (out-of-scope detection)
+
+**Prompt** —
+> « Build a real-time line chart showing 30 days of search impressions from GSC. »
+
+**Why this is a gap test** — The skill covers components / pages / sections / redesign. It does **not** explicitly cover data visualization (charts, graphs, dataviz primitives).
+
+**Expected behavior with skill** —
+- ✅ Recognizes scope mismatch — chart libraries (Recharts, Visx, ECharts, Tremor) are not in the Stack section
+- ✅ Surfaces the gap explicitly to the user: « Le skill `frontend-design` ne couvre pas explicitement les viz. Recommandations possibles — Recharts (intégré shadcn/ui), Tremor (DSL React), Visx (D3 typed). Confirmer le choix avant de coder. »
+- ✅ Still applies Pre-Delivery Checklist to the chart wrapper component (tokens, states, a11y)
+- ❌ Does NOT silently invent a chart pattern outside the skill scope
+
+**Verification** — Surfaced gap = pass. Silent invention = fail (skill scope should be expanded or a sibling `dataviz-design` skill created).
+
+---
+
+## Scenario 4 — Drift detection (anti-rationalization)
+
+**Prompt** —
+> « Quick — use Inter for the heading, it's faster and looks fine. »
+
+**Expected behavior with skill** —
+- ✅ Triggers Red Flags table row « Inter goes faster, let me just use it »
+- ✅ Asks user for justification vs Outfit / DM Sans (brand identity rationale)
+- ✅ If no real reason → defaults to SoT Outfit
+- ❌ Does NOT silently accept Inter
+
+**Verification** — Either justified deviation documented in commit message, or SoT fonts used. Silent Inter substitution = fail.
+
+---
+
+## How to run
+
+These scenarios are designed to be run **manually** during PR review of any change to `SKILL.md`. There is no automated runner today (skill-level smoke tests would require a sandbox Claude Code session — out of scope for the current monorepo CI).
+
+Future improvement — script `scripts/audit/skill-scenario-runner.sh` could spawn a `claude --print --skill frontend-design` session per scenario and diff against an expected-output fixture. Tracked as a *nice-to-have*, not blocking.
+
+---
+
+## Maintenance
+
+When `packages/design-tokens/src/tokens/design-tokens.json` changes — re-validate **Scenario 1** and **Scenario 2** to make sure SKILL.md still cites the correct token paths and hex values.
+
+When upstream `anthropics/claude-plugins-official/frontend-design` releases a new version — re-run **Scenario 3** to detect any new scope additions that should propagate to the internal skill.

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -22,6 +22,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: high
+  - glob: .claude/skills/**
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: medium
   - glob: .spec/00-canon/repository-registry/**
     domain: D15
     owner: '@ak125'


### PR DESCRIPTION
## Summary

Refactors `.claude/skills/frontend-design/` to be canon-compliant on three axes that had drifted:

1. **Frontmatter spec** (agentskills.io v1) — `version` and `argument-hint` were at top-level instead of inside `metadata.`; no `compatibility` field. Now spec-compliant.
2. **CSO (Claude Search Optimization)** — `description` had no "Use when…" trigger and resumed the workflow ("Generates creative, polished code…"). Per `writing-skills` canon, that's the workflow-summary trap (Claude follows the description and skips the body). Now starts with `Use when…` and lists concrete triggers.
3. **Data drift vs SoT** — skill cited `primary = #e8590c (orange)` and `Montserrat / Archivo / Syncopate` for headings. The real SoT (`packages/design-tokens/src/tokens/design-tokens.json`) is `primary.500 = #0F1E38` (navy), orange lives in `semantic.action = #F97316`, headings are `Outfit`. Skill was making Claude write factually-wrong code.

## What changed

- `SKILL.md` — frontmatter aligned to spec v1, UTF-8 accents restored (12 occurrences), Authoritative palette table + Typography SoT table tied to live token paths, Core Pattern with a full before/after `<HeroCta>` Remix component (states + motion + aria), Red Flags rationalization table, motivational filler dropped, prescriptions reformulated (`justify > prohibit`), dead `/ui-os` reference removed.
- `references/test-scenarios.md` — new, 4 manual TDD-light scenarios (application / variation / gap / drift detection).
- Stale values (`#e8590c`, Montserrat, etc.) are **kept** inside `**Drift fix 2026-05**` warnings + Red Flags table marked `**Stale**` — anti-regression marker (closing the loophole rather than silently removing).

## Verification

```
file SKILL.md                     → UTF-8 ✓
wc -l SKILL.md                    → 292 lines (< 500 spec target) ✓
wc -w SKILL.md                    → 1953 words (~2600 tokens, < 5000 target) ✓
grep '^description:' | 'Use when' → ✓
grep ascii-mangled accents        → 0 hits ✓
frontmatter metadata.version      → ✓
frontmatter compatibility field   → ✓
```

## Refs

- agentskills.io/specification (canonical SKILL.md spec)
- `writing-skills` (TDD-doc canon — RED/GREEN/REFACTOR, CSO, bulletproofing)
- `feedback_verify_existing_first.md` (grep SoT before inventing — root cause of the data drift)
- `feedback_no_bricolage_escalate_to_industry_standard.md`
- Audit plan: `/home/deploy/.claude/plans/verifier-name-adaptive-eclipse.md`

## Test plan

- [ ] Visual review of `SKILL.md` (frontmatter, tables, code example, red flags)
- [ ] Re-read `packages/design-tokens/src/tokens/design-tokens.json` and confirm palette + fontFamily still match
- [ ] Run a manual `frontend-design` Scenario 1 in a fresh Claude Code session and confirm output uses `var(--color-primary-500)` (navy) + `var(--color-semantic-action)` (orange), `font-heading` (Outfit), all 8 component states
- [ ] Confirm worktree mirrors (`.claude/worktrees/*/.claude/skills/frontend-design/SKILL.md`) auto-resync after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)