### PR TITLE
chore(docs): reconcile RAG references with canon ADR-031/046 + anti-drift guard

### DIFF
--- a/.github/workflows/rag-scope-guard.yml
+++ b/.github/workflows/rag-scope-guard.yml
@@ -1,0 +1,26 @@
+name: RAG scope guard
+
+# Block markdown that positions RAG as a content/SEO source.
+# Canon ADR-031 (Four-Layer Content Architecture) + ADR-046 (R-stack canonique):
+# RAG = retrieval for the chatbot ONLY — SEO content consumes the wiki exports,
+# never the RAG. This guard prevents future doc drift mechanically. The local
+# pre-commit hook runs the same check; CI is authoritative.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  no-rag-as-content-source:
+    name: Block RAG-as-content/SEO-source phrasing in .md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint RAG scope vocabulary (full repo)
+        run: bash scripts/lint/check-rag-scope-vocabulary.sh

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -101,6 +101,14 @@ if [ -n "$STAGED_MD" ]; then
   bash scripts/lint/check-preprod-vocabulary.sh $STAGED_MD || exit 1
 fi
 
+# Block markdown drift that positions RAG as a content/SEO source (ADR-031/046).
+# RAG = retrieval for the chatbot only; SEO consumes wiki exports, never the RAG.
+# See scripts/lint/check-rag-scope-vocabulary.sh for patterns + allowlist.
+if [ -n "$STAGED_MD" ]; then
+  # shellcheck disable=SC2086
+  bash scripts/lint/check-rag-scope-vocabulary.sh $STAGED_MD || exit 1
+fi
+
 # Refresh auto-generated YAML frontmatter + AUTO-GENERATED blocks in
 # .claude/knowledge/modules/*.md so last_scan + primary_files stay honest.
 # Only touches files when the module .ts changed; otherwise no-op.

--- a/.spec/00-canon/brand-md-schema.md
+++ b/.spec/00-canon/brand-md-schema.md
@@ -1,5 +1,7 @@
 # Schema brand.md v1 — Architecture RAG Constructeur
 
+> ⚠️ **RAG = chatbot only — canon ADR-031 / ADR-046.** RAG est une couche de *retrieval pour le chatbot*, **jamais** une source de contenu/SEO. Le contenu SEO (dont R7 brand) consomme les **exports wiki**, n'écrit jamais dans le RAG. L'architecture « brand.md → RAG → R7 » décrite ici est **legacy / non-canonique** — superseded par ADR-031 (accepted 2026-04-28) et ADR-046 (2026-05-07). Détail canon : vault ADR-031, ADR-046.
+
 > Source de verite pour la structure des fichiers `/opt/automecanik/rag/knowledge/constructeurs/*.md`
 >
 > Consommateurs : agent `r7-brand-rag-generator`, pipeline R7 (keyword planner + content batch)

--- a/.spec/AUDIT-SEO-2026-02.md
+++ b/.spec/AUDIT-SEO-2026-02.md
@@ -9,6 +9,8 @@ tags: [audit, seo, marketing, supabase, database]
 
 # Audit SEO & Marketing — 9 Fevrier 2026
 
+> ⚠️ **RAG = chatbot only — canon ADR-031 / ADR-046.** Cet audit (2026-02-09) est **antérieur** à la décision : RAG est une couche de *retrieval pour le chatbot*, **jamais** une source de contenu/SEO. Le contenu SEO consomme les **exports wiki**, n'écrit jamais dans le RAG. Ses recommandations d'« exploiter le corpus RAG inexploité pour enrichir / remplir les champs vides » sont **superseded / non-canoniques** (ADR-031 accepted 2026-04-28, ADR-046 2026-05-07). Détail canon : vault ADR-031, ADR-046.
+
 > Audit complet realise via MCP Supabase sur le projet de production.
 
 ---

--- a/.spec/AUDIT-SEO-GLOBAL-2026-02.md
+++ b/.spec/AUDIT-SEO-GLOBAL-2026-02.md
@@ -1,5 +1,7 @@
 # Audit SEO Global Multi-Roles — Rapport Complet
 
+> ⚠️ **RAG = chatbot only — canon ADR-031 / ADR-046.** Ce rapport (2026-02-17) est **antérieur** à la décision : RAG est une couche de *retrieval pour le chatbot*, **jamais** une source de contenu/SEO. Le contenu SEO consomme les **exports wiki**, n'écrit jamais dans le RAG. Les passages présentant le RAG comme « source » d'enrichissement à répliquer sont **superseded / non-canoniques** (ADR-031 accepted 2026-04-28, ADR-046 2026-05-07). Détail canon : vault ADR-031, ADR-046.
+
 > Date : 2026-02-17 | Auditeur : Claude Opus 4.6
 > Framework : content-audit R2D2 (Intent-First, Evidence-First, Decision-First)
 > Base : Supabase massdoc (cxpojprgwgubzjyqzmoq)

