### PR TITLE
ci(deploy): tee smoke debug dump to stdout so logs are visible without UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -901,31 +901,38 @@ jobs:
         if: failure()
         run: |
           set +e
-          echo "## 🐛 Soft-404 R2 smoke failure debug" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          # tee duplicates output to BOTH the workflow log (visible via gh run
+          # view --log) AND the GITHUB_STEP_SUMMARY markdown panel — covers the
+          # case where the summary-only redirect of the original step was empty
+          # in API responses (PR #636 run 26106977897). Logs now visible from
+          # the standard workflow output without needing the UI summary.
+          {
+            echo "## 🐛 Soft-404 R2 smoke failure debug"
+            echo ""
 
-          echo "### Backend container logs (last 200 lines, filtered)" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          docker logs nestjs-remix-monorepo-preprod --tail 200 2>&1 \
-            | grep -iE 'rmAlternatives|alternatives|callRpc|rpcGate|supabase|permission|denied|jwt|anon|error|warn' \
-            | tail -80 >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Backend container logs (last 200 lines, filtered)"
+            echo '```'
+            docker logs nestjs-remix-monorepo-preprod --tail 200 2>&1 \
+              | grep -iE 'rmAlternatives|alternatives|callRpc|rpcGate|supabase|permission|denied|jwt|anon|error|warn' \
+              | tail -80
+            echo '```'
+            echo ""
 
-          echo "### Direct probe of /api/rm/alternatives for fixture #1" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          curl -s --max-time 10 "http://localhost:3200/api/rm/alternatives?gamme_id=3859&type_id=11836&limit=12" \
-            | python3 -c 'import sys, json; d=json.loads(sys.stdin.read()); print(json.dumps({"alternativeVehicles": len(d.get("alternativeVehicles",[])), "alternativeGammes": len(d.get("alternativeGammes",[])), "relatedModels": len(d.get("relatedModels",[])), "etag": d.get("etag")}, indent=2))' \
-            >> $GITHUB_STEP_SUMMARY 2>&1
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Direct probe of /api/rm/alternatives for fixture #1"
+            echo '```json'
+            curl -s --max-time 10 "http://localhost:3200/api/rm/alternatives?gamme_id=3859&type_id=11836&limit=12" \
+              | python3 -c 'import sys, json; d=json.loads(sys.stdin.read()); print(json.dumps({"alternativeVehicles": len(d.get("alternativeVehicles",[])), "alternativeGammes": len(d.get("alternativeGammes",[])), "relatedModels": len(d.get("relatedModels",[])), "etag": d.get("etag")}, indent=2))' \
+              2>&1
+            echo '```'
+            echo ""
 
-          echo "### First 4-segment /pieces/.../.../...html links in rendered page (fixture #1)" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          curl -s --max-time 15 "http://localhost:3200/pieces/kit-de-freins-arriere-3859/bmw-33/serie-5-f10-f18-33053/2-0-525-d-11836.html" \
-            | grep -oE 'href="/pieces/[^"]+\.html"' \
-            | sort -u | head -10 >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "### First 4-segment /pieces/.../.../...html links in rendered page (fixture #1)"
+            echo '```'
+            curl -s --max-time 15 "http://localhost:3200/pieces/kit-de-freins-arriere-3859/bmw-33/serie-5-f10-f18-33053/2-0-525-d-11836.html" \
+              | grep -oE 'href="/pieces/[^"]+\.html"' \
+              | sort -u | head -10
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: ⏱️ Response Time Baseline
         run: |


### PR DESCRIPTION
## Summary

PR #636 ran successfully on commit \`7a6aa8782\` (run [26106977897](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26106977897)) but the debug output went only to \`GITHUB_STEP_SUMMARY\`, which is uploaded as an internal artifact not exposed by either:

- \`gh run view <run> --log\` (workflow log)
- \`gh api repos/.../actions/jobs/<id>/logs\` (job logs API)

The step shows up as \`success\` with the inputs visible, but the actual content the script produced is only viewable via the GitHub Actions UI summary panel.

## Change

Switch all \`>> \$GITHUB_STEP_SUMMARY\` redirects to a single \`tee -a "\$GITHUB_STEP_SUMMARY"\` over a grouped block. Output now duplicates to both:

- workflow log (visible from \`gh run view --log\` and the API job logs)
- markdown summary panel (visible in UI, same as before)

No behavioural change otherwise: still \`if: failure()\`, still filtered container logs + direct \`/api/rm/alternatives\` probe + rendered link grep.

## Why this matters

Without log-visible debug, we'd still be hours away from finding the actual cause of the soft-404 smoke failures (today's debug chain : PR #630 → #633 → #636 → this PR). The cost of duplicating output is zero; the cost of having to wait for the next failure and click into the UI is non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)