### PR TITLE
feat(diagnostic): V1A.0 post-merge hardening guards (ADR-080 amendment follow-up)

### DIFF
--- a/.ast-grep/rules/diagnostic-intent-layer-pure-no-db.yml
+++ b/.ast-grep/rules/diagnostic-intent-layer-pure-no-db.yml
@@ -1,0 +1,63 @@
+id: diagnostic-intent-layer-pure-no-db
+language: typescript
+severity: error
+message: |
+  V1A.0 — Intent Resolution layer = **pure**, aucun accès direct DB
+  (cf. ADR-080 §1 composition pure + §2 backend SoT + §3 boundary
+  non-indexabilité amendement 2026-05-24).
+
+  Les 5 services Intent (IntentClassifier / ActionRecommender /
+  DiagnosticResolutionPipeline / HumanEscalationBuilder / InvariantAsserter)
+  ne doivent JAMAIS appeler `.from()` directement sur Supabase.
+
+  Contrat V1A.0 :
+    INPUT  ← EvidencePack canonique (calculé par engines amont)
+    OUTPUT → OutcomeEmitter (un seul canonical event `diagnostic_resolution_outcome`,
+             hors scope cette règle, write légitime vers __seo_event_log)
+
+  Si tu as besoin de DB read : passe par EvidencePack ou ajoute le calcul à
+  un engine amont (signal-interpretation, hypothesis-scoring, etc.).
+  Si tu as besoin d'un write autre que le canonical event : c'est très
+  probablement une violation de doctrine (cardinality explosion, double-truth).
+
+note: |
+  Pourquoi Intent layer = pure :
+
+    1. **Composition pure pipeline ≤50 LOC** (ADR-080 §1) — un appel DB
+       force la logique métier dans le pipeline.
+    2. **Backend = SoT unique, frontend = renderer pur** (ADR-080 §2) —
+       les services Intent assemblent le payload depuis EvidencePack.
+    3. **Boundary non-indexabilité** (ADR-080 §3 amendement) — Intent layer
+       NE DOIT JAMAIS muter __seo_* (mute potentiellement le contenu
+       indexable → drift SEO-implicite). Le pattern "no .from()" couvre
+       cette interdiction par construction.
+    4. **Replayability V1.1** (ADR-080 V1.1 gate) — output_hash =
+       sha256(canonical(input + pipeline_version)) exige inputs immutables ;
+       un appel DB live introduit une dépendance externe non-replay.
+
+  Cette règle est plus stricte que l'amendement ADR-080 (qui parlait de
+  "track __seo_* mutations") mais cohérente avec la doctrine ADR-080
+  §1/§2/§3. Si un Intent service a besoin de DB, c'est un signal architectural
+  à challenger en review.
+
+  Si false-positive légitime : ajouter le fichier à `ignores:` avec
+  commentaire ADR-amendment.
+
+files:
+  - backend/src/modules/diagnostic-engine/services/intent-classifier.service.ts
+  - backend/src/modules/diagnostic-engine/services/action-recommender.service.ts
+  - backend/src/modules/diagnostic-engine/services/diagnostic-resolution-pipeline.service.ts
+  - backend/src/modules/diagnostic-engine/services/human-escalation-builder.service.ts
+  - backend/src/modules/diagnostic-engine/services/invariant-asserter.service.ts
+
+ignores:
+  # Tests : Supabase mock OK en test
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "**/__tests__/**"
+
+rule:
+  any:
+    - pattern: $X.from($T)
+    - pattern: this.supabase.from($T)
+    - pattern: supabase.from($T)