--- a/.spec/ROADMAP-2026.md
+++ b/.spec/ROADMAP-2026.md
@@ -10,6 +10,8 @@ tags: [roadmap, seo, marketing, v-level, r4, r5, rag, backlinks]
 
 # Roadmap 2026 — AutoMecanik SEO & Marketing
 
+> ⚠️ **RAG = chatbot only — canon ADR-031 / ADR-046.** Ce document (2026-02-09) est **antérieur** à la décision de gouvernance : RAG est une couche de *retrieval pour le chatbot*, **jamais** une source de contenu/SEO. Le contenu SEO consomme les **exports wiki**, n'écrit jamais dans le RAG. Toute recommandation ci-dessous d'« exploiter le corpus RAG » / « mine d'or à enrichir » pour le SEO est **superseded / non-canonique** (ADR-031 accepted 2026-04-28, ADR-046 2026-05-07). Détail canon : vault ADR-031, ADR-046.
+
 > Basee sur l'audit Supabase du 9 fevrier 2026 (projet `cxpojprgwgubzjyqzmoq`)
 
 ---

--- a/.spec/marketing-module/README.md
+++ b/.spec/marketing-module/README.md
@@ -1,5 +1,7 @@
 # Module Marketing - Specification
 
+> ⚠️ **RAG = chatbot only — canon ADR-031 / ADR-046.** RAG est une couche de *retrieval pour le chatbot*, **jamais** une source de contenu/SEO. Le contenu/marketing consomme les **exports wiki**, n'écrit jamais dans le RAG. Les références ci-dessous au RAG comme source de planification de contenu sont **legacy / non-canoniques** (ADR-031 accepted 2026-04-28, ADR-046 2026-05-07). Détail canon : vault ADR-031, ADR-046.
+
 > Mis a jour le 9 fevrier 2026 suite a l'audit Supabase MCP
 
 ## Vue d'ensemble

--- a/ENRICHMENT_SUMMARY.md
+++ b/ENRICHMENT_SUMMARY.md
@@ -1,5 +1,7 @@
 # SEO Content Enrichment - Task Summary
 
+> ⚠️ **RAG = chatbot only — canon ADR-031 / ADR-046.** RAG est une couche de *retrieval pour le chatbot*, **jamais** une source de contenu/SEO. Le contenu SEO consomme les **exports wiki**, n'écrit jamais dans le RAG. Le travail décrit ci-dessous (R4/R5 enrichis depuis des fichiers RAG disque) est **legacy / non-canonique** — superseded par ADR-031 (accepted 2026-04-28) et ADR-046 (2026-05-07). Détail canon : vault ADR-031, ADR-046.
+
 ## Objective
 Enrich R4 Reference and R5 Diagnostic generators with real content from RAG knowledge files.
 

--- a/PROCEDURE-SEO.md
+++ b/PROCEDURE-SEO.md
@@ -1,5 +1,7 @@
 # Procedure SEO Pipeline V4
 
+> ⚠️ **RAG = chatbot only — canon ADR-031 / ADR-046.** RAG est une couche de *retrieval pour le chatbot*, **jamais** une source de contenu/SEO. Le contenu SEO consomme les **exports wiki** (`automecanik-wiki/exports/`), n'écrit **jamais** dans le RAG. Les étapes ci-dessous « Vérifier la suffisance RAG » / « Enrichir le RAG » décrivent un workflow **legacy non-canonique** — superseded par ADR-031 (accepted 2026-04-28) et ADR-046 (2026-05-07). Ne pas les étendre. Détail canon : vault ADR-031, ADR-046.
+
 > Fichier de reference pour le workflow SEO. Ouvrir ce fichier au debut de chaque session Claude Code.
 
 ---

