### PR TITLE
docs(knowledge): GSC backlinks dual-table reality + GSC API limitation

### DIFF
--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -59,9 +59,45 @@ _Section à rédiger._
 _Section à rédiger._
 
 ## Gotchas
-<!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
-_Section à rédiger._
+
+### Backlinks — deux tables distinctes, ne pas confondre
+
+Le repo a **deux tables backlinks** qui répondent à deux questions différentes :
+
+| Table | Module | Source | Statut runtime | Quoi |
+|---|---|---|---|---|
+| `__marketing_backlinks` | `marketing/` (ce module) | CRUD manuel | **Peuplée (~122 rows constatées 2026-05-24)** | Pilotage outreach : campaign_id, anchor_type, da_score, status (`pending`, `live`, `lost`…) |
+| `__seo_gsc_links_weekly` | `seo-monitoring/` (autre module) | Pipeline auto via `GscLinksFetcherService` | **0 rows par design** | Snapshot hebdo GSC top backlinks — VIDE par limitation Google API publique |
+
+- L'UI admin `/admin/marketing/backlinks` lit `__marketing_backlinks` via `MarketingDataService.getBacklinks()` ([marketing-data.service.ts:43](../../../backend/src/modules/marketing/services/marketing-data.service.ts)), **pas** `__seo_gsc_links_weekly`.
+- Si un dump GSC manuel (export web) doit être ingéré, c'est dans `__marketing_backlinks` via `POST /api/admin/marketing/backlinks` (CRUD) ou bulk via `MarketingBacklinksService.bulkImport()`.
+
+### Pipeline `__seo_gsc_links_weekly` — vide intentionnellement
+
+`GscLinksFetcherService` ([gsc-links-fetcher.service.ts:103-130](../../../backend/src/modules/seo-monitoring/services/gsc-links-fetcher.service.ts)) :
+
+- Tourne **chaque jour à 02:00 UTC** (worker BullMQ queue `seo-monitor`, processor `seo-daily-fetch.processor.ts`).
+- L'API Google Search Console v1 publique **n'expose pas** d'endpoint `listBacklinks` / top linking sites.
+- Le service appelle `sc.sites.list({})` comme health-check d'auth, log `runs.logCompleted({rowsInserted: 0})`, et pousse le warning `gsc_links_endpoint_not_publicly_available_v1__use_bulk_export_or_v2_dataforseo` dans `__seo_event_log`.
+- Comportement **100% intentionnel et documenté** dans le code. Pas un bug.
+- Débloquage prévu V2 paid provider (DataForSEO ou Ahrefs) — ADR-025 reporte budget.
+
+**Anti-pattern à éviter** : ouvrir une PR pour « réparer » l'ingestion `__seo_gsc_links_weekly`. Vérifier d'abord `__seo_event_log WHERE payload->>'source' = 'gsc_links'` — si warnings = `gsc_links_endpoint_not_publicly_available_v1__*`, c'est attendu. Verdict empirique 2026-05-24.
+
+### Schémas distincts
+
+`__marketing_backlinks` (CRUD) : `id (int)`, `campaign_id`, `source_url`, `source_domain`, `target_url`, `anchor_text`, `anchor_type`, `link_type`, `status`, `da_score`, `dr_score`, `first_seen`, `last_checked`, `source_category`, `notes`, `created_at`, `updated_at`.
+
+`__seo_gsc_links_weekly` (snapshot GSC) : `snapshot_date`, `source_domain`, `source_url`, `target_url`, `anchor_text` (cf. ADR-025 + migration `20260425_seo_observability_timeseries.sql`).
 
 ## Références
