### PR TITLE
feat(media-factory): 3 Remotion compositions Fafa V1 (PR #2)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -822,6 +822,12 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: low
+  # Remotion render microservice (Fafa Media Factory) — video pipeline (D12).
+  - glob: services/remotion-renderer/**
+    domain: D12
+    owner: '@ak125/marketing-team'
+    sourceConfidence: high
+    risk: medium
   - glob: workspaces/wiki/**
     domain: D15
     owner: '@ak125'

--- a/services/remotion-renderer/src/compositions/NeChangePasTropVite.tsx
+++ b/services/remotion-renderer/src/compositions/NeChangePasTropVite.tsx
@@ -1,0 +1,357 @@
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+  Audio,
+} from 'remotion';
+
+/**
+ * NeChangePasTropVite — Vertical short (1080x1920, 38s @ 30fps = 1140 frames).
+ *
+ * Format Fafa "ne-change-pas-trop-vite" : avant de changer la pièce X,
+ * vérifie d'abord les causes alternatives.
+ *
+ * Sections:
+ *   Hook     (0-150)     : accroche symptôme + "ne change pas trop vite"
+ *   Problem  (150-330)   : pourquoi le réflexe "changer X" est risqué
+ *   Causes   (330-870)   : 3 causes possibles (ordonnées par probabilité)
+ *   Advice   (870-1050)  : conseil de vérification ordonné
+ *   Closer   (1050-1140) : brand + CTA
+ *
+ * Palette: #1a1a2e bg, #e94560 accent, #16213e panel, Liberation Sans.
+ * Aucun visuel n'est une preuve (G6) — texte animé + schéma stylisé uniquement.
+ */
+
+interface Cause {
+  cause: string;
+  duration_sec?: number;
+  check_suggestion?: string;
+}
+
+interface NeChangePasTropViteProps {
+  briefId?: string;
+  videoType?: string;
+  vertical?: string;
+  hook: string;
+  symptom: string;
+  pieceWrong: string;
+  causes: Cause[];
+  advice: string;
+  cta: string;
+  disclaimer?: string;
+  audioUrl?: string;
+  brandName?: string;
+}
+
+export const NeChangePasTropVite: React.FC<NeChangePasTropViteProps> = ({
+  hook = 'Perte de puissance ? Ne change pas ta pièce trop vite.',
+  symptom = 'Perte de puissance',
+  pieceWrong = 'vanne EGR',
+  causes = [
+    { cause: 'Filtre à air bouché', check_suggestion: 'Inspection visuelle' },
+    { cause: 'Débitmètre fatigué', check_suggestion: 'Test multimètre' },
+    { cause: 'Durite percée', check_suggestion: 'Visuel + écoute' },
+  ],
+  advice = 'Vérifie dans l’ordre : visuel → test → atelier',
+  cta = 'Sur AutoMecanik, sélectionne ton véhicule pour voir les pièces compatibles.',
+  disclaimer = 'Conseil informatif. Diagnostic à confirmer selon véhicule.',
+  audioUrl,
+  brandName = 'AutoMecanik',
+}) => {
+  const frame = useCurrentFrame();
+  const { fps, durationInFrames } = useVideoConfig();
+
+  const HOOK_END = 150;
+  const PROBLEM_END = 330;
+  const CAUSES_END = 870;
+  const ADVICE_END = 1050;
+
+  const progress = frame / durationInFrames;
+
+  return (
+    <AbsoluteFill
+      style={{
+        backgroundColor: '#1a1a2e',
+        fontFamily: 'Liberation Sans, Arial, sans-serif',
+        overflow: 'hidden',
+      }}
+    >
+      {audioUrl && <Audio src={audioUrl} />}
+
+      <HookSection frame={frame} fps={fps} endFrame={HOOK_END} hook={hook} symptom={symptom} />
+
+      <ProblemSection
+        frame={frame}
+        startFrame={HOOK_END}
+        endFrame={PROBLEM_END}
+        pieceWrong={pieceWrong}
+      />
+
+      <CausesSection
+        frame={frame}
+        startFrame={PROBLEM_END}
+        endFrame={CAUSES_END}
+        causes={causes}
+      />
+
+      <AdviceSection
+        frame={frame}
+        startFrame={CAUSES_END}
+        endFrame={ADVICE_END}
+        advice={advice}
+      />
+
+      <CloserSection frame={frame} fps={fps} startFrame={ADVICE_END} brandName={brandName} cta={cta} />
+
+      {disclaimer && <DisclaimerOverlay text={disclaimer} />}
+
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          width: `${progress * 100}%`,
+          height: 4,
+          backgroundColor: '#e94560',
+        }}
+      />
+    </AbsoluteFill>
+  );
+};
+
+// ── Hook ──
+const HookSection: React.FC<{
+  frame: number;
+  fps: number;
+  endFrame: number;
+  hook: string;
+  symptom: string;
+}> = ({ frame, fps, endFrame, hook, symptom }) => {
+  if (frame >= endFrame) return null;
+
+  const titleScale = spring({ frame, fps, config: { damping: 12, stiffness: 70 } });
+  const symptomOpacity = interpolate(frame, [40, 70], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
+      <div
+        style={{
+          color: '#e94560',
+          fontSize: 28,
+          fontWeight: 'bold',
+          letterSpacing: 4,
+          textTransform: 'uppercase',
+          marginBottom: 24,
+          opacity: symptomOpacity,
+        }}
+      >
+        {symptom}
+      </div>
+      <div
+        style={{
+          color: '#ffffff',
+          fontSize: 64,
+          fontWeight: 'bold',
+          lineHeight: 1.25,
+          textAlign: 'center',
+          transform: `scale(${titleScale})`,
+        }}
+      >
+        {hook}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+// ── Problem ──
+const ProblemSection: React.FC<{
+  frame: number;
+  startFrame: number;
+  endFrame: number;
+  pieceWrong: string;
+}> = ({ frame, startFrame, endFrame, pieceWrong }) => {
+  if (frame < startFrame || frame >= endFrame) return null;
+  const local = frame - startFrame;
+  const fadeIn = interpolate(local, [0, 20], [0, 1], { extrapolateRight: 'clamp' });
+  const slideY = interpolate(local, [0, 30], [40, 0], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill
+      style={{ justifyContent: 'center', alignItems: 'center', opacity: fadeIn, padding: '0 60px' }}
+    >
+      <div style={{ transform: `translateY(${slideY}px)`, textAlign: 'center', maxWidth: 900 }}>
+        <div style={{ color: 'rgba(255,255,255,0.85)', fontSize: 44, lineHeight: 1.5 }}>
+          Changer directement{' '}
+          <span style={{ color: '#e94560', fontWeight: 'bold' }}>la {pieceWrong}</span>, c’est
+          tentant. Mais si la vraie cause est ailleurs, tu paies pour rien.
+        </div>
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+// ── Causes (3 cards, sequential reveal) ──
+const CausesSection: React.FC<{
+  frame: number;
+  startFrame: number;
+  endFrame: number;
+  causes: Cause[];
+}> = ({ frame, startFrame, endFrame, causes }) => {
+  if (frame < startFrame || frame >= endFrame) return null;
+  const local = frame - startFrame;
+  const sectionDuration = endFrame - startFrame;
+  const perCard = sectionDuration / Math.max(causes.length, 1);
+
+  return (
+    <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 50px' }}>
+      <div
+        style={{
+          color: 'rgba(255,255,255,0.5)',
+          fontSize: 24,
+          letterSpacing: 3,
+          textTransform: 'uppercase',
+          marginBottom: 40,
+        }}
+      >
+        Vérifie d’abord
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 28, width: '100%', maxWidth: 880 }}>
+        {causes.slice(0, 3).map((c, i) => {
+          const cardStart = i * perCard;
+          const reveal = interpolate(local, [cardStart, cardStart + 18], [0, 1], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          });
+          const slideX = interpolate(local, [cardStart, cardStart + 18], [-50, 0], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          });
+          return (
+            <div
+              key={i}
+              style={{
+                opacity: reveal,
+                transform: `translateX(${slideX}px)`,
+                backgroundColor: '#16213e',
+                borderLeft: '6px solid #e94560',
+                borderRadius: 12,
+                padding: '28px 32px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 24,
+              }}
+            >
+              <span style={{ color: '#e94560', fontSize: 52, fontWeight: 'bold', lineHeight: 1 }}>
+                {i + 1}
+              </span>
+              <div>
+                <div style={{ color: '#ffffff', fontSize: 38, fontWeight: 600 }}>{c.cause}</div>
+                {c.check_suggestion && (
+                  <div style={{ color: 'rgba(255,255,255,0.55)', fontSize: 24, marginTop: 6 }}>
+                    {c.check_suggestion}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+// ── Advice ──
+const AdviceSection: React.FC<{
+  frame: number;
+  startFrame: number;
+  endFrame: number;
+  advice: string;
+}> = ({ frame, startFrame, endFrame, advice }) => {
+  if (frame < startFrame || frame >= endFrame) return null;
+  const local = frame - startFrame;
+  const fadeIn = interpolate(local, [0, 20], [0, 1], { extrapolateRight: 'clamp' });
+
+  return (
+    <AbsoluteFill
+      style={{ justifyContent: 'center', alignItems: 'center', opacity: fadeIn, padding: '0 60px' }}
+    >
+      <div style={{ textAlign: 'center', maxWidth: 900 }}>
+        <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: 46, lineHeight: 1.45, fontWeight: 500 }}>
+          {advice}
+        </div>
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+// ── Closer (brand + CTA) ──
+const CloserSection: React.FC<{
+  frame: number;
+  fps: number;
+  startFrame: number;
+  brandName: string;
+  cta: string;
+}> = ({ frame, fps, startFrame, brandName, cta }) => {
+  if (frame < startFrame) return null;
+  const local = frame - startFrame;
+  const brandScale = spring({ frame: local, fps, config: { damping: 12, stiffness: 80 } });
+  const ctaOpacity = interpolate(local, [20, 45], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
+      <div
+        style={{
+          color: '#e94560',
+          fontSize: 80,
+          fontWeight: 'bold',
+          letterSpacing: 5,
+          transform: `scale(${brandScale})`,
+        }}
+      >
+        {brandName}
+      </div>
+      <div
+        style={{
+          marginTop: 32,
+          color: 'rgba(255,255,255,0.85)',
+          fontSize: 34,
+          lineHeight: 1.4,
+          textAlign: 'center',
+          maxWidth: 820,
+          opacity: ctaOpacity,
+        }}
+      >
+        {cta}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+// ── Disclaimer overlay (shared) ──
+const DisclaimerOverlay: React.FC<{ text: string }> = ({ text }) => (
+  <div
+    style={{
+      position: 'absolute',
+      bottom: 80,
+      left: 40,
+      right: 40,
+      textAlign: 'center',
+      color: 'rgba(255,255,255,0.4)',
+      fontSize: 18,
+      lineHeight: 1.4,
+    }}
+  >
+    {text}
+  </div>
+);

--- a/services/remotion-renderer/src/compositions/PieceExpliquee.tsx
+++ b/services/remotion-renderer/src/compositions/PieceExpliquee.tsx
@@ -1,0 +1,372 @@
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+  Audio,
+} from 'remotion';
+
+/**
+ * PieceExpliquee — Vertical short (1080x1920, 40s @ 30fps = 1200 frames).
+ *
+ * Format Fafa "piece-expliquee" : à quoi sert la pièce X, comment elle s'use,
+ * quand la changer.
+ *
+ * Sections:
+ *   Intro      (0-120)     : nom de la pièce, accroche
+ *   Function   (120-420)   : rôle mécanique + emplacement
+ *   WearSigns  (420-720)   : 2-3 signes d'usure observables
+ *   WhenChange (720-960)   : critère objectif (km / signe critique)
+ *   Closer     (960-1200)  : brand + CTA
+ *
+ * Palette: #1a1a2e bg, #e94560 accent, #16213e panel, Liberation Sans.
+ * Claim safety (ex. freinage compromis) → validation humaine obligatoire (G2 STRICT).
+ */
+
+interface WearSign {
+  sign: string;
+  severity?: 'low' | 'medium' | 'high';
+}
+
+interface PieceExpliqueeProps {
+  briefId?: string;
+  videoType?: string;
+  vertical?: string;
+  piece: string;
+  pieceFunction: string;
+  location: string;
+  wearSigns: WearSign[];
+  whenToChange: string;
+  cta: string;
+  disclaimer?: string;
+  audioUrl?: string;
+  brandName?: string;
+}
+
+const SEVERITY_COLOR: Record<string, string> = {
+  low: 'rgba(255,255,255,0.4)',
+  medium: '#f0a500',
+  high: '#e94560',
+};
+
+export const PieceExpliquee: React.FC<PieceExpliqueeProps> = ({
+  piece = 'Vanne EGR',
+  pieceFunction = 'Elle recircule une partie des gaz d’échappement pour réduire les émissions.',
+  location = 'Entre le collecteur d’échappement et l’admission',
+  wearSigns = [
+    { sign: 'Perte de puissance', severity: 'medium' },
+    { sign: 'Fumée noire à l’accélération', severity: 'medium' },
+    { sign: 'Voyant moteur allumé', severity: 'high' },
+  ],
+  whenToChange = 'En général vers 120 000 km, ou dès que les symptômes persistent après nettoyage.',
+  cta = 'Sur AutoMecanik, sélectionne ton véhicule pour vérifier la compatibilité.',
+  disclaimer = 'Conseil informatif. Diagnostic à confirmer selon véhicule.',
+  audioUrl,
+  brandName = 'AutoMecanik',
+}) => {
+  const frame = useCurrentFrame();
+  const { fps, durationInFrames } = useVideoConfig();
+
+  const INTRO_END = 120;
+  const FUNCTION_END = 420;
+  const WEAR_END = 720;
+  const WHEN_END = 960;
+
+  const progress = frame / durationInFrames;
+
+  return (
+    <AbsoluteFill
+      style={{
+        backgroundColor: '#1a1a2e',
+        fontFamily: 'Liberation Sans, Arial, sans-serif',
+        overflow: 'hidden',
+      }}
+    >
+      {audioUrl && <Audio src={audioUrl} />}
+
+      <IntroSection frame={frame} fps={fps} endFrame={INTRO_END} piece={piece} />
+
+      <LabelSection
+        frame={frame}
+        startFrame={INTRO_END}
+        endFrame={FUNCTION_END}
+        label="À quoi ça sert"
+        body={pieceFunction}
+        footnote={location}
+        footLabel="Emplacement"
+      />
+
+      <WearSignsSection
+        frame={frame}
+        startFrame={FUNCTION_END}
+        endFrame={WEAR_END}
+        wearSigns={wearSigns}
+      />
+
+      <LabelSection
+        frame={frame}
+        startFrame={WEAR_END}
+        endFrame={WHEN_END}
+        label="Quand la changer"
+        body={whenToChange}
+      />
+
+      <CloserSection frame={frame} fps={fps} startFrame={WHEN_END} brandName={brandName} cta={cta} />
+
+      {disclaimer && <DisclaimerOverlay text={disclaimer} />}
+
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          width: `${progress * 100}%`,
+          height: 4,
+          backgroundColor: '#e94560',
+        }}
+      />
+    </AbsoluteFill>
+  );
+};
+
+// ── Intro ──
+const IntroSection: React.FC<{
+  frame: number;
+  fps: number;
+  endFrame: number;
+  piece: string;
+}> = ({ frame, fps, endFrame, piece }) => {
+  if (frame >= endFrame) return null;
+  const scale = spring({ frame, fps, config: { damping: 12, stiffness: 70 } });
+  const subOpacity = interpolate(frame, [45, 75], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
+      <div
+        style={{
+          color: 'rgba(255,255,255,0.5)',
+          fontSize: 30,
+          letterSpacing: 4,
+          textTransform: 'uppercase',
+          marginBottom: 24,
+          opacity: subOpacity,
+        }}
+      >
+        La pièce expliquée
+      </div>
+      <div
+        style={{
+          color: '#ffffff',
+          fontSize: 80,
+          fontWeight: 'bold',
+          textAlign: 'center',
+          lineHeight: 1.15,
+          transform: `scale(${scale})`,
+        }}
+      >
+        {piece}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+// ── Generic label + body section (Function, WhenChange) ──
+const LabelSection: React.FC<{
+  frame: number;
+  startFrame: number;
+  endFrame: number;
+  label: string;
+  body: string;
+  footnote?: string;
+  footLabel?: string;
+}> = ({ frame, startFrame, endFrame, label, body, footnote, footLabel }) => {
+  if (frame < startFrame || frame >= endFrame) return null;
+  const local = frame - startFrame;
+  const fadeIn = interpolate(local, [0, 20], [0, 1], { extrapolateRight: 'clamp' });
+  const slideY = interpolate(local, [0, 30], [40, 0], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+  const footOpacity = interpolate(local, [50, 80], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill
+      style={{ justifyContent: 'center', alignItems: 'center', opacity: fadeIn, padding: '0 60px' }}
+    >
+      <div
+        style={{
+          color: '#e94560',
+          fontSize: 30,
+          fontWeight: 'bold',
+          letterSpacing: 3,
+          textTransform: 'uppercase',
+          marginBottom: 32,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          transform: `translateY(${slideY}px)`,
+          color: 'rgba(255,255,255,0.9)',
+          fontSize: 46,
+          lineHeight: 1.45,
+          textAlign: 'center',
+          maxWidth: 900,
+        }}
+      >
+        {body}
+      </div>
+      {footnote && (
+        <div
+          style={{
+            marginTop: 36,
+            opacity: footOpacity,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 10,
+            backgroundColor: '#16213e',
+            color: 'rgba(255,255,255,0.6)',
+            fontSize: 24,
+            padding: '12px 24px',
+            borderRadius: 8,
+          }}
+        >
+          {footLabel && <span style={{ color: '#e94560', fontWeight: 'bold' }}>{footLabel}:</span>}
+          {footnote}
+        </div>
+      )}
+    </AbsoluteFill>
+  );
+};
+
+// ── Wear signs (list reveal) ──
+const WearSignsSection: React.FC<{
+  frame: number;
+  startFrame: number;
+  endFrame: number;
+  wearSigns: WearSign[];
+}> = ({ frame, startFrame, endFrame, wearSigns }) => {
+  if (frame < startFrame || frame >= endFrame) return null;
+  const local = frame - startFrame;
+  const signs = wearSigns.slice(0, 3);
+
+  return (
+    <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 50px' }}>
+      <div
+        style={{
+          color: '#e94560',
+          fontSize: 30,
+          fontWeight: 'bold',
+          letterSpacing: 3,
+          textTransform: 'uppercase',
+          marginBottom: 48,
+        }}
+      >
+        Signes d’usure
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 24, width: '100%', maxWidth: 860 }}>
+        {signs.map((s, i) => {
+          const cardStart = 20 + i * 50;
+          const reveal = interpolate(local, [cardStart, cardStart + 18], [0, 1], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          });
+          const slideX = interpolate(local, [cardStart, cardStart + 18], [-40, 0], {
+            extrapolateLeft: 'clamp',
+            extrapolateRight: 'clamp',
+          });
+          const dot = SEVERITY_COLOR[s.severity ?? 'low'] ?? SEVERITY_COLOR.low;
+          return (
+            <div
+              key={i}
+              style={{
+                opacity: reveal,
+                transform: `translateX(${slideX}px)`,
+                backgroundColor: '#16213e',
+                borderRadius: 12,
+                padding: '26px 30px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 22,
+              }}
+            >
+              <div style={{ width: 18, height: 18, borderRadius: '50%', backgroundColor: dot, flex: '0 0 auto' }} />
+              <div style={{ color: '#ffffff', fontSize: 38, fontWeight: 500 }}>{s.sign}</div>
+            </div>
+          );
+        })}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+// ── Closer ──
+const CloserSection: React.FC<{
+  frame: number;
+  fps: number;
+  startFrame: number;
+  brandName: string;
+  cta: string;
+}> = ({ frame, fps, startFrame, brandName, cta }) => {
+  if (frame < startFrame) return null;
+  const local = frame - startFrame;
+  const brandScale = spring({ frame: local, fps, config: { damping: 12, stiffness: 80 } });
+  const ctaOpacity = interpolate(local, [20, 45], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
+      <div
+        style={{
+          color: '#e94560',
+          fontSize: 80,
+          fontWeight: 'bold',
+          letterSpacing: 5,
+          transform: `scale(${brandScale})`,
+        }}
+      >
+        {brandName}
+      </div>
+      <div
+        style={{
+          marginTop: 32,
+          color: 'rgba(255,255,255,0.85)',
+          fontSize: 34,
+          lineHeight: 1.4,
+          textAlign: 'center',
+          maxWidth: 820,
+          opacity: ctaOpacity,
+        }}
+      >
+        {cta}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+const DisclaimerOverlay: React.FC<{ text: string }> = ({ text }) => (
+  <div
+    style={{
+      position: 'absolute',
+      bottom: 80,
+      left: 40,
+      right: 40,
+      textAlign: 'center',
+      color: 'rgba(255,255,255,0.4)',
+      fontSize: 18,
+      lineHeight: 1.4,
+    }}
+  >
+    {text}
+  </div>
+);

--- a/services/remotion-renderer/src/compositions/SymptomeTroisCauses.tsx
+++ b/services/remotion-renderer/src/compositions/SymptomeTroisCauses.tsx
@@ -1,0 +1,315 @@
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+  Audio,
+} from 'remotion';
+
+/**
+ * SymptomeTroisCauses — Vertical short (1080x1920, 33s @ 30fps = 990 frames).
+ *
+ * Format Fafa "symptome-3-causes" : un symptôme observable → 3 causes
+ * possibles ordonnées par probabilité, chacune avec signe + check.
+ *
+ * Sections:
+ *   Symptom  (0-120)   : symptôme observable, accroche
+ *   Cause 1  (120-390) : cause fréquente + signe + check
+ *   Cause 2  (390-630) : cause intermédiaire
+ *   Cause 3  (630-870) : cause moins fréquente mais sérieuse
+ *   Closer   (870-990) : brand + CTA
+ *
+ * Palette: #1a1a2e bg, #e94560 accent, #16213e panel, Liberation Sans.
+ * Photos pièces autorisées en illustration (G6) — jamais comme preuve diagnostic.
+ */
+
+interface CauseDetail {
+  cause: string;
+  sign?: string;
+  check?: string;
+}
+
+interface SymptomeTroisCausesProps {
+  briefId?: string;
+  videoType?: string;
+  vertical?: string;
+  symptom: string;
+  causes: CauseDetail[];
+  cta: string;
+  disclaimer?: string;
+  audioUrl?: string;
+  brandName?: string;
+}
+
+export const SymptomeTroisCauses: React.FC<SymptomeTroisCausesProps> = ({
+  symptom = 'Perte de puissance',
+  causes = [
+    { cause: 'Filtre à air bouché', sign: 'Ralenti instable', check: 'Inspection visuelle' },
+    { cause: 'Débitmètre encrassé', sign: 'À-coups à l’accélération', check: 'Lecture valeurs OBD' },
+    { cause: 'Vanne EGR grippée', sign: 'Fumée + voyant moteur', check: 'Diagnostic atelier' },
+  ],
+  cta = 'Sur AutoMecanik, sélectionne ton véhicule pour voir les pièces compatibles.',
+  disclaimer = 'Conseil informatif. Diagnostic à confirmer selon véhicule.',
+  audioUrl,
+  brandName = 'AutoMecanik',
+}) => {
+  const frame = useCurrentFrame();
+  const { fps, durationInFrames } = useVideoConfig();
+
+  const SYMPTOM_END = 120;
+  const CAUSE_BOUNDS = [120, 390, 630, 870]; // start of cause1, cause2, cause3, closer
+  const CLOSER_START = 870;
+
+  const progress = frame / durationInFrames;
+  const safeCauses = causes.slice(0, 3);
+
+  return (
+    <AbsoluteFill
+      style={{
+        backgroundColor: '#1a1a2e',
+        fontFamily: 'Liberation Sans, Arial, sans-serif',
+        overflow: 'hidden',
+      }}
+    >
+      {audioUrl && <Audio src={audioUrl} />}
+
+      <SymptomSection frame={frame} fps={fps} endFrame={SYMPTOM_END} symptom={symptom} />
+
+      {safeCauses.map((c, i) => (
+        <CauseSection
+          key={i}
+          frame={frame}
+          index={i}
+          startFrame={CAUSE_BOUNDS[i]}
+          endFrame={CAUSE_BOUNDS[i + 1]}
+          cause={c}
+          total={safeCauses.length}
+        />
+      ))}
+
+      <CloserSection frame={frame} fps={fps} startFrame={CLOSER_START} brandName={brandName} cta={cta} />
+
+      {disclaimer && <DisclaimerOverlay text={disclaimer} />}
+
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          width: `${progress * 100}%`,
+          height: 4,
+          backgroundColor: '#e94560',
+        }}
+      />
+    </AbsoluteFill>
+  );
+};
+
+// ── Symptom hook ──
+const SymptomSection: React.FC<{
+  frame: number;
+  fps: number;
+  endFrame: number;
+  symptom: string;
+}> = ({ frame, fps, endFrame, symptom }) => {
+  if (frame >= endFrame) return null;
+  const scale = spring({ frame, fps, config: { damping: 12, stiffness: 70 } });
+  const subOpacity = interpolate(frame, [45, 75], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
+      <div
+        style={{
+          color: '#ffffff',
+          fontSize: 72,
+          fontWeight: 'bold',
+          textAlign: 'center',
+          lineHeight: 1.2,
+          transform: `scale(${scale})`,
+        }}
+      >
+        {symptom}
+      </div>
+      <div
+        style={{
+          marginTop: 28,
+          color: '#e94560',
+          fontSize: 34,
+          letterSpacing: 2,
+          opacity: subOpacity,
+        }}
+      >
+        3 causes possibles
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+// ── Single cause panel ──
+const CauseSection: React.FC<{
+  frame: number;
+  index: number;
+  startFrame: number;
+  endFrame: number;
+  cause: CauseDetail;
+  total: number;
+}> = ({ frame, index, startFrame, endFrame, cause, total }) => {
+  if (frame < startFrame || frame >= endFrame) return null;
+  const local = frame - startFrame;
+  const fadeIn = interpolate(local, [0, 18], [0, 1], { extrapolateRight: 'clamp' });
+  const numScale = spring({ frame: local, fps: 30, config: { damping: 10, stiffness: 60 } });
+  const detailSlideY = interpolate(local, [15, 40], [40, 0], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill
+      style={{ justifyContent: 'center', alignItems: 'center', opacity: fadeIn, padding: '0 60px' }}
+    >
+      {/* progress dots */}
+      <div style={{ display: 'flex', gap: 14, marginBottom: 50 }}>
+        {Array.from({ length: total }).map((_, d) => (
+          <div
+            key={d}
+            style={{
+              width: 14,
+              height: 14,
+              borderRadius: '50%',
+              backgroundColor: d === index ? '#e94560' : 'rgba(255,255,255,0.25)',
+            }}
+          />
+        ))}
+      </div>
+
+      <div
+        style={{
+          color: '#e94560',
+          fontSize: 96,
+          fontWeight: 'bold',
+          lineHeight: 1,
+          transform: `scale(${numScale})`,
+        }}
+      >
+        {index + 1}
+      </div>
+
+      <div
+        style={{
+          marginTop: 24,
+          color: '#ffffff',
+          fontSize: 52,
+          fontWeight: 'bold',
+          textAlign: 'center',
+          maxWidth: 880,
+        }}
+      >
+        {cause.cause}
+      </div>
+
+      <div style={{ transform: `translateY(${detailSlideY}px)`, marginTop: 40, width: '100%', maxWidth: 760 }}>
+        {cause.sign && (
+          <DetailRow label="Signe" value={cause.sign} />
+        )}
+        {cause.check && (
+          <DetailRow label="Vérifie" value={cause.check} />
+        )}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+const DetailRow: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 18,
+      backgroundColor: '#16213e',
+      borderRadius: 10,
+      padding: '18px 24px',
+      marginBottom: 16,
+    }}
+  >
+    <span
+      style={{
+        color: '#e94560',
+        fontSize: 22,
+        fontWeight: 'bold',
+        textTransform: 'uppercase',
+        letterSpacing: 2,
+        minWidth: 110,
+      }}
+    >
+      {label}
+    </span>
+    <span style={{ color: 'rgba(255,255,255,0.85)', fontSize: 30 }}>{value}</span>
+  </div>
+);
+
+// ── Closer ──
+const CloserSection: React.FC<{
+  frame: number;
+  fps: number;
+  startFrame: number;
+  brandName: string;
+  cta: string;
+}> = ({ frame, fps, startFrame, brandName, cta }) => {
+  if (frame < startFrame) return null;
+  const local = frame - startFrame;
+  const brandScale = spring({ frame: local, fps, config: { damping: 12, stiffness: 80 } });
+  const ctaOpacity = interpolate(local, [20, 45], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  return (
+    <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center', padding: '0 60px' }}>
+      <div
+        style={{
+          color: '#e94560',
+          fontSize: 80,
+          fontWeight: 'bold',
+          letterSpacing: 5,
+          transform: `scale(${brandScale})`,
+        }}
+      >
+        {brandName}
+      </div>
+      <div
+        style={{
+          marginTop: 32,
+          color: 'rgba(255,255,255,0.85)',
+          fontSize: 34,
+          lineHeight: 1.4,
+          textAlign: 'center',
+          maxWidth: 820,
+          opacity: ctaOpacity,
+        }}
+      >
+        {cta}
+      </div>
+    </AbsoluteFill>
+  );
+};
+
+const DisclaimerOverlay: React.FC<{ text: string }> = ({ text }) => (
+  <div
+    style={{
+      position: 'absolute',
+      bottom: 80,
+      left: 40,
+      right: 40,
+      textAlign: 'center',
+      color: 'rgba(255,255,255,0.4)',
+      fontSize: 18,
+      lineHeight: 1.4,
+    }}
+  >
+    {text}
+  </div>
+);

--- a/services/remotion-renderer/src/compositions/index.tsx
+++ b/services/remotion-renderer/src/compositions/index.tsx
@@ -2,6 +2,9 @@ import { registerRoot, Composition } from 'remotion';
 import { TestCard } from './TestCard';
 import { ShortProductHighlight } from './ShortProductHighlight';
 import { ShortBrakingFact } from './ShortBrakingFact';
+import { NeChangePasTropVite } from './NeChangePasTropVite';
+import { SymptomeTroisCauses } from './SymptomeTroisCauses';
+import { PieceExpliquee } from './PieceExpliquee';
 
 export const RemotionRoot: React.FC = () => {
   return (
@@ -57,6 +60,71 @@ export const RemotionRoot: React.FC = () => {
           schemaSvgId: 'full' as const,
           brandName: 'AutoMecanik',
           tagline: 'Pièces auto de qualité',
+        }}
+      />
+      <Composition
+        id="NeChangePasTropVite"
+        component={NeChangePasTropVite}
+        durationInFrames={1140}
+        fps={30}
+        width={1080}
+        height={1920}
+        defaultProps={{
+          hook: 'Perte de puissance et fumée noire ? Ne change pas ta vanne EGR trop vite.',
+          symptom: 'Perte de puissance',
+          pieceWrong: 'vanne EGR',
+          causes: [
+            { cause: 'Filtre à air bouché', check_suggestion: 'Inspection visuelle' },
+            { cause: 'Débitmètre fatigué', check_suggestion: 'Test multimètre' },
+            { cause: 'Durite percée', check_suggestion: 'Visuel + écoute' },
+          ],
+          advice: 'Vérifie dans l’ordre : visuel → multimètre → atelier.',
+          cta: 'Sur AutoMecanik, sélectionne ton véhicule pour voir les pièces compatibles.',
+          disclaimer: 'Conseil informatif. Diagnostic à confirmer selon véhicule.',
+          brandName: 'AutoMecanik',
+        }}
+      />
+      <Composition
+        id="SymptomeTroisCauses"
+        component={SymptomeTroisCauses}
+        durationInFrames={990}
+        fps={30}
+        width={1080}
+        height={1920}
+        defaultProps={{
+          symptom: 'Perte de puissance',
+          causes: [
+            { cause: 'Filtre à air bouché', sign: 'Ralenti instable', check: 'Inspection visuelle' },
+            { cause: 'Débitmètre encrassé', sign: 'À-coups à l’accélération', check: 'Lecture valeurs OBD' },
+            { cause: 'Vanne EGR grippée', sign: 'Fumée + voyant moteur', check: 'Diagnostic atelier' },
+          ],
+          cta: 'Sur AutoMecanik, sélectionne ton véhicule pour voir les pièces compatibles.',
+          disclaimer: 'Conseil informatif. Diagnostic à confirmer selon véhicule.',
+          brandName: 'AutoMecanik',
+        }}
+      />
+      <Composition
+        id="PieceExpliquee"
+        component={PieceExpliquee}
+        durationInFrames={1200}
+        fps={30}
+        width={1080}
+        height={1920}
+        defaultProps={{
+          piece: 'Vanne EGR',
+          pieceFunction:
+            'Elle recircule une partie des gaz d’échappement pour réduire les émissions.',
+          location: 'Entre le collecteur d’échappement et l’admission',
+          wearSigns: [
+            { sign: 'Perte de puissance', severity: 'medium' as const },
+            { sign: 'Fumée noire à l’accélération', severity: 'medium' as const },
+            { sign: 'Voyant moteur allumé', severity: 'high' as const },
+          ],
+          whenToChange:
+            'En général vers 120 000 km, ou dès que les symptômes persistent après nettoyage.',
+          cta: 'Sur AutoMecanik, sélectionne ton véhicule pour vérifier la compatibilité.',
+          disclaimer: 'Conseil informatif. Diagnostic à confirmer selon véhicule.',
+          brandName: 'AutoMecanik',
         }}
       />
     </>

--- a/services/remotion-renderer/test/fixtures/pilot-ne-change-pas-trop-vite.json
+++ b/services/remotion-renderer/test/fixtures/pilot-ne-change-pas-trop-vite.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "1.0.0",
+  "briefId": "fafa-vanne-egr-001",
+  "executionLogId": 0,
+  "videoType": "short",
+  "vertical": "alimentation",
+  "composition": "NeChangePasTropVite",
+  "outputFormat": "mp4",
+  "resolution": { "width": 1080, "height": 1920 },
+  "fps": 30,
+  "durationSecs": 38,
+  "compositionProps": {
+    "hook": "Perte de puissance et fumée noire ? Ne change pas ta vanne EGR trop vite.",
+    "symptom": "Perte de puissance",
+    "pieceWrong": "vanne EGR",
+    "causes": [
+      { "cause": "Filtre à air bouché", "check_suggestion": "Inspection visuelle" },
+      { "cause": "Débitmètre fatigué", "check_suggestion": "Test multimètre" },
+      { "cause": "Durite percée", "check_suggestion": "Visuel + écoute" }
+    ],
+    "advice": "Vérifie dans l'ordre : visuel → multimètre → atelier.",
+    "cta": "Sur AutoMecanik, sélectionne ton véhicule pour voir les pièces compatibles.",
+    "disclaimer": "Conseil informatif. Diagnostic à confirmer selon véhicule.",
+    "brandName": "AutoMecanik"
+  }
+}


### PR DESCRIPTION
## Summary

PR Monorepo #2 — les 3 compositions Remotion de Fafa Media Factory V1, correspondant aux 3 formats narratifs livrés en Foundation (#789).

| Composition | Dimensions | Durée | Format Fafa |
|---|---|---|---|
| `NeChangePasTropVite` | 1080×1920 | 1140f / 38s | Avant de changer la pièce X, vérifie 3 causes alternatives |
| `SymptomeTroisCauses` | 1080×1920 | 990f / 33s | 1 symptôme → 3 causes ordonnées par probabilité |
| `PieceExpliquee` | 1080×1920 | 1200f / 40s | Rôle pièce + signes d'usure + quand changer |

Enregistrées dans `src/compositions/index.tsx`. Suite de #789 (Foundation, mergé).

## Pattern

Aligné exactement sur `ShortBrakingFact` (composition existante) :
- `AbsoluteFill` + sections par bornes de frames + `spring`/`interpolate`
- `Audio` via prop `audioUrl` (voix ElevenLabs optionnelle)
- `DisclaimerOverlay` + progress bar
- Palette `#1a1a2e` / `#e94560` / `#16213e`, Liberation Sans
- Props injectés via `compositionProps` (P8 du render contract)

## Conformité gouvernance vidéo P0

- ✅ Disclaimer overlay obligatoire sur chaque composition
- ✅ Aucun visuel utilisé comme preuve (G6) — texte animé + cartes stylisées uniquement, pas de photo présentée comme preuve diagnostic
- ✅ `PieceExpliquee` : la sévérité des signes d'usure est un code couleur illustratif, claim safety → validation humaine (G2) reste requise côté brief

## Test plan / vérification

- [x] `remotion compositions src/compositions/index.tsx` → 6/6 listées, 3 nouvelles aux bonnes dimensions/durées (bundle webpack OK)
- [x] `remotion still --frame=200` → 3/3 rendent des pixels (PNG 68-89 KB), design on-brand vérifié visuellement
- [x] Fixture `test/fixtures/pilot-ne-change-pas-trop-vite.json` valide vs `renderRequestSchema` (Zod)
- [x] Aucun `node_modules`/binaire committé
- [ ] **Smoke render mp4 + S3 complet** : à exécuter sur le host renderer ou CI (Chromium + ffmpeg + S3) — non lançable dans le sandbox de dev

## Note tsc (pré-existant, non bloquant)

`tsc --noEmit` reporte une erreur de typing sur `<Composition component={...}>` — elle affecte **aussi** `ShortBrakingFact` sur `main` (quirk de typing Remotion). Le rendu réel passe par `@remotion/bundler` (esbuild/webpack), pas tsc — d'où le bundle + still render verts. Non refactoré : hors scope, pattern établi repo-wide (refactorer le typing des 3 compositions existantes serait un cleanup opportuniste).

## Suite

- **PR #3 Pilotes** (backlog) : 10 vidéos DRAFT_ONLY utilisant ces compositions via le workflow skills + `/render` manuel
- **Vault Phase 1** : 3 PRs ADR/rules en attente de signature G3 owner (drafts `/tmp/vault-fafa-media-factory/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)