### PR TITLE
fix(seo): emit noindex on constructeurs catch-all error pages (#798/#800 follow-up)

### DIFF
--- a/frontend/app/routes/constructeurs.$.tsx
+++ b/frontend/app/routes/constructeurs.$.tsx
@@ -18,6 +18,7 @@ import {
 } from "@remix-run/react";
 import { Car, ChevronRight, Fuel, Gauge, Calendar } from "lucide-react";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
 import { normalizeTypeAlias } from "~/utils/url-builder.utils";
@@ -32,6 +33,17 @@ export const handle = {
     clusterId: "constructeurs",
   }),
 };
+
+// 🔒 Route R1 catch-all : sert du 200 indexable MAIS throw aussi des 404/410
+// (URLs constructeur inconnues). Ses throws sont des `new Response(..., {status})`
+// NUS (sans X-Robots-Tag). Sans ce `headers` export + `defaultErrorRobots`, Remix v2
+// retombe sur root.tsx `headers()` et — l'interceptor supprimant le X-Robots-Tag
+// défaut pour /constructeurs/ — la page d'erreur sort SANS noindex (vérifié live
+// PROD 2026-05-30). Le succès garde `private, max-age=60` (inchangé). Voir le gotcha
+// Remix headers-export (PR #798/#800).
+export const headers = buildCacheHeaders("private, max-age=60", {
+  defaultErrorRobots: "noindex, follow",
+});
 
 interface MotorOption {
   id: number;

--- a/frontend/app/routes/constructeurs.$brand.$model.$type[.].tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type[.].tsx
@@ -4,7 +4,15 @@
 import { redirect, type LoaderFunctionArgs } from "@remix-run/node";
 import { useRouteError, isRouteErrorResponse } from "@remix-run/react";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import { detectMalformedSegment } from "~/utils/pieces-route.utils";
+
+// 🔒 Shim 301 (→ .html) qui throw aussi 400 (nu) et 404 (inline noindex). Sans ce
+// `headers` export, Remix v2 DROP ces directives. `defaultErrorRobots` couvre le 400
+// nu ; le 404 inline est propagé tel quel. Voir gotcha Remix headers-export (#798/#800).
+export const headers = buildCacheHeaders("no-cache", {
+  defaultErrorRobots: "noindex, follow",
+});
 
 export async function loader({ params }: LoaderFunctionArgs) {
   const { brand, model, type } = params;

--- a/frontend/app/utils/cache-control.ts
+++ b/frontend/app/utils/cache-control.ts
@@ -19,15 +19,23 @@ const NO_STORE = "no-cache, no-store, must-revalidate";
  *   3. `successPolicy` → fallback when neither set anything explicit
  *
  * X-Robots-Tag is propagated unchanged from whichever source carried it
- * (loader on success, error response on failure).
+ * (loader on success, error response on failure). Pass `opts.defaultErrorRobots`
+ * (e.g. `"noindex, follow"`) for routes whose error throws are *bare*
+ * (`new Response("Not Found", { status: 404 })` with no headers): the directive
+ * is then asserted on the error response instead of relying on the absence-of-
+ * header default — without overriding an explicit X-Robots-Tag when present.
  */
-export function buildCacheHeaders(successPolicy: string): HeadersFunction {
+export function buildCacheHeaders(
+  successPolicy: string,
+  opts?: { defaultErrorRobots?: string },
+): HeadersFunction {
   return ({ loaderHeaders, errorHeaders }) => {
     const out: Record<string, string> = {};
 
     if (errorHeaders) {
       out["Cache-Control"] = errorHeaders.get("Cache-Control") ?? NO_STORE;
-      const xRobots = errorHeaders.get("X-Robots-Tag");
+      const xRobots =
+        errorHeaders.get("X-Robots-Tag") ?? opts?.defaultErrorRobots;
       if (xRobots) out["X-Robots-Tag"] = xRobots;
       return out;
     }

--- a/frontend/tests/unit/utils/cache-control.test.ts
+++ b/frontend/tests/unit/utils/cache-control.test.ts
@@ -93,6 +93,37 @@ describe("buildCacheHeaders", () => {
     expect(result["X-Robots-Tag"]).toBe("noindex");
   });
 
+  it("falls back to defaultErrorRobots when a bare thrown Response carries no X-Robots-Tag", () => {
+    // Covers catch-all routes (e.g. constructeurs.$.tsx) whose throws are
+    // `new Response("Not Found", { status: 404 })` with no robots header.
+    const fn = buildCacheHeaders(SUCCESS_POLICY, {
+      defaultErrorRobots: "noindex, follow",
+    });
+    const result = fn({
+      loaderHeaders: new Headers(),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders: new Headers(),
+    });
+
+    expect(result["X-Robots-Tag"]).toBe("noindex, follow");
+    expect(result["Cache-Control"]).toBe(NO_STORE_CACHE_CONTROL);
+  });
+
+  it("an explicit X-Robots-Tag on the thrown Response overrides defaultErrorRobots", () => {
+    const fn = buildCacheHeaders(SUCCESS_POLICY, {
+      defaultErrorRobots: "noindex, follow",
+    });
+    const result = fn({
+      loaderHeaders: new Headers(),
+      parentHeaders: new Headers(),
+      actionHeaders: new Headers(),
+      errorHeaders: headers([["X-Robots-Tag", "noindex"]]),
+    });
+
+    expect(result["X-Robots-Tag"]).toBe("noindex");
+  });
+
   it("never leaks the success policy onto an error response (the cache-poisoning regression)", () => {
     const fn = buildCacheHeaders(SUCCESS_POLICY);
     const result = fn({


### PR DESCRIPTION
## Contexte

Suite de #798 + #800 (X-Robots-Tag `noindex` sur les pages d'erreur). Ces deux PRs ont couvert la route véhicule **base** + le **wrapper `.html`**. En auditant la famille `constructeurs.*`, deux frères restaient avec le même trou.

## Gap (vérifié live PROD 2026-05-30)

| URL (route) | Status | X-Robots-Tag live (avant) |
|---|---|---|
| `/constructeurs/zzz-nonexistent-9999` (`$.tsx`) | 404 | **(aucun)** |
| `/constructeurs/foo-123/bar-456` (`$.tsx`) | 410 | **(aucun)** |

`constructeurs.$.tsx` (catch-all R1) throw des `new Response("Not Found",{status:404})` **nus** (sans X-Robots-Tag) et n'avait **pas de `headers` export** → Remix v2 retombe sur `root.tsx headers()` et, l'interceptor supprimant le X-Robots-Tag défaut pour `/constructeurs/`, la page d'erreur sort **sans noindex** (noindex explicite manquant ; **pas** de leak `index, follow`). Même cas pour le shim 301 `constructeurs.$brand.$model.$type[.].tsx` (400 nu + 404 inline noindex droppé).

Impact SEO réel ≈ nul (404/410 désindexe de toute façon), mais le contrat « error responses carry noindex » n'était pas tenu.

## Fix (étend la couche existante, rétro-compatible)

- **`buildCacheHeaders`** gagne une option `defaultErrorRobots` : asserte une directive robots sur les réponses d'erreur dont les headers throw sont **nus**, **sans** écraser un X-Robots-Tag explicite quand le throw en porte un. Les appelants existants (`/pieces`, base constructeurs) ne passent pas d'opts → **comportement identique**.
- **`constructeurs.$.tsx`** + **`[.].tsx`** : `export const headers = buildCacheHeaders("private, max-age=60" | "no-cache", { defaultErrorRobots: "noindex, follow" })`. Le **200 indexable** du catch-all garde `private, max-age=60` (inchangé).

## Vérification

- ✅ vitest `cache-control` **9/9** (7 + 2 nouveaux : bare-throw default + précédence override explicite).
- ✅ ESLint changed files : **0 erreur**.
- ✅ `tsc` : **0 erreur**.

## Vérification post-déploiement (après merge + tag PROD)

```bash
# attendu : noindex, follow (au lieu d'aucun header)
curl -sI "https://www.automecanik.com/constructeurs/zzz-nonexistent-brand-9999" | grep -i x-robots-tag
curl -sI "https://www.automecanik.com/constructeurs/foo-123/bar-456"            | grep -i x-robots-tag
# non-régression : 404 véhicule base/.html reste noindex,follow ; 200 reste indexable
```

## Note hors-scope (observé, non corrigé)

`/constructeurs/{b}/{m}/{type}` (sans `.html`, valide) renvoie **200 indexable** (vs 301→`.html` attendu) — question canonical/duplicate distincte du robots, **pas touchée** ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
