### PR TITLE
feat(governance): vault-canon-exists CI gate V1 warn-only (INC-2026-016)

### DIFF
--- a/.github/workflows/vault-canon-exists.yml
+++ b/.github/workflows/vault-canon-exists.yml
@@ -1,0 +1,146 @@
+name: Vault Canon Exists
+# Gate mécanique ADR-060 : tout fichier monorepo référençant "canon ADR-XXX"
+# doit avoir governance-vault/ledger/decisions/adr/ADR-XXX-*.md présent en main.
+#
+# V1 = WARN-ONLY (continue-on-error + $GITHUB_STEP_SUMMARY only). Pas de sticky
+# PR comment. V2 séparée : ast-grep rule + sticky comment après preuve V1
+# fonctionne.
+#
+# Promotion vers blocking (continue-on-error: false) = PR 2 lignes après vault
+# ratifie le premier ADR via ce mécanisme (preuve qu'il accepte la résolution).
+#
+# Refs : ADR-060 (repository roles), INC-2026-016 (authority drift PR #765),
+# feedback_no_canon_claim_without_vault_adr (mémoire Layer 0).
+
+on:
+  pull_request:
+    paths:
+      - '.claude/**'
+      - '.spec/**'
+      - '.github/**'
+      - 'CLAUDE.md'
+
+permissions:
+  contents: read
+
+jobs:
+  vault-canon-exists:
+    name: Verify ADR canon references have vault backing
+    runs-on: ubuntu-latest
+    continue-on-error: true   # WARN-ONLY V1. Flip to false after vault ratifies ADR-082.
+
+    steps:
+      - name: Checkout monorepo (full history for reliable base_ref diff)
+        uses: actions/checkout@v4
+        with:
+          # fetch-depth: 0 — robustesse base_ref diff sur PRs multi-commits ou
+          # branches éloignées (Réserve 2 v2.1). Coût acceptable pour gate
+          # gouvernance peu fréquent.
+          fetch-depth: 0
+
+      - name: Checkout vault (sparse — ADR ledger only)
+        uses: actions/checkout@v4
+        with:
+          # Vault est public (confirmé via gh api repos/ak125/governance-vault
+          # --jq .private → false, 2026-05-27). Pas de PAT requis. Si le vault
+          # devient privé : ajouter token: ${{ secrets.VAULT_READ_TOKEN }}.
+          repository: ak125/governance-vault
+          path: .vault-canon-check
+          ref: main
+          sparse-checkout: |
+            ledger/decisions/adr
+          sparse-checkout-cone-mode: false
+
+      - name: Detect ADR canon references in changed files
+        id: extract
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            -- '.claude/**' '.spec/**' '.github/**' 'CLAUDE.md' 2>/dev/null || true)
+          if [ -z "$changed" ]; then
+            echo "no_changed=true" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ No changed files in scoped paths." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Pattern bidirectionnel : "(canon|canonique|doctrine|source of truth|
+          # SoT|conforme)" entoure une référence ADR-NNN, dans les deux directions.
+          #
+          # Exclusion CIBLÉE (Réserve 3 v2.1) — n'exclut QUE les lignes
+          # explicitement non-canoniques :
+          #   "proposed ADR-NNN"        → downgrade inline
+          #   "ADR-NNN ... draft"       → mention explicite draft sur même ligne
+          #   "experimental"            → status frontmatter ou banner
+          #   "advisory only"           → phrase explicite
+          # Ce qui RESTE détecté (intentionnellement) :
+          #   "Doctrine canon = ADR-099, pending ratification"
+          #   "canon ADR-099 (vault PR open)"
+          PATTERN_FORWARD='(canon|canonique|doctrine|source of truth|SoT|conforme)[^[:space:]]*[[:space:]:=]+[^[:space:]]*(ADR-[0-9]{2,3})'
+          PATTERN_REVERSE='(ADR-[0-9]{2,3})[^[:space:]]*[[:space:]]+[^[:space:]]*(canon|canonique|doctrine|source of truth|SoT|conforme)'
+          EXCLUDE='(proposed ADR-[0-9]{2,3}|ADR-[0-9]{2,3}.*draft|experimental|advisory only)'
+
+          : > .canon-refs.txt
+          for f in $changed; do
+            [ -f "$f" ] || continue
+            # Auto-exclude this workflow file and the ADR-060 self-reference itself
+            case "$f" in
+              .github/workflows/vault-canon-exists.yml) continue ;;
+            esac
+            grep -EHn -e "$PATTERN_FORWARD" -e "$PATTERN_REVERSE" "$f" 2>/dev/null \
+              | grep -vEi "$EXCLUDE" >> .canon-refs.txt || true
+          done
+
+          if [ -s .canon-refs.txt ]; then
+            echo "found_refs=true" >> "$GITHUB_OUTPUT"
+            cat .canon-refs.txt
+          else
+            echo "found_refs=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify each ADR reference exists in vault main
+        if: steps.extract.outputs.found_refs == 'true'
+        id: verify
+        shell: bash
+        run: |
+          set -euo pipefail
+          : > .vault-canon-warnings.md
+          missing_count=0
+
+          while IFS= read -r line; do
+            adr=$(echo "$line" | grep -oE "ADR-[0-9]{2,3}" | sort -u | head -1)
+            [ -z "$adr" ] && continue
+            if ! ls .vault-canon-check/ledger/decisions/adr/${adr}-*.md >/dev/null 2>&1; then
+              echo "- \`$adr\` ← $line" >> .vault-canon-warnings.md
+              missing_count=$((missing_count + 1))
+            fi
+          done < .canon-refs.txt
+
+          if [ "$missing_count" -gt 0 ]; then
+            {
+              echo "## ⚠️ Vault Canon Exists — ADR references without vault backing"
+              echo ""
+              echo "Per **[ADR-060](https://github.com/ak125/governance-vault/blob/main/ledger/decisions/adr/ADR-060-repository-roles-doctrine.md)** (vault décide → monorepo exécute) + Invariant G3, the monorepo cannot declare \`canon ADR-XXX\` without the ADR being ratified in \`governance-vault/ledger/decisions/adr/\` main (status: accepted, G3-signed)."
+              echo ""
+              echo "### Missing vault ADRs referenced as canon by this PR"
+              echo ""
+              cat .vault-canon-warnings.md
+              echo ""
+              echo "### Resolution options"
+              echo ""
+              echo "1. **Ratify** the ADR(s) in vault first (G3-signed PR), then re-run this check."
+              echo "2. **Downgrade** the references to \`proposed ADR-XXX (draft, vault pending)\` + \`status: experimental\` frontmatter."
+              echo "3. **Remove** the normative claim entirely."
+              echo ""
+              echo "Refs : vault incident **INC-2026-016** (lien \`main\` ajouté une fois l'incident mergé côté vault)."
+              echo ""
+              echo "_(V1 warn-only — ce job ne bloque pas le merge. Promotion vers blocking après preuve de fonctionnement du mécanisme.)_"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "violation=true" >> "$GITHUB_OUTPUT"
+            echo "Found $missing_count missing vault ADR(s) referenced as canon."
+            # WARN-ONLY V1 : exit 0 (continue-on-error: true le garantit aussi)
+            exit 0
+          else
+            echo "✅ All ADR canon references in this PR are backed by vault main." >> "$GITHUB_STEP_SUMMARY"
+            echo "✅ All ADR canon references backed by vault main."
+          fi


### PR DESCRIPTION
## Summary

Nouveau workflow CI **`vault-canon-exists.yml`** V1 **warn-only**. Détecte toute référence "canon ADR-XXX" dans `.claude/`, `.spec/`, `.github/`, `CLAUDE.md` qui n'a pas de fichier ADR correspondant dans `governance-vault/ledger/decisions/adr/main`.

Gate **mécanique** d'ADR-060 — restaure la **visibilité**, pas encore l'autorité (V1 = warn-only, V2 ratchet vers blocking après preuve de fonctionnement).

Lié à **vault incident INC-2026-016** (authority drift PR #765).

## Pourquoi

PR #765 a pu merger "canon ADR-082 vault" sur un ADR vault inexistant. Sans gate CI, ADR-060 reste lettre morte. Ce workflow rend l'invariant vérifiable automatiquement.

**Important** : V1 est **warn-only** (`continue-on-error: true`). Le job génère un warning dans `$GITHUB_STEP_SUMMARY` mais ne bloque jamais le merge. Le gate restaure la **visibilité**, pas encore l'**autorité** — ce sera l'étape suivante (PR follow-up 2 lignes vers blocking) après que le pipeline ait ratifié au moins un ADR via ce mécanisme.

## Contenu (1 fichier, 146 lignes)

- **`.github/workflows/vault-canon-exists.yml`** — workflow + 5 steps
  - Trigger `pull_request` paths `.claude/**`, `.spec/**`, `.github/**`, `CLAUDE.md`
  - `permissions: contents: read` (minimum nécessaire)
  - `continue-on-error: true` (warn-only V1)
  - `fetch-depth: 0` (robustesse base_ref diff)
  - Sparse-checkout vault `ledger/decisions/adr/` (~50ms ; vault confirmé public)
  - Pattern regex bidirectionnel + exclusions ciblées (`proposed ADR-XXX | ADR-XXX ... draft | experimental | advisory only`) — préserve détection de `canon X pending`
  - Auto-exclude du workflow lui-même pour éviter self-trigger
  - Output via `$GITHUB_STEP_SUMMARY` only (0 supply chain risk, pas d'action third-party)

## Test plan

- [ ] CI vert : workflow passe sur cette PR elle-même (pas de "canon ADR-XXX" sans backing dans son propre diff)
- [ ] Aucune action third-party importée (vérifier `grep -E "uses:" .github/workflows/vault-canon-exists.yml` ne contient que `actions/checkout@v4`)
- [ ] YAML valide : `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/vault-canon-exists.yml'))"` retourne 0
- [ ] Self-test post-merge : ouvrir une PR test qui ajoute `"canon ADR-099"` dans `.spec/test.md` → gate doit warn (job summary visible dans Checks UI) mais NE PAS bloquer le merge
- [ ] Contre-test : PR test avec `"proposed ADR-099 (draft)"` → pas de warn (exclusion ciblée)
- [ ] Contre-test : PR test avec `"canon ADR-031"` (ADR existant accepté) → pas de warn

## Suite (PR séparées)

- **PR V2** (séparée, après preuve V1) : ast-grep rule `.ast-grep/rules/governance-no-canon-adr-without-vault.yml` pour lint local + sticky PR comment via `marocchino/sticky-pull-request-comment@v2`
- **PR follow-up** (post-ratification ADR-082 vault) : flip `continue-on-error: true → false` (~2 lignes) — gate passe de warn-only à blocking

## Allowlist PR monorepo (INC-2026-016 Annexe B)

✅ Cette PR est **autorisée** : nouvelle détection warn-only (pas un gate bloquant immédiat).

❌ Interdit pendant ADR-082 draft vault : activation d'un gate bloquant, extension de doctrine, promotion canon, etc.

## Refs

- Vault incident : **INC-2026-016**
- ADR : ADR-060 (repository roles doctrine) + Invariant 2 G3 (ADR-015)
- PR Phase B (downgrade artefacts) : #771
- Mémoire : `feedback_no_canon_claim_without_vault_adr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)