### PR TITLE
perf(blog-r3): cap vehicles 1000→24 + honest UX copy (LCP /conseils/*)

### DIFF
--- a/backend/src/modules/blog/services/r3-guide.service.test.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.test.ts
@@ -104,6 +104,7 @@ async function buildService(): Promise<{
   service: R3GuideService;
   cache: InMemoryCacheServiceStub;
   dataService: ReturnType<typeof makeMocks>['dataService'];
+  relationService: ReturnType<typeof makeMocks>['relationService'];
 }> {
   const cache = new InMemoryCacheServiceStub();
   const mocks = makeMocks();
@@ -123,7 +124,12 @@ async function buildService(): Promise<{
   }).compile();
 
   const service = moduleRef.get(R3GuideService);
-  return { service, cache, dataService: mocks.dataService };
+  return {
+    service,
+    cache,
+    dataService: mocks.dataService,
+    relationService: mocks.relationService,
+  };
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -151,7 +157,23 @@ describe('R3GuideService — cache + single-flight + invalidation (PR-A)', () =>
       const result = await service.getR3GuidePayload('inconnu');
 
       expect(result).toBeNull();
-      expect(await cache.get('r3-guide:v1:inconnu')).toBeNull();
+      expect(await cache.get('r3-guide:v2:inconnu')).toBeNull();
+    });
+  });
+
+  describe('LCP payload cap (PR LCP-R3-PR1)', () => {
+    it('passes limit=24 to relationService.getCompatibleVehicles (anti-régression payload cap)', async () => {
+      const { service, relationService } = await buildService();
+
+      await service.getR3GuidePayload(PG_ALIAS);
+
+      // Régression : remettre 1000 (ou tout autre valeur > 24) ferait grossir le
+      // payload SSR de ~150 KB → LCP mobile +1-2s sur /blog-pieces-auto/conseils/*.
+      expect(relationService.getCompatibleVehicles).toHaveBeenCalledWith(
+        expect.any(Number),
+        24,
+        expect.any(String),
+      );
     });
   });
 

--- a/backend/src/modules/blog/services/r3-guide.service.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.ts
@@ -34,8 +34,9 @@ import {
 import { PRIX_PAS_CHER } from '../../seo/seo-v4.types';
 import { InternalLinkingService } from '../../seo/internal-linking.service';
 
-/** Cache key prefix versionnée — bump v1→v2 invalide tous les payloads. */
-const R3_CACHE_PREFIX = 'r3-guide:v1:';
+/** Cache key prefix versionnée — bump v1→v2 invalide tous les payloads.
+ *  v2 (2026-05-24) : compatible vehicles capped à 24 (LCP /blog-pieces-auto/conseils/* — voir PR LCP-R3-PR1). */
+const R3_CACHE_PREFIX = 'r3-guide:v2:';
 
 /** TTL fresh window (seconds) — CacheService utilise ioredis SETEX en secondes. */
 const R3_CACHE_TTL_SECONDS = 30 * 60;
@@ -201,9 +202,13 @@ export class R3GuideService {
       this.seoService.getGammeConseil(gammeData.pg_id),
       this.seoService.getSeoItemSwitches(gammeData.pg_id),
       this.dataService.getRelatedArticles(article.legacy_id),
+      // LCP fix R3 conseils : carrousel affiche 12 par défaut (PAGE_SIZE), pagination locale +12.
+      // Cap 24 = 2× safety margin → -150 KB payload SSR mobile vs 1000 véhicules (~80% du JSON).
+      // Trade-off documenté : count "X motorisations" affiché reflète désormais le sample (24 max),
+      // pas le total catalogue compat — accepté (les vehicle pages sont déjà dans sitemap.xml).
       this.relationService.getCompatibleVehicles(
         gammeData.pg_id,
-        1000,
+        24,
         pg_alias,
       ),
       this.dataService.getAdjacentArticles(article.slug),

--- a/backend/src/modules/blog/services/r3-guide.service.ts
+++ b/backend/src/modules/blog/services/r3-guide.service.ts
@@ -206,11 +206,7 @@ export class R3GuideService {
       // Cap 24 = 2× safety margin → -150 KB payload SSR mobile vs 1000 véhicules (~80% du JSON).
       // Trade-off documenté : count "X motorisations" affiché reflète désormais le sample (24 max),
       // pas le total catalogue compat — accepté (les vehicle pages sont déjà dans sitemap.xml).
-      this.relationService.getCompatibleVehicles(
-        gammeData.pg_id,
-        24,
-        pg_alias,
-      ),
+      this.relationService.getCompatibleVehicles(gammeData.pg_id, 24, pg_alias),
       this.dataService.getAdjacentArticles(article.slug),
       this.seoService.getSeoBrief(gammeData.pg_id),
       this.seoService.hasPublishedR6Guide(gammeData.pg_id),

--- a/frontend/app/components/blog/VehicleCarousel.tsx
+++ b/frontend/app/components/blog/VehicleCarousel.tsx
@@ -87,10 +87,11 @@ const VehicleCarousel: React.FC<VehicleCarouselProps> = ({
             {dynamicTitle}
           </h2>
           <p className="text-sm text-gray-600 dark:text-gray-400 max-w-2xl mx-auto mt-2">
+            Voici un échantillon de{" "}
             <strong className="text-gray-800">
               {vehicles.length} motorisations
             </strong>{" "}
-            identifiées d'après les données de compatibilité constructeur —
+            compatibles d'après les données de compatibilité constructeur —
             usure normale, usage spécifique ou kilométrage élevé.
           </p>
         </div>


### PR DESCRIPTION
## Bug

GSC reports **LCP mobile 4.8s** on 47 R3 `/blog-pieces-auto/conseils/*` URLs
(chronique, première détection 2024-06-27).

Audit : **~80% du payload SSR JSON (150-250 KB)** = 1000 véhicules compatibles
chargés depuis `relationService.getCompatibleVehicles(pg_id, 1000)`, alors que
le composant `VehicleCarousel` n'affiche que **12 véhicules par défaut** (PAGE_SIZE)
avec pagination locale `+12` au clic *"Voir plus"*.

## Fix (2 commits)

### Commit 1 — `perf(blog-r3): cap vehicles 1000→24`

`r3-guide.service.ts:209` — `getCompatibleVehicles(pg_id, 1000, pg_alias)` →
`getCompatibleVehicles(pg_id, 24, pg_alias)`.

- **Cap 24** = 2× safety margin (couvre exactement un clic *"Voir plus"*).
- **Cache prefix bumped** `r3-guide:v1:` → `r3-guide:v2:` pour flusher les
  payloads stale (TTL 30 min) au moment du déploiement.
- **Sélection préservée** : la boucle niveaux 1→4 sur `__cross_gamme_car_new`
  break toujours au premier niveau avec ≥ 1 résultat → les véhicules surfacés
  restent les plus populaires (Niveau 1 saturé en quasi-totalité des gammes).

### Commit 2 — `test(blog-r3): assert getCompatibleVehicles(limit=24) + honest UX copy`

Issu de la code-review interne du commit 1 :

- **Test anti-régression** :
  ```ts
  expect(relationService.getCompatibleVehicles).toHaveBeenCalledWith(
    expect.any(Number), 24, expect.any(String),
  );
  ```
  Bloque toute remontée future à `1000` (ou > 24).
- **Fix obsolescence** : `cache.get('r3-guide:v1:inconnu')` → `'v2:inconnu'`.
  L'assertion `toBeNull()` était trivialement vraie après le bump (clé v1
  inexistante par définition).
- **UX honnête (Option B)** `VehicleCarousel.tsx:89-95` :
  > _Voici un échantillon de **N motorisations** compatibles d'après les données
  > de compatibilité constructeur…_
  
  remplace l'ancien _"N motorisations identifiées d'après…"_ qui under-claimait
  après le cap (un utilisateur avec véhicule peu courant pouvait conclure à tort
  "seulement 24 véhicules utilisent cette pièce"). Option B = zéro requête
  supplémentaire, cohérente avec l'objectif LCP. Un vrai `totalCount` peut venir
  plus tard si valeur business démontrée.

## Trade-off accepté

`blog.service.ts:167` (autre site avec `limit=1000` consommé par `/pieces/*` via
`pieces-route.service.ts` → composant `CompatibilitySheetV2`) **NON couvert ici**.
Discipline de scope : PR-2 séparée pour ce site (UI différente, headcount
`CompatibilitySheetV2.tsx:609` affiche le total → trade-off à arbitrer
séparément).

## Test plan

- [x] `npx jest src/modules/blog/services/r3-guide.service.test.ts` → 10/10 ✓
  (incluant nouveau cas `LCP payload cap`)
- [x] `npx tsc --noEmit -p tsconfig.json` (backend + frontend) → clean sur les
  3 fichiers modifiés (2 erreurs pré-existantes `@repo/domain-commerce` et
  `LCPAttribution.target` non liées)
- [x] Rebase propre sur `origin/main` (absorbé #730 docs/marketing.md, fichiers
  disjoints, zéro conflit)
- [ ] Smoke en preview : route `/blog-pieces-auto/conseils/<gamme>` → vérifier
  payload SSR (DevTools → Network → blog-pieces-auto.conseils.*) : taille passe
  de ~200 KB à ~50 KB
- [ ] Post-merge (~7-14j) : Lighthouse LCP mobile sur 5 URLs `/conseils/*` →
  baseline 4.8s → cible < 2.5s

## Scope respect

- 1 service backend modifié + 1 composant frontend + 1 fichier test.
- Aucune migration DB, aucun module `payments/`, aucune route, aucun canonical URL.
- Pas de `@repo/database-types` touché, pas de `.spec/`, pas de `governance-vault/`.
- Aucun secret commité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)