### PR TITLE
fix(governance): R-role cart/conversion classification invariant + CI ratchet

### DIFF
--- a/.github/workflows/governance-checks.yml
+++ b/.github/workflows/governance-checks.yml
@@ -3,6 +3,8 @@ name: governance-checks
 # Wire les scripts bash de gouvernance ADR-081 sur les PRs.
 # - validate-top-priorities.sh : sections / bornes / kebab-case (5 sections, dont EXPLORATION_BUDGET)
 # - validate-exploration-probe.sh : scope strict measurement-only si la PR est une probe G10
+# - check-cart-conversion-r-role.sh : invariant R-role classification panier/conversion
+#   (R8 ≠ cart-capable, canon .spec/00-canon/role-matrix.md)
 #
 # check-verdict-expirations.sh = cron weekly, pas wired ici (follow-up dédié).
 
@@ -10,14 +12,18 @@ on:
   pull_request:
     paths:
       - '.claude/top-priorities.md'
+      - '.spec/00-canon/role-matrix.md'
       - 'scripts/governance/**'
       - 'docs/research/**'
       - '.github/workflows/governance-checks.yml'
+      - '**/*.md'
   push:
     branches: [main]
     paths:
       - '.claude/top-priorities.md'
+      - '.spec/00-canon/role-matrix.md'
       - 'scripts/governance/**'
+      - '**/*.md'
 
 permissions:
   contents: read
@@ -40,3 +46,11 @@ jobs:
           fetch-depth: 0
       - name: Run probe scope linter (single check au PR final, anti over-governance creep)
         run: bash scripts/governance/validate-exploration-probe.sh "origin/${{ github.base_ref }}"
+
+  check-cart-conversion-r-role:
+    name: check-cart-conversion-r-role.sh (R-role invariant)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run R-role cart/conversion classification check
+        run: bash scripts/governance/check-cart-conversion-r-role.sh

--- a/.spec/00-canon/role-matrix.md
+++ b/.spec/00-canon/role-matrix.md
@@ -330,6 +330,21 @@ Aucun systeme aval ne peut redefinir librement un role ou une gate
 en dehors de ces deux referentiels.
 Le critere principal de qualification est la promesse centrale exclusive du role.
 
+## URL pattern → R-role (cart/conversion analysis) — invariant 2026-05-25
+
+Toute analyse panier / conversion / funnel doit classifier les URLs selon le mapping suivant. Confondre R8 et R2_PRODUCT véhicule-aware = P1 business-mapping error (mauvais levier UX).
+
+| URL pattern | R-role canon | Cart-capable ? | Composants frontend |
+|-------------|--------------|----------------|---------------------|
+| `/pieces/<gamme>-<id>.html` | **R1_ROUTER** | ❌ (sélecteur véhicule) | `pieces.$slug.tsx` |
+| `/pieces/<gamme>-<id>/<marque>-<id>/<modele>-<id>/<type>-<id>.html` | **R2_PRODUCT** véhicule-aware | ✅ via `PiecesGridView` / `PiecesListView` | `pieces.$gamme.$marque.$modele.$type[.]html.tsx` |
+| `/constructeurs/<brand>/<model>/<type>.html` | **R8_VEHICLE** | ❌ (fiche véhicule pure) | `constructeurs.$brand.$model.$type[.]html.tsx` |
+| `/search/...` | hors R-matrix (utilitaire) | ✅ via `PiecesGridView` / `PiecesListView` | `search.tsx` |
+
+**Règle stricte** : tout texte mentionnant `R8` dans la même ligne que `panier|cart|conver|achat|landing piece` est une violation (sauf citation de cet invariant ou contexte négatif explicite « R8 = fiche véhicule », « JAMAIS R8 », « PAS R8 », « R8 ne convertit pas »). Enforcement : `scripts/governance/check-cart-conversion-r-role.sh` (CI ratchet, wired dans `.github/workflows/governance-checks.yml`).
+
+Doctrine mémoire liée (vieux canon, sessions 2026-04-25) : *"R8 = page véhicule, JAMAIS gamme/pièce"*. Investigation runtime 2026-05-25 a confirmé que 7/8 paniers réels passent par R2_PRODUCT véhicule-aware + `/search/`, et 0 via R8.
+
 ## Lien avec les phases pipeline
 
 Phase 1 garantit la matiere sure.

