### PR TITLE
fix(ci): unblock wiki-readiness C3 — diag-canon export verify + freshness signal

### DIFF
--- a/.github/workflows/diag-canon-slugs-export.yml
+++ b/.github/workflows/diag-canon-slugs-export.yml
@@ -105,25 +105,14 @@ jobs:
         # (e.g. a schema bump landed without bumping `version` literal),
         # this step fails before anything is committed to wiki.
         #
-        # Async IIFE wrapper : `tsx -e` compiles in CJS by default which
-        # forbids top-level await. The IIFE keeps dynamic import() which
-        # is robust with TS + esbuild + module interop.
+        # File-based tsx invocation (mirrors the schema-gen step above). A prior
+        # inline `tsx -e` dynamic import() regressed on 2026-05-20 — under the CI
+        # fresh-install layout the named export `DiagCanon` resolved to
+        # `undefined` (TypeError: reading 'safeParse'). The committed .ts script
+        # avoids that `tsx -e` / `.ts` interop edge entirely.
         run: |
           cd monorepo
-          npx tsx -e "
-            (async () => {
-              const { DiagCanon } = await import('./backend/src/config/diag-canon.schema.ts');
-              const fs = await import('node:fs');
-              const data = JSON.parse(fs.readFileSync('/tmp/canon/diag-canon.json', 'utf8'));
-              const result = DiagCanon.safeParse(data);
-              if (!result.success) {
-                console.error('ZOD PARSE FAIL — shape drift detected:');
-                console.error(JSON.stringify(result.error.format(), null, 2));
-                process.exit(1);
-              }
-              console.log('OK — diag-canon.json parses against Zod canon');
-            })();
-          "
+          npx tsx scripts/wiki/verify-diag-canon-parse.ts /tmp/canon/diag-canon.json
 
       - name: Checkout automecanik-wiki
         uses: actions/checkout@v4

--- a/scripts/wiki/verify-diag-canon-parse.ts
+++ b/scripts/wiki/verify-diag-canon-parse.ts
@@ -1,0 +1,39 @@
+/**
+ * verify-diag-canon-parse.ts — drift fail-fast for the diag-canon nightly export.
+ *
+ * Parses the Python-exported flat-map `diag-canon.json` against the Zod canon
+ * (single source of truth `backend/src/config/diag-canon.schema.ts`). If the
+ * exported data does not match the Zod shape (e.g. a schema bump landed without
+ * bumping the `version` literal), this exits non-zero BEFORE anything is
+ * committed to the wiki repo.
+ *
+ * Usage :
+ *   npx tsx scripts/wiki/verify-diag-canon-parse.ts [data.json]
+ *   (default data path: /tmp/canon/diag-canon.json)
+ *
+ * Exit codes :
+ *   0          — data parses against the Zod canon
+ *   non-zero   — shape drift, or read/import failure
+ *
+ * Why a committed .ts file (not `tsx -e`) : the previous inline
+ * `npx tsx -e "... await import('./backend/src/config/diag-canon.schema.ts') ..."`
+ * regressed on 2026-05-20 — under the CI fresh-install layout the dynamic
+ * import resolved `DiagCanon` to `undefined` (TypeError: reading 'safeParse').
+ * The adjacent file-based tsx step (`print-diag-canon-jsonschema.ts`) importing
+ * the same module never had this issue, so we mirror that invocation style.
+ */
+import { readFileSync } from 'node:fs';
+import { DiagCanon } from '../../backend/src/config/diag-canon.schema';
+
+const dataPath = process.argv[2] ?? '/tmp/canon/diag-canon.json';
+
+const data: unknown = JSON.parse(readFileSync(dataPath, 'utf8'));
+const result = DiagCanon.safeParse(data);
+
+if (!result.success) {
+  console.error('ZOD PARSE FAIL — shape drift detected:');
+  console.error(JSON.stringify(result.error.format(), null, 2));
+  process.exit(1);
+}
+
+console.log(`OK — ${dataPath} parses against Zod canon`);

--- a/scripts/wiki/wiki-readiness-check.py
+++ b/scripts/wiki/wiki-readiness-check.py
@@ -18,10 +18,12 @@ Criteria (each is independent, returns PASS/FAIL with evidence) :
        - .github/workflows/wiki-validate.yml exists in monorepo
        - workflow includes blocking validator step (no continue-on-error)
 
-  C3 — exports/diag-canon-slugs.json à jour :
-       - automecanik-wiki/exports/diag-canon-slugs.json exists
-       - last commit on this file < 7 days old (proof cron is alive)
-       - jq shows ≥ 5 distinct slugs (DB has at least the 5 brake_*)
+  C3 — diag-canon export à jour :
+       - automecanik-wiki/exports/diag-canon-slugs.json + diag-canon.json exist
+       - ≥ 5 distinct slugs (validity, read from diag-canon-slugs.json)
+       - last commit on diag-canon.json < 7 days old (liveness — this file
+         carries `generated_at` so it is re-committed every run; the slugs
+         array is content-stable and not a reliable freshness signal)
 
   C4 — fiches gamme migrées :
        - 0 hits for `entity_data.symptoms:` or `^symptoms:` in
