### PR TITLE
fix(wiki-auto-review): human-friendly markdown rendering + near-dup detection

### DIFF
--- a/scripts/wiki-generators/auto_review_wiki_proposal.py
+++ b/scripts/wiki-generators/auto_review_wiki_proposal.py
@@ -34,6 +34,7 @@ import argparse
 import json
 import re
 import sys
+import unicodedata
 from pathlib import Path
 
 try:
@@ -41,6 +42,20 @@ try:
 except ImportError:
     sys.stderr.write("Manque : pip install pyyaml\n")
     sys.exit(1)
+
+
+def _ascii_fold(s):
+    """Normalize string for near-duplicate detection : NFKD + remove diacritics + lowercase + collapse whitespace.
+
+    Used to detect cases where the same criterion appears twice with different
+    diacritics (e.g. "Utiliser la référence OE" vs "Utiliser la reference OE")
+    or whitespace.
+    """
+    if not isinstance(s, str):
+        return ""
+    normalized = unicodedata.normalize('NFKD', s)
+    no_diacritics = ''.join(c for c in normalized if not unicodedata.combining(c))
+    return re.sub(r'\s+', ' ', no_diacritics).strip().lower()
 
 
 # === Verdict states (single source of truth) ===
@@ -194,26 +209,40 @@ def check_function_clarity(fm, body):
 
 
 def check_selection_actionability(fm, body):
-    """Check 4 : selection_criteria_top actionability (warn but not block)."""
+    """Check 4 : selection_criteria_top actionability + near-duplicate detection (warn but not block).
+
+    Near-duplicate detection (ASCII-fold normalization) catches cases where the
+    same criterion appears twice with different diacritics or whitespace
+    (e.g. "Utiliser la référence OE" vs "Utiliser la reference OE"). These are
+    upstream RAW frontmatter quality issues that the human reviewer should be
+    alerted to.
+    """
     ed = fm.get("entity_data") or {}
     db = ed.get("decision_brief") or {}
     items = db.get("selection_criteria_top") or []
     if not items:
-        return {"pass": False, "actionable_count": 0, "total": 0, "non_actionable_items": []}
+        return {"pass": False, "actionable_count": 0, "total": 0,
+                "non_actionable_items": [], "near_duplicates": []}
     non_actionable = []
     actionable_count = 0
+    folded = [_ascii_fold(str(it)) for it in items]
+    near_duplicates = []
+    for i, f in enumerate(folded):
+        if f and folded.count(f) > 1 and folded.index(f) < i:
+            near_duplicates.append(str(items[i]))
     for it in items:
         s = str(it).strip()
         if NON_ACTIONABLE_SELECTION_RE.match(s):
             non_actionable.append(s)
         elif ACTIONABLE_SELECTION_HINT_RE.search(s):
             actionable_count += 1
-        # else : neutral (neither flagged actionable nor non-actionable) — counts as borderline
+        # else : neutral (neither flagged actionable nor non-actionable) — borderline
     return {
-        "pass": actionable_count >= 1 and len(non_actionable) == 0,
+        "pass": actionable_count >= 1 and len(non_actionable) == 0 and len(near_duplicates) == 0,
         "actionable_count": actionable_count,
         "total": len(items),
         "non_actionable_items": non_actionable,
+        "near_duplicates": near_duplicates,
     }
 
 
@@ -363,6 +392,12 @@ def derive_fix_suggestions(checks):
                 "severity": "minor",
                 "message": "Aucun critère actionnable (OEM, motorisation, dimension, marque, etc.) détecté. À enrichir.",
             })
+        if sa.get("near_duplicates"):
+            suggestions.append({
+                "field": "decision_brief.selection_criteria_top",
+                "severity": "minor",
+                "message": f"Doublons quasi-identiques détectés (ASCII-fold) : {sa['near_duplicates']}. Corriger la source RAW pour dédoublonner ; symptôme typique d'entrées doublées avec/sans accents.",
+            })
     cr = checks["compatibility_readability"]
     if not cr["pass"]:
         if cr["has_debug_separator"]:
@@ -436,15 +471,119 @@ def review_proposal_data(frontmatter, body):
 
 
 def review_proposal_file(path):
-    """Top-level wrapper : read a proposal file from disk and run the review."""
+    """Top-level wrapper : read a proposal file from disk and run the review.
+
+    Returns (report, frontmatter). Frontmatter is returned so callers (CLI
+    --write-audit) can render the "Brief actuel" section inline.
+    """
     fm, body = parse_proposal_file(path)
