### PR TITLE
feat(claude-harness): runtime-truth + web-vitals skills + SessionStart/Stop hooks (Couche 1 stabilité runtime)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,6 +66,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /opt/automecanik/app/scripts/claude-hooks/sessionstart-workspace-context.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/runtime-truth-audit/SKILL.md
+++ b/.claude/skills/runtime-truth-audit/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: runtime-truth-audit
+description: Use when auditing runtime drift vs spec/registry (dead services, RPC drift, STABLE functions that write, partitions without rotation, attribution columns never written, orphan feature flags). Triggers — "audit runtime drift", "detect dead service", "check partition rotation", "verify attribution write path", "audit feature flags". 6 atomic checks, each tied to a real PR incident or MEMORY reference. Informational only (autofixable=false strict V1).
+type: technique
+status: experimental
+owners: ['@ak125']
+domain: D15
+runtime_class: read-only
+llm_safe: true
+last_verified: '2026-05-23'
+license: Internal - Automecanik
+compatibility: Claude Code in the AutoMecanik monorepo. Reads audit/registry/canonical.json + pg_proc via supabase MCP. No mutations.
+allowed-tools: Read Grep Glob Bash
+tags: [audit, runtime, governance, adr-058, prevention]
+metadata:
+  version: "0.1"
+  argument-hint: "[check-name or 'all']"
+  spec: agentskills.io/specification v1
+---
+
+# Runtime Truth Audit
+
+Audite les **dérives runtime vs spec/registry** : ce qui est déclaré dans
+`audit/registry/canonical.json` + `.spec/00-canon/` mais qui ne se comporte
+pas comme attendu en runtime, ou inversement.
+
+**Origine** : 6 PRs PROD récentes (#693/#695/#696/#697 + cas préventifs
+documentés MEMORY) ont révélé des dérives silencieuses entre la spec et
+le runtime. Chaque check de ce skill correspond à un pattern d'incident
+réel ou un risque documenté.
+
+## Quand proposer ce skill
+
+- Triggers utilisateur : "audit runtime", "détecte dead code",
+  "vérifie attribution", "check partition rotation", "audit feature flags"
+- Après un incident PROD inattendu (5xx silencieux, attribution manquante,
+  service non instancié)
+- Avant une release majeure (`v*` tag) pour scanner les dérives non détectées
+
+## Périmètre
+
+Ce skill **ne fait que lire**. Il **ne modifie aucun fichier**, **ne crée
+aucune PR**, **n'écrit en DB que via supabase MCP read-only**. Output =
+rapport markdown structuré listant les findings par check.
+
+## Architecture atomique (6 checks)
+
+```
+.claude/skills/runtime-truth-audit/
+  SKILL.md                          # ce fichier (orchestration)
+  checks/
+    nest-dead-services.md           # @Injectable jamais résolus DI (#696)
+    rpc-registry-drift.md           # registry L2 RPC ↔ pg_proc divergence
+    pg-stable-write.md              # STABLE/IMMUTABLE qui écrivent (#693)
+    partition-cron-gap.md           # partitions sans cron.job (#697, #698)
+    attribution-write-gap.md        # colonnes attribution sans writer (#695)
+    orphan-runtime-flags.md         # feature flags morts (préventif)
+```
+
+**Un check = une responsabilité** (≤ 100 lignes). Pas de check "mega"
+qui regroupe plusieurs patterns. Si un check tente de couvrir 2 patterns
+distincts, le scinder.
+
+## Sources de vérité
+
+Chaque check lit des sources **canoniques**, jamais des grep markdown
+spéculatifs :
+
+| Source | Usage |
+|---|---|
+| `audit/registry/canonical.json` | files / RPC declared / db_tables |
+| `.spec/00-canon/repository-registry/*.yaml` | ownership, domains, glob |
+| `pg_proc` via supabase MCP | volatility, prosrc, écritures réelles |
+| `pg_partitioned_table` + `cron.job` via supabase MCP | partition rotation |
+| `__feature_flags` table + `.env.example` via supabase MCP | flags actifs |
+| Grep AST ciblé (backend/src + frontend/app) | uniquement pour confirmer écriture |
+
+**Interdit** : grep aveugle de markdown, regex sur tout le repo, inférence
+LLM sur la spec. Si une donnée canonique n'est pas accessible (registry
+stale, MCP indisponible), le check **fail explicitement** — jamais skip.
+
+## Métadonnées par check
+
+Chaque `checks/*.md` porte un frontmatter conforme au schéma local du
+skill (vérifié par convention review humaine, pas par schema CI) :
+
+```yaml
+---
+check: nest-dead-services
+severity: high                       # critical | high | medium | low
+confidence: medium                   # high | medium | low
+expected_false_positive_rate: 0.20   # 0.0-1.0 cohérent avec confidence
+autofixable: false                   # TOUJOURS false en V1 — informational only
+sources:
+  - audit/registry/canonical.json
+  - backend/src/**/*.ts (grep ciblé)
+incidents_proven:
+  - "#696 (2026-05-22, OrderStatusService doublon mort retiré)"
+# OU risk_documented: pour préventifs sans incident PROD encore
+---
+```
+
+### Taxonomie severity (anti-dérive)
+
+- `critical` : prod corruption | silent data loss | GSC 5xx | SEO deindex risk
+- `high` : attribution broken | runtime drift vs registry | queue inconsistency
+- `medium` : stale config | orphan flag | unused feature
+- `low` : cleanup | advisory | naming inconsistency
+
+### confidence × FPR
+
+- `high` ⇒ `expected_false_positive_rate ≤ 0.10`
+- `medium` ⇒ `0.10 < FPR ≤ 0.30`
+- `low` ⇒ `FPR > 0.30` (à reviewer ou retirer)
+
+### autofixable = false (strict V1)
+
+**Pas d'auto-remediation Claude.** Informational only. Réévaluation
+conditionnée à 6 mois de mesure + `FPR < 0.01` + autofix trivial.
+
+## Procédure (orchestrateur)
+
+1. Si l'utilisateur demande "audit runtime drift" sans préciser :
+   exécuter les 6 checks dans l'ordre listé ci-dessus, agréger les findings.
+2. Si l'utilisateur cite un check spécifique (ex: "check partition rotation") :
+   exécuter uniquement ce check.
+3. Format de sortie attendu :
+   ```markdown
+   # Runtime Truth Audit Report
+   Date : YYYY-MM-DD
+   Checks exécutés : N/6
+
+   ## Findings par severity
+   - critical : X
+   - high     : Y
+   - medium   : Z
+   - low      : W
+
+   ## Détail par check
+   ### {check-name} (severity, confidence, FPR)
+   - finding 1 (source, ligne, contexte)
+   - finding 2 ...
+   ```
+4. **Ne pas auto-créer de PR**. Le rapport est lu par l'humain qui décide
+   des actions à prendre.
+
+## Garde-fous (anti-AST-universe)
+
+Les checks ne doivent PAS dériver vers :
+- Un linter maison (eslint/ts-prune/knip/madge couvrent déjà)
+- Un static analyzer généraliste (CodeQL existe)
+- Une analyse exhaustive "tant qu'on y est" du repo
+
+Si un check tente de devenir mega-analyzer, **le retirer ou le scinder**
+en checks atomiques nouveaux. Croissance organique interdite.
+
+## Règle d'admission d'un nouveau check
+
+Un check `checks/<new-name>.md` n'est mergé que si :
+
+1. `incidents_proven:` (préféré) OU `risk_documented:` est renseigné
+2. `severity:` cite un critère de la taxonomie ci-dessus
+3. `expected_false_positive_rate:` cohérent avec `confidence:`
+4. `autofixable: false` (V1 stricte)
+5. Logique ≤ 100 lignes, 1 responsabilité, sortie JSON structuré
+6. Pas de duplication avec un outil existant (`ts-prune`, `knip`,
+   `madge`, `eslint`, `CodeQL`)
+
+## Mémoires liées
+
+- `feedback_no_silent_fallback.md` — fail explicite, pas de skip
+- `feedback_verify_existing_first.md` — réutiliser sources canoniques
+- `reference_postgrest_stable_function_write_readonly.md` — pattern #693
+- `feedback_audit_needs_runtime_wiring_and_db_truth.md` — runtime+DB, pas
+  file-vs-file
+- `feedback_v1_first_dont_build_ultimate_engine_too_early.md` — STOP at V1

--- a/.claude/skills/runtime-truth-audit/checks/attribution-write-gap.md
+++ b/.claude/skills/runtime-truth-audit/checks/attribution-write-gap.md
@@ -1,0 +1,91 @@
+---
+check: attribution-write-gap
+severity: high
+confidence: medium
+expected_false_positive_rate: 0.15
+autofixable: false
+sources:
+  - audit/registry/canonical.json (db_tables, files)
+  - backend/src/**/*.ts (grep AST ciblé)
+  - pg_stat_user_tables.n_tup_ins / n_tup_upd via supabase MCP
+incidents_proven:
+  - "#695 (2026-05-22, F1 orl_website_url attribution orpheline + F5 prix custom non audité)"
+---
+
+# Check : Attribution Columns Without Runtime Writer
+
+## Pattern audité
+
+Colonnes de tables identifiées comme **attribution / tracking** (par
+convention de nommage ou marqueur) qui ne reçoivent **aucun INSERT / UPDATE**
+côté code runtime malgré une déclaration explicite côté schéma.
+
+**Conventions d'attribution** : colonnes nommées `*_url`, `*_referrer`,
+`*_attribution_*`, `*_source`, `*_campaign`, `*_utm_*`, ou marquées dans
+le registry L2 avec tag `attribution`.
+
+**Impact** : la donnée business arrive en BI/analytics comme `NULL` partout
+alors que la spec promet une attribution complète — cas #695 où
+`orl_website_url` était orpheline en runtime.
+
+## Origine
+
+PR #695 (2026-05-22) audit runtime-truth a révélé :
+- F1 : `orl_website_url` (table `___order_lines`) écrite par 0 service
+- F5 : prix `custom_price` reçu mais jamais audité
+
+Pattern : la colonne existe en DDL, le registry la connaît, mais aucun
+service NestJS ne l'écrit. Détection manuelle après l'incident.
+
+## Méthode
+
+1. Lister les colonnes candidates dans `audit/registry/canonical.json` (ou
+   directement `information_schema.columns`) matchant les conventions de
+   nommage attribution.
+2. Pour chaque colonne `(table, col)` :
+   a. Grep AST `backend/src/**/*.ts` pour `\.insert\(.*['"]col['"]` ou
+      `\.update\(.*['"]col['"]` ou pattern Supabase équivalent.
+   b. Compter les occurrences. Si 0 → finding `no_runtime_writer`.
+   c. Vérifier `pg_stat_user_tables.n_tup_ins` pour confirmer absence
+      d'écriture en runtime (corroboration DB-live, anti faux positif
+      "grep manqué").
+3. Cross-checker : si la colonne reçoit du trafic (n_tup_ins > 0) mais
+   aucun service grepé → finding `unknown_writer` (severity medium,
+   probablement extension ou trigger DB à documenter).
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "attribution-write-gap",
+  "pass": false,
+  "findings": [
+    {
+      "table": "___order_lines",
+      "column": "orl_website_url",
+      "category": "no_runtime_writer",
+      "grep_count": 0,
+      "n_tup_ins": 0,
+      "severity": "high",
+      "fix_hint": "Soit câbler l'écriture dans cart.service.ts (selon ADR-073), soit DROP COLUMN si la donnée n'est plus collectée"
+    }
+  ],
+  "summary": { "candidates": 23, "no_writer": 1, "unknown_writer": 0 }
+}
+```
+
+## Faux positifs connus
+
+- Colonnes écrites uniquement par migration backfill (one-shot). Mitigation :
+  vérifier la date de dernier `n_tup_ins` — si > 30 jours et 0 service runtime,
+  c'est probablement legacy à drop.
+- Colonnes écrites par trigger DB (jamais grepables côté TS). Mitigation :
+  category `unknown_writer` + reviewer-decide.
+
+## Limites
+
+- Le pattern de naming attribution est heuristique. Ne couvre pas les
+  conventions custom (préférer registry L2 tag `attribution` explicite si
+  ajouté plus tard).
+- Grep AST simplifié — ne détecte pas les écritures dynamiques via
+  `Object.keys(payload).reduce(...)` génériques. Risque résiduel.

--- a/.claude/skills/runtime-truth-audit/checks/nest-dead-services.md
+++ b/.claude/skills/runtime-truth-audit/checks/nest-dead-services.md
@@ -1,0 +1,71 @@
+---
+check: nest-dead-services
+severity: high
+confidence: medium
+expected_false_positive_rate: 0.20
+autofixable: false
+sources:
+  - audit/registry/canonical.json
+  - backend/src/**/*.ts
+  - backend/src/**/*.module.ts
+incidents_proven:
+  - "#696 (2026-05-22, OrderStatusService/Controller doublon mort retiré — F3 audit runtime-truth)"
+---
+
+# Check : NestJS Dead Services
+
+## Pattern audité
+
+Services NestJS marqués `@Injectable()` mais **jamais résolus par le DI
+container** : pas de `providers: [X]` actif dans un `*.module.ts` chargé,
+ou module chargé uniquement en sous-arbre mort (module parent non importé
+par AppModule).
+
+## Origine
+
+PR #696 (2026-05-22) a retiré `OrderStatusService` + `OrderStatusController`
+détectés morts manuellement après plusieurs semaines de coexistence avec
+le service vivant. Sans audit déterministe, ce type de doublon se découvre
+par accident.
+
+## Méthode
+
+1. Lister tous les `@Injectable()` dans `backend/src/**/*.ts` (grep AST).
+2. Pour chaque classe `X`, vérifier :
+   a. `providers: [..., X, ...]` dans un `*.module.ts` du repo.
+   b. Ce module est-il dans la chaîne `imports:` partant de `AppModule` ?
+3. Si `X` n'est dans aucun `providers:` actif → finding `dead-service`.
+4. Si `X` est dans `providers:` mais le module n'est jamais importé →
+   finding `dead-module` (severity high aussi).
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "nest-dead-services",
+  "pass": false,
+  "findings": [
+    {
+      "file": "backend/src/modules/orders/orphan.service.ts",
+      "class": "OrphanService",
+      "reason": "Not in any providers[] of an imported module",
+      "severity": "high"
+    }
+  ],
+  "summary": { "scanned": 412, "dead": 1, "dead_modules": 0 }
+}
+```
+
+## Faux positifs connus
+
+- Services exportés dans un package interne (`packages/**`) consommés par
+  un autre app worktree non scanné. Mitigation : marker `@PublicAPI()` ou
+  exclusion via path glob.
+- Services en cours de migration progressive (flag de bascule). Mitigation :
+  vérifier `# wip:` commentaire dans le fichier (à formaliser plus tard).
+
+## Limites
+
+- N'audite pas les services injectés par `useFactory` ou `useExisting`
+  dynamique. À documenter explicitement dans `summary.skipped`.
+- N'audite pas le frontend Remix (pas de DI NestJS).

