### PR TITLE
fix(seo): R2 H1 frontend disambiguation (follow-up PR #762)

### DIFF
--- a/backend/src/modules/catalog/services/__tests__/vehicle-aware-label.composer.test.ts
+++ b/backend/src/modules/catalog/services/__tests__/vehicle-aware-label.composer.test.ts
@@ -2,7 +2,7 @@ import {
   enrichTypeNameForHeadings,
   isTypeNameAmbiguousForSeo,
   type VehicleLabelInput,
-} from '../vehicle-aware-label.composer';
+} from '@repo/seo-types';
 
 describe('vehicle-aware-label.composer', () => {
   describe('FIXTURES audit 2026-05-26 (audit/seo-h1-meta-empirical-verification-2026-05-26.md)', () => {

--- a/backend/src/modules/catalog/services/seo-template.service.ts
+++ b/backend/src/modules/catalog/services/seo-template.service.ts
@@ -9,8 +9,8 @@ import {
   SEO_PROPOSE_VARIATIONS,
   selectVariation,
 } from '../../../config/seo-variations.config';
+import { enrichTypeNameForHeadings } from '@repo/seo-types';
 import { composeVehicleAwareDescription } from './vehicle-aware-description.composer';
-import { enrichTypeNameForHeadings } from './vehicle-aware-label.composer';
 
 /**
  * 📝 Contexte SEO pour le remplacement des variables

--- a/frontend/app/components/pieces/PiecesHeader.tsx
+++ b/frontend/app/components/pieces/PiecesHeader.tsx
@@ -5,6 +5,7 @@
  * ⚠️ URLS PRÉSERVÉES - Breadcrumb et navigation inchangés
  */
 
+import { enrichTypeNameForHeadings } from "@repo/seo-types";
 import { Car, Package, Shield, Truck } from "lucide-react";
 import React, { useState, memo } from "react";
 
@@ -48,6 +49,17 @@ export const PiecesHeader = memo(function PiecesHeader({
   // Utiliser le texte dynamique ou fallback
   const finalText = prixPasCherText || "au meilleur prix";
 
+  // R2 H1/title disambiguation : enrichir `typeName` avec `powerPs`/`fuel`
+  // quand le type_name est ambigu (ex. "2.0 HDi" partagé par 140/163 ch).
+  // No-op si non-ambigu → byte-identique à l'actuel. Cause empirique :
+  // audit/seo-h1-meta-empirical-verification-2026-05-26.md (3 H1 + 1 title
+  // EXACT duplicates sur 100 paires LIVE PROD).
+  const enrichedTypeLabel = enrichTypeNameForHeadings({
+    typeName: vehicle.typeName || vehicle.type,
+    powerPs: vehicle.typePowerPs?.toString(),
+    fuel: vehicle.typeFuel,
+  }).value;
+
   // Récupérer le gradient de la marque du véhicule
   const brandGradient = vehicle.marqueAlias
     ? brandColorsService.getBrandGradient(vehicle.marqueAlias)
@@ -89,8 +101,8 @@ export const PiecesHeader = memo(function PiecesHeader({
                 <h1 className="text-2xl sm:text-3xl lg:text-4xl font-black leading-tight mb-3 tracking-tight">
                   <span className="text-foreground from-white via-white to-white/90 drop-shadow-[0_8px_32px_rgba(0,0,0,0.5)]">
                     {gamme.name} {vehicle.marque?.toUpperCase()}{" "}
-                    {vehicle.modele?.toUpperCase()}{" "}
-                    {vehicle.typeName || vehicle.type} {finalText}
+                    {vehicle.modele?.toUpperCase()} {enrichedTypeLabel}{" "}
+                    {finalText}
                   </span>
                 </h1>
               </header>

--- a/frontend/app/utils/pieces-vehicle.loader.server.ts
+++ b/frontend/app/utils/pieces-vehicle.loader.server.ts
@@ -11,6 +11,7 @@ import {
   redirect,
   type LoaderFunctionArgs,
 } from "@remix-run/node";
+import { enrichTypeNameForHeadings } from "@repo/seo-types";
 import { type NoProductsData } from "~/components/pieces/NoProductsAlternatives";
 import { type FiltersData } from "~/components/pieces/PiecesFilterSidebar";
 import { fetchRmPageV2 } from "~/services/api/rm-api.service";
@@ -503,7 +504,16 @@ export async function piecesVehicleLoader({
         seo: {
           title:
             rmV2Response.seo?.title ||
-            `${gamme.name} ${vehicle.marque} ${vehicle.modele} ${vehicle.type} | Pièces Auto`,
+            // R2 title fallback : enrichir `type_name` ambigu avec
+            // `powerPs`/`fuel` (audit 2026-05-26, H1+title duplicates).
+            // No-op si non-ambigu → byte-identique à l'actuel.
+            `${gamme.name} ${vehicle.marque} ${vehicle.modele} ${
+              enrichTypeNameForHeadings({
+                typeName: vehicle.typeName || vehicle.type,
+                powerPs: vehicle.typePowerPs?.toString(),
+                fuel: vehicle.typeFuel,
+              }).value
+            } | Pièces Auto`,
           h1: rmV2Response.seo?.h1 || loaderData.seoContent.h1,
           description: stripHtmlForMeta(
             rmV2Response.seo?.description ||

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "@repo/database-types": "*",
     "@repo/registry": "*",
     "@repo/seo-roles": "*",
+    "@repo/seo-types": "*",
     "@repo/seo-url-contract": "*",
     "@sentry/remix": "^10.51.0",
     "@tanstack/react-query": "^5.87.1",

--- a/packages/seo-types/package.json
+++ b/packages/seo-types/package.json
@@ -50,6 +50,11 @@
       "types": "./dist/control-dashboard.rules.d.ts",
       "import": "./dist/control-dashboard.rules.js",
       "require": "./dist/control-dashboard.rules.js"
+    },
+    "./vehicle-aware-label": {
+      "types": "./dist/vehicle-aware-label.d.ts",
+      "import": "./dist/vehicle-aware-label.js",
+      "require": "./dist/vehicle-aware-label.js"
     }
   },
   "scripts": {

--- a/packages/seo-types/src/index.ts
+++ b/packages/seo-types/src/index.ts
@@ -36,3 +36,4 @@ export * from "./geo-aeo.js";
 export * from "./content-ops.js";
 export * from "./crux.js";
 export * from "./control-dashboard.js";
+export * from "./vehicle-aware-label.js";

--- a/packages/seo-types/src/vehicle-aware-label.test.ts
+++ b/packages/seo-types/src/vehicle-aware-label.test.ts
@@ -1,0 +1,229 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  enrichTypeNameForHeadings,
+  isTypeNameAmbiguousForSeo,
+  type VehicleLabelInput,
+} from "./vehicle-aware-label.js";
+
+describe("vehicle-aware-label", () => {
+  describe("FIXTURES audit 2026-05-26", () => {
+    it("FIXTURE #1 EXACT — C5 III 2.0 HDi 140 ch vs 163 ch", () => {
+      const a = enrichTypeNameForHeadings({
+        typeName: "2.0 HDi",
+        powerPs: "140",
+        fuel: "Diesel",
+      });
+      const b = enrichTypeNameForHeadings({
+        typeName: "2.0 HDi",
+        powerPs: "163",
+        fuel: "Diesel",
+      });
+      assert.notStrictEqual(a.value, b.value);
+      assert.strictEqual(a.value, "2.0 HDi 140 ch");
+      assert.strictEqual(b.value, "2.0 HDi 163 ch");
+      assert.strictEqual(a.isEnriched, true);
+      assert.strictEqual(b.isEnriched, true);
+    });
+
+    it("FIXTURE #2 — 1.4 HDI Diesel 69 ch (fuel implicite, no duplication)", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "1.4 HDI",
+        powerPs: "69",
+        fuel: "Diesel",
+      });
+      assert.strictEqual(r.value, "1.4 HDI 69 ch");
+      assert.strictEqual(r.isEnriched, true);
+    });
+
+    it("FIXTURE #2 bis — 1.4 Essence 75 ch (fuel explicite ajouté)", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "1.4",
+        powerPs: "75",
+        fuel: "Essence",
+      });
+      assert.strictEqual(r.value, "1.4 Essence 75 ch");
+      assert.strictEqual(r.isEnriched, true);
+    });
+
+    it("FIXTURE #3 — 206 1.1 60 ch vs 1.4 75 ch", () => {
+      const a = enrichTypeNameForHeadings({
+        typeName: "1.1",
+        powerPs: "60",
+        fuel: "Essence",
+      });
+      const b = enrichTypeNameForHeadings({
+        typeName: "1.4",
+        powerPs: "75",
+        fuel: "Essence",
+      });
+      assert.notStrictEqual(a.value, b.value);
+      assert.strictEqual(a.value, "1.1 Essence 60 ch");
+      assert.strictEqual(b.value, "1.4 Essence 75 ch");
+    });
+  });
+
+  describe("Sport trim & extended fuel coverage", () => {
+    it("enriches short sport trims like '2.0 RC' with power_ps", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "2.0 RC",
+        powerPs: "177",
+      });
+      assert.strictEqual(r.value, "2.0 RC 177 ch");
+      assert.strictEqual(r.isEnriched, true);
+    });
+
+    it("enriches TDCI (Ford) without adding fuel", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "1.4 TDCI",
+        powerPs: "90",
+        fuel: "Diesel",
+      });
+      assert.strictEqual(r.value, "1.4 TDCI 90 ch");
+    });
+
+    it("enriches CRDI (Hyundai/Kia) without adding fuel", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "1.6 CRDI",
+        powerPs: "115",
+        fuel: "Diesel",
+      });
+      assert.strictEqual(r.value, "1.6 CRDI 115 ch");
+    });
+  });
+
+  describe("Idempotency & normalization", () => {
+    it("is idempotent when typeName already contains 'X ch'", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "2.0 HDi 140 ch",
+        powerPs: "140",
+      });
+      assert.deepStrictEqual(r, {
+        value: "2.0 HDi 140 ch",
+        isEnriched: false,
+      });
+    });
+
+    it("normalizes powerPs with ' ch' suffix (no 'ch ch')", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "2.0 HDi",
+        powerPs: "140 ch",
+      });
+      assert.strictEqual(r.value, "2.0 HDi 140 ch");
+    });
+
+    it("handles whitespace-only powerPs as absent", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "2.0 HDi",
+        powerPs: "   ",
+      });
+      assert.deepStrictEqual(r, { value: "2.0 HDi", isEnriched: false });
+    });
+  });
+
+  describe("No-op cases (zero-regression guarantee)", () => {
+    it("returns baseline when powerPs is undefined", () => {
+      const r = enrichTypeNameForHeadings({ typeName: "2.0 HDi" });
+      assert.deepStrictEqual(r, { value: "2.0 HDi", isEnriched: false });
+    });
+
+    it("returns empty when typeName is empty", () => {
+      const r = enrichTypeNameForHeadings({ typeName: "", powerPs: "140" });
+      assert.deepStrictEqual(r, { value: "", isEnriched: false });
+    });
+
+    it("returns empty when input is fully empty", () => {
+      const r = enrichTypeNameForHeadings({});
+      assert.deepStrictEqual(r, { value: "", isEnriched: false });
+    });
+
+    it("does not enrich non-displacement labels", () => {
+      for (const tn of ["GTI", "Hybrid Touring", "4x4 Limited"]) {
+        const r = enrichTypeNameForHeadings({ typeName: tn, powerPs: "180" });
+        assert.deepStrictEqual(
+          r,
+          { value: tn, isEnriched: false },
+          `expected no-op for "${tn}"`,
+        );
+      }
+    });
+
+    it("does not enrich '1.4 HDI 16V' (3 parts) — fallback safe", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "1.4 HDI 16V",
+        powerPs: "90",
+      });
+      assert.deepStrictEqual(r, { value: "1.4 HDI 16V", isEnriched: false });
+    });
+
+    it("does not enrich '2.0i' (no space) — fallback safe", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "2.0i",
+        powerPs: "140",
+      });
+      assert.deepStrictEqual(r, { value: "2.0i", isEnriched: false });
+    });
+  });
+
+  describe("Determinism", () => {
+    it("produces same output for same input across multiple calls", () => {
+      const input: VehicleLabelInput = {
+        typeName: "2.0 HDi",
+        powerPs: "140",
+        fuel: "Diesel",
+      };
+      assert.deepStrictEqual(
+        enrichTypeNameForHeadings(input),
+        enrichTypeNameForHeadings(input),
+      );
+    });
+  });
+
+  describe("Pattern regex coverage", () => {
+    it("matches displacement formats", () => {
+      for (const tn of [
+        "2.0",
+        "1.4",
+        "2,0",
+        "3.0 V6",
+        "1.6 TDI",
+        "2.0 RC",
+        "1.0",
+        "5.0 V10",
+      ]) {
+        assert.strictEqual(
+          isTypeNameAmbiguousForSeo(tn, "100"),
+          true,
+          `expected ambiguous match for "${tn}"`,
+        );
+      }
+    });
+
+    it("does not match non-displacement formats", () => {
+      for (const tn of [
+        "GTI",
+        "Hybrid Touring",
+        "4x4 Limited",
+        "1.4 HDI 16V",
+        "2.0i",
+        "Dynamique Cuir",
+        "",
+      ]) {
+        assert.strictEqual(
+          isTypeNameAmbiguousForSeo(tn, "100"),
+          false,
+          `expected NO ambiguous match for "${tn}"`,
+        );
+      }
+    });
+
+    it("enriches '2,0 HDi' (FR comma + abbrev)", () => {
+      const r = enrichTypeNameForHeadings({
+        typeName: "2,0 HDi",
+        powerPs: "140",
+      });
+      assert.strictEqual(r.value, "2,0 HDi 140 ch");
+    });
+  });
+});

