### PR TITLE
feat(cart): F1 attribution par-ligne (orl_website_url) + F5 autorité de prix — audit runtime-truth

### DIFF
--- a/backend/src/database/services/cart-data.service.ts
+++ b/backend/src/database/services/cart-data.service.ts
@@ -26,6 +26,7 @@ export const CartItemSchema = z.object({
   product_image: z.string().optional(), // URL image
   weight: z.number().min(0).optional(),
   type_id: z.number().int().positive().optional(), // Vehicle type_id (contexte vehicule a l'ajout)
+  website_url: z.string().optional(), // F1 attribution : source d'ajout (URL/chemin de la page) → orl_website_url
 });
 
 export const CartMetadataSchema = z.object({
@@ -304,6 +305,7 @@ export class CartDataService extends SupabaseBaseService {
     customPrice?: number,
     replace: boolean = false,
     typeId?: number,
+    sourceUrl?: string, // F1 attribution : page d'où l'article a été ajouté → orl_website_url
   ): Promise<CartItem> {
     try {
       // 1. Récupérer le produit avec TOUTES les vraies données
@@ -345,6 +347,7 @@ export class CartDataService extends SupabaseBaseService {
         product_image: product.piece_image || undefined,
         weight: product.piece_weight_kgm,
         ...(typeId && { type_id: typeId }),
+        ...(sourceUrl && { website_url: sourceUrl }),
       };
 
       if (existingItemIndex >= 0) {

--- a/backend/src/modules/cart/controllers/cart-items.controller.ts
+++ b/backend/src/modules/cart/controllers/cart-items.controller.ts
@@ -82,6 +82,15 @@ export class CartItemsController {
 
       const isReplace = (body as Record<string, unknown>)?.replace === true;
 
+      // F5 autorité de prix : observabilité. Si le client tente un override de prix,
+      // on le LOGGE (jamais de drop silencieux) — il est ignoré (prix = catalogue serveur).
+      const rawBody = body as Record<string, unknown>;
+      if (rawBody?.custom_price != null || rawBody?.customPrice != null) {
+        this.logger.warn(
+          `🔒 Price override client ignoré (autorité serveur) — session: ${sessionId}, product: ${productIdNum}, valeur reçue: ${String(rawBody.custom_price ?? rawBody.customPrice)}`,
+        );
+      }
+
       // Forcer la persistance de la session pour les visiteurs non connectes
       ensureSessionPersisted(req);
 
@@ -89,7 +98,7 @@ export class CartItemsController {
         userIdForCart,
         productIdNum,
         addItemDto.quantity,
-        addItemDto.custom_price,
+        undefined, // F5 : prix = autorité serveur (catalogue), jamais un prix client
         isReplace,
         addItemDto.type_id,
         addItemDto.website_url, // F1 attribution : source d'ajout par-ligne

--- a/backend/src/modules/cart/controllers/cart-items.controller.ts
+++ b/backend/src/modules/cart/controllers/cart-items.controller.ts
@@ -92,6 +92,7 @@ export class CartItemsController {
         addItemDto.custom_price,
         isReplace,
         addItemDto.type_id,
+        addItemDto.website_url, // F1 attribution : source d'ajout par-ligne
       );
 
       this.logger.log(

--- a/backend/src/modules/cart/dto/__tests__/add-item.dto.test.ts
+++ b/backend/src/modules/cart/dto/__tests__/add-item.dto.test.ts
@@ -33,3 +33,24 @@ describe('AddItemDto — website_url (F1 attribution source d’ajout)', () => {
     ).toThrow();
   });
 });
+
+describe('AddItemDto — autorité de prix (F5, anti price-tampering)', () => {
+  it('ignore (strip) un custom_price fourni par le client', () => {
+    const dto = validateAddItem({
+      product_id: 12345,
+      quantity: 1,
+      custom_price: 0.01,
+    }) as Record<string, unknown>;
+    expect(dto.custom_price).toBeUndefined();
+  });
+
+  it('reste valide malgré un custom_price client (non rejeté, juste ignoré)', () => {
+    const dto = validateAddItem({
+      product_id: 12345,
+      quantity: 2,
+      custom_price: 999,
+    });
+    expect(dto.product_id).toBe(12345);
+    expect(dto.quantity).toBe(2);
+  });
+});

--- a/backend/src/modules/cart/dto/__tests__/add-item.dto.test.ts
+++ b/backend/src/modules/cart/dto/__tests__/add-item.dto.test.ts
@@ -1,0 +1,35 @@
+/**
+ * F1 attribution — AddItemDto : la source d'ajout par-ligne (website_url) doit être
+ * acceptée, threadée, optionnelle, et bornée. Ref vault audit 2026-05-22 (F1).
+ */
+
+import { validateAddItem } from '../add-item.dto';
+
+describe('AddItemDto — website_url (F1 attribution source d’ajout)', () => {
+  const base = { product_id: 12345, quantity: 1 };
+
+  it('accepte et conserve website_url', () => {
+    const dto = validateAddItem({
+      ...base,
+      website_url: '/pieces/filtre-a-huile-7/bmw-serie-3.html',
+    });
+    expect(dto.website_url).toBe('/pieces/filtre-a-huile-7/bmw-serie-3.html');
+  });
+
+  it('trim les espaces autour de website_url', () => {
+    const dto = validateAddItem({ ...base, website_url: '  /pieces/x  ' });
+    expect(dto.website_url).toBe('/pieces/x');
+  });
+
+  it('reste valide sans website_url (optionnel, rétro-compat)', () => {
+    const dto = validateAddItem({ ...base });
+    expect(dto.website_url).toBeUndefined();
+    expect(dto.product_id).toBe(12345);
+  });
+
+  it('rejette une website_url au-delà de 2048 caractères', () => {
+    expect(() =>
+      validateAddItem({ ...base, website_url: 'x'.repeat(2049) }),
+    ).toThrow();
+  });
+});

--- a/backend/src/modules/cart/dto/add-item.dto.ts
+++ b/backend/src/modules/cart/dto/add-item.dto.ts
@@ -36,16 +36,10 @@ export const AddItemSchema = z
         .transform(Number),
     ]),
     product_variant_id: z.string().uuid().optional(),
-    custom_price: z
-      .union([
-        z.number().positive().optional(),
-        z
-          .string()
-          .regex(/^\d+(\.\d+)?$/, 'Prix doit être numérique')
-          .transform(Number)
-          .optional(),
-      ])
-      .optional(),
+    // F5 autorité de prix : le prix de vente est autorité SERVEUR (catalogue).
+    // `custom_price` client volontairement RETIRÉ — un override de prix fourni par
+    // le client sur cet endpoint (OptionalAuthGuard, anonyme autorisé) = price-tampering.
+    // Toute clé custom_price/customPrice envoyée est ignorée (strip Zod) + loggée au boundary.
     metadata: z.record(z.string(), z.any()).optional(),
     type_id: z.number().int().positive().optional(),
     // F1 attribution : URL/chemin de la page d'où l'article a été ajouté au panier

--- a/backend/src/modules/cart/dto/add-item.dto.ts
+++ b/backend/src/modules/cart/dto/add-item.dto.ts
@@ -48,6 +48,9 @@ export const AddItemSchema = z
       .optional(),
     metadata: z.record(z.string(), z.any()).optional(),
     type_id: z.number().int().positive().optional(),
+    // F1 attribution : URL/chemin de la page d'où l'article a été ajouté au panier
+    // (source d'ajout par-ligne). Threadé jusqu'à ___xtr_order_line.orl_website_url.
+    website_url: z.string().trim().max(2048).optional(),
   })
   .refine((data) => data.productId || data.product_id, {
     message: "Il faut fournir soit 'productId' soit 'product_id'",

--- a/backend/src/modules/cart/dto/update-item.dto.ts
+++ b/backend/src/modules/cart/dto/update-item.dto.ts
@@ -7,7 +7,8 @@ import { z } from 'zod';
 // 🏷️ Schema Zod pour la validation
 export const UpdateItemSchema = z.object({
   quantity: z.number().int().min(0, 'La quantité ne peut pas être négative'),
-  custom_price: z.number().positive().optional(),
+  // F5 autorité de prix : `custom_price` RETIRÉ (champ mort — le chemin update n'utilisait
+  // que `quantity`). Le prix de vente est autorité serveur, jamais fourni par le client.
   metadata: z.record(z.string(), z.any()).optional(),
 });
 

--- a/backend/src/modules/orders/events/order.events.ts
+++ b/backend/src/modules/orders/events/order.events.ts
@@ -20,11 +20,20 @@ export interface OrderEventBase {
   correlationId?: string;
 }
 
+/** F1 attribution : source d'ajout par-ligne propagée sur l'event de création */
+export interface OrderLineSource {
+  lineId: string;
+  productId: string | null;
+  websiteUrl: string | null;
+}
+
 export interface OrderCreatedEvent extends OrderEventBase {
   orderId: string;
   customerId: string;
   totalTtc: number;
   linesCount: number;
+  /** F1 : attribution add-to-cart par-ligne (source d'ajout). Vide si non capturée. */
+  lines?: OrderLineSource[];
 }
 
 export interface OrderPaidEvent extends OrderEventBase {

--- a/backend/src/modules/orders/listeners/order-audit.listener.ts
+++ b/backend/src/modules/orders/listeners/order-audit.listener.ts
@@ -54,7 +54,14 @@ export class OrderAuditListener extends SupabaseBaseService {
       event.orderId,
       event.customerId,
       undefined,
-      { totalTtc: event.totalTtc, linesCount: event.linesCount },
+      {
+        totalTtc: event.totalTtc,
+        linesCount: event.linesCount,
+        // F1 attribution : trace de la source d'ajout par-ligne (lignes avec source captée)
+        ...(event.lines?.some((l) => l.websiteUrl)
+          ? { lineSources: event.lines.filter((l) => l.websiteUrl) }
+          : {}),
+      },
       undefined,
       event.correlationId,
     );

--- a/backend/src/modules/orders/services/orders.service.ts
+++ b/backend/src/modules/orders/services/orders.service.ts
@@ -46,6 +46,7 @@ export interface CreateOrderData {
     discount?: number;
     consigne_unit?: number;
     has_consigne?: boolean;
+    website_url?: string; // F1 attribution : source d'ajout par-ligne → orl_website_url
   }>;
   billingAddress: OrderAddress;
   shippingAddress: OrderAddress;
@@ -374,6 +375,8 @@ export class OrdersService extends SupabaseBaseService {
             ),
             orl_art_deposit_unit_ttc: depositUnit,
             orl_art_deposit_ttc: depositTotal,
+            // F1 attribution : source d'ajout par-ligne (NULL si absente — rétro-compat RPC)
+            orl_website_url: line.website_url || null,
           };
         }),
       );
