### PR TITLE
fix(r8): breadcrumb position 5 missing item URL + microdata coverage

### DIFF
--- a/frontend/app/components/vehicle/r8/r8-schema.ts
+++ b/frontend/app/components/vehicle/r8/r8-schema.ts
@@ -4,13 +4,25 @@
 
 import { type LoaderData, type VehicleData } from "./r8.types";
 
+// 🌐 SoT des URLs canoniques R8 (réutilisé par BreadcrumbSection microdata)
+export function buildR8CanonicalUrls(vehicle: VehicleData) {
+  const baseUrl = "https://www.automecanik.com";
+  return {
+    home: `${baseUrl}/`,
+    constructeurs: `${baseUrl}/constructeurs`,
+    brand: `${baseUrl}/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}.html`,
+    model: `${baseUrl}/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}/${vehicle.modele_alias}-${vehicle.modele_id}.html`,
+    type: `${baseUrl}/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}/${vehicle.modele_alias}-${vehicle.modele_id}/${vehicle.type_alias}-${vehicle.type_id}.html`,
+  };
+}
+
 // 🚗 Génère le schema @graph complet: Car + BreadcrumbList
 export function generateVehicleSchema(
   vehicle: VehicleData,
   breadcrumb: LoaderData["breadcrumb"],
 ) {
-  const baseUrl = "https://www.automecanik.com";
-  const canonicalUrl = `${baseUrl}/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}/${vehicle.modele_alias}-${vehicle.modele_id}/${vehicle.type_alias}-${vehicle.type_id}.html`;
+  const urls = buildR8CanonicalUrls(vehicle);
+  const canonicalUrl = urls.type;
 
   return {
     "@context": "https://schema.org",
@@ -67,30 +79,31 @@ export function generateVehicleSchema(
             "@type": "ListItem",
             position: 1,
             name: "Accueil",
-            item: `${baseUrl}/`,
+            item: urls.home,
           },
           {
             "@type": "ListItem",
             position: 2,
             name: "Constructeurs",
-            item: `${baseUrl}/constructeurs`,
+            item: urls.constructeurs,
           },
           {
             "@type": "ListItem",
             position: 3,
             name: breadcrumb.brand,
-            item: `${baseUrl}/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}.html`,
+            item: urls.brand,
           },
           {
             "@type": "ListItem",
             position: 4,
             name: breadcrumb.model,
-            item: `${baseUrl}/constructeurs/${vehicle.marque_alias}-${vehicle.marque_id}/${vehicle.modele_alias}-${vehicle.modele_id}.html`,
+            item: urls.model,
           },
           {
             "@type": "ListItem",
             position: 5,
             name: `${breadcrumb.type} ${vehicle.type_power_ps} ch`,
+            item: urls.type,
           },
         ],
       },

--- a/frontend/app/components/vehicle/r8/sections/BreadcrumbSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/BreadcrumbSection.tsx
@@ -1,6 +1,7 @@
 // 🍞 R8 Vehicle — S_BREADCRUMB
 // Schema.org BreadcrumbList microdata (for Google rich snippets).
 
