### PR TITLE
feat(imgproxy): AVIF auto-negotiation + anti cache-poisoning fallback (ADR-078 follow-up)

### DIFF
--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -41,12 +41,13 @@ automecanik.com, www.automecanik.com {
     redir @apex https://www.automecanik.com{uri} permanent
 
     # ===== IMGPROXY - TRANSFORMATION IMAGES GRATUITE =====
-    # Route: /imgproxy/{processing_options}/plain/{source_url}@{format}
-    # Exemple: /imgproxy/rs:fit:800/q:80/plain/https://supabase.co/.../image.jpg@webp
+    # Route: /imgproxy/{processing_options}/plain/{source_url}[@{format}]
+    # Sans modifier @{format} → imgproxy négocie AVIF > WebP > original via
+    # IMGPROXY_AUTO_AVIF + IMGPROXY_AUTO_WEBP (Accept header navigateur).
     # Documentation: https://docs.imgproxy.net/generating_the_url
     @imgproxy path /imgproxy/*
     handle @imgproxy {
-        # Cache 1 an (Cloudflare edge + navigateur)
+        # Cache 1 an par défaut (success). Overridden pour 4xx ci-dessous.
         header Cache-Control "public, max-age=31536000, immutable"
         header Vary "Accept"
         header X-Robots-Tag "noindex, nofollow"
@@ -57,6 +58,16 @@ automecanik.com, www.automecanik.com {
         reverse_proxy imgproxy:8080 {
             header_up Host imgproxy
             header_down -Server
+
+            # Anti cache-poisoning (INC-2026-015 / ADR-078) — upstream 4xx
+            # (source absente, fallback no.png servi par imgproxy) → cache
+            # court 5min, pas le 1 an immutable du parent (qui piégerait
+            # toute future ingestion sous le même nom).
+            @upstream_4xx status 4xx
+            handle_response @upstream_4xx {
+                header Cache-Control "public, max-age=300, must-revalidate"
+                copy_response
+            }
         }
     }
 
@@ -104,7 +115,9 @@ automecanik.com, www.automecanik.com {
     handle @gamme_images {
         header Cache-Control "public, max-age=31536000, immutable"
         header Vary "Accept"
-        rewrite * /rs:fit:800/q:85/plain/https://cxpojprgwgubzjyqzmoq.supabase.co/storage/v1/object/public/uploads/articles/gammes-produits/r1/{re.gamme_img.1}@webp
+        # No @webp modifier — imgproxy negotiates AVIF > WebP via Accept header
+        # (IMGPROXY_AUTO_AVIF + IMGPROXY_AUTO_WEBP).
+        rewrite * /rs:fit:800/q:85/plain/https://cxpojprgwgubzjyqzmoq.supabase.co/storage/v1/object/public/uploads/articles/gammes-produits/r1/{re.gamme_img.1}
         reverse_proxy imgproxy:8080 {
             header_up Host imgproxy
             header_down -Server
@@ -115,13 +128,13 @@ automecanik.com, www.automecanik.com {
     # URLs historiques stockées en base → imgproxy (WebP optimisé)
     # Préserve le PageRank via 301 permanent + images optimisées
 
-    # /rack/{folder}/{file} → imgproxy WebP (800px, q85)
+    # /rack/{folder}/{file} → imgproxy (négocie AVIF > WebP via Accept)
     @rack_legacy path_regexp rack_path ^/rack/(.+)$
-    redir @rack_legacy /imgproxy/rs:fit:800/q:85/plain/https://cxpojprgwgubzjyqzmoq.supabase.co/storage/v1/object/public/rack-images/{re.rack_path.1}@webp permanent
+    redir @rack_legacy /imgproxy/rs:fit:800/q:85/plain/https://cxpojprgwgubzjyqzmoq.supabase.co/storage/v1/object/public/rack-images/{re.rack_path.1} permanent
 
-    # /upload/{path} → imgproxy WebP (800px, q85)
+    # /upload/{path} → imgproxy (négocie AVIF > WebP via Accept)
     @upload_legacy path_regexp upload_path ^/upload/(.+)$
-    redir @upload_legacy /imgproxy/rs:fit:800/q:85/plain/https://cxpojprgwgubzjyqzmoq.supabase.co/storage/v1/object/public/uploads/{re.upload_path.1}@webp permanent
+    redir @upload_legacy /imgproxy/rs:fit:800/q:85/plain/https://cxpojprgwgubzjyqzmoq.supabase.co/storage/v1/object/public/uploads/{re.upload_path.1} permanent
 
     # ===== SITEMAPS V10 (par temperature + unifie) =====
     # Servis directement depuis /var/www/sitemaps (volume persistant)

--- a/docker-compose.imgproxy.yml
+++ b/docker-compose.imgproxy.yml
@@ -48,16 +48,26 @@ services:
       IMGPROXY_SET_CANONICAL_HEADER: "true"
 
       # ═══════════════════════════════════════════════════════════════
-      # 🛡️ Anti cache-poisoning sur upstream failure (INC-2026-015 / ADR-078)
+      # 🛡️ Anti cache-poisoning sur upstream failure (INC-2026-015 / ADR-078/079)
       # ═══════════════════════════════════════════════════════════════
-      # Avant ce fix : un upstream Supabase 400 (« Source image is unreachable »)
-      # était renvoyé HTTP 200 + cache-control max-age=1an + immutable. Conséquence :
-      # quand Tier B-rev livre enfin les vraies images, le placeholder cached 1 an
-      # gagne tant qu'aucune purge manuelle. Fix : fallback explicite, court-cached
-      # (60s), avec status code de l'upstream (404 si Supabase 404, etc.).
+      # Sans ces 3 vars, un upstream Supabase 400 (« Source image is unreachable »)
+      # était renvoyé HTTP 200 + cache-control max-age=1an + immutable, et Caddy
+      # ne pouvait pas matcher pour court-cache → tout futur Tier B-rev sous le
+      # même nom serait masqué par le placeholder cached 1 an.
+      #
+      # Architecture finale (corrigée v3.2) :
+      #   1. imgproxy détecte upstream 4xx → sert no.png comme fallback.
+      #   2. imgproxy renvoie HTTP 404 explicite (HTTP_CODE=404) — non plus 200.
+      #   3. Caddy `handle_response @upstream_4xx` (Caddyfile) match le 404 et
+      #      écrase Cache-Control en 5min must-revalidate.
+      # → Le placeholder est servi (UX OK), mais cache court → toute future
+      # vraie image arrive sous 5min sans purge manuelle.
       IMGPROXY_FALLBACK_IMAGE_URL: "https://cxpojprgwgubzjyqzmoq.supabase.co/storage/v1/object/public/uploads/articles/no.png"
-      IMGPROXY_FALLBACK_IMAGE_TTL: "60"      # 60 secondes (vs 1 an success)
-      IMGPROXY_FALLBACK_IMAGE_HTTP_CODE: "0" # 0 = passthrough upstream code
+      IMGPROXY_FALLBACK_IMAGE_TTL: "60"        # TTL interne d'imgproxy pour rafraîchir
+                                               # la source fallback en cache mémoire
+                                               # (pas le Cache-Control HTTP renvoyé).
+      IMGPROXY_FALLBACK_IMAGE_HTTP_CODE: "404" # Status explicite 4xx, condition
+                                               # nécessaire pour le matching Caddy.
 
       # Performance
       IMGPROXY_CONCURRENCY: "4"


### PR DESCRIPTION
## Contexte

Suivi [INC-2026-015 / ADR-078 vault#302](https://github.com/ak125/governance-vault/pull/302). Le P1 « stop bleeding UX » avait soft-hidden 1,1 M lignes et activé le fallback no.png via imgproxy. Vérification empirique post-PROD a révélé 2 améliorations restantes :

1. **AVIF non négocié** : le rewrite Caddy hardcodait `@webp` dans l'URL imgproxy → l'auto-selection `IMGPROXY_AUTO_AVIF=true` était court-circuitée. Tous les navigateurs récents recevaient WebP au lieu d'AVIF (~20-30 % de gain bandwidth manqué).

2. **Cache poisoning sur fallback** : imgproxy renvoyait HTTP 200 + `Cache-Control: max-age=31536000, immutable` même sur upstream 4xx. Conséquence : quand Tier B-rev livrera enfin les vraies images sous le même nom, le placeholder cached 1 an gagne tant qu'aucune purge manuelle n'est faite.

## Changements

**`config/caddy/Caddyfile`** :
- Retirer `@webp` des 3 redirs (`@gamme_images`, `@rack_legacy`, `@upload_legacy`) → imgproxy négocie AVIF > WebP via Accept header navigateur.
- Ajouter `handle_response @upstream_4xx` dans `reverse_proxy imgproxy` pour écraser Cache-Control en `max-age=300, must-revalidate` sur 4xx.

**`docker-compose.imgproxy.yml`** :
- `IMGPROXY_FALLBACK_IMAGE_HTTP_CODE: \"404\"` (au lieu de `\"0\"`) pour rendre le fallback HTTP 404 explicite et permettre le matching Caddy ci-dessus.

## Effets attendus PROD post-tag

- AVIF servi à Chrome 85+ / Firefox 93+ / Safari 16+ (UA modernes), WebP fallback pour anciens.
- Fallback no.png cached 5min must-revalidate (au lieu de 1 an immutable) → toute future ingestion de vraies images visible sous 5min sans purge manuelle.
- Aucune régression possible sur les success responses (Cache-Control 1 an inchangé pour 2xx).

## Vérification

- `curl -sIL -H 'Accept: image/avif,image/webp,*/*' .../rack/30/REAL.JPG?ts=…` → Content-Type `image/avif` (UA récent) ou `image/webp` (fallback).
- `curl -sIL .../rack/21/INEXISTANT.JPG` → HTTP 404 + `Cache-Control: max-age=300, must-revalidate` (au lieu de HTTP 200 + 1 an immutable).
- PROD healthcheck inchangé.

## Cross-refs

- Incident : [INC-2026-015 / ADR-078 vault](https://github.com/ak125/governance-vault/pull/302) ✅ merged.
- Long terme : ADR-079 « Product Media Control Plane » (vault, en parallèle de ce PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)