@@ -405,6 +408,12 @@ export class OrdersService extends SupabaseBaseService {
         customerId: String(orderData.customerId),
         totalTtc: totals.total,
         linesCount: orderLines.length,
+        // F1 attribution : propager la source d'ajout par-ligne (funnel/analytics)
+        lines: orderLines.map((l) => ({
+          lineId: l.orl_id,
+          productId: l.orl_pg_id,
+          websiteUrl: l.orl_website_url,
+        })),
         timestamp: new Date().toISOString(),
       } satisfies OrderCreatedEvent);
 

--- a/backend/supabase/migrations/20260522160000_order_line_website_url_attribution.sql
+++ b/backend/supabase/migrations/20260522160000_order_line_website_url_attribution.sql
@@ -1,0 +1,81 @@
+-- 20260522160000_order_line_website_url_attribution.sql
+-- F1 attribution add-to-cart par-ligne : persiste la source d'ajout (orl_website_url)
+-- via create_order_atomic. ADDITIF UNIQUEMENT — ajoute orl_website_url à l'INSERT ligne ;
+-- aucune colonne/comportement existant changé. La colonne orl_website_url existe déjà
+-- (text) dans ___xtr_order_line (71% peuplée historiquement, 0 code l'écrivait).
+-- Idempotent (CREATE OR REPLACE). Pour les appelants qui n'envoient pas la clé,
+-- (v_line->>'orl_website_url') = NULL → strictement rétro-compatible.
+-- Ref : governance-vault ledger/audit-trail/2026-05-22-commerce-runtime-truth-audit.md (F1).
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+CREATE OR REPLACE FUNCTION public.create_order_atomic(p_order jsonb, p_lines jsonb)
+ RETURNS text
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_ord_id TEXT;
+  v_line JSONB;
+BEGIN
+  -- Extract order ID
+  v_ord_id := p_order->>'ord_id';
+
+  IF v_ord_id IS NULL OR v_ord_id = '' THEN
+    RAISE EXCEPTION 'ord_id is required';
+  END IF;
+
+  -- INSERT order (single transaction — auto-rollback on any error)
+  INSERT INTO "___xtr_order" (
+    ord_id, ord_cst_id, ord_date, ord_parent, ord_is_pay, ord_date_pay,
+    ord_amount_ttc, ord_deposit_ttc, ord_shipping_fee_ttc, ord_total_ttc,
+    ord_info, ord_ords_id, ord_cba_id, ord_cda_id,
+    ord_billing_snapshot, ord_shipping_snapshot
+  ) VALUES (
+    v_ord_id,
+    p_order->>'ord_cst_id',
+    p_order->>'ord_date',
+    COALESCE(p_order->>'ord_parent', '0'),
+    COALESCE(p_order->>'ord_is_pay', '0'),
+    NULL,
+    p_order->>'ord_amount_ttc',
+    p_order->>'ord_deposit_ttc',
+    p_order->>'ord_shipping_fee_ttc',
+    p_order->>'ord_total_ttc',
+    COALESCE(p_order->>'ord_info', ''),
+    COALESCE(p_order->>'ord_ords_id', '1'),
+    p_order->>'ord_cba_id',
+    p_order->>'ord_cda_id',
+    (p_order->'ord_billing_snapshot')::JSONB,
+    (p_order->'ord_shipping_snapshot')::JSONB
+  );
+
+  -- INSERT all lines (same transaction).
+  -- orl_website_url AJOUTÉ (F1) : source d'ajout par-ligne ; NULL si absent (rétro-compat).
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    INSERT INTO "___xtr_order_line" (
+      orl_id, orl_ord_id, orl_pg_name, orl_pg_id, orl_pm_name,
+      orl_art_ref, orl_art_quantity, orl_art_price_sell_unit_ttc,
+      orl_art_price_sell_ttc, orl_art_deposit_unit_ttc, orl_art_deposit_ttc,
+      orl_website_url
+    ) VALUES (
+      v_line->>'orl_id',
+      v_line->>'orl_ord_id',
+      v_line->>'orl_pg_name',
+      v_line->>'orl_pg_id',
+      v_line->>'orl_pm_name',
+      v_line->>'orl_art_ref',
+      v_line->>'orl_art_quantity',
+      v_line->>'orl_art_price_sell_unit_ttc',
+      v_line->>'orl_art_price_sell_ttc',
+      v_line->>'orl_art_deposit_unit_ttc',
+      v_line->>'orl_art_deposit_ttc',
+      v_line->>'orl_website_url'
+    );
+  END LOOP;
+
+  RETURN v_ord_id;
+END;
+$function$;

--- a/frontend/app/hooks/useCart.ts
+++ b/frontend/app/hooks/useCart.ts
@@ -54,7 +54,17 @@ export function useCart() {
       setError(null);
 
       try {
-        const result = await cartApi.addItem(productId, quantity, typeId);
+        // F1 attribution : capture la page d'où l'article est ajouté (source par-ligne).
+        const sourceUrl =
+          typeof window !== "undefined"
+            ? window.location.pathname + window.location.search
+            : undefined;
+        const result = await cartApi.addItem(
+          productId,
+          quantity,
+          typeId,
+          sourceUrl,
+        );
         if (result.success) {
           emitCartUpdated();
           // Commerce-Loop V1 étape 4-A — intention d'achat (funnel R2).

--- a/frontend/app/schemas/cart.schemas.ts
+++ b/frontend/app/schemas/cart.schemas.ts
@@ -60,6 +60,9 @@ export const cartItemSchema = z
     // Vehicle context (type_id du vehicule a l'ajout)
     type_id: z.number().optional(),
 
+    // F1 attribution : source d'ajout par-ligne (page d'où l'article a été ajouté) → orl_website_url
+    website_url: z.string().optional(),
+
     // Metadata flexible
     options: z.record(z.any()).optional(),
 

--- a/frontend/app/services/cart.api.ts
+++ b/frontend/app/services/cart.api.ts
@@ -151,6 +151,7 @@ export const cartApi = {
     productId: number,
     quantity: number = 1,
     typeId?: number,
+    sourceUrl?: string, // F1 attribution : page d'où l'article est ajouté → orl_website_url
   ): Promise<AddItemResponse> {
     try {
       logger.log("➕ [cartApi.addItem]", { productId, quantity, typeId });
@@ -162,6 +163,7 @@ export const cartApi = {
           product_id: productId,
           quantity,
           ...(typeId && { type_id: typeId }),
+          ...(sourceUrl && { website_url: sourceUrl }),
         }),
       });
 

--- a/frontend/app/services/order.server.ts
+++ b/frontend/app/services/order.server.ts
@@ -33,6 +33,7 @@ export interface CreateCheckoutOrderPayload {
     discount: number;
     consigne_unit: number;
     has_consigne: boolean;
+    website_url?: string; // F1 attribution : source d'ajout par-ligne → orl_website_url
   }>;
   billingAddress: AddressData;
   shippingAddress: AddressData;
@@ -77,6 +78,8 @@ export function buildOrderLines(items: CartItem[]) {
     discount: 0,
     consigne_unit: item.consigne_unit || 0,
     has_consigne: item.has_consigne || false,
+    website_url: item.website_url, // F1 attribution : source d'ajout par-ligne
+
   }));
 }
 

