### PR TITLE
fix(seo): r2 alternatives — surface upstream failure + short-TTL empty (closes #769)

### DIFF
--- a/frontend/app/utils/pieces-vehicle.loader.server.ts
+++ b/frontend/app/utils/pieces-vehicle.loader.server.ts
@@ -254,49 +254,43 @@ export async function piecesVehicleLoader({
       `🔄 [NO_PRODUCTS] 0 produits, page alternatives pour: /pieces/${gammeData.alias}-${gammeId}.html`,
     );
 
-    // Fetch alternatives en parallele (autres gammes pour ce vehicule + autres vehicules pour cette gamme)
-    const alternativesData = await fetchJsonOrNull<{
+    // Fetch alternatives — distinguish transient upstream failure from
+    // genuine empty so each gets the right cache policy downstream.
+    // `fetchJsonOrNull` would conflate both into `null`, leading to silent
+    // long-TTL caching of a transient blip (canon: no silent fallback).
+    type RmAlternativesResponse = {
       success: boolean;
       version?: 'v2';
       etag?: string;
-      alternativeGammes: Array<{
-        pg_id: number;
-        pg_name: string;
-        pg_alias: string;
-        pg_pic: string | null;
-        piece_count: number;
-        tier: 1 | 2 | 3;
-      }>;
-      alternativeVehicles: Array<{
-        type_id: string;
-        type_name: string;
-        type_alias: string | null;
-        type_fuel: string;
-        type_power_ps: string;
-        type_year_from: string;
-        type_year_to: string;
-        modele_id: number;
-        modele_name: string;
-        modele_alias: string;
-        marque_id: number;
-        marque_name: string;
-        marque_alias: string;
-        tier: 1 | 2 | 3;
-      }>;
-      relatedModels: Array<{
-        modele_id: number;
-        modele_name: string;
-        modele_alias: string;
-        marque_id: number;
-        marque_name: string;
-        marque_alias: string;
-        representative_type_id: string;
-        representative_type_alias: string;
-      }>;
-    }>(
-      `http://127.0.0.1:3000/api/rm/alternatives?gamme_id=${gammeId}&type_id=${vehicleIds.typeId}&limit=12`,
-      3000,
-    );
+      alternativeGammes: NoProductsData['alternativeGammes'];
+      alternativeVehicles: NoProductsData['alternativeVehicles'];
+      relatedModels: NoProductsData['relatedModels'];
+    };
+    let alternativesData: RmAlternativesResponse | null = null;
+    let alternativesFetchOk = false;
+    try {
+      const altResp = await fetch(
+        `http://127.0.0.1:3000/api/rm/alternatives?gamme_id=${gammeId}&type_id=${vehicleIds.typeId}&limit=12`,
+        {
+          headers: { Accept: 'application/json' },
+          signal: AbortSignal.timeout(3000),
+        },
+      );
+      if (altResp.ok) {
+        alternativesData = (await altResp.json()) as RmAlternativesResponse;
+        alternativesFetchOk = true;
+      } else {
+        logger.warn(
+          `[R2_ALTS_FETCH_NON_OK] gamme=${gammeId} type=${vehicleIds.typeId} status=${altResp.status}`,
+        );
+      }
+    } catch (e) {
+      logger.warn(
+        `[R2_ALTS_FETCH_FAILED] gamme=${gammeId} type=${vehicleIds.typeId}: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+    }
 
     // Construire le label vehicule lisible depuis les params URL
     const vehicleLabel = [rawMarque, rawModele, rawType]
@@ -330,6 +324,23 @@ export async function piecesVehicleLoader({
       /* swallow: jamais bloquant */
     });
 
+    const alternativeGammes = alternativesData?.alternativeGammes ?? [];
+    const alternativeVehicles = alternativesData?.alternativeVehicles ?? [];
+    const relatedModels = alternativesData?.relatedModels ?? [];
+    const hasAlternatives =
+      alternativeGammes.length + alternativeVehicles.length + relatedModels.length > 0;
+
+    // Canon: cache TTL must reflect payload confidence — no silent fallback,
+    // no long-TTL on error paths (feedback_no_long_ttl_cache_on_error_paths).
+    //   upstream fetch failed  → no-store (don't poison CDN, recover next req)
+    //   genuine empty payload  → ≤30s   (fast recovery if alts become available)
+    //   populated              → 1h CDN as designed
+    const cacheControl = !alternativesFetchOk
+      ? "no-store, must-revalidate"
+      : hasAlternatives
+        ? "public, max-age=300, s-maxage=3600"
+        : "public, max-age=30, s-maxage=30";
+
     return json(
       {
         noProducts: true as const,
@@ -339,14 +350,14 @@ export async function piecesVehicleLoader({
           rmV2Response?.gamme?.pg_name || gammeData.alias.replace(/-/g, " "),
         vehicleLabel,
         vehicleContext,
-        alternativeGammes: alternativesData?.alternativeGammes ?? [],
-        alternativeVehicles: alternativesData?.alternativeVehicles ?? [],
-        relatedModels: alternativesData?.relatedModels ?? [],
+        alternativeGammes,
+        alternativeVehicles,
+        relatedModels,
       } satisfies NoProductsData,
       {
         headers: {
           "X-Robots-Tag": "noindex, follow",
-          "Cache-Control": "public, max-age=300, s-maxage=3600",
+          "Cache-Control": cacheControl,
         },
       },
     );


### PR DESCRIPTION
## Summary

- Closes #769 — R2 soft-404 alternatives page served empty in PROD due to CDN cache poisoning.
- Root cause: `fetchJsonOrNull` collapses transient upstream failure and genuine empty into the same `null`, and the loader sent both with `s-maxage=3600`. A single timeout on `/api/rm/alternatives` could pin an empty HTML in Cloudflare for 1h.
- Canon-aligned fix: three discrete outcomes, three cache policies, no silent fallback, no long-TTL on error paths.

## Reproduction (PROD before fix)

```bash
$ curl -sI 'https://www.automecanik.com/pieces/alternateur-4/bmw-33/serie-5-e60-33052/530-i-phase-2-16023.html'
HTTP/2 200
cache-control: public, max-age=7200, s-maxage=3600, stale-while-revalidate=3600
x-robots-tag: noindex, follow
cf-cache-status: HIT
age: 134

# canonical URL → 0 alternative links in body
$ curl -s '...530-i-phase-2-16023.html' \
    | grep -oE '/pieces/alternateur-4/bmw-33/[a-z0-9-]+-[0-9]+/[a-z0-9-]+-[0-9]+\.html' \
    | sort -u
(nothing)

# cache-bust → MISS → 6 vehicles + 8 gammes + 4 models rendered
$ curl -s '...530-i-phase-2-16023.html?cb=fresh' \
    | grep -oE '/pieces/alternateur-4/bmw-33/[a-z0-9-]+-[0-9]+/[a-z0-9-]+-[0-9]+\.html' \
    | sort -u
/pieces/alternateur-4/bmw-33/serie-3-e46-33027/330-xi-14802.html
/pieces/alternateur-4/bmw-33/serie-5-e39-33051/530-i-15271.html
/pieces/alternateur-4/bmw-33/serie-5-e60-33052/530-i-phase-1-17291.html
/pieces/alternateur-4/bmw-33/x5-e53-33075/3-0-i-17176.html
/pieces/alternateur-4/bmw-33/z3-e36-33080/3-0-i-14924.html
/pieces/alternateur-4/bmw-33/z4-e85-33082/3-0-i-16828.html
```

Live runtime API health confirmed — `GET /api/rm/alternatives?gamme_id=4&type_id=16023&limit=12` returns 6 vehicles, 8 gammes, 4 models. The bug is purely a CDN-pinned stale empty response from a past transient blip.

## Canon

- CLAUDE.md `[CRITICAL] No silent fallback` — `fetchJsonOrNull` masking transient failure as `null` is exactly the forbidden pattern.
- [`feedback_no_long_ttl_cache_on_error_paths`](MEMORY) — empty/error payloads must use `≤30s` TTL (PR #637 precedent).
- [`feedback_vehicle_page_notfound_is_404_not_503`](MEMORY) — design `200 + noindex + alternatives` for the R2 zero-products branch is preserved (per route comment L74); only the cache contract changes.

## Strategy — three outcomes, three policies

| Outcome | Detection | `Cache-Control` | Log |
|---|---|---|---|
| Upstream fetch failed (timeout, non-2xx, network) | `try/catch` on inline `fetch` + `AbortSignal.timeout(3000)` | `no-store, must-revalidate` | `logger.warn [R2_ALTS_FETCH_FAILED]` / `[R2_ALTS_FETCH_NON_OK]` |
| Payload returned, every list empty (genuine no-alts combo) | `alternativesFetchOk && hasAlternatives === false` | `public, max-age=30, s-maxage=30` | none — expected |
| Populated payload | `alternativesFetchOk && hasAlternatives` | `public, max-age=300, s-maxage=3600` | existing `[NO_PRODUCTS]` info log |

Replaces `fetchJsonOrNull` with an explicit `try/catch` so the failure mode is observable rather than swallowed.

## Surface impact

- Status code: **unchanged** (still `200` for all three branches; loader does not throw `Response`).
- `X-Robots-Tag: noindex, follow`: **unchanged** (set on every branch).
- Response body shape (`NoProductsData`): **unchanged**.
- Tracking beacon `track-soft-404`: **unchanged** (still fire-and-forget on all branches).

The only observable differences are (a) the `Cache-Control` header value and (b) two new structured `logger.warn` lines on the failure branch.

## Test plan

- [ ] CI: lint + build + frontend tests + e2e smoke green
- [ ] Post-merge runtime probe: `curl -sI <bmw-e60-530i-alternateur-url>` returns `cache-control: public, max-age=300, s-maxage=3600` once cache is refreshed; body contains the 6 vehicle links.
- [ ] Optional immediate relief: Cloudflare purge for the reported URL (natural eviction in ≤1h otherwise).
- [ ] Negative probe: hit the loader against a `(gamme, type)` pair the alternatives RPC cannot resolve (or block the API briefly via firewall) and confirm `Cache-Control: no-store, must-revalidate` is returned + warn log emitted.
- [ ] Confirm `[R2_ALTS_FETCH_FAILED]` shows up in DEV logs only when the API actually fails, never on populated/genuine-empty paths.

## OBSERVE window compatibility

Owner request explicit (corriger le bug). Change is canon-stabilization (removes a CRITICAL-tier silent fallback), surface-stable, no schema/auth/payment touch, single frontend file. Aligns with `project_observe_window_decision_matrix_20260526` carve-out for canon-correction PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)