-    return review_proposal_data(fm, body)
+    report = review_proposal_data(fm, body)
+    return report, fm
 
 
 # === Markdown formatter (audit output) ===
 
-def render_review_markdown(report):
-    """Render a human-readable Markdown summary of the review JSON."""
+# FR labels for each check (replaces raw Python dict dump).
+_CHECK_LABELS_FR = {
+    "structural": "Validité structurelle",
+    "anti_filler": "Anti-filler",
+    "function_clarity": "Clarté de la fonction",
+    "selection_actionability": "Critères de choix actionnables",
+    "compatibility_readability": "Lisibilité de la compatibilité",
+    "source_quality": "Qualité de la source",
+}
+
+
+def _format_check_line(name, result):
+    """Render a single check result as a FR human-readable line (no dict dump)."""
+    symbol = "✅" if result.get("pass") else "⚠️"
+    label = _CHECK_LABELS_FR.get(name, name)
+    summary = ""
+    if name == "structural":
+        if result.get("pass"):
+            summary = "tous les champs requis présents"
+        else:
+            reason = result.get("reason", "?")
+            details = result.get("details") or ""
+            if details:
+                summary = f"{reason} ({details})"
+            else:
+                summary = reason
+    elif name == "anti_filler":
+        if result.get("pass"):
+            summary = "aucun placeholder ni phrase générique"
+        else:
+            v = result.get("violations") or []
+            summary = f"filler détecté : {', '.join(v)}"
+    elif name == "function_clarity":
+        bits = []
+        if result.get("has_technical_verb"):
+            bits.append("verbe technique présent")
+        else:
+            bits.append("**pas de verbe technique** (filtre/régule/entraîne/etc.)")
+        if result.get("marketing_detected"):
+            bits.append("**marketing détecté**")
+        else:
+            bits.append("pas de marketing")
+        summary = " ; ".join(bits)
+    elif name == "selection_actionability":
+        ac = result.get("actionable_count", 0)
+        tot = result.get("total", 0)
+        bits = [f"{ac}/{tot} critères actionnables"]
+        if result.get("non_actionable_items"):
+            bits.append(f"non-actionnables : {result['non_actionable_items']}")
+        if result.get("near_duplicates"):
+            bits.append(f"doublons (ASCII-fold) : {result['near_duplicates']}")
+        summary = " ; ".join(bits)
+    elif name == "compatibility_readability":
+        bits = []
+        if result.get("has_debug_separator"):
+            bits.append("**séparateurs debug détectés (pipe/slash)**")
+        else:
+            bits.append("pas de séparateurs debug")
+        if result.get("has_context"):
+            bits.append("phrase FR naturelle (selon/avec/et)")
+        else:
+            bits.append("**manque mots de liaison FR**")
+        summary = " ; ".join(bits)
+    elif name == "source_quality":
+        summary = f"verdict source = `{result.get('verdict', '?')}`"
+    else:
+        summary = str(result)
+    return f"- {symbol} **{label}** : {summary}"
+
+
+def _format_brief_section(frontmatter):
+    """Render the actual decision_brief facets inline in the review markdown.
+
+    Avoids the reviewer having to open the proposal file separately.
+    """
+    ed = frontmatter.get("entity_data") or {}
+    db = ed.get("decision_brief")
+    if not db:
+        return ["## Brief actuel", "", "_(aucun decision_brief dans cette proposal)_"]
+    lines = ["## Brief actuel (facettes extraites de la proposal)"]
+    lines.append("")
+    lines.append(f"- **Fonction** : {db.get('function_oneliner', '_(absent)_')}")
+    lines.append("- **Critères de choix prioritaires** :")
+    for c in db.get("selection_criteria_top") or []:
+        lines.append(f"  - {c}")
+    if not db.get("selection_criteria_top"):
+        lines.append("  - _(aucun)_")
+    lines.append(f"- **Compatibilité** : {db.get('compatibility_summary', '_(absent)_')}")
+    lines.append(
+        f"- **Sourcing** : `source_kind={db.get('source_kind', '?')}` ; "
+        f"`cross_check_status={db.get('cross_check_status', '?')}`"
+    )
+    return lines
+
+
+def render_review_markdown(report, frontmatter=None):
+    """Render a human-readable Markdown summary of the review JSON.
+
+    If `frontmatter` is provided, include a "## Brief actuel" section showing
+    the decision_brief facets inline (avoids the reviewer juggling 2 files).
+    """
     lines = []
     lines.append(f"# Auto-review WIKI proposal — {report['slug']}")
     lines.append("")
