### PR TITLE
feat(commerce-loop): sitemap freshness alert — heartbeat + SITEMAP_STALE_V1 (étape 2)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -606,6 +606,11 @@ entries:
     owner: '@ak125/admin-team'
     sourceConfidence: high
     risk: medium
+  - glob: backend/supabase/migrations/*seo_sitemap_freshness*
+    domain: D8
+    owner: '@ak125/admin-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/supabase/migrations/*order_landing_attribution*
     domain: D11
     owner: '@ak125/payments-team'

--- a/backend/src/modules/seo/processors/sitemap-regenerate.processor.ts
+++ b/backend/src/modules/seo/processors/sitemap-regenerate.processor.ts
@@ -20,6 +20,7 @@ import { Job } from 'bull';
 import { getAppConfig } from '../../../config/app.config';
 import { getErrorMessage } from '../../../common/utils/error.utils';
 import { SitemapV10Service } from '../services/sitemap-v10.service';
+import { SitemapEventLogService } from '../services/sitemap-event-log.service';
 import {
   SITEMAP_REGENERATE_JOB_NAME,
   SitemapRegenerateJobData,
@@ -44,7 +45,10 @@ export class SitemapRegenerateProcessor {
   private readonly readOnly: boolean;
   private lastQueueErrorLog = 0;
 
-  constructor(private readonly sitemapService: SitemapV10Service) {
+  constructor(
+    private readonly sitemapService: SitemapV10Service,
+    private readonly eventLog: SitemapEventLogService,
+  ) {
     this.readOnly = getAppConfig().supabase.readOnly;
   }
 
@@ -89,6 +93,15 @@ export class SitemapRegenerateProcessor {
           `${result.totalUrls} URLs across ${result.totalFiles} files`,
       );
 
+      // Étape 2 — heartbeat dans __seo_event_log (alimente l'alerte SITEMAP_STALE_V1
+      // via rpc_seo_alerts_v1). Fire-and-forget : le service avale ses erreurs.
+      await this.eventLog.recordHeartbeat(result.success, {
+        totalUrls: result.totalUrls,
+        totalFiles: result.totalFiles,
+        durationMs,
+        triggeredBy,
+      });
+
       return {
         startedAt: startedAtIso,
         finishedAt: new Date().toISOString(),
@@ -105,6 +118,11 @@ export class SitemapRegenerateProcessor {
         `❌ Sitemap V10 regeneration threw: ${message}`,
         err instanceof Error ? err.stack : String(err),
       );
+      await this.eventLog.recordHeartbeat(false, {
+        durationMs: Date.now() - startedAtMs,
+        triggeredBy,
+        errorMessage: message,
+      });
       return {
         startedAt: startedAtIso,
         finishedAt: new Date().toISOString(),

--- a/backend/src/modules/seo/seo.module.ts
+++ b/backend/src/modules/seo/seo.module.ts
@@ -76,6 +76,7 @@ import { SitemapDeltaService } from './services/sitemap-delta.service';
 import { SitemapStreamingService } from './services/sitemap-streaming.service';
 import { SitemapV10SchedulerService } from './services/sitemap-v10-scheduler.service';
 import { SitemapRegenerateProcessor } from './processors/sitemap-regenerate.processor';
+import { SitemapEventLogService } from './services/sitemap-event-log.service';
 import { SitemapHygieneService } from './services/sitemap-hygiene.service';
 import { SitemapVehiclePiecesValidator } from './services/sitemap-vehicle-pieces-validator.service';
 
@@ -250,6 +251,7 @@ import { R2V2Module } from './r2/r2-v2.module';
     // Régénération nocturne BullMQ (fix traffic-drop 2026-04-22 → 2026-05-13)
     SitemapV10SchedulerService,
     SitemapRegenerateProcessor,
+    SitemapEventLogService,
     // Content
     ReferenceService,
     DiagnosticService,

--- a/backend/src/modules/seo/services/sitemap-event-log.service.ts
+++ b/backend/src/modules/seo/services/sitemap-event-log.service.ts
@@ -1,0 +1,59 @@
+/**
+ * SitemapEventLogService — Commerce-Loop V1 étape 2.
+ *
+ * Wrapper d'écriture du heartbeat de régénération sitemap dans la table unifiée
+ * `__seo_event_log` (#601). Le `SitemapRegenerateProcessor` émet :
+ *   - `sitemap_generation_complete` (severity info) sur succès
+ *   - `sitemap_generation_failed`   (severity high)  sur échec
+ *
+ * L'absence de `sitemap_generation_complete` >26h lève l'alerte `SITEMAP_STALE_V1`
+ * (rpc_seo_alerts_v1, migration 20260521_seo_sitemap_freshness_001_alert_rpc.sql).
+ *
+ * Étend `SupabaseBaseService` (chemin DI canonique, mirror de `FunnelEventsService`) :
+ * `this.supabase` service-role + sémaphore + circuit breaker + fallback ADR-028. Pas
+ * de `createClient` local (anti-duplication).
+ */
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+
+export interface SitemapHeartbeatPayload {
+  totalUrls?: number;
+  totalFiles?: number;
+  durationMs: number;
+  triggeredBy: string;
+  errorMessage?: string;
+}
+
+@Injectable()
+export class SitemapEventLogService extends SupabaseBaseService {
+  constructor(configService: ConfigService) {
+    super(configService);
+  }
+
+  /**
+   * Persiste le heartbeat de régénération. Fire-and-forget côté appelant : on log
+   * l'erreur mais on ne lève jamais (un heartbeat raté ne doit pas casser le job).
+   */
+  async recordHeartbeat(
+    success: boolean,
+    payload: SitemapHeartbeatPayload,
+  ): Promise<{ ok: boolean }> {
+    const eventType = success
+      ? 'sitemap_generation_complete'
+      : 'sitemap_generation_failed';
+    const { error } = await this.supabase.from('__seo_event_log').insert({
+      event_type: eventType,
+      entity_url: null,
+      severity: success ? 'info' : 'high',
+      payload,
+    });
+    if (error) {
+      this.logger.error(
+        `sitemap heartbeat insert failed (${eventType}): ${error.message}`,
+      );
+      return { ok: false };
+    }
+    return { ok: true };
+  }
+}

