### PR TITLE
hotfix(ci): soft-404 smoke step swallows FAIL details (bash -e + cmd subst)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -795,6 +795,11 @@ jobs:
           echo "- / (homepage): $STATUS" >> $GITHUB_STEP_SUMMARY
 
       - name: 🩹 Soft-404 R2 smoke
+        # shell explicite : par défaut `bash -e {0}` (errexit). Or la capture
+        # `ASSERT_OUT=$(python3 ... )` propage l'exit code si le script exit 1
+        # → bash quitte AVANT d'imprimer le motif du FAIL. On force shell sans
+        # errexit pour collecter tous les FAILs + leurs raisons.
+        shell: bash {0}
         run: |
           BASE="http://localhost:3200"
           FAILED=0
@@ -805,10 +810,11 @@ jobs:
             [[ -z "${url// }" ]] && continue
             case "$url" in \#*) continue ;; esac
             echo "🔎 $url"
-            HTTP_OUT=$(curl -s -i --max-time 15 "$BASE$url" || true)
-            if [ -z "$HTTP_OUT" ]; then
-              echo "❌ curl failed for $url"
-              echo "- $url: ❌ curl failed" >> $GITHUB_STEP_SUMMARY
+            HTTP_OUT=$(curl -s -i --max-time 15 "$BASE$url")
+            CURL_RC=$?
+            if [ "$CURL_RC" != "0" ] || [ -z "$HTTP_OUT" ]; then
+              echo "❌ curl failed for $url (rc=$CURL_RC)"
+              echo "- $url: ❌ curl failed (rc=$CURL_RC)" >> $GITHUB_STEP_SUMMARY
               FAILED=1
               continue
             fi


### PR DESCRIPTION
## Problème

PR #600 deploy run 26046987267 → \`🧪 Deploy PREPROD\` job échec sur step \`🩹 Soft-404 R2 smoke\`. Log final :

\`\`\`
🔎 /pieces/kit-de-freins-arriere-3859/bmw-33/serie-5-f10-f18-33053/2-0-525-d-11836.html
##[error]Process completed with exit code 1.
\`\`\`

**220ms entre les 2 lignes**, aucun motif de FAIL imprimé. Or le container preprod est UP (deploy-watcher après le smoke step confirme health check OK).

## Cause racine

\`\`\`bash
ASSERT_OUT=\$(echo "\$HTTP_OUT" | python3 scripts/ci/assert-soft-404.py 2>&1)
ASSERT_RC=\$?  # ← jamais atteint
\`\`\`

GHA injecte \`bash -e {0}\` par défaut (errexit). Quand \`python3 assert-soft-404.py\` exit 1 (FAIL legitimate), la substitution \`\$(...)\` propage l'exit code et \`set -e\` tue le shell **AVANT** la ligne \`ASSERT_RC=\$?\` + l'affichage du motif \`\$ASSERT_OUT\`.

## Fix

- \`shell: bash {0}\` (sans \`-e\`) explicite pour ce step
- La logique interne accumule \`FAILED=1\` puis \`exit 1\` à la fin si nécessaire (déjà présent)
- Bonus diagnostic : capture \`CURL_RC=\$?\` séparé (rc=7 = connection refused, rc=28 = timeout)

## Impact preprod

Container hotfix #600 **déjà déployé et healthy** sur 49.12.233.2:3200 (deploy-watcher OK). Cette PR n'affecte pas le runtime — elle expose juste les détails du FAIL pour qu'on sache si c'est :
- (A) un vrai bug rendering soft-404 sur preprod → on saura quoi corriger
- (B) un false positive (e.g. PopularCategories pas chargé au moment du smoke) → on saura ajuster le seuil

## Self-review verdict

APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)