### PR TITLE
fix(ci): set HUSKY=0 on peter-evans step — pre-commit fires in bot commit

### DIFF
--- a/.github/workflows/dependency-family-bump.yml
+++ b/.github/workflows/dependency-family-bump.yml
@@ -150,6 +150,12 @@ jobs:
       - name: 🤖 Open (or update) PR
         if: ${{ !inputs.dry_run }}
         id: cpr
+        env:
+          # peter-evans runs `git commit` internally, which triggers husky
+          # pre-commit → lint-staged → exits 1 on "no matching staged files"
+          # (caught on cycle 1, gh run #26366771736). The bot commit doesn't
+          # need lint-staged (deps-only diff, scope-gate + turbo already ran).
+          HUSKY: '0'
         uses: peter-evans/create-pull-request@v6
         with:
           branch: deps/auto/${{ inputs.family }}


### PR DESCRIPTION
## Summary

Cycle 1 (gh run [#26366771736](https://github.com/ak125/nestjs-remix-monorepo/actions/runs/26366771736)) reached **every gate successfully** — scope-dirty, turbo lint, typecheck, build, test — then failed only at PR creation:

```
##[error]Unexpected error: → lint-staged could not find any staged files matching configured tasks.
```

Cause: `peter-evans/create-pull-request@v6` invokes `git commit` in the runner workspace, which inherits husky's pre-commit hook. `lint-staged@>=12` exits 1 when no staged files match its configured patterns. The bot commit is a deps-only diff that lint-staged has nothing to lint.

## Fix

Add `HUSKY: '0'` on the peter-evans step env:

```diff
       - name: 🤖 Open (or update) PR
         if: ${{ !inputs.dry_run }}
         id: cpr
+        env:
+          HUSKY: '0'
         uses: peter-evans/create-pull-request@v6
```

## Why this is safe

`HUSKY=0` scopes only to that one step. Local human commits keep all hooks. The repo's actual quality gates already ran **upstream** of this step:
- scope-dirty gate (hard-fail on non-allowlisted paths)
- `turbo lint` / `turbo typecheck` / `turbo build` / `turbo test`

The bypassed hook (lint-staged) was running on a diff it has nothing to say about.

## Test plan

- [ ] CI green
- [ ] Re-trigger cycle 1: `gh workflow run dependency-family-bump.yml -f family=tooling-typescript-eslint -f target=minor -f dry_run=false -f confirm=BUMP` — should now create the first auto-PR on branch `deps/auto/tooling-typescript-eslint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)