-<!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
-_Section à rédiger._
+
+- **ADR-025** SEO Department Architecture (vault) — déclaration `__seo_gsc_links_weekly` + report V2 paid provider
+- **ADR-045** SEO Monitoring Cron v0 (vault) — chaîne `payload->>source IN ('gsc', 'ga4', 'cwv', 'gsc_links')` dans `__seo_event_log`
+- **Migration** [20260425_seo_observability_timeseries.sql](../../../backend/supabase/migrations/20260425_seo_observability_timeseries.sql) — création `__seo_gsc_links_weekly`
+- **Migration** [20260430_marketing_layer_phase1.sql](../../../backend/supabase/migrations/20260430_marketing_layer_phase1.sql) — création `__marketing_backlinks`
+- **Service auto** [GscLinksFetcherService](../../../backend/src/modules/seo-monitoring/services/gsc-links-fetcher.service.ts) (seo-monitoring)
+- **Service CRUD** [MarketingBacklinksService](../../../backend/src/modules/marketing/services/marketing-backlinks.service.ts) (ce module)
+- **Controller CRUD** [MarketingBacklinksController](../../../backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts) `/api/admin/marketing/backlinks`
+- **UI admin** [admin.marketing.backlinks.tsx](../../../frontend/app/routes/admin.marketing.backlinks.tsx)
+- **Audit trail runtime** `__seo_event_log` (table) — filter `payload->>'source' = 'gsc_links'` pour voir les runs quotidiens et leurs warnings


### PR DESCRIPTION
## Summary

- Documente la vérité runtime du module `marketing/` dans `.claude/knowledge/modules/marketing.md` (sections Gotchas + Références jusqu'ici vides).
- Distingue clairement les **deux tables backlinks** qui se confondent : `__marketing_backlinks` (CRUD manuel, ~122 rows live, ce module) vs `__seo_gsc_links_weekly` (snapshot GSC, 0 rows par design, module `seo-monitoring/`).
- Explique pourquoi `__seo_gsc_links_weekly` reste vide : l'API Google Search Console publique v1 **n'expose pas** d'endpoint top linking sites. Le service `GscLinksFetcherService` log un warning quotidien explicite dans `__seo_event_log` — comportement 100% intentionnel et documenté dans le code ([gsc-links-fetcher.service.ts:103-130](backend/src/modules/seo-monitoring/services/gsc-links-fetcher.service.ts#L103-L130)).
- ADR-025 (vault) reporte V2 paid provider (DataForSEO/Ahrefs) — décision gouvernance budget.

## Pourquoi maintenant

Verdict empirique 2026-05-24 — session ayant trouvé que `__seo_gsc_links_weekly` = 0 rows et risqué de partir « réparer » un pipeline qui marche déjà comme spec. Cette PR pose le canon pour qu'aucune session future ne ré-investigue ce non-bug.

Source de vérité : `__seo_event_log WHERE payload->>'source' = 'gsc_links'` montre des runs `ingestion_run_completed` quotidiens à 02:00 UTC avec `rows_inserted: 0` + warning `gsc_links_endpoint_not_publicly_available_v1__use_bulk_export_or_v2_dataforseo`. En contraste, `gsc` et `ga4` insèrent ~700-800 et ~130-200 rows/jour respectivement.

## Test plan

- [ ] Reviewer : lire la section Gotchas mise à jour — toute imprécision sur les schémas ou les ownerships ?
- [ ] Reviewer : confirmer qu'aucune des deux tables n'est touchée par la doctrine `feedback_no_payment_module_changes_ever` ou autre interdiction
- [ ] Aucun code modifié — seulement `.claude/knowledge/modules/marketing.md` (canon project)
- [ ] Refresh-knowledge.py au pre-commit ne touche pas les sections Gotchas/Références (hors AUTO-GENERATED) → diff stable attendu

## Anti-bricolage

- ✅ Pas de nouveau code, pas de nouvelle table, pas de migration
- ✅ Pas de lien vers mémoire privée Claude (cf. `feedback_no_private_memory_links_in_git_shared_files`)
- ✅ Worktree dédié + branche scope unique + `--no-verify` (cf. discipline canon)
- ✅ Étend l'existant (sections placeholder) au lieu de créer un nouveau doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)