### PR TITLE
fix(dependabot): enforce ecosystem group precedence + ignore Storybook majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,27 +17,51 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@remix-run/*"
         update-types: ["version-update:semver-major"]
+      # Storybook major (9→10) = migration manuelle planifiée, jamais auto-PR
+      # (cf. cas #280 / PR #605 : addon-onboarding@10 émis seul casse storybook@9).
+      - dependency-name: "storybook"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@storybook/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@chromatic-com/storybook"
+        update-types: ["version-update:semver-major"]
     groups:
-      dev-dependencies:
-        dependency-type: "development"
-        update-types: ["minor", "patch"]
-      # Ecosystem-coupling groups : forcent les bumps cohérents pour les
-      # familles qui doivent rester alignées sur le même major (sinon
-      # incompat runtime, cf. cas #280 storybook 9 vs addon-onboarding@10
-      # le 2026-05-04). Dependabot émettra une seule PR par écosystème
-      # plutôt que des PRs partielles.
+      # Ecosystem-coupling groups (déclarés EN PREMIER pour prendre précédence
+      # sur le groupe générique dev-dependencies). Dependabot évalue les groupes
+      # top-down ; sans cet ordre + sans exclude-patterns ci-dessous, un addon
+      # ecosystem version-bumped en minor matchait dev-dependencies en premier
+      # et bypassait son groupe ecosystem (cas #280 storybook 9 vs
+      # addon-onboarding@10 le 2026-05-04, re-fire sur PR #605 le 2026-05-18).
       storybook-ecosystem:
         patterns:
           - "storybook"
           - "@storybook/*"
+          - "@chromatic-com/storybook"
+        update-types: ["minor", "patch"]
       tiptap-ecosystem:
         patterns:
           - "@tiptap/*"
+        update-types: ["minor", "patch"]
       vite-ecosystem:
         patterns:
           - "vite"
           - "vitest"
           - "@vitejs/*"
+          - "@vitest/*"
+          - "vite-tsconfig-paths"
+        update-types: ["minor", "patch"]
+      dev-dependencies:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+        exclude-patterns:
+          - "storybook"
+          - "@storybook/*"
+          - "@chromatic-com/storybook"
+          - "@tiptap/*"
+          - "vite"
+          - "vitest"
+          - "@vitejs/*"
+          - "@vitest/*"
           - "vite-tsconfig-paths"
 
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Summary

- Re-orders Dependabot npm groups so **ecosystem-coupling groups (storybook / vite / tiptap) are declared BEFORE** the generic `dev-dependencies` group → Dependabot evaluates top-down, ecosystem packages now hit their dedicated group first.
- Adds explicit `exclude-patterns` to `dev-dependencies` (belt-and-braces) for `storybook`, `@storybook/*`, `@chromatic-com/storybook`, `@tiptap/*`, `vite`, `vitest`, `@vitejs/*`, `@vitest/*`, `vite-tsconfig-paths`.
- Adds `ignore` directives for Storybook **major** bumps (`storybook`, `@storybook/*`, `@chromatic-com/storybook`) — 9→10 is a planned manual migration, never auto-PR'd.
- Adds `@vitest/*` to `vite-ecosystem` and `@chromatic-com/storybook` to `storybook-ecosystem` (were leaking into dev-dependencies).

## Why

PR #605 (re-fire of incident #280) failed every blocking check this morning: `@storybook/addon-onboarding@10.4.0` was bundled into the `dev-dependencies` group as a minor bump, bypassing `storybook-ecosystem` which would have kept it coherent with the pinned `storybook@^9.1.13`. `npm ci` → ERESOLVE → all downstream gates red (ESLint, TS, tests, audits, **modernization-inventory BLOCKING**). Root cause was Dependabot group-precedence: first matching group wins, and the generic group was declared first.

The previous mitigation (adding ecosystem groups in PR #281 on 2026-05-04) was partial — the ordering + exclude-patterns piece was missing.

## Test plan

- [x] YAML parses cleanly (`js-yaml.load(...)` returns expected structure, groups order `storybook-ecosystem → tiptap-ecosystem → vite-ecosystem → dev-dependencies`).
- [x] `dev-dependencies.exclude-patterns` contains all 9 ecosystem patterns.
- [x] `ignore` array contains 3 new Storybook major-version-update entries (total 7).
- [ ] Merge this PR, then post `@dependabot recreate` on #605 — verify the recreated PR no longer includes `@storybook/addon-onboarding` (since storybook itself stays at 9.x, no coherent ecosystem bump available).
- [ ] Monitor next weekly Dependabot run (Monday 2026-05-25) — verify no mixed ecosystem/dev-deps PR is emitted.

## Out of scope

- Repo Map Drift (`.spec/00-canon/repo-map.md` claim≠reality) — pre-existing on main, warn-only ADR-048 J+30, will be handled in a dedicated follow-up.
- Storybook 9→10 migration — explicitly blocked by the new `ignore` directives ; will be a planned manual PR when capacity permits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)