### PR TITLE
feat(rm): hoist soft-404 cache constants + declarative TTL invariants

### DIFF
--- a/backend/src/modules/rm/services/__tests__/soft-404-cache.constants.test.ts
+++ b/backend/src/modules/rm/services/__tests__/soft-404-cache.constants.test.ts
@@ -1,0 +1,37 @@
+import {
+  CACHE_TTL_SOFT_404_ERROR_SECONDS,
+  CACHE_TTL_SOFT_404_SUCCESS_SECONDS,
+  CACHE_KEY_PREFIX_SOFT_404,
+  CACHE_KEY_VERSION_SOFT_404,
+} from '../soft-404-cache.constants';
+
+/**
+ * Declarative invariants for the soft-404 cache discipline.
+ *
+ * If any of these break, the regression detected by run 26104292014
+ * (5min poisoning of empty payloads under a rotated Supabase key) can
+ * recur. Treat as load-bearing.
+ */
+describe('soft-404 cache constants — invariants', () => {
+  it('error TTL is ≤ 30 seconds (no long-TTL poisoning on error path)', () => {
+    expect(CACHE_TTL_SOFT_404_ERROR_SECONDS).toBeLessThanOrEqual(30);
+  });
+
+  it('success TTL is strictly greater than error TTL', () => {
+    expect(CACHE_TTL_SOFT_404_SUCCESS_SECONDS).toBeGreaterThan(
+      CACHE_TTL_SOFT_404_ERROR_SECONDS,
+    );
+  });
+
+  it('error TTL is strictly positive (no caching at all would be cheaper than 0s)', () => {
+    expect(CACHE_TTL_SOFT_404_ERROR_SECONDS).toBeGreaterThan(0);
+  });
+
+  it('cache key prefix is the canonical `alt` namespace', () => {
+    expect(CACHE_KEY_PREFIX_SOFT_404).toBe('alt');
+  });
+
+  it('cache key version is a non-empty short tag', () => {
+    expect(CACHE_KEY_VERSION_SOFT_404).toMatch(/^v\d+$/);
+  });
+});

--- a/backend/src/modules/rm/services/rm-alternatives.service.ts
+++ b/backend/src/modules/rm/services/rm-alternatives.service.ts
@@ -4,20 +4,12 @@ import { createHash } from 'node:crypto';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { CacheService } from '@cache/cache.service';
 import type { AlternativesV2Response } from '../dto/alternatives-v2.dto';
