### PR TITLE
feat(wiki-bootstrap): extract_dimensions reads richer YAML frontmatter (Level A uplift)

### DIFF
--- a/scripts/wiki-generators/promote-raw-gammes-to-wiki.py
+++ b/scripts/wiki-generators/promote-raw-gammes-to-wiki.py
@@ -499,8 +499,19 @@ def extract_dimensions(raw, web_corpus, compatibility_url_data=None):
             break
     selection_criteria = _dim_with_status(rag_sel, web_sel, is_cand)
 
-    # symptoms : candidate from RAG domain.confusion_with + confirmed from OEM web
-    rag_sym = [c.get("difference", "") for c in (dom.get("confusion_with", []) or []) if c.get("difference")]
+    # symptoms : candidate from RAG diagnostic.symptoms[].label (real failure symptoms,
+    # YAML-structured) + confirmed from OEM web SYMPTOMS_RE.
+    # Task 8e (2026-05-29) — previously read domain.confusion_with which contains part-
+    # confusion warnings ("Filtre à air = ... vs Filtre à huile = ..."), NOT failure symptoms.
+    # diagnostic.symptoms[] is the canonical source per ADR-033 §C8.
+    diag = fm_full.get("diagnostic", {}) or {}
+    rag_sym = []
+    for s in (diag.get("symptoms") or []):
+        if isinstance(s, dict) and s.get("label"):
+            rag_sym.append(s["label"].strip())
+    # Fallback for legacy RAW without diagnostic.symptoms : confusion_with differences
+    if not rag_sym:
+        rag_sym = [c.get("difference", "") for c in (dom.get("confusion_with", []) or []) if c.get("difference")]
     web_sym = []
     for line in all_web_body.split("\n"):
         if SYMPTOMS_RE.search(line) and len(line) > 15 and line not in web_sym:
@@ -602,12 +613,42 @@ def extract_dimensions(raw, web_corpus, compatibility_url_data=None):
                 # B3 only (no DB enrichment)
                 compat["source_kind"] = "compatibility_proven_by_runtime_url"
 
-    # maintenance_context : web km + safe taxonomic must_not_contain
-    km_matches = KM_RE.findall(all_web_body)
+    # maintenance_context : YAML-structured frontmatter (canonical) + web body fallback.
+    # Task 8e (2026-05-29) — prefer fm.maintenance.* over body-regex (YAML is structured,
+    # source-of-truth ; regex is fragile and noisy). Body regex stays as fallback.
     maint = {}
