### PR TITLE
feat(funnel): r2_view + r2_order_placed events emission

### DIFF
--- a/frontend/app/components/pieces/PiecesVehicleContent.tsx
+++ b/frontend/app/components/pieces/PiecesVehicleContent.tsx
@@ -41,6 +41,11 @@ import { usePiecesFilters } from "~/hooks/use-pieces-filters";
 import { openCartSidebar } from "~/hooks/useCartSidebar";
 import { useRootCart } from "~/hooks/useRootData";
 import { useSeoLinkTracking } from "~/hooks/useSeoLinkTracking";
+import {
+  classifyReferrer,
+  emitFunnel,
+  getFunnelSessionId,
+} from "~/utils/funnel-beacon";
 import { isValidPosition } from "~/utils/pieces-filters.utils";
 import { buildPiecesBreadcrumbs } from "~/utils/url-builder.utils";
 
@@ -88,6 +93,42 @@ export function PiecesVehicleContent() {
       trackImpression("CrossSelling", data.crossSellingGammes.length);
     }
   }, [trackImpression, data.crossSellingGammes?.length]);
+
+  // Commerce-Loop V1 étape 4-B — view event (funnel R2). Fire-and-forget,
+  // SSR-safe (no-op côté serveur via funnel-beacon). Dédup sessionStorage par
+  // pathname pour éviter remount/hydration/StrictMode double-fire (même
+  // pattern que trackPurchase dans checkout-payment-return.tsx:184-188).
+  // Sans ce dédup : risque 2-4 events r2_view pour 1 vue réelle = volume
+  // funnel pollué.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    // Namespace `amk_funnel_dedup_*` aligné avec `amk_funnel_sid` dans
+    // funnel-beacon.ts — évite collision sessionStorage avec d'autres composants.
+    const dedupKey = `amk_funnel_dedup_r2v_${window.location.pathname}`;
+    if (sessionStorage.getItem(dedupKey)) return;
+    emitFunnel({
+      event_type: "r2_view",
+      payload: {
+        session_id: getFunnelSessionId(),
+        referrer: classifyReferrer(),
+        // data.gamme.alias = slug canonique (cf. line 129/250 du composant).
+        // Pas .slug ni .pg_alias (n'existent pas sur ce data).
+        gamme_slug: data?.gamme?.alias ?? null,
+        // type_id (motorisation TecDoc) — R2 vehicle-aware, clé métier qui
+        // permettra la corrélation runtime moteur/véhicule/conversion.
+        // ATTENTION : data.vehicle.typeId est en CAMELCASE côté JS
+        // (cf. line 380/391/400 du composant), mais le payload JSON est
+        // snake_case `type_id` selon le schema Zod canon.
+        type_id:
+          typeof data?.vehicle?.typeId === "number"
+            ? data.vehicle.typeId
+            : null,
+      },
+    });
+    sessionStorage.setItem(dedupKey, "1");
+    // Mount-only — pas de deps pour éviter re-fire sur filter change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Handlers pour tracker les clics "Voir aussi"
   const handleVoirAussiClick = useCallback(

--- a/frontend/app/routes/checkout-payment-return.tsx
+++ b/frontend/app/routes/checkout-payment-return.tsx
@@ -21,6 +21,11 @@ import { useEffect } from "react";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { Alert } from "~/components/ui/alert";
 import { trackPurchase } from "~/utils/analytics";
+import {
+  classifyReferrer,
+  emitFunnel,
+  getFunnelSessionId,
+} from "~/utils/funnel-beacon";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
 import { processPaymentReturn } from "../services/payment.server";
@@ -185,6 +190,26 @@ export default function PaymentReturnPage() {
       const key = `purchase_tracked_${txId}`;
       if (!sessionStorage.getItem(key)) {
         trackPurchase(txId, result.amount);
+        // Commerce-Loop V1 étape 4-B — funnel R2 order_placed (mirror GA4
+        // purchase sur __seo_event_log : canal résilient indépendant de GA4 —
+        // protège la mesure même si GA4 conversions = 0 reste cassé côté GTM).
+        // item_count = 1 par défaut : PaymentResult (interface ligne 51) ne
+        // contient ni totalQuantity ni items[], le loader Paybox transmet
+        // seulement status/transactionId/orderId/amount. À enrichir si un
+        // futur loader expose la quantité totale (follow-up).
+        emitFunnel({
+          event_type: "r2_order_placed",
+          payload: {
+            session_id: getFunnelSessionId() || null,
+            order_id: String(txId),
+            item_count: 1,
+            revenue_cents:
+              typeof result.amount === "number" && Number.isFinite(result.amount)
+                ? Math.round(result.amount * 100)
+                : null,
+            referrer: classifyReferrer(),
+          },
+        });
         sessionStorage.setItem(key, "1");
       }
     }

--- a/frontend/app/utils/funnel-beacon.ts
+++ b/frontend/app/utils/funnel-beacon.ts
@@ -57,6 +57,52 @@ export function getFunnelDevice(): FunnelDevice {
 }
 
 /**
+ * Domaines moteurs de recherche reconnus. Scope strict : engines généralistes
+ * + français usuels. PAS exhaustif (Discover/Images/Brave/Perplexity/ChatGPT/
+ * Google Apps Android → "other" intentionnel pour ne pas mentir sur le mix).
+ * Si la composition du trafic change, ce regex peut évoluer SANS casser les
+ * events existants (les anciennes valeurs restent dans l'enum FunnelReferrer).
+ */
+const ORGANIC_HOSTS_RE =
+  /(^|\.)(google|bing|qwant|duckduckgo|ecosia|yahoo|yandex)\./i;
+
+/** Domaine canon AutoMecanik — couvre www, apex, futurs sous-domaines. */
+const SELF_HOST_SUFFIX = "automecanik.com";
+
+/**
+ * Classifie `document.referrer` en `FunnelReferrer` canon pour les events
+ * funnel client-side (r2_view, r2_order_placed). SSR-safe : retourne "direct"
+ * si `window` indisponible. "diagnostic" et "paid" ne sont PAS dérivables
+ * depuis le seul referrer — relèvent du landing attribution backend
+ * (cf. backend `LandingAttributionMiddleware` + `classifyLandingSource`).
+ *
+ * Notes :
+ * - `"internal"` couvre www ↔ apex ↔ tout sous-domaine `*.automecanik.com`
+ *   pour résister aux changements de structure (CDN, futur subdomain).
+ * - `"organic"` cible UNIQUEMENT search engines généralistes. Si tu observes
+ *   un drop "organic" futur, vérifie d'abord si du trafic est migré vers
+ *   surface "other" (Brave/Perplexity/ChatGPT referral, Google Discover).
+ */
+export function classifyReferrer(): "direct" | "internal" | "organic" | "other" {
+  if (typeof window === "undefined") return "direct";
+  const ref = document.referrer ?? "";
+  if (!ref) return "direct";
+  try {
+    const refHost = new URL(ref).hostname.toLowerCase();
+    if (
+      refHost === SELF_HOST_SUFFIX ||
+      refHost.endsWith("." + SELF_HOST_SUFFIX)
+    ) {
+      return "internal";
+    }
+    if (ORGANIC_HOSTS_RE.test(refHost)) return "organic";
+    return "other";
+  } catch {
+    return "direct";
+  }
+}
+
+/**
  * Envoie un event funnel. No-op côté serveur. `entity_url` par défaut =
  * URL courante. Ne lève jamais.
  */

--- a/frontend/tests/unit/funnel-beacon.test.ts
+++ b/frontend/tests/unit/funnel-beacon.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { classifyReferrer } from "~/utils/funnel-beacon";
+
+describe("classifyReferrer", () => {
+  // Cleanup avant ET après chaque test : évite leak de stub entre tests
+  // (un test qui fail au milieu pourrait laisser le stub actif sinon).
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns "direct" if no referrer', () => {
+    vi.stubGlobal("document", { referrer: "" });
+    vi.stubGlobal("window", { location: { hostname: "www.automecanik.com" } });
+    expect(classifyReferrer()).toBe("direct");
+  });
+
+  it('returns "internal" for same-host www referrer', () => {
+    vi.stubGlobal("document", {
+      referrer: "https://www.automecanik.com/blog-pieces-auto/conseils/cardan",
+    });
+    vi.stubGlobal("window", { location: { hostname: "www.automecanik.com" } });
+    expect(classifyReferrer()).toBe("internal");
+  });
+
+  it('returns "internal" for apex referrer (non-www → www)', () => {
+    vi.stubGlobal("document", { referrer: "https://automecanik.com/anything" });
+    vi.stubGlobal("window", { location: { hostname: "www.automecanik.com" } });
+    expect(classifyReferrer()).toBe("internal");
+  });
+
+  it('returns "internal" for any automecanik.com subdomain', () => {
+    vi.stubGlobal("document", { referrer: "https://blog.automecanik.com/x" });
+    vi.stubGlobal("window", { location: { hostname: "www.automecanik.com" } });
+    expect(classifyReferrer()).toBe("internal");
+  });
+
+  it('returns "organic" for google referrer', () => {
+    vi.stubGlobal("document", {
+      referrer: "https://www.google.fr/search?q=cardan+206",
+    });
+    vi.stubGlobal("window", { location: { hostname: "www.automecanik.com" } });
+    expect(classifyReferrer()).toBe("organic");
+  });
+
+  it('returns "other" for arbitrary external referrer', () => {
+    vi.stubGlobal("document", { referrer: "https://example.com/whatever" });
+    vi.stubGlobal("window", { location: { hostname: "www.automecanik.com" } });
+    expect(classifyReferrer()).toBe("other");
+  });
+
+  it('returns "direct" in SSR (no window)', () => {
+    vi.stubGlobal("window", undefined);
+    expect(classifyReferrer()).toBe("direct");
+  });
+});

