### PR TITLE
fix(seo): 404 catch-all emits X-Robots-Tag noindex,follow

### DIFF
--- a/frontend/app/routes/$.tsx
+++ b/frontend/app/routes/$.tsx
@@ -30,7 +30,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         status: 410,
         headers: {
           "Cache-Control": "public, max-age=86400",
-          "X-Robots-Tag": "noindex",
+          "X-Robots-Tag": "noindex, follow",
         },
       },
     );
@@ -221,13 +221,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
           status: 410,
           headers: {
             "Cache-Control": "public, max-age=86400", // Cache 24h pour accélérer la désindexation
-            "X-Robots-Tag": "noindex",
+            "X-Robots-Tag": "noindex, follow",
           },
         },
       );
     }
 
     // 6. Retourner erreur 404 enrichie avec suggestions
+    // X-Robots-Tag obligatoire : sans ce header, SeoHeadersInterceptor.intercept()
+    // applique le default `index, follow` pour les paths non-matchés (ex /wp-admin/,
+    // /panier inexistant). Canon SEO : un 404 ne s'indexe jamais.
     throw json(
       {
         ...errorResponseData,
@@ -237,6 +240,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         status: 404,
         headers: {
           "Cache-Control": "no-cache", // Ne pas cacher les 404
+          "X-Robots-Tag": "noindex, follow",
         },
       },
     );
@@ -254,7 +258,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
         message: "Page non trouvée",
         error: "Une erreur technique s'est produite lors de la vérification",
       },
-      { status: 404 },
+      {
+        status: 404,
+        headers: {
+          "Cache-Control": "no-cache",
+          "X-Robots-Tag": "noindex, follow",
+        },
+      },
     );
   }
 }

