### PR TITLE
feat(seo-audit): GSC Cannibalization Audit — verdict intra-R2 (84%)

### DIFF
--- a/backend/src/modules/seo/audit/__tests__/cannibalization-classifier.test.ts
+++ b/backend/src/modules/seo/audit/__tests__/cannibalization-classifier.test.ts
@@ -1,0 +1,61 @@
+import {
+  classifyCannibalizedPage,
+  ClusterContext,
+  LoserPageInput,
+} from '../cannibalization-classifier';
+
+const cluster: ClusterContext = {
+  competingPages: 5,
+  winnerPosition: 3,
+  clusterClicks: 2,
+};
+
+const base: LoserPageInput = {
+  position: 50,
+  impressions: 0,
+  clicks: 0,
+  isWinner: false,
+};
+
+describe('classifyCannibalizedPage', () => {
+  it('winner → keep / HIGH', () => {
+    const r = classifyCannibalizedPage({ ...base, position: 3, isWinner: true }, cluster);
+    expect(r.action).toBe('keep');
+    expect(r.confidence_level).toBe('HIGH');
+  });
+
+  it('loser profond + 0 clic + écart large → canonical_candidate / HIGH', () => {
+    const r = classifyCannibalizedPage({ ...base, position: 60, impressions: 20, clicks: 0 }, cluster);
+    expect(r.action).toBe('canonical_candidate');
+    expect(r.confidence_level).toBe('HIGH');
+  });
+
+  it('quasi invisible (impr<=1, 0 clic, distancée) → noindex_candidate / MEDIUM', () => {
+    const r = classifyCannibalizedPage({ ...base, position: 30, impressions: 1, clicks: 0 }, cluster);
+    expect(r.action).toBe('noindex_candidate');
+    expect(r.confidence_level).toBe('MEDIUM');
+  });
+
+  it('loser avec clics propres → differentiate / LOW', () => {
+    const r = classifyCannibalizedPage({ ...base, position: 12, impressions: 40, clicks: 3 }, cluster);
+    expect(r.action).toBe('differentiate');
+    expect(r.confidence_level).toBe('LOW');
+  });
+
+  it('loser proche du winner (écart < 10) sans clic → differentiate / MEDIUM', () => {
+    const r = classifyCannibalizedPage({ ...base, position: 8, impressions: 15, clicks: 0 }, cluster);
+    expect(r.action).toBe('differentiate');
+    expect(r.confidence_level).toBe('MEDIUM');
+  });
+
+  it('canonical_candidate exige position profonde (>=40), sinon pas canonical', () => {
+    // écart large (>=10) mais position 20 (<40), 0 clic, impressions 20
+    const r = classifyCannibalizedPage({ ...base, position: 20, impressions: 20, clicks: 0 }, cluster);
+    expect(r.action).not.toBe('canonical_candidate');
+  });
+
+  it('reason est toujours renseigné', () => {
+    const r = classifyCannibalizedPage(base, cluster);
+    expect(r.reason.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/modules/seo/audit/cannibalization-classifier.ts
+++ b/backend/src/modules/seo/audit/cannibalization-classifier.ts
@@ -1,0 +1,105 @@
+/**
+ * GSC Cannibalization Classifier (fonction pure).
+ *
+ * Pour une page "perdante" d'un cluster de cannibalisation (plusieurs pages du site
+ * se disputant la même requête Google), recommande une action + un niveau de confiance.
+ *
+ * Source du signal = GSC réel (`__seo_gsc_daily`), pas de similarité de contenu floue.
+ * AUCUNE action appliquée : produit des recommandations `proposed` pour révision humaine.
+ *
+ * Actions V1 (merge/fusion EXCLU — trop dangereux : URL/routing/redirects) :
+ *   keep · differentiate · canonical_candidate · noindex_candidate
+ */
+
+export type CannibalAction =
+  | "keep"
+  | "differentiate"
+  | "canonical_candidate"
+  | "noindex_candidate";
+
+export type ConfidenceLevel = "HIGH" | "MEDIUM" | "LOW";
+
+export interface ClusterContext {
+  /** nb de pages distinctes se disputant la requête */
+  competingPages: number;
+  /** meilleure position du cluster (la page winner) */
+  winnerPosition: number;
+  /** clics totaux du cluster (28j) */
+  clusterClicks: number;
+}
+
+export interface LoserPageInput {
+  /** position moyenne de CETTE page sur la requête (28j) */
+  position: number;
+  /** impressions de cette page sur la requête (28j) */
+  impressions: number;
+  /** clics de cette page sur la requête (28j) */
+  clicks: number;
+  /** cette page est-elle le winner du cluster (meilleure position) ? */
+  isWinner: boolean;
+}
+
+export interface ClassificationResult {
+  action: CannibalAction;
+  confidence_level: ConfidenceLevel;
+  reason: string;
+}
+
+/** Écart de position au-delà duquel un loser est clairement distancé par le winner. */
+const POSITION_GAP_CLEAR = 10;
+/** Position au-delà de laquelle une page n'a quasi aucune chance de trafic (page 4+). */
+const POSITION_DEEP = 40;
+
+export function classifyCannibalizedPage(
+  page: LoserPageInput,
+  cluster: ClusterContext,
+): ClassificationResult {
+  // Le winner du cluster : on le garde, c'est lui qui doit ranker.
+  if (page.isWinner) {
+    return {
+      action: "keep",
+      confidence_level: "HIGH",
+      reason: `Winner du cluster (position ${page.position.toFixed(1)}) — page de référence à conserver.`,
+    };
+  }
+
+  const positionGap = page.position - cluster.winnerPosition;
+
+  // Loser profond + 0 clic + winner clairement devant → candidat canonical vers winner.
+  if (
+    page.clicks === 0 &&
+    positionGap >= POSITION_GAP_CLEAR &&
+    page.position >= POSITION_DEEP
+  ) {
+    return {
+      action: "canonical_candidate",
+      confidence_level: "HIGH",
+      reason: `Loser profond (pos ${page.position.toFixed(1)} vs winner ${cluster.winnerPosition.toFixed(1)}, écart ${positionGap.toFixed(1)}), 0 clic — canonical vers winner consolide le signal.`,
+    };
+  }
+
+  // Loser sans aucune impression utile + distancé → candidat noindex (manuel).
+  if (page.clicks === 0 && page.impressions <= 1 && positionGap >= POSITION_GAP_CLEAR) {
+    return {
+      action: "noindex_candidate",
+      confidence_level: "MEDIUM",
+      reason: `Quasi invisible (impr ${page.impressions}, 0 clic, distancée) — candidate noindex à valider.`,
+    };
+  }
+
+  // Loser proche du winner OU avec ses propres clics → la page a une valeur, la différencier.
+  if (page.clicks > 0 || positionGap < POSITION_GAP_CLEAR) {
+    return {
+      action: "differentiate",
+      confidence_level: page.clicks > 0 ? "LOW" : "MEDIUM",
+      reason: `Page avec valeur propre (clics ${page.clicks}, écart pos ${positionGap.toFixed(1)}) — différencier le contenu plutôt que canonical/noindex.`,
+    };
+  }
+
+  // Signaux contradictoires → garder + LOW confidence (révision humaine requise).
+  return {
+    action: "keep",
+    confidence_level: "LOW",
+    reason: `Signaux contradictoires (pos ${page.position.toFixed(1)}, impr ${page.impressions}, clics ${page.clicks}) — garder en l'état, investiguer manuellement.`,
+  };
+}

--- a/backend/supabase/migrations/20260520_seo_cannibalization_recommendations.sql
+++ b/backend/supabase/migrations/20260520_seo_cannibalization_recommendations.sql
@@ -20,6 +20,11 @@ CREATE TABLE IF NOT EXISTS __seo_cannibalization_recommendations (
   page_impressions int NOT NULL DEFAULT 0,
   page_clicks int NOT NULL DEFAULT 0,
   is_winner boolean NOT NULL DEFAULT false,
+  -- Forme structurelle du cluster (pour réviser par PATTERN, pas page par page) :
+  --   same_model_diff_motor  = même gamme × même modèle, motorisations différentes (fix canonical structurel)
+  --   same_gamme_diff_model  = même gamme, modèles/générations différents
+  --   diff_gamme             = gammes différentes (probable ambiguïté requête)
+  cluster_shape text NULL,
   -- Recommandation
   recommended_action text NOT NULL CHECK (recommended_action IN ('keep','differentiate','canonical_candidate','noindex_candidate')),
   confidence_level text NOT NULL CHECK (confidence_level IN ('HIGH','MEDIUM','LOW')),

--- a/backend/supabase/migrations/20260520_seo_cannibalization_recommendations.sql
+++ b/backend/supabase/migrations/20260520_seo_cannibalization_recommendations.sql
@@ -1,0 +1,39 @@
+-- GSC Cannibalization Audit — table de recommandations (Phase audit, additive isolée)
+-- Une row par page "perdante" d'un cluster de cannibalisation (requête disputée par >1 page).
+-- status DEFAULT 'proposed' : AUCUNE action appliquée. Révision humaine requise avant tout
+-- changement canonical/noindex (cf feedback_no_url_changes_ever + feedback_no_auto_page_suppression_ever).
+
+CREATE TABLE IF NOT EXISTS __seo_cannibalization_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  captured_at timestamptz NOT NULL DEFAULT now(),
+  -- Cluster (identifié par la requête Google)
+  query text NOT NULL,
+  cluster_pattern text NOT NULL,  -- 'intra_r2' | 'intra_r8' | 'r8_vs_r2' | 'mixed'
+  competing_pages int NOT NULL,
+  winner_page text NOT NULL,
+  winner_position numeric(6,2) NOT NULL,
+  cluster_clicks int NOT NULL DEFAULT 0,
+  cluster_impressions int NOT NULL DEFAULT 0,
+  -- Page concernée (le "loser" ou winner)
+  page text NOT NULL,
+  page_position numeric(6,2) NOT NULL,
+  page_impressions int NOT NULL DEFAULT 0,
+  page_clicks int NOT NULL DEFAULT 0,
+  is_winner boolean NOT NULL DEFAULT false,
+  -- Recommandation
+  recommended_action text NOT NULL CHECK (recommended_action IN ('keep','differentiate','canonical_candidate','noindex_candidate')),
+  confidence_level text NOT NULL CHECK (confidence_level IN ('HIGH','MEDIUM','LOW')),
+  target_canonical_url text NULL,  -- pour canonical_candidate : pointe vers winner_page
+  reason text NOT NULL,
+  -- Workflow révision (jamais 'applied' par le script)
+  status text NOT NULL DEFAULT 'proposed' CHECK (status IN ('proposed','reviewed','approved','rejected','applied')),
+  reviewed_by text NULL,
+  applied_at timestamptz NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cannibal_reco_query ON __seo_cannibalization_recommendations (query, captured_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cannibal_reco_action ON __seo_cannibalization_recommendations (recommended_action, confidence_level);
+CREATE INDEX IF NOT EXISTS idx_cannibal_reco_status ON __seo_cannibalization_recommendations (status, captured_at DESC);
+
+COMMENT ON TABLE __seo_cannibalization_recommendations IS
+  'GSC Cannibalization Audit : recommandations par page perdante (canonical/noindex/differentiate/keep). status proposed par défaut — JAMAIS appliqué auto. Source signal = __seo_gsc_daily (requêtes disputées par >1 page).';

--- a/docs/superpowers/specs/2026-05-20-canonical-changeset-strict-safe.md
+++ b/docs/superpowers/specs/2026-05-20-canonical-changeset-strict-safe.md
@@ -1,0 +1,58 @@
+# Change-set canonical STRICT-SAFE — à réviser avant application
+
+**Date** : 2026-05-20
+**Source** : `__seo_cannibalization_recommendations WHERE safety_flag='strict_safe_true_dup'`
+**Volume** : 30 pages (vrais doublons : même gamme + marque + modèle + motorisation, seul `type_id` diffère)
+
+> ⚠️ **Rien n'est appliqué.** Cette liste est un change-set proposé pour révision humaine. Appliquer = étape manuelle approuvée (garde `feedback_no_url_changes_ever`).
+
+## Pourquoi seulement 30 sur 142 ?
+
+L'audit GSC a identifié 142 `canonical_candidate` (pages perdantes sur une requête disputée). Mais sélectionner le « winner » par meilleure position GSC est **dangereux** : le winner est parfois un **produit différent** (gamme/modèle/moteur ≠). Canonicaliser vers lui dirait à Google « ces pages sont identiques » → client sur la mauvaise pièce → retour SAV.
+
+Filtrage de sécurité (préfixe URL complet identique, seul `type_id` diffère) :
+- **30 strict_safe_true_dup** : vrai doublon (ex. 2 entrées type_id du même `207 1.6 hdi`) → SÛR à canonicaliser
+- **112 needs_human_review_diff_product** : gamme/modèle/moteur différent → NE PAS canonicaliser automatiquement (révision cas par cas, ou relève du fix structurel niveau-modèle)
+
+## Les 30 paires sûres (source → canonical cible)
+
+| Requête | Source (pos) | Canonical → cible (pos) |
+|---|---|---|
+| 816 x 5 | filtre-a-huile bmw x5-e70 30-i-xdrive-**61929** (86) | …**61930** (48) |
+| c15 1.9d | cardan citroen c15 1-9-d-**18017** (83) | …**21090** (39) |
+| calorstat 207 1.6 hdi | thermostat 207 1-6-hdi-**19353** (47) | …**33260** (20) |
+| catalyseur laguna 2 1.9 dci | catalyseur laguna-ii 1-9-dci-**18643** (48) | …**15771** (32) |
+| contacteur feu recul laguna 2 | …laguna-ii-break 1-9-dci-**15774** (59) | …**18583** (23) |
+| embrayage saxo 1.5d | butee-d-embrayage saxo 1-5-d-**5616** (53) | …**5551** (29) |
+| emetteur embrayage 807 hdi | emetteur 807 2-0-hdi-**27570** (64) | …**19771** (8) |
+| filtre à air kangoo 1.5 dci | filtre-a-air kangoo-ii 1-5-dci-**23465** (55) | …**58648** (39) |
+| filtre habitacle trafic 2 | filtre-habitacle trafic-ii 2-5-dci-**31996** (41) | …**19863** (25) |
+| pajero 3.2 did | constructeurs pajero-iii 3-2-did-**57188** (47) | …**57184** (24) |
+| turbo c8 2.0 hdi 163 | turbo c8 2-0-hdi-**16729** (42) | …**23048** (28) |
+| turbo megane 2 1.5 dci | turbo megane-ii 1-5-dci-**17718** (48) | …**18791** (38) |
+| vanne egr 207 1.6 hdi (×4 requêtes) | vanne-egr 207 1-6-hdi-**19353** | …**33260** |
+| vanne egr 307 1.6 hdi (×2) | vanne-egr 307 1-6-hdi-**17989** | …**19341** |
+| vanne egr 308 1.6 hdi (×2) | vanne-egr 308-sw-i 1-6-hdi-**11074** | …**59020** |
+| vanne egr 407 sw | vanne-egr 407-sw 2-0-hdi-**76499** (49) | …**28141** (34) |
+| vanne egr clio 1.5 dci (×2) | vanne-egr clio-ii 1-5-dci-**54943**/**29998** | (réciproque) |
+| vanne egr clio 4 1.5 dci | vanne-egr clio-iv 1-5-dci-**57282** (63) | …**57281** (32) |
+| vanne egr golf 6 1.6 tdi (×2) | vanne-egr golf-vi 1-6-tdi-**31340**/**33030** | (réciproque) |
+| vanne egr laguna 2 1.9 dci | vanne-egr laguna-ii 1-9-dci-**18579** (81) | …**15476** (66) |
+| vanne egr megane 2 (×2) | vanne-egr megane-ii 1-5-dci-**18790** | …**16919** |
+| vanne egr scenic 3 1.5 dci 110 | vanne-egr scenic-iii 1-5-dci-**31546** (72) | …**5853** (42) |
+
+(liste complète exacte dans `__seo_cannibalization_recommendations`, requête : `WHERE safety_flag='strict_safe_true_dup'`)
+
+> ⚠️ **Doublons réciproques** : certaines paires apparaissent dans les 2 sens (ex. clio 1.5 dci) car la requête varie. Lors de l'application, choisir UN sens unique par paire (la cible = meilleure position stable) pour éviter une boucle canonical.
+
+## Application (étape SÉPARÉE, manuelle, après votre validation)
+
+1. Pour chaque paire, vérifier que les 2 type_id sont bien le **même produit** (compat identique) — c'est un doublon catalogue, pas 2 pièces.
+2. Choisir la cible stable (mieux classée, en stock).
+3. Déclarer `rel=canonical` source → cible **+ aligner les liens internes** (fil d'ariane, listings) vers la cible (best practice onwardSEO).
+4. Ne PAS combiner avec noindex.
+5. Idéalement : dédupliquer aussi les 2 type_id côté catalogue (cause racine = doublons de type véhicule).
+
+## Le reste (112 + 84% intra-R2) = fix structurel
+
+Les 112 non-strict-safe et la masse intra-R2 ne se règlent PAS par canonical page-à-page. Le vrai fix = **créer des pages niveau-modèle** (`/pieces/{gamme}/{marque}/{modele}.html`) qui captent la requête modèle et consolident les motorisations — chantier structurel à décider (cf rapport principal, chemin B).

--- a/docs/superpowers/specs/2026-05-20-gsc-cannibalization-audit.md
+++ b/docs/superpowers/specs/2026-05-20-gsc-cannibalization-audit.md
@@ -1,0 +1,59 @@
+# GSC Cannibalization Audit — rapport cluster-first (run réel 2026-05-20)
+
+**Source** : signal Google réel (`__seo_gsc_daily`, 28j) — pas de similarité de contenu, pas de crawl
+**Clusters cannibalisés** : 286 · **Pages analysées** : 662
+**Recommandations** : stockées dans `__seo_cannibalization_recommendations` (100% `status='proposed'`)
+
+> Reproduction : `npx ts-node scripts/audit/render-cannibalization-report.ts`
+
+## Pivot diagnostic (vs hypothèse initiale)
+
+L'hypothèse de départ était un duplicate **R8↔R2**. Le signal Google réel le contredit :
+
+| Pattern de cannibalisation | Clusters | Part |
+|---|---|---|
+| **intra-R2** (pages /pieces/ entre elles) | **241** | **84%** |
+| intra-R8 (/constructeurs/ sœurs) | 43 | 15% |
+| R8↔R2 (inter-rôles) | 2 | <1% |
+
+➡️ **Le vrai coupable est l'auto-cannibalisation R2** (pages produit/gamme se disputant les mêmes requêtes), PAS le duplicate R8↔R2. Données pilotes confirmant le contexte : `__seo_r8_pages`=155 (154 noindex), `__seo_r2_pages`=0 — ces tables de génération v2 ne sont pas les pages live indexées.
+
+## Distribution des actions recommandées
+
+| Action | Nb pages | Lecture |
+|---|---|---|
+| keep (HIGH) | 286 | winners de cluster — page de référence |
+| differentiate (MEDIUM) | 180 | page proche du winner, à différencier |
+| **canonical_candidate (HIGH)** | **142** | loser profond + 0 clic → canonical vers winner |
+| noindex_candidate (MEDIUM) | 31 | quasi invisible → candidate noindex (manuel) |
+| keep (LOW) | 20 | signaux contradictoires → investiguer |
+| differentiate (LOW) | 3 | a ses propres clics |
+
+**Actionnable haute confiance** : 142 canonical_candidate + 31 noindex_candidate = **173 pages** clairement en cannibalisation, recommandées pour consolidation.
+
+## Exemples de clusters réels (requêtes produit)
+
+| Requête | Pattern | Pages | Winner pos | Reco dominante |
+|---|---|---|---|---|
+| support moteur 207 | intra_r2 | 5 | 15.8 | 4× canonical_candidate |
+| embrayage zx | intra_r2 | 5 | 43.0 | 4× canonical_candidate |
+| vanne egr 308 1.6 hdi 110 | intra_r2 | 4 | 48.3 | 3× canonical_candidate |
+| embrayage saxo 1.5d | r8_vs_r2 | 4 | 29.0 | 3× canonical_candidate |
+| vanne egr laguna 2 | intra_r2 | 4 | 47.0 | 2× canonical + 1 diff |
+| poulie vilebrequin 1.9 dci | intra_r2 | 5 | 1.0 | 4× differentiate |
+
+Toutes ces requêtes : **0 clic** malgré des impressions — signal clair que la dispersion entre pages dilue le ranking.
+
+## ⚠️ Aucune action appliquée
+
+Toutes les recommandations sont `status='proposed'`. **Révision humaine obligatoire** avant tout changement canonical/noindex (gardes `feedback_no_url_changes_ever`, `feedback_no_auto_page_suppression_ever`). L'application des canonical/noindex est une étape SÉPARÉE, approuvée page par page (ou batch validé).
+
+## Recommandation orientation
+
+1. **Prioriser les 142 canonical_candidate HIGH** : consolider les losers vers leur winner sur les requêtes produit cannibalisées. Réversible, faible risque.
+2. **Cibler le pattern intra-R2** (84% du problème) : comprendre POURQUOI plusieurs pages /pieces/ rankent sur la même requête produit (variantes véhicule ? pages quasi-doublons ?).
+3. Le duplicate R8↔R2 et intra-R8 sont secondaires (16% combiné) — traiter après l'intra-R2.
+4. Lien avec verdict `conversion_funnel` (0.17%) : la cannibalisation dilue le peu de trafic restant ; consolider peut améliorer position ET conversion.
+
+---
+_Étape suivante = révision humaine des recommandations dans `__seo_cannibalization_recommendations`, puis application manuelle approuvée._

--- a/docs/superpowers/specs/2026-05-20-gsc-cannibalization-audit.md
+++ b/docs/superpowers/specs/2026-05-20-gsc-cannibalization-audit.md
@@ -44,6 +44,20 @@ L'hypothèse de départ était un duplicate **R8↔R2**. Le signal Google réel 
 
 Toutes ces requêtes : **0 clic** malgré des impressions — signal clair que la dispersion entre pages dilue le ranking.
 
+## Cause STRUCTURELLE (root-cause, pas symptôme)
+
+Analyse des URLs en concurrence : pattern `/pieces/{gamme}/{marque}/{modèle}/{motorisation}.html`. Les pages produit existent au niveau **motorisation** (type_id), mais les utilisateurs cherchent au niveau **modèle** (« support moteur 207 », pas « support moteur 207 1.6 hdi »). Google voit donc N pages motorisation quasi-identiques matcher la requête modèle → cannibalisation.
+
+| Forme du cluster | Clusters | Pages | Fix structurel |
+|---|---|---|---|
+| **same_model_diff_motor** (même gamme × même modèle, motorisations ≠) | 117 (48%) | 245 | canonical motorisation → page niveau-modèle |
+| same_gamme_diff_model (même gamme, modèles/générations ≠) | 104 (43%) | 271 | examiner : générations distinctes (garder) vs doublons |
+| diff_gamme (gammes ≠) | 22 (9%) | 51 | ambiguïté requête, souvent garder |
+
+Exemple `support moteur 207` : 5 URLs `support-moteur-247/peugeot-128/207-128018/{1-4-16v, 1-6-hdi×4}` → même gamme, même modèle 207, 5 motorisations.
+
+➡️ **Le bon fix n'est PAS 142 canonicals ad-hoc, mais UNE règle structurelle** : pour les 117 clusters `same_model_diff_motor`, les pages motorisation devraient déclarer un canonical vers la page niveau-modèle (si le contenu ne varie pas matériellement par motorisation). À valider + appliquer manuellement (règle, pas page par page).
+
 ## ⚠️ Aucune action appliquée
 
 Toutes les recommandations sont `status='proposed'`. **Révision humaine obligatoire** avant tout changement canonical/noindex (gardes `feedback_no_url_changes_ever`, `feedback_no_auto_page_suppression_ever`). L'application des canonical/noindex est une étape SÉPARÉE, approuvée page par page (ou batch validé).

--- a/docs/superpowers/specs/2026-05-20-gsc-cannibalization-audit.md
+++ b/docs/superpowers/specs/2026-05-20-gsc-cannibalization-audit.md
@@ -58,6 +58,30 @@ Exemple `support moteur 207` : 5 URLs `support-moteur-247/peugeot-128/207-128018
 
 ➡️ **Le bon fix n'est PAS 142 canonicals ad-hoc, mais UNE règle structurelle** : pour les 117 clusters `same_model_diff_motor`, les pages motorisation devraient déclarer un canonical vers la page niveau-modèle (si le contenu ne varie pas matériellement par motorisation). À valider + appliquer manuellement (règle, pas page par page).
 
+## Validation Google + best practices (vérifié web 2026-05-20)
+
+La solution (canonical des pages motorisation vers le niveau modèle) est **confirmée** par la doc officielle Google + best practice e-commerce variant.
+
+**Google Search Central — Consolidate duplicate URLs :**
+- `rel=canonical` recommandé pour « consolidate signals for similar or duplicate pages ».
+- Ordre de force : **redirects > rel=canonical > sitemap**.
+- ⚠️ `noindex` **bloque** la page de Search → préférer canonical pour consolider (ne PAS combiner noindex + canonical sur la même page).
+- Ne pas mixer méthodes de canonical contradictoires.
+
+**Best practice variant cannibalization (onwardSEO 7 rules) :**
+- Cible canonical = page parent « base product » OU variante dominante (selon distribution de la demande). → pour nous : **page niveau-modèle** (demande répartie sur motorisations) OU motorisation dominante si une rank nettement mieux.
+- **Tous les liens internes** (PLP, fil d'ariane, recommandations) doivent pointer la cible canonical, **pas seulement la balise** `rel=canonical`. ← raffinement clé.
+- Demande répartie → canonical vers parent ; une variante domine → canonical vers elle ; stock fluctuant → canonical parent, noindex seulement si discontinué définitivement.
+- Renfort requis : schema `url`, sitemap exclusif, ancres internes cohérentes — pas la balise canonical seule.
+
+### 2 raffinements intégrés au plan d'action
+
+1. **Cible canonical — fait structurel décisif** : vérification GSC = **1489 pages niveau-motorisation indexées, MAIS 0 page niveau-modèle** (ni niveau-marque). La cible canonical « parent base product » idéale **n'existe pas**. Deux chemins :
+   - **(A) Court terme, réversible, aucun changement d'URL** : canonical des motorisations → la motorisation **dominante** (mieux classée) du cluster, conforme onwardSEO « one variant dominates → canonical to that variant ». C'est le `winner` déjà identifié par l'audit. Applicable immédiatement après revue.
+   - **(B) Stratégique, structurel** : **créer des pages niveau-modèle** (`/pieces/{gamme}/{marque}/{modele}.html`) comme hub canonical — meilleure cible long terme (capte la requête modèle « support moteur 207 »), mais = nouveau pattern d'URL/route → décision utilisateur (garde `feedback_no_url_changes_ever`) + chantier dédié. **C'est probablement le vrai fix de fond** : la requête est au niveau modèle, il manque la page de ce niveau.
+2. **Congruence des liens internes** : appliquer le canonical ne suffit pas — fil d'ariane + PLP + recos doivent aussi pointer la cible. Sinon Google reçoit des signaux contradictoires (cf onwardSEO : canonical resout seul 55-70% du clustering).
+3. **noindex vs canonical** : les 31 `noindex_candidate` ne doivent PAS recevoir aussi un canonical (mutuellement exclusifs). Réservés aux pages sans valeur SEO, pas aux variants à consolider.
+
 ## ⚠️ Aucune action appliquée
 
 Toutes les recommandations sont `status='proposed'`. **Révision humaine obligatoire** avant tout changement canonical/noindex (gardes `feedback_no_url_changes_ever`, `feedback_no_auto_page_suppression_ever`). L'application des canonical/noindex est une étape SÉPARÉE, approuvée page par page (ou batch validé).

--- a/docs/superpowers/specs/2026-05-20-gsc-cannibalization-audit.md
+++ b/docs/superpowers/specs/2026-05-20-gsc-cannibalization-audit.md
@@ -82,6 +82,19 @@ La solution (canonical des pages motorisation vers le niveau modèle) est **conf
 2. **Congruence des liens internes** : appliquer le canonical ne suffit pas — fil d'ariane + PLP + recos doivent aussi pointer la cible. Sinon Google reçoit des signaux contradictoires (cf onwardSEO : canonical resout seul 55-70% du clustering).
 3. **noindex vs canonical** : les 31 `noindex_candidate` ne doivent PAS recevoir aussi un canonical (mutuellement exclusifs). Réservés aux pages sans valeur SEO, pas aux variants à consolider.
 
+## ⚠️ Safety check du change-set — 30/142 seulement applicables
+
+En préparant le change-set, vérification critique : le « winner » (meilleure position GSC) est parfois un **produit différent** (gamme/modèle/moteur ≠). Canonicaliser vers lui = dire à Google « pages identiques » → mauvaise pièce servie → retour SAV. Classement par sécurité (`safety_flag`) :
+
+| safety_flag | Pages | Sens |
+|---|---|---|
+| `strict_safe_true_dup` | **30** | vrai doublon (même gamme+modèle+motorisation, type_id ≠) → SÛR à canonicaliser |
+| `needs_human_review_diff_product` | 112 | gamme/modèle/moteur ≠ → NE PAS auto-canonicaliser |
+
+Exemples de pièges écartés : `kit-d-embrayage`→`butée-d-embrayage` (gammes ≠), `207`→`208` (modèles ≠), `1-6-16v` essence→`1-6-hdi` diesel (moteurs ≠), `alternateur`→`maître-cylindre` (requête junk « gjk f »).
+
+➡️ Change-set sûr (30 paires) : voir `docs/superpowers/specs/2026-05-20-canonical-changeset-strict-safe.md`. Les 112 autres relèvent du fix structurel niveau-modèle (chemin B), pas du canonical page-à-page.
+
 ## ⚠️ Aucune action appliquée
 
 Toutes les recommandations sont `status='proposed'`. **Révision humaine obligatoire** avant tout changement canonical/noindex (gardes `feedback_no_url_changes_ever`, `feedback_no_auto_page_suppression_ever`). L'application des canonical/noindex est une étape SÉPARÉE, approuvée page par page (ou batch validé).

--- a/scripts/audit/gsc-cannibalization-audit.ts
+++ b/scripts/audit/gsc-cannibalization-audit.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env -S npx ts-node
+/**
+ * GSC Cannibalization Audit.
+ *
+ * Mesure la cannibalisation SEO RÉELLE via Google Search Console (`__seo_gsc_daily`) :
+ * requêtes où plusieurs pages du site se disputent le même mot-clé. Clusterise par
+ * requête, identifie le winner (meilleure position) vs losers, classe chaque loser
+ * (canonical_candidate / noindex_candidate / differentiate / keep) avec niveau de
+ * confiance, et écrit des recommandations `proposed` (JAMAIS appliquées).
+ *
+ * Usage :
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+ *     npx ts-node scripts/audit/gsc-cannibalization-audit.ts [--window=28] [--min-pages=2] [--dry-run]
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import {
+  classifyCannibalizedPage,
+  ClusterContext,
+  LoserPageInput,
+} from "../../backend/src/modules/seo/audit/cannibalization-classifier";
+
+interface GscRow {
+  query: string;
+  page: string;
+  impressions: number;
+  clicks: number;
+  position: number;
+}
+
+interface PageAgg {
+  page: string;
+  impressions: number;
+  clicks: number;
+  position: number; // moyenne pondérée approx (moyenne simple ici)
+  _posSum: number;
+  _posN: number;
+}
+
+function patternOf(page: string): "r8" | "r2" | "other" {
+  if (/\/constructeurs\//.test(page)) return "r8";
+  if (/\/pieces\//.test(page)) return "r2";
+  return "other";
+}
+
+/** Filtre le bruit : opérateurs site:, requêtes trop courtes, refs internes (ai12345), mots vides. */
+function isNoiseQuery(q: string): boolean {
+  const s = q.trim().toLowerCase();
+  if (s.length < 4) return true;
+  if (s.startsWith("site:")) return true;
+  if (/^ai\d+$/.test(s)) return true; // refs internes
+  if (/^\d+$/.test(s)) return true; // requête purement numérique
+  if (["oui", "non", "automecanik", "auto mecanik"].includes(s)) return true;
+  return false;
+}
+
+async function fetchGsc(
+  sb: SupabaseClient,
+  windowDays: number,
+): Promise<GscRow[]> {
+  const since = new Date(Date.now() - windowDays * 864e5).toISOString().slice(0, 10);
+  const rows: GscRow[] = [];
+  const pageSize = 1000;
+  let from = 0;
+  // pagination pour dépasser la limite par défaut
+  for (;;) {
+    const { data, error } = await sb
+      .from("__seo_gsc_daily")
+      .select("query, page, impressions, clicks, position")
+      .gte("date", since)
+      .not("query", "is", null)
+      .range(from, from + pageSize - 1);
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+    for (const r of data as any[]) {
+      if (!r.query || isNoiseQuery(r.query)) continue;
+      rows.push({
+        query: r.query,
+        page: r.page,
+        impressions: Number(r.impressions ?? 0),
+        clicks: Number(r.clicks ?? 0),
+        position: Number(r.position ?? 0),
+      });
+    }
+    if (data.length < pageSize) break;
+    from += pageSize;
+  }
+  return rows;
+}
+
+interface ClusterReco {
+  query: string;
+  cluster_pattern: "intra_r2" | "intra_r8" | "r8_vs_r2" | "mixed";
+  competing_pages: number;
+  winner_page: string;
+  winner_position: number;
+  cluster_clicks: number;
+  cluster_impressions: number;
+  rows: Array<{
+    page: string;
+    page_position: number;
+    page_impressions: number;
+    page_clicks: number;
+    is_winner: boolean;
+    recommended_action: string;
+    confidence_level: string;
+    target_canonical_url: string | null;
+    reason: string;
+  }>;
+}
+
+function buildClusters(gsc: GscRow[], minPages: number): ClusterReco[] {
+  // group by query → page agg
+  const byQuery = new Map<string, Map<string, PageAgg>>();
+  for (const r of gsc) {
+    if (!byQuery.has(r.query)) byQuery.set(r.query, new Map());
+    const pages = byQuery.get(r.query)!;
+    if (!pages.has(r.page)) {
+      pages.set(r.page, {
+        page: r.page,
+        impressions: 0,
+        clicks: 0,
+        position: 0,
+        _posSum: 0,
+        _posN: 0,
+      });
+    }
+    const a = pages.get(r.page)!;
+    a.impressions += r.impressions;
+    a.clicks += r.clicks;
+    a._posSum += r.position;
+    a._posN += 1;
+  }
+
+  const clusters: ClusterReco[] = [];
+  for (const [query, pagesMap] of byQuery) {
+    const pages = Array.from(pagesMap.values()).map((a) => ({
+      ...a,
+      position: a._posN ? a._posSum / a._posN : 0,
+    }));
+    // ne garder que les pages catalog (r8/r2), ignorer 'other'
+    const catalog = pages.filter((p) => patternOf(p.page) !== "other");
+    if (catalog.length < minPages) continue;
+
+    const r8 = catalog.filter((p) => patternOf(p.page) === "r8").length;
+    const r2 = catalog.filter((p) => patternOf(p.page) === "r2").length;
+    let pattern: ClusterReco["cluster_pattern"];
+    if (r8 >= 1 && r2 >= 1) pattern = "r8_vs_r2";
+    else if (r2 >= 2) pattern = "intra_r2";
+    else if (r8 >= 2) pattern = "intra_r8";
+    else continue; // single page, pas de cannibalisation
+
+    const winner = catalog.reduce((best, p) =>
+      p.position > 0 && (best.position === 0 || p.position < best.position) ? p : best,
+    );
+    const ctx: ClusterContext = {
+      competingPages: catalog.length,
+      winnerPosition: winner.position,
+      clusterClicks: catalog.reduce((s, p) => s + p.clicks, 0),
+    };
+    const clusterImpr = catalog.reduce((s, p) => s + p.impressions, 0);
+
+    const rows = catalog.map((p) => {
+      const input: LoserPageInput = {
+        position: p.position,
+        impressions: p.impressions,
+        clicks: p.clicks,
+        isWinner: p.page === winner.page,
+      };
+      const res = classifyCannibalizedPage(input, ctx);
+      return {
+        page: p.page,
+        page_position: Math.round(p.position * 100) / 100,
+        page_impressions: p.impressions,
+        page_clicks: p.clicks,
+        is_winner: input.isWinner,
+        recommended_action: res.action,
+        confidence_level: res.confidence_level,
+        target_canonical_url:
+          res.action === "canonical_candidate" ? winner.page : null,
+        reason: res.reason,
+      };
+    });
+
+    clusters.push({
+      query,
+      cluster_pattern: pattern,
+      competing_pages: catalog.length,
+      winner_page: winner.page,
+      winner_position: Math.round(winner.position * 100) / 100,
+      cluster_clicks: ctx.clusterClicks,
+      cluster_impressions: clusterImpr,
+      rows,
+    });
+  }
+  // tri sévérité : nb pages × impressions × écart positions
+  clusters.sort(
+    (a, b) =>
+      b.competing_pages * b.cluster_impressions -
+      a.competing_pages * a.cluster_impressions,
+  );
+  return clusters;
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error("ERROR: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required");
+    process.exit(2);
+  }
+  const args = process.argv.slice(2);
+  const windowDays = parseInt(
+    args.find((a) => a.startsWith("--window="))?.split("=")[1] ?? "28",
+    10,
+  );
+  const minPages = parseInt(
+    args.find((a) => a.startsWith("--min-pages="))?.split("=")[1] ?? "2",
+    10,
+  );
+  const dryRun = args.includes("--dry-run");
+
+  const sb = createClient(url, key);
+  console.error(`Fetching GSC (${windowDays}j)...`);
+  const gsc = await fetchGsc(sb, windowDays);
+  console.error(`${gsc.length} rows GSC (noise filtré). Clustering...`);
+  const clusters = buildClusters(gsc, minPages);
+
+  const totalReco = clusters.reduce((s, c) => s + c.rows.length, 0);
+  const byAction: Record<string, number> = {};
+  for (const c of clusters)
+    for (const r of c.rows)
+      byAction[r.recommended_action] = (byAction[r.recommended_action] ?? 0) + 1;
+
+  console.error(
+    `${clusters.length} clusters cannibalisés, ${totalReco} recommandations. Distribution: ${JSON.stringify(byAction)}`,
+  );
+
+  if (dryRun) {
+    console.log(JSON.stringify({ clusters: clusters.length, byAction }, null, 2));
+    return;
+  }
+
+  // INSERT recommandations (status proposed)
+  const rows = clusters.flatMap((c) =>
+    c.rows.map((r) => ({
+      query: c.query,
+      cluster_pattern: c.cluster_pattern,
+      competing_pages: c.competing_pages,
+      winner_page: c.winner_page,
+      winner_position: c.winner_position,
+      cluster_clicks: c.cluster_clicks,
+      cluster_impressions: c.cluster_impressions,
+      page: r.page,
+      page_position: r.page_position,
+      page_impressions: r.page_impressions,
+      page_clicks: r.page_clicks,
+      is_winner: r.is_winner,
+      recommended_action: r.recommended_action,
+      confidence_level: r.confidence_level,
+      target_canonical_url: r.target_canonical_url,
+      reason: r.reason,
+      status: "proposed",
+    })),
+  );
+  // insert par batch de 500
+  for (let i = 0; i < rows.length; i += 500) {
+    const { error } = await sb
+      .from("__seo_cannibalization_recommendations")
+      .insert(rows.slice(i, i + 500));
+    if (error) throw error;
+  }
+  console.error(`Inséré ${rows.length} recommandations (status=proposed).`);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}
+
+export { buildClusters, isNoiseQuery };

--- a/scripts/audit/render-cannibalization-report.ts
+++ b/scripts/audit/render-cannibalization-report.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env -S npx ts-node
+/**
+ * Render GSC Cannibalization Report (cluster-first).
+ *
+ * Lit `__seo_cannibalization_recommendations` et rend un rapport markdown organisé
+ * PAR CLUSTER (requête), trié par sévérité, avec distribution des actions + encart
+ * "aucune action appliquée".
+ *
+ * Usage :
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+ *     npx ts-node scripts/audit/render-cannibalization-report.ts > report.md
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+async function main() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error("ERROR: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required");
+    process.exit(2);
+  }
+  const sb: SupabaseClient = createClient(url, key);
+
+  const { data: all, error } = await sb
+    .from("__seo_cannibalization_recommendations")
+    .select("*")
+    .order("competing_pages", { ascending: false });
+  if (error) throw error;
+  if (!all?.length) {
+    console.error("Aucune recommandation. Run gsc-cannibalization-audit.ts d'abord.");
+    process.exit(1);
+  }
+
+  // group by query
+  const byQuery = new Map<string, any[]>();
+  for (const r of all as any[]) {
+    if (!byQuery.has(r.query)) byQuery.set(r.query, []);
+    byQuery.get(r.query)!.push(r);
+  }
+
+  const actionCounts: Record<string, number> = {};
+  for (const r of all as any[])
+    actionCounts[r.recommended_action] =
+      (actionCounts[r.recommended_action] ?? 0) + 1;
+
+  const patternClusters: Record<string, Set<string>> = {};
+  for (const r of all as any[]) {
+    (patternClusters[r.cluster_pattern] ??= new Set()).add(r.query);
+  }
+
+  let md = `# GSC Cannibalization Audit — rapport cluster-first
+
+**Date** : ${new Date().toISOString().slice(0, 10)}
+**Source** : signal Google réel (\`__seo_gsc_daily\`, 28j) — pas de similarité de contenu, pas de crawl
+**Clusters** : ${byQuery.size} · **Pages analysées** : ${all.length}
+
+## Distribution par pattern de cannibalisation
+| Pattern | Clusters |
+|---|---|
+${Object.entries(patternClusters)
+  .map(([p, s]) => `| ${p} | ${s.size} |`)
+  .join("\n")}
+
+> 🔑 **Constat clé** : la cannibalisation est dominée par l'**intra-R2** (pages /pieces/ qui se disputent entre elles). Le duplicate R8↔R2 inter-rôles est marginal.
+
+## Distribution des actions recommandées
+| Action | Nb pages |
+|---|---|
+${Object.entries(actionCounts)
+  .map(([a, n]) => `| ${a} | ${n} |`)
+  .join("\n")}
+
+> ⚠️ **AUCUNE action appliquée.** Toutes les lignes sont \`status='proposed'\`. Révision humaine **obligatoire** avant tout canonical/noindex (cf gardes \`feedback_no_url_changes_ever\`, \`feedback_no_auto_page_suppression_ever\`).
+
+## Top clusters par sévérité (nb pages × impressions)
+
+`;
+
+  const clusters = Array.from(byQuery.entries())
+    .map(([query, rows]) => ({
+      query,
+      rows,
+      competing: rows[0].competing_pages,
+      impr: rows[0].cluster_impressions,
+      pattern: rows[0].cluster_pattern,
+      winner: rows[0].winner_page,
+      winnerPos: rows[0].winner_position,
+    }))
+    .sort((a, b) => b.competing * b.impr - a.competing * a.impr)
+    .slice(0, 25);
+
+  for (const c of clusters) {
+    md += `### \`${c.query}\` — ${c.pattern}\n`;
+    md += `- ${c.competing} pages · ${c.impr} impressions · winner \`${c.winner}\` (pos ${c.winnerPos})\n`;
+    md += `\n| page | pos | impr | clics | action | conf |\n|---|---|---|---|---|---|\n`;
+    for (const r of c.rows.sort((a: any, b: any) => a.page_position - b.page_position)) {
+      const w = r.is_winner ? " 🏆" : "";
+      md += `| \`${r.page}\`${w} | ${r.page_position} | ${r.page_impressions} | ${r.page_clicks} | ${r.recommended_action} | ${r.confidence_level} |\n`;
+    }
+    md += `\n`;
+  }
+
+  md += `---
+_Recommandations stockées dans \`__seo_cannibalization_recommendations\` (status=proposed)._
+_Étape suivante = révision humaine page par page, puis application manuelle approuvée des canonical/noindex._
+`;
+
+  process.stdout.write(md);
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Audit de cannibalisation SEO via **signal Google réel** (`__seo_gsc_daily`, 28j) — requêtes où plusieurs pages du site se disputent le même mot-clé. Pivot data-driven depuis l'hypothèse initiale "duplicate R8↔R2".

**Verdict (run réel)** : la cannibalisation est dominée par l'**auto-cannibalisation intra-R2** (pages /pieces/ entre elles), PAS le duplicate R8↔R2.

| Pattern | Clusters | Part |
|---|---|---|
| intra-R2 | 241 | **84%** |
| intra-R8 | 43 | 15% |
| R8↔R2 | 2 | <1% |

- 286 clusters cannibalisés, 662 pages analysées
- **142 canonical_candidate (HIGH) + 31 noindex_candidate** = 173 pages actionnables
- Exemples réels : `support moteur 207` (5 pages, 0 clic), `vanne egr 308 1.6 hdi` (4 pages, winner pos 48), `embrayage saxo 1.5d` (R8↔R2)

## Pourquoi pivot vs plan initial

Vérification MCP : `__seo_r8_pages`=155 (154 `noindex`) et `__seo_r2_pages`=0 → tables **pilotes v2**, déconnectées des pages live indexées. Mesurer une similarité de contenu dessus aurait été un audit vide. Le signal GSC (comportement réel de Google) est la bonne source.

## Livré

- `cannibalization-classifier.ts` — fonction pure (keep / differentiate / canonical_candidate / noindex_candidate + confidence HIGH/MEDIUM/LOW). **merge exclu V1** (trop dangereux). **7 tests TDD verts**.
- migration `__seo_cannibalization_recommendations` (additive, CHECK actions, appliquée)
- `gsc-cannibalization-audit.ts` — cluster par requête, noise-filter (`site:`, refs internes, junk)
- `render-cannibalization-report.ts` — rapport cluster-first
- `docs/.../2026-05-20-gsc-cannibalization-audit.md` — snapshot réel

## Gardes respectées

- **100% des recommandations `status='proposed'`** — aucune action appliquée
- Pas d'auto canonical/noindex (`feedback_no_url_changes_ever`, `feedback_no_auto_page_suppression_ever`)
- Révision humaine requise avant toute application

## Test plan

- [x] 7 tests TDD classifier verts
- [x] Migration appliquée + table peuplée (662 reco, 0 non-proposed)
- [x] Clusters réels validés via MCP
- [ ] (post-merge) Révision humaine des 142 canonical_candidate HIGH

🤖 Generated with [Claude Code](https://claude.com/claude-code)