### PR TITLE
perf(inp): contain off-screen /pieces/ sections to cut mobile INP (537ms→)

### DIFF
--- a/frontend/app/components/pieces/PiecesVehicleContent.tsx
+++ b/frontend/app/components/pieces/PiecesVehicleContent.tsx
@@ -421,8 +421,8 @@ export function PiecesVehicleContent() {
                 vehicle={data.vehicle}
               />
 
-              {/* Sections SEO */}
-              <div className="space-y-6 mt-12">
+              {/* Sections SEO (below-fold → cv-auto: skip layout when off-screen) */}
+              <div className="space-y-6 mt-12 cv-auto">
                 <PiecesSEOSection
                   content={data.seoContent}
                   vehicleName={`${data.vehicle.marque} ${data.vehicle.modele} ${data.vehicle.type}`}
@@ -467,7 +467,7 @@ export function PiecesVehicleContent() {
 
         {/* Cross-selling - SSR pour maillage interne (5-12 liens) */}
         {data.crossSellingGammes.length > 0 && (
-          <div className="mt-12">
+          <div className="mt-12 cv-auto">
             <PiecesCrossSelling
               gammes={data.crossSellingGammes}
               vehicle={data.vehicle}
@@ -483,7 +483,7 @@ export function PiecesVehicleContent() {
                 (a): a is NonNullable<typeof a> => a !== null,
               );
               return validArticles.length > 0 ? (
-                <div className="container mx-auto px-4">
+                <div className="container mx-auto px-4 cv-auto">
                   <PiecesRelatedArticles
                     articles={validArticles}
                     gammeName={data.gamme.name}
@@ -496,12 +496,14 @@ export function PiecesVehicleContent() {
         </Suspense>
 
         {/* Section "Voir aussi" - Maillage interne SEO (composant extrait) */}
-        <PiecesVoirAussi
-          links={data.voirAussiLinks}
-          gamme={data.gamme}
-          vehicle={data.vehicle}
-          onLinkClick={handleVoirAussiClick}
-        />
+        <div className="cv-auto">
+          <PiecesVoirAussi
+            links={data.voirAussiLinks}
+            gamme={data.gamme}
+            vehicle={data.vehicle}
+            onLinkClick={handleVoirAussiClick}
+          />
+        </div>
       </div>
 
       {/* Bouton retour en haut */}

--- a/frontend/app/global.css
+++ b/frontend/app/global.css
@@ -368,6 +368,20 @@
 
 /* Animations: définies dans animations.css, seules les classes utilitaires ici */
 @layer utilities {
+  /* INP: skip style/layout of OFF-SCREEN content. A forced reflow triggered
+     inside a click handler (notably opening a Radix Dialog/Sheet, which mutates
+     <body> for scroll-lock) otherwise recomputes style+layout for the ENTIRE
+     large /pieces/ document (~1250 nodes → ~120-270ms forced layout, scaling to
+     the 537ms mobile INP p75 on slow devices). Applied to below-the-fold section
+     wrappers so off-screen blocks are skipped. `auto` intrinsic-size remembers
+     the last rendered size to avoid scroll jumps. Validated on prod DOM
+     (menu-toggle INP 288→192ms @6x CPU). SEO-safe: content stays in the DOM and
+     content-visibility:auto is rendered/indexed when reached. */
+  .cv-auto {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 700px;
+  }
+
   .animate-shimmer {
     animation: shimmer 3s ease-in-out infinite;
     will-change: transform;

--- a/frontend/app/routes/pieces.$slug.tsx
+++ b/frontend/app/routes/pieces.$slug.tsx
@@ -870,7 +870,7 @@ export default function PiecesDetailPage() {
            H2 #2 — Qualité, prix et marques
            Image PRICE, marques, fiche technique
            ═══════════════════════════════════════════════════════ */}
-      <section id="qualite-prix" className="py-10 px-4 sm:px-6 bg-slate-50">
+      <section id="qualite-prix" className="py-10 px-4 sm:px-6 bg-slate-50 cv-auto">
         <div className="max-w-[1280px] mx-auto">
           <h2 className="text-2xl font-bold text-slate-900 mb-6">
             Qualité, prix et marques
@@ -938,7 +938,7 @@ export default function PiecesDetailPage() {
            H2 #3 — Où se trouve et quand remplacer
            Image LOCATION, rôle, symptômes, entretien
            ═══════════════════════════════════════════════════════ */}
-      <section id="emplacement" className="py-10 px-4 sm:px-6 bg-white">
+      <section id="emplacement" className="py-10 px-4 sm:px-6 bg-white cv-auto">
         <div className="max-w-[1280px] mx-auto">
           <h2 className="text-2xl font-bold text-slate-900 mb-6">
             Où se trouve le {n} et quand le remplacer
@@ -993,7 +993,7 @@ export default function PiecesDetailPage() {
            H2 #4 — Trouver la bonne référence
            Compatibilités, motorisations, commande
            ═══════════════════════════════════════════════════════ */}
-      <section id="reference" className="py-10 px-4 sm:px-6 bg-slate-50">
+      <section id="reference" className="py-10 px-4 sm:px-6 bg-slate-50 cv-auto">
         <div className="max-w-[1280px] mx-auto">
           <h2 className="text-2xl font-bold text-slate-900 mb-6">
             Trouver la bonne référence pour votre véhicule
@@ -1036,7 +1036,7 @@ export default function PiecesDetailPage() {
       {/* ═══════════════════════════════════════════════════════
            H2 #5 — Questions fréquentes (UNE SEULE)
            ═══════════════════════════════════════════════════════ */}
-      <section id="faq" className="py-10 px-4 sm:px-6 bg-white">
+      <section id="faq" className="py-10 px-4 sm:px-6 bg-white cv-auto">
         <div className="max-w-[1280px] mx-auto">
           <GammeFaq
             items={mergedFaq}
@@ -1049,7 +1049,7 @@ export default function PiecesDetailPage() {
            H2 #6 — Aller plus loin
            Maillage, famille, guide CTA
            ═══════════════════════════════════════════════════════ */}
-      <section id="aller-plus-loin" className="py-10 px-4 sm:px-6 bg-slate-50">
+      <section id="aller-plus-loin" className="py-10 px-4 sm:px-6 bg-slate-50 cv-auto">
         <div className="max-w-[1280px] mx-auto">
           <h2 className="text-2xl font-bold text-slate-900 mb-6">
             Aller plus loin


### PR DESCRIPTION
## Problème (GSC / CrUX)
INP **537 ms ("Médiocre", > 500 ms) mobile** sur **355 URLs `/pieces/`** (gamme-only **et** produit).

## Cause racine — mesurée, pas devinée
Outils : attribution `web-vitals/attribution` (livrée en #692) + sonde Playwright throttlée sur **prod** + **trace CDP**.

- L'interaction coupable = **taper le menu hamburger mobile** (header **partagé** → explique les 2 types de page).
- Elle ouvre un **Radix Sheet/Dialog** dont le scroll-lock mute `<body>` → **recalcul style+layout SYNCHRONE de tout le document** (~**1250 nœuds**, trace : `UpdateLayoutTree` 92+84 ms via `radix-vendor` dans le commit React).
- Phase dominante = **forced style&layout**, qui **scale avec le CPU** :

| CPU throttle | INP | forced layout |
|---|---|---|
| 4× | 208 ms | 119 ms |
| 6× | 320 ms | 187 ms |
| 8× | **456 ms** | 272 ms |

→ sur un mobile d'entrée de gamme (~9-10×) ça franchit **500 ms = le p75 CrUX de 537 ms**. LCP/CLS sont "good" : c'est purement l'INP d'interaction.

## Fix
Utilitaire **`.cv-auto`** (`content-visibility:auto` + `contain-intrinsic-size:auto 700px`) sur les **blocs sous la ligne de flottaison** :
- **Produit** (`PiecesVehicleContent.tsx`) : sections SEO/OEM/FAQ/compatibilité, cross-selling, articles liés, voir-aussi.
- **Gamme** (`pieces.$slug.tsx`) : sections `qualite-prix` / `emplacement` / `reference` / `faq` / `aller-plus-loin`.

Le navigateur saute le style+layout des blocs hors-écran → le reflow forcé ne recalcule plus tout le document.

## Validation
- **A/B sur le DOM prod réel** (injection content-visibility) : INP menu **288 → 192 ms @6× (-33 %)**, processing 256 → 159 ms.
- Contre-épreuve : contenir **les cartes seules** (10 nœuds) ne changeait rien (336→344) — c'est bien le **volume total de nœuds** qui compte, d'où le ciblage des grandes sections.
- `tsc` **0 erreur** ; `remix vite:build` **OK** ; `.cv-auto` présent dans le bundle CSS client.

## SEO & comportement
Contenu **toujours dans le DOM** ; `content-visibility:auto` est rendu/indexé à l'approche (confirmé par Google). **Aucun changement de comportement** ni d'UX.

## Suite
Confirmation **champ** via l'attribution INP de #692 sur les fenêtres CrUX suivantes (~28 j). Garde anti-régression (budget TBT/INP CI) = PR séparée (Workstream D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)