--- a/scripts/governance/check-cart-conversion-r-role.sh
+++ b/scripts/governance/check-cart-conversion-r-role.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# check-cart-conversion-r-role.sh
+#
+# Invariant : tout texte mentionnant R8 dans même ligne que panier|cart|conver|achat
+# est une violation P1 (mauvaise cartographie business-mapping).
+#
+# Canon : .spec/00-canon/role-matrix.md § "URL pattern → R-role (cart/conversion analysis)"
+# Doctrine mémoire : feedback_r8_is_vehicle_not_gamme (R8 = page véhicule pure, JAMAIS cart)
+#
+# Pourquoi : confondre R8 (fiche véhicule /constructeurs/...) et R2_PRODUCT véhicule-aware
+# (/pieces/<gamme>/<marque>/<modele>/<motorisation>.html) envoie le levier UX sur la
+# mauvaise surface. Erreur observée 2026-05-25 lors de l'investigation funnel cart.
+#
+# Whitelist (fichiers où R8 + role-list context est légitime, pas violation cart) :
+#   - .spec/00-canon/role-matrix.md (le canon lui-même)
+#   - scripts/governance/check-cart-conversion-r-role.sh (ce fichier)
+#   - scripts/governance/__tests__/* (tests bats)
+#   - log.md / log-archive-*.md (session timeline append-only, review humaine)
+#   - .claude/prompts/** (prompts agents Claude Code, doc R-role)
+#   - workspaces/**/.claude/** (workspace agents + skills SEO, discussion multi-role)
+#   - workspaces/**/AGENTS/** (AGENTS.md SEO workspace)
+#
+# Negative-match : phrasings qui CITENT R8 pour clarifier la doctrine (pas violation)
+#   - "JAMAIS R8" / "PAS R8" / "R8 ne convertit pas" / "R8 ne porte pas"
+#   - "R8 = fiche véhicule" / "R8 (`/constructeurs/...`)" / "hors R-matrix"
+#   - "invariant" (le nom de la règle elle-même)
+#   - Role ranges (R0-R8, R1-R8, etc.) — list canon, pas analyse cart
+#   - "R6_GUIDE_ACHAT" / autres noms canon uppercase contenant ACHAT
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+WHITELIST_RE='^(\.spec/00-canon/role-matrix\.md|scripts/governance/check-cart-conversion-r-role\.sh|scripts/governance/__tests__/.*cart-conversion-r-role.*|log\.md|log-archive-.*\.md|\.claude/prompts/.*|workspaces/.*/\.claude/.*|workspaces/.*/AGENTS/.*)$'
+
+# Cherche \bR8\b sur même ligne que panier/cart/conver/achat/landing piece, exclut whitelist et negative-match
+VIOLATIONS=$(
+  git ls-files '*.md' \
+  | grep -vE "$WHITELIST_RE" \
+  | xargs -r grep -nE '\bR8\b' 2>/dev/null \
+  | grep -iE '(panier|cart|conver|achat[^c-r_]|landing.*pi[èe]ce)' \
+  | grep -ivE '(JAMAIS R8|R8 = fiche|R8.*pas catalogue|PAS R8|ne convertit pas|hors R-matrix|R8 ne porte pas|invariant|R8 \(`?/constructeurs|R[0-9]-R8|R[0-9] [aà] R8|R6_GUIDE_ACHAT|GUIDE_ACHAT)' \
+  || true
+)
+
+if [ -n "$VIOLATIONS" ]; then
+  cat <<'EOF' >&2
+❌ R-role cart/conversion classification violation détectée.
+
+R8 = fiche véhicule pure (/constructeurs/...). JAMAIS source de panier ou conversion.
+Le vrai canal cart-capable véhicule-aware = R2_PRODUCT
+  (/pieces/<gamme>-<id>/<marque>-<id>/<modele>-<id>/<type>-<id>.html)
+
+Canon : .spec/00-canon/role-matrix.md § "URL pattern → R-role (cart/conversion analysis)"
+
+Lignes en violation :
+EOF
+  echo "$VIOLATIONS" >&2
+  exit 1
+fi
+
+echo "✓ R-role cart/conversion classification : aucune violation détectée."


