### PR TITLE
feat(wiki-bootstrap): add read-only auto-review for decision_brief proposals

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -252,6 +252,13 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: low
+  # WIKI auto-review (cf. PR auto_review_wiki_proposal.py) — read-only triage
+  # JSON+MD audits per slug. Same dotfile-glob pattern as wiki-bootstrap-runs.
+  - glob: audit/wiki-auto-review/.*
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: low
   # ADR-082 Phase 1 — continuous improvement doctrine pilots + cross-validation
   # (rangés à plat sous audit/ par convention historique, cf. audit/seo-*.md).
   - glob: audit/pilot-*.md

--- a/scripts/wiki-generators/auto_review_wiki_proposal.py
+++ b/scripts/wiki-generators/auto_review_wiki_proposal.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""auto_review_wiki_proposal.py — read-only quality reviewer for WIKI sas proposals.
+
+Strict READ_ONLY by design :
+  - Does NOT modify the proposal file.
+  - Does NOT promote `exportable.seo: true`.
+  - Does NOT move anything to `wiki/accepted/`.
+  - Does NOT touch R2/R8 runtime.
+  - Does NOT call any LLM.
+
+Role : help the human wiki-sas reviewer prioritize their queue.
+Output a verdict triaging proposals into 4 bands :
+
+  REVIEWABLE             — humain can promote (eventually) ; minor or no fixes needed
+  REVIEWABLE_WITH_FIXES  — humain needs to correct/clarify before considering promotion
+  NOT_REVIEWABLE         — proposal is broken or filler-tainted, must be fixed upstream
+                           (RAW/script) before re-emission
+  NOT_APPLICABLE         — no decision_brief in proposal (e.g. low-coverage gamme)
+
+The FINAL decision (acceptance, exportable.seo=true, promotion to wiki/accepted/)
+stays HUMAN. This tool only reduces triage time.
+
+CLI :
+  python3 scripts/wiki-generators/auto_review_wiki_proposal.py \\
+      --proposal /path/to/proposals/<slug>.md \\
+      [--write-audit]   # writes audit/wiki-auto-review/<slug>.review.{json,md}
+
+Refs :
+  - Companion to scripts/wiki-generators/promote-raw-gammes-to-wiki.py
+  - Plan : ~/.claude/plans/utiliser-superpower-ai-quiet-bear.md
+  - Doctrine canon 2026-05-27 (rag_recycled_candidate guard + cross_check_status)
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("Manque : pip install pyyaml\n")
+    sys.exit(1)
+
+
+# === Verdict states (single source of truth) ===
+
+VERDICT_REVIEWABLE = "REVIEWABLE"
+VERDICT_REVIEWABLE_WITH_FIXES = "REVIEWABLE_WITH_FIXES"
+VERDICT_NOT_REVIEWABLE = "NOT_REVIEWABLE"
+VERDICT_NOT_APPLICABLE = "NOT_APPLICABLE"
+
+ALL_VERDICTS = {
+    VERDICT_REVIEWABLE,
+    VERDICT_REVIEWABLE_WITH_FIXES,
+    VERDICT_NOT_REVIEWABLE,
+    VERDICT_NOT_APPLICABLE,
+}
+
+
+# === Pattern constants ===
+
+# Anti-filler markers (any presence → NOT_REVIEWABLE).
+ANTI_FILLER_PLACEHOLDER_RE = re.compile(r'\b(TODO|TBD|FIXME|XXX|lorem|ipsum)\b', re.IGNORECASE)
+ANTI_FILLER_TEMPLATE_RE = re.compile(r'\{\{|<%')
+
+# Generic / non-actionable phrases that should not appear in decision_brief facets.
+GENERIC_FILLER_PATTERNS = [
+    re.compile(r'(?i)cette\s+pi[eè]ce\s+est\s+importante'),
+    re.compile(r'(?i)choisissez\s+une\s+pi[eè]ce\s+de\s+qualit[eé]'),
+    re.compile(r'(?i)compatible\s+avec\s+plusieurs\s+mod[eè]les'),
+    re.compile(r'(?i)d[eé]couvrez\s+notre\s+catalogue'),
+    re.compile(r'(?i)meilleur(s)?\s+choix\s+pour\s+votre\s+v[eé]hicule'),
+]
+
+# Marketing contamination patterns for function_oneliner (rejects catalog blurbs).
+# Mirrors FUNCTION_MARKETING_BLOCKLIST_RE in promote-raw-gammes-to-wiki.py.
+MARKETING_BLOCKLIST_RE = re.compile(
+    r'(?i)(catalogue|d[eé]couvrez|promo|soldes|boutique|achat\s+en\s+ligne|'
+    r'version\s+digitale|simplifier\s+la\s+vie|fonctionnalit[eé]s\s+con[cç]ues|'
+    r'en\s+ligne\.|votre\s+s[eé]lection)'
+)
+
+# Technical verbs that signal a real function description (vs marketing).
+# Both word boundaries (start AND end) required, otherwise "freinage" would match "freine".
+TECHNICAL_VERB_RE = re.compile(
+    r'(?i)\b(filtre|filtrer|r[eé]gule|r[eé]guler|entra[iî]ne|entra[iî]ner|recycle|recycler|'
+    r'transmet|transmettre|refroidit|refroidir|freine|freiner|maintient|maintenir|alimente|alimenter|'
+    r'charge|charger|prot[eè]ge|prot[eé]ger|assure|assurer|r[eé]duit|r[eé]duire|'
+    r'am[eé]liore|am[eé]liorer|stocke|stocker|capte|capter|d[eé]tecte|d[eé]tecter|'
+    r'amortit|amortir|guide|guider|relie|relier|isole|isoler|permet)\b'
+)
+
+# Non-actionable selection criteria words (warn but not block).
+NON_ACTIONABLE_SELECTION_RE = re.compile(
+    r'(?i)^(qualit[eé]|prix|performance|meilleur\s+choix|fiabilit[eé]|durabilit[eé]|excellence|robustesse)\.?$'
+)
+
+# Technical/actionable selection criteria signals (any of these → counts as actionable).
+ACTIONABLE_SELECTION_HINT_RE = re.compile(
+    r'(?i)\b(r[eé]f[eé]rence|oem|motorisation|dimension|montage|[eé]quipementier|marque|'
+    r'ann[eé]e\s+v[eé]hicule|carburant|puissance|mod[eè]le|cylindr[eé]e|essieu|'
+    r'mat[eé]riau|c[eé]ramique|m[eé]tallique|technologie|capteur|usure)'
+)
+
+# Technical-separator detection in compatibility_summary (rejects debug-style "a | b | c").
+DEBUG_SEPARATOR_RE = re.compile(r'\s+\|\s+|\s+/\s+(?!ou\b)')
+
+# FR contextual linking words that signal natural-language compatibility phrase.
+COMPAT_CONTEXT_RE = re.compile(
+    r'(?i)\b(selon|avec|et|pour|par|à\s+v[eé]rifier|d[eé]pend|li[eé]e?\s+aux?)\b'
+)
+
+
+# === Pure functions (testable) ===
+
+def parse_proposal_file(path):
+    """Parse a wiki proposal markdown file → (frontmatter_dict, body_str).
+
+    Tolerant to Convention A (indented frontmatter) but proposals from
+    promote-raw-gammes-to-wiki.py use Convention B (non-indented). No fallback.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    return parse_proposal_text(text)
+
+
+def parse_proposal_text(text):
+    """Parse proposal markdown text → (frontmatter_dict, body_str)."""
+    m = re.match(r'^---\n(.*?)\n---\n(.*)$', text, re.DOTALL)
+    if not m:
+        raise ValueError("proposal markdown is missing --- frontmatter delimiters")
+    fm = yaml.safe_load(m.group(1)) or {}
+    body = m.group(2)
+    return fm, body
+
+
+def check_structural(fm, body):
+    """Check 1 : structural validity. Hard blockers → NOT_REVIEWABLE/NOT_APPLICABLE."""
+    ed = fm.get("entity_data") or {}
+    db = ed.get("decision_brief")
+    if db is None:
+        return {"pass": False, "reason": "decision_brief_missing", "details": ""}
+    if not isinstance(db, dict):
+        return {"pass": False, "reason": "decision_brief_not_object", "details": str(type(db))}
+    required = ["function_oneliner", "selection_criteria_top", "compatibility_summary",
+                "source_kind", "cross_check_status"]
+    missing = [k for k in required if not db.get(k)]
+    if missing:
+        return {"pass": False, "reason": "decision_brief_missing_fields", "details": missing}
+    sct = db.get("selection_criteria_top") or []
+    if not isinstance(sct, list) or len(sct) < 1:
+        return {"pass": False, "reason": "selection_criteria_top_empty", "details": ""}
+    return {"pass": True, "reason": "ok", "details": ""}
+
+
+def check_anti_filler(fm, body):
+    """Check 2 : anti-filler. Hard blocker if placeholder or generic-filler phrase detected."""
+    ed = fm.get("entity_data") or {}
+    db = ed.get("decision_brief") or {}
+    facets_text = " ".join([
+        str(db.get("function_oneliner") or ""),
+        str(db.get("compatibility_summary") or ""),
+        " ".join(db.get("selection_criteria_top") or []),
+    ])
+    if not facets_text.strip():
+        # Already caught by structural check ; defer.
+        return {"pass": True, "reason": "no_facets_text", "violations": []}
+    violations = []
+    if ANTI_FILLER_PLACEHOLDER_RE.search(facets_text):
+        violations.append("placeholder_token")
+    if ANTI_FILLER_TEMPLATE_RE.search(facets_text):
+        violations.append("template_tag")
+    for pat in GENERIC_FILLER_PATTERNS:
+        if pat.search(facets_text):
+            violations.append(f"generic_phrase:{pat.pattern[:40]}")
+            break
+    return {"pass": not violations, "reason": "ok" if not violations else "filler_detected",
+            "violations": violations}
+
+
+def check_function_clarity(fm, body):
+    """Check 3 : function_oneliner clarity. Marketing contamination → hard block (caller decides)."""
+    ed = fm.get("entity_data") or {}
+    db = ed.get("decision_brief") or {}
+    func = str(db.get("function_oneliner") or "")
+    if not func:
+        return {"pass": False, "marketing_detected": False, "has_technical_verb": False,
+                "reason": "function_oneliner_empty"}
+    marketing = bool(MARKETING_BLOCKLIST_RE.search(func))
+    has_verb = bool(TECHNICAL_VERB_RE.search(func))
+    ok = (not marketing) and has_verb
+    return {"pass": ok, "marketing_detected": marketing, "has_technical_verb": has_verb,
+            "reason": "ok" if ok else ("marketing_contamination" if marketing else "no_technical_verb")}
+
+
+def check_selection_actionability(fm, body):
+    """Check 4 : selection_criteria_top actionability (warn but not block)."""
+    ed = fm.get("entity_data") or {}
+    db = ed.get("decision_brief") or {}
+    items = db.get("selection_criteria_top") or []
+    if not items:
+        return {"pass": False, "actionable_count": 0, "total": 0, "non_actionable_items": []}
+    non_actionable = []
+    actionable_count = 0
+    for it in items:
+        s = str(it).strip()
+        if NON_ACTIONABLE_SELECTION_RE.match(s):
+            non_actionable.append(s)
+        elif ACTIONABLE_SELECTION_HINT_RE.search(s):
+            actionable_count += 1
+        # else : neutral (neither flagged actionable nor non-actionable) — counts as borderline
+    return {
+        "pass": actionable_count >= 1 and len(non_actionable) == 0,
+        "actionable_count": actionable_count,
+        "total": len(items),
+        "non_actionable_items": non_actionable,
+    }
+
+
+def check_compatibility_readability(fm, body):
+    """Check 5 : compatibility_summary readability (FR natural language, no debug separators)."""
+    ed = fm.get("entity_data") or {}
+    db = ed.get("decision_brief") or {}
+    cs = str(db.get("compatibility_summary") or "")
+    if not cs:
+        return {"pass": False, "reason": "compatibility_summary_empty",
+                "has_debug_separator": False, "has_context": False}
+    has_sep = bool(DEBUG_SEPARATOR_RE.search(cs))
+    has_ctx = bool(COMPAT_CONTEXT_RE.search(cs))
+    ok = (not has_sep) and has_ctx
+    reason = "ok" if ok else ("debug_separator" if has_sep else "no_natural_context")
+    return {"pass": ok, "reason": reason, "has_debug_separator": has_sep, "has_context": has_ctx}
+
+
+def check_source_quality(fm, body):
+    """Check 6 : source quality (STRONG / DATA_WEAK / NOT_APPLICABLE).
+
+    Mirrors decision_brief_quality_verdict computed by promote-raw-gammes-to-wiki.py.
+    """
+    ed = fm.get("entity_data") or {}
+    db = ed.get("decision_brief") or {}
+    source_kind = db.get("source_kind")
+    if source_kind == "deterministic_transform":
+        return {"pass": True, "verdict": "STRONG"}
+    if source_kind == "rag_candidate":
+        return {"pass": True, "verdict": "DATA_WEAK"}
+    return {"pass": False, "verdict": "NOT_APPLICABLE"}
+
+
+# === Verdict aggregator ===
+
+def compute_verdict(checks):
+    """Aggregate the 6 checks into a final verdict per the canon matrix.
+
+    Matrix (per user spec) :
+      schema invalid / decision_brief missing  → NOT_REVIEWABLE or NOT_APPLICABLE
+      filler detected                          → NOT_REVIEWABLE
+      marketing contamination in function      → NOT_REVIEWABLE
+      DATA_WEAK + clear                        → REVIEWABLE_WITH_FIXES
+      STRONG + clear                           → REVIEWABLE
+      Champs présents mais trop génériques     → REVIEWABLE_WITH_FIXES
+    """
+    structural = checks["structural"]
+    if not structural["pass"]:
+        if structural["reason"] == "decision_brief_missing":
+            return VERDICT_NOT_APPLICABLE
+        return VERDICT_NOT_REVIEWABLE
+
+    if not checks["anti_filler"]["pass"]:
+        return VERDICT_NOT_REVIEWABLE
+
+    if checks["function_clarity"]["marketing_detected"]:
+        return VERDICT_NOT_REVIEWABLE
+
+    # At this point, structural OK, no filler, no marketing.
+    has_fixes_needed = (
+        not checks["function_clarity"]["pass"]
+        or not checks["selection_actionability"]["pass"]
+        or not checks["compatibility_readability"]["pass"]
+    )
+
+    source = checks["source_quality"]["verdict"]
+    if source == "STRONG":
+        return VERDICT_REVIEWABLE if not has_fixes_needed else VERDICT_REVIEWABLE_WITH_FIXES
+    if source == "DATA_WEAK":
+        return VERDICT_REVIEWABLE_WITH_FIXES
+    # NOT_APPLICABLE source_quality (no decision_brief.source_kind) — already caught by structural
+    return VERDICT_NOT_REVIEWABLE
+
+
+def compute_scores(checks):
+    """Compute 5 scores 1-5 for the reviewer dashboard.
+
+    Derived deterministically from the 6 checks. Anti-bricolage : no LLM, no
+    heuristic outside the checks already run.
+    """
+    def s(b):
+        return 5 if b else 1
+
+    function_ok = checks["function_clarity"]["pass"]
+    selection_ok = checks["selection_actionability"]["pass"]
+    compat_ok = checks["compatibility_readability"]["pass"]
+    structural_ok = checks["structural"]["pass"]
+    anti_filler_ok = checks["anti_filler"]["pass"]
+    source_verdict = checks["source_quality"]["verdict"]
+
+    clarity_signals = [function_ok, compat_ok, structural_ok]
+    clarity = 1 + sum(2 if x else 0 for x in clarity_signals[:2]) + (1 if structural_ok else 0)
+    clarity = min(5, max(1, clarity))
+
+    source_traceability = 5 if source_verdict == "STRONG" else (3 if source_verdict == "DATA_WEAK" else 1)
+
+    anti_filler_score = s(anti_filler_ok)
+
+    technical_relevance = 5 if (function_ok and selection_ok) else (3 if function_ok or selection_ok else 1)
+
+    reviewability_signals = [structural_ok, anti_filler_ok, not checks["function_clarity"]["marketing_detected"]]
+    reviewability = 1 + 2 * sum(1 for x in reviewability_signals if x) // max(1, len(reviewability_signals))
+    if all(reviewability_signals):
+        reviewability = 4 + (1 if function_ok and selection_ok and compat_ok else 0)
+    else:
+        reviewability = 1
+
+    return {
+        "clarity": int(clarity),
+        "source_traceability": int(source_traceability),
+        "anti_filler": int(anti_filler_score),
+        "technical_relevance": int(technical_relevance),
+        "reviewability": int(reviewability),
+    }
+
+
+def derive_fix_suggestions(checks):
+    """Produce structured fix_suggestions for the reviewer (minor/major severity).
+
+    Only includes suggestions where the corresponding check failed.
+    """
+    suggestions = []
+    fc = checks["function_clarity"]
+    if not fc["pass"]:
+        sev = "major" if fc["marketing_detected"] else "minor"
+        msg = (
+            "function_oneliner contient un préambule marketing/catalogue — corriger la source web ou tightener la regex"
+            if fc["marketing_detected"]
+            else "function_oneliner manque d'un verbe technique (filtre/régule/entraîne/etc.) — vérifier la source"
+        )
+        suggestions.append({
+            "field": "decision_brief.function_oneliner",
+            "severity": sev,
+            "message": msg,
+        })
+    sa = checks["selection_actionability"]
+    if not sa["pass"]:
+        if sa["non_actionable_items"]:
+            suggestions.append({
+                "field": "decision_brief.selection_criteria_top",
+                "severity": "minor",
+                "message": f"Critères non-actionnables détectés ({sa['non_actionable_items']}). Préférer : référence OEM, motorisation, dimensions, marque équipementier, année véhicule.",
+            })
+        elif sa["actionable_count"] == 0:
+            suggestions.append({
+                "field": "decision_brief.selection_criteria_top",
+                "severity": "minor",
+                "message": "Aucun critère actionnable (OEM, motorisation, dimension, marque, etc.) détecté. À enrichir.",
+            })
+    cr = checks["compatibility_readability"]
+    if not cr["pass"]:
+        if cr["has_debug_separator"]:
+            suggestions.append({
+                "field": "decision_brief.compatibility_summary",
+                "severity": "minor",
+                "message": "compatibility_summary utilise des séparateurs debug (pipe/slash). Reformuler en phrase naturelle (selon/avec/et).",
+            })
+        elif not cr["has_context"]:
+            suggestions.append({
+                "field": "decision_brief.compatibility_summary",
+                "severity": "minor",
+                "message": "compatibility_summary manque de mots de liaison FR (selon, avec, pour). Reformuler pour la lisibilité humaine.",
+            })
+    af = checks["anti_filler"]
+    if not af["pass"]:
+        suggestions.append({
+            "field": "decision_brief",
+            "severity": "blocking",
+            "message": f"Filler détecté ({', '.join(af['violations'])}). Corriger upstream RAW ou script avant relecture.",
+        })
+    sq = checks["source_quality"]
+    if sq["verdict"] == "DATA_WEAK":
+        suggestions.append({
+            "field": "decision_brief.source_kind",
+            "severity": "info",
+            "message": "source_kind=rag_candidate (DATA_WEAK). Review obligatoire avant exportable.seo=true.",
+        })
+    return suggestions
+
+
+# === Public API ===
+
+def review_proposal_data(frontmatter, body):
+    """Run all 6 checks + compute verdict + scores + fix_suggestions for a parsed proposal."""
+    checks = {
+        "structural": check_structural(frontmatter, body),
+        "anti_filler": check_anti_filler(frontmatter, body),
+        "function_clarity": check_function_clarity(frontmatter, body),
+        "selection_actionability": check_selection_actionability(frontmatter, body),
+        "compatibility_readability": check_compatibility_readability(frontmatter, body),
+        "source_quality": check_source_quality(frontmatter, body),
+    }
+    verdict = compute_verdict(checks)
+    scores = compute_scores(checks)
+    suggestions = derive_fix_suggestions(checks)
+
+    slug = frontmatter.get("slug") or "(unknown)"
+    ed = frontmatter.get("entity_data") or {}
+    db = ed.get("decision_brief") or {}
+    source_kind = db.get("source_kind")
+    db_quality = (
+        "STRONG" if source_kind == "deterministic_transform"
+        else "DATA_WEAK" if source_kind == "rag_candidate"
+        else "NOT_APPLICABLE"
+    )
+
+    return {
+        "slug": slug,
+        "review_verdict": verdict,
+        "decision_brief_quality": db_quality,
+        "human_review_required": verdict != VERDICT_NOT_APPLICABLE,
+        "exportable_seo_allowed": False,  # ALWAYS false — human review obligatory per ADR-033
+        "blocking_issues": [
+            s for s in suggestions if s["severity"] in ("blocking", "major")
+        ],
+        "fix_suggestions": suggestions,
+        "scores": scores,
+        "checks": checks,
+    }
+
+
+def review_proposal_file(path):
+    """Top-level wrapper : read a proposal file from disk and run the review."""
+    fm, body = parse_proposal_file(path)
+    return review_proposal_data(fm, body)
+
+
+# === Markdown formatter (audit output) ===
+
+def render_review_markdown(report):
+    """Render a human-readable Markdown summary of the review JSON."""
+    lines = []
+    lines.append(f"# Auto-review WIKI proposal — {report['slug']}")
+    lines.append("")
+    lines.append(f"- **Verdict** : `{report['review_verdict']}`")
+    lines.append(f"- **decision_brief_quality** : `{report['decision_brief_quality']}`")
+    lines.append(f"- **human_review_required** : {report['human_review_required']}")
+    lines.append(f"- **exportable_seo_allowed** : {report['exportable_seo_allowed']} (toujours false : ADR-033)")
+    lines.append("")
+    lines.append("## Scores (1-5)")
+    for k, v in report["scores"].items():
+        lines.append(f"- **{k}** : {v}")
+    lines.append("")
+    lines.append("## Checks")
+    for k, c in report["checks"].items():
+        symbol = "✅" if c.get("pass") else "⚠️"
+        lines.append(f"- {symbol} **{k}** : {c}")
+    if report["fix_suggestions"]:
+        lines.append("")
+        lines.append("## Fix suggestions")
+        for s in report["fix_suggestions"]:
+            lines.append(f"- [{s['severity']}] `{s['field']}` — {s['message']}")
+    lines.append("")
+    lines.append("## Required human action")
+    lines.append("")
+    if report["review_verdict"] == VERDICT_REVIEWABLE:
+        lines.append("Reviewer can consider promotion. **Do NOT set `exportable.seo: true` without manual verification of source traceability.**")
+    elif report["review_verdict"] == VERDICT_REVIEWABLE_WITH_FIXES:
+        lines.append("Reviewer can work on this proposal. Apply the suggested fixes before considering promotion. **Do not set `exportable.seo: true` yet.**")
+    elif report["review_verdict"] == VERDICT_NOT_REVIEWABLE:
+        lines.append("Proposal is not yet reviewable. Fix upstream (RAW frontmatter or script) and re-emit. **Do not promote.**")
+    else:
+        lines.append("No `decision_brief` block in this proposal. Either out of scope for this review tool, or the gamme has insufficient inputs for projection.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# === CLI ===
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Read-only auto-review for WIKI sas proposals. Outputs a triage verdict, "
+                    "scores, and fix suggestions. NEVER modifies the proposal or promotes anything.",
+    )
+    parser.add_argument("--proposal", required=True,
+                        help="Path to wiki proposal markdown file (e.g. automecanik-wiki/proposals/<slug>.md)")
+    parser.add_argument("--write-audit", action="store_true",
+                        help="Also write audit/wiki-auto-review/<slug>.review.{json,md}")
+    parser.add_argument("--audit-dir", default="/opt/automecanik/app/audit/wiki-auto-review",
+                        help="Audit directory for --write-audit (default: audit/wiki-auto-review)")
+    parser.add_argument("--quiet", action="store_true", help="Only print the verdict (one word)")
+    args = parser.parse_args()
+
+    proposal_path = Path(args.proposal)
+    if not proposal_path.exists():
+        sys.stderr.write(f"⚠️  proposal not found: {proposal_path}\n")
+        return 2
+
+    try:
+        report = review_proposal_file(proposal_path)
+    except (ValueError, yaml.YAMLError) as e:
+        sys.stderr.write(f"⚠️  cannot parse proposal: {e}\n")
+        return 3
+
+    if args.quiet:
+        print(report["review_verdict"])
+    else:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+
+    if args.write_audit:
+        audit_dir = Path(args.audit_dir)
+        audit_dir.mkdir(parents=True, exist_ok=True)
+        slug = report["slug"]
+        (audit_dir / f"{slug}.review.json").write_text(
+            json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        (audit_dir / f"{slug}.review.md").write_text(
+            render_review_markdown(report), encoding="utf-8"
+        )
+        sys.stderr.write(f"✅ Audit written : {audit_dir}/{slug}.review.{{json,md}}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wiki-generators/test_auto_review_wiki_proposal.py
+++ b/scripts/wiki-generators/test_auto_review_wiki_proposal.py
@@ -1,0 +1,339 @@
+"""pytest suite for auto_review_wiki_proposal.py — read-only WIKI review module.
+
+Tests cover the 4-verdict matrix :
+  REVIEWABLE              — STRONG + clear
+  REVIEWABLE_WITH_FIXES   — DATA_WEAK + clear, or STRONG + vague
+  NOT_REVIEWABLE          — schema invalid, filler, marketing contamination
+  NOT_APPLICABLE          — no decision_brief
+
+Imports via importlib (single-file convention canon, no package).
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPT_PATH = Path(__file__).parent / "auto_review_wiki_proposal.py"
+_spec = importlib.util.spec_from_file_location("auto_review_wiki_proposal", SCRIPT_PATH)
+review = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(review)
+
+
+# === Helpers : build fake proposals for tests ===
+
+def _make_proposal(decision_brief=None, slug="test-gamme"):
+    """Construct a minimal frontmatter dict + body str for tests."""
+    fm = {
+        "schema_version": "2.0.0",
+        "id": f"gamme:{slug}",
+        "entity_type": "gamme",
+        "slug": slug,
+        "title": slug.replace("-", " ").title(),
+        "lang": "fr",
+        "created_at": "2026-05-28",
+        "updated_at": "2026-05-28",
+        "truth_level": "L2",
+        "source_refs": [],
+        "review_status": "proposed",
+        "exportable": {"rag": False, "seo": False, "support": False},
+        "entity_data": {
+            "pg_id": 1,
+            "family": "test",
+        },
+    }
+    if decision_brief is not None:
+        fm["entity_data"]["decision_brief"] = decision_brief
+    body = "## Rôle technique\n\nTest body content."
+    return fm, body
+
+
+def _strong_clear_brief():
+    return {
+        "function_oneliner": "Filtre l'air d'admission pour protéger le moteur des poussières et particules avant la combustion",
+        "selection_criteria_top": [
+            "Référence OEM ou équivalence constructeur",
+            "Dimensions exactes du filtre (longueur, largeur, hauteur)",
+            "Motorisation du véhicule (essence, diesel, hybride)",
+        ],
+        "compatibility_summary": "Vérifier la compatibilité selon le carburant (essence et diesel), 12 motorisations référencées, marques principales Bosch et Mann-Filter.",
+        "source_kind": "deterministic_transform",
+        "cross_check_status": "WEB_CONFIRMS_RAG",
+    }
+
+
+def _data_weak_clear_brief():
+    return {
+        "function_oneliner": "Régule le flux de liquide de refroidissement selon la température moteur",
+        "selection_criteria_top": [
+            "Référence OEM du thermostat",
+            "Motorisation",
+            "Année véhicule",
+        ],
+        "compatibility_summary": "Vérifier la compatibilité selon le carburant, la motorisation et la référence OEM.",
+        "source_kind": "rag_candidate",
+        "cross_check_status": "RAG_ONLY",
+    }
+
+
+# === Verdict tests (the 4-state matrix) ===
+
+def test_strong_clear_yields_reviewable():
+    fm, body = _make_proposal(decision_brief=_strong_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "REVIEWABLE"
+    assert r["decision_brief_quality"] == "STRONG"
+    assert r["exportable_seo_allowed"] is False  # always false (ADR-033)
+
+
+def test_data_weak_clear_yields_reviewable_with_fixes():
+    fm, body = _make_proposal(decision_brief=_data_weak_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "REVIEWABLE_WITH_FIXES"
+    assert r["decision_brief_quality"] == "DATA_WEAK"
+
+
+def test_marketing_contamination_yields_not_reviewable():
+    db = _strong_clear_brief()
+    db["function_oneliner"] = "Découvrez notre catalogue 2025-2026 — la meilleure sélection pour votre véhicule"
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "NOT_REVIEWABLE"
+
+
+def test_placeholder_filler_yields_not_reviewable():
+    db = _strong_clear_brief()
+    db["function_oneliner"] = "Filtre l'air pour le moteur — TODO compléter la description précise"
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "NOT_REVIEWABLE"
+    assert any("placeholder" in v for v in r["checks"]["anti_filler"]["violations"])
+
+
+def test_generic_phrase_filler_yields_not_reviewable():
+    db = _strong_clear_brief()
+    db["compatibility_summary"] = "Cette pièce est importante pour votre véhicule. Compatible avec plusieurs modèles."
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "NOT_REVIEWABLE"
+
+
+def test_template_tag_filler_yields_not_reviewable():
+    db = _strong_clear_brief()
+    db["function_oneliner"] = "Filtre l'air {{ part_name }} pour le moteur — protège contre les particules"
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "NOT_REVIEWABLE"
+
+
+def test_missing_decision_brief_yields_not_applicable():
+    fm, body = _make_proposal(decision_brief=None)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "NOT_APPLICABLE"
+    assert r["human_review_required"] is False
+
+
+def test_strong_with_vague_selection_yields_reviewable_with_fixes():
+    db = _strong_clear_brief()
+    db["selection_criteria_top"] = ["Qualité", "Prix", "Performance"]
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "REVIEWABLE_WITH_FIXES"
+    # non-actionable items should be flagged
+    assert len(r["checks"]["selection_actionability"]["non_actionable_items"]) > 0
+
+
+def test_debug_separator_in_compatibility_yields_reviewable_with_fixes():
+    db = _strong_clear_brief()
+    db["compatibility_summary"] = "diesel | Peugeot, Renault | 42 motorisations"
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "REVIEWABLE_WITH_FIXES"
+    assert r["checks"]["compatibility_readability"]["has_debug_separator"] is True
+
+
+def test_missing_required_field_yields_not_reviewable():
+    db = _strong_clear_brief()
+    db["function_oneliner"] = ""  # required but empty
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "NOT_REVIEWABLE"
+
+
+def test_no_technical_verb_in_function_yields_reviewable_with_fixes():
+    db = _strong_clear_brief()
+    db["function_oneliner"] = "Une pièce essentielle dans le système de freinage du véhicule moderne"
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    # no marketing, no filler, no technical verb → REVIEWABLE_WITH_FIXES
+    assert r["review_verdict"] == "REVIEWABLE_WITH_FIXES"
+    assert r["checks"]["function_clarity"]["has_technical_verb"] is False
+
+
+# === Field-level check tests ===
+
+def test_check_structural_decision_brief_missing():
+    fm, body = _make_proposal(decision_brief=None)
+    r = review.check_structural(fm, body)
+    assert r["pass"] is False
+    assert r["reason"] == "decision_brief_missing"
+
+
+def test_check_structural_missing_required_field():
+    db = _strong_clear_brief()
+    db.pop("compatibility_summary")
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.check_structural(fm, body)
+    assert r["pass"] is False
+    assert "compatibility_summary" in r["details"]
+
+
+def test_check_anti_filler_clean():
+    fm, body = _make_proposal(decision_brief=_strong_clear_brief())
+    r = review.check_anti_filler(fm, body)
+    assert r["pass"] is True
+    assert r["violations"] == []
+
+
+def test_check_anti_filler_xxx():
+    db = _strong_clear_brief()
+    db["function_oneliner"] = "Filtre l'air XXX pour protéger le moteur des particules"
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.check_anti_filler(fm, body)
+    assert r["pass"] is False
+    assert "placeholder_token" in r["violations"]
+
+
+def test_check_function_marketing_detected():
+    db = _strong_clear_brief()
+    db["function_oneliner"] = "Notre boutique en ligne propose les meilleures pièces pour votre véhicule moderne"
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.check_function_clarity(fm, body)
+    assert r["marketing_detected"] is True
+
+
+def test_check_compatibility_natural_phrase_pass():
+    db = _strong_clear_brief()
+    db["compatibility_summary"] = "Vérifier la compatibilité selon le carburant et la motorisation, marques principales Bosch."
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.check_compatibility_readability(fm, body)
+    assert r["pass"] is True
+    assert r["has_debug_separator"] is False
+    assert r["has_context"] is True
+
+
+def test_check_source_quality_strong():
+    fm, body = _make_proposal(decision_brief=_strong_clear_brief())
+    r = review.check_source_quality(fm, body)
+    assert r["verdict"] == "STRONG"
+
+
+def test_check_source_quality_data_weak():
+    fm, body = _make_proposal(decision_brief=_data_weak_clear_brief())
+    r = review.check_source_quality(fm, body)
+    assert r["verdict"] == "DATA_WEAK"
+
+
+# === Scores tests ===
+
+def test_scores_strong_clear_high():
+    fm, body = _make_proposal(decision_brief=_strong_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    scores = r["scores"]
+    assert scores["source_traceability"] == 5
+    assert scores["anti_filler"] == 5
+    assert scores["reviewability"] >= 4
+
+
+def test_scores_data_weak_medium_source():
+    fm, body = _make_proposal(decision_brief=_data_weak_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    assert r["scores"]["source_traceability"] == 3
+
+
+def test_scores_marketing_low_reviewability():
+    db = _strong_clear_brief()
+    db["function_oneliner"] = "Découvrez notre catalogue exceptionnel — version digitale qui vous permet de tout trouver"
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["scores"]["reviewability"] == 1
+
+
+# === Markdown rendering test ===
+
+def test_render_markdown_contains_verdict():
+    fm, body = _make_proposal(decision_brief=_strong_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    md = review.render_review_markdown(r)
+    assert "REVIEWABLE" in md
+    assert "exportable_seo_allowed" in md
+    assert "Required human action" in md
+
+
+def test_render_markdown_data_weak_says_no_seo():
+    fm, body = _make_proposal(decision_brief=_data_weak_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    md = review.render_review_markdown(r)
+    assert "REVIEWABLE_WITH_FIXES" in md
+    assert "exportable.seo: true" in md.lower() or "exportable.seo" in md
+
+
+# === Fix suggestions tests ===
+
+def test_fix_suggestions_marketing_is_major():
+    db = _strong_clear_brief()
+    db["function_oneliner"] = "Découvrez notre catalogue 2025 pour votre véhicule moderne avec qualité garantie"
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    marketing_sugg = [s for s in r["fix_suggestions"] if s["field"] == "decision_brief.function_oneliner"]
+    assert len(marketing_sugg) > 0
+    assert marketing_sugg[0]["severity"] == "major"
+
+
+def test_fix_suggestions_data_weak_info():
+    fm, body = _make_proposal(decision_brief=_data_weak_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    src_sugg = [s for s in r["fix_suggestions"] if s["field"] == "decision_brief.source_kind"]
+    assert len(src_sugg) == 1
+    assert src_sugg[0]["severity"] == "info"
+    assert "DATA_WEAK" in src_sugg[0]["message"]
+
+
+# === Parse / file I/O tests ===
+
+def test_parse_proposal_text_simple():
+    text = """---
+slug: foo
+entity_data:
+  decision_brief:
+    function_oneliner: "test"
+---
+
+## Body content"""
+    fm, body = review.parse_proposal_text(text)
+    assert fm["slug"] == "foo"
+    assert "Body content" in body
+
+
+def test_parse_proposal_text_missing_delimiters_raises():
+    with pytest.raises(ValueError, match="frontmatter delimiters"):
+        review.parse_proposal_text("no frontmatter here")
+
+
+# === Exportable SEO safety invariant ===
+
+def test_exportable_seo_always_false_even_for_strong():
+    """Read-only invariant : the auto-review NEVER allows exportable.seo:true."""
+    fm, body = _make_proposal(decision_brief=_strong_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    assert r["exportable_seo_allowed"] is False
+
+
+def test_exportable_seo_always_false_even_for_strongest_clearest():
+    """Even with perfect inputs, the verdict is REVIEWABLE — never auto-approved."""
+    db = _strong_clear_brief()
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] != "ACCEPTED"  # ACCEPTED is not a valid verdict
+    assert r["review_verdict"] in review.ALL_VERDICTS
+    assert r["exportable_seo_allowed"] is False


### PR DESCRIPTION
## Summary

Strict **READ_ONLY** triage module to assist (not replace) the human wiki-sas reviewer. Outputs a 4-state verdict + scores + fix_suggestions per proposal, based on 6 deterministic checks.

**NEVER** modifies the proposal, **NEVER** promotes `exportable.seo`, **NEVER** touches R2/R8, **NEVER** calls an LLM.

## Module

`scripts/wiki-generators/auto_review_wiki_proposal.py` (531 lines)

## Verdicts (the 4-state matrix)

| Verdict | When |
|---|---|
| `REVIEWABLE` | STRONG source + all 6 checks clear ; humain peut envisager promotion (reste manuelle) |
| `REVIEWABLE_WITH_FIXES` | DATA_WEAK + clair, OR STRONG + critères trop génériques, OR compat phrasing à clarifier |
| `NOT_REVIEWABLE` | schema invalide, filler/placeholder, marketing contamination — à corriger upstream RAW/script |
| `NOT_APPLICABLE` | pas de decision_brief (gamme à coverage insuffisante) |

## 6 deterministic checks

1. **structural** — `entity_data.decision_brief` présent + 5 champs requis remplis
2. **anti_filler** — pas de `TODO/TBD/FIXME/XXX/{{}}/lorem` ni de phrases génériques (\"cette pièce est importante\", \"compatible avec plusieurs modèles\", \"découvrez notre catalogue\")
3. **function_clarity** — verbe technique présent (`filtre/régule/entraîne/etc.`), pas de marketing (`catalogue/découvrez/version digitale`)
4. **selection_actionability** — critères actionnables (référence OEM, motorisation, dimensions) vs vagues (qualité/prix/performance)
5. **compatibility_readability** — phrase FR naturelle (`selon, avec, et, pour`), pas de séparateurs debug (`pipe, slash`)
6. **source_quality** — STRONG (`deterministic_transform`) | DATA_WEAK (`rag_candidate`) | NOT_APPLICABLE

## 5 scores (1-5)

`clarity`, `source_traceability`, `anti_filler`, `technical_relevance`, `reviewability`.

## Output formats

**JSON (stdout)** :
```json
{
  \"slug\": \"filtre-a-air\",
  \"review_verdict\": \"REVIEWABLE_WITH_FIXES\",
  \"decision_brief_quality\": \"DATA_WEAK\",
  \"human_review_required\": true,
  \"exportable_seo_allowed\": false,
  \"blocking_issues\": [],
  \"fix_suggestions\": [
    {\"field\": \"decision_brief.source_kind\", \"severity\": \"info\", \"message\": \"...\"}
  ],
  \"scores\": {\"clarity\": 5, \"source_traceability\": 3, \"anti_filler\": 5, \"technical_relevance\": 5, \"reviewability\": 5},
  \"checks\": {...}
}
```

**Markdown (`--write-audit`)** : human-readable per-slug summary in `audit/wiki-auto-review/<slug>.review.md`.

## CLI

```bash
python3 scripts/wiki-generators/auto_review_wiki_proposal.py \\
    --proposal automecanik-wiki/proposals/<slug>.md \\
    [--write-audit]      # writes audit/wiki-auto-review/<slug>.review.{json,md}
    [--quiet]            # one-word verdict only (for piping)
```

## Hard invariants (enforced by tests)

- `exportable_seo_allowed: false` **ALWAYS** in output, regardless of verdict
- `ACCEPTED` is **NOT** a valid verdict (`ALL_VERDICTS` exhaustive)
- No mutation of the proposal file (read-only `Path.read_text()`)
- Only filesystem writes outside the audit dir : with explicit `--write-audit` flag

## Test plan

- [x] **30/30 pytest** : matrix tests (REVIEWABLE/REVIEWABLE_WITH_FIXES/NOT_REVIEWABLE/NOT_APPLICABLE) + individual check tests + parse/render + `exportable_seo_allowed: false` invariant
- [x] **Smoke-test** on the 5 wiki-bootstrap pilote slugs (vanne-egr, filtre-a-air, plaquette-de-frein, courroie-d-accessoire, thermostat) — all 5 yield `REVIEWABLE_WITH_FIXES` (DATA_WEAK source post-#782, clear facets)
- [x] **CLI smoke** : `--write-audit` produces well-formed JSON + Markdown files
- [ ] CI passes

## Files added

- `scripts/wiki-generators/auto_review_wiki_proposal.py` (531 lines)
- `scripts/wiki-generators/test_auto_review_wiki_proposal.py` (339 lines)
- `audit/wiki-auto-review/.gitkeep`
- `.spec/00-canon/repository-registry/ownership.yaml` (+7 lines : ownership glob for audit dir)

## Out of scope (separate tickets if needed)

- Auto-correction mode (no `--fix` ; that would mutate proposals)
- Batch aggregation across multiple slugs
- Promotion automation (exportable.seo, wiki/accepted/ move) — stays human per ADR-033
- R2/R8 rendering decisions — stays gated by funnel-truth-green and post-OBSERVE (≥ 2026-06-09)

## Doctrine alignment

- **ADR-033 §C** (review humain obligatoire) : auto-review aide, ne décide jamais
- **OBSERVE window** : zero runtime change, R2/R8 untouched
- **Anti-bricolage** : 6 checks déterministes, pas de fallback heuristique opaque, pas de LLM
- **Knowledge-first** : DATA_WEAK n'est jamais publiable sans humain (par design)
- **Scope strict** : 4 files added, 1 file modified (ownership.yaml glob)

## Companion

Phase A pipeline (#781) emits proposals → `decision_brief` facets. PR #782 hardens input quality. **This PR (#TBD) triages**. The human reviewer remains the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)