### PR TITLE
perf(blog-r3): imgproxy AVIF/WebP picture + responsive preload on conseils hero (LCP)

### DIFF
--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -61,6 +61,9 @@ import {
   type R3GuidePage,
 } from "~/types/r3-guide.types";
 import { trackArticleView, trackReadingTime } from "~/utils/analytics";
+import ImageOptimizer, {
+  type PictureImageSet,
+} from "~/utils/image-optimizer";
 import { getInternalApiUrlFromRequest } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { getOgImageUrl } from "~/utils/og-image.utils";
@@ -73,6 +76,36 @@ const RelatedArticlesSidebar = lazy(() =>
   })),
 );
 const VehicleCarousel = lazy(() => import("~/components/blog/VehicleCarousel"));
+
+// ── LCP optimization (PR LCP-R3-PR2) ────────────────────────
+// Featured image is the LCP candidate on R3 conseils (GSC report 4.8s mobile).
+// Apply imgproxy AVIF/WebP srcSet + responsive preload. Guard absolute URLs
+// (handled by browser as-is) — only relative Supabase paths get optimized.
+const HERO_WIDTHS = [400, 800, 1200];
+const HERO_SIZES = "(max-width: 640px) 100vw, 800px";
+const HERO_WIDTH = 800;
+const HERO_HEIGHT = 256;
+
+function buildHeroImageSet(
+  featuredImage: string | null | undefined,
+): PictureImageSet | null {
+  if (!featuredImage) return null;
+  // Skip imgproxy if absolute URL or already-proxied path — keep raw rendering
+  // (fallback to current behavior, no LCP optimization but no regression).
+  if (
+    featuredImage.startsWith("http") ||
+    featuredImage.startsWith("/img/") ||
+    featuredImage.startsWith("/imgproxy/")
+  ) {
+    return null;
+  }
+  return ImageOptimizer.getPictureImageSet(featuredImage, {
+    widths: HERO_WIDTHS,
+    sizes: HERO_SIZES,
+    width: HERO_WIDTH,
+    height: HERO_HEIGHT,
+  });
+}
 
 // Types
 
@@ -357,12 +390,29 @@ export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
   ];
 
   if (page.featuredImage) {
-    result.push({
-      tagName: "link",
-      rel: "preload",
-      as: "image",
-      href: page.featuredImage,
-    });
+    const heroSet = buildHeroImageSet(page.featuredImage);
+    if (heroSet) {
+      // Responsive preload — browser picks the optimal AVIF variant matching
+      // its viewport via imagesrcset+imagesizes. fetchpriority=high signals LCP.
+      result.push({
+        tagName: "link",
+        rel: "preload",
+        as: "image",
+        href: heroSet.fallbackSrc,
+        imagesrcset: heroSet.avifSrcSet,
+        imagesizes: heroSet.sizes,
+        type: "image/avif",
+        fetchpriority: "high",
+      });
+    } else {
+      // Absolute URL or already-proxied — preload raw (current behavior).
+      result.push({
+        tagName: "link",
+        rel: "preload",
+        as: "image",
+        href: page.featuredImage,
+      });
+    }
   }
 
   return result;
