### PR TITLE
feat(ops): sync-dev-runtime.sh — garde DEV:3000 aligné sur origin/main

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -16,6 +16,28 @@
 
 **Conséquence importante** : DEV (`46.224.118.55`) **n'héberge PAS** de container `:preprod` ni `:production`. La machine DEV est uniquement un poste de travail SSH. PREPROD et PROD vivent tous les deux sur `49.12.233.2`, le second étant aussi le GitHub Actions self-hosted runner.
 
+## Sync du runtime DEV:3000 (où on teste/mesure)
+
+DEV:3000 = `npm run dev` (nodemon) servant **le working tree `/opt/automecanik/app/backend/dist`**.
+**Le merge `main` ne met PAS à jour DEV:3000** (il ne réécrit que le tag `:preprod`). Pour
+que DEV serve le code mergé, il faut le **resynchroniser** — automatisé par
+[`scripts/ops/sync-dev-runtime.sh`](../../scripts/ops/sync-dev-runtime.sh) (cron ~10 min).
+
+**Convention** : le checkout principal `/opt/automecanik/app` **reste sur `main`** ; tout
+travail feature/agent se fait en **worktree** (`.claude/worktrees/`). Ne jamais y laisser
+une branche feature (sinon DEV:3000 sert du code périmé).
+
+**4 axes de dérive** que le runtime DEV peut accumuler vs `main` (le script garde 1-2,
+alerte sur 3-4 — jamais d'action destructive auto) :
+
+1. **Git** : checkout sur main + ff-pull `origin/main`. (auto)
+2. **`.env`** : `backend/.env` doit avoir toutes les vars REQUIRED de `env-validation.ts`
+   (ex. `JWT_SECRET` depuis #606). Manquante → boot crash. (alerte via health-check KO)
+3. **Node** : doit matcher `.nvmrc`/`engines` (≥22). Node < 22 → crash `@supabase/realtime-js`.
+   Upgrade = manuel (`NodeSource setup_22.x`). (alerte)
+4. **Migrations DB** : les migrations mergées ne sont **pas auto-appliquées** à la DB
+   partagée. Appliquer l'additif réviewé à la main (`ADD VALUE IF NOT EXISTS`…). (alerte)
+
 ## Mécanique du tag Docker `:preprod` (alias flottant)
 
 - Le tag `:preprod` est **réécrit à chaque merge sur `main`** (workflow `ci.yml` → step `build`).

--- a/scripts/ops/sync-dev-runtime.sh
+++ b/scripts/ops/sync-dev-runtime.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# sync-dev-runtime.sh — garde DEV:3000 aligné sur origin/main
+#
+# CONTEXTE (cf. mémoire feedback_dev_runtime_parity_4_gaps + deployment.md) :
+#   DEV (46.224.118.55:3000) = environnement réel de dev/tests/MESURES, servi par
+#   `npm run dev` (nodemon) DEPUIS CE working tree. Le merge `main` ne met à jour
+#   que le container PREPROD — JAMAIS DEV:3000. Ce script comble ce trou : il
+#   resynchronise le runtime DEV sur `origin/main` après chaque merge.
+#
+# PHILOSOPHIE : alerter, jamais casser. Si une dérive non auto-réparable est
+#   détectée (env, version Node, migration, branche, working tree sale), le
+#   script ABORTE proprement + alerte — il ne laisse jamais DEV dans un état pire.
+#   Il n'upgrade PAS Node et n'applique PAS de migration DB (actions manuelles,
+#   trop risquées en cron sur une DB partagée).
+#
+# Idempotent : no-op si le SHA local == origin/main. Conçu pour tourner en cron
+#   (~10 min) sur la box DEV. Voir crontab `* /10 * * * *`.
+# ==============================================================================
+set -uo pipefail
+
+export PATH="/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+APP_DIR="${APP_DIR:-/opt/automecanik/app}"
+HEALTH_URL="${HEALTH_URL:-http://localhost:3000/health}"
+LOG_TAG="sync-dev-runtime"
+START=$(date +%s)
+
+cd "$APP_DIR" 2>/dev/null || { echo "[$LOG_TAG] FATAL: $APP_DIR introuvable" >&2; exit 1; }
+
+# shellcheck disable=SC1091
+source scripts/cron/lib-supabase-report.sh 2>/dev/null || true
+
+log()   { echo "[$LOG_TAG] $1"; }
+alert() {
+  echo "[$LOG_TAG] ⚠️ ALERT: $1" >&2
+  [ -n "${ALERT_WEBHOOK_URL:-}" ] && curl -sf --max-time 5 -X POST "$ALERT_WEBHOOK_URL" \
+    -H 'Content-Type: application/json' -d "{\"text\":\"[DEV sync] $1\"}" >/dev/null 2>&1 || true
+}
+report() { command -v cron_report >/dev/null 2>&1 && cron_report "$LOG_TAG" "$1" "$(( $(date +%s) - START ))" "${2:-{}}" "${3:-}" 2>/dev/null || true; }
+abort()  { alert "$1"; report "error" "{}" "$1"; exit 1; }
+
+# 1. Garde branche : le checkout runtime DOIT rester sur main (features = worktrees).
+branch=$(git rev-parse --abbrev-ref HEAD)
+[ "$branch" = "main" ] || abort "checkout sur '$branch' (pas main) — resync refusée (cf. convention worktree)"
+
+# 2. Garde working tree sale (on tolère le bruit log.md du hook session-log).
+dirty=$(git status --porcelain --untracked-files=no | grep -vE '(^| )log\.md$' || true)
+[ -z "$dirty" ] || abort "working tree sale — resync refusée: $(echo "$dirty" | tr '\n' ' ')"
+
+# 3. Fetch + comparer.
+git fetch --quiet origin main || abort "git fetch échoué"
+local_sha=$(git rev-parse HEAD)
+remote_sha=$(git rev-parse origin/main)
+if [ "$local_sha" = "$remote_sha" ]; then
+  report "ok" "{\"action\":\"noop\",\"sha\":\"$local_sha\"}" ""
+  exit 0
+fi
+
+# 4. Fast-forward only (jamais reset --hard ; une divergence = réconciliation manuelle).
+git merge --ff-only origin/main || abort "non fast-forwardable (lignée divergente) — réconcilier main à la main"
+log "synced $local_sha → $remote_sha"
+
+# 5. Garde parité Node (.nvmrc) — alerte seulement (upgrade = manuel via NodeSource).
+want_major=$(tr -d 'v' < .nvmrc 2>/dev/null | cut -d. -f1)
+have_major=$(node -v 2>/dev/null | tr -d 'v' | cut -d. -f1)
+if [ -n "$want_major" ] && [ -n "$have_major" ] && [ "$want_major" != "$have_major" ]; then
+  alert "dérive Node : v$have_major installé, .nvmrc=$want_major attendu — l'app peut crasher ; upgrade manuel requis (NodeSource setup_${want_major}.x)"
+fi
+
+# 6. npm install seulement si le lockfile a changé, puis build.
+if ! git diff --quiet "$local_sha" "$remote_sha" -- package-lock.json 2>/dev/null; then
+  log "package-lock.json modifié → npm install"
+  npm install >/dev/null 2>&1 || abort "npm install échoué"
+fi
+npm run build >/dev/null 2>&1 || abort "npm run build échoué (probable régression code ou parité deps)"
+
+# 7. Redémarrer le runtime (nodemon surveille dist ; le build l'a réécrit, on force un boot propre).
+touch backend/dist/main.js
+
+# 8. Health check avec retries — un échec ici = dérive non auto-réparable (env manquant,
+#    migration DB pendante, Node…). On alerte pour intervention manuelle, sans masquer.
+healthy=0
+for i in $(seq 1 12); do
+  sleep 5
+  if curl -sf --max-time 5 "$HEALTH_URL" >/dev/null 2>&1; then healthy=1; break; fi
+done
+if [ "$healthy" != "1" ]; then
+  abort ":3000 KO après resync vers $remote_sha — vérifier : env (env-validation.ts), migrations DB pendantes, version Node"
+fi
+
+log "✅ DEV:3000 sain sur $remote_sha"
+report "ok" "{\"action\":\"synced\",\"from\":\"$local_sha\",\"to\":\"$remote_sha\"}" ""
+exit 0


### PR DESCRIPTION
## Pourquoi

Problème récurrent : **DEV:3000** (où l'on teste/mesure TOUT, cf. `deployment.md`) = `npm run dev` servant le working tree. **Le merge `main` ne met à jour que le tag `:preprod`, jamais DEV:3000** → DEV sert du code périmé. Incident 2026-05-21 : DEV avait dérivé sur **4 axes** (git lineage, `.env` JWT_SECRET, Node 20 vs 22, migration ENUM non appliquée).

## Quoi

- **NEW `scripts/ops/sync-dev-runtime.sh`** : cron ~10 min. `ff-pull origin/main` → `build` (si SHA changé) → restart nodemon → health-check. **Philosophie alerte-pas-casse** : aborte+alerte (jamais d'action destructive) si branche≠main, working tree sale, dérive Node (.nvmrc), ou `:3000` KO post-sync (env/migration drift). N'upgrade **pas** Node et n'applique **pas** de migration (manuel, trop risqué en cron sur DB partagée).
- **`deployment.md`** : section *Sync du runtime DEV:3000* + les 4 axes de dérive + convention « checkout principal reste sur main, features en worktree ».

Le cron sera ajouté à la crontab de la box DEV après merge (config box, hors repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)