### PR TITLE
chore(registry): add audit/seo-*.md ownership glob (PR #736 follow-up)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -212,6 +212,13 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: low
+  # Audits SEO empiriques (Ahrefs, sitemap V10, etc.) — verdicts read-only,
+  # rangés à plat sous audit/ par convention historique (cf. PR #736).
+  - glob: audit/seo-*.md
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: low
   - glob: backend/src/auth/**
     domain: D11
     owner: '@ak125/auth-team'

--- a/log.md
+++ b/log.md
@@ -513,3 +513,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/automation-reality-registry`
 - **Décision** : Merge remote-tracking branch 'origin/main' into feat/automation-reality-registry (+6 other commits)
 - **Sortie** : PR #726 | commits 220f8cf08 970c2c08d b9cb833df 522703395 d3cb777b6 3f2bfbba9 79dfa5792
+
+## 2026-05-25 — chore/ownership-yaml-audit-seo-glob (auto)
+
+- **Branche** : `chore/ownership-yaml-audit-seo-glob`
+- **Décision** : chore(registry): add audit/seo-*.md ownership glob (PR #736 follow-up)
+- **Sortie** : PR #740 | commits 080868ce8


### PR DESCRIPTION
## Contexte

PR #736 (\`docs(audit): seo Ahrefs evidence-pack 2026-05-25 (4 verdicts read-only)\`)
a mergé 4 fichiers sous \`audit/\` :

- \`audit/seo-ahrefs-external-anchors-verdict-2026-05-24.md\`
- \`audit/seo-ahrefs-external-backlinks-verdict-2026-05-25.md\`
- \`audit/seo-ahrefs-internal-links-verdict-2026-05-24.md\`
- \`audit/seo-sitemap-v10-issues-draft-2026-05-25.md\`

…sans glob correspondant dans \`.spec/00-canon/repository-registry/ownership.yaml\`.

## Conséquence (cas concret)

Toute PR ouverte AVANT #736 qui rebase sur main est bloquée par le hook
\`pre-push\` registry block-new gate (\`MISSING_BOTH\` sur les 4 fichiers — ni
owner ni domain résolus).

Reproduit ce soir sur **PR #729** (R8 breadcrumb fix) rebasée juste après
\`#735\` : impossible de push sans \`SKIP_REGISTRY_GATE=1\` (workaround qui cache
la dette ownership).

## Fix

Ajout d'un glob structurel \`audit/seo-*.md\` dans \`ownership.yaml\` :

\`\`\`yaml
  # Audits SEO empiriques (Ahrefs, sitemap V10, etc.) — verdicts read-only,
  # rangés à plat sous audit/ par convention historique (cf. PR #736).
  - glob: audit/seo-*.md
    domain: D3
    owner: '@ak125/seo-team'
    sourceConfidence: high
    risk: low
\`\`\`

Couvre les 4 fichiers existants + tout futur verdict empirique SEO rangé à
plat sous \`audit/\` (convention historique post-#736).

## Validation

- ✅ \`minimatch\` confirme \`audit/seo-*.md\` matche les 4 fichiers (4/4 OK)
- ✅ Schéma yaml identique aux 5 autres \`audit/<subdir>/**\` voisins
  (\`cleanup\`, \`baselines\`, \`dependencies\`, \`impeccable\`, \`unreachable-modules\`)
- ✅ Choix domain D3 (SEO) + owner \`@ak125/seo-team\` cohérent avec
  \`backend/scripts/seo/audit/**\` voisin (D3 + seo-team)

## Test plan

- [x] \`grep -c \"audit/seo-\\*.md\" .spec/00-canon/repository-registry/ownership.yaml\` → 1
- [x] commitlint pass
- [ ] CI \`registry-new-file-gate\` vert
- [ ] CI \`validate-overlay\` vert (schéma + coverage)
- [ ] Post-merge : rebase PR #729 et vérifier que le pre-push registry-gate
      passe sans \`SKIP_REGISTRY_GATE=1\`

## Scope respect

- 1 fichier modifié, +7 lignes (1 entrée glob + 2 lignes commentaire)
- Aucune logique runtime touchée
- Aucun module \`payments/\`
- Aucun secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)