### PR TITLE
feat(env-contract): enforce SUPABASE_ANON_KEY publishable-shape regex

### DIFF
--- a/backend/src/contract/env-contract/__tests__/preprod.schema.test.ts
+++ b/backend/src/contract/env-contract/__tests__/preprod.schema.test.ts
@@ -1,0 +1,47 @@
+import { PreprodEnvContractSchema } from '../preprod.schema';
+
+const baseEnv = {
+  NODE_ENV: 'preprod',
+  SUPABASE_URL: 'https://cxpojprgwgubzjyqzmoq.supabase.co',
+  SUPABASE_ANON_KEY: 'sb_publishable_pY14nFB7dZsSlEBQ4kdpxQ_4ka_FJqX',
+  JWT_SECRET: 'x'.repeat(32),
+  SESSION_SECRET: 'x'.repeat(32),
+  READ_ONLY: 'true',
+  REDIS_URL: 'redis://redis-preprod:6379',
+};
+
+describe('PreprodEnvContractSchema — SUPABASE_ANON_KEY publishable-shape regex', () => {
+  it('accepts modern publishable key (sb_publishable_…)', () => {
+    expect(PreprodEnvContractSchema.safeParse(baseEnv).success).toBe(true);
+  });
+
+  it('rejects legacy disabled JWT (eyJ… ~200c) — Supabase disabled it 2025', () => {
+    const env = {
+      ...baseEnv,
+      SUPABASE_ANON_KEY:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' + 'a'.repeat(150),
+    };
+    const r = PreprodEnvContractSchema.safeParse(env);
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some((i) => /publishable/i.test(i.message)),
+      ).toBe(true);
+    }
+  });
+
+  it('rejects truncated/short publishable (right prefix but <30c body)', () => {
+    const env = { ...baseEnv, SUPABASE_ANON_KEY: 'sb_publishable_short' };
+    expect(PreprodEnvContractSchema.safeParse(env).success).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    const env = { ...baseEnv, SUPABASE_ANON_KEY: '' };
+    expect(PreprodEnvContractSchema.safeParse(env).success).toBe(false);
+  });
+
+  it('rejects unrelated free-form string', () => {
+    const env = { ...baseEnv, SUPABASE_ANON_KEY: 'some-random-token-without-prefix' };
+    expect(PreprodEnvContractSchema.safeParse(env).success).toBe(false);
+  });
+});

--- a/backend/src/contract/env-contract/__tests__/preprod.schema.test.ts
+++ b/backend/src/contract/env-contract/__tests__/preprod.schema.test.ts
@@ -30,8 +30,26 @@ describe('PreprodEnvContractSchema — SUPABASE_ANON_KEY publishable-shape regex
     }
   });
 
-  it('rejects truncated/short publishable (right prefix but <30c body)', () => {
+  it('rejects truncated/short publishable (right prefix but body <31c)', () => {
     const env = { ...baseEnv, SUPABASE_ANON_KEY: 'sb_publishable_short' };
+    expect(PreprodEnvContractSchema.safeParse(env).success).toBe(false);
+  });
+
+  it('rejects oversized publishable (right prefix but body >31c — drift catch)', () => {
+    const env = {
+      ...baseEnv,
+      // 32-char body — one char too many vs documented spec
+      SUPABASE_ANON_KEY: 'sb_publishable_' + 'a'.repeat(32),
+    };
+    expect(PreprodEnvContractSchema.safeParse(env).success).toBe(false);
+  });
+
+  it('rejects body containing whitespace or invalid chars', () => {
+    const env = {
+      ...baseEnv,
+      // 31 chars total but contains a space
+      SUPABASE_ANON_KEY: 'sb_publishable_' + 'a'.repeat(15) + ' ' + 'b'.repeat(15),
+    };
     expect(PreprodEnvContractSchema.safeParse(env).success).toBe(false);
   });
 

--- a/backend/src/contract/env-contract/__tests__/preprod.schema.test.ts
+++ b/backend/src/contract/env-contract/__tests__/preprod.schema.test.ts
@@ -24,9 +24,9 @@ describe('PreprodEnvContractSchema — SUPABASE_ANON_KEY publishable-shape regex
     const r = PreprodEnvContractSchema.safeParse(env);
     expect(r.success).toBe(false);
     if (!r.success) {
-      expect(
-        r.error.issues.some((i) => /publishable/i.test(i.message)),
-      ).toBe(true);
+      expect(r.error.issues.some((i) => /publishable/i.test(i.message))).toBe(
+        true,
+      );
     }
   });
 
@@ -41,7 +41,10 @@ describe('PreprodEnvContractSchema — SUPABASE_ANON_KEY publishable-shape regex
   });
 
   it('rejects unrelated free-form string', () => {
-    const env = { ...baseEnv, SUPABASE_ANON_KEY: 'some-random-token-without-prefix' };
+    const env = {
+      ...baseEnv,
+      SUPABASE_ANON_KEY: 'some-random-token-without-prefix',
+    };
     expect(PreprodEnvContractSchema.safeParse(env).success).toBe(false);
   });
 });

