### PR TITLE
fix(db): get_vehicle_page_data_cached VOLATILE — true root cause of R8 503 (GSC 5xx)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -534,6 +534,11 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: medium
+  - glob: backend/supabase/migrations/*vehicle_page_cached*
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/supabase/migrations/*default_privileges*
     domain: D15
     owner: '@ak125'

--- a/backend/supabase/migrations/20260522_vehicle_page_cached_volatile.down.sql
+++ b/backend/supabase/migrations/20260522_vehicle_page_cached_volatile.down.sql
@@ -1,0 +1,42 @@
+-- Rollback for 20260522_vehicle_page_cached_volatile.sql
+-- Restores get_vehicle_page_data_cached() to STABLE (its pre-fix volatility).
+-- NOTE: reverting reintroduces the "cannot execute DELETE in a read-only transaction"
+-- 503 for not-found / cold vehicles via PostgREST. Only roll back if the VOLATILE
+-- change itself causes a regression.
+
+CREATE OR REPLACE FUNCTION public.get_vehicle_page_data_cached(p_type_id integer)
+ RETURNS json
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+AS $function$
+DECLARE
+  v_cached_payload JSONB;
+  v_cached_stale   BOOLEAN;
+  v_built          BOOLEAN;
+BEGIN
+  SELECT payload, stale
+    INTO v_cached_payload, v_cached_stale
+    FROM public.__vehicle_page_cache
+    WHERE type_id = p_type_id;
+
+  IF v_cached_payload IS NOT NULL AND v_cached_stale = FALSE THEN
+    RETURN v_cached_payload::JSON;
+  END IF;
+
+  v_built := public.rebuild_vehicle_page_cache(p_type_id);
+
+  IF v_built = FALSE THEN
+    RETURN json_build_object(
+      'success', FALSE,
+      'error', 'Vehicle not found',
+      'type_id', p_type_id
+    );
+  END IF;
+
+  SELECT payload INTO v_cached_payload
+    FROM public.__vehicle_page_cache
+    WHERE type_id = p_type_id;
+
+  RETURN v_cached_payload::JSON;
+END;
+$function$;

--- a/backend/supabase/migrations/20260522_vehicle_page_cached_volatile.sql
+++ b/backend/supabase/migrations/20260522_vehicle_page_cached_volatile.sql
@@ -1,0 +1,65 @@
+-- 20260522_vehicle_page_cached_volatile.sql
+--
+-- Fix GSC "Erreur serveur (5xx)" on /constructeurs/ (R8) vehicle pages.
+--
+-- ROOT CAUSE (confirmed via Postgres logs: "cannot execute DELETE in a read-only transaction"):
+--   get_vehicle_page_data_cached() is declared STABLE, but its cold path calls
+--   rebuild_vehicle_page_cache() which WRITES (__vehicle_page_cache DELETE on a
+--   not-found vehicle, UPSERT on a good one). PostgREST runs STABLE/IMMUTABLE
+--   functions inside a READ ONLY transaction, so that write fails. The backend's
+--   callRpc() surfaces the error, and VehiclesController maps any non-not-found
+--   error to HTTP 503 → not-found vehicles (type_display != '1', e.g. type_id 857,
+--   ~25k rows) deterministically returned 503. Google retried forever and the GSC
+--   fix-validation failed.
+--
+-- FIX: declare get_vehicle_page_data_cached() VOLATILE so PostgREST uses a
+--   read-write transaction. The lazy cache write then succeeds; a not-found vehicle
+--   returns {success:false} → VehicleRpcService throws DomainNotFoundException → the
+--   controller returns 404, and the Remix loader (PR #690) renders 404 + noindex.
+--   This also fixes a latent 503 for *cold* (uncached) good vehicles.
+--
+-- SAFETY: CREATE OR REPLACE only — no data, no schema, no signature change. The body
+--   is byte-identical to the live definition; only STABLE → VOLATILE changes.
+--   rebuild_vehicle_page_cache() is already VOLATILE; build_vehicle_page_payload()
+--   stays STABLE (genuinely read-only). No other function references this one.
+--   Reversible via 20260522_vehicle_page_cached_volatile.down.sql.
+
+CREATE OR REPLACE FUNCTION public.get_vehicle_page_data_cached(p_type_id integer)
+ RETURNS json
+ LANGUAGE plpgsql
+ VOLATILE SECURITY DEFINER
+AS $function$
+DECLARE
+  v_cached_payload JSONB;
+  v_cached_stale   BOOLEAN;
+  v_built          BOOLEAN;
+BEGIN
+  SELECT payload, stale
+    INTO v_cached_payload, v_cached_stale
+    FROM public.__vehicle_page_cache
+    WHERE type_id = p_type_id;
+
+  IF v_cached_payload IS NOT NULL AND v_cached_stale = FALSE THEN
+    RETURN v_cached_payload::JSON;
+  END IF;
+
+  v_built := public.rebuild_vehicle_page_cache(p_type_id);
+
+  IF v_built = FALSE THEN
+    RETURN json_build_object(
+      'success', FALSE,
+      'error', 'Vehicle not found',
+      'type_id', p_type_id
+    );
+  END IF;
+
+  SELECT payload INTO v_cached_payload
+    FROM public.__vehicle_page_cache
+    WHERE type_id = p_type_id;
+
+  RETURN v_cached_payload::JSON;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.get_vehicle_page_data_cached(integer) IS
+  'Cache-first vehicle page payload. VOLATILE (not STABLE): lazily writes __vehicle_page_cache on miss via rebuild_vehicle_page_cache, so PostgREST must run it read-write. See 20260522_vehicle_page_cached_volatile.sql.';

--- a/backend/supabase/migrations/20260522_vehicle_page_cached_volatile.sql
+++ b/backend/supabase/migrations/20260522_vehicle_page_cached_volatile.sql
@@ -23,6 +23,13 @@
 --   rebuild_vehicle_page_cache() is already VOLATILE; build_vehicle_page_payload()
 --   stays STABLE (genuinely read-only). No other function references this one.
 --   Reversible via 20260522_vehicle_page_cached_volatile.down.sql.
+--
+-- Le runner (scripts/ci/apply-supabase-migration.py) wrappe déjà chaque fichier
+-- dans une transaction (squawk: assume_in_transaction) → pas de BEGIN/COMMIT
+-- explicite. Timeouts robustes avant DDL (require-timeout-settings).
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '15s';
 
 CREATE OR REPLACE FUNCTION public.get_vehicle_page_data_cached(p_type_id integer)
  RETURNS json


### PR DESCRIPTION
## Why — the real root cause behind GSC "Erreur serveur (5xx)"

PR #690 fixed the **frontend half** (loader → 404 + noindex, interceptor robots) but `/constructeurs/` vehicle pages **still 503'd in PROD**. Live diagnosis revealed the actual source:

`/api/vehicles/types/:id/page-data-rpc` returns **503** because `get_vehicle_page_data_cached()` is declared **`STABLE`**, yet its cold path lazily **writes** `__vehicle_page_cache` (via `rebuild_vehicle_page_cache`: `DELETE` for a not-found vehicle, `UPSERT` for a cold-good one). PostgREST runs `STABLE` functions in a **READ ONLY transaction**, so the write throws — **confirmed in Postgres logs**:

```
ERROR: cannot execute DELETE in a read-only transaction
```

`VehiclesController` maps that error to **503**. So every not-found vehicle (`type_display != '1'` — ~25k rows incl. `type_id 857`) deterministically 503'd → Google retried forever → GSC validation failed. (MCP `SELECT` worked because direct SQL isn't read-only.)

## Fix

Declare `get_vehicle_page_data_cached` **`VOLATILE`** → PostgREST uses a read-write transaction → the lazy write succeeds → not-found returns `{success:false}` → `VehicleRpcService` throws `DomainNotFoundException` → controller returns **404** → the Remix loader (#690) renders **404 + noindex**. Also fixes a **latent 503 for cold (uncached) good vehicles**.

## Safety

- `CREATE OR REPLACE` only — **no data, no schema, no signature change**. Body byte-identical to the live definition; only `STABLE` → `VOLATILE`.
- `rebuild_vehicle_page_cache` is already `VOLATILE`; `build_vehicle_page_payload` stays `STABLE` (genuinely read-only).
- Verified **no other function references** `get_vehicle_page_data_cached` (no STABLE-context caller).
- Reversible via `20260522_vehicle_page_cached_volatile.down.sql`.

## Verification plan

Apply migration → `curl /api/vehicles/types/857/page-data-rpc` returns **404** (was 503); `/constructeurs/.../230-857.html` renders **404 + `x-robots-tag: noindex`**; a healthy vehicle stays **200**.

> Migrations are **not** auto-applied at merge (per `apply-supabase-migrations.yml`); application to the shared DB is a deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)