--- a/backend/supabase/migrations/20260521_seo_sitemap_freshness_000_enum.sql
+++ b/backend/supabase/migrations/20260521_seo_sitemap_freshness_000_enum.sql
@@ -1,0 +1,40 @@
+-- =====================================================
+-- Commerce-Loop V1 — Étape 2 : sitemap freshness alert (000 — ENUM extension)
+-- Date: 2026-05-21
+-- Refs: plan commerce-loop-v1 étape 2 ("alert on absence of expected events")
+--       20260425_seo_event_log.sql (table + ENUM seo_event_type)
+--       20260521_seo_event_funnel_enum.sql (pattern ALTER TYPE ADD VALUE, guard pg_enum)
+--       feedback_no_external_canary_when_internal_observability_exists (réutilise
+--         __seo_event_log + rpc_seo_alerts_v1 livrés par #601, aucune surface externe)
+-- =====================================================
+--
+-- Étend l'ENUM `seo_event_type` avec 2 events émis par le SitemapRegenerateProcessor
+-- (heartbeat de régénération nocturne 03:00 UTC). Le bloc `001` (alert RPC) s'appuie
+-- sur l'ABSENCE de `sitemap_generation_complete` >26h pour lever SITEMAP_STALE_V1.
+--
+--   sitemap_generation_complete → succès régénération (severity info, heartbeat)
+--   sitemap_generation_failed   → échec régénération (severity high, forensics)
+--
+-- AUCUNE consommation ici — migration ordonnée AVANT l'émission ET avant le RPC `001`
+-- qui référence le label en littéral (contrainte PG : un nouveau label ENUM ne peut
+-- être utilisé dans la transaction qui l'ajoute). Additif. Idempotent (guard pg_enum).
+-- Forward-only (ALTER TYPE ADD VALUE est irréversible en Postgres — pas de down).
+-- =====================================================
+
+-- Garde-fous obligatoires (squawk require-timeout-settings, ADR-064).
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'sitemap_generation_complete' AND enumtypid = 'seo_event_type'::regtype) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'sitemap_generation_complete';
+    END IF;
+END $$;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_enum WHERE enumlabel = 'sitemap_generation_failed' AND enumtypid = 'seo_event_type'::regtype) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'sitemap_generation_failed';
+    END IF;
+END $$;
+
+COMMENT ON TYPE seo_event_type IS 'Event log unifié SEO + funnel diagnostic + heartbeat sitemap (étape 2). Variants discriminés par event_type, payload JSONB. Extensible via ALTER TYPE ADD VALUE.';

