### PR TITLE
fix(migrations): mark seo_control_003 indexes @non_transactional (unblock ledger convergence)

### DIFF
--- a/backend/supabase/migrations/20260518_seo_control_003_indexes.sql
+++ b/backend/supabase/migrations/20260518_seo_control_003_indexes.sql
@@ -1,4 +1,5 @@
 -- squawk-ignore-file ban-concurrent-index-creation-in-transaction
+-- @non_transactional
 -- =====================================================
 -- PR-SBD-1 Task 1 Step 11 — Indexes CONCURRENTLY (non-transactional)
 -- Date: 2026-05-18
@@ -9,9 +10,12 @@
 --
 -- Squawk directive : `ban-concurrent-index-creation-in-transaction` ignored
 -- file-wide because this migration is EXPLICITLY non-transactional. The
--- Supabase migration runner detects the absence of BEGIN/COMMIT and applies
--- each CREATE INDEX CONCURRENTLY as a standalone statement. Cf. existing
--- patterns 20260120_rm_expression_index.sql / 20260128_add_index_pieces_*.sql.
+-- forward-only engine (scripts/ci/apply-supabase-migration.py) runs a file in
+-- autocommit ONLY when it carries the standalone `-- @non_transactional` header
+-- marker (above) — it does NOT infer non-tx from the absence of BEGIN/COMMIT.
+-- Without that marker the engine wraps the file in BEGIN/COMMIT and Postgres
+-- rejects CREATE INDEX CONCURRENTLY. Cf. existing patterns
+-- 20260120_rm_expression_index.sql / 20260128_add_index_pieces_*.sql.
 --
 -- CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
 -- Apply each statement separately (psql \i or migration runner with


### PR DESCRIPTION
## Context
The forward-only migration engine reports a 9-migration ledger backlog (frozen since 2026-05-16). While converging it via apply-supabase-migrations.yml, the dry-run classified 20260518_seo_control_003_indexes as **(tx)** — a defect.

## Problem
That migration runs CREATE INDEX CONCURRENTLY x4, which **cannot execute inside a transaction block**. The engine (scripts/ci/apply-supabase-migration.py, NON_TX_MARKER_RE, first 20 lines) only runs a file in autocommit when it carries a **standalone -- @non_transactional marker** — it does not infer non-tx from absence of BEGIN/COMMIT (the original header comment wrongly assumed it did). Without the marker the engine wraps the file in BEGIN/COMMIT and Postgres rejects the build.

## Fix
- Add the standalone -- @non_transactional marker (line 2, within the 20-line header window — verified against the engine regex).
- Correct the misleading header comment to describe the engine's actual marker contract.

No SQL/DDL change; indexes remain IF NOT EXISTS (idempotent). Squawk file-wide ignore retained.

## Verification
Backlog #1-#6 already applied cleanly (Stage 1); this unblocks #7 (4-index build, 2 on __seo_gsc_daily ~30M rows, CONCURRENTLY = non-blocking), then #8-#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)