### PR TITLE
feat(commerce-loop): merchant center xml feed v1 (step 5B)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -333,6 +333,16 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: high
+  - glob: backend/src/modules/merchant-center/**
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
+  - glob: backend/supabase/migrations/*merchant_center_feed*
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/supabase/migrations/*seo_snapshot*
     domain: D3
     owner: '@ak125/seo-team'

--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 176,
+  "total": 177,
   "functions": [
     {
       "name": "__gov_m1_table_sizes",
@@ -403,6 +403,11 @@
       "name": "get_mandatory_fields",
       "volatility": "STABLE",
       "reason": "SELECT only"
+    },
+    {
+      "name": "get_merchant_center_feed_v1",
+      "volatility": "STABLE",
+      "reason": "PR commerce-loop V1 step 5B — Google Shopping XML feed rows. STABLE pure SELECT joins pieces × price × gamme × marque × media_img. Called by MerchantCenterFeedService.fetchPage (pagination). GRANT EXECUTE service_role only."
     },
     {
       "name": "get_missing_v4_type_ids",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -36,6 +36,7 @@ import { InvoicesModule } from './modules/invoices/invoices.module'; // 🧾 NOU
 import { SeoModule } from './modules/seo/seo.module'; // 🔍 NOUVEAU - Module SEO avec services intégrés !
 import { SeoMonitoringModule } from './modules/seo-monitoring/seo-monitoring.module'; // 📊 Phase 1 — Observability GSC/GA4/CWV daily ingestion
 import { SeoControlPlaneModule } from './modules/seo-control-plane/seo-control-plane.module'; // 🤖 ADR-064 — SEO Production Control Plane (L1 synthetic crawler q15min)
+import { MerchantCenterModule } from './modules/merchant-center/merchant-center.module'; // 🛒 PR commerce-loop V1 step 5B — Google Shopping XML feed
 import { SearchModule } from './modules/search/search.module'; // 🔍 NOUVEAU - Module de recherche optimisé v3.0 !
 import { SystemModule } from './modules/system/system.module'; // ⚡ NOUVEAU - Module system monitoring !
 import { BlogModule } from './modules/blog/blog.module'; // 📚 NOUVEAU - Module blog avec tables __blog_* intégrées !
@@ -198,6 +199,7 @@ import { DiagnosticEngineModule } from './modules/diagnostic-engine/diagnostic-e
     SeoModule, // 🔍 NOUVEAU - Module SEO avec SeoService et SitemapService !
     SeoMonitoringModule, // 📊 Phase 1 — Observability GSC/GA4/CWV daily ingestion (cf. ADR-025)
     SeoControlPlaneModule, // 🤖 ADR-064 — SEO Production Control Plane (L1 synthetic crawler q15min)
+    MerchantCenterModule, // 🛒 PR commerce-loop V1 step 5B — Google Shopping XML feed /api/feed/merchant-center.xml
     SearchModule, // 🔍 NOUVEAU - Module de recherche optimisé v3.0 avec Meilisearch !
     BlogModule, // 📚 NOUVEAU - Module blog avec conseils, guides et glossaire intégrés !
     SystemModule, // ⚡ NOUVEAU - Module system monitoring et métriques !

--- a/backend/src/modules/merchant-center/controllers/merchant-center.controller.ts
+++ b/backend/src/modules/merchant-center/controllers/merchant-center.controller.ts
@@ -1,0 +1,105 @@
+/**
+ * MerchantCenterController — Google Shopping XML feed endpoint.
+ *
+ * GET /api/feed/merchant-center.xml
+ *   Streams RSS 2.0 with `g:*` Google Shopping namespace.
+ *   Pages 1000 items per RPC call ; cache-friendly `s-maxage=14400` (4h).
+ *
+ * Per Google Shopping spec : 1 <item> per piece, mandatory fields g:id, g:title,
+ * g:description, g:link, g:image_link, g:availability, g:price, g:brand,
+ * g:gtin OR g:mpn, g:condition. Optional g:product_type (drives category in GMC).
+ *
+ * V1 scope :
+ *   - No __merchant_center_feed_log table (V1.5+)
+ *   - No GH workflow (GMC pulls the URL directly per its schedule)
+ *   - No item_group_id (V1.5+ for variants)
+ *
+ * Refs :
+ *   - migration 20260519_merchant_center_feed_v1.sql
+ *   - plan superpower-1-d-abord-proud-cookie.md step 5B
+ */
+import { Controller, Get, Header, Logger, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import {
+  MerchantCenterFeedRow,
+  MerchantCenterFeedService,
+} from '../services/merchant-center-feed.service';
+
+@Controller('feed')
+export class MerchantCenterController {
+  private readonly logger = new Logger(MerchantCenterController.name);
+
+  constructor(private readonly feedService: MerchantCenterFeedService) {}
+
+  @Get('merchant-center.xml')
+  @Header('Content-Type', 'application/xml; charset=utf-8')
+  @Header('Cache-Control', 'public, max-age=3600, s-maxage=14400')
+  async stream(@Res() res: Response): Promise<void> {
+    const startedAt = Date.now();
+
+    res.write('<?xml version="1.0" encoding="UTF-8"?>\n');
+    res.write('<rss version="2.0" xmlns:g="http://base.google.com/ns/1.0">\n');
+    res.write('  <channel>\n');
+    res.write('    <title>AutoMecanik — Pièces auto</title>\n');
+    res.write('    <link>https://www.automecanik.com</link>\n');
+    res.write(
+      '    <description>Catalogue Google Shopping AutoMecanik (pièces détachées automobile, équipementiers OE)</description>\n',
+    );
+
+    let offset = 0;
+    let total = 0;
+
+    while (true) {
+      const batch = await this.feedService.fetchPage(offset);
+      if (batch.length === 0) break;
+
+      for (const row of batch) {
+        res.write(renderItemXml(row));
+      }
+
+      total += batch.length;
+      offset += batch.length;
+
+      if (batch.length < MerchantCenterFeedService.PAGE_SIZE) break;
+    }
+
+    res.write('  </channel>\n');
+    res.write('</rss>\n');
+    res.end();
+
+    this.logger.log(
+      `Streamed ${total} items in ${Date.now() - startedAt}ms (offset=${offset})`,
+    );
+  }
+}
+
+function xmlEscape(value: string | null | undefined): string {
+  if (!value) return '';
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function renderItemXml(row: MerchantCenterFeedRow): string {
+  const identityTag = row.gtin
+    ? `<g:gtin>${xmlEscape(row.gtin)}</g:gtin>`
+    : `<g:mpn>${xmlEscape(row.mpn)}</g:mpn>`;
+
+  return `    <item>
+      <g:id>${xmlEscape(row.id)}</g:id>
+      <g:title>${xmlEscape(row.title)}</g:title>
+      <g:description>${xmlEscape(row.description)}</g:description>
+      <g:link>${xmlEscape(row.link)}</g:link>
+      <g:image_link>${xmlEscape(row.image_link)}</g:image_link>
+      <g:availability>${xmlEscape(row.availability)}</g:availability>
+      <g:price>${xmlEscape(row.price)}</g:price>
+      <g:brand>${xmlEscape(row.brand)}</g:brand>
+      ${identityTag}
+      <g:product_type>${xmlEscape(row.product_type)}</g:product_type>
+      <g:condition>${xmlEscape(row.condition)}</g:condition>
+    </item>
+`;
+}

--- a/backend/src/modules/merchant-center/merchant-center.module.ts
+++ b/backend/src/modules/merchant-center/merchant-center.module.ts
@@ -1,0 +1,20 @@
+/**
+ * MerchantCenterModule — Google Shopping XML feed.
+ *
+ * Wires up the public `/api/feed/merchant-center.xml` endpoint.
+ * GMC fetches the URL directly per its own schedule (default daily).
+ *
+ * Plan ref : superpower-1-d-abord-proud-cookie.md step 5B.
+ */
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { MerchantCenterController } from './controllers/merchant-center.controller';
+import { MerchantCenterFeedService } from './services/merchant-center-feed.service';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [MerchantCenterController],
+  providers: [MerchantCenterFeedService],
+  exports: [MerchantCenterFeedService],
+})
+export class MerchantCenterModule {}

