### PR TITLE
fix(vehicles): /models/:modelId/types renvoyait 400 sur ~82% des modèles (pipe smallint vs colonne int4)

### DIFF
--- a/backend/src/modules/vehicles/vehicles.controller.ts
+++ b/backend/src/modules/vehicles/vehicles.controller.ts
@@ -110,7 +110,9 @@ export class VehiclesController {
 
   @Get('models/:modelId/types')
   async getTypesByModel(
-    @Param('modelId', PositiveSmallIntParamPipe) modelId: number,
+    // modele_id est int4 (max DB 667022 ; ~82% des modèles > smallint 32767).
+    // Comme typeId/getMinesByModel — jamais le pipe smallint ici. Cf. log 400 #46021.
+    @Param('modelId', PositiveIntParamPipe) modelId: number,
     @Query() query: Record<string, string>,
   ) {
     const params = this.parseQueryParams(query);


### PR DESCRIPTION
## Bug (critique, en prod depuis #592, 2026-05-18)

\`GET /api/vehicles/models/:modelId/types\` renvoyait **400 Validation failed** pour tout \`modelId > 32767\`.

\`\`\`
GET /api/vehicles/models/46021/types?year=2013 - 400 - Validation failed
PositiveSmallIntParamPipe.transform … rejected="46021"
\`\`\`

Trouvé par hasard dans les logs — aucune alerte ne s'est déclenchée.

## Cause racine (vérifiée en base)

Le param \`modelId\` était validé par \`PositiveSmallIntParamPipe\` (range \`1..32767\`), **plus étroit que la colonne elle-même** : \`auto_modele.modele_id\` est \`integer\` (int4), max DB **667 022**.

| table | type colonne | max id | rows > smallint |
|---|---|---|---|
| \`auto_modele\` | integer | 667022 | **6 664 / 8 150 (82%)** |
| \`auto_marque\` | integer | 670 | 0 |

→ **82% des modèles** étaient injoignables via cette route.

## Fix

Une ligne : \`PositiveSmallIntParamPipe\` → \`PositiveIntParamPipe\` pour \`modelId\`. Cohérent avec \`typeId\` (l.158) et \`getMinesByModel\` (l.163) qui validaient déjà des ids int4 **dans le même fichier**. \`brandId\` reste smallint (marque max 670).

## Vérification

- Tests pipes params : 29/29 ✓
- Build backend (\`tsc --build\` via turbo) ✓
- Pas de test controller (convention repo : import controller casse ts-jest via modules transitifs — câblage couvert par inspection ; les pipes sont testés en isolation)

## Hors scope (signalé, non inclus)

- \`brandId\` (lignes 80/87/103) : colonne aussi int4, pipe smallint — sûr aujourd'hui (max 670), même défaut latent.
- Garde-fou prévention (pipe < colonne) et détection (alerte 4xx) : à décider séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)