### PR TITLE
fix(seo-control): partition rotation cron for snapshot tables (ADR-064 PR-2A-1.5)

### DIFF
--- a/backend/supabase/migrations/20260522_seo_snapshot_partition_rotation.down.sql
+++ b/backend/supabase/migrations/20260522_seo_snapshot_partition_rotation.down.sql
@@ -1,0 +1,18 @@
+-- Rollback : rotation des partitions snapshot L1 — ADR-064 PR-2A-1.5.
+--
+-- Annule UNIQUEMENT le mécanisme (job cron + fonction). NE TOUCHE PAS aux
+-- partitions ni aux données : un rollback de l'outil de rotation ne doit jamais
+-- supprimer des snapshots. Après ce down, les partitions cessent d'être
+-- pré-créées/purgées automatiquement (retour à l'état "premake manuel" d'avant).
+--
+-- Idempotent : ré-exécutable sans erreur (mirror des gardes de la migration up).
+-- Le runner wrappe déjà chaque fichier dans une transaction : pas de BEGIN/COMMIT.
+
+-- Désenregistrer le job cron (guardé — cron.unschedule lève si le job est absent).
+SELECT cron.unschedule('snapshot-partition-rotation')
+WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'snapshot-partition-rotation'
+);
+
+-- Supprimer la fonction de maintenance.
+DROP FUNCTION IF EXISTS public.maintain_snapshot_partitions(INT, INT);

