### PR TITLE
feat(seo-runtime): bloc 2 — CWV taxonomy canon + @repo/cwv-taxonomy package

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -52,6 +52,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: high
+  - glob: .spec/00-canon/seo-runtime/**
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: high
   - glob: packages/domain-commerce/**
     domain: D11
     owner: '@ak125/payments-team'
@@ -575,6 +580,11 @@ entries:
   - glob: packages/eslint-plugin-fafa-ports/**
     domain: D13
     owner: '@ak125'
+    sourceConfidence: high
+    risk: medium
+  - glob: packages/cwv-taxonomy/**
+    domain: D11
+    owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: medium
   - glob: packages/registry/**

--- a/.spec/00-canon/seo-runtime/cwv-taxonomy.yaml
+++ b/.spec/00-canon/seo-runtime/cwv-taxonomy.yaml
@@ -1,0 +1,310 @@
+# CWV Runtime Taxonomy — canon L2 overlay
+#
+# Premier entry du dossier `seo-runtime/`. Canon `feedback_seo_runtime_must_integrate_repo_control_plane`
+# — chaque dimension utilisée par la chaîne d'ingestion CWV beacon DOIT être
+# déclarée ici. Le package `@repo/cwv-taxonomy` est la SoT technique runtime ;
+# ce fichier est la SoT humaine documentaire (review humaine sur changement).
+#
+# Discipline : enum strict (DB CHECK IN) — cardinalité bornée pour
+# requêtage SQL ; pas de string libre cross-couches.
+#
+# Sources de vérité associées :
+#   - Plan : /home/deploy/.claude/plans/automecanik-com-confidentialit-condition-abundant-adleman.md
+#   - Package TS : packages/cwv-taxonomy/src/
+#   - Migration consommatrices : 20260526_seo_cwv_raw.sql (bloc 3), 20260527_seo_cwv_hourly.sql (bloc 4)
+
+schemaVersion: 1.0.0
+domain: seo-runtime
+generated: false
+
+# =============================================================================
+# Surfaces — granularité métier (ce que vit l'utilisateur)
+# =============================================================================
+# Chaque surface est mappée à un funnel_step. Une surface = une intention business.
+
+surfaces:
+  R2_PRODUCT:
+    description: "Page produit pieces (fiche article unique)"
+    funnel_role: view_product
+  R2_GAMME_VEHICLE:
+    description: "Page gamme × véhicule (liste de pièces filtrée)"
+    funnel_role: view_listing
+  R3_GUIDE:
+    description: "Guide thématique / article éditorial"
+    funnel_role: view_guide
+  R5_DIAGNOSTIC:
+    description: "Page symptôme / diagnostic / réparation"
+    funnel_role: view_diagnostic
+  R8_VEHICLE:
+    description: "Fiche véhicule (constructeur/modèle/type)"
+    funnel_role: view_vehicle
+  SEARCH:
+    description: "Résultats de recherche / autocomplete"
+    funnel_role: view_search
+  HOME:
+    description: "Page d'accueil"
+    funnel_role: landing
+  CART:
+    description: "Panier (étape pré-checkout)"
+    funnel_role: checkout_entry
+  CHECKOUT:
+    description: "Étapes checkout (1..N)"
+    funnel_role: checkout_step
+  PAYMENT:
+    description: "Page paiement (Paybox / SystemPay redirect)"
+    funnel_role: payment
+  ACCOUNT:
+    description: "Espace client (commandes, profil)"
+    funnel_role: account
+  OTHER:
+    description: "Fallback toute route non classée"
+    funnel_role: other
+
+# =============================================================================
+# Route groups — granularité technique (pattern Remix)
+# =============================================================================
+# Map déterministe path → route_group → surface. Whitelist fermée.
+# Ajout d'une nouvelle route = PR explicite (anti-bricolage discovery).
+
+route_groups:
+  pieces_product:
+    surface: R2_PRODUCT
+    path_prefix: "/pieces/"
+    path_suffix: ".html"
+    remix_pattern: "/pieces/$gamme/$marque/$modele/$type/$product.html"
+    description: "Fiche pièce détaillée (URL canonique 5-segments + .html)"
+
+  pieces_gamme_vehicle:
+    surface: R2_GAMME_VEHICLE
+    path_prefix: "/pieces/"
+    remix_pattern: "/pieces/$gamme/$marque/$modele/$type"
+    description: "Listing gamme×véhicule (URL 4-segments, sans suffix)"
+
+  r3_guide:
+    surface: R3_GUIDE
+    path_prefix: "/conseils/"
+    remix_pattern: "/conseils/$slug"
+    description: "Guides R3 thématiques"
+
+  r5_diagnostic:
+    surface: R5_DIAGNOSTIC
+    path_prefix: "/diagnostic/"
+    remix_pattern: "/diagnostic/$symptom"
+    description: "Pages diagnostic R5 (V1A.0 actif)"
+
+  r8_vehicle:
+    surface: R8_VEHICLE
+    path_prefix: "/constructeurs/"
+    remix_pattern: "/constructeurs/$marque/$modele/$type.html"
+    description: "Fiches véhicule R8"
+
+  marques_listing:
+    surface: R2_GAMME_VEHICLE
+    path_prefix: "/marques/"
+    remix_pattern: "/marques/$brand"
+    description: "Listing par marque (équipementier)"
+
+  search:
+    surface: SEARCH
+    path_prefix: "/recherche"
+    remix_pattern: "/recherche"
+    description: "Résultats de recherche"
+
+  cart:
+    surface: CART
+    path_prefix: "/panier"
+    remix_pattern: "/panier"
+    description: "Panier"
+
+  checkout:
+    surface: CHECKOUT
+    path_prefix: "/checkout"
+    remix_pattern: "/checkout/*"
+    description: "Étapes checkout (1..N, normalisé en CHECKOUT_STEP_*)"
+
+  payment:
+    surface: PAYMENT
+    path_prefix: "/paiement"
+    remix_pattern: "/paiement"
+    description: "Redirect Paybox / SystemPay (très court time-on-page)"
+
+  account:
+    surface: ACCOUNT
+    path_prefix: "/compte"
+    remix_pattern: "/compte/*"
+    description: "Espace client authentifié"
+
+  home:
+    surface: HOME
+    path_prefix: "/"
+    remix_pattern: "/"
+    description: "Home page (exact match uniquement)"
+
+  other:
+    surface: OTHER
+    path_prefix: ""
+    remix_pattern: "*"
+    description: "Fallback fermé — tout path non classé"
+
+# =============================================================================
+# Priority tiers — pondération business pour alerting & dashboards
+# =============================================================================
+# CWV_P0 = surveillance stricte (alerts), CWV_P1 = monitoring standard,
+# CWV_P2 = best-effort. Mapping Surface → Tier.
+
+priority_tiers:
+  CWV_P0:
+    description: "Critiques business — alerts trend-divergence-sustained activables (bloc 6)"
+    surfaces:
+      - PAYMENT
+      - CHECKOUT
+      - CART
+      - R5_DIAGNOSTIC
+      - R2_PRODUCT
+  CWV_P1:
+    description: "Monitoring standard — dashboard mais pas d'alert auto"
+    surfaces:
+      - R2_GAMME_VEHICLE
+      - R8_VEHICLE
+      - SEARCH
+      - R3_GUIDE
+  CWV_P2:
+    description: "Best-effort — tracking sans alerte"
+    surfaces:
+      - HOME
+      - ACCOUNT
+      - OTHER
+
+# =============================================================================
+# Funnel steps — ordre canonique du parcours conversion
+# =============================================================================
+# Ordre strict. previous_funnel_step doit être <= funnel_step dans cet array.
+
+funnel_steps_order:
+  - landing
+  - view_listing
+  - view_product
+  - view_guide
+  - view_diagnostic
+  - view_vehicle
+  - view_search
+  - view_account
+  - view_other
+  - add_cart
+  - checkout_entry
+  - checkout_step
+  - payment
+  - completed
+
+# =============================================================================
+# User-Agent classification — ségrégation bot/human pour aggregation pure
+# =============================================================================
+# Canon : bots → __seo_event_log (debug), humans → __seo_cwv_raw (aggregation).
+# Liste maintenue, ajout d'un bot = PR explicite (anti-pollution p75 humains).
+
+user_agent_classes:
+  bot_search:
+    description: "Crawlers SEO classiques (indexation Google/Bing)"
+    patterns:
+      - Googlebot
+      - bingbot
+      - Bingbot
+      - DuckDuckBot
+      - YandexBot
+      - Baiduspider
+      - facebookexternalhit
+      - LinkedInBot
+      - Twitterbot
+      - Slackbot
+  bot_ai:
+    description: "Crawlers AI/LLM (training, search, retrieval)"
+    patterns:
+      - GPTBot
+      - ClaudeBot
+      - Claude-Web
+      - ChatGPT-User
+      - OAI-SearchBot
+      - PerplexityBot
+      - Perplexity-User
+      - anthropic-ai
+      - Bytespider
+      - Amazonbot
+      - Applebot
+      - Google-Extended
+      - CCBot
+      - Diffbot
+  bot_other:
+    description: "Bots de monitoring, archivage, scraping divers"
+    patterns:
+      - AhrefsBot
+      - SemrushBot
+      - DotBot
+      - MJ12bot
+      - PetalBot
+      - WebPageTest
+      - Pingdom
+      - UptimeRobot
+      - Lighthouse
+      - Chrome-Lighthouse
+      - SpeedCurve
+  human:
+    description: "Tout User-Agent ne matchant aucun pattern bot ci-dessus"
+    fallback: true
+
+# =============================================================================
+# Web Vitals metrics — bornes runtime (Zod validation backend)
+# =============================================================================
+
+metrics:
+  LCP:
+    unit: ms
+    min: 0
+    max: 60000        # 60s ceiling (au-delà = payload corrompu)
+    good_threshold: 2500
+    poor_threshold: 4000
+  INP:
+    unit: ms
+    min: 0
+    max: 60000
+    good_threshold: 200
+    poor_threshold: 500
+  CLS:
+    unit: ratio
+    min: 0
+    max: 5            # CLS >5 = aberrant, on rejette
+    good_threshold: 0.1
+    poor_threshold: 0.25
+  FCP:
+    unit: ms
+    min: 0
+    max: 60000
+    good_threshold: 1800
+    poor_threshold: 3000
+  TTFB:
+    unit: ms
+    min: 0
+    max: 60000
+    good_threshold: 800
+    poor_threshold: 1800
+
+# =============================================================================
+# Devices & navigation types — petits enums fermés
+# =============================================================================
+
+device_types: [mobile, desktop, tablet, unknown]
+nav_types: [navigate, reload, back_forward, prerender, restore, unknown]
+
+# =============================================================================
+# Discipline anti-bricolage
+# =============================================================================
+
+discipline:
+  - "Toutes les colonnes enum DB (surface, route_group, priority_tier, funnel_step,
+    metric, device, ua_class) DOIVENT avoir CHECK IN clause stricte (alignée sur
+    les enums TS via runtime test)."
+  - "Ajout d'une nouvelle surface ou route_group = PR explicite avec ADR si
+    sémantique business change."
+  - "Bots détectés → écrits dans __seo_event_log uniquement, JAMAIS dans
+    __seo_cwv_raw (canon cross-source anti-fusion)."
+  - "Le package @repo/cwv-taxonomy est CJS uniquement (convention monorepo,
+    cf. @repo/seo-roles, @repo/seo-url-contract)."

--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:b98f5e68e63ea0ebd8628c110a5625a7a9e3aa6da2f4b4e31140c15e41e6d900",
+  "artifact_immutability_hash": "sha256:460a2c80aec5d64146cd5eb13c600c4d68345944f9fc1f733644989ec0769a80",
   "divergences": [
     {
       "kind": "specifier",
@@ -3852,7 +3852,7 @@
     "deps_registry": "audit/registry/deps.json",
     "deps_registry_sha": "sha256:ccfbd71d0225371602d43ce9d28f79f480111fc06d78eb98b63312212045edb3",
     "lockfile": "package-lock.json",
-    "lockfile_sha": "sha256:c6ee621fd54a4ea3d8f40182a0cba0538bbbc056e2655438108a4b2ad1922432",
+    "lockfile_sha": "sha256:e03a568334510ed53f61bc9bc75cd30029120197ec55db743b1eba0252e963e3",
     "overlay": "audit/dependencies/family-overlay.yaml",
     "overlay_sha": "sha256:4067a5535b22d0d6c98fa6f3c980189b2a68f9837edd7f7caf1e7b1e10c44746"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2178,6 +2178,278 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.17.6",
       "cpu": [
@@ -2191,6 +2463,159 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -6527,6 +6952,10 @@
       "dependencies": {
         "web-streams-polyfill": "^3.1.1"
       }
+    },
+    "node_modules/@repo/cwv-taxonomy": {
+      "resolved": "packages/cwv-taxonomy",
+      "link": true
     },
     "node_modules/@repo/database-types": {
       "resolved": "packages/database-types",
@@ -13787,6 +14216,363 @@
         "esbuild": ">=0.12 <1"
       }
     },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.6.tgz",
+      "integrity": "sha512-bSC9YVUjADDy1gae8RrioINU6e1lCkg3VGVwm0QQ2E1CWcC4gnMce9+B6RpxuSsrsXsk1yojn7sp1fnG8erE2g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.6.tgz",
+      "integrity": "sha512-YnYSCceN/dUzUr5kdtUzB+wZprCafuD89Hs0Aqv9QSdwhYQybhXTaSTcrl6X/aWThn1a/j0eEpUBGOE7269REg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.6.tgz",
+      "integrity": "sha512-MVcYcgSO7pfu/x34uX9u2QIZHmXAB7dEiLQC5bBl5Ryqtpj9lT2sg3gNDEsrPEmimSJW2FXIaxqSQ501YLDsZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.6.tgz",
+      "integrity": "sha512-bsDRvlbKMQMt6Wl08nHtFz++yoZHsyTOxnjfB2Q95gato+Yi4WnRl13oC2/PJJA9yLCoRv9gqT/EYX0/zDsyMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.6.tgz",
+      "integrity": "sha512-xh2A5oPrYRfMFz74QXIQTQo8uA+hYzGWJFoeTE8EvoZGHb+idyV4ATaukaUvnnxJiauhs/fPx3vYhU4wiGfosg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.6.tgz",
+      "integrity": "sha512-EnUwjRc1inT4ccZh4pB3v1cIhohE2S4YXlt1OvI7sw/+pD+dIE4smwekZlEPIwY6PhU6oDWwITrQQm5S2/iZgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.6.tgz",
+      "integrity": "sha512-Uh3HLWGzH6FwpviUcLMKPCbZUAFzv67Wj5MTwK6jn89b576SR2IbEp+tqUHTr8DIl0iDmBAf51MVaP7pw6PY5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.6.tgz",
+      "integrity": "sha512-7YdGiurNt7lqO0Bf/U9/arrPWPqdPqcV6JCZda4LZgEn+PTQ5SMEI4MGR52Bfn3+d6bNEGcWFzlIxiQdS48YUw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.6.tgz",
+      "integrity": "sha512-bUR58IFOMJX523aDVozswnlp5yry7+0cRLCXDsxnUeQYJik1DukMY+apBsLOZJblpH+K7ox7YrKrHmJoWqVR9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.6.tgz",
+      "integrity": "sha512-ujp8uoQCM9FRcbDfkqECoARsLnLfCUhKARTP56TFPog8ie9JG83D5GVKjQ6yVrEVdMie1djH86fm98eY3quQkQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.6.tgz",
+      "integrity": "sha512-y2NX1+X/Nt+izj9bLoiaYB9YXT/LoaQFYvCkVD77G/4F+/yuVXYCWz4SE9yr5CBMbOxOfBcy/xFL4LlOeNlzYQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.6.tgz",
+      "integrity": "sha512-09AXKB1HDOzXD+j3FdXCiL/MWmZP0Ex9eR8DLMBVcHorrWJxWmY8Nms2Nm41iRM64WVx7bA/JVHMv081iP2kUA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.6.tgz",
+      "integrity": "sha512-AmLhMzkM8JuqTIOhxnX4ubh0XWJIznEynRnZAVdA2mMKE6FAfwT2TWKTwdqMG+qEaeyDPtfNoZRpJbD4ZBv0Tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.6.tgz",
+      "integrity": "sha512-Y4Ri62PfavhLQhFbqucysHOmRamlTVK10zPWlqjNbj2XMea+BOs4w6ASKwQwAiqf9ZqcY9Ab7NOU4wIgpxwoSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.6.tgz",
+      "integrity": "sha512-SPUiz4fDbnNEm3JSdUW8pBJ/vkop3M1YwZAVwvdwlFLoJwKEZ9L98l3tzeyMzq27CyepDQ3Qgoba44StgbiN5Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.6.tgz",
+      "integrity": "sha512-EanJqcU/4uZIBreTrnbnre2DXgXSa+Gjap7ifRfllpmyAU7YMvaXmljdArptTHmjrkkKm9BK6GH5D5Yo+p6y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.6.tgz",
+      "integrity": "sha512-xaxeSunhQRsTNGFanoOkkLtnmMn5QbA0qBhNet/XLVsc+OVkpIWPHcr3zTW2gxVU5YOHFbIHR9ODuaUdNza2Vw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.6.tgz",
+      "integrity": "sha512-gnMnMPg5pfMkZvhHee21KbKdc6W3GR8/JuE0Da1kjwpK6oiFU3nqfHuVPgUX2rsOx9N2SadSQTIYV1CIjYG+xw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.6.tgz",
+      "integrity": "sha512-G95n7vP1UnGJPsVdKXllAJPtqjMvFYbN20e8RK8LVLhlTiSOH1sd7+Gt7rm70xiG+I5tM58nYgwWrLs6I1jHqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.6.tgz",
+      "integrity": "sha512-96yEFzLhq5bv9jJo5JhTs1gI+1cKQ83cUpyxHuGqXVwQtY5Eq54ZEsKs8veKtiKwlrNimtckHEkj4mRh4pPjsg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.6.tgz",
+      "integrity": "sha512-n6d8MOyUrNp6G4VSpRcgjs5xj4A91svJSaiwLIDWVWEsZtpN5FA9NlBbZHDmAJc2e8e6SF4tkBD3HAvPF+7igA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "license": "MIT",
@@ -15766,6 +16552,20 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -22729,6 +23529,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plimit-lit": {
       "version": "1.6.1",
       "dev": true,
@@ -25674,6 +26490,278 @@
         }
       }
     },
+    "node_modules/storybook/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/storybook/node_modules/@esbuild/linux-x64": {
       "version": "0.25.12",
       "cpu": [
@@ -25684,6 +26772,159 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/storybook/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -27267,6 +28508,278 @@
         }
       }
     },
+    "node_modules/tsup/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tsup/node_modules/@esbuild/linux-x64": {
       "version": "0.27.7",
       "cpu": [
@@ -27277,6 +28790,159 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -28331,6 +29997,262 @@
         }
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/linux-x64": {
       "version": "0.21.5",
       "cpu": [
@@ -28340,6 +30262,102 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -29236,6 +31254,96 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/cwv-taxonomy": {
+      "name": "@repo/cwv-taxonomy",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.22.3",
+        "typescript": "^5.9.3"
+      }
+    },
+    "packages/cwv-taxonomy/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cwv-taxonomy/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "packages/cwv-taxonomy/node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "packages/database-types": {

--- a/packages/cwv-taxonomy/package.json
+++ b/packages/cwv-taxonomy/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@repo/cwv-taxonomy",
+  "version": "0.1.0",
+  "description": "Single source of truth for CWV runtime taxonomy — Surface / RouteGroup / PriorityTier / FunnelStep enums, classifyRoute(), classifyUserAgent(), Zod schemas. Mirror of .spec/00-canon/seo-runtime/cwv-taxonomy.yaml.",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/__tests__/*.test.ts"
+  },
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.22.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/cwv-taxonomy/src/__tests__/funnel-step.test.ts
+++ b/packages/cwv-taxonomy/src/__tests__/funnel-step.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests FunnelStep ordering + transition validation.
+ */
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import {
+  FUNNEL_STEP_ORDER,
+  FUNNEL_STEP_VALUES,
+  isValidFunnelTransition,
+  SURFACE_TO_FUNNEL_STEP,
+} from '../funnel-step';
+
+test('FUNNEL_STEP_ORDER: monotonic ascending', () => {
+  let prev = -1;
+  for (const step of FUNNEL_STEP_VALUES) {
+    const idx = FUNNEL_STEP_ORDER[step];
+    assert.ok(idx > prev, `expected order monotonic ascending, got ${idx} after ${prev}`);
+    prev = idx;
+  }
+});
+
+test('FUNNEL_STEP_ORDER: completed is terminal (highest index)', () => {
+  const completed = FUNNEL_STEP_ORDER.completed;
+  for (const step of FUNNEL_STEP_VALUES) {
+    assert.ok(
+      FUNNEL_STEP_ORDER[step] <= completed,
+      `${step} (${FUNNEL_STEP_ORDER[step]}) should be <= completed (${completed})`,
+    );
+  }
+});
+
+test('isValidFunnelTransition: null previous always valid', () => {
+  assert.equal(isValidFunnelTransition(null, 'landing'), true);
+  assert.equal(isValidFunnelTransition(null, 'completed'), true);
+  assert.equal(isValidFunnelTransition(undefined, 'view_product'), true);
+});
+
+test('isValidFunnelTransition: same step is valid (idempotent)', () => {
+  assert.equal(isValidFunnelTransition('view_product', 'view_product'), true);
+});
+
+test('isValidFunnelTransition: forward valid, backward invalid', () => {
+  assert.equal(isValidFunnelTransition('view_product', 'add_cart'), true);
+  assert.equal(isValidFunnelTransition('add_cart', 'view_product'), false);
+  assert.equal(isValidFunnelTransition('payment', 'landing'), false);
+  assert.equal(isValidFunnelTransition('landing', 'completed'), true);
+});
+
+test('SURFACE_TO_FUNNEL_STEP: every Surface mapped', () => {
+  // Si une nouvelle Surface est ajoutée sans mise à jour du mapping, TS broker
+  // déjà. Ce test catch sémantique : pas de step "invalide" mappé.
+  for (const step of Object.values(SURFACE_TO_FUNNEL_STEP)) {
+    assert.ok(
+      (FUNNEL_STEP_VALUES as readonly string[]).includes(step),
+      `mapped step ${step} not in canonical FUNNEL_STEP_VALUES`,
+    );
+  }
+});

