### PR TITLE
chore(registry): resync deps.json + modernization inventory (catch-up stale)

### DIFF
--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:a09b8a53cf642595b7be59c74922f9ed065b2454fa4ed4d275667fd59f82ecc5",
+  "artifact_immutability_hash": "sha256:b2574e39cf80fe65998055138661921c4b1be8cf0817f7eef27a87ad3570d0b9",
   "divergences": [
     {
       "kind": "specifier",
@@ -86,6 +86,49 @@
       "resolved_versions": [
         "1.18.2",
         "1.19.0"
+      ]
+    },
+    {
+      "kind": "specifier",
+      "name": "@types/js-yaml",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^4.0.9",
+          "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "packages/registry/package.json",
+          "specifier": "4.0.9",
+          "workspace": "@repo/registry"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^4.0.9",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "4.0.9"
+      ]
+    },
+    {
+      "kind": "specifier",
+      "name": "@types/micromatch",
+      "occurrences": [
+        {
+          "declaredIn": "packages/registry/package.json",
+          "specifier": "^4.0.9",
+          "workspace": "@repo/registry"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^4.0.10",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "4.0.10"
       ]
     },
     {
@@ -202,6 +245,21 @@
         "2.1.9",
         "4.0.18",
         "4.1.5"
+      ]
+    },
+    {
+      "kind": "resolved",
+      "name": "ajv",
+      "occurrences": [
+        {
+          "declaredIn": "package.json",
+          "specifier": "^8.12.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "6.14.0",
+        "8.12.0"
       ]
     },
     {
@@ -377,13 +435,23 @@
       ]
     },
     {
-      "kind": "resolved",
+      "kind": "specifier",
       "name": "js-yaml",
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
           "specifier": "^4.1.1",
           "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "packages/registry/package.json",
+          "specifier": "4.1.1",
+          "workspace": "@repo/registry"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^4.1.1",
+          "workspace": "nestjs-remix-monorepo"
         }
       ],
       "resolved_versions": [
@@ -771,13 +839,18 @@
       ]
     },
     {
-      "kind": "resolved",
+      "kind": "specifier",
       "name": "zod-to-json-schema",
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
           "specifier": "^3.25.2",
           "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "packages/registry/package.json",
+          "specifier": "3.23.0",
+          "workspace": "@repo/registry"
         }
       ],
       "resolved_versions": [
@@ -3752,13 +3825,18 @@
         },
         {
           "divergent_resolved": true,
-          "divergent_specifiers": false,
+          "divergent_specifiers": true,
           "name": "zod-to-json-schema",
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
               "specifier": "^3.25.2",
               "workspace": "@fafa/backend"
+            },
+            {
+              "declaredIn": "packages/registry/package.json",
+              "specifier": "3.23.0",
+              "workspace": "@repo/registry"
             }
           ],
           "resolved_versions": [
@@ -3836,7 +3914,7 @@
       ],
       "supports_dual_runtime": "none",
       "target_major": "4.x",
-      "total_occurrences": 9,
+      "total_occurrences": 10,
       "upgrade_cost_estimate": {
         "estimated_engineer_days": 10,
         "estimated_review_load": "high"
@@ -3850,7 +3928,7 @@
   ],
   "generatedFrom": {
     "deps_registry": "audit/registry/deps.json",
-    "deps_registry_sha": "sha256:0b01ca94e9a39e3e8b19f00152e9c4f4c71fa963048593734003e39a058c79af",
+    "deps_registry_sha": "sha256:b9916cacb9cd8cc5732c6827783f125af6157f2089420cf16cffcab9b20630ff",
     "lockfile": "package-lock.json",
     "lockfile_sha": "sha256:1ad44768980b5a52a74e4fd898994adf86ee48497c745ac5820853871a1e5e58",
     "overlay": "audit/dependencies/family-overlay.yaml",
@@ -3869,7 +3947,7 @@
       "runtime-backend": 17,
       "runtime-frontend": 10,
       "tooling": 16,
-      "unassigned": 140,
+      "unassigned": 153,
       "validation": 2
     },
     "by_pr_assignment": {
@@ -3881,11 +3959,11 @@
       "pr-9f": 17,
       "pr-9g": 0
     },
-    "divergent_packages_count": 38,
+    "divergent_packages_count": 41,
     "families_count": 12,
