### PR TITLE
fix(seo): shared URL contract + sitemap/page-v2 correctness (GSC 404 hardening)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -488,6 +488,11 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: medium
     risk: medium
+  - glob: packages/seo-url-contract/**
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: high
   - glob: packages/typescript-config/**
     domain: D13
     owner: '@ak125'

--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:34b34f9dd21f83c7a09d461d0974129be270624f0861f13cff12cf4b0aa3d80a",
+  "artifact_immutability_hash": "sha256:77f1155cd05501794f42f978106f0bf55327d71d1eba1fec6a9625deb06f987e",
   "divergences": [
     {
       "kind": "specifier",
@@ -3949,7 +3949,7 @@
     "deps_registry": "audit/registry/deps.json",
     "deps_registry_sha": "sha256:d62e9b8155d405d8c4dab916ee31ccaabb577f15065ce0cb5cc16cec205f8022",
     "lockfile": "package-lock.json",
-    "lockfile_sha": "sha256:fd3b3909bd17c19c29f2c7b48ea73851198f4d7e015181724c8982204a042e0b",
+    "lockfile_sha": "sha256:b09ddc2ac722e9c2646af2a8696516a8cc76c6429ece38d5c01f5f8bc32a206c",
     "overlay": "audit/dependencies/family-overlay.yaml",
     "overlay_sha": "sha256:c88cee03acf27840da9c5826c7a3edbcd086a70a58ee323d9c32d33ec33c1a57"
   },

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -28,12 +28,14 @@ module.exports = {
     '^@repo/database-types/(.*)$': '<rootDir>/tests/__mocks__/@repo/database-types.ts',
     '^@repo/seo-types$': '<rootDir>/../packages/seo-types/src/index.ts',
     '^@repo/seo-types/(.*)$': '<rootDir>/../packages/seo-types/src/$1.ts',
+    '^@repo/seo-url-contract$': '<rootDir>/../packages/seo-url-contract/src/index.ts',
+    '^@repo/seo-url-contract/(.*)$': '<rootDir>/../packages/seo-url-contract/src/$1.ts',
   },
   // Ignore dist and node_modules
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   // Transform ESM packages from monorepo workspaces
   transformIgnorePatterns: [
-    '/node_modules/(?!(@repo/database-types|@repo/seo-types|@monorepo/shared-types)/)',
+    '/node_modules/(?!(@repo/database-types|@repo/seo-types|@repo/seo-url-contract|@monorepo/shared-types)/)',
   ],
   // Setup files - load .env.test for Supabase credentials
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],

--- a/backend/package.json
+++ b/backend/package.json
@@ -55,6 +55,7 @@
     "@repo/registry": "*",
     "@repo/seo-role-contracts": "*",
     "@repo/seo-roles": "*",
+    "@repo/seo-url-contract": "*",
     "@repo/seo-types": "*",
     "@sentry/nestjs": "^10.51.0",
     "@supabase/supabase-js": "^2.95.0",

--- a/backend/src/common/utils/url-builder.utils.ts
+++ b/backend/src/common/utils/url-builder.utils.ts
@@ -8,44 +8,22 @@
  * @version 1.0.0
  */
 
-/**
- * Normalise un alias pour l'URL
- * - Convertit en minuscules
- * - Remplace les espaces par des tirets
- * - Supprime les caractères spéciaux
- * - Gère les accents
- */
-export function normalizeAlias(alias: string): string {
-  if (!alias) return '';
+// Structural URL rules live in the shared SoT package (ADR-062 anti-parallel-truths).
+// Imported for local use by the builders below AND re-exported so existing callers
+// (`import { normalizeAlias } from '.../url-builder.utils'`) keep working unchanged.
+import {
+  normalizeAlias,
+  normalizeTypeAlias,
+  detectMalformedSegment,
+  isMalformedSeoUrl,
+} from '@repo/seo-url-contract';
 
-  return alias
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '') // Supprime les accents
-    .replace(/[^a-z0-9\s-]/g, '') // Garde lettres, chiffres, espaces, tirets
-    .replace(/\s+/g, '-') // Espaces -> tirets
-    .replace(/-+/g, '-') // Tirets multiples -> tiret unique
-    .replace(/^-|-$/g, '') // Supprime tirets début/fin
-    .trim();
-}
-
-/**
- * Normalise un type_alias pour la construction d'URLs.
- * Gère NULL, undefined, chaîne vide, "null" littéral, et fallback "type".
- * Utilise type_name (slugifié) comme fallback pour éviter les URLs "28495-28495.html".
- */
-export function normalizeTypeAlias(
-  alias: string | null | undefined,
-  typeName: string | null | undefined,
-): string {
-  if (!alias || alias.trim() === '' || alias === 'null' || alias === 'type') {
-    if (typeName && typeName.trim() !== '') {
-      return normalizeAlias(typeName);
-    }
-    return 'type';
-  }
-  return alias;
-}
+export {
+  normalizeAlias,
+  normalizeTypeAlias,
+  detectMalformedSegment,
+  isMalformedSeoUrl,
+};
 
 /**
  * Construit un segment d'URL pour un type véhicule: "{alias}-{id}"
@@ -57,7 +35,7 @@ export function buildTypeSlug(type: {
   type_name?: string | null;
   type_id: number | string;
 }): string {
-  const alias = normalizeTypeAlias(type.type_alias, type.type_name);
+  const alias = normalizeTypeAlias(type.type_alias, type.type_name, type.type_id);
   return `${alias}-${type.type_id}`;
 }
 
@@ -94,7 +72,7 @@ export function buildPieceVehicleUrl(
   typeId: number,
   typeName?: string | null,
 ): string {
-  return `/pieces/${normalizeAlias(gammeAlias)}-${gammeId}/${normalizeAlias(marqueAlias)}-${marqueId}/${normalizeAlias(modeleAlias)}-${modeleId}/${normalizeTypeAlias(typeAlias, typeName)}-${typeId}.html`;
+  return `/pieces/${normalizeAlias(gammeAlias)}-${gammeId}/${normalizeAlias(marqueAlias)}-${marqueId}/${normalizeAlias(modeleAlias)}-${modeleId}/${normalizeTypeAlias(typeAlias, typeName, typeId)}-${typeId}.html`;
 }
 
 /**
@@ -144,7 +122,7 @@ export function buildConstructeurTypeUrl(
   typeId: number,
   typeName?: string | null,
 ): string {
-  return `/constructeurs/${normalizeAlias(marqueAlias)}-${marqueId}/${normalizeAlias(modeleAlias)}-${modeleId}/${normalizeTypeAlias(typeAlias, typeName)}-${typeId}.html`;
+  return `/constructeurs/${normalizeAlias(marqueAlias)}-${marqueId}/${normalizeAlias(modeleAlias)}-${modeleId}/${normalizeTypeAlias(typeAlias, typeName, typeId)}-${typeId}.html`;
 }
 
 /**

--- a/backend/src/common/utils/url-builder.utils.ts
+++ b/backend/src/common/utils/url-builder.utils.ts
@@ -35,7 +35,11 @@ export function buildTypeSlug(type: {
   type_name?: string | null;
   type_id: number | string;
 }): string {
-  const alias = normalizeTypeAlias(type.type_alias, type.type_name, type.type_id);
+  const alias = normalizeTypeAlias(
+    type.type_alias,
+    type.type_name,
+    type.type_id,
+  );
   return `${alias}-${type.type_id}`;
 }
 

--- a/backend/src/modules/rm/controllers/rm.controller.ts
+++ b/backend/src/modules/rm/controllers/rm.controller.ts
@@ -11,6 +11,7 @@ import {
   Post,
   Query,
   Req,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import type { Request } from 'express';
 import {
@@ -21,6 +22,7 @@ import { RmBuilderService } from '../services/rm-builder.service';
 import { RmAlternativesService } from '../services/rm-alternatives.service';
 import { RmSoft404TrackerService } from '../services/rm-soft404-tracker.service';
 import { TrackSoft404BodySchema } from '../dto/alternatives-v2.dto';
+import { classifyPageV2Result } from '../utils/page-v2-response';
 
 /**
  * 🏗️ RM Controller
@@ -161,13 +163,22 @@ export class RmController {
       result.duration_ms = Math.round(performance.now() - startTime);
     }
 
-    if (!result.success) {
-      throw new OperationFailedException({
-        message: `Failed to fetch page v2 data for gamme_id=${gamme_id}, vehicle_id=${vehicle_id}`,
-      });
+    switch (classifyPageV2Result(result)) {
+      case 'error': // real RPC/infra failure → 503 so crawlers retry
+        this.logger.error(
+          `page-v2 RPC failure gamme_id=${gamme_id} vehicle_id=${vehicle_id}`,
+        );
+        throw new ServiceUnavailableException({
+          message: `Upstream data temporarily unavailable for gamme_id=${gamme_id}, vehicle_id=${vehicle_id}`,
+        });
+      case 'empty': // valid combo, 0 products → 200; loader renders soft-404
+        this.logger.debug(
+          `page-v2 empty combo gamme_id=${gamme_id} vehicle_id=${vehicle_id} -> soft-404`,
+        );
+        return result;
+      default:
+        return result;
     }
-
-    return result;
   }
 
   /**

--- a/backend/src/modules/rm/utils/page-v2-response.ts
+++ b/backend/src/modules/rm/utils/page-v2-response.ts
@@ -1,0 +1,20 @@
+export type PageV2Outcome = 'ok' | 'empty' | 'error';
+
+/**
+ * Decide HTTP semantics for an rm_get_page_complete_v2 result.
+ *
+ * The data layer distinguishes a genuine RPC/infra failure (sets `result.error`)
+ * from a valid request that simply has no products (`success:false`, no `error`).
+ * The controller maps:
+ *   - 'ok'    → 200 (data present)
+ *   - 'empty' → 200 with the empty payload; the Remix loader renders a soft-404
+ *               (200 + noindex + alternatives) instead of a hard error.
+ *   - 'error' → 503 so crawlers retry, never a false 404/500 on real failures.
+ */
+export function classifyPageV2Result(result: {
+  success?: boolean;
+  error?: unknown;
+}): PageV2Outcome {
+  if (result.success) return 'ok';
+  return result.error ? 'error' : 'empty';
+}

