### PR TITLE
fix(wiki-bootstrap): harden decision_brief source quality before export

### DIFF
--- a/scripts/wiki-generators/promote-raw-gammes-to-wiki.py
+++ b/scripts/wiki-generators/promote-raw-gammes-to-wiki.py
@@ -350,6 +350,21 @@ OEM_REF_RE = re.compile(r'\b[A-Z]?\d{5,10}[A-Z]?\b')
 FUNCTION_HINT_RE = re.compile(
     r'(?i)^(.*?(?:permet|sert à|assure|régule|recycle|filtre|alimente|charge|protège|réduit|améliore).{20,200})'
 )
+# Issue 1 fix : preamble marketing rejection. The OEM web corpus often opens with
+# generic catalog/marketing blurbs (cf. ngk-*.md "Notre catalogue 2025-2026...
+# qui vous permet de trouver vos références") that match FUNCTION_HINT_RE on
+# "permet" but describe the e-commerce experience, not the part function. Lines
+# matching this blocklist are skipped when scanning for the function statement.
+FUNCTION_MARKETING_BLOCKLIST_RE = re.compile(
+    r'(?i)(catalogue|découvrez|promo|soldes|boutique|achat\s+en\s+ligne|'
+    r'version\s+digitale|simplifier la vie|fonctionnalités conçues|en\s+ligne\.|'
+    r'votre\s+sélection)'
+)
+# Issue 2 fix : RAW frontmatter slug-pattern enforcement. Some RAW files put
+# free-text in related_parts (e.g. plaquette-de-frein has
+# "Disques de frein (a controler systematiquement...)" instead of "disques-de-frein").
+# The wiki schema requires `^[a-z0-9][a-z0-9-]*[a-z0-9]$`. Defensive filter.
+SLUG_RE = re.compile(r'^[a-z0-9][a-z0-9-]*[a-z0-9]$')
 
 
 def classify_source_tier(domain, frontmatter=None):
@@ -448,14 +463,28 @@ def extract_dimensions(raw, web_corpus, compatibility_url_data=None):
 
     all_web_body = "\n".join(w.get("body", "") for w in web_corpus)
 
-    # function : candidate from RAG domain.role + confirmed from OEM web FUNCTION_HINT_RE
+    # function : candidate from RAG domain.role + confirmed from OEM web FUNCTION_HINT_RE.
+    # Issue 1 fix (2026-05-28) : line-by-line scan with marketing-preamble rejection.
+    # Some OEM corpus pages (e.g. ngk-*.md for vanne-egr) open with catalog blurbs that
+    # match FUNCTION_HINT_RE on "permet" but describe e-commerce, not part function.
+    # We now scan body line-by-line, skip lines matching FUNCTION_MARKETING_BLOCKLIST_RE,
+    # and take the first non-marketing line that matches FUNCTION_HINT_RE.
     rag_function = (dom.get("role") or "").strip()
     web_function, web_function_uri = "", None
     for w in web_corpus:
-        m = FUNCTION_HINT_RE.search(w.get("body", "")[:2000])
-        if m:
-            web_function = m.group(1).strip()[:280]
-            web_function_uri = w.get("source_uri")
+        body = w.get("body", "")[:2000]
+        for line in body.split("\n"):
+            line = line.strip()
+            if len(line) < 30:
+                continue
+            if FUNCTION_MARKETING_BLOCKLIST_RE.search(line):
+                continue  # marketing preamble, skip
+            m = FUNCTION_HINT_RE.search(line)
+            if m:
+                web_function = m.group(1).strip()[:280]
+                web_function_uri = w.get("source_uri")
+                break
+        if web_function:
             break
     function = _dim_with_status(rag_function, web_function, is_cand, web_function_uri)
 
@@ -479,8 +508,16 @@ def extract_dimensions(raw, web_corpus, compatibility_url_data=None):
             break
     symptoms = _dim_with_status(rag_sym, web_sym, is_cand)
 
-    # related_parts : taxonomic, always safe (slugs only)
-    related_parts = list(safe_tax.get("related_parts", []) or [])
+    # related_parts : taxonomic, always safe (slugs only).
+    # Issue 2 fix (2026-05-28) : defensive filter against RAW frontmatter quality issues.
+    # Some RAW files put human-readable free-text (e.g. plaquette-de-frein has
+    # "Disques de frein (a controler systematiquement...)") instead of slugs. The wiki
+    # schema requires pattern `^[a-z0-9][a-z0-9-]*[a-z0-9]$`. We filter out non-slugs
+    # to avoid schema validation failures downstream. Upstream RAW frontmatter should
+    # be fixed separately (out of scope here).
+    related_parts_raw = list(safe_tax.get("related_parts", []) or [])
+    related_parts = [s for s in related_parts_raw if isinstance(s, str) and SLUG_RE.fullmatch(s)]
+    related_parts_filtered_count = len(related_parts_raw) - len(related_parts)
 
     # compatibility_factors : web extraction (factuel motorisation) + B3 URL-proven enrichment
     compat = {}
@@ -610,6 +647,8 @@ def extract_dimensions(raw, web_corpus, compatibility_url_data=None):
         "web_relations": web_relations,
         "compatibility_proven_by_url": compatibility_proven_by_url,
         "motorisation_profiles": motorisation_profiles,
+        # Issue 2 trace : count of related_parts entries filtered out as non-slug
+        "related_parts_filtered_count": related_parts_filtered_count,
     }
 # === Task 8c (2026-05-28, additive) : decision_brief projection (post-extraction) ===
 
