### PR TITLE
docs(agents): directive canonique de recherche documentaire

### DIFF
--- a/.claude/rules/agent-doc-search.md
+++ b/.claude/rules/agent-doc-search.md
@@ -1,0 +1,37 @@
+# Recherche documentaire des agents — registry-first, Grep natif, zéro nouvelle couche
+
+> Comment un agent retrouve du contexte documentaire dans ce monorepo.
+> **Aide à la lecture uniquement** — la vérité reste `RAW → WIKI → exports → consommateurs`.
+
+## Ordre de recherche (avant toute exploration en rafale)
+
+1. **`audit/registry/canonical.json`** — Source of Truth machine-readable (ADR-058).
+   Query via `jq` (ex. `jq '.files[] | select(.path | contains("payments"))' audit/registry/canonical.json`).
+2. **`.claude/knowledge/REPO_MAP.md`** puis `.claude/knowledge/{modules,db,integrations,routes}/`.
+3. **Grep natif** pour debugging ciblé, strings, cas non couverts par le registry.
+
+L'outil **Grep** de Claude Code **EST** ripgrep (smart-case, `--glob '*.md'`, exclusions,
+numéros de ligne intégrés). Donc :
+
+- **Pas de wrapper** type `md-find.sh` — re-wrapper le natif = abstraction plus faible.
+- **Pas de nouvel index**, pas de QMD, pas de couche RAG parallèle, pas de vérité parallèle.
+
+## Interdits
+
+- Ne **jamais** trancher un fait canonique (SEO runtime, R2, supplier truth, canonical URL)
+  à partir d'un grep de markdown. Ces décisions passent par leurs sources dédiées (vault,
+  RPC, funnel), pas par cette recherche.
+- Lecture seule : cette recherche aide à comprendre, elle ne décide pas.
+- La gouvernance canon vit au vault (`governance-vault/`) — `.claude/knowledge/` et
+  `audit/registry/` la **référencent**, ne la dupliquent pas.
+
+## Outils CLI (ergonomie humaine — hors agents)
+
+`rg` / `fd` / `bat` / `fzf` installés sur le VPS servent l'**humain** en shell. Les agents
+Claude Code utilisent l'outil **Grep natif** (déjà ripgrep), pas ces binaires système.
+
+## Agents sans filesystem (runtime AI-COS / Paperclip)
+
+Les agents remote (HTTP/MCP only) n'ont pas accès au repo. Pour eux, « recherche
+documentaire » = consulter le canon via le **vault** + les **APIs/MCP** listées dans leur
+`AGENTS.md` (lecture seule). Aucun grep local — même discipline « canon d'abord ».

--- a/agents/ceo/AGENTS.md
+++ b/agents/ceo/AGENTS.md
@@ -88,3 +88,13 @@ Consulter les commentaires Paperclip des agents RAG Lead et IA-SEO Master.
 - **P1** : impact direct prod ou pipeline bloqué (service down, données corrompues)
 - **P2** : défaut important mais contournable
 - **P3** : amélioration, optimisation
+
+## Recherche documentaire (avant analyse)
+
+Avant toute analyse, **consulter le canon — ne jamais réinventer ni contredire l'existant** :
+vault `governance-vault/` (ADRs, règles, evidence-packs), `MEMORY.md`, et les sources listées
+en « Infrastructure » (APIs + MCP, lecture seule). Runtime AI-COS HTTP-only : pas de `grep`
+local du repo — l'accès au canon passe par le vault et ces APIs/MCP. Cette recherche aide à
+comprendre ; elle ne tranche aucun fait canonique. Vérité documentaire :
+`RAW → WIKI → exports → consommateurs`. Protocole des sessions Claude Code :
+`.claude/rules/agent-doc-search.md`.

--- a/agents/cmo/AGENTS.md
+++ b/agents/cmo/AGENTS.md
@@ -95,3 +95,13 @@ FROM __seo_r6_keyword_plan;
 - **P1** : pipeline SEO bloqué, gamme prioritaire sans contenu depuis > 30j, IA-SEO Master down
 - **P2** : couverture KP < 80%, sections incomplètes sur gammes top trafic
 - **P3** : refresh, optimisation, amélioration scores qualité
+
+## Recherche documentaire (avant analyse)
+
+Avant toute analyse, **consulter le canon — ne jamais réinventer ni contredire l'existant** :
+vault `governance-vault/` (ADRs, règles, evidence-packs), `MEMORY.md`, et les sources listées
+en « Infrastructure » (APIs + MCP, lecture seule). Runtime AI-COS HTTP-only : pas de `grep`
+local du repo — l'accès au canon passe par le vault et ces APIs/MCP. Cette recherche aide à
+comprendre ; elle ne tranche aucun fait canonique. Vérité documentaire :
+`RAW → WIKI → exports → consommateurs`. Protocole des sessions Claude Code :
+`.claude/rules/agent-doc-search.md`.

--- a/agents/cto/AGENTS.md
+++ b/agents/cto/AGENTS.md
@@ -79,3 +79,13 @@ GET /api/knowledge/stats (FastAPI 8000)
 - **P1** : service down, données corrompues, agent bloqué
 - **P2** : config drift, couverture faible, warnings récurrents
 - **P3** : optimisation, observabilité
+
+## Recherche documentaire (avant analyse)
+
+Avant toute analyse, **consulter le canon — ne jamais réinventer ni contredire l'existant** :
+vault `governance-vault/` (ADRs, règles, evidence-packs), `MEMORY.md`, et les sources listées
+en « Infrastructure » (APIs + MCP, lecture seule). Runtime AI-COS HTTP-only : pas de `grep`
+local du repo — l'accès au canon passe par le vault et ces APIs/MCP. Cette recherche aide à
+comprendre ; elle ne tranche aucun fait canonique. Vérité documentaire :
+`RAW → WIKI → exports → consommateurs`. Protocole des sessions Claude Code :
+`.claude/rules/agent-doc-search.md`.