--- a/.ast-grep/rules/diagnostic-no-adaptive-scoring-v1ax.yml
+++ b/.ast-grep/rules/diagnostic-no-adaptive-scoring-v1ax.yml
@@ -1,0 +1,66 @@
+id: diagnostic-no-adaptive-scoring-v1ax
+language: typescript
+severity: error
+message: |
+  V1A.0 — Scoring discipline (cf. ADR-080 §"Determinism guarantee V1A.x",
+  amendement 2026-05-24).
+
+  Le pipeline V1A.0 (IntentClassifier / ActionRecommender /
+  DiagnosticResolutionPipeline / HumanEscalationBuilder / InvariantAsserter)
+  doit rester **règles déterministes pures**.
+
+  INTERDIT en V1A.x :
+    - stochasticité runtime : Math.random / crypto.randomBytes / Date.now() % N
+    - adaptive scoring : learnedWeights, userAffinity, boostFactor, adaptiveScore
+    - online learning : onlineLearning, modèles auto-calibrés au runtime
+    - probabilistic feedback loops (boucle outcome → poids futurs)
+    - heuristique adaptative ("petit score dynamique", "boost comportemental")
+
+  Tout scoring V1A.x = règles déterministes pures. Si un score doit varier,
+  ce sont des constantes hardcodées (score += 2 pour règle X) dans des
+  branches déterministes.
+
+  Si tu as besoin d'adaptive scoring / ML / boucle outcome → c'est V1.5+
+  (gate-locked, ADR amendment requis cf. ADR-077 G9). Pas d'unlock anticipé.
+
+note: |
+  Le déterminisme V1A.x garantit :
+    1. Replayability V1.1 — output_hash = sha256(canonical(input + pipeline_version))
+    2. Debug auditable — même input ⇒ même output, traçable forensiquement
+    3. A/B comparaisons valides — pas de drift latent
+    4. Aucun comportement émergent non-traçable
+
+  Précédent canon :
+    - ADR-080 §"Determinism guarantee V1A.x" (amendement 2026-05-24)
+    - ADR-077 STOP-at-V1 G9 (10 gates V1.5+ deferral)
+    - memory feedback_v1_first_dont_build_ultimate_engine_too_early
+
+  Si false-positive légitime : ajouter le fichier à `ignores:` ci-dessus
+  avec commentaire expliquant pourquoi.
+
+files:
+  - backend/src/modules/diagnostic-engine/services/intent-classifier.service.ts
+  - backend/src/modules/diagnostic-engine/services/action-recommender.service.ts
+  - backend/src/modules/diagnostic-engine/services/diagnostic-resolution-pipeline.service.ts
+  - backend/src/modules/diagnostic-engine/services/human-escalation-builder.service.ts
+  - backend/src/modules/diagnostic-engine/services/invariant-asserter.service.ts
+
+ignores:
+  # Tests : fixtures aléatoires + jest seeded mocks autorisés
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "**/__tests__/**"
+
+rule:
+  any:
+    # ── Stochasticité runtime ──
+    - pattern: Math.random()
+    - pattern: 'crypto.randomBytes($$$)'
+    - pattern: 'crypto.randomInt($$$)'
+    - pattern: 'Date.now() % $_'
+    # ── Adaptive scoring / online learning identifiers ──
+    - pattern: learnedWeights
+    - pattern: userAffinity
+    - pattern: adaptiveScore
+    - pattern: onlineLearning
+    - pattern: boostFactor

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -210,6 +210,31 @@ SEO_ALERTS_EMAIL_TO=
 SEO_ALERTS_THRESHOLD_POSITION_PCT=20
 SEO_ALERTS_THRESHOLD_TRAFFIC_PCT=30
 
+# ─────────────────────────────────────────────────────────────────────────────
+# DIAGNOSTIC RESOLUTION PIPELINE V1A.0 (ADR-080 — Intent Resolution V1)
+# ─────────────────────────────────────────────────────────────────────────────
+# Feature flag canon V1A.0 — gate le câblage R5 traffic SEO → Diagnostic Engine
+# → CTA commerce via DiagnosticResolutionPipelineService (composition pure ≤50 LOC).
+#
+# Default OFF par construction (zéro régression). Si absent ou "false" : page R5
+# sert HTML actuel pur SEO inchangé (feature OFF par défaut, controller fallback
+# explicit cf. diagnostic-engine.controller.ts:63).
+#
+# Rollout progressif après V1A.0 ship-gate (ADR-080 §Acceptance Criteria) :
+#   - "false" (default)  → V1A.0 désactivé partout
+#   - "true" + 5% traffic → première mesure prod (14j observation)
+#   - "true" + 25%        → escalation après gates verts
+#   - "true" + 100%       → full rollout
+#
+# Gates V1A.0 → V1A.1 :
+#   - resolved_intent_rate ≥ 55%
+#   - intent_to_commerce_rate ≥ baseline + 20%
+#   - human_escalation_uptake_rate mesuré
+#   - 0 incident sev2+ pendant 14j prod
+#
+# ADR follow-up : graduation vers GrowthBook canon Phase 2.
+DIAGNOSTIC_PIPELINE_V1_ENABLED=false
+
 # Chrome UX Report (CrUX) API key — ADR-063 (Accepted 2026-05-14)
 # Scope : Chrome UX Report API in Google Cloud Console.
 # Quota gratuit : 150 RPM. V1 consomme ~102 calls/jour (< 1 RPM moyen).


