### PR TITLE
fix(seo): re-export headers through constructeurs .html wrapper (#798 follow-up)

### DIFF
--- a/frontend/app/routes/constructeurs.$brand.$model.$type[.]html.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type[.]html.tsx
@@ -9,4 +9,8 @@ export {
   default,
   ErrorBoundary,
   handle, // Phase 10: Propager pageRole au root Layout
+  // #798 follow-up : sans ce re-export, Remix v2 DROP le X-Robots-Tag noindex
+  // throw par seoError() sur cette route .html (qui sert les vraies URLs véhicules),
+  // car la route source exporte `headers` mais le wrapper ne le ré-exportait pas.
+  headers,
 } from "./constructeurs.$brand.$model.$type";

--- a/frontend/tests/unit/constructeurs-html-wrapper-noindex.test.ts
+++ b/frontend/tests/unit/constructeurs-html-wrapper-noindex.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+// Import the `.html` wrapper route — the one that actually serves real vehicle
+// URLs (`/constructeurs/{brand}/{model}/{type}.html`). It is a thin re-export of
+// the source route `constructeurs.$brand.$model.$type`.
+//
+// Régression #798 follow-up : la PR #798 a ajouté `export const headers =
+// buildCacheHeaders(...)` sur la route SOURCE, mais le wrapper `.html`
+// ré-exportait `loader/meta/default/...` SANS `headers`. Conséquence : Remix v2
+// retombe sur `root.tsx headers()` et DROP le `X-Robots-Tag: noindex, follow`
+// throw par `seoError()` sur les 404/410 des vraies URLs véhicules → la page
+// d'erreur fuit en `index, follow`. Ce test couvre explicitement la route `.html`
+// (pas seulement la route source) pour empêcher la récidive.
+import * as htmlRoute from "~/routes/constructeurs.$brand.$model.$type[.]html";
+
+type HeadersArgs = Parameters<NonNullable<typeof htmlRoute.headers>>[0];
+
+describe("constructeurs .html wrapper — re-exports headers (noindex propagation)", () => {
+  it("ré-exporte bien une fonction `headers` (régression : le wrapper l'omettait)", () => {
+    expect(typeof htmlRoute.headers).toBe("function");
+  });
+
+  it("404/410 (loader throw) → X-Robots-Tag: noindex, follow + Cache-Control de seoError (pas le fallback root)", () => {
+    // Simule un loader-throw : Remix passe les headers de la Response jetée via `errorHeaders`.
+    const errorHeaders = new Headers({
+      "X-Robots-Tag": "noindex, follow",
+      "Cache-Control": "public, max-age=300", // seoError(404)
+    });
+
+    const result = htmlRoute.headers!({
+      loaderHeaders: new Headers(),
+      parentHeaders: new Headers(),
+      errorHeaders,
+      actionHeaders: new Headers(),
+    } as HeadersArgs);
+
+    const out = new Headers(result);
+    expect(out.get("X-Robots-Tag")).toBe("noindex, follow");
+    // La policy d'erreur prime sur le fallback root — preuve que le throw a bien atteint le doc.
+    expect(out.get("Cache-Control")).toBe("public, max-age=300");
+  });
+
+  it("200 (succès) → aucun noindex accidentel, garde la policy de succès `private, max-age=60`", () => {
+    const result = htmlRoute.headers!({
+      loaderHeaders: new Headers(),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+    } as HeadersArgs);
+
+    const out = new Headers(result);
+    expect(out.get("X-Robots-Tag")).toBeNull();
+    expect(out.get("Cache-Control")).toBe("private, max-age=60");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #798. #798 added `export const headers = buildCacheHeaders("private, max-age=60")` to the **source** route `constructeurs.$brand.$model.$type.tsx`, but the `.html` **wrapper** that actually serves real vehicle URLs (`/constructeurs/{brand}/{model}/{type}.html`) re-exported `loader/meta/default/ErrorBoundary/handle` **without `headers`**. So Remix v2 kept dropping the `seoError()` `X-Robots-Tag: noindex, follow` on 404/410 — the exact bug #798 targeted, on the variant in production use. One-line fix: add `headers` to the wrapper's re-export.

## Test plan

- [x] `npm --workspace=@fafa/frontend run test -- run constructeurs-html-wrapper-noindex` → 3/3 pass
- [x] `eslint` clean on both touched files
- [ ] PREPROD green (soft-404 smoke / E2E / Lighthouse)
- [ ] After owner `v*` tag → PROD curl: `/constructeurs/.../.../….html` 404 returns a **single** `X-Robots-Tag: noindex, follow` + `Cache-Control` from `seoError(404)` (not the root fallback); product 200 has **no** accidental noindex

## Changes

- `frontend/app/routes/constructeurs.$brand.$model.$type[.]html.tsx` — add `headers` to the re-export (1 line).
- `frontend/tests/unit/constructeurs-html-wrapper-noindex.test.ts` — new test importing from the **`.html`** route explicitly: asserts it re-exports `headers`, propagates `noindex, follow` + error cache-control on a loader-throw, and adds no accidental noindex on success.

Out of scope (verified, not touched): the sibling `constructeurs.$brand.$model.$type[.].tsx` is a **301-redirect route**, not an equivalent re-export wrapper. SeoHeadersInterceptor, `$.tsx`, `buildCacheHeaders`, R2/pieces, sitemap, canonical, GSC workflow, global cache policy — all untouched.

---

## Improvement Check

- **Problem:** #798 shipped & deployed to PROD but its primary goal (404 vehicle → `noindex`) is **not achieved** — the `.html` wrapper dropped the header.
- **Evidence before:** Live PROD after `v2026.05.30-seo-noindex-404-410`: `/constructeurs/mercedes-benz-108/classe-g-w460-108059/230-857.html` → 404 with **no** `X-Robots-Tag`, carrying root-fallback `cache-control: private, max-age=60` (cache purged + `cf-cache-status: DYNAMIC` → not a cache artifact).
- **Expected gain:** the `.html` 404/410 vehicle pages emit `X-Robots-Tag: noindex, follow` (coherence / defense-in-depth on error pages).
- **Risk:** minimal — adds one re-export of an existing, tested function; success path keeps `private, max-age=60` (no cache-behaviour change). Rollback = revert this PR (no PROD regression; the 404 was already bare).
- **Test:** new test imports from the `.html` route and asserts header propagation (3/3); eslint clean.
- **Evidence after:** to confirm on PROD post-tag (see Test plan) — local + PREPROD first.
- **Verdict:** GO_WITH_WATCH
- **Next action:** merge → PREPROD; owner `v*` tag (nominative GO) → PROD curl confirms single `noindex` on the `.html` 404 → then close the GSC/noindex point.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)