### PR TITLE
chore(github): add canon-pointing PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Checklist d'entrée vers le canon (G5 canon-only) — PAS une policy.
+Supprimez les sections non applicables. Restez bref.
+-->
+
+## Résumé
+<!-- Quoi + pourquoi : le « pourquoi » du changement vit ici (cf. CLAUDE.md). -->
+
+## Scope
+<!-- CLAUDE.md « Vérifier l'existant AVANT d'inventer » · ambiguïté = stop & demander -->
+- [ ] Diff chirurgical, une seule promesse, pas de cleanup opportuniste
+- [ ] Existant grepé avant tout nouvel artefact (ENV/table/service/route)
+
+## Verification
+- [ ] Commande(s) lancée(s) + sortie collée ci-dessous
+
+## SoT & invariants (si applicable)
+<!-- Selon domaine : ADR-058 (ownership) · .spec/00-canon/role-matrix.md (SEO) · payments (HMAC/timingSafeEqual) · no-url-changes -->
+- [ ] Aucune vérité parallèle ; invariants touchés identifiés
+
+## Runtime impact (si applicable)
+<!-- .claude/knowledge/REPO_MAP.md · feature flag / shadow mode si risqué (ADR-055) -->
+- [ ] Surfaces : routes / workers / cron / RPC / cache / RLS / SEO / CI gates
+
+## Rollback (si applicable)

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -72,6 +72,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: critical
+  - glob: .github/PULL_REQUEST_TEMPLATE.md
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   - glob: .github/workflows/**
     domain: D13
     owner: '@ak125'


### PR DESCRIPTION
## Résumé

Ajoute `.github/PULL_REQUEST_TEMPLATE.md` — seul trou vérifié après audit empirique (vault + monorepo + mémoire, 3 agents Explore) des « 6 couches manquantes » alléguées : SoT, invariants, runtime awareness, control plane, progressive delivery, deterministic-first **existent déjà** (ADR-015/058/060/066/068, role-matrix, shadow mode ADR-055, anti-bricolage canon, 5 ratchets CI). La seule absence réelle : pas de template PR standardisé.

## Approche (canon-pointing, no bricolage)

Le template est un **point d'entrée vers le canon existant**, pas une réécriture :
- chaque section *référence* la règle (CLAUDE.md, ADR-058, role-matrix, REPO_MAP, ADR-055) au lieu de la dupliquer → conforme **G5 canon-only**
- **2 sections requises** (Scope, Verification) ; le reste en `(si applicable)` pour éviter le bruit « N/A partout »
- liens repo-root stables ; pointeurs only, zéro logique métier

## Hors scope (refusé explicitement)

- ❌ nouvelle ADR / policy vault « LLM coding discipline » — duplique l'existant
- ❌ propagation CLAUDE.md / AGENTS.md / `.codex/`
- ❌ gate CI bloquant sur sections PR — viole observe → ratchet → enforce

## Verification

- 3 chemins référencés vérifiés existants (`CLAUDE.md`, `.spec/00-canon/role-matrix.md`, `.claude/knowledge/REPO_MAP.md`)
- aucun template préexistant écrasé
- diff worktree byte-identical à la version revue

🤖 Generated with [Claude Code](https://claude.com/claude-code)