--- a/agents/rag-lead/AGENTS.md
+++ b/agents/rag-lead/AGENTS.md
@@ -385,3 +385,13 @@ Champs requis : `run_id` (UUID v4), `alias`, `run_date`, `execution_mode`, `stat
 ### Seuil stop global (D10)
 
 Si >20% du lot en v5_blocked ou v5_pending_review → suspendre. Stratifier les lots par densite de sources (courante/niche/specialiste).
+
+## Recherche documentaire (avant analyse)
+
+Avant toute analyse, **consulter le canon — ne jamais réinventer ni contredire l'existant** :
+vault `governance-vault/` (ADRs, règles, evidence-packs), `MEMORY.md`, et les sources listées
+en « Services disponibles » (APIs + MCP + `refs/`, lecture seule). Runtime AI-COS HTTP-only : pas
+de `grep` local du repo — l'accès au canon passe par le vault et ces APIs/MCP. Cette recherche
+aide à comprendre ; elle ne tranche aucun fait canonique. Vérité documentaire :
+`RAW → WIKI → exports → consommateurs`. Protocole des sessions Claude Code :
+`.claude/rules/agent-doc-search.md`.

--- a/agents/seo-content/AGENTS.md
+++ b/agents/seo-content/AGENTS.md
@@ -194,3 +194,13 @@ Action DEV : `claude --print "/seo-gamme-audit <alias>"` dans `/opt/automecanik/
 - **P1** : KP manquant → bloque la génération de contenu
 - **P2** : KP présent mais contenu absent → génération possible, non déclenchée
 - **P3** : refresh, amélioration scores qualité, optimisation
+
+## Recherche documentaire (avant analyse)
+
+Avant toute analyse, **consulter le canon — ne jamais réinventer ni contredire l'existant** :
+vault `governance-vault/` (ADRs, règles, evidence-packs), `MEMORY.md`, et les sources listées
+en « Infrastructure » (APIs + MCP, lecture seule). Runtime AI-COS HTTP-only : pas de `grep`
+local du repo — l'accès au canon passe par le vault et ces APIs/MCP. Cette recherche aide à
+comprendre ; elle ne tranche aucun fait canonique. Vérité documentaire :
+`RAW → WIKI → exports → consommateurs`. Protocole des sessions Claude Code :
+`.claude/rules/agent-doc-search.md`.

--- a/agents/seo-qa/AGENTS.md
+++ b/agents/seo-qa/AGENTS.md
@@ -84,3 +84,13 @@ Output : clics, impressions, CTR, position moyenne, top requêtes
 3. **Retry policy** : 0 retry sur erreur API. 1 retry sur timeout.
 4. **Budget tokens** : rester concis, pas de dump exhaustif des 241 gammes
 5. **Escalade** : anomalies critiques (chute trafic > 30%) → ticket P1 vers IA-SEO Master
+
+## Recherche documentaire (avant analyse)
+
+Avant toute analyse, **consulter le canon — ne jamais réinventer ni contredire l'existant** :
+vault `governance-vault/` (ADRs, règles, evidence-packs), `MEMORY.md`, et les sources listées
+en « MCP Servers disponibles » (lecture seule). Runtime AI-COS HTTP-only : pas de `grep` local
+du repo — l'accès au canon passe par le vault et ces APIs/MCP. Cette recherche aide à
+comprendre ; elle ne tranche aucun fait canonique. Vérité documentaire :
+`RAW → WIKI → exports → consommateurs`. Protocole des sessions Claude Code :
+`.claude/rules/agent-doc-search.md`.


### PR DESCRIPTION
## Pourquoi

Demande : une **recherche documentaire automatique pour les agents**. L'investigation a révélé que les agents qui font le travail (Claude Code R0-R8, marketing) **cherchent déjà** automatiquement via l'outil **Grep natif (= ripgrep)**. Un script `md-find.sh` ou un nouvel index serait donc redondant pour eux et une couche injustifiée pour les agents Paperclip (HTTP/MCP-only) → **bricolage**.

Le seul vrai écart : la directive « chercher le canon d'abord » était **incohérente** entre agents (seul le CPO la portait). Ce PR l'**uniformise** — instruction, pas code.

## Ce que fait ce PR

- **NEW** `.claude/rules/agent-doc-search.md` — protocole canonique : `canonical.json` → `.claude/knowledge/` → **Grep natif**. Interdits explicites : pas de wrapper, pas d'index/QMD/RAG parallèle. Vérité = `RAW → WIKI → exports → consommateurs`.
- **6 AGENTS.md** (`ceo/cto/cmo/rag-lead/seo-content/seo-qa`) — bloc « Recherche documentaire (avant analyse) », **runtime-honnête** : ces agents sont API-only (IA-SEO Master dit explicitement *« skills/SQL non disponibles sur AI-COS »*), donc canon via vault + APIs/MCP, **pas de grep local**.

## Garanties

- **100 % markdown** : 0 script, 0 index, 0 migration, 0 endpoint, 0 nouvelle couche.
- `validate-agents-md.sh --staged` (équivalent CI/pre-commit) : **`blocks: 0`**. Les `WARN` restants sont des sections optionnelles pré-existantes.
- À noter : `rg/fd/bat/fzf` installés sur le VPS DEV servent l'ergonomie **humaine** — les agents utilisent le Grep natif, indépendant de ces binaires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)