### PR TITLE
feat(ai-registry): PR-V2 Skills Canon — schema + validator + ratchet (Phase 0)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,142 @@
+# `.claude/skills/` — AutoMecanik Skill canon
+
+> Cette page est le **guide de création / modification** d'un Claude Code skill dans le monorepo AutoMecanik. Le contrat technique vit dans [`.spec/00-canon/ai-registry/skill.schema.json`](../../.spec/00-canon/ai-registry/skill.schema.json) (SoT JSON Schema). Si une règle prose diverge du schema, **le schema gagne**.
+
+## TL;DR
+
+1. Crée un répertoire `.claude/skills/<kebab-case-name>/`
+2. Ajoute un `SKILL.md` avec le **frontmatter canonique** (voir template ci-dessous)
+3. Lance `node scripts/governance/validate-skills-frontmatter.js --skill <name>` → doit retourner `ok`
+4. Lance `node scripts/governance/build-skills-registry.js` → doit incrémenter `totalSkills` dans `.spec/00-canon/ai-registry/skills.registry.json`
+5. Le glob `.claude/skills/**` est déjà couvert par `ownership.yaml` — pas de glob à rajouter pour un nouveau skill
+6. CI : le job `Skills canon gate` validera automatiquement (warn-only en Phase 0, hard-fail dès PR-V2.5)
+
+## Frontmatter canonique (template)
+
+```yaml
+---
+# === REQUIS (agentskills.io v1) ===
+name: <kebab-case>                        # doit matcher dirname
+description: >                            # contient OBLIGATOIREMENT "Use when"
+  Use when <triggers concrets>. <Ce que le skill produit>. Triggers — "X", "Y", "Z".
+
+# === REQUIS (gouvernance AutoMecanik) ===
+type: technique                           # technique | reference | discipline
+status: experimental                      # experimental | stable | deprecated
+owners: ['@your-handle']                  # min 1, doit matcher ownership.yaml
+domain: D15                               # D1..D15 per domains.yaml
+runtime_class: read-only                  # read-only | mutating | privileged
+llm_safe: true                            # false si génère faits métier hallucinables
+
+# === RECOMMANDÉ ===
+last_verified: '2026-MM-DD'               # touch on modification
+license: Internal - Automecanik
+compatibility: Designed for Claude Code in AutoMecanik monorepo. Stack — …
+allowed-tools: Read Grep Glob             # space-separated, agentskills.io v1 experimental
+tags: [scope, role, stack, ...]
+
+# === METADATA libre ===
+metadata:
+  version: "1.0"
+  argument-hint: "[args]"
+  spec: agentskills.io/specification v1
+---
+```
+
+## Champs canon — sémantique
+
+### `type` (taxonomy writing-skills)
+
+| Valeur | Sens | Exemples |
+|---|---|---|
+| `technique` | Méthode avec étapes à suivre | `frontend-design`, `responsive-audit`, `code-review` |
+| `reference` | Documentation / lookup | `ui-ux-pro-max` |
+| `discipline` | Enforcement d'une règle | `db-migration`, `governance-vault-ops` |
+
+### `runtime_class` (profil d'effets de bord)
+
+| Valeur | Effets | Exemple |
+|---|---|---|
+| `read-only` | Inspection / audit, zéro mutation | `responsive-audit`, `code-review` |
+| `mutating` | Édite fichiers locaux, ouvre PR, run npm | `frontend-design`, `session-log` |
+| `privileged` | Touche secrets, infra, deploys, DDL | `db-migration`, `governance-vault-ops` |
+
+### `llm_safe`
+
+- `true` si les outputs sont dérivés déterministiquement de fichiers + tools (pas d'invention LLM de faits métier)
+- `false` si le skill génère du contenu métier potentiellement hallucinable (slug, prix, compatibilité véhicule) → DOIT s'appuyer sur RAG + vault (voir `feedback_rag_vault_always_first`)
+
+### `domain`
+
+- Skills d'AI Governance Control Plane → **D15** Security & Governance
+- Domain de la donnée touchée disponible dans le frontmatter via `tags:` pour la recherche
+
+## Description = trigger CSO (critique)
+
+La `description` est le seul champ que Claude lit pour décider de charger le skill. Doctrine canon :
+
+1. **Commencer par `Use when …`**
+2. Lister 2-4 triggers concrets entre guillemets : `"build a [component]"`, `"audit responsive"`, etc.
+3. **Pas de résumé de workflow** (« generates X », « produces Y ») — ça crée le workflow-summary trap où Claude suit la description et zappe le body
+4. Multilingue OK (FR + EN) — cohérent avec le contenu
+
+Cf. mémoire [`feedback_skill_sot_drift_audit_pattern`](../../../home/deploy/.claude/projects/-opt-automecanik-app/memory/feedback_skill_sot_drift_audit_pattern.md) pour le pattern audit.
+
+## Validation locale (avant de commit)
+
+```bash
+# 1. Schema + cross-refs ownership + domains
+node scripts/governance/validate-skills-frontmatter.js --skill <name>
+
+# 2. JSON output pour debug
+node scripts/governance/validate-skills-frontmatter.js --json | jq
+
+# 3. Régénérer le registry projection (committed)
+node scripts/governance/build-skills-registry.js
+
+# 4. Vérifier registry up-to-date (sans modifier)
+node scripts/governance/build-skills-registry.js --check
+```
+
+## CI ratchet (enforcement progressif)
+
+| Phase | PR | Comportement | Critère de sortie |
+|---|---|---|---|
+| **Phase 0** | PR-V2 (this) | warn-only (`continue-on-error: true`), summary visible | observation 7 jours sans régression |
+| **Phase 1** | PR-V2.5 | hard-fail sur **new skills** uniquement | 7+ jours stable |
+| **Phase 2** | PR-V3 | hard-fail sur **tous skills** + required check branch protection | promote ADR vault |
+
+Modèle de séquençage : ADR-058 PR-G (Repository Control Plane). Validé empiriquement, non spéculatif.
+
+## Skills existants
+
+| Skill | Type | Status | Runtime | LLM-safe | Domain |
+|---|---|---|---|---|---|
+| `code-review` | technique | stable | read-only | ✓ | D15 |
+| `db-migration` | discipline | stable | privileged | ✗ | D15 |
+| `frontend-design` | technique | stable | mutating | ✓ | D15 |
+| `governance-vault-ops` | discipline | stable | privileged | ✗ | D15 |
+| `responsive-audit` | technique | stable | read-only | ✓ | D15 |
+| `session-log` | technique | stable | mutating | ✓ | D15 |
+| `ui-ux-pro-max` | reference | stable | read-only | ✓ | D15 |
+| `vehicle-ops` | technique | stable | mutating | ✗ | D15 |
+
+Source-of-truth machine-readable : [`.spec/00-canon/ai-registry/skills.registry.json`](../../.spec/00-canon/ai-registry/skills.registry.json) (généré).
+
+## Anti-patterns à éviter
+
+- ❌ Frontmatter au top-level pour `version` / `argument-hint` → mettre sous `metadata:`
+- ❌ Description sans « Use when » → CSO trigger manquant, skill jamais invoqué
+- ❌ Description qui résume le workflow → workflow-summary trap
+- ❌ Body sans frontmatter du tout → spec broken silently (cf. `governance-vault-ops` pré-PR-V2)
+- ❌ Hex couleur / nom de font hardcodés sans référence au SoT → drift quasi-certain dans 6 mois (cf. `feedback_skill_sot_drift_audit_pattern`)
+- ❌ Phrases motivationnelles (« Don't hold back », « Claude is capable of … ») → non-actionnable, encourage over-engineering
+
+## Liens canon
+
+- Spec normative : <https://agentskills.io/specification>
+- TDD doctrine pour skills : `superpowers:writing-skills` (RED/GREEN/REFACTOR + CSO + bulletproofing)
+- Schema : [`.spec/00-canon/ai-registry/skill.schema.json`](../../.spec/00-canon/ai-registry/skill.schema.json)
+- Validator : [`scripts/governance/validate-skills-frontmatter.js`](../../scripts/governance/validate-skills-frontmatter.js)
+- Registry projection : [`scripts/governance/build-skills-registry.js`](../../scripts/governance/build-skills-registry.js)
+- CI gate : [`.github/workflows/skills-canon-gate.yml`](../../.github/workflows/skills-canon-gate.yml)

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: code-review
-description: "Systematic PR/code review: security, architecture, performance, business compliance. Checklist adapted to AutoMecanik monorepo."
-argument-hint: "[PR-number or file-path]"
-allowed-tools: Read, Grep, Glob, Bash
-version: "1.1"
+description: Use when reviewing a PR, diff, or recent changes for security, architecture, performance, and business compliance against AutoMecanik monorepo checklists (HMAC payment safety, RLS, RPC contracts, ADR adherence, no-bricolage). Triggers — "review PR #N", "code review this branch", "audit this diff for production readiness", or before merging any non-trivial PR.
+type: technique
+status: stable
+owners: ['@ak125']
+domain: D15
+runtime_class: read-only
+llm_safe: true
+last_verified: '2026-05-18'
+license: Internal - Automecanik
+compatibility: Designed for Claude Code in the AutoMecanik monorepo. Read-only audit + analysis. Does NOT mutate code.
+allowed-tools: Read Grep Glob Bash
+tags: [review, security, hmac, rls, governance, adr]
+metadata:
+  version: "1.1"
+  argument-hint: "[PR-number or file-path]"
+  spec: agentskills.io/specification v1
 ---
 
 # Code Review Skill

--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: db-migration
-description: "Supabase migration patterns, RLS audit, schema validation. Guides safe DDL operations."
-argument-hint: "[migration-name]"
-disable-model-invocation: true
-version: "1.1"
+description: Use when writing or reviewing a Supabase migration — applies safe DDL patterns (idempotent, reversible, additive-first), RLS audit, schema validation against canonical types. Triggers — "create migration X", "audit migration Y", "add RLS policy", "alter table Z safely", or any task in backend/supabase/migrations/.
+type: discipline
+status: stable
+owners: ['@ak125']
+domain: D15
+runtime_class: privileged
+llm_safe: false
+last_verified: '2026-05-18'
+license: Internal - Automecanik
+compatibility: Designed for Claude Code in the AutoMecanik monorepo. Stack — Supabase + PostgreSQL. Touches backend/supabase/migrations/ and __* canonical tables. Privileged because DDL is irreversible on prod.
+tags: [supabase, postgres, ddl, rls, migration, governance]
+metadata:
+  version: "1.1"
+  argument-hint: "[migration-name]"
+  disable-model-invocation: true
+  spec: agentskills.io/specification v1
 ---
 
 # Database Migration Skill

--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,8 +1,16 @@
 ---
 name: frontend-design
 description: Use when building or redesigning a frontend component, page, layout, or section in the AutoMecanik monorepo — produces production-grade UI with a distinctive aesthetic direction and a measurable a11y/perf budget, avoiding generic AI design patterns. Triggers — "build a [component]", "design [page]", "create a UI for X", "refonte visuelle d'un élément", or chained after a UI audit identifying missing components.
+type: technique
+status: stable
+owners: ['@ak125']
+domain: D15
+runtime_class: mutating
+llm_safe: true
+last_verified: '2026-05-18'
 license: Internal - Automecanik. Inherits upstream MIT terms from anthropics/claude-plugins-official/frontend-design.
 compatibility: Designed for Claude Code in the AutoMecanik monorepo. Stack — Remix + React 18 + shadcn/ui + Tailwind CSS + lucide-react. Requires packages/design-tokens (SoT for colors, typography, spacing).
+tags: [frontend, remix, shadcn, tailwind, design-tokens, a11y, wcag]
 metadata:
   version: "2.0"
   upstream: anthropics/claude-plugins-official/frontend-design@2026-05

--- a/.claude/skills/governance-vault-ops/SKILL.md
+++ b/.claude/skills/governance-vault-ops/SKILL.md
@@ -1,3 +1,22 @@
+---
+name: governance-vault-ops
+description: Use when operating the Obsidian governance-vault as an auditable ledger — sync canon mirrors, check orphans, audit signatures, propose ADR/rule edits, never write directly. Triggers — "sync vault canon", "audit vault signatures", "open vault PR", "verify ADR-X", or any task touching governance-vault/ or .claude/canon-mirrors/.
+type: discipline
+status: stable
+owners: ['@ak125']
+domain: D15
+runtime_class: privileged
+llm_safe: false
+last_verified: '2026-05-18'
+license: Internal - Automecanik
+compatibility: Designed for Claude Code on the DEV VPS (single-write-point per ADR-015). Requires /opt/automecanik/governance-vault checkout, SSH signing configured, GOVERNANCE_VAULT_PATH env var. CI read-only enforced.
+tags: [governance, vault, adr-015, ssh-signing, ledger, audit]
+metadata:
+  version: "1.0"
+  spec: agentskills.io/specification v1
+  adr_references: "ADR-015, ADR-058, ADR-061"
+---
+
 # Skill: governance-vault-ops
 
 Objectif: opérer le vault Obsidian `governance-vault` comme un registre (ledger) auditable:

--- a/.claude/skills/responsive-audit/SKILL.md
+++ b/.claude/skills/responsive-audit/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: responsive-audit
-description: "Mobile-first responsive audit v1.1 : shadcn/ui compliance, touch targets WCAG, viewport units, fluid tokens, design consistency."
-argument-hint: "[/url-path or file-pattern]"
-allowed-tools: Read, Grep, Glob
-version: "1.1"
+description: Use when auditing a Remix route or component for mobile-first responsive compliance — checks shadcn/ui usage, WCAG touch targets (44×44 px), viewport units, fluid tokens, design consistency at 375 / 768 / 1024 / 1440 px breakpoints. Triggers — "audit responsive on /page", "check mobile compliance", "verify touch targets", or chained after /frontend-design.
+type: technique
+status: stable
+owners: ['@ak125']
+domain: D15
+runtime_class: read-only
+llm_safe: true
+last_verified: '2026-05-18'
+license: Internal - Automecanik
+compatibility: Designed for Claude Code in the AutoMecanik monorepo. Stack — Remix + shadcn/ui + Tailwind CSS. Read-only audit, no code mutations.
+allowed-tools: Read Grep Glob
+tags: [responsive, mobile-first, wcag, viewport, shadcn]
+metadata:
+  version: "1.1"
+  argument-hint: "[/url-path or file-pattern]"
+  spec: agentskills.io/specification v1
 ---
 
 # Responsive Audit Skill — v1.1

--- a/.claude/skills/session-log/SKILL.md
+++ b/.claude/skills/session-log/SKILL.md
@@ -1,6 +1,19 @@
 ---
 name: session-log
-description: Append a 3-4 line curated entry to log.md at the monorepo root. Use when the current Claude Code session has produced commits or PRs and the user (or Stop hook) requests recording it. Format strict, no secrets, append-only. Trigger keywords - "log session", "/log-session", "record this work", or auto-suggested by Stop hook when git activity detected.
+description: Use when the current Claude Code session has produced commits or PRs and needs to be appended as a 3-4 line curated entry in log.md at the monorepo root. Format strict, no secrets, append-only. Triggers — "log session", "/log-session", "record this work", or auto-suggested by Stop hook when git activity is detected.
+type: technique
+status: stable
+owners: ['@ak125']
+domain: D15
+runtime_class: mutating
+llm_safe: true
+last_verified: '2026-05-18'
+license: Internal - Automecanik
+compatibility: Designed for Claude Code in the AutoMecanik monorepo. Append-only to log.md (no DDL, no infra).
+tags: [logging, session, audit-trail, stop-hook]
+metadata:
+  version: "1.0"
+  spec: agentskills.io/specification v1
 ---
 
 # session-log

--- a/.claude/skills/ui-ux-pro-max/SKILL.md
+++ b/.claude/skills/ui-ux-pro-max/SKILL.md
@@ -1,8 +1,20 @@
 ---
 name: ui-ux-pro-max
-description: "UI/UX design intelligence. 67 styles, 96 palettes, 57 font pairings, 25 charts, 13 stacks. Search, generate design systems, accessibility audit."
-argument-hint: "[design-query or component-type]"
-version: "1.1"
+description: Use when validating or choosing design system primitives (67 styles, 96 color palettes, 57 font pairings, 99 UX guidelines, 25 chart types across 13 stacks) for an AutoMecanik front-end. Triggers — "validate this design", "choose a palette", "audit a11y", "what font pairs with X", or chained after /frontend-design for standards check.
+type: reference
+status: stable
+owners: ['@ak125']
+domain: D15
+runtime_class: read-only
+llm_safe: true
+last_verified: '2026-05-18'
+license: Internal - Automecanik
+compatibility: Designed for Claude Code in the AutoMecanik monorepo. Stack — Remix + shadcn/ui + Tailwind CSS. Consults packages/design-tokens as project-specific overlay.
+tags: [design-system, ui, ux, a11y, typography, palettes, charts]
+metadata:
+  version: "1.1"
+  argument-hint: "[design-query or component-type]"
+  spec: agentskills.io/specification v1
 ---
 # UI/UX Pro Max - Design Intelligence
 

--- a/.claude/skills/vehicle-ops/SKILL.md
+++ b/.claude/skills/vehicle-ops/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: vehicle-ops
-description: "Vehicle operations: lookup, V-Level classification, compatibility RPC, cache, data quality, diagnostic & maintenance (ADR-032). Anti-patterns DB (no FK, TEXT columns, type_display string)."
-argument-hint: "[diagnose|vlevel|cache|quality|maintenance|dtc] [gamme-id or type-id]"
-allowed-tools: Read, Grep, Glob, Bash, mcp__claude_ai_Supabase__execute_sql
-version: "1.1"
+description: Use when working with vehicle data — lookup by type / gamme, V-Level classification, compatibility RPC, cache strategy, data quality audit, diagnostic / maintenance (ADR-032). Surfaces the known DB anti-patterns (no FK, TEXT columns, type_display as string). Triggers — "diagnose vehicle X", "audit gamme Y", "check compatibility", "VehicleSelector broken", or any task touching auto_type / pieces_gamme tables.
+type: technique
+status: stable
+owners: ['@ak125']
+domain: D15
+runtime_class: mutating
+llm_safe: false
+last_verified: '2026-05-18'
+license: Internal - Automecanik
+compatibility: Designed for Claude Code in the AutoMecanik monorepo. Stack — NestJS + Supabase. Requires Supabase MCP read access to auto_type, pieces_gamme, v_compat_strict views. Uses RAG/vault as SoT for vehicle facts (no LLM hallucination).
+allowed-tools: Read Grep Glob Bash mcp__claude_ai_Supabase__execute_sql
+tags: [vehicle, vlevel, compatibility, supabase, adr-032, diagnostic]
+metadata:
+  version: "1.1"
+  argument-hint: "[diagnose|vlevel|cache|quality|maintenance|dtc] [gamme-id or type-id]"
+  spec: agentskills.io/specification v1
 ---
 
 # Vehicle Operations — v1.0

--- a/.github/workflows/skills-canon-gate.yml
+++ b/.github/workflows/skills-canon-gate.yml
@@ -1,0 +1,87 @@
+name: Skills Canon gate (PR-V2 Phase 0, warn-only)
+
+# AI Governance Control Plane — Phase 0 (warn-only).
+#
+# For every SKILL.md under .claude/skills/<name>/, validates :
+#   1. Frontmatter present + valid YAML
+#   2. Conforms to .spec/00-canon/ai-registry/skill.schema.json
+#   3. `name` matches dirname
+#   4. `owners[]` cross-referenced in ownership.yaml (warn if not)
+#   5. `domain` exists in domains.yaml
+#   6. `description` contains "Use when" (CSO trigger)
+#
+# Progressive enforcement per ADR-058 PR-G / PR-7a ratchet pattern :
+#   - Phase 0 (this PR-V2)   : warn-only, continue-on-error: true
+#   - Phase 1 (PR-V2.5, J+7) : hard-fail on NEW skills only
+#   - Phase 2 (PR-V3, J+14)  : hard-fail on all skills + required check
+#
+# Trigger : PRs touching .claude/skills/** OR the schema/validator itself.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".claude/skills/**"
+      - ".spec/00-canon/ai-registry/**"
+      - "scripts/governance/validate-skills-frontmatter.js"
+      - ".github/workflows/skills-canon-gate.yml"
+
+jobs:
+  skills-canon-gate:
+    name: Skills canon (frontmatter + schema, warn-only Phase 0)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Phase 0 — warn-only. Promote to hard-fail in PR-V2.5 / PR-V3.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install
+        run: npm ci
+
+      - name: Validate skills frontmatter (the gate)
+        id: gate
+        run: |
+          set -e
+          node scripts/governance/validate-skills-frontmatter.js --json > /tmp/skills-report.json
+          cat /tmp/skills-report.json | jq -c '{ok, totalSkills, failureCount}'
+
+      - name: Surface findings
+        if: always()
+        run: |
+          {
+            REPORT=/tmp/skills-report.json
+            if [ ! -f "$REPORT" ]; then
+              echo "## ⚠️ Skills canon gate — report not generated"
+              exit 0
+            fi
+            OK=$(jq -r '.ok' "$REPORT")
+            TOTAL=$(jq -r '.totalSkills' "$REPORT")
+            FAIL=$(jq -r '.failureCount' "$REPORT")
+            if [ "$OK" = "true" ]; then
+              echo "## ✅ Skills canon gate PASSED (Phase 0 warn-only)"
+              echo ""
+              echo "- Total skills: $TOTAL"
+              echo "- All passed: $OK"
+            else
+              echo "## ⚠️ Skills canon gate — $FAIL/$TOTAL skill(s) drifted (Phase 0 warn-only)"
+              echo ""
+              echo "Failures :"
+              echo ""
+              jq -r '.results[] | select(.verdict != "ok") | "### `\(.skill)` — **\(.verdict)**\n" + (.errors // [] | map("- ERROR: \(.)") | join("\n")) + "\n" + (.warnings // [] | map("- WARN: \(.)") | join("\n"))' "$REPORT"
+              echo ""
+              echo "**Fix** : align frontmatter with \`.spec/00-canon/ai-registry/skill.schema.json\`."
+              echo "See \`.claude/skills/README.md\` (skill creation guide) for canonical template."
+              echo ""
+              echo "_Phase 0 = warn-only. Hard-fail starts in PR-V2.5 (new skills only)._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.spec/00-canon/ai-registry/skill.schema.json
+++ b/.spec/00-canon/ai-registry/skill.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ak125/nestjs-remix-monorepo/.spec/00-canon/ai-registry/skill.schema.json",
+  "title": "AutoMecanik Skill Frontmatter Schema",
+  "description": "Canonical schema for .claude/skills/<name>/SKILL.md frontmatter. Sur-ensemble agentskills.io v1 + gouvernance AutoMecanik (ownership, runtime classification, llm safety, status, audit trail). See PR-V2-SKILLS-CANON + plans/pr-v2-skills-canon-ai-governance.md.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "description",
+    "type",
+    "status",
+    "owners",
+    "domain",
+    "runtime_class",
+    "llm_safe"
+  ],
+  "properties": {
+    "name": {
+      "description": "Skill identifier. Must match dirname under .claude/skills/. agentskills.io v1: lowercase letters, numbers, hyphens only; no consecutive hyphens; max 64 chars; no leading/trailing hyphen.",
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 64,
+      "minLength": 1
+    },
+    "description": {
+      "description": "What the skill does AND when to use it. MUST contain the trigger pattern 'Use when'. Max 1024 chars (agentskills.io v1).",
+      "type": "string",
+      "minLength": 20,
+      "maxLength": 1024,
+      "pattern": "Use when"
+    },
+    "type": {
+      "description": "Skill taxonomy per writing-skills doctrine. technique = how-to (steps); reference = lookup/docs; discipline = enforce-rule (TDD-style).",
+      "type": "string",
+      "enum": ["technique", "reference", "discipline"]
+    },
+    "status": {
+      "description": "Lifecycle stage. stable = production-ready; experimental = under iteration, breaking changes allowed; deprecated = scheduled for removal.",
+      "type": "string",
+      "enum": ["stable", "experimental", "deprecated"]
+    },
+    "owners": {
+      "description": "Responsible humans or teams. At least one. Each entry MUST be cross-referenced in .spec/00-canon/repository-registry/ownership.yaml (resolved via build-skills-registry).",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^@[a-z0-9][a-z0-9_-]*$"
+      }
+    },
+    "domain": {
+      "description": "Repository Control Plane domain (D1..D15 per .spec/00-canon/repository-registry/domains.yaml). Used for ownership routing and impact assessment.",
+      "type": "string",
+      "pattern": "^D(1[0-5]|[1-9])$"
+    },
+    "runtime_class": {
+      "description": "Side-effect profile. read-only = inspect/audit only; mutating = edits files / opens PR / runs npm; privileged = touches secrets / infra / deploys / DB DDL.",
+      "type": "string",
+      "enum": ["read-only", "mutating", "privileged"]
+    },
+    "llm_safe": {
+      "description": "True if outputs are derived deterministically from local files + tools. False if the skill generates business facts via LLM that could be hallucinated (requires RAG / vault grounding per feedback_rag_vault_always_first).",
+      "type": "boolean"
+    },
+    "last_verified": {
+      "description": "ISO date (YYYY-MM-DD) of last manual review. Skills with status=stable older than 365 days SHOULD be re-verified.",
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "format": "date"
+    },
+    "license": {
+      "description": "License identifier or short text. agentskills.io v1 free-form.",
+      "type": "string",
+      "maxLength": 200
+    },
+    "compatibility": {
+      "description": "Environment requirements (stack, runtime, MCP servers, etc.). agentskills.io v1 field, max 500 chars.",
+      "type": "string",
+      "maxLength": 500
+    },
+    "allowed-tools": {
+      "description": "Space-separated pre-approved tool names (agentskills.io v1 experimental). Example: 'Read Grep Bash(npm:*)'.",
+      "type": "string"
+    },
+    "tags": {
+      "description": "Free-form discovery tags (stack, scope, role, ADR refs). Indexed by skills.registry.json for searchability.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9_./-]*$",
+        "maxLength": 50
+      }
+    },
+    "metadata": {
+      "description": "Free-form metadata map (agentskills.io v1). Recommended slots: version, upstream, argument-hint, spec.",
+      "type": "object",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean"]
+      }
+    }
+  }
+}

