### PR TITLE
feat(governance): vault-canon-exists v1.1 — extend scope to audit/ + docs/

### DIFF
--- a/.github/workflows/vault-canon-exists.yml
+++ b/.github/workflows/vault-canon-exists.yml
@@ -9,8 +9,20 @@ name: Vault Canon Exists
 # Promotion vers blocking (continue-on-error: false) = PR 2 lignes après vault
 # ratifie le premier ADR via ce mécanisme (preuve qu'il accepte la résolution).
 #
+# V1.1 (2026-05-28) — scope extension additive : ajout audit/** + docs/**
+# pour couvrir les artefacts dérivés du repo (verdicts, audits, rapports,
+# proposals), conformément au canon lexical fresh 2026-05-28
+# feedback_canon_vs_reference_post_inc_2026_016 : "Artefacts dérivés
+# (audit/docs/rapports/verdicts) éviter 'Schema canon'/'Skill canon',
+# préférer 'de référence'". Reste warn-only, aucune logique de scan modifiée.
+#
+# Limitation V1 connue (résolue en V2 ast-grep) : pattern regex `canon` peut
+# faussement matcher des chemins comme `.spec/00-canon/...` (folder name
+# canonique du projet, non doctrinal). V2 utilisera ast-grep markdown-aware.
+#
 # Refs : ADR-060 (repository roles), INC-2026-016 (authority drift PR #765),
-# feedback_no_canon_claim_without_vault_adr (mémoire Layer 0).
+# feedback_no_canon_claim_without_vault_adr (mémoire Layer 0),
+# feedback_canon_vs_reference_post_inc_2026_016 (mémoire Layer 0 fresh 05-28).
 
 on:
   pull_request:
@@ -19,6 +31,9 @@ on:
       - '.spec/**'
       - '.github/**'
       - 'CLAUDE.md'
+      # V1.1 — extension scope artefacts dérivés (2026-05-28)
+      - 'audit/**'
+      - 'docs/**'
 
 permissions:
   contents: read
@@ -57,7 +72,8 @@ jobs:
         run: |
           set -euo pipefail
           changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-            -- '.claude/**' '.spec/**' '.github/**' 'CLAUDE.md' 2>/dev/null || true)
+            -- '.claude/**' '.spec/**' '.github/**' 'CLAUDE.md' \
+               'audit/**' 'docs/**' 2>/dev/null || true)
           if [ -z "$changed" ]; then
             echo "no_changed=true" >> "$GITHUB_OUTPUT"
             echo "ℹ️ No changed files in scoped paths." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- V1.1 additive : étend les trigger paths de vault-canon-exists.yml (PR #772 V1) à `audit/**` + `docs/**` pour couvrir les artefacts dérivés repo, conformément au canon lexical fresh 2026-05-28 `feedback_canon_vs_reference_post_inc_2026_016`.
- Reste **warn-only** (continue-on-error: true). Aucune logique de scan modifiée. Aucune promotion blocking. Aucune V2 (ast-grep/sticky comment) — celles-ci attendent toujours la preuve in-the-wild.
- Single-purpose : V1.1 ne contient que la modif du workflow. Les 7 lignes détectées par simulation locale (4 true positives + 3 false positives) restent intactes, à traiter en PRs séparés si owner décide.

## Test plan
- [ ] CI : workflow doit se déclencher sur cette PR (`.github/**` changé) + auto-exclure lui-même + retourner PASS warn-only ("No canon refs detected")
- [ ] Verifier YAML syntactique valide (validation locale OK : `python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] Verifier git diff filter list contient bien audit/** + docs/**
- [ ] Verifier paths list ON trigger contient bien audit/** + docs/**

## Out-of-scope (single-purpose discipline)
- Downgrade lexical des 4 true positives détectés (ADR-082 doctrine claims dans 3 audit files) → owner décide PR séparé
- Annotation des 3 false positives (.spec/00-canon/ paths + 'wiki canonique' adjective) → V2 ast-grep markdown-aware
- Promotion vers blocking (continue-on-error: false) → après preuve V1+V1.1 in-the-wild

## Background
Owner ratified V1 via PR #772 (merged 2026-05-27 21:56 UTC, warn-only, scoped to .claude/.spec/.github/CLAUDE.md). The fresh 2026-05-28 doctrine update extended the lexical canon discipline to repo-derived artifacts (audit/docs/rapports/verdicts). V1.1 brings the gate in alignment.

Refs :
- PR #772 (V1 deploy)
- vault ADR-060 (status: proposed) — repository roles doctrine
- vault INC-2026-016 — authority drift root incident
- `feedback_no_canon_claim_without_vault_adr` (Layer 0 STRICT 2026-05-27)
- `feedback_canon_vs_reference_post_inc_2026_016` (Layer 0 fresh 2026-05-28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)