@@ -453,14 +592,18 @@ def render_review_markdown(report):
     lines.append(f"- **human_review_required** : {report['human_review_required']}")
     lines.append(f"- **exportable_seo_allowed** : {report['exportable_seo_allowed']} (toujours false : ADR-033)")
     lines.append("")
+
+    if frontmatter is not None:
+        lines.extend(_format_brief_section(frontmatter))
+        lines.append("")
+
     lines.append("## Scores (1-5)")
     for k, v in report["scores"].items():
         lines.append(f"- **{k}** : {v}")
     lines.append("")
     lines.append("## Checks")
     for k, c in report["checks"].items():
-        symbol = "✅" if c.get("pass") else "⚠️"
-        lines.append(f"- {symbol} **{k}** : {c}")
+        lines.append(_format_check_line(k, c))
     if report["fix_suggestions"]:
         lines.append("")
         lines.append("## Fix suggestions")
@@ -503,7 +646,7 @@ def main():
         return 2
 
     try:
-        report = review_proposal_file(proposal_path)
+        report, frontmatter = review_proposal_file(proposal_path)
     except (ValueError, yaml.YAMLError) as e:
         sys.stderr.write(f"⚠️  cannot parse proposal: {e}\n")
         return 3
@@ -521,7 +664,7 @@ def main():
             json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
         )
         (audit_dir / f"{slug}.review.md").write_text(
-            render_review_markdown(report), encoding="utf-8"
+            render_review_markdown(report, frontmatter=frontmatter), encoding="utf-8"
         )
         sys.stderr.write(f"✅ Audit written : {audit_dir}/{slug}.review.{{json,md}}\n")
     return 0

--- a/scripts/wiki-generators/test_auto_review_wiki_proposal.py
+++ b/scripts/wiki-generators/test_auto_review_wiki_proposal.py
@@ -337,3 +337,172 @@ def test_exportable_seo_always_false_even_for_strongest_clearest():
     assert r["review_verdict"] != "ACCEPTED"  # ACCEPTED is not a valid verdict
     assert r["review_verdict"] in review.ALL_VERDICTS
     assert r["exportable_seo_allowed"] is False