--- a/.spec/00-canon/ai-registry/skills.registry.json
+++ b/.spec/00-canon/ai-registry/skills.registry.json
@@ -1,0 +1,234 @@
+{
+  "compliantCount": 8,
+  "generatedAt": "2026-05-18T14:37:29.046Z",
+  "issues": [],
+  "schemaPath": ".spec/00-canon/ai-registry/skill.schema.json",
+  "schemaVersion": "1.0.0",
+  "skills": [
+    {
+      "checksum": "sha256:689e4195c2799da2e52871d2ccb6d059cb1ff1b195f75939f347431edd5d417b",
+      "domain": "D15",
+      "last_verified": "2026-05-18",
+      "llm_safe": true,
+      "metadata": {
+        "argument-hint": "[PR-number or file-path]",
+        "spec": "agentskills.io/specification v1",
+        "version": "1.1"
+      },
+      "name": "code-review",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/code-review/SKILL.md",
+      "runtime_class": "read-only",
+      "spec_compliant": true,
+      "status": "stable",
+      "tags": [
+        "adr",
+        "governance",
+        "hmac",
+        "review",
+        "rls",
+        "security"
+      ],
+      "type": "technique"
+    },
+    {
+      "checksum": "sha256:ee71c215d24e15e4545b7c3849617a7486e848f1759c36bc0e62e29cc080f128",
+      "domain": "D15",
+      "last_verified": "2026-05-18",
+      "llm_safe": false,
+      "metadata": {
+        "argument-hint": "[migration-name]",
+        "disable-model-invocation": true,
+        "spec": "agentskills.io/specification v1",
+        "version": "1.1"
+      },
+      "name": "db-migration",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/db-migration/SKILL.md",
+      "runtime_class": "privileged",
+      "spec_compliant": true,
+      "status": "stable",
+      "tags": [
+        "ddl",
+        "governance",
+        "migration",
+        "postgres",
+        "rls",
+        "supabase"
+      ],
+      "type": "discipline"
+    },
+    {
+      "checksum": "sha256:8ca10c2fb164f10c3dc5c23a7e3b8bd7cb233c441f6920ee68bcb7a3672c8feb",
+      "domain": "D15",
+      "last_verified": "2026-05-18",
+      "llm_safe": true,
+      "metadata": {
+        "argument-hint": "[component or page description]",
+        "spec": "agentskills.io/specification v1",
+        "upstream": "anthropics/claude-plugins-official/frontend-design@2026-05",
+        "version": "2.0"
+      },
+      "name": "frontend-design",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/frontend-design/SKILL.md",
+      "runtime_class": "mutating",
+      "spec_compliant": true,
+      "status": "stable",
+      "tags": [
+        "a11y",
+        "design-tokens",
+        "frontend",
+        "remix",
+        "shadcn",
+        "tailwind",
+        "wcag"
+      ],
+      "type": "technique"
+    },
+    {
+      "checksum": "sha256:808af540f907829ba6209469756272b35b404ccfdec7f4ed2032e0715fd4f67f",
+      "domain": "D15",
+      "last_verified": "2026-05-18",
+      "llm_safe": false,
+      "metadata": {
+        "adr_references": "ADR-015, ADR-058, ADR-061",
+        "spec": "agentskills.io/specification v1",
+        "version": "1.0"
+      },
+      "name": "governance-vault-ops",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/governance-vault-ops/SKILL.md",
+      "runtime_class": "privileged",
+      "spec_compliant": true,
+      "status": "stable",
+      "tags": [
+        "adr-015",
+        "audit",
+        "governance",
+        "ledger",
+        "ssh-signing",
+        "vault"
+      ],
+      "type": "discipline"
+    },
+    {
+      "checksum": "sha256:dcc01148c536d8c60faf0ce7f68d5ff94270e76f74d230daf6855e6836e0158d",
+      "domain": "D15",
+      "last_verified": "2026-05-18",
+      "llm_safe": true,
+      "metadata": {
+        "argument-hint": "[/url-path or file-pattern]",
+        "spec": "agentskills.io/specification v1",
+        "version": "1.1"
+      },
+      "name": "responsive-audit",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/responsive-audit/SKILL.md",
+      "runtime_class": "read-only",
+      "spec_compliant": true,
+      "status": "stable",
+      "tags": [
+        "mobile-first",
+        "responsive",
+        "shadcn",
+        "viewport",
+        "wcag"
+      ],
+      "type": "technique"
+    },
+    {
+      "checksum": "sha256:2635f7fee262729b9670f8bd2777a707f26b1bceb4131652b0a08102f37be7d5",
+      "domain": "D15",
+      "last_verified": "2026-05-18",
+      "llm_safe": true,
+      "metadata": {
+        "spec": "agentskills.io/specification v1",
+        "version": "1.0"
+      },
+      "name": "session-log",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/session-log/SKILL.md",
+      "runtime_class": "mutating",
+      "spec_compliant": true,
+      "status": "stable",
+      "tags": [
+        "audit-trail",
+        "logging",
+        "session",
+        "stop-hook"
+      ],
+      "type": "technique"
+    },
+    {
+      "checksum": "sha256:e48cd63c0c1b5d5036b9ea424a7751772ecc58719347579bb8c59e531cc2edd1",
+      "domain": "D15",
+      "last_verified": "2026-05-18",
+      "llm_safe": true,
+      "metadata": {
+        "argument-hint": "[design-query or component-type]",
+        "spec": "agentskills.io/specification v1",
+        "version": "1.1"
+      },
+      "name": "ui-ux-pro-max",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/ui-ux-pro-max/SKILL.md",
+      "runtime_class": "read-only",
+      "spec_compliant": true,
+      "status": "stable",
+      "tags": [
+        "a11y",
+        "charts",
+        "design-system",
+        "palettes",
+        "typography",
+        "ui",
+        "ux"
+      ],
+      "type": "reference"
+    },
+    {
+      "checksum": "sha256:814551595593f803f9589acd0a1a27f4414c679286b431a2b283a7a9de6fb7a4",
+      "domain": "D15",
+      "last_verified": "2026-05-18",
+      "llm_safe": false,
+      "metadata": {
+        "argument-hint": "[diagnose|vlevel|cache|quality|maintenance|dtc] [gamme-id or type-id]",
+        "spec": "agentskills.io/specification v1",
+        "version": "1.1"
+      },
+      "name": "vehicle-ops",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/vehicle-ops/SKILL.md",
+      "runtime_class": "mutating",
+      "spec_compliant": true,
+      "status": "stable",
+      "tags": [
+        "adr-032",
+        "compatibility",
+        "diagnostic",
+        "supabase",
+        "vehicle",
+        "vlevel"
+      ],
+      "type": "technique"
+    }
+  ],
+  "totalSkills": 8
+}

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -27,6 +27,26 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: medium
+  - glob: .spec/00-canon/ai-registry/**
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: high
+  - glob: scripts/governance/validate-skills-frontmatter.js
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: high
+  - glob: scripts/governance/build-skills-registry.js
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: high
+  - glob: .github/workflows/skills-canon-gate.yml
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: high
   - glob: .spec/00-canon/repository-registry/**
     domain: D15
     owner: '@ak125'

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
   "devDependencies": {
     "@ast-grep/cli": "0.42.2",
     "@changesets/cli": "^2.31.0",
+    "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
     "@nestjs/common": "^10.4.20",

--- a/scripts/governance/build-skills-registry.js
+++ b/scripts/governance/build-skills-registry.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * scripts/governance/build-skills-registry.js
+ *
+ * Builds `.spec/00-canon/ai-registry/skills.registry.json` from the
+ * frontmatters of every `.claude/skills/<name>/SKILL.md`.
+ *
+ * AI Governance Control Plane — projection layer (PR-V2 Layer 4). Mirrors
+ * the pattern used by `scripts/registry/build-canonical-registry.js` for the
+ * Repository Control Plane (ADR-058 canonical.json).
+ *
+ * The output is machine-readable, deterministic (skills sorted by name,
+ * tags sorted, fields ordered), and includes a sha256 content checksum
+ * per skill for change detection.
+ *
+ * Usage :
+ *   node scripts/governance/build-skills-registry.js
+ *   node scripts/governance/build-skills-registry.js --check  # diff vs current
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const yaml = require("js-yaml");
+const stableStringify = require("fast-json-stable-stringify");
+
+const { extractFrontmatter } = require("./validate-skills-frontmatter");
+
+const MONOREPO_ROOT = path.resolve(__dirname, "..", "..");
+const SKILLS_DIR = path.join(MONOREPO_ROOT, ".claude", "skills");
+const OUTPUT_PATH = path.join(
+  MONOREPO_ROOT,
+  ".spec",
+  "00-canon",
+  "ai-registry",
+  "skills.registry.json"
+);
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  return { check: args.includes("--check") };
+}
+
+function sha256(content) {
+  return "sha256:" + crypto.createHash("sha256").update(content).digest("hex");
+}
+
+function buildEntry(name) {
+  const skillFile = path.join(SKILLS_DIR, name, "SKILL.md");
+  const content = fs.readFileSync(skillFile, "utf8");
+  let fm;
+  try {
+    fm = extractFrontmatter(content);
+  } catch {
+    fm = null;
+  }
+
+  const entry = {
+    name,
+    path: path.relative(MONOREPO_ROOT, skillFile).replace(/\\/g, "/"),
+    checksum: sha256(content),
+    spec_compliant: false,
+  };
+
+  if (fm) {
+    entry.spec_compliant =
+      typeof fm.name === "string" &&
+      typeof fm.description === "string" &&
+      typeof fm.type === "string" &&
+      typeof fm.status === "string" &&
+      Array.isArray(fm.owners) &&
+      typeof fm.domain === "string" &&
+      typeof fm.runtime_class === "string" &&
+      typeof fm.llm_safe === "boolean";
+
+    if (fm.type) entry.type = fm.type;
+    if (fm.status) entry.status = fm.status;
+    if (Array.isArray(fm.owners)) entry.owners = [...fm.owners].sort();
+    if (fm.domain) entry.domain = fm.domain;
+    if (fm.runtime_class) entry.runtime_class = fm.runtime_class;
+    if (typeof fm.llm_safe === "boolean") entry.llm_safe = fm.llm_safe;
+    if (fm.last_verified) entry.last_verified = fm.last_verified;
+    if (Array.isArray(fm.tags)) entry.tags = [...fm.tags].sort();
+    if (fm.metadata && typeof fm.metadata === "object") {
+      entry.metadata = fm.metadata;
+    }
+  }
+
+  return entry;
+}
+
+function listSkills() {
+  if (!fs.existsSync(SKILLS_DIR)) return [];
+  return fs
+    .readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+}
+
+function buildRegistry() {
+  const names = listSkills();
+  const skills = names.map(buildEntry);
+  const issues = skills
+    .filter((s) => !s.spec_compliant)
+    .map((s) => ({ skill: s.name, reason: "frontmatter not spec-compliant" }));
+
+  return {
+    schemaVersion: "1.0.0",
+    generatedAt: new Date().toISOString(),
+    schemaPath:
+      ".spec/00-canon/ai-registry/skill.schema.json",
+    totalSkills: skills.length,
+    compliantCount: skills.filter((s) => s.spec_compliant).length,
+    skills,
+    issues,
+  };
+}
+
+function serialize(obj) {
+  // Stable-stringify gives canonical key order (alphabetical), but we want
+  // a more readable layout — apply stable on the deep values only.
+  return JSON.stringify(JSON.parse(stableStringify(obj)), null, 2) + "\n";
+}
+
+function main() {
+  const args = parseArgs();
+  const registry = buildRegistry();
+  const serialized = serialize(registry);
+
+  if (args.check) {
+    if (!fs.existsSync(OUTPUT_PATH)) {
+      process.stderr.write(
+        `[FATAL] registry file missing : ${OUTPUT_PATH}\n` +
+          "Run without --check to generate it.\n"
+      );
+      process.exit(1);
+    }
+    const current = fs.readFileSync(OUTPUT_PATH, "utf8");
+    // Allow generatedAt drift (timestamp). Strip it before diff.
+    const normalize = (s) =>
+      s.replace(/"generatedAt":\s*"[^"]*"/, '"generatedAt":"<ts>"');
+    if (normalize(current) === normalize(serialized)) {
+      process.stdout.write(
+        `[build-skills-registry] ✓ registry is up-to-date (${registry.totalSkills} skills, ${registry.compliantCount} compliant)\n`
+      );
+      process.exit(0);
+    }
+    process.stderr.write(
+      `[build-skills-registry] ✗ registry DRIFT detected — run without --check to update\n`
+    );
+    process.exit(1);
+  }
+
+  fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  fs.writeFileSync(OUTPUT_PATH, serialized);
+  process.stdout.write(
+    `[build-skills-registry] wrote ${OUTPUT_PATH}\n` +
+      `  ${registry.totalSkills} skills, ${registry.compliantCount} compliant, ${registry.issues.length} issue(s)\n`
+  );
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (e) {
+    process.stderr.write(`[FATAL] ${e.message}\n`);
+    if (process.env.DEBUG) process.stderr.write(e.stack + "\n");
+    process.exit(2);
+  }
+}
+
+module.exports = { buildRegistry };

--- a/scripts/governance/validate-skills-frontmatter.js
+++ b/scripts/governance/validate-skills-frontmatter.js
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * scripts/governance/validate-skills-frontmatter.js
+ *
+ * Skills canon validator (PR-V2-SKILLS-CANON, Phase 0 warn-only).
+ *
+ * For every `SKILL.md` under `.claude/skills/<name>/`, validates :
+ *   1. Frontmatter present (YAML block at top, fenced by `---`)
+ *   2. Conformance to `.spec/00-canon/ai-registry/skill.schema.json`
+ *   3. `name` matches the directory name
+ *   4. Every entry in `owners[]` is mentioned in
+ *      `.spec/00-canon/repository-registry/ownership.yaml`
+ *   5. `domain` is a real domain in
+ *      `.spec/00-canon/repository-registry/domains.yaml`
+ *   6. `description` contains the trigger phrase "Use when" (CSO)
+ *   7. (Soft) `last_verified` is not in the future and not older than
+ *      365 days for stable skills.
+ *
+ * Usage :
+ *   node scripts/governance/validate-skills-frontmatter.js
+ *   node scripts/governance/validate-skills-frontmatter.js --skill <name>
+ *   node scripts/governance/validate-skills-frontmatter.js --json > report.json
+ *
+ * Exit codes :
+ *   0 — all skills pass
+ *   1 — at least one skill failed validation
+ *   2 — internal error (schema missing, parse error)
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+const Ajv2020 = require("ajv/dist/2020");
+const addFormats = require("ajv-formats");
+
+const MONOREPO_ROOT = path.resolve(__dirname, "..", "..");
+const SKILLS_DIR = path.join(MONOREPO_ROOT, ".claude", "skills");
+const SCHEMA_PATH = path.join(
+  MONOREPO_ROOT,
+  ".spec",
+  "00-canon",
+  "ai-registry",
+  "skill.schema.json"
+);
+const OWNERSHIP_PATH = path.join(
+  MONOREPO_ROOT,
+  ".spec",
+  "00-canon",
+  "repository-registry",
+  "ownership.yaml"
+);
+const DOMAINS_PATH = path.join(
+  MONOREPO_ROOT,
+  ".spec",
+  "00-canon",
+  "repository-registry",
+  "domains.yaml"
+);
+
+const STALE_DAYS = 365;
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const out = { skill: null, json: false };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--skill") out.skill = args[++i];
+    else if (args[i] === "--json") out.json = true;
+  }
+  return out;
+}
+
+function loadSchema() {
+  return JSON.parse(fs.readFileSync(SCHEMA_PATH, "utf8"));
+}
+
+function loadKnownOwners() {
+  const raw = yaml.load(fs.readFileSync(OWNERSHIP_PATH, "utf8"));
+  const owners = new Set();
+  for (const entry of raw.entries || []) {
+    if (typeof entry.owner === "string") owners.add(entry.owner);
+  }
+  return owners;
+}
+
+function loadKnownDomains() {
+  const raw = yaml.load(fs.readFileSync(DOMAINS_PATH, "utf8"));
+  const domains = new Set();
+  const list = Array.isArray(raw) ? raw : raw.entries || raw.domains || [];
+  for (const entry of list) {
+    if (typeof entry.id === "string") domains.add(entry.id);
+  }
+  return domains;
+}
+
+function listSkills(filterName) {
+  if (!fs.existsSync(SKILLS_DIR)) return [];
+  return fs
+    .readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .filter((name) => !filterName || name === filterName)
+    .sort();
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]+?)\r?\n---/;
+
+function extractFrontmatter(content) {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return null;
+  try {
+    return yaml.load(match[1]);
+  } catch (e) {
+    throw new Error(`YAML parse error: ${e.message}`);
+  }
+}
+
+function validateSkill(name, ctx) {
+  const skillDir = path.join(SKILLS_DIR, name);
+  const skillFile = path.join(skillDir, "SKILL.md");
+  const result = {
+    skill: name,
+    path: path.relative(MONOREPO_ROOT, skillFile),
+    verdict: "ok",
+    errors: [],
+    warnings: [],
+  };
+
+  if (!fs.existsSync(skillFile)) {
+    result.verdict = "missing_file";
+    result.errors.push(`SKILL.md not found at ${skillFile}`);
+    return result;
+  }
+
+  const content = fs.readFileSync(skillFile, "utf8");
+  let fm;
+  try {
+    fm = extractFrontmatter(content);
+  } catch (e) {
+    result.verdict = "yaml_parse_error";
+    result.errors.push(e.message);
+    return result;
+  }
+
+  if (!fm) {
+    result.verdict = "no_frontmatter";
+    result.errors.push(
+      "No YAML frontmatter block found (expected `---\\n…\\n---` at top of file)"
+    );
+    return result;
+  }
+
+  const valid = ctx.validate(fm);
+  if (!valid) {
+    result.verdict = "schema_invalid";
+    for (const err of ctx.validate.errors || []) {
+      const where = err.instancePath || "(root)";
+      result.errors.push(`${where}: ${err.message}`);
+    }
+  }
+
+  if (fm.name && fm.name !== name) {
+    result.verdict = "name_mismatch";
+    result.errors.push(
+      `frontmatter name "${fm.name}" does not match directory "${name}"`
+    );
+  }
+
+  if (Array.isArray(fm.owners)) {
+    for (const owner of fm.owners) {
+      if (!ctx.knownOwners.has(owner)) {
+        result.warnings.push(
+          `owner "${owner}" not found in ownership.yaml — consider adding`
+        );
+      }
+    }
+  }
+
+  if (typeof fm.domain === "string" && !ctx.knownDomains.has(fm.domain)) {
+    if (result.verdict === "ok") result.verdict = "schema_invalid";
+    result.errors.push(
+      `domain "${fm.domain}" not in domains.yaml`
+    );
+  }
+
+  if (typeof fm.last_verified === "string") {
+    const verified = new Date(fm.last_verified);
+    const now = new Date();
+    if (verified > now) {
+      result.warnings.push(
+        `last_verified ${fm.last_verified} is in the future`
+      );
+    } else if (fm.status === "stable") {
+      const ageMs = now - verified;
+      const ageDays = Math.floor(ageMs / (1000 * 60 * 60 * 24));
+      if (ageDays > STALE_DAYS) {
+        result.warnings.push(
+          `last_verified ${fm.last_verified} is ${ageDays} days old (status=stable, threshold=${STALE_DAYS}d) — manual review recommended`
+        );
+      }
+    }
+  }
+
+  return result;
+}
+
+function main() {
+  const args = parseArgs();
+  let schema;
+  try {
+    schema = loadSchema();
+  } catch (e) {
+    process.stderr.write(`[FATAL] Cannot load schema at ${SCHEMA_PATH}: ${e.message}\n`);
+    process.exit(2);
+  }
+
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+
+  const knownOwners = loadKnownOwners();
+  const knownDomains = loadKnownDomains();
+
+  const ctx = { validate, knownOwners, knownDomains };
+
+  const skills = listSkills(args.skill);
+  if (skills.length === 0) {
+    process.stderr.write(
+      args.skill
+        ? `[FATAL] Skill "${args.skill}" not found under ${SKILLS_DIR}\n`
+        : `[INFO] No skills found under ${SKILLS_DIR}\n`
+    );
+    process.exit(args.skill ? 2 : 0);
+  }
+
+  const results = skills.map((name) => validateSkill(name, ctx));
+  const failures = results.filter((r) => r.verdict !== "ok");
+  const ok = failures.length === 0;
+
+  if (args.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          ok,
+          schemaVersion: "1.0.0",
+          generatedAt: new Date().toISOString(),
+          totalSkills: results.length,
+          failureCount: failures.length,
+          results,
+        },
+        null,
+        2
+      ) + "\n"
+    );
+  } else {
+    process.stdout.write(
+      `[validate-skills-frontmatter] evaluating ${results.length} skill(s)\n`
+    );
+    for (const r of results) {
+      const tag = r.verdict === "ok" ? "✓" : "✗";
+      process.stdout.write(`  ${tag} ${r.skill} — ${r.verdict}\n`);
+      for (const err of r.errors) process.stdout.write(`     ERROR: ${err}\n`);
+      for (const warn of r.warnings)
+        process.stdout.write(`     WARN : ${warn}\n`);
+    }
+    process.stdout.write(
+      `\n[validate-skills-frontmatter] ${results.length - failures.length} ok, ${failures.length} failure(s)\n`
+    );
+  }
+
+  process.exit(ok ? 0 : 1);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (e) {
+    process.stderr.write(`[FATAL] ${e.message}\n`);
+    if (process.env.DEBUG) process.stderr.write(e.stack + "\n");
+    process.exit(2);
+  }
+}
+
+module.exports = { extractFrontmatter, validateSkill };


### PR DESCRIPTION
## Context — AI Governance Control Plane Phase 0

Issue surfaced during PR #592 (`frontend-design` canon fix) : the drift was not isolated — 5 sibling skills had the same 3 frontmatter regressions, and `governance-vault-ops` had **no frontmatter at all** (broken silently, skill description fallback to H1 header).

Root cause : **no Skills Schema-as-Code + no validator + no CI invariant**. Each skill created on ad-hoc conventions, drift inevitable.

This PR transforms the discovery into a **reusable invariant**, following the trajectory : « collection de prompts → AI Governance Control Plane » (user 2026-05-18).

## What this PR delivers

5 atomic commits, layered cleanly :

| # | Commit | Layer |
|---|---|---|
| 1 | `feat(ai-registry): add canonical skill.schema.json + ownership coverage` | **L1** Schema SoT + L1.5 ownership pre-resolution |
| 2 | `feat(governance): skills frontmatter validator + registry generator` | **L2** Validator + **L4** Registry generator + explicit deps (ajv) |
| 3 | `feat(ci): skills-canon-gate.yml warn-only Phase 0` | **L3** CI ratchet (warn-only) |
| 4 | `chore(skills): migrate 8 SKILL.md to canon frontmatter + initial registry` | **L5** Migration of 8 skills + repair `governance-vault-ops` |
| 5 | `docs(skills): add .claude/skills/README.md — skill creation guide` | **L6** Documentation |

## Canonical schema (excerpt)

```yaml
---
# === REQUIS (agentskills.io v1) ===
name: <kebab-case>
description: |
  Use when <triggers>.  # CSO trigger mandatory

# === REQUIS (gouvernance AutoMecanik) ===
type: technique | reference | discipline
status: stable | experimental | deprecated
owners: ['@handle']         # cross-checked vs ownership.yaml
domain: D1..D15             # cross-checked vs domains.yaml
runtime_class: read-only | mutating | privileged
llm_safe: true | false

# Recommandé : last_verified, license, compatibility, allowed-tools, tags
# Libre : metadata.* (version, argument-hint, spec, ...)
---
```

Full contract : [`.spec/00-canon/ai-registry/skill.schema.json`](https://github.com/ak125/nestjs-remix-monorepo/blob/chore/pr-v2-skills-canon-ai-governance/.spec/00-canon/ai-registry/skill.schema.json).

## Special case — `governance-vault-ops` (incident-grade)

Before this PR, `governance-vault-ops/SKILL.md` had **no YAML frontmatter at all** — just `# Skill: governance-vault-ops` as first line. Skill description in Claude Code skill list was the H1 header by fallback. The skill was loaded by accident, not by contract. Now it has full canon frontmatter + body preserved.

This is treated as a silent governance bypass incident, not cosmetic.

## Progressive enforcement (3 phases)

| Phase | When | Behavior | Exit criterion |
|---|---|---|---|
| **Phase 0** | This PR-V2 | `continue-on-error: true`, warn in step summary | 7+ days observation, 0 regression |
| **Phase 1** | PR-V2.5 (J+7) | Hard-fail on **new skills only** (parallel to block-new ADR-058 PR-G) | 7+ days stable |
| **Phase 2** | PR-V3 (J+14-21) | Hard-fail **all skills** + required check on main branch protection | Promote ADR vault |

Aligned with ADR-058 PR-G + PR-7a contract-drift-ratchet (validated patterns).

## Verification (empirical, run pre-push)

```
$ node scripts/governance/validate-skills-frontmatter.js
  ✓ code-review — ok
  ✓ db-migration — ok
  ✓ frontend-design — ok
  ✓ governance-vault-ops — ok
  ✓ responsive-audit — ok
  ✓ session-log — ok
  ✓ ui-ux-pro-max — ok
  ✓ vehicle-ops — ok
[validate-skills-frontmatter] 8 ok, 0 failure(s)

$ node scripts/governance/build-skills-registry.js --check
[build-skills-registry] ✓ registry is up-to-date (8 skills, 8 compliant)

$ node scripts/registry/check-new-files.js --base origin/main
[check-new-files] new files: 6 (6 ok, 0 failures)
[check-new-files] ✓ All new files pass owner+domain gate
```

## Files

### Created
- `.spec/00-canon/ai-registry/skill.schema.json` — JSON Schema (draft 2020-12)
- `.spec/00-canon/ai-registry/skills.registry.json` — initial generated projection
- `scripts/governance/validate-skills-frontmatter.js` — validator (Ajv + ownership/domains cross-check)
- `scripts/governance/build-skills-registry.js` — registry generator
- `.github/workflows/skills-canon-gate.yml` — CI ratchet (warn-only Phase 0)
- `.claude/skills/README.md` — skill creation guide

### Modified
- `.spec/00-canon/repository-registry/ownership.yaml` — +4 globs for new files
- `package.json` — +2 explicit devDeps (ajv, ajv-formats)
- `.claude/skills/{code-review,db-migration,frontend-design,governance-vault-ops,responsive-audit,session-log,ui-ux-pro-max,vehicle-ops}/SKILL.md` — frontmatter migration

## NOT in scope (deferred)

- ❌ `agents/*/AGENTS.md` migration → **PR-V3-AGENTS-CANON** (sibling)
- ❌ Prompt registry → **PR-V4** (when scope justifies)
- ❌ Workflow registry → **PR-V5** (when scope justifies)
- ❌ Phase 1+2 hard-fail enforcement → **PR-V2.5 / PR-V3** after observation

## Refs

- agentskills.io/specification v1 (normative)
- `superpowers:writing-skills` (TDD-doc canon)
- ADR-058 PR-G (block-new gate progressive pattern reused)
- PR-7a contract-drift-ratchet (warn → hard-fail pattern reused)
- Plan : `/home/deploy/.claude/plans/pr-v2-skills-canon-ai-governance.md`
- Predecessor : #592 (frontend-design canon fix — tactical, this is systemic)

## Test plan

- [ ] CI : block-new gate passes (new files pre-resolved in ownership)
- [ ] CI : skills-canon-gate runs (warn-only Phase 0)
- [ ] CI : all other existing checks pass
- [ ] Local : `node scripts/governance/validate-skills-frontmatter.js` returns 0
- [ ] Local : `node scripts/governance/build-skills-registry.js --check` returns 0
- [ ] Manual : open Claude Code on monorepo, verify all 8 skills appear with new descriptions
- [ ] Manual : verify `governance-vault-ops` now loads with proper frontmatter (no H1 fallback)
- [ ] Observation : monitor `skills-canon-gate` summary across 3-5 unrelated PRs (Phase 0 evidence collection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)