--- a/packages/seo-types/src/vehicle-aware-label.ts
+++ b/packages/seo-types/src/vehicle-aware-label.ts
@@ -1,5 +1,8 @@
 /**
- * 🚗 Vehicle-aware label composer for R2 SEO headings (H1 + meta_title)
+ * 🚗 Vehicle-aware label helper for R2 SEO headings (H1 + meta_title)
+ *
+ * Shared between backend (`seo-template.service.ts:processTemplates`) and
+ * frontend (`PiecesHeader.tsx`, `pieces-vehicle.loader.server.ts`).
  *
  * Enrichit conditionnellement `type_name` avec `power_ps` (et `fuel` si non
  * implicite) quand `type_name` est ambigu — deux `type_ids` peuvent partager
@@ -10,17 +13,20 @@
  * duplicates R2 H1 + 1 duplicate R2 title (1 EXACT lev=0) sur 100 paires
  * intra-gamme.
  *
- * Strategy : enrichissement appliqué AVANT `processTemplate(templates.h1/title)`
- * dans `seo-template.service.ts`. Les templates DB `__seo_gamme_car` (SGC_H1,
- * SGC_TITLE) restent intacts ; `composeVehicleAwareDescription` (PR #665) reste
- * intact ; switches `__seo_item_switch` / `__seo_gamme_car_switch` préservés.
+ * GATE 1 doctrine — empirical implementation path proven 2026-05-26 :
+ * - Backend `seo-template.service.ts` couvre <title> HEAD pour les ~118
+ *   pg_ids avec template DB existant (~1.2% du catalogue), via Redis cache
+ *   `seo:processed:{pg_id}:{type_id}:{modifier}` TTL 24h.
+ * - Frontend `PiecesHeader.tsx` couvre le `<h1>` visible utilisateur + le
+ *   `<title>` HEAD pour les pg_ids sans template DB (fallback dans
+ *   `pieces-vehicle.loader.server.ts`).
  *
  * Invariants critiques :
  * - **Idempotent** : si `type_name` contient déjà `${powerPs} ch`, no-op.
  * - **Normalisation `powerPs`** : `"140 ch"` accepté en input → strip suffixe
  *   → pas de `"140 ch ch"`.
- * - **Conditionnel strict** : si `isAmbiguous === false` → no-op exact
- *   (référence identique au context), zero régression sur 97% des paires.
+ * - **Conditionnel strict** : si `isAmbiguous === false` → no-op exact, zero
+ *   régression sur 97% des paires non-ambiguës.
  * - **Fallback safe** : si `power_ps` absent, type_name vide, ou pattern
  *   non-match → no-op.
  */