--- a/.claude/skills/runtime-truth-audit/checks/orphan-runtime-flags.md
+++ b/.claude/skills/runtime-truth-audit/checks/orphan-runtime-flags.md
@@ -1,0 +1,104 @@
+---
+check: orphan-runtime-flags
+severity: medium
+confidence: low
+expected_false_positive_rate: 0.35
+autofixable: false
+sources:
+  - backend/.env.example
+  - backend/src/**/*.ts (grep process.env / configService.get)
+  - frontend/.env.example
+  - frontend/app/**/*.{ts,tsx} (grep import.meta.env / VITE_*)
+risk_documented:
+  - feedback_more_seo_engineering_not_equal_more_business.md
+  - feedback_v1_first_dont_build_ultimate_engine_too_early.md
+---
+
+# Check : Orphan Runtime Flags
+
+## Pattern audité
+
+Variables d'environnement et feature flags déclarés mais **jamais lus en
+runtime** :
+
+1. Entry dans `.env.example` sans `process.env.X` / `configService.get('X')` /
+   `import.meta.env.X` correspondant côté code.
+2. Variable `FEATURE_*` / `*_FLAG` / `*_ENABLED` lue 0 fois après scan AST.
+3. (Optionnel V2) Flag GrowthBook déclaré côté plateforme externe mais
+   sans handler runtime correspondant.
+
+**Impact business** : flags morts accumulent du bruit cognitif, masquent
+les flags actifs, et peuvent réintroduire des comportements obsolètes si
+re-câblés par inadvertance.
+
+## Origine
+
+Check **préventif** — pas d'incident PROD documenté à ce jour pour ce
+pattern dans le monorepo, mais [feedback_v1_first_dont_build_ultimate_engine_too_early.md](feedback_v1_first_dont_build_ultimate_engine_too_early.md)
++ [feedback_more_seo_engineering_not_equal_more_business.md](feedback_more_seo_engineering_not_equal_more_business.md)
+documentent le risque général d'accumulation de surfaces mortes en
+monorepo gouverné. Audit déterministe = anti-bloat mécanique.
+
+**Note** : ce check accepte un FPR élevé (≤ 0.35) car heuristique (regex
+sur naming). C'est intentionnel : `severity: medium` + `confidence: low`
+signale que les findings doivent passer par review humaine, pas en CI.
+
+## Méthode
+
+1. Parser `backend/.env.example` et `frontend/.env.example` → set de
+   variables déclarées.
+2. Pour chaque variable `V` :
+   a. Grep `backend/src/**/*.ts` pour
+      `process\.env\.V\b|configService\.get\(['"]V['"]\)|envContract\.V\b`.
+   b. Si frontend var (`VITE_*`) : grep `frontend/app/**/*.{ts,tsx}` pour
+      `import\.meta\.env\.V\b`.
+   c. Compter les occurrences. Si 0 → finding `declared_unused`.
+3. Pour les variables matching pattern `FEATURE_*|*_FLAG|*_ENABLED`,
+   sortir avec un severity bump si findings (les flags morts sont
+   particulièrement coûteux cognitivement).
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "orphan-runtime-flags",
+  "pass": false,
+  "findings": [
+    {
+      "variable": "OLD_R5_FALLBACK_ENABLED",
+      "declared_in": "backend/.env.example",
+      "grep_count": 0,
+      "category": "declared_unused",
+      "severity": "medium",
+      "fix_hint": "DROP de .env.example si vraiment mort, ou rebrancher si rollout en cours"
+    }
+  ],
+  "summary": { "declared": 87, "orphans": 1, "flag_orphans": 1 }
+}
+```
+
+## Faux positifs connus
+
+- Variables lues uniquement dans un fichier `.json`/`.yaml` config (CI,
+  docker-compose, k8s). Mitigation : étendre le grep aux extensions
+  pertinentes via flag explicite ou exclusion list.
+- Variables lues dynamiquement via `process.env[varName]` avec `varName`
+  construit. Détection impossible — accepter le FPR.
+- Variables documentées dans `.env.example` mais ENV "well-known"
+  jamais explicitement lue (NODE_ENV est utilisé par Node lui-même).
+  Mitigation : whitelist `WELL_KNOWN_ENVS = ["NODE_ENV", "PORT", "DATABASE_URL"]`.
+
+## Limites
+
+- Heuristique pure naming + grep. FPR ≥ 0.30 attendu en V1.
+- N'audite pas la **valeur** des flags (un flag déclaré `false` partout
+  est syntaxiquement vivant mais sémantiquement mort — V2).
+- Pas de détection GrowthBook (V2 si pertinent).
+
+## Action recommandée pour les findings
+
+1. Pour `category: declared_unused` + variable claire (`OLD_*`, `LEGACY_*`,
+   `*_DEPRECATED`) : DROP de `.env.example`.
+2. Pour flags ambigus : reviewer-decide, vérifier d'abord l'historique
+   git (`git log -S "VAR_NAME" --all`) pour comprendre l'intention.
+3. Ne jamais auto-supprimer (autofixable=false strict).

--- a/.claude/skills/runtime-truth-audit/checks/partition-cron-gap.md
+++ b/.claude/skills/runtime-truth-audit/checks/partition-cron-gap.md
@@ -1,0 +1,110 @@
+---
+check: partition-cron-gap
+severity: critical
+confidence: high
+expected_false_positive_rate: 0.10
+autofixable: false
+sources:
+  - pg_partitioned_table via supabase MCP
+  - cron.job via supabase MCP
+  - backend/supabase/migrations/**/*.sql
+incidents_proven:
+  - "#697 (2026-05-22, snapshot daily partitions épuisées — no partition found for row)"
+  - "#698 (2026-05-22, gsc/ga4/cwv monthly partition falaise 2026-07-01)"
+risk_documented:
+  - reference_partitioned_snapshot_tables_need_premake_cron.md
+  - reference_seo_partition_rotation_pattern.md
+---
+
+# Check : Partitioned Tables Without Rotation Cron
+
+## Pattern audité
+
+Tables partitionnées par range (daily / monthly) qui :
+
+1. N'ont **aucune partition future** disponible au-delà des N prochains jours/mois
+2. Ont une fonction de maintenance (`maintain_*_partitions`, `ensure_next_*_partition`)
+   définie mais **AUCUNE entrée `cron.job` correspondante**
+
+**Impact** : à la frontière temporelle, `INSERT` échoue avec
+`no partition found for row` — cas PR #697/#698. Symptôme typique : incident
+nocturne / mensuel à minuit UTC.
+
+## Origine
+
+- PR #697 : snapshot daily partitions hardcodées épuisées, rotation jamais
+  schédulée.
+- PR #698 : gsc/ga4/cwv monthly partitions falaise au 2026-07-01.
+- Pattern récurrent documenté
+  [reference_partitioned_snapshot_tables_need_premake_cron.md](reference_partitioned_snapshot_tables_need_premake_cron.md).
+
+## Méthode
+
+1. Lister les tables partitionnées par range :
+   ```sql
+   SELECT parent.relname AS parent_table, partstrat
+   FROM pg_partitioned_table pt
+   JOIN pg_class parent ON parent.oid = pt.partrelid
+   WHERE partstrat = 'r'
+   ```
+2. Pour chaque table partitionnée, lister les partitions :
+   ```sql
+   SELECT inhrelid::regclass AS partition_name,
+          pg_get_expr(c.relpartbound, c.oid) AS bound
+   FROM pg_inherits i
+   JOIN pg_class c ON c.oid = i.inhrelid
+   WHERE i.inhparent = '<parent>'::regclass
+   ```
+3. Parser les bornes max → identifier les tables sans partition couvrant
+   les N prochaines unités (N=14 days pour daily, N=2 months pour monthly,
+   N=12 months pour yearly).
+4. Vérifier `cron.job` :
+   ```sql
+   SELECT jobname, schedule, command FROM cron.job
+   ```
+   Pour chaque table en risque, chercher un job dont `command` mentionne
+   `maintain_<table>_partitions` ou `ensure_next_<table>_partition`.
+5. Findings :
+   - `no_future_partition` : pas de partition au-delà du seuil N (severity critical)
+   - `no_rotation_cron` : fonction maintenance présente mais pas dans `cron.job`
+     (severity high)
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "partition-cron-gap",
+  "pass": false,
+  "findings": [
+    {
+      "table": "__seo_snapshot_daily",
+      "max_partition_date": "2026-06-15",
+      "days_remaining": 23,
+      "category": "no_future_partition",
+      "severity": "critical",
+      "fix_hint": "CALL maintain_snapshot_daily_partitions() + schedule pg_cron"
+    },
+    {
+      "table": "__quality_history_monthly",
+      "maintenance_fn": "ensure_next_quality_history_partition",
+      "cron_job": null,
+      "category": "no_rotation_cron",
+      "severity": "high",
+      "fix_hint": "SELECT cron.schedule('quality-history-rotation', '0 3 * * *', 'CALL ensure_next_quality_history_partition()')"
+    }
+  ],
+  "summary": { "scanned": 8, "at_risk": 2 }
+}
+```
+
+## Faux positifs connus
+
+- Tables partitionnées historiques (archives) où l'absence de partition
+  future est volontaire. Mitigation : whitelist via commentaire SQL
+  `COMMENT ON TABLE <t> IS 'archive-no-future-partition'`.
+
+## Limites
+
+- Ne couvre que `RANGE` partitioning (pas `LIST` ni `HASH`).
+- Le seuil N par type est codé en dur ; à externaliser dans une V2 si
+  besoin de tuning par table.