@@ -402,6 +452,10 @@ export default function R3GuidePage() {
 
   // Hero badges from pre-computed metadata
   const heroBadges = buildHeroBadges(page);
+
+  // LCP optimization: imgproxy AVIF/WebP set for the featured image candidate.
+  // null = absolute URL / already-proxied → fallback to raw <img> below.
+  const heroImageSet = buildHeroImageSet(page.featuredImage);
 
   // Adapter sections → GammeConseil for legacy components
   const conseilForSnippet: GammeConseil[] | null =
@@ -474,22 +528,47 @@ export default function R3GuidePage() {
           <span className="font-medium text-gray-700">Retour au blog</span>
         </button>
 
-        {/* Featured Image */}
+        {/* Featured Image — LCP candidate, served via imgproxy AVIF/WebP when path is a relative Supabase asset. */}
         {page.featuredImage && (
           <Card className="mb-8 border shadow-lg overflow-hidden">
             <CardContent className="p-0">
               <div className="bg-gradient-to-br from-gray-50 via-white to-gray-100 p-6 flex items-center justify-center">
-                <img
-                  src={page.featuredImage}
-                  alt={page.title}
-                  width={800}
-                  height={256}
-                  sizes="(max-width: 640px) 100vw, 800px"
-                  className="w-full h-64 object-contain drop-shadow-lg"
-                  loading="eager"
-                  decoding="async"
-                  fetchPriority="high"
-                />
+                {heroImageSet ? (
+                  <picture>
+                    <source
+                      type="image/avif"
+                      srcSet={heroImageSet.avifSrcSet}
+                      sizes={heroImageSet.sizes}
+                    />
+                    <source
+                      type="image/webp"
+                      srcSet={heroImageSet.webpSrcSet}
+                      sizes={heroImageSet.sizes}
+                    />
+                    <img
+                      src={heroImageSet.fallbackSrc}
+                      alt={page.title}
+                      width={HERO_WIDTH}
+                      height={HERO_HEIGHT}
+                      className="w-full h-64 object-contain drop-shadow-lg"
+                      loading="eager"
+                      decoding="async"
+                      fetchPriority="high"
+                    />
+                  </picture>
+                ) : (
+                  <img
+                    src={page.featuredImage}
+                    alt={page.title}
+                    width={800}
+                    height={256}
+                    sizes="(max-width: 640px) 100vw, 800px"
+                    className="w-full h-64 object-contain drop-shadow-lg"
+                    loading="eager"
+                    decoding="async"
+                    fetchPriority="high"
+                  />
+                )}
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Context

GSC reports LCP mobile **4,8 s** on 47 URLs `/blog-pieces-auto/conseils/*` (chronique, première détection 2024-06-27 — repère cohorte CrUX, pas date régression code per `feedback_no_blind_trust_gsc_first_detection_date.md`). PR-2 d'une séquence de 3 PRs ; complémentaire de #735 (cap vehicles 1000→24, biggest server-side lever) qu'il faut merger en premier.

L'image featured de l'article est le LCP candidate. Auparavant servie raw Supabase (pas de resize, pas d'AVIF/WebP, pas de srcSet) → mobile décode un asset desktop-size.

## Changes

- `<picture>` avec sources AVIF + WebP via `ImageOptimizer.getPictureImageSet` (widths 400/800/1200, sizes `(max-width: 640px) 100vw, 800px`) + `<img>` fallback avec `width=800 height=256` (LCP-friendly, no CLS).
- Preload responsive `<link rel="preload" as="image" imagesrcset=<avif> imagesizes=… type="image/avif" fetchpriority="high">` dans `meta()` — le navigateur choisit la variante optimale matchant son viewport avant que `<picture>` ne render.
- Helper local `buildHeroImageSet()` avec garde absolute-URL / `/img/` / `/imgproxy/` → retourne `null` → rendu raw (no regression sur les inputs hors path Supabase relatif).
- **Aucune nouvelle infra** : réutilise `frontend/app/utils/image-optimizer.ts:257` `getPictureImageSet` existant.

## Hypothèse de gain

- AVIF/WebP au lieu de raw JPEG/PNG → **-50-70% transfert mobile** sur l'image
- Resize 400-1200w via imgproxy → **-200-300 ms decode** sur device mobile bas/moyen
- Preload responsive `imagesrcset` → image initiée plus tôt dans la waterfall
- **LCP estimé : -300 à -500 ms** sur R3 conseils mobile, cumulé avec #735

Verdict réel = Sentry web-vitals attribution `attr_element` + fenêtre CrUX 28 j post-merge tag prod, pas garantie ex-ante.

## Scope

- R3 conseils only (`blog-pieces-auto.conseils.\$pg_alias.tsx` uniquement)
- No R2 pieces changes (même anti-pattern `<img>` raw potentiel ailleurs → follow-up séparé si confirmé)
- No SEO meta/H1 changes (cf. `feedback_no_touch_meta_h1_if_optimized.md`)
- No payment/runtime changes
- HeroBlog.tsx untouched (non utilisé par conseils route)

## Validation

- [ ] build/typecheck CI
- [ ] visual check mobile `/blog-pieces-auto/conseils/emetteur-d-embrayage` Chrome DevTools 4× CPU throttle Fast 3G
- [ ] Network panel confirme servings AVIF + srcSet adaptatif
- [ ] LCP attribution post-merge via Sentry `metric:LCP` + `route_path:/blog-pieces-auto/conseils/*` (J−14 vs J+14)
- [ ] CrUX 28 j comparison post-tag prod (verdict final)

## Sequencing

À merger après #735 (PR-1 payload cap). PR-3 (`.cv-auto` containment below-fold, séquencé après celle-ci) viendra ensuite.

## Refs

- PR #694 (`.cv-auto` /pieces/ INP -33% A/B prod) — méthodo A/B harness DOM
- PR #692 (web-vitals attribution Sentry/GA4)
- PR #408 (blog R3 cache + single-flight + web-vitals, fix LCP antérieur)
- Plan local `/home/deploy/.claude/plans/automecanik-com-confidentialit-condition-abundant-adleman.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)