--- a/packages/seo-types/src/intelligence.ts
+++ b/packages/seo-types/src/intelligence.ts
@@ -188,6 +188,11 @@ export const R2ViewPayloadSchema = z.object({
   session_id: z.string().min(1),
   referrer: FunnelReferrerSchema,
   gamme_slug: z.string().nullable(),
+  // type_id (motorisation TecDoc) — R2 est vehicle-aware, clé métier qui permet
+  // la corrélation moteur/véhicule/gamme/conversion runtime (cross-ref avec
+  // ___xtr_order_line.orl_website_url). Nullable + optional pour rétrocompat
+  // events existants émis sans type_id (extension additive, pattern PR #756 source_url).
+  type_id: z.number().int().positive().nullable().optional(),
 });
 export type R2ViewPayload = z.infer<typeof R2ViewPayloadSchema>;
 


### PR DESCRIPTION
## Summary

Émet les 2 events funnel critiques manquants côté frontend pour débloquer la mesure du commerce-loop complet **`r2_view → r2_add_to_cart → r2_order_placed`**.

Audit business 2026-05-25 a révélé que 5/7 events ENUM canon sont définis mais jamais émis (cf. `reference_funnel_instrumentation_gaps_2026-05-25`). Cette PR débloque les 2 plus critiques : view et order_placed. Les 3 autres (`diag_wizard_start`, `diag_analyze_complete`, `diag_gamme_cta_click`) sont des follow-ups séparés.

