### PR TITLE
chore(husky): impeccable ratchet warn-only pre-commit hook (PR 6/6)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -138,3 +138,38 @@ if command -v npx >/dev/null 2>&1; then
     fi
   }
 fi
+
+# impeccable design ratchet (warn-only) — runs only if frontend/** or
+# the ratchet's own files are staged. Catches reintroductions of the
+# anti-patterns we've already eliminated (side-tab, pure-black-white,
+# bounce-easing, ai-color-palette) before they hit CI.
+#
+# - WARN-only (Phase 1): prints a notice on regression but does not
+#   block the commit. CI's `.github/workflows/impeccable-ratchet.yml`
+#   is the authoritative BLOCKING gate.
+# - Override: set `IMPECCABLE_HOOK=skip` to silence entirely.
+# - Promote to blocking: set `IMPECCABLE_HOOK=block` (planned for
+#   Phase 2 once the cascade closes; tracked in
+#   audit/impeccable/README.md).
+IMPECCABLE_HOOK="${IMPECCABLE_HOOK:-warn}"
+if [ "$IMPECCABLE_HOOK" != "skip" ]; then
+  FRONTEND_TOUCHED=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '^(frontend/|packages/design-tokens/|audit/impeccable/|scripts/audit/impeccable-|\.github/workflows/impeccable-ratchet\.yml)' || true)
+  if [ -n "$FRONTEND_TOUCHED" ] && [ -f scripts/audit/impeccable-ratchet-check.mjs ] && command -v npm >/dev/null 2>&1; then
+    if npm --workspace=@fafa/frontend run design:detect:json --silent 2>/dev/null \
+      | node scripts/audit/impeccable-ratchet-check.mjs >/tmp/impeccable-hook.log 2>&1; then
+      :  # green — silent
+    else
+      echo ""
+      echo "⚠️  impeccable ratchet (warn-only): frontend changes increased the design anti-pattern count."
+      echo "    See /tmp/impeccable-hook.log for the diff."
+      echo "    CI workflow .github/workflows/impeccable-ratchet.yml is the authoritative BLOCKING gate."
+      echo "    Set IMPECCABLE_HOOK=skip to silence this hook."
+      if [ "$IMPECCABLE_HOOK" = "block" ]; then
+        echo ""
+        echo "    IMPECCABLE_HOOK=block is set — refusing the commit."
+        cat /tmp/impeccable-hook.log
+        exit 1
+      fi
+    fi
+  fi
+fi

