### PR TITLE
fix(observability): calibrate Sentry traces sample rate to 2% for free quota

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -248,8 +248,16 @@ SENTRY_PROJECT_FRONTEND=automecanik-frontend-dev
 SENTRY_ENVIRONMENT=dev
 
 # 0..1 — fraction of transactions sampled for performance monitoring.
-# 0.1 = 10%. Lower in production if quota becomes an issue.
-SENTRY_TRACES_SAMPLE_RATE=0.1
+# Governs all three init sites (backend instrument.ts, frontend SSR
+# entry.server.tsx, frontend client entry.client.tsx via window.ENV).
+# 0.02 = 2%. Calibrated for the Sentry Developer (free) 5M-span/month quota:
+# at 0.1 the backend OTel http instrumentation projected ~15-20M spans/month
+# (9.1M observed over a 14-day Business trial), which exhausts the quota in
+# ~10 days then drops every span for the rest of the month. 0.02 lands at
+# ~3-4M spans/month → continuous month-long coverage with headroom. Raise on
+# a paid plan; set "0" to disable performance tracing entirely (errors,
+# replays and uptime are unaffected — they have separate quotas).
+SENTRY_TRACES_SAMPLE_RATE=0.02
 
 # Set to "true" to opt-in to default PII collection (IP, cookies). Defaults
 # to false for RGPD minimisation. Enable only if user-impact debugging requires it.

--- a/backend/src/instrument.ts
+++ b/backend/src/instrument.ts
@@ -61,9 +61,12 @@ if (dsn) {
     // against the correct source maps once they are uploaded post-deploy.
     release: process.env.SENTRY_RELEASE || process.env.GIT_SHA || undefined,
 
-    // 10 % traces sampled in DEV. Tune downward in PROD if volume becomes a
-    // cost issue (Sentry quota is event-based for performance monitoring).
-    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.1),
+    // 2 % default — calibrated so monthly span volume stays under the Sentry
+    // Developer (free) 5M-span quota with month-long even coverage. At 10% the
+    // backend OTel http instrumentation alone projected ~15-20M spans/month,
+    // which burns the quota in ~10 days then goes blind. Override per-env via
+    // SENTRY_TRACES_SAMPLE_RATE. See backend/.env.example for the math.
+    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.02),
 
     // RGPD-safe default — opt-in IP / cookie collection only when explicitly
     // requested by the operator. The Sentry NestJS wizard's default is `true`

--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -79,12 +79,21 @@ const initObservability = async (): Promise<void> => {
     import("@remix-run/react"),
   ]);
 
+  // Same knob as backend/SSR (SENTRY_TRACES_SAMPLE_RATE), exposed via
+  // window.ENV in root.tsx. Empty string (env unset) falls back to 0.02 (2%);
+  // an explicit "0" is honoured so an operator can disable client tracing.
+  const envTracesSampleRate = (
+    window as unknown as { ENV?: { SENTRY_TRACES_SAMPLE_RATE?: string } }
+  ).ENV?.SENTRY_TRACES_SAMPLE_RATE;
+
   Sentry.init({
     dsn,
     environment:
       (window as unknown as { ENV?: { SENTRY_ENVIRONMENT?: string } }).ENV
         ?.SENTRY_ENVIRONMENT || "development",
-    tracesSampleRate: 0.1,
+    tracesSampleRate: envTracesSampleRate
+      ? Number(envTracesSampleRate)
+      : 0.02,
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 0,
     // Ne remonter que les erreurs issues du JS qu'on a buildé (`/assets/*.js`).

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -27,7 +27,7 @@ if (process.env.SENTRY_DSN) {
       process.env.APP_ENV ||
       process.env.NODE_ENV ||
       "development",
-    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.1),
+    tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? 0.02),
   });
 }
 

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -145,6 +145,10 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
         process.env.APP_ENV ||
         process.env.NODE_ENV ||
         "development",
+      // Same knob as backend/SSR (SENTRY_TRACES_SAMPLE_RATE) so all three init
+      // sites share one governance point. Passed as the raw string; the client
+      // coerces with Number() and a 0.02 fallback (see entry.client.tsx).
+      SENTRY_TRACES_SAMPLE_RATE: process.env.SENTRY_TRACES_SAMPLE_RATE || "",
     },
   });
 };

