### PR TITLE
feat(commerce-pkg): PR-B — @repo/domain-commerce + order_history event stream + composite RPCs (Vault #301)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -52,6 +52,21 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: high
+  - glob: packages/domain-commerce/**
+    domain: D11
+    owner: '@ak125/payments-team'
+    sourceConfidence: high
+    risk: medium
+  - glob: backend/supabase/migrations/*order_history*
+    domain: D11
+    owner: '@ak125/payments-team'
+    sourceConfidence: high
+    risk: high
+  - glob: backend/supabase/migrations/*cancel_order_atomic*
+    domain: D11
+    owner: '@ak125/payments-team'
+    sourceConfidence: high
+    risk: high
   - glob: scripts/governance/validate-authority-graph.js
     domain: D15
     owner: '@ak125'

--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:d84208039e45684ad38be5be93e6e7fdb4108078df72fc4fed5ccf8375c62572",
+  "artifact_immutability_hash": "sha256:4917dc46713d762e2beafe8e95202fa4c63c7d55fb089f6d63eb3c46562494e0",
   "divergences": [
     {
       "kind": "specifier",
@@ -3953,7 +3953,7 @@
     "deps_registry": "audit/registry/deps.json",
     "deps_registry_sha": "sha256:0f7f54bef54b962cf4c85f2cf430c5bf05526092d9c1035539bcc05ae51b6278",
     "lockfile": "package-lock.json",
-    "lockfile_sha": "sha256:b09ddc2ac722e9c2646af2a8696516a8cc76c6429ece38d5c01f5f8bc32a206c",
+    "lockfile_sha": "sha256:c20c587a85baadcc02bc0b933a9d3a06859ccd0ffb56b7a125205b3123a01a7d",
     "overlay": "audit/dependencies/family-overlay.yaml",
     "overlay_sha": "sha256:c88cee03acf27840da9c5826c7a3edbcd086a70a58ee323d9c32d33ec33c1a57"
   },

--- a/backend/supabase/migrations/20260523_cancel_order_atomic.down.sql
+++ b/backend/supabase/migrations/20260523_cancel_order_atomic.down.sql
@@ -1,0 +1,72 @@
+-- Reversal of 20260523_cancel_order_atomic.sql
+-- IMPORTANT: this rollback restores create_order_atomic to its pre-PR-B signature
+-- (without p_correlation_id parameter, without ORDER_CREATED event emission).
+-- If PR-C (OrdersService refactor) has been merged AND callers pass p_correlation_id,
+-- rolling back THIS migration will break those callers — apply PR-C rollback first.
+
+DROP FUNCTION IF EXISTS public.cancel_order_atomic(TEXT, TEXT, BIGINT, UUID);
+
+-- Restore create_order_atomic to pre-PR-B body (PR #695 baseline + F1 line URL).
+CREATE OR REPLACE FUNCTION public.create_order_atomic(p_order JSONB, p_lines JSONB)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  v_ord_id TEXT;
+  v_line   JSONB;
+BEGIN
+  v_ord_id := p_order->>'ord_id';
+  IF v_ord_id IS NULL OR v_ord_id = '' THEN
+    RAISE EXCEPTION 'ord_id is required';
+  END IF;
+
+  INSERT INTO "___xtr_order" (
+    ord_id, ord_cst_id, ord_date, ord_parent, ord_is_pay, ord_date_pay,
+    ord_amount_ttc, ord_deposit_ttc, ord_shipping_fee_ttc, ord_total_ttc,
+    ord_info, ord_ords_id, ord_cba_id, ord_cda_id,
+    ord_billing_snapshot, ord_shipping_snapshot
+  ) VALUES (
+    v_ord_id,
+    p_order->>'ord_cst_id',
+    p_order->>'ord_date',
+    COALESCE(p_order->>'ord_parent', '0'),
+    COALESCE(p_order->>'ord_is_pay', '0'),
+    NULLIF(p_order->>'ord_date_pay', ''),
+    p_order->>'ord_amount_ttc',
+    p_order->>'ord_deposit_ttc',
+    p_order->>'ord_shipping_fee_ttc',
+    p_order->>'ord_total_ttc',
+    p_order->>'ord_info',
+    COALESCE(p_order->>'ord_ords_id', '1'),
+    NULLIF(p_order->>'ord_cba_id', ''),
+    NULLIF(p_order->>'ord_cda_id', ''),
+    (p_order->'ord_billing_snapshot')::jsonb,
+    (p_order->'ord_shipping_snapshot')::jsonb
+  );
+
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    INSERT INTO "___xtr_order_line" (
+      orl_id, orl_ord_id, orl_pg_id, orl_pg_name, orl_pm_name, orl_art_ref,
+      orl_art_quantity, orl_art_price_sell_unit_ttc, orl_art_price_sell_ttc,
+      orl_art_deposit_unit_ttc, orl_art_deposit_ttc, orl_website_url
+    ) VALUES (
+      v_line->>'orl_id',
+      v_ord_id,
+      v_line->>'orl_pg_id',
+      v_line->>'orl_pg_name',
+      v_line->>'orl_pm_name',
+      v_line->>'orl_art_ref',
+      v_line->>'orl_art_quantity',
+      v_line->>'orl_art_price_sell_unit_ttc',
+      v_line->>'orl_art_price_sell_ttc',
+      v_line->>'orl_art_deposit_unit_ttc',
+      v_line->>'orl_art_deposit_ttc',
+      v_line->>'orl_website_url'
+    );
+  END LOOP;
+
+  RETURN v_ord_id;
+END;
+$function$;

--- a/backend/supabase/migrations/20260523_cancel_order_atomic.sql
+++ b/backend/supabase/migrations/20260523_cancel_order_atomic.sql
@@ -1,0 +1,187 @@
+-- =====================================================
+-- cancel_order_atomic + extend create_order_atomic for atomic audit
+-- Date: 2026-05-23
+-- Refs: plans/utiliser-superpower-p0-modular-brooks.md (PR-B)
+--       governance-vault ADR-079 (Commerce Runtime Authority canon)
+--       Vault #301 résidus F3 deeper rot (OrdersService.cancelOrder broken)
+-- =====================================================
+-- Composite RPCs: UPDATE order + append_order_event in same Postgres transaction.
+-- Benefit: impossible to have UPDATE without event (atomicity). Rollback on any error.
+--
+-- V1 status transitions enforced server-side (defense in depth + same canon as
+-- @repo/domain-commerce.ORDER_STATUS_TRANSITIONS):
+--   - cancel allowed from '1' (PROCESSING), '3' (AWAITING_FEE), '4' (FEE_RECEIVED)
+--   - cancel FORBIDDEN from '5' (PAID) → refund workflow required (payments/ off-limits)
+--   - cancel FORBIDDEN from '2' (CANCELLED) → already terminal
+-- =====================================================
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+-- =====================================================
+-- cancel_order_atomic
+-- =====================================================
+CREATE OR REPLACE FUNCTION public.cancel_order_atomic(
+  p_ord_id         TEXT,
+  p_reason         TEXT,
+  p_user_id        BIGINT,
+  p_correlation_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_from_status TEXT;
+  v_payload     JSONB;
+BEGIN
+  IF p_ord_id IS NULL OR p_ord_id = '' THEN
+    RAISE EXCEPTION 'cancel_order_atomic: p_ord_id is required';
+  END IF;
+
+  IF p_correlation_id IS NULL THEN
+    RAISE EXCEPTION 'cancel_order_atomic: p_correlation_id is required';
+  END IF;
+
+  -- Lock the row & capture from_status atomically
+  SELECT ord_ords_id INTO v_from_status
+  FROM public.___xtr_order
+  WHERE ord_id = p_ord_id
+  FOR UPDATE;
+
+  IF v_from_status IS NULL THEN
+    RAISE EXCEPTION 'cancel_order_atomic: order % not found', p_ord_id;
+  END IF;
+
+  -- Canon V1 transition guards (defense in depth — domain-commerce enforces TS-side).
+  IF v_from_status = '2' THEN
+    RAISE EXCEPTION 'cancel_order_atomic: order % already cancelled (status 2)', p_ord_id;
+  END IF;
+
+  IF v_from_status = '5' THEN
+    RAISE EXCEPTION 'cancel_order_atomic: order % is paid (status 5) — refund workflow required, payments/ module is off-limits (feedback_no_payment_module_changes_ever). V1.7+: reopen via Human Override Authority.', p_ord_id;
+  END IF;
+
+  -- UPDATE order to cancelled status
+  UPDATE public.___xtr_order
+  SET ord_ords_id     = '2',
+      ord_cancel_date = now(),
+      ord_cancel_reason = p_reason,
+      ord_updated_at  = now()
+  WHERE ord_id = p_ord_id;
+
+  -- Build payload with full context for replay / observability
+  v_payload := jsonb_build_object(
+    'reason', COALESCE(p_reason, ''),
+    'cancelled_by_user_id', p_user_id
+  );
+
+  -- Append audit event ATOMICALLY (same transaction — rollback if this fails)
+  PERFORM public.append_order_event(
+    p_ord_id, 'ORDER_CANCELLED', v_from_status, '2',
+    v_payload, 'orders_service',
+    p_correlation_id, p_user_id
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.cancel_order_atomic(TEXT, TEXT, BIGINT, UUID) IS
+  'Composite RPC: UPDATE ___xtr_order to status=2 + append ORDER_CANCELLED event in same transaction. Enforces V1 transition guards (5 → 2 forbidden, refund required). Owner: OrdersService.cancelOrder per authority-graph.yaml#rpc_authority.rpcs.cancel_order_atomic.';
+
+-- =====================================================
+-- create_order_atomic — extend non-breaking with correlation_id + atomic audit
+-- Adds optional p_correlation_id parameter (DEFAULT gen_random_uuid() for back-compat).
+-- Existing callers (no parameter) still work; new callers pass an explicit UUID.
+-- After successful order INSERT, atomically appends ORDER_CREATED event.
+-- =====================================================
+CREATE OR REPLACE FUNCTION public.create_order_atomic(
+  p_order          JSONB,
+  p_lines          JSONB,
+  p_correlation_id UUID DEFAULT gen_random_uuid()
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_ord_id  TEXT;
+  v_line    JSONB;
+  v_payload JSONB;
+BEGIN
+  -- Extract order ID
+  v_ord_id := p_order->>'ord_id';
+
+  IF v_ord_id IS NULL OR v_ord_id = '' THEN
+    RAISE EXCEPTION 'ord_id is required';
+  END IF;
+
+  -- INSERT order (single transaction — auto-rollback on any error)
+  INSERT INTO "___xtr_order" (
+    ord_id, ord_cst_id, ord_date, ord_parent, ord_is_pay, ord_date_pay,
+    ord_amount_ttc, ord_deposit_ttc, ord_shipping_fee_ttc, ord_total_ttc,
+    ord_info, ord_ords_id, ord_cba_id, ord_cda_id,
+    ord_billing_snapshot, ord_shipping_snapshot
+  ) VALUES (
+    v_ord_id,
+    p_order->>'ord_cst_id',
+    p_order->>'ord_date',
+    COALESCE(p_order->>'ord_parent', '0'),
+    COALESCE(p_order->>'ord_is_pay', '0'),
+    NULLIF(p_order->>'ord_date_pay', ''),
+    p_order->>'ord_amount_ttc',
+    p_order->>'ord_deposit_ttc',
+    p_order->>'ord_shipping_fee_ttc',
+    p_order->>'ord_total_ttc',
+    p_order->>'ord_info',
+    COALESCE(p_order->>'ord_ords_id', '1'),
+    NULLIF(p_order->>'ord_cba_id', ''),
+    NULLIF(p_order->>'ord_cda_id', ''),
+    (p_order->'ord_billing_snapshot')::jsonb,
+    (p_order->'ord_shipping_snapshot')::jsonb
+  );
+
+  -- INSERT order lines (loop preserves PR #695 / F1 attribution support)
+  FOR v_line IN SELECT * FROM jsonb_array_elements(p_lines)
+  LOOP
+    INSERT INTO "___xtr_order_line" (
+      orl_id, orl_ord_id, orl_pg_id, orl_pg_name, orl_pm_name, orl_art_ref,
+      orl_art_quantity, orl_art_price_sell_unit_ttc, orl_art_price_sell_ttc,
+      orl_art_deposit_unit_ttc, orl_art_deposit_ttc, orl_website_url
+    ) VALUES (
+      v_line->>'orl_id',
+      v_ord_id,
+      v_line->>'orl_pg_id',
+      v_line->>'orl_pg_name',
+      v_line->>'orl_pm_name',
+      v_line->>'orl_art_ref',
+      v_line->>'orl_art_quantity',
+      v_line->>'orl_art_price_sell_unit_ttc',
+      v_line->>'orl_art_price_sell_ttc',
+      v_line->>'orl_art_deposit_unit_ttc',
+      v_line->>'orl_art_deposit_ttc',
+      v_line->>'orl_website_url'
+    );
+  END LOOP;
+
+  -- ATOMIC audit: append ORDER_CREATED event in same transaction.
+  -- from_status = NULL (creation has no prior state) ; to_status = '1' (PROCESSING canon initial).
+  v_payload := jsonb_build_object(
+    'lines_count', jsonb_array_length(p_lines),
+    'total_ttc',   p_order->>'ord_total_ttc',
+    'customer_id', p_order->>'ord_cst_id'
+  );
+
+  PERFORM public.append_order_event(
+    v_ord_id, 'ORDER_CREATED', NULL, COALESCE(p_order->>'ord_ords_id', '1'),
+    v_payload, 'orders_service',
+    p_correlation_id, NULL
+  );
+
+  RETURN v_ord_id;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.create_order_atomic(JSONB, JSONB, UUID) IS
+  'Composite RPC extended from PR #695: INSERT ___xtr_order + ___xtr_order_line + append ORDER_CREATED event, all in same transaction. p_correlation_id is optional (DEFAULT gen_random_uuid()) for back-compat. Owner: OrdersService.createOrder per authority-graph.yaml#rpc_authority.rpcs.create_order_atomic.';

--- a/backend/supabase/migrations/20260523_create_order_history.down.sql
+++ b/backend/supabase/migrations/20260523_create_order_history.down.sql
@@ -1,0 +1,6 @@
+-- Reversal of 20260523_create_order_history.sql
+DROP FUNCTION IF EXISTS public.append_order_event(TEXT, TEXT, TEXT, TEXT, JSONB, TEXT, UUID, BIGINT);
+DROP INDEX IF EXISTS public.idx_order_history_correlation;
+DROP INDEX IF EXISTS public.idx_order_history_event_type_created;
+DROP INDEX IF EXISTS public.idx_order_history_ord_id_created;
+DROP TABLE IF EXISTS public.___xtr_order_history;

--- a/backend/supabase/migrations/20260523_create_order_history.sql
+++ b/backend/supabase/migrations/20260523_create_order_history.sql
@@ -1,0 +1,157 @@
+-- =====================================================
+-- ___xtr_order_history (event stream, append-only)
+-- Date: 2026-05-23
+-- Refs: plans/utiliser-superpower-p0-modular-brooks.md (PR-B)
+--       governance-vault ADR-079 (Commerce Runtime Authority canon)
+--       Vault #301 résidus F3 deeper rot (createStatusHistory broken)
+-- =====================================================
+-- Schema event-stream extensible: V1 uses 3 event_types (ORDER_CREATED,
+-- STATUS_CHANGED, ORDER_CANCELLED) ; V1.5+ extends via ALTER CHECK additive.
+-- Single entry point for writes: RPC append_order_event (idempotent, RLS-safe).
+-- Causality preserved from day 1 (correlation_id obligatoire) — enables future
+-- event lineage / replay / Operational Knowledge Graph without retro backfill.
+-- =====================================================
+
+-- squawk-ignore-file require-concurrent-index-creation
+-- Justification: ___xtr_order is small (~1.7k rows / ~2 MB) and the new history
+-- table is empty at migration time. CONCURRENTLY would force non-transactional,
+-- losing atomicity. Revisit if history grows past ~1M rows.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+CREATE TABLE IF NOT EXISTS public.___xtr_order_history (
+  hist_id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  ord_id         TEXT NOT NULL,
+  event_type     TEXT NOT NULL,
+  from_status    TEXT,
+  to_status      TEXT,
+  payload        JSONB NOT NULL DEFAULT '{}'::jsonb,
+  source         TEXT NOT NULL DEFAULT 'system',
+  correlation_id UUID NOT NULL,
+  user_id        BIGINT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- FKs (NOT VALID skips existing-row scan — table is empty at migration time).
+ALTER TABLE public.___xtr_order_history
+  DROP CONSTRAINT IF EXISTS fk_order_history_ord_id;
+ALTER TABLE public.___xtr_order_history
+  ADD CONSTRAINT fk_order_history_ord_id
+  FOREIGN KEY (ord_id) REFERENCES public.___xtr_order(ord_id)
+  ON DELETE RESTRICT
+  NOT VALID;
+
+ALTER TABLE public.___xtr_order_history
+  DROP CONSTRAINT IF EXISTS fk_order_history_from_status;
+ALTER TABLE public.___xtr_order_history
+  ADD CONSTRAINT fk_order_history_from_status
+  FOREIGN KEY (from_status) REFERENCES public.___xtr_order_status(ords_id)
+  ON DELETE RESTRICT
+  NOT VALID;
+
+ALTER TABLE public.___xtr_order_history
+  DROP CONSTRAINT IF EXISTS fk_order_history_to_status;
+ALTER TABLE public.___xtr_order_history
+  ADD CONSTRAINT fk_order_history_to_status
+  FOREIGN KEY (to_status) REFERENCES public.___xtr_order_status(ords_id)
+  ON DELETE RESTRICT
+  NOT VALID;
+
+-- Canon event_type enum (extensible: V1.5+ adds via ALTER CHECK additive).
+ALTER TABLE public.___xtr_order_history
+  DROP CONSTRAINT IF EXISTS chk_order_history_event_type;
+ALTER TABLE public.___xtr_order_history
+  ADD CONSTRAINT chk_order_history_event_type
+  CHECK (event_type IN (
+    'ORDER_CREATED',
+    'ORDER_CANCELLED',
+    'STATUS_CHANGED',
+    'NOTE_UPDATED',
+    'ADDRESS_UPDATED',
+    'PAYMENT_CONFIRMED'
+  ));
+
+-- Indexes optimized for common read paths:
+--   1. order detail timeline (ord_id, created_at DESC)
+--   2. global event monitoring (event_type, created_at DESC)
+--   3. correlation lineage (correlation_id) — partial to skip NULLs (none expected,
+--      but kept as belt-and-suspenders to allow future migration loosening NOT NULL).
+CREATE INDEX IF NOT EXISTS idx_order_history_ord_id_created
+  ON public.___xtr_order_history (ord_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_order_history_event_type_created
+  ON public.___xtr_order_history (event_type, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_order_history_correlation
+  ON public.___xtr_order_history (correlation_id);
+
+-- RLS enabled — append-only via RPC only.
+-- Pas de policy INSERT direct côté authenticated : tous les appels passent par
+-- la RPC append_order_event (SECURITY DEFINER) déclarée plus bas, qui est elle
+-- même restreinte aux modules orders.* via ast-grep commerce-no-rpc-without-authority.
+ALTER TABLE public.___xtr_order_history ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "order_history_admin_read" ON public.___xtr_order_history;
+CREATE POLICY "order_history_admin_read"
+  ON public.___xtr_order_history
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+COMMENT ON TABLE public.___xtr_order_history IS
+  'Event stream append-only pour le cycle de vie commande. Canon: .spec/00-canon/commerce-runtime/authority-graph.yaml#rpc_authority. Writes via RPC append_order_event uniquement (atomique avec create_order_atomic / cancel_order_atomic).';
+
+-- =====================================================
+-- RPC append_order_event
+-- Single entry point for INSERT into ___xtr_order_history.
+-- Called from inside cancel_order_atomic / create_order_atomic for atomic audit,
+-- and from OrderStatusService.createStatusHistory for standalone events.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.append_order_event(
+  p_ord_id         TEXT,
+  p_event_type     TEXT,
+  p_from_status    TEXT,
+  p_to_status      TEXT,
+  p_payload        JSONB,
+  p_source         TEXT,
+  p_correlation_id UUID,
+  p_user_id        BIGINT DEFAULT NULL
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_hist_id BIGINT;
+BEGIN
+  IF p_ord_id IS NULL OR p_ord_id = '' THEN
+    RAISE EXCEPTION 'append_order_event: p_ord_id is required';
+  END IF;
+
+  IF p_event_type IS NULL OR p_event_type = '' THEN
+    RAISE EXCEPTION 'append_order_event: p_event_type is required';
+  END IF;
+
+  IF p_correlation_id IS NULL THEN
+    RAISE EXCEPTION 'append_order_event: p_correlation_id is required (causality preserved from day 1)';
+  END IF;
+
+  INSERT INTO public.___xtr_order_history (
+    ord_id, event_type, from_status, to_status,
+    payload, source, correlation_id, user_id
+  ) VALUES (
+    p_ord_id, p_event_type, p_from_status, p_to_status,
+    COALESCE(p_payload, '{}'::jsonb), COALESCE(p_source, 'system'),
+    p_correlation_id, p_user_id
+  )
+  RETURNING hist_id INTO v_hist_id;
+
+  RETURN v_hist_id;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.append_order_event(TEXT, TEXT, TEXT, TEXT, JSONB, TEXT, UUID, BIGINT) IS
+  'Single entry point for ___xtr_order_history INSERTs. Called from cancel_order_atomic / create_order_atomic (atomic audit) and from OrderStatusService.createStatusHistory (standalone). Owner: OrderStatusService.createStatusHistory per authority-graph.yaml#rpc_authority.rpcs.append_order_event.';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9573,6 +9573,10 @@
       "resolved": "packages/database-types",
       "link": true
     },
+    "node_modules/@repo/domain-commerce": {
+      "resolved": "packages/domain-commerce",
+      "link": true
+    },
     "node_modules/@repo/registry": {
       "resolved": "packages/registry",
       "link": true
@@ -40856,6 +40860,15 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "packages/domain-commerce": {
+      "name": "@repo/domain-commerce",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.9.3"
       }
     },
     "packages/eslint-config": {

--- a/packages/domain-commerce/package.json
+++ b/packages/domain-commerce/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@repo/domain-commerce",
+  "version": "0.1.0",
+  "description": "Single source of truth for commerce domain enums (order status, order line status) + canonical transitions + event types. Consumed by backend services, admin frontend, BullMQ workers, and analytics. ADR-079.",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/**/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/domain-commerce/src/index.ts
+++ b/packages/domain-commerce/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @repo/domain-commerce
+ *
+ * Canon enums and transitions for the commerce domain.
+ * Consumed by backend services, admin frontend, BullMQ workers, analytics.
+ *
+ * Resolves the divergence between '2' (DB) / 'cancelled' (label) / ORDER_CANCELLED
+ * (event) / status=2 (legacy code) that motivated the package creation (Vault #301).
+ *
+ * See .spec/00-canon/commerce-runtime/authority-graph.yaml for the runtime
+ * authority canon this package types.
+ */
+
+export {
+  OrderStatus,
+  type OrderStatusCode,
+  ORDER_STATUS_LABEL,
+  ORDER_STATUS_TRANSITIONS,
+  isOrderStatusCode,
+  isValidTransition,
+  getOrderStatusLabel,
+} from './order-status';
+
+export {
+  OrderLineStatus,
+  type OrderLineStatusCode,
+  ORDER_LINE_STATUS_LABEL,
+  isOrderLineStatusCode,
+  getOrderLineStatusLabel,
+} from './order-line-status';
+
+export {
+  OrderEventType,
+  type OrderEventTypeCode,
+  isOrderEventType,
+} from './order-events';

--- a/packages/domain-commerce/src/order-events.ts
+++ b/packages/domain-commerce/src/order-events.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical order event types written to ___xtr_order_history.event_type.
+ *
+ * V1 uses: ORDER_CREATED, STATUS_CHANGED, ORDER_CANCELLED.
+ * Schema permits NOTE_UPDATED, ADDRESS_UPDATED, PAYMENT_CONFIRMED for V1.5+
+ * (extension via ALTER TABLE CHECK additive, idempotent migration).
+ *
+ * Single entry point for writes: RPC append_order_event (idempotent, RLS-safe,
+ * called from inside cancel_order_atomic / create_order_atomic transactions
+ * for atomic audit trail).
+ */
+
+export const OrderEventType = {
+  ORDER_CREATED: 'ORDER_CREATED',
+  ORDER_CANCELLED: 'ORDER_CANCELLED',
+  STATUS_CHANGED: 'STATUS_CHANGED',
+  NOTE_UPDATED: 'NOTE_UPDATED',
+  ADDRESS_UPDATED: 'ADDRESS_UPDATED',
+  PAYMENT_CONFIRMED: 'PAYMENT_CONFIRMED',
+} as const;
+
+export type OrderEventTypeCode =
+  (typeof OrderEventType)[keyof typeof OrderEventType];
+
+export function isOrderEventType(value: unknown): value is OrderEventTypeCode {
+  return (
+    typeof value === 'string' &&
+    Object.values(OrderEventType).includes(value as OrderEventTypeCode)
+  );
+}

--- a/packages/domain-commerce/src/order-line-status.test.ts
+++ b/packages/domain-commerce/src/order-line-status.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  OrderLineStatus,
+  ORDER_LINE_STATUS_LABEL,
+  isOrderLineStatusCode,
+  getOrderLineStatusLabel,
+} from './order-line-status';
+
+describe('OrderLineStatus enum', () => {
+  it('has the 10 canonical DB values (1..6, 91..94)', () => {
+    assert.deepEqual(
+      Object.values(OrderLineStatus).sort(),
+      ['1', '2', '3', '4', '5', '6', '91', '92', '93', '94'].sort(),
+    );
+  });
+
+  it('exposes equivalence workflow statuses (91..94)', () => {
+    assert.equal(OrderLineStatus.EQUIV_PROPOSED, '91');
+    assert.equal(OrderLineStatus.EQUIV_VALIDATED, '94');
+  });
+});
+
+describe('ORDER_LINE_STATUS_LABEL', () => {
+  it('has a label for each canon code', () => {
+    for (const code of Object.values(OrderLineStatus)) {
+      assert.ok(
+        typeof ORDER_LINE_STATUS_LABEL[code] === 'string' &&
+          ORDER_LINE_STATUS_LABEL[code].length > 0,
+        `missing label for ${code}`,
+      );
+    }
+  });
+
+  it('exposes the FR label exactly as DB stores it', () => {
+    assert.equal(ORDER_LINE_STATUS_LABEL['5'], 'Pièce disponible');
+    assert.equal(ORDER_LINE_STATUS_LABEL['91'], "Proposition d'équivalence");
+  });
+});
+
+describe('isOrderLineStatusCode type guard', () => {
+  it('accepts canonical codes', () => {
+    assert.equal(isOrderLineStatusCode('1'), true);
+    assert.equal(isOrderLineStatusCode('94'), true);
+  });
+
+  it('rejects non-canonical values', () => {
+    assert.equal(isOrderLineStatusCode('99'), false);
+    assert.equal(isOrderLineStatusCode('7'), false);
+    assert.equal(isOrderLineStatusCode(91), false);
+  });
+});
+
+describe('getOrderLineStatusLabel', () => {
+  it('returns the canonical FR label', () => {
+    assert.equal(getOrderLineStatusLabel('2'), 'Pièce annulée');
+    assert.equal(getOrderLineStatusLabel('92'), 'Equivalence acceptée');
+  });
+});

--- a/packages/domain-commerce/src/order-line-status.ts
+++ b/packages/domain-commerce/src/order-line-status.ts
@@ -1,0 +1,49 @@
+/**
+ * Canonical order line status (___xtr_order_line.orl_orls_id, FK ___xtr_order_line_status.orls_id).
+ *
+ * Source of truth: DB lookup ___xtr_order_line_status (10 rows, verified live
+ * 2026-05-23 project cxpojprgwgubzjyqzmoq). Vault #301 F3 confirmed SoT.
+ *
+ * Managed by OrderActionsService (backend/src/modules/orders/services/order-actions.service.ts).
+ * Direct writes on orl_orls_id from other services are forbidden by ast-grep rule
+ * commerce-no-direct-line-status-write.
+ */
+
+export const OrderLineStatus = {
+  PENDING: '1',
+  CANCELLED: '2',
+  NOT_COMPATIBLE: '3',
+  NOT_AVAILABLE: '4',
+  AVAILABLE: '5',
+  ORDERED_FROM_SUPPLIER: '6',
+  EQUIV_PROPOSED: '91',
+  EQUIV_ACCEPTED: '92',
+  EQUIV_REFUSED: '93',
+  EQUIV_VALIDATED: '94',
+} as const;
+
+export type OrderLineStatusCode =
+  (typeof OrderLineStatus)[keyof typeof OrderLineStatus];
+
+export const ORDER_LINE_STATUS_LABEL: Record<OrderLineStatusCode, string> = {
+  '1': 'Pièce en attente de traitement',
+  '2': 'Pièce annulée',
+  '3': 'Pièce non compatible',
+  '4': 'Pièce non disponible',
+  '5': 'Pièce disponible',
+  '6': 'Pièce commandée chez fournisseur',
+  '91': "Proposition d'équivalence",
+  '92': 'Equivalence acceptée',
+  '93': 'Equivalence refusée',
+  '94': "Valider l'équivalence",
+};
+
+export function isOrderLineStatusCode(
+  value: unknown,
+): value is OrderLineStatusCode {
+  return typeof value === 'string' && value in ORDER_LINE_STATUS_LABEL;
+}
+
+export function getOrderLineStatusLabel(status: OrderLineStatusCode): string {
+  return ORDER_LINE_STATUS_LABEL[status];
+}

--- a/packages/domain-commerce/src/order-status.test.ts
+++ b/packages/domain-commerce/src/order-status.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  OrderStatus,
+  ORDER_STATUS_LABEL,
+  ORDER_STATUS_TRANSITIONS,
+  isOrderStatusCode,
+  isValidTransition,
+  getOrderStatusLabel,
+} from './order-status';
+
+describe('OrderStatus enum', () => {
+  it('has the 5 canonical DB values', () => {
+    assert.deepEqual(Object.values(OrderStatus).sort(), ['1', '2', '3', '4', '5']);
+  });
+
+  it('PROCESSING is 1, CANCELLED is 2, PAID is 5', () => {
+    assert.equal(OrderStatus.PROCESSING, '1');
+    assert.equal(OrderStatus.CANCELLED, '2');
+    assert.equal(OrderStatus.PAID, '5');
+  });
+});
+
+describe('ORDER_STATUS_LABEL', () => {
+  it('has a label for each canon code', () => {
+    for (const code of Object.values(OrderStatus)) {
+      assert.ok(
+        typeof ORDER_STATUS_LABEL[code] === 'string' && ORDER_STATUS_LABEL[code].length > 0,
+        `missing label for ${code}`,
+      );
+    }
+  });
+
+  it('exposes the cancellation label exactly as DB stores it', () => {
+    assert.equal(ORDER_STATUS_LABEL['2'], 'Commande annulée');
+  });
+});
+
+describe('ORDER_STATUS_TRANSITIONS — V1 anti-refund invariant', () => {
+  it('5 (PAID) is terminal — refund would require payments/ module (off-limits)', () => {
+    assert.deepEqual(ORDER_STATUS_TRANSITIONS['5'], []);
+    assert.equal(isValidTransition('5', '2'), false);
+  });
+
+  it('2 (CANCELLED) is terminal', () => {
+    assert.deepEqual(ORDER_STATUS_TRANSITIONS['2'], []);
+  });
+
+  it('1 → 2 (cancel from processing) is valid', () => {
+    assert.equal(isValidTransition('1', '2'), true);
+  });
+
+  it('1 → 5 (processing → paid) is valid', () => {
+    assert.equal(isValidTransition('1', '5'), true);
+  });
+
+  it('1 → 3 (processing → awaiting fee) is valid', () => {
+    assert.equal(isValidTransition('1', '3'), true);
+  });
+
+  it('3 → 4 → 5 (fee workflow) is valid', () => {
+    assert.equal(isValidTransition('3', '4'), true);
+    assert.equal(isValidTransition('4', '5'), true);
+  });
+
+  it('5 → 1 (paid → processing) is invalid', () => {
+    assert.equal(isValidTransition('5', '1'), false);
+  });
+
+  it('2 → 1 (cancelled → processing) is invalid', () => {
+    assert.equal(isValidTransition('2', '1'), false);
+  });
+});
+
+describe('isOrderStatusCode type guard', () => {
+  it('accepts canonical codes', () => {
+    assert.equal(isOrderStatusCode('1'), true);
+    assert.equal(isOrderStatusCode('5'), true);
+  });
+
+  it('rejects non-canonical values', () => {
+    assert.equal(isOrderStatusCode('99'), false);
+    assert.equal(isOrderStatusCode('6'), false);
+    assert.equal(isOrderStatusCode(2), false);
+    assert.equal(isOrderStatusCode(null), false);
+    assert.equal(isOrderStatusCode(undefined), false);
+    assert.equal(isOrderStatusCode(''), false);
+  });
+});
+
+describe('getOrderStatusLabel', () => {
+  it('returns the canonical FR label', () => {
+    assert.equal(getOrderStatusLabel('1'), 'Commande en cours de traitement');
+    assert.equal(getOrderStatusLabel('5'), 'Payée — En préparation');
+  });
+});

