### PR TITLE
feat(commerce-loop): funnel event tracking outil diagnostic (étape 4-A)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -388,6 +388,11 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: medium
+  - glob: backend/supabase/migrations/*seo_event_funnel*
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/supabase/migrations/*seo_control*
     domain: D8
     owner: '@ak125/admin-team'

--- a/backend/src/modules/seo-monitoring/controllers/funnel-events.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/funnel-events.controller.ts
@@ -1,0 +1,33 @@
+/**
+ * Funnel Events Controller — Commerce-Loop V1 étape 4-A.
+ *
+ * Endpoint PUBLIC posté par le beacon frontend (`navigator.sendBeacon`) :
+ *   POST /api/seo/funnel/event   — enregistre 1 event funnel (diag_* | r2_*)
+ *
+ * Public à dessein (mesure de parcours utilisateur, pas de donnée sensible).
+ * Validation stricte Zod (FunnelEventInputSchema). L'écriture passe par
+ * `FunnelEventsService` (extends SupabaseBaseService → service-role + RLS ADR-028).
+ */
+import { Body, Controller, HttpCode, Logger, Post } from '@nestjs/common';
+import { FunnelEventInputSchema } from '@repo/seo-types';
+import { FunnelEventsService } from '../services/funnel-events.service';
+
+@Controller('api/seo/funnel')
+export class FunnelEventsController {
+  private readonly logger = new Logger(FunnelEventsController.name);
+
+  constructor(private readonly funnelEvents: FunnelEventsService) {}
+
+  @Post('event')
+  @HttpCode(202)
+  async event(@Body() body: unknown): Promise<{ ok: boolean }> {
+    const parsed = FunnelEventInputSchema.safeParse(body);
+    if (!parsed.success) {
+      // Beacon malformé : ignoré silencieusement (202) pour ne pas polluer les
+      // logs ni casser le client. On trace en debug uniquement.
+      this.logger.debug(`funnel event rejected (schema): ${parsed.error.message}`);
+      return { ok: false };
+    }
+    return this.funnelEvents.record(parsed.data);
+  }
+}