--- a/backend/src/modules/merchant-center/services/merchant-center-feed.service.ts
+++ b/backend/src/modules/merchant-center/services/merchant-center-feed.service.ts
@@ -1,0 +1,50 @@
+/**
+ * MerchantCenterFeedService — Google Shopping XML feed source.
+ *
+ * Calls `get_merchant_center_feed_v1` RPC (STABLE, GRANT EXECUTE service_role
+ * only — cf governance/rpc/rpc_allowlist.json). Pagination via p_limit/p_offset.
+ *
+ * Canon : `extends SupabaseBaseService` + `this.callRpc()` (203 services
+ * monorepo pattern). Rejects raw `.from()` SELECTs.
+ *
+ * Refs :
+ *   - migration 20260519_merchant_center_feed_v1.sql
+ *   - PR commerce-loop V1 step 5B (plan superpower-1-d-abord-proud-cookie.md)
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
+
+export interface MerchantCenterFeedRow {
+  id: string;
+  title: string;
+  description: string;
+  link: string;
+  image_link: string;
+  availability: 'in_stock' | 'preorder' | 'out_of_stock';
+  price: string;
+  brand: string;
+  gtin: string | null;
+  mpn: string;
+  product_type: string;
+  condition: 'new';
+}
+
+@Injectable()
+export class MerchantCenterFeedService extends SupabaseBaseService {
+  protected override readonly logger = new Logger(
+    MerchantCenterFeedService.name,
+  );
+
+  static readonly PAGE_SIZE = 1000;
+
+  async fetchPage(
+    offset: number,
+    limit: number = MerchantCenterFeedService.PAGE_SIZE,
+  ): Promise<MerchantCenterFeedRow[]> {
+    const result = await this.callRpc<MerchantCenterFeedRow[]>(
+      'get_merchant_center_feed_v1',
+      { p_limit: limit, p_offset: offset },
+    );
+    return result ?? [];
+  }
+}

--- a/backend/src/modules/merchant-center/services/merchant-center-feed.service.ts
+++ b/backend/src/modules/merchant-center/services/merchant-center-feed.service.ts
@@ -41,10 +41,16 @@ export class MerchantCenterFeedService extends SupabaseBaseService {
     offset: number,
     limit: number = MerchantCenterFeedService.PAGE_SIZE,
   ): Promise<MerchantCenterFeedRow[]> {
-    const result = await this.callRpc<MerchantCenterFeedRow[]>(
+    const { data, error } = await this.callRpc<MerchantCenterFeedRow[]>(
       'get_merchant_center_feed_v1',
       { p_limit: limit, p_offset: offset },
     );
-    return result ?? [];
+    if (error) {
+      this.logger.error(
+        `get_merchant_center_feed_v1 failed at offset=${offset}: ${error.message}`,
+      );
+      throw error;
+    }
+    return data ?? [];
   }
 }

--- a/backend/supabase/migrations/20260519_merchant_center_feed_v1.sql
+++ b/backend/supabase/migrations/20260519_merchant_center_feed_v1.sql
@@ -1,0 +1,135 @@
+-- =====================================================
+-- PR commerce-loop V1 step 5B — Google Merchant Center XML feed RPC
+-- Date: 2026-05-19
+-- Refs: /home/deploy/.claude/plans/superpower-1-d-abord-proud-cookie.md (step 5B)
+--       project_commerce_loop_v1_plan_20260519
+-- =====================================================
+--
+-- get_merchant_center_feed_v1(p_limit, p_offset)
+-- ----------------------------------------------
+-- Streams piece rows ready for Google Shopping XML feed (g:* namespace).
+-- Each row maps 1:1 to a <item> element in the RSS 2.0 output.
+--
+-- Filters (canonical e-commerce eligibility) :
+--   - piece_display = '1'             (visible in catalog)
+--   - pmi_display IS DISTINCT FROM '0' (image available)
+--   - pri_dispo IN ('1', '3')          (in_stock OR preorder ; '0' excluded)
+--   - pri_vente_ttc > 0                (real selling price)
+--   - pm_display = '1'                 (brand visible)
+--   - pg_display = '1'                 (gamme visible)
+--
+-- Source canon :
+--   - pieces, pieces_price, pieces_gamme, pieces_marque, pieces_media_img
+--     (cf canonical.json domain D7 catalog ; URLs via SITE_ORIGIN canon).
+--   - R1 URL pattern : /pieces/{pg_alias}-{pg_id}.html (cf pieces.$slug.tsx)
+--   - Image URL pattern : https://www.automecanik.com/img/rack-images/{folder}/{name}
+--     (cf frontend/app/utils/image-optimizer.ts RACK_IMAGES bucket).
+--
+-- V1 scope (V1.5+ deferred) :
+--   - SHIP_TO_FR + free shipping default → see frontend pieces-schema-commerce.constants
+--   - One feed item per piece (no vehicle compatibility split → V1.5+ if needed)
+--   - g:link = R1 gamme URL (universal landing) ; V1.5+ deep-link with #piece-{id}
+--   - g:gtin from pri_ean when ≥ 8 digits ; else g:mpn = piece_ref
+--   - No item_group_id (V1.5+ for variants)
+-- =====================================================
+
+set lock_timeout = '2s';
+set statement_timeout = '30s';
+
+CREATE OR REPLACE FUNCTION get_merchant_center_feed_v1(
+  p_limit INT DEFAULT 1000,
+  p_offset INT DEFAULT 0
+) RETURNS TABLE (
+  id TEXT,
+  title TEXT,
+  description TEXT,
+  link TEXT,
+  image_link TEXT,
+  availability TEXT,
+  price TEXT,
+  brand TEXT,
+  gtin TEXT,
+  mpn TEXT,
+  product_type TEXT,
+  condition TEXT
+) LANGUAGE sql STABLE AS $$
+  WITH primary_image AS (
+    -- One image per piece (lowest sort = primary)
+    SELECT DISTINCT ON (pmi_piece_id_i)
+      pmi_piece_id_i AS piece_id_i,
+      pmi_folder,
+      pmi_name
+    FROM public.pieces_media_img
+    WHERE COALESCE(pmi_display, '1') <> '0'
+      AND pmi_folder IS NOT NULL AND pmi_folder <> ''
+      AND pmi_name IS NOT NULL AND pmi_name <> ''
+    ORDER BY pmi_piece_id_i, COALESCE(NULLIF(pmi_sort, '')::INT, 999) ASC
+  ),
+  primary_ean AS (
+    -- Pick first valid EAN per piece (length ≥ 8 digits)
+    SELECT DISTINCT ON (pri_piece_id_i)
+      pri_piece_id_i AS piece_id_i,
+      pri_ean,
+      pri_vente_ttc::NUMERIC AS price_ttc,
+      pri_dispo
+    FROM public.pieces_price
+    WHERE pri_dispo IN ('1', '3')
+      AND pri_vente_ttc IS NOT NULL
+      AND pri_vente_ttc <> ''
+      AND NULLIF(pri_vente_ttc, '')::NUMERIC > 0
+    ORDER BY pri_piece_id_i, pri_vente_ttc::NUMERIC ASC
+  )
+  SELECT
+    p.piece_id::TEXT AS id,
+    LEFT(
+      g.pg_name || ' ' || COALESCE(m.pm_name, '') || ' ' || COALESCE(p.piece_name, '')
+        || COALESCE(' ' || NULLIF(p.piece_name_side, ''), ''),
+      150
+    ) AS title,
+    LEFT(
+      COALESCE(p.piece_des, '')
+        || ' — ' || g.pg_name || ' '
+        || COALESCE(m.pm_name, '') || ' référence ' || p.piece_ref,
+      5000
+    ) AS description,
+    'https://www.automecanik.com/pieces/' || g.pg_alias || '-' || g.pg_id || '.html' AS link,
+    'https://www.automecanik.com/img/rack-images/'
+      || pi.pmi_folder || '/' || pi.pmi_name AS image_link,
+    CASE pe.pri_dispo
+      WHEN '1' THEN 'in_stock'
+      WHEN '3' THEN 'preorder'
+      ELSE 'out_of_stock'
+    END AS availability,
+    ROUND(pe.price_ttc, 2)::TEXT || ' EUR' AS price,
+    m.pm_name AS brand,
+    CASE
+      WHEN pe.pri_ean IS NOT NULL
+        AND pe.pri_ean ~ '^[0-9]{8,14}$'
+      THEN pe.pri_ean
+      ELSE NULL
+    END AS gtin,
+    p.piece_ref AS mpn,
+    g.pg_name AS product_type,
+    'new'::TEXT AS condition
+  FROM public.pieces p
+  INNER JOIN public.pieces_gamme g
+    ON g.pg_id::TEXT = p.piece_pg_id
+    AND COALESCE(g.pg_display, '1') = '1'
+  INNER JOIN public.pieces_marque m
+    ON m.pm_id::TEXT = p.piece_pm_id
+    AND COALESCE(m.pm_display, '1') = '1'
+  INNER JOIN primary_image pi
+    ON pi.piece_id_i = p.piece_id::INT
+  INNER JOIN primary_ean pe
+    ON pe.piece_id_i = p.piece_id::INT
+  WHERE COALESCE(p.piece_display, '1') = '1'
+  ORDER BY p.piece_id
+  LIMIT p_limit
+  OFFSET p_offset;
+$$;
+
+COMMENT ON FUNCTION get_merchant_center_feed_v1(INT, INT) IS
+  'PR commerce-loop V1 step 5B — Streams piece rows for Google Shopping XML feed (g:* namespace). 1 row = 1 <item>. Pagination via p_limit/p_offset. STABLE pure read. GRANT EXECUTE TO service_role only.';
+
+REVOKE ALL ON FUNCTION get_merchant_center_feed_v1(INT, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_merchant_center_feed_v1(INT, INT) TO service_role;


### PR DESCRIPTION
## Pourquoi

Étape 5B du plan commerce-loop V1 (`/home/deploy/.claude/plans/superpower-1-d-abord-proud-cookie.md`). Compagnon de l'étape 5A (PR #640 merged) : Google Shopping = canal d'acquisition direct + rich snippets SERP. Sans feed Merchant Center, on rate 30-50% de la SERP commerciale automobile.

## Quoi (V1 minimal)

### Migration `20260519_merchant_center_feed_v1.sql`

RPC `get_merchant_center_feed_v1(p_limit, p_offset)` :
- STABLE pure SELECT joins `pieces × pieces_price × pieces_gamme × pieces_marque × pieces_media_img`
- Filtres canon : `piece_display='1' · pri_dispo IN ('1','3') · pri_vente_ttc > 0 · pm_display · pg_display · pmi_folder/name NOT NULL`
- Mapping `pri_dispo` : `1→in_stock · 3→preorder · 0` exclu
- GTIN-13 via `pri_ean` regex `[0-9]{8,14}` ; fallback `g:mpn = piece_ref`
- URL canon : `R1 /pieces/{pg_alias}-{pg_id}.html` (matches `pieces.$slug.tsx`)
- Image canon : `https://www.automecanik.com/img/rack-images/{folder}/{name}` (RACK_IMAGES bucket)
- `GRANT EXECUTE TO service_role` only

### Backend NestJS

`backend/src/modules/merchant-center/` :
- `MerchantCenterFeedService extends SupabaseBaseService` — canon `callRpc()` pagination 1000 items/page
- `MerchantCenterController` GET `/api/feed/merchant-center.xml` — streaming chunked RSS 2.0 namespace `g:`, `Cache-Control: public, s-maxage=14400` (4h CDN)
- `MerchantCenterModule` wired into `app.module.ts` après `SeoControlPlaneModule`

### Governance

- `rpc_allowlist.json` : entry `get_merchant_center_feed_v1` STABLE (176 → 177)
- `ownership.yaml` : 2 globs D3 seo-team

## V1 scope (V1.5+ deferred)

- ❌ `__merchant_center_feed_log` table (export history + delta)
- ❌ GitHub workflow daily push (GMC pulls la URL directement)
- ❌ `item_group_id` variant grouping
- ❌ Per-item `g:shipping` / `g:return_policy` (GMC account global settings)

## Anti-régression

- ✅ `feedback_verify_existing_first` : reuse RACK_IMAGES bucket pattern + R1 URL canon + SupabaseBaseService pattern
- ✅ `feedback_no_bricolage_escalate_to_industry_standard` : canonical Google Shopping XML feed RSS 2.0 + g:* namespace
- ✅ `feedback_supabase_grant_explicit_for_new_projects` : REVOKE PUBLIC + GRANT service_role
- ✅ `feedback_no_url_changes_ever` : aucune URL/slug modifié (additif endpoint)
- ✅ `feedback_v1_first_dont_build_ultimate_engine_too_early` : V1 minimal, V1.5+ explicit defer
- ✅ canon pattern `extends SupabaseBaseService` + `callRpc()` (203 services)

## Post-merge apply

Migration appliquée via Supabase MCP `apply_migration` avec **GO textuel utilisateur** (canon `feedback_sandbox_destructive_actions`).

## Test plan

- Smoke local : `curl http://localhost:3000/api/feed/merchant-center.xml | head -50`
- Vérifier structure : `<?xml` + `<rss xmlns:g>` + `<channel>` + `<item><g:id>...` + valid close tags
- Vérifier 1+ item présent avec g:gtin OU g:mpn
- Post-merge : créer Merchant Center account + ajouter feed URL ; vérifier ≥80% items indexés sous 30j

## Refs

- Plan : `/home/deploy/.claude/plans/superpower-1-d-abord-proud-cookie.md` étape 5B
- Étape 5A compagnon : PR #640 (merged)
- Google docs : https://support.google.com/merchants/answer/7052112 (feed XML)
- Project memory : `project_commerce_loop_v1_plan_20260519`

🤖 Generated with [Claude Code](https://claude.com/claude-code)