+
+
+# === ASCII-fold near-duplicate detection (improvement c) ===
+
+def test_ascii_fold_strips_diacritics():
+    assert review._ascii_fold("référence OE") == "reference oe"
+    assert review._ascii_fold("Référence OE") == "reference oe"
+    assert review._ascii_fold("RÉFÉRENCE  OE") == "reference oe"  # collapses whitespace
+    assert review._ascii_fold("réference OE") == review._ascii_fold("reference OE")
+
+
+def test_ascii_fold_empty_safe():
+    assert review._ascii_fold("") == ""
+    assert review._ascii_fold(None) == ""
+
+
+def test_near_duplicate_detected_in_selection_criteria():
+    """The real bug : 'Utiliser la référence OE' vs 'Utiliser la reference OE'."""
+    db = _strong_clear_brief()
+    db["selection_criteria_top"] = [
+        "Utiliser la référence OE ou l'équivalence constructeur",
+        "Respecter les dimensions exactes",
+        "Utiliser la reference OE ou l'equivalence constructeur",  # ASCII-fold dup of [0]
+    ]
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["review_verdict"] == "REVIEWABLE_WITH_FIXES"
+    assert len(r["checks"]["selection_actionability"]["near_duplicates"]) == 1
+    dup_sugg = [s for s in r["fix_suggestions"] if "Doublons" in s["message"]]
+    assert len(dup_sugg) == 1
+
+
+def test_no_near_duplicate_when_distinct():
+    db = _strong_clear_brief()
+    db["selection_criteria_top"] = [
+        "Référence OEM constructeur",
+        "Dimensions du filtre",
+        "Motorisation du véhicule",
+    ]
+    fm, body = _make_proposal(decision_brief=db)
+    r = review.review_proposal_data(fm, body)
+    assert r["checks"]["selection_actionability"]["near_duplicates"] == []
+
+
+# === FR check formatter (improvement a) ===
+
+def test_format_check_structural_pass():
+    line = review._format_check_line("structural", {"pass": True, "reason": "ok", "details": ""})
+    assert "✅" in line
+    assert "Validité structurelle" in line
+    assert "{" not in line and "}" not in line  # no Python dict dump
+    assert "requis" in line
+
+
+def test_format_check_anti_filler_violation():
+    line = review._format_check_line(
+        "anti_filler",
+        {"pass": False, "reason": "filler_detected", "violations": ["placeholder_token"]},
+    )
+    assert "⚠️" in line
+    assert "Anti-filler" in line
+    assert "placeholder_token" in line
+    assert "{" not in line
+
+
+def test_format_check_function_clarity_marketing():
+    line = review._format_check_line(
+        "function_clarity",
+        {"pass": False, "marketing_detected": True, "has_technical_verb": False, "reason": "marketing_contamination"},
+    )
+    assert "Clarté de la fonction" in line
+    assert "marketing détecté" in line.lower()
+    assert "pas de verbe technique" in line.lower()
+
+
+def test_format_check_selection_with_near_duplicates():
+    line = review._format_check_line(
+        "selection_actionability",
+        {"pass": False, "actionable_count": 2, "total": 3, "non_actionable_items": [],
+         "near_duplicates": ["foo"]},
+    )
+    assert "2/3 critères actionnables" in line
+    assert "doublons" in line.lower()
+
+
+def test_format_check_compatibility_debug_separator():
+    line = review._format_check_line(
+        "compatibility_readability",
+        {"pass": False, "reason": "debug_separator", "has_debug_separator": True, "has_context": False},
+    )
+    assert "séparateurs debug" in line.lower()
+
+
+def test_format_check_source_quality_data_weak():
+    line = review._format_check_line(
+        "source_quality",
+        {"pass": True, "verdict": "DATA_WEAK"},
+    )
+    assert "DATA_WEAK" in line
+    assert "Qualité de la source" in line
+
+
+# === "Brief actuel" inline section (improvement b) ===
+
+def test_render_markdown_includes_brief_actuel_when_frontmatter_passed():
+    fm, body = _make_proposal(decision_brief=_strong_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    md = review.render_review_markdown(r, frontmatter=fm)
+    assert "## Brief actuel" in md
+    assert "Filtre l'air d'admission" in md  # function_oneliner content visible inline
+
+
+def test_render_markdown_omits_brief_actuel_when_frontmatter_none():
+    """Backward-compat : calling render_review_markdown(report) without frontmatter still works."""
+    fm, body = _make_proposal(decision_brief=_strong_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    md = review.render_review_markdown(r)  # no frontmatter arg
+    assert "## Brief actuel" not in md
+    assert "REVIEWABLE" in md  # still renders verdict
+
+
+def test_render_markdown_brief_actuel_handles_missing_decision_brief():
+    fm, body = _make_proposal(decision_brief=None)
+    r = review.review_proposal_data(fm, body)
+    md = review.render_review_markdown(r, frontmatter=fm)
+    assert "## Brief actuel" in md
+    assert "aucun decision_brief" in md.lower()
+
+
+def test_render_markdown_no_python_dict_dump():
+    """The Checks section must not contain Python dict repr like {'pass': True, ...}."""
+    fm, body = _make_proposal(decision_brief=_strong_clear_brief())
+    r = review.review_proposal_data(fm, body)
+    md = review.render_review_markdown(r, frontmatter=fm)
+    assert "{'pass'" not in md
+    assert "{'reason'" not in md
+    assert "'violations'" not in md
+
+
+# === review_proposal_file returns tuple (CLI integration) ===
+
+def test_review_proposal_file_returns_tuple(tmp_path):
+    """review_proposal_file now returns (report, frontmatter) for --write-audit usage."""
+    proposal_text = """---
+slug: test-x
+entity_type: gamme
+entity_data:
+  pg_id: 1
+  family: test
+  decision_brief:
+    function_oneliner: Filtre l'air d'admission pour protéger le moteur des particules
+    selection_criteria_top:
+    - Référence OEM
+    - Dimensions
+    - Motorisation
+    compatibility_summary: Vérifier la compatibilité selon le carburant et la motorisation.
+    source_kind: deterministic_transform
+    cross_check_status: WEB_CONFIRMS_RAG
+---
+
+## Body content"""
+    p = tmp_path / "test-x.md"
+    p.write_text(proposal_text, encoding="utf-8")
+    result = review.review_proposal_file(p)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    report, fm = result
+    assert report["slug"] == "test-x"
+    assert fm["entity_data"]["decision_brief"]["source_kind"] == "deterministic_transform"


### PR DESCRIPTION
## Summary

Addresses 3 frictions surfaced by the filtre-a-air pilot run on the auto-review module (#783). All within strict READ_ONLY scope — no R2/R8 touch, no proposal mutation, no `exportable.seo` change.

## Improvements

### (a) FR check rendering — no more Python dict dump

The `Checks` section in `<slug>.review.md` was rendering raw Python dict repr (e.g. `{'pass': True, 'reason': 'ok', 'details': ''}`). Now each of the 6 checks has a dedicated formatter producing a structured FR human-readable line.

**Before** :
```
- ✅ **structural** : {'pass': True, 'reason': 'ok', 'details': ''}
- ✅ **anti_filler** : {'pass': True, 'reason': 'ok', 'violations': []}
```

**After** :
```
- ✅ **Validité structurelle** : tous les champs requis présents
- ✅ **Anti-filler** : aucun placeholder ni phrase générique
- ✅ **Clarté de la fonction** : verbe technique présent ; pas de marketing
- ✅ **Critères de choix actionnables** : 3/3 critères actionnables
- ✅ **Lisibilité de la compatibilité** : pas de séparateurs debug ; phrase FR naturelle (selon/avec/et)
- ✅ **Qualité de la source** : verdict source = `DATA_WEAK`
```

Test invariant : `'pass'` Python dict syntax never appears in rendered markdown.

### (b) "Brief actuel" inline section

When `--write-audit` is used, the rendered markdown includes a self-contained view of the actual `decision_brief` facets. Reviewer no longer needs to open the proposal file separately.

```
## Brief actuel (facettes extraites de la proposal)

- **Fonction** : Filtre l'air d'admission pour protéger le moteur...
- **Critères de choix prioritaires** :
  - Respecter les dimensions exactes du filtre
  - Utiliser la référence OE ou l'équivalence constructeur
  - ...
- **Compatibilité** : Vérifier la compatibilité véhicule, motorisation et référence OEM.
- **Sourcing** : `source_kind=rag_candidate` ; `cross_check_status=NEITHER`
```

API change : `review_proposal_file()` now returns `(report, frontmatter)` tuple. Backward-compat preserved : `render_review_markdown(report)` without frontmatter still works (omits the new section).

### (c) ASCII-fold near-duplicate detection in `selection_criteria_top`

New `_ascii_fold()` helper normalizes strings (NFKD + drop diacritics + collapse whitespace + lowercase). The selection_actionability check now flags cases where two entries are identical after fold :

```
"Utiliser la référence OE"  ←  fold  →  "utiliser la reference oe"
"Utiliser la reference OE"  ←  fold  →  "utiliser la reference oe"  ← DUP detected
```

Surfaced via :
- new field `check["selection_actionability"]["near_duplicates"]` (list of duplicate items)
- new `fix_suggestion` of severity `minor` recommending upstream RAW dedup

**Limitation (documented, out of scope)** : entries differing by suffix words (e.g. `"X"` vs `"X pour le véhicule"`) still pass. Fuzzy matching with edit distance / Jaccard similarity would catch those but is a future refinement requiring semantic similarity logic.

## Test plan

- [x] 45/45 pytest pass (was 30/30 — added 15 tests covering the 3 improvements + backward-compat invariants)
- [x] Smoke-test on filtre-a-air : verdict `REVIEWABLE_WITH_FIXES` preserved, markdown now self-contained
- [x] Backward-compat : `render_review_markdown(report)` without frontmatter still works
- [x] Invariant : `exportable_seo_allowed: false` always, no `{'pass'` leak in rendered markdown
- [ ] CI passes

## Out of scope

- Fuzzy near-duplicate matching (edit distance / Jaccard) — requires semantic similarity, separate concern
- Proposal mutation, R2/R8 rendering, paid Meta surface — all out of doctrine
- Auto-promotion of `exportable.seo` — stays human per ADR-033

## Doctrine alignment

- **READ_ONLY** : no mutation of proposal files, no filesystem writes outside `--audit-dir`
- **Anti-bricolage** : `_ascii_fold` uses stdlib `unicodedata`, no fuzzy heuristics, no LLM
- **Knowledge-first** : DATA_WEAK still requires human review by design
- **OBSERVE window** : zero runtime change, R2/R8 untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)