--- a/backend/src/contract/env-contract/preprod.schema.ts
+++ b/backend/src/contract/env-contract/preprod.schema.ts
@@ -36,21 +36,25 @@ export const PreprodEnvContractSchema = z
   .object({
     NODE_ENV: z.enum(['preprod']),
     SUPABASE_URL: z.string().url(),
-    // Modern Supabase publishable key only : `sb_publishable_<≥30 char body>`.
+    // Modern Supabase publishable key. Documented format
+    // (https://supabase.com/docs/guides/api-keys) :
+    //   `sb_publishable_<22-char-random>_<8-char-checksum>`
+    // Body length is exactly 31 chars after the prefix (22 + 1 separator + 8).
     // The legacy JWT anon (`eyJ…` ~200 chars) is disabled on project
-    // cxpojprgwgubzjyqzmoq since 2025 (confirmed via Supabase MCP
-    // get_publishable_keys: legacy entry has disabled=true). Accepting the
-    // legacy shape was a silent failure mode — schema passed, deploy succeeded,
-    // every RPC then returned 'Invalid API key', and downstream caches poisoned
-    // with empty payloads (incident root cause for run 26104292014, fixed
-    // structurally by PR #637 + this regex).
-    // Backend validation (app.config.ts:67) only requires truthy at runtime ;
-    // preflight remains stricter — typo catch + key-rotation catch.
+    // cxpojprgwgubzjyqzmoq since 2025 (Supabase MCP get_publishable_keys
+    // confirms legacy entry has disabled=true). Accepting the legacy shape
+    // was the silent failure mode behind run 26104292014 — schema passed,
+    // deploy succeeded, every RPC returned 'Invalid API key', caches poisoned
+    // with empty payloads. Fixed structurally by PR #637 + this regex.
+    //
+    // Exact-length regex (not min) so Supabase format drift fails loud at
+    // preflight instead of silently. If Supabase ever publishes a longer
+    // key format, this is the canonical place to update.
     SUPABASE_ANON_KEY: z
       .string()
       .regex(
-        /^sb_publishable_[A-Za-z0-9_-]{30,}$/,
-        'SUPABASE_ANON_KEY must be a Supabase modern publishable key (prefix "sb_publishable_", ≥30 char body). Legacy JWT (eyJ…) format is disabled on project cxpojprgwgubzjyqzmoq — rotate via `gh secret set SUPABASE_ANON_KEY` with the value from Supabase Dashboard → Project Settings → API → Publishable API keys.',
+        /^sb_publishable_[A-Za-z0-9_-]{31}$/,
+        'SUPABASE_ANON_KEY must be a Supabase modern publishable key (`sb_publishable_<22-char-random>_<8-char-checksum>`, 46c total). Legacy JWT (eyJ…) is disabled on project cxpojprgwgubzjyqzmoq — rotate via Supabase Dashboard → Project Settings → API → Publishable API keys, then `gh secret set SUPABASE_ANON_KEY`.',
       ),
     JWT_SECRET: z
       .string()

--- a/backend/src/contract/env-contract/preprod.schema.ts
+++ b/backend/src/contract/env-contract/preprod.schema.ts
@@ -36,11 +36,22 @@ export const PreprodEnvContractSchema = z
   .object({
     NODE_ENV: z.enum(['preprod']),
     SUPABASE_URL: z.string().url(),
-    // 20 chars covers both Supabase key formats :
-    //   - Legacy JWT anon : `eyJ...` ~200 chars (disabled in our project since 2025)
-    //   - Modern publishable : `sb_publishable_<32 random chars>` ~46 chars (currently active key for project cxpojprgwgubzjyqzmoq)
-    // Backend validation (app.config.ts:67) only requires truthy ; preflight remains stricter for protocol-floor + typo catch.
-    SUPABASE_ANON_KEY: z.string().min(20),
+    // Modern Supabase publishable key only : `sb_publishable_<≥30 char body>`.
+    // The legacy JWT anon (`eyJ…` ~200 chars) is disabled on project
+    // cxpojprgwgubzjyqzmoq since 2025 (confirmed via Supabase MCP
+    // get_publishable_keys: legacy entry has disabled=true). Accepting the
+    // legacy shape was a silent failure mode — schema passed, deploy succeeded,
+    // every RPC then returned 'Invalid API key', and downstream caches poisoned
+    // with empty payloads (incident root cause for run 26104292014, fixed
+    // structurally by PR #637 + this regex).
+    // Backend validation (app.config.ts:67) only requires truthy at runtime ;
+    // preflight remains stricter — typo catch + key-rotation catch.
+    SUPABASE_ANON_KEY: z
+      .string()
+      .regex(
+        /^sb_publishable_[A-Za-z0-9_-]{30,}$/,
+        'SUPABASE_ANON_KEY must be a Supabase modern publishable key (prefix "sb_publishable_", ≥30 char body). Legacy JWT (eyJ…) format is disabled on project cxpojprgwgubzjyqzmoq — rotate via `gh secret set SUPABASE_ANON_KEY` with the value from Supabase Dashboard → Project Settings → API → Publishable API keys.',
+      ),
     JWT_SECRET: z
       .string()
       .min(32, 'JWT_SECRET must be >= 32 chars (HS256 / NIST 2026 guidance)'),

--- a/log.md
+++ b/log.md
@@ -849,3 +849,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/preprod-env-contract-preflight`
 - **Décision** : style(env-contract): apply prettier (CI lint fix) (+3 other commits)
 - **Sortie** : PR #632 | commits 22cd9867e 690c78525 eacfdcbe3 fbc50be95
+
+## 2026-05-19 — feat/env-contract-publishable-regex (auto)
+
+- **Branche** : `feat/env-contract-publishable-regex`
+- **Décision** : style(env-contract): prettier autofix on schema test (CI lint) (+1 other commit)
+- **Sortie** : PR #641 | commits 95ac8f099 c572bf94b


### PR DESCRIPTION
## Why

The preprod env contract Zod schema (PR #635) accepted `SUPABASE_ANON_KEY` with `min(20)` — non-discriminant.

Both shapes pass `min(20)` :
- Modern publishable (`sb_publishable_pY14nFB7dZsSlEBQ4kdpxQ_4ka_FJqX`, 46c, **active**)
- Legacy JWT (`eyJ…`, ~200c, **disabled** on project `cxpojprgwgubzjyqzmoq` since 2025)

Source : Supabase MCP `get_publishable_keys` for project — legacy entry has `disabled=true`.

The non-discrimination was the silent failure mode behind run `26104292014` (5/5 fixtures fail "Aucun lien profond") that PR #637 had to recover from at the cache layer. This PR closes the failure at the **preflight** layer — fail-fast before `docker compose up`, before cache poisoning, before smoke red.

## What

`backend/src/contract/env-contract/preprod.schema.ts` :

```diff
-SUPABASE_ANON_KEY: z.string().min(20),
+SUPABASE_ANON_KEY: z.string().regex(
+  /^sb_publishable_[A-Za-z0-9_-]{30,}$/,
+  'SUPABASE_ANON_KEY must be a Supabase modern publishable key (prefix "sb_publishable_", ≥30 char body). Legacy JWT (eyJ…) format is disabled on project cxpojprgwgubzjyqzmoq — rotate via `gh secret set SUPABASE_ANON_KEY` with the value from Supabase Dashboard → Project Settings → API → Publishable API keys.',
+),
```

5 Jest invariants in `backend/src/contract/env-contract/__tests__/preprod.schema.test.ts` :

- accepts modern publishable
- rejects legacy disabled JWT
- rejects truncated publishable (right prefix, body <30c)
- rejects empty string
- rejects unrelated free-form string

## Test plan

- [x] Jest 5/5 PASS local : `npx jest src/contract/env-contract/__tests__/preprod.schema.test.ts`
- [ ] CI green on this PR
- [ ] Preflight step still `✓ Preflight env contract OK` on next preprod deploy (the rotated secret is the active publishable)

## Sequencing

Part of the 4-PR Supabase auth contract hardening :
- **PR-A (this)** schema regex
- PR-B preflight HTTP live-probe (catches right-shape-but-Supabase-disabled key)
- PR-C dynamic DB-derived soft-404 smoke
- PR-D consolidates `CACHE_TTL_ERROR_SECONDS` from PR #637 into typed constants module

Plan : `/home/deploy/.claude/plans/superpower-et-verifier-existant-melodic-lagoon.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)