### PR TITLE
fix(deps): ncu has no --dry-run flag — omit -u instead

### DIFF
--- a/scripts/audit/__tests__/bump-dependency-family.test.mjs
+++ b/scripts/audit/__tests__/bump-dependency-family.test.mjs
@@ -89,7 +89,8 @@ test('expandWildcards passes through literal names even when not in lockfile', (
   assert.deepEqual(expanded, ['some-pkg']);
 });
 
-test('buildNcuArgs assembles deterministic argv for dry-run', () => {
+test('buildNcuArgs assembles deterministic argv for dry-run (no -u, no --dry-run)', () => {
+  // ncu's default IS dry-run; the flag does not exist in npm-check-updates.
   const args = buildNcuArgs({
     members: ['typescript', 'eslint'],
     target: 'latest',
@@ -100,8 +101,9 @@ test('buildNcuArgs assembles deterministic argv for dry-run', () => {
     '--filter', 'typescript,eslint',
     '--deep',
     '--errorLevel', '2',
-    '--dry-run',
   ]);
+  assert.ok(!args.includes('--dry-run'), 'ncu has no --dry-run flag — it is the default behaviour');
+  assert.ok(!args.includes('-u'), 'dry-run must NOT include -u (which would apply upgrades)');
 });
 
 test('buildNcuArgs uses -u (apply) when dryRun=false', () => {

--- a/scripts/audit/bump-dependency-family.mjs
+++ b/scripts/audit/bump-dependency-family.mjs
@@ -57,9 +57,10 @@ export function expandWildcards(members, lockfile) {
 }
 
 export function buildNcuArgs({ members, target, dryRun }) {
+  // ncu's default mode IS dry-run (reports upgrades without writing). The -u
+  // flag is what applies them. There is no --dry-run flag in npm-check-updates.
   const args = ['--target', target, '--filter', members.join(','), '--deep', '--errorLevel', '2'];
-  if (dryRun) args.push('--dry-run');
-  else args.push('-u');
+  if (!dryRun) args.push('-u');
   return args;
 }
 


### PR DESCRIPTION
## Summary

PR-9b dry-run from main (gh run [#26365772610](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26365772610)) failed at the bump step:
```
error: unknown option '--dry-run'
```

`npm-check-updates` has no `--dry-run` flag — **its default behaviour IS dry-run** (reports without writing). The `-u` flag is what applies the upgrades. So for dry-run we simply omit `-u`; the tool will print the would-be upgrade table and exit 0.

## Fix

[scripts/audit/bump-dependency-family.mjs:59-65](scripts/audit/bump-dependency-family.mjs#L59-L65):
```diff
 export function buildNcuArgs({ members, target, dryRun }) {
+  // ncu's default mode IS dry-run (reports upgrades without writing). The -u
+  // flag is what applies them. There is no --dry-run flag in npm-check-updates.
   const args = ['--target', target, '--filter', members.join(','), '--deep', '--errorLevel', '2'];
-  if (dryRun) args.push('--dry-run');
-  else args.push('-u');
+  if (!dryRun) args.push('-u');
   return args;
 }
```

[scripts/audit/__tests__/bump-dependency-family.test.mjs](scripts/audit/__tests__/bump-dependency-family.test.mjs) updated to assert dry-run argv has neither `-u` nor `--dry-run`. 9/9 tests pass.

## Meta

This bug was caught by the very workflow it ships — exactly what dry-run is for. No real PR was created (dry_run=true), no scope-dirty gate was bypassed, no human review wasted.

## Test plan

- [x] Local `node --test` — 9/9 pass
- [ ] CI green
- [ ] Re-trigger workflow dry-run from main → bump step should now print the ncu upgrade table and continue to the dry-run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)