### PR TITLE
fix(migrations): @non_transactional marker for seo_control_003_indexes (unblock apply batch)

### DIFF
--- a/backend/supabase/migrations/20260518_seo_control_003_indexes.sql
+++ b/backend/supabase/migrations/20260518_seo_control_003_indexes.sql
@@ -1,3 +1,4 @@
+-- @non_transactional
 -- squawk-ignore-file ban-concurrent-index-creation-in-transaction
 -- =====================================================
 -- PR-SBD-1 Task 1 Step 11 — Indexes CONCURRENTLY (non-transactional)
@@ -8,10 +9,15 @@
 -- =====================================================
 --
 -- Squawk directive : `ban-concurrent-index-creation-in-transaction` ignored
--- file-wide because this migration is EXPLICITLY non-transactional. The
--- Supabase migration runner detects the absence of BEGIN/COMMIT and applies
--- each CREATE INDEX CONCURRENTLY as a standalone statement. Cf. existing
--- patterns 20260120_rm_expression_index.sql / 20260128_add_index_pieces_*.sql.
+-- file-wide because this migration is EXPLICITLY non-transactional.
+--
+-- The canonical engine (scripts/ci/apply-supabase-migration.py) wraps every
+-- migration in BEGIN/COMMIT UNLESS it finds the `-- @non_transactional` marker
+-- in the first 20 lines (see is_non_transactional_header). The marker above is
+-- REQUIRED here: without it the engine would run these statements inside a
+-- transaction and CREATE INDEX CONCURRENTLY would raise SQLSTATE 25001. With
+-- it, the engine runs in autocommit and each CONCURRENTLY build is standalone.
+-- Cf. existing patterns 20260120_rm_expression_index.sql / 20260128_add_index_pieces_*.sql.
 --
 -- CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
 -- Apply each statement separately (psql \i or migration runner with


### PR DESCRIPTION
## Problem

The canonical migration engine (`scripts/ci/apply-supabase-migration.py`) wraps every migration in `BEGIN/COMMIT` **unless** it finds a bare `-- @non_transactional` marker in the first 20 lines (`is_non_transactional_header`).

`20260518_seo_control_003_indexes.sql` runs **4 `CREATE INDEX CONCURRENTLY`** statements but was missing that marker — it only carried `-- squawk-ignore-file ban-concurrent-index-creation-in-transaction`. The engine therefore planned it as `(tx)`. A dry-run of the apply workflow against `main` confirmed all 9 pending migrations, with `003_indexes` slated to run transactionally.

Applying it in a transaction would raise Postgres **SQLSTATE 25001** (`CREATE INDEX CONCURRENTLY cannot run inside a transaction block`), failing the migration and blocking the rest of the 9-migration backlog mid-batch.

The header already *documented* the file as non-transactional, but relied on a different runner's (Supabase CLI) BEGIN/COMMIT auto-detection — semantics the canonical Flyway-pattern engine does not implement.

## Fix

- Add the engine's explicit `-- @non_transactional` marker (line 1).
- Correct the header prose to reference the actual engine mechanism.

This is a **pending, never-applied** migration (last applied = `20260518_seo_admin_job_table`, 2026-05-16), so editing it before first apply is safe — no checksum drift.

## Verification

Validated with the engine's own parser:
```
20260518_seo_control_003_indexes      → non_transactional = True   (was False)
20260520_order_landing_attribution    → non_transactional = False  (correctly tx, unchanged)
```

No new files added (registry block-new gate N/A). After merge: re-run the apply dry-run, then `confirm=APPLY` for the full 9-migration batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)