### PR TITLE
fix(seo): R2 H1/title disambiguation when type_name is ambiguous

### DIFF
--- a/backend/src/modules/catalog/services/__tests__/vehicle-aware-label.composer.test.ts
+++ b/backend/src/modules/catalog/services/__tests__/vehicle-aware-label.composer.test.ts
@@ -1,0 +1,225 @@
+import {
+  enrichTypeNameForHeadings,
+  isTypeNameAmbiguousForSeo,
+  type VehicleLabelInput,
+} from '../vehicle-aware-label.composer';
+
+describe('vehicle-aware-label.composer', () => {
+  describe('FIXTURES audit 2026-05-26 (audit/seo-h1-meta-empirical-verification-2026-05-26.md)', () => {
+    it('FIXTURE #1 EXACT — C5 III 2.0 HDi 140 ch vs 163 ch (lev=0, jaccard=1)', () => {
+      const a = enrichTypeNameForHeadings({
+        typeName: '2.0 HDi',
+        powerPs: '140',
+        fuel: 'Diesel',
+      });
+      const b = enrichTypeNameForHeadings({
+        typeName: '2.0 HDi',
+        powerPs: '163',
+        fuel: 'Diesel',
+      });
+      expect(a.value).not.toEqual(b.value);
+      expect(a.value).toBe('2.0 HDi 140 ch');
+      expect(b.value).toBe('2.0 HDi 163 ch');
+      expect(a.isEnriched).toBe(true);
+      expect(b.isEnriched).toBe(true);
+    });
+
+    it('FIXTURE #2 — 1.4 HDI Diesel 69 ch (fuel implicite HDI, no Diesel duplication)', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '1.4 HDI',
+        powerPs: '69',
+        fuel: 'Diesel',
+      });
+      expect(r.value).toBe('1.4 HDI 69 ch'); // fuel "Diesel" non-ajouté car HDI implicite
+      expect(r.isEnriched).toBe(true);
+    });
+
+    it('FIXTURE #2 bis — 1.4 Essence 75 ch (fuel explicite ajouté)', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '1.4',
+        powerPs: '75',
+        fuel: 'Essence',
+      });
+      expect(r.value).toBe('1.4 Essence 75 ch');
+      expect(r.isEnriched).toBe(true);
+    });
+
+    it('FIXTURE #3 — 206 1.1 60 ch vs 1.4 75 ch (displacement disambiguation)', () => {
+      const a = enrichTypeNameForHeadings({
+        typeName: '1.1',
+        powerPs: '60',
+        fuel: 'Essence',
+      });
+      const b = enrichTypeNameForHeadings({
+        typeName: '1.4',
+        powerPs: '75',
+        fuel: 'Essence',
+      });
+      expect(a.value).not.toEqual(b.value);
+      expect(a.value).toBe('1.1 Essence 60 ch');
+      expect(b.value).toBe('1.4 Essence 75 ch');
+    });
+  });
+
+  describe('Sport trim & extended fuel coverage', () => {
+    it('enriches short sport trims such as "2.0 RC" with power_ps', () => {
+      // Deux 2.0 RC à puissances ≠ peuvent coexister (ex. PEUGEOT 207 RC)
+      const r = enrichTypeNameForHeadings({
+        typeName: '2.0 RC',
+        powerPs: '177',
+      });
+      expect(r.value).toBe('2.0 RC 177 ch');
+      expect(r.isEnriched).toBe(true);
+    });
+
+    it('enriches TDCI (Ford) with power_ps without adding fuel', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '1.4 TDCI',
+        powerPs: '90',
+        fuel: 'Diesel',
+      });
+      expect(r.value).toBe('1.4 TDCI 90 ch');
+      expect(r.isEnriched).toBe(true);
+    });
+
+    it('enriches CRDI (Hyundai/Kia) with power_ps without adding fuel', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '1.6 CRDI',
+        powerPs: '115',
+        fuel: 'Diesel',
+      });
+      expect(r.value).toBe('1.6 CRDI 115 ch');
+      expect(r.isEnriched).toBe(true);
+    });
+  });
+
+  describe('Idempotency & normalization', () => {
+    it('is idempotent when type_name already contains power_ps " ch"', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '2.0 HDi 140 ch',
+        powerPs: '140',
+      });
+      expect(r).toEqual({ value: '2.0 HDi 140 ch', isEnriched: false });
+    });
+
+    it('normalizes powerPs when input includes " ch" suffix (no "ch ch")', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '2.0 HDi',
+        powerPs: '140 ch',
+      });
+      expect(r.value).toBe('2.0 HDi 140 ch');
+      expect(r.isEnriched).toBe(true);
+    });
+
+    it('handles whitespace-only powerPs as absent', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '2.0 HDi',
+        powerPs: '   ',
+      });
+      expect(r).toEqual({ value: '2.0 HDi', isEnriched: false });
+    });
+  });
+
+  describe('No-op cases (zero-regression guarantee)', () => {
+    it('returns baseline when powerPs is undefined', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '2.0 HDi',
+      });
+      expect(r).toEqual({ value: '2.0 HDi', isEnriched: false });
+    });
+
+    it('returns empty when typeName is empty', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '',
+        powerPs: '140',
+      });
+      expect(r).toEqual({ value: '', isEnriched: false });
+    });
+
+    it('returns empty when input is fully empty', () => {
+      const r = enrichTypeNameForHeadings({});
+      expect(r).toEqual({ value: '', isEnriched: false });
+    });
+
+    it('does not enrich non-displacement labels (GTI, Hybrid Touring, 4x4 Limited)', () => {
+      expect(
+        enrichTypeNameForHeadings({ typeName: 'GTI', powerPs: '180' }),
+      ).toEqual({ value: 'GTI', isEnriched: false });
+      expect(
+        enrichTypeNameForHeadings({ typeName: 'Hybrid Touring', powerPs: '180' }),
+      ).toEqual({ value: 'Hybrid Touring', isEnriched: false });
+      expect(
+        enrichTypeNameForHeadings({ typeName: '4x4 Limited', powerPs: '180' }),
+      ).toEqual({ value: '4x4 Limited', isEnriched: false });
+    });
+
+    it('does not enrich "1.4 HDI 16V" (3 parts) — fallback safe', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '1.4 HDI 16V',
+        powerPs: '90',
+      });
+      expect(r).toEqual({ value: '1.4 HDI 16V', isEnriched: false });
+    });
+
+    it('does not enrich "2.0i" (no space before abbrev) — fallback safe', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '2.0i',
+        powerPs: '140',
+      });
+      expect(r).toEqual({ value: '2.0i', isEnriched: false });
+    });
+  });
+
+  describe('Determinism', () => {
+    it('produces same output for same input across multiple calls', () => {
+      const input: VehicleLabelInput = {
+        typeName: '2.0 HDi',
+        powerPs: '140',
+        fuel: 'Diesel',
+      };
+      const a = enrichTypeNameForHeadings(input);
+      const b = enrichTypeNameForHeadings(input);
+      const c = enrichTypeNameForHeadings(input);
+      expect(a).toEqual(b);
+      expect(b).toEqual(c);
+    });
+  });
+
+  describe('Pattern regex coverage (matches)', () => {
+    it.each([
+      '2.0',
+      '1.4',
+      '2,0', // virgule décimale FR
+      '3.0 V6',
+      '1.6 TDI',
+      '2.0 RC',
+      '1.0',
+      '5.0 V10',
+    ])('matches "%s" as ambiguous when power_ps is present', (typeName) => {
+      expect(isTypeNameAmbiguousForSeo(typeName, '100')).toBe(true);
+    });
+
+    it('matches "2,0 HDi" (FR comma + abbrev) and enriches correctly', () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: '2,0 HDi',
+        powerPs: '140',
+      });
+      expect(r.value).toBe('2,0 HDi 140 ch');
+      expect(r.isEnriched).toBe(true);
+    });
+  });
+
+  describe('Pattern regex coverage (non-matches)', () => {
+    it.each([
+      'GTI',
+      'Hybrid Touring',
+      '4x4 Limited',
+      '1.4 HDI 16V',
+      '2.0i',
+      'Dynamique Cuir',
+      '',
+    ])('does not match "%s" as ambiguous', (typeName) => {
+      expect(isTypeNameAmbiguousForSeo(typeName, '100')).toBe(false);
+    });
+  });
+});