--- a/secrets/sentry.prod.sops.env
+++ b/secrets/sentry.prod.sops.env
@@ -5,14 +5,14 @@ SENTRY_ORG=ENC[AES256_GCM,data:ET2h1stoL94U+Fq+WvcqzoHA2Tmdxw==,iv:tYpbBUt341Ee8
 SENTRY_PROJECT_BACKEND=ENC[AES256_GCM,data:GUlVMnrZYcipbb+P/SuiEQlQ//N76BvL,iv:0po3rdqArPksTPQ4jPiYhgw/NR0veP7opaW4R30BzeU=,tag:ealsV7tTPzjqI8IJAqQCRQ==,type:str]
 SENTRY_PROJECT_FRONTEND=ENC[AES256_GCM,data:NK8EkRwP/34+iR95/PEFBW3jbwNh0cnNHw==,iv:zwu9A4agICB+Z4VxDnshmuUMc4yY5nlR6+JyX9ZoLVE=,tag:KhgRK26huw7bT/635lgakQ==,type:str]
 SENTRY_ENVIRONMENT=ENC[AES256_GCM,data:+Zy8EeL8pjneMw==,iv:Z5Khp+zjty61I5XPFkYUjp7Jkio7Dkkigh/scxopw1M=,tag:nU3KyIFac8p0N16KFWpbOw==,type:str]
-SENTRY_TRACES_SAMPLE_RATE=ENC[AES256_GCM,data:uxc6tg==,iv:Hm/viPw1/RE3m/CWpS+pgwIxCY8jLRkZaN2pv3SPYUc=,tag:3TpJyAkGQdFz71VSuJnflw==,type:str]
+SENTRY_TRACES_SAMPLE_RATE=ENC[AES256_GCM,data:17VJxQ==,iv:SFwWVzH0FWwm90dP5V6aIo0A8RZpKDLq+YHAfA0nDXY=,tag:5I9R5+B8lzPhIejLvKb/6g==,type:str]
 SENTRY_SEND_PII=ENC[AES256_GCM,data:MYlNUwE=,iv:UBjwuik+SG/N2FbeDluf/23pz5YV1bCxpmgT4VD1Q88=,tag:5mWjgsI0MzT7fANAyqmfyg==,type:str]
 SENTRY_ALLOW_DEBUG_ENDPOINT=ENC[AES256_GCM,data:DxWE/jA=,iv:JN0bcNL7F9ptPGNuxLBZWLXmslyEKl677oRYD6FuCjg=,tag:1UmXAmFB6n95M/AkP+uITA==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzTmpIVHlWcU9oZGV0bzFj\nMXVNckFvUyt4MitJL2tPOG9TUzJSMzd2OWgwCmRBV3lGQTc0U242RkNybkVPMHFZ\nN2J3L28rUEtGQUl2ZStoSTRUTk5VblkKLS0tIEhKZlNZNkNvRS9tR2tKL2VxVC9G\nYWtpTVlxTTZCMUFqZmtzZ0pjS044M1EKgrwHi2eMvU7NHCW3Y7oQ1YS6wed0KbIa\ngwdKM79orM8z9AuJW/AeLIQw6fwd9zDi+gYCYxApFYFvHTsdTNr+nw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age17p8cdc42j9fj0045pqd33epc4z3fkgr7643365uj73hl2zq74gzqfkx6jd
 sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzN0pHNVJPcUZNNzl5L2Er\nMU8rRGNBMHhZOG1QVGVaSnV4blJKWjFLa1Q0CkFPbW16R29qa2NVd1A2Y3pJaDVQ\nVkJCQUJURGlSTG10RHlhaFFxUFQyVkUKLS0tIFZqSjhwSzIvaVhEUUtpL2pzaGdv\nN3NpdWtTK3Z6c2d2NzJWajQxWGVrbDgKlLfSjNwEQLU4tyZL0tQOqu4uklc40nJc\n2g6skj5a6hEOxXyyuGNj6GLVzhtYVqcGwH4IZlan7ezdJ42PKSPdSg==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age14v0s0qhn68ctmf5m649lra4fzkv56sz7wuzuaq7adavxvrggpe0qa2v8n2
-sops_lastmodified=2026-05-06T16:09:04Z
-sops_mac=ENC[AES256_GCM,data:MV8Wx96cjg4twmJ5zgseOtFCFk0OQCMxhqn5lLRu/6M+t9JllAH+F6erzTGVoetYpEhr8bjCbMVxFRL1NOtwMFTeEF02wHX+0GzuUjJPv3Qr123weC8TIKLbcU4Sdr7A5Q9OpUps4xX2xl6BLBlaWFn+sdH+9pkaGA1KPYXtLBE=,iv:kBsPiWKVmRccmoVcYYnnACvOBvqOokn6Xmi1+TnutWA=,tag:wEjjxVfFZFCrZJDLpa0avw==,type:str]
+sops_lastmodified=2026-05-20T17:21:15Z
+sops_mac=ENC[AES256_GCM,data:ao/owIfdp+gNb24BQYEGD8KroclH96crE1jDLBr6nYrDhpfAgRX6EIobGHV2f32Pew0iMB/72cBErYfIRvEv4siJUCZ4u8DcSonwbbMedi/VfgSLpjDs1MAVs1pZsHBN0HZrK3l+I4AOkhaitL/ZuaHEe+vGdHLYmgky75Kd36A=,iv:1PHvHs/d3sW+BkpJoncBwgqcDGMn0/pQZXmzRPf11t0=,tag:O7UTRVwNMeEpYhktzQFwCw==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.9.1


### PR DESCRIPTION
## Problème

L'org Sentry « Auto Pièces Équipement » est repassée au plan **Developer (gratuit)** après la fin de l'essai Business. Quota org-wide : **5M spans/mois**, partagé entre tous les environnements. Les sample rates effectifs (dev 10% via défaut, prod 5%) projetaient **~19,5M spans/mois** (9,1M observés sur l'essai de 14j) → quota épuisé en ~10 jours puis **tous les spans droppés** le reste du mois (couverture aveugle). Aucun risque de facture (pas de moyen de paiement), mais perte de couverture perf.

## Changement — réduction uniforme ~5×

**Code (commit 1)** — `0.1 → 0.02` + unification du knob :
- `backend/src/instrument.ts`, `frontend/app/entry.server.tsx` : fallback `0.1 → 0.02`.
- `frontend/app/entry.client.tsx` : **fin du `0.1` codé en dur** → lit le knob via `window.ENV` (correctif d'incohérence).
- `frontend/app/root.tsx` : expose `SENTRY_TRACES_SAMPLE_RATE` dans `window.ENV`.
- `backend/.env.example` : défaut `0.02` + calcul documenté.
- `"0"` désactive proprement le tracing ; unset → défaut `0.02`.

**Secret PROD (commit 2)** — `secrets/sentry.prod.sops.env` : `SENTRY_TRACES_SAMPLE_RATE 0.05 → 0.01`.
- Prod surchargeait déjà le knob à `0.05` (pas `0.1`). Comme prod est la source dominante et que le quota est org-wide, prod reçoit le **même cut 5×** que le défaut code (0.1→0.02), soit 0.05→0.01.
- Valeur choisie par l'opérateur (confirmation explicite).
- Chiffré en place via `sops set` (seuls valeur + MAC modifiés, aucun plaintext sur disque).

**Résultat** : cut 5× uniforme → org total **~3,9M spans/mois**, sous le cap 5M avec marge. Errors / replays / uptime **non affectés** (quotas séparés). DEV : clé absente du SOPS → hérite du défaut `0.02` automatiquement.

Pas de nouveau service, pas de migration, pas de `tracesSampler` custom.

## Déploiement

- Merge `main` → deploy DEV préprod (défaut 0.02 actif).
- Le secret prod 0.01 prend effet au prochain deploy PROD (tag `v*`), décrypté par `scripts/secrets/run-with-secrets.sh`.

## Vérification

`tsc --noEmit` backend + frontend : les 4 fichiers TS modifiés compilent clean (erreurs tsc résiduelles = packages `@repo/*` non buildés dans le worktree, sans rapport). Diff SOPS = valeur + MAC uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)