### PR TITLE
ci(deploy): dump container logs + alternatives JSON + rendered links on smoke failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -897,6 +897,36 @@ jobs:
           fi
           echo "✅ All soft-404 fixtures passed"
 
+      - name: 🐛 Dump container + rendered HTML on smoke failure (observability)
+        if: failure()
+        run: |
+          set +e
+          echo "## 🐛 Soft-404 R2 smoke failure debug" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Backend container logs (last 200 lines, filtered)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          docker logs nestjs-remix-monorepo-preprod --tail 200 2>&1 \
+            | grep -iE 'rmAlternatives|alternatives|callRpc|rpcGate|supabase|permission|denied|jwt|anon|error|warn' \
+            | tail -80 >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Direct probe of /api/rm/alternatives for fixture #1" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          curl -s --max-time 10 "http://localhost:3200/api/rm/alternatives?gamme_id=3859&type_id=11836&limit=12" \
+            | python3 -c 'import sys, json; d=json.loads(sys.stdin.read()); print(json.dumps({"alternativeVehicles": len(d.get("alternativeVehicles",[])), "alternativeGammes": len(d.get("alternativeGammes",[])), "relatedModels": len(d.get("relatedModels",[])), "etag": d.get("etag")}, indent=2))' \
+            >> $GITHUB_STEP_SUMMARY 2>&1
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### First 4-segment /pieces/.../.../...html links in rendered page (fixture #1)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          curl -s --max-time 15 "http://localhost:3200/pieces/kit-de-freins-arriere-3859/bmw-33/serie-5-f10-f18-33053/2-0-525-d-11836.html" \
+            | grep -oE 'href="/pieces/[^"]+\.html"' \
+            | sort -u | head -10 >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
       - name: ⏱️ Response Time Baseline
         run: |
           BASE="http://localhost:3200"


### PR DESCRIPTION
## Summary

Today's soft-404 R2 smoke debugging chain (runs [26049337425](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26049337425), [26096588258](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26096588258), [26101726823](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26101726823), [26104292014](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26104292014)) burned hours because the CI exposes only the smoke's exit code — the deployed container's logs are not in the workflow log, and there's no probe of the underlying \`/api/rm/alternatives\` endpoint nor of the rendered HTML.

This PR adds a single \`if: failure()\` step right after the Soft-404 R2 smoke. On failure it writes three diagnostic blocks to \`GITHUB_STEP_SUMMARY\`:

1. **Last 200 lines of \`docker logs nestjs-remix-monorepo-preprod\`**, grep-filtered to \`alternatives / callRpc / rpcGate / supabase / permission / denied / jwt / anon / error / warn\`. Surfaces \`RmAlternativesService\` warnings, \`RpcBlockedError\`, \`permission denied\`, etc. that today were invisible.
2. **Direct probe of \`http://localhost:3200/api/rm/alternatives?gamme_id=3859&type_id=11836&limit=12\`** → reports \`{alternativeVehicles, alternativeGammes, relatedModels}\` lengths + \`etag\`. Isolates whether the backend endpoint OR the Remix loader is the failing layer.
3. **Greps the rendered page HTML for \`href=\"/pieces/.../.../...html\"\` matches** on fixture #1 → confirms whether the page contains the deeplink format the assertion expects, or whether something else is going on (URL shape regression in \`NoProductsAlternatives\`, JSON-LD only / no link rendering, etc.).

## Anti-bricolage notes

- Pure observability: no change to the smoke's pass/fail logic, no new secret, no new gate. Smoke still fails the run with the same exit code.
- The \`docker logs ... | grep\` is wrapped in \`set +e\` so a missing container or grep miss does not mask the original failure.
- All output goes to \`GITHUB_STEP_SUMMARY\` (markdown, no terminal-only output) so the PR/run page is the at-a-glance triage surface — matches the existing pattern used by the smoke and Response Time Baseline steps.

## Test plan

- [x] \`python3 -c 'yaml.safe_load(...)'\` clean.
- [ ] CI passes on this branch (the new step never runs because smoke passes on the unrelated changeset — it'll only fire the next time soft-404 smoke fails on \`main\`).
- [ ] Next failed deploy on \`main\` shows the three diagnostic blocks in the step summary, giving us the actual cause in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)