### PR TITLE
fix(seo): propagate noindex X-Robots-Tag to 404/410 error pages

### DIFF
--- a/backend/src/modules/seo/interceptors/seo-headers.interceptor.ts
+++ b/backend/src/modules/seo/interceptors/seo-headers.interceptor.ts
@@ -71,6 +71,17 @@ export class SeoHeadersInterceptor implements NestInterceptor {
     else if (!this.robotsTxtService.shouldIndex(path)) {
       headers = this.seoHeadersService.getNoIndexHeaders();
     }
+    // Fallthrough = route document générique indexable (home, pages statiques) OU
+    // un 404/410 servi par le catch-all Remix ($.tsx). `index, follow` est le défaut
+    // implicite de Google quand aucun X-Robots-Tag n'est présent : l'affirmer via
+    // header est redondant sur un succès et NUISIBLE sur une erreur (il fuyait sur
+    // les 404/410 du catch-all, contredisant le `noindex` throw de la route — cf.
+    // catch-all-404-noindex.test.ts). On laisse la route Remix posséder robots via
+    // <meta> / `headers`. Les autres headers par défaut (Vary, Referrer-Policy,
+    // X-Content-Type-Options) restent appliqués.
+    else {
+      delete headers['X-Robots-Tag'];
+    }
 
     // Appliquer headers globaux (n'écrase pas les headers explicites définis ensuite)
     Object.entries(headers).forEach(([key, value]) => {

--- a/backend/tests/unit/seo-headers-interceptor.test.ts
+++ b/backend/tests/unit/seo-headers-interceptor.test.ts
@@ -1,0 +1,87 @@
+/**
+ * SeoHeadersInterceptor — propriété du X-Robots-Tag.
+ *
+ * Régression (empirique live 2026-05-29, DEV:3000 origin) : le branch fallthrough
+ * par défaut posait `X-Robots-Tag: index, follow` sur TOUTE route non-typée — y
+ * compris les 404/410 servis par le catch-all Remix (`$.tsx`) et la 404 véhicule —
+ * contredisant le `noindex` posé par la Response throw de la route. Comme
+ * `@remix-run/express` fait `res.append` (et non `setHeader`), le défaut interceptor
+ * survivait au header Remix (ou le doublait).
+ *
+ * Fix : le fallthrough ne pose plus de X-Robots-Tag (`index, follow` est le défaut
+ * implicite de Google quand le header est absent). Les routes `/pieces` et
+ * `/constructeurs` délèguent déjà robots à Remix ; `/admin`, `/api` et
+ * `!shouldIndex` restent explicitement noindex.
+ *
+ * @see backend/src/modules/seo/interceptors/seo-headers.interceptor.ts
+ */
+import { of } from 'rxjs';
+
+import { SeoHeadersService } from '../../src/modules/seo/infrastructure/seo-headers.service';
+import { RobotsTxtService } from '../../src/modules/seo/infrastructure/robots-txt.service';
+import { SeoHeadersInterceptor } from '../../src/modules/seo/interceptors/seo-headers.interceptor';
+
+function run(path: string): Record<string, string> {
+  const captured: Record<string, string> = {};
+  const ctx = {
+    switchToHttp: () => ({
+      getResponse: () => ({
+        setHeader: (k: string, v: string) => {
+          captured[k] = v;
+        },
+      }),
+      getRequest: () => ({ path, url: path }),
+    }),
+  };
+  const interceptor = new SeoHeadersInterceptor(
+    new SeoHeadersService(),
+    // shouldIndex() est pur (regex only) ; le constructeur lit juste NODE_ENV/BASE_URL.
+    new RobotsTxtService({
+      get: (_key: string, defaultValue?: unknown) => defaultValue,
+    } as never),
+  );
+  interceptor.intercept(ctx as never, { handle: () => of(null) } as never);
+  return captured;
+}
+
+describe('SeoHeadersInterceptor — X-Robots-Tag ownership', () => {
+  it('ne force PAS index,follow sur un path générique fallthrough (home)', () => {
+    const h = run('/');
+    expect(h['X-Robots-Tag']).toBeUndefined();
+    // les headers de sécurité par défaut restent appliqués
+    expect(h['X-Content-Type-Options']).toBe('nosniff');
+  });
+
+  it('ne force PAS index,follow sur un 404/garbage servi par le catch-all', () => {
+    expect(run('/Us8wiFwI2rH4caEMb2bfQ==')['X-Robots-Tag']).toBeUndefined();
+    expect(run('/this-page-does-not-exist-12345')['X-Robots-Tag']).toBeUndefined();
+  });
+
+  it('ne pose PAS de X-Robots-Tag sur /constructeurs/ (Remix possède robots)', () => {
+    expect(
+      run('/constructeurs/bmw-33/serie-3-e90-33028/328-i-58077.html')[
+        'X-Robots-Tag'
+      ],
+    ).toBeUndefined();
+  });
+
+  it('ne pose PAS de X-Robots-Tag sur /pieces/ (Remix possède robots)', () => {
+    expect(
+      run('/pieces/filtre-a-huile-7/bmw-33/serie-3-e90-33028/328-i-58077.html')[
+        'X-Robots-Tag'
+      ],
+    ).toBeUndefined();
+  });
+
+  it('garde noindex,nofollow sur /admin/', () => {
+    expect(run('/admin/dashboard')['X-Robots-Tag']).toBe('noindex, nofollow');
+  });
+
+  it('garde noindex,nofollow sur /api/', () => {
+    expect(run('/api/health')['X-Robots-Tag']).toBe('noindex, nofollow');
+  });
+
+  it('garde index,follow (blog) sur /blog/', () => {
+    expect(run('/blog/mon-article')['X-Robots-Tag']).toContain('index, follow');
+  });
+});

--- a/frontend/app/routes/$.tsx
+++ b/frontend/app/routes/$.tsx
@@ -7,6 +7,7 @@ import {
 } from "@remix-run/node";
 import { useRouteError, isRouteErrorResponse } from "@remix-run/react";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { logger } from "~/utils/logger";
 
 export const meta: MetaFunction = () => [
@@ -17,6 +18,13 @@ export const meta: MetaFunction = () => [
   },
   { name: "robots", content: "noindex, nofollow" },
 ];
+
+// 🔒 Le catch-all throw TOUJOURS (404 / 410 / redirect) — il ne sert jamais un 200
+// indexable. Sans ce `headers` export, Remix v2 retombe sur root.tsx `headers()` et
+// le `X-Robots-Tag: noindex, follow` posé sur la Response throw était perdu (live :
+// la 410 garbage ressortait `index, follow` via le défaut interceptor). Paire avec
+// la suppression du défaut `index, follow` côté SeoHeadersInterceptor (fallthrough).
+export const headers = buildCacheHeaders("no-cache");
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -59,10 +59,20 @@ import {
 } from "../components/vehicle/r8";
 import { hierarchyApi } from "../services/api/hierarchy.api";
 import { brandColorsService } from "../services/brand-colors.service";
+import { buildCacheHeaders } from "../utils/cache-control";
 import { isValidImagePath } from "../utils/image-optimizer";
 import { detectMalformedSegment } from "../utils/pieces-route.utils";
 import { normalizeTypeAlias } from "../utils/url-builder.utils";
 import { resolveVehiclePageError } from "../utils/vehicle-page-status";
+
+// 🔒 Propagate the loader / error-thrown X-Robots-Tag + Cache-Control to the
+// document response. Without a route-level `headers` export, Remix v2 falls back
+// to root.tsx `headers()` and DROPS the seoError() `noindex` on 404/410/503 — the
+// SeoHeadersInterceptor default then leaks onto the error page (live: 404 vehicle
+// shipped no X-Robots-Tag at all). `buildCacheHeaders` (shared with /pieces) reads
+// errorHeaders first; success keeps the historical `private, max-age=60` (no
+// caching-behaviour change).
+export const headers = buildCacheHeaders("private, max-age=60");
 
 /**
  * Handle export pour propager le rôle SEO au root Layout

--- a/frontend/tests/unit/catch-all-404-noindex.test.ts
+++ b/frontend/tests/unit/catch-all-404-noindex.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { loader } from "~/routes/$";
+import { headers as catchAllHeaders, loader } from "~/routes/$";
 
 // vi.mock is hoisted by Vitest's transformer (runs before imports at runtime),
 // safe to declare after the import for ESLint's `import/first` rule.
@@ -84,5 +84,45 @@ describe("catch-all $.tsx — 404/410 X-Robots-Tag noindex,follow", () => {
     expect(thrown).toBeInstanceOf(Response);
     expect(thrown?.status).toBe(404);
     expect(thrown?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+  });
+});
+
+/**
+ * Régression runtime (live 2026-05-29) : le loader throw bien `noindex, follow`,
+ * MAIS sans `headers` export Remix v2 retombait sur root.tsx `headers()` et le
+ * X-Robots-Tag de la Response throw était perdu → le défaut interceptor
+ * (`index, follow`) ressortait sur la 410. Les 3 tests ci-dessus ne couvraient que
+ * la Response *throw*, pas la propagation vers la réponse document. Ce bloc ferme
+ * ce trou : `headers()` DOIT propager le X-Robots-Tag (et le Cache-Control) porté
+ * par errorHeaders.
+ */
+describe("catch-all $.tsx — headers() propage le X-Robots-Tag de la Response throw", () => {
+  const ctx = (errorHeaders?: Headers) =>
+    ({
+      loaderHeaders: new Headers(),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders,
+    }) as never;
+
+  it("propage noindex,follow + Cache-Control depuis errorHeaders (410)", () => {
+    const result = catchAllHeaders(
+      ctx(
+        new Headers({
+          "X-Robots-Tag": "noindex, follow",
+          "Cache-Control": "public, max-age=86400",
+        }),
+      ),
+    ) as Record<string, string>;
+    expect(result["X-Robots-Tag"]).toBe("noindex, follow");
+    expect(result["Cache-Control"]).toBe("public, max-age=86400");
+  });
+
+  it("refuse le cache CDN (no-store) quand la Response throw n'a pas de Cache-Control", () => {
+    const result = catchAllHeaders(
+      ctx(new Headers({ "X-Robots-Tag": "noindex, follow" })),
+    ) as Record<string, string>;
+    expect(result["X-Robots-Tag"]).toBe("noindex, follow");
+    expect(result["Cache-Control"]).toBe("no-cache, no-store, must-revalidate");
   });
 });


### PR DESCRIPTION
## Contexte

Suivi de l'incident GSC **« Erreur serveur (5xx) »** (1000 URLs, validation Échec le 26/05).

**Le 5xx lui-même est déjà résolu** (status `503→404` par #690 / tag `v2026.05.22-seo-5xx-vehicle-404`, renforcé #741). Vérifié live le 2026-05-29 : **0 × 5xx** sur 11 URLs d'exemple GSC **+ 400 URLs aléatoires** échantillonnées sur le sitemap (392×200, 8×301, 0×5xx ; borne 95 % du résiduel < ~0,75 %). La validation GSC du 26/05 a échoué par **lag de crawl** (dates « dernière exploration » 10–21 mai, toutes antérieures au correctif du 22), pas par régression.

Cette PR corrige une **incohérence d'en-têtes** découverte pendant cette vérification — distincte du status 5xx, qui reste correct.

## Problème (root cause)

Les Responses d'erreur throw par les loaders posent bien `X-Robots-Tag: noindex, follow`, **mais Remix v2 les jetait** quand la route n'exporte pas de `headers` : il retombe sur `root.tsx` `headers()` et le défaut `SeoHeadersInterceptor` (`index, follow`) fuitait sur les pages d'erreur. Comme `@remix-run/express` fait `res.append` (et non `setHeader`), le défaut interceptor survivait.

Mesuré live (DEV:3000 origin **et** PROD, UA normal + Googlebot) :

| URL | Status (OK) | `X-Robots-Tag` observé | Attendu (contrat) |
|---|---|---|---|
| 404 véhicule `/constructeurs/…` | 404 ✓ | **(aucun)** | `noindex, follow` |
| 410 garbage `/Us8…==` | 410 ✓ | **`index, follow`** | `noindex` |

Le contrat est pourtant explicite dans le code (`vehicle-page-status.ts:12` « No non-200 verdict is ever index,follow » ; interceptor `:60-61`). Le test `catch-all-404-noindex.test.ts` était vert car il n'assertait que la Response *throw*, jamais la réponse document → le bug a shippé en vert.

## Fix (étend le pattern `/pieces` existant — aucune nouvelle couche)

1. **`constructeurs.$brand.$model.$type.tsx`** — ajoute `export const headers = buildCacheHeaders("private, max-age=60")` (propage le `X-Robots-Tag` + `Cache-Control` de `seoError()` sur 404/410/503 ; **le succès garde `private, max-age=60`** — aucun changement de cache).
2. **`$.tsx`** (catch-all) — même `headers` export pour que le `noindex` throw atteigne la réponse document.
3. **`SeoHeadersInterceptor`** — le fallthrough ne force plus `index, follow` (c'est le **défaut implicite de Google** quand le header est absent ; il ne servait qu'à polluer les erreurs). Headers de sécurité + branches `admin`/`api`/`blog`/`!shouldIndex` **inchangés**.

## Vérification

- ✅ **Frontend vitest 12/12** : 3 catch-all loader (existants) + **2 nouveaux** `headers()` propagation + 7 `cache-control`.
- ✅ **Backend jest 7/7** (nouveau `seo-headers-interceptor.test.ts`) : fallthrough/catch-all → pas de header ; admin/api → noindex ; blog → index ; pieces/constructeurs → délégués.
- ✅ **ESLint** sur les routes modifiées : clean.
- ✅ **`tsc` frontend** : 0 erreur dans les fichiers modifiés (5 erreurs pré-existantes tiptap/web-vitals dans des fichiers non touchés, hors scope).
- ⓘ La chaîne end-to-end (`res.append` après suppression du défaut interceptor → header `noindex` unique) est prouvée par les routes `/pieces` qui fonctionnent déjà ainsi en PROD + le test interceptor.

## Runtime-awareness / blast radius

- **SEO-safe** : retirer le `index, follow` du fallthrough **ne désindexe rien** — l'absence de `X-Robots-Tag` = `index, follow` par défaut chez Google. Les pages génériques (home, statiques) restent indexées (meta + défaut implicite).
- **Réversible** : revert PR. Pas de migration, pas de queue, pas de feature flag.
- **Impact mesuré nul sur le 5xx** (déjà résolu) — c'est de la cohérence/defense-in-depth sur des pages d'erreur (404/410 = désindexation quel que soit le robots).
- **OBSERVE (jusqu'au 2026-06-08)** : changement d'en-tête site-wide (fallthrough) → **owner-gated** (merge + tag = décision owner), comme il se doit.

## Vérification post-déploiement (à exécuter après merge + tag PROD)

```bash
# Attendu : un SEUL X-Robots-Tag, noindex, sur les pages d'erreur
curl -sI https://www.automecanik.com/constructeurs/mercedes-benz-108/classe-g-w460-108059/230-857.html \
  | grep -i x-robots-tag          # attendu: noindex, follow
curl -sI https://www.automecanik.com/Us8wiFwI2rH4caEMb2bfQ== \
  | grep -i x-robots-tag          # attendu: noindex (plus index,follow)
# Contrôle non-régression : une page produit reste indexable
curl -sI https://www.automecanik.com/pieces/plaquette-de-frein-402/skoda-150/octavia-ii-combi-150017/2-0-tdi-16v-4x4-6042.html | grep -iE "HTTP/|x-robots"
```

## Improvement Gate (résumé)

- **Problème réel & mesuré** : oui (en-têtes live divergents du contrat code, 2 familles).
- **Preuve** : mesures live UA normal+Googlebot, DEV origin vs PROD edge isolés.
- **Risque maîtrisé** : SEO-safe, réversible, scope 5 fichiers, owner-gated en OBSERVE.
- **Tests** : +9 cas (2 frontend + 7 backend), comble le trou du test vert-sur-bug.
- **Next action** : merge owner → tag → re-probe post-déploiement (recette ci-dessus) → re-valider l'issue GSC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