+import { buildR8CanonicalUrls } from "../r8-schema";
 import { type LoaderData } from "../r8.types";
 
 interface Props {
@@ -9,6 +10,7 @@ interface Props {
 }
 
 export function BreadcrumbSection({ vehicle, breadcrumb }: Props) {
+  const urls = buildR8CanonicalUrls(vehicle);
   return (
     <nav
       className="bg-white border-b border-gray-200 py-3"
@@ -73,8 +75,15 @@ export function BreadcrumbSection({ vehicle, breadcrumb }: Props) {
             itemScope
             itemType="https://schema.org/ListItem"
           >
-            <span itemProp="name" className="text-gray-600">
-              {breadcrumb.model}
+            <span
+              itemProp="item"
+              itemScope
+              itemType="https://schema.org/WebPage"
+            >
+              <meta itemProp="url" content={urls.model} />
+              <span itemProp="name" className="text-gray-600">
+                {breadcrumb.model}
+              </span>
             </span>
             <meta itemProp="position" content="4" />
           </li>
@@ -86,8 +95,15 @@ export function BreadcrumbSection({ vehicle, breadcrumb }: Props) {
             itemScope
             itemType="https://schema.org/ListItem"
           >
-            <span itemProp="name" className="font-semibold text-gray-900">
-              {vehicle.type_name} {vehicle.type_power_ps} ch
+            <span
+              itemProp="item"
+              itemScope
+              itemType="https://schema.org/WebPage"
+            >
+              <meta itemProp="url" content={urls.type} />
+              <span itemProp="name" className="font-semibold text-gray-900">
+                {vehicle.type_name} {vehicle.type_power_ps} ch
+              </span>
             </span>
             <meta itemProp="position" content="5" />
           </li>

--- a/frontend/tests/unit/r8-schema.test.ts
+++ b/frontend/tests/unit/r8-schema.test.ts
@@ -57,7 +57,7 @@ describe("buildR8CanonicalUrls", () => {
   it("toutes les URLs sont absolues HTTPS", () => {
     const urls = buildR8CanonicalUrls(vehicleFixture);
     for (const url of Object.values(urls)) {
-      expect(url.startsWith("https://www.automecanik.com")).toBe(true);
+      expect(url.startsWith("https://www.automecanik.com/")).toBe(true);
     }
   });
 });

--- a/frontend/tests/unit/r8-schema.test.ts
+++ b/frontend/tests/unit/r8-schema.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildR8CanonicalUrls,
+  generateVehicleSchema,
+} from "~/components/vehicle/r8/r8-schema";
+import  { type LoaderData, type VehicleData } from "~/components/vehicle/r8/r8.types";
+
+// Fixture = Renault Safrane I 2.1 TD (URL réelle remontée par GSC le 2026-05-23)
+const vehicleFixture: VehicleData = {
+  marque_id: 140,
+  marque_alias: "renault",
+  marque_name: "Renault",
+  marque_name_meta: "Renault",
+  marque_name_meta_title: "Renault",
+  marque_logo: "renault.png",
+  marque_relfollow: 1,
+  modele_id: 140082,
+  modele_alias: "safrane-i",
+  modele_name: "Safrane I",
+  modele_name_meta: "Safrane I",
+  modele_relfollow: 1,
+  type_id: 3766,
+  type_alias: "2-1-td",
+  type_name: "2.1 TD",
+  type_name_meta: "2.1 TD",
+  type_power_ps: "88",
+  type_body: "Berline",
+  type_fuel: "Diesel",
+  type_month_from: "01",
+  type_year_from: "1993",
+  type_month_to: "12",
+  type_year_to: "1996",
+  type_relfollow: 1,
+  power: "88 ch",
+  date: "1993-2000",
+};
+
+const breadcrumbFixture: LoaderData["breadcrumb"] = {
+  brand: "Renault",
+  model: "Safrane I",
+  type: "2.1 TD",
+};
+
+describe("buildR8CanonicalUrls", () => {
+  it("produit les 5 URLs canoniques au format attendu", () => {
+    const urls = buildR8CanonicalUrls(vehicleFixture);
+    expect(urls).toEqual({
+      home: "https://www.automecanik.com/",
+      constructeurs: "https://www.automecanik.com/constructeurs",
+      brand: "https://www.automecanik.com/constructeurs/renault-140.html",
+      model:
+        "https://www.automecanik.com/constructeurs/renault-140/safrane-i-140082.html",
+      type: "https://www.automecanik.com/constructeurs/renault-140/safrane-i-140082/2-1-td-3766.html",
+    });
+  });
+
+  it("toutes les URLs sont absolues HTTPS", () => {
+    const urls = buildR8CanonicalUrls(vehicleFixture);
+    for (const url of Object.values(urls)) {
+      expect(url.startsWith("https://www.automecanik.com")).toBe(true);
+    }
+  });
+});
+
+describe("generateVehicleSchema — BreadcrumbList", () => {
+  const schema = generateVehicleSchema(vehicleFixture, breadcrumbFixture);
+  const breadcrumbNode = schema["@graph"].find(
+    (n) => (n as { "@type": string })["@type"] === "BreadcrumbList",
+  ) as { itemListElement: Array<Record<string, unknown>> };
+
+  it("expose un nœud BreadcrumbList dans @graph", () => {
+    expect(breadcrumbNode).toBeDefined();
+    expect(breadcrumbNode.itemListElement).toHaveLength(5);
+  });
+
+  it("tous les itemListElement (positions 1-5) ont position, name et item", () => {
+    for (const li of breadcrumbNode.itemListElement) {
+      expect(li["@type"]).toBe("ListItem");
+      expect(typeof li.position).toBe("number");
+      expect(typeof li.name).toBe("string");
+      expect((li.name as string).length).toBeGreaterThan(0);
+      expect(typeof li.item).toBe("string");
+      expect((li.item as string).startsWith("https://")).toBe(true);
+    }
+  });
+
+  it("position 5 (type) référence l'URL canonique de la page courante — régression GSC", () => {
+    const last = breadcrumbNode.itemListElement[4];
+    expect(last.position).toBe(5);
+    expect(last.item).toBe(
+      "https://www.automecanik.com/constructeurs/renault-140/safrane-i-140082/2-1-td-3766.html",
+    );
+  });
+
+  it("positions ordonnées 1..5 sans trou", () => {
+    expect(
+      breadcrumbNode.itemListElement.map((li) => li.position),
+    ).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("chaque URL est imbriquée dans la précédente (cohérence hiérarchique)", () => {
+    const items = breadcrumbNode.itemListElement.map(
+      (li) => li.item as string,
+    );
+    expect(items[2].startsWith(items[1])).toBe(true);
+    expect(items[3].startsWith(items[2].replace(/\.html$/, ""))).toBe(true);
+    expect(items[4].startsWith(items[3].replace(/\.html$/, ""))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Bug

Sur la page véhicule R8 (`/constructeurs/{brand}/{model}/{type}.html`), le
**BreadcrumbList** SEO comportait deux trous de conformité Schema.org détectés
sur GSC le 2026-05-23 (URL incidente : `/constructeurs/renault-140/safrane-i-140082/2-1-td-3766.html`) :

1. **JSON-LD (`r8-schema.ts`)** : la position 5 (type véhicule = page courante)
   n'avait pas de champ `item` — Google remontait *\"Item missing URL\"* dans le
   rapport rich snippets.
2. **Microdata (`BreadcrumbSection.tsx`)** : positions 4 (modèle) et 5 (type)
   n'enveloppaient pas le `<span itemProp=\"name\">` dans un
   `<span itemProp=\"item\" itemType=\"WebPage\"><meta itemProp=\"url\">…</span>`.
   Même cause côté HTML semantic pour les crawlers qui ne parsent pas le JSON-LD.

## Fix

- **Position 5 JSON-LD** : ajout du champ `item: urls.type` (URL canonique de
  la page courante).
- **Microdata positions 4 + 5** : enveloppage du nom dans le scope `WebPage` +
  `meta url`, conforme aux deux autres positions (brand position 3 déjà OK).
- **Refactor SoT** : extraction de \`buildR8CanonicalUrls(vehicle)\` →
  retourne `{ home, constructeurs, brand, model, type }`. Réutilisé par les
  deux composants. Plus de duplication de la construction des 5 URLs.

## URLs inchangées

⚠️ Aucune URL canonique modifiée (cf. mémoire \`feedback_no_url_changes_ever.md\`).
Le fix ajoute uniquement le champ \`item\` manquant pointant **sur la même URL
canonique déjà présente dans le \`<link rel=\"canonical\">\`** de la route.

## Test

Nouveau fichier `frontend/tests/unit/r8-schema.test.ts` — 7 cas vitest sur
fixture **Renault Safrane I 2.1 TD** (l'URL exacte remontée par GSC) :

- `buildR8CanonicalUrls` : forme attendue + scheme HTTPS absolu
- `BreadcrumbList` : nœud présent, 5 ListItem
- **Régression** : position 5 référence bien l'URL canonique
- Ordre positions 1..5 sans trou
- Cohérence hiérarchique : chaque URL préfixe la suivante

```
✓ 7 tests passed (935ms)
```

## Test plan

- [x] `npx vitest run tests/unit/r8-schema.test.ts` → 7/7
- [x] `npx tsc --noEmit -p tsconfig.json` → clean (pas d'erreur sur les 3 fichiers)
- [x] `npx eslint ... --max-warnings=0` → clean
- [ ] Smoke route `/constructeurs/renault-140/safrane-i-140082/2-1-td-3766.html`
      en preview → vérifier dans le HTML source que les 5 \`<li itemProp=\"itemListElement\">\`
      ont bien la structure \`<span itemProp=\"item\">…<meta itemProp=\"url\" content=\"...\">\`
- [ ] (post-merge, ~7-14j) Re-tester via Google Search Console *URL Inspection* → warning
      \"Item missing URL\" sur position 5 disparu

## Scope respect

- Pas de changement de routes, slugs, canonical URLs (juste exposition explicite
  des URLs existantes en \`item\`).
- Pas de modification meta_title / desc / H1 (cf. \`feedback_no_touch_meta_h1_if_optimized.md\`).
- Pas de toucher payments/ (n/a — frontend R8 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)