### PR TITLE
fix(deps): remove --errorLevel 2 — it exits 1 when upgrades exist

### DIFF
--- a/scripts/audit/__tests__/bump-dependency-family.test.mjs
+++ b/scripts/audit/__tests__/bump-dependency-family.test.mjs
@@ -89,8 +89,10 @@ test('expandWildcards passes through literal names even when not in lockfile', (
   assert.deepEqual(expanded, ['some-pkg']);
 });
 
-test('buildNcuArgs assembles deterministic argv for dry-run (no -u, no --dry-run)', () => {
-  // ncu's default IS dry-run; the flag does not exist in npm-check-updates.
+test('buildNcuArgs assembles deterministic argv for dry-run (no -u, no --dry-run, no --errorLevel)', () => {
+  // ncu's default IS dry-run; the --dry-run flag does not exist in npm-check-updates.
+  // We omit --errorLevel because the default level 1 always exits 0; level 2 would
+  // exit 1 whenever upgrades exist (the entire reason we run the tool).
   const args = buildNcuArgs({
     members: ['typescript', 'eslint'],
     target: 'latest',
@@ -100,16 +102,17 @@ test('buildNcuArgs assembles deterministic argv for dry-run (no -u, no --dry-run
     '--target', 'latest',
     '--filter', 'typescript,eslint',
     '--deep',
-    '--errorLevel', '2',
   ]);
   assert.ok(!args.includes('--dry-run'), 'ncu has no --dry-run flag — it is the default behaviour');
   assert.ok(!args.includes('-u'), 'dry-run must NOT include -u (which would apply upgrades)');
+  assert.ok(!args.includes('--errorLevel'), '--errorLevel 2 would exit 1 when upgrades exist');
 });
 
 test('buildNcuArgs uses -u (apply) when dryRun=false', () => {
   const args = buildNcuArgs({ members: ['x'], target: 'minor', dryRun: false });
   assert.ok(!args.includes('--dry-run'));
   assert.ok(args.includes('-u'));
+  assert.ok(!args.includes('--errorLevel'));
   assert.ok(args.includes('--target') && args[args.indexOf('--target') + 1] === 'minor');
 });
 

--- a/scripts/audit/bump-dependency-family.mjs
+++ b/scripts/audit/bump-dependency-family.mjs
@@ -59,7 +59,11 @@ export function expandWildcards(members, lockfile) {
 export function buildNcuArgs({ members, target, dryRun }) {
   // ncu's default mode IS dry-run (reports upgrades without writing). The -u
   // flag is what applies them. There is no --dry-run flag in npm-check-updates.
-  const args = ['--target', target, '--filter', members.join(','), '--deep', '--errorLevel', '2'];
+  //
+  // We intentionally do NOT pass --errorLevel 2 — it makes ncu exit 1 whenever
+  // upgrades are available, which is the entire reason we run this tool.
+  // Default --errorLevel 1 means exit 0 unless ncu itself errors.
+  const args = ['--target', target, '--filter', members.join(','), '--deep'];
   if (!dryRun) args.push('-u');
   return args;
 }


### PR DESCRIPTION
## Summary

PR-9b dry-run #2 (gh run [#26365959661](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26365959661)) — after the first fix landed (#721) — failed again with `ncu exited with status 1`. Looking at the log, ncu printed `Run npx npm-check-updates ... -u to upgrade <path>` for 15 workspace `package.json` files (so upgrades WERE found), then exited 1.

Cause: `--errorLevel 2` in [ncu docs](https://github.com/raineorshine/npm-check-updates#options) means "exit with non-zero only if upgrades are available". That is exactly the inverse of what we want — we run this tool to FIND upgrades. Default `--errorLevel 1` (always exit 0 unless ncu itself errors) is the right behaviour.

## Fix

```diff
-  const args = ['--target', target, '--filter', members.join(','), '--deep', '--errorLevel', '2'];
+  const args = ['--target', target, '--filter', members.join(','), '--deep'];
```

Tests assert the flag is absent in both dry-run and apply modes (9/9 pass).

## Why the original plan had it

I added `--errorLevel 2` as a "strict mode" safety net without checking semantics. Two consecutive dry-run failures (this one + #721) proved the value of dry-run mode — both bugs caught before any real PR was opened.

## Test plan

- [x] Local `node --test` — 9/9 pass
- [ ] CI green
- [ ] Re-trigger workflow dry-run from main → bump step prints the actual ncu upgrade table, continues through evidence upload + dry-run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)