--- a/scripts/lint/check-rag-scope-vocabulary.sh
+++ b/scripts/lint/check-rag-scope-vocabulary.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Block markdown drift that positions RAG as a content/SEO source.
+#
+# Why: canon ADR-031 (accepted 2026-04-28) + ADR-046 (2026-05-07) state that RAG
+# is a *retrieval layer for the chatbot ONLY* — never a source of content or SEO
+# data. SEO content consumes the wiki exports (`automecanik-wiki/exports/`), and
+# never reads from or writes to the RAG. Legacy docs predating that decision kept
+# describing RAG as a "gold mine to exploit for SEO" / an enrichment target; this
+# guard prevents NEW docs from re-introducing that confusion mechanically.
+#
+# Mirrors scripts/lint/check-preprod-vocabulary.sh (same allowlist + bypass model).
+# Used by: .husky/pre-commit (staged .md only) + CI lint job (full repo).
+#
+# Bypass: any line that references the canon (`ADR-031` / `ADR-046`) or is marked
+# `RAG-ERRATUM` is considered reconciled and skipped (mirror of the ERRATUM bypass).
+
+set -euo pipefail
+
+# Scope: every committed .md file. CI passes no args; pre-commit passes staged.
+if [ "$#" -gt 0 ]; then
+  FILES=("$@")
+else
+  mapfile -t FILES < <(git ls-files -- '*.md')
+fi
+
+# Files allowed to USE the forbidden phrasings: dated docs PREDATING the canon
+# that carry a reconciling banner (a doc cannot be faulted for a decision that
+# did not yet exist), plus archives / logs / errata / this script itself.
+ALLOWLIST_REGEX='^(PROCEDURE-SEO\.md|ENRICHMENT_SUMMARY\.md|\.spec/00-canon/brand-md-schema\.md|\.spec/ROADMAP-2026\.md|\.spec/AUDIT-SEO-2026-02\.md|\.spec/AUDIT-SEO-GLOBAL-2026-02\.md|\.spec/marketing-module/README\.md|.*/_archive/.*|CHANGELOG.*\.md|log\.md|.*\.errata\.md|.*-errata-.*\.md|scripts/lint/check-rag-scope-vocabulary\.sh)$'
+
+# Case-sensitive: the RAG token is always uppercase, so "storage"/"garage" never
+# match. Patterns stay within a single sentence ([^.]{0,N}) to avoid cross-line
+# false positives. Each pattern is a clear "RAG as content/SEO source" phrasing.
+declare -a PATTERNS=(
+  'exploiter[^.]{0,40}RAG|RAG[^.]{0,25}(à|a) exploiter'
+  'RAG[^.]{0,30}inexploit|inexploit[^.]{0,30}RAG'
+  'enrichir (le|du|les) RAG|écrire[^.]{0,25}dans (le|les) RAG'
+  'RAG[^.]{0,30}pour (enrichir|remplir)'
+  '(enrichir|remplir)[^.]{0,40}(depuis|via|avec)[^.]{0,15}RAG'
+  'RAG[^.]{0,30}source de (contenu|donn|vérit)'
+  'mine d.or[^.]{0,30}RAG|RAG[^.]{0,30}mine d.or'
+  'RAG[^.]{0,20}as a (content|SEO) source|exploit[^.]{0,25}RAG[^.]{0,20}(content|SEO)'
+)
+declare -a LABELS=(
+  '"exploiter le RAG" (RAG is chatbot-retrieval only — SEO consumes wiki exports, not RAG)'
+  '"RAG inexploité" (frames RAG as an untapped content/SEO resource — non-canonical per ADR-031/046)'
+  '"enrichir le RAG" / "écrire dans le RAG" (RAG is never a write target for SEO content)'
+  '"RAG pour enrichir/remplir" (SEO content does not draw from RAG — use wiki exports)'
+  '"enrichir … depuis/via/avec RAG" (RAG is not a content source — ADR-031/046)'
+  '"RAG source de contenu/données/vérité" (RAG = retrieval for the chatbot only)'
+  '"mine d''or … RAG" (RAG is not an SEO content opportunity — non-canonical)'
+  '"RAG as a content/SEO source" (RAG = chatbot retrieval only — ADR-031/046)'
+)
+
+violations=0
+
+for f in "${FILES[@]}"; do
+  [ -f "$f" ] || continue
+  case "$f" in
+    *.md) ;;
+    *) continue ;;
+  esac
+
+  # Skip allowlisted (reconciled / historical / immutable) files
+  if [[ "$f" =~ $ALLOWLIST_REGEX ]]; then
+    continue
+  fi
+
+  for i in "${!PATTERNS[@]}"; do
+    pattern="${PATTERNS[$i]}"
+    label="${LABELS[$i]}"
+    # grep -E (POSIX ERE), case-sensitive. Exit 0 = match = candidate violation.
+    if matches=$(grep -nE "$pattern" "$f" 2>/dev/null); then
+      # Lines that reference the canon (ADR-031/046) or carry RAG-ERRATUM are reconciled.
+      filtered=$(echo "$matches" | grep -vE 'ADR-031|ADR-046|RAG-ERRATUM' || true)
+      if [ -n "$filtered" ]; then
+        echo ""
+        echo "❌ RAG scope drift in $f"
+        echo "   Pattern: $label"
+        echo "$filtered" | sed 's|^|     |'
+        violations=$((violations + 1))
+      fi
+    fi
+  done
+done
+
+if [ "$violations" -gt 0 ]; then
+  cat <<'EOF'
+
+────────────────────────────────────────────────────────────────────────────
+RAG scope drift detected.
+
+Canon: ADR-031 (Four-Layer Content Architecture) + ADR-046 (R-stack canonique).
+  RAG = retrieval layer for the chatbot ONLY — never a content/SEO source.
+  SEO content consumes the wiki exports (automecanik-wiki/exports/);
+  it never reads from, nor writes to, the RAG.
+
+To reconcile a legitimate mention, reference the canon on the same line
+(e.g. "… RAG … (legacy, voir ADR-031/046)") or prefix the line with
+"RAG-ERRATUM". See scripts/lint/check-preprod-vocabulary.sh for the sibling guard.
+────────────────────────────────────────────────────────────────────────────
+EOF
+  exit 1
+fi
+
+echo "✅ RAG scope vocabulary lint: $((${#FILES[@]})) file(s) checked, 0 violations."


