### PR TITLE
fix(seo): restore R2 H1 suffix rotation

### DIFF
--- a/backend/src/modules/rm/rm.types.ts
+++ b/backend/src/modules/rm/rm.types.ts
@@ -218,6 +218,13 @@ export interface RmSeoData {
   description: string;
   content: string;
   preview: string;
+  /**
+   * Per-pg_id technique variations (`__seo_gamme_car_switch.sgcs_alias=2`)
+   * exposées pour rotation H1 suffix côté frontend (`PiecesHeader.tsx`).
+   * Vide si pg_id n'a pas de rows alias=2 → frontend tombe en fallback
+   * SEO_PRICE_VARIATIONS local. Voir `@repo/seo-types pickH1Suffix`.
+   */
+  compSwitch2?: string[];
 }
 
 /**

--- a/backend/src/modules/rm/services/rm-builder.service.ts
+++ b/backend/src/modules/rm/services/rm-builder.service.ts
@@ -627,6 +627,12 @@ export class RmBuilderService extends SupabaseBaseService {
               description: processed.description,
               content: processed.content,
               preview: processed.preview,
+              // Expose per-pg_id technique variations (sgcs_alias=2) pour
+              // rotation H1 suffix côté frontend. `ctx.comp_switches` est
+              // déjà chargé via `loadSeoCtxSwitches(pgId, gammeName)` ;
+              // entities HTML déjà décodées. Aucune nouvelle query DB.
+              // Voir @repo/seo-types pickH1Suffix.
+              compSwitch2: ctx.comp_switches?.['2'] ?? [],
             };
 
             // Retrofit ADR-055 — shadow observation via SeoShadowObservatoryModule (I1).

--- a/frontend/app/components/pieces/PiecesHeader.tsx
+++ b/frontend/app/components/pieces/PiecesHeader.tsx
@@ -5,7 +5,11 @@
  * ⚠️ URLS PRÉSERVÉES - Breadcrumb et navigation inchangés
  */
 
-import { enrichTypeNameForHeadings } from "@repo/seo-types";
+import {
+  enrichTypeNameForHeadings,
+  pickH1Suffix,
+  SEO_PRICE_VARIATIONS,
+} from "@repo/seo-types";
 import { Car, Package, Shield, Truck } from "lucide-react";
 import React, { useState, memo } from "react";
 
@@ -22,7 +26,12 @@ interface PiecesHeaderProps {
   gamme: GammeData;
   count: number;
   minPrice?: number;
-  prixPasCherText?: string; // Texte dynamique "pas cher"
+  prixPasCherText?: string; // Texte dynamique "pas cher" (legacy override)
+  /** Per-pg_id technique variations (__seo_gamme_car_switch.sgcs_alias=2) :
+   * pool de suffixes H1 gamme-specific (ex. "synchroniser les soupapes" pour
+   * pg_id=307 kit-distribution). Rotation déterministe par (typeId+pgId)
+   * via @repo/seo-types pickH1Suffix. Vide → fallback SEO_PRICE_VARIATIONS. */
+  compSwitch2?: readonly string[];
   performance?: PerformanceInfo;
 }
 