--- a/packages/cwv-taxonomy/src/__tests__/route-group.test.ts
+++ b/packages/cwv-taxonomy/src/__tests__/route-group.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests classifyRoute() — first-match-wins déterministe.
+ *
+ * Cible spec : route_group + surface + priority_tier + funnel_step cohérents
+ * sur 100% des fixtures, dont sous-ensemble représentatif des 376 URLs
+ * /pieces/* du rapport GSC INP 537ms (PR #694).
+ */
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { classifyRoute } from '../route-group';
+
+test('classifyRoute: pieces_product (.html suffix 5-segments)', () => {
+  const r = classifyRoute('/pieces/freinage/peugeot/308/1.6-hdi/68681.html');
+  assert.equal(r.route_group, 'pieces_product');
+  assert.equal(r.surface, 'R2_PRODUCT');
+  assert.equal(r.priority_tier, 'CWV_P0');
+  assert.equal(r.funnel_step, 'view_product');
+});
+
+test('classifyRoute: pieces_gamme_vehicle (no .html, 4-segments)', () => {
+  const r = classifyRoute('/pieces/freinage/peugeot/308/1.6-hdi');
+  assert.equal(r.route_group, 'pieces_gamme_vehicle');
+  assert.equal(r.surface, 'R2_GAMME_VEHICLE');
+  assert.equal(r.priority_tier, 'CWV_P1');
+  assert.equal(r.funnel_step, 'view_listing');
+});
+
+test('classifyRoute: pieces_gamme_vehicle short (2-segments)', () => {
+  const r = classifyRoute('/pieces/freinage');
+  assert.equal(r.route_group, 'pieces_gamme_vehicle');
+  assert.equal(r.surface, 'R2_GAMME_VEHICLE');
+});
+
+test('classifyRoute: r3_guide', () => {
+  const r = classifyRoute('/conseils/changer-plaquettes-frein');
+  assert.equal(r.route_group, 'r3_guide');
+  assert.equal(r.surface, 'R3_GUIDE');
+  assert.equal(r.priority_tier, 'CWV_P1');
+  assert.equal(r.funnel_step, 'view_guide');
+});
+
+test('classifyRoute: r5_diagnostic', () => {
+  const r = classifyRoute('/diagnostic/voiture-ne-demarre-pas');
+  assert.equal(r.route_group, 'r5_diagnostic');
+  assert.equal(r.surface, 'R5_DIAGNOSTIC');
+  assert.equal(r.priority_tier, 'CWV_P0');
+  assert.equal(r.funnel_step, 'view_diagnostic');
+});
+
+test('classifyRoute: r8_vehicle', () => {
+  const r = classifyRoute('/constructeurs/peugeot/308/1.6-hdi.html');
+  assert.equal(r.route_group, 'r8_vehicle');
+  assert.equal(r.surface, 'R8_VEHICLE');
+  assert.equal(r.priority_tier, 'CWV_P1');
+  assert.equal(r.funnel_step, 'view_vehicle');
+});
+
+test('classifyRoute: marques_listing', () => {
+  const r = classifyRoute('/marques/valeo');
+  assert.equal(r.route_group, 'marques_listing');
+  assert.equal(r.surface, 'R2_GAMME_VEHICLE');
+});
+
+test('classifyRoute: search', () => {
+  assert.equal(classifyRoute('/recherche').route_group, 'search');
+  assert.equal(classifyRoute('/recherche?q=plaquette').route_group, 'search');
+});
+
+test('classifyRoute: cart', () => {
+  const r = classifyRoute('/panier');
+  assert.equal(r.route_group, 'cart');
+  assert.equal(r.surface, 'CART');
+  assert.equal(r.priority_tier, 'CWV_P0');
+  assert.equal(r.funnel_step, 'checkout_entry');
+});
+
+test('classifyRoute: checkout', () => {
+  const r = classifyRoute('/checkout/livraison');
+  assert.equal(r.route_group, 'checkout');
+  assert.equal(r.surface, 'CHECKOUT');
+  assert.equal(r.priority_tier, 'CWV_P0');
+  assert.equal(r.funnel_step, 'checkout_step');
+});
+
+test('classifyRoute: payment', () => {
+  const r = classifyRoute('/paiement');
+  assert.equal(r.route_group, 'payment');
+  assert.equal(r.surface, 'PAYMENT');
+  assert.equal(r.priority_tier, 'CWV_P0');
+  assert.equal(r.funnel_step, 'payment');
+});
+
+test('classifyRoute: account', () => {
+  const r = classifyRoute('/compte/commandes');
+  assert.equal(r.route_group, 'account');
+  assert.equal(r.surface, 'ACCOUNT');
+  assert.equal(r.priority_tier, 'CWV_P2');
+});
+
+test('classifyRoute: home exact match', () => {
+  const r = classifyRoute('/');
+  assert.equal(r.route_group, 'home');
+  assert.equal(r.surface, 'HOME');
+  assert.equal(r.funnel_step, 'landing');
+});
+
+test('classifyRoute: other fallback', () => {
+  assert.equal(classifyRoute('/sitemap.xml').route_group, 'other');
+  assert.equal(classifyRoute('/robots.txt').route_group, 'other');
+  assert.equal(classifyRoute('/api/health').route_group, 'other');
+  assert.equal(classifyRoute('/foo/bar/baz').route_group, 'other');
+});
+
+test('classifyRoute: null/undefined/empty → other', () => {
+  assert.equal(classifyRoute(null).route_group, 'other');
+  assert.equal(classifyRoute(undefined).route_group, 'other');
+  assert.equal(classifyRoute('').route_group, 'other');
+});
+
+test('classifyRoute: GSC INP report fixtures (sample 12 of 376 /pieces/* URLs)', () => {
+  // Sous-ensemble représentatif extrait du rapport GSC INP mobile 537ms /pieces/*
+  // (cf. plan owner). Toutes ces URLs doivent map à pieces_product (suffix .html)
+  // ou pieces_gamme_vehicle (sans .html). Surface = R2_PRODUCT ou R2_GAMME_VEHICLE.
+  const fixtures: Array<{ path: string; expectedGroup: 'pieces_product' | 'pieces_gamme_vehicle' }> = [
+    { path: '/pieces/disque-de-frein/peugeot/308/1.6-hdi/68681.html', expectedGroup: 'pieces_product' },
+    { path: '/pieces/plaquette-de-frein/renault/clio-iv/1.5-dci/45112.html', expectedGroup: 'pieces_product' },
+    { path: '/pieces/filtre-a-huile/peugeot/208/1.2-puretech/23145.html', expectedGroup: 'pieces_product' },
+    { path: '/pieces/amortisseur/citroen/c3/1.6-hdi/89231.html', expectedGroup: 'pieces_product' },
+    { path: '/pieces/courroie-de-distribution/peugeot/2008/1.6-hdi/55421.html', expectedGroup: 'pieces_product' },
+    { path: '/pieces/freinage/peugeot/308/1.6-hdi', expectedGroup: 'pieces_gamme_vehicle' },
+    { path: '/pieces/freinage/renault/clio-iv/1.5-dci', expectedGroup: 'pieces_gamme_vehicle' },
+    { path: '/pieces/embrayage/peugeot/308', expectedGroup: 'pieces_gamme_vehicle' },
+    { path: '/pieces/suspension/citroen/c3/1.6-hdi', expectedGroup: 'pieces_gamme_vehicle' },
+    { path: '/pieces/distribution/peugeot/2008', expectedGroup: 'pieces_gamme_vehicle' },
+    { path: '/pieces/freinage', expectedGroup: 'pieces_gamme_vehicle' },
+    { path: '/pieces/echappement', expectedGroup: 'pieces_gamme_vehicle' },
+  ];
+  for (const { path, expectedGroup } of fixtures) {
+    const r = classifyRoute(path);
+    assert.equal(r.route_group, expectedGroup, `expected ${expectedGroup} for ${path}, got ${r.route_group}`);
+    // R2_PRODUCT et R2_GAMME_VEHICLE diffèrent en tier (P0 vs P1) mais sont toutes
+    // sous le surface family "R2_*"
+    assert.ok(r.surface.startsWith('R2_'), `expected R2_* surface for ${path}`);
+  }
+});
+
+test('classifyRoute: idempotence (re-classification stable)', () => {
+  const paths = ['/pieces/x/y/z.html', '/conseils/foo', '/checkout', '/'];
+  for (const p of paths) {
+    const a = classifyRoute(p);
+    const b = classifyRoute(p);
+    assert.deepEqual(a, b);
+  }
+});

