### PR TITLE
feat(support-crm): CONCURRENTLY indexes follow-up (___xtr_msg msg_crm_*)

### DIFF
--- a/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.down.sql
+++ b/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.down.sql
@@ -1,0 +1,8 @@
+-- supabase: no-transaction
+--
+-- Rollback: 20260529_xtr_msg_crm_indexes
+-- DROP INDEX CONCURRENTLY pour éviter le lock ACCESS EXCLUSIVE sur ___xtr_msg.
+-- Acquiert seulement SHARE UPDATE EXCLUSIVE → ne bloque pas les writes.
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_xtr_msg_crm_follow_up_due;
+DROP INDEX CONCURRENTLY IF EXISTS idx_xtr_msg_crm_status_active;

--- a/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
+++ b/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
@@ -1,0 +1,45 @@
+-- supabase: no-transaction
+-- squawk-ignore-file disallowed-in-transaction prefer-robust-stmts require-timeout-settings
+--
+-- Migration: 20260529_xtr_msg_crm_indexes
+-- Follow-up structurel de #784 (mini-CRM V0). Crée les 2 indexes partiels
+-- DIFFÉRÉS dans la migration `20260528_xtr_msg_crm_v0`.
+--
+-- Pourquoi maintenant et pas avant ?
+--   ___xtr_msg = 14.6M lignes / 10 GB (table legacy XTR). Un CREATE INDEX
+--   non-concurrent acquiert un lock SHARE qui bloque tous les writes
+--   pendant le build (potentiellement plusieurs minutes — incident risqué
+--   sur table hot). CREATE INDEX CONCURRENTLY contourne le lock mais ne
+--   peut pas s'exécuter dans une transaction.
+--
+-- ⚠️  CONTRAINTES D'APPLICATION :
+--   • PEUT PAS être appliquée via Supabase MCP `apply_migration` (wrap tx).
+--   • PEUT PAS être appliquée via une migration runner standard si celui-ci
+--     emballe en transaction.
+--   • Application correcte (2 voies équivalentes) :
+--       1. Supabase CLI qui respecte le marker `-- supabase: no-transaction`
+--          en tête : `supabase db push`
+--       2. psql direct : `psql "$DATABASE_URL" -f \
+--          backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql`
+--   • Durée typique : 5-20 minutes (CONCURRENTLY = 2 scans + suivi writes).
+--     N'occupe pas de lock bloquant → safe sur prod hot.
+--
+-- Rollback : companion .down.sql avec DROP INDEX CONCURRENTLY (symétrique
+-- sur le lock side ; SHARE UPDATE EXCLUSIVE ne bloque pas les writes).
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_xtr_msg_crm_status_active
+  ON ___xtr_msg (msg_crm_status, msg_date DESC)
+  WHERE msg_crm_status IS NOT NULL
+    AND msg_crm_status NOT IN ('won', 'lost');
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_xtr_msg_crm_follow_up_due
+  ON ___xtr_msg (msg_crm_next_follow_up_at)
+  WHERE msg_crm_next_follow_up_at IS NOT NULL
+    AND msg_crm_status IS NOT NULL
+    AND msg_crm_status NOT IN ('won', 'lost');
+
+-- Documentation inline (visible via \d+ ___xtr_msg).
+COMMENT ON INDEX idx_xtr_msg_crm_status_active IS
+  'Mini-CRM V0 : couvre /admin/leads (filtre status, tri msg_date DESC). Partiel sur leads actifs (NOT IN won, lost) pour minimiser la taille.';
+COMMENT ON INDEX idx_xtr_msg_crm_follow_up_due IS
+  'Mini-CRM V0 : couvre filtre follow_up=due|overdue. Partiel sur leads actifs avec date de relance planifiée.';

--- a/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
+++ b/backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
@@ -1,5 +1,6 @@
 -- supabase: no-transaction
--- squawk-ignore-file disallowed-in-transaction prefer-robust-stmts require-timeout-settings
+-- squawk-ignore-file ban-concurrent-index-creation-in-transaction
+-- squawk-ignore-file require-timeout-settings
 --
 -- Migration: 20260529_xtr_msg_crm_indexes
 -- Follow-up structurel de #784 (mini-CRM V0). Crée les 2 indexes partiels


### PR DESCRIPTION
## Summary

Follow-up structurel à #784 — ajoute les 2 indexes partiels que la migration V0 a explicitement différés. CREATE INDEX CONCURRENTLY hors-transaction pour ne pas bloquer les writes pendant le build sur la table legacy `___xtr_msg` (14.6M lignes / 10 GB).

## Why deferred from #784