--- a/packages/domain-commerce/src/order-status.ts
+++ b/packages/domain-commerce/src/order-status.ts
@@ -1,0 +1,54 @@
+/**
+ * Canonical order status (___xtr_order.ord_ords_id, FK ___xtr_order_status.ords_id).
+ *
+ * Source of truth: DB lookup ___xtr_order_status (5 rows, verified live 2026-05-23
+ * project cxpojprgwgubzjyqzmoq). Vault #301 audit — canonical values.
+ *
+ * IMPORTANT V1: transition 5 → 2 (cancel paid order) is FORBIDDEN.
+ *   Reason: refund requires the payments/ module (Paybox/SystemPay) which is
+ *   STRICTLY off-limits (cf. feedback_no_payment_module_changes_ever). Without
+ *   refund gate, status='2' DB + money kept = customer dispute + accounting drift.
+ *   V1.7+: the transition can be reopened via Human Override Authority
+ *   (admin double-auth, TTL <= 4h) coupled with a manual refund workflow.
+ */
+
+export const OrderStatus = {
+  PROCESSING: '1',
+  CANCELLED: '2',
+  AWAITING_SHIPPING_FEE: '3',
+  SHIPPING_FEE_RECEIVED: '4',
+  PAID: '5',
+} as const;
+
+export type OrderStatusCode = (typeof OrderStatus)[keyof typeof OrderStatus];
+
+export const ORDER_STATUS_LABEL: Record<OrderStatusCode, string> = {
+  '1': 'Commande en cours de traitement',
+  '2': 'Commande annulée',
+  '3': 'En attente de rajout de frais de port',
+  '4': 'Rajout de frais de port reçu',
+  '5': 'Payée — En préparation',
+};
+
+export const ORDER_STATUS_TRANSITIONS: Record<OrderStatusCode, OrderStatusCode[]> = {
+  '1': ['2', '3', '5'],
+  '2': [],
+  '3': ['4', '2'],
+  '4': ['5', '2'],
+  '5': [],
+};
+
+export function isOrderStatusCode(value: unknown): value is OrderStatusCode {
+  return typeof value === 'string' && value in ORDER_STATUS_LABEL;
+}
+
+export function isValidTransition(
+  from: OrderStatusCode,
+  to: OrderStatusCode,
+): boolean {
+  return ORDER_STATUS_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function getOrderStatusLabel(status: OrderStatusCode): string {
+  return ORDER_STATUS_LABEL[status];
+}

--- a/packages/domain-commerce/tsconfig.json
+++ b/packages/domain-commerce/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

**Foundation PR-B of 4** (V1 Commerce Runtime Control Plane). Builds on PR-A canon (#703).

Ships:
1. **`@repo/domain-commerce`** — typed enums + canonical transitions + label resolvers (22 tests pass)
2. **Migration `___xtr_order_history`** — append-only event stream (RLS, FK to ___xtr_order + ___xtr_order_status, CHECK on event_type)
3. **RPC `append_order_event`** — single entry point for history INSERTs
4. **RPC `cancel_order_atomic`** — composite (UPDATE order + append event in same tx, transition guard enforced)
5. **Extension `create_order_atomic`** non-breaking — adds optional `p_correlation_id` + atomically appends `ORDER_CREATED` event

## V1 anti-refund invariant matérialisé

`ORDER_STATUS_TRANSITIONS['5'] = []` (terminal) **côté TS**, et `cancel_order_atomic` `RAISE EXCEPTION` sur `from_status='5'` **côté DB** (defense in depth). Aligné avec `feedback_no_payment_module_changes_ever` — annuler une commande payée requiert un workflow refund manuel hors-scope V1.

## Test results

```
$ npm run build -w @repo/domain-commerce
✓ tsc clean (dist/ generated)

$ npm test -w @repo/domain-commerce
# tests 22 / pass 22 / fail 0

$ node scripts/governance/validate-authority-graph.js
commerce-runtime/authority-graph.yaml: 213 lines, schemaOk=true
Summary: 0 error(s), 3 warning(s)   # test files planned for PR-C
```

## Ownership entries added

- `packages/domain-commerce/**` → D11 / @ak125/payments-team / medium
- `backend/supabase/migrations/*order_history*` → D11 / @ak125/payments-team / high
- `backend/supabase/migrations/*cancel_order_atomic*` → D11 / @ak125/payments-team / high

## Migration application

Migrations are **NOT auto-applied** at merge (cf. `feedback_branch_scope_discipline` axe 4). After merge: trigger `apply-supabase-migrations.yml` workflow (gated owner GO).

State after migration applied:
- `___xtr_order_history` table empty (no backfill — history starts post-deploy, intentional)
- `append_order_event` + `cancel_order_atomic` callable from `orders.*` services
- `create_order_atomic` accepts `p_correlation_id` (back-compat preserved — existing callers continue working)
- `OrdersService.cancelOrder` **still broken** until PR-C lands (transitional state safe — no new regression vs main, just gap audit for cancel actions until PR-C consumes the RPC)

## Plan & companion ADR

- Plan: `/home/deploy/.claude/plans/utiliser-superpower-p0-modular-brooks.md`
- Canon: `.spec/00-canon/commerce-runtime/authority-graph.yaml#rpc_authority` (declared PR-A)
- Companion ADR: **ADR-079** (Commerce Runtime Authority canon) — to file in `ak125/governance-vault` after V1 lands

## Test plan

- [ ] CI `commerce-runtime-canon-gate` workflow runs green (no canon changes here)
- [ ] CI lint section (ast-grep + ESLint + TypeScript) passes
- [ ] CI Migration Safety check passes (additive migrations, idempotent, FKs NOT VALID)
- [ ] After merge: owner triggers `apply-supabase-migrations.yml` for `20260523_create_order_history` and `20260523_cancel_order_atomic`
- [ ] Owner: verify migration applies clean on DB live (check `___xtr_order_history` table exists + RPCs callable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)