### PR TITLE
fix(seo): review follow-ups for #677 (family log + undefined detection)

### DIFF
--- a/backend/src/modules/seo/services/sitemap-v10-pieces.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-pieces.service.ts
@@ -510,11 +510,6 @@ export class SitemapV10PiecesService extends SupabaseBaseService {
           `   🧹 Filtered out ${skippedOrphans.toLocaleString()} orphan type_ids for ${familyKey}`,
         );
       }
-      if (skippedMalformed > 0) {
-        this.logger.warn(
-          `   🧹 Skipped ${skippedMalformed.toLocaleString()} malformed URLs for ${familyKey}`,
-        );
-      }
 
       // 4. Construire les SitemapUrl
       const { urls, skipped } = this.pieceShardUrls(
@@ -523,6 +518,11 @@ export class SitemapV10PiecesService extends SupabaseBaseService {
         'weekly',
       );
       skippedMalformed += skipped;
+      if (skippedMalformed > 0) {
+        this.logger.warn(
+          `   🧹 Skipped ${skippedMalformed.toLocaleString()} malformed URLs for ${familyKey}`,
+        );
+      }
 
       // 4.5 Dedupliquer inter-familles
       const processedUrlsCache = this.dataService.getProcessedUrlsCache();

--- a/packages/seo-url-contract/src/url-rules.test.ts
+++ b/packages/seo-url-contract/src/url-rules.test.ts
@@ -11,6 +11,7 @@ test("detectMalformedSegment flags real malformed forms", () => {
   const cases: Array<[string, string]> = [
     ["null-55453", "null_in_url"],
     ["null-55453-55453", "null_in_url"], // multi-id form seen in the GSC report
+    ["undefined-123", "null_in_url"], // legacy frontend parity (parseUrlParam)
     ["-30389", "missing_alias"],
     ["type-7379", "type_prefix_fallback"],
     ["122813-122813", "repeated_id"],
@@ -28,6 +29,7 @@ test("detectMalformedSegment passes valid segments (no faux-positives)", () => {
     "a6-iv-22057",
     "ds3-decapotable-46050",
     "nullpunkt-123",
+    "undefinedxyz-9",
     "x-type-99",
     "type-c-50",
   ]) {

--- a/packages/seo-url-contract/src/url-rules.ts
+++ b/packages/seo-url-contract/src/url-rules.ts
@@ -60,8 +60,10 @@ export function detectMalformedSegment(seg: string): string | null {
   if (!seg) return "empty_segment";
   if (seg.includes(" ") || seg.includes("%20")) return "spaces_in_url";
   if (/^-\d/.test(seg)) return "missing_alias";
-  // alias token literally "null" — covers "null-55453" AND "null-55453-55453"
-  if (/^null(-|$)/i.test(seg)) return "null_in_url";
+  // alias token literally "null"/"undefined" — covers "null-55453",
+  // "null-55453-55453", "undefined-123" (leading token only, so valid slugs
+  // like "nullpunkt-123" are not flagged)
+  if (/^(null|undefined)(-|$)/i.test(seg)) return "null_in_url";
   if (/^type-\d+$/.test(seg)) return "type_prefix_fallback";
   const repeated = seg.match(/^(\d+)-(\d+)$/);
   if (repeated && repeated[1] === repeated[2]) return "repeated_id";


### PR DESCRIPTION
Two review findings from the automated review of #677 that raced past auto-merge (the prior green commit merged before this fix's CI finished). Re-applied here.

1. **`sitemap-v10-pieces.generateByFamily`** — the `skippedMalformed` warn was logged *before* `pieceShardUrls` increments it, so the family-level malformed count always logged 0. Moved the log after the increment (the skipping itself was always correct; this restores observability). The other two emit sites already ordered it correctly.

2. **`@repo/seo-url-contract` detector** — restore `undefined`-literal detection (leading token `^(null|undefined)(-|$)`) for parity with the legacy frontend `detectMalformedSegment`, so `undefined-123` segments resolve to `null_in_url` (410) instead of falling through to a soft-404. Valid slugs (`undefinedxyz-9`, `nullpunkt-123`) still pass. Tests added.

No new files → no registry/inventory changes. Package contract test 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)