--- a/.claude/skills/runtime-truth-audit/checks/pg-stable-write.md
+++ b/.claude/skills/runtime-truth-audit/checks/pg-stable-write.md
@@ -1,0 +1,90 @@
+---
+check: pg-stable-write
+severity: critical
+confidence: high
+expected_false_positive_rate: 0.05
+autofixable: false
+sources:
+  - pg_proc via supabase MCP (provolatile, prosrc)
+incidents_proven:
+  - "#693 (2026-05-22, GSC 5xx, fonction SEO marquée STABLE qui contenait DELETE — fail PostgREST read-only tx)"
+risk_documented:
+  - reference_postgrest_stable_function_write_readonly.md
+---
+
+# Check : Postgres STABLE/IMMUTABLE Functions That Write
+
+## Pattern audité
+
+Fonctions Postgres marquées `STABLE` ou `IMMUTABLE` (volatility ≠ `VOLATILE`)
+dont le corps contient une instruction d'écriture : `INSERT`, `UPDATE`,
+`DELETE`, `TRUNCATE`, `COPY`, ou `CALL` vers une autre fonction écrivante.
+
+**Impact** : PostgREST exécute les `STABLE/IMMUTABLE` dans une transaction
+read-only. L'écriture lève `cannot execute X in a read-only transaction`,
+visible côté client comme **5xx silencieux**, alors qu'un test SQL direct
+passe (sans la contrainte read-only).
+
+## Origine
+
+PR #693 (2026-05-22) — incident GSC 5xx massif causé par une RPC SEO marquée
+`STABLE` qui faisait `DELETE` dans une table de cache. Cas confirmé par
+`pg_proc.provolatile = 's'` + body contenant `DELETE FROM`. Mémoire
+[reference_postgrest_stable_function_write_readonly.md](reference_postgrest_stable_function_write_readonly.md)
+documente le pattern complet.
+
+## Méthode
+
+1. Lister les fonctions non-`VOLATILE` :
+   ```sql
+   SELECT proname, provolatile, prosrc
+   FROM pg_proc
+   WHERE pronamespace = 'public'::regnamespace
+     AND provolatile IN ('s', 'i')  -- STABLE or IMMUTABLE
+   ```
+2. Pour chaque, grep `prosrc` (case-insensitive, mot-frontière) :
+   ```regex
+   \b(INSERT INTO|UPDATE\s+\w+\s+SET|DELETE FROM|TRUNCATE|COPY \w+ FROM)
+   ```
+3. Pour les matches, finding `severity: critical` (toujours — risque
+   data-loss + 5xx silencieux).
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "pg-stable-write",
+  "pass": false,
+  "findings": [
+    {
+      "function": "rpc_cleanup_old_keywords",
+      "volatility": "STABLE",
+      "writes": ["DELETE FROM __seo_keywords WHERE ..."],
+      "severity": "critical",
+      "fix_hint": "ALTER FUNCTION rpc_cleanup_old_keywords VOLATILE;"
+    }
+  ],
+  "summary": { "scanned": 199, "violating": 1 }
+}
+```
+
+## Faux positifs connus
+
+- Fonctions qui écrivent dans une `TEMP TABLE` (technique acceptable en
+  STABLE car local à la session). Mitigation : whitelist explicite
+  `CREATE TEMP TABLE` ou commentaire `-- safe-temp-write`.
+- String literals contenant `DELETE FROM` dans une chaîne dynamique non
+  exécutée. Faible probabilité — le regex peut être affiné si signalé.
+
+## Limites
+
+- Ne détecte pas les écritures via `EXECUTE format(...)` dynamique
+  (couverture régex limitée — risque résiduel à documenter).
+- Ne détecte pas les fonctions PL/pgSQL appelant une autre fonction
+  qui écrit (chaînage). À ajouter dans une V2 si pattern observé en PROD.
+
+## Action recommandée pour les findings
+
+- `ALTER FUNCTION <name> VOLATILE;` (ne pas tenter `STABLE` + tx workaround)
+- Si la fonction doit rester `STABLE` (pour le query planner), extraire
+  l'écriture vers une fonction `VOLATILE` séparée appelée séparément.

--- a/.claude/skills/runtime-truth-audit/checks/rpc-registry-drift.md
+++ b/.claude/skills/runtime-truth-audit/checks/rpc-registry-drift.md
@@ -1,0 +1,88 @@
+---
+check: rpc-registry-drift
+severity: high
+confidence: high
+expected_false_positive_rate: 0.05
+autofixable: false
+sources:
+  - audit/registry/canonical.json
+  - .spec/00-canon/repository-registry/*.yaml
+  - pg_proc via supabase MCP
+incidents_proven:
+  - "#691 (2026-05-22, SWR job-name↔processor contract pinning — dead injection dropped)"
+risk_documented:
+  - reference_postgrest_stable_function_write_readonly.md
+---
+
+# Check : RPC Registry Drift
+
+## Pattern audité
+
+Fonctions RPC déclarées dans la spec L2 (`.spec/00-canon/repository-registry/`
+ou `audit/registry/canonical.json` champ `rpc`) qui :
+
+1. **N'existent pas dans `pg_proc`** (déclarées côté spec, absentes côté DB)
+2. **Existent dans `pg_proc` mais absentes de la spec** (DB drift sans
+   registry mis à jour)
+3. **Signature divergente** : nombre/types d'arguments ne matchent pas
+   entre spec et `pg_proc.proargtypes`
+
+## Origine
+
+PR #691 a corrigé un contrat job-name↔processor SWR où un processor mort
+était injecté faute de validation registry↔runtime. Pattern identique
+applicable aux RPC Postgres.
+
+## Méthode
+
+1. Lire la liste RPC déclarée dans `audit/registry/canonical.json` (champ
+   `rpc` ou via la projection L1+L2).
+2. Lire `pg_proc` via supabase MCP :
+   ```sql
+   SELECT proname, pronargs, proargtypes::regtype[]
+   FROM pg_proc
+   WHERE pronamespace = 'public'::regnamespace
+   ```
+3. Comparer set spec vs set DB, signaler 3 catégories de findings :
+   - `spec_only` (déclaré mais absent DB)
+   - `db_only` (existe DB mais pas spec)
+   - `signature_drift` (présent des deux côtés, signature ≠)
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "rpc-registry-drift",
+  "pass": false,
+  "findings": [
+    {
+      "rpc": "rpc_legacy_helper",
+      "category": "db_only",
+      "severity": "medium",
+      "hint": "Ajouter au registry L2 ou DROP FUNCTION"
+    },
+    {
+      "rpc": "rpc_seo_url_generate",
+      "category": "signature_drift",
+      "spec_args": ["text", "int4"],
+      "db_args": ["text", "int4", "boolean"],
+      "severity": "high"
+    }
+  ],
+  "summary": { "spec_count": 197, "db_count": 199, "drift": 2 }
+}
+```
+
+## Faux positifs connus
+
+- Fonctions internes (préfixe `_`) parfois absentes du registry par
+  convention. Mitigation : exclure regex `^_`.
+- Extensions Postgres (pg_cron, pg_net) ajoutent des fonctions
+  pas dans la spec. Mitigation : filtrer par `pronamespace = 'public'` et
+  ignorer schémas d'extensions.
+
+## Limites
+
+- Comparaison nominale, pas sémantique (le corps SQL n'est pas comparé).
+- Ne détecte pas les RPC consommés en TypeScript mais absents partout
+  (couvert par check séparé `attribution-write-gap` pour la partie write).

--- a/.claude/skills/web-vitals-audit/SKILL.md
+++ b/.claude/skills/web-vitals-audit/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: web-vitals-audit
+description: Use when investigating INP/LCP/CLS regressions on Remix routes — detects shared-component reflow, eager-loaded Radix, hydration cost, below-fold blocks without content-visibility, CWV ingestion gaps. Triggers — "INP élevé sur X", "audit web-vitals", "root cause LCP/CLS". Strictly scoped to Core Web Vitals root-cause ; does NOT cover Lighthouse, SEO global, WCAG, bundle size, image optimization.
+type: technique
+status: experimental
+owners: ['@ak125']
+domain: D3
+runtime_class: read-only
+llm_safe: true
+last_verified: '2026-05-23'
+license: Internal - Automecanik
+compatibility: Claude Code in the AutoMecanik monorepo. Reads frontend/app/** + audit/registry/canonical.json + __seo_cwv_daily. No mutations.
+allowed-tools: Read Grep Glob Bash
+tags: [audit, web-vitals, frontend, performance, inp, lcp, cls, remix]
+metadata:
+  version: "0.1"
+  argument-hint: "[check-name or 'all']"
+  spec: agentskills.io/specification v1
+---
+
+# Web Vitals Audit
+
+Audit **root-cause INP/LCP/CLS** uniquement. Scope strictement borné aux
+Core Web Vitals — ce skill ne devient PAS un "SEO frontend mega analyzer".
+
+**Origine** : PRs #692/#694 ont diagnostiqué et corrigé l'INP 537 ms mobile
+`/pieces/` causé par (a) l'ouverture du Sheet menu hamburger forçant reflow
+document (~1250 nœuds) et (b) blocs below-fold sans `content-visibility:
+auto`. Sans audit déterministe, ce type de cause racine se trouve par
+instrumentation web-vitals + Playwright + analyse manuelle.
+
+## Quand proposer ce skill
+
+- Triggers utilisateur : "INP élevé sur X", "LCP régression sur Y", "CLS
+  shifted blocks", "root cause web-vitals"
+- Après alerte CrUX / RUM / `__seo_cwv_daily` sur une route P0
+- Avant un audit responsive (`responsive-audit` couvre touch targets / WCAG,
+  pas la root-cause CWV)
+
+## Scope STRICTEMENT borné
+
+### Inclus uniquement
+- INP root-cause (interaction → next paint)
+- LCP root-cause (largest contentful paint)
+- CLS root-cause (cumulative layout shift)
+- Reflow forcé par composants UI partagés (header, sheet, dialog, drawer)
+- Hydration patterns coûteux (props serializable lourde, useState init)
+- Blocs below-fold sans `content-visibility: auto` (cause #694)
+- Composants Radix lourds eager-loaded en route (cause indirecte INP)
+- Gap ingestion `__seo_cwv_daily` (la stack existe-t-elle vraiment ?)
+
+### EXCLUS explicitement
+- ❌ Lighthouse complet (déjà couvert par `responsive-audit` + CI
+  Lighthouse PREPROD `.github/workflows/lighthouse-preprod.yml`)
+- ❌ SEO global, meta-tags, canonical URLs (couvert par `seo-gamme-audit`)
+- ❌ Accessibility WCAG, touch targets 44×44 (couvert par `responsive-audit`)
+- ❌ Bundle size analyzer (chantier séparé)
+- ❌ Image optimization (chantier séparé)
+
+Si une demande utilisateur dépasse ce scope, **rediriger vers le skill
+existant** plutôt qu'étendre `web-vitals-audit`.
+
+## Architecture atomique (6 checks)
+
+```
+.claude/skills/web-vitals-audit/
+  SKILL.md                            # ce fichier (orchestration)
+  checks/
+    inp-shared-component-reflow.md    # cause #692 (Sheet reflow document)
+    inp-eager-radix.md                # composants Radix eager-loaded
+    lcp-route-hydration.md            # init useState coûteux dans route
+    cls-shifted-blocks.md             # absence aspect-ratio / fixed dim
+    content-visibility-gap.md         # cause #694 (below-fold non cv:auto)
+    cwv-ingestion-gap.md              # __seo_cwv_daily vide alors que stack existe
+```
+
+**Un check = une responsabilité** (≤ 100 lignes).
+
+## Sources de vérité
+
+| Source | Usage |
+|---|---|
+| `audit/registry/canonical.json` | files frontend, routes Remix |
+| `frontend/app/components/**` | composants partagés (Sheet, Dialog) |
+| `frontend/app/routes/**` | eager imports, hydration cost |
+| `__seo_cwv_daily` via supabase MCP | ingestion CWV réelle |
+| `web-vitals` library calls grep | attribution wired? |
+| CrUX API / Sentry / GA4 | gap d'ingestion runtime (V2) |
+
+**Interdit** : Lighthouse en ligne, audit visuel pur, grep aveugle.
+
+## Métadonnées par check
+
+Identique à `runtime-truth-audit` : `severity` (taxonomie INP/LCP/CLS),
+`confidence`, `expected_false_positive_rate`, `autofixable: false`
+strict V1, `incidents_proven:` OU `risk_documented:`.
+
+### Taxonomie severity pour CWV
+
+- `critical` : INP > 500ms sur route P0 | LCP > 4s mobile | CLS > 0.25
+- `high` : INP 300-500ms | LCP 2.5-4s | CLS 0.10-0.25
+- `medium` : pattern qui dégradera CWV sous charge mais pas mesuré encore
+- `low` : optimisation incrémentale
+
+## Procédure (orchestrateur)
+
+1. "audit web-vitals sur /pieces" → exécuter les 6 checks sur la route
+   ciblée + ses composants partagés.
+2. "INP élevé global" → exécuter `inp-*` checks + `cwv-ingestion-gap`.
+3. Format sortie : rapport markdown structuré par metric (INP/LCP/CLS) +
+   liste de root-causes priorisées par severity.
+4. **Pas d'auto-fix**. Suggérer le patch (ex: `cv: auto` sur block X) en
+   description du finding.
+
+## Garde-fous
+
+Si un check tente de devenir "mega analyzer" (audit perf globale,
+bundle stats, profiling React), **le retirer**. Le scope CWV est non
+négociable.
+
+## Règle d'admission d'un nouveau check
+
+Identique à `runtime-truth-audit` :
+1. `incidents_proven:` OU `risk_documented:`
+2. `severity:` cite la taxonomie CWV
+3. `expected_false_positive_rate:` cohérent
+4. `autofixable: false` (V1 stricte)
+5. ≤ 100 lignes, 1 responsabilité
+6. Pas de duplication avec `responsive-audit` (WCAG/mobile)
+   ni Lighthouse CI
+
+## Mémoires liées
+
+- `project_inp_pieces_root_cause_20260522.md` — méthodo Playwright+CDP
+  réutilisable
+- `feedback_cwv_rum_stack_already_exists.md` — gap ingestion documenté
+- `feedback_no_blind_trust_gsc_first_detection_date.md` — distinguer
+  date détection cohorte vs date régression code

--- a/.claude/skills/web-vitals-audit/checks/cls-shifted-blocks.md
+++ b/.claude/skills/web-vitals-audit/checks/cls-shifted-blocks.md
@@ -1,0 +1,78 @@
+---
+check: cls-shifted-blocks
+severity: high
+confidence: medium
+expected_false_positive_rate: 0.20
+autofixable: false
+sources:
+  - frontend/app/components/**
+  - frontend/app/routes/**/*.tsx
+risk_documented:
+  - project_inp_pieces_root_cause_20260522.md
+---
+
+# Check : CLS — Shifted Blocks Without Fixed Dimensions
+
+## Pattern audité
+
+Blocs DOM susceptibles de provoquer Cumulative Layout Shift :
+
+1. `<img>` sans `width` + `height` ou `aspect-ratio` (image-driven shift)
+2. Composants dont le contenu varie après hydration (skeleton → real)
+   sans réserve d'espace équivalente (`min-height` ou skeleton iso-taille)
+3. Ads / iframes embeds sans dimension fixe (rare ici, mais à vérifier)
+4. Fonts (`font-display: swap`) sans `size-adjust` ni fallback métrique
+   compatible → FOUT shift
+
+**Impact** : CLS > 0.10 = `needs improvement`, > 0.25 = poor.
+
+## Origine
+
+Préventif — pas d'incident PROD CLS documenté à ce jour. `responsive-audit`
+couvre les touch targets et la mobile-first, mais pas le CLS spécifiquement.
+Ce check comble le gap CWV.
+
+## Méthode
+
+1. Grep `<img` dans `frontend/app/**/*.{tsx,ts}` sans `width=` ni
+   `aspect-ratio:` ni `className.*aspect-` à proximité → findings
+   `unsized_img`.
+2. Grep skeleton patterns (`<Skeleton`, `animate-pulse`) → vérifier le
+   composant remplaçant a un `min-height` matching (heuristique : même
+   composant parent défini avec h-X).
+3. Lire `app/styles/fonts.css` ou root.tsx — vérifier que les @font-face
+   ont `size-adjust` ou que le `font-family fallback` minimise le FOUT.
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "cls-shifted-blocks",
+  "pass": false,
+  "findings": [
+    {
+      "file": "frontend/app/components/product/Card.tsx",
+      "line": 42,
+      "issue": "<img src={product.image} alt=...> without width/height or aspect-ratio",
+      "category": "unsized_img",
+      "severity": "high",
+      "fix_hint": "Add width={300} height={200} or className='aspect-[3/2]'"
+    }
+  ],
+  "summary": { "scanned": 1280, "unsized_imgs": 1, "skeleton_mismatch": 0 }
+}
+```
+
+## Faux positifs connus
+
+- `<img>` dans des SVG decoratifs où le shift n'est pas perçu (background).
+  Mitigation : exclure ceux avec `aria-hidden="true"` ou parents
+  `position: absolute`.
+- Skeletons intentionnellement plus petits que le réel (cas rare,
+  acceptable). Mitigation : marker commentaire `// cls-ok` à formaliser.
+
+## Limites
+
+- Pas de mesure réelle CLS — recoupe `__seo_cwv_daily.cls` pour priorisation.
+- Ne couvre pas les shifts causés par JS dynamique post-hydration
+  (animations, infinite scroll). À ajouter en V2 si pattern observé.

