### PR TITLE
chore(knowledge): bootstrap 8 fichiers module manquants

### DIFF
--- a/.claude/knowledge/modules/maintenance.md
+++ b/.claude/knowledge/modules/maintenance.md
@@ -1,0 +1,40 @@
+---
+module: maintenance
+sources:
+- backend/src/modules/maintenance
+last_scan: '2026-05-21'
+primary_files:
+- backend/src/modules/maintenance/maintenance.module.ts
+depends_on: []
+---
+
+# Module Maintenance
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- _(aucun export dans le `@Module({exports: [...]})`)_
+
+### Providers (top 15)
+- _(aucun provider détecté)_
+
+### Fichiers primaires
+- [backend/src/modules/maintenance/maintenance.module.ts](../../../backend/src/modules/maintenance/maintenance.module.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/merchant-center.md
+++ b/.claude/knowledge/modules/merchant-center.md
@@ -1,0 +1,45 @@
+---
+module: merchant-center
+sources:
+- backend/src/modules/merchant-center
+last_scan: '2026-05-21'
+primary_files:
+- backend/src/modules/merchant-center/controllers/merchant-center.controller.ts
+- backend/src/modules/merchant-center/merchant-center.module.ts
+- backend/src/modules/merchant-center/services/merchant-center-feed.service.ts
+depends_on:
+- DatabaseModule
+---
+
+# Module Merchant Center
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `MerchantCenterFeedService`
+
+### Providers (top 15)
+- `MerchantCenterFeedService`
+
+### Fichiers primaires
+- [backend/src/modules/merchant-center/controllers/merchant-center.controller.ts](../../../backend/src/modules/merchant-center/controllers/merchant-center.controller.ts)
+- [backend/src/modules/merchant-center/merchant-center.module.ts](../../../backend/src/modules/merchant-center/merchant-center.module.ts)
+- [backend/src/modules/merchant-center/services/merchant-center-feed.service.ts](../../../backend/src/modules/merchant-center/services/merchant-center-feed.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/observability.md
+++ b/.claude/knowledge/modules/observability.md
@@ -1,0 +1,55 @@
+---
+module: observability
+sources:
+- backend/src/modules/observability
+last_scan: '2026-05-21'
+primary_files:
+- backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.test.ts
+- backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.ts
+- backend/src/modules/observability/diagnostic-kg-shadow.metrics.ts
+- backend/src/modules/observability/observability.module.ts
+- backend/src/modules/observability/observability.tokens.ts
+- backend/src/modules/observability/prometheus.controller.ts
+- backend/src/modules/observability/vehicle-context-metrics.listener.test.ts
+- backend/src/modules/observability/vehicle-context-metrics.listener.ts
+depends_on:
+- EventEmitterModule
+---
+
+# Module Observability
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- _(aucun export dans le `@Module({exports: [...]})`)_
+
+### Providers (top 15)
+- _(aucun provider détecté)_
+
+### Fichiers primaires
+- [backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.test.ts](../../../backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.test.ts)
+- [backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.ts](../../../backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.ts)
+- [backend/src/modules/observability/diagnostic-kg-shadow.metrics.ts](../../../backend/src/modules/observability/diagnostic-kg-shadow.metrics.ts)
+- [backend/src/modules/observability/observability.module.ts](../../../backend/src/modules/observability/observability.module.ts)
+- [backend/src/modules/observability/observability.tokens.ts](../../../backend/src/modules/observability/observability.tokens.ts)
+- [backend/src/modules/observability/prometheus.controller.ts](../../../backend/src/modules/observability/prometheus.controller.ts)
+- [backend/src/modules/observability/vehicle-context-metrics.listener.test.ts](../../../backend/src/modules/observability/vehicle-context-metrics.listener.test.ts)
+- [backend/src/modules/observability/vehicle-context-metrics.listener.ts](../../../backend/src/modules/observability/vehicle-context-metrics.listener.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/rag-knowledge-bootstrap.md
+++ b/.claude/knowledge/modules/rag-knowledge-bootstrap.md
@@ -1,0 +1,42 @@
+---
+module: rag-knowledge-bootstrap
+sources:
+- backend/src/modules/rag-knowledge-bootstrap
+last_scan: '2026-05-21'
+primary_files:
+- backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
+- backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts
+depends_on: []
+---
+
+# Module Rag Knowledge Bootstrap
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `RagKnowledgeBootstrapGuardService`
+
+### Providers (top 15)
+- `RagKnowledgeBootstrapGuardService`
+
+### Fichiers primaires
+- [backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts](../../../backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts)
+- [backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts](../../../backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/seo-control-plane.md
+++ b/.claude/knowledge/modules/seo-control-plane.md
@@ -1,0 +1,65 @@
+---
+module: seo-control-plane
+sources:
+- backend/src/modules/seo-control-plane
+last_scan: '2026-05-21'
+primary_files:
+- backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.processor.ts
+- backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.scheduler.service.ts
+- backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.service.test.ts
+- backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.service.ts
+- backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.types.ts
+- backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.processor.ts
+- backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.scheduler.service.ts
+- backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.test.ts
+depends_on:
+- ConfigModule
+- DatabaseModule
+- BullModule
+---
+
+# Module Seo Control Plane
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `CriticalityLoaderService`
+
+### Providers (top 15)
+- `CriticalityLoaderService`
+- `SyntheticCrawlerService`
+- `SyntheticCrawlerSchedulerService`
+- `CfAnalyticsCollectorService`
+- `CfAnalyticsSchedulerService`
+- `CfRumCollectorService`
+- `CfRumSchedulerService`
+- `RuntimeLogsCollectorService`
+- `RuntimeLogsSchedulerService`
+
+### Fichiers primaires
+- [backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.processor.ts](../../../backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.processor.ts)
+- [backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.scheduler.service.ts](../../../backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.scheduler.service.ts)
+- [backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.service.test.ts](../../../backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.service.test.ts)
+- [backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.service.ts](../../../backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.service.ts)
+- [backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.types.ts](../../../backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.types.ts)
+- [backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.processor.ts](../../../backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.processor.ts)
+- [backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.scheduler.service.ts](../../../backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.scheduler.service.ts)
+- [backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.test.ts](../../../backend/src/modules/seo-control-plane/collectors/cf-rum/cf-rum.service.test.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/seo-monitoring.md
+++ b/.claude/knowledge/modules/seo-monitoring.md
@@ -1,0 +1,76 @@
+---
+module: seo-monitoring
+sources:
+- backend/src/modules/seo-monitoring
+last_scan: '2026-05-21'
+primary_files:
+- backend/src/modules/seo-monitoring/controllers/quality-history.controller.ts
+- backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
+- backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts
+- backend/src/modules/seo-monitoring/seo-monitoring.module.ts
+- backend/src/modules/seo-monitoring/services/audit-findings.service.ts
+- backend/src/modules/seo-monitoring/services/crux-alerter.service.ts
+- backend/src/modules/seo-monitoring/services/crux-alerter.test.ts
+- backend/src/modules/seo-monitoring/services/crux-api-client.service.ts
+depends_on:
+- ConfigModule
+---
+
+# Module Seo Monitoring
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `GoogleCredentialsService`
+- `GscDailyFetcherService`
+- `Ga4DailyFetcherService`
+- `CwvFetcherService`
+- `GscLinksFetcherService`
+- `CruxFieldFetcherService`
+- `CruxAlerterService`
+- `AuditFindingsService`
+- `RContentAuditorService`
+- `QualityHistorySnapshotService`
+- `RagMirrorFreshnessService`
+
+### Providers (top 15)
+- `GoogleCredentialsService`
+- `SeoMonitoringRunsService`
+- `GscDailyFetcherService`
+- `Ga4DailyFetcherService`
+- `CwvFetcherService`
+- `GscLinksFetcherService`
+- `CruxFieldFetcherService`
+- `CruxAlerterService`
+- `AuditFindingsService`
+- `RContentAuditorService`
+- `QualityHistorySnapshotService`
+- `RagMirrorFreshnessService`
+
+### Fichiers primaires
+- [backend/src/modules/seo-monitoring/controllers/quality-history.controller.ts](../../../backend/src/modules/seo-monitoring/controllers/quality-history.controller.ts)
+- [backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts](../../../backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts)
+- [backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts](../../../backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts)
+- [backend/src/modules/seo-monitoring/seo-monitoring.module.ts](../../../backend/src/modules/seo-monitoring/seo-monitoring.module.ts)
+- [backend/src/modules/seo-monitoring/services/audit-findings.service.ts](../../../backend/src/modules/seo-monitoring/services/audit-findings.service.ts)
+- [backend/src/modules/seo-monitoring/services/crux-alerter.service.ts](../../../backend/src/modules/seo-monitoring/services/crux-alerter.service.ts)
+- [backend/src/modules/seo-monitoring/services/crux-alerter.test.ts](../../../backend/src/modules/seo-monitoring/services/crux-alerter.test.ts)
+- [backend/src/modules/seo-monitoring/services/crux-api-client.service.ts](../../../backend/src/modules/seo-monitoring/services/crux-api-client.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/seo-shadow-observatory.md
+++ b/.claude/knowledge/modules/seo-shadow-observatory.md
@@ -1,0 +1,56 @@
+---
+module: seo-shadow-observatory
+sources:
+- backend/src/modules/seo-shadow-observatory
+last_scan: '2026-05-21'
+primary_files:
+- backend/src/modules/seo-shadow-observatory/env.schema.ts
+- backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts
+- backend/src/modules/seo-shadow-observatory/seo-shadow-diff-engine.service.ts
+- backend/src/modules/seo-shadow-observatory/seo-shadow-event-sink.service.ts
+- backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.module.ts
+- backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.service.ts
+- backend/src/modules/seo-shadow-observatory/seo-shadow-purge.cron.ts
+- backend/src/modules/seo-shadow-observatory/seo-shadow-sampler.service.ts
+depends_on:
+- SeoModule
+- ConfigModule
+---
+
+# Module Seo Shadow Observatory
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- _(aucun export dans le `@Module({exports: [...]})`)_
+
+### Providers (top 15)
+- _(aucun provider détecté)_
+
+### Fichiers primaires
+- [backend/src/modules/seo-shadow-observatory/env.schema.ts](../../../backend/src/modules/seo-shadow-observatory/env.schema.ts)
+- [backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts](../../../backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts)
+- [backend/src/modules/seo-shadow-observatory/seo-shadow-diff-engine.service.ts](../../../backend/src/modules/seo-shadow-observatory/seo-shadow-diff-engine.service.ts)
+- [backend/src/modules/seo-shadow-observatory/seo-shadow-event-sink.service.ts](../../../backend/src/modules/seo-shadow-observatory/seo-shadow-event-sink.service.ts)
+- [backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.module.ts](../../../backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.module.ts)
+- [backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.service.ts](../../../backend/src/modules/seo-shadow-observatory/seo-shadow-observatory.service.ts)
+- [backend/src/modules/seo-shadow-observatory/seo-shadow-purge.cron.ts](../../../backend/src/modules/seo-shadow-observatory/seo-shadow-purge.cron.ts)
+- [backend/src/modules/seo-shadow-observatory/seo-shadow-sampler.service.ts](../../../backend/src/modules/seo-shadow-observatory/seo-shadow-sampler.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.claude/knowledge/modules/vehicle-context.md
+++ b/.claude/knowledge/modules/vehicle-context.md
@@ -1,0 +1,48 @@
+---
+module: vehicle-context
+sources:
+- backend/src/modules/vehicle-context
+last_scan: '2026-05-21'
+primary_files:
+- backend/src/modules/vehicle-context/vehicle-context.middleware.test.ts
+- backend/src/modules/vehicle-context/vehicle-context.middleware.ts
+- backend/src/modules/vehicle-context/vehicle-context.module.ts
+- backend/src/modules/vehicle-context/vehicle-context.service.ts
+depends_on:
+- ConfigModule
+- EventEmitterModule
+---
+
+# Module Vehicle Context
+
+## Rôle
+<!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
+_Section à rédiger._
+
+<!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
+
+### Exports publics du module
+- `VehicleContextService`
+
+### Providers (top 15)
+- `VehicleContextService`
+
+### Fichiers primaires
+- [backend/src/modules/vehicle-context/vehicle-context.middleware.test.ts](../../../backend/src/modules/vehicle-context/vehicle-context.middleware.test.ts)
+- [backend/src/modules/vehicle-context/vehicle-context.middleware.ts](../../../backend/src/modules/vehicle-context/vehicle-context.middleware.ts)
+- [backend/src/modules/vehicle-context/vehicle-context.module.ts](../../../backend/src/modules/vehicle-context/vehicle-context.module.ts)
+- [backend/src/modules/vehicle-context/vehicle-context.service.ts](../../../backend/src/modules/vehicle-context/vehicle-context.service.ts)
+
+<!-- END AUTO-GENERATED -->
+
+## Pourquoi
+<!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
+_Section à rédiger._
+
+## Gotchas
+<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
+_Section à rédiger._
+
+## Références
+<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
+_Section à rédiger._

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -32,6 +32,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: medium
+  - glob: .claude/knowledge/**
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   - glob: .spec/00-canon/ai-registry/**
     domain: D15
     owner: '@ak125'


### PR DESCRIPTION
## Pourquoi

8 modules backend ont du **code** mais **aucun fichier knowledge** → un agent qui interroge `.claude/knowledge/modules/<x>` n'avait rien. Ce PR comble la couverture **structurelle** (machine layer) : 42 → 50 modules.

Ajoutés : `maintenance`, `merchant-center`, `observability`, `rag-knowledge-bootstrap`, `seo-control-plane`, `seo-monitoring`, `seo-shadow-observatory`, `vehicle-context`.

## Comment

`scripts/knowledge/refresh-knowledge.py bootstrap` (script existant). Chaque fichier = frontmatter (`sources`/`primary_files`/`depends_on`) + bloc `AUTO-GENERATED` (exports/providers) lu depuis `@Module()`. **Zéro fabrication.**

Inclut aussi le glob ownership manquant **`.claude/knowledge/**` (D15)** : le gate `registry-new-file` exige owner+domain pour tout nouveau fichier, et `.claude/knowledge/` n'était pas couvert (seuls `rules`/`skills`/`governance` l'étaient). `check-new-files.js --base origin/main` → **8/8 ok**.

## Choix de scope (no-bricolage)

- **Prose laissée vide** — Rôle/Pourquoi/Gotchas sont human-authored par design (CLAUDE.md). Pas d'invention depuis le code.
- **Churn `last_scan` écarté** : les 42 fichiers existants n'avaient qu'un bump de date (blocs AUTO non dérivés) → reverté, diff focalisé.
- **Registry db/rpc + queue configs : hors scope** (roadmappé PR-R / cosmétique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)