## Changes (~175 lignes, 100% additif)

- `packages/seo-types/src/intelligence.ts` : `R2ViewPayloadSchema` étendu avec `type_id` optional nullable (pattern identique PR #756 `source_url`)
- `frontend/app/utils/funnel-beacon.ts` : nouveau helper `classifyReferrer()` SSR-safe (~46 lignes)
- `frontend/app/components/pieces/PiecesVehicleContent.tsx` : useEffect mount-only avec dedup sessionStorage namespacée `amk_funnel_dedup_r2v_<pathname>` émettant `r2_view`
- `frontend/app/routes/checkout-payment-return.tsx` : extension du useEffect existant pour mirror `r2_order_placed` sur `__seo_event_log` (canal résilient indépendant de GA4)
- `frontend/tests/unit/funnel-beacon.test.ts` : **7 tests vitest tous PASS** couvrant direct/internal-www/internal-apex/internal-subdomain/organic/other/SSR

## B0 Cash-first score (canon 2026-05-25)

| Axe B0 | ✓ | Justification |
|--------|---|---------------|
| 3. Mesurer | ✅ | Débloque funnel complet `view → cart → order` runtime |
| 4. Sécuriser | ✅ | Mirror `r2_order_placed` sur `__seo_event_log` = canal **résilient indépendant de GA4** (GA4 conversions = 0 actuellement cassé côté GTM) |

- **Niveau hiérarchie** : N2 (protection système — protège la mesure runtime)
- **Réversible** : revert PR (< 5 min, 0 backend, 0 DB, 0 cron)
- **Low-risk** : additif pur, schemas Zod existants, 0 backend changes, dedup sessionStorage anti-double-fire

## Limites V1 assumées (à NE PAS fixer dans cette PR)

- **L1** Dédup sans TTL → potentiel sous-comptage léger de re-vues. Préfère sous-comptage à pollution.
- **L2** `"organic"` couvre engines généralistes seulement (Google Discover/Brave/Perplexity/ChatGPT → `"other"` intentionnel). Anti-overclaim documenté.
- **L3** `r2_view = mount-time`, pas une "vue qualifiée". Pas d'engaged-view avant baseline mount-view. Évite optimisation prématurée.

## Test plan

- [ ] CI verte (typecheck + ESLint + tests vitest 7/7)
- [ ] Post-merge sur DEV runtime : visiter `/pieces/<gamme>/<marque>/<modele>/<motorisation>.html` → vérifier 1 row `r2_view` dans `__seo_event_log`
- [ ] Test E2E paiement Paybox → vérifier 1 row `r2_order_placed` post-checkout SUCCESS
- [ ] Audit 24h post-merge : `views_per_session ≤ 3` (sinon revert + investiguer duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)