### PR DESCRIPTION
## Summary

PR #711 (V1A.0 Intent Resolution code, 2463 LOC) merged earlier than planned via stack-merge with audit #708. Audit confirms the V1A.0 layer is doctrine-compliant **but** the 2 mechanical guards promised in [vault ADR-080 amendment 2026-05-24](https://github.com/ak125/governance-vault/pull/304) are not yet in place — V1A.0 is **not "safe to operate"** until these ratchets activate.

This PR ships them.

## What ships

- **`.ast-grep/rules/diagnostic-no-adaptive-scoring-v1ax.yml`** (severity: error) — Flags `Math.random`, `crypto.random*`, `Date.now() % N`, `learnedWeights`, `userAffinity`, `adaptiveScore`, `onlineLearning`, `boostFactor` in the 5 V1A.0 Intent layer service files. Implements ADR-080 §"Determinism guarantee V1A.x".

- **`.ast-grep/rules/diagnostic-intent-layer-pure-no-db.yml`** (severity: error) — Flags any `.from()` / `supabase.from()` in V1A.0 Intent layer services (`intent-classifier`, `action-recommender`, `pipeline`, `escalation-builder`, `invariant-asserter`). **outcome-emitter is OUT of scope** (legitimate canonical `__seo_event_log` write). Stricter than the amendment text — broader "no DB at all" is more robust and aligned with ADR-080 §1 (composition pure) + §2 (backend SoT) + §3 (boundary non-indexabilité).

- **`backend/.env.example`** — Documents `DIAGNOSTIC_PIPELINE_V1_ENABLED=false` default + rollout gates 5%/25%/100% per ADR-080 §Acceptance Criteria.

## Audit results (pre-PR, on origin/main HEAD `938f23e08`)

| # | Pattern | Result |
|---|---------|--------|
| A1 | `__seo_*` mut from Intent | ✓ clean (only legitimate event_log via outcome-emitter) |
| A2 | `Math.random` / stochasticity in V1A.0 | ✓ clean |
| A3 | Adaptive scoring patterns in V1A.0 | ✓ clean (hypothesis-scoring is pre-V1A.0, uses deterministic `score += N` constants) |
| A4 | RAG facts consumed by Intent | ✓ clean (Finding #1 respected) |
| A5 | Canonical event count | ✓ exactly 1 `diagnostic_resolution_outcome` |
| A6 | Frontend renderer purity | ✓ clean (no sort/filter/if intent) |

Both new rules tested locally via `npx ast-grep scan` : **0 violations on current main**.

## Why now

User feedback 2026-05-24 : "cascade réussie, mais ne pas considérer V1A.0 'safe to operate' tant que les 2 ast-grep guards post-merge ne sont pas en place." Correct call — without these ratchets, the next dev session could accidentally introduce adaptive scoring or SEO-content mutation in the Intent layer, and the doctrine would only be enforced socially (PR review). With ratchet : enforced mechanically at CI time.

## Test plan

- [x] `npx ast-grep scan --config sgconfig.yml --rule .ast-grep/rules/diagnostic-no-adaptive-scoring-v1ax.yml` → 0 violations
- [x] `npx ast-grep scan --config sgconfig.yml --rule .ast-grep/rules/diagnostic-intent-layer-pure-no-db.yml` → 0 violations
- [ ] CI ast-grep job passes
- [ ] CI Block-new gate passes (rules covered by existing `.ast-grep/rules/**` D15 ownership glob)
- [ ] Flag `DIAGNOSTIC_PIPELINE_V1_ENABLED` documented in `.env.example` is recognized as default-OFF by env-validation (no test added — flag is already optional)

## Post-merge

V1A.0 "safe to operate" = ratchet active. Next step (yours, not in this PR) :
1. Flip flag to `DIAGNOSTIC_PIPELINE_V1_ENABLED=true` in PROD .env with 5% rollout
2. 14j prod observation per ADR-080 V1A.0 → V1A.1 gates
3. Measure `resolved_intent_rate ≥ 55%` + `intent_to_commerce_rate ≥ baseline+20%` + 0 sev2+

## Related

- Vault ADR-080 amendment : ak125/governance-vault#304 (merged `c4ef1a24`)
- V1A.0 code : #711 (merged `fe9a4a7f`)
- Block A audit : #708 (merged `938f23e08`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)