--- a/frontend/tests/unit/catch-all-404-noindex.test.ts
+++ b/frontend/tests/unit/catch-all-404-noindex.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock du logger pour éviter les I/O test
+vi.mock("~/utils/logger", () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+// Mock fetch pour éviter l'appel API de logging 404
+const fetchMock = vi.fn(() =>
+  Promise.resolve(new Response(JSON.stringify({ redirectUrl: null }))),
+);
+vi.stubGlobal("fetch", fetchMock);
+
+import { loader } from "~/routes/$";
+
+/**
+ * Régression : SeoHeadersInterceptor (backend) applique
+ * `X-Robots-Tag: index, follow` par défaut pour les paths non-matchés (catch-all).
+ * Sans header explicite côté Remix loader, Google reçoit `index, follow` sur
+ * des 404 (`/wp-admin/`, `/panier`, etc.) ce qui contredit la doctrine SEO.
+ *
+ * Empirique 2026-05-25 : audit GSC automecanik.com confirme bug sur 3/3 URLs sondées.
+ * Fix : tout throw json(..., status 404|410) du catch-all DOIT inclure
+ * `"X-Robots-Tag": "noindex, follow"` (canon : `noindex` + `follow` pour permettre
+ * crawl des liens internes existants tout en empêchant l'indexation).
+ */
+describe("catch-all $.tsx — 404/410 X-Robots-Tag noindex,follow", () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+  });
+
+  it("404 catch-all émet X-Robots-Tag: noindex, follow", async () => {
+    const request = new Request("https://www.automecanik.com/wp-admin/");
+
+    let thrown: Response | undefined;
+    try {
+      await loader({ request, params: {}, context: {} } as never);
+    } catch (e) {
+      thrown = e as Response;
+    }
+
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown?.status).toBe(404);
+    expect(thrown?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+
+  it("410 garbage URL émet X-Robots-Tag: noindex, follow (pas noindex seul)", async () => {
+    // Base64-style garbage path → short-circuit isGarbageUrl()
+    const request = new Request(
+      "https://www.automecanik.com/wl8k5m6HsSkVW3cXi61ZQ==",
+    );
+
+    let thrown: Response | undefined;
+    try {
+      await loader({ request, params: {}, context: {} } as never);
+    } catch (e) {
+      thrown = e as Response;
+    }
+
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown?.status).toBe(410);
+    expect(thrown?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+
+  it("404 de fallback (error path) émet X-Robots-Tag: noindex, follow", async () => {
+    // Force l'erreur try/catch en faisant échouer le fetch interne
+    fetchMock.mockRejectedValueOnce(new Error("API unreachable"));
+    fetchMock.mockRejectedValueOnce(new Error("API unreachable"));
+
+    const request = new Request(
+      "https://www.automecanik.com/this-page-does-not-exist-12345",
+    );
+
+    let thrown: Response | undefined;
+    try {
+      await loader({ request, params: {}, context: {} } as never);
+    } catch (e) {
+      thrown = e as Response;
+    }
+
+    expect(thrown).toBeInstanceOf(Response);
+    expect(thrown?.status).toBe(404);
+    expect(thrown?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+});

--- a/frontend/tests/unit/catch-all-404-noindex.test.ts
+++ b/frontend/tests/unit/catch-all-404-noindex.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock du logger pour éviter les I/O test
+import { loader } from "~/routes/$";
+
+// vi.mock is hoisted by Vitest's transformer (runs before imports at runtime),
+// safe to declare after the import for ESLint's `import/first` rule.
 vi.mock("~/utils/logger", () => ({
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }));
 
-// Mock fetch pour éviter l'appel API de logging 404
 const fetchMock = vi.fn(() =>
   Promise.resolve(new Response(JSON.stringify({ redirectUrl: null }))),
 );
-vi.stubGlobal("fetch", fetchMock);
-
-import { loader } from "~/routes/$";
 
 /**
  * Régression : SeoHeadersInterceptor (backend) applique
@@ -26,7 +25,11 @@ import { loader } from "~/routes/$";
  */
 describe("catch-all $.tsx — 404/410 X-Robots-Tag noindex,follow", () => {
   beforeEach(() => {
-    fetchMock.mockClear();
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ redirectUrl: null }))),
+    );
+    vi.stubGlobal("fetch", fetchMock);
   });
 
   it("404 catch-all émet X-Robots-Tag: noindex, follow", async () => {


### PR DESCRIPTION
## Summary

Fix empirique du verdict audit GSC crawl health 2026-05-25 (Étape 3 branche B, scope étroit). Le catch-all Remix `$.tsx` retournait des 404/410 sans header `X-Robots-Tag` ; le `SeoHeadersInterceptor` NestJS appliquait alors le default `index, follow` — Google recevait `index, follow` sur des 404 (`/wp-admin/`, `/panier`, etc.).

**3 throws fixés** dans `frontend/app/routes/$.tsx` :
- 410 garbage URL (l.33) : `noindex` → `noindex, follow`
- 410 contenu supprimé (l.224) : `noindex` → `noindex, follow`
- 404 standard (l.238) : ajout `X-Robots-Tag: noindex, follow`
- 404 fallback erreur (l.258) : ajout headers complets

R8 `/constructeurs/*` 404/410 et `/pieces/*` 404/410 inchangés (logique métier dédiée déjà correcte).

## Test plan

- [x] Test unitaire : `frontend/tests/unit/catch-all-404-noindex.test.ts` (3 assertions, reproduit les 3 chemins du loader 410 garbage / 404 standard / 404 fallback)
- [ ] CI verte (validation locale impossible — worktree sans `node_modules`)
- [ ] Post-merge : curl PROD sur `/wp-admin/`, `/panier`, `/this-page-does-not-exist-*` → vérifier `x-robots-tag: noindex, follow` (au lieu de `index, follow`)
- [ ] Mesure +30j (Étape 4 du plan) : GSC stats crawl, distribution 404 par bucket

## Scope canon

Branche B Étape 3 du plan audit GSC : **max 1 fix par cycle** + mesure +30j avant prochain. Pas de modification URL/canonical/meta/H1/payments. Worktree dédiée depuis `origin/main`.

## Verdict audit complet (logué dans log.md 2026-05-25)

3 root causes identifiées initialement, **seul Fix #2 (404 noindex) inclus ici** :

| Fix | Status PR | Raison |
|-----|-----------|--------|
| #1 Cache-Control duplication | ❌ Drop | Source réelle = Caddy `header` mode append (Caddyfile l.219-244). Le `>` prefix replace mode fixerait, mais user scope explicite "pas Cloudflare rules globales au départ" — classifier denied l'édition Caddyfile (edge config). **Follow-up PR scope edge requis.** |
| #2 404 catch-all noindex | ✅ Ce PR | Pur Remix loader, scope strict in-app. |
| #3 sitemap-`*`.xml 302→/404 | ❌ Drop | Root cause : `sitemap-$.tsx` flat-routes naming ne match aucun pattern (DEV confirme 404 catch-all sur `/sitemap-racine.xml` ET `/sitemap-temperature-hot.xml`). Le 302 PROD vient en plus d'une REDIRECT_RULE `___xtr_msg` que le catch-all consulte. **Follow-up PR** : rename `[sitemap-]$.tsx` (escape brackets) + data-only cleanup `___xtr_msg`. |

**Effet collatéral positif Fix #2** : les sitemap-`*`.xml URLs en DEV (où il n'y a pas de REDIRECT_RULE) retourneront maintenant 404 + `noindex, follow` au lieu de 404 + `index, follow`. Le symptôme PROD 302→/404 reste mais la chaîne aval est saine.

## Mémoires canon liées

- `feedback_vehicle_page_notfound_is_404_not_503.md` — R8 noindex doctrine
- `feedback_audit_must_correlate_business_and_provenance.md` (créée 2026-05-25)
- `feedback_unknown_before_404_when_edge_in_chain.md` (créée 2026-05-25)
- `feedback_stop_modeling_start_executing.md` (créée 2026-05-25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)