### PR DESCRIPTION
## Context

**Erreur identifiée 2026-05-25** : pendant l'investigation funnel cart/conversion (PR #756), classification erronée "R8 véhicule-pièce" comme canal de paniers. **R8 = fiche véhicule pure** (`/constructeurs/...`), pas catalogue produit. Vrai canal cart-capable véhicule-aware = **R2_PRODUCT** (`/pieces/<gamme>-<id>/<marque>-<id>/<modele>-<id>/<type>-<id>.html` — `PageRole.R2_PRODUCT` dans `pieces.$gamme.$marque.$modele.$type[.]html.tsx:38`).

**Verdict P1 business-mapping error** : confondre R8 ↔ R2_PRODUCT véhicule-aware envoie le levier UX sur la mauvaise surface. Doctrine canon `feedback_r8_is_vehicle_not_gamme` (sessions 2026-04-25) disait déjà *"R8 = page véhicule, JAMAIS gamme/pièce"* — règle existante mais non-mécaniquement enforced.

## Changes (3 fichiers, +92 lignes, 100% additif)

### 1. Extension canon `.spec/00-canon/role-matrix.md`

Nouvelle section après "Formulation normative" : **"URL pattern → R-role (cart/conversion analysis) — invariant 2026-05-25"** avec table canon 4 lignes :

| URL pattern | R-role | Cart-capable ? |
|---|---|---|
| `/pieces/<gamme>-<id>.html` | **R1_ROUTER** | ❌ |
| `/pieces/<gamme>-<id>/<marque>-<id>/<modele>-<id>/<type>-<id>.html` | **R2_PRODUCT** véhicule-aware | ✅ |
| `/constructeurs/<brand>/<model>/<type>.html` | **R8_VEHICLE** | ❌ |
| `/search/...` | hors R-matrix | ✅ |

### 2. Script CI `scripts/governance/check-cart-conversion-r-role.sh`

Ratchet pattern canon existant (`check-family-pr-scope.sh`, `validate-top-priorities.sh`, etc.). Détecte `\bR8\b` sur même ligne que `panier|cart|conver|achat|landing piece`. Whitelist explicite (canon SoT + log.md + `.claude/prompts/` + `workspaces/.claude/`). Negative-match robuste (`JAMAIS R8`, `PAS R8`, role-ranges `R0-R8`, `R6_GUIDE_ACHAT`).

### 3. Wiring `.github/workflows/governance-checks.yml`

Nouveau job `check-cart-conversion-r-role`, paths déclencheurs étendus à `.spec/00-canon/role-matrix.md` + `**/*.md`.

## Tests locaux exécutés

```bash
# Positif (clean main)
$ bash scripts/governance/check-cart-conversion-r-role.sh
✓ R-role cart/conversion classification : aucune violation détectée.
# exit 0

# Négatif (violation synthétique "Les 7/8 paniers viennent de R8 véhicule-pièce.")
❌ R-role cart/conversion classification violation détectée.
[...message clair + ligne pointant vers le canon...]
# exit 1
```

## B0 Cash-first score (canon 2026-05-25)

| Axe B0 | Coché | Justification |
|--------|-------|---------------|
| 3. Mesurer | ✅ | Empêche futurs mismatches dans audits cart/conversion |
| 4. Sécuriser | ✅ | Protège la doctrine business-mapping (P1) |

- **Niveau hiérarchie** : N2 (protection système)
- **Réversible** : revert PR (< 5 min, 0 backend, 0 DB, 0 cron)
- **Low-risk** : additif pur (doc canon + script ratchet)

## Anti-patterns écartés

- ❌ Nouveau `.claude/rules/r-role-classification.md` → doublonnerait `role-matrix.md` (canon SoT)
- ❌ ast-grep sur markdown → grep regex est natif et plus adapté
- ❌ Mémoire process séparée → `feedback_verify_existing_first` couvre déjà
- ❌ Multi-PR (1 canon + 1 script + 1 workflow) → fragmente changement atomique

## Test plan

- [ ] CI verte (governance-checks workflow + autres)
- [ ] Le nouveau check passe sur son propre commit (auto-vérification)
- [ ] Post-merge : grep `R8.*cart|R8.*panier` retourne 0 violations sur `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)