@@ -1242,6 +1281,17 @@ def main():
             "decision_brief_present": bool(dims.get("decision_brief")),
             "decision_brief_source_kind": (dims.get("decision_brief") or {}).get("source_kind"),
             "decision_brief_cross_check_status": (dims.get("decision_brief") or {}).get("cross_check_status"),
+            # Issue 3 fix (2026-05-28) : explicit quality verdict for downstream consumers
+            # (wiki sas reviewers + future batch aggregators). Maps source_kind 1:1 :
+            #   deterministic_transform -> STRONG (all facets from CONFIRMED dimensions)
+            #   rag_candidate           -> DATA_WEAK (requires_review humain, NOT a FAIL)
+            #   no decision_brief       -> NOT_APPLICABLE (insufficient inputs)
+            "decision_brief_quality_verdict": (
+                "STRONG" if (dims.get("decision_brief") or {}).get("source_kind") == "deterministic_transform"
+                else "DATA_WEAK" if (dims.get("decision_brief") or {}).get("source_kind") == "rag_candidate"
+                else "NOT_APPLICABLE"
+            ),
+            "related_parts_filtered_count": dims.get("related_parts_filtered_count", 0),
         }],
     }
     print("\nRUN LOG:")


### PR DESCRIPTION
## Summary

Addresses 3 input-quality issues surfaced by PR #781 dry-runs. Anti-bricolage : defensive filters at script boundary, no R2/R8 touch (OBSERVE window respected).

## Issues fixed

### 1. `vanne-egr` function extraction contamination

**Cause** : `FUNCTION_HINT_RE` matched the wrong text in NGK catalog marketing preamble. The body of `ngk-32397b6deed4-s001.md` opens with:

> _"Notre **catalogue 2025-2026 bougies d'allumage et bougies de préchauffage **est désormais accessible en ligne. Une version digitale qui vous permet de trouver facilement vos références..."_

The regex matched `permet` in this catalog text and emitted a `function_oneliner` about bougies for a vanne-egr proposal.

**Fix** : line-by-line scan with `FUNCTION_MARKETING_BLOCKLIST_RE` rejection (`catalogue`, `découvrez`, `promo`, `version digitale`, `simplifier la vie`, `votre sélection`, etc.). First non-marketing line matching `FUNCTION_HINT_RE` wins.

**Before** :
```
function_oneliner: Notre **catalogue 2025-2026 bougies d'allumage et bougies de préchauffage...
```

**After** :
```
function_oneliner: Recycler une partie des gaz d'echappement vers l'admission pour reduire les emissions de NOx
```

### 2. `plaquette-de-frein` invalid `related_parts` slug pattern

**Cause** : RAW frontmatter `automecanik-raw/recycled/rag-knowledge/gammes/plaquette-de-frein.md` contains human-readable free-text in `related_parts` instead of slugs :

```yaml
related_parts:
- Disques de frein (a controler systematiquement au changement de plaquettes)
- Etrier de frein (presse les plaquettes contre le disque)
- ...
```

Wiki schema requires `pattern: ^[a-z0-9][a-z0-9-]*[a-z0-9]$` → schema validation fails on these entries.

**Fix** : defensive filter via `SLUG_RE.fullmatch()` on each entry. Non-slugs are dropped silently. Count tracked via `dimensions.related_parts_filtered_count`, surfaced in run log.

**Before** : `schema_valid: false`, `schema_errors: ["'Liquide de frein...' does not match '^[a-z0-9][a-z0-9-]*[a-z0-9]$'"]`
**After** : `schema_valid: true`, `related_parts_filtered_count: 5`.

Upstream RAW frontmatter quality is a separate concern (not fixed here).

### 3. Explicit `DATA_WEAK` verdict in run log

**Cause** : run log only exposed `decision_brief_source_kind`, not a clear pass/warn verdict for downstream consumers (wiki sas reviewers + future batch aggregators).

**Fix** : add `decision_brief_quality_verdict` mapping per plan §4 verdict-trois-niveaux :

| `source_kind` | `quality_verdict` |
|---|---|
| `deterministic_transform` | `STRONG` |
| `rag_candidate` | `DATA_WEAK` |
| (no decision_brief) | `NOT_APPLICABLE` |

`DATA_WEAK` is **not a FAIL** — `exportable.seo=false` default means zero publication risk. It signals `requires_review` humain to the wiki sas.

## Test plan

- [x] Dry-run vanne-egr : function_oneliner correct (no bougies)
- [x] Dry-run plaquette-de-frein : schema_valid true (5 invalid related_parts filtered)
- [x] Dry-run filtre-a-air / courroie-d-accessoire / thermostat : no regression
- [x] All 5 slugs : DATA_WEAK verdict emitted
- [x] pytest : 42 passed / 11 skipped / 0 failed

## Out of scope (separate tickets)

- Upstream RAW frontmatter quality (e.g. plaquette-de-frein human text in related_parts) — needs raw-side curation.
- Promoting any output from `DATA_WEAK` to `STRONG` — requires OEM web sources matching slug topics consistently.
- R2/R8 rendering of `decision_brief` — gated by funnel-truth-green and post-OBSERVE (≥ 2026-06-09).

## Doctrine alignment

- **OBSERVE window** : zero runtime change, R2/R8 untouched.
- **Anti-bricolage** : defensive filters, no LLM fallback, no template escape, no silent skip — all events tracked in run log.
- **Knowledge-first** : `exportable.seo=false` default ; DATA_WEAK is non-blocking by design.
- **Scope strict** : single file changed (the script), all 3 fixes related to the same surface (decision_brief input quality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)