@@ -122,15 +124,26 @@ def c2_validator_ci_active(monorepo_path: Path) -> tuple[bool, str]:
 
 
 def c3_export_diag_canon_slugs_fresh(wiki_path: Path) -> tuple[bool, str]:
-    """C3 — exports/diag-canon-slugs.json exists, commit < 7 days, ≥ 5 slugs."""
-    export_file = wiki_path / "exports" / "diag-canon-slugs.json"
-    if not export_file.exists():
-        return False, f"FAIL: {export_file} missing (PR-D ADR-033 cron not yet wired)"
+    """C3 — diag-canon export is alive: ≥ 5 slugs present AND it ran < 7 days ago.
+
+    Content validity (≥ 5 distinct slugs) is read from the legacy array
+    `diag-canon-slugs.json`. Freshness (liveness) is measured on
+    `diag-canon.json` instead: the flat-map artifact carries a `generated_at`
+    field, so it is re-committed on EVERY nightly run. The legacy array is only
+    re-committed when the slug set itself changes — so its commit age is NOT a
+    reliable "export ran recently" signal (a healthy nightly emitting identical
+    slugs would never re-commit it, ageing out C3 while the export is fine).
+    """
+    slugs_file = wiki_path / "exports" / "diag-canon-slugs.json"
+    fresh_file = wiki_path / "exports" / "diag-canon.json"
+    for f in (slugs_file, fresh_file):
+        if not f.exists():
+            return False, f"FAIL: {f} missing (PR-D ADR-033 cron not yet wired)"
 
     try:
-        data = json.loads(export_file.read_text(encoding="utf-8"))
+        data = json.loads(slugs_file.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:
-        return False, f"FAIL: {export_file} not valid JSON: {e}"
+        return False, f"FAIL: {slugs_file} not valid JSON: {e}"
 
     if not isinstance(data, list):
         return False, "FAIL: export should be a JSON array"
@@ -138,18 +151,19 @@ def c3_export_diag_canon_slugs_fresh(wiki_path: Path) -> tuple[bool, str]:
     if len(slugs) < 5:
         return False, f"FAIL: only {len(slugs)} distinct slugs (expected ≥ 5)"
 
-    # Check git log freshness — last commit on this file
+    # Freshness measured on diag-canon.json (re-committed every run via
+    # `generated_at`), NOT the content-stable legacy array.
     try:
         result = subprocess.run(
-            ["git", "-C", str(wiki_path), "log", "-1", "--format=%ct", "--", "exports/diag-canon-slugs.json"],
+            ["git", "-C", str(wiki_path), "log", "-1", "--format=%ct", "--", "exports/diag-canon.json"],
             capture_output=True, text=True, check=True
         )
         ts = int(result.stdout.strip())
         last_commit = datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc)
         age = datetime.datetime.now(tz=datetime.timezone.utc) - last_commit
         if age.days >= EXPORT_FRESHNESS_DAYS:
-            return False, f"FAIL: last commit on export was {age.days}d ago (expected < {EXPORT_FRESHNESS_DAYS}d)"
-        return True, f"{export_file.relative_to(wiki_path)}: {len(slugs)} slugs, last commit {age.days}d ago ✓"
+            return False, f"FAIL: last export commit was {age.days}d ago (expected < {EXPORT_FRESHNESS_DAYS}d)"
+        return True, f"{len(slugs)} slugs; diag-canon.json last commit {age.days}d ago ✓"
     except (subprocess.CalledProcessError, ValueError) as e:
         return False, f"FAIL: cannot read git log: {e}"
 


### PR DESCRIPTION
Débloque `wiki-readiness-check.py` (gate ADR-033 Partie 3), qui était **NOT_READY** à cause de **deux bugs distincts** sur l'export nightly `diag-canon-slugs-export.yml`.

## Bug 1 — l'étape *Verify Zod parse* crashe (depuis 2026-05-20)
```
TypeError: Cannot read properties of undefined (reading 'safeParse')
```
Le `npx tsx -e "... await import('./backend/src/config/diag-canon.schema.ts') ..."` inline résout `DiagCanon` en `undefined` sous le fresh-install CI (régression interop `tsx -e` + dynamic `import()` de `.ts`). L'étape voisine *Generate JSON Schema* (import **par fichier**) n'a jamais eu le souci.
**Fix** : nouveau `scripts/wiki/verify-diag-canon-parse.ts` (committé) appelé en `npx tsx scripts/wiki/...ts`, calque du pattern qui marche. Zéro changement de dépendance. ✅ validé via `workflow_dispatch` (run vert, export re-committé).

## Bug 2 — C3 mesure la fraîcheur du mauvais fichier
C3 vérifiait l'âge de commit de `exports/diag-canon-slugs.json` (array de slugs), ré-committé **uniquement si les slugs changent**. Canon stable depuis le 05-01 → fichier vieux de 20j → C3 FAIL alors que l'export tournait. **Faux négatif structurel.**
**Fix** : mesurer la fraîcheur sur `exports/diag-canon.json` (porte `generated_at` → re-committé chaque run = vraie preuve de vie), en gardant la validation contenu (≥5 slugs) sur l'array.

## Résultat
`wiki-readiness-check.py` → **READY** (C1–C6 ✓, vérifié localement après refresh de l'export). Le nightly redevient sain et maintient C3 frais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)