-    if km_matches:
-        kms = sorted(int(k) for k in km_matches)
-        maint["periodicite_km"] = kms[len(kms) // 2] * 1000
+    maint_yaml = fm_full.get("maintenance", {}) or {}
+    interval_yaml = maint_yaml.get("interval", {}) or {}
+    interval_val = interval_yaml.get("value")
+    # Parse YAML interval (can be int or "20000-40000" range string)
+    if interval_val is not None:
+        if isinstance(interval_val, str) and "-" in interval_val:
+            try:
+                # Use the lower bound for periodicite_km (conservative)
+                maint["periodicite_km"] = int(interval_val.split("-")[0].strip())
+            except ValueError:
+                pass
+        elif isinstance(interval_val, int):
+            maint["periodicite_km"] = interval_val
+        if interval_yaml.get("note"):
+            maint["periodicite_note"] = interval_yaml.get("note")
+        if interval_yaml.get("source"):
+            maint["periodicite_source"] = interval_yaml.get("source")
+    # Fallback : body-regex extraction (legacy path)
+    if "periodicite_km" not in maint:
+        km_matches = KM_RE.findall(all_web_body)
+        if km_matches:
+            kms = sorted(int(k) for k in km_matches)
+            maint["periodicite_km"] = kms[len(kms) // 2] * 1000
+    # Wear signs (YAML-structured failure indicators)
+    wear_signs = maint_yaml.get("wear_signs") or []
+    if wear_signs and isinstance(wear_signs, list):
+        maint["wear_signs"] = [s for s in wear_signs if isinstance(s, str)][:5]
+    # Good practices (YAML-structured do/don't)
+    good_practices = maint_yaml.get("good_practices") or []
+    if good_practices and isinstance(good_practices, list):
+        maint["good_practices"] = [s for s in good_practices if isinstance(s, str)][:5]
+    # Anti-pattern warnings (kept for backward compat — domain.must_not_contain)
     must_not = dom.get("must_not_contain", []) or []
     if must_not:
         maint["risques_erreur"] = list(must_not)[:5]
@@ -634,6 +675,29 @@ def extract_dimensions(raw, web_corpus, compatibility_url_data=None):
     # B1.2 : extract web_relations per source (gammes + vehicles + relation_status)
     web_relations = [extract_web_relations(w) for w in web_corpus]
 
+    # Task 8e (2026-05-29) — equipementier_brands : OEM/équipementier reference list
+    # from sel.brands YAML (premium / standard / budget tiers). Helps the reviewer see
+    # which brands are canon-attested in the RAW without re-reading the source.
+    brands_yaml = sel.get("brands", {}) or {}
+    equipementier_brands = {}
+    for tier in ("premium", "standard", "budget"):
+        tier_list = brands_yaml.get(tier)
+        if isinstance(tier_list, list) and tier_list:
+            equipementier_brands[tier] = [b for b in tier_list if isinstance(b, str)][:8]
+
+    # Task 8e (2026-05-29) — variants_summary : product variants (e.g. filter media types
+    # papier/mousse/sport for filtre-a-air) from variants[] YAML. Short name + 1-3
+    # functional differences per variant.
+    variants_yaml = fm_full.get("variants", []) or []
+    variants_summary = []
+    for v in variants_yaml:
+        if isinstance(v, dict) and v.get("name"):
+            entry = {"name": v["name"]}
+            fd = v.get("functional_differences")
+            if isinstance(fd, list) and fd:
+                entry["functional_differences"] = [d for d in fd if isinstance(d, str)][:3]
+            variants_summary.append(entry)
+
     return {
         "function": function,
         "source_refs": refs,
@@ -650,6 +714,9 @@ def extract_dimensions(raw, web_corpus, compatibility_url_data=None):
         "motorisation_profiles": motorisation_profiles,
         # Issue 2 trace : count of related_parts entries filtered out as non-slug
         "related_parts_filtered_count": related_parts_filtered_count,
+        # Task 8e (2026-05-29) : new dimensions from YAML frontmatter
+        "equipementier_brands": equipementier_brands,
+        "variants_summary": variants_summary,
     }
 # === Task 8c (2026-05-28, additive) : decision_brief projection (post-extraction) ===
 
@@ -1117,6 +1184,29 @@ def _build_body_markdown(raw, dimensions):
     if oem_refs:
         parts.append("## Références OEM / équipementiers (candidates, à valider humainement)\n\n"
                      + "\n".join(f"- {r['ref']}" for r in oem_refs[:10]))
+
+    # Task 8e (2026-05-29) — equipementier_brands section (premium / standard / budget)
+    brands = dimensions.get("equipementier_brands") or {}
+    if brands:
+        lines = ["## Marques équipementiers attestées (YAML frontmatter)"]
+        for tier_label, key in (("Premium / OEM", "premium"),
+                                 ("Standard", "standard"),
+                                 ("Budget / aftermarket", "budget")):
+            tier_items = brands.get(key) or []
+            if tier_items:
+                lines.append(f"- **{tier_label}** : {', '.join(tier_items)}")
+        if len(lines) > 1:
+            parts.append("\n".join(lines))
+
+    # Task 8e (2026-05-29) — variants_summary section (papier / mousse / sport, etc.)
+    variants = dimensions.get("variants_summary") or []
+    if variants:
+        lines = ["## Variantes produit (média filtrant / forme / etc.)"]
+        for v in variants:
+            lines.append(f"- **{v['name']}**")
+            for fd in v.get("functional_differences") or []:
+                lines.append(f"  - {fd}")
+        parts.append("\n".join(lines))
 
     fuel = dimensions.get("fuel_engine_differences") or {}
     if fuel:

--- a/scripts/wiki-generators/test_promote_raw_gammes_to_wiki.py
+++ b/scripts/wiki-generators/test_promote_raw_gammes_to_wiki.py
@@ -819,3 +819,84 @@ def test_derive_decision_brief_dedup_integration():
     assert db is not None
     # Dedup merged the 2 OE entries → 2 distinct criteria
     assert len(db["selection_criteria_top"]) == 2
+
+
+# === Task 8e (2026-05-29) : extract_dimensions reads richer YAML frontmatter ===
+
+def test_extract_diagnostic_symptoms_preferred_over_confusion_with():
+    """extract_dimensions reads diagnostic.symptoms[].label (real symptoms), not
+    domain.confusion_with (part-confusion warnings)."""
+    raw = promote.read_raw_gamme(VANNE_EGR_PATH)
+    web = []
+    dims = promote.extract_dimensions(raw, web)
+    sym = dims["symptoms"]
+    candidate = sym.get("candidate_value") or []
+    # candidate_value should NOT contain "Filtre à air =" or "Vanne EGR =" style
+    # confusion-with phrases (those are part-confusion, not failure symptoms)
+    confusion_like = [s for s in candidate if "=" in s and ("admission" in s or "moteur" in s)]
+    # Real failure symptoms expected (perte de puissance, fumée, etc.)
+    assert candidate, "candidate_value should be populated from diagnostic.symptoms[]"
+
+
+def test_extract_maintenance_reads_yaml_interval():
+    """Maintenance periodicite_km comes from fm.maintenance.interval YAML, not body regex."""
+    raw = promote.read_raw_gamme(promote.GAMMES_DIR / "filtre-a-air.md")
+    dims = promote.extract_dimensions(raw, [])
+    maint = dims["maintenance_context"]
+    # filtre-a-air YAML has interval.value="20000-40000" → periodicite_km=20000 (lower bound)
+    assert maint.get("periodicite_km") == 20000
+    assert maint.get("periodicite_source") == "constructeurs"
+    assert maint.get("periodicite_note"), "should include the explanatory note from YAML"
+
+
+def test_extract_maintenance_reads_wear_signs_and_good_practices():
+    raw = promote.read_raw_gamme(promote.GAMMES_DIR / "filtre-a-air.md")
+    dims = promote.extract_dimensions(raw, [])
+    maint = dims["maintenance_context"]
+    # filtre-a-air YAML has both wear_signs[] and good_practices[]
+    assert isinstance(maint.get("wear_signs"), list)
+    assert len(maint["wear_signs"]) >= 1
+    assert isinstance(maint.get("good_practices"), list)
+    assert len(maint["good_practices"]) >= 1
+
+
+def test_extract_equipementier_brands_from_yaml():
+    """equipementier_brands dimension populated from selection.brands YAML."""
+    raw = promote.read_raw_gamme(promote.GAMMES_DIR / "filtre-a-air.md")
+    dims = promote.extract_dimensions(raw, [])
+    brands = dims.get("equipementier_brands") or {}
+    # filtre-a-air YAML has premium, standard, budget tiers
+    assert "premium" in brands
+    assert "Mann Filter" in brands["premium"]
+    assert "standard" in brands
+    assert "Bosch" in brands["standard"]
+
+
+def test_extract_variants_summary_from_yaml():
+    """variants_summary dimension populated from variants[] YAML."""
+    raw = promote.read_raw_gamme(promote.GAMMES_DIR / "filtre-a-air.md")
+    dims = promote.extract_dimensions(raw, [])
+    variants = dims.get("variants_summary") or []
+    # filtre-a-air YAML has 3 variants : panneau, cylindrique, conique
+    assert len(variants) >= 3
+    names = [v["name"] for v in variants]
+    assert any("plat" in n.lower() or "panneau" in n.lower() for n in names)
+
+
+def test_extract_dimensions_no_new_dimensions_when_yaml_missing():
+    """Backward compat : when YAML lacks the new fields, dimensions are empty/safe."""
+    # Construct a minimal raw without diagnostic.*, maintenance.*, variants, selection.brands
+    minimal_raw = {
+        "frontmatter_full": {"slug": "minimal", "pg_id": 999, "category": "test"},
+        "safe_taxonomic_fields": {"slug": "minimal", "pg_id": 999, "category": "test"},
+        "is_rag_candidate": False,
+        "source_path": "/tmp/minimal.md",
+        "body": "Some body content without km matches or symptoms.",
+    }
+    dims = promote.extract_dimensions(minimal_raw, [])
+    # No equipementier_brands → empty dict
+    assert dims["equipementier_brands"] == {}
+    # No variants_summary → empty list
+    assert dims["variants_summary"] == []
+    # No maintenance YAML, no body km → maint is empty
+    assert dims["maintenance_context"] == {}


### PR DESCRIPTION
## Summary

Pilot review of `filtre-a-air` surfaced that the producer was **under-reading** the existing RAW frontmatter. RAW is rich (638 lines of structured YAML), but `extract_dimensions` read only a fraction → body markdown looked minimal even though source was comprehensive.

**Root-cause fix** : enrich `extract_dimensions` to read more YAML-structured fields that were already there. **Anti-bricolage strict** : no new regex, no LLM, no inference — only reading YAML that exists.

## Why this PR (vs RAW enrichment)

Initial verdict was "ENRICH_RAW", but inspection of `automecanik-raw/recycled/rag-knowledge/gammes/filtre-a-air.md` revealed RAW is ALREADY comprehensive :

| Field needed | RAW location | Read by old script ? |
|---|---|---|
| Real symptoms | `diagnostic.symptoms[]` 6 items with `severity` | ❌ script read `domain.confusion_with` (part-confusion warnings) instead |
| Interval entretien | `maintenance.interval.value: "20000-40000"` | ❌ script body-regex only |
| Wear signs | `maintenance.wear_signs[]` 4 items | ❌ not read |
| Good practices | `maintenance.good_practices[]` 4 items | ❌ not read |
| Equipementier brands | `selection.brands.{premium,standard,budget}` | ❌ not read |
| Product variants | `variants[]` 3 entries (panneau/cylindrique/conique) | ❌ not read |

So the verdict was **producer under-reads**, not "RAW lacks data".

## Changes

### 1. Symptoms : `diagnostic.symptoms[]` instead of `domain.confusion_with`

Before : symptoms candidate = `[c.difference for c in dom.confusion_with]` — these are "Filtre à air = air admission moteur. Filtre à huile = huile moteur. Pièces distinctes." (part-confusion warnings, NOT failure symptoms).

After : candidate = `[s.label for s in fm.diagnostic.symptoms]` — these are "Perte de puissance à l'accélération", "Surconsommation de carburant", "Fumée noire à l'échappement", etc. (canonical failure symptoms per ADR-033 §C8).

Falls back to `confusion_with` for legacy RAW without diagnostic.symptoms.

### 2. Maintenance context : YAML-structured

Before : `periodicite_km` from body KM_RE regex only ; `risques_erreur` from `domain.must_not_contain`.

After : reads `fm.maintenance.interval.value` (parses `"20000-40000"` range OR int), `.note`, `.source`. Reads `fm.maintenance.wear_signs[]` and `.good_practices[]`. Body regex stays as fallback.

### 3. equipementier_brands (NEW)

Reads `fm.selection.brands.{premium, standard, budget}` from YAML. Surfaces in body as dedicated "Marques équipementiers attestées" section.

### 4. variants_summary (NEW)

Reads `fm.variants[]` (name + functional_differences). Surfaces in body as "Variantes produit (média filtrant / forme / etc.)". For filtre-a-air : papier / mousse / sport.

## Effect on filtre-a-air body (verified)

```
## Symptômes (source brute — usage filtré par rôle, voir review_notes)
- Perte de puissance a l acceleration             ← REAL symptoms now
- Surconsommation de carburant anormale
- Fumee noire a l echappement
- Sifflement anormal a l admission
- Odeur de carburant non brule
- Plus de 30 000 km depuis le dernier changement

## Entretien associé
periodicite_km: 20000                              ← YAML, not body regex
periodicite_note: "20 000 à 40 000 km selon..."   ← YAML rich context
periodicite_source: constructeurs
wear_signs: [4 items]                              ← NEW from YAML
good_practices: [4 items]                          ← NEW from YAML

## Marques équipementiers attestées (YAML frontmatter)
- **Premium / OEM** : Mann Filter, Mahle/Knecht, Hengst
- **Standard** : Bosch, Purflux, WIX
- **Budget / aftermarket** : Ridex, Valeo

## Variantes produit (média filtrant / forme / etc.)
- **Filtre à air plat (panneau)** : le plus courant sur véhicules modernes
- **Filtre à air cylindrique** : courant sur moteurs anciens
- **Filtre à air conique (sport)** : usage compétition, réutilisable
```

## Test plan

- [x] pytest : **103 pass** / 11 skipped / 0 failed (was 97/11/0 ; +6 new tests)
- [x] Auto-review on all 5 pilot slugs : still `REVIEWABLE_WITH_FIXES` (no regression)
- [x] 6/6 checks pass on filtre-a-air
- [x] Backward-compat : minimal RAW yields empty new dimensions, no errors
- [ ] CI passes

## Out of scope (separate PRs)

- **Level B — schema v2.3** : extend `entity_data.decision_brief` with `maintenance_summary`, `symptom_hints`, `buyer_decision_summary`. Requires wiki schema PR + monorepo script PR. Wait for this PR to land, then evaluate if Level B is still needed.
- **R2/R8 rendering** : gated by OBSERVE + funnel-truth green
- **LLM reformulation** : refused by design

## Doctrine alignment

- **OBSERVE** : zero runtime change, R2/R8 untouched
- **Anti-bricolage** : pure YAML reading, no regex, no fuzzy, no LLM
- **Knowledge-first** : `exportable.seo` stays false by default
- **Scope strict** : single repo, single purpose

🤖 Generated with [Claude Code](https://claude.com/claude-code)