--- a/packages/cwv-taxonomy/src/__tests__/schema.test.ts
+++ b/packages/cwv-taxonomy/src/__tests__/schema.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests Zod schemas — boundary enforcement, strict mode.
+ */
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { CwvBeaconClientPayloadSchema, CwvBeaconServerInsertSchema } from '../schema';
+
+const validClientPayload = {
+  session_id: 'abc12345',
+  surface: 'R2_PRODUCT',
+  route_group: 'pieces_product',
+  funnel_step: 'view_product',
+  previous_funnel_step: 'view_listing',
+  url: 'https://www.automecanik.com/pieces/x/y/z.html',
+  metric: 'INP',
+  value: 250,
+  device: 'mobile',
+  attribution: {
+    attr_target: '.btn-add-cart',
+    attr_input_delay: 50,
+    attr_processing_duration: 100,
+    attr_presentation_delay: 100,
+  },
+  nav_type: 'navigate',
+} as const;
+
+test('CwvBeaconClientPayloadSchema: valid payload passes', () => {
+  const r = CwvBeaconClientPayloadSchema.safeParse(validClientPayload);
+  assert.equal(r.success, true);
+});
+
+test('CwvBeaconClientPayloadSchema: rejects unknown surface (CHECK IN strict)', () => {
+  const r = CwvBeaconClientPayloadSchema.safeParse({
+    ...validClientPayload,
+    surface: 'NOT_A_SURFACE',
+  });
+  assert.equal(r.success, false);
+});
+
+test('CwvBeaconClientPayloadSchema: rejects negative metric value', () => {
+  const r = CwvBeaconClientPayloadSchema.safeParse({ ...validClientPayload, value: -1 });
+  assert.equal(r.success, false);
+});
+
+test('CwvBeaconClientPayloadSchema: rejects value > 60000', () => {
+  const r = CwvBeaconClientPayloadSchema.safeParse({ ...validClientPayload, value: 60001 });
+  assert.equal(r.success, false);
+});
+
+test('CwvBeaconClientPayloadSchema: rejects short session_id (<8)', () => {
+  const r = CwvBeaconClientPayloadSchema.safeParse({ ...validClientPayload, session_id: 'abc' });
+  assert.equal(r.success, false);
+});
+
+test('CwvBeaconClientPayloadSchema: rejects long session_id (>64)', () => {
+  const r = CwvBeaconClientPayloadSchema.safeParse({
+    ...validClientPayload,
+    session_id: 'a'.repeat(65),
+  });
+  assert.equal(r.success, false);
+});
+
+test('CwvBeaconClientPayloadSchema: rejects non-URL url', () => {
+  const r = CwvBeaconClientPayloadSchema.safeParse({ ...validClientPayload, url: 'not-a-url' });
+  assert.equal(r.success, false);
+});
+
+test('CwvBeaconClientPayloadSchema: strict mode rejects extra keys', () => {
+  const r = CwvBeaconClientPayloadSchema.safeParse({ ...validClientPayload, extra_field: 'x' });
+  assert.equal(r.success, false);
+});
+
+test('CwvBeaconClientPayloadSchema: previous_funnel_step nullable', () => {
+  const r = CwvBeaconClientPayloadSchema.safeParse({
+    ...validClientPayload,
+    previous_funnel_step: null,
+  });
+  assert.equal(r.success, true);
+});
+
+test('CwvBeaconClientPayloadSchema: attribution optional', () => {
+  const { attribution, ...rest } = validClientPayload;
+  void attribution;
+  const r = CwvBeaconClientPayloadSchema.safeParse(rest);
+  assert.equal(r.success, true);
+});
+
+test('CwvBeaconServerInsertSchema: extends client + adds priority_tier + ua_class', () => {
+  const r = CwvBeaconServerInsertSchema.safeParse({
+    ...validClientPayload,
+    priority_tier: 'CWV_P0',
+    ua_class: 'human',
+  });
+  assert.equal(r.success, true);
+});
+
+test('CwvBeaconServerInsertSchema: rejects without priority_tier', () => {
+  const r = CwvBeaconServerInsertSchema.safeParse({
+    ...validClientPayload,
+    ua_class: 'human',
+  });
+  assert.equal(r.success, false);
+});
+
+test('CwvBeaconServerInsertSchema: rejects unknown ua_class', () => {
+  const r = CwvBeaconServerInsertSchema.safeParse({
+    ...validClientPayload,
+    priority_tier: 'CWV_P0',
+    ua_class: 'martian',
+  });
+  assert.equal(r.success, false);
+});