Cf. commit `7effea523` dans #784 : tentative initiale d'application via Supabase MCP a déclenché un `statement_timeout` (60s) parce que CREATE INDEX non-concurrent acquiert un lock SHARE pendant le full scan d'une table 10 GB. Même avec un timeout bumpé, on aurait bloqué les writes pendant plusieurs minutes — exactement ce que squawk avertissait via `require-concurrent-index-creation`.

## Constraints (lis avant d'appliquer)

⚠️  Cette migration **ne peut pas** s'exécuter via `apply_migration` MCP (wrap tx). Application correcte (2 voies équivalentes) :

1. **Supabase CLI** : respecte le marker `-- supabase: no-transaction` en tête
   ```
   supabase db push
   ```

2. **psql direct** : autocommit par statement
   ```
   psql "$DATABASE_URL" -f backend/supabase/migrations/20260529_xtr_msg_crm_indexes.sql
   ```

Durée typique : **5-20 minutes** (CONCURRENTLY = 2 scans + suivi writes). N'occupe **pas** de lock bloquant → safe sur prod hot.

## Doctrine alignment

| Garde | État |
|---|---|
| OBSERVE window | Owner-gated GO via #784 ; follow-up structurel pur (aucun runtime touched, aucune route ajoutée) |
| Q1 anti-bricolage | Solution structurelle (vrais indexes BTree partiels) — pas un workaround |
| supabase-js 1000-row cap | Index couvre la pagination du `/admin/leads` listing |
| Rollback | `.down.sql` avec DROP INDEX CONCURRENTLY symétrique |
| Ownership | Couverte par le glob `*xtr_msg_crm*` ajouté dans #784 (D11 / @ak125) |

## squawk-ignore-file justification

```
-- squawk-ignore-file disallowed-in-transaction prefer-robust-stmts require-timeout-settings
```

- `disallowed-in-transaction` : CREATE INDEX CONCURRENTLY est précisément un statement qui ne peut PAS être en tx. Le marker no-transaction est intentionnel.
- `prefer-robust-stmts` : pas applicable ici, on utilise déjà `IF NOT EXISTS`.
- `require-timeout-settings` : CONCURRENTLY peut durer 20+ min, on ne veut PAS de statement_timeout court.

## Definition of Done — self-evaluation

> Référence canon : vault `rules-engineering-definition-of-done.md` (items 1 à 9).

### [x] DoD1 — Tests verts

- [x] Pas de tests applicatifs touchés (pur DDL infra)
- [x] CI à exécuter sur la PR — verra Migration Safety + ratchets

### [x] DoD2 — Ownership explicite

- [x] Assignee : @ak125
- [x] Domain D11 / @ak125 via glob `*xtr_msg_crm*` (ajouté dans #784, hérité)

### [x] DoD3 — Rollback défini

- [x] `.down.sql` symétrique : `DROP INDEX CONCURRENTLY IF EXISTS`
- [x] Reversibility : **instant** (DROP INDEX CONCURRENTLY = no-lock writes)

### [x] DoD4 — Observabilité présente

- N/A (pas de runtime code touché) — N/A justifié

### [x] DoD5 — Drift zéro

- [x] Migration atomique `YYYYMMDD_<snake_case>.sql` + `.down.sql` companion
- [x] Pas de regen types nécessaire (purs indexes, pas de schema change)

### [x] DoD6 — Docs à jour

- [x] Header de migration documente les contraintes d'application (no-tx + CLI/psql)
- [x] COMMENT ON INDEX sur les 2 objets nouveaux pour `\d+ ___xtr_msg`

### [x] DoD7 — Monitoring post-merge armé

- [x] Watcher : @ak125 (T+0 à T+24h après application)
- [x] Signaux watchés :
    - `SELECT indexrelname, idx_scan FROM pg_stat_user_indexes WHERE indexrelname LIKE 'idx_xtr_msg_crm_%'`
    - Latence `/admin/leads` API (devrait passer de seq-scan à index-scan)
- [x] Window : T+24h
- [x] Critère d'abort : si CONCURRENTLY échoue (lock conflict), il laisse un index INVALID → `DROP INDEX CONCURRENTLY` + retry

### [x] DoD8 — No TODO unresolved

- [x] Aucun TODO ajouté

### [x] DoD9 — No silent skip

- [x] Pas de feature flag, pas de skip silencieux
- [x] squawk-ignore-file documenté avec justification inline + dans le PR body

## Test plan

- [x] Migration syntax valide localement
- [ ] CI Migration Safety pass (squawk-ignore-file devrait satisfaire)
- [ ] Application sur DEV DB via Supabase CLI ou psql (manuel post-merge, durée 5-20 min)
- [ ] `\d+ ___xtr_msg` confirme les 2 indexes présents
- [ ] EXPLAIN ANALYZE sur `SELECT * FROM ___xtr_msg WHERE msg_crm_status IS NOT NULL ORDER BY msg_date DESC LIMIT 50` montre Index Scan (pas Seq Scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)