@@ -36,18 +45,22 @@ export const PiecesHeader = memo(function PiecesHeader({
   count,
   minPrice,
   prixPasCherText,
+  compSwitch2,
   performance,
 }: PiecesHeaderProps) {
   const [imageError, setImageError] = useState(false);
 
-  // Formater le prix et le texte "pas cher"
-  const _priceText =
-    minPrice && minPrice > 0
-      ? `à partir de ${minPrice.toFixed(2)} €`
-      : "au meilleur prix";
-
-  // Utiliser le texte dynamique ou fallback
-  const finalText = prixPasCherText || "au meilleur prix";
+  // Suffix H1 R2 rotation : compSwitch2 per-gamme primary (pattern legacy PHP
+  // #CompSwitch_2#), fallback SEO_PRICE_VARIATIONS 7 variantes prix, fallback
+  // ultime literal "au meilleur prix" (compatibilité legacy prixPasCherText).
+  // Cause : audit 2026-05-26 montre `au meilleur prix` figé 4/4 fixtures car
+  // prop n'était jamais passée. Restauration pattern legacy via #763 follow-up.
+  const finalText = pickH1Suffix({
+    compSwitch2,
+    priceVariations: SEO_PRICE_VARIATIONS,
+    ctx: { typeId: vehicle.typeId, pgId: gamme.id },
+    literalFallback: prixPasCherText ?? "au meilleur prix",
+  });
 
   // R2 H1/title disambiguation : enrichir `typeName` avec `powerPs`/`fuel`
   // quand le type_name est ambigu (ex. "2.0 HDi" partagé par 140/163 ch).

--- a/frontend/app/components/pieces/PiecesVehicleContent.tsx
+++ b/frontend/app/components/pieces/PiecesVehicleContent.tsx
@@ -235,6 +235,7 @@ export function PiecesVehicleContent() {
           gamme={data.gamme}
           count={data.count}
           performance={data.performance}
+          compSwitch2={data.seo?.compSwitch2}
         />
       </div>
 

--- a/frontend/app/services/api/rm-api.service.ts
+++ b/frontend/app/services/api/rm-api.service.ts
@@ -187,6 +187,9 @@ export interface RmSeoData {
   description: string;
   content: string;
   preview: string;
+  /** Per-pg_id technique variations from `__seo_gamme_car_switch.sgcs_alias=2`.
+   * Exposed by backend pour rotation H1 suffix via @repo/seo-types pickH1Suffix. */
+  compSwitch2?: string[];
 }
 
 export interface RmCrossSelling {

--- a/frontend/app/types/pieces-route.types.ts
+++ b/frontend/app/types/pieces-route.types.ts
@@ -144,6 +144,9 @@ export interface SEOInfo {
   title: string;
   h1: string;
   description: string;
+  /** Per-pg_id technique variations (`__seo_gamme_car_switch.sgcs_alias=2`)
+   * pour rotation H1 suffix dans PiecesHeader via @repo/seo-types pickH1Suffix. */
+  compSwitch2?: readonly string[];
 }
 
 export interface CatalogueItem {
@@ -175,6 +178,9 @@ export interface LoaderData {
   minPrice: number;
   maxPrice: number;
   prixPasCherText?: string; // Texte dynamique "pas cher"
+  /** Per-pg_id technique variations (__seo_gamme_car_switch.sgcs_alias=2)
+   * pour rotation H1 suffix via @repo/seo-types pickH1Suffix. */
+  compSwitch2?: readonly string[];
 
   // Contenu enrichi V5
   seoContent: SEOEnrichedContent;

--- a/frontend/app/utils/pieces-vehicle.loader.server.ts
+++ b/frontend/app/utils/pieces-vehicle.loader.server.ts
@@ -519,6 +519,10 @@ export async function piecesVehicleLoader({
             rmV2Response.seo?.description ||
               loaderData.seoContent.longDescription,
           ),
+          // Per-pg_id technique variations (sgcs_alias=2) pour rotation H1
+          // suffix côté PiecesHeader (audit 2026-05-26 : "au meilleur prix"
+          // figé partout, restaurer le pattern legacy PHP #CompSwitch_2#).
+          compSwitch2: rmV2Response.seo?.compSwitch2 ?? [],
         },
         performance: {
           loadTime,

--- a/frontend/app/utils/rm-mapper.ts
+++ b/frontend/app/utils/rm-mapper.ts
@@ -174,6 +174,7 @@ function mapSeoInfo(rmV2: RmPageV2Response): SEOInfo {
     title: seo.title || "",
     h1: seo.h1 || "",
     description: seo.description || "",
+    compSwitch2: seo.compSwitch2 ?? [],
   };
 }
 

--- a/packages/seo-types/package.json
+++ b/packages/seo-types/package.json
@@ -55,6 +55,11 @@
       "types": "./dist/vehicle-aware-label.d.ts",
       "import": "./dist/vehicle-aware-label.js",
       "require": "./dist/vehicle-aware-label.js"
+    },
+    "./seo-variations": {
+      "types": "./dist/seo-variations.d.ts",
+      "import": "./dist/seo-variations.js",
+      "require": "./dist/seo-variations.js"
     }
   },
   "scripts": {

--- a/packages/seo-types/src/index.ts
+++ b/packages/seo-types/src/index.ts
@@ -37,3 +37,4 @@ export * from "./content-ops.js";
 export * from "./crux.js";
 export * from "./control-dashboard.js";
 export * from "./vehicle-aware-label.js";
+export * from "./seo-variations.js";

--- a/packages/seo-types/src/seo-variations.test.ts
+++ b/packages/seo-types/src/seo-variations.test.ts
@@ -1,0 +1,144 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  pickH1Suffix,
+  selectFromPool,
+  SEO_PRICE_VARIATIONS,
+} from "./seo-variations.js";
+
+describe("selectFromPool", () => {
+  it("deterministic rotation by (typeId+pgId+offset)", () => {
+    const pool = ["A", "B", "C", "D", "E"];
+    // (0+0+0) % 5 = 0 → "A"
+    assert.strictEqual(selectFromPool(pool, { typeId: 0, pgId: 0 }), "A");
+    // (1+0+0) % 5 = 1 → "B"
+    assert.strictEqual(selectFromPool(pool, { typeId: 1, pgId: 0 }), "B");
+    // (0+0+2) % 5 = 2 → "C"
+    assert.strictEqual(selectFromPool(pool, { typeId: 0, pgId: 0 }, 2), "C");
+  });
+
+  it("returns undefined when pool empty", () => {
+    assert.strictEqual(selectFromPool([], { typeId: 1, pgId: 1 }), undefined);
+  });
+
+  it("normalizes negative modulo (defensive)", () => {
+    const pool = ["A", "B", "C"];
+    // (0+0-1) % 3 = -1 → normalized to 2 → "C"
+    assert.strictEqual(selectFromPool(pool, { typeId: 0, pgId: 0 }, -1), "C");
+  });
+});
+
+describe("pickH1Suffix", () => {
+  it("primary compSwitch2 when non-empty (deterministic exact match)", () => {
+    const compSwitch2 = [
+      "synchroniser les soupapes",
+      "entraîner la pompe à eau",
+    ];
+    const ctx = { typeId: 9466, pgId: 307 };
+    // (9466 + 307 + 2) % 2 = 9775 % 2 = 1 → index 1
+    const r = pickH1Suffix({
+      compSwitch2,
+      priceVariations: SEO_PRICE_VARIATIONS,
+      ctx,
+    });
+    assert.strictEqual(r, "entraîner la pompe à eau");
+  });
+
+  it("fallback priceVariations when compSwitch2 empty", () => {
+    // (31997 + 3902 + 0) % 7 = 35899 % 7 = 3 → SEO_PRICE_VARIATIONS[3] = "économique"
+    const r = pickH1Suffix({
+      compSwitch2: [],
+      priceVariations: SEO_PRICE_VARIATIONS,
+      ctx: { typeId: 31997, pgId: 3902 },
+    });
+    assert.strictEqual(r, "économique");
+  });
+
+  it("fallback literal when both pools empty", () => {
+    const r = pickH1Suffix({
+      compSwitch2: [],
+      priceVariations: [],
+      ctx: { typeId: 1, pgId: 1 },
+      literalFallback: "au meilleur prix",
+    });
+    assert.strictEqual(r, "au meilleur prix");
+  });
+
+  it("fallback literal defaults to 'au meilleur prix'", () => {
+    const r = pickH1Suffix({
+      compSwitch2: [],
+      priceVariations: [],
+      ctx: { typeId: 1, pgId: 1 },
+    });
+    assert.strictEqual(r, "au meilleur prix");
+  });
+
+  it("normalizes trailing punctuation", () => {
+    // (0+0+2) % 1 = 0 → only element
+    const r = pickH1Suffix({
+      compSwitch2: ["synchroniser les soupapes."],
+      priceVariations: SEO_PRICE_VARIATIONS,
+      ctx: { typeId: 0, pgId: 0 },
+    });
+    assert.strictEqual(r, "synchroniser les soupapes");
+  });
+
+  it("collapses multiple whitespace", () => {
+    const r = pickH1Suffix({
+      compSwitch2: ["entraîner  la  pompe"],
+      priceVariations: SEO_PRICE_VARIATIONS,
+      ctx: { typeId: 0, pgId: 0 },
+    });
+    assert.strictEqual(r, "entraîner la pompe");
+  });
+
+  it("is deterministic across multiple calls", () => {
+    const opts = {
+      compSwitch2: ["A", "B", "C"],
+      priceVariations: SEO_PRICE_VARIATIONS,
+      ctx: { typeId: 100, pgId: 200 },
+    };
+    assert.strictEqual(pickH1Suffix(opts), pickH1Suffix(opts));
+    assert.strictEqual(pickH1Suffix(opts), pickH1Suffix(opts));
+  });
+
+  it("4 audit fixtures produce >= 3 distinct suffixes (rotation OK)", () => {
+    // Représente la situation réelle post-deploy : pg_id=307 a compSwitch2 chargé,
+    // pg_id=3902 n'a pas de rows alias=2 → fallback SEO_PRICE_VARIATIONS.
+    const compSwitch2_307 = [
+      "synchroniser les soupapes",
+      "entraîner la pompe à eau",
+      "optimiser les performances",
+    ];
+    const fixtures = [
+      { typeId: 30091, pgId: 307 },
+      { typeId: 9466, pgId: 307 },
+      { typeId: 31997, pgId: 3902 },
+      { typeId: 32794, pgId: 3902 },
+    ];
+    const results = fixtures.map((ctx) =>
+      pickH1Suffix({
+        compSwitch2: ctx.pgId === 307 ? compSwitch2_307 : [],
+        priceVariations: SEO_PRICE_VARIATIONS,
+        ctx,
+      }),
+    );
+    const distinct = new Set(results);
+    assert.ok(
+      distinct.size >= 3,
+      `expected >=3 distinct suffixes, got ${distinct.size}: ${JSON.stringify(results)}`,
+    );
+    // None ends with "au meilleur prix" via fallback literal (because both pools non-empty)
+    const allLiteralFallback = results.every((r) => r === "au meilleur prix");
+    assert.ok(
+      !allLiteralFallback,
+      "expected at least one suffix from compSwitch2 or priceVariations rotation",
+    );
+  });
+
+  it("SEO_PRICE_VARIATIONS contains 7 distinct entries", () => {
+    assert.strictEqual(SEO_PRICE_VARIATIONS.length, 7);
+    assert.strictEqual(new Set(SEO_PRICE_VARIATIONS).size, 7);
+  });
+});

--- a/packages/seo-types/src/seo-variations.ts
+++ b/packages/seo-types/src/seo-variations.ts
@@ -27,11 +27,15 @@ export interface ContextKeys {
  * Strip trailing punctuation + collapse whitespace. Defensive vs DB content
  * quirks (legacy `sgcs_content` parfois avec ponctuation finale ou double
  * espaces). Backend `loadCompSwitches` décode déjà HTML entities.
+ *
+ * Bounded quantifiers `{1,N}` pour éviter ReDoS (js/polynomial-redos) — les
+ * inputs réels (DB `sgcs_content`) sont bornés à ~100 chars practically,
+ * 50 espaces/dots max couvre tous les cas avec marge.
  */
 function normalizeSuffix(s: string): string {
   return s
-    .replace(/\s+/g, " ")
-    .replace(/[.。]+$/g, "")
+    .replace(/\s{1,50}/g, " ")
+    .replace(/[.。]{1,10}$/g, "")
     .trim();
 }
 

--- a/packages/seo-types/src/seo-variations.ts
+++ b/packages/seo-types/src/seo-variations.ts
@@ -1,0 +1,83 @@
+/**
+ * 🎯 SEO H1 suffix rotation — shared helper for R2 H1 visible component.
+ *
+ * Restaure le comportement legacy PHP (`#CompSwitch_2#` per-gamme technique
+ * suffix + `#PrixPasCher#` fallback price variation) après que PR #763
+ * a réparé la disambiguation `type_name` mais laissé le suffix figé sur
+ * `"au meilleur prix"` partout.
+ *
+ * Architecture validée owner :
+ * - Backend (`@fafa/backend rm-builder.service.ts`) expose uniquement
+ *   `seo.compSwitch2: string[]` chargé via `loadSeoCtxSwitches(pgId)`
+ *   depuis `__seo_gamme_car_switch.sgcs_alias=2` (per-pg_id technique
+ *   variations, 1000 rows / 396 distinctes).
+ * - Frontend (`PiecesHeader.tsx`) consomme `compSwitch2` + importe
+ *   `SEO_PRICE_VARIATIONS` constant côté package (pas via API).
+ * - Rotation déterministe par `(typeId + pgId + offset) % pool.length`.
+ *
+ * Fallback chain : compSwitch2 > priceVariations > literal.
+ */
+
+export interface ContextKeys {
+  typeId: number;
+  pgId: number;
+}
+
+/**
+ * Strip trailing punctuation + collapse whitespace. Defensive vs DB content
+ * quirks (legacy `sgcs_content` parfois avec ponctuation finale ou double
+ * espaces). Backend `loadCompSwitches` décode déjà HTML entities.
+ */
+function normalizeSuffix(s: string): string {
+  return s
+    .replace(/\s+/g, " ")
+    .replace(/[.。]+$/g, "")
+    .trim();
+}
+
+/**
+ * Déterministe rotation : `(typeId + pgId + offset) % pool.length`.
+ * Retourne `undefined` si pool vide.
+ */
+export function selectFromPool<T>(
+  pool: readonly T[],
+  ctx: ContextKeys,
+  offset = 0,
+): T | undefined {
+  if (!pool.length) return undefined;
+  const len = pool.length;
+  const idx = (((ctx.typeId + ctx.pgId + offset) % len) + len) % len;
+  return pool[idx];
+}
+
+/**
+ * Build R2 H1 suffix : compSwitch2 primary > priceVariations fallback > literal.
+ * Tous suffixes passent par `normalizeSuffix` avant retour.
+ */
+export function pickH1Suffix(opts: {
+  compSwitch2?: readonly string[];
+  priceVariations: readonly string[];
+  ctx: ContextKeys;
+  literalFallback?: string;
+}): string {
+  const c2 = selectFromPool(opts.compSwitch2 ?? [], opts.ctx, 2);
+  if (c2 && c2.trim()) return normalizeSuffix(c2);
+  const pv = selectFromPool(opts.priceVariations, opts.ctx);
+  if (pv && pv.trim()) return normalizeSuffix(pv);
+  return opts.literalFallback ?? "au meilleur prix";
+}
+
+/**
+ * Rotation prix générique (7 variantes), fallback si pg_id n'a pas de
+ * `compSwitch2` chargé via `__seo_gamme_car_switch.sgcs_alias=2`.
+ * Constante volontairement côté package partagé — pas exposée via API.
+ */
+export const SEO_PRICE_VARIATIONS = [
+  "à prix imbattables",
+  "pas cher",
+  "à petit prix",
+  "économique",
+  "à prix réduit",
+  "à tarif avantageux",
+  "au meilleur prix",
+] as const;


### PR DESCRIPTION
## Summary

Follow-up de [PR #762](https://github.com/ak125/nestjs-remix-monorepo/pull/762) + [PR #763](https://github.com/ak125/nestjs-remix-monorepo/pull/763) (LIVE_CONFIRMED 4/4 H1 disambiguation). Owner observation post-deploy : **suffixe `au meilleur prix` figé sur 4/4 fixtures** + wording trop générique vs legacy PHP `#CompSwitch_2#`.

Cette PR restaure le pattern legacy en câblant la rotation per-pg_id `__seo_gamme_car_switch.sgcs_alias=2` (déjà chargée backend, jamais exposée frontend) dans le H1 visible R2.

## GATE 1 — Empirical implementation path PROVEN

Per `[[feedback_runtime_verification_mandatory]]` 2-gates doctrine :

| Evidence | Result |
|---|---|
| LIVE curl 4 audit fixtures post-PR-#763 | 4/4 H1 finissent par `au meilleur prix` (régression confirmée) |
| Grep `PiecesVehicleContent.tsx:233-238` | `prixPasCherText` **jamais passé** → fallback figé |
| Grep `rm-builder.service.ts:614-630` | `ctx.comp_switches['2']` chargé via `loadSeoCtxSwitches` mais non exposé dans `legacySeo` |
| Query `__seo_gamme_car_switch` (Phase 1) | 1000 rows alias=2 / 396 distinctes / ~15 par pg_id (ex. pg_id=307 : `synchroniser les soupapes`, `entraîner la pompe à eau`, `optimiser les performances`) |

→ **PATH_PROVEN** : exposer `compSwitch2` côté backend + câbler dans `PiecesHeader.tsx` via shared helper résout les 2 problèmes.

## Implementation (3 maillons, 6-7 fichiers)

### 1) Shared package `@repo/seo-types`

- **CREATE** `packages/seo-types/src/seo-variations.ts` (~75 LOC)
  - `pickH1Suffix({ compSwitch2, priceVariations, ctx, literalFallback })` : chaîne fallback déterministe
  - `selectFromPool(pool, ctx, offset)` : rotation `(typeId + pgId + offset) % length`
  - `SEO_PRICE_VARIATIONS` (7 variantes) constant local — **PAS exposé via API**
  - `normalizeSuffix` strip ponctuation finale + collapse whitespace
- **CREATE** `packages/seo-types/src/seo-variations.test.ts` (12 node tsx tests verts)
- Export via `index.ts` + `package.json` exports map

### 2) Backend exposure (zero new query)

- **MODIFY** `backend/src/modules/rm/rm.types.ts` : ajoute `RmSeoData.compSwitch2?: string[]`
- **MODIFY** `backend/src/modules/rm/services/rm-builder.service.ts` : ajoute `compSwitch2: ctx.comp_switches?.['2'] ?? []` dans `legacySeo`
- `ctx.comp_switches` déjà chargé via `loadSeoCtxSwitches(pgId, gammeName)` — aucune nouvelle query DB

### 3) Frontend wiring (propagation surgical)

- **MODIFY** `frontend/app/services/api/rm-api.service.ts` `RmSeoData` : ajoute champ `compSwitch2?`
- **MODIFY** `frontend/app/types/pieces-route.types.ts` `SEOInfo` : ajoute champ `compSwitch2?`
- **MODIFY** `frontend/app/utils/rm-mapper.ts` `mapSeoInfo` : propage `seo.compSwitch2 ?? []`
- **MODIFY** `frontend/app/utils/pieces-vehicle.loader.server.ts` : passe `compSwitch2` dans le `seo:` block
- **MODIFY** `frontend/app/components/pieces/PiecesHeader.tsx` :
  - Import `pickH1Suffix` + `SEO_PRICE_VARIATIONS` depuis `@repo/seo-types`
  - Remplace `finalText = prixPasCherText || "au meilleur prix"` par `pickH1Suffix(...)`
  - Ajoute prop `compSwitch2?: readonly string[]`
- **MODIFY** `frontend/app/components/pieces/PiecesVehicleContent.tsx` : passe `compSwitch2={data.seo?.compSwitch2}`

## Coverage (combined PR #762 + #763 + #764)

| Surface | PR #762 | PR #763 | This PR | Total |
|---|---|---|---|---|
| R2 `<h1>` visible (typeName enriched) | ❌ | ✅ | maintenu | ✅ |
| R2 `<h1>` visible (suffix rotation) | ❌ | ❌ (figé) | ✅ | ✅ |
| R2 `<title>` HEAD pg_ids template (1.2%) | ✅ | maintenu | maintenu | ✅ |
| R2 `<title>` HEAD pg_ids fallback (98.8%) | ❌ | ✅ | maintenu | ✅ |
| R2 `<meta description>` (PR #665) | intact | intact | intact | ✅ |

## Test plan

- [x] **12/12 node tsx tests** `seo-variations.test.ts` (rotation déterministe + 4 fixtures distinct + normalizeSuffix + fallback chain + idempotence)
- [x] **55/55 Jest backend regression** `src/modules/catalog/services/__tests__/` (composer + seo-template-switch + vehicle-aware-label)
- [x] **0 erreur TS sur fichiers modifiés** (`tsc --noEmit` filtré)
- [x] **0 erreur ESLint** sur fichiers modifiés
- [ ] CI green (à vérifier après push)
- [ ] Post-tag deploy LIVE PROD GATE 2 verdict `LIVE_CONFIRMED` :
  - `cf-cache-status: MISS/BYPASS/EXPIRED` (4/4 — sinon owner CF purge ciblée)
  - H1 4/4 ne finit **plus tous** par `au meilleur prix`
  - ≥**3 suffixes distincts** sur 4 fixtures (rotation déterministe vérifiée)
  - `<title>` reste distinct + motorisation enrichie (non-régression PR #763)
- [ ] J+7 mini-audit 20 paires R2 → rotation déterministe + signal qualité wording legacy

## Scope strict (verrouillé)

| Inclus | Exclu |
|---|---|
| Shared helper `pickH1Suffix` + tests | priceVariations exposé via API |
| Backend `compSwitch2` field optional + 1 LOC expose | DB / migrations / RPC SQL changes |
| Frontend propagation + 1 prop + 1 helper call | R8 / payments / canonical / routes |
| GATE 1 PROVEN + GATE 2 LIVE H1+title obligatoire | `composeVehicleAwareDescription` (PR #665) intact |
| | Templates DB `__seo_gamme_car` (lecture only via existing path) |
| | Switches `__seo_item_switch`/`__seo_gamme_car_switch` (lecture seule via existing `loadCompSwitches`) |

## Risque résiduel monitor post-deploy

Wording legacy `sgcs_alias=2` peut paraître grammaticalement brutal en suffix H1 (`synchroniser les soupapes`, `entraîner la pompe à eau`). Per owner correction : monitor LIVE 4 fixtures, si phrases vraiment incohérentes → V1.5+ bascule `SEO_PRICE_VARIATIONS` primary (out-of-scope cette PR).

## Références

- Audit empirique : `audit/seo-h1-meta-empirical-verification-2026-05-26.md`
- PR shipped : #762 (backend disambiguation) + #763 (frontend disambiguation LIVE_CONFIRMED 4/4)
- Doctrine canon : `[[feedback_runtime_verification_mandatory]]` 2-gates
- Plan : `~/.claude/plans/les-h1-et-meta-whimsical-waterfall.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)