--- a/log.md
+++ b/log.md
@@ -423,3 +423,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/retire-smallint-id-param-pipe`
 - **Décision** : fix(vehicles): retire smallint id param pipe (root-cause foot-gun) + ast-grep guard
 - **Sortie** : PR #689 | commits 196dade1c
+
+## 2026-05-22 — feat/cart-line-source-attribution (auto)
+
+- **Branche** : `feat/cart-line-source-attribution`
+- **Décision** : feat(cart): attribution source d'ajout par-ligne (orl_website_url)
+- **Sortie** : PR #695 | commits 30b25cc02


### PR DESCRIPTION
## Pourquoi

F1 de l'audit runtime-truth ([governance-vault PR #301](https://github.com/ak125/governance-vault/pull/301)) : la colonne `___xtr_order_line.orl_website_url` existe (peuplée à **71%** historiquement) mais **aucun code actuel ne l'écrivait ni ne la propageait** — la source d'ajout par-ligne (page/listing/gamme d'où une pièce est ajoutée au panier) était un **signal d'attribution funnel orphelin**. C'est directement lié au problème conversion (~0.17%, reality-audit #652).

Doctrine : on **reconstruit l'invariant mieux** dans l'archi actuelle, on ne recopie pas le legacy. Wiring **purement additif**, **bout-en-bout**, en **étendant** l'existant (pas de système parallèle).

## Chaîne câblée

**Capture → Persistence → Propagation** (la chaîne qui était rompue) :

| Couche | Fichier | Changement |
|--------|---------|-----------|
| Capture front | `useCart.ts` | `addToCart` capture `window.location.pathname+search` (zéro changement chez les ~6 appelants) |
| Transport | `cart.api.ts` | `addItem(…, sourceUrl)` → body `website_url` |
| DTO | `add-item.dto.ts` | `website_url` optionnel (≤2048, trim) |
| Cart (Redis) | `cart-data.service.ts` | `addCartItem(…, sourceUrl)` stocke `website_url` sur l'item + `CartItemSchema` |
| Checkout | `order.server.ts`, `cart.schemas.ts` | `buildOrderLines` mappe `item.website_url` → `orderLine.website_url` |
| Order line | `orders.service.ts` | écrit `orl_website_url` sur la ligne |
| **Migration RPC** | `20260522160000_*.sql` | étend `create_order_atomic` pour insérer `orl_website_url` (CREATE OR REPLACE, idempotent) |
| Propagation | `order.events.ts`, `order-audit.listener.ts` | `OrderCreatedEvent.lines[].websiteUrl` + audit `lineSources` |

## Sécurité / rétro-compat

- **Additif strict** : colonne déjà existante ; `NULL` si source absente ; `(v_line->>'orl_website_url')` rétro-compatible pour tout appelant n'envoyant pas la clé. **Aucun comportement existant modifié.**
- Migration **non auto-appliquée au merge** → via `apply-supabase-migrations.yml` (additif, sans risque).
- Dégradation gracieuse : SSR / JS-off → `sourceUrl` vide, ligne créée normalement.

## Hors-scope (différé, blast-radius)

Enrichir le payload funnel `r2_add_to_cart` (`@repo/seo-types` `FunnelEventInput`, contrat #676) avec la source — propagation supplémentaire vers le funnel R2. Non inclus pour ne pas toucher le contrat gouverné #676 dans cette PR. La propagation event/audit actuelle ferme déjà la chaîne.

## Vérifs

- `add-item.dto.test.ts` : 4/4 ✅
- Typecheck backend + frontend : clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## F5 (2ᵉ commit) — autorité de prix serveur (anti price-tampering)

L'endpoint `POST /api/cart/items` (`OptionalAuthGuard`, anonyme autorisé) acceptait un `custom_price` **client** qui écrasait le prix catalogue → trou de price-tampering. **Aucun frontend ne l'envoie** ; le chemin update ne l'utilisait jamais (champ mort).

- `add-item.dto.ts` / `update-item.dto.ts` : `custom_price` retiré (prix = **autorité serveur**).
- `cart-items.controller.ts` : passe `undefined` comme prix + **logge** toute tentative client d'override (observabilité, pas de drop silencieux).
- `addCartItem(customPrice?)` **conservé** pour les appelants serveur de confiance (cart.service, recovery, composition).
- Rétro-compat : aucun appelant légitime impacté. Tests `add-item.dto.test.ts` **6/6**.