-
-const CACHE_TTL_SECONDS = 300;
-// Error-path TTL kept low so a transient RPC failure does not poison the cache
-// for 5 minutes. Long-TTL caching of empty responses was the amplifier behind
-// the soft-404 R2 smoke regression detected 2026-05-19 (stale anon publishable
-// key → 'Invalid API key' on every RPC → 300s cache of [] → 5min false-empty).
-const CACHE_TTL_ERROR_SECONDS = 30;
-const CACHE_KEY_PREFIX = 'alt';
-// v1 → v2 (PR #633) : reset stale empty entries from the .from() RLS-bypass era.
-// v2 → v3 (2026-05-19) : reset stale empty entries from the rotated-publishable-key
-// era (preprod ANON_KEY rotated by Supabase but GitHub secret not synced — every RPC
-// returned 'Invalid API key', cached as empty for 5min). Pair with the short
-// CACHE_TTL_ERROR_SECONDS above to prevent the next rotation from repeating this.
-const CACHE_KEY_VERSION = 'v3';
+import {
+  CACHE_TTL_SOFT_404_SUCCESS_SECONDS,
+  CACHE_TTL_SOFT_404_ERROR_SECONDS,
+  CACHE_KEY_PREFIX_SOFT_404,
+  CACHE_KEY_VERSION_SOFT_404,
+} from './soft-404-cache.constants';
 
 interface RpcPayload {
   alternativeVehicles: unknown[];
@@ -54,7 +46,7 @@ export class RmAlternativesService extends SupabaseBaseService {
     pg_id: number,
     limit: number,
   ): Promise<AlternativesV2Response> {
-    const cacheKey = `${CACHE_KEY_PREFIX}:${type_id}:${pg_id}:${CACHE_KEY_VERSION}`;
+    const cacheKey = `${CACHE_KEY_PREFIX_SOFT_404}:${type_id}:${pg_id}:${CACHE_KEY_VERSION_SOFT_404}`;
 
     const cached = await this.cache.get(cacheKey);
     if (cached) {
@@ -101,13 +93,17 @@ export class RmAlternativesService extends SupabaseBaseService {
       await this.cache.set(
         cacheKey,
         JSON.stringify(empty),
-        CACHE_TTL_ERROR_SECONDS,
+        CACHE_TTL_SOFT_404_ERROR_SECONDS,
       );
       return empty;
     }
 
     const response = this.buildResponse(data);
-    await this.cache.set(cacheKey, JSON.stringify(response), CACHE_TTL_SECONDS);
+    await this.cache.set(
+      cacheKey,
+      JSON.stringify(response),
+      CACHE_TTL_SOFT_404_SUCCESS_SECONDS,
+    );
     return response;
   }
 

--- a/backend/src/modules/rm/services/soft-404-cache.constants.ts
+++ b/backend/src/modules/rm/services/soft-404-cache.constants.ts
@@ -1,0 +1,45 @@
+/**
+ * Typed cache constants for `RmAlternativesService` (soft-404 R2 alternatives).
+ *
+ * Hoisted from `rm-alternatives.service.ts` to make the cache discipline
+ * declarative and invariant-testable.
+ *
+ * Failure modes these constants prevent :
+ *
+ *   1. **Long-TTL poisoning of empty payloads** (incident 2026-05-19,
+ *      run 26104292014). When the upstream Supabase key was rotated but the
+ *      deployment secret was not, every RPC returned `Invalid API key`, the
+ *      service caught the error, returned an empty payload, and cached it
+ *      for 5 min. Recovery was unbounded until the secret was re-synced.
+ *      Fix : error/empty path uses `CACHE_TTL_ERROR_SECONDS` (≤30s).
+ *
+ *   2. **Cache-key reuse across breaking changes**. `CACHE_KEY_VERSION` is a
+ *      one-time reset knob ; bumping it invalidates every key under the
+ *      previous version. v1 → v2 was PR #633, v2 → v3 was PR #637.
+ *
+ * Linked memory : `feedback_no_long_ttl_cache_on_error_paths` — never cache
+ * an error/empty result at the same TTL as a success result.
+ */
+
+/** Success-path TTL : 5 min. Free to tune up to hours. */
+export const CACHE_TTL_SOFT_404_SUCCESS_SECONDS = 300;
+
+/**
+ * Error / empty-payload TTL : 30 s. **Invariant ≤ 30 s** — see file header.
+ * Tuning this above 30 s is a regression and the invariant test will fail.
+ */
+export const CACHE_TTL_SOFT_404_ERROR_SECONDS = 30;
+
+/**
+ * Cache-key namespace prefix. Stable across versions ; the version suffix
+ * isolates breaking changes.
+ */
+export const CACHE_KEY_PREFIX_SOFT_404 = 'alt';
+
+/**
+ * Cache-key version. Bump when the cached payload shape changes OR to flush
+ * all entries (e.g. recovery from a poisoning event). History :
+ *   - v1 → v2 (PR #633) : reset stale empties from the `.from()` era.
+ *   - v2 → v3 (PR #637) : reset stale empties from the rotated-anon-key era.
+ */
+export const CACHE_KEY_VERSION_SOFT_404 = 'v3';


### PR DESCRIPTION
## Why

PR #637 (33adc308a) added `CACHE_TTL_ERROR_SECONDS=30` and `CACHE_KEY_VERSION='v3'` as file-local consts inside `rm-alternatives.service.ts`. That fixed the live incident (300s poisoning of empty payloads under rotated anon key), but the **rule** behind it — _never cache an error/empty result at the same TTL as a success result_, cf. memory `feedback_no_long_ttl_cache_on_error_paths` — was buried in code review and a single mock assertion (`expect(cacheMock.set).toHaveBeenCalledWith(..., 30)`).

A future engineer tuning TTL for performance reasons could easily raise the error TTL past 30s — the existing test would need to be updated alongside, but nothing prevents it from being updated mistakenly. That's how poisoning regressions recur.

## What

- Extracts the 4 cache constants into `backend/src/modules/rm/services/soft-404-cache.constants.ts` with the full failure-mode rationale inline (incident reference, key-version history).
- Adds 5 declarative invariants in `__tests__/soft-404-cache.constants.test.ts` :
  - error TTL ≤ 30s
  - success TTL > error TTL
  - error TTL > 0
  - prefix is canonical \`alt\`
  - version matches \`^v\\d+\$\`
- Refactors `rm-alternatives.service.ts` to import from the new module. **No behavior change** — exact same TTLs, exact same key shape. Existing PR #637 test (`alt:11836:3859:v3` + TTL=30) still passes.

## Test plan

- [x] Jest `rm-alternatives.service.test.ts` : 8/8 PASS (PR #637 tests unchanged)
- [x] Jest `soft-404-cache.constants.test.ts` : 5/5 PASS (new invariants)
- [ ] CI green on this PR

## Sequencing

Part of the 4-PR Supabase auth contract hardening :
- PR-A #641 schema regex (auto-merge enabled)
- PR-B preflight HTTP live-probe
- PR-C dynamic DB-derived soft-404 smoke
- **PR-D (this)** declarative TTL invariants

Plan : `/home/deploy/.claude/plans/superpower-et-verifier-existant-melodic-lagoon.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)