--- a/.claude/skills/web-vitals-audit/checks/content-visibility-gap.md
+++ b/.claude/skills/web-vitals-audit/checks/content-visibility-gap.md
@@ -1,0 +1,89 @@
+---
+check: content-visibility-gap
+severity: high
+confidence: high
+expected_false_positive_rate: 0.10
+autofixable: false
+sources:
+  - frontend/app/routes/**/*.tsx
+  - frontend/app/components/**
+  - tailwind.config.ts (cv-auto utility class)
+incidents_proven:
+  - "#694 (2026-05-22, /pieces below-fold blocks without content-visibility:auto — INP -33% prod A/B)"
+---
+
+# Check : Below-Fold Blocks Without content-visibility:auto
+
+## Pattern audité
+
+Sections / blocs DOM **below the fold** (hors viewport initial) sur des
+routes P0 qui ne déclarent pas `content-visibility: auto` (ou son alias
+Tailwind `.cv-auto`).
+
+`content-visibility: auto` permet au navigateur de **skipper le rendering**
+des sections hors-viewport jusqu'à ce qu'elles entrent dans la scroll
+zone, réduisant le main-thread cost à l'init et améliorant INP.
+
+**Impact mesuré (#694)** : -33% INP sur `/pieces/` après application
+content-visibility sur les blocs below-fold. Validation A/B en PROD.
+
+## Origine
+
+PR #694 (2026-05-22) a appliqué `.cv-auto` sur les blocs below-fold de
+`/pieces/`. Validation A/B en PROD a montré -33% INP. Le pattern est
+généralisable aux autres routes long-form (catalog, blog, gamme pages).
+
+## Méthode
+
+1. Identifier les routes long-form (P0 trafic + scroll significatif) :
+   `frontend/app/routes/{_index,blog,pieces,gamme}*.tsx` initialement,
+   ensuite via heuristique nombre de sections / hauteur estimée.
+2. Pour chaque, parser le composant default export — identifier les
+   sections après les ~2-3 premiers blocs (estimation viewport mobile
+   ~600-800px haut).
+3. Vérifier qu'elles déclarent `cv-auto` (Tailwind) ou
+   `content-visibility-auto` (CSS direct) ou un wrapper équivalent.
+4. Si absent et hauteur cumulée estimée > 1500 px → finding
+   `missing_cv_auto`.
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "content-visibility-gap",
+  "pass": false,
+  "findings": [
+    {
+      "route": "frontend/app/routes/gamme.$slug.tsx",
+      "below_fold_sections": ["RelatedProducts", "GammeDescription", "ReviewsBlock"],
+      "category": "missing_cv_auto",
+      "severity": "high",
+      "fix_hint": "Wrap sections in <section className='cv-auto contain-intrinsic-size-[800px]'>"
+    }
+  ],
+  "summary": { "long_form_routes": 18, "missing_cv_auto": 1 }
+}
+```
+
+## Faux positifs connus
+
+- Routes courtes (login, 404) où le scroll est minimal — pas concernées.
+  Mitigation : seuil hauteur cumulée 1500 px.
+- Sections déjà optimisées via `loading="lazy"` (images) couvrent
+  partiellement le problème mais pas le DOM rendering coût. À considérer
+  comme `partial-fix` plutôt que `pass`.
+
+## Limites
+
+- Estimation hauteur statique heuristique — réel CWV peut varier selon
+  device / viewport. Méthodo Playwright dans `project_inp_pieces_root_cause_20260522.md`.
+- Tailwind utility `.cv-auto` est custom (à confirmer dans
+  `tailwind.config.ts`) — sinon utiliser `style={{ contentVisibility: 'auto' }}`.
+
+## Action recommandée pour findings
+
+1. Wrapper la section dans
+   `<section className="cv-auto contain-intrinsic-size-[Xpx]">` où X est
+   l'estimation de hauteur (Tailwind class à activer).
+2. Ne pas appliquer sur sections above-the-fold (pas de bénéfice).
+3. Mesurer avant/après via web-vitals attribution réelle pour confirmer.

--- a/.claude/skills/web-vitals-audit/checks/cwv-ingestion-gap.md
+++ b/.claude/skills/web-vitals-audit/checks/cwv-ingestion-gap.md
@@ -1,0 +1,82 @@
+---
+check: cwv-ingestion-gap
+severity: medium
+confidence: high
+expected_false_positive_rate: 0.05
+autofixable: false
+sources:
+  - frontend/app/**/*.{ts,tsx} (grep web-vitals library calls)
+  - __seo_cwv_daily via supabase MCP (count rows last 7d)
+  - audit/registry/canonical.json
+risk_documented:
+  - feedback_cwv_rum_stack_already_exists.md
+---
+
+# Check : CWV Ingestion Gap
+
+## Pattern audité
+
+La stack RUM web-vitals est **présente côté code** (import `web-vitals`,
+appels `onINP/onLCP/onCLS`) mais l'ingestion `__seo_cwv_daily` est **vide
+ou stale** (aucune nouvelle ligne sur les 7 derniers jours).
+
+**Impact** : sans ingestion CWV, impossible de mesurer l'effet des
+optimisations CWV (le présent skill perd sa boucle de mesure).
+
+## Origine
+
+Mémoire [feedback_cwv_rum_stack_already_exists.md](feedback_cwv_rum_stack_already_exists.md)
+documente le constat : la stack est wirée (web-vitals → Sentry+GA4),
+table `__seo_cwv_daily` existe (cf. `reference_seo_partition_rotation_pattern.md`),
+mais le gap d'ingestion vers la table interne reste un risque structurel.
+
+## Méthode
+
+1. Grep `from 'web-vitals'` dans `frontend/app/**/*.{ts,tsx}` — confirmer
+   présence de `onINP`, `onLCP`, `onCLS` calls.
+2. Query `__seo_cwv_daily` via supabase MCP :
+   ```sql
+   SELECT
+     COUNT(*) FILTER (WHERE date >= CURRENT_DATE - 7) AS rows_last_7d,
+     MAX(date) AS last_date
+   FROM __seo_cwv_daily
+   ```
+3. Findings :
+   - `web-vitals lib appelée + rows_last_7d = 0` → `ingestion_gap` (severity medium)
+   - `web-vitals lib non appelée` → `library_not_wired` (severity high) —
+     pas couvert par ce check, signale plutôt qu'une régression silencieuse
+   - `rows_last_7d > 0 et last_date >= today - 2` → `pass`
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "cwv-ingestion-gap",
+  "pass": false,
+  "findings": [
+    {
+      "category": "ingestion_gap",
+      "library_calls_grep_count": 3,
+      "rows_last_7d": 0,
+      "last_date": "2026-04-12",
+      "severity": "medium",
+      "fix_hint": "Vérifier le pipeline backend qui consomme l'event web-vitals (route Remix /api/cwv ou edge function). Mémoire feedback_cwv_rum_stack_already_exists.md"
+    }
+  ],
+  "summary": { "library_wired": true, "ingestion_live": false }
+}
+```
+
+## Faux positifs connus
+
+- Période de freeze (release lock, week-end) où l'ingestion est volontairement
+  stoppée. Mitigation : seuil 7 jours déjà tolérant.
+- Migration en cours du pipeline d'ingestion (cas transitoire). Mitigation :
+  documenter dans `top-priorities.md` section `ACTIVE_INCIDENTS`.
+
+## Limites
+
+- Ne vérifie pas la **qualité** des rows ingérées (Sentry vs GA4 vs interne
+  peuvent diverger). Hors scope V1 — l'objectif ici est juste de détecter
+  un pipeline mort.
+- Ne propose pas de fix automatique — pointer vers la mémoire est suffisant.

--- a/.claude/skills/web-vitals-audit/checks/inp-eager-radix.md
+++ b/.claude/skills/web-vitals-audit/checks/inp-eager-radix.md
@@ -1,0 +1,78 @@
+---
+check: inp-eager-radix
+severity: high
+confidence: medium
+expected_false_positive_rate: 0.20
+autofixable: false
+sources:
+  - frontend/app/routes/**/*.tsx
+  - frontend/app/components/**
+risk_documented:
+  - project_inp_pieces_root_cause_20260522.md
+---
+
+# Check : INP — Eager-Loaded Radix Components
+
+## Pattern audité
+
+Routes Remix qui importent **statiquement** plusieurs composants Radix
+lourds (`@radix-ui/react-*`) au top-level, hydratant tout au mount initial
+même si le composant n'est jamais ouvert par l'utilisateur dans cette
+session.
+
+**Composants Radix considérés "lourds"** : Sheet, Dialog, Popover,
+Tooltip, DropdownMenu, NavigationMenu, Combobox, Select (avec virtual list).
+
+**Impact** : hydration CPU + main-thread blocked à l'init → INP dégradé
+sur la première interaction même hors-Radix (le main thread est saturé).
+
+## Origine
+
+Pattern dérivé de l'audit #692 (INP 537 ms) — l'ouverture du Sheet n'était
+que le déclencheur, mais l'hydration eager de plusieurs Radix dans le header
+contribuait au baseline cost. Préventif tant que pas mesuré individuellement.
+
+## Méthode
+
+1. Pour chaque route Remix (`frontend/app/routes/**/*.tsx`) :
+   - Compter les imports `from '@radix-ui/react-*'` au top-level
+   - Identifier ceux importés mais conditionnellement rendus (`{open && <X/>}`)
+     — candidats à `lazy()` ou `<Suspense>`
+2. Seuil heuristique : **≥ 3 composants Radix lourds eager-loaded sur une
+   route P0** (catalog routes, home, pieces) = finding `high`.
+3. Sur routes admin / low-traffic : finding `medium` ou skip selon
+   convention.
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "inp-eager-radix",
+  "pass": false,
+  "findings": [
+    {
+      "route": "frontend/app/routes/pieces.$gamme.$type.tsx",
+      "eager_radix": ["Sheet", "Dialog", "Popover", "Tooltip", "Select"],
+      "count": 5,
+      "severity": "high",
+      "fix_hint": "Convert Sheet + Dialog to dynamic import via React.lazy + Suspense"
+    }
+  ],
+  "summary": { "routes_scanned": 242, "at_risk": 1 }
+}
+```
+
+## Faux positifs connus
+
+- Composants Radix dans un layout parent (root.tsx) qui sont effectivement
+  utilisés dans 100% des sessions. Mitigation : compter par route feuille,
+  pas par layout.
+- Composants minimaux (`@radix-ui/react-label`) qui n'ajoutent pas de coût.
+  Mitigation : liste whitelist "lourd" explicite ci-dessus.
+
+## Limites
+
+- Heuristique pure (count). Pas de profiling hydration réel. À corroborer
+  avec Sentry/web-vitals attribution pour priorisation.
+- Ne détecte pas les composants Radix wrapped dans un composant maison
+  exporté (ex: `<MyAwesomeMenu />` qui use Radix dedans). Risque résiduel.

