### PR TITLE
fix(r-seo-09): exclude admin.** routes from canonical surface guard

### DIFF
--- a/scripts/seo/check-url-immutability.mjs
+++ b/scripts/seo/check-url-immutability.mjs
@@ -57,6 +57,11 @@ import { fileURLToPath } from "node:url";
 import { extractCanonicalSurface } from "./lib/canonical-surface-extractor.mjs";
 
 const ROUTE_RE = /^frontend\/app\/routes\/.+\.tsx$/;
+// Admin routes are auth-only, non-indexed, non-canonical SEO surfaces.
+// 102+ admin.* routes prove this is a canonical pattern. R-SEO-09 Phase 2
+// AST guard is designed for public SEO surfaces — exclude admin to avoid
+// requiring r-seo-09-override label on every admin-* PR.
+const ADMIN_RE = /^frontend\/app\/routes\/admin(\..+)?\.tsx$/;
 const WARN_RE = /^backend\/src\/modules\/seo\/.*(?:canonical|seo-canonical|sitemap|redirect).*\.ts$/;
 
 function parseArgs(args) {
@@ -210,6 +215,8 @@ async function main() {
       continue;
     }
     if (!ROUTE_RE.test(entry.path)) continue;
+    // Skip admin.* routes — auth-only, non-canonical, hors scope SEO public.
+    if (ADMIN_RE.test(entry.path)) continue;
 
     const baseSource = entry.status === "A" ? null : readBaseVersion(baseRef, entry.path);
     const headSource = entry.status === "D" ? null : readHeadVersion(entry.path);


### PR DESCRIPTION
## Summary

Le guard R-SEO-09 Phase 2 (AST canonical surface diff) traite actuellement **toutes** les routes `frontend/app/routes/**/*.tsx` comme des surfaces SEO publiques. C'est faux pour les 102+ routes `admin.*` qui sont :

- **auth-only** (derrière `IsAdminGuard`)
- **non-indexées** (jamais dans le sitemap ni canonical)
- **non-canonical** (changement de filename ne casse aucun SEO)

Résultat : chaque PR touchant /admin/* devait appliquer le label `r-seo-09-override` à la main (cas récent #734 cwv-dashboard, label posé + commentaire justification).

## Fix structurel

Ajout d'un `ADMIN_RE = /^frontend\/app\/routes\/admin(\..+)?\.tsx\$/` dans `scripts/seo/check-url-immutability.mjs`, et skip dans la boucle de scan **avant** l'extraction AST. Le label override reste utilisable pour les vrais cas SEO public.

## Test plan

- [x] Regex validée 8/8 cas :
  - **Match** : `admin.tsx`, `admin._index.tsx`, `admin.seo-hub.cwv.tsx`, `admin.gammes-seo.\$pgId.tsx`
  - **No match** : `_index.tsx`, `pieces.\$gamme.tsx`, `blog-pieces-auto.conseils.\$gamme.tsx`, `admin-public.tsx`
- [ ] CI : `R-SEO-09 URL Immutability Gate` doit passer sur cette PR (le seul fichier touché = le script lui-même, hors scope ROUTE_RE)
- [ ] Validation : prochaine PR introduisant une route `admin.*` (cas naturel) ne devra plus avoir besoin du label `r-seo-09-override`.

## Scope respect

- 1 seul fichier touché (`scripts/seo/check-url-immutability.mjs`)
- 7 lignes ajoutées (5 commentaire + 2 code)
- Aucun comportement modifié pour les routes publiques (pieces, blog-pieces-auto, _index, etc.)
- Label `r-seo-09-override` reste fonctionnel pour les vrais cas SEO

## Pourquoi pas un test unitaire

Le test smoke est dans le commit message (regex testée en 8 cas via Node REPL). Pas de framework de test pour les `scripts/*.mjs` dans ce repo (pattern observé). Si CI fail malgré ça, ouverture immédiate d'une issue.

## Liens

- Mémoire `feedback_no_url_changes_ever.md` (STRICT) — préservée : changement canonical URL publique reste hard-block
- PR #734 (bloc 6 CWV) — premier cas pratique du label override sur admin route
- Vault rule `rules-seo-pagerole.md` (R-SEO-09) — guard publique inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)