@@ -58,21 +64,21 @@ const FUEL_IMPLICIT_PATTERN =
   /\b(HDI|HDi|TDI|TDi|DCI|dCi|CDI|JTD|TDCI|CRDI|D)\b/i;
 
 function normalizePowerPs(powerPs?: string): string {
-  return (powerPs ?? '').replace(/\s*ch\s*$/i, '').trim();
+  return (powerPs ?? "").replace(/\s*ch\s*$/i, "").trim();
 }
 
 function alreadyContainsPower(typeName: string, powerPs?: string): boolean {
   const power = normalizePowerPs(powerPs);
   if (!power) return false;
-  const escaped = power.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`\\b${escaped}\\s*ch\\b`, 'i').test(typeName);
+  const escaped = power.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\s*ch\\b`, "i").test(typeName);
 }
 
 export function isTypeNameAmbiguousForSeo(
   typeName?: string,
   powerPs?: string,
 ): boolean {
-  const baseName = (typeName ?? '').trim();
+  const baseName = (typeName ?? "").trim();
   const power = normalizePowerPs(powerPs);
   if (!baseName || !power) return false;
   if (alreadyContainsPower(baseName, power)) return false;
@@ -82,7 +88,7 @@ export function isTypeNameAmbiguousForSeo(
 export function enrichTypeNameForHeadings(
   input: VehicleLabelInput,
 ): EnrichedTypeName {
-  const baseName = (input.typeName ?? '').trim();
+  const baseName = (input.typeName ?? "").trim();
   const power = normalizePowerPs(input.powerPs);
 
   if (!isTypeNameAmbiguousForSeo(baseName, power)) {
@@ -90,11 +96,11 @@ export function enrichTypeNameForHeadings(
   }
 
   const fuelImplicit = FUEL_IMPLICIT_PATTERN.test(baseName);
-  const fuel = (input.fuel ?? '').trim();
+  const fuel = (input.fuel ?? "").trim();
   const suffix = !fuelImplicit && fuel ? `${fuel} ${power} ch` : `${power} ch`;
 
   return {
-    value: `${baseName} ${suffix}`.replace(/\s+/g, ' ').trim(),
+    value: `${baseName} ${suffix}`.replace(/\s+/g, " ").trim(),
     isEnriched: true,
   };
 }

--- a/packages/seo-types/src/vehicle-aware-label.ts
+++ b/packages/seo-types/src/vehicle-aware-label.ts
@@ -63,15 +63,19 @@ const AMBIGUOUS_TYPE_NAME_PATTERN = /^\d+([.,]\d+)?(\s+[A-Za-z0-9]{1,5})?$/i;
 const FUEL_IMPLICIT_PATTERN =
   /\b(HDI|HDi|TDI|TDi|DCI|dCi|CDI|JTD|TDCI|CRDI|D)\b/i;
 
+// Quantifiers bornés pour éviter ReDoS (js/polynomial-redos) — les inputs
+// réels (DB `auto_type.type_name`, `type_power_ps`) sont contraints (motorisation
+// standard, puissance ≤4 chiffres) ; 0-3 espaces suffisent pour matcher les
+// formes canoniques "140 ch", "140  ch", "140ch".
 function normalizePowerPs(powerPs?: string): string {
-  return (powerPs ?? "").replace(/\s*ch\s*$/i, "").trim();
+  return (powerPs ?? "").replace(/\s{0,3}ch\s{0,3}$/i, "").trim();
 }
 
 function alreadyContainsPower(typeName: string, powerPs?: string): boolean {
   const power = normalizePowerPs(powerPs);
   if (!power) return false;
   const escaped = power.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`\\b${escaped}\\s*ch\\b`, "i").test(typeName);
+  return new RegExp(`\\b${escaped}\\s{0,3}ch\\b`, "i").test(typeName);
 }
 
 export function isTypeNameAmbiguousForSeo(


### PR DESCRIPTION
## Summary

Follow-up of [PR #762](https://github.com/ak125/nestjs-remix-monorepo/pull/762) — which corrected the backend SEO template service but, **after empirical post-deploy verification, was identified as `LIVE_INEFFECTIVE` on the visible R2 `<h1>`** because R2 H1/title are actually rendered **frontend-side** in [`PiecesHeader.tsx:89-94`](frontend/app/components/pieces/PiecesHeader.tsx#L89-L94) using raw `vehicle.typeName`, bypassing the backend path entirely.

This PR closes the gap by sharing the existing `enrichTypeNameForHeadings` helper between backend + frontend and wiring it where the H1 + title actually render.

## GATE 1 — Empirical implementation path proof

Per [`feedback_runtime_verification_mandatory.md`](`~/.claude/projects/-opt-automecanik-app/memory/feedback_runtime_verification_mandatory.md`) GATE 1 (codified 2026-05-26 from the PR #762 lesson learned) :

| Evidence | Value |
|---|---|
| LIVE curl 4 audit fixtures post-PR-#762 deploy | All show H1 format `${gamme.name} ${MARQUE.upper} ${MODELE.upper} ${type} {variation}` |
| Template DB `__seo_gamme_car.sgc_h1` format | `Kit de distribution #VMarque# #VModele# #VType# #VNbCh# ch #VAnnee# #CompSwitch_2#` — different (contains `#VNbCh# ch #VAnnee#`) |
| `__seo_gamme_car` row coverage | 118 / 9719 pg_ids (1.2%) → frontend fallback for 98.8% |
| frontend [`PiecesHeader.tsx:89-94`](frontend/app/components/pieces/PiecesHeader.tsx#L89-L94) source | `{gamme.name} {marque.upper} {modele.upper} {vehicle.typeName} {finalText}` — **matches LIVE format byte-for-byte** |

→ **PATH_PROVEN** : the visible H1 is controlled by frontend `PiecesHeader.tsx`. The backend path modified by PR #762 only affects `<title>` HEAD for 118 pg_ids with template (1.2% coverage).

## Implementation

1. **Move helper** `enrichTypeNameForHeadings` from `backend/src/modules/catalog/services/vehicle-aware-label.composer.ts` → `packages/seo-types/src/vehicle-aware-label.ts` (shared package, zero duplication)
2. **Backend** `seo-template.service.ts` : import from `@repo/seo-types` (path-only change, behavior identical)
3. **Frontend `PiecesHeader.tsx`** : compute `enrichedTypeLabel` via shared helper, display in `<h1>` instead of raw `vehicle.typeName`
4. **Frontend `pieces-vehicle.loader.server.ts`** : enrich `seo.title` fallback (covers the 98.8% of pg_ids without backend template)

## Coverage combined PR #762 + this PR

| Surface visible | PR #762 alone | PR #762 + this PR |
|---|---|---|
| R2 `<h1>` visible (frontend) | ❌ INEFFECTIVE | ✅ ENRICHED |
| R2 `<title>` HEAD (118 pg_ids backend template, 1.2%) | ⚠️ Pending Redis TTL 24h | ✅ |
| R2 `<title>` HEAD (9601 pg_ids fallback frontend, 98.8%) | ❌ INEFFECTIVE | ✅ ENRICHED |
| R2 `<meta description>` (PR #665) | ✅ intact | ✅ intact |

## Test plan

- [x] **20/20 node tsx tests** dans `packages/seo-types/src/vehicle-aware-label.test.ts` (3 audit fixtures + idempotence + sport trim + edge cases)
- [x] **55/55 Jest backend tests** dans `src/modules/catalog/services/__tests__/` (regression composer + seo-template-switch + label)
- [x] **0 erreur TS** sur fichiers modifiés (`tsc --noEmit` filtré)
- [x] **ESLint clean** sur fichiers modifiés
- [ ] **CI green** (à vérifier après push)
- [ ] **Post-tag-deploy LIVE curl 4 fixtures** → verdict attendu `LIVE_CONFIRMED` (cf-cache-status: MISS premier hit, H1 contient 140 ch / 163 ch / 69 ch / 75 ch)
- [ ] **J+7** : mini-audit 20 paires R2 → confirmer `R2.H1 duplicate=0`

## Scope strict (verrouillé)

| Inclus | Exclu |
|---|---|
| `packages/seo-types/src/vehicle-aware-label.ts` (CREATE shared) | R8 (toutes surfaces) |
| `packages/seo-types/src/index.ts` + `package.json` (exports) | Templates DB `__seo_gamme_car` |
| `backend/.../seo-template.service.ts` (import path only) | Switches `__seo_item_switch` / `__seo_gamme_car_switch` |
| `backend/.../__tests__/vehicle-aware-label.composer.test.ts` (import path) | `composeVehicleAwareDescription` (PR #665) |
| Delete `backend/.../vehicle-aware-label.composer.ts` (moved) | payments / paybox / systempay |
| `frontend/.../PiecesHeader.tsx` (3 edits surgical) | canonical / routes |
| `frontend/.../pieces-vehicle.loader.server.ts` (1 import + 1 wrap) | content / preview |
| `frontend/package.json` (add @repo/seo-types dep) | Migration DB / RPC SQL |

## Références

- Audit : [`audit/seo-h1-meta-empirical-verification-2026-05-26.md`](audit/seo-h1-meta-empirical-verification-2026-05-26.md)
- Doctrine : `[[feedback_runtime_verification_mandatory]]` (GATE 1 + GATE 2)
- PR antérieure : #762 (backend path, partial coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)