--- a/backend/supabase/migrations/20260522_seo_snapshot_partition_rotation.sql
+++ b/backend/supabase/migrations/20260522_seo_snapshot_partition_rotation.sql
@@ -22,8 +22,13 @@
 -- Pas de partition DEFAULT (best practice range-partitioning : une fois des rows
 -- dans DEFAULT, créer la partition réelle de cette plage échoue jusqu'à migration
 -- manuelle des rows → on s'appuie sur le premake, pas sur un fourre-tout).
+--
+-- Le runner (scripts/ci/apply-supabase-migration.py) wrappe déjà chaque fichier
+-- dans une transaction (squawk: assume_in_transaction) → pas de BEGIN/COMMIT
+-- explicite. Timeouts robustes avant DDL (require-timeout-settings).
 
-BEGIN;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
 
 CREATE OR REPLACE FUNCTION public.maintain_snapshot_partitions(
   p_lookahead_days INT DEFAULT 14,
@@ -112,5 +117,3 @@ SELECT cron.schedule(
 WHERE NOT EXISTS (
   SELECT 1 FROM cron.job WHERE jobname = 'snapshot-partition-rotation'
 );
-
-COMMIT;

--- a/backend/supabase/migrations/20260522_seo_snapshot_partition_rotation.sql
+++ b/backend/supabase/migrations/20260522_seo_snapshot_partition_rotation.sql
@@ -1,0 +1,116 @@
+-- Migration : rotation des partitions des tables snapshot L1 — ADR-064 PR-2A-1.5
+--
+-- Contexte : __seo_snapshot_synthetic (et __seo_snapshot_cf_rum) sont
+-- partitionnées par jour (RANGE created_at). La migration de création
+-- (20260514_seo_snapshot_synthetic.sql) ne pré-créait que 8 jours de
+-- partitions et déléguait la rotation à « PR-2A-1.5 » — jamais implémenté.
+-- Résultat : épuisement des partitions à 2026-05-22 00:00 UTC → INSERT en
+-- échec « no partition of relation found for row », rows perdues à chaque run.
+--
+-- Cette migration livre le mécanisme manquant :
+--   - fonction idempotente maintain_snapshot_partitions() : premake J+lookahead,
+--     drop > rétention (TTL 90j ADR-064) ;
+--   - job pg_cron quotidien « snapshot-partition-rotation » qui l'appelle.
+--
+-- Patterns réutilisés (pas de nouvelle couche) :
+--   - ensure_next_quality_history_partition() (20260507_seo_quality_history.sql)
+--     pour la création idempotente de partition via pg_class + format()/EXECUTE ;
+--   - cron.schedule(...) WHERE NOT EXISTS (20260420_error_logs_dedicated_table.sql)
+--     pour l'enregistrement idempotent du job.
+--
+-- premake J+14 avec un cron quotidien : survit à 13 runs ratés d'affilée.
+-- Pas de partition DEFAULT (best practice range-partitioning : une fois des rows
+-- dans DEFAULT, créer la partition réelle de cette plage échoue jusqu'à migration
+-- manuelle des rows → on s'appuie sur le premake, pas sur un fourre-tout).
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.maintain_snapshot_partitions(
+  p_lookahead_days INT DEFAULT 14,
+  p_retention_days INT DEFAULT 90
+)
+RETURNS TABLE(action TEXT, partition_name TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tables  TEXT[] := ARRAY['__seo_snapshot_synthetic', '__seo_snapshot_cf_rum'];
+  v_parent  TEXT;
+  v_day     DATE;
+  v_next    DATE;
+  v_part    TEXT;
+  v_child   RECORD;
+  v_cutoff  DATE := CURRENT_DATE - p_retention_days;
+  v_suffix  DATE;
+BEGIN
+  FOREACH v_parent IN ARRAY v_tables LOOP
+    -- skip silencieux si le parent n'est pas provisionné dans cet env
+    -- (ex. __seo_snapshot_cf_analytics dont la migration n'a pas été appliquée).
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relname = v_parent AND n.nspname = 'public' AND c.relkind = 'p'
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    -- premake : CURRENT_DATE .. CURRENT_DATE + lookahead (idempotent par pg_class)
+    v_day := CURRENT_DATE;
+    WHILE v_day <= CURRENT_DATE + p_lookahead_days LOOP
+      v_next := v_day + 1;
+      v_part := v_parent || '_p' || to_char(v_day, 'YYYYMMDD');
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = v_part AND n.nspname = 'public'
+      ) THEN
+        EXECUTE format(
+          'CREATE TABLE public.%I PARTITION OF public.%I FOR VALUES FROM (%L) TO (%L)',
+          v_part, v_parent, v_day::text, v_next::text
+        );
+        action := 'created'; partition_name := v_part; RETURN NEXT;
+      END IF;
+      v_day := v_next;
+    END LOOP;
+
+    -- TTL : drop des partitions strictement plus vieilles que la rétention.
+    -- Dormant au premier run (partition la plus ancienne < 90j). Ne cible que
+    -- les enfants au nom canonique <parent>_pYYYYMMDD.
+    FOR v_child IN
+      SELECT c.relname
+      FROM pg_inherits i
+      JOIN pg_class p     ON p.oid = i.inhparent
+      JOIN pg_class c     ON c.oid = i.inhrelid
+      JOIN pg_namespace n ON n.oid = p.relnamespace
+      WHERE p.relname = v_parent AND n.nspname = 'public'
+        AND c.relname ~ ('^' || v_parent || '_p\d{8}$')
+    LOOP
+      v_suffix := to_date(right(v_child.relname, 8), 'YYYYMMDD');
+      IF v_suffix < v_cutoff THEN
+        EXECUTE format('DROP TABLE IF EXISTS public.%I', v_child.relname);
+        action := 'dropped'; partition_name := v_child.relname; RETURN NEXT;
+      END IF;
+    END LOOP;
+  END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION public.maintain_snapshot_partitions(INT, INT) IS
+  'ADR-064 PR-2A-1.5 — premake J+lookahead & drop >retention pour les snapshot tables partitionnées par jour. Idempotent. Cron: snapshot-partition-rotation.';
+
+GRANT EXECUTE ON FUNCTION public.maintain_snapshot_partitions(INT, INT) TO service_role;
+
+-- Backfill immédiat à l'application (no-op idempotent si le hotfix MCP a déjà
+-- créé les partitions sur la DB partagée).
+SELECT public.maintain_snapshot_partitions();
+
+-- Cron quotidien @ 02:20 UTC. Enregistrement idempotent (mirror error-logs-retention).
+SELECT cron.schedule(
+  'snapshot-partition-rotation',
+  '20 2 * * *',
+  $cron$SELECT public.maintain_snapshot_partitions();$cron$
+)
+WHERE NOT EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'snapshot-partition-rotation'
+);
+
+COMMIT;


### PR DESCRIPTION
## Problème (incident live 2026-05-22)

\`__seo_snapshot_synthetic\` est partitionnée par jour (RANGE \`created_at\`). La migration de création [\`20260514_seo_snapshot_synthetic.sql\`](backend/supabase/migrations/20260514_seo_snapshot_synthetic.sql#L70-L90) ne pré-créait que **8 jours** de partitions (14→21 mai) et déléguait la rotation à un cron « créé en PR-2A-1.5 » — **jamais implémenté**.

À **2026-05-22 00:00 UTC**, plus aucune partition ne couvrait le jour courant → chaque INSERT du synthetic crawler (q15min) échouait avec :

\`\`\`
no partition of relation "__seo_snapshot_synthetic" found for row
\`\`\`

État confirmé sur la DB partagée : \`max(created_at) = 2026-05-21 23:45:47\`, 150 900 rows, **rien depuis minuit** — perte de données à chaque run. \`__seo_snapshot_cf_rum\` portait le même bug latent (épuisement le 28/05). \`pg_cron 1.6\` est installé mais aucun job de rotation n'existait.

## Correctif

Livre le mécanisme manquant (**PR-2A-1.5**) en **étendant les patterns existants**, sans nouvelle couche :

- **\`maintain_snapshot_partitions(p_lookahead_days=14, p_retention_days=90)\`** — fonction idempotente : premake \`J..J+14\` + drop des partitions \`> 90j\` (TTL ADR-064). Modelée sur \`ensure_next_quality_history_partition()\` ([20260507](backend/supabase/migrations/20260507_seo_quality_history.sql#L87-L115)). \`SECURITY DEFINER\` + \`SET search_path\`.
- **Job pg_cron quotidien \`snapshot-partition-rotation\`** (02:20 UTC), enregistrement idempotent via le pattern \`cron.schedule(...) WHERE NOT EXISTS\` de [\`error-logs-retention\`](backend/supabase/migrations/20260420_error_logs_dedicated_table.sql#L56-L63).
- **Backfill immédiat** à l'application (\`SELECT maintain_snapshot_partitions()\`), no-op idempotent.

Couvre les deux tables journalières existantes (\`__seo_snapshot_synthetic\` + \`__seo_snapshot_cf_rum\`).

### Choix de conception
- **Premake J+14 ≫ cadence cron quotidienne** → survit à 13 runs ratés. Pas de partition \`DEFAULT\` (best practice range-partitioning : des rows dans DEFAULT bloquent la création ultérieure de la partition réelle de la plage).
- **DROP TTL dormant au premier run** (partition la plus ancienne = 14/05 < 90j) ; ne cible que les enfants au nom canonique \`<parent>_pYYYYMMDD\`.
- **pg_partman écarté** : non installé ; fonction ~40 lignes plus déterministe et alignée sur la convention \`ensure_next_*_partition\` du repo.

## Remédiation déjà appliquée (hotfix)

L'incident saignant a été stoppé immédiatement : backfill additif idempotent (\`CREATE TABLE ... PARTITION OF\`) appliqué via Supabase MCP → les deux tables couvrent désormais jusqu'au **2026-06-05** (J+14). Insert-probe vérifié OK. Cette migration est donc un **no-op idempotent** sur la DB partagée et installe le job cron permanent quand elle passe par \`apply-supabase-migrations.yml\`.

## Vérification (post-apply)
1. Couverture : \`latest_day ≥ CURRENT_DATE + 14\` pour les deux tables.
2. \`SELECT max(created_at) FROM __seo_snapshot_synthetic\` avance ; plus d'ERROR \`persist failed\` dans \`SyntheticCrawlerService\`.
3. \`SELECT jobname, schedule, active FROM cron.job WHERE jobname='snapshot-partition-rotation'\`.
4. Idempotence : 2ᵉ appel de la fonction → 0 row.

## Hors scope (suivi)
- \`ensure_next_quality_history_partition()\` (\`__seo_quality_history\`, mensuel) a le **même** trou « fonction présente, jamais schédulée » — à folder dans ce cron plus tard.
- Hardening optionnel : alerte « partition runway < 3j » via \`__seo_event_log\` / \`rpc_*_alerts_v1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)