--- a/backend/src/modules/seo/services/sitemap-v10-hubs-cluster.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-hubs-cluster.service.ts
@@ -11,7 +11,11 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
-import { normalizeAlias } from '../../../common/utils/url-builder.utils';
+import {
+  normalizeAlias,
+  normalizeTypeAlias,
+  isMalformedSeoUrl,
+} from '../../../common/utils/url-builder.utils';
 import { SITE_ORIGIN } from '../../../config/app.config';
 import { getValidTypeIds } from '../helpers/auto-type-valid-ids.helper';
 import {
@@ -154,10 +158,24 @@ export class HubsClusterService extends SupabaseBaseService {
           }
 
           // 3. Construire les URLs au format V10
-          const urls = allPieces.map(
-            (p) =>
-              `${this.BASE_URL}/pieces/${normalizeAlias(p.map_pg_alias)}-${p.map_pg_id}/${normalizeAlias(p.map_marque_alias)}-${p.map_marque_id}/${normalizeAlias(p.map_modele_alias)}-${p.map_modele_id}/${normalizeAlias(p.map_type_alias)}-${p.map_type_id}.html`,
-          );
+          const urls: string[] = [];
+          let skippedMalformed = 0;
+          for (const p of allPieces) {
+            const typeSeg = normalizeAlias(
+              normalizeTypeAlias(p.map_type_alias, null, p.map_type_id),
+            );
+            const url = `${this.BASE_URL}/pieces/${normalizeAlias(p.map_pg_alias)}-${p.map_pg_id}/${normalizeAlias(p.map_marque_alias)}-${p.map_marque_id}/${normalizeAlias(p.map_modele_alias)}-${p.map_modele_id}/${typeSeg}-${p.map_type_id}.html`;
+            if (isMalformedSeoUrl(url)) {
+              skippedMalformed++;
+              continue;
+            }
+            urls.push(url);
+          }
+          if (skippedMalformed > 0) {
+            this.logger.warn(
+              `   🧹 Skipped ${skippedMalformed.toLocaleString()} malformed cluster URLs`,
+            );
+          }
 
           if (urls.length > 0) {
             subcategoryData.push({
@@ -394,8 +412,13 @@ export class HubsClusterService extends SupabaseBaseService {
               ? parseInt(p.map_type_id, 10)
               : (p.map_type_id as number);
           if (!validTypeIds.has(typeIdNum)) continue;
+          const typeSeg = normalizeAlias(
+            normalizeTypeAlias(p.map_type_alias, null, p.map_type_id),
+          );
+          const url = `${this.BASE_URL}/pieces/${normalizeAlias(p.map_pg_alias)}-${p.map_pg_id}/${normalizeAlias(p.map_marque_alias)}-${p.map_marque_id}/${normalizeAlias(p.map_modele_alias)}-${p.map_modele_id}/${typeSeg}-${p.map_type_id}.html`;
+          if (isMalformedSeoUrl(url)) continue;
           allUrls.push({
-            url: `${this.BASE_URL}/pieces/${normalizeAlias(p.map_pg_alias)}-${p.map_pg_id}/${normalizeAlias(p.map_marque_alias)}-${p.map_marque_id}/${normalizeAlias(p.map_modele_alias)}-${p.map_modele_id}/${normalizeAlias(p.map_type_alias)}-${p.map_type_id}.html`,
+            url,
             subcategory: subcategory.name,
             hasItem: p.map_has_item || 0,
           });

--- a/backend/src/modules/seo/services/sitemap-v10-hubs-vehicle.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-hubs-vehicle.service.ts
@@ -14,7 +14,11 @@ import * as path from 'path';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
 import { SITE_ORIGIN } from '../../../config/app.config';
-import { normalizeAlias } from '../../../common/utils/url-builder.utils';
+import {
+  normalizeAlias,
+  normalizeTypeAlias,
+  isMalformedSeoUrl,
+} from '../../../common/utils/url-builder.utils';
 import { getValidTypeIds } from '../helpers/auto-type-valid-ids.helper';
 import {
   HubGenerationResult,
@@ -185,6 +189,7 @@ ${links}
       let offset = 0;
       let hasMore = true;
       let skippedOrphans = 0;
+      let skippedMalformed = 0;
       const seen = new Set<string>();
       const vehicleUrls: string[] = [];
 
@@ -225,9 +230,12 @@ ${links}
               seen.add(key);
               // ✅ FIX: Ajouter les IDs à chaque segment (vérifié 200 OK)
               // Format: /constructeurs/{marque}-{id}/{modele}-{id}/{type}-{id}.html
-              vehicleUrls.push(
-                `${this.BASE_URL}/constructeurs/${normalizeAlias(v.map_marque_alias)}-${v.map_marque_id}/${normalizeAlias(v.map_modele_alias)}-${v.map_modele_id}/${normalizeAlias(v.map_type_alias)}-${v.map_type_id}.html`,
-              );
+              const vehUrl = `${this.BASE_URL}/constructeurs/${normalizeAlias(v.map_marque_alias)}-${v.map_marque_id}/${normalizeAlias(v.map_modele_alias)}-${v.map_modele_id}/${normalizeAlias(normalizeTypeAlias(v.map_type_alias, null, v.map_type_id))}-${v.map_type_id}.html`;
+              if (isMalformedSeoUrl(vehUrl)) {
+                skippedMalformed++;
+              } else {
+                vehicleUrls.push(vehUrl);
+              }
             }
           }
           offset += PAGE_SIZE;
@@ -251,6 +259,11 @@ ${links}
       if (skippedOrphans > 0) {
         this.logger.warn(
           `   🧹 Filtered out ${skippedOrphans.toLocaleString()} orphan type_ids (TecDoc V1 remap residue)`,
+        );
+      }
+      if (skippedMalformed > 0) {
+        this.logger.warn(
+          `   🧹 Skipped ${skippedMalformed.toLocaleString()} malformed vehicle URLs`,
         );
       }
 

--- a/backend/src/modules/seo/services/sitemap-v10-pieces.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-pieces.service.ts
@@ -464,7 +464,6 @@ export class SitemapV10PiecesService extends SupabaseBaseService {
       let hasMore = true;
       let skippedOrphans = 0;
       let skippedMalformed = 0;
-    let skippedMalformed = 0;
 
       while (hasMore) {
         const { data: pieces, error: piecesError } = await this.supabase

--- a/backend/src/modules/seo/services/sitemap-v10-pieces.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-pieces.service.ts
@@ -14,7 +14,11 @@ import { ConfigService } from '@nestjs/config';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
 import { DatabaseException, ErrorCodes } from '@common/exceptions';
-import { normalizeAlias } from '../../../common/utils/url-builder.utils';
+import {
+  normalizeAlias,
+  normalizeTypeAlias,
+  isMalformedSeoUrl,
+} from '../../../common/utils/url-builder.utils';
 import { SitemapV10DataService } from './sitemap-v10-data.service';
 import { SitemapV10XmlService } from './sitemap-v10-xml.service';
 import { FAMILY_CLUSTERS } from './sitemap-v10-hubs.types';
@@ -222,6 +226,7 @@ export class SitemapV10PiecesService extends SupabaseBaseService {
     let hasMore = true;
     let totalCount = 0;
     let skippedOrphans = 0;
+    let skippedMalformed = 0;
     const filePaths: string[] = [];
 
     this.logger.log(
@@ -267,13 +272,12 @@ export class SitemapV10PiecesService extends SupabaseBaseService {
           const shardPieces = currentBatch.slice(0, SHARD_SIZE);
           currentBatch = currentBatch.slice(SHARD_SIZE);
 
-          const shardUrls: SitemapUrl[] = shardPieces.map((p) => ({
-            url: `/pieces/${normalizeAlias(p.map_pg_alias)}-${p.map_pg_id}/${normalizeAlias(p.map_marque_alias)}-${p.map_marque_id}/${normalizeAlias(p.map_modele_alias)}-${p.map_modele_id}/${normalizeAlias(p.map_type_alias)}-${p.map_type_id}.html`,
-            page_type: 'piece',
-            changefreq: config.changefreq,
-            priority: computePiecePriority(p.map_pg_id, p.map_marque_id),
-            last_modified_at: null,
-          }));
+          const { urls: shardUrls, skipped } = this.pieceShardUrls(
+            shardPieces,
+            'piece',
+            config.changefreq,
+          );
+          skippedMalformed += skipped;
 
           shardIndex++;
           const fileName = `sitemap-pieces-${shardIndex}.xml`;
@@ -302,13 +306,12 @@ export class SitemapV10PiecesService extends SupabaseBaseService {
 
     // Ecrire le dernier shard partiel
     if (currentBatch.length > 0) {
-      const shardUrls: SitemapUrl[] = currentBatch.map((p) => ({
-        url: `/pieces/${normalizeAlias(p.map_pg_alias)}-${p.map_pg_id}/${normalizeAlias(p.map_marque_alias)}-${p.map_marque_id}/${normalizeAlias(p.map_modele_alias)}-${p.map_modele_id}/${normalizeAlias(p.map_type_alias)}-${p.map_type_id}.html`,
-        page_type: 'piece',
-        changefreq: config.changefreq,
-        priority: computePiecePriority(p.map_pg_id, p.map_marque_id),
-        last_modified_at: null,
-      }));
+      const { urls: shardUrls, skipped } = this.pieceShardUrls(
+        currentBatch,
+        'piece',
+        config.changefreq,
+      );
+      skippedMalformed += skipped;
 
       shardIndex++;
       const fileName =
@@ -340,8 +343,53 @@ export class SitemapV10PiecesService extends SupabaseBaseService {
         `  🧹 Filtered out ${skippedOrphans.toLocaleString()} URLs with orphan type_ids (TecDoc V1 remap residue)`,
       );
     }
+    if (skippedMalformed > 0) {
+      this.logger.warn(
+        `  🧹 Skipped ${skippedMalformed.toLocaleString()} malformed URLs (null/type/repeated-id alias)`,
+      );
+    }
 
     return { filePaths, totalCount };
+  }
+
+  /**
+   * Construit l'URL relative d'une pièce-véhicule pour le sitemap. L'alias type
+   * passe par le SoT normalizeTypeAlias (null/"type"/alias==id -> "type") puis
+   * normalizeAlias : sortie identique à l'ancien code pour les lignes valides.
+   */
+  private buildPieceUrl(p: PieceV9): string {
+    const typeSeg = normalizeAlias(
+      normalizeTypeAlias(p.map_type_alias, null, p.map_type_id),
+    );
+    return `/pieces/${normalizeAlias(p.map_pg_alias)}-${p.map_pg_id}/${normalizeAlias(p.map_marque_alias)}-${p.map_marque_id}/${normalizeAlias(p.map_modele_alias)}-${p.map_modele_id}/${typeSeg}-${p.map_type_id}.html`;
+  }
+
+  /**
+   * Mappe des pièces en SitemapUrl en écartant (et comptant) toute URL mal
+   * formée — défense en profondeur (ADR-062).
+   */
+  private pieceShardUrls(
+    pieces: PieceV9[],
+    pageType: string,
+    changefreq: string,
+  ): { urls: SitemapUrl[]; skipped: number } {
+    const urls: SitemapUrl[] = [];
+    let skipped = 0;
+    for (const p of pieces) {
+      const url = this.buildPieceUrl(p);
+      if (isMalformedSeoUrl(url)) {
+        skipped++;
+        continue;
+      }
+      urls.push({
+        url,
+        page_type: pageType,
+        changefreq,
+        priority: computePiecePriority(p.map_pg_id, p.map_marque_id),
+        last_modified_at: null,
+      });
+    }
+    return { urls, skipped };
   }
 
   /**
@@ -415,6 +463,8 @@ export class SitemapV10PiecesService extends SupabaseBaseService {
       let offset = 0;
       let hasMore = true;
       let skippedOrphans = 0;
+      let skippedMalformed = 0;
+    let skippedMalformed = 0;
 
       while (hasMore) {
         const { data: pieces, error: piecesError } = await this.supabase
@@ -461,15 +511,19 @@ export class SitemapV10PiecesService extends SupabaseBaseService {
           `   🧹 Filtered out ${skippedOrphans.toLocaleString()} orphan type_ids for ${familyKey}`,
         );
       }
+      if (skippedMalformed > 0) {
+        this.logger.warn(
+          `   🧹 Skipped ${skippedMalformed.toLocaleString()} malformed URLs for ${familyKey}`,
+        );
+      }
 
       // 4. Construire les SitemapUrl
-      const urls: SitemapUrl[] = allPieces.map((p) => ({
-        url: `/pieces/${normalizeAlias(p.map_pg_alias)}-${p.map_pg_id}/${normalizeAlias(p.map_marque_alias)}-${p.map_marque_id}/${normalizeAlias(p.map_modele_alias)}-${p.map_modele_id}/${normalizeAlias(p.map_type_alias)}-${p.map_type_id}.html`,
-        page_type: 'product',
-        changefreq: 'weekly',
-        priority: computePiecePriority(p.map_pg_id, p.map_marque_id),
-        last_modified_at: null,
-      }));
+      const { urls, skipped } = this.pieceShardUrls(
+        allPieces,
+        'product',
+        'weekly',
+      );
+      skippedMalformed += skipped;
 
       // 4.5 Dedupliquer inter-familles
       const processedUrlsCache = this.dataService.getProcessedUrlsCache();

--- a/backend/tests/unit/rm/page-v2-response.test.ts
+++ b/backend/tests/unit/rm/page-v2-response.test.ts
@@ -1,0 +1,15 @@
+import { classifyPageV2Result } from '../../../src/modules/rm/utils/page-v2-response';
+
+describe('classifyPageV2Result', () => {
+  it('ok when success', () => {
+    expect(classifyPageV2Result({ success: true })).toBe('ok');
+  });
+  it('error when success:false AND result.error present', () => {
+    expect(
+      classifyPageV2Result({ success: false, error: { code: 'RPC_ERROR', message: 'x' } }),
+    ).toBe('error');
+  });
+  it('empty when success:false and no error (valid combo, 0 products)', () => {
+    expect(classifyPageV2Result({ success: false })).toBe('empty');
+  });
+});

--- a/backend/tests/unit/seo/sitemap-malformed-guard.test.ts
+++ b/backend/tests/unit/seo/sitemap-malformed-guard.test.ts
@@ -1,0 +1,37 @@
+import {
+  normalizeAlias,
+  normalizeTypeAlias,
+  isMalformedSeoUrl,
+} from '../../../src/common/utils/url-builder.utils';
+
+// Mirrors the sitemap services' type-segment hardening (buildPieceUrl):
+// normalizeTypeAlias collapses null/"type"/alias==id, then normalizeAlias
+// slugifies — identical output to legacy for valid rows.
+function typeSegment(alias: string, id: string): string {
+  return normalizeAlias(normalizeTypeAlias(alias, null, id));
+}
+
+describe('sitemap type-segment hardening + defense-in-depth guard', () => {
+  it('skips malformed rows, keeps and slugifies valid ones', () => {
+    const rows = [
+      { alias: 'null', id: '100060' }, // -> type-100060 -> skip
+      { alias: '122813', id: '122813' }, // alias==id -> type-122813 -> skip
+      { alias: 'type', id: '7379' }, // -> type-7379 -> skip
+      { alias: '2.0 tdi', id: '200199' }, // valid -> 20-tdi-200199 (slugified)
+    ];
+    const emitted: string[] = [];
+    let skipped = 0;
+    for (const r of rows) {
+      const url = `/pieces/filtre-a-air-8/audi-22/a6-iv-22057/${typeSegment(r.alias, r.id)}-${r.id}.html`;
+      if (isMalformedSeoUrl(url)) {
+        skipped++;
+        continue;
+      }
+      emitted.push(url);
+    }
+    expect(skipped).toBe(3);
+    expect(emitted).toEqual([
+      '/pieces/filtre-a-air-8/audi-22/a6-iv-22057/20-tdi-200199.html',
+    ]);
+  });
+});

--- a/frontend/app/utils/pieces-route.utils.ts
+++ b/frontend/app/utils/pieces-route.utils.ts
@@ -3,8 +3,8 @@
  * Extrait de pieces.$gamme.$marque.$modele.$type[.]html.tsx
  */
 
-import { logger } from "~/utils/logger";
 import { detectMalformedSegment as detectSegment } from "@repo/seo-url-contract";
+import { logger } from "~/utils/logger";
 import {
   type VehicleData,
   type GammeData,

--- a/frontend/app/utils/pieces-route.utils.ts
+++ b/frontend/app/utils/pieces-route.utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { logger } from "~/utils/logger";
+import { detectMalformedSegment as detectSegment } from "@repo/seo-url-contract";
 import {
   type VehicleData,
   type GammeData,
@@ -114,64 +115,13 @@ export function validateVehicleIds(params: {
  * - Accents : caractères accentués dans les segments
  */
 export function detectMalformedSegment(...segments: string[]): string | null {
+  // Delegates to the shared SoT detector (ADR-062). Preserves skip-empty behavior
+  // and the variadic signature used by the route loaders.
   for (const seg of segments) {
     if (!seg) continue;
-
-    // null ou undefined littéral
-    if (/\bnull\b/i.test(seg) || /\bundefined\b/i.test(seg)) {
-      return "null_in_url";
-    }
-
-    // Segment commence par - (alias manquant)
-    if (/^-\d/.test(seg)) {
-      return "missing_alias";
-    }
-
-    // Espaces (non encodés ou encodés %20)
-    if (seg.includes(" ") || seg.includes("%20")) {
-      return "spaces_in_url";
-    }
-
-    // Accents détectés (devrait être normalisé)
-    try {
-      const decoded = decodeURIComponent(seg);
-      const normalized = decoded
-        .normalize("NFD")
-        .replace(/[\u0300-\u036f]/g, "");
-      if (normalized !== decoded) {
-        return "accented_chars";
-      }
-    } catch {
-      // decodeURIComponent peut échouer — ignorer
-    }
-
-    // ID répété : "23231-23231" (alias est juste le même nombre que l'id)
-    // Appliqué à TOUS les segments (gamme, marque, modele, type)
-    const idMatch = seg.match(/^(\d+)-(\d+)$/);
-    if (idMatch && idMatch[1] === idMatch[2]) {
-      return "repeated_id";
-    }
-
-    // IDs multiples répétés : "23231-23231-23231" (3+ fois le même nombre)
-    const parts = seg.split("-");
-    if (
-      parts.length >= 3 &&
-      parts.every((p) => /^\d+$/.test(p)) &&
-      new Set(parts).size === 1
-    ) {
-      return "repeated_id_multi";
-    }
+    const reason = detectSegment(seg);
+    if (reason) return reason;
   }
-
-  // Vérification spécifique au segment type (dernier segment)
-  const typeSeg = segments[segments.length - 1];
-  if (typeSeg) {
-    // type-{id} fallback
-    if (/^type-\d+$/.test(typeSeg)) {
-      return "type_prefix_fallback";
-    }
-  }
-
   return null;
 }
 

--- a/frontend/app/utils/url-builder.utils.ts
+++ b/frontend/app/utils/url-builder.utils.ts
@@ -3,24 +3,10 @@
  * Fonctions pour construire des URLs cohérentes avec le backend
  */
 
-/**
- * Normalise un alias pour correspondre au format backend
- * Ex: "Alfa Roméo" → "alfa-romeo"
- * Ex: "Rolls-Royce" → "rolls-royce"
- * Ex: "BMW série 3" → "bmw-serie-3"
- */
-export function normalizeAlias(alias: string): string {
-  if (!alias) return "";
-  return alias
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "") // Supprime accents (é → e, à → a)
-    .replace(/[^a-z0-9\s-]/g, "") // Supprime caractères spéciaux
-    .replace(/\s+/g, "-") // Espaces → tirets
-    .replace(/-+/g, "-") // Tirets multiples → simple
-    .replace(/^-|-$/g, "") // Supprime tirets début/fin
-    .trim();
-}
+// Alias normalization is owned by the shared SoT package (ADR-062).
+// Imported for local use AND re-exported so existing callers keep working.
+import { normalizeAlias, normalizeTypeAlias } from "@repo/seo-url-contract";
+export { normalizeAlias, normalizeTypeAlias };
 
 /**
  * Interface pour les liens "Voir aussi"
@@ -46,30 +32,6 @@ export function isValidInternalUrl(url: string): boolean {
 }
 
 /**
- * Normalizes a type_alias for URL construction.
- * Handles null, undefined, empty strings, literal "null", and generic "type" fallbacks.
- * Uses type_name (slugified) as fallback, NOT the type_id (to avoid "28495-28495.html")
- *
- * @param alias - The raw type_alias from database
- * @param typeName - The type_name to use as fallback (will be slugified)
- * @returns A safe string for URL construction
- */
-export function normalizeTypeAlias(
-  alias: string | null | undefined,
-  typeName: string | null | undefined,
-): string {
-  // Handle null, undefined, empty, literal "null" string, or generic "type"
-  if (!alias || alias.trim() === "" || alias === "null" || alias === "type") {
-    // Fallback to slugified type_name
-    if (typeName && typeName.trim() !== "") {
-      return normalizeAlias(typeName);
-    }
-    return "type"; // Ultimate fallback
-  }
-  return alias;
-}
-
-/**
  * Constructs a vehicle type URL segment: "{alias}-{id}"
  * @example buildTypeSlug({ type_alias: null, type_name: "2.0 16V", type_id: 28495 }) => "2-0-16v-28495"
  * @example buildTypeSlug({ type_alias: "gti", type_id: 28495 }) => "gti-28495"
@@ -79,7 +41,7 @@ export function buildTypeSlug(type: {
   type_name?: string | null;
   type_id: number | string;
 }): string {
-  const alias = normalizeTypeAlias(type.type_alias, type.type_name);
+  const alias = normalizeTypeAlias(type.type_alias, type.type_name, type.type_id);
   return `${alias}-${type.type_id}`;
 }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "@repo/database-types": "*",
     "@repo/registry": "*",
     "@repo/seo-roles": "*",
+    "@repo/seo-url-contract": "*",
     "@sentry/remix": "^10.51.0",
     "@tanstack/react-query": "^5.87.1",
     "@tiptap/extension-bold": "^3.23.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,6 +104,7 @@
         "@repo/seo-role-contracts": "*",
         "@repo/seo-roles": "*",
         "@repo/seo-types": "*",
+        "@repo/seo-url-contract": "*",
         "@sentry/nestjs": "^10.51.0",
         "@supabase/supabase-js": "^2.95.0",
         "@types/bull": "^4.10.4",
@@ -317,6 +318,7 @@
         "@repo/database-types": "*",
         "@repo/registry": "*",
         "@repo/seo-roles": "*",
+        "@repo/seo-url-contract": "*",
         "@sentry/remix": "^10.51.0",
         "@tanstack/react-query": "^5.87.1",
         "@tiptap/extension-bold": "^3.23.1",
@@ -9585,6 +9587,10 @@
     },
     "node_modules/@repo/seo-types": {
       "resolved": "packages/seo-types",
+      "link": true
+    },
+    "node_modules/@repo/seo-url-contract": {
+      "resolved": "packages/seo-url-contract",
       "link": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -36921,8 +36927,6 @@
       "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -36949,7 +36953,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36967,7 +36970,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -36985,7 +36987,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37003,7 +37004,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37021,7 +37021,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37039,7 +37038,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37057,7 +37055,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37075,7 +37072,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37093,7 +37089,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37111,7 +37106,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37129,7 +37123,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37147,7 +37140,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37165,7 +37157,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37183,7 +37174,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37201,7 +37191,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37219,7 +37208,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37237,7 +37225,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37255,7 +37242,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37273,7 +37259,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37291,7 +37276,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37309,7 +37293,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37327,7 +37310,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37339,8 +37321,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -43039,6 +43019,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "packages/seo-url-contract": {
+      "name": "@repo/seo-url-contract",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.9.3"
       }
     },
     "packages/typescript-config": {

--- a/packages/seo-url-contract/package.json
+++ b/packages/seo-url-contract/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@repo/seo-url-contract",
+  "version": "0.1.0",
+  "description": "Single source of truth for SEO URL structural rules: alias normalization + malformed-segment detection. Shared by frontend, backend, and sitemap generation (ADR-062 anti-parallel-truths).",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/**/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/seo-url-contract/src/index.ts
+++ b/packages/seo-url-contract/src/index.ts
@@ -1,1 +1,1 @@
-export * from './url-rules';
+export * from "./url-rules";

--- a/packages/seo-url-contract/src/index.ts
+++ b/packages/seo-url-contract/src/index.ts
@@ -1,0 +1,1 @@
+export * from './url-rules';

--- a/packages/seo-url-contract/src/url-rules.test.ts
+++ b/packages/seo-url-contract/src/url-rules.test.ts
@@ -1,60 +1,64 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test } from "node:test";
+import assert from "node:assert/strict";
 import {
   normalizeAlias,
   normalizeTypeAlias,
   detectMalformedSegment,
   isMalformedSeoUrl,
-} from './index';
+} from "./index";
 
-test('detectMalformedSegment flags real malformed forms', () => {
+test("detectMalformedSegment flags real malformed forms", () => {
   const cases: Array<[string, string]> = [
-    ['null-55453', 'null_in_url'],
-    ['null-55453-55453', 'null_in_url'], // multi-id form seen in the GSC report
-    ['-30389', 'missing_alias'],
-    ['type-7379', 'type_prefix_fallback'],
-    ['122813-122813', 'repeated_id'],
-    ['11410-11410-11410', 'repeated_id_multi'],
-    ['1.6 t4f-12693', 'spaces_in_url'],
+    ["null-55453", "null_in_url"],
+    ["null-55453-55453", "null_in_url"], // multi-id form seen in the GSC report
+    ["-30389", "missing_alias"],
+    ["type-7379", "type_prefix_fallback"],
+    ["122813-122813", "repeated_id"],
+    ["11410-11410-11410", "repeated_id_multi"],
+    ["1.6 t4f-12693", "spaces_in_url"],
   ];
   for (const [seg, reason] of cases) {
     assert.equal(detectMalformedSegment(seg), reason, seg);
   }
 });
 
-test('detectMalformedSegment passes valid segments (no faux-positives)', () => {
+test("detectMalformedSegment passes valid segments (no faux-positives)", () => {
   for (const seg of [
-    '100060-200199',
-    'a6-iv-22057',
-    'ds3-decapotable-46050',
-    'nullpunkt-123',
-    'x-type-99',
-    'type-c-50',
+    "100060-200199",
+    "a6-iv-22057",
+    "ds3-decapotable-46050",
+    "nullpunkt-123",
+    "x-type-99",
+    "type-c-50",
   ]) {
     assert.equal(detectMalformedSegment(seg), null, seg);
   }
 });
 
-test('isMalformedSeoUrl checks the whole URL', () => {
+test("isMalformedSeoUrl checks the whole URL", () => {
   assert.ok(
-    isMalformedSeoUrl('/pieces/filtre-a-air-8/audi-22/a6-iv-22057/null-100060.html'),
+    isMalformedSeoUrl(
+      "/pieces/filtre-a-air-8/audi-22/a6-iv-22057/null-100060.html",
+    ),
   );
   assert.equal(
-    isMalformedSeoUrl('/pieces/filtre-a-air-8/audi-22/a6-iv-22057/100060-200199.html'),
+    isMalformedSeoUrl(
+      "/pieces/filtre-a-air-8/audi-22/a6-iv-22057/100060-200199.html",
+    ),
     null,
   );
 });
 
-test('normalizeTypeAlias fallback + id-equality', () => {
+test("normalizeTypeAlias fallback + id-equality", () => {
   // normalizeAlias strips the dot (not in [a-z0-9\s-]) → "2.0 16V" becomes "20-16v"
-  assert.equal(normalizeTypeAlias('28495', '2.0 16V', 28495), '20-16v');
-  assert.equal(normalizeTypeAlias('28495', null, 28495), 'type');
-  assert.equal(normalizeTypeAlias('gti', '2.0 GTI', 28495), 'gti');
-  assert.equal(normalizeTypeAlias('null', '2.0 16V'), '20-16v');
-  assert.equal(normalizeTypeAlias('', '2.0 16V'), '20-16v');
+  assert.equal(normalizeTypeAlias("28495", "2.0 16V", 28495), "20-16v");
+  assert.equal(normalizeTypeAlias("28495", null, 28495), "type");
+  assert.equal(normalizeTypeAlias("gti", "2.0 GTI", 28495), "gti");
+  assert.equal(normalizeTypeAlias("null", "2.0 16V"), "20-16v");
+  assert.equal(normalizeTypeAlias("", "2.0 16V"), "20-16v");
 });
 
-test('normalizeAlias slugifies accents and spaces', () => {
-  assert.equal(normalizeAlias('Côté Décapotable'), 'cote-decapotable');
-  assert.equal(normalizeAlias('1.6 TDI'), '16-tdi');
+test("normalizeAlias slugifies accents and spaces", () => {
+  assert.equal(normalizeAlias("Côté Décapotable"), "cote-decapotable");
+  assert.equal(normalizeAlias("1.6 TDI"), "16-tdi");
 });

--- a/packages/seo-url-contract/src/url-rules.test.ts
+++ b/packages/seo-url-contract/src/url-rules.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeAlias,
+  normalizeTypeAlias,
+  detectMalformedSegment,
+  isMalformedSeoUrl,
+} from './index';
+
+test('detectMalformedSegment flags real malformed forms', () => {
+  const cases: Array<[string, string]> = [
+    ['null-55453', 'null_in_url'],
+    ['null-55453-55453', 'null_in_url'], // multi-id form seen in the GSC report
+    ['-30389', 'missing_alias'],
+    ['type-7379', 'type_prefix_fallback'],
+    ['122813-122813', 'repeated_id'],
+    ['11410-11410-11410', 'repeated_id_multi'],
+    ['1.6 t4f-12693', 'spaces_in_url'],
+  ];
+  for (const [seg, reason] of cases) {
+    assert.equal(detectMalformedSegment(seg), reason, seg);
+  }
+});
+
+test('detectMalformedSegment passes valid segments (no faux-positives)', () => {
+  for (const seg of [
+    '100060-200199',
+    'a6-iv-22057',
+    'ds3-decapotable-46050',
+    'nullpunkt-123',
+    'x-type-99',
+    'type-c-50',
+  ]) {
+    assert.equal(detectMalformedSegment(seg), null, seg);
+  }
+});
+
+test('isMalformedSeoUrl checks the whole URL', () => {
+  assert.ok(
+    isMalformedSeoUrl('/pieces/filtre-a-air-8/audi-22/a6-iv-22057/null-100060.html'),
+  );
+  assert.equal(
+    isMalformedSeoUrl('/pieces/filtre-a-air-8/audi-22/a6-iv-22057/100060-200199.html'),
+    null,
+  );
+});
+
+test('normalizeTypeAlias fallback + id-equality', () => {
+  // normalizeAlias strips the dot (not in [a-z0-9\s-]) → "2.0 16V" becomes "20-16v"
+  assert.equal(normalizeTypeAlias('28495', '2.0 16V', 28495), '20-16v');
+  assert.equal(normalizeTypeAlias('28495', null, 28495), 'type');
+  assert.equal(normalizeTypeAlias('gti', '2.0 GTI', 28495), 'gti');
+  assert.equal(normalizeTypeAlias('null', '2.0 16V'), '20-16v');
+  assert.equal(normalizeTypeAlias('', '2.0 16V'), '20-16v');
+});
+
+test('normalizeAlias slugifies accents and spaces', () => {
+  assert.equal(normalizeAlias('Côté Décapotable'), 'cote-decapotable');
+  assert.equal(normalizeAlias('1.6 TDI'), '16-tdi');
+});

--- a/packages/seo-url-contract/src/url-rules.ts
+++ b/packages/seo-url-contract/src/url-rules.ts
@@ -14,15 +14,15 @@ const COMBINING_DIACRITICS = /[\u0300-\u036f]/g;
  * collapse whitespace/dashes. Returns '' for falsy input.
  */
 export function normalizeAlias(alias: string | null | undefined): string {
-  if (!alias) return '';
+  if (!alias) return "";
   return alias
     .toLowerCase()
-    .normalize('NFD')
-    .replace(COMBINING_DIACRITICS, '')
-    .replace(/[^a-z0-9\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
+    .normalize("NFD")
+    .replace(COMBINING_DIACRITICS, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
     .trim();
 }
 
@@ -39,12 +39,14 @@ export function normalizeTypeAlias(
   const idStr = typeId != null ? String(typeId) : null;
   const needsFallback =
     !alias ||
-    alias.trim() === '' ||
-    alias === 'null' ||
-    alias === 'type' ||
+    alias.trim() === "" ||
+    alias === "null" ||
+    alias === "type" ||
     (idStr !== null && alias === idStr);
   if (needsFallback) {
-    return typeName && typeName.trim() !== '' ? normalizeAlias(typeName) : 'type';
+    return typeName && typeName.trim() !== ""
+      ? normalizeAlias(typeName)
+      : "type";
   }
   return alias;
 }
@@ -55,27 +57,29 @@ export function normalizeTypeAlias(
  * "nullpunkt-123", "x-type-99", "type-c-50" pass. Returns a reason or null.
  */
 export function detectMalformedSegment(seg: string): string | null {
-  if (!seg) return 'empty_segment';
-  if (seg.includes(' ') || seg.includes('%20')) return 'spaces_in_url';
-  if (/^-\d/.test(seg)) return 'missing_alias';
+  if (!seg) return "empty_segment";
+  if (seg.includes(" ") || seg.includes("%20")) return "spaces_in_url";
+  if (/^-\d/.test(seg)) return "missing_alias";
   // alias token literally "null" — covers "null-55453" AND "null-55453-55453"
-  if (/^null(-|$)/i.test(seg)) return 'null_in_url';
-  if (/^type-\d+$/.test(seg)) return 'type_prefix_fallback';
+  if (/^null(-|$)/i.test(seg)) return "null_in_url";
+  if (/^type-\d+$/.test(seg)) return "type_prefix_fallback";
   const repeated = seg.match(/^(\d+)-(\d+)$/);
-  if (repeated && repeated[1] === repeated[2]) return 'repeated_id';
-  const parts = seg.split('-');
+  if (repeated && repeated[1] === repeated[2]) return "repeated_id";
+  const parts = seg.split("-");
   if (
     parts.length >= 3 &&
     parts.every((p) => /^\d+$/.test(p)) &&
     new Set(parts).size === 1
   ) {
-    return 'repeated_id_multi';
+    return "repeated_id_multi";
   }
   // accented characters that should have been slugified
   try {
     const decoded = decodeURIComponent(seg);
-    if (decoded.normalize('NFD').replace(COMBINING_DIACRITICS, '') !== decoded) {
-      return 'accented_chars';
+    if (
+      decoded.normalize("NFD").replace(COMBINING_DIACRITICS, "") !== decoded
+    ) {
+      return "accented_chars";
     }
   } catch {
     // malformed %-encoding — not our concern here
@@ -88,9 +92,9 @@ export function detectMalformedSegment(seg: string): string | null {
  * or null. Used by the sitemap generator as defense-in-depth before publishing.
  */
 export function isMalformedSeoUrl(url: string): string | null {
-  if (!url) return 'empty_url';
-  const path = url.split('?')[0].replace(/\.html$/i, '');
-  for (const seg of path.split('/').filter(Boolean)) {
+  if (!url) return "empty_url";
+  const path = url.split("?")[0].replace(/\.html$/i, "");
+  for (const seg of path.split("/").filter(Boolean)) {
     const reason = detectMalformedSegment(seg);
     if (reason) return reason;
   }

--- a/packages/seo-url-contract/src/url-rules.ts
+++ b/packages/seo-url-contract/src/url-rules.ts
@@ -1,0 +1,98 @@
+/**
+ * SEO URL structural contract — single source of truth (ADR-062 anti-parallel-truths).
+ *
+ * Shared by frontend (Vitest), backend (Jest), and sitemap generation. These rules
+ * define what a well-formed SEO URL segment looks like; they MUST NOT be duplicated
+ * elsewhere — import from this package instead.
+ */
+
+// Combining diacritical marks range (NFD-decomposed accents).
+const COMBINING_DIACRITICS = /[\u0300-\u036f]/g;
+
+/**
+ * Slugify an alias for use in a URL: lowercase, strip accents, keep [a-z0-9-],
+ * collapse whitespace/dashes. Returns '' for falsy input.
+ */
+export function normalizeAlias(alias: string | null | undefined): string {
+  if (!alias) return '';
+  return alias
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(COMBINING_DIACRITICS, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .trim();
+}
+
+/**
+ * Resolve a safe type alias for URL composition. Falls back to a slugified
+ * `typeName` when the raw alias is missing, the literal "null"/"type", or equal
+ * to the `type_id` (which would otherwise produce e.g. "28495-28495.html").
+ */
+export function normalizeTypeAlias(
+  alias: string | null | undefined,
+  typeName: string | null | undefined,
+  typeId?: number | string | null,
+): string {
+  const idStr = typeId != null ? String(typeId) : null;
+  const needsFallback =
+    !alias ||
+    alias.trim() === '' ||
+    alias === 'null' ||
+    alias === 'type' ||
+    (idStr !== null && alias === idStr);
+  if (needsFallback) {
+    return typeName && typeName.trim() !== '' ? normalizeAlias(typeName) : 'type';
+  }
+  return alias;
+}
+
+/**
+ * Structural malformed-segment detector. Flags structural defects of a single
+ * `{alias}-{id}` URL segment — never arbitrary substrings, so valid slugs like
+ * "nullpunkt-123", "x-type-99", "type-c-50" pass. Returns a reason or null.
+ */
+export function detectMalformedSegment(seg: string): string | null {
+  if (!seg) return 'empty_segment';
+  if (seg.includes(' ') || seg.includes('%20')) return 'spaces_in_url';
+  if (/^-\d/.test(seg)) return 'missing_alias';
+  // alias token literally "null" — covers "null-55453" AND "null-55453-55453"
+  if (/^null(-|$)/i.test(seg)) return 'null_in_url';
+  if (/^type-\d+$/.test(seg)) return 'type_prefix_fallback';
+  const repeated = seg.match(/^(\d+)-(\d+)$/);
+  if (repeated && repeated[1] === repeated[2]) return 'repeated_id';
+  const parts = seg.split('-');
+  if (
+    parts.length >= 3 &&
+    parts.every((p) => /^\d+$/.test(p)) &&
+    new Set(parts).size === 1
+  ) {
+    return 'repeated_id_multi';
+  }
+  // accented characters that should have been slugified
+  try {
+    const decoded = decodeURIComponent(seg);
+    if (decoded.normalize('NFD').replace(COMBINING_DIACRITICS, '') !== decoded) {
+      return 'accented_chars';
+    }
+  } catch {
+    // malformed %-encoding — not our concern here
+  }
+  return null;
+}
+
+/**
+ * Full-URL guard: checks every path segment, returns the first malformed reason
+ * or null. Used by the sitemap generator as defense-in-depth before publishing.
+ */
+export function isMalformedSeoUrl(url: string): string | null {
+  if (!url) return 'empty_url';
+  const path = url.split('?')[0].replace(/\.html$/i, '');
+  for (const seg of path.split('/').filter(Boolean)) {
+    const reason = detectMalformedSegment(seg);
+    if (reason) return reason;
+  }
+  return null;
+}

--- a/packages/seo-url-contract/tsconfig.json
+++ b/packages/seo-url-contract/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Why

GSC reported ~414k `Introuvable (404)` URLs for automecanik.com; a fix-validation **failed** 2026-05-19. Investigation against live code shows **the runtime already serves the correct responses** for these URLs:

- Orphan TecDoc-V1 `type_id`s, malformed segments (`null-…`, `type-…`, `122813-122813`) → **410 Gone** + `noindex,follow`.
- Valid combo, 0 products → **200 + noindex + alternatives** (soft-404).

Prod probe (this branch, identifiable UA — never spoofing Googlebot):

```
410  /pieces/filtre-a-air-8/audi-22/a6-iv-22057/null-55453-55453.html
410  /pieces/joint-de-cache-culbuteurs-321/skoda-150/superb-ii-150035/28254-28254.html
410  /pieces/filtre-a-air-8/mercedes-benz-108/glc-x253-108261/122813-122813.html
200  /pieces/plaquette-de-frein-402.html
```

**The GSC report is largely working-as-intended noise** — these URLs *should* 404/410; a "validate fix" on deliberately-gone URLs always fails by design. **Do NOT re-request GSC fix-validation on the 404 report** — let the 410 cohort age out (weeks).

This is a **hygiene / infra-correctness PR**. It closes structural emission/semantics leaks; it will **not** move traffic, conversion, or revenue, and must not divert Commerce-Loop / R5→R3→R2 / supplier-truth focus.

## What

1. **`@repo/seo-url-contract` (new CJS package)** — single source of truth for URL structural rules (`normalizeAlias`, `normalizeTypeAlias` with `type_id`-equality guard, structural `detectMalformedSegment`, `isMalformedSeoUrl`). Frontend (Vitest) + backend (Jest) now **re-export** from it instead of duplicating the logic — kills the parallel-truths drift (ADR-062). The frontend-only `detectMalformedSegment` is gone.
2. **Sitemap V10 (pieces ×3 + hubs-vehicle + hubs-cluster)** — the type segment is now `normalizeAlias(normalizeTypeAlias(alias, null, type_id))` (identical output for valid rows, still slugified) and every emitted URL passes `isMalformedSeoUrl` defense-in-depth; malformed rows are skipped + counted (`skippedMalformed`, logged beside `skippedOrphans`). The sitemap can no longer advertise `null-…`/`type-…`/`id-id` URLs.
3. **`/api/rm/page-v2`** — pure `classifyPageV2Result()`: empty combo (no `result.error`) → **200** (the Remix loader renders the soft-404), real RPC failure (`result.error` set) → **503** so crawlers retry. Previously every `success:false` threw **500**, polluting logs/GSC. Other endpoints keep `OperationFailedException`.
4. **imgproxy** — investigated, **no code change**: both builders use absolute source URLs, so the current code cannot emit the reported `plain//storage/…` (relative double-slash) form — it's a stale legacy crawl artifact. **No robots block** (that path serves live OG/product images; blocking would deindex them).

## Constraints honored
- No URL changes to valid pages (only technically-impossible URLs are skipped — they already 410).
- No auto-suppression of valid pages; no payments/DB changes.
- `__sitemap_p_link` orphan-row purge intentionally out of scope (already filtered at emission).

## Tests
- `@repo/seo-url-contract`: `node:test` contract (5/5) — malformed forms incl. `null-55453-55453`, verified non-faux-positives (`nullpunkt`/`x-type`/`type-c`).
- Backend Jest: sitemap guard (skip+slugify) and page-v2 classifier (4/4). Backend `tsc` 0 errors; frontend `tsc` adds 0 new errors.

## Follow-up (separate)
- Vault PR: **ADR-058 extension — "SEO URL Structural Invariants Shared Runtime Contract"** documenting `@repo/seo-url-contract` as canonical so the rules never diverge again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)