### PR TITLE
chore(deps): allowlist services/* + retire eslint-plugin-storybook from PR-9b

### DIFF
--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:c2d0899ec14b9ac6e34231523ad6964eddeca94567241b3b049b9ed5fbdca85c",
+  "artifact_immutability_hash": "sha256:982fb905906d1798778b5cc634a55691cb7bb02e7be6e1ea4fd1a9eb916f00d3",
   "divergences": [
     {
       "kind": "specifier",
@@ -3215,7 +3215,6 @@
         "eslint-plugin-prettier",
         "eslint-plugin-react",
         "eslint-plugin-react-hooks",
-        "eslint-plugin-storybook",
         "typescript"
       ],
       "migration_blockers": [
@@ -3450,21 +3449,6 @@
         {
           "divergent_resolved": false,
           "divergent_specifiers": false,
-          "name": "eslint-plugin-storybook",
-          "occurrences": [
-            {
-              "declaredIn": "frontend/package.json",
-              "specifier": "^9.1.13",
-              "workspace": "@fafa/frontend"
-            }
-          ],
-          "resolved_versions": [
-            "9.1.20"
-          ]
-        },
-        {
-          "divergent_resolved": false,
-          "divergent_specifiers": false,
           "name": "typescript",
           "occurrences": [
             {
@@ -3602,7 +3586,7 @@
       ],
       "supports_dual_runtime": "none",
       "target_major": "locked-at-execution",
-      "total_occurrences": 37,
+      "total_occurrences": 36,
       "upgrade_cost_estimate": {
         "estimated_engineer_days": 5,
         "estimated_review_load": "medium"
@@ -3941,7 +3925,7 @@
     "lockfile": "package-lock.json",
     "lockfile_sha": "sha256:8fdd2986d1a09086fa1079bee0509fe8368fa6a502e6a035c6181214f3887dbb",
     "overlay": "audit/dependencies/family-overlay.yaml",
-    "overlay_sha": "sha256:c88cee03acf27840da9c5826c7a3edbcd086a70a58ee323d9c32d33ec33c1a57"
+    "overlay_sha": "sha256:4067a5535b22d0d6c98fa6f3c980189b2a68f9837edd7f7caf1e7b1e10c44746"
   },
   "inventoryFormat": "pr-9-modernization-inventory",
   "matrixVersion": "pr9-v1",
@@ -3955,13 +3939,13 @@
       "queues": 5,
       "runtime-backend": 17,
       "runtime-frontend": 10,
-      "tooling": 16,
-      "unassigned": 157,
+      "tooling": 15,
+      "unassigned": 158,
       "validation": 2
     },
     "by_pr_assignment": {
       "deferred": 25,
-      "pr-9b": 11,
+      "pr-9b": 10,
       "pr-9c": 2,
       "pr-9d": 5,
       "pr-9e": 8,
@@ -3972,7 +3956,7 @@
     "families_count": 12,
     "total_occurrences": 319,
     "total_packages": 225,
-    "unassigned_count": 157
+    "unassigned_count": 158
   },
   "unassigned_packages": [
     {
@@ -5497,6 +5481,21 @@
       ],
       "resolved_versions": [
         "<unresolved>"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "eslint-plugin-storybook",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^9.1.13",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "9.1.20"
       ]
     },
     {

--- a/audit/dependencies/family-overlay.yaml
+++ b/audit/dependencies/family-overlay.yaml
@@ -106,9 +106,14 @@ families:
       - eslint-plugin-prettier
       - eslint-plugin-react
       - eslint-plugin-react-hooks
-      - eslint-plugin-storybook
       - "@typescript-eslint/eslint-plugin"
       - "@typescript-eslint/parser"
+      # eslint-plugin-storybook intentionally OUT of this family.
+      # Its major track is coupled to storybook itself (peer storybook@^X requires
+      # bumping storybook in lockstep), and storybook belongs to a frontend cluster.
+      # Bumping it here triggered ERESOLVE on 2026-05-24 (gh run #26366212645)
+      # while storybook stayed pinned at ^9.1.13. Move to a future frontend-storybook
+      # family.
 
   - family: validation-zod
     blast_radius: validation

--- a/scripts/governance/__tests__/check-family-pr-scope.bats
+++ b/scripts/governance/__tests__/check-family-pr-scope.bats
@@ -46,6 +46,15 @@ teardown() { rm -rf "$TMPDIR_BATS"; }
   [ "$status" -eq 0 ]
 }
 
+@test "exit 0 when services/*/package.json changes" {
+  mkdir -p services/remotion-renderer services/another-service
+  echo '{}' > services/remotion-renderer/package.json
+  echo '{}' > services/another-service/package.json
+  git add . && git commit -q -m bump-services
+  run ./check.sh --base HEAD~1
+  [ "$status" -eq 0 ]
+}
+
 @test "exit 1 when backend/src code changes" {
   mkdir -p backend/src
   echo 'x' > backend/src/main.ts

--- a/scripts/governance/check-family-pr-scope.sh
+++ b/scripts/governance/check-family-pr-scope.sh
@@ -27,6 +27,7 @@ ALLOWLIST=(
   '^backend/package\.json$'
   '^frontend/package\.json$'
   '^packages/[^/]+/package\.json$'
+  '^services/[^/]+/package\.json$'
   '^audit/registry/deps\.json$'
   '^audit/registry/canonical\.json$'
   '^audit/dependencies/dependency-modernization-inventory\.json$'
@@ -127,8 +128,19 @@ self_test() {
     return 1
   fi
 
+  # Case 5: services/* workspace bump — allowlisted (e.g. services/remotion-renderer)
+  git reset --hard HEAD~1 -q
+  mkdir -p services/example-service
+  echo '{}' > services/example-service/package.json
+  git add . && git commit -q -m services-clean
+  if ! bash "$script_path" --base HEAD~1 >/dev/null; then
+    echo "self-test FAILED: services/*/package.json rejected" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+
   rm -rf "$tmp"
-  echo "✅ self-test passed (4/4 cases)"
+  echo "✅ self-test passed (5/5 cases)"
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## Summary

Two follow-ups from the 1st real-run of `dependency-family-bump.yml` (post-PR #720).

## 1. Scope-gate allowlist — add `services/*/package.json`

[scripts/governance/check-family-pr-scope.sh:30](scripts/governance/check-family-pr-scope.sh#L30) +
[scripts/governance/__tests__/check-family-pr-scope.bats](scripts/governance/__tests__/check-family-pr-scope.bats) (+1 bats case, self-test now 5/5):

```diff
 ALLOWLIST=(
   '^package\.json$'
   '^package-lock\.json$'
   '^backend/package\.json$'
   '^frontend/package\.json$'
   '^packages/[^/]+/package\.json$'
+  '^services/[^/]+/package\.json$'
   '^audit/registry/deps\.json$'
   '^audit/registry/canonical\.json$'
   '^audit/dependencies/dependency-modernization-inventory\.json$'
 )
```

**Why**: `services/remotion-renderer/package.json` exists on main with typescript/zod/fastify deps. ncu's `--deep` discovers it; without this pattern the scope-gate hard-fails the otherwise-legitimate bump.

## 2. family-overlay — retire `eslint-plugin-storybook` from PR-9b

[audit/dependencies/family-overlay.yaml:100-116](audit/dependencies/family-overlay.yaml#L100-L116) (PR-9b members: 11 → 10) + inline comment documenting why.

**Why**: ERESOLVE on gh run [#26366212645](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26366212645) — ncu bumped `eslint-plugin-storybook` to `^10.4.1`, which requires `storybook@^10.4.1` as peer, but the workspace pins `storybook@^9.1.13`. Storybook belongs to a future **frontend cluster**, not to "tooling lint core". Inventory regenerated (10 members in PR-9b, was 11).

## Verification

- [x] `bash scripts/governance/check-family-pr-scope.sh --self-test` → `✅ self-test passed (5/5 cases)`
- [x] `node --test scripts/audit/__tests__/bump-dependency-family.test.mjs` → 9/9 pass
- [x] `npm run audit:pr-9-modernization-inventory` → `✓ wrote ... 225 packages, 12 families, 39 divergent`
- [x] `jq '.families[] | select(.family == "tooling-typescript-eslint") | .members'` → 10 entries, no `eslint-plugin-storybook`
- [ ] CI green
- [ ] Next: cycle 1 manual trigger with `target=minor` (safer than `latest` for first real cycle)

## Out of scope

- ❌ No code path bumped
- ❌ No PR-9b family bump triggered by this PR
- ❌ Creating a `frontend-storybook` family — separate plan once we know if/when storybook cluster needs lockstep bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)