--- a/.claude/skills/web-vitals-audit/checks/inp-shared-component-reflow.md
+++ b/.claude/skills/web-vitals-audit/checks/inp-shared-component-reflow.md
@@ -1,0 +1,82 @@
+---
+check: inp-shared-component-reflow
+severity: critical
+confidence: high
+expected_false_positive_rate: 0.10
+autofixable: false
+sources:
+  - frontend/app/components/header/**
+  - frontend/app/components/ui/sheet.tsx (Radix Sheet)
+  - frontend/app/routes/**/*.tsx (header import)
+incidents_proven:
+  - "#692 (2026-05-22, INP 537ms mobile /pieces/ — Sheet menu hamburger force reflow ~1250 nodes)"
+  - "#694 (2026-05-22, content-visibility fix complementary to #692)"
+---
+
+# Check : INP — Shared Component Forces Document Reflow
+
+## Pattern audité
+
+Composants UI partagés (header, sheet, dialog, drawer) qui, à l'ouverture
+sur mobile, **forcent un reflow du document entier** (~1000+ nœuds) à cause
+de :
+
+1. Animation `transform` ou `width` qui pousse tout le layout
+2. `overflow: hidden` sur body sans `scroll-position` préservée
+3. Sheet/Dialog qui injecte des wrappers ancestraux affectant le viewport
+4. Hauteur calculée dynamiquement (`vh` non figé) déclenchant relayout
+
+**Impact** : INP > 500 ms sur la première interaction → seuil **CRITICAL**
+selon CrUX. Cause directe de l'incident #692 (INP 537 ms mobile `/pieces/`).
+
+## Origine
+
+PR #692 (instrumentation web-vitals attribution) + #694 (fix content-visibility)
+ont diagnostiqué l'ouverture du Radix Sheet menu hamburger forçant un reflow
+de ~1250 nœuds DOM, scalant CPU à 537 ms sur mobile bas-de-gamme.
+
+## Méthode
+
+1. Lister les composants `Sheet`, `Dialog`, `Drawer`, `Popover` (Radix UI) :
+   `grep -r "from '@radix-ui/react-(sheet|dialog|popover)'" frontend/app/`
+2. Pour chaque, vérifier la présence :
+   - de `<style jsx>` ou `className` contenant `vh-100`, `h-screen`,
+     `min-h-screen` sur `body` ou `html` ancestor
+   - d'animation `transform: translate*` longue durée (> 200 ms)
+   - de wrappers ajoutés au `body` à l'ouverture (`document.body.style.*`)
+3. Cross-check : grep usage du composant dans `frontend/app/components/header/**`
+   et `frontend/app/root.tsx` (composants partagés globalement = blast radius
+   maximal).
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "inp-shared-component-reflow",
+  "pass": false,
+  "findings": [
+    {
+      "component": "frontend/app/components/header/MobileSheet.tsx",
+      "issue": "Sheet ancestor sets overflow:hidden on body without preserving scrollTop",
+      "blast_radius": "shared (root.tsx)",
+      "severity": "critical",
+      "fix_hint": "Use Radix Sheet built-in scroll lock + content-visibility:auto on hidden sections"
+    }
+  ],
+  "summary": { "scanned": 8, "at_risk": 1 }
+}
+```
+
+## Faux positifs connus
+
+- Composants Sheet utilisés uniquement en admin (`/admin/**`) — pas un
+  blast radius CWV public. Mitigation : pondérer par route public/admin.
+- Animation `transform: translate3d` GPU-accelerated qui n'a pas d'impact
+  CPU réel. Mitigation : whitelist explicite si profiling confirme.
+
+## Limites
+
+- Pas de profiling CPU réel (statique uniquement). Recoupe avec
+  `__seo_cwv_daily` ou Sentry web-vitals attribution pour confirmer.
+- Méthodo Playwright + CDP documentée dans
+  `project_inp_pieces_root_cause_20260522.md` pour aller plus loin.

--- a/.claude/skills/web-vitals-audit/checks/lcp-route-hydration.md
+++ b/.claude/skills/web-vitals-audit/checks/lcp-route-hydration.md
@@ -1,0 +1,79 @@
+---
+check: lcp-route-hydration
+severity: high
+confidence: medium
+expected_false_positive_rate: 0.25
+autofixable: false
+sources:
+  - frontend/app/routes/**/*.tsx
+risk_documented:
+  - project_inp_pieces_root_cause_20260522.md
+---
+
+# Check : LCP — Route Hydration Cost
+
+## Pattern audité
+
+Routes Remix dont l'hydration initiale paie un coût élevé qui retarde le
+LCP (Largest Contentful Paint), typiquement à cause de :
+
+1. `useState` initialisé avec un appel coûteux (`computeLargeArray()`,
+   `parse(huge JSON)`) sans `useMemo` ou lazy initialiser
+2. `useEffect` synchrone avec dépendance lourde au mount
+3. Props de loader sérialisées massives (>50 KB JSON) traversant
+   l'hydration
+4. Composant principal LCP entouré de wrappers non-essentiels (theme
+   provider, framer-motion) ajoutant un délai paint
+
+**Impact** : LCP > 2.5 s mobile = seuil `needs improvement`, > 4 s = poor.
+
+## Origine
+
+Préventif — pattern recurrent dans les apps Remix mais pas d'incident
+PROD documenté pour cette codebase encore. Risque pondéré modéré.
+
+## Méthode
+
+1. Pour chaque route Remix avec `loader` :
+   - Estimer la taille du JSON retourné (parser le type TS du loader si
+     typé, sinon heuristique sur `serializable` shapes).
+   - Si > 50 KB sérialisé estimé → finding `large_loader_payload`.
+2. Grep `useState\(\s*[a-z][a-zA-Z]+\(` dans le composant `default export`
+   de la route — si init non-trivial sans `() => ...` lazy → finding
+   `eager_state_init`.
+3. Identifier le composant LCP candidat (premier `<img>`, `<h1>`, ou bloc
+   de texte large > 100 chars dans le viewport) — vérifier qu'il n'est pas
+   wrapped dans 3+ niveaux de Context providers spécifiques à la route.
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "lcp-route-hydration",
+  "pass": false,
+  "findings": [
+    {
+      "route": "frontend/app/routes/blog.$slug.tsx",
+      "issue": "useState init: parsing 80KB markdown without lazy initializer",
+      "category": "eager_state_init",
+      "severity": "high",
+      "fix_hint": "useState(() => parseMarkdown(data)) → lazy initializer"
+    }
+  ],
+  "summary": { "routes_scanned": 242, "at_risk": 1 }
+}
+```
+
+## Faux positifs connus
+
+- Routes admin / dashboard où le LCP n'est pas critique (pas indexé,
+  audience interne). Mitigation : pondérer par route public/admin.
+- Lazy initializer absent mais avec valeur constante simple
+  (`useState({})`) — pas un problème réel. Mitigation : regex affinée.
+
+## Limites
+
+- Pas de mesure réelle LCP — corroboration `__seo_cwv_daily` ou CrUX
+  recommandée avant action.
+- Ne couvre pas la cause LCP serveur (TTFB, render-blocking CSS).
+  Hors scope par convention CWV root-cause client-side.

--- a/.claude/top-priorities.md
+++ b/.claude/top-priorities.md
@@ -1,0 +1,31 @@
+# Top Priorities — Manifest machine-readable
+
+# Format strict — éditer 1 ligne = 1 slug kebab-case. Pas de prose.
+# Bornes (anti-bloat mécanique, enforced par validate-top-priorities.sh) :
+#   TOP ≤ 5, DO_NOT_START ≤ 7, ACTIVE_INCIDENTS ≤ 10, STRUCTURAL_CONSTRAINTS ≤ 10
+# Lecteurs : SessionStart hook, Stop hook, skills, CI dashboards, agents Paperclip
+# Mise à jour : édit manuel git tracké, max 1×/semaine (ou pivot business)
+# updated_at: 2026-05-23
+
+## TOP
+- commerce-loop-v1
+- runtime-truth-p0
+- runtime-truth-p1
+- web-vitals-attribution-ingestion
+
+## DO_NOT_START
+- r5-diagnostic-engine
+- claude-plugin-marketplace
+- new-control-plane
+- new-seo-platform
+- new-meta-architecture-adr
+
+## ACTIVE_INCIDENTS
+- snapshot-partition-rotation-sensitive
+- web-vitals-attribution-unstable
+
+## STRUCTURAL_CONSTRAINTS
+- supabase-js-1000-row-cap
+- postgrest-stable-function-write
+- dev-runtime-not-auto-updated-on-merge
+- node-22-required-for-architecture-build

--- a/.spec/00-canon/ai-registry/skills.registry.json
+++ b/.spec/00-canon/ai-registry/skills.registry.json
@@ -1,6 +1,6 @@
 {
-  "compliantCount": 8,
-  "generatedAt": "2026-05-18T14:37:29.046Z",
+  "compliantCount": 10,
+  "generatedAt": "2026-05-23T10:26:42.241Z",
   "issues": [],
   "schemaPath": ".spec/00-canon/ai-registry/skill.schema.json",
   "schemaVersion": "1.0.0",
@@ -148,6 +148,33 @@
       "type": "technique"
     },
     {
+      "checksum": "sha256:b1ad11e3dc7ce67295c359e5aac80f61019034b91bf27193c99abaf52480f641",
+      "domain": "D15",
+      "last_verified": "2026-05-23",
+      "llm_safe": true,
+      "metadata": {
+        "argument-hint": "[check-name or 'all']",
+        "spec": "agentskills.io/specification v1",
+        "version": "0.1"
+      },
+      "name": "runtime-truth-audit",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/runtime-truth-audit/SKILL.md",
+      "runtime_class": "read-only",
+      "spec_compliant": true,
+      "status": "experimental",
+      "tags": [
+        "adr-058",
+        "audit",
+        "governance",
+        "prevention",
+        "runtime"
+      ],
+      "type": "technique"
+    },
+    {
       "checksum": "sha256:2635f7fee262729b9670f8bd2777a707f26b1bceb4131652b0a08102f37be7d5",
       "domain": "D15",
       "last_verified": "2026-05-18",
@@ -228,7 +255,37 @@
         "vlevel"
       ],
       "type": "technique"
+    },
+    {
+      "checksum": "sha256:9a60e7fb172ba81dca3f2c11e37a6374788f1e4f2ed647a07cfc065bac45eba4",
+      "domain": "D3",
+      "last_verified": "2026-05-23",
+      "llm_safe": true,
+      "metadata": {
+        "argument-hint": "[check-name or 'all']",
+        "spec": "agentskills.io/specification v1",
+        "version": "0.1"
+      },
+      "name": "web-vitals-audit",
+      "owners": [
+        "@ak125"
+      ],
+      "path": ".claude/skills/web-vitals-audit/SKILL.md",
+      "runtime_class": "read-only",
+      "spec_compliant": true,
+      "status": "experimental",
+      "tags": [
+        "audit",
+        "cls",
+        "frontend",
+        "inp",
+        "lcp",
+        "performance",
+        "remix",
+        "web-vitals"
+      ],
+      "type": "technique"
     }
   ],
-  "totalSkills": 8
+  "totalSkills": 10
 }

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -37,6 +37,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: low
+  - glob: .claude/top-priorities.md
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   - glob: .spec/00-canon/ai-registry/**
     domain: D15
     owner: '@ak125'

--- a/scripts/claude-hooks/posttool-lint-check.sh
+++ b/scripts/claude-hooks/posttool-lint-check.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # PostToolUse hook for Edit/Write tools
-# After editing backend/frontend files, warns if lint issues are likely
-# Exit 0 = ok, Exit 2 = send feedback (file was still written)
+# After editing backend/frontend/skills/CLAUDE.md/AGENTS.md files, warns if validators fail.
+# Exit 0 = ok (file already written ; warn-only contract).
+
+# Rollback rapide : si CLAUDE_HOOKS_DISABLE=1, court-circuiter sans git revert.
+if [ "${CLAUDE_HOOKS_DISABLE:-0}" = "1" ]; then
+  exit 0
+fi
 
 if ! command -v jq &>/dev/null; then
   echo "WARN: jq not installed — hook bypassed. Install: apt install jq" >&2
@@ -17,7 +22,36 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Only check .ts and .tsx files
+REPO_ROOT="/opt/automecanik/app"
+
+# .claude/skills/**/*.md → validate-skills-frontmatter.js
+# Branche le validateur existant au PostToolUse pour feedback immédiat (sinon le validateur
+# ne tourne qu'en pre-commit + CI). Validators existants réutilisés tels quels — no wrapper.
+if echo "$FILE_PATH" | grep -qE '/\.claude/skills/.*\.md$'; then
+  if [ -f "$FILE_PATH" ] && [ -f "$REPO_ROOT/scripts/governance/validate-skills-frontmatter.js" ]; then
+    if ! node "$REPO_ROOT/scripts/governance/validate-skills-frontmatter.js" "$FILE_PATH" >/tmp/skills-frontmatter.log 2>&1; then
+      echo "WARN skill frontmatter: $FILE_PATH" >&2
+      tail -5 /tmp/skills-frontmatter.log >&2
+      echo "→ corriger avant pre-commit (validate-skills-frontmatter.js)" >&2
+    fi
+  fi
+  exit 0
+fi
+
+# CLAUDE.md | AGENTS.md → validate-agents-md.sh --file <path>
+# Validateur anti-pattern (pas d'IP/URL/UUID/clé hardcodée) — feedback immédiat.
+if echo "$FILE_PATH" | grep -qE '(/|^)(CLAUDE|AGENTS)\.md$'; then
+  if [ -f "$REPO_ROOT/scripts/agents/validate-agents-md.sh" ]; then
+    if ! bash "$REPO_ROOT/scripts/agents/validate-agents-md.sh" --file "$FILE_PATH" >/tmp/agents-md.log 2>&1; then
+      echo "WARN AGENTS/CLAUDE.md: $FILE_PATH" >&2
+      tail -5 /tmp/agents-md.log >&2
+      echo "→ corriger avant pre-commit (validate-agents-md.sh --file)" >&2
+    fi
+  fi
+  exit 0
+fi
+
+# TypeScript backend/frontend (existant)
 if ! echo "$FILE_PATH" | grep -qE '\.(ts|tsx)$'; then
   exit 0
 fi
@@ -25,7 +59,7 @@ fi
 # Backend: quick eslint check on the modified file
 if echo "$FILE_PATH" | grep -q '/backend/'; then
   if [ -f "$FILE_PATH" ]; then
-    RESULT=$(cd /opt/automecanik/app/backend && npx eslint --no-eslintrc --rule '{"no-unused-vars":"warn","@typescript-eslint/no-unused-vars":"warn"}' --parser @typescript-eslint/parser "$FILE_PATH" 2>/dev/null | tail -1 || true)
+    RESULT=$(cd "$REPO_ROOT/backend" && npx eslint --no-eslintrc --rule '{"no-unused-vars":"warn","@typescript-eslint/no-unused-vars":"warn"}' --parser @typescript-eslint/parser "$FILE_PATH" 2>/dev/null | tail -1 || true)
     if echo "$RESULT" | grep -qE '[0-9]+ error'; then
       echo "LINT: $RESULT — Pense a verifier avec 'npm run lint' dans backend/" >&2
     fi
@@ -36,7 +70,7 @@ fi
 # Frontend: quick check
 if echo "$FILE_PATH" | grep -q '/frontend/'; then
   if [ -f "$FILE_PATH" ]; then
-    RESULT=$(cd /opt/automecanik/app/frontend && npx eslint "$FILE_PATH" 2>/dev/null | tail -1 || true)
+    RESULT=$(cd "$REPO_ROOT/frontend" && npx eslint "$FILE_PATH" 2>/dev/null | tail -1 || true)
     if echo "$RESULT" | grep -qE '[0-9]+ error'; then
       echo "LINT: $RESULT — Pense a verifier avec 'npm run lint' dans frontend/" >&2
     fi

--- a/scripts/claude-hooks/sessionstart-workspace-context.sh
+++ b/scripts/claude-hooks/sessionstart-workspace-context.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SessionStart hook — émet contexte workspace + TOP PRIORITIES + KNOWN INCIDENTS
+#
+# Pattern Anthropic ("How Claude Code works in large codebases"):
+#   "A start hook can load team-specific context dynamically so every
+#    developer gets the right setup for their module"
+#
+# Émet via stdout un manifest compact ≤ 500 tokens lu comme additional
+# context au début de chaque session. Borné par assertion `wc -c < 2000`.
+#
+# Détection workspace : walk-up `package.json` (pas `case $PWD` hardcodé).
+#
+# Désactivation rapide : `CLAUDE_HOOKS_DISABLE=1` court-circuite sans diff git.
+
+set -euo pipefail
+
+# Rollback rapide
+if [ "${CLAUDE_HOOKS_DISABLE:-0}" = "1" ]; then
+  exit 0
+fi
+
+CWD="${PWD:-/opt/automecanik/app}"
+# REPO_ROOT = top-level du git repo courant (worktree-aware).
+# Fallback path canon si on est hors git.
+if REPO_ROOT=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null); then
+  :
+else
+  REPO_ROOT="/opt/automecanik/app"
+fi
+# Anchor de comparaison : le path attendu de la racine canonique (worktrees vivent sous
+# .claude/worktrees/ et leur toplevel = leur propre path). On normalise pour matcher.
+REPO_ROOT_CANON="/opt/automecanik/app"
+
+# Walk-up : trouver le premier package.json (workspace ou racine)
+find_workspace_root() {
+  local dir="$1"
+  while [ "$dir" != "/" ] && [ "$dir" != "$REPO_ROOT/.." ]; do
+    if [ -f "$dir/package.json" ]; then
+      echo "$dir"
+      return 0
+    fi
+    dir=$(dirname "$dir")
+  done
+  echo "$REPO_ROOT"
+}
+
+WORKSPACE_DIR=$(find_workspace_root "$CWD")
+WORKSPACE_NAME=$(basename "$WORKSPACE_DIR")
+
+# Comparaison sur le SUFFIX (relatif au REPO_ROOT) pour être worktree-aware.
+# WORKSPACE_REL = path après le toplevel du repo (vide si racine).
+WORKSPACE_REL="${WORKSPACE_DIR#$REPO_ROOT}"
+WORKSPACE_REL="${WORKSPACE_REL#/}"
+
+case "$WORKSPACE_REL" in
+  "")
+    WORKSPACE_LABEL="monorepo-root (dev session)"
+    SKILLS_HINT="8 skills DEV (code-review, db-migration, frontend-design, governance-vault-ops, responsive-audit, session-log, ui-ux-pro-max, vehicle-ops) + 2 nouveaux (runtime-truth-audit, web-vitals-audit)"
+    ;;
+  "workspaces/seo-batch")
+    WORKSPACE_LABEL="workspaces/seo-batch (SEO campaigns)"
+    SKILLS_HINT="39 agents R0-R8 + 16 skills SEO (content-gen, kw-classify, v5-guardian, ...)"
+    ;;
+  "workspaces/marketing")
+    WORKSPACE_LABEL="workspaces/marketing (G1 brand voice + AEC)"
+    SKILLS_HINT="3 agents marketing (LEAD/LOCAL/RETENTION) + canon brand voice"
+    ;;
+  "workspaces/wiki")
+    WORKSPACE_LABEL="workspaces/wiki (documentation sas ADR-033)"
+    SKILLS_HINT="skill wiki-proposal-writer + canon ADR-033"
+    ;;
+  *)
+    WORKSPACE_LABEL="$WORKSPACE_NAME (custom workspace or worktree)"
+    SKILLS_HINT="Worktree de dev — skills hérités du monorepo-root"
+    ;;
+esac
+
+# Lecture top-priorities.md (machine-readable) — chercher dans le toplevel courant
+# (worktree-aware) puis fallback canon.
+TOP_FILE="$REPO_ROOT/.claude/top-priorities.md"
+if [ ! -f "$TOP_FILE" ] && [ -f "$REPO_ROOT_CANON/.claude/top-priorities.md" ]; then
+  TOP_FILE="$REPO_ROOT_CANON/.claude/top-priorities.md"
+fi
+
+extract_section() {
+  local section="$1"
+  if [ ! -f "$TOP_FILE" ]; then
+    echo "(top-priorities.md absent)"
+    return
+  fi
+  awk -v s="## ${section}" '
+    $0 == s { flag=1; next }
+    /^## / { flag=0 }
+    flag && /^- / { print }
+  ' "$TOP_FILE"
+}
+
+# Assemblage compact
+{
+  echo "## Workspace en cours"
+  echo "$WORKSPACE_LABEL"
+  echo ""
+  echo "Surface : $SKILLS_HINT"
+  echo ""
+  echo "## TOP priorities (do these)"
+  extract_section "TOP"
+  echo ""
+  echo "## DO NOT start (paused by doctrine)"
+  extract_section "DO_NOT_START"
+  echo ""
+  echo "## Active incidents (transient — be careful)"
+  extract_section "ACTIVE_INCIDENTS"
+  echo ""
+  echo "## Structural constraints (permanent gotchas)"
+  extract_section "STRUCTURAL_CONSTRAINTS"
+  echo ""
+  echo "_Source : .claude/top-priorities.md — mise à jour max 1×/sem_"
+} > /tmp/sessionstart-output.txt
+
+# Borne taille : sortie ≤ 2000 bytes (~500 tokens). Si dépasse → fail silencieux (exit 0)
+# avec message stderr ; ne JAMAIS bloquer la session sur ce défaut.
+SIZE=$(wc -c < /tmp/sessionstart-output.txt)
+if [ "$SIZE" -gt 2000 ]; then
+  echo "WARN: SessionStart output $SIZE > 2000 bytes — manifest dépasse la borne" >&2
+  echo "→ vérifier les bornes top-priorities.md (TOP≤5, DO_NOT_START≤7, ...)" >&2
+  # On émet quand même mais tronqué pour ne pas saturer le contexte
+  head -c 2000 /tmp/sessionstart-output.txt
+  exit 0
+fi
+
+cat /tmp/sessionstart-output.txt
+exit 0

--- a/scripts/claude-hooks/stop-claude-md-suggest.sh
+++ b/scripts/claude-hooks/stop-claude-md-suggest.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# stop-claude-md-suggest.sh — sous-script Stop hook, propose mise à jour
+# de CLAUDE.md / MEMORY.md / .claude/rules quand la session a montré des
+# signaux de correction itérative.
+#
+# Pattern Anthropic ("How Claude Code works in large codebases"):
+#   "A stop hook can reflect on what happened during a session and propose
+#    CLAUDE.md updates while the context is fresh"
+#
+# Signal disponible (le Stop hook n'a PAS accès aux messages user) :
+#   - Subjects des N derniers commits sur la branche feature
+#   - Si ≥ 2/N sont "fix:", "revert:", "correction:" → émet stderr suggestion
+#
+# Action proposée : suggestion seulement, JAMAIS d'auto-edit. L'humain décide.
+#
+# Désactivation : CLAUDE_HOOKS_DISABLE=1
+
+set -u
+
+if [ "${CLAUDE_HOOKS_DISABLE:-0}" = "1" ]; then
+  exit 0
+fi
+
+REPO_ROOT="$(git -C "${PWD}" rev-parse --show-toplevel 2>/dev/null || echo /opt/automecanik/app)"
+cd "$REPO_ROOT" 2>/dev/null || exit 0
+
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
+
+# Skip on protected branches / no branch
+case "$current_branch" in
+  main|master|HEAD|"") exit 0 ;;
+esac
+
+# Compter les commits "fix:" / "revert:" / "correction:" parmi les 5 derniers
+# de la branche feature (commits ahead of origin/main).
+N=5
+SUBJECTS=$(git log origin/main..HEAD --pretty=%s 2>/dev/null | head -n "$N")
+
+if [ -z "$SUBJECTS" ]; then
+  exit 0
+fi
+
+CORRECTIONS=$(printf '%s\n' "$SUBJECTS" | grep -cE '^(fix|revert|correction|hotfix)(\(|:)' || true)
+
+# Marker pour éviter de spammer le même conseil à chaque Stop sur le même HEAD
+MARKER_DIR="${REPO_ROOT}/.claude/.session-log-state"
+mkdir -p "$MARKER_DIR" 2>/dev/null
+SUGGEST_MARKER="${MARKER_DIR}/last-claude-md-suggest-head"
+last_head="$(cat "$SUGGEST_MARKER" 2>/dev/null || echo '')"
+current_head="$(git rev-parse HEAD 2>/dev/null || echo '')"
+
+if [ "$last_head" = "$current_head" ]; then
+  exit 0
+fi
+
+# Seuil : ≥ 2 corrections sur les 5 derniers commits → suggestion
+if [ "$CORRECTIONS" -ge 2 ]; then
+  cat >&2 <<EOF
+
+[stop-claude-md-suggest] La branche '$current_branch' a $CORRECTIONS commits
+de correction parmi les $N derniers. Cela peut signaler un pattern non
+documenté qui mérite une mémoire MEMORY ou une règle .claude/rules/*.md.
+
+Suggéré (action humaine, pas auto-edit) :
+  1. Examiner les subjects fix/revert :
+$(printf '%s\n' "$SUBJECTS" | grep -E '^(fix|revert|correction|hotfix)(\(|:)' | sed 's/^/       /')
+  2. Si convention récurrente : ajouter une mémoire à
+     /home/deploy/.claude/projects/-opt-automecanik-app/memory/ (type feedback)
+     ou une règle dans .claude/rules/<topic>.md
+  3. Sinon : skip — pas de capture nécessaire.
+
+EOF
+  printf '%s\n' "$current_head" > "$SUGGEST_MARKER"
+fi
+
+exit 0

--- a/scripts/claude-hooks/stop-log-session-suggest.sh
+++ b/scripts/claude-hooks/stop-log-session-suggest.sh
@@ -110,6 +110,14 @@ fi
 ARCHIVE_FILE="${REPO_ROOT}/log-archive-$(date +%Y).md"
 bash "${REPO_ROOT}/scripts/claude-hooks/rotate-log.sh" "$LOG_FILE" "$ARCHIVE_FILE" 2>/dev/null || true
 
+# Stop hook companion : suggérer (stderr-only) une mise à jour CLAUDE.md /
+# MEMORY si la branche a accumulé des commits de correction. Hors du flow de
+# commit log — émet uniquement un message advisory. Idempotent, opt-out via
+# CLAUDE_HOOKS_DISABLE=1.
+if [ -x "${REPO_ROOT}/scripts/claude-hooks/stop-claude-md-suggest.sh" ]; then
+  bash "${REPO_ROOT}/scripts/claude-hooks/stop-claude-md-suggest.sh" 2>&1 >&2 || true
+fi
+
 # Stage log.md (+ the archive if rotation just touched it) and commit.
 git add -- "$LOG_FILE" 2>/dev/null
 [ -f "$ARCHIVE_FILE" ] && git add -- "$ARCHIVE_FILE" 2>/dev/null

--- a/scripts/governance/validate-top-priorities.sh
+++ b/scripts/governance/validate-top-priorities.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Valide .claude/top-priorities.md :
+#   - 4 sections obligatoires (TOP / DO_NOT_START / ACTIVE_INCIDENTS / STRUCTURAL_CONSTRAINTS)
+#   - bornes strictes (5 / 7 / 10 / 10) — anti-bloat mécanique
+#   - slugs kebab-case stricts (^[a-z][a-z0-9-]*$)
+#
+# Usage : scripts/governance/validate-top-priorities.sh [path]
+# Exit 0 = OK, 1 = FAIL (au moins une violation)
+
+set -euo pipefail
+
+FILE="${1:-.claude/top-priorities.md}"
+
+if [ ! -f "$FILE" ]; then
+  echo "FAIL: $FILE introuvable"
+  exit 1
+fi
+
+ERRORS=0
+
+# 1. Sections obligatoires
+for section in TOP DO_NOT_START ACTIVE_INCIDENTS STRUCTURAL_CONSTRAINTS; do
+  if ! grep -qE "^## ${section}$" "$FILE"; then
+    echo "FAIL: section ## $section manquante"
+    ERRORS=$((ERRORS+1))
+  fi
+done
+
+# 2. Bornes (anti-bloat)
+declare -A LIMITS=([TOP]=5 [DO_NOT_START]=7 [ACTIVE_INCIDENTS]=10 [STRUCTURAL_CONSTRAINTS]=10)
+for section in "${!LIMITS[@]}"; do
+  count=$(awk -v s="## ${section}" '
+    $0 == s { flag=1; next }
+    /^## / { flag=0 }
+    flag && /^- / { c++ }
+    END { print c+0 }
+  ' "$FILE")
+  limit=${LIMITS[$section]}
+  if (( count > limit )); then
+    echo "FAIL: $section a $count slugs > limite $limit"
+    ERRORS=$((ERRORS+1))
+  fi
+done
+
+# 3. Slugs kebab-case strict (^- [a-z][a-z0-9-]*$)
+INVALID=$(grep -nE "^- " "$FILE" | grep -vE "^[0-9]+:- [a-z][a-z0-9-]*$" || true)
+if [ -n "$INVALID" ]; then
+  echo "FAIL: slugs non-kebab-case détectés :"
+  echo "$INVALID" | sed 's/^/  /'
+  ERRORS=$((ERRORS+1))
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "$ERRORS violation(s) détectée(s) dans $FILE"
+  exit 1
+fi
+
+echo "OK: $FILE conforme (sections / bornes / slugs)"
+exit 0

--- a/scripts/test-claude-hooks.sh
+++ b/scripts/test-claude-hooks.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#
+# test-claude-hooks.sh — tests bash plain pour les nouveaux hooks Claude.
+#
+# Pattern repo `scripts/test-<thing>.sh` (cohérent avec test-internal-links.sh,
+# test-payment-tunnel.sh, etc.). Pas de bats — non installé.
+#
+# Couvre 3 cas par hook neuf :
+#   1. Nominal (entrée attendue → comportement attendu)
+#   2. Fichier inexistant / input vide
+#   3. CLAUDE_HOOKS_DISABLE=1 (rollback rapide)
+
+set -u
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo /opt/automecanik/app)"
+cd "$REPO_ROOT" || exit 1
+
+assert_exit() {
+  local description="$1"
+  local expected_exit="$2"
+  local actual_exit="$3"
+  if [ "$expected_exit" = "$actual_exit" ]; then
+    PASS=$((PASS+1))
+    echo "  PASS: $description"
+  else
+    FAIL=$((FAIL+1))
+    FAILED_TESTS+=("$description (expected exit=$expected_exit, got $actual_exit)")
+    echo "  FAIL: $description (expected exit=$expected_exit, got $actual_exit)"
+  fi
+}
+
+assert_contains() {
+  local description="$1"
+  local needle="$2"
+  local haystack="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    PASS=$((PASS+1))
+    echo "  PASS: $description"
+  else
+    FAIL=$((FAIL+1))
+    FAILED_TESTS+=("$description (missing: '$needle')")
+    echo "  FAIL: $description (missing: '$needle')"
+  fi
+}
+
+assert_size_lt() {
+  local description="$1"
+  local max="$2"
+  local actual="$3"
+  if [ "$actual" -lt "$max" ]; then
+    PASS=$((PASS+1))
+    echo "  PASS: $description ($actual < $max)"
+  else
+    FAIL=$((FAIL+1))
+    FAILED_TESTS+=("$description ($actual >= $max)")
+    echo "  FAIL: $description ($actual >= $max)"
+  fi
+}
+
+# ============================================================
+# Hook 1 : posttool-lint-check.sh
+# ============================================================
+
+echo ""
+echo "=== posttool-lint-check.sh ==="
+
+# Cas 1 : édition CLAUDE.md → invoque validate-agents-md.sh (warn stderr possible)
+INPUT='{"tool_name":"Edit","file_path":"/opt/automecanik/app/CLAUDE.md"}'
+echo "$INPUT" | bash scripts/claude-hooks/posttool-lint-check.sh > /tmp/h1-out 2> /tmp/h1-err
+assert_exit "posttool CLAUDE.md edit → exit 0 (warn-only)" "0" "$?"
+
+# Cas 2 : input vide → exit 0
+echo "" | bash scripts/claude-hooks/posttool-lint-check.sh > /tmp/h1b-out 2> /tmp/h1b-err
+assert_exit "posttool empty input → exit 0" "0" "$?"
+
+# Cas 3 : rollback CLAUDE_HOOKS_DISABLE=1
+INPUT='{"tool_name":"Edit","file_path":"/opt/automecanik/app/CLAUDE.md"}'
+CLAUDE_HOOKS_DISABLE=1 bash scripts/claude-hooks/posttool-lint-check.sh <<<"$INPUT" > /tmp/h1c-out 2>&1
+assert_exit "posttool CLAUDE_HOOKS_DISABLE=1 → exit 0 silent" "0" "$?"
+
+# Cas 4 (sanity) : fichier non-matching → exit 0, no output
+echo '{"tool_name":"Edit","file_path":"/opt/automecanik/app/log.md"}' \
+  | bash scripts/claude-hooks/posttool-lint-check.sh > /tmp/h1d-out 2> /tmp/h1d-err
+assert_exit "posttool non-matching file → exit 0" "0" "$?"
+
+# ============================================================
+# Hook 2 : sessionstart-workspace-context.sh
+# ============================================================
+
+echo ""
+echo "=== sessionstart-workspace-context.sh ==="
+
+# Cas 1 : nominal depuis repo root → output contient sections attendues
+OUT=$(bash scripts/claude-hooks/sessionstart-workspace-context.sh 2>/tmp/h2-err)
+EXIT=$?
+assert_exit "sessionstart nominal → exit 0" "0" "$EXIT"
+assert_contains "sessionstart contient ## Workspace" "## Workspace" "$OUT"
+assert_contains "sessionstart contient ## TOP" "## TOP" "$OUT"
+assert_contains "sessionstart contient ## DO NOT start" "## DO NOT start" "$OUT"
+
+# Cas 2 : borne taille — output < 2000 bytes
+SIZE=$(echo -n "$OUT" | wc -c)
+assert_size_lt "sessionstart output bounded" "2000" "$SIZE"
+
+# Cas 3 : rollback CLAUDE_HOOKS_DISABLE=1 → output vide, exit 0
+OUT=$(CLAUDE_HOOKS_DISABLE=1 bash scripts/claude-hooks/sessionstart-workspace-context.sh 2>/tmp/h2c-err)
+EXIT=$?
+assert_exit "sessionstart CLAUDE_HOOKS_DISABLE=1 → exit 0" "0" "$EXIT"
+if [ -z "$OUT" ]; then
+  PASS=$((PASS+1))
+  echo "  PASS: sessionstart CLAUDE_HOOKS_DISABLE=1 → output vide"
+else
+  FAIL=$((FAIL+1))
+  FAILED_TESTS+=("sessionstart CLAUDE_HOOKS_DISABLE=1 should emit nothing")
+  echo "  FAIL: sessionstart CLAUDE_HOOKS_DISABLE=1 should emit nothing"
+fi
+
+# ============================================================
+# Hook 3 : stop-claude-md-suggest.sh
+# ============================================================
+
+echo ""
+echo "=== stop-claude-md-suggest.sh ==="
+
+# Cas 1 : nominal sur branche feature → exit 0 (peut émettre ou non selon count fix)
+bash scripts/claude-hooks/stop-claude-md-suggest.sh > /tmp/h3-out 2> /tmp/h3-err
+assert_exit "stop-claude-md-suggest nominal → exit 0" "0" "$?"
+
+# Cas 2 : rollback CLAUDE_HOOKS_DISABLE=1
+CLAUDE_HOOKS_DISABLE=1 bash scripts/claude-hooks/stop-claude-md-suggest.sh > /tmp/h3b-out 2> /tmp/h3b-err
+assert_exit "stop-claude-md-suggest CLAUDE_HOOKS_DISABLE=1 → exit 0" "0" "$?"
+if [ ! -s /tmp/h3b-out ] && [ ! -s /tmp/h3b-err ]; then
+  PASS=$((PASS+1))
+  echo "  PASS: stop-claude-md-suggest CLAUDE_HOOKS_DISABLE=1 → silent"
+else
+  FAIL=$((FAIL+1))
+  FAILED_TESTS+=("stop-claude-md-suggest should emit nothing when disabled")
+  echo "  FAIL: stop-claude-md-suggest disabled should emit nothing"
+fi
+
+# Cas 3 : sur branche 'main' simulée (HEAD detached) → exit 0 (skip)
+ORIG_HEAD=$(git rev-parse HEAD)
+git checkout --detach >/dev/null 2>&1
+bash scripts/claude-hooks/stop-claude-md-suggest.sh > /tmp/h3c-out 2> /tmp/h3c-err
+RC=$?
+git checkout - >/dev/null 2>&1
+assert_exit "stop-claude-md-suggest detached HEAD → exit 0 skip" "0" "$RC"
+
+# ============================================================
+# Validator : validate-top-priorities.sh
+# ============================================================
+
+echo ""
+echo "=== validate-top-priorities.sh ==="
+
+bash scripts/governance/validate-top-priorities.sh .claude/top-priorities.md > /tmp/v1-out 2>&1
+assert_exit "validate-top-priorities nominal → exit 0" "0" "$?"
+
+# Cas 2 : fichier inexistant
+bash scripts/governance/validate-top-priorities.sh /tmp/nonexistent.md > /tmp/v2-out 2>&1
+assert_exit "validate-top-priorities missing file → exit 1" "1" "$?"
+
+# Cas 3 : sur-dépassement borne TOP (créer fichier temporaire)
+cat > /tmp/top-bloat.md <<'EOF'
+## TOP
+- a
+- b
+- c
+- d
+- e
+- f
+- g
+
+## DO_NOT_START
+- x
+
+## ACTIVE_INCIDENTS
+- y
+
+## STRUCTURAL_CONSTRAINTS
+- z
+EOF
+bash scripts/governance/validate-top-priorities.sh /tmp/top-bloat.md > /tmp/v3-out 2>&1
+assert_exit "validate-top-priorities TOP>5 → exit 1" "1" "$?"
+assert_contains "validate-top-priorities flags TOP overflow" "TOP a 7" "$(cat /tmp/v3-out)"
+
+# ============================================================
+# Résumé
+# ============================================================
+
+echo ""
+echo "======================================"
+echo "Tests : $PASS passed / $FAIL failed"
+echo "======================================"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Échecs :"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

**Couche 1 — Stabilité runtime** du plan Claude Harness Optimization (`/home/deploy/.claude/plans/squishy-wishing-rabin.md`).

Transforme le harness Claude en **système borné de prévention runtime** — pas en générateur de sophistication. Convergence de 7 analyses ChatGPT successives filtrées par MEMORY + audit empirique de 6 PRs PROD récentes (#691-#697).

**Zéro modification runtime backend/frontend.** Uniquement infrastructure Claude Code.

## Contenu

### 2 skills atomiques (12 checks au total)
- **`runtime-truth-audit`** (D15, experimental) — détecte les dérives runtime vs spec/registry :
  - `nest-dead-services` (cas #696 OrderStatusService doublon mort)
  - `rpc-registry-drift` (cas #691 SWR contract pinning)
  - `pg-stable-write` (cas #693 GSC 5xx fonction STABLE qui DELETE)
  - `partition-cron-gap` (cas #697/#698 partitions épuisées)
  - `attribution-write-gap` (cas #695 orl_website_url orpheline)
  - `orphan-runtime-flags` (préventif feature flags morts)
- **`web-vitals-audit`** (D3, experimental) — root-cause INP/LCP/CLS uniquement :
  - `inp-shared-component-reflow` (cas #692 Sheet reflow document)
  - `inp-eager-radix` (composants Radix eager-loaded)
  - `lcp-route-hydration` (init useState coûteux)
  - `cls-shifted-blocks` (img/skeleton sans dimension fixe)
  - `content-visibility-gap` (cas #694 below-fold non cv:auto)
  - `cwv-ingestion-gap` (`__seo_cwv_daily` vide alors que stack existe)

**Discipline atomique** par check : ≤ 1 responsabilité, ≤ 100 lignes, frontmatter avec `severity` taxonomie explicite, `confidence` couplée à `expected_false_positive_rate`, `autofixable: false` strict V1 (anti-auto-remediation), `incidents_proven:` OU `risk_documented:` obligatoire.

### 2 hooks neufs (recommandations article Anthropic)
- **`SessionStart`** → `sessionstart-workspace-context.sh` : émet manifest workspace + `TOP`/`DO_NOT_START`/`ACTIVE_INCIDENTS`/`STRUCTURAL_CONSTRAINTS` depuis `.claude/top-priorities.md`. Détection workspace via walk-up `package.json` (worktree-aware, pas `case $PWD`). Output borné ≤ 2000 bytes.
- **`Stop` étendu** → `stop-claude-md-suggest.sh` : détecte ≥ 2 commits fix/revert/correction parmi les 5 derniers, suggère (stderr-only, pas auto-edit) mise à jour MEMORY/CLAUDE.md/rules.

### 1 PostToolUse étendu
- `posttool-lint-check.sh` : branche `validate-skills-frontmatter.js` sur édition `.claude/skills/**/*.md` et `validate-agents-md.sh --file` sur `CLAUDE.md`/`AGENTS.md`. Validators existants réutilisés tels quels (zéro wrapper).

### 1 manifest machine-readable + validator
- `.claude/top-priorities.md` : 4 sections avec bornes strictes (TOP ≤ 5, DO_NOT_START ≤ 7, ACTIVE_INCIDENTS ≤ 10, STRUCTURAL_CONSTRAINTS ≤ 10). Slugs kebab-case stricts.
- `scripts/governance/validate-top-priorities.sh` enforce les bornes (fail si bloat).

### Discipline opérationnelle
- **Rollback rapide** via `CLAUDE_HOOKS_DISABLE=1` sur tous les hooks neufs (pattern `AI_VAULT_WRITE=false` ADR-012).
- **Test bash unifié** `scripts/test-claude-hooks.sh` (pattern repo `test-*.sh` — bats non installé). **19/19 cas passent** (nominal / edge / disable).
- Skills registry régénéré (`build-skills-registry.js`) : 10 skills, 0 issue.
- Ownership registry mis à jour (`.claude/top-priorities.md` → D15 @ak125).

## Refusés explicitement par doctrine

- ❌ Pivot R5/diagnostic engine (PAUSE selon `project_diagnostic_control_plane_v1_plan`)
- ❌ Plugin Claude maison (différé à 8 semaines de mesure)
- ❌ Skills commerce-funnel-audit / diagnostic-auto-r5 / seo-incident-response (prématurés ou déjà couverts par `seo-gamme-audit`)
- ❌ Refactor LSP root `tsconfig.json` (chantier transverse hors scope)
- ❌ Modifications CLAUDE.md de contenu (audit Phase 1 erroné — 3 agents déjà documentés lignes 184-186)
- ❌ AST-universe (refaire dep-cruiser/ts-prune/knip/madge/eslint/CodeQL)

## Phase 8 — mesure 8 semaines post-merge

Critères de succès (avant toute extension) :
- ≥ 1 incident PROD pattern (#690-#698) **prévenu** par invocation skill
- ≥ 5 invocations utiles documentées dans `log.md`
- 0 nouveau skill/hook ajouté entre-temps (STOP at V1)
- 0 régression sur les hooks/skills existants

Si succès → décision plugin packaging conditionnelle. Si échec → retrait/correction, **pas escalation**.

## Test plan

- [x] `node scripts/governance/validate-skills-frontmatter.js` → 10 ok, 0 failure
- [x] `bash scripts/governance/validate-top-priorities.sh` → OK
- [x] `bash scripts/test-claude-hooks.sh` → 19 passed / 0 failed
- [x] `bash scripts/agents/validate-agents-md.sh --staged` → PASS
- [x] Pre-push gate ADR-058 PR-G → OK (ownership registry mis à jour)
- [ ] **Post-merge** : vérifier que `SessionStart` injecte le manifest dans une session Claude Code réelle
- [ ] **Post-merge** : invoquer `Skill: runtime-truth-audit` et confirmer détection rétroactive d'au moins 2 patterns #690-#698
- [ ] **Post-merge** : invoquer `Skill: web-vitals-audit` sur `/pieces/` et confirmer cohérence avec audit manuel #692

Plan complet : `/home/deploy/.claude/plans/squishy-wishing-rabin.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)