### PR TITLE
fix(governance): retire ADR-082 while keeping improvement skill active

### DIFF
--- a/.claude/skills/continuous-improvement-global/SKILL.md
+++ b/.claude/skills/continuous-improvement-global/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: continuous-improvement-global
-description: Use as the priority operational filter for AutoMecanik PRs, audits, scripts, pipelines, owner-actions and code changes. It checks whether the action improves a real measured problem with evidence, controlled risk, tests, and a clear next action. Non-blocking by default; proportional to risk. Triggers — "review PR", "audit this change", "validate before merge", "should I add this layer", "this looks ready", "ready to ship", "ouvrir une PR", or any request that touches code/archi/DB/contenu/SEO/conversion/pipeline.
+description: Use when reviewing any AutoMecanik PR, audit, script, pipeline, owner-action or code change as the priority operational filter — checks whether the action improves a real measured problem with evidence, controlled risk, tests, and a clear next action. Non-blocking by default; proportional to risk. Triggers — "review PR", "audit this change", "validate before merge", "should I add this layer", "this looks ready", "ready to ship", "ouvrir une PR", or any request that touches code/archi/DB/contenu/SEO/conversion/pipeline.
 type: technique
-status: active
+status: stable
 owners: ['@ak125']
 domain: D15
 runtime_class: read-only

--- a/.claude/skills/continuous-improvement-global/SKILL.md
+++ b/.claude/skills/continuous-improvement-global/SKILL.md
@@ -1,183 +1,100 @@
 ---
 name: continuous-improvement-global
-description: Use when validating any PR, pipeline, audit, script, code-change or owner-action for AutoMecanik continuous improvement compliance — produces a `## Improvement Gate` section in the PR and an `improvement-report.json` validated against `.spec/00-canon/improvement-report.schema.json` (JSON Schema 2020-12 Draft, 9 verdicts enum). Apply systematically before any merge, deploy, refactor, layer-addition, or owner validation — even when the user doesn't explicitly say "validate" or "improve". Triggers — "review PR", "audit this change", "validate before merge", "should I add this layer", "this looks ready", "ready to ship", "ouvrir une PR", or any request that touches code/archi/DB/contenu/SEO/conversion/pipeline. Proposed doctrine (ADR-082 draft, vault ratification pending — see INC-2026-016).
+description: Use as the priority operational filter for AutoMecanik PRs, audits, scripts, pipelines, owner-actions and code changes. It checks whether the action improves a real measured problem with evidence, controlled risk, tests, and a clear next action. Non-blocking by default; proportional to risk. Triggers — "review PR", "audit this change", "validate before merge", "should I add this layer", "this looks ready", "ready to ship", "ouvrir une PR", or any request that touches code/archi/DB/contenu/SEO/conversion/pipeline.
 type: technique
-status: experimental
+status: active
 owners: ['@ak125']
 domain: D15
 runtime_class: read-only
 llm_safe: true
-last_verified: '2026-05-27'
-metadata:
-  vault_ratification: pending
-  vault_adr_ref: "ADR-082 draft, branch adr/082-continuous-improvement-doctrine, NOT in vault main"
-  vault_incident_ref: "INC-2026-016"
+last_verified: '2026-05-28'
 ---
 
 # Skill : continuous-improvement-global
 
