### PR TITLE
feat(deploy): env-contract preflight (Zod SoT, Phase 1)

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -53,6 +53,14 @@ Toute occurrence des patterns ci-dessous dans un fichier `.md` du repo (hors err
 - `git tag v… && git push --tags` = **promotion `:preprod` → `:production` + redéploiement container PROD**.
 - Jamais annoncer "déployé en PROD" après un simple merge sur `main`.
 
+## Contrat env CI (preflight)
+
+Le `.env.preprod` heredoc-généré par le step `🧪 Deploy to PREPROD` (ci.yml) est validé **avant** `docker compose up` par `scripts/ci/preflight-env-contract.ts` contre le SoT Zod `backend/src/contract/env-contract/preprod.schema.ts`. Toute divergence entre les invariants runtime backend et l'env injecté = CI fail immédiat lisible (avec liste structurée des issues), plutôt qu'un crash boot NestJS opaque dans le container.
+
+Le schema PREPROD couvre les vars qui font crash le boot si absentes ou mal-formées : `NODE_ENV` (literal `preprod`), `SUPABASE_URL`, `SUPABASE_ANON_KEY` (anon only, ADR-028 Option D), `JWT_SECRET` (≥32c, HS256 VCP cookie depuis PR #606), `SESSION_SECRET` (≥32c, main.ts:102 fail-fast), `READ_ONLY=true` (literal, ADR-028), `REDIS_URL` (regex `^rediss?://`).
+
+`.passthrough()` Phase 1 — les vars hors-contrat (`SEO_CHAIN_*_MODE`, `APP_URL`, `RAG_*`, `CRUX_API_KEY`, etc.) passent. Premier pas vers Environment Contract Control Plane (ADR follow-up Phase 2 : convergence runtime/CI/schemas/env.example/deploy + ratchet new-var-without-schema-entry).
+
 ## Workflow nominal — Promote DEV (code) → PROD
 
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,6 +601,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Node.js + deps install required by the env-contract preflight step
+      # below: `scripts/ci/preflight-env-contract.ts` runs under tsx and
+      # imports the Zod schema from `backend/src/contract/env-contract/`.
+      # Without `npm ci` on this self-hosted runner, tsx is unavailable and
+      # the preflight cannot enforce the canonical SoT (no auto-install
+      # fallback — `npm install @latest` would be non-deterministic, see
+      # memory feedback_ci_no_dynamic_latest_install).
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies (required for env-contract preflight)
+        run: npm ci
+
       - name: 🧪 Deploy to PREPROD (read-only hardening — ADR-028 Option D)
         env:
           # ADR-028 Option D : couches 1+2 (privilege downgrade + anon key only).
@@ -697,6 +713,34 @@ jobs:
           # shellcheck disable=SC1091
           . "$PREPROD_DIR/.env"
           set +a
+
+          # 🛡️ Preflight env contract check — first projection of the canonical
+          # Zod SoT into CI (backend/src/contract/env-contract/preprod.schema.ts).
+          # Loads the REAL `.env.preprod` in an isolated subshell (not the
+          # ambient GHA env block) to validate EXACTLY what docker-compose
+          # injects into the container. Turns an opaque NestJS boot crash
+          # ("Configuration key X does not exist") into a CI fail immediately
+          # before `docker compose up`, with a structured diff.
+          #
+          # `set -euo pipefail` hardens the subshell against silent interpolation
+          # / sourcing failures (GHA `bash -e {0}` alone can let empty
+          # interpolations through). Determinism: tsx must be present via the
+          # `npm ci` step above — no dynamic `@latest` install (memory
+          # feedback_ci_no_dynamic_latest_install).
+          echo "🛡️ Preflight env contract check (loads real .env.preprod)..."
+          if ! (cd "$GITHUB_WORKSPACE" && npx --no-install tsx --version >/dev/null 2>&1); then
+            echo "::error::tsx not available — the 'Install dependencies' step above must run before this step (no auto-install fallback by design)."
+            exit 1
+          fi
+          (
+            set -euo pipefail
+            cd "$GITHUB_WORKSPACE"
+            set -o allexport
+            # shellcheck disable=SC1091
+            . "$PREPROD_DIR/.env"
+            set +o allexport
+            npx --no-install tsx scripts/ci/preflight-env-contract.ts
+          )
 
           # Arreter anciens conteneurs
           docker stop nestjs-remix-monorepo-preprod redis-preprod 2>/dev/null || true

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -172,6 +172,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: medium
     risk: medium
+  - glob: backend/src/contract/env-contract/**
+    domain: D13
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/src/modules/admin/**
     domain: D8
     owner: '@ak125/admin-team'

--- a/backend/src/contract/env-contract/index.ts
+++ b/backend/src/contract/env-contract/index.ts
@@ -1,0 +1,2 @@
+export { PreprodEnvContractSchema } from './preprod.schema';
+export type { PreprodEnvContract } from './preprod.schema';

--- a/backend/src/contract/env-contract/preprod.schema.ts
+++ b/backend/src/contract/env-contract/preprod.schema.ts
@@ -40,9 +40,7 @@ export const PreprodEnvContractSchema = z
     JWT_SECRET: z
       .string()
       .min(32, 'JWT_SECRET must be >= 32 chars (HS256 / NIST 2026 guidance)'),
-    SESSION_SECRET: z
-      .string()
-      .min(32, 'SESSION_SECRET must be >= 32 chars'),
+    SESSION_SECRET: z.string().min(32, 'SESSION_SECRET must be >= 32 chars'),
     READ_ONLY: z.literal('true'),
     REDIS_URL: z
       .string()

--- a/backend/src/contract/env-contract/preprod.schema.ts
+++ b/backend/src/contract/env-contract/preprod.schema.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+/**
+ * Source of Truth — env contract for PREPROD (ADR-028 Option D).
+ *
+ * Consumers:
+ *   Phase 1 (active): scripts/ci/preflight-env-contract.ts
+ *     Fail-fast CI before `docker compose up` — validates the `.env.preprod`
+ *     heredoc-generated file matches the backend's runtime invariants.
+ *   Phase 2 (deferred, ADR Environment Contract Control Plane):
+ *     Backend env-validation.ts convergence + drift detection + ratchet.
+ *
+ * Required vars mirror `REQUIRED_ENV_VARS_READ_ONLY` in
+ * `backend/src/config/env-validation.ts` (NODE_ENV, SUPABASE_URL,
+ * SUPABASE_ANON_KEY, REDIS_URL, JWT_SECRET) plus SESSION_SECRET
+ * (validated by main.ts:102 fail-fast in NODE_ENV=production, which is
+ * what the preprod container actually runs as per docker-compose override)
+ * plus READ_ONLY=true (ADR-028 Option D invariant).
+ *
+ * Design notes Phase 1 → Phase 2:
+ *   - `.passthrough()` (Phase 1): tolerates supplementary vars (SEO_CHAIN_*_MODE,
+ *     APP_URL, RAG_*, CRUX_API_KEY, GitHub-Actions injected vars, etc.).
+ *     Phase 2: migrate to `.strict()` once drift cleanup is feasible
+ *     (strict surfaces zombies / typos / dead secrets).
+ *   - `NODE_ENV: z.enum(['preprod'])`: strict literal. Prevents NODE_ENV=banana
+ *     from passing silently. The Docker image overrides this to 'production' at
+ *     runtime (docker-compose.preprod.yml) — we validate the SHELL/env-file
+ *     value here, not the runtime override.
+ *   - `REDIS_URL`: regex instead of `.url()` — Zod's `.url()` parser is fragile
+ *     for the `redis://` scheme; regex covers redis://, rediss://,
+ *     redis://:pwd@host:port/db.
+ *   - 32-char minimum for JWT_SECRET / SESSION_SECRET: matches main.ts:102
+ *     enforcement and 2026 NIST guidance for HS256 keys.
+ */
+export const PreprodEnvContractSchema = z
+  .object({
+    NODE_ENV: z.enum(['preprod']),
+    SUPABASE_URL: z.string().url(),
+    SUPABASE_ANON_KEY: z.string().min(40),
+    JWT_SECRET: z
+      .string()
+      .min(32, 'JWT_SECRET must be >= 32 chars (HS256 / NIST 2026 guidance)'),
+    SESSION_SECRET: z
+      .string()
+      .min(32, 'SESSION_SECRET must be >= 32 chars'),
+    READ_ONLY: z.literal('true'),
+    REDIS_URL: z
+      .string()
+      .regex(
+        /^rediss?:\/\/.+/,
+        'REDIS_URL must start with redis:// or rediss:// and have a host',
+      ),
+  })
+  .passthrough();
+
+export type PreprodEnvContract = z.infer<typeof PreprodEnvContractSchema>;

--- a/log.md
+++ b/log.md
@@ -843,3 +843,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/preprod-env-contract-preflight`
 - **Décision** : chore(registry): scope env-contract paths in ownership.yaml (D13) (+1 other commit)
 - **Sortie** : PR #632 | commits eacfdcbe3 fbc50be95
+
+## 2026-05-19 — fix/preprod-env-contract-preflight (auto)
+
+- **Branche** : `fix/preprod-env-contract-preflight`
+- **Décision** : style(env-contract): apply prettier (CI lint fix) (+3 other commits)
+- **Sortie** : PR #632 | commits 22cd9867e 690c78525 eacfdcbe3 fbc50be95

--- a/log.md
+++ b/log.md
@@ -837,3 +837,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/impeccable-husky-hardening`
 - **Décision** : chore(registry): regenerate after PR #606 (vehicle-context cookie devDep bump) (+2 other commits)
 - **Sortie** : PR #621 | commits 4d635fac7 8bd1c7c84 c7b056d68
+
+## 2026-05-19 — fix/preprod-env-contract-preflight (auto)
+
+- **Branche** : `fix/preprod-env-contract-preflight`
+- **Décision** : chore(registry): scope env-contract paths in ownership.yaml (D13) (+1 other commit)
+- **Sortie** : PR #632 | commits eacfdcbe3 fbc50be95

--- a/scripts/ci/preflight-env-contract.ts
+++ b/scripts/ci/preflight-env-contract.ts
@@ -1,0 +1,36 @@
+/**
+ * Preflight env contract check — fail-fast CI before `docker compose up`.
+ *
+ * Pattern:
+ *   1. The CI step has sourced the real `.env.preprod` via
+ *      `set -a; . "$PREPROD_DIR/.env"; set +a` in a fresh subshell BEFORE
+ *      invoking this script. `process.env` reflects exactly what will be
+ *      injected into the preprod container.
+ *   2. safeParse(process.env) against PreprodEnvContractSchema (SoT Zod).
+ *   3. Exit 1 + structured GHA error log if validation fails.
+ *
+ * Premier pas vers Environment Contract Control Plane (cf. ADR follow-up).
+ * SoT : backend/src/contract/env-contract/preprod.schema.ts.
+ *
+ * Usage: npx --no-install tsx scripts/ci/preflight-env-contract.ts
+ */
+import { PreprodEnvContractSchema } from '../../backend/src/contract/env-contract/index.ts';
+
+const result = PreprodEnvContractSchema.safeParse(process.env);
+
+if (!result.success) {
+  console.error('::error::Preflight env contract violation — backend boot would crash.');
+  console.error('');
+  console.error('Issues détectées :');
+  for (const issue of result.error.issues) {
+    const path = issue.path.length > 0 ? String(issue.path[0]) : '(root)';
+    console.error(`  ❌ ${path}: ${issue.message}`);
+  }
+  console.error('');
+  console.error('SoT contrat : backend/src/contract/env-contract/preprod.schema.ts');
+  console.error('Fix : compléter le heredoc .env.preprod du step "🧪 Deploy to PREPROD".');
+  process.exit(1);
+}
+
+console.log('✓ Preflight env contract OK — PreprodEnvContractSchema validé');
+process.exit(0);

--- a/scripts/ci/preflight-env-contract.ts
+++ b/scripts/ci/preflight-env-contract.ts
@@ -14,23 +14,29 @@
  *
  * Usage: npx --no-install tsx scripts/ci/preflight-env-contract.ts
  */
-import { PreprodEnvContractSchema } from '../../backend/src/contract/env-contract/index.ts';
+import { PreprodEnvContractSchema } from "../../backend/src/contract/env-contract/index.ts";
 
 const result = PreprodEnvContractSchema.safeParse(process.env);
 
 if (!result.success) {
-  console.error('::error::Preflight env contract violation — backend boot would crash.');
-  console.error('');
-  console.error('Issues détectées :');
+  console.error(
+    "::error::Preflight env contract violation — backend boot would crash.",
+  );
+  console.error("");
+  console.error("Issues détectées :");
   for (const issue of result.error.issues) {
-    const path = issue.path.length > 0 ? String(issue.path[0]) : '(root)';
+    const path = issue.path.length > 0 ? String(issue.path[0]) : "(root)";
     console.error(`  ❌ ${path}: ${issue.message}`);
   }
-  console.error('');
-  console.error('SoT contrat : backend/src/contract/env-contract/preprod.schema.ts');
-  console.error('Fix : compléter le heredoc .env.preprod du step "🧪 Deploy to PREPROD".');
+  console.error("");
+  console.error(
+    "SoT contrat : backend/src/contract/env-contract/preprod.schema.ts",
+  );
+  console.error(
+    'Fix : compléter le heredoc .env.preprod du step "🧪 Deploy to PREPROD".',
+  );
   process.exit(1);
 }
 
-console.log('✓ Preflight env contract OK — PreprodEnvContractSchema validé');
+console.log("✓ Preflight env contract OK — PreprodEnvContractSchema validé");
 process.exit(0);


### PR DESCRIPTION
## Summary

Phase 1 of the Environment Contract Control Plane (Phase 2 ADR follow-up). Projects backend env invariants as a **Zod schema** consumed by CI **before** `docker compose up`, turning opaque NestJS boot crashes (`Configuration key X does not exist`) into structured CI fails with a diff of all violations.

Builds on top of #630 (which propagated `JWT_SECRET` to the preprod heredoc): this PR adds the first **SoT projection** so a future missing/invalid env var fails CI at the preflight step instead of looping in `crash → 12 retries → healthcheck fail → deploy fail` for ~5 min.

## Changes

- `backend/src/contract/env-contract/preprod.schema.ts` (NEW) — Zod SoT. Required: `NODE_ENV` literal `preprod`, `SUPABASE_URL`, `SUPABASE_ANON_KEY≥40`, `JWT_SECRET≥32`, `SESSION_SECRET≥32`, `READ_ONLY` literal `true`, `REDIS_URL` regex `^rediss?://.+`. `.passthrough()` Phase 1 (`SEO_CHAIN_*` / `RAG_*` / `CRUX_API_KEY` tolerated). Mirrors `REQUIRED_ENV_VARS_READ_ONLY` from `env-validation.ts` (added by #630).
- `backend/src/contract/env-contract/index.ts` (NEW) — re-exports.
- `scripts/ci/preflight-env-contract.ts` (NEW) — `safeParse(process.env)`, exit 1 + structured `::error::` log listing every issue.
- `.github/workflows/ci.yml`:
  - `setup-node@v6` + `npm ci` added to `🧪 Deploy PREPROD` job (was missing — needed for tsx; **no dynamic `@latest` install**, fail-fast if absent, per `feedback_ci_no_dynamic_latest_install`).
  - Preflight invocation added between `.env` source and `docker compose up`, in an isolated subshell with `set -euo pipefail` that re-sources `.env.preprod` so validation reflects EXACTLY what compose injects (not the ambient GHA `env:` block).
- `.claude/rules/deployment.md` — additive section "Contrat env CI (preflight)" referencing the SoT + schema fields + Phase 2 follow-up.
- `.spec/00-canon/repository-registry/ownership.yaml` — ultra-scoped glob `backend/src/contract/env-contract/**` (D13, `@ak125`), per `feedback_no_broad_migration_glob_in_ownership`.

## Determinism notes

- No `@latest` install in the deploy step (per project canon). `tsx` + `zod` come from `npm ci` (lockfile-pinned).
- `.passthrough()` Phase 1 → `.strict()` deferred to Phase 2 (drift cleanup needed first).
- `NODE_ENV` enum is strict to the shell value `preprod` — docker-compose override to `production` at container runtime is intentional and out of scope of this preflight (we validate the artifact, not the runtime).

## Test plan

- [x] Preflight positive (all required vars valid) → exit 0 + `✓ Preflight env contract OK`
- [x] Preflight negative (`JWT_SECRET` too short) → exit 1 + structured `JWT_SECRET: must be >= 32 chars`
- [x] Preflight multi-error (7 vars invalid) → exit 1 + **7** `❌` lines (safeParse collects ALL issues, not just short-circuit on first)
- [x] `tsc --noEmit -p backend/tsconfig.json` clean on env-contract scope
- [x] `python3 -c yaml.safe_load(ci.yml)` clean
- [x] `check-new-files.js --base origin/main` → 3 new files, 3 ok, 0 failures
- [ ] CI green on `main` after merge — confirm `🛡️ Preflight env contract check` log line appears in the `🧪 Deploy PREPROD` job
- [ ] Preprod `http://49.12.233.2:3200/health` returns 200 post-deploy

## Phase 2 follow-up (separate ADR, not in this PR)

- **Environment Contract Control Plane** ADR : converge runtime/CI/schemas/env.example/deploy + ratchet pattern (new env var without schema entry = CI FAIL, analogue PR-7a Contract Drift Ratchet).
- Audit config pipeline alignment — `env-validation.ts` is **NOT** dead code as I initially hypothesized: it's mode-dispatched (`REQUIRED_ENV_VARS` writeable vs `REQUIRED_ENV_VARS_READ_ONLY` preprod, both modified by #630). Phase 2.2 = full Zod schema consumed by `EnvironmentValidator` runtime, SoT effectively unique across CI + runtime.
- `prod.schema.ts` + `dev.schema.ts` (with appropriate strict/permissive shapes per role).
- Migrate `set -a; . .env; set +a` → dotenv loader (Phase 2.2) for cases where `.env` may contain shell-special chars (currently safe : heredoc machine-generated).
- Extraction `packages/config-contract` (Phase 2.3, last) — only when other consumers (frontend, infra scripts) emerge.

Direction stratégique : on construit une **chaîne de vérité** (Canonical → CI Projection → Runtime Validation → Governance Ratchet), pas un patch JWT isolé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)