### PR TITLE
fix(seo-control): register named BullMQ processor for SWR refresh jobs

### DIFF
--- a/backend/src/modules/admin/constants/seo-control.constants.ts
+++ b/backend/src/modules/admin/constants/seo-control.constants.ts
@@ -6,3 +6,12 @@
  */
 
 export const SEO_CONTROL_REFRESH_QUEUE = 'seo-control-refresh' as const;
+
+/**
+ * Static job name for the per-block SWR refresh jobs.
+ *
+ * Legacy `bull` requires a named processor (`@Process(name)`) to match named
+ * jobs; a single static name keeps the processor handler DRY (block/range live
+ * in `job.data`, idempotency via per-(block,range) `jobId`).
+ */
+export const SEO_CONTROL_REFRESH_JOB = 'seo-control-refresh-block' as const;

--- a/backend/src/modules/admin/processors/seo-control-refresh.processor.ts
+++ b/backend/src/modules/admin/processors/seo-control-refresh.processor.ts
@@ -10,7 +10,10 @@
 import { Logger } from '@nestjs/common';
 import { OnQueueError, OnQueueFailed, Process, Processor } from '@nestjs/bull';
 import { Job } from 'bull';
-import { SEO_CONTROL_REFRESH_QUEUE } from '../constants/seo-control.constants';
+import {
+  SEO_CONTROL_REFRESH_JOB,
+  SEO_CONTROL_REFRESH_QUEUE,
+} from '../constants/seo-control.constants';
 import {
   type SeoControlRefreshJobData,
   SeoControlRefresherService,
@@ -27,7 +30,7 @@ export class SeoControlRefreshProcessor {
     private readonly _refresher: SeoControlRefresherService,
   ) {}
 
-  @Process()
+  @Process(SEO_CONTROL_REFRESH_JOB)
   async handleRefresh(job: Job<SeoControlRefreshJobData>): Promise<void> {
     const { block, range } = job.data;
     const start = Date.now();

--- a/backend/src/modules/admin/services/seo-control-refresher.service.ts
+++ b/backend/src/modules/admin/services/seo-control-refresher.service.ts
@@ -17,7 +17,10 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
-import { SEO_CONTROL_REFRESH_QUEUE } from '../constants/seo-control.constants';
+import {
+  SEO_CONTROL_REFRESH_JOB,
+  SEO_CONTROL_REFRESH_QUEUE,
+} from '../constants/seo-control.constants';
 
 export interface SeoControlRefreshJobData {
   block: 'traffic' | 'losers' | 'lowctr' | 'alerts' | 'conversion';
@@ -63,18 +66,27 @@ export class SeoControlRefresherService implements OnModuleInit {
 
   private async scheduleAll(): Promise<void> {
     try {
+      // Purge orphaned repeatables before re-registering (canon pattern, cf.
+      // seo-monitor-scheduler.service.ts). Removes stale entries left in Redis
+      // by prior code versions — e.g. the old per-block named jobs
+      // `refresh-<block>-<range>` that had no matching processor handler.
+      const stale = await this.queue.getRepeatableJobs();
+      for (const j of stale) {
+        await this.queue.removeRepeatableByKey(j.key);
+      }
+
       for (const { block, intervalMs } of REFRESH_SCHEDULE) {
         for (const range of ['7d', '28d'] as const) {
-          const jobName = `refresh-${block}-${range}`;
-          // Bull v3 signature : queue.add(name, data, opts)
+          // Single static job name (matches @Process(SEO_CONTROL_REFRESH_JOB) in
+          // the processor) ; block/range carried in data, idempotency via jobId.
           await this.queue.add(
-            jobName,
+            SEO_CONTROL_REFRESH_JOB,
             { block, range },
             {
               repeat: { every: intervalMs },
               removeOnComplete: 100,
               removeOnFail: 50,
-              jobId: jobName, // idempotent : 1 job per (block,range), survives restart
+              jobId: `refresh-${block}-${range}`, // 1 repeatable per (block,range), survives restart
             },
           );
         }


### PR DESCRIPTION
## Problem

A running instance spams WARN every ~2 min:

```
WARN: Job repeat:…:… (alerts/7d) failed: Missing process handler for job type refresh-alerts-7d
WARN: Job repeat:…:… (alerts/28d) failed: Missing process handler for job type refresh-alerts-28d
    context: "SeoControlRefreshProcessor"
```

**Root cause:** The PR-SBD-1 SWR refresher (`seo-control-refresh` queue) adds **named** jobs (`refresh-<block>-<range>`) but the processor used a **bare `@Process()`**. In the legacy `bull` package (this repo uses `bull` + `@nestjs/bull`, not `bullmq`), bare `@Process()` registers a handler **only for the default/unnamed job type**, so a named job with no matching handler throws `Missing process handler for job type <name>`.

All 10 jobs (5 blocks × 2 ranges) were broken; only `alerts` surfaced in logs because it refreshes every **2 min** vs 15–30 min for the other blocks. Net effect: the SWR cache-warming PR-SBD-1 was designed for never actually ran (cold-miss 800 ms dog-pile not prevented).

## Fix

Aligns to the repo's canonical convention (**named job + named `@Process('name')`**, as in seo-daily-fetch / email / agentic / r8 / cf-* collectors):

- **constants** — add `SEO_CONTROL_REFRESH_JOB = 'seo-control-refresh-block'` (single static name; `block`/`range` stay in `job.data`, idempotency via per-`(block,range)` `jobId` — keeps the handler DRY).
- **processor** — `@Process(SEO_CONTROL_REFRESH_JOB)`.
- **refresher** — purge stale repeatables on boot via `getRepeatableJobs()` + `removeRepeatableByKey()` (canon pattern, cf. `seo-monitor-scheduler`) so the renamed jobs self-heal the orphaned Redis entries from the old code, then re-add under the static name.

Scope-contained: no DB, no module wiring, no queue-name change.

## Verification

- ✅ `turbo run build --filter=@fafa/backend` — clean (tsc --build, 0 errors).
- ✅ Static match: `@Process(SEO_CONTROL_REFRESH_JOB)` ↔ `queue.add(SEO_CONTROL_REFRESH_JOB, …)` (same constant).
- ✅ Runtime (dev, post-restart): repeatable-definition ZSET = **10 entries all under `seo-control-refresh-block`**, old orphan definitions purged; alerts jobs now land in the **completed** set (`name=seo-control-refresh-block`, `data={"block":"alerts","range":"28d"}`) instead of failing. No new "Missing process handler" failures accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)