--- a/backend/src/modules/catalog/services/__tests__/vehicle-aware-label.composer.test.ts
+++ b/backend/src/modules/catalog/services/__tests__/vehicle-aware-label.composer.test.ts
@@ -146,7 +146,10 @@ describe('vehicle-aware-label.composer', () => {
         enrichTypeNameForHeadings({ typeName: 'GTI', powerPs: '180' }),
       ).toEqual({ value: 'GTI', isEnriched: false });
       expect(
-        enrichTypeNameForHeadings({ typeName: 'Hybrid Touring', powerPs: '180' }),
+        enrichTypeNameForHeadings({
+          typeName: 'Hybrid Touring',
+          powerPs: '180',
+        }),
       ).toEqual({ value: 'Hybrid Touring', isEnriched: false });
       expect(
         enrichTypeNameForHeadings({ typeName: '4x4 Limited', powerPs: '180' }),

--- a/backend/src/modules/catalog/services/seo-template.service.ts
+++ b/backend/src/modules/catalog/services/seo-template.service.ts
@@ -10,6 +10,7 @@ import {
   selectVariation,
 } from '../../../config/seo-variations.config';
 import { composeVehicleAwareDescription } from './vehicle-aware-description.composer';
+import { enrichTypeNameForHeadings } from './vehicle-aware-label.composer';
 
 /**
  * 📝 Contexte SEO pour le remplacement des variables
@@ -147,10 +148,24 @@ export class SeoTemplateService {
       }
 
       // 2. Traitement des templates
+      // Enrichissement conditionnel `type_name` pour H1 + title uniquement
+      // (audit empirique 2026-05-26 : 3 duplicates R2 H1 + 1 EXACT title dûs
+      // à `type_name` ambigu — ex. "2.0 HDi" partagé par 140 ch et 163 ch).
+      // `description` (composer PR #665), `content`, `preview` reçoivent le
+      // context ORIGINAL (zero impact hors H1/title).
+      const enrichedTypeName = enrichTypeNameForHeadings({
+        typeName: context.type_name,
+        powerPs: context.power_ps,
+        fuel: context.fuel,
+      });
+      const headingContext: SeoContext = enrichedTypeName.isEnriched
+        ? { ...context, type_name: enrichedTypeName.value }
+        : context;
+
       const processed: ProcessedSeo = {
         success: true,
-        h1: this.processTemplate(templates.h1, context),
-        title: this.processTemplate(templates.title, context),
+        h1: this.processTemplate(templates.h1, headingContext),
+        title: this.processTemplate(templates.title, headingContext),
         description: this.composeDescription(templates.description, context),
         content: this.processTemplate(templates.content, context),
         preview: this.processTemplate(templates.preview, context),

--- a/backend/src/modules/catalog/services/vehicle-aware-label.composer.ts
+++ b/backend/src/modules/catalog/services/vehicle-aware-label.composer.ts
@@ -46,8 +46,7 @@ export interface EnrichedTypeName {
  *   - "1.4 HDI 16V" (3 parties) — pattern accepte 1 abbrev max
  *   - "GTI", "Dynamique Cuir", "Hybrid Touring" — pas de displacement initial
  */
-const AMBIGUOUS_TYPE_NAME_PATTERN =
-  /^\d+([.,]\d+)?(\s+[A-Za-z0-9]{1,5})?$/i;
+const AMBIGUOUS_TYPE_NAME_PATTERN = /^\d+([.,]\d+)?(\s+[A-Za-z0-9]{1,5})?$/i;
 
 /**
  * Carburants implicites dans les abréviations communes (Ford TDCI, Hyundai/Kia

--- a/backend/src/modules/catalog/services/vehicle-aware-label.composer.ts
+++ b/backend/src/modules/catalog/services/vehicle-aware-label.composer.ts
@@ -1,0 +1,101 @@
+/**
+ * 🚗 Vehicle-aware label composer for R2 SEO headings (H1 + meta_title)
+ *
+ * Enrichit conditionnellement `type_name` avec `power_ps` (et `fuel` si non
+ * implicite) quand `type_name` est ambigu — deux `type_ids` peuvent partager
+ * un même `type_name` (ex. `"2.0 HDi"` pour 140 ch et 163 ch).
+ *
+ * Cause racine : audit empirique 2026-05-26
+ * (`audit/seo-h1-meta-empirical-verification-2026-05-26.md`) a confirmé 3
+ * duplicates R2 H1 + 1 duplicate R2 title (1 EXACT lev=0) sur 100 paires
+ * intra-gamme.
+ *
+ * Strategy : enrichissement appliqué AVANT `processTemplate(templates.h1/title)`
+ * dans `seo-template.service.ts`. Les templates DB `__seo_gamme_car` (SGC_H1,
+ * SGC_TITLE) restent intacts ; `composeVehicleAwareDescription` (PR #665) reste
+ * intact ; switches `__seo_item_switch` / `__seo_gamme_car_switch` préservés.
+ *
+ * Invariants critiques :
+ * - **Idempotent** : si `type_name` contient déjà `${powerPs} ch`, no-op.
+ * - **Normalisation `powerPs`** : `"140 ch"` accepté en input → strip suffixe
+ *   → pas de `"140 ch ch"`.
+ * - **Conditionnel strict** : si `isAmbiguous === false` → no-op exact
+ *   (référence identique au context), zero régression sur 97% des paires.
+ * - **Fallback safe** : si `power_ps` absent, type_name vide, ou pattern
+ *   non-match → no-op.
+ */
+
+export interface VehicleLabelInput {
+  typeName?: string;
+  powerPs?: string;
+  fuel?: string;
+}
+
+export interface EnrichedTypeName {
+  value: string;
+  isEnriched: boolean;
+}
+
+/**
+ * Pattern conservateur : `type_name` ambigu = motorisation au format standard
+ * `<displacement>[.<decimal>]( <abbrev>)?` où abbrev ≤ 5 chars (ex. "2.0 HDi",
+ * "1.4", "1.6 TDI", "3.0 V6", "2.0 RC", "2,0 HDi" virgule décimale FR).
+ *
+ * Cas non-matchés (fallback no-op safe) :
+ *   - "2.0i" (sans espace) — pattern requiert `\s+` avant abbrev
+ *   - "1.4 HDI 16V" (3 parties) — pattern accepte 1 abbrev max
+ *   - "GTI", "Dynamique Cuir", "Hybrid Touring" — pas de displacement initial
+ */
+const AMBIGUOUS_TYPE_NAME_PATTERN =
+  /^\d+([.,]\d+)?(\s+[A-Za-z0-9]{1,5})?$/i;
+
+/**
+ * Carburants implicites dans les abréviations communes (Ford TDCI, Hyundai/Kia
+ * CRDI, Citroën/Peugeot HDI, VAG TDI, Fiat JTD, Mercedes CDI, Renault DCI).
+ * Quand `type_name` contient un de ces tokens, on n'ajoute pas le `fuel`
+ * (`"Diesel"`) explicitement → évite redondance "Diesel HDI 140 ch".
+ */
+const FUEL_IMPLICIT_PATTERN =
+  /\b(HDI|HDi|TDI|TDi|DCI|dCi|CDI|JTD|TDCI|CRDI|D)\b/i;
+
+function normalizePowerPs(powerPs?: string): string {
+  return (powerPs ?? '').replace(/\s*ch\s*$/i, '').trim();
+}
+
+function alreadyContainsPower(typeName: string, powerPs?: string): boolean {
+  const power = normalizePowerPs(powerPs);
+  if (!power) return false;
+  const escaped = power.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`\\b${escaped}\\s*ch\\b`, 'i').test(typeName);
+}
+
+export function isTypeNameAmbiguousForSeo(
+  typeName?: string,
+  powerPs?: string,
+): boolean {
+  const baseName = (typeName ?? '').trim();
+  const power = normalizePowerPs(powerPs);
+  if (!baseName || !power) return false;
+  if (alreadyContainsPower(baseName, power)) return false;
+  return AMBIGUOUS_TYPE_NAME_PATTERN.test(baseName);
+}
+
+export function enrichTypeNameForHeadings(
+  input: VehicleLabelInput,
+): EnrichedTypeName {
+  const baseName = (input.typeName ?? '').trim();
+  const power = normalizePowerPs(input.powerPs);
+
+  if (!isTypeNameAmbiguousForSeo(baseName, power)) {
+    return { value: baseName, isEnriched: false };
+  }
+
+  const fuelImplicit = FUEL_IMPLICIT_PATTERN.test(baseName);
+  const fuel = (input.fuel ?? '').trim();
+  const suffix = !fuelImplicit && fuel ? `${fuel} ${power} ch` : `${power} ch`;
+
+  return {
+    value: `${baseName} ${suffix}`.replace(/\s+/g, ' ').trim(),
+    isEnriched: true,
+  };
+}


### PR DESCRIPTION
## Summary

Audit empirique 2026-05-26 ([`audit/seo-h1-meta-empirical-verification-2026-05-26.md`](../blob/main/audit/seo-h1-meta-empirical-verification-2026-05-26.md)) sur 90 URLs LIVE PROD a confirmé que :

- ✅ R8 (H1/title/desc) = **0/80 duplicate** — PR #422 pool actif
- ✅ R2 description = **0/100 duplicate** — PR #665 composer actif
- ⚠️ **R2 H1 = 3/100 duplicates** (dont 1 EXACT, lev=0 jaccard=1)
- ⚠️ **R2 title = 1/100 EXACT** (même paire)

Cette PR fixe le R2 H1/title via enrichissement conditionnel de `context.type_name` quand `type_name` est ambigu (ex. `"2.0 HDi"` partagé par 2 `type_ids` à puissances différentes).

## Cause racine

Templates DB `__seo_gamme_car.sgc_h1` / `sgc_title` consomment `%type_name%` seul. Quand 2 `type_ids` partagent un même `type_name` sans inclure `power_ps` ni `fuel`, le H1/title sont identiques.

Exemple confirmé par cross-check DB :
- `type_id=31997` : CITROËN C5 III 2.0 HDi **140 ch** (2008-)
- `type_id=32794` : CITROËN C5 III 2.0 HDi **163 ch** (2009-)
- → Même `type_name='2.0 HDi'`, H1+title identiques

La description (PR #665) injecte déjà `(${power_ps} ch)` → différenciée.

## Avant/Après

**Avant** (template DB inchangé : `"%pg_name_site% %marque_name% %modele_name% %type_name% au meilleur prix"`) :
```
H1 31997 : Injecteur CITROËN C5 III 2.0 HDi au meilleur prix  ← identique
H1 32794 : Injecteur CITROËN C5 III 2.0 HDi au meilleur prix  ← identique
```

**Après** (`type_name` enrichi conditionnellement) :
```
H1 31997 : Injecteur CITROËN C5 III 2.0 HDi 140 ch au meilleur prix
H1 32794 : Injecteur CITROËN C5 III 2.0 HDi 163 ch au meilleur prix
```

Description (PR #665) reste identique (context original).

## Scope (verrouillé strictement)

| Inclus | Exclu |
|--------|-------|
| R2 H1 (path `seo-template.service.ts:152`) | R8 (toutes surfaces) |
| R2 meta_title (path `seo-template.service.ts:153`) | R2 meta_description (PR #665 OK) |
| Helper pur `enrichTypeNameForHeadings` | Templates DB `__seo_gamme_car` |
| 33 tests unitaires (3 fixtures audit + idempotence + edge cases) | Switches `__seo_item_switch` / `__seo_gamme_car_switch` |
| Conditionnel : no-op exact si non-ambigu (zero régression) | content / preview |
| Cache key Redis inchangé (TTL 24h invalidation passive) | payments / canonical / routes |
| `tsc --noEmit` clean | Migration DB / RPC SQL |

## Invariants critiques du helper

- **Pattern conservateur** : ambigu si `type_name` matche `/^\d+([.,]\d+)?(\s+[A-Za-z0-9]{1,5})?$/` ET `power_ps` présent
- **Idempotent** : si `type_name` contient déjà `"${powerPs} ch"`, no-op (`alreadyContainsPower` guard)
- **Normalisation `powerPs`** : `"140 ch"` accepté → strip suffixe → no `"140 ch ch"`
- **Fuel implicite détecté** (HDI/TDI/CRDI/CDI/JTD/TDCI/DCI) → pas de doublon `"Diesel HDI"`
- **No-op exact** si non-ambigu : `headingContext === context` (référence identique)

## Test plan

- [x] **33/33 tests** dans `vehicle-aware-label.composer.test.ts` (3 fixtures audit + idempotence + sport trim + 7 edge cases + déterminisme + regex coverage)
- [x] **22/22 non-régression** dans `vehicle-aware-description.composer.test.ts` + `seo-template-switch.test.ts`
- [x] **`tsc --noEmit` clean** (zero erreur TypeScript)
- [ ] **CI verte** (à vérifier après push)
- [ ] **Post-merge J+1** : curl 4 fixtures audit LIVE PROD → vérifier H1 distinct (post cache TTL 24h)
- [ ] **J+7** : mini-audit 20 paires R2 → confirmer `R2.H1 duplicate=0`

## Références

- Audit : `audit/seo-h1-meta-empirical-verification-2026-05-26.md`
- Pattern de référence : `vehicle-aware-description.composer.ts` (PR #665, `bf61cac4a`, 2026-05-21)
- Plan : `~/.claude/plans/les-h1-et-meta-whimsical-waterfall.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)