### PR DESCRIPTION
## Pourquoi

Canon **ADR-031** (Four-Layer Content Architecture, accepted 2026-04-28) + **ADR-046** (R-stack canonique, 2026-05-07) énoncent déjà : **RAG = retrieval pour le chatbot uniquement, jamais une source de contenu/SEO** ; le contenu SEO consomme les **exports wiki**, ne lit ni n'écrit jamais le RAG. Plusieurs docs du monorepo avaient **dérivé** de ce canon (la plupart **antérieurs** à la décision — datés 2026-02). Cette PR réconcilie la couche doc et pose une garde mécanique anti-récidive.

**Doc-only — zéro changement runtime/code.** `git diff` ne touche que docs + lint + workflow + husky.

## Ce que fait la PR

### A. Bannière canon (lien, pas duplication — CLAUDE.md règle #3) sur les 7 docs réellement dérivés
- `PROCEDURE-SEO.md` (doc opérateur live : étapes « Enrichir le RAG » = legacy)
- `ENRICHMENT_SUMMARY.md` (R4/R5 enrichis depuis RAG disque)
- `.spec/00-canon/brand-md-schema.md` (archi « brand.md → RAG → R7 »)
- `.spec/ROADMAP-2026.md`, `.spec/AUDIT-SEO-2026-02.md`, `.spec/AUDIT-SEO-GLOBAL-2026-02.md` (« exploiter le corpus RAG », « mine d'or inexploitée »)
- `.spec/marketing-module/README.md` (RAG comme source de planif contenu)

Chaque bannière pointe ADR-031/046 et marque les passages RAG→contenu **legacy / superseded**, sans réécrire l'analyse historique (les 3 audits/roadmap **prédatent** le canon).

**4 candidats volontairement non touchés** (déjà canon-alignés ou factuels) : `.claude/knowledge/db/tables-rag.md`, `scripts/wiki-generators/README.md` (cite déjà ADR-031), `workspaces/wiki/README.md` (RAG = consommateur gated wiki-readiness).

### B. Garde mécanique anti-dérive (mirror de `check-preprod-vocabulary.sh`)
- `scripts/lint/check-rag-scope-vocabulary.sh` — patterns conservateurs, case-sensitive sur le token `RAG`, allowlist des 7 docs réconciliés + bypass ligne `ADR-031`/`ADR-046`/`RAG-ERRATUM`.
- Wiré dans `.husky/pre-commit` (staged .md) + `.github/workflows/rag-scope-guard.yml` (full repo, PR + push main).
- Complémentaire (pas doublon) de l'ast-grep existant `no-direct-rag-knowledge-write.yml` (qui garde l'écriture disque RAG).

**Vérif** : full-repo lint = 0 violation (533 fichiers) · drift temp → exit 1 · bypass ADR → exit 0 · sibling preprod-lint clean · 0 fichier `backend/src`/route/migration.

## Finding tracké (PAS exécuté dans cette PR)

Le **code RAG→contenu reste câblé** et contredit ADR-031/046. Faits runtime déterministes :
- `RAG_ENABLED` lu uniquement dans `diagnostic-engine.module.ts:35` (charge `RagProxyModule`) ; **absent de `.env.example`** → off par défaut.
- Enrichers contenu (`r1/r2/r7/r8-enricher`, `buying-guide-enricher`, `rag-gamme-reader`) lisent les **fichiers disque** `RAG_KNOWLEDGE_PATH` via `execution-router.service.ts` ; **déclenchés à la main par l'admin** (aucun `@Cron`).
- Le composeur R2 véhicule-aware récemment livré est déjà **no-RAG** → migration cohérente.

**Recommandation** : track de dépréciation **séparé, confirmé owner**, runtime-aware (flag `RAG_ENABLED`, usage chatbot du diagnostic-engine). Aucune suppression de code ici.

## Hors scope (signalé, non corrigé)
`CLAUDE.md` / `.claude/rules/deployment.md:4` réfèrent un chemin stale `scripts/governance/lint-preprod-vocabulary.sh` (réel = `scripts/lint/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)