### PR TITLE
feat(seo-monitoring): bloc 3 — CWV beacon ingestion (POST /api/seo/cwv/beacon)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -51,6 +51,7 @@
     "@nestjs/websockets": "^10.4.20",
     "@paralleldrive/cuid2": "^2.2.2",
     "@remix-run/express": "^2.17.4",
+    "@repo/cwv-taxonomy": "*",
     "@repo/database-types": "*",
     "@repo/domain-commerce": "*",
     "@repo/registry": "*",

--- a/backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
@@ -1,0 +1,68 @@
+/**
+ * CWV Beacon Controller — Bloc 3 / CWV Runtime Observability.
+ *
+ * Endpoint PUBLIC :
+ *   POST /api/seo/cwv/beacon — reçoit 1 metric web-vitals émise via
+ *   `navigator.sendBeacon` depuis le frontend.
+ *
+ * Public à dessein (mesure runtime utilisateur, no PII collected client-side).
+ * Validation stricte Zod (`CwvBeaconClientPayloadSchema`). Enrichissement
+ * serveur (priority_tier dérivé + ua_class via classifyUserAgent du UA header)
+ * puis routing déterministe vers `__seo_cwv_raw` (humans) ou `__seo_event_log`
+ * (bots) via `CwvBeaconService`.
+ *
+ * Pattern mirror de `FunnelEventsController` :
+ *   - @HttpCode(202) — beacon = fire-and-forget, jamais 4xx visible côté UA
+ *   - Validation safeParse → 202 silencieux si malformé (ne pas casser le client)
+ *   - Throttler @nestjs/throttler 120/min/IP (= ~5 metrics × 24 pages-views/min absolute max)
+ */
+import {
+  Body,
+  Controller,
+  Headers,
+  HttpCode,
+  Logger,
+  Post,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import {
+  CwvBeaconClientPayloadSchema,
+  classifyUserAgent,
+  priorityTierFromSurface,
+  type Surface,
+} from '@repo/cwv-taxonomy';
+import { CwvBeaconService } from '../services/cwv-beacon.service';
+
+@Controller('api/seo/cwv')
+export class CwvBeaconController {
+  private readonly logger = new Logger(CwvBeaconController.name);
+
+  constructor(private readonly cwvBeacon: CwvBeaconService) {}
+
+  @Post('beacon')
+  @HttpCode(202)
+  @Throttle({ default: { limit: 120, ttl: 60_000 } })
+  async beacon(
+    @Body() body: unknown,
+    @Headers('user-agent') ua: string | undefined,
+  ): Promise<{ ok: boolean }> {
+    const parsed = CwvBeaconClientPayloadSchema.safeParse(body);
+    if (!parsed.success) {
+      this.logger.debug(
+        `cwv beacon rejected (schema): ${parsed.error.message}`,
+      );
+      return { ok: false };
+    }
+
+    // Enrichissement serveur (pas envoyé par le client — anti-spoofing) :
+    //   - priority_tier dérivé de surface (lookup déterministe)
+    //   - ua_class via classifyUserAgent sur header (anti-pollution p75 humains)
+    const enriched = {
+      ...parsed.data,
+      priority_tier: priorityTierFromSurface(parsed.data.surface as Surface),
+      ua_class: classifyUserAgent(ua ?? null),
+    };
+
+    return this.cwvBeacon.record(enriched);
+  }
+}

--- a/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
+++ b/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
@@ -25,9 +25,11 @@ import { RContentAuditorService } from './services/r-content-auditor.service';
 import { QualityHistorySnapshotService } from './services/quality-history-snapshot.service';
 import { RagMirrorFreshnessService } from './services/rag-mirror-freshness.service';
 import { FunnelEventsService } from './services/funnel-events.service';
+import { CwvBeaconService } from './services/cwv-beacon.service';
 import { SeoMonitoringController } from './controllers/seo-monitoring.controller';
 import { QualityHistoryController } from './controllers/quality-history.controller';
 import { FunnelEventsController } from './controllers/funnel-events.controller';
+import { CwvBeaconController } from './controllers/cwv-beacon.controller';
 
 @Module({
   imports: [ConfigModule],
@@ -46,11 +48,13 @@ import { FunnelEventsController } from './controllers/funnel-events.controller';
     QualityHistorySnapshotService, // ADR-050 Phase 0 baseline
     RagMirrorFreshnessService, // ADR-046 § L3 RAG MIRROR read-only — PR-E.2
     FunnelEventsService, // Commerce-Loop V1 étape 4-A — funnel outil diagnostic
+    CwvBeaconService, // CWV Runtime Observability bloc 3 — landing beacons web-vitals
   ],
   controllers: [
     SeoMonitoringController,
     QualityHistoryController,
     FunnelEventsController, // POST /api/seo/funnel/event (public beacon)
+    CwvBeaconController, // POST /api/seo/cwv/beacon (public beacon, bloc 3)
   ],
   exports: [
     GoogleCredentialsService,

--- a/backend/src/modules/seo-monitoring/services/cwv-beacon.service.ts
+++ b/backend/src/modules/seo-monitoring/services/cwv-beacon.service.ts
@@ -1,0 +1,89 @@
+/**
+ * CWV Beacon Service — Bloc 3 / CWV Runtime Observability.
+ *
+ * Persiste un beacon CWV émis depuis le frontend (`navigator.sendBeacon`).
+ *
+ * Discipline :
+ *   - Bots (`ua_class != 'human'`) : écrits dans __seo_event_log (debug only),
+ *     JAMAIS dans __seo_cwv_raw — anti-pollution p75 humains (canon plan §5).
+ *   - Humans : INSERT direct dans __seo_cwv_raw (partitioned daily, TTL 48h).
+ *   - Erreurs INSERT : log + retour `ok: false`, JAMAIS d'exception (un beacon
+ *     raté ne doit pas casser une requête user).
+ *   - Pattern mirror de FunnelEventsService (extends SupabaseBaseService).
+ */
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import type { CwvBeaconServerInsert } from '@repo/cwv-taxonomy';
+import { isBot } from '@repo/cwv-taxonomy';
+
+@Injectable()
+export class CwvBeaconService extends SupabaseBaseService {
+  constructor(configService: ConfigService) {
+    super(configService);
+  }
+
+  /**
+   * Persiste un beacon CWV. Fire-and-forget côté appelant.
+   *
+   * Routing déterministe par ua_class :
+   *   - human       → __seo_cwv_raw (aggregation pure, p75 humains)
+   *   - bot_search/ai/other → __seo_event_log (debug only, séparation canon)
+   */
+  async record(input: CwvBeaconServerInsert): Promise<{ ok: boolean }> {
+    if (isBot(input.ua_class)) {
+      return this.recordBot(input);
+    }
+    return this.recordHuman(input);
+  }
+
+  private async recordHuman(input: CwvBeaconServerInsert): Promise<{ ok: boolean }> {
+    const { error } = await this.supabase.from('__seo_cwv_raw').insert({
+      session_id: input.session_id,
+      surface: input.surface,
+      route_group: input.route_group,
+      priority_tier: input.priority_tier,
+      funnel_step: input.funnel_step,
+      previous_funnel_step: input.previous_funnel_step,
+      url: input.url,
+      metric: input.metric,
+      value: input.value,
+      device: input.device,
+      ua_class: input.ua_class,
+      attribution: input.attribution ?? null,
+      nav_type: input.nav_type,
+    });
+    if (error) {
+      this.logger.error(
+        `cwv beacon insert failed (${input.metric}/${input.route_group}): ${error.message}`,
+      );
+      return { ok: false };
+    }
+    return { ok: true };
+  }
+
+  private async recordBot(input: CwvBeaconServerInsert): Promise<{ ok: boolean }> {
+    // Bots : event_log avec payload pour debug, jamais agrégé.
+    const { error } = await this.supabase.from('__seo_event_log').insert({
+      event_type: 'seo.runtime.bot_cwv_beacon',
+      entity_url: input.url,
+      severity: 'info',
+      payload: {
+        ua_class: input.ua_class,
+        metric: input.metric,
+        value: input.value,
+        surface: input.surface,
+        route_group: input.route_group,
+        priority_tier: input.priority_tier,
+        device: input.device,
+      },
+    });
+    if (error) {
+      this.logger.error(
+        `cwv beacon (bot) event_log insert failed (${input.metric}): ${error.message}`,
+      );
+      return { ok: false };
+    }
+    return { ok: true };
+  }
+}

--- a/backend/src/modules/seo-monitoring/services/cwv-beacon.service.ts
+++ b/backend/src/modules/seo-monitoring/services/cwv-beacon.service.ts
@@ -37,7 +37,9 @@ export class CwvBeaconService extends SupabaseBaseService {
     return this.recordHuman(input);
   }
 
-  private async recordHuman(input: CwvBeaconServerInsert): Promise<{ ok: boolean }> {
+  private async recordHuman(
+    input: CwvBeaconServerInsert,
+  ): Promise<{ ok: boolean }> {
     const { error } = await this.supabase.from('__seo_cwv_raw').insert({
       session_id: input.session_id,
       surface: input.surface,
@@ -62,7 +64,9 @@ export class CwvBeaconService extends SupabaseBaseService {
     return { ok: true };
   }
 
-  private async recordBot(input: CwvBeaconServerInsert): Promise<{ ok: boolean }> {
+  private async recordBot(
+    input: CwvBeaconServerInsert,
+  ): Promise<{ ok: boolean }> {
     // Bots : event_log avec payload pour debug, jamais agrégé.
     const { error } = await this.supabase.from('__seo_event_log').insert({
       event_type: 'seo.runtime.bot_cwv_beacon',

--- a/backend/supabase/migrations/20260526_seo_cwv_raw.down.sql
+++ b/backend/supabase/migrations/20260526_seo_cwv_raw.down.sql
@@ -1,0 +1,11 @@
+-- Rollback : __seo_cwv_raw + cron + fn.
+--
+-- Idempotent (mirror up).
+
+SELECT cron.unschedule('cwv-raw-rotation')
+WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'cwv-raw-rotation'
+);
+
+DROP FUNCTION IF EXISTS public.maintain_cwv_raw_partitions(INT, INT);
+DROP TABLE IF EXISTS __seo_cwv_raw CASCADE;

--- a/backend/supabase/migrations/20260526_seo_cwv_raw.sql
+++ b/backend/supabase/migrations/20260526_seo_cwv_raw.sql
@@ -1,0 +1,198 @@
+-- Migration : __seo_cwv_raw + self-rotation atomique.
+--
+-- Plan bloc 3 (CWV Runtime Observability). Table de landing des beacons
+-- web-vitals émis depuis le frontend (`navigator.sendBeacon` POST
+-- `/api/seo/cwv/beacon`). Aggregation hourly + daily livrée bloc 4.
+--
+-- Anti-régression PR #697 (partitions épuisées) : la fonction de rotation
+-- ET son job pg_cron sont déclarés DANS LA MÊME MIGRATION (pattern atomique).
+--
+-- TTL court (48h) : la landing n'est jamais consommée en SLO, uniquement par
+-- l'agg horaire/journalière. Après agg, raw devient redondant.
+--
+-- Le runner (scripts/ci/apply-supabase-migration.py) wrappe chaque fichier dans
+-- une transaction (squawk: assume_in_transaction).
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+-- =============================================================================
+-- 0. ENUM seo_event_type extension — AVANT toute écriture
+-- =============================================================================
+-- `CwvBeaconService.recordBot()` écrit ce event_type dans __seo_event_log dès
+-- le déploiement de bloc 3. Owner-flagged : "ENUM doit arriver AVANT l'usage
+-- en DB live". L'ajout est dans cette migration (pas bloc 5) pour atomicité
+-- code↔schema. Idempotent via DO bloc.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum
+        WHERE enumlabel = 'seo.runtime.bot_cwv_beacon'
+          AND enumtypid = 'seo_event_type'::regtype
+    ) THEN
+        ALTER TYPE seo_event_type ADD VALUE 'seo.runtime.bot_cwv_beacon';
+    END IF;
+END $$;
+
+-- =============================================================================
+-- Table __seo_cwv_raw — landing beacons CWV, partitions daily, TTL 48h
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS __seo_cwv_raw (
+  -- Réception
+  received_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- Session (anon, no PII — sessionStorage côté client)
+  session_id            TEXT NOT NULL CHECK (char_length(session_id) BETWEEN 8 AND 64),
+
+  -- Taxonomie (CHECK IN alignés sur @repo/cwv-taxonomy)
+  surface               TEXT NOT NULL CHECK (surface IN (
+    'R2_PRODUCT', 'R2_GAMME_VEHICLE', 'R3_GUIDE', 'R5_DIAGNOSTIC',
+    'R8_VEHICLE', 'SEARCH', 'HOME', 'CART', 'CHECKOUT', 'PAYMENT',
+    'ACCOUNT', 'OTHER'
+  )),
+  route_group           TEXT NOT NULL CHECK (route_group IN (
+    'pieces_product', 'pieces_gamme_vehicle', 'r3_guide', 'r5_diagnostic',
+    'r8_vehicle', 'marques_listing', 'search', 'cart', 'checkout',
+    'payment', 'account', 'home', 'other'
+  )),
+  priority_tier         TEXT NOT NULL CHECK (priority_tier IN ('CWV_P0', 'CWV_P1', 'CWV_P2')),
+
+  -- Funnel (journey reconstruction)
+  funnel_step           TEXT NOT NULL CHECK (funnel_step IN (
+    'landing', 'view_listing', 'view_product', 'view_guide',
+    'view_diagnostic', 'view_vehicle', 'view_search', 'view_account',
+    'view_other', 'add_cart', 'checkout_entry', 'checkout_step',
+    'payment', 'completed'
+  )),
+  previous_funnel_step  TEXT CHECK (previous_funnel_step IS NULL OR previous_funnel_step IN (
+    'landing', 'view_listing', 'view_product', 'view_guide',
+    'view_diagnostic', 'view_vehicle', 'view_search', 'view_account',
+    'view_other', 'add_cart', 'checkout_entry', 'checkout_step',
+    'payment', 'completed'
+  )),
+
+  -- Debug only (jamais utilisé en agg — risque PII si pas sanitized)
+  url                   TEXT NOT NULL CHECK (char_length(url) <= 2000),
+
+  -- Web Vital
+  metric                TEXT NOT NULL CHECK (metric IN ('LCP', 'INP', 'CLS', 'FCP', 'TTFB')),
+  value                 REAL NOT NULL CHECK (value >= 0 AND value <= 60000),
+
+  -- Device + UA classification (serveur side après classifyUserAgent)
+  device                TEXT NOT NULL CHECK (device IN ('mobile', 'desktop', 'tablet', 'unknown')),
+  ua_class              TEXT NOT NULL CHECK (ua_class IN ('human', 'bot_search', 'bot_ai', 'bot_other')),
+
+  -- Attribution sanitized JSONB (selector CSS structure only, no #id)
+  attribution           JSONB,
+
+  -- Navigation context
+  nav_type              TEXT NOT NULL CHECK (nav_type IN (
+    'navigate', 'reload', 'back_forward', 'prerender', 'restore', 'unknown'
+  ))
+) PARTITION BY RANGE (received_at);
+
+COMMENT ON TABLE __seo_cwv_raw IS
+  'Bloc 3 — landing beacons Core Web Vitals. Partitions daily, TTL 48h via maintain_cwv_raw_partitions(). NE PAS consommer en SLO direct — utiliser __seo_cwv_hourly/daily (bloc 4). Bots écrits dans __seo_event_log (jamais ici).';
+
+COMMENT ON COLUMN __seo_cwv_raw.url IS
+  'Debug only — JAMAIS utilisé en aggregation (PII potentiel). Pour segmenter, utiliser surface/route_group.';
+
+COMMENT ON COLUMN __seo_cwv_raw.attribution IS
+  'JSONB sanitized — selectors CSS structure only (#id strippé client-side avant send). Pour INP/LCP/CLS uniquement.';
+
+-- Index pour agrégations bloc 4
+CREATE INDEX IF NOT EXISTS idx_seo_cwv_raw_recv_surf_tier
+  ON __seo_cwv_raw (received_at, surface, priority_tier);
+CREATE INDEX IF NOT EXISTS idx_seo_cwv_raw_session
+  ON __seo_cwv_raw (session_id, received_at)
+  WHERE ua_class = 'human';
+
+-- RLS — service_role only via JWT bypass (backend insert)
+ALTER TABLE __seo_cwv_raw ENABLE ROW LEVEL SECURITY;
+
+-- =============================================================================
+-- Fonction de rotation : premake D+lookahead + drop >retention (atomique)
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.maintain_cwv_raw_partitions(
+  p_lookahead_days INT DEFAULT 3,
+  p_retention_days INT DEFAULT 2     -- TTL 48h ≈ 2 jours
+)
+RETURNS TABLE(action TEXT, partition_name TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_parent TEXT := '__seo_cwv_raw';
+  v_day    DATE;
+  v_next   DATE;
+  v_last   DATE;
+  v_part   TEXT;
+  v_child  RECORD;
+  v_cutoff DATE := (CURRENT_DATE - make_interval(days => p_retention_days))::date;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relname = v_parent AND n.nspname = 'public' AND c.relkind = 'p'
+  ) THEN
+    RETURN;
+  END IF;
+
+  v_day  := CURRENT_DATE;
+  v_last := CURRENT_DATE + make_interval(days => p_lookahead_days);
+  WHILE v_day <= v_last LOOP
+    v_next := (v_day + INTERVAL '1 day')::date;
+    v_part := v_parent || '_p' || to_char(v_day, 'YYYYMMDD');
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relname = v_part AND n.nspname = 'public'
+    ) THEN
+      EXECUTE format(
+        'CREATE TABLE public.%I PARTITION OF public.%I FOR VALUES FROM (%L) TO (%L)',
+        v_part, v_parent, v_day::text, v_next::text
+      );
+      action := 'created'; partition_name := v_part; RETURN NEXT;
+    END IF;
+    v_day := v_next;
+  END LOOP;
+
+  FOR v_child IN
+    SELECT c.relname
+    FROM pg_inherits i
+    JOIN pg_class p     ON p.oid = i.inhparent
+    JOIN pg_class c     ON c.oid = i.inhrelid
+    JOIN pg_namespace n ON n.oid = p.relnamespace
+    WHERE p.relname = v_parent AND n.nspname = 'public'
+      AND c.relname ~ ('^' || v_parent || '_p\d{8}$')
+  LOOP
+    IF to_date(right(v_child.relname, 8), 'YYYYMMDD') < v_cutoff THEN
+      EXECUTE format('DROP TABLE IF EXISTS public.%I', v_child.relname);
+      action := 'dropped'; partition_name := v_child.relname; RETURN NEXT;
+    END IF;
+  END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION public.maintain_cwv_raw_partitions(INT, INT) IS
+  'Bloc 3 — premake D+lookahead & drop >retention days pour __seo_cwv_raw. Idempotent. TTL 48h. Cron : cwv-raw-rotation quotidien 02:50 UTC.';
+
+GRANT EXECUTE ON FUNCTION public.maintain_cwv_raw_partitions(INT, INT) TO service_role;
+
+-- =============================================================================
+-- Backfill + cron job (idempotent, atomique)
+-- =============================================================================
+
+SELECT public.maintain_cwv_raw_partitions();
+
+-- Cron quotidien @ 02:55 UTC (après quality-history 02:50).
+SELECT cron.schedule(
+  'cwv-raw-rotation',
+  '55 2 * * *',
+  $cron$SELECT public.maintain_cwv_raw_partitions();$cron$
+)
+WHERE NOT EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'cwv-raw-rotation'
+);

--- a/frontend/app/utils/web-vitals.client.ts
+++ b/frontend/app/utils/web-vitals.client.ts
@@ -30,6 +30,11 @@ import {
   onTTFB,
   type MetricWithAttribution,
 } from "web-vitals/attribution";
+import {
+  classifyRoute,
+  type DeviceType,
+  type NavType,
+} from "@repo/cwv-taxonomy";
 
 interface SentryMetricsDistribution {
   (
@@ -189,10 +194,132 @@ function reportToConsole(metric: MetricWithAttribution): void {
   });
 }
 
+// =============================================================================
+// Beacon backend ingestion (bloc 3) — POST /api/seo/cwv/beacon via sendBeacon
+// =============================================================================
+//
+// Discipline :
+//   - session_id : sessionStorage anon (no PII, regenerated per browsing session,
+//     never cookie/localStorage — RGPD-friendly)
+//   - Honor navigator.doNotTrack — opt-out respect
+//   - Feature-detect sendBeacon — fail silently if unavailable
+//   - Funnel step tracking : derived from route via classifyRoute(), previous
+//     step kept in sessionStorage for journey reconstruction
+//   - Sanitize attribution selector : strip #ids client-side before send (bloc
+//     3 backend re-sanitizes via Zod for defense in depth)
+
+const SESSION_ID_KEY = "_aut_cwv_sid";
+const PREVIOUS_STEP_KEY = "_aut_cwv_prev_step";
+
+function getOrCreateSessionId(): string {
+  try {
+    const existing = sessionStorage.getItem(SESSION_ID_KEY);
+    if (existing && existing.length >= 8) return existing;
+    const fresh = crypto.randomUUID();
+    sessionStorage.setItem(SESSION_ID_KEY, fresh);
+    return fresh;
+  } catch {
+    // Storage disabled (private mode strict, CMP block) — fallback ephemeral.
+    return crypto.randomUUID();
+  }
+}
+
+function detectDevice(): DeviceType {
+  if (typeof window === "undefined") return "unknown";
+  const ua = navigator.userAgent.toLowerCase();
+  if (/ipad|tablet|playbook|silk/.test(ua) && !/mobile/.test(ua)) return "tablet";
+  if (/mobile|android|iphone|ipod|blackberry|opera mini|iemobile/.test(ua)) {
+    return "mobile";
+  }
+  return "desktop";
+}
+
+function detectNavType(metric: MetricWithAttribution): NavType {
+  const t = metric.navigationType;
+  if (t === "navigate" || t === "reload" || t === "back-forward" || t === "prerender" || t === "restore") {
+    return t === "back-forward" ? "back_forward" : t;
+  }
+  return "unknown";
+}
+
+function dntOptedOut(): boolean {
+  if (typeof navigator === "undefined") return false;
+  // navigator.doNotTrack returns '1' when DNT enabled in most browsers.
+  // Honor strict (any non-'0' / non-null/unspecified value is opt-out signal).
+  const dnt = navigator.doNotTrack;
+  return dnt === "1" || dnt === "yes";
+}
+
+/** Sanitize CSS selector client-side : strip #ids, keep tag.class structure. */
+function sanitizeSelector(raw: string | undefined): string | undefined {
+  if (!raw) return raw;
+  return raw.replace(/#[a-zA-Z0-9_-]+/g, "#dyn").slice(0, 120);
+}
+
+function buildBeaconPayload(metric: MetricWithAttribution): Record<string, unknown> | null {
+  if (typeof window === "undefined") return null;
+  const url = window.location.href;
+  const pathname = window.location.pathname;
+  const classification = classifyRoute(pathname);
+
+  // previous_funnel_step lookup + persist current
+  let previous_funnel_step: string | null = null;
+  try {
+    previous_funnel_step = sessionStorage.getItem(PREVIOUS_STEP_KEY);
+    sessionStorage.setItem(PREVIOUS_STEP_KEY, classification.funnel_step);
+  } catch {
+    // ignore storage errors
+  }
+
+  // Sanitize attribution selectors (defense in depth, backend re-sanitizes via Zod)
+  const rawAttr = attributionFields(metric);
+  const attribution: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rawAttr)) {
+    if (typeof v === "string" && (k === "attr_target" || k === "attr_element" || k === "attr_largest_shift_target")) {
+      const s = sanitizeSelector(v);
+      if (s !== undefined) attribution[k] = s;
+    } else {
+      attribution[k] = v;
+    }
+  }
+
+  return {
+    session_id: getOrCreateSessionId(),
+    surface: classification.surface,
+    route_group: classification.route_group,
+    funnel_step: classification.funnel_step,
+    previous_funnel_step,
+    url: url.slice(0, 2000),
+    metric: metric.name,
+    value: Number(metric.value.toFixed(metric.name === "CLS" ? 4 : 0)),
+    device: detectDevice(),
+    attribution: Object.keys(attribution).length > 0 ? attribution : undefined,
+    nav_type: detectNavType(metric),
+  };
+}
+
+function reportToBeacon(metric: MetricWithAttribution): boolean {
+  if (typeof window === "undefined") return false;
+  if (typeof navigator.sendBeacon !== "function") return false;
+  if (dntOptedOut()) return false;
+
+  try {
+    const payload = buildBeaconPayload(metric);
+    if (!payload) return false;
+    const blob = new Blob([JSON.stringify(payload)], {
+      type: "application/json",
+    });
+    return navigator.sendBeacon("/api/seo/cwv/beacon", blob);
+  } catch {
+    return false;
+  }
+}
+
 function dispatchMetric(metric: MetricWithAttribution) {
   try {
     reportToSentry(metric);
     reportToGtag(metric);
+    reportToBeacon(metric);
     reportToConsole(metric);
   } catch {
     // Reporter passif — ne jamais propager dans une callback PerformanceObserver.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "@remix-run/react": "^2.17.4",
     "@remix-run/serve": "^2.17.4",
     "@remix-run/server-runtime": "^2.17.4",
+    "@repo/cwv-taxonomy": "*",
     "@repo/database-types": "*",
     "@repo/registry": "*",
     "@repo/seo-roles": "*",


### PR DESCRIPTION
## Summary

**Bloc 3 / 6** du plan owner révisé "CWV Runtime Observability". Stacked sur #728 (`feat/cwv-taxonomy-bloc2`).

Le bloc 3 livre l'**ingestion beacon end-to-end** : depuis `web-vitals` côté client → `navigator.sendBeacon` → endpoint NestJS → routing déterministe humans/bots → table partitionnée daily TTL 48h.

## Migration `20260526_seo_cwv_raw.sql` (atomique)

- Table `__seo_cwv_raw` partitioned by RANGE(received_at) daily
- **CHECK IN strictes** sur tous les enums (surface, route_group, priority_tier, funnel_step, metric, device, ua_class, nav_type) — cardinalité bornée
- Fonction `maintain_cwv_raw_partitions(lookahead=3, retention=2)` premake + drop atomique (pattern `maintain_observability_partitions`)
- **`pg_cron` `cwv-raw-rotation` daily 02:55 UTC inscrit dans la migration** — canon `reference_partitioned_snapshot_tables_need_premake_cron`, anti-PR #697
- TTL 48h (raw jamais consommé en SLO direct, seulement par agg bloc 4)
- Index `(received_at, surface, priority_tier)` + index partiel `(session_id, received_at) WHERE ua_class='human'` (futur funnel correlation bloc 6)
- RLS enabled, service_role only

## Backend — controller + service

### `CwvBeaconController` (`POST /api/seo/cwv/beacon`)

- **Public** (no auth, no PII collected client-side)
- `@HttpCode(202)` — fire-and-forget, jamais de 4xx visible UA
- `@Throttle({ limit: 120, ttl: 60_000 })` — 120/min/IP (≈ 5 metrics × 24 page-views/min absolute max)
- Validation Zod stricte via `CwvBeaconClientPayloadSchema` (cf. PR #728)
- **Enrichissement serveur anti-spoofing** :
  - `priority_tier` dérivé de `surface` (lookup déterministe, jamais envoyé par client)
  - `ua_class` via `classifyUserAgent` sur header `User-Agent` (jamais trustable côté client)

### `CwvBeaconService` (routing déterministe)

| `ua_class` | Destination | Rationale |
|---|---|---|
| `human` | `__seo_cwv_raw` (agg pure) | Source p75 humains |
| `bot_search` / `bot_ai` / `bot_other` | `__seo_event_log` (debug only) | **JAMAIS dans `__seo_cwv_raw`** — canon anti-pollution p75 humains, plan §5 |

Pattern mirror `FunnelEventsService` (extends `SupabaseBaseService`, fire-and-forget côté appelant, log erreur jamais d'exception).

## Frontend — extension `web-vitals.client.ts`

PR #692 reste **source de dispatch live** (Sentry + GA4 + console). Ajout d'une 4ème cible en cascade : `reportToBeacon()` (POST `/api/seo/cwv/beacon` via `navigator.sendBeacon`).

Discipline :
- **`session_id`** : `sessionStorage` anon (no PII, no cookie, no localStorage — RGPD-friendly)
- **`previous_funnel_step`** persisted en `sessionStorage` pour journey reconstruction (futur funnel correlation bloc 6)
- **`detectDevice()`** heuristique tablet/mobile/desktop via UA regex
- **Honor `navigator.doNotTrack`** (`'1'` ou `'yes'` = opt-out, beacon skipped)
- **Feature-detect `sendBeacon`** — fail silently si absent (vieux navigateurs)
- **Sanitize selectors client-side** : strip `#ids` → `#dyn` (defense in depth, backend re-sanitize via Zod)
- `import { classifyRoute }` depuis `@repo/cwv-taxonomy` — SoT canon partagé client/serveur

## Fix amend PR #728

Suppression du cast `as unknown as [string, ...string[]]` sur `z.enum()` dans `packages/cwv-taxonomy/src/schema.ts` — préserve l'inférence littérale Zod. Sans ce fix, `ua_class` était typé `string` au lieu de `UserAgentClass`, ce qui cassait `isBot()` routing dans `CwvBeaconService`. **50 tests verts** après fix.

## Anti-bricolage

- Whitelist enum DB (CHECK IN) ↔ enum TS `@repo/cwv-taxonomy` — sync runtime
- Bots redirigés vers `__seo_event_log` **existant** (canon "extend existing infra")
- Pattern collector mirror `cf-rum` / `funnel-events` (extends `SupabaseBaseService`)
- TTL court 48h sur landing — pas de drift volume DB
- pg_cron inscrit dans la migration (atomique, anti-PR #697)

## Suite (gates de unlock)

- **Bloc 4** : aggregation `__seo_cwv_hourly` (TTL 14d) + `__seo_cwv_daily` étendue (12mo) via RPCs VOLATILE + processors NestJS @Cron
- **Bloc 5** : runtime errors → `__seo_event_log` (hydration / longtask / chunk-load)
- **Bloc 6** : dashboard admin + funnel correlation (SQL RPC `get_cwv_funnel_correlation`) + alerts trend-divergence-sustained

## Test plan

- [x] `tsc --noEmit` backend ✓
- [x] `tsc` frontend ✓
- [x] `npm run build` `@repo/cwv-taxonomy` ✓
- [x] 50 tests `@repo/cwv-taxonomy` verts (incluant schéma Zod fix)
- [ ] Migration applied live DB via `apply-supabase-migrations.yml`
- [ ] Smoke manual : `curl -X POST /api/seo/cwv/beacon` avec UA human + bot → vérifier routing tables
- [ ] CI verte (lint, registry validation, etc.)

## Base

Stacked sur **#728** (bloc 2). PR mergeable indépendamment **après** #728 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)