### PR TITLE
fix(frontend): polyfill Array.prototype.at for Sentry INP crash on old engines

### DIFF
--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -4,6 +4,12 @@
  * For more information, see https://remix.run/file-conventions/entry.client
  */
 
+// MUST be first: installs the ES2022 Array.prototype.at polyfill before any
+// other module loads. Sentry's bundled INP web-vital code calls `.at(-1)`,
+// which throws on engines without it (Safari < 15.4, old WebViews, crawlers).
+// See ~/utils/array-at-polyfill.client for the full rationale.
+import "~/utils/array-at-polyfill.client";
+
 import { RemixBrowser } from "@remix-run/react";
 import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";

--- a/frontend/app/utils/array-at-polyfill.client.ts
+++ b/frontend/app/utils/array-at-polyfill.client.ts
@@ -1,0 +1,52 @@
+/**
+ * Polyfill for `Array.prototype.at` (ES2022) — client only.
+ *
+ * Why this exists
+ * ---------------
+ * `@sentry-internal/browser-utils` (pulled in by `@sentry/remix`) ships INP
+ * web-vital instrumentation that calls `this._longestInteractionList.at(-1)`
+ * in `InteractionManager._processEntry`. Sentry explicitly declares
+ * "We support ES2021 and earlier" and de-`.at()`-ed the sibling CLS path
+ * (`LayoutShiftManager`, now `[length - 1]`) but MISSED this INP call-site.
+ * On engines without `Array.prototype.at` (Safari < 15.4, old Chromium /
+ * Android WebViews, several crawler engines) the INP `PerformanceObserver`
+ * callback throws `… .at is not a function`. It is thrown inside Sentry's own
+ * instrumentation and re-captured by Sentry's global handler, so it surfaces
+ * in PROD as `this.i.at is not a function` / `i.entries.at is not a function`.
+ * The page itself is unaffected (async observer callback), but it spams the
+ * Sentry error budget and loses INP telemetry for those clients.
+ *
+ * A polyfill at the root (rather than patching `node_modules`) fixes every
+ * `.at()` call-site — Sentry's INP path and any other bundled dependency —
+ * for old engines, and is the correct interim until `@sentry/*` ships an
+ * upstream release that also fixes the INP `.at(-1)`. Remove this module then.
+ *
+ * Loaded as the FIRST import in `entry.client.tsx` so `.at` exists before the
+ * lazily-scheduled Sentry init registers its observers. The method is defined
+ * non-enumerable to match the native descriptor — a plain assignment would be
+ * enumerable and leak into `for…in` iteration over arrays.
+ */
+export function installArrayAtPolyfill(): void {
+  if (typeof (Array.prototype as { at?: unknown }).at === "function") {
+    return;
+  }
+
+  // Intentional, spec-faithful prototype extension (see file header) — only
+  // installed when the native method is absent, and non-enumerable.
+  // eslint-disable-next-line no-extend-native
+  Object.defineProperty(Array.prototype, "at", {
+    value: function at(this: unknown[], index: number): unknown {
+      const len = this.length;
+      let k = Math.trunc(index) || 0;
+      if (k < 0) {
+        k += len;
+      }
+      return k < 0 || k >= len ? undefined : this[k];
+    },
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+installArrayAtPolyfill();

--- a/frontend/tests/unit/array-at-polyfill.test.ts
+++ b/frontend/tests/unit/array-at-polyfill.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { installArrayAtPolyfill } from "~/utils/array-at-polyfill.client";
+
+/**
+ * Regression guard for the Sentry INP crash on engines without ES2022
+ * `Array.prototype.at`.
+ *
+ * `@sentry-internal/browser-utils` (via `@sentry/remix`) calls
+ * `this._longestInteractionList.at(-1)` in `InteractionManager._processEntry`
+ * (INP web-vital). Sentry declares ES2021 support and de-`.at()`-ed the
+ * sibling CLS path but missed this INP call-site, so on Safari < 15.4 / old
+ * Chromium-WebViews / several crawler engines the INP PerformanceObserver
+ * callback throws `… .at is not a function` — surfaced in Sentry PROD as
+ * `this.i.at is not a function` / `i.entries.at is not a function`.
+ *
+ * Node ships native `.at`, so these tests simulate the old engine by deleting
+ * the method, then assert the polyfill restores spec-correct behaviour.
+ */
+describe("Array.prototype.at polyfill", () => {
+  const nativeDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, "at");
+
+  afterEach(() => {
+    if (nativeDescriptor) {
+      // Restore the native descriptor after each simulated old-engine test.
+      // eslint-disable-next-line no-extend-native
+      Object.defineProperty(Array.prototype, "at", nativeDescriptor);
+    }
+  });
+
+  const removeNativeAt = () => {
+    delete (Array.prototype as { at?: unknown }).at;
+  };
+
+  const atOf = (arr: unknown[]) =>
+    (arr as unknown as { at(index: number): unknown }).at.bind(arr);
+
+  it("reproduces the crash on an engine lacking Array.prototype.at", () => {
+    removeNativeAt();
+    expect(() =>
+      (([1, 2, 3] as unknown as { at(index: number): unknown }).at(-1)),
+    ).toThrow(/is not a function/);
+  });
+
+  it("restores spec-correct .at() — including the .at(-1) Sentry's INP code calls", () => {
+    removeNativeAt();
+    installArrayAtPolyfill();
+
+    const at = atOf([10, 20, 30]);
+    expect(at(-1)).toBe(30); // the exact access InteractionManager makes
+    expect(at(0)).toBe(10);
+    expect(at(2)).toBe(30);
+    expect(at(-3)).toBe(10);
+    expect(at(3)).toBeUndefined();
+    expect(at(-4)).toBeUndefined();
+  });
+
+  it("defines .at as non-enumerable (no leak into for…in over arrays)", () => {
+    removeNativeAt();
+    installArrayAtPolyfill();
+
+    const keys: string[] = [];
+    // eslint-disable-next-line guard-for-in
+    for (const k in [1, 2, 3]) keys.push(k);
+    expect(keys).not.toContain("at");
+  });
+
+  it("is a no-op when native .at is present (does not overwrite)", () => {
+    const before = (Array.prototype as { at?: unknown }).at;
+    installArrayAtPolyfill();
+    expect((Array.prototype as { at?: unknown }).at).toBe(before);
+  });
+});


### PR DESCRIPTION
## Problème

Alerte Sentry PROD (`automecanik-frontend-prod`, 31 mai 2026 05:25 UTC), route `/pieces/thermostat-316/toyota-…` :

- `TypeError: this.i.at is not a function`
- `TypeError: i.entries.at is not a function`

## Cause racine (bug upstream Sentry, confirmé)

Ce n'est **pas** du code applicatif — c'est l'instrumentation **INP** que le SDK Sentry embarque. Dans `@sentry-internal/browser-utils` (tiré par `@sentry/remix`), `InteractionManager._processEntry` appelle :

```js
const minLongestInteraction = this._longestInteractionList.at(-1);  // → minifié this.i.at(-1)
```

Détail accablant : le fichier frère **CLS** a été corrigé, le **INP** a été oublié —

```js
// LayoutShiftManager.js (CLS — CORRIGÉ)
// "This previously used `this._sessionEntries.at(-1)` but that is ES2022. We support ES2021 and earlier."
const lastSessionEntry = this._sessionEntries[this._sessionEntries.length - 1];
```

`Array.prototype.at` est ES2022. Sur les moteurs sans (`Safari < 15.4`, vieux Chromium/WebViews Android, plusieurs moteurs de crawlers), le callback `PerformanceObserver` INP lève `… .at is not a function`. L'exception est jetée **dans** l'instrumentation Sentry puis re-capturée par son propre global handler → remontée comme erreur « frontend PROD ». Les deux signaux (`this.i.at`, `i.entries.at`) sont la même classe : un `.at()` sur un tableau dans du code bundlé.

## Impact : ~nul côté utilisateur

L'exception est levée dans un callback `PerformanceObserver` asynchrone — **pas** dans le rendu/hydratation. La page fonctionne. Coût réel = bruit dans le budget d'erreurs Sentry + perte de télémétrie INP pour ces clients. **Ce n'est pas un P0.**

## Correctif

Polyfill `Array.prototype.at` (spec-faithful, **non-enumerable**), installé en **premier import** de `entry.client.tsx`, avant que l'init Sentry différée n'enregistre ses observers.

Corriger à la racine couvre le call-site INP de Sentry **et** tout autre `.at()` de dépendance bundlée pour les vieux moteurs — vs un fix chirurgical impossible (la ligne fautive vit dans `node_modules`). À **retirer** dès que `@sentry/*` publie une release corrigeant aussi le `.at(-1)` INP en amont.

## Vérification

- `vitest` : 4/4 (RED→GREEN — repro « moteur sans `.at` » + comportement spec-correct + non-enumerable + no-op si natif présent)
- `eslint` : 0 erreur (le seul warning `import/order` est **préexistant** sur `origin/main`)
- `tsc` : 0 erreur

## Déploiement

Merge `main` → **container PREPROD** (CI : E2E Smoke + Lighthouse). **Pas** de déploiement PROD — celui-ci nécessite un tag `v*` sous décision owner explicite.

## Réserves honnêtes

- Bundle PROD live non inspecté directement ; la cause racine s'appuie sur la source `@sentry@10.53.1` installée (ce que PROD build) + le bundle local. Le mécanisme est certain.
- Le call-site exact du 2ᵉ signal (`i.entries.at`) n'a pas été épinglé frame par frame — mais un polyfill `Array.prototype.at` unique couvre les deux quelle qu'en soit l'origine.

## Suivi possible

- Bump `@sentry/*` une fois le fix INP publié upstream (owner-gated) → retirer ce polyfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
