### PR TITLE
perf(web-vitals): capture INP/LCP/CLS attribution for field root-cause

### DIFF
--- a/frontend/app/utils/web-vitals.client.ts
+++ b/frontend/app/utils/web-vitals.client.ts
@@ -6,6 +6,14 @@
  *   2. window.gtag (GA4) - déjà câblé via root.tsx, RGPD consent géré
  *   3. console.info (toujours, pour debug + Sentry breadcrumbs)
  *
+ * ⚡ Attribution (web-vitals/attribution) : on capture, en plus de la valeur,
+ * le *pourquoi* (élément interagi + décomposition des phases). C'est ce qui
+ * permet de diagnostiquer un INP > 500ms en champ (quel sélecteur, et si le
+ * coût est en input delay / processing / presentation). Sans ça on ne voit
+ * que la valeur agrégée, jamais la cause. Le build attribution est le même
+ * package `web-vitals` (pas de nouvelle dépendance) et ne tourne que côté
+ * client après hydratation.
+ *
  * Aucun appel n'est inventé : `Sentry.metrics?.distribution` est testé runtime
  * avant usage. Si la lib n'expose pas cette API (build minimal, version sans
  * Metrics, DSN absent → init noop), on tombe sur le fallback GA4/console
@@ -14,7 +22,14 @@
  * `console`, CMP qui mock `gtag`, etc.).
  */
 
