### PR TITLE
fix(rm): soft-404 R2 cache-poisoning recovery (anti-stale-key)

### DIFF
--- a/backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts
+++ b/backend/src/modules/rm/services/__tests__/rm-alternatives.service.test.ts
@@ -46,7 +46,7 @@ describe('RmAlternativesService (RPC canon)', () => {
 
       const result = await service.compute(11836, 3859, 12);
 
-      expect(cacheMock.get).toHaveBeenCalledWith('alt:11836:3859:v2');
+      expect(cacheMock.get).toHaveBeenCalledWith('alt:11836:3859:v3');
       expect(callRpcMock).not.toHaveBeenCalled();
       expect(result).toEqual(cached);
     });
@@ -90,7 +90,7 @@ describe('RmAlternativesService (RPC canon)', () => {
       expect(cacheMock.set).toHaveBeenCalled();
     });
 
-    it('fallback gracieux sur RPC error (payload vide, cache OK)', async () => {
+    it('fallback gracieux sur RPC error : payload vide + cache short-TTL (anti-poisoning)', async () => {
       cacheMock.get!.mockResolvedValue(null);
       callRpcMock.mockResolvedValue({
         data: null,
@@ -103,7 +103,33 @@ describe('RmAlternativesService (RPC canon)', () => {
       expect(result.alternativeVehicles).toEqual([]);
       expect(result.alternativeGammes).toEqual([]);
       expect(result.relatedModels).toEqual([]);
-      expect(cacheMock.set).toHaveBeenCalled();
+      // Error path uses CACHE_TTL_ERROR_SECONDS=30, not 300, so a transient
+      // failure does not poison the cache for 5 min (regression 2026-05-19).
+      expect(cacheMock.set).toHaveBeenCalledWith(
+        'alt:11836:3859:v3',
+        expect.any(String),
+        30,
+      );
+    });
+
+    it('auth failure (Invalid API key) is logged at ERROR not WARN', async () => {
+      cacheMock.get!.mockResolvedValue(null);
+      callRpcMock.mockResolvedValue({
+        data: null,
+        error: { message: 'Invalid API key', name: 'SupabaseRpcError' },
+      });
+      const errorSpy = jest
+        .spyOn((service as any).logger, 'error')
+        .mockImplementation(() => {});
+      const warnSpy = jest
+        .spyOn((service as any).logger, 'warn')
+        .mockImplementation(() => {});
+
+      await service.compute(11836, 3859, 12);
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(errorSpy.mock.calls[0][0]).toMatch(/Invalid API key/);
     });
 
     it('propage le payload RPC (vehicles/gammes/relatedModels)', async () => {

--- a/backend/src/modules/rm/services/rm-alternatives.service.ts
+++ b/backend/src/modules/rm/services/rm-alternatives.service.ts
@@ -80,9 +80,10 @@ export class RmAlternativesService extends SupabaseBaseService {
       // Auth/permission failures get ERROR level — they signal infra config drift
       // (e.g. rotated key not synced to deployment secrets) and need pager-grade
       // visibility, not the same WARN as a benign empty result.
-      const isAuthFailure = /invalid api key|jwt|permission denied|unauthorized/i.test(
-        error?.message ?? '',
-      );
+      const isAuthFailure =
+        /invalid api key|jwt|permission denied|unauthorized/i.test(
+          error?.message ?? '',
+        );
       const logLevel = isAuthFailure ? 'error' : 'warn';
       this.logger[logLevel](
         `RPC get_soft_404_alternatives failed for type=${type_id} pg=${pg_id}: ${

--- a/backend/src/modules/rm/services/rm-alternatives.service.ts
+++ b/backend/src/modules/rm/services/rm-alternatives.service.ts
@@ -6,13 +6,18 @@ import { CacheService } from '@cache/cache.service';
 import type { AlternativesV2Response } from '../dto/alternatives-v2.dto';
 
 const CACHE_TTL_SECONDS = 300;
+// Error-path TTL kept low so a transient RPC failure does not poison the cache
+// for 5 minutes. Long-TTL caching of empty responses was the amplifier behind
+// the soft-404 R2 smoke regression detected 2026-05-19 (stale anon publishable
+// key → 'Invalid API key' on every RPC → 300s cache of [] → 5min false-empty).
+const CACHE_TTL_ERROR_SECONDS = 30;
 const CACHE_KEY_PREFIX = 'alt';
-// v1 → v2 (2026-05-19) : v1 entries were populated with empty arrays during the
-// window where the service ran the direct `.from().select()` path under preprod's
-// anon key (PR #595→#618 timeline). Redis-preprod uses appendonly + named volume,
-// so those empty entries survive deploys and short-circuit the new RPC path.
-// Bumping the version forces a cache miss → RPC call → real data.
-const CACHE_KEY_VERSION = 'v2';
+// v1 → v2 (PR #633) : reset stale empty entries from the .from() RLS-bypass era.
+// v2 → v3 (2026-05-19) : reset stale empty entries from the rotated-publishable-key
+// era (preprod ANON_KEY rotated by Supabase but GitHub secret not synced — every RPC
+// returned 'Invalid API key', cached as empty for 5min). Pair with the short
+// CACHE_TTL_ERROR_SECONDS above to prevent the next rotation from repeating this.
+const CACHE_KEY_VERSION = 'v3';
 
 interface RpcPayload {
   alternativeVehicles: unknown[];
@@ -72,7 +77,14 @@ export class RmAlternativesService extends SupabaseBaseService {
     );
 
     if (error || !data) {
-      this.logger.warn(
+      // Auth/permission failures get ERROR level — they signal infra config drift
+      // (e.g. rotated key not synced to deployment secrets) and need pager-grade
+      // visibility, not the same WARN as a benign empty result.
+      const isAuthFailure = /invalid api key|jwt|permission denied|unauthorized/i.test(
+        error?.message ?? '',
+      );
+      const logLevel = isAuthFailure ? 'error' : 'warn';
+      this.logger[logLevel](
         `RPC get_soft_404_alternatives failed for type=${type_id} pg=${pg_id}: ${
           error?.message ?? 'no data'
         }`,
@@ -82,7 +94,14 @@ export class RmAlternativesService extends SupabaseBaseService {
         alternativeGammes: [],
         relatedModels: [],
       });
-      await this.cache.set(cacheKey, JSON.stringify(empty), CACHE_TTL_SECONDS);
+      // Short TTL on error path: thundering-herd protection without long-window
+      // cache poisoning. If the underlying issue clears (key re-synced, RLS
+      // policy fixed, transient timeout), recovery is bounded to 30s.
+      await this.cache.set(
+        cacheKey,
+        JSON.stringify(empty),
+        CACHE_TTL_ERROR_SECONDS,
+      );
       return empty;
     }
 


### PR DESCRIPTION
## Summary

Closes the 5/5 soft-404 R2 smoke failure visible in [ci.yml run 26104292014](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26104292014) (container PREPROD, 2026-05-19 14:37 UTC). Every fixture failed with the same assertion: `Aucun lien profond /pieces/.../.../...html (alternatives véhicules absentes)`.

The RPC and data layer were never wrong:
- `mcp__supabase__execute_sql get_soft_404_alternatives(11836, 3859, 12)` → 4 vehicles + 8 gammes + 4 relatedModels (live query)
- Same combo via service_role REST → 4/8/4 (live)
- Same combo via the publishable key consumed by container PREPROD → `{"message":"Invalid API key"}` 401

`mcp__supabase__get_publishable_keys` revealed the current valid publishable key for project `cxpojprgwgubzjyqzmoq` is `sb_publishable_pY14nFB7dZsSlEBQ4kdpxQ_4ka_FJqX` (legacy anon JWT is `disabled:true`; the prior publishable was rotated by Supabase and the GitHub secret never resynced). The cache-on-error path in `RmAlternativesService` then turned every failed call into a 300s cached `[]`, so every subsequent request served the false-empty payload to the soft-404 R2 component, which has no deep R2 link to render.

## Fix (3 layers)

| Layer | Change | Why |
|-------|--------|-----|
| Infra | `gh secret set SUPABASE_ANON_KEY` rotated to the current valid publishable key (2026-05-19 15:28 UTC, scope `repo`) | Immediate unblock — restores RPC connectivity from container PREPROD |
| Code | `CACHE_KEY_VERSION` v2 → v3 | One-time reset of poisoned `alt:*:v2` Redis entries from the rotated-key window |
| Code | Error-path TTL 300s → 30s (`CACHE_TTL_ERROR_SECONDS`) + ERROR log on auth-shaped errors | Anti-poisoning hardening — next time a transient or auth failure happens, recovery is bounded to 30s and the failure mode is loud, not silent |

The PROD container is unaffected: PROD uses `SUPABASE_SERVICE_ROLE_KEY` (`sb_secret_*`) which is still valid. Only container PREPROD (READ_ONLY=true, ADR-028 Option D, anon key only) was caught by the stale publishable.

## Scope

This PR is the **canary fix**. The soft-404 R2 smoke was the only step that surfaced the regression — every RPC from container PREPROD was equally affected. Other features that read via RPC will recover automatically post-redeploy.

Out-of-scope (deferred to a separate cycle if signal persists):
- Boot-time auth healthcheck in `SupabaseBaseService` (fail-fast on Invalid API key at startup) — would have caught this within seconds of secret rotation drift
- Secret-rotation runbook + automated drift detection (`gh secret list` vs `supabase get_publishable_keys`) in a scheduled workflow

## Test plan

- [x] Local: `mcp__supabase__execute_sql` + `curl` direct against the rotated publishable key confirm full payload (4 vehicles + 8 gammes + 4 relatedModels for fixture #1)
- [x] Unit tests updated: cache key `alt:11836:3859:v3`, error-path TTL=30 assertion, new test for ERROR log level on `Invalid API key`
- [ ] CI: `🧪 Deploy PREPROD` job → `🩹 Soft-404 R2 smoke` step → 5/5 fixtures PASS
- [ ] Post-merge: `🎭 E2E Smoke Tests` + `🔦 Lighthouse Performance Audit` reenchain (were skipped due to deploy preprod fail)
- [ ] `__error_logs` table monitored for residual auth failures over T+1h

## Linked

- PR #595 (soft-404 R2 strategy + multi-tier alternatives)
- PR #618 (port to SECURITY DEFINER RPCs, canon callRpc)
- PR #633 (v1 → v2 cache key bump — same anti-poisoning pattern, different trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)