--- a/backend/supabase/migrations/20260521_seo_sitemap_freshness_001_alert_rpc.sql
+++ b/backend/supabase/migrations/20260521_seo_sitemap_freshness_001_alert_rpc.sql
@@ -1,0 +1,154 @@
+-- =====================================================
+-- Commerce-Loop V1 — Étape 2 : sitemap freshness alert (001 — alert rule)
+-- Date: 2026-05-21
+-- Refs: plan commerce-loop-v1 étape 2
+--       20260518_seo_control_002_rpcs.sql (définition d'origine de rpc_seo_alerts_v1)
+--       20260521_seo_sitemap_freshness_000_enum.sql (DOIT s'appliquer AVANT — le
+--         littéral 'sitemap_generation_complete' doit être un label ENUM valide ici)
+--       feedback_no_external_canary_when_internal_observability_exists
+-- =====================================================
+--
+-- Étend `rpc_seo_alerts_v1` avec une 3ᵉ source d'alerte : SITEMAP_STALE_V1.
+-- Contrairement aux sources A (audit_findings) et B (event_log bad events) qui
+-- alertent sur la PRÉSENCE de lignes, celle-ci alerte sur l'ABSENCE d'un heartbeat
+-- `sitemap_generation_complete` dans les 26 dernières heures — pattern SRE canonique
+-- "alert on absence of expected events". Le job nocturne (03:00 UTC) émet le
+-- heartbeat ; s'il s'arrête (scheduler mort, échecs répétés), l'alerte high apparaît
+-- dans le bloc Alerts du dashboard cockpit (#601) après 26h, sans surface externe.
+--
+-- CREATE OR REPLACE = redéfinition wholesale. Sources A+B reproduites À L'IDENTIQUE
+-- depuis 002_rpcs (seule définition existante, aucune redéfinition postérieure
+-- vérifiée). Forward-only ; rollback = ré-appliquer 002_rpcs.
+--
+-- Note warmup : avant le tout premier heartbeat (fraîche instance, ou PREPROD
+-- READ_ONLY qui ne régénère jamais — ADR-028), SITEMAP_STALE_V1 est actif. C'est
+-- correct (le sitemap n'a effectivement pas été régénéré) ; en steady-state PROD le
+-- heartbeat nocturne éteint l'alerte. Gate : 7j post-merge → 0 alerte quand le
+-- service tourne normalement.
+-- =====================================================
+
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+
+CREATE OR REPLACE FUNCTION rpc_seo_alerts_v1(
+  p_now TIMESTAMPTZ DEFAULT NOW(),
+  p_limit INT DEFAULT 50
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH unified AS (
+    -- Source A : audit findings unresolved (severity critical|high|medium)
+    SELECT
+      'audit_findings'::TEXT AS source,
+      audit_type::TEXT AS alert_type,
+      entity_url,
+      severity::TEXT AS severity,
+      detected_at,
+      COALESCE(
+        jsonb_strip_nulls(jsonb_build_object(
+          'reason', payload->>'reason',
+          'metric', payload->>'metric',
+          'expected', payload->'expected'
+        )),
+        '{}'::jsonb
+      ) AS payload_minimal
+    FROM __seo_audit_findings
+    WHERE resolved_at IS NULL
+      AND severity IN ('critical', 'high', 'medium')
+    UNION ALL
+    -- Source B : event log unresolved (severity critical|high, anomalies+ingestion failures)
+    SELECT
+      'event_log'::TEXT,
+      event_type::TEXT,
+      entity_url,
+      severity::TEXT,
+      created_at,
+      COALESCE(
+        jsonb_strip_nulls(jsonb_build_object(
+          'reason', payload->>'reason',
+          'source', payload->>'source',
+          'count', payload->'count'
+        )),
+        '{}'::jsonb
+      )
+    FROM __seo_event_log
+    WHERE resolved_at IS NULL
+      AND severity IN ('critical', 'high')
+      AND event_type IN ('anomaly_detected', 'alert_sent', 'ingestion_run_failed')
+    UNION ALL
+    -- Source C : sitemap freshness — alert on ABSENCE of a completion heartbeat >26h
+    -- (étape 2). Une seule ligne synthétique quand aucun `sitemap_generation_complete`
+    -- récent n'existe. Réutilise __seo_event_log (#601), aucune surface externe.
+    SELECT
+      'sitemap_freshness'::TEXT,
+      'SITEMAP_STALE_V1'::TEXT,
+      NULL::TEXT,
+      'high'::TEXT,
+      p_now,
+      jsonb_build_object(
+        'reason', 'no sitemap_generation_complete heartbeat in last 26h',
+        'threshold_hours', 26
+      )
+    WHERE NOT EXISTS (
+      SELECT 1 FROM __seo_event_log
+      WHERE event_type = 'sitemap_generation_complete'
+        AND created_at > p_now - INTERVAL '26 hours'
+    )
+  ),
+  enriched AS (
+    SELECT
+      u.source,
+      u.alert_type,
+      u.entity_url,
+      u.severity,
+      u.detected_at,
+      u.payload_minimal,
+      _seo_resolve_operational_domain(u.alert_type) AS operational_domain,
+      _seo_resolve_surface_key(u.entity_url) AS surface_key,
+      ROUND(
+        ((CASE u.severity
+          WHEN 'critical' THEN 10
+          WHEN 'high' THEN 5
+          WHEN 'medium' THEN 2
+          ELSE 1 END)::NUMERIC
+        * (1 + COALESCE(LOG(GREATEST(1, COALESCE(gsc.clicks_7d, 0))), 0))::NUMERIC)::NUMERIC,
+        2
+      )::FLOAT8 AS business_impact_score
+    FROM unified u
+    LEFT JOIN LATERAL (
+      SELECT SUM(clicks)::BIGINT AS clicks_7d
+      FROM __seo_gsc_daily
+      WHERE page = u.entity_url
+        AND date >= p_now::DATE - 7
+        AND date < p_now::DATE
+    ) gsc ON TRUE
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'source', e.source,
+        'alert_type', e.alert_type,
+        'entity_url', e.entity_url,
+        'surface_key', e.surface_key,
+        'operational_domain', e.operational_domain,
+        'severity', e.severity,
+        'detected_at', e.detected_at,
+        'payload_minimal', e.payload_minimal,
+        'business_impact_score', e.business_impact_score,
+        'impact_score_version', 'v1'
+      )
+      ORDER BY e.business_impact_score DESC, e.detected_at DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM (
+    SELECT *
+    FROM enriched
+    ORDER BY business_impact_score DESC, detected_at DESC
+    LIMIT p_limit
+  ) e;
+$$;
+COMMENT ON FUNCTION rpc_seo_alerts_v1(TIMESTAMPTZ, INT) IS
+  'PR-SBD-1 v1 + étape 2 — Unresolved alerts UNION (audit_findings + event_log + sitemap freshness absence SITEMAP_STALE_V1) with operational_domain + surface_key + business_impact_score (severity weighted by page traffic). payload_minimal ≤ 3 keys (anti-bloat).';
+
+-- CREATE OR REPLACE preserves privileges, but re-state them explicitly (canon 002_rpcs).
+REVOKE ALL ON FUNCTION rpc_seo_alerts_v1(TIMESTAMPTZ, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION rpc_seo_alerts_v1(TIMESTAMPTZ, INT) TO service_role;


### PR DESCRIPTION
## Pourquoi

**Commerce-Loop V1 — Étape 2** (plan approuvé 2026-05-19). Le sitemap est régénéré chaque nuit (03:00 UTC, `SitemapRegenerateProcessor` BullMQ). **Gap unique** identifié : aucun signal en cas d'absence de régénération → impossible d'alerter si le job meurt. Sans fraîcheur du sitemap, l'**acquisition** (étape 1 de la hiérarchie Google du plan) se dégrade silencieusement.

Application stricte de `feedback_no_external_canary_when_internal_observability_exists` : **pas de canary externe, pas de workflow GitHub Actions, pas de script custom** — on réutilise l'infra interne livrée par #601 (`__seo_event_log` + `rpc_seo_alerts_v1` + bloc Alerts du dashboard cockpit).

## Quoi — "alert on absence of expected events" (pattern SRE canonique)

1. **Migration 000** (`..._freshness_000_enum.sql`) : étend l'ENUM `seo_event_type` avec `sitemap_generation_complete` (heartbeat, severity `info`) + `sitemap_generation_failed` (severity `high`). Mirror exact de `20260521_seo_event_funnel_enum` (guard `pg_enum`, idempotent, forward-only).
2. **Migration 001** (`..._freshness_001_alert_rpc.sql`) : `CREATE OR REPLACE rpc_seo_alerts_v1` — sources A (audit_findings) + B (event_log) **reproduites à l'identique** depuis `002_rpcs` (seule définition existante, aucune redéfinition postérieure) + **source C `SITEMAP_STALE_V1`** : ligne synthétique `high` quand **aucun** `sitemap_generation_complete` dans les 26 dernières heures. Ordonnée APRÈS 000 (le littéral ENUM doit exister à la création de la fonction).
3. **`SitemapEventLogService`** (mirror de `FunnelEventsService`, extends `SupabaseBaseService`) + **`SitemapRegenerateProcessor`** émet le heartbeat sur succès **et** échec. Le path **READ_ONLY** (PREPROD, ADR-028) reste **silencieux** — pas de fausse complétion.

## Sécurité / blast radius

- **Aucun changement** de génération sitemap / URL / `lastmod` / canonical (vérifié : seul un INSERT heartbeat ajouté, fire-and-forget qui avale ses erreurs).
- **Migration apply = GATE owner GO** : additif (`ADD VALUE IF NOT EXISTS` + `CREATE OR REPLACE`), rollback = ré-appliquer `002_rpcs`. `ALTER TYPE ADD VALUE` irréversible (documenté forward-only).
- **Warmup** : avant le 1ᵉʳ heartbeat (fraîche instance / PREPROD READ_ONLY), `SITEMAP_STALE_V1` est actif — correct (sitemap pas encore régénéré) ; en steady-state PROD le heartbeat nocturne l'éteint.

## Gate (plan)

7j post-merge → ≥1 `sitemap_generation_complete`/24h, **0 alerte `SITEMAP_STALE_V1`** quand le service tourne normalement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)