### PR TITLE
fix(deploy): require + inject JWT_SECRET in deploy-prod.yml (PREPROD↔PROD parity)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -84,6 +84,9 @@ jobs:
           NODE_ENV: production
           SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          # Optional override. If unset, the value already present in the PROD
+          # .env is used (REQUIRED_VARS below guarantees it exists).
+          JWT_SECRET_OVERRIDE: ${{ secrets.PROD_JWT_SECRET }}
         run: |
           docker pull massdoc/nestjs-remix-monorepo:production
 
@@ -106,7 +109,12 @@ jobs:
             exit 1
           fi
           source .env
-          REQUIRED_VARS="SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY SYSTEMPAY_SITE_ID PAYBOX_SITE PAYBOX_HMAC_KEY PAYBOX_CALLBACK_MODE SESSION_SECRET"
+          # JWT_SECRET required since PR #606 (VehicleContextService does
+          # configService.getOrThrow('JWT_SECRET') at construction — missing
+          # value = crash boot, not a graceful skip). Listed here so a missing
+          # value fails fast with a readable message instead of an opaque
+          # container crash + failed auto-rollback (incident 2026-05-20).
+          REQUIRED_VARS="SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY SYSTEMPAY_SITE_ID PAYBOX_SITE PAYBOX_HMAC_KEY PAYBOX_CALLBACK_MODE SESSION_SECRET JWT_SECRET"
           for var in $REQUIRED_VARS; do
             if [ -z "${!var}" ]; then
               echo "❌ FATAL: Missing required env var: $var"
@@ -123,6 +131,17 @@ jobs:
           if [ -n "$SUPABASE_PUBLISHABLE_KEY" ]; then
             sed -i "s|^SUPABASE_ANON_KEY=.*|SUPABASE_ANON_KEY=${SUPABASE_PUBLISHABLE_KEY}|" .env
             echo "✅ SUPABASE_ANON_KEY updated from GitHub Secrets"
+          fi
+          # Inject JWT_SECRET from GitHub Secret if provided (parity with the
+          # PREPROD path in ci.yml, PR #630). Optional: when the secret is
+          # unset the .env value (guaranteed present by REQUIRED_VARS) is kept.
+          if [ -n "$JWT_SECRET_OVERRIDE" ]; then
+            if grep -q '^JWT_SECRET=' .env; then
+              sed -i "s|^JWT_SECRET=.*|JWT_SECRET=${JWT_SECRET_OVERRIDE}|" .env
+            else
+              echo "JWT_SECRET=${JWT_SECRET_OVERRIDE}" >> .env
+            fi
+            echo "✅ JWT_SECRET updated from GitHub Secrets"
           fi
 
           docker network create automecanik-prod 2>/dev/null || true


### PR DESCRIPTION
## Summary

Closes the env-parity gap that caused the **2026-05-20 PROD outage**.

- Add `JWT_SECRET` to `REQUIRED_VARS` in `deploy-prod.yml` → missing value fails fast with a readable message instead of an opaque crash-boot + failed auto-rollback.
- Inject `JWT_SECRET` from an optional `secrets.PROD_JWT_SECRET` (mirror of the PREPROD path added in #630). When the secret is unset, the value already present in the PROD `.env` is kept (now guaranteed by `REQUIRED_VARS`).

## Incident context

Tag `v2026.05.20-inp-sentry-scheduler` promoted an image whose `VehicleContextService` (PR #606) calls `configService.getOrThrow('JWT_SECRET')` at construction. `JWT_SECRET` had been propagated to the **PREPROD** container (#630, `ci.yml`) but **never to `deploy-prod.yml` nor the PROD `.env`**. Result on first PROD deploy post-#606:

1. Container crash-looped on boot (`EnvValidation FATAL: Missing JWT_SECRET`)
2. 5-attempt health check failed
3. Auto-rollback **also failed** → full PROD outage (500 on all routes)
4. Recovered manually by adding `JWT_SECRET` to `/home/deploy/production/.env` and recreating the `monorepo_prod` service

The Zod env-contract preflight (#632) only covers PREPROD, so CI was green while PROD was missing the var.

## Why this is the right fix

`deploy-prod.yml` already injects `SUPABASE_*` from GitHub Secrets and validates a `REQUIRED_VARS` list — this PR brings `JWT_SECRET` to parity with both mechanisms and with the PREPROD path. No new behaviour, just closing the gap.

## Test plan

- [ ] Workflow lint / YAML valid (validated locally with `yaml.safe_load`).
- [ ] On next tag deploy: confirm the `REQUIRED_VARS` loop prints `✅ All required environment variables present` (JWT_SECRET now in PROD `.env`).
- [ ] If `PROD_JWT_SECRET` secret is later added, confirm `✅ JWT_SECRET updated from GitHub Secrets` appears and the container boots.
- [ ] Negative check: temporarily removing JWT_SECRET from PROD `.env` should now fail with `❌ FATAL: Missing required env var: JWT_SECRET` **before** stopping the running container (no outage).

## Follow-up (separate PR, not in scope here)

Extend the Zod env-contract preflight (`scripts/ci/preflight-env-contract.ts`, currently `preprod.schema.ts` only) with a `prod.schema.ts` so this class of PREPROD↔PROD env drift is caught in CI rather than at PROD boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)