### PR TITLE
hotfix(rm): refactor 2 soft-404 services to extends SupabaseBaseService (PR #595 DI crash)

### DIFF
--- a/backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts
+++ b/backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts
@@ -1,17 +1,27 @@
 // backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts
-import { Test, TestingModule } from '@nestjs/testing';
+
+// SupabaseBaseService check les env vars dans son constructor. En test on
+// court-circuite avec un stub minimal (canon, cf. rm-builder-seo-shadow.test.ts).
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+process.env.SUPABASE_SERVICE_KEY =
+  process.env.SUPABASE_SERVICE_KEY || 'test-service-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-service-role-key';
+
 import { RmAlternativesService } from '../rm-alternatives.service';
-// ↑ This import WILL fail in TDD red — the service does not exist yet. That's intentional.
+import type { CacheService } from '@cache/cache.service';
 
-import { SupabaseBaseService } from '@database/services/supabase-base.service';
-import { CacheService } from '@cache/cache.service';
-
+/**
+ * Pattern test : instanciation directe + Object.assign de `this.supabase`
+ * (canon repo : 203 services `extends SupabaseBaseService`, cf.
+ * rm-builder-seo-shadow.test.ts pour la référence).
+ */
 describe('RmAlternativesService', () => {
   let service: RmAlternativesService;
   let cacheMock: jest.Mocked<Partial<CacheService>>;
   let supabaseMock: any;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     cacheMock = {
       get: jest.fn(),
       set: jest.fn(),
@@ -30,14 +40,9 @@ describe('RmAlternativesService', () => {
       __builder: builder,
     };
 
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        RmAlternativesService,
-        { provide: SupabaseBaseService, useValue: { client: supabaseMock } },
-        { provide: CacheService, useValue: cacheMock },
-      ],
-    }).compile();
-    service = module.get<RmAlternativesService>(RmAlternativesService);
+    service = new RmAlternativesService(cacheMock as unknown as CacheService);
+    // Override le client supabase hérité (protected readonly) en runtime
+    (service as any).supabase = supabaseMock;
   });
 
   describe('compute()', () => {

--- a/backend/src/modules/rm/services/__tests__/rm-soft404-tracker.service.test.ts
+++ b/backend/src/modules/rm/services/__tests__/rm-soft404-tracker.service.test.ts
@@ -1,27 +1,31 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { RmSoft404TrackerService } from '../rm-soft404-tracker.service';
-import { SupabaseBaseService } from '@database/services/supabase-base.service';
-import { CacheService } from '@cache/cache.service';
+// SupabaseBaseService check les env vars dans son constructor. En test on
+// court-circuite avec un stub minimal (canon, cf. rm-builder-seo-shadow.test.ts).
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || 'http://localhost:54321';
+process.env.SUPABASE_SERVICE_KEY =
+  process.env.SUPABASE_SERVICE_KEY || 'test-service-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-service-role-key';
 
+import { RmSoft404TrackerService } from '../rm-soft404-tracker.service';
+import type { CacheService } from '@cache/cache.service';
+
+/**
+ * Pattern test : instanciation directe + Object.assign de `this.supabase`
+ * (canon repo : 203 services `extends SupabaseBaseService`, cf.
+ * rm-builder-seo-shadow.test.ts pour la référence).
+ */
 describe('RmSoft404TrackerService', () => {
   let service: RmSoft404TrackerService;
   let cache: jest.Mocked<Partial<CacheService>>;
   let supabaseInsert: jest.Mock;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     cache = { get: jest.fn(), set: jest.fn() };
     supabaseInsert = jest.fn().mockResolvedValue({ error: null });
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        RmSoft404TrackerService,
-        {
-          provide: SupabaseBaseService,
-          useValue: { client: { from: () => ({ insert: supabaseInsert }) } },
-        },
-        { provide: CacheService, useValue: cache },
-      ],
-    }).compile();
-    service = module.get<RmSoft404TrackerService>(RmSoft404TrackerService);
+
+    service = new RmSoft404TrackerService(cache as unknown as CacheService);
+    // Override le client supabase hérité (protected readonly) en runtime
+    (service as any).supabase = { from: () => ({ insert: supabaseInsert }) };
   });
 
   it('classifie un UA Googlebot comme "bot"', () => {

--- a/backend/src/modules/rm/services/rm-alternatives.service.ts
+++ b/backend/src/modules/rm/services/rm-alternatives.service.ts
@@ -43,13 +43,12 @@ interface VehicleTarget {
 }
 
 @Injectable()
-export class RmAlternativesService {
-  private readonly logger = new Logger(RmAlternativesService.name);
+export class RmAlternativesService extends SupabaseBaseService {
+  protected readonly logger = new Logger(RmAlternativesService.name);
 
-  constructor(
-    private readonly supabase: SupabaseBaseService,
-    private readonly cache: CacheService,
-  ) {}
+  constructor(private readonly cache: CacheService) {
+    super();
+  }
 
   async compute(
     type_id: number,
@@ -105,21 +104,9 @@ export class RmAlternativesService {
     return response;
   }
 
-  /**
-   * Returns the Supabase query client.
-   * The injected `SupabaseBaseService` instance exposes the client via `.client`
-   * (as set up in tests) or `.supabase` (the actual protected property).
-   */
-  private getClient(): any {
-    return (
-      (this.supabase as any).client ??
-      (this.supabase as any).supabase ??
-      this.supabase
-    );
-  }
-
   private async loadTarget(type_id: number): Promise<VehicleTarget | null> {
-    const sb = this.getClient();
+    // inherited from SupabaseBaseService (extends pattern, 203 services canon)
+    const sb = this.supabase;
     const { data, error } = await sb
       .from('auto_type')
       .select('type_modele_id, type_marque_id, type_power_ps')
@@ -148,7 +135,8 @@ export class RmAlternativesService {
     pg_id: number,
     raw_limit: number,
   ): Promise<VehicleCandidate[]> {
-    const sb = this.getClient();
+    // inherited from SupabaseBaseService (extends pattern, 203 services canon)
+    const sb = this.supabase;
     const { data: compat } = await sb
       .from('pieces_relation_type')
       .select('rtp_type_id')
@@ -283,7 +271,8 @@ export class RmAlternativesService {
       piece_count: number;
     }>
   > {
-    const sb = this.getClient();
+    // inherited from SupabaseBaseService (extends pattern, 203 services canon)
+    const sb = this.supabase;
     const { data: rels } = await sb
       .from('pieces_relation_type')
       .select('rtp_pg_id')
@@ -360,7 +349,8 @@ export class RmAlternativesService {
   ): Promise<
     Array<{ modele_id: number; modele_name: string; modele_alias: string }>
   > {
-    const sb = this.getClient();
+    // inherited from SupabaseBaseService (extends pattern, 203 services canon)
+    const sb = this.supabase;
     const { data: compat_types } = await sb
       .from('pieces_relation_type')
       .select('rtp_type_id')
@@ -412,7 +402,8 @@ export class RmAlternativesService {
     target: VehicleTarget,
   ): Promise<RelatedModel[]> {
     if (modeles.length === 0) return [];
-    const sb = this.getClient();
+    // inherited from SupabaseBaseService (extends pattern, 203 services canon)
+    const sb = this.supabase;
 
     // Fetch marque once — all related models share the same target_marque_id
     const { data: marque } = await sb

--- a/backend/src/modules/rm/services/rm-soft404-tracker.service.ts
+++ b/backend/src/modules/rm/services/rm-soft404-tracker.service.ts
@@ -31,13 +31,12 @@ function hasAny(haystack: string, needles: readonly string[]): boolean {
 }
 
 @Injectable()
-export class RmSoft404TrackerService {
-  private readonly logger = new Logger(RmSoft404TrackerService.name);
+export class RmSoft404TrackerService extends SupabaseBaseService {
+  protected readonly logger = new Logger(RmSoft404TrackerService.name);
 
-  constructor(
-    private readonly supabase: SupabaseBaseService,
-    private readonly cache: CacheService,
-  ) {}
+  constructor(private readonly cache: CacheService) {
+    super();
+  }
 
   classifyUA(ua: string | null | undefined): UaClass {
     if (!ua) return 'unknown';
@@ -45,14 +44,6 @@ export class RmSoft404TrackerService {
     if (hasAny(ua, BROWSER_NAMES) && hasAny(ua, BROWSER_ENGINES))
       return 'browser';
     return 'unknown';
-  }
-
-  private getClient() {
-    return (
-      (this.supabase as any).client ??
-      (this.supabase as any).supabase ??
-      this.supabase
-    );
   }
 
   async track(
@@ -69,13 +60,15 @@ export class RmSoft404TrackerService {
     if (recent) return;
 
     const ua_class = this.classifyUA(ctx.ua);
-    const sb = this.getClient();
-    const { error } = await sb.from('__soft_404_events').insert({
-      pg_id: body.pg_id,
-      type_id: body.type_id,
-      referrer: ctx.referrer,
-      ua_class,
-    });
+    // inherited from SupabaseBaseService (extends pattern, 203 services canon)
+    const { error } = await this.supabase
+      .from('__soft_404_events' as any)
+      .insert({
+        pg_id: body.pg_id,
+        type_id: body.type_id,
+        referrer: ctx.referrer,
+        ua_class,
+      } as any);
     if (error) {
       this.logger.warn(`Soft-404 track insert failed: ${error.message}`);
       return;


### PR DESCRIPTION
## Urgence

**Hotfix critique** : PR #595 (soft-404 R2) mergée — \`🚀 Deploy PREPROD\` job échec runtime sur 46.224.118.55 :

\`\`\`
Nest can't resolve dependencies of the RmAlternativesService
(?, CacheService). SupabaseBaseService at index [0] not available
in RmModule context.
\`\`\`

→ Container preprod **down** (NestJS bootstrap fail).

## Cause racine

\`DatabaseModule\` n'exporte PAS \`SupabaseBaseService\` comme provider. Le canon repo = \`extends SupabaseBaseService\` (**203 services** dans le codebase utilisent ce pattern, dont \`RmBuilderService\` ligne 41). J'avais introduit le seul pattern injection par constructor dans le repo — incompatible avec le DI graph existant.

## Fix

- \`RmAlternativesService\` et \`RmSoft404TrackerService\` passent à \`extends SupabaseBaseService\` (canon)
- Constructor réduit à \`(cache: CacheService)\` + \`super()\`
- \`this.supabase\` directement accessible (protected readonly du parent)
- Helper \`getClient()\` dual-access supprimé
- Tests : instanciation directe + override \`(service as any).supabase = mock\` (canon \`rm-builder-seo-shadow.test.ts\`)

## Validation

- [x] 12/12 tests Jest verts (5 alternatives + 7 tracker)
- [x] TS compile clean sur scope
- [x] Prettier formatted

## Self-review verdict

APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)