--- a/audit/impeccable/README.md
+++ b/audit/impeccable/README.md
@@ -47,6 +47,17 @@ See `baseline.json` for current snapshot. The cascade ROADMAP (see [tout-fait-r-
 
 Residual categories (<11 each) are accepted in backlog; the ratchet prevents regrowth.
 
+## Local pre-commit hook (Phase 1: warn-only)
+
+A Husky pre-commit hook (`.husky/pre-commit`) runs the ratchet locally when a commit touches `frontend/**`, `packages/design-tokens/**`, `audit/impeccable/**`, or any of the ratchet's own files. It is **warn-only** in Phase 1 — it prints a notice if your change increases the count but does NOT block the commit. The CI workflow `.github/workflows/impeccable-ratchet.yml` is the authoritative BLOCKING gate.
+
+Hook env vars:
+- `IMPECCABLE_HOOK=skip` — silence the hook entirely (e.g., commits unrelated to design)
+- `IMPECCABLE_HOOK=block` — promote to blocking (planned default in Phase 2 once the cascade closes)
+- `IMPECCABLE_HOOK=warn` — default (print warning on regression)
+
+The hook fires impeccable in `--fast` mode (skip Chromium download via `.npmrc`), so cost is ≤ 5s on average for affected commits.
+
 ## Anti-bricolage discipline
 
 - **Never** raise the baseline to dodge a CI failure (use `--allow-increase` only at initial bootstrap).

--- a/log.md
+++ b/log.md
@@ -831,3 +831,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/impeccable-husky-hardening`
 - **Décision** : chore(husky): wire impeccable ratchet as warn-only pre-commit hook (PR 6)
 - **Sortie** : PR #621 | commits f977316a4
+
+## 2026-05-19 — chore/impeccable-husky-hardening (auto)
+
+- **Branche** : `chore/impeccable-husky-hardening`
+- **Décision** : chore(registry): regenerate after PR #606 (vehicle-context cookie devDep bump) (+2 other commits)
+- **Sortie** : PR #621 | commits 4d635fac7 8bd1c7c84 c7b056d68

--- a/log.md
+++ b/log.md
@@ -825,3 +825,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `refactor/impeccable-bounce-easing`
 - **Décision** : refactor(frontend): smooth bounce-easing animations (-8, components-only)
 - **Sortie** : PR #610 | commits f260a8de4
+
+## 2026-05-19 — chore/impeccable-husky-hardening (auto)
+
+- **Branche** : `chore/impeccable-husky-hardening`
+- **Décision** : chore(husky): wire impeccable ratchet as warn-only pre-commit hook (PR 6)
+- **Sortie** : PR #621 | commits f977316a4


### PR DESCRIPTION
## Summary

**Final PR of the impeccable cascade.** Adds a Husky pre-commit hook that runs the ratchet locally when a commit touches `frontend/**`, `packages/design-tokens/**`, `audit/impeccable/**`, or any of the ratchet's own files.

**Warn-only in Phase 1**: prints a notice if your change increases the count but does NOT block the commit. CI workflow `.github/workflows/impeccable-ratchet.yml` remains the authoritative BLOCKING gate. This avoids forcing the hook onto every developer before the cascade fully settles.

## Why warn-only

- The cascade still has ~162 residual issues (mostly R-SEO-09-blocked route files). Some commits will legitimately touch areas adjacent to those. Blocking too early forces developers into the hook escape-hatch (`IMPECCABLE_HOOK=skip`).
- Local hooks should *help*, not punish. CI is the source of truth.
- Promotion to `block` is planned for Phase 2 once R-SEO-09 routes are addressed.

## Env vars (documented in `audit/impeccable/README.md`)

- `IMPECCABLE_HOOK=skip` — silence the hook entirely
- `IMPECCABLE_HOOK=block` — promote to blocking (Phase 2 default)
- `IMPECCABLE_HOOK=warn` — default

## Cost

- Staged frontend commits: ≤ 5s (impeccable `--fast` + `.npmrc` puppeteer-skip-download already on main since PR #597)
- Non-frontend commits: 0 (grep filter on `git diff --cached` exits early)

## Test plan

- [x] Hook syntax validated (`bash -n .husky/pre-commit`)
- [x] Grep filter scoped (only fires on frontend/design-tokens/ratchet-files)
- [x] Warn-only verified — non-zero exit from ratchet-check does NOT propagate to hook exit
- [x] `IMPECCABLE_HOOK=skip` short-circuit
- [x] `IMPECCABLE_HOOK=block` promotes to blocking
- [ ] CI green (this PR doesn't touch frontend; impeccable-ratchet workflow path filter should skip)

## Final shape of the cascade

| PR | Title | Effect |
|----|-------|--------|
| #597 | impeccable@2.1.9 devDep + registry catch-up | infra |
| #602 | ratchet infra + side-tab partial | -16 |
| #610 | bounce-easing | -8 |
| #608 | pure-black-white | -21 |
| #620 | ai-color-palette | -57 |
| **this** | Husky pre-commit warn-only | local feedback loop |

**Cumulative count drop: 264 → 162 (-102, -39%)**.

Remaining 162 split:
- `ai-color-palette` 60 (route files, R-SEO-09 deferred)
- `side-tab` 34 (route files, R-SEO-09 deferred)
- `gray-on-color` 25 (deferred — context-dependent)
- `pure-black-white` 21 (route files, R-SEO-09 deferred)
- Backlog low-priority: `border-accent-on-rounded` 10, `gradient-text` 7, `bounce-easing` 3, `overused-font` 2

## Follow-up (separate PRs, not blocking this cascade)

- **R-SEO-09 Phase 2 override** then re-run codemods with `--include-routes` → expected -97 from routes alone
- **`gray-on-color` codemod** (context-aware: `text-{gray,slate}-* on bg-{color}-*` → `text-foreground` or `text-muted-foreground`)
- **Promote pre-commit hook to `block` default** once residuals stabilize

🤖 Generated with [Claude Code](https://claude.com/claude-code)