### PR TITLE
perf(blog-r3): content-visibility:auto on conseils below-fold blocks (LCP)

### DIFF
--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -660,9 +660,9 @@ export default function R3GuidePage() {
               </Card>
             </article>
 
-            {/* Véhicules Compatibles */}
+            {/* Véhicules Compatibles — below-fold, content-visibility:auto skips paint until scrolled in. */}
             {guide.vehicles.length > 0 && (
-              <div className="lg:col-span-3 order-3">
+              <div className="lg:col-span-3 order-3 cv-auto">
                 <Suspense
                   fallback={
                     <div className="h-48 animate-pulse bg-gray-100 rounded-lg" />
@@ -760,24 +760,26 @@ export default function R3GuidePage() {
                 </Suspense>
                 {/* END R4 deferred block — was previously blocking TTFB by 200-400ms */}
 
-                {/* Articles Croisés */}
+                {/* Articles Croisés — below-fold, content-visibility:auto skips paint until visible. */}
                 {guide.related.length > 0 && (
-                  <Suspense
-                    fallback={
-                      <div className="h-32 animate-pulse bg-gray-100 rounded-lg" />
-                    }
-                  >
-                    <RelatedArticlesSidebar
-                      articles={guide.related as never[]}
-                    />
-                  </Suspense>
+                  <div className="cv-auto">
+                    <Suspense
+                      fallback={
+                        <div className="h-32 animate-pulse bg-gray-100 rounded-lg" />
+                      }
+                    >
+                      <RelatedArticlesSidebar
+                        articles={guide.related as never[]}
+                      />
+                    </Suspense>
+                  </div>
                 )}
               </div>
             </aside>
           </div>
 
-          {/* Navigation entre articles (précédent/suivant) */}
-          <div className="max-w-6xl mx-auto mt-8">
+          {/* Navigation entre articles (précédent/suivant) — below-fold, content-visibility:auto. */}
+          <div className="max-w-6xl mx-auto mt-8 cv-auto">
             <ArticleNavigation
               previous={guide.adjacent.previous as never}
               next={guide.adjacent.next as never}


### PR DESCRIPTION
## Context

3ᵉ PR de la séquence LCP R3 conseils (4,8 s mobile, 47 URLs `/blog-pieces-auto/conseils/*` chronique depuis 2024-06-27 — repère cohorte CrUX, pas date régression code).

Après PR #735 (cap vehicles 1000→24, **server-side payload**) et PR #738 (imgproxy AVIF/WebP `<picture>` + preload responsive, **transfer + decode**), cette 3ᵉ PR cible la **layout/paint work** initiale en appliquant `content-visibility: auto` aux blocs below-fold — exact pattern de PR #694 validé -33% INP sur `/pieces/*` en A/B prod.

Bloc le plus sensible UX de la séquence : à reviewer pour s'assurer que rien ne casse en ancrage clavier / scroll / impression / SEO visibility.

## Changes

3 wrappers below-fold reçoivent la className `cv-auto` (classe existante, définie `global.css:380` lors du PR #694, pas de nouveau CSS) :

- `VehicleCarousel` wrapper (`lg:col-span-3 order-3 cv-auto`) — grid lourd, déjà lazy + Suspense
- `RelatedArticlesSidebar` Suspense — wrappé dans une `<div className="cv-auto">` séparée pour ne pas casser le `position: sticky` du parent `<aside>` (sticky doit voir la hauteur, cv-auto sur enfants OK)
- `ArticleNavigation` footer (`max-w-6xl mx-auto mt-8 cv-auto`) — nav précédent/suivant en bas de page

Le hero + Card intro + sections article (above-the-fold) ne reçoivent **pas** `cv-auto` (sinon casserait le LCP image candidate).

## Hypothèse de gain

- Réduit layout/paint work pendant le rendu initial → image LCP candidate peint plus tôt
- **LCP estimé : -200 à -400 ms** selon device CPU, cumulé avec PR-1+PR-2
- INP also improves (bonus) — moins de nœuds dans le render tree initial

Verdict réel = Sentry LCP/INP attribution + CrUX 28 j post-merge, pas garantie.

## SEO-safe par construction

`content-visibility: auto` garde le contenu dans le DOM ET le rend dès qu'il entre dans le viewport. Pas de noindex, pas de hidden, pas de skip-link. Crawlers (Googlebot, GPTBot, ClaudeBot…) reçoivent exactement le même HTML — ils ne dépendent pas du viewport pour parser.

## Points UX à valider en review

- Ancrage clavier (Tab) sur les liens dans `VehicleCarousel`, `RelatedArticlesSidebar`, `ArticleNavigation`
- Scroll-to-anchor via TableOfContents (les anchors restent valides : cv-auto ne change pas la position des éléments)
- Impression CSS (`@media print`) : `content-visibility: auto` peut hider en print — à confirmer si AutoMecanik a un cas usage print article (probablement non, donc OK)
- HTML visible côté SEO (vue source) : identique au pré-PR

## Scope

- R3 conseils only
- No R2 pieces changes (PR #694 a déjà appliqué `.cv-auto` sur `/pieces/*`)
- No SEO meta/H1 changes
- No payment/runtime changes
- Aucune modification CSS (réutilise `.cv-auto` global.css)

## Validation

- [ ] build/typecheck CI
- [ ] visual check mobile `/blog-pieces-auto/conseils/emetteur-d-embrayage` : pas de FOUC au scroll, pas de saut layout
- [ ] Keyboard nav (Tab) atteint tous les liens below-fold
- [ ] Lighthouse local 4× CPU throttle : LCP avant/après measure
- [ ] LCP + INP attribution post-merge via Sentry (J−14 vs J+14)
- [ ] CrUX 28 j comparison post-tag prod (verdict final)

## Sequencing

À merger après #738 (PR-2 imgproxy hero), elle-même après #735 (PR-1 payload cap). Rebase requis post-#738 merge (les deux PRs touchent `blog-pieces-auto.conseils.\$pg_alias.tsx`).

## Refs

- PR #694 (-33% INP `/pieces/*` A/B prod) — pattern source réutilisé
- PR #692 (web-vitals attribution Sentry/GA4)
- Plan local `/home/deploy/.claude/plans/automecanik-com-confidentialit-condition-abundant-adleman.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)