--- a/packages/cwv-taxonomy/src/__tests__/user-agent.test.ts
+++ b/packages/cwv-taxonomy/src/__tests__/user-agent.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests classifyUserAgent() — patterns case-insensitive, first-category-wins.
+ *
+ * Fixtures représentatives des bots actuellement rencontrés en field (Googlebot,
+ * ClaudeBot, Perplexity, Bytespider) + UAs humains canoniques (Chrome mobile
+ * Android, Safari iOS).
+ */
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { classifyUserAgent, isBot } from '../user-agent';
+
+test('classifyUserAgent: bot_search — Googlebot', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'),
+    'bot_search',
+  );
+});
+
+test('classifyUserAgent: bot_search — Bingbot lowercase variant', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'),
+    'bot_search',
+  );
+});
+
+test('classifyUserAgent: bot_ai — GPTBot', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.0; +https://openai.com/gptbot'),
+    'bot_ai',
+  );
+});
+
+test('classifyUserAgent: bot_ai — ClaudeBot', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ClaudeBot/1.0; +claudebot@anthropic.com'),
+    'bot_ai',
+  );
+});
+
+test('classifyUserAgent: bot_ai — PerplexityBot', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://docs.perplexity.ai/docs/perplexity-bot)'),
+    'bot_ai',
+  );
+});
+
+test('classifyUserAgent: bot_ai — Bytespider', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 (Linux; Android 5.0) Bytespider; spider-feedback@bytedance.com'),
+    'bot_ai',
+  );
+});
+
+test('classifyUserAgent: bot_other — AhrefsBot', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)'),
+    'bot_other',
+  );
+});
+
+test('classifyUserAgent: bot_other — Lighthouse', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 (Linux; Android 11) AppleWebKit Chrome-Lighthouse'),
+    'bot_other',
+  );
+});
+
+test('classifyUserAgent: human — Chrome mobile Android', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 (Linux; Android 14; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Mobile Safari/537.36'),
+    'human',
+  );
+});
+
+test('classifyUserAgent: human — Safari iOS', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1'),
+    'human',
+  );
+});
+
+test('classifyUserAgent: human — Firefox desktop', () => {
+  assert.equal(
+    classifyUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0'),
+    'human',
+  );
+});
+
+test('classifyUserAgent: null/undefined/empty → human (graceful fallback)', () => {
+  assert.equal(classifyUserAgent(null), 'human');
+  assert.equal(classifyUserAgent(undefined), 'human');
+  assert.equal(classifyUserAgent(''), 'human');
+});
+
+test('classifyUserAgent: case-insensitivity (BOTH cases handled)', () => {
+  assert.equal(classifyUserAgent('GOOGLEBOT/2.1'), 'bot_search');
+  assert.equal(classifyUserAgent('googlebot/2.1'), 'bot_search');
+  assert.equal(classifyUserAgent('GoogleBot/2.1'), 'bot_search');
+});
+
+test('isBot: true for bot_*, false for human', () => {
+  assert.equal(isBot('bot_search'), true);
+  assert.equal(isBot('bot_ai'), true);
+  assert.equal(isBot('bot_other'), true);
+  assert.equal(isBot('human'), false);
+});

