### PR TITLE
feat(diagnostic): PR-1a Result UX — drivability, rapport garage, toggle (kill-switch, OFF par défaut)

### DIFF
--- a/frontend/app/components/diagnostic-wizard/results/AudienceToggle.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/AudienceToggle.tsx
@@ -1,0 +1,51 @@
+/**
+ * AudienceToggle — bascule "particulier / mécano" (PR-1a)
+ *
+ * Même diagnostic, deux niveaux de lecture. Ne change PAS les données : seul le rendu
+ * (verbosité technique : scoring breakdown, vocabulaire) est ajusté en aval.
+ */
+/* eslint-disable no-restricted-syntax */ // print:hidden intentionnel (masquer le toggle à l'impression)
+import { User, Wrench } from "lucide-react";
+
+export type Audience = "particulier" | "mecano";
+
+interface Props {
+  value: Audience;
+  onChange: (a: Audience) => void;
+}
+
+const OPTIONS: { id: Audience; label: string; icon: typeof User }[] = [
+  { id: "particulier", label: "Particulier", icon: User },
+  { id: "mecano", label: "Mécano", icon: Wrench },
+];
+
+export function AudienceToggle({ value, onChange }: Props) {
+  return (
+    <div
+      className="inline-flex items-center rounded-lg border border-gray-200 bg-gray-50 p-0.5 print:hidden"
+      role="group"
+      aria-label="Niveau de lecture du diagnostic"
+    >
+      {OPTIONS.map((opt) => {
+        const Icon = opt.icon;
+        const active = value === opt.id;
+        return (
+          <button
+            key={opt.id}
+            type="button"
+            onClick={() => onChange(opt.id)}
+            aria-pressed={active}
+            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              active
+                ? "bg-white text-blue-700 shadow-sm"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            <Icon className="w-3.5 h-3.5" />
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/app/components/diagnostic-wizard/results/DiagnosticResults.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/DiagnosticResults.tsx
@@ -5,11 +5,15 @@
  * Order: Safety → Summary → Hypotheses → RAG Facts → Maintenance → Catalog → Missing → Disclaimer
  */
 import { Loader2, RefreshCw } from "lucide-react";
+import { useState } from "react";
 import { Button } from "~/components/ui/button";
 import { type WizardState, type WizardAction } from "../types";
+import { AudienceToggle, type Audience } from "./AudienceToggle";
 import { IntentResolutionBlock } from "./IntentResolutionBlock";
 import { ResultCatalog } from "./ResultCatalog";
 import { ResultDisclaimer } from "./ResultDisclaimer";
+import { ResultDrivability } from "./ResultDrivability";
+import { ResultGarageReport } from "./ResultGarageReport";
 import { ResultHypotheses } from "./ResultHypotheses";
 import { ResultMaintenance } from "./ResultMaintenance";
 import { ResultMissing } from "./ResultMissing";
@@ -17,6 +21,19 @@ import { ResultRagFacts } from "./ResultRagFacts";
 import { ResultSafety } from "./ResultSafety";
 import { ResultSummary } from "./ResultSummary";
 // V1A.0 — Intent Resolution renderer (additif, conditionné par présence des champs)
+
+/**
+ * Kill-switch PR-1a (DIAGNOSTIC_RESULT_UX_V2_ENABLED, exposé via window.ENV dans root.tsx).
+ * OFF (défaut) → rendu inchangé. Lecture sûre (cast local, cf. entry.client.tsx).
+ * Les résultats sont rendus côté client (step 3 après fetch) → pas de mismatch SSR.
+ */
+function isResultUxV2Enabled(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    (window as unknown as { ENV?: { DIAGNOSTIC_RESULT_UX_V2_ENABLED?: boolean } })
+      .ENV?.DIAGNOSTIC_RESULT_UX_V2_ENABLED === true
+  );
+}
 
 interface Props {
   state: WizardState;
@@ -31,6 +48,10 @@ export function DiagnosticResults({
   loadingStepLabel,
   onRetry,
 }: Props) {
+  // PR-1a — hooks/flags AVANT tout early-return (règle des hooks React)
+  const uxV2 = isResultUxV2Enabled();
+  const [audience, setAudience] = useState<Audience>("particulier");
+
   if (state.loading) {
     return (
       <div
@@ -86,11 +107,26 @@ export function DiagnosticResults({
 
   return (
     <div className="space-y-4" aria-live="polite">
+      {/* PR-1a — bascule particulier / mécano (kill-switch DIAGNOSTIC_RESULT_UX_V2_ENABLED) */}
+      {uxV2 && (
+        <div className="flex justify-end">
+          <AudienceToggle value={audience} onChange={setAudience} />
+        </div>
+      )}
+
       {/* Block 1: Safety alert (only if risk_flags present) */}
       {ep.risk_flags.length > 0 && (
         <ResultSafety
           riskLevel={ep.risk_level}
           riskFlags={ep.risk_flags}
+          safetyAlert={ep.safety_alert}
+        />
+      )}
+
+      {/* PR-1a — Puis-je rouler ? (verdict toujours affiché ; "à confirmer" si risk_level absent) */}
+      {uxV2 && (
+        <ResultDrivability
+          riskLevel={ep.risk_level}
           safetyAlert={ep.safety_alert}
         />
       )}
@@ -115,9 +151,12 @@ export function DiagnosticResults({
           />
         )}
 
-      {/* Block 3: Hypotheses */}
+      {/* Block 3: Hypotheses (audience par défaut "mecano" si flag OFF → rendu inchangé) */}
       {ep.candidate_hypotheses.length > 0 && (
-        <ResultHypotheses hypotheses={ep.candidate_hypotheses} />
+        <ResultHypotheses
+          hypotheses={ep.candidate_hypotheses}
+          audience={uxV2 ? audience : "mecano"}
+        />
       )}
 
       {/* Block 4: RAG documentation facts */}
@@ -140,6 +179,17 @@ export function DiagnosticResults({
       {/* Block 7: Missing data */}
       {ep.factual_inputs_missing.length > 0 && (
         <ResultMissing missing={ep.factual_inputs_missing} />
+      )}
+
+      {/* PR-1a — Rapport garage (composition éphémère client-side, 0 persistance) */}
+      {uxV2 && (
+        <ResultGarageReport
+          vehicle={state.vehicle}
+          symptomSlugs={state.symptomSlugs}
+          hypotheses={ep.candidate_hypotheses}
+          suggestedGammes={ep.catalog_guard.suggested_gammes}
+          missing={ep.factual_inputs_missing}
+        />
       )}
 
       {/* Block 8: Disclaimer */}

--- a/frontend/app/components/diagnostic-wizard/results/ResultDrivability.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/ResultDrivability.tsx
@@ -1,0 +1,101 @@
+/**
+ * ResultDrivability — Bloc "Puis-je rouler ?" (PR-1a, kill-switch DIAGNOSTIC_RESULT_UX_V2_ENABLED)
+ *
+ * Verdict de roulabilité TOUJOURS affiché, dérivé du `risk_level` de l'EvidencePack
+ * (donnée déjà produite par RiskSafetyEngine — aucune nouvelle table, aucun calcul inventé).
+ *
+ * No-fake-confidence : si `risk_level` est absent, on affiche « À confirmer » (gris),
+ * jamais un feu vert/rouge non fondé.
+ */
+import { CircleCheck, CircleAlert, OctagonAlert, CircleHelp } from "lucide-react";
+
+interface Props {
+  riskLevel?: string;
+  safetyAlert?: string;
+}
+
+interface Verdict {
+  title: string;
+  message: string;
+  bg: string;
+  border: string;
+  text: string;
+  icon: typeof CircleCheck;
+}
+
+// Mapping risk_level (RiskSafetyEngine) → verdict roulabilité. Pas de feu vert "par défaut".
+const VERDICTS: Record<string, Verdict> = {
+  critical: {
+    title: "Ne roulez pas",
+    message:
+      "Arrêtez le véhicule dès que possible en sécurité et contactez une assistance ou un garage.",
+    bg: "bg-red-50",
+    border: "border-red-300",
+    text: "text-red-800",
+    icon: OctagonAlert,
+  },
+  high: {
+    title: "Roulez avec prudence",
+    message:
+      "Un court trajet reste possible, mais évitez l'autoroute et faites contrôler rapidement.",
+    bg: "bg-orange-50",
+    border: "border-orange-300",
+    text: "text-orange-800",
+    icon: CircleAlert,
+  },
+  moderate: {
+    title: "Vous pouvez rouler, mais surveillez",
+    message:
+      "Aucun danger immédiat identifié. Faites contrôler ce point lors d'un prochain entretien.",
+    bg: "bg-amber-50",
+    border: "border-amber-300",
+    text: "text-amber-800",
+    icon: CircleAlert,
+  },
+  low: {
+    title: "Vous pouvez rouler",
+    message:
+      "Aucun signe de danger immédiat. Restez attentif à l'évolution des symptômes.",
+    bg: "bg-green-50",
+    border: "border-green-300",
+    text: "text-green-800",
+    icon: CircleCheck,
+  },
+};
+
+const UNKNOWN: Verdict = {
+  title: "À confirmer",
+  message:
+    "Précisez les symptômes (et un code OBD si disponible) pour évaluer si vous pouvez rouler.",
+  bg: "bg-gray-50",
+  border: "border-gray-200",
+  text: "text-gray-700",
+  icon: CircleHelp,
+};
+
+export function ResultDrivability({ riskLevel, safetyAlert }: Props) {
+  const verdict = (riskLevel && VERDICTS[riskLevel]) || UNKNOWN;
+  const Icon = verdict.icon;
+
+  return (
+    <div
+      className={`rounded-lg border-2 ${verdict.border} ${verdict.bg} p-4`}
+      role="status"
+    >
+      <div className="flex items-start gap-3">
+        <Icon className={`w-6 h-6 flex-shrink-0 mt-0.5 ${verdict.text}`} />
+        <div className="space-y-1">
+          <p className="text-[11px] font-medium uppercase tracking-wide text-gray-500">
+            Puis-je rouler ?
+          </p>
+          <h3 className={`font-semibold text-sm ${verdict.text}`}>
+            {verdict.title}
+          </h3>
+          <p className={`text-sm ${verdict.text}`}>
+            {safetyAlert || verdict.message}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/diagnostic-wizard/results/ResultGarageReport.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/ResultGarageReport.tsx
@@ -1,0 +1,120 @@
+/**
+ * ResultGarageReport — Bloc "Rapport garage" (PR-1a)
+ *
+ * Compose un résumé lisible (véhicule + symptômes + hypothèses + tests + pièces) à montrer
+ * au garagiste. 100% CLIENT-SIDE et ÉPHÉMÈRE : rien n'est persisté (respecte OPTION A + NO-GO
+ * Pilier B). Aucune donnée personnelle (pas de plaque, pas d'identité).
+ */
+import { ClipboardCheck, Copy, FileText } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { type Hypothesis, type SuggestedGamme, type WizardState } from "../types";
+
+interface Props {
+  vehicle: WizardState["vehicle"];
+  symptomSlugs: string[];
+  hypotheses: Hypothesis[];
+  suggestedGammes: SuggestedGamme[];
+  missing: string[];
+}
+
+function buildReport({
+  vehicle,
+  symptomSlugs,
+  hypotheses,
+  suggestedGammes,
+  missing,
+}: Props): string {
+  const lines: string[] = [];
+  lines.push("RAPPORT DIAGNOSTIC — AutoMecanik");
+  lines.push("(à titre indicatif — à confirmer par un professionnel)");
+  lines.push("");
+
+  const veh = [
+    vehicle.brand,
+    vehicle.model,
+    vehicle.year ? `${vehicle.year}` : "",
+    vehicle.fuel,
+    vehicle.mileage_km ? `${vehicle.mileage_km} km` : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  lines.push(`Véhicule : ${veh || "non précisé"}`);
+
+  if (symptomSlugs.length > 0) {
+    lines.push(`Symptômes signalés : ${symptomSlugs.join(", ")}`);
+  }
+  lines.push("");
+
+  lines.push("Hypothèses (par ordre de probabilité) :");
+  hypotheses.slice(0, 5).forEach((h, i) => {
+    lines.push(
+      `  ${i + 1}. ${h.label} — score ${h.relative_score}/100 — urgence ${h.urgency}`,
+    );
+    if (h.verification_method) {
+      lines.push(`     Vérification : ${h.verification_method}`);
+    }
+  });
+  lines.push("");
+
+  if (suggestedGammes.length > 0) {
+    lines.push("Pièces possiblement concernées :");
+    suggestedGammes.forEach((g) => lines.push(`  - ${g.gamme_label}`));
+    lines.push("");
+  }
+
+  if (missing.length > 0) {
+    lines.push("Informations manquantes (utiles pour affiner) :");
+    missing.forEach((m) => lines.push(`  - ${m}`));
+  }
+
+  return lines.join("\n");
+}
+
+export function ResultGarageReport(props: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    const text = buildReport(props);
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [props]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <FileText className="w-5 h-5 text-blue-600" />
+          Rapport pour le garage
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-gray-500">
+          Un résumé à montrer à votre garagiste : véhicule, symptômes, hypothèses,
+          vérifications et pièces possibles. Aucune donnée n&apos;est enregistrée.
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleCopy}
+          className="gap-1.5"
+        >
+          {copied ? (
+            <>
+              <ClipboardCheck className="w-3.5 h-3.5 text-green-600" />
+              <span className="text-green-600">Copié</span>
+            </>
+          ) : (
+            <>
+              <Copy className="w-3.5 h-3.5" />
+              Copier le rapport
+            </>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/app/components/diagnostic-wizard/results/ResultHypotheses.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/ResultHypotheses.tsx
@@ -17,6 +17,8 @@ import { type Hypothesis } from "../types";
 
 interface Props {
   hypotheses: Hypothesis[];
+  /** PR-1a : "particulier" masque le détail technique (scoring breakdown). Défaut = comportement actuel (mécano). */
+  audience?: "particulier" | "mecano";
 }
 
 const URGENCY_BADGE: Record<string, string> = {
@@ -39,7 +41,7 @@ const PROGRESS_COLOR = (score: number) => {
   return "[&>div]:bg-gray-400";
 };
 
-export function ResultHypotheses({ hypotheses }: Props) {
+export function ResultHypotheses({ hypotheses, audience = "mecano" }: Props) {
   const [expandedId, setExpandedId] = useState<string | null>(
     hypotheses[0]?.hypothesis_id || null,
   );
@@ -119,8 +121,8 @@ export function ResultHypotheses({ hypotheses }: Props) {
               {/* Expanded details */}
               {expanded && (
                 <div className="px-3 pb-3 space-y-3 border-t border-gray-100 pt-3 ml-10">
-                  {/* Scoring breakdown */}
-                  {h.scoring_breakdown && (
+                  {/* Scoring breakdown — détail technique masqué en mode particulier (PR-1a) */}
+                  {h.scoring_breakdown && audience === "mecano" && (
                     <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                       {Object.entries(h.scoring_breakdown).map(([key, val]) => (
                         <div

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -145,6 +145,9 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
         process.env.APP_ENV ||
         process.env.NODE_ENV ||
         "development",
+      // PR-1a — kill-switch UX résultat diagnostic V2 (rollback rapide). OFF par défaut.
+      DIAGNOSTIC_RESULT_UX_V2_ENABLED:
+        process.env.DIAGNOSTIC_RESULT_UX_V2_ENABLED === "true",
     },
   });
 };

--- a/frontend/tests/unit/diagnostic-result-ux-v2.test.tsx
+++ b/frontend/tests/unit/diagnostic-result-ux-v2.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * PR-1a — Diagnostic Result UX v2 : tests des invariants
+ *  - kill-switch DIAGNOSTIC_RESULT_UX_V2_ENABLED (rollback : flag OFF → rendu inchangé)
+ *  - no-fake-confidence (risk_level absent → "À confirmer", jamais de verdict vert inventé)
+ *  - bascule particulier/mécano (verbosité technique transmise à ResultHypotheses)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ResultDrivability } from "~/components/diagnostic-wizard/results/ResultDrivability";
+import { AudienceToggle } from "~/components/diagnostic-wizard/results/AudienceToggle";
+import { ResultGarageReport } from "~/components/diagnostic-wizard/results/ResultGarageReport";
+import { DiagnosticResults } from "~/components/diagnostic-wizard/results/DiagnosticResults";
+import type {
+  EvidencePack,
+  WizardState,
+  Hypothesis,
+} from "~/components/diagnostic-wizard/types";
+
+// Isole PR-1a : on stubbe les sous-blocs préexistants (testés ailleurs / hors scope).
+// ResultHypotheses expose son prop `audience` pour vérifier le câblage de la bascule.
+vi.mock("~/components/diagnostic-wizard/results/ResultSafety", () => ({
+  ResultSafety: () => <div data-testid="safety" />,
+}));
+vi.mock("~/components/diagnostic-wizard/results/ResultSummary", () => ({
+  ResultSummary: () => <div data-testid="summary" />,
+}));
+vi.mock("~/components/diagnostic-wizard/results/ResultHypotheses", () => ({
+  ResultHypotheses: ({ audience }: { audience?: string }) => (
+    <div data-testid="hypotheses" data-audience={audience} />
+  ),
+}));
+vi.mock("~/components/diagnostic-wizard/results/ResultCatalog", () => ({
+  ResultCatalog: () => <div data-testid="catalog" />,
+}));
+vi.mock("~/components/diagnostic-wizard/results/ResultMissing", () => ({
+  ResultMissing: () => <div data-testid="missing" />,
+}));
+vi.mock("~/components/diagnostic-wizard/results/ResultDisclaimer", () => ({
+  ResultDisclaimer: () => <div data-testid="disclaimer" />,
+}));
+vi.mock("~/components/diagnostic-wizard/results/ResultRagFacts", () => ({
+  ResultRagFacts: () => <div data-testid="rag" />,
+}));
+vi.mock("~/components/diagnostic-wizard/results/ResultMaintenance", () => ({
+  ResultMaintenance: () => <div data-testid="maintenance" />,
+}));
+vi.mock("~/components/diagnostic-wizard/results/IntentResolutionBlock", () => ({
+  IntentResolutionBlock: () => <div data-testid="intent" />,
+}));
+
+const HYP: Hypothesis = {
+  hypothesis_id: "h1",
+  label: "Vanne EGR encrassée",
+  cause_type: "component_fault",
+  relative_score: 72,
+  urgency: "haute",
+  evidence_for: ["perte de puissance compatible"],
+  evidence_against: [],
+  verification_method: "Lire le code OBD",
+  requires_verification: true,
+};
+
+function makeEvidencePack(over: Partial<EvidencePack> = {}): EvidencePack {
+  return {
+    factual_inputs_confirmed: ["Véhicule: Renault Clio"],
+    factual_inputs_missing: ["Kilométrage non renseigné"],
+    system_suspects: ["moteur"],
+    candidate_hypotheses: [HYP],
+    maintenance_links: [],
+    risk_flags: [],
+    safety_alert: undefined,
+    risk_level: "low",
+    catalog_guard: {
+      ready_for_catalog: true,
+      confidence_before_purchase: "medium",
+      allowed_output_mode: "catalog_family_only",
+      reason: "ok",
+      suggested_gammes: [
+        {
+          gamme_slug: "vanne-egr",
+          gamme_label: "Vanne EGR",
+          pg_id: 123,
+          confidence: "medium",
+        },
+      ],
+    },
+    maintenance_recommendations: [],
+    rag_facts: [],
+    allowed_claims: ["Un contrôle visuel est recommandé."],
+    forbidden_claims_runtime: [],
+    signal_quality: "medium",
+    ui_block_inputs: {},
+    ...over,
+  };
+}
+
+function makeState(ep: EvidencePack): WizardState {
+  return {
+    step: 3,
+    vehicle: {
+      brand: "Renault",
+      model: "Clio",
+      year: 2015,
+      mileage_km: 165000,
+      fuel: "Diesel",
+    },
+    systemScope: "moteur",
+    symptomSlugs: ["perte-puissance", "fumee-noire"],
+    result: { success: true, session_id: "sess-1", evidence_pack: ep },
+    loading: false,
+    error: null,
+  };
+}
+
+type EnvWindow = Window & { ENV?: { DIAGNOSTIC_RESULT_UX_V2_ENABLED?: boolean } };
+
+function setFlag(enabled: boolean | undefined) {
+  (window as unknown as EnvWindow).ENV =
+    enabled === undefined ? {} : { DIAGNOSTIC_RESULT_UX_V2_ENABLED: enabled };
+}
+
+afterEach(() => {
+  delete (window as unknown as EnvWindow).ENV;
+});
+
+describe("ResultDrivability — verdict & no-fake-confidence", () => {
+  it("risk_level=critical → ne pas rouler", () => {
+    render(<ResultDrivability riskLevel="critical" />);
+    expect(screen.getByText("Puis-je rouler ?")).toBeTruthy();
+    expect(screen.getByText("Ne roulez pas")).toBeTruthy();
+  });
+
+  it("risk_level=low → peut rouler", () => {
+    render(<ResultDrivability riskLevel="low" />);
+    expect(screen.getByText("Vous pouvez rouler")).toBeTruthy();
+  });
+
+  it('risk_level absent → "À confirmer" (jamais de verdict vert inventé)', () => {
+    render(<ResultDrivability riskLevel={undefined} />);
+    expect(screen.getByText("À confirmer")).toBeTruthy();
+    expect(screen.queryByText("Vous pouvez rouler")).toBeNull();
+  });
+});
+
+describe("AudienceToggle", () => {
+  it("rend les deux niveaux et notifie le changement", () => {
+    const onChange = vi.fn();
+    render(<AudienceToggle value="particulier" onChange={onChange} />);
+    expect(screen.getByText("Particulier")).toBeTruthy();
+    const mecano = screen.getByText("Mécano");
+    fireEvent.click(mecano);
+    expect(onChange).toHaveBeenCalledWith("mecano");
+  });
+});
+
+describe("ResultGarageReport — éphémère, copie", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("copie un rapport contenant véhicule + hypothèse", async () => {
+    render(
+      <ResultGarageReport
+        vehicle={{ brand: "Renault", model: "Clio", fuel: "Diesel" }}
+        symptomSlugs={["perte-puissance"]}
+        hypotheses={[HYP]}
+        suggestedGammes={[
+          { gamme_slug: "vanne-egr", gamme_label: "Vanne EGR", pg_id: 1, confidence: "medium" },
+        ]}
+        missing={["Kilométrage non renseigné"]}
+      />,
+    );
+    fireEvent.click(screen.getByText("Copier le rapport"));
+    const writeText = navigator.clipboard.writeText as ReturnType<typeof vi.fn>;
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const payload = writeText.mock.calls[0][0] as string;
+    expect(payload).toContain("Renault");
+    expect(payload).toContain("Vanne EGR encrassée");
+  });
+});
+
+describe("DiagnosticResults — kill-switch (rollback)", () => {
+  it("flag OFF → blocs PR-1a absents, audience par défaut mécano", () => {
+    setFlag(false);
+    render(
+      <DiagnosticResults state={makeState(makeEvidencePack())} dispatch={vi.fn()} />,
+    );
+    expect(screen.queryByText("Puis-je rouler ?")).toBeNull();
+    expect(screen.queryByText("Rapport pour le garage")).toBeNull();
+    expect(
+      screen.getByTestId("hypotheses").getAttribute("data-audience"),
+    ).toBe("mecano");
+  });
+
+  it("flag ON → verdict roulabilité + rapport garage + audience particulier", () => {
+    setFlag(true);
+    render(
+      <DiagnosticResults state={makeState(makeEvidencePack())} dispatch={vi.fn()} />,
+    );
+    expect(screen.getByText("Puis-je rouler ?")).toBeTruthy();
+    expect(screen.getByText("Rapport pour le garage")).toBeTruthy();
+    expect(
+      screen.getByTestId("hypotheses").getAttribute("data-audience"),
+    ).toBe("particulier");
+  });
+});


### PR DESCRIPTION
## Contexte
Améliore le **résultat** de l'outil diagnostic existant (`diagnostic-wizard/results/`) sans nouvelle table ni migration — surface des sorties **déjà produites** par les 6 engines via `/api/diagnostic-engine/analyze`. Aligné OBSERVE (PR frontend ciblée + réversible) et avec la vision diagnostic-first (ADR-product-C draft, hors-repo).

## Changements (additifs, gated)
- **ResultDrivability** — verdict *« Puis-je rouler ? »* toujours affiché (vert/orange/rouge depuis `risk_level`). **No-fake-confidence** : `risk_level` absent → *« À confirmer »*, jamais de verdict vert inventé (invariant anti-fausse-précision Surface C).
- **ResultGarageReport** — rapport copiable **100% client-side éphémère** (0 persistance → respecte VehicleContext OPTION A + NO-GO Pilier B).
- **AudienceToggle** (particulier / mécano) — ajuste la verbosité technique (scoring breakdown masqué en mode particulier), **mêmes données**.
- **Kill-switch** `DIAGNOSTIC_RESULT_UX_V2_ENABLED` (via `window.ENV`, root loader). **OFF par défaut → rendu strictement inchangé** (rollback immédiat).

## Vérification
- ✅ `tsc` 0 erreur sur les fichiers touchés · ✅ `eslint` 0 erreur · ✅ **7/7 tests vitest** (`tests/unit/diagnostic-result-ux-v2.test.tsx`) : kill-switch rollback (flag OFF → blocs absents + audience `mecano`), no-fake-confidence, audience wiring, copie éphémère.
- ⏳ **Vérif visuelle DEV:3000** : à faire avec le flag ON (DEV sert `main`, pas cette branche). Comme le flag est **OFF par défaut**, le merge est sans risque (rendu inchangé) ; activation = gate ops séparé + vérif POST-MERGE LIVE (canon 2-gates).

## Hors scope (NO-GO)
Aucune table, aucune migration, aucun changement canonical/URL, aucune persistance Pilier B. Les buckets de confiance numériques + actions recommandées restent fournis par la couche V1A.0 existante (`DIAGNOSTIC_PIPELINE_V1_ENABLED`, OFF) — activation = décision ops owner-gated, pas dans cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)