### PR TITLE
feat(cwv): alert on raw→hourly aggregation coverage gap

### DIFF
--- a/backend/supabase/migrations/20260601_seo_cwv_aggregation_coverage_alert.down.sql
+++ b/backend/supabase/migrations/20260601_seo_cwv_aggregation_coverage_alert.down.sql
@@ -1,0 +1,9 @@
+-- Down — retire le cron + la fonction de détection coverage-gap.
+-- Aucun enum ajouté (réutilise anomaly_detected) → réversibilité totale.
+
+SELECT cron.unschedule('cwv-aggregation-coverage-check')
+WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'cwv-aggregation-coverage-check'
+);
+
+DROP FUNCTION IF EXISTS public.detect_cwv_aggregation_coverage_gap(INT, INT, INT);

--- a/backend/supabase/migrations/20260601_seo_cwv_aggregation_coverage_alert.sql
+++ b/backend/supabase/migrations/20260601_seo_cwv_aggregation_coverage_alert.sql
@@ -1,0 +1,130 @@
+-- Migration : detect_cwv_aggregation_coverage_gap() + pg_cron alert.
+--
+-- Plan bloc 4 — follow-up #3 (suite PR #803). Détecte le trou SILENCIEUX
+-- raw → hourly : des heures présentes dans __seo_cwv_raw (ua_class='human',
+-- TTL ~48h) mais JAMAIS agrégées dans __seo_cwv_hourly. C'est exactement le
+-- gap qui, le 2026-05-31, n'a agrégé que 22 / 150 samples LCP (85% perdus) et
+-- a failli purger 178 samples du 2026-05-30 — cause : scheduler d'agrégation
+-- BullMQ off/absent SANS signal (cf. SEO_CWV_AGGREGATION_ENABLED, PR #803).
+--
+-- Mode : READ-ONLY / ALERTING. La fonction NE backfille PAS, NE mute PAS le
+-- raw, NE touche PAS le scheduler. Elle émet une alerte dans __seo_event_log
+-- (sink canon, identique à detect_cwv_trend_divergence), dédupliquée sur les
+-- événements ouverts (resolved_at IS NULL). Le backfill reste une action
+-- OWNER via aggregate_cwv_hourly(<hour>) + aggregate_cwv_daily_rum(<date>)
+-- tant que le raw (TTL ~48h) n'est pas purgé.
+--
+-- Taxonomie : réutilise l'enum existant seo_event_type='anomaly_detected' +
+-- discriminant payload.alert_kind='cwv_aggregation_coverage_gap'. Aucun
+-- ALTER TYPE ADD VALUE → migration 100% réversible. Sévérité 'high'.
+--
+-- Anti-régression PR #697 : fonction + pg_cron ATOMIQUES, idempotents.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+-- =============================================================================
+-- Détecteur : heures raw humaines non agrégées dans hourly → alerte event_log
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.detect_cwv_aggregation_coverage_gap(
+  p_window_hours INT DEFAULT 48,   -- borne = TTL raw (au-delà : partition purgée)
+  p_grace_hours  INT DEFAULT 2,    -- heures récentes pas encore agrégées (job @ :05 + retries)
+  p_min_missing  INT DEFAULT 2     -- seuil anti-flapping : 1 heure isolée = transient toléré
+)
+RETURNS TABLE(alerts_inserted INT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count         INT := 0;
+  v_missing_hours INT := 0;
+  v_oldest        TIMESTAMPTZ;
+  v_newest        TIMESTAMPTZ;
+  v_rows_at_risk  BIGINT := 0;
+BEGIN
+  -- Heures avec du raw HUMAIN (ce que l'agrégation traite) mais SANS ligne
+  -- correspondante dans __seo_cwv_hourly, en excluant les p_grace_hours plus
+  -- récentes (qui peuvent légitimement ne pas être encore agrégées).
+  WITH raw_hours AS (
+    SELECT date_trunc('hour', received_at) AS hr, count(*)::BIGINT AS n
+    FROM __seo_cwv_raw
+    WHERE received_at >= now() - make_interval(hours => p_window_hours)
+      AND ua_class = 'human'
+      AND date_trunc('hour', received_at)
+            < date_trunc('hour', now()) - make_interval(hours => p_grace_hours)
+    GROUP BY 1
+  ),
+  missing AS (
+    SELECT rh.hr, rh.n
+    FROM raw_hours rh
+    WHERE NOT EXISTS (
+      SELECT 1 FROM __seo_cwv_hourly h WHERE h.hour = rh.hr
+    )
+  )
+  SELECT count(*), min(hr), max(hr), COALESCE(sum(n), 0)
+  INTO v_missing_hours, v_oldest, v_newest, v_rows_at_risk
+  FROM missing;
+
+  -- Sous le seuil → pas de bruit (heure transitoire isolée tolérée).
+  IF v_missing_hours < p_min_missing THEN
+    alerts_inserted := 0;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  -- Dédup : ne pas ré-alerter si une alerte de couverture est déjà OUVERTE (7j).
+  IF EXISTS (
+    SELECT 1 FROM __seo_event_log e
+    WHERE e.event_type = 'anomaly_detected'
+      AND e.resolved_at IS NULL
+      AND e.created_at >= now() - INTERVAL '7 days'
+      AND e.payload->>'alert_kind' = 'cwv_aggregation_coverage_gap'
+  ) THEN
+    alerts_inserted := 0;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  INSERT INTO __seo_event_log (event_type, entity_url, severity, payload)
+  VALUES (
+    'anomaly_detected'::seo_event_type,
+    NULL,
+    'high'::seo_severity,
+    jsonb_build_object(
+      'alert_kind',          'cwv_aggregation_coverage_gap',
+      'missing_hours',       v_missing_hours,
+      'oldest_missing_hour', v_oldest,
+      'newest_missing_hour', v_newest,
+      'raw_rows_at_risk',    v_rows_at_risk,
+      'window_hours',        p_window_hours,
+      'grace_hours',         p_grace_hours,
+      'hint',                'raw humain présent dans __seo_cwv_raw mais non agrégé dans __seo_cwv_hourly. Backfill OWNER : aggregate_cwv_hourly(<hour>) puis aggregate_cwv_daily_rum(<date>) AVANT purge raw (TTL ~48h). Vérifier SEO_CWV_AGGREGATION_ENABLED + worker BullMQ.'
+    )
+  );
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  alerts_inserted := v_count;
+  RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.detect_cwv_aggregation_coverage_gap(INT, INT, INT) IS
+  'Bloc 4 follow-up (#3) — READ-ONLY/ALERTING. Détecte des heures raw humaines (TTL ~48h) non agrégées dans __seo_cwv_hourly et émet anomaly_detected (payload.alert_kind=cwv_aggregation_coverage_gap) dans __seo_event_log, dédupliqué sur événements ouverts. Ne backfille pas / ne mute pas raw / ne touche pas le scheduler. Mirror de detect_cwv_trend_divergence.';
+
+GRANT EXECUTE ON FUNCTION public.detect_cwv_aggregation_coverage_gap(INT, INT, INT) TO service_role;
+
+-- =============================================================================
+-- pg_cron : quotidien 03:35 UTC (après agg hourly @ :05 + daily_rum @ 03:15).
+-- Le gap reste backfillable tant que le raw (TTL ~48h) n'est pas purgé.
+-- =============================================================================
+
+SELECT cron.schedule(
+  'cwv-aggregation-coverage-check',
+  '35 3 * * *',
+  $cron$SELECT public.detect_cwv_aggregation_coverage_gap();$cron$
+)
+WHERE NOT EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'cwv-aggregation-coverage-check'
+);


### PR DESCRIPTION
## Summary

Read-only **alerting** detector that closes the observability blind spot behind PR #803: the CWV RUM **raw → hourly aggregation gap** that silently dropped 85% of the 2026-05-31 LCP samples (22/150 aggregated) and nearly purged 178 samples from 2026-05-30 before a manual backfill recovered them.

When `__seo_cwv_raw` accumulates human hours that the BullMQ aggregation scheduler never turns into `__seo_cwv_hourly` rows (flag off/absent, worker down, …), nothing surfaced it. Now a daily check raises a deduped alert in `__seo_event_log`.

## Scope (1 migration + down)

- **`detect_cwv_aggregation_coverage_gap(p_window_hours=48, p_grace_hours=2, p_min_missing=2)`** — `SECURITY DEFINER`, mirrors `detect_cwv_trend_divergence`:
  - finds hours with **human** raw (last 48h, excluding the most recent 2h grace) that have **no** `__seo_cwv_hourly` row;
  - if `missing_hours >= 2`, inserts ONE `__seo_event_log` row (`event_type='anomaly_detected'`, `severity='high'`, `payload.alert_kind='cwv_aggregation_coverage_gap'` + diagnostics + backfill hint);
  - **deduped** against open events (`resolved_at IS NULL`, 7d) of the same `alert_kind`.
- **pg_cron** `cwv-aggregation-coverage-check` @ `35 3 * * *` UTC (idempotent `WHERE NOT EXISTS`), after hourly (`:05`) + daily_rum (`03:15`) aggregation.

## Reuses existing mechanism (no new layer)

- Sink = `__seo_event_log` (same path as the trend-divergence alert) — canon *no external canary when internal observability exists*.
- Event type = existing **`anomaly_detected`** enum value + payload discriminator → **no `ALTER TYPE ADD VALUE`**, so the migration is **100% reversible** (down drops fn + cron).

## What it does NOT do (intentional)

- No backfill, no `__seo_cwv_raw` mutation, no change to the aggregation scheduler (`CwvAggregationSchedulerService`) — backfill stays an owner action via `aggregate_cwv_hourly(<hour>)` + `aggregate_cwv_daily_rum(<date>)`.
- No new enum value, no new table, no new alert channel.

## Verification (read-only, live DB)

- Detector core logic run against live DB: **`missing_hours = 0`** now (post-backfill, aggregation running forward; `hourly_max` = current−1h, within the 2h grace) → **no false positive**.
- Full plpgsql body validated via `BEGIN; CREATE …; ROLLBACK;` (parses cleanly, **zero persistence** — confirmed temp fn not persisted, real fn absent).
- It WOULD have fired on the 2026-05-30/31 incident (20+ missing hours).

## Activation (owner, post-merge)

This migration is **not auto-applied** (DB drift axis #4). Owner applies `20260601_seo_cwv_aggregation_coverage_alert.sql` via Supabase Studio SQL editor (no `ALTER TYPE`, so no own-tx caveat). The cron then runs daily; alerts land in `__seo_event_log` and flow through the existing consumers.

## Test plan

- [x] Detector logic returns 0 on current healthy data — read-only on live DB
- [x] plpgsql parses (BEGIN/CREATE/ROLLBACK)
- [x] Migration Safety / CI gates (this PR)
- [ ] Post-apply (owner): confirm `cron.job` has `cwv-aggregation-coverage-check`; optionally `SELECT public.detect_cwv_aggregation_coverage_gap();` → expect `alerts_inserted=0` on healthy data

Independent of #803 (already merged to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