-    "total_occurrences": 285,
-    "total_packages": 208,
-    "unassigned_count": 140
+    "total_occurrences": 306,
+    "total_packages": 221,
+    "unassigned_count": 153
   },
   "unassigned_packages": [
     {
@@ -4312,6 +4390,36 @@
     {
       "divergent_resolved": false,
       "divergent_specifiers": false,
+      "name": "@repo/registry",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "*",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "<unresolved>"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "@repo/seo-types",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "*",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "<unresolved>"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
       "name": "@sentry/nestjs",
       "occurrences": [
         {
@@ -4337,6 +4445,21 @@
       ],
       "resolved_versions": [
         "10.51.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "@size-limit/file",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^12.1.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "12.1.0"
       ]
     },
     {
@@ -4762,17 +4885,47 @@
     },
     {
       "divergent_resolved": false,
-      "divergent_specifiers": false,
+      "divergent_specifiers": true,
       "name": "@types/js-yaml",
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
           "specifier": "^4.0.9",
           "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "packages/registry/package.json",
+          "specifier": "4.0.9",
+          "workspace": "@repo/registry"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^4.0.9",
+          "workspace": "nestjs-remix-monorepo"
         }
       ],
       "resolved_versions": [
         "4.0.9"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": true,
+      "name": "@types/micromatch",
+      "occurrences": [
+        {
+          "declaredIn": "packages/registry/package.json",
+          "specifier": "^4.0.9",
+          "workspace": "@repo/registry"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^4.0.10",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "4.0.10"
       ]
     },
     {
@@ -5035,6 +5188,37 @@
       ]
     },
     {
+      "divergent_resolved": true,
+      "divergent_specifiers": false,
+      "name": "ajv",
+      "occurrences": [
+        {
+          "declaredIn": "package.json",
+          "specifier": "^8.12.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "6.14.0",
+        "8.12.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "ajv-formats",
+      "occurrences": [
+        {
+          "declaredIn": "package.json",
+          "specifier": "^2.1.1",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "2.1.1"
+      ]
+    },
+    {
       "divergent_resolved": false,
       "divergent_specifiers": true,
       "name": "autoprefixer",
@@ -5185,6 +5369,21 @@
     {
       "divergent_resolved": false,
       "divergent_specifiers": false,
+      "name": "cron-parser",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^4.9.0",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "4.9.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
       "name": "dependency-cruiser",
       "occurrences": [
         {
@@ -5262,6 +5461,26 @@
       ],
       "resolved_versions": [
         "6.4.9"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "fast-json-stable-stringify",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^2.1.0",
+          "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^2.1.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "2.1.0"
       ]
     },
     {
@@ -5358,6 +5577,21 @@
     {
       "divergent_resolved": false,
       "divergent_specifiers": false,
+      "name": "ioredis-mock",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^8.13.1",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "8.13.1"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
       "name": "isbot",
       "occurrences": [
         {
@@ -5401,14 +5635,39 @@
       ]
     },
     {
-      "divergent_resolved": true,
+      "divergent_resolved": false,
       "divergent_specifiers": false,
+      "name": "jose",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^5.10.0",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "5.10.0"
+      ]
+    },
+    {
+      "divergent_resolved": true,
+      "divergent_specifiers": true,
       "name": "js-yaml",
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
           "specifier": "^4.1.1",
           "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "packages/registry/package.json",
+          "specifier": "4.1.1",
+          "workspace": "@repo/registry"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^4.1.1",
+          "workspace": "nestjs-remix-monorepo"
         }
       ],
       "resolved_versions": [
@@ -5475,6 +5734,26 @@
       ],
       "resolved_versions": [
         "0.52.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "micromatch",
+      "occurrences": [
+        {
+          "declaredIn": "package.json",
+          "specifier": "^4.0.8",
+          "workspace": "@repo/registry"
+        },
+        {
+          "declaredIn": "packages/registry/package.json",
+          "specifier": "^4.0.8",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "4.0.8"
       ]
     },
     {
@@ -5755,6 +6034,21 @@
       ]
     },
     {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "size-limit",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^12.1.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "12.1.0"
+      ]
+    },
+    {
       "divergent_resolved": true,
       "divergent_specifiers": false,
       "name": "socket.io",
@@ -5799,6 +6093,21 @@
       "resolved_versions": [
         "0.5.13",
         "0.5.21"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "squawk-cli",
+      "occurrences": [
+        {
+          "declaredIn": "package.json",
+          "specifier": "2.52.1",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "2.52.1"
       ]
     },
     {

--- a/audit/registry/deps.json
+++ b/audit/registry/deps.json
@@ -962,6 +962,22 @@
       "declaredIn": [
         "frontend/package.json"
       ],
+      "id": "npm:@size-limit/file@^12.1.0",
+      "name": "@size-limit/file",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^12.1.0",
+      "workspaces": [
+        "@fafa/frontend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "frontend/package.json"
+      ],
       "id": "npm:@storybook/addon-a11y@^9.1.13",
       "name": "@storybook/addon-a11y",
       "owner": "__unassigned__",
@@ -1426,7 +1442,24 @@
     },
     {
       "declaredIn": [
-        "backend/package.json"
+        "packages/registry/package.json"
+      ],
+      "id": "npm:@types/js-yaml@4.0.9",
+      "name": "@types/js-yaml",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "4.0.9",
+      "workspaces": [
+        "@repo/registry"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json",
+        "package.json"
       ],
       "id": "npm:@types/js-yaml@^4.0.9",
       "name": "@types/js-yaml",
@@ -1437,7 +1470,40 @@
       "status": "LIVE",
       "version": "^4.0.9",
       "workspaces": [
-        "@fafa/backend"
+        "@fafa/backend",
+        "nestjs-remix-monorepo"
+      ]
+    },
+    {
+      "declaredIn": [
+        "package.json"
+      ],
+      "id": "npm:@types/micromatch@^4.0.10",
+      "name": "@types/micromatch",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^4.0.10",
+      "workspaces": [
+        "nestjs-remix-monorepo"
+      ]
+    },
+    {
+      "declaredIn": [
+        "packages/registry/package.json"
+      ],
+      "id": "npm:@types/micromatch@^4.0.9",
+      "name": "@types/micromatch",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^4.0.9",
+      "workspaces": [
+        "@repo/registry"
       ]
     },
     {
@@ -1820,6 +1886,38 @@
       "declaredIn": [
         "package.json"
       ],
+      "id": "npm:ajv-formats@^2.1.1",
+      "name": "ajv-formats",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^2.1.1",
+      "workspaces": [
+        "nestjs-remix-monorepo"
+      ]
+    },
+    {
+      "declaredIn": [
+        "package.json"
+      ],
+      "id": "npm:ajv@^8.12.0",
+      "name": "ajv",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^8.12.0",
+      "workspaces": [
+        "nestjs-remix-monorepo"
+      ]
+    },
+    {
+      "declaredIn": [
+        "package.json"
+      ],
       "id": "npm:autoprefixer@^10.4.14",
       "name": "autoprefixer",
       "owner": "__unassigned__",
@@ -2056,6 +2154,22 @@
       "sourceConfidence": "high",
       "status": "LIVE",
       "version": "^2.8.5",
+      "workspaces": [
+        "@fafa/backend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json"
+      ],
+      "id": "npm:cron-parser@^4.9.0",
+      "name": "cron-parser",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^4.9.0",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -2390,6 +2504,24 @@
     },
     {
       "declaredIn": [
+        "backend/package.json",
+        "package.json"
+      ],
+      "id": "npm:fast-json-stable-stringify@^2.1.0",
+      "name": "fast-json-stable-stringify",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^2.1.0",
+      "workspaces": [
+        "@fafa/backend",
+        "nestjs-remix-monorepo"
+      ]
+    },
+    {
+      "declaredIn": [
         "backend/package.json"
       ],
       "id": "npm:file-type@^20.4.1",
@@ -2504,6 +2636,22 @@
       "declaredIn": [
         "backend/package.json"
       ],
+      "id": "npm:ioredis-mock@^8.13.1",
+      "name": "ioredis-mock",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^8.13.1",
+      "workspaces": [
+        "@fafa/backend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json"
+      ],
       "id": "npm:ioredis@^5.8.2",
       "name": "ioredis",
       "owner": "__unassigned__",
@@ -2568,6 +2716,39 @@
       "declaredIn": [
         "backend/package.json"
       ],
+      "id": "npm:jose@^5.10.0",
+      "name": "jose",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^5.10.0",
+      "workspaces": [
+        "@fafa/backend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "packages/registry/package.json"
+      ],
+      "id": "npm:js-yaml@4.1.1",
+      "name": "js-yaml",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "4.1.1",
+      "workspaces": [
+        "@repo/registry"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json",
+        "package.json"
+      ],
       "id": "npm:js-yaml@^4.1.1",
       "name": "js-yaml",
       "owner": "__unassigned__",
@@ -2577,7 +2758,8 @@
       "status": "LIVE",
       "version": "^4.1.1",
       "workspaces": [
-        "@fafa/backend"
+        "@fafa/backend",
+        "nestjs-remix-monorepo"
       ]
     },
     {
@@ -2660,6 +2842,24 @@
       "version": "^0.52.0",
       "workspaces": [
         "@fafa/backend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "package.json",
+        "packages/registry/package.json"
+      ],
+      "id": "npm:micromatch@^4.0.8",
+      "name": "micromatch",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^4.0.8",
+      "workspaces": [
+        "@repo/registry",
+        "nestjs-remix-monorepo"
       ]
     },
     {
@@ -3170,6 +3370,22 @@
     },
     {
       "declaredIn": [
+        "frontend/package.json"
+      ],
+      "id": "npm:size-limit@^12.1.0",
+      "name": "size-limit",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "^12.1.0",
+      "workspaces": [
+        "@fafa/frontend"
+      ]
+    },
+    {
+      "declaredIn": [
         "backend/package.json"
       ],
       "id": "npm:socket.io@^4.8.1",
@@ -3214,6 +3430,22 @@
       "version": "^0.5.21",
       "workspaces": [
         "@fafa/backend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "package.json"
+      ],
+      "id": "npm:squawk-cli@2.52.1",
+      "name": "squawk-cli",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "2.52.1",
+      "workspaces": [
+        "nestjs-remix-monorepo"
       ]
     },
     {
@@ -3664,6 +3896,22 @@
     },
     {
       "declaredIn": [
+        "packages/registry/package.json"
+      ],
+      "id": "npm:zod-to-json-schema@3.23.0",
+      "name": "zod-to-json-schema",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "3.23.0",
+      "workspaces": [
+        "@repo/registry"
+      ]
+    },
+    {
+      "declaredIn": [
         "backend/package.json"
       ],
       "id": "npm:zod-to-json-schema@^3.25.2",
@@ -3784,6 +4032,22 @@
       "declaredIn": [
         "backend/package.json"
       ],
+      "id": "workspace:@repo/registry@*",
+      "name": "@repo/registry",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "workspace",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "*",
+      "workspaces": [
+        "@fafa/backend"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json"
+      ],
       "id": "workspace:@repo/seo-role-contracts@*",
       "name": "@repo/seo-role-contracts",
       "owner": "__unassigned__",
@@ -3816,6 +4080,22 @@
         "@fafa/frontend",
         "@repo/seo-role-contracts",
         "nestjs-remix-monorepo"
+      ]
+    },
+    {
+      "declaredIn": [
+        "backend/package.json"
+      ],
+      "id": "workspace:@repo/seo-types@*",
+      "name": "@repo/seo-types",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "workspace",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "*",
+      "workspaces": [
+        "@fafa/backend"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- Rebuilds `audit/registry/deps.json` (ADR-058 L1 raw) — 233→249 unique declared workspace deps (catch-up 16 entries that drifted since #592)
- Rebuilds `audit/dependencies/dependency-modernization-inventory.json` (PR-9a L3 projection) — 221 packages, 12 families, 41 divergent
- Both files are pure deterministic projections — no logic / no policy change

## Why

The `audit:pr-9-modernization-inventory:check` BLOCKING gate (PR-9a) caught drift while preparing PR #597 (impeccable CLI devDep). The drift pre-existed PR #597 — 16 already-declared deps (ajv, jose, cron-parser, ioredis-mock, js-yaml, micromatch, @repo/registry, @repo/seo-types, size-limit, @size-limit/file, squawk-cli, zod-to-json-schema, etc.) were added to package.json across workspaces but never registered.

Splitting the catch-up here keeps the cascade clean: PR #597 then carries only `impeccable` + its transitive in its diff (no scope creep).

## Test plan

- [x] `npm run registry:build:deps` → ✓ 249 entries, sha256:b9916cacb9cd
- [x] `npm run audit:pr-9-modernization-inventory` → ✓ 221 packages
- [x] `npm run audit:pr-9-modernization-inventory:check` → ✓ deterministic (sha256: 0fe78d52777c)
- [x] Spot-checked 8 newly-registered deps — all confirmed real top-level declarations in respective workspace `package.json`
- [ ] CI checks pass (BLOCKING determinism, registry freshness, block-new gate)

## Risks

None — both files are derived artifacts, no code/policy/runtime behavior change. Pure ratcheting of SoT projections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)