-import { onLCP, onCLS, onINP, onFCP, onTTFB, type Metric } from "web-vitals";
+import {
+  onLCP,
+  onCLS,
+  onINP,
+  onFCP,
+  onTTFB,
+  type MetricWithAttribution,
+} from "web-vitals/attribution";
 
 interface SentryMetricsDistribution {
   (
@@ -53,7 +68,62 @@ interface GtagWindow {
   ) => void;
 }
 
-function reportToSentry(metric: Metric): boolean {
+// GA4 param values et Sentry tag values sont bornés (≈100-200 chars). Les
+// sélecteurs CSS d'attribution peuvent être longs → on tronque.
+const MAX_SELECTOR_LEN = 100;
+function truncate(s: string, n = MAX_SELECTOR_LEN): string {
+  return s.length > n ? s.slice(0, n) : s;
+}
+
+/**
+ * Champs d'attribution actionnables par métrique. Le narrowing sur
+ * `metric.name` (union discriminée web-vitals) type `metric.attribution`.
+ * Valeurs numériques arrondies (ms). Renvoie {} pour les métriques dont
+ * l'attribution n'apporte pas de diagnostic actionnable (FCP/TTFB).
+ */
+function attributionFields(
+  metric: MetricWithAttribution,
+): Record<string, string | number> {
+  switch (metric.name) {
+    case "INP":
+      return {
+        attr_target: truncate(metric.attribution.interactionTarget),
+        attr_interaction_type: metric.attribution.interactionType,
+        attr_load_state: metric.attribution.loadState,
+        attr_input_delay: Math.round(metric.attribution.inputDelay),
+        attr_processing_duration: Math.round(
+          metric.attribution.processingDuration,
+        ),
+        attr_presentation_delay: Math.round(
+          metric.attribution.presentationDelay,
+        ),
+      };
+    case "LCP":
+      return {
+        attr_element: truncate(metric.attribution.element ?? ""),
+        attr_ttfb: Math.round(metric.attribution.timeToFirstByte),
+        attr_resource_load_delay: Math.round(
+          metric.attribution.resourceLoadDelay,
+        ),
+        attr_resource_load_duration: Math.round(
+          metric.attribution.resourceLoadDuration,
+        ),
+        attr_element_render_delay: Math.round(
+          metric.attribution.elementRenderDelay,
+        ),
+      };
+    case "CLS":
+      return {
+        attr_largest_shift_target: truncate(
+          metric.attribution.largestShiftTarget ?? "",
+        ),
+      };
+    default:
+      return {};
+  }
+}
+
+function reportToSentry(metric: MetricWithAttribution): boolean {
   // Vérification runtime : ne pas inventer l'API. Si Sentry est noop (DSN
   // absent), pas encore chargé (idle pas encore fired), ou build sans Metrics,
   // on échoue silencieusement.
@@ -61,6 +131,11 @@ function reportToSentry(metric: Metric): boolean {
   if (typeof sentry?.metrics?.distribution !== "function") return false;
 
   try {
+    // Tags Sentry = strings uniquement → on stringify l'attribution.
+    const attrTags: Record<string, string> = {};
+    for (const [k, v] of Object.entries(attributionFields(metric))) {
+      attrTags[k] = String(v);
+    }
     sentry.metrics.distribution(
       `web_vital.${metric.name.toLowerCase()}`,
       metric.value,
@@ -69,6 +144,7 @@ function reportToSentry(metric: Metric): boolean {
         tags: {
           rating: metric.rating,
           navigation_type: metric.navigationType ?? "unknown",
+          ...attrTags,
         },
       },
     );
@@ -78,7 +154,7 @@ function reportToSentry(metric: Metric): boolean {
   }
 }
 
-function reportToGtag(metric: Metric): boolean {
+function reportToGtag(metric: MetricWithAttribution): boolean {
   const gtag = (window as GtagWindow).gtag;
   if (typeof gtag !== "function") return false;
 
@@ -90,6 +166,7 @@ function reportToGtag(metric: Metric): boolean {
       metric_id: metric.id,
       navigation_type: metric.navigationType,
       page_path: typeof window !== "undefined" ? window.location.pathname : "",
+      ...attributionFields(metric),
     });
     return true;
   } catch {
@@ -97,9 +174,10 @@ function reportToGtag(metric: Metric): boolean {
   }
 }
 
-function reportToConsole(metric: Metric): void {
+function reportToConsole(metric: MetricWithAttribution): void {
   // Toujours appelé : utile pour debug local + capturé en breadcrumb par Sentry
   // si `Sentry.init` capture les console (default v10 = true via integrations).
+  // L'attribution rend ce log directement actionnable en lab (élément + phase).
   // eslint-disable-next-line no-console
   console.info("[web-vitals]", {
     name: metric.name,
@@ -107,10 +185,11 @@ function reportToConsole(metric: Metric): void {
     rating: metric.rating,
     id: metric.id,
     path: typeof window !== "undefined" ? window.location.pathname : "",
+    ...attributionFields(metric),
   });
 }
 
-function dispatchMetric(metric: Metric) {
+function dispatchMetric(metric: MetricWithAttribution) {
   try {
     reportToSentry(metric);
     reportToGtag(metric);


### PR DESCRIPTION
## Pourquoi

GSC/CrUX signale **INP 537ms ("Médiocre", > 500ms) mobile** sur un groupe de **355 URLs `/pieces/`**. Investigation (systematic-debugging, lecture seule) : on est **aveugles** sur la cause — le reporter `web-vitals.client.ts` utilisait `onINP` **sans attribution** (valeur capturée, pas le *pourquoi*), et le pipeline CWV interne est vide (`__seo_cwv_daily` 0 ligne, table CrUX non migrée). Le chemin filtres est déjà optimisé INP ; corriger plus loin à l'aveugle = random fix.

Ce PR **débloque le diagnostic** (Workstream A du plan), prérequis avant tout correctif.

## Quoi

- Bascule sur le build **`web-vitals/attribution`** (même package `web-vitals@4.2.4`, **pas de nouvelle dépendance**).
- Pousse les champs d'attribution **actionnables** vers les 3 sinks existants (Sentry `metrics.distribution` + GA4 `web_vitals` + `console.info`) :
  - **INP** : `interactionTarget`, `interactionType`, `loadState`, et la décomposition `inputDelay` / `processingDuration` / `presentationDelay` → on saura *quel élément* et *quelle phase*.
  - **LCP** : `element` + sous-phases. **CLS** : `largestShiftTarget`.
- Sélecteurs tronqués à 100 chars (limites GA4/Sentry). Reporter **passif** (try/catch + runtime-check Sentry inchangés). Signatures exportées identiques → **zéro impact** sur `entry.client.tsx`.

## Vérification

- `tsc` frontend : **0 erreur**.
- `remix vite:build` : **OK** (exit 0). Bundle client (`app-core-*.js`) contient bien le build attribution (`interactionTarget`, `presentationDelay`) **et** nos champs (`attr_input_delay`, `attr_presentation_delay`).

## Suite (hors de ce PR — gated par la mesure)

- **B** : repro lab DevTools (build prod, mobile + 4× CPU) sur une URL gamme-only ET une URL produit → identifier la phase/élément coupant (hypothèse n°1 = chargement tiers GTM/gtag à la 1ʳᵉ interaction, site-wide ; n°2 = cascade VehicleSelector).
- **C** : correctif structurel **du seul coupable confirmé**.
- **D** : garde anti-régression (budget TBT CI + alerte champ via infra interne) + réparation ingestion CWV (PR séparée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)