--- a/backend/src/modules/seo-monitoring/controllers/funnel-events.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/funnel-events.controller.ts
@@ -25,7 +25,9 @@ export class FunnelEventsController {
     if (!parsed.success) {
       // Beacon malformé : ignoré silencieusement (202) pour ne pas polluer les
       // logs ni casser le client. On trace en debug uniquement.
-      this.logger.debug(`funnel event rejected (schema): ${parsed.error.message}`);
+      this.logger.debug(
+        `funnel event rejected (schema): ${parsed.error.message}`,
+      );
       return { ok: false };
     }
     return this.funnelEvents.record(parsed.data);

--- a/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
+++ b/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
@@ -24,8 +24,10 @@ import { AuditFindingsService } from './services/audit-findings.service';
 import { RContentAuditorService } from './services/r-content-auditor.service';
 import { QualityHistorySnapshotService } from './services/quality-history-snapshot.service';
 import { RagMirrorFreshnessService } from './services/rag-mirror-freshness.service';
+import { FunnelEventsService } from './services/funnel-events.service';
 import { SeoMonitoringController } from './controllers/seo-monitoring.controller';
 import { QualityHistoryController } from './controllers/quality-history.controller';
+import { FunnelEventsController } from './controllers/funnel-events.controller';
 
 @Module({
   imports: [ConfigModule],
@@ -43,8 +45,13 @@ import { QualityHistoryController } from './controllers/quality-history.controll
     RContentAuditorService,
     QualityHistorySnapshotService, // ADR-050 Phase 0 baseline
     RagMirrorFreshnessService, // ADR-046 § L3 RAG MIRROR read-only — PR-E.2
+    FunnelEventsService, // Commerce-Loop V1 étape 4-A — funnel outil diagnostic
   ],
-  controllers: [SeoMonitoringController, QualityHistoryController],
+  controllers: [
+    SeoMonitoringController,
+    QualityHistoryController,
+    FunnelEventsController, // POST /api/seo/funnel/event (public beacon)
+  ],
   exports: [
     GoogleCredentialsService,
     GscDailyFetcherService,

--- a/backend/src/modules/seo-monitoring/services/funnel-events.service.ts
+++ b/backend/src/modules/seo-monitoring/services/funnel-events.service.ts
@@ -1,0 +1,46 @@
+/**
+ * Funnel Events Service — Commerce-Loop V1 étape 4-A.
+ *
+ * Wrapper d'écriture dans la table unifiée `__seo_event_log` pour les events du
+ * funnel de l'outil diagnostic → commande (diag_* + r2_*).
+ *
+ * Étend `SupabaseBaseService` (chemin DI canonique : `this.supabase` service-role
+ * + sémaphore connexions + circuit breaker + fallback ADR-028 read-only). Pas de
+ * `createClient` local (anti-duplication).
+ *
+ * Refs:
+ * - 20260521_seo_event_funnel_enum.sql (ENUM seo_event_type +7)
+ * - packages/seo-types/src/intelligence.ts (FunnelEventInputSchema)
+ */
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import type { FunnelEventInput } from '@repo/seo-types';
+
+@Injectable()
+export class FunnelEventsService extends SupabaseBaseService {
+  constructor(configService: ConfigService) {
+    super(configService);
+  }
+
+  /**
+   * Persiste un event funnel. Fire-and-forget côté appelant : on log l'erreur
+   * mais on ne lève jamais (un beacon raté ne doit pas casser une requête user).
+   * `severity` est toujours `info` (events de mesure, pas d'alerte).
+   */
+  async record(input: FunnelEventInput): Promise<{ ok: boolean }> {
+    const { error } = await this.supabase.from('__seo_event_log').insert({
+      event_type: input.event_type,
+      entity_url: input.entity_url ?? null,
+      severity: 'info',
+      payload: input.payload,
+    });
+    if (error) {
+      this.logger.error(
+        `funnel event insert failed (${input.event_type}): ${error.message}`,
+      );
+      return { ok: false };
+    }
+    return { ok: true };
+  }
+}

--- a/backend/src/modules/seo-monitoring/services/funnel-events.test.ts
+++ b/backend/src/modules/seo-monitoring/services/funnel-events.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests — contrat d'entrée funnel `FunnelEventInputSchema` (étape 4-A).
+ *
+ * On teste le CONTRAT (validation Zod) qui protège l'insert : c'est la pièce
+ * critique de correction. Pas de test d'internes Supabase (éviter les casts).
+ */
+import { FunnelEventInputSchema } from '@repo/seo-types';
+
+describe('FunnelEventInputSchema', () => {
+  it('accepts a valid diag_hub_view event', () => {
+    const r = FunnelEventInputSchema.safeParse({
+      event_type: 'diag_hub_view',
+      entity_url: 'https://www.automecanik.com/diagnostic-auto',
+      payload: { session_id: 's1', device: 'mobile' },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a valid r2_add_to_cart event', () => {
+    const r = FunnelEventInputSchema.safeParse({
+      event_type: 'r2_add_to_cart',
+      payload: {
+        session_id: 's1',
+        product_id: 'p123',
+        quantity: 2,
+        unit_price_cents: 4990,
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts r2_order_placed with nullable session/referrer', () => {
+    const r = FunnelEventInputSchema.safeParse({
+      event_type: 'r2_order_placed',
+      payload: {
+        session_id: null,
+        order_id: 'o-42',
+        item_count: 3,
+        revenue_cents: 12990,
+        referrer: 'diagnostic',
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects an unknown event_type', () => {
+    const r = FunnelEventInputSchema.safeParse({
+      event_type: 'totally_unknown',
+      payload: { session_id: 's1' },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a payload that does not match its event_type', () => {
+    const r = FunnelEventInputSchema.safeParse({
+      event_type: 'r2_add_to_cart',
+      payload: { session_id: 's1' }, // missing product_id/quantity
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/backend/supabase/migrations/20260521_seo_event_funnel_enum.sql
+++ b/backend/supabase/migrations/20260521_seo_event_funnel_enum.sql
@@ -1,0 +1,68 @@
+-- =====================================================
+-- Commerce-Loop V1 — Étape 4-A : funnel event taxonomy (outil diagnostic)
+-- Date: 2026-05-21
+-- Refs: plan commerce-loop-v1 étape 4 ("Mesure d'abord")
+--       20260425_seo_event_log.sql (table + ENUM seo_event_type)
+--       20260514_seo_crux_field_history.sql (pattern ALTER TYPE ADD VALUE)
+--       ADR-027 (R5 sub-pages sunset ; le HUB /diagnostic-auto reste indexé)
+--       packages/seo-types/src/intelligence.ts (Zod mirror)
+-- =====================================================
+--
+-- Étend l'ENUM `seo_event_type` avec les 7 events du funnel de l'OUTIL diagnostic
+-- (entonnoir d'acquisition central → conversion), pour localiser la fuite du
+-- verdict Reality Audit 2026-05-20 (conversion_funnel 0,17 %).
+--
+-- Parcours mesuré (hub indexé → wizard → résultat → catalogue → produit → commande) :
+--   diag_hub_view → diag_wizard_start → diag_analyze_complete
+--   → diag_gamme_cta_click → r2_view → r2_add_to_cart → r2_order_placed
+-- Les r2_* sont entry-agnostic (payload.referrer = diagnostic|organic|internal).
+-- N'instrumente PAS les sous-pages noindex /diagnostic-auto/{slug} (ADR-027).
+--
+-- AUCUNE consommation ici — migration ordonnée AVANT l'émission (contrainte PG :
+-- un nouveau label ENUM ne peut être utilisé dans la transaction qui l'ajoute).
+-- Additif uniquement. Idempotent (guard pg_enum, 1 bloc/label). Forward-only.
+-- =====================================================
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'diag_hub_view' AND enumtypid = 'seo_event_type'::regtype) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'diag_hub_view';
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'diag_wizard_start' AND enumtypid = 'seo_event_type'::regtype) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'diag_wizard_start';
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'diag_analyze_complete' AND enumtypid = 'seo_event_type'::regtype) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'diag_analyze_complete';
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'diag_gamme_cta_click' AND enumtypid = 'seo_event_type'::regtype) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'diag_gamme_cta_click';
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'r2_view' AND enumtypid = 'seo_event_type'::regtype) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'r2_view';
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'r2_add_to_cart' AND enumtypid = 'seo_event_type'::regtype) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'r2_add_to_cart';
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'r2_order_placed' AND enumtypid = 'seo_event_type'::regtype) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'r2_order_placed';
+    END IF;
+END $$;
+
+COMMENT ON TYPE seo_event_type IS 'Event log unifié SEO + funnel outil diagnostic → commande (étape 4-A). Variants discriminés par event_type, payload typé Zod (packages/seo-types/src/intelligence.ts).';

--- a/backend/supabase/migrations/20260521_seo_event_funnel_enum.sql
+++ b/backend/supabase/migrations/20260521_seo_event_funnel_enum.sql
@@ -23,6 +23,10 @@
 -- Additif uniquement. Idempotent (guard pg_enum, 1 bloc/label). Forward-only.
 -- =====================================================
 
+-- Garde-fous obligatoires (squawk require-timeout-settings, ADR-064).
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+
 DO $$ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'diag_hub_view' AND enumtypid = 'seo_event_type'::regtype) THEN
         ALTER TYPE seo_event_type ADD VALUE 'diag_hub_view';

--- a/frontend/app/hooks/useCart.ts
+++ b/frontend/app/hooks/useCart.ts
@@ -9,6 +9,7 @@ import { useState, useCallback } from "react";
 
 import { useRootCart } from "../root";
 import { cartApi, formatPrice, getProductImageUrl } from "../services/cart.api";
+import { emitFunnel, getFunnelSessionId } from "~/utils/funnel-beacon";
 
 // Re-export les utilitaires
 export { formatPrice, getProductImageUrl };
@@ -56,6 +57,16 @@ export function useCart() {
         const result = await cartApi.addItem(productId, quantity, typeId);
         if (result.success) {
           emitCartUpdated();
+          // Commerce-Loop V1 étape 4-A — intention d'achat (funnel R2).
+          emitFunnel({
+            event_type: "r2_add_to_cart",
+            payload: {
+              session_id: getFunnelSessionId(),
+              product_id: String(productId),
+              quantity,
+              unit_price_cents: null,
+            },
+          });
           return true;
         } else {
           setError(result.error || "Erreur lors de l'ajout");

--- a/frontend/app/routes/diagnostic-auto._index.tsx
+++ b/frontend/app/routes/diagnostic-auto._index.tsx
@@ -38,7 +38,12 @@ import {
   BookOpen,
   type LucideIcon,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import {
+  emitFunnel,
+  getFunnelDevice,
+  getFunnelSessionId,
+} from "~/utils/funnel-beacon";
 
 import { DiagnosticWizard } from "~/components/diagnostic-wizard/DiagnosticWizard";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
@@ -280,6 +285,14 @@ export default function DiagnosticAutoIndex() {
     useLoaderData<typeof loader>();
   const [searchQuery, setSearchQuery] = useState("");
   const [dtcCode, setDtcCode] = useState("");
+
+  // Commerce-Loop V1 étape 4-A — entrée du funnel outil diagnostic.
+  useEffect(() => {
+    emitFunnel({
+      event_type: "diag_hub_view",
+      payload: { session_id: getFunnelSessionId(), device: getFunnelDevice() },
+    });
+  }, []);
 
   const filteredClusters = clusters.filter(
     (c) =>

--- a/frontend/app/utils/funnel-beacon.ts
+++ b/frontend/app/utils/funnel-beacon.ts
@@ -15,15 +15,30 @@ import { safeLocalStorage } from "~/utils/safe-storage";
 const ENDPOINT = "/api/seo/funnel/event";
 const SID_KEY = "amk_funnel_sid";
 
+/**
+ * Génère un id de session aléatoire. Crypto uniquement (jamais `Math.random`,
+ * cryptographiquement faible — CodeQL js/insecure-randomness, l'id sert de
+ * contexte de session).
+ */
+function generateSessionId(): string {
+  const c = typeof window !== "undefined" ? window.crypto : undefined;
+  if (c?.randomUUID) return c.randomUUID();
+  if (c?.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    c.getRandomValues(bytes);
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  }
+  // Crypto indisponible (très vieux navigateur) : horodatage seul, pas d'aléa faible.
+  return `s_${Date.now()}`;
+}
+
 /** Identifiant de session funnel (persistant sur la visite). "" côté serveur. */
 export function getFunnelSessionId(): string {
   if (typeof window === "undefined") return "";
   // safeLocalStorage : ne throw jamais (SecurityError WebView, mode privé…).
   let sid = safeLocalStorage.getItem(SID_KEY);
   if (!sid) {
-    sid =
-      window.crypto?.randomUUID?.() ??
-      `s_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    sid = generateSessionId();
     safeLocalStorage.setItem(SID_KEY, sid);
   }
   return sid;

--- a/frontend/app/utils/funnel-beacon.ts
+++ b/frontend/app/utils/funnel-beacon.ts
@@ -1,0 +1,71 @@
+/**
+ * Funnel beacon — Commerce-Loop V1 étape 4-A.
+ *
+ * Émet les events du funnel outil diagnostic → commande vers
+ * `POST /api/seo/funnel/event` (backend FunnelEventsController) via
+ * `navigator.sendBeacon` (non-bloquant, survit à l'unload), fallback `fetch`
+ * keepalive. Strictement additif, SSR-safe (no-op côté serveur), et ne lève
+ * jamais (un beacon raté ne doit jamais casser l'UX).
+ *
+ * Le `session_id` (localStorage) stitche les marches du funnel pour un visiteur.
+ */
+import type { FunnelEventInput } from "@repo/seo-types";
+
+const ENDPOINT = "/api/seo/funnel/event";
+const SID_KEY = "amk_funnel_sid";
+
+/** Identifiant de session funnel (persistant sur la visite). "" côté serveur. */
+export function getFunnelSessionId(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    let sid = window.localStorage.getItem(SID_KEY);
+    if (!sid) {
+      sid =
+        window.crypto?.randomUUID?.() ??
+        `s_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+      window.localStorage.setItem(SID_KEY, sid);
+    }
+    return sid;
+  } catch {
+    return "";
+  }
+}
+
+export type FunnelDevice = "mobile" | "desktop" | "tablet" | "unknown";
+
+/** Bucket device — le drop-off mobile est un suspect prioritaire (Reality Audit). */
+export function getFunnelDevice(): FunnelDevice {
+  if (typeof window === "undefined") return "unknown";
+  const ua = window.navigator?.userAgent ?? "";
+  if (/iPad|Tablet|PlayBook|Silk/i.test(ua)) return "tablet";
+  if (/Mobi|Android|iPhone|iPod|Windows Phone/i.test(ua)) return "mobile";
+  if (ua) return "desktop";
+  return "unknown";
+}
+
+/**
+ * Envoie un event funnel. No-op côté serveur. `entity_url` par défaut =
+ * URL courante. Ne lève jamais.
+ */
+export function emitFunnel(input: FunnelEventInput): void {
+  if (typeof window === "undefined") return;
+  try {
+    const body = JSON.stringify({
+      ...input,
+      entity_url: input.entity_url ?? window.location.href,
+    });
+    if (typeof window.navigator?.sendBeacon === "function") {
+      const blob = new Blob([body], { type: "application/json" });
+      window.navigator.sendBeacon(ENDPOINT, blob);
+      return;
+    }
+    void fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      keepalive: true,
+    });
+  } catch {
+    /* never break UX */
+  }
+}

--- a/frontend/app/utils/funnel-beacon.ts
+++ b/frontend/app/utils/funnel-beacon.ts
@@ -10,6 +10,7 @@
  * Le `session_id` (localStorage) stitche les marches du funnel pour un visiteur.
  */
 import type { FunnelEventInput } from "@repo/seo-types";
+import { safeLocalStorage } from "~/utils/safe-storage";
 
 const ENDPOINT = "/api/seo/funnel/event";
 const SID_KEY = "amk_funnel_sid";
@@ -17,18 +18,15 @@ const SID_KEY = "amk_funnel_sid";
 /** Identifiant de session funnel (persistant sur la visite). "" côté serveur. */
 export function getFunnelSessionId(): string {
   if (typeof window === "undefined") return "";
-  try {
-    let sid = window.localStorage.getItem(SID_KEY);
-    if (!sid) {
-      sid =
-        window.crypto?.randomUUID?.() ??
-        `s_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-      window.localStorage.setItem(SID_KEY, sid);
-    }
-    return sid;
-  } catch {
-    return "";
+  // safeLocalStorage : ne throw jamais (SecurityError WebView, mode privé…).
+  let sid = safeLocalStorage.getItem(SID_KEY);
+  if (!sid) {
+    sid =
+      window.crypto?.randomUUID?.() ??
+      `s_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    safeLocalStorage.setItem(SID_KEY, sid);
   }
+  return sid;
 }
 
 export type FunnelDevice = "mobile" | "desktop" | "tablet" | "unknown";

--- a/log.md
+++ b/log.md
@@ -399,3 +399,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/preprod-env-contract-preflight`
 - **Décision** : style(env-contract): apply prettier (CI lint fix) (+3 other commits)
 - **Sortie** : PR #632 | commits 22cd9867e 690c78525 eacfdcbe3 fbc50be95
+
+## 2026-05-21 — worktree-commerce-loop-step4-funnel (auto)
+
+- **Branche** : `worktree-commerce-loop-step4-funnel`
+- **Décision** : feat(commerce-loop): funnel event tracking outil diagnostic (étape 4-A)
+- **Sortie** : PR #676 | commits 8d7652572

--- a/log.md
+++ b/log.md
@@ -405,3 +405,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `worktree-commerce-loop-step4-funnel`
 - **Décision** : feat(commerce-loop): funnel event tracking outil diagnostic (étape 4-A)
 - **Sortie** : PR #676 | commits 8d7652572
+
+## 2026-05-21 — worktree-commerce-loop-step4-funnel (auto)
+
+- **Branche** : `worktree-commerce-loop-step4-funnel`
+- **Décision** : fix(commerce-loop): squawk require-timeout-settings sur migration funnel (+4 other commits)
+- **Sortie** : PR #676 | commits af96bc122 367574432 a8b1dd059 93c0f8664 8d7652572

--- a/log.md
+++ b/log.md
@@ -411,3 +411,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `worktree-commerce-loop-step4-funnel`
 - **Décision** : fix(commerce-loop): squawk require-timeout-settings sur migration funnel (+4 other commits)
 - **Sortie** : PR #676 | commits af96bc122 367574432 a8b1dd059 93c0f8664 8d7652572
+
+## 2026-05-21 — worktree-commerce-loop-step4-funnel (auto)
+
+- **Branche** : `worktree-commerce-loop-step4-funnel`
+- **Décision** : fix(commerce-loop): eslint — prettier wrap + safeLocalStorage dans funnel (+5 other commits)
+- **Sortie** : PR #676 | commits 477564255 71198a3ab af96bc122 367574432 a8b1dd059 8d7652572

--- a/packages/seo-types/src/intelligence.ts
+++ b/packages/seo-types/src/intelligence.ts
@@ -18,8 +18,38 @@ export const EventTypeSchema = z.enum([
   "ingestion_run_failed",
   "forecast_generated",
   "digest_sent",
+  // Commerce-Loop V1 — funnel de l'outil diagnostic → commande (étape 4-A).
+  // Mirror: migration 20260521_seo_event_funnel_enum.sql.
+  "diag_hub_view",
+  "diag_wizard_start",
+  "diag_analyze_complete",
+  "diag_gamme_cta_click",
+  "r2_view",
+  "r2_add_to_cart",
+  "r2_order_placed",
 ]);
 export type EventType = z.infer<typeof EventTypeSchema>;
+
+// ─── Funnel enums (étape 4-A) ───────────────────────────────────────────────
+
+/** Device bucket — le drop-off mobile est un suspect prioritaire (Reality Audit). */
+export const FunnelDeviceSchema = z.enum(["mobile", "desktop", "tablet", "unknown"]);
+export type FunnelDevice = z.infer<typeof FunnelDeviceSchema>;
+
+/** Porte d'entrée du parcours produit — rend les events r2_* entry-agnostic. */
+export const FunnelReferrerSchema = z.enum([
+  "diagnostic",
+  "organic",
+  "internal",
+  "direct",
+  "paid",
+  "other",
+]);
+export type FunnelReferrer = z.infer<typeof FunnelReferrerSchema>;
+
+/** Score de confiance d'une gamme suggérée par le moteur diagnostic. */
+export const FunnelConfidenceSchema = z.enum(["high", "medium", "low"]);
+export type FunnelConfidence = z.infer<typeof FunnelConfidenceSchema>;
 
 // ─── Payload variants ─────────────────────────────────────────────────────
 
@@ -123,6 +153,61 @@ export const DigestSentPayloadSchema = z.object({
 });
 export type DigestSentPayload = z.infer<typeof DigestSentPayloadSchema>;
 
+// ─── Funnel payload variants (étape 4-A) ────────────────────────────────────
+// session_id stitche les marches du funnel pour un même visiteur.
+
+export const DiagHubViewPayloadSchema = z.object({
+  session_id: z.string().min(1),
+  referrer_source: FunnelReferrerSchema.optional(),
+  device: FunnelDeviceSchema.default("unknown"),
+});
+export type DiagHubViewPayload = z.infer<typeof DiagHubViewPayloadSchema>;
+
+export const DiagWizardStartPayloadSchema = z.object({
+  session_id: z.string().min(1),
+  device: FunnelDeviceSchema.default("unknown"),
+});
+export type DiagWizardStartPayload = z.infer<typeof DiagWizardStartPayloadSchema>;
+
+export const DiagAnalyzeCompletePayloadSchema = z.object({
+  session_id: z.string().min(1),
+  hypothesis_count: z.number().int().nonnegative(),
+  has_suggested_gammes: z.boolean(),
+  vehicle_known: z.boolean(),
+});
+export type DiagAnalyzeCompletePayload = z.infer<typeof DiagAnalyzeCompletePayloadSchema>;
+
+export const DiagGammeCtaClickPayloadSchema = z.object({
+  session_id: z.string().min(1),
+  gamme_slug: z.string().min(1),
+  confidence: FunnelConfidenceSchema.nullable(),
+});
+export type DiagGammeCtaClickPayload = z.infer<typeof DiagGammeCtaClickPayloadSchema>;
+
+export const R2ViewPayloadSchema = z.object({
+  session_id: z.string().min(1),
+  referrer: FunnelReferrerSchema,
+  gamme_slug: z.string().nullable(),
+});
+export type R2ViewPayload = z.infer<typeof R2ViewPayloadSchema>;
+
+export const R2AddToCartPayloadSchema = z.object({
+  session_id: z.string().min(1),
+  product_id: z.string().min(1),
+  quantity: z.number().int().positive(),
+  unit_price_cents: z.number().int().nonnegative().nullable(),
+});
+export type R2AddToCartPayload = z.infer<typeof R2AddToCartPayloadSchema>;
+
+export const R2OrderPlacedPayloadSchema = z.object({
+  session_id: z.string().min(1).nullable(),
+  order_id: z.string().min(1),
+  item_count: z.number().int().positive(),
+  revenue_cents: z.number().int().nonnegative().nullable(),
+  referrer: FunnelReferrerSchema.nullable(),
+});
+export type R2OrderPlacedPayload = z.infer<typeof R2OrderPlacedPayloadSchema>;
+
 // ─── Discriminated union ─────────────────────────────────────────────────
 
 /** One event log row. Mirrors __seo_event_log table. */
@@ -197,5 +282,120 @@ export const EventLogEntrySchema = z.discriminatedUnion("event_type", [
     ack_at: z.null(),
     resolved_at: z.null(),
   }),
+  // ─── Funnel outil diagnostic (étape 4-A) — entity_url = URL de la page émettrice.
+  z.object({
+    id: z.string().uuid().optional(),
+    event_type: z.literal("diag_hub_view"),
+    entity_url: z.string().url().nullable(),
+    severity: SeveritySchema,
+    payload: DiagHubViewPayloadSchema,
+    created_at: z.string().datetime(),
+    ack_at: z.null(),
+    resolved_at: z.null(),
+  }),
+  z.object({
+    id: z.string().uuid().optional(),
+    event_type: z.literal("diag_wizard_start"),
+    entity_url: z.string().url().nullable(),
+    severity: SeveritySchema,
+    payload: DiagWizardStartPayloadSchema,
+    created_at: z.string().datetime(),
+    ack_at: z.null(),
+    resolved_at: z.null(),
+  }),
+  z.object({
+    id: z.string().uuid().optional(),
+    event_type: z.literal("diag_analyze_complete"),
+    entity_url: z.string().url().nullable(),
+    severity: SeveritySchema,
+    payload: DiagAnalyzeCompletePayloadSchema,
+    created_at: z.string().datetime(),
+    ack_at: z.null(),
+    resolved_at: z.null(),
+  }),
+  z.object({
+    id: z.string().uuid().optional(),
+    event_type: z.literal("diag_gamme_cta_click"),
+    entity_url: z.string().url().nullable(),
+    severity: SeveritySchema,
+    payload: DiagGammeCtaClickPayloadSchema,
+    created_at: z.string().datetime(),
+    ack_at: z.null(),
+    resolved_at: z.null(),
+  }),
+  z.object({
+    id: z.string().uuid().optional(),
+    event_type: z.literal("r2_view"),
+    entity_url: z.string().url().nullable(),
+    severity: SeveritySchema,
+    payload: R2ViewPayloadSchema,
+    created_at: z.string().datetime(),
+    ack_at: z.null(),
+    resolved_at: z.null(),
+  }),
+  z.object({
+    id: z.string().uuid().optional(),
+    event_type: z.literal("r2_add_to_cart"),
+    entity_url: z.string().url().nullable(),
+    severity: SeveritySchema,
+    payload: R2AddToCartPayloadSchema,
+    created_at: z.string().datetime(),
+    ack_at: z.null(),
+    resolved_at: z.null(),
+  }),
+  z.object({
+    id: z.string().uuid().optional(),
+    event_type: z.literal("r2_order_placed"),
+    entity_url: z.string().url().nullable(),
+    severity: SeveritySchema,
+    payload: R2OrderPlacedPayloadSchema,
+    created_at: z.string().datetime(),
+    ack_at: z.null(),
+    resolved_at: z.null(),
+  }),
 ]);
 export type EventLogEntry = z.infer<typeof EventLogEntrySchema>;
+
+// ─── Funnel event INPUT contract (étape 4-A) ────────────────────────────────
+// Contrat public posté par le beacon frontend → POST /api/seo/funnel/event.
+// Le serveur fixe severity='info' + created_at ; le client ne fournit que
+// event_type (∈ funnel) + payload typé + entity_url optionnel (URL page).
+
+const funnelInput = <T extends z.ZodTypeAny>(
+  eventType:
+    | "diag_hub_view"
+    | "diag_wizard_start"
+    | "diag_analyze_complete"
+    | "diag_gamme_cta_click"
+    | "r2_view"
+    | "r2_add_to_cart"
+    | "r2_order_placed",
+  payload: T,
+) =>
+  z.object({
+    event_type: z.literal(eventType),
+    entity_url: z.string().url().nullable().optional(),
+    payload,
+  });
+
+export const FunnelEventInputSchema = z.discriminatedUnion("event_type", [
+  funnelInput("diag_hub_view", DiagHubViewPayloadSchema),
+  funnelInput("diag_wizard_start", DiagWizardStartPayloadSchema),
+  funnelInput("diag_analyze_complete", DiagAnalyzeCompletePayloadSchema),
+  funnelInput("diag_gamme_cta_click", DiagGammeCtaClickPayloadSchema),
+  funnelInput("r2_view", R2ViewPayloadSchema),
+  funnelInput("r2_add_to_cart", R2AddToCartPayloadSchema),
+  funnelInput("r2_order_placed", R2OrderPlacedPayloadSchema),
+]);
+export type FunnelEventInput = z.infer<typeof FunnelEventInputSchema>;
+
+/** Liste des event_type funnel — utile pour filtrer le dashboard. */
+export const FUNNEL_EVENT_TYPES = [
+  "diag_hub_view",
+  "diag_wizard_start",
+  "diag_analyze_complete",
+  "diag_gamme_cta_click",
+  "r2_view",
+  "r2_add_to_cart",
+  "r2_order_placed",
+] as const;


### PR DESCRIPTION
## Pourquoi

Verdict Reality Audit (#652) : **conversion_funnel 0,17 %** — le trafic existe, il ne convertit pas. Cette PR **instrumente** le funnel de l'**outil `/diagnostic-auto`** (hub indexé, entonnoir d'acquisition central) → commande, pour localiser la fuite. *Mesure d'abord, pas de re-design* (Commerce-Loop V1, étape 4-A).

## Ancrage canon (ADR-027)

R5 = **section dans R3**, mais le **hub `/diagnostic-auto` est `index,follow`** et reste l'outil d'acquisition. On instrumente le **hub + parcours**, **jamais** les sous-pages noindex `/diagnostic-auto/{slug}`.

## Contenu

- **Migration** `20260521_seo_event_funnel_enum.sql` : ENUM `seo_event_type` += 7 labels funnel. Additif, idempotent (guard `pg_enum`), forward-only. **Appliquée par le pipeline, jamais en live.**
- **Zod** (`@repo/seo-types`) : payloads + `discriminatedUnion` + `FunnelEventInputSchema` (contrat public). Additif.
- **Backend** : `FunnelEventsService` (**extends `SupabaseBaseService`** — service-role + sémaphore + circuit breaker, pas de `createClient` dupliqué) + `POST /api/seo/funnel/event` (public beacon, validation Zod) + wiring module + test schéma.
- **Frontend** : util `funnel-beacon` (`navigator.sendBeacon`, SSR-safe, ne lève jamais) + **2 émissions wirées** : `diag_hub_view` (entrée) et `r2_add_to_cart` (intention d'achat).
- **ownership.yaml** : glob `*seo_event_funnel*` (D3) — requis par le registry-new-file-gate.

## Scope (minimal, vérifiable)

Émissions mid-funnel (`diag_wizard_start`/`analyze_complete`/`gamme_cta_click`, `r2_view`) **définies dans l'ENUM mais wirées en suivi** (PR minimale + anchors composant à vérifier en env buildable). `r2_order_placed` = couvert par l'attribution commande #664 (`___xtr_order.landing_source`), pas de double source.

## Vérification

Build local impossible (worktree éphémère) → **CI = gate** : Migration Safety, Backend Tests, ESLint, Core Build, typecheck. Post-merge : dashboard #601 mesure hub_view → add_to_cart → commande (#664).

🤖 Generated with [Claude Code](https://claude.com/claude-code)