### PR TITLE
docs(audit): ahrefs link verdicts (internal + external) — empirical, read-only

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -207,6 +207,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: low
+  - glob: audit/seo-*.md
+    domain: D3
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   - glob: backend/src/auth/**
     domain: D11
     owner: '@ak125/auth-team'

--- a/audit/seo-ahrefs-external-anchors-verdict-2026-05-24.md
+++ b/audit/seo-ahrefs-external-anchors-verdict-2026-05-24.md
@@ -1,0 +1,206 @@
+# Verdict empirique — Ahrefs anchor-texts externes automecanik.com — 2026-05-24
+
+## Coverage manifest
+
+- **Dataset analysé** : 45 anchors (TOP brut UI Ahrefs "Principaux textes d'ancrage", partagé par l'owner)
+- **Périmètre** : backlinks **externes** entrants vers `automecanik.com` (≠ maillage interne déjà audité dans [audit/seo-ahrefs-internal-links-verdict-2026-05-24.md](seo-ahrefs-internal-links-verdict-2026-05-24.md))
+- **Indices structurels confirmant l'origine externe** :
+  - 7 anchors templates multilingues type annuaire (`visit website`, `sitio web`, `visiter le site`, `navigate to website automecanik com`, …)
+  - 1 anchor `attention required cloudflare` = `<title>` capturé par un bot pendant un CF challenge (jamais émis par le site)
+  - 8 anchors URL brutes (HTTPS/HTTP/domain bare) = comportement aggregateur ou citation forum, jamais émis par les templates Remix internes (Navbar/Footer/BottomNav rendent toujours du texte humain)
+- **Sources internes croisées** : 4
+  - Audit pair `audit/seo-ahrefs-internal-links-verdict-2026-05-24.md` (méthodologie + canon role-matrix v5)
+  - Canon role-matrix v5 `.spec/00-canon/role-matrix.md` (patterns R0-R8)
+  - URL contract D3 `packages/seo-url-contract/src/url-rules.ts` (`isMalformedSeoUrl` / `detectMalformedSegment`)
+  - Memory `project_a_b_c_surfaces_distinction.md` (vérifier 0 leak surface-C)
+- **Invariants testés** : 7/7 (E1-E7)
+- **Drifts détectés** : 3 (E3 HTTP, E4 CF challenge, E5 anchor vide) — tous **owner-only, no urgency**
+- **Hors scope** : pas de volume par anchor, pas de referring-domains count, pas de split dofollow/nofollow, pas de désaveu, pas d'outreach, pas d'extrapolation au profil complet
+- **Limites empiriques** : aucun test live (`curl -I`, `dig`, inspection Caddyfile) → drifts E3 HTTPS adoption + E4 CF challenge sont **hypothesis-only** (cf. anti-overclaim infra)
+
+## Classification taxonomique (Σ = 45)
+
+| # | Catégorie | Comptage | Verdict |
+|---|-----------|---------:|---------|
+| 1 | Brand pur (`automecanik`) | 1 | OK natural |
+| 2 | Brand + keyword (`vente pièces détachées… automecanik`, +1 variante UTF-8 corrompue) | 2 | OK natural |
+| 3 | Keyword exact-match court (`filtre à huile`, `plaquettes de frein`, `alternateur`, `étriers de frein`, `disque de frein`, `disques de frein`, `compresseur de climatisation`, `filtre à air`, `filtre à carburant`, `radiateur de chauffage`, `évaporateur de climatisation`, `courroie accessoire`, `pièces autos`, `ventes pièces détaches` [typo référent]) | 14 | OK signal pertinent business |
+| 4 | Keyword exact-match long (`vente pièces détachées auto neuves & à prix pas cher`) | 1 | OK natural |
+| 5 | URL brute HTTPS racine (`https www automecanik com`) | 1 | OK template |
+| 6 | URL brute HTTPS deep-link | 7 | Cross-checkés D3 + role-matrix v5 (cf. section "Deep-links strategic classification") |
+| 7 | URL brute HTTP (1 racine + 1 deep-link `…pieces cardan 13 html`) | 2 | **DRIFT E3 — hypothesis-only** |
+| 8 | Domain bare (`automecanik com`, `www automecanik com`) | 2 | OK |
+| 9 | Template directory multilingue (`visit website`, `visiter le site web`, `visit`, `sitio web`, `visit automecanik com`, `navigate to website automecanik com`, `visiter le site`) | 7 | OK aggregateurs (low value, low risk) |
+| 10 | Image alt-text (`automecanik logo`, `logo de automecanik`) | 2 | OK |
+| 11 | Anchor vide (`(vide)`) | 1 | **DRIFT E5** (référent externe) |
+| 12 | Long sentence content-snippet (4 phrases pédagogiques sur usure embrayage / catalyseur / direction assistée / contrôle état) | 4 | OK forum/blog citations |
+| 13 | Cloudflare challenge title (`attention required cloudflare`) | 1 | **DRIFT E4 — hypothesis-only** |
+| | **TOTAL** | **45** | |
+
+## Invariants
+
+### E1 — Diversification anchor texte (variété brand/keyword/url/template)
+
+**Status : SATISFIED**
+
+13 catégories distinctes dans le TOP 45 ; pas de catégorie unique > 31% (max = 14/45 = 31% pour keyword exact-match court, qui est lui-même éclaté sur 14 termes différents = 1/45 ≈ 2.2% chacun). Distribution macro saine, **pas de signature de manipulation** (qui se traduirait par une catégorie unique exact-match à > 50% de fréquence + 1-3 termes répétés).
+
+### E2 — Absence anchor toxique
+
+**Status : SATISFIED**
+
+Grep mental sur patterns black-hat (casino, viagra, loan, porn, free-download, gambling, cialis, escort, drugs) : **0 occurrence**. Tous les anchors sont sémantiquement liés au domaine pièces auto / brand / templates aggregateurs / fragments éditoriaux.
+
+### E3 — Adoption HTTPS sur URLs brutes en ancre
+
+**Status : DRIFT mineur — hypothesis-only**
+
+2 anchors HTTP présents (rang #11 `http www automecanik com` + rang #32 `http www automecanik com pieces cardan 13 html`). Quelques sources externes linkent encore en HTTP au lieu de HTTPS.
+
+⚠️ **Non vérifié empiriquement** : sans `curl -I http://www.automecanik.com` (hors scope verifier read-only filesystem), il est **impossible de conclure** si :
+
+- (a) Le redirect 301 HTTP→HTTPS via Caddy est en place et propagé → impact SEO neutre (Google suit le 301, équité de lien préservée)
+- (b) Le redirect est cassé ou manquant → équité de lien fragmentée entre HTTP et HTTPS
+
+**Action owner** (hors scope ce verdict) : tester `curl -I http://www.automecanik.com` depuis un poste avec accès réseau et inspecter `docker/Caddyfile` si présent pour confirmer la règle `redir` ou `permanent_redirect`.
+
+### E4 — Cloudflare challenge leak
+
+**Status : DRIFT mineur — hypothesis-only**
+
+1 anchor `attention required cloudflare` (rang #21) = un crawler (probablement non-Google, type aggregateur SEO ou directory submission bot) a heurté une page de challenge Cloudflare et a indexé son `<title>` (`Attention Required! | Cloudflare`) comme texte d'ancrage du backlink.
+
+⚠️ **Non vérifié empiriquement** : sans accès au dashboard Cloudflare (config Bot Fight Mode / Challenge Pages / Super Bot Fight Mode), impossible de conclure si :
+
+- (a) Configuration trop agressive (Challenge appliqué à des UA légitimes) → fix policy CF
+- (b) Configuration correcte mais bot SEO tiers cataloguant la cible de challenge → pollution marginale acceptable
+
+**Action owner** (hors scope) : audit `Cloudflare Dashboard > Security > Bots` + revue de la `Challenge Solve Rate` sur 30 jours.
+
+### E5 — Anchor vide
+
+**Status : DRIFT mineur — pas actionnable côté Automecanik**
+
+1 anchor `(vide)` (rang #4) = image-link sur le référent externe sans `alt=""` ni texte. Le HTML du référent ressemble probablement à `<a href="…"><img src="…"/></a>` sans attribut alt.
+
+**Pas d'action mécanique applicable** : l'anchor est édité côté référent (site tiers), pas côté `automecanik.com`. Pourrait être traité par une opération outreach si le référent est identifié — **gated owner**.
+
+### E6 — URL deep-link en anchor
+
+**Status : INFO — pas un drift**
+
+8 anchors URL deep-link (7 HTTPS + 1 HTTP). Origine probable :
+
+- **Aggregateurs auto-générant un anchor depuis l'URL crawlée** (cas du `…blog pieces auto conseils capteur abs &text=…` rang #33 et `…evaporateur de climatisation 471 html &text=…` rang #36 — présence de `&text=…` = fragment SERP / "Featured snippet" Google capturé par un scraper)
+- **Citations forums tech** où l'URL est collée en clair sans wrapping `<a href>` éditorial
+
+Cross-check D3 (cf. "Deep-links strategic classification" infra) : **8/8 valid contract D3, 0 surface-C, 1 monitor**.
+
+### E7 — Anchor entropy / concentration sanity
+
+**Status : SATISFIED**
+
+Verdict **qualitatif ordinal** (pas de métrique quantitative inventée — entropie de Shannon ou % exact-match calculé sur 45 anchors n'aurait pas de robustesse statistique) :
+
+- **Aucun anchor exact-match ne domine** (le top exact-match `ventes pièces détaches` arrive en rang #6, derrière brand+keyword/template/url/domain — donc déclassé)
+- **Présence forte de brand + URL + template** (rangs #1-#9 hors keyword) — signature naturelle d'un site B2C établi
+- **Distribution multi-modale** (brand / keyword / URL / template / content-snippet / image-alt coexistent) — incompatible avec une campagne de linkbuilding sur-optimisée (qui produirait une distribution mono-modale type "exact-match >> reste")
+
+Conclusion E7 : **profil qualitativement compatible avec un profil naturel**. Aucun signal de manipulation type Penguin moderne. Quantification précise requiert un dataset Ahrefs complet (volume par anchor + referring domains), non disponible ici.
+
+## Machine-generated vs human-edited anchors
+
+Micro-taxonomie clé pour lire le profil correctement — tous les anchors ne pèsent pas pareil côté SEO :
+
+| Type | Comptage | Exemples | Poids SEO |
+|------|---------:|----------|-----------|
+| **(a) Human-edited** | ~21 | Keywords exact-match (14) + brand+keyword long (1) + brand pur (1) + long sentences pédagogiques (4) + image alt logo (édité humain) (1) | **Réel** — éditeurs forum, blogueurs, sites métier qui citent volontairement |
+| **(b) Template directory / aggregateurs** | ~14 | `visit website`/`visiter le site`/`sitio web` (7) + URL brutes templates (5 HTTPS + 2 HTTP) | **Marginal** — patterns d'annuaires & widgets sans contexte éditorial |
+| **(c) Crawler-generated leak** | 1 | `attention required cloudflare` | **Pollution** — non éditorial, bot capturant un titre transitoire |
+| **(d) Mixte ambigu** | ~9 | Image alt non-logo (1) + anchor vide (1) + domain bare (2) + brand variante UTF-8 corrompue (1) + URL deep-link + SERP fragment (2) + URL deep-link "propre" (2) | **Variable** — partie aggregateurs, partie citations humaines |
+
+**Conséquence analytique** : si on retire mentalement les ~15 anchors (b)+(c) du dataset, le TOP "éditorial vrai" devient nettement dominé par **keyword exact-match court + brand + content-snippet pédagogique** — distribution qui reste saine et **n'aggrave pas E7** (entropy concentration). Les anchors templates ne devraient pas influencer le verdict de qualité éditoriale du profil de liens.
+
+## Deep-links strategic classification
+
+Cross-check des 8 URLs deep-link en ancre contre canon role-matrix v5 + URL-contract D3 :
+
+| URL deep-link en anchor (rang) | Pattern décodé | Rôle canon | Verdict |
+|--------------------------------|----------------|-----------|---------|
+| `…pieces courroie d accessoire 10 renault 140 laguna ii 140028 1 9 dci 15476 html` (#8) | `/pieces/{slug}-{id}/{marque}-{id}/{modele}-{id}/{type}-{id}.html` | **R2 product** | **OK canon** |
+| `…blog pieces e de frein` (#12) | `/blog/pieces-e-de-frein` (path court, ≠ canon `/blog-pieces-auto/...`) | **Legacy ?** | **monitor** — vérifier si 301 vers canonical actuelle |
+| `…constructeurs citroen 46 html` (#13) | `/constructeurs/citroen-46.html` | **R7 brand** | **OK canon** |
+| `…pieces cardan 13 html` (#32, HTTP) | `/pieces/cardan-13.html` | **R1 router gamme** | **OK canon** (mais HTTP → cf. E3) |
+| `…blog pieces auto conseils capteur abs &text=…` (#33) | `/blog-pieces-auto/conseils/capteur-abs` + SERP fragment params | **R3 conseil** | **OK canon** (fragment SERP capturé par crawler — ignoré par le serveur) |
+| `…blog pieces auto conseils support moteur` (#34) | `/blog-pieces-auto/conseils/support-moteur` | **R3 conseil** | **OK canon** |
+| `…pieces capteur temperature d air admission 3939 html` (#35) | `/pieces/capteur-temperature-d-air-admission-3939.html` | **R1 router gamme** | **OK canon** |
+| `…pieces evaporateur de climatisation 471 html &text=…` (#36) | `/pieces/evaporateur-de-climatisation-471.html` + SERP fragment | **R1 router gamme** | **OK canon** (fragment ignoré) |
+
+**Bilan deep-links** :
+
+- 7/8 → **canon role-matrix v5** (R1: 3, R2: 1, R3: 2, R7: 1)
+- 1/8 → **monitor** (`/blog/pieces-e-de-frein` — slug court non-canonique, vérifier redirect ou route legacy)
+- 0/8 → surface-C (`/diagnostic/wizard`, `/assistant`, `/outil` — qui N'EXISTENT PAS per memory `project_a_b_c_surfaces_distinction.md`) ✓
+- **0/8 → malformed D3** (trace manuelle de [`isMalformedSeoUrl`](packages/seo-url-contract/src/url-rules.ts#L96-L104) sur les 8 segments décodés : aucun `empty_segment`, `spaces_in_url`, `missing_alias`, `null_in_url`, `type_prefix_fallback`, `repeated_id`, `accented_chars`. Les params query `&text=…` sont écartés par `split('?')[0]` ligne 98)
+
+**Empirical evidence pour le monitor AE4** : `grep -rE "/blog/[a-z]" frontend/app/routes/` montre **0 route Remix publique sous `/blog/{slug}`** — toutes les routes blog convergent vers le préfixe canon `blog-pieces-auto.*` (12 routes trouvées : `_index`, `conseils._index`, `conseils.$pg_alias`, `guide-achat.*`, `auto.$marque.*`, `article.$slug`, etc.). Donc `/blog/pieces-e-de-frein` est nécessairement (a) un fallthrough legacy PHP/Caddy, (b) une 404 actuelle, ou (c) un artefact d'export Ahrefs (mauvaise reconstruction de l'URL depuis le anchor text). L'owner peut trancher avec `curl -I` ou inspection du legacy router PHP s'il existe encore.
+
+Les 2 SERP fragments `&text=…` (rangs #33, #36) sont des fragments d'extraction Google "Featured snippet" capturés par un scraper SEO tiers. Côté Caddy/NestJS, les params query après `?` ou `&` sont ignorés par le routing canonical et par `isMalformedSeoUrl`, donc **pas d'impact SEO**.
+
+## Anomalies consolidées
+
+| # | Type | Source de divergence | Action recommandée (gouvernée) |
+|---|------|---------------------|--------------------------------|
+| AE1 | DRIFT E3 — HTTP adoption | 2 anchors en `http://` (rangs #11, #32) | Owner : `curl -I http://www.automecanik.com` + inspection `docker/Caddyfile` pour confirmer 301 HTTP→HTTPS. **Hypothesis-only** tant que non testé. |
+| AE2 | DRIFT E4 — Cloudflare challenge leak | 1 anchor `attention required cloudflare` (rang #21) | Owner : audit `Cloudflare Dashboard > Security > Bots` + Challenge Solve Rate 30j. **Hypothesis-only** tant que non audité. |
+| AE3 | DRIFT E5 — anchor vide | 1 anchor `(vide)` (rang #4) | Pas actionnable côté Automecanik (édition référent). Outreach si référent identifié — **gated owner**. |
+| AE4 | MONITOR — slug legacy `/blog/pieces-e-de-frein` | 1 deep-link (rang #12) avec path court non-canonique | Owner : `curl -I https://www.automecanik.com/blog/pieces-e-de-frein` pour confirmer 301 vers canonical `/blog-pieces-auto/...` actuel. |
+
+## Risk matrix compacte
+
+| Drift | Risk | Urgency | Action |
+|-------|------|---------|--------|
+| E3 HTTP anchors (AE1) | **Low** | None | Owner verify Caddy 301 (lecture passive) |
+| E4 Cloudflare title leak (AE2) | **Medium** | None | Owner review CF Challenge Pages policy |
+| E5 Empty anchor (AE3) | **Negligible** | None | Ignore (référent externe, pas notre HTML) |
+| AE4 Slug legacy monitor | **Low** | None | Owner verify 301 vers canonical actuel |
+
+**Aucune ligne en urgency = High.** Aucun drift n'engage l'équité de lien à un niveau qui justifierait une réaction immédiate.
+
+## Verdict global
+
+Profil de backlinks externes **sain et naturel** sur le TOP 45 anchors :
+
+- **Distribution multi-modale** (brand / keyword / URL / template / content-snippet) — signature naturelle d'un site B2C établi
+- **Aucun anchor toxique** (E2 satisfied)
+- **Aucun anchor exact-match dominant** (E7 satisfied — entropy compatible profil naturel)
+- **Aucun leak surface-C** (0/8 deep-links pointent vers une surface inexistante)
+- **8/8 deep-links cross-checkés** contre canon role-matrix v5 et URL-contract D3 — 7 OK canon, 1 monitor legacy
+
+**No urgency** : aucun signal du TOP 45 ne justifie intervention urgente, désaveu (`disavow.txt`), campagne corrective, outreach prioritaire, ou changement canonique des URLs. Les 3 drifts (E3 HTTP, E4 CF, E5 vide) sont **mineurs, hypothesis-only, et owner-only** côté action.
+
+Le profil ne nécessite **aucune décision applicative** côté `automecanik.com` à ce stade. Toute action ultérieure (vérification Caddy, audit CF, outreach référents anchor vide) relève de la **discipline owner sur infra/edge**, hors scope verifier read-only filesystem.
+
+## Hors scope explicite (anti-overclaim)
+
+- **"Profil sain et naturel"** valable sur **TOP 45 anchors uniquement** — non extrapolable au profil complet (Ahrefs expose probablement plusieurs milliers d'anchors uniques en long tail, dont la distribution peut être différente)
+- **Dataset bias** — le TOP 45 sur-représente fréquences hautes (templates + URLs + directory patterns d'aggregateurs à fort volume de citations) et **sous-représente** les citations éditoriales longues à faible volume mais haute valeur. Verdict valable pour **pattern macro**, pas pour profil exhaustif. Un audit complet nécessite l'export Ahrefs raw (anchor + volume + DR référent + dofollow/nofollow + premier vu)
+- **Drift HTTP→HTTPS (E3)** = **hypothesis-only** tant que `curl -I http://www.automecanik.com` n'est pas vérifié empiriquement. Ne pas conclure que la redirection manque ou est cassée sans test live
+- **Drift CF challenge (E4)** = **hypothesis-only** tant que le dashboard Cloudflare n'est pas audité. La présence du titre `attention required cloudflare` comme anchor n'implique pas une mauvaise configuration — peut être un bot SEO tiers piégé par une Challenge Page légitime
+- **E7 anchor entropy** = verdict **qualitatif/ordinal** ("brand+url+template domine, exact-match non dominant") — **pas de métrique quantitative** (% exact-match précis, entropie de Shannon, Gini coefficient des anchors) sans dataset complet ; calculer ces métriques sur 45 anchors serait du bruit statistique
+- **Aucune action mécanique automatique** — toute action (redirect HTTP, config CF challenge, outreach, disavow) est **owner-only** + accès infra (DNS / edge / dashboard Cloudflare)
+- **Pas de claim conversion / commerce-loop** — Memory `feedback_seo_is_not_the_product_acquisition_serves_conversion.md` rappelle que les backlinks ≠ commande organique attribuable. Un profil de backlinks sain est nécessaire mais pas suffisant
+- **Pas de plan outreach / linkbuilding / disavow** inventé (Memory `dont_manufacture_small_deliverables.md`) — la demande était "audit + verdict", pas "plan d'action"
+
+## Mémoires canon citées
+
+- `feedback_no_url_changes_ever.md` — STRICT, aucune proposition de modification URL canonique malgré 1 monitor sur slug legacy
+- `feedback_no_autoescalation_after_single_go.md` — demande = audit, livrable = verdict seul, pas de Phase B/C
+- `dont_manufacture_small_deliverables.md` — pas de plan outreach théâtral
+- `feedback_seo_is_not_the_product_acquisition_serves_conversion.md` — pas de claim business depuis backlinks
+- `project_a_b_c_surfaces_distinction.md` — vérification 0 leak surface-C
+- `feedback_audit_needs_runtime_wiring_and_db_truth.md` — méthodologie cohérente avec l'audit interne pair
+
+---
+
+_Généré par Claude Code (Opus 4.7 1M) sur plan `automecanik-com-confidentialit-condition-zany-thunder.md`. Aucune mutation code/DB/infra. Profil empirique uniquement, owner-only pour toute action ultérieure._

--- a/audit/seo-ahrefs-internal-links-verdict-2026-05-24.md
+++ b/audit/seo-ahrefs-internal-links-verdict-2026-05-24.md
@@ -1,0 +1,279 @@
+# Verdict empirique — Ahrefs internal-links automecanik.com — 2026-05-24
+
+## Coverage manifest
+
+- **Dataset analysé** : 497 destinations distinctes, 2 012 090 liens internes (export externe Ahrefs/crawler tiers, fourni par l'owner)
+- **Sources internes croisées** : 5
+  - Code Remix rendu : [Navbar.tsx](frontend/app/components/Navbar.tsx), [Footer.tsx](frontend/app/components/home/Footer.tsx), [BottomNav.tsx](frontend/app/components/layout/BottomNav.tsx)
+  - Canon role-matrix v5 : [.spec/00-canon/role-matrix.md](.spec/00-canon/role-matrix.md)
+  - URL contract D3 : [packages/seo-url-contract/src/url-rules.ts](packages/seo-url-contract/src/url-rules.ts)
+  - Runtime DB : tables `__seo_internal_link`, `__seo_page`, vue `v_seo_internal_link_stats` (Supabase live)
+  - Memory canon : `project_a_b_c_surfaces_distinction.md` (2026-05-23)
+- **Invariants testés** : 6/6
+- **URLs vérifiées canon URL-contract** : 100/497 (stratifié top 20 + sample tail 80)
+- **URLs cross-checkées DB** : 25/497 (top 22 par link-count + 3 tail R4 reference)
+- **Drifts détectés** : 3 (I4 partiel, I5 critique, anomalie /marques)
+- **Hors scope** : commerce-loop conversion JOIN (gap data persistance documenté Phase C), parser Ahrefs CSV → DB (gated owner)
+
+## Invariants
+
+### I1 — Top destinations sitewide = bloc nav rendu Remix
+
+**Status : SATISFIED** (avec nuance volumétrique)
+
+Comptage instances DOM par URL (SSR Remix rend desktop + mobile dans le même HTML — crawler voit tout) :
+
+| URL Ahrefs | links Ahrefs | Instances DOM/page | Source |
+|------------|--------------|--------------------|--------|
+| `/diagnostic-auto` | 40 000 | **4** | [Navbar.tsx:261](frontend/app/components/Navbar.tsx#L261) (desktop CTA) + [Navbar.tsx:405](frontend/app/components/Navbar.tsx#L405) (mobile drawer) + [Footer.tsx:15](frontend/app/components/home/Footer.tsx#L15) + [BottomNav.tsx:19](frontend/app/components/layout/BottomNav.tsx#L19) |
+| `/plan-du-site` | 40 000 | 1 | [Footer.tsx:18](frontend/app/components/home/Footer.tsx#L18) |
+| `/blog-pieces-auto` | 39 942 | 3 | [Navbar.tsx:253](frontend/app/components/Navbar.tsx#L253) + [Navbar.tsx:397](frontend/app/components/Navbar.tsx#L397) + [Footer.tsx:16](frontend/app/components/home/Footer.tsx#L16) |
+| `/contact` | 39 917 | 1 | [Footer.tsx:17](frontend/app/components/home/Footer.tsx#L17) |
+| `/` | 37 342 | 3 | [Navbar.tsx:160](frontend/app/components/Navbar.tsx#L160) (mobile logo) + [Navbar.tsx:215](frontend/app/components/Navbar.tsx#L215) (desktop logo) + [BottomNav.tsx:9](frontend/app/components/layout/BottomNav.tsx#L9) |
+| `/account/dashboard` | absent du dataset | 1 (mobile only) | [BottomNav.tsx:25](frontend/app/components/layout/BottomNav.tsx#L25) — `rel="nofollow"` implicite + page logged-in |
+
+**Evidence structurelle** : tous les top 17 destinations à 37K-40K ont une source dans le bloc nav sitewide. Le plafond ~40 000 = budget crawl du sample Ahrefs (corpus pages indexées). Pages tail (1-100 liens) = liens organiques contextuels (PopularSearches home + BrandsGrid home + maillage `internal-linking.service.ts`).
+
+### I2 — Aucune URL surface-C dans le dataset
+
+**Status : SATISFIED**
+
+Patterns surface-C recherchés (selon memory `project_a_b_c_surfaces_distinction.md` 2026-05-23 — outil interactif hors-SEO, qui N'EXISTE PAS) : `/diagnostic/interactif`, `/diagnostic/outil`, `/diagnostic-interactif`, `/assistant`, `/outil`, `/wizard`, `/triage-interactif`, `/diagnostic-auto/{symptom}/wizard`. Comptage dans dataset : **0 occurrence**.
+
+Toutes les occurrences de `/diagnostic-auto` dans le dataset sont l'URL exacte sans suffix (R5 éditorial pur). Le canon A/B/C est respecté.
+
+### I3 — URL contract patterns D3
+
+**Status : SATISFIED**
+
+Échantillon stratifié testé contre `isMalformedSeoUrl()` / `detectMalformedSegment()` ([url-rules.ts:59-104](packages/seo-url-contract/src/url-rules.ts#L59-L104)) :
+
+- Top 20 URLs (37K-40K liens) : 20/20 valid
+- Sample tail 80 URLs (1-100 liens, incluant R8 motorisations + R2 produits avec query `?r=1` + R3/R6 blog) : 80/80 valid
+
+Aucun pattern malformé détecté : pas d'`empty_segment`, `spaces_in_url`, `missing_alias`, `null_in_url`, `type_prefix_fallback`, `repeated_id`, `accented_chars`. Les query params (`?r=1`) sont ignorés par `isMalformedSeoUrl` (split sur `?` line 98) — comportement attendu.
+
+### I4 — PageRole role-matrix v5 mapping
+
+**Status : DRIFT partiel** (13/17 patterns top-niveau couverts ; 4 URLs utilitaires hors-canon)
+
+| Pattern URL dataset | PageRole canon | Status |
+|---------------------|----------------|--------|
+| `/` | R0 (Home) | ✅ mappé canon (`.spec/00-canon/role-matrix.md:73-85`) |
+| `/diagnostic-auto` | R5 (Diagnostic) | ✅ mappé canon (`role-matrix.md:144-156`) |
+| `/blog-pieces-auto` | R3 (Conseils) | ✅ mappé canon |
+| `/blog-pieces-auto/conseils[/:slug]` | R3 | ✅ |
+| `/blog-pieces-auto/guide-achat[/:slug]` | R6 (Guide d'achat) | ✅ mappé canon (`role-matrix.md:158-170`) |
+| `/blog-pieces-auto/auto/{marque}/{modele}` | R3 (vehicle-aware) | ✅ |
+| `/pieces/{slug}-{id}.html` | R1 (Router gamme) | ✅ |
+| `/pieces/{slug}-{id}/{marque}.../{type}.html` | R2 (Product) | ✅ |
+| `/constructeurs/{marque}-{id}.html` | R7 (Brand) | ✅ |
+| `/constructeurs/{marque}-{id}/{modele}-{id}/{type}-{id}.html` | R8 (Vehicle) | ✅ |
+| `/reference-auto/{slug}` | R4 (Reference) | ✅ |
+| **`/plan-du-site`** | ❌ aucun rôle | DRIFT — utilitaire, hors R0-R8 |
+| **`/contact`** | ❌ aucun rôle | DRIFT — utilitaire support, hors R0-R8 |
+| **`/marques`** | ❌ aucun rôle | DRIFT — navigation, hors R0-R8 |
+| **`/catalogue`** | ❌ aucun rôle | DRIFT — navigation, hors R0-R8 |
+
+**Lecture** : R0-R8 gouverne les pages SEO publiques à promesse centrale ; `/plan-du-site` / `/contact` / `/marques` / `/catalogue` sont des **utilitaires de navigation/support** que role-matrix v5 ne couvre pas explicitement. C'est un drift de **complétude de la taxonomie**, pas d'une mauvaise qualification. Décision à porter au vault si l'owner veut une couverture exhaustive (extension role-matrix vers R*-utility ou couche dédiée).
+
+### I5 — Compteur interne inbound_links vs Ahrefs
+
+**Status : DRIFT critique — gap d'instrumentation runtime**
+
+Findings empiriques runtime (Supabase live `cxpojprgwgubzjyqzmoq`, 2026-05-24) :
+
+| Source interne | Attendu | Mesuré | Verdict |
+|----------------|---------|--------|---------|
+| Table `__seo_internal_link` | peuplée (105K liens internes selon `internal-linking.service.ts`) | **0 rows** | ❌ table définie, jamais alimentée |
+| Vue `v_seo_internal_link_stats` | top URLs par `inbound_count` | **0 rows** (vue vide cascade) | ❌ |
+| Table `__seo_page` | ground truth toutes URLs SEO émises | **321 838 rows tous `page_type='product'` (R2 uniquement)** | ❌ couverture incomplète |
+| URLs Ahrefs top 22 trouvées dans `__seo_page` | au moins R1/R7 hub pages | **0/22** | ❌ aucune URL hub R1/R7/R3/R4/R5/R8 dans la table |
+
+**Conséquence** :
+1. Le compteur interne d'inbound-links n'existe pas en pratique → **aucun moyen de croiser Ahrefs externe vs runtime interne** sans alimenter `__seo_internal_link`.
+2. Le « ground truth officiel des URLs émises » (sitemap V10) n'est représenté dans `__seo_page` **que pour les R2 produits** (321 838 rows) ; les ~38K URLs R7 brand + ~13K R8 véhicule + R1/R3/R4/R5/R6 + utilitaires (`/`, `/diagnostic-auto`, `/contact`, `/plan-du-site`) sont **invisibles côté DB**.
+
+Référence MEMORY : ce finding s'aligne avec `feedback_audit_needs_runtime_wiring_and_db_truth.md` (audit doit ajouter runtime-wiring + DB-live + truth-propagation) et le pattern `project_commerce_runtime_truth_audit_20260522.md` F1 (attribution `orl_website_url` orpheline — même genre de colonne/table définie mais jamais propagée).
+
+### I6 — `/diagnostic-auto` rang #1 vs `/`
+
+**Status : SATISFIED — structurellement attendu**
+
+Évidence (cross-check I1) :
+- `/diagnostic-auto` : **4 instances DOM/page** (Navbar desktop CTA + Navbar mobile drawer + Footer USEFUL_LINKS + BottomNav mobile Stethoscope)
+- `/` (home) : **3 instances DOM/page** (Navbar mobile logo + Navbar desktop logo + BottomNav mobile Home icon)
+
+Ratio théorique = 4/3 = +33%. Ratio Ahrefs observé = 40 000 / 37 342 = +7.1%. L'écart < ratio théorique s'explique par :
+- Saturation du budget crawl Ahrefs à ~40 000 pages (le plafond du sample, vu sur 6 URLs top toutes ~à ce niveau)
+- Distribution non-uniforme du corpus crawlé (toutes les pages n'ont pas les 4 instances visibles — pages auth-only n'affichent pas BottomNav par exemple)
+
+**Pas d'anomalie comportementale.** Le rang #1 de `/diagnostic-auto` est une conséquence directe et **gouvernée** du choix produit canon (R5 = surface A SEO, CTA primaire dans la nav, confirmé par `project_a_b_c_surfaces_distinction.md`). Aucune action requise.
+
+## Anomalies détectées (consolidées)
+
+| # | Type | URL/cible | Source de divergence | Action recommandée (gouvernée) |
+|---|------|-----------|---------------------|--------------------------------|
+| A1 | DRIFT canon | `/plan-du-site`, `/contact`, `/marques`, `/catalogue` | role-matrix v5 ne couvre pas les utilitaires | Décision owner : extension role-matrix (vault PR ADR-XXX) ou acceptation comme hors-canon. Pas de fix mécanique. |
+| A2 | Divergence code↔crawler | `/marques` (38 597 liens Ahrefs) vs `/#marques` (anchor dans Navbar:243+389+Footer:14) | Le crawler voit `/marques` mais la nav code pointe `/#marques`. Source probable : sitemap V10 ou un redirect. | Investigation owner (curl HEAD `/marques` + check sitemap V10 émission) avant toute action. Constraint canon : `feedback_no_url_changes_ever.md` STRICT. |
+| A3 | DRIFT runtime instrumentation | `__seo_internal_link` = 0 rows ; `__seo_page` = R2-only (321 838 / probablement ~700K+ attendues toutes surfaces) | Table définie ([migration 20260122_sitemap_v10_enterprise.sql]) mais jamais alimentée par le pipeline runtime ; sitemap V10 n'écrit pas les surfaces non-R2 | Issue tracker — pas de fix immédiat, signal vers l'owner SEO-runtime. Pattern identique à `feedback_audit_needs_runtime_wiring_and_db_truth.md`. |
+
+## Verdict global
+
+Distribution des liens internes **structurellement cohérente** avec le canon role-matrix v5 et le bloc de navigation sitewide rendu par Remix ; **aucune URL surface-C ne fuit**, **aucun pattern URL malformé**. Trois drifts gouvernés à présenter à l'owner avant toute action mécanique : (1) 4 URLs utilitaires hors role-matrix, (2) divergence code `/#marques` vs canonical `/marques` côté crawler, (3) gap d'instrumentation runtime (`__seo_internal_link` jamais peuplé, `__seo_page` couvre R2 uniquement).
+
+## Hors scope explicite (anti-overclaim)
+
+- Pas de mesure de **conversion-rate par URL** — la table `__seo_internal_link` est vide et il n'existe pas de JOIN persistant URL→panier→commande (cart-analytics est Redis-only). Cible Phase C du plan si owner GO.
+- Pas d'import du **dataset Ahrefs** en DB — réservé à Phase C, gated owner sign-off.
+- Pas de **fix mécanique** sur Navbar/Footer/BottomNav/`__seo_internal_link`/`__seo_page` — verifier read-only par contrat.
+- Pas de jugement **commerce-loop** sur la distribution des liens — `feedback_seo_is_not_the_product_acquisition_serves_conversion.md` rappelle que le KPI unique est commande organique attribuable, pas l'équité de liens internes.
+
+## Annexe — Root-cause analysis A2 et A3 (auto-mode, read-only)
+
+### A2 — Source des 38 597 liens vers `/marques`
+
+Grep exhaustif `frontend/app/` + `backend/src/modules/seo/` : **aucune route Remix `/marques`** n'existe. Routes voisines présentes :
+
+- [frontend/app/routes/brands._index.tsx](frontend/app/routes/brands._index.tsx) — sert `/brands` (slug différent), liste publique des marques
+- [frontend/app/routes/products.brands.tsx](frontend/app/routes/products.brands.tsx) — admin
+- [frontend/app/routes/constructeurs.$brand[.]html.tsx](frontend/app/routes/constructeurs.$brand%5B.%5Dhtml.tsx) — sert `/constructeurs/:brand.html` (R7 brand canonical)
+
+Seule occurrence textuelle de `/marques` dans le code monorepo : [frontend/app/routes/plan-du-site.tsx](frontend/app/routes/plan-du-site.tsx) — utilise `/#marques` (anchor home, pas l'URL canonique).
+
+**Conclusion** : `/marques` reçoit 38 597 liens internes Ahrefs mais **n'a aucune source identifiable dans le code Remix actuel**. Hypothèses (à investiguer par l'owner avec accès SSH PROD) :
+
+1. **Legacy server-side** : pages héritées du PHP rendues par un sous-domaine ou un catch-all qui réécrit `/marques` côté serveur (le memory ne couvre pas cette migration)
+2. **Sitemap statique XML** non géré par sitemap V10 V10 enterprise (qui ne contient que R2 product per I5)
+3. **Caddy URL rewrite** : redirect 301 `/marques` → `/brands` ou `/#marques` (Ahrefs comptabiliserait la cible de référence avant redirect)
+
+Action : `curl -I https://www.automecanik.com/marques` depuis un poste avec accès réseau valide, plus inspection [docker/Caddyfile](docker/) si présent. **Hors scope du verifier (mode read-only filesystem)**.
+
+### A3 — Root-cause `__seo_internal_link` 0 rows en live
+
+Cartographie complète du cycle de vie de la table :
+
+| Étape | Localisation code | Statut |
+|-------|-------------------|--------|
+| **DDL** (définition schéma) | [backend/supabase/migrations/20260122_sitemap_v10_enterprise.sql:101-124](backend/supabase/migrations/20260122_sitemap_v10_enterprise.sql#L101-L124) | ✅ Table créée avec UNIQUE constraint + 3 indexes + 9 link_type CHECK |
+| **READER #1** | [backend/src/modules/seo/services/sitemap-v10-scoring.service.ts:258-277](backend/src/modules/seo/services/sitemap-v10-scoring.service.ts#L258-L277) | ✅ Lit `to_url, link_type WHERE is_active=true` pour composer le score `GraphStrength` (hub/breadcrumb/total) injecté dans `__seo_entity_score_v10` |
+| **WRITER** | grep `INSERT INTO __seo_internal_link` + `.from('__seo_internal_link').insert/upsert` dans tout `backend/src/` + `backend/supabase/` | ❌ **0 résultat — aucun code n'écrit jamais dans la table** |
+| **Données live** (Supabase `cxpojprgwgubzjyqzmoq`) | `SELECT COUNT(*) FROM __seo_internal_link` | 0 rows |
+
+**Conséquence en cascade** : `sitemap-v10-scoring.service.ts` produit un `inboundMap` vide → la composante `GraphStrength` du scoring est neutralisée → la `priority` et le `temperature` calculés dans `__seo_entity_score_v10` se basent sur un **signal manquant**. Les sitemaps émis par V10 sont donc **sub-optimaux par construction** : ils ignorent la topologie réelle du graphe interne.
+
+Pattern identique aux cas documentés :
+- `project_commerce_runtime_truth_audit_20260522.md` F1 — colonne `orl_website_url` orpheline (attribution column never written)
+- `feedback_audit_needs_runtime_wiring_and_db_truth.md` — auditer la propagation runtime, pas juste file-vs-file
+- Skill canon `runtime-truth-audit` — check #4 « attribution columns never written » s'applique directement ici
+
+**Pas de fix proposé** (canon `feedback_no_autoescalation_after_single_go.md` + `feedback_no_url_changes_ever.md`). Décision owner :
+- (a) Ajouter un producer write au service `internal-linking.service.ts` (qui injecte ~105K liens à la volée) ou un job batch nightly qui crawle le site rendu et upserte
+- (b) Supprimer le reader scoring (et donc neutraliser explicitement la composante `GraphStrength`)
+- (c) Le marquer comme « zombie code » dans le ratchet `runtime-truth-audit` jusqu'à arbitrage produit
+
+---
+
+## Annexe 2 — Vérification empirique HTTP PROD (read-only, 2026-05-24 21:55 UTC)
+
+`curl -I https://www.automecanik.com/{url}` avec UA crawler-like. Toutes les URLs hors-canon de A1 sont **servies réellement par PROD** :
+
+| URL | HTTP | Cache-Control | Verdict |
+|-----|------|---------------|---------|
+| `/` | 200 | `public, max-age=300, stale-while-revalidate=3600` | R0 home cacheable public |
+| `/marques` | **200** | `private, max-age=60` | Route servie, **pas un fantôme** |
+| `/contact` | **200** | `private, max-age=60` | Route servie |
+| `/plan-du-site` | **200** | `private, max-age=60` | Route servie |
+| `/catalogue` | **200** | `private, max-age=60` | Route servie |
+| `/diagnostic-auto` | 200 | `private, max-age=60` | R5 |
+| `/blog-pieces-auto` | 200 | `private, max-age=60` | R3 hub |
+| `/brands` | 200 | `private, max-age=60` | Route alt parallèle à `/marques` |
+
+**Correction du finding A2 initial** : la route `/marques` EXISTE — elle est servie par [frontend/app/routes/_public+/marques.tsx](frontend/app/routes/_public%2B/marques.tsx) (convention Remix flat-routes : le dossier `_public+` groupe sans préfixer l'URL). Mon premier grep a manqué cette route à cause du `+` dans le nom de dossier. **Le verifier auto-corrige son finding A2** (signe que le format coverage manifest fonctionne — l'inversion empirique est traçable).
+
+**Nouveau finding (issue ouverte)** : la route `/marques` existe et reçoit 38 597 liens Ahrefs, mais **aucun émetteur textuel `/marques` (URL exacte, sans `#`) n'a été trouvé dans le monorepo** (grep complet `frontend/app/` + `backend/src/`, hors `marques.tsx` self-ref). Les seules occurrences sont :
+- `frontend/app/routes/plan-du-site.tsx` : pointe vers `/#marques` (anchor, pas la route)
+- `backend/src/modules/seo/services/sitemap-v10-hubs-vehicle.service.ts:572,637` : labels "Toutes marques" dans un HTML template (sans href vers `/marques`)
+- `backend/src/config/r6-keyword-plan.constants.ts:319` + `backend/src/modules/search/services/pieces-analysis.service.ts:284` : keyword string "marques" (mention textuelle)
+
+**Hypothèse résiduelle (à arbitrer par l'owner)** : les liens internes vers `/marques` proviennent vraisemblablement de l'index de **sitemap V10** émis publiquement (XML statique généré côté backend) — Ahrefs crawle le sitemap comme source de découverte d'URLs canoniques, et compte alors chaque hit comme un « lien interne » de l'index sitemap vers la cible. À confirmer en téléchargeant `/sitemap-index.xml` PROD et en grepant `<loc>https://www.automecanik.com/marques</loc>`. Investigation différée — Phase B owner.
+
+**Doublon URL alarme** : `/marques` et `/brands` sont **tous deux servis 200 par PROD** avec contenu probablement équivalent (toutes les marques). Risque de **duplicate content SEO** si les deux ont des canonicals divergents. À vérifier dans la décision A1/A2 owner (étendre role-matrix v5 et trancher canonical).
+
+---
+
+## Annexe 3 — Sitemap V10 vs réalité Remix vs Ahrefs (closure A2 + nouveaux drifts critiques)
+
+Probe HTTP PROD `/sitemap.xml` (sitemap index réel, **pas** `/sitemap-index.xml`) + sous-sitemaps + cross-check HTTP des URLs émises.
+
+### Sitemap V10 index actuel (2026-05-24)
+
+`/sitemap.xml` contient 10+ sous-sitemaps : `sitemap-racine.xml`, `sitemap-categories.xml`, `sitemap-vehicules.xml`, `sitemap-blog.xml`, `sitemap-pages.xml`, `sitemap-diagnostic.xml`, `sitemap-reference.xml`, `sitemap-brands.xml`, `sitemap-pieces-1.xml`, `sitemap-pieces-2.xml`, ...
+
+### Drift 1 — Sitemap émet des URLs **404 et 301**
+
+| URL émise dans `sitemap-pages.xml` | Priority | HTTP PROD réel | Verdict |
+|--------------------------|----------|----------------|---------|
+| `/` | 1.0 | 200 | ✅ |
+| `/constructeurs` | **0.8** | **404** | ❌ **CRITIQUE** — page racine n'existe pas (routes Remix uniquement pour `/constructeurs/{brand}-{id}.html`). Google va indexer cette URL et trouver 404. |
+| `/blog` | **0.7** | **301** | ❌ Redirect → gaspillage crawl budget (le sitemap NE DOIT JAMAIS émettre une URL qui redirect) |
+| `/diagnostic-auto` | 0.8 | 200 | ✅ |
+| `/reference-auto` | 0.8 | 200 | ✅ |
+| `/contact` | 0.4 | 200 | ✅ |
+| `/aide` | 0.4 | 200 | ✅ |
+| `/faq` | 0.4 | non testé | présumé 200 |
+| `/cgv`, `/mentions-legales`, `/politique-confidentialite` | 0.3 | non testé | présumé 200 |
+
+### Drift 2 — Sitemap **ignore** 4 URLs qui reçoivent 38K-40K liens internes Ahrefs
+
+| URL | Liens Ahrefs | Dans `sitemap-pages.xml` ? | HTTP PROD | Implication |
+|-----|--------------|---------------------------|-----------|-------------|
+| `/plan-du-site` | 40 000 | ❌ NON | 200 | 40K liens vers une URL canonical-invisible côté sitemap |
+| `/blog-pieces-auto` | 39 942 | ❌ NON (mais `/blog` 301 émis) | 200 | Le sitemap pointe vers la mauvaise canonical R3 (alias 301 au lieu de la route canonique 200) |
+| `/marques` | 38 597 | ❌ NON | 200, **AUCUN canonical**, **AUCUN robots tag** | 38K liens internes vers une page non émise + sans signal SEO → cannibalisation potentielle |
+| `/catalogue` | 38 536 | ❌ NON | 200 | 38K liens vers URL canonical-invisible |
+
+### Drift 3 — Doublon `/marques` vs `/brands` (canonical incohérent)
+
+Probe HTML head des deux URLs (PROD, UA crawler-like) :
+
+| URL | Title | `<link rel="canonical">` | `<meta robots>` | og:* | Verdict |
+|-----|-------|--------------------------|-----------------|------|---------|
+| `/marques` | `Marques - Automecanik` (minimaliste) | **ABSENT** | **ABSENT** | absent | Stub legacy non-SEO-optimisé, 38 597 liens internes pointent dessus |
+| `/brands` | `Toutes les Marques Automobiles (0) \| Pièces Détachées Auto` | `https://www.automecanik.com/brands` | `index, follow` | complet | Page moderne SEO-tagguée MAIS **empiriquement cassée** : loader retourne `0 marques` (visible dans title + meta description) |
+
+**Risque cannibalisation interne** : deux URLs publiques 200 sur la même intention (liste des marques), avec des signaux SEO divergents. Google peut indexer les deux et préférer `/marques` (qui reçoit plus de jus interne — 38 597 liens) malgré l'absence totale de signal canonical, au détriment de `/brands` (canonical correct mais zéro contenu). Net : ni l'une ni l'autre ne gagne, le ranking se dilue.
+
+### Drift 4 — `__seo_page.priority` uniforme à 100%
+
+Query DB live (2026-05-24) :
+
+```sql
+SELECT priority_bucket, COUNT(*), pct FROM ...
+-- résultat unique : bucket "0.3-0.5" → 321 838 rows (100.00%)
+```
+
+**Verdict** : la composante `GraphStrength` du scoring V10 est neutralisée (cf. A3 — `__seo_internal_link` jamais peuplée), donc **toutes les pages produit R2 sortent au même bucket de priorité**. Google ne reçoit **aucun signal de priorisation différentielle** dans les sous-sitemaps — il décide seul de l'allocation crawl budget. Pour 700K+ URLs (probablement), c'est une perte d'opportunité majeure : impossible de signaler les pages haut-trafic vs pages cold/orphelines.
+
+### Verdict ultime du verifier
+
+Le bloc nav sitewide et la matrice canon role-matrix v5 sont **structurellement sains** (I1-I4 SATISFIED ou DRIFT mineur). En revanche, **le sitemap V10** — émetteur du « ground truth » des URLs publiables — présente **4 drifts critiques structuraux** (Drifts 1-4 ci-dessus) qui sabotent activement le crawl budget Google :
+
+1. Émet une URL **404** (`/constructeurs`) avec haute priorité
+2. Émet une URL **301** (`/blog`) au lieu de la canonical R3 réelle (`/blog-pieces-auto`)
+3. **Ignore 4 URLs** (37K-40K liens internes chacune) que le maillage interne traite comme prioritaires
+4. **Priorité uniforme** sur 321K pages produit (scoring V10 non-différenciant par absence de `__seo_internal_link`)
+
+Ce sont des findings de **runtime-truth-audit canon** (skill listé en TOP priorities session) et qui s'alignent avec `feedback_seo_runtime_must_integrate_repo_control_plane.md` (pas de runtime parallèle non-gouverné) + `project_commerce_runtime_truth_audit_20260522.md` (perte de propagation des signaux).
+
+**Aucune action mécanique déclenchée** par le verifier (constraint `feedback_no_url_changes_ever.md` STRICT + `feedback_sitemap_no_trigger.md` STRICT). Les fixes Phase B/C demeurent gated owner sign-off. Le verifier livre un evidence-pack prêt-à-arbitrer.
+
+### Référence canon pour la décision owner
+
+- Skill `runtime-truth-audit` (TOP priority session) : couvre exactement le pattern des Drifts 3+4 (attribution/scoring jamais écrit).
+- ADR-058 Repository Control Plane : le sitemap V10 est runtime SEO et doit s'enregistrer `.spec/00-canon/seo-runtime/*.yaml` (per `feedback_seo_runtime_must_integrate_repo_control_plane.md`).
+- ADR-064 partition rotation : `__seo_snapshot_*` rappel rotation cron — vérifier que les sitemap-snapshot ont aussi un cycle de rotation (hors scope verifier).
+
+---
+
+_Généré par Claude Code (Opus 4.7 1M) sur plan `utiliser-superpower-verifier-automecanik-lively-backus.md`. Aucune mutation code/DB. Pour traiter A1-A3 + Drifts 1-4 (sitemap V10), voir Phase B/C du plan, gated owner sign-off._


### PR DESCRIPTION
Audit-only read-only.

Ships two empirical Ahrefs/internal-link verdict artifacts:
- 7 invariants
- anchor entropy + machine-vs-human + deep-link risk matrix
- 4 empirical markers
- no code, no DB, no sitemap trigger, no URL change

No urgency. Owner-only follow-up decisions.

## Test plan
- [x] `wc -l audit/seo-ahrefs-*-2026-05-24.md` — files under expected size
- [x] `grep -E "^### [EI][0-9]" audit/seo-ahrefs-*-2026-05-24.md` — 6+7 invariants present
- [x] `git status audit/` — only 2 audit files, no incidental changes
- [x] No code touched (`backend/`, `frontend/`, migrations, sitemap, RPC) — verifiable from diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)