-> ⚠️ **EXPERIMENTAL — DO NOT TREAT AS CANON**
->
-> Ce skill applique une **doctrine proposée** (ADR-082) actuellement en **draft non-ratifié** dans le vault (branche `adr/082-continuous-improvement-doctrine`, pas en `main`). Conformément à [ADR-060](https://github.com/ak125/governance-vault/blob/main/ledger/decisions/adr/ADR-060-repository-roles-doctrine.md) (vault décide → monorepo exécute), ce skill **n'a pas autorité de canon** tant que la PR vault ADR-082 n'est pas mergée G3.
->
-> Usage advisory only. Aucun verdict de ce skill ne doit être traité comme bloquant.
->
-> Status tracking : vault incident **INC-2026-016** (pending owner G3 PR — lien `main` sera ajouté une fois l'incident mergé dans vault).
+## Purpose
 
-> **Filtre** opérationnel — pas un nouveau système. Doctrine proposée (ADR-082 draft, vault pending).
-> Ce skill est court par design (cf v15.2 "doctrine = filtre léger, pas couche").
+This skill is the priority operational filter for AutoMecanik decisions.
 
-## Quand utiliser
+- It does not create a governance layer.
+- It does not block automatically.
+- It helps decide whether an action is useful, measured, safe, and actionable.
 
-Dès qu'un changement AutoMecanik est envisagé (PR, pipeline, audit, script, refacto, ajout de couche, validation). Aussi quand le résultat d'un audit doit aboutir à une décision GO / NO-GO.
+## Use when
 
-**Ne pas attendre que l'utilisateur dise "validate"** — beaucoup de demandes ("est-ce que je peux merger ?", "ça a l'air prêt", "j'ajoute X ?") sont des points de décision implicites où ce filtre s'applique.
+Use for:
 
-## Procédure — 7 étapes dans cet ordre
+- PR review
+- Audit review
+- Pipeline decision
+- Owner action
+- Code change
+- SEO / content / conversion change
+- CI / config change
+- Runtime or production decision
 
-Pour chaque changement, produire **les 7 sorties suivantes** dans l'ordre. Si une étape ne peut pas être complétée honnêtement, c'est un signal — descendre le verdict (ex. PARTIAL_READY au lieu d'OPERATIONAL_READY) plutôt que d'inventer une réponse.
+Apply implicitly when the user signals an implicit decision point ("est-ce que je peux merger ?", "ça a l'air prêt", "j'ajoute X ?") — these are improvement-check moments even without the word "validate".
 
-1. **Identifier l'écart mesuré** — état actuel vs état attendu, en 1 phrase + 1 preuve concrète (log, métrique, SQL, screenshot, commande). Pourquoi : sans écart mesuré, il n'y a pas d'amélioration à valider — juste une hypothèse.
+## Default output : Improvement Check
 
-2. **Classer la priorité (P1-P6)** — P1 Survie business (cash/paiement) > P2 Acquisition (SEO/ranking) > P3 Conversion (UX/panier) > P4 Stabilité (bugs/perf) > P5 Simplification (dette) > P6 Gouvernance (doc/confort). Pourquoi : un fix SEO qui ne vend rien est moins prioritaire qu'un blocker paiement, même si l'enthousiasme du moment dit le contraire.
+For normal changes, use this lightweight format:
 
-3. **Vérifier anti-complexité (6 questions)** — peut-on **étendre** l'existant ? **simplifier** ? **fusionner** avec un mécanisme déjà présent ? **supprimer** une duplication ? **réduire** le nombre de scripts/fichiers ? obtenir le même résultat avec **moins de code** ? Si OUI à une seule question, **ne pas ajouter** une nouvelle couche — appliquer la voie qui simplifie. Pourquoi : la dette technique tue les projets plus vite que les bugs.
+- **Problem:**
+- **Evidence before:**
+- **Expected gain:**
+- **Risk:**
+- **Test:**
+- **Evidence after:**
+- **Verdict:**
+- **Next action:**
 
-4. **Vérifier non-régression** — routes existantes / panier / paiement / SEO indexé / données / pipelines critiques / CI / build / performance / UX. 0 régression introduite. Pourquoi : une "amélioration" qui casse l'existant n'est pas une amélioration — c'est une régression masquée.
+For trivial changes (typo, doc), fill only `Problem`, `Test`, `Verdict`, `Next action`.
 
-5. **Produire evidence before/after** — preuves concrètes, idéalement machine-readable (sortie commande, JSON, ligne de log, capture, query SQL avec résultat). AVANT et APRÈS sont tous les deux nécessaires. Pourquoi : sans before/after comparable, on ne sait pas si le changement a vraiment résolu quelque chose.
+For critical changes (payment, prod runtime, destructive migration, bulk SEO, RLS, auth), include stronger `Evidence before/after` and explicit rollback notes inside `Risk` and `Next action`.
 
-6. **Donner le verdict** — exactement un parmi 9 (alignés sur l'enum du JSON Schema canonique, source autoritative unique). Sémantique d'exécution v15.3 : un verdict < OPERATIONAL_READY n'est **pas un stop** — c'est un mode d'exécution prudent.
+## Verdicts
 
-   | Verdict | Sémantique | Mode exécution | Autorisé | Bloqué |
-   |---|---|---|---|---|
-   | `PASS` | gates verts, livrable OK | STABLE | tout | — |
-   | `FIX_AND_RETEST` | correction à faire mid-cycle | CONTINUE_LIMITED | retour fix-loop | scale, ratchet |
-   | `PARTIAL_READY` | test isolé OK + humain-gated explicite | **CONTINUE_LIMITED** | PR, pilot, manual gate, observation, audit, correction | scale, ratchet, automatisation large, mutations irréversibles, promotion masse |
-   | `OPERATIONAL_READY` | boucle contrôle complète + 6/6 preuves | STABLE | usage processus stable | scale large sans validation |
-   | `SCALE_READY` | OPERATIONAL + observabilité prod + robustesse | SCALE | automatiser/généraliser/ratchet CI/CI bloquant | — |
-   | `BLOCKED_OWNER` | décision humaine obligatoire | DIAGNOSTIC | observation, audit | toute action attendant la décision |
-   | `STOP_LOW_VALUE` | gain marginal < coût | DIAGNOSTIC | reporter au backlog | itérer |
-   | `STOP_TOO_COMPLEX` | coût/complexité > enveloppe | DIAGNOSTIC | simplifier scope ou abandonner | continuer comme avant |
-   | `ROLLBACK_REQUIRED` | régression détectée | CONTINUE_LIMITED (rollback) | retour arrière | suite sans rollback |
+Use one of these simple verdicts:
 
-   **Règle canon v15.3 :** *« PARTIAL_READY = avancer sans scaler. OPERATIONAL_READY = stabiliser. SCALE_READY = généraliser. »* Bloquer tout le système parce qu'un composant est PARTIAL_READY = mauvaise application doctrine.
-
-   Pourquoi : un verdict binaire force la clarté. "À revoir" n'est pas un verdict — c'est une procrastination. Mais PARTIAL_READY n'est pas une procrastination — c'est un mode d'exécution prudent qui permet de continuer à apprendre sans casser.
-
-7. **Donner la next action** — courte, concrète, owner-actionable si bloquant. Format suggéré : `[OWNER-X]` ou `[AUTO]` selon qui doit agir. Pourquoi : sans next action, la boucle s'arrête et le sujet pourrit dans le backlog.
-
-## Output (format proposé) : `improvement-report.json`
-
-Sortie machine-readable obligatoire pour toute application de ce skill sur un sujet réel (pas pour une exploration informelle). Path conventionné : `audit/<sujet>-<date>.verdict.json` ou inline dans la PR description.
-
-**Schema proposé (advisory until vault ratifies ADR-082)** : `.spec/00-canon/improvement-report.schema.json`
-
-Tout output DOIT déclarer `"$schema": "improvement-report.schema.json"` pour validation auto via `ajv-cli` (Phase 2) + auto-completion VSCode.
-
-Exemple minimal valide :
-
-```json
-{
-  "$schema": "improvement-report.schema.json",
-  "tested_entity": "filtre-a-air",
-  "scope": "global",
-  "axis": ["seo", "governance"],
-  "regression_risk": "low",
-  "anti_complexity_check": "passed",
-  "owner_required": false,
-  "status": "PASS",
-  "decision": "PASS"
-}
-```
-
-Validation locale (sans wrapper — wrapper Phase 2) :
-
-```bash
-npx --yes ajv-cli@5 validate --spec=draft2020 \
-  -s /opt/automecanik/app/.spec/00-canon/improvement-report.schema.json \
-  -d <path-to-output.json>
-```
-
-## Section PR : `## Improvement Gate`
-
-Pour toute PR importante, ajouter cette section dans la description (copier depuis `.github/PULL_REQUEST_TEMPLATE.md`) :
-
-```markdown
-<!-- IMPROVEMENT_GATE_BEGIN -->
-## Improvement Gate (proposed ADR-082 — draft, vault pending)
-- Problème mesuré :
-- Preuve avant :
-- Axe amélioré : (≥ 1 parmi business/seo/ranking/content/conversion/code/architecture/performance/security/simplification/observability/governance)
-- Priorité : P_
-- Check anti-complexité : passed / simplification_applied / new_layer_justified / failed
-- Check non-régression : (énumérer surfaces vérifiées)
-- Tests run : (commandes exactes)
-- Preuve après :
-- Verdict : (un des 9)
-- Next action :
-<!-- IMPROVEMENT_GATE_END -->
-```
-
-Les marqueurs HTML permettent la validation automatique Phase 2 (GitHub Action `improvement-gate.yml` qui grep ces balises). En Phase 1 = section textuelle seule.
-
-## SAFE intégré (dimension du score, pas couche séparée)
-
-Le contrôle SAFE est **inclus dans le score d'amélioration et dans le filtre 6 questions** (étape 5 du filtre : « Est-ce sûr ? »). Il ne crée pas de nouvelle couche, de nouveau workflow, ou de nouvelle checklist lourde.
-
-4 niveaux (champ `safe_level` du `improvement-report.json`) :
-
-| Niveau | Sémantique | Preuve attendue |
-|---|---|---|
-| `SAFE_0` | aucun risque runtime (doc, plan, mémoire, audit) | aucune preuve runtime requise |
-| `SAFE_1` | risque faible, réversible (proposal uncommitted, schema additif, edit `.md` Phase 1) | rollback path explicite (`git checkout`, `rm`) |
-| `SAFE_2` | risque moyen, preuve ciblée nécessaire (skill modif, ratchet CI informationnel, migration additive) | non-régression 9/9 + test sur cas réel |
-| `SAFE_3` | risque critique, owner decision si rollback/proof insuffisant (payment, prod runtime, migration destructive, bulk SEO) | rollback testé + preuve avant/après + owner GO explicite |
-
-**Une action est ralentie SEULEMENT si** : surface critique touchée AND (risque de casse > gain OR rollback absent OR preuve non-régression insuffisante). Sinon SAFE reste un signal léger non-bloquant.
-
-**Règle canon :** *« SAFE n'est pas un frein. SAFE est le calcul intelligent du risque dans le score d'amélioration. »*
-
-## Filtre 6 questions : soft signal, pas hard gate (clarification v15.4 — owner decision 2026-05-27, review PR #765 finding C5)
-
-> *« Les 6 questions filtre ne sont pas un blocage mécanique. Elles servent à classifier le risque et la valeur. Une action peut continuer avec des NO si la justification, le score, le SAFE level et le coût/gain restent acceptables. »*
-
-Calibration :
-
-| Pattern | Décision |
+| Verdict | When |
 |---|---|
-| 6/6 OUI + score HIGH_VALUE + SAFE_0/1 | go vert clair, PASS ou OPERATIONAL_READY si preuves |
-| 4-5/6 OUI + score MEDIUM/HIGH + SAFE_1/2 | go prudent, PARTIAL_READY / CONTINUE_LIMITED |
-| 2-3/6 OUI + score LOW + SAFE_2/3 | challenge fort, justification owner ou défer |
-| 0-1/6 OUI ou score DANGEROUS_COMPLEXITY ou SAFE_3 sans preuve | STOP_LOW_VALUE / STOP_TOO_COMPLEX / BLOCKED_OWNER |
+| `GO` | useful, measured, low risk, tests pass → proceed |
+| `GO_WITH_WATCH` | proceed but monitor a specific signal post-merge |
+| `FIX_AND_RETEST` | small correction needed, then re-run the check |
+| `OWNER_DECISION` | non-trivial trade-off — owner must arbitrate before action |
+| `STOP_LOW_VALUE` | gain marginal vs cost → backlog or drop |
+| `STOP_TOO_COMPLEX` | cost / complexity > envelope → simplify scope or abandon |
+| `ROLLBACK_REQUIRED` | regression detected → revert before continuing |
 
-Le filtre n'est jamais un blocage automatique d'un seul NON. Il informe le verdict (étape 6 de la procédure), il ne le décide pas seul. Cf application empirique Pilot #2 (2 NOs `prioritaire`+`rapproche_business` mais score MEDIUM + SAFE_2 → PARTIAL_READY justifié — SAFE level post-correction finding C4, recovery via replay/backup, pas git rollback).
+## Risk modes
 
-## Anti-patterns à bloquer
+The check scales with risk. Pick one mode per change:
 
-- **Pivot pour éviter un blocker** — si filtre-a-air échoue, ne pas dire "essayons capteur-abs"
-- **Sur-loop sans gain marginal** — > 3 cycles sans convergence ⇒ verdict `BLOCKED_OWNER` ou `STOP_TOO_COMPLEX`
-- **Scale sans pilote `OPERATIONAL_READY`** — bulk, mass-automation, ratchet CI, publication SEO large, génération volume = interdits avant ≥1 pilote prouvé
-- **"Improvement" qui casse l'existant** — verdict `ROLLBACK_REQUIRED`
-- **Ajout de couche quand simplification possible** — relire les 6 questions anti-complexité
-- **Isolation SEO seule** — le ranking est conséquence d'un système global sain, pas d'une machine SEO
+| Mode | Surface | What to fill |
+|---|---|---|
+| **Lite** | doc, plan, audit, small reversible config | Problem, Test, Verdict, Next action |
+| **Standard** | product feature, SEO, conversion, CI / workflow change | full 8 fields |
+| **Full** | DB, auth, RLS, payment, production runtime, bulk SEO, destructive migration | full 8 fields + explicit rollback + owner GO when in doubt |
 
-## Références
+## Rules
 
-- **ADR-082 vault** `governance-vault/ledger/decisions/adr/ADR-082-global-continuous-improvement-doctrine.md` — loi complète (5 types d'amélioration / 11 effets valides / 6 questions filtre / hiérarchie P1-P6 / formule AVANT/ACTION/APRÈS / 9 critères non-régression / règle d'or "utile, mesurable, bornée — sinon dette")
-- **JSON Schema** `.spec/00-canon/improvement-report.schema.json` — format machine proposé (Draft 2020-12, enum 9 verdicts ; statut normatif pending ADR-082 vault ratification)
-- **PR template** `.github/PULL_REQUEST_TEMPLATE.md` — section `## Improvement Gate` à remplir
+- Prefer **action over documentation** — a small shipped fix beats a written plan.
+- Prefer **extending existing mechanisms** over new layers (cf. anti-bricolage rules).
+- **No new workflow** unless repeated manual use has proven value (≥3 real PRs).
+- **No blocking gate** unless the owner explicitly promotes it.
+- A failed pilot must create a **fix-and-retest loop**, not just a write-up.
+- The `Next action` must be **concrete** (owner, file, command, or decision — not "to be defined").
+- "Improvement" that breaks existing surface = `ROLLBACK_REQUIRED`, never silently pivot to another topic.
 
-Ce skill = procédure courte. ADR = loi. Schema = format machine. PR template = enforcement.
+## Anti-patterns
 
-**Phase 1 v15.3+v15.4** : ce skill est livré seul (pas de `_scripts/` ni `references/`).
+- **Pivot to dodge a blocker** — if X fails, do not silently switch to Y to inflate the win rate.
+- **Over-loop without convergence** — more than 3 cycles without a result ⇒ `OWNER_DECISION` or `STOP_TOO_COMPLEX`.
+- **Scale before a working pilot** — bulk / mass-automation / ratchet CI / large SEO publication require ≥1 proven pilot.
+- **Adding a layer when a simpler path exists** — re-read the rules above; extension > creation.
 
-**Phase 2 v15.4 — découpée en micro-ajouts prouvés (owner-gated, jamais en bloc)** :
-- **2A** : wrapper `validate-improvement-report.sh` (ajv-cli) — éligible si validation JSON Schema déjà répétée ≥2× manuellement
-- **2B** : `references/checklist.md` (lazy-load) — éligible si SKILL.md sature context budget
-- **2C** : GitHub Action `improvement-gate.yml` informationnel non-bloquant — éligible après ≥1 PR réelle utilisant Improvement Gate
-- **2D conditionnel** : vault policy séparée — éligible si ADR jugée insuffisante
+## Notes
 
-Phase 3 ratchet bloquant nécessite 5 critères cumulatifs (≥3-5 PRs + <10 min friction + 0 false blocker + ≥1 vraie erreur captée + owner GO).
-
-**Phrase canon v15.4 (révisée 2026-05-27, review PR #765 finding I6+NEW-I3)** : *« Deux pilots ont survécu sans casser la doctrine. Cela ne prouve pas l'absence de biais (N=2 ≠ preuve statistique — promotion vers `DOCTRINE_NON_BIASED_CONFIRMED` requiert N≥5 cross-domain + tests falsification définis, cf `audit/doctrine-v15-3-cross-validation-2026-05-26.md`). Mais c'est suffisant pour continuer à l'utiliser ; pas suffisant pour rendre le gate bloquant. »*
+- This skill is intentionally short.
+- Historical schema `.spec/00-canon/improvement-report.schema.json` is kept for prior `audit/*.verdict.json` files; it is not required for new Improvement Checks.
+- PR template `.github/PULL_REQUEST_TEMPLATE.md` exposes the same lightweight `Improvement Check` block.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Template PR AutoMecanik — créé en Phase 1 v15.2 (ADR-082 draft, advisory only). See vault incident INC-2026-016 — ADR-082 not yet ratified in governance-vault main. -->
+<!-- Template PR AutoMecanik — lightweight Improvement Check (see .claude/skills/continuous-improvement-global/SKILL.md). Non-blocking, proportional to risk. -->
 
 ## Summary
 
@@ -18,28 +18,21 @@
 
 ---
 
-<details>
-<summary><strong>[OPTIONAL — EXPERIMENTAL]</strong> Improvement Gate (proposed ADR-082 — draft, vault pending)</summary>
+## Improvement Check
 
-<!-- IMPROVEMENT_GATE_BEGIN — EXPERIMENTAL: ADR-082 not yet ratified in governance-vault main (only draft branch adr/082-continuous-improvement-doctrine). See vault incident INC-2026-016. Per ADR-060, this section is advisory only. Remplir uniquement si la PR souhaite documenter son rapport d'amélioration au format ADR-082-proposed. Markers preserved for future workflow if/when ratified. -->
+<!-- Lightweight operational filter (see .claude/skills/continuous-improvement-global/SKILL.md).
+     For trivial changes (typo, doc) fill only: Problem, Test, Verdict, Next action.
+     For critical changes (DB / auth / RLS / payment / prod runtime / bulk SEO / destructive migration)
+     include stronger Evidence before/after and explicit rollback notes. -->
 
-Pour toute PR importante (code / archi / pipeline / contenu / SEO / DB / migration / config), répondre aux 7 questions du filtre. Le skill `continuous-improvement-global` (`.claude/skills/continuous-improvement-global/SKILL.md`) peut générer un `improvement-report.json` validé contre `.spec/00-canon/improvement-report.schema.json` (JSON Schema 2020-12). Pour PR triviale (typo, doc), indiquer **Verdict : PASS** et ignorer les autres champs.
-
-- **Problème mesuré :**
-- **Preuve avant :** <!-- log / metric / SQL / screenshot — sinon CONCEPTUEL au mieux -->
-- **Axe amélioré :** <!-- ≥ 1 parmi : business / seo / ranking / content / conversion / code / architecture / performance / security / simplification / observability / governance -->
-- **Priorité (P1-P6) :** <!-- P1 Survie business > P2 SEO > P3 Conversion > P4 Stabilité > P5 Simplification > P6 Gouvernance -->
-- **Check anti-complexité :** <!-- passed / simplification_applied / new_layer_justified / failed — voir 6 questions skill -->
-- **Check non-régression :** <!-- routes / panier / paiement / SEO indexé / données / CI / build / perf / UX -->
-- **SAFE level :** <!-- SAFE_0 aucun risque runtime / SAFE_1 faible réversible / SAFE_2 moyen preuve ciblée / SAFE_3 critique owner GO. Dimension du score, pas couche. -->
-- **Tests run :** <!-- commandes exactes + sortie -->
-- **Preuve après :** <!-- lien -->
-- **Verdict :** <!-- PASS / FIX_AND_RETEST / PARTIAL_READY / OPERATIONAL_READY / SCALE_READY / BLOCKED_OWNER / STOP_LOW_VALUE / STOP_TOO_COMPLEX / ROLLBACK_REQUIRED -->
-- **Next action :** <!-- courte, owner-actionable si bloquant -->
-
-<!-- IMPROVEMENT_GATE_END -->
-
-</details>
+- **Problem:**
+- **Evidence before:**
+- **Expected gain:**
+- **Risk:**
+- **Test:**
+- **Evidence after:**
+- **Verdict:** <!-- GO / GO_WITH_WATCH / FIX_AND_RETEST / OWNER_DECISION / STOP_LOW_VALUE / STOP_TOO_COMPLEX / ROLLBACK_REQUIRED -->
+- **Next action:**
 
 ---
 

--- a/.spec/00-canon/improvement-report.schema.json
+++ b/.spec/00-canon/improvement-report.schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "improvement-report.schema.json",
-  "$comment": "EXPERIMENTAL — ADR-082 not yet ratified in governance-vault main (only draft branch adr/082-continuous-improvement-doctrine exists). See vault incident INC-2026-016. Per ADR-060 (vault decides, monorepo executes), this schema is advisory until G3-signed vault PR merges ADR-082. DO NOT treat verdicts as blocking.",
-  "title": "Improvement Report v1 (proposed ADR-082 — draft, vault pending)",
-  "description": "Schema proposé pour tout improvement-report.json produit par un pipeline / PR / audit AutoMecanik. **Advisory only** tant que ADR-082 reste en draft vault (branche adr/082-continuous-improvement-doctrine). Conformément à ADR-060, le monorepo n'a pas autorité pour déclarer un schéma 'canon' sans backing vault. Voir vault incident INC-2026-016. Cohérent avec enrichment-report.schema.json (même path .spec/00-canon/, même style $id court relatif). 9 verdicts currently represented via enum; normative status pending ADR-082 vault ratification. Cf .claude/skills/continuous-improvement-global/SKILL.md pour la méthode opérationnelle.",
+  "$comment": "Deprecated as a mandatory gate. Kept only as a structural reference for historical audit/*.verdict.json files. The active operational filter is .claude/skills/continuous-improvement-global/SKILL.md (lightweight Improvement Check, non-blocking).",
+  "title": "Improvement Report v1 (historical — kept for prior audit files)",
+  "description": "Structure used by historical improvement-report.json files under audit/. Not required for new Improvement Checks — the active operational filter is .claude/skills/continuous-improvement-global/SKILL.md, which uses a lightweight non-blocking format. This schema is kept so that prior audit/*.verdict.json files still validate; do not extend it without owner decision.",
   "type": "object",
   "additionalProperties": true,
   "required": [


### PR DESCRIPTION
## Summary

This PR retires ADR-082 as an active governance dependency while keeping the continuous improvement skill active and operational.

The goal is to remove the confusing doctrine/vault/canon layer (which was already downgraded to experimental in #771 after INC-2026-016) and preserve the useful execution filter: **problem → evidence → risk → test → result → next action**.

Aligned with [[feedback_no_canon_claim_without_vault_adr]] (monorepo never claims canon ADR-XXX without vault G3) and [[feedback_canon_vs_reference_post_inc_2026_016]] (derived artefacts prefer "de référence" / advisory wording).

## Changes

- `.claude/skills/continuous-improvement-global/SKILL.md` — rewritten: `status: active` (no longer experimental), no ADR-082 / INC-2026-016 / vault-pending wording, lightweight 8-field Improvement Check format, 7 simple verdicts, 3 risk modes (Lite / Standard / Full).
- `.github/PULL_REQUEST_TEMPLATE.md` — `Improvement Gate (proposed ADR-082)` block replaced by lightweight `Improvement Check` block (non-blocking, proportional to risk).
- `.spec/00-canon/improvement-report.schema.json` — `$comment` / `title` / `description` soft-deprecate the schema (kept structurally for the 3 historical `audit/*.verdict.json` files that reference it; not required for new Improvement Checks). Structure itself is unchanged — historical files still validate (verified locally via `ajv-cli + ajv-formats`).

## Out of scope

- No runtime code change
- No SEO / R2 / commerce-loop change
- No DB / migration change
- No vault change (separate action if needed)
- No new workflow / no blocking CI gate / no ratchet
- No cleanup of historical `audit/*.md` or `audit/*.json` files
- Schema file kept (not deleted) so existing audit reports remain validatable

## Test plan

- [x] `git grep` confirms zero `ADR-082` / `adr-082` / `Improvement Gate` / `INC-2026-016` / `experimental` in the three modified files.
- [x] `git grep "Improvement Check"` returns hits in both SKILL.md and the PR template.
- [x] `git diff --stat` shows exactly 3 files changed (within the user's "max 3" budget).
- [x] `node -e "JSON.parse(...)"` confirms updated schema is still valid JSON.
- [x] `ajv validate -c ajv-formats` confirms the three historical `audit/*.verdict.json` files still validate against the updated schema.

## Improvement Check

- **Problem:** ADR-082 created confusion between an operational improvement skill and a governance doctrine; after #771 downgraded it to `experimental`, the skill ended up labelled "DO NOT TREAT AS CANON" and "advisory only", which weakened the intended priority filter without removing the friction.
- **Evidence before:** SKILL.md frontmatter `status: experimental` + bandeau `⚠️ EXPERIMENTAL — DO NOT TREAT AS CANON` + PR template wrapped in `<details>[OPTIONAL — EXPERIMENTAL]</details>` Improvement Gate referencing ADR-082 draft + schema title `Improvement Report v1 (proposed ADR-082 — draft, vault pending)`.
- **Expected gain:** Keep the useful operational filter (8-field check, simple verdicts, risk modes) while removing the governance/vault/canon layer that made it unclear and discouraged use.
- **Risk:** Low. Documentation / skill / template only. No runtime code, no DB, no workflow, no CI gate added. Historical schema kept structurally identical so prior verdict JSONs still validate.
- **Test:** See Test plan above (5 checks, all green locally).
- **Evidence after:** SKILL.md `status: active`, no ADR-082 anywhere in the three active files, PR template exposes a plain `## Improvement Check` block, schema `$comment` soft-deprecates it.
- **Verdict:** GO_WITH_WATCH
- **Next action:** Use the simplified Improvement Check on the next real PR and observe whether it improves decision quality without slowing execution. If the lightweight format is filled meaningfully on 2-3 PRs, keep; if it is skipped or feels like noise, simplify further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