--- a/packages/cwv-taxonomy/src/funnel-step.ts
+++ b/packages/cwv-taxonomy/src/funnel-step.ts
@@ -1,0 +1,74 @@
+/**
+ * FunnelStep — ordre canonique du parcours conversion.
+ *
+ * Mirror strict de `.spec/00-canon/seo-runtime/cwv-taxonomy.yaml` §funnel_steps_order.
+ * Ordre dans le tableau = ordre business attendu. Validation `previous_funnel_step
+ * <= funnel_step` faite côté collector via FUNNEL_STEP_ORDER lookup.
+ */
+
+import type { Surface } from './surface';
+
+export const FUNNEL_STEP_VALUES = [
+  'landing',
+  'view_listing',
+  'view_product',
+  'view_guide',
+  'view_diagnostic',
+  'view_vehicle',
+  'view_search',
+  'view_account',
+  'view_other',
+  'add_cart',
+  'checkout_entry',
+  'checkout_step',
+  'payment',
+  'completed',
+] as const;
+
+export type FunnelStep = (typeof FUNNEL_STEP_VALUES)[number];
+
+/** Lookup ordre (0-indexed) — utilisé pour valider previous_funnel_step <= funnel_step. */
+export const FUNNEL_STEP_ORDER: Readonly<Record<FunnelStep, number>> = Object.freeze(
+  FUNNEL_STEP_VALUES.reduce(
+    (acc, step, idx) => {
+      acc[step] = idx;
+      return acc;
+    },
+    {} as Record<FunnelStep, number>,
+  ),
+);
+
+/** Mapping Surface → FunnelStep canonique (par défaut, peut être overridé via context). */
+export const SURFACE_TO_FUNNEL_STEP: Readonly<Record<Surface, FunnelStep>> = Object.freeze({
+  R2_PRODUCT: 'view_product',
+  R2_GAMME_VEHICLE: 'view_listing',
+  R3_GUIDE: 'view_guide',
+  R5_DIAGNOSTIC: 'view_diagnostic',
+  R8_VEHICLE: 'view_vehicle',
+  SEARCH: 'view_search',
+  HOME: 'landing',
+  CART: 'checkout_entry',
+  CHECKOUT: 'checkout_step',
+  PAYMENT: 'payment',
+  ACCOUNT: 'view_account',
+  OTHER: 'view_other',
+});
+
+export function isFunnelStep(value: unknown): value is FunnelStep {
+  return (
+    typeof value === 'string' &&
+    (FUNNEL_STEP_VALUES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Validate that `previous` precedes (or equals) `current` in funnel order.
+ * Returns true if `previous` is null/undefined (initial step).
+ */
+export function isValidFunnelTransition(
+  previous: FunnelStep | null | undefined,
+  current: FunnelStep,
+): boolean {
+  if (previous === null || previous === undefined) return true;
+  return FUNNEL_STEP_ORDER[previous] <= FUNNEL_STEP_ORDER[current];
+}

--- a/packages/cwv-taxonomy/src/index.ts
+++ b/packages/cwv-taxonomy/src/index.ts
@@ -1,0 +1,74 @@
+/**
+ * @repo/cwv-taxonomy — Single source of truth for CWV runtime taxonomy.
+ *
+ * Mirror runtime de `.spec/00-canon/seo-runtime/cwv-taxonomy.yaml`. Consommé
+ * par :
+ *   - frontend/app/utils/web-vitals.client.ts (envoi beacon)
+ *   - backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
+ *     (validation + classification + INSERT)
+ *
+ * Discipline V1A :
+ *   - Enums fermés, CHECK IN au niveau DB
+ *   - classifyRoute() = whitelist déterministe (jamais d'auto-discovery)
+ *   - classifyUserAgent() = patterns case-insensitive (anti-pollution p75)
+ *   - SoT humaine = YAML ; SoT runtime = ce package
+ */
+
+export {
+  SURFACE_VALUES,
+  SURFACE_DESCRIPTIONS,
+  isSurface,
+} from './surface';
+export type { Surface } from './surface';
+
+export {
+  FUNNEL_STEP_VALUES,
+  FUNNEL_STEP_ORDER,
+  SURFACE_TO_FUNNEL_STEP,
+  isFunnelStep,
+  isValidFunnelTransition,
+} from './funnel-step';
+export type { FunnelStep } from './funnel-step';
+
+export {
+  PRIORITY_TIER_VALUES,
+  SURFACE_TO_PRIORITY_TIER,
+  isPriorityTier,
+  priorityTierFromSurface,
+} from './priority-tier';
+export type { PriorityTier } from './priority-tier';
+
+export {
+  ROUTE_GROUP_VALUES,
+  ROUTE_GROUP_TO_SURFACE,
+  isRouteGroup,
+  classifyRoute,
+} from './route-group';
+export type { RouteGroup, RouteClassification } from './route-group';
+
+export {
+  USER_AGENT_CLASS_VALUES,
+  isUserAgentClass,
+  classifyUserAgent,
+  isBot,
+} from './user-agent';
+export type { UserAgentClass } from './user-agent';
+
+export {
+  METRIC_NAME_VALUES,
+  DEVICE_TYPE_VALUES,
+  NAV_TYPE_VALUES,
+  METRIC_BOUNDS,
+  isMetricName,
+  isDeviceType,
+  isNavType,
+  rateMetric,
+} from './metric';
+export type { MetricName, DeviceType, NavType, MetricBounds, MetricRating } from './metric';
+
+export {
+  CwvAttributionSchema,
+  CwvBeaconClientPayloadSchema,
+  CwvBeaconServerInsertSchema,
+} from './schema';
+export type { CwvBeaconClientPayload, CwvBeaconServerInsert } from './schema';

--- a/packages/cwv-taxonomy/src/metric.ts
+++ b/packages/cwv-taxonomy/src/metric.ts
@@ -1,0 +1,66 @@
+/**
+ * Web Vitals metrics — types + bornes Zod-ready.
+ *
+ * Mirror strict de `.spec/00-canon/seo-runtime/cwv-taxonomy.yaml` §metrics.
+ * Bornes runtime (min/max) enforcées au beacon controller via Zod.
+ */
+
+export const METRIC_NAME_VALUES = ['LCP', 'INP', 'CLS', 'FCP', 'TTFB'] as const;
+export type MetricName = (typeof METRIC_NAME_VALUES)[number];
+
+export const DEVICE_TYPE_VALUES = ['mobile', 'desktop', 'tablet', 'unknown'] as const;
+export type DeviceType = (typeof DEVICE_TYPE_VALUES)[number];
+
+export const NAV_TYPE_VALUES = [
+  'navigate',
+  'reload',
+  'back_forward',
+  'prerender',
+  'restore',
+  'unknown',
+] as const;
+export type NavType = (typeof NAV_TYPE_VALUES)[number];
+
+export interface MetricBounds {
+  unit: 'ms' | 'ratio';
+  min: number;
+  max: number;
+  good_threshold: number;
+  poor_threshold: number;
+}
+
+export const METRIC_BOUNDS: Readonly<Record<MetricName, MetricBounds>> = Object.freeze({
+  LCP: { unit: 'ms', min: 0, max: 60000, good_threshold: 2500, poor_threshold: 4000 },
+  INP: { unit: 'ms', min: 0, max: 60000, good_threshold: 200, poor_threshold: 500 },
+  CLS: { unit: 'ratio', min: 0, max: 5, good_threshold: 0.1, poor_threshold: 0.25 },
+  FCP: { unit: 'ms', min: 0, max: 60000, good_threshold: 1800, poor_threshold: 3000 },
+  TTFB: { unit: 'ms', min: 0, max: 60000, good_threshold: 800, poor_threshold: 1800 },
+});
+
+export function isMetricName(value: unknown): value is MetricName {
+  return (
+    typeof value === 'string' && (METRIC_NAME_VALUES as readonly string[]).includes(value)
+  );
+}
+
+export function isDeviceType(value: unknown): value is DeviceType {
+  return (
+    typeof value === 'string' && (DEVICE_TYPE_VALUES as readonly string[]).includes(value)
+  );
+}
+
+export function isNavType(value: unknown): value is NavType {
+  return (
+    typeof value === 'string' && (NAV_TYPE_VALUES as readonly string[]).includes(value)
+  );
+}
+
+/** Rating tier per Web Vitals lib spec — based on metric thresholds. */
+export type MetricRating = 'good' | 'needs-improvement' | 'poor';
+
+export function rateMetric(name: MetricName, value: number): MetricRating {
+  const b = METRIC_BOUNDS[name];
+  if (value <= b.good_threshold) return 'good';
+  if (value <= b.poor_threshold) return 'needs-improvement';
+  return 'poor';
+}

--- a/packages/cwv-taxonomy/src/priority-tier.ts
+++ b/packages/cwv-taxonomy/src/priority-tier.ts
@@ -1,0 +1,42 @@
+/**
+ * PriorityTier — pondération business pour alerting & dashboards.
+ *
+ * Mirror strict de `.spec/00-canon/seo-runtime/cwv-taxonomy.yaml` §priority_tiers.
+ *
+ * CWV_P0 = surveillance stricte (alerts trend-divergence-sustained, bloc 6).
+ * CWV_P1 = monitoring standard (dashboard, pas d'alert auto).
+ * CWV_P2 = best-effort (tracking sans alerte).
+ */
+
+import type { Surface } from './surface';
+
+export const PRIORITY_TIER_VALUES = ['CWV_P0', 'CWV_P1', 'CWV_P2'] as const;
+
+export type PriorityTier = (typeof PRIORITY_TIER_VALUES)[number];
+
+export const SURFACE_TO_PRIORITY_TIER: Readonly<Record<Surface, PriorityTier>> =
+  Object.freeze({
+    PAYMENT: 'CWV_P0',
+    CHECKOUT: 'CWV_P0',
+    CART: 'CWV_P0',
+    R5_DIAGNOSTIC: 'CWV_P0',
+    R2_PRODUCT: 'CWV_P0',
+    R2_GAMME_VEHICLE: 'CWV_P1',
+    R8_VEHICLE: 'CWV_P1',
+    SEARCH: 'CWV_P1',
+    R3_GUIDE: 'CWV_P1',
+    HOME: 'CWV_P2',
+    ACCOUNT: 'CWV_P2',
+    OTHER: 'CWV_P2',
+  });
+
+export function isPriorityTier(value: unknown): value is PriorityTier {
+  return (
+    typeof value === 'string' &&
+    (PRIORITY_TIER_VALUES as readonly string[]).includes(value)
+  );
+}
+
+export function priorityTierFromSurface(surface: Surface): PriorityTier {
+  return SURFACE_TO_PRIORITY_TIER[surface];
+}

--- a/packages/cwv-taxonomy/src/route-group.ts
+++ b/packages/cwv-taxonomy/src/route-group.ts
@@ -1,0 +1,122 @@
+/**
+ * RouteGroup + classifyRoute() — mapping déterministe path → route_group → surface.
+ *
+ * Mirror strict de `.spec/00-canon/seo-runtime/cwv-taxonomy.yaml` §route_groups.
+ * Whitelist fermée — ajout d'une nouvelle route = PR explicite (anti-discovery).
+ *
+ * Algorithm : first-match-wins par ordre de spécificité (plus longue ou
+ * suffix-distinctive d'abord).
+ */
+
+import type { FunnelStep } from './funnel-step';
+import { SURFACE_TO_FUNNEL_STEP } from './funnel-step';
+import type { PriorityTier } from './priority-tier';
+import { SURFACE_TO_PRIORITY_TIER } from './priority-tier';
+import type { Surface } from './surface';
+
+export const ROUTE_GROUP_VALUES = [
+  'pieces_product',
+  'pieces_gamme_vehicle',
+  'r3_guide',
+  'r5_diagnostic',
+  'r8_vehicle',
+  'marques_listing',
+  'search',
+  'cart',
+  'checkout',
+  'payment',
+  'account',
+  'home',
+  'other',
+] as const;
+
+export type RouteGroup = (typeof ROUTE_GROUP_VALUES)[number];
+
+export const ROUTE_GROUP_TO_SURFACE: Readonly<Record<RouteGroup, Surface>> = Object.freeze({
+  pieces_product: 'R2_PRODUCT',
+  pieces_gamme_vehicle: 'R2_GAMME_VEHICLE',
+  r3_guide: 'R3_GUIDE',
+  r5_diagnostic: 'R5_DIAGNOSTIC',
+  r8_vehicle: 'R8_VEHICLE',
+  marques_listing: 'R2_GAMME_VEHICLE',
+  search: 'SEARCH',
+  cart: 'CART',
+  checkout: 'CHECKOUT',
+  payment: 'PAYMENT',
+  account: 'ACCOUNT',
+  home: 'HOME',
+  other: 'OTHER',
+});
+
+export function isRouteGroup(value: unknown): value is RouteGroup {
+  return (
+    typeof value === 'string' &&
+    (ROUTE_GROUP_VALUES as readonly string[]).includes(value)
+  );
+}
+
+export interface RouteClassification {
+  route_group: RouteGroup;
+  surface: Surface;
+  priority_tier: PriorityTier;
+  funnel_step: FunnelStep;
+}
+
+/**
+ * Classify a pathname (no query/hash) into the taxonomy.
+ *
+ * Algorithm (first match wins, order matters):
+ *   1. Exact match `/` → home
+ *   2. `/pieces/...` + `.html` → pieces_product (5-segments URL canonical)
+ *   3. `/pieces/...` (no `.html`)         → pieces_gamme_vehicle (4-segments listing)
+ *   4. `/conseils/...`     → r3_guide
+ *   5. `/diagnostic/...`   → r5_diagnostic
+ *   6. `/constructeurs/...`→ r8_vehicle
+ *   7. `/marques/...`      → marques_listing
+ *   8. `/recherche`        → search
+ *   9. `/panier`           → cart
+ *   10. `/checkout`        → checkout
+ *   11. `/paiement`        → payment
+ *   12. `/compte/...`      → account
+ *   13. fallback           → other
+ *
+ * Input is a pathname (e.g. from `URL.pathname`) — query/hash must be stripped
+ * by caller. Empty/null/undefined → 'other'.
+ */
+export function classifyRoute(pathname: string | null | undefined): RouteClassification {
+  let group: RouteGroup = 'other';
+
+  if (pathname !== null && pathname !== undefined && pathname.length > 0) {
+    if (pathname === '/') {
+      group = 'home';
+    } else if (pathname.startsWith('/pieces/')) {
+      group = pathname.endsWith('.html') ? 'pieces_product' : 'pieces_gamme_vehicle';
+    } else if (pathname.startsWith('/conseils/')) {
+      group = 'r3_guide';
+    } else if (pathname.startsWith('/diagnostic/')) {
+      group = 'r5_diagnostic';
+    } else if (pathname.startsWith('/constructeurs/')) {
+      group = 'r8_vehicle';
+    } else if (pathname.startsWith('/marques/')) {
+      group = 'marques_listing';
+    } else if (pathname.startsWith('/recherche')) {
+      group = 'search';
+    } else if (pathname.startsWith('/panier')) {
+      group = 'cart';
+    } else if (pathname.startsWith('/checkout')) {
+      group = 'checkout';
+    } else if (pathname.startsWith('/paiement')) {
+      group = 'payment';
+    } else if (pathname.startsWith('/compte')) {
+      group = 'account';
+    }
+  }
+
+  const surface = ROUTE_GROUP_TO_SURFACE[group];
+  return {
+    route_group: group,
+    surface,
+    priority_tier: SURFACE_TO_PRIORITY_TIER[surface],
+    funnel_step: SURFACE_TO_FUNNEL_STEP[surface],
+  };
+}

--- a/packages/cwv-taxonomy/src/schema.ts
+++ b/packages/cwv-taxonomy/src/schema.ts
@@ -1,0 +1,90 @@
+/**
+ * Zod schemas for CWV beacon payload — runtime validation.
+ *
+ * Bornes alignées sur DB CHECK IN clauses (cf. canon
+ * `feedback_param_pipe_bound_must_match_db_column_type`).
+ *
+ * Used by :
+ *   - backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
+ *     (bloc 3) — POST /api/seo/cwv/beacon body validation
+ */
+
+import { z } from 'zod';
+import { DEVICE_TYPE_VALUES, METRIC_NAME_VALUES, NAV_TYPE_VALUES } from './metric';
+import { ROUTE_GROUP_VALUES } from './route-group';
+import { SURFACE_VALUES } from './surface';
+import { FUNNEL_STEP_VALUES } from './funnel-step';
+import { PRIORITY_TIER_VALUES } from './priority-tier';
+import { USER_AGENT_CLASS_VALUES } from './user-agent';
+
+// z.enum() accepte directement un readonly tuple non-vide → préserve les
+// littéraux côté inférence Zod (sinon `z.infer` collapse vers string).
+const surfaceEnum = z.enum(SURFACE_VALUES);
+const routeGroupEnum = z.enum(ROUTE_GROUP_VALUES);
+const funnelStepEnum = z.enum(FUNNEL_STEP_VALUES);
+const priorityTierEnum = z.enum(PRIORITY_TIER_VALUES);
+const metricNameEnum = z.enum(METRIC_NAME_VALUES);
+const deviceTypeEnum = z.enum(DEVICE_TYPE_VALUES);
+const navTypeEnum = z.enum(NAV_TYPE_VALUES);
+const userAgentClassEnum = z.enum(USER_AGENT_CLASS_VALUES);
+
+/** Attribution payload — selector sanitized client-side before send. */
+export const CwvAttributionSchema = z
+  .object({
+    // INP attribution (truncated 100c côté client)
+    attr_target: z.string().max(120).optional(),
+    attr_interaction_type: z.string().max(40).optional(),
+    attr_load_state: z.string().max(40).optional(),
+    attr_input_delay: z.number().int().min(0).max(60000).optional(),
+    attr_processing_duration: z.number().int().min(0).max(60000).optional(),
+    attr_presentation_delay: z.number().int().min(0).max(60000).optional(),
+    // LCP attribution
+    attr_element: z.string().max(120).optional(),
+    attr_ttfb: z.number().int().min(0).max(60000).optional(),
+    attr_resource_load_delay: z.number().int().min(0).max(60000).optional(),
+    attr_resource_load_duration: z.number().int().min(0).max(60000).optional(),
+    attr_element_render_delay: z.number().int().min(0).max(60000).optional(),
+    // CLS attribution
+    attr_largest_shift_target: z.string().max(120).optional(),
+  })
+  .strict()
+  .optional();
+
+/**
+ * Beacon payload — POST /api/seo/cwv/beacon body.
+ *
+ * Discipline :
+ *   - Tous les enums sont CHECK IN au niveau DB (bloc 3 migration)
+ *   - `value` est borné par metric (vérif applicative supplémentaire, pas
+ *     dans le schema Zod car bounds varient par metric)
+ *   - `url` debug-only, jamais utilisé en agg (PII potential — sanitization
+ *     applicative en aval)
+ *   - `priority_tier` calculé applicatif (pas envoyé par client) — voir
+ *     `CwvBeaconClientPayloadSchema` ci-dessous (subset client) vs
+ *     `CwvBeaconServerInsertSchema` (record DB après enrichissement)
+ */
+export const CwvBeaconClientPayloadSchema = z
+  .object({
+    session_id: z.string().min(8).max(64),
+    surface: surfaceEnum,
+    route_group: routeGroupEnum,
+    funnel_step: funnelStepEnum,
+    previous_funnel_step: funnelStepEnum.nullable(),
+    url: z.string().url().max(2000),
+    metric: metricNameEnum,
+    value: z.number().min(0).max(60000),
+    device: deviceTypeEnum,
+    attribution: CwvAttributionSchema,
+    nav_type: navTypeEnum,
+  })
+  .strict();
+
+export type CwvBeaconClientPayload = z.infer<typeof CwvBeaconClientPayloadSchema>;
+
+/** Server-side enrichment after UA classification + priority_tier mapping. */
+export const CwvBeaconServerInsertSchema = CwvBeaconClientPayloadSchema.extend({
+  priority_tier: priorityTierEnum,
+  ua_class: userAgentClassEnum,
+});
+
+export type CwvBeaconServerInsert = z.infer<typeof CwvBeaconServerInsertSchema>;

--- a/packages/cwv-taxonomy/src/surface.ts
+++ b/packages/cwv-taxonomy/src/surface.ts
@@ -1,0 +1,48 @@
+/**
+ * Surface — granularité métier (ce que vit l'utilisateur).
+ *
+ * Mirror strict de `.spec/00-canon/seo-runtime/cwv-taxonomy.yaml` §surfaces.
+ * Une surface = une intention business. Mapping Surface → FunnelStep figé
+ * (cf. SURFACE_TO_FUNNEL_STEP). Cardinalité bornée (~12 valeurs V1).
+ *
+ * Anti-bricolage : enum const + readonly array → DB CHECK IN enforcé via
+ * runtime test (sync DB enum check ↔ ce code, voir __tests__/surface.test.ts).
+ */
+
+export const SURFACE_VALUES = [
+  'R2_PRODUCT',
+  'R2_GAMME_VEHICLE',
+  'R3_GUIDE',
+  'R5_DIAGNOSTIC',
+  'R8_VEHICLE',
+  'SEARCH',
+  'HOME',
+  'CART',
+  'CHECKOUT',
+  'PAYMENT',
+  'ACCOUNT',
+  'OTHER',
+] as const;
+
+export type Surface = (typeof SURFACE_VALUES)[number];
+
+export const SURFACE_DESCRIPTIONS: Record<Surface, string> = {
+  R2_PRODUCT: 'Page produit pieces (fiche article unique)',
+  R2_GAMME_VEHICLE: 'Page gamme × véhicule (liste de pièces filtrée)',
+  R3_GUIDE: 'Guide thématique / article éditorial',
+  R5_DIAGNOSTIC: 'Page symptôme / diagnostic / réparation',
+  R8_VEHICLE: 'Fiche véhicule (constructeur/modèle/type)',
+  SEARCH: 'Résultats de recherche / autocomplete',
+  HOME: "Page d'accueil",
+  CART: 'Panier (étape pré-checkout)',
+  CHECKOUT: 'Étapes checkout (1..N)',
+  PAYMENT: 'Page paiement (Paybox / SystemPay redirect)',
+  ACCOUNT: 'Espace client (commandes, profil)',
+  OTHER: 'Fallback toute route non classée',
+};
+
+export function isSurface(value: unknown): value is Surface {
+  return (
+    typeof value === 'string' && (SURFACE_VALUES as readonly string[]).includes(value)
+  );
+}

--- a/packages/cwv-taxonomy/src/user-agent.ts
+++ b/packages/cwv-taxonomy/src/user-agent.ts
@@ -1,0 +1,101 @@
+/**
+ * UserAgentClass + classifyUserAgent() — ségrégation bot/human pour aggregation.
+ *
+ * Mirror strict de `.spec/00-canon/seo-runtime/cwv-taxonomy.yaml` §user_agent_classes.
+ *
+ * Canon : bots écrits dans __seo_event_log (debug), humans dans __seo_cwv_raw
+ * (aggregation pure). Évite la pollution p75 humains par les visites crawlers.
+ *
+ * Patterns case-insensitive. First-match-wins par catégorie (search → ai → other → human).
+ */
+
+export const USER_AGENT_CLASS_VALUES = [
+  'human',
+  'bot_search',
+  'bot_ai',
+  'bot_other',
+] as const;
+
+export type UserAgentClass = (typeof USER_AGENT_CLASS_VALUES)[number];
+
+// Patterns sont des sous-chaînes (case-insensitive). Ordre = priorité.
+const BOT_SEARCH_PATTERNS: readonly string[] = [
+  'googlebot',
+  'bingbot',
+  'duckduckbot',
+  'yandexbot',
+  'baiduspider',
+  'facebookexternalhit',
+  'linkedinbot',
+  'twitterbot',
+  'slackbot',
+];
+
+const BOT_AI_PATTERNS: readonly string[] = [
+  'gptbot',
+  'claudebot',
+  'claude-web',
+  'chatgpt-user',
+  'oai-searchbot',
+  'perplexitybot',
+  'perplexity-user',
+  'anthropic-ai',
+  'bytespider',
+  'amazonbot',
+  'applebot',
+  'google-extended',
+  'ccbot',
+  'diffbot',
+];
+
+const BOT_OTHER_PATTERNS: readonly string[] = [
+  'ahrefsbot',
+  'semrushbot',
+  'dotbot',
+  'mj12bot',
+  'petalbot',
+  'webpagetest',
+  'pingdom',
+  'uptimerobot',
+  'lighthouse',
+  'chrome-lighthouse',
+  'speedcurve',
+  'headlesschrome',
+];
+
+export function isUserAgentClass(value: unknown): value is UserAgentClass {
+  return (
+    typeof value === 'string' &&
+    (USER_AGENT_CLASS_VALUES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Classify a UA string.
+ *
+ * Null/empty → 'human' (graceful fallback — un UA absent côté beacon est
+ * exceptionnel mais on ne veut pas dropper la metric ; le filtre bot s'applique
+ * sur match positif uniquement).
+ *
+ * Order : search → ai → other → human. Un UA qui match plusieurs catégories
+ * tombe dans la première (typiquement bot_search prend la priorité).
+ */
+export function classifyUserAgent(ua: string | null | undefined): UserAgentClass {
+  if (!ua) return 'human';
+  const lower = ua.toLowerCase();
+
+  for (const pattern of BOT_SEARCH_PATTERNS) {
+    if (lower.includes(pattern)) return 'bot_search';
+  }
+  for (const pattern of BOT_AI_PATTERNS) {
+    if (lower.includes(pattern)) return 'bot_ai';
+  }
+  for (const pattern of BOT_OTHER_PATTERNS) {
+    if (lower.includes(pattern)) return 'bot_other';
+  }
+  return 'human';
+}
+
+export function isBot(uaClass: UserAgentClass): boolean {
+  return uaClass !== 'human';
+}

--- a/packages/cwv-taxonomy/tsconfig.json
+++ b/packages/cwv-taxonomy/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

**Bloc 2 / 6** du plan owner révisé "CWV Runtime Observability" — taxonomie canonique. **Précède le bloc 3 (beacon ingestion)** : sans ce bloc, les beacons collectés sont non-segmentables et exigeraient un backfill.

**Bloc 1 (rotation partitions) skipped** suite à fact-check live MCP — voir Justification ci-dessous.

## Périmètre

### SoT humaine — canon YAML

`.spec/00-canon/seo-runtime/cwv-taxonomy.yaml` (premier entry du dossier, ownership D15 governance) :
- 12 surfaces (`R2_PRODUCT`, `R2_GAMME_VEHICLE`, `R3_GUIDE`, `R5_DIAGNOSTIC`, `R8_VEHICLE`, `SEARCH`, `HOME`, `CART`, `CHECKOUT`, `PAYMENT`, `ACCOUNT`, `OTHER`)
- 13 route_groups (whitelist fermée, distinction `pieces_product` `.html` 5-segments vs `pieces_gamme_vehicle` 4-segments)
- 3 priority_tiers (`CWV_P0` alerting / `CWV_P1` dashboard / `CWV_P2` best-effort)
- 14 funnel_steps ordonnés (landing → completed)
- 3 catégories bots avec patterns (search / ai / other) + fallback `human`
- 5 metrics avec bornes (LCP/INP/CLS/FCP/TTFB)

### SoT runtime — package `@repo/cwv-taxonomy`

Pattern strict `@repo/seo-roles` (CJS only, tsx test runner, tsconfig composite, ownership D11) :

- **Enums fermés** + type guards : `Surface`, `RouteGroup`, `PriorityTier`, `FunnelStep`, `UserAgentClass`, `MetricName`, `DeviceType`, `NavType`
- **`classifyRoute(pathname)`** : first-match-wins déterministe → `{ route_group, surface, priority_tier, funnel_step }`
- **`classifyUserAgent(ua)`** : case-insensitive patterns Googlebot/GPTBot/ClaudeBot/Perplexity/Bytespider/AhrefsBot/Lighthouse/… → ségrégation bot/human canon
- **`isValidFunnelTransition(prev, curr)`** : validation ordre canonique du parcours
- **Zod schemas** : `CwvBeaconClientPayloadSchema` (strict mode, CHECK IN bounds alignés DB bloc 3) + `CwvBeaconServerInsertSchema` (enrichi `priority_tier` + `ua_class` côté server)

### Tests

**50 tests verts** (`tsx --test`) :
- `route-group.test.ts` × 17 (incluant sous-échantillon 12 fixtures URLs `/pieces/*` du rapport GSC INP 537ms)
- `user-agent.test.ts` × 14 (Googlebot, GPTBot, ClaudeBot, Perplexity, Bytespider, AhrefsBot, Lighthouse, Chrome mobile Android, Safari iOS, Firefox desktop, case-insensitivity, null fallback)
- `funnel-step.test.ts` × 6 (ordering, transitions, surface mapping)
- `schema.test.ts` × 13 (boundary enforcement, strict mode rejects extras, server-side enrichment)

```
# tests 50  # pass 50  # fail 0
```

### Discipline anti-bricolage

- Pattern strict `@repo/seo-roles` (no codegen, TS native + Zod, CJS only — convention monorepo)
- Whitelist routes **fermée** — ajout d'une nouvelle route = PR explicite
- Bots redirigés vers `__seo_event_log` (bloc 5), **JAMAIS** dans `__seo_cwv_raw` (bloc 3)
- Cross-source : col `source` PK anti-fusion (CrUX/Sentry/CF/Lighthouse coexist, jamais d'écrasement)
- `packages/cwv-taxonomy/**` ownership D11 (seo-team) + `.spec/00-canon/seo-runtime/**` D15 (governance)

## Justification — Bloc 1 skipped (fact-check live)

Le plan original disait que `maintain_snapshot_partitions()` excluait `__seo_cwv_daily` et `__seo_snapshot_cf_rum`, créant un "cliff Sept 2026". **Fact-check via MCP supabase** :

| Plan affirme | Réalité live |
|---|---|
| "`maintain_snapshot_partitions` exclut `__seo_snapshot_cf_rum`" | **FAUX** — `cf_rum` est dans `v_tables` depuis migration `20260522_seo_snapshot_partition_rotation.sql:43` |
| "`__seo_cwv_daily` aucun cron" | **FAUX** — couvert par `observability-partition-rotation` 02:40 UTC (actif) |
| "Cliff Sept 2026" | **FAUX** — les 3 cron quotidiens (snapshot 02:20, observability 02:40, quality-history 02:50) maintiennent l'horizon en continu (J+14 perpétuel) |

Les nouvelles tables `__seo_cwv_raw` (bloc 3) et `__seo_cwv_hourly` (bloc 4) s'auto-rotateront via leurs migrations respectives (pattern atomique canon `reference_partitioned_snapshot_tables_need_premake_cron`).

## Suite

- **Bloc 3** : beacon ingestion (`__seo_cwv_raw` migration + controller `/api/seo/cwv/beacon` + frontend `sendBeacon` extension de `web-vitals.client.ts`) — PR séparée
- **Bloc 4** : aggregation hourly + daily + RPCs VOLATILE
- **Bloc 5** : runtime error capture vers `__seo_event_log`
- **Bloc 6** : dashboard admin + funnel correlation + alerts trend-divergence-sustained

## Test plan

- [x] `npm run typecheck` — clean (no errors)
- [x] `npm test` — 50/50 verts via `tsx --test`
- [x] `npm run build` — `dist/` généré (CJS)
- [ ] CI verte (typecheck monorepo + lint + registry validation)
- [ ] Owner review

🤖 Generated with [Claude Code](https://claude.com/claude-code)