### PR TITLE
fix(merchant-center): realign migration SQL types with deployed canon

### DIFF
--- a/backend/supabase/migrations/20260519_merchant_center_feed_v1.sql
+++ b/backend/supabase/migrations/20260519_merchant_center_feed_v1.sql
@@ -92,7 +92,7 @@ CREATE OR REPLACE FUNCTION get_merchant_center_feed_v1(
         || COALESCE(m.pm_name, '') || ' référence ' || p.piece_ref,
       5000
     ) AS description,
-    'https://www.automecanik.com/pieces/' || g.pg_alias || '-' || g.pg_id || '.html' AS link,
+    'https://www.automecanik.com/pieces/' || g.pg_alias || '-' || g.pg_id::TEXT || '.html' AS link,
     'https://www.automecanik.com/img/rack-images/'
       || pi.pmi_folder || '/' || pi.pmi_name AS image_link,
     CASE pe.pri_dispo
@@ -113,16 +113,16 @@ CREATE OR REPLACE FUNCTION get_merchant_center_feed_v1(
     'new'::TEXT AS condition
   FROM public.pieces p
   INNER JOIN public.pieces_gamme g
-    ON g.pg_id::TEXT = p.piece_pg_id
+    ON g.pg_id = p.piece_pg_id
     AND COALESCE(g.pg_display, '1') = '1'
   INNER JOIN public.pieces_marque m
-    ON m.pm_id::TEXT = p.piece_pm_id
+    ON m.pm_id = p.piece_pm_id
     AND COALESCE(m.pm_display, '1') = '1'
   INNER JOIN primary_image pi
-    ON pi.piece_id_i = p.piece_id::INT
+    ON pi.piece_id_i = p.piece_id
   INNER JOIN primary_ean pe
-    ON pe.piece_id_i = p.piece_id::INT
-  WHERE COALESCE(p.piece_display, '1') = '1'
+    ON pe.piece_id_i = p.piece_id
+  WHERE p.piece_display = true
   ORDER BY p.piece_id
   LIMIT p_limit
   OFFSET p_offset;


### PR DESCRIPTION
## Pourquoi

PR #644 a shippé la migration `20260519_merchant_center_feed_v1.sql` avec des type casts incorrects qui font échouer `apply_migration` :
\`\`\`
ERROR: operator does not exist: text = integer
\`\`\`

Le RPC déployé sur Supabase (`cxpojprgwgubzjyqzmoq`) a été appliqué post-merge avec des casts corrigés (3 itérations diagnostic). Le source file diverge donc du canon déployé : si quelqu'un re-applique la migration depuis le repo, ça échoue.

## Réalité du schéma (vérifié via `information_schema.columns`)

| Colonne | Type réel | Attendu source #644 |
|---|---|---|
| `pieces.piece_id` | INTEGER | TEXT (faux) |
| `pieces.piece_pg_id` | INTEGER | TEXT (faux) |
| `pieces.piece_pm_id` | SMALLINT | TEXT (faux) |
| `pieces.piece_display` | BOOLEAN | TEXT (faux, comparé à `'1'`) |
| `pieces_gamme.pg_id` | INTEGER | TEXT (faux) |
| `pieces_marque.pm_id` | INTEGER | TEXT (faux) |
| `pieces_media_img.pmi_piece_id_i` | INTEGER | INTEGER ✓ |
| `pieces_price.pri_piece_id_i` | INTEGER | INTEGER ✓ |

## Fix (6 lignes, 1 fichier)

\`\`\`diff
- ON g.pg_id::TEXT = p.piece_pg_id
+ ON g.pg_id = p.piece_pg_id
- ON m.pm_id::TEXT = p.piece_pm_id
+ ON m.pm_id = p.piece_pm_id
- ON pi.piece_id_i = p.piece_id::INT
+ ON pi.piece_id_i = p.piece_id
- ON pe.piece_id_i = p.piece_id::INT
+ ON pe.piece_id_i = p.piece_id
- WHERE COALESCE(p.piece_display, '1') = '1'
+ WHERE p.piece_display = true
- ... || g.pg_alias || '-' || g.pg_id || '.html' ...
+ ... || g.pg_alias || '-' || g.pg_id::TEXT || '.html' ...
\`\`\`

Note : le seul cast `::TEXT` ajouté est dans la concaténation string (\`||\`) où on a besoin de convertir INT→TEXT pour produire l'URL.

## Vérification post-fix

Smoke test sur RPC déployé : **100 rows / 100% with GTIN / 100% in_stock**. RPC fonctionnel, le fichier reflète maintenant exactement le canon déployé.

## Doctrine

- ✅ `feedback_no_bricolage_escalate_to_industry_standard` : aligner source ↔ runtime, ne pas laisser de divergence silencieuse
- ✅ `feedback_verify_existing_first` : information_schema.columns consulté avant fix
- Aucun changement comportemental, juste alignment types pour permettre future re-application

🤖 Generated with [Claude Code](https://claude.com/claude-code)