### PR TITLE
feat(merchant-center): GMC price-competitiveness benchmark (inbound, OBSERVE-only)

### DIFF
--- a/.claude/knowledge/REPO_MAP.md
+++ b/.claude/knowledge/REPO_MAP.md
@@ -3,7 +3,7 @@ title: Repository Map
 kind: registry-index
 generated_at: "1970-01-01T00:00:00.000Z"
 source: audit/registry/canonical.json
-source_sha256: caf4d0046537c5bf877f75ddbdefbda1d00b06639085fd20513333ed7782aa76
+source_sha256: 3980539d423d48a84576507551bdbb6afcc6364520663769d9d14dc09e1d0711
 schema_version: "1.0.0"
 do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-058 PR-F)
 ---
@@ -21,10 +21,10 @@ do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-
 | Files (Layer 1) | 2425 |
 | DB tables (Layer 1) | 257 |
 | DB RPC (Layer 1) | 197 |
-| Dependencies (Layer 1) | 254 |
+| Dependencies (Layer 1) | 246 |
 | Runtime entrypoints (Layer 1) | 488 |
 
-Source sotFingerprint: `6e792261164c`.
+Source sotFingerprint: `8f2fc393634b`.
 
 ## Comment l'utiliser
 

--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/constants/seo-control.constants.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog-metadata.md
+++ b/.claude/knowledge/modules/blog-metadata.md
@@ -2,7 +2,7 @@
 module: blog-metadata
 sources:
 - backend/src/modules/blog-metadata
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/blog-metadata/blog-metadata.controller.ts
 - backend/src/modules/blog-metadata/blog-metadata.module.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.test.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/maintenance.md
+++ b/.claude/knowledge/modules/maintenance.md
@@ -2,7 +2,7 @@
 module: maintenance
 sources:
 - backend/src/modules/maintenance
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/maintenance/maintenance.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/merchant-center.md
+++ b/.claude/knowledge/modules/merchant-center.md
@@ -2,11 +2,13 @@
 module: merchant-center
 sources:
 - backend/src/modules/merchant-center
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/merchant-center/controllers/merchant-center.controller.ts
+- backend/src/modules/merchant-center/controllers/price-competitiveness.controller.ts
 - backend/src/modules/merchant-center/merchant-center.module.ts
 - backend/src/modules/merchant-center/services/merchant-center-feed.service.ts
+- backend/src/modules/merchant-center/services/price-competitiveness.service.ts
 depends_on:
 - DatabaseModule
 ---

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/observability.md
+++ b/.claude/knowledge/modules/observability.md
@@ -2,7 +2,7 @@
 module: observability
 sources:
 - backend/src/modules/observability
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.test.ts
 - backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-knowledge-bootstrap.md
+++ b/.claude/knowledge/modules/rag-knowledge-bootstrap.md
@@ -2,7 +2,7 @@
 module: rag-knowledge-bootstrap
 sources:
 - backend/src/modules/rag-knowledge-bootstrap
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
 - backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/dto/alternatives-v2.dto.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-control-plane.md
+++ b/.claude/knowledge/modules/seo-control-plane.md
@@ -2,7 +2,7 @@
 module: seo-control-plane
 sources:
 - backend/src/modules/seo-control-plane
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.processor.ts
 - backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.scheduler.service.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo-monitoring.md
+++ b/.claude/knowledge/modules/seo-monitoring.md
@@ -2,16 +2,16 @@
 module: seo-monitoring
 sources:
 - backend/src/modules/seo-monitoring
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
+- backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
+- backend/src/modules/seo-monitoring/controllers/cwv-dashboard.controller.ts
 - backend/src/modules/seo-monitoring/controllers/funnel-events.controller.ts
 - backend/src/modules/seo-monitoring/controllers/quality-history.controller.ts
+- backend/src/modules/seo-monitoring/controllers/runtime-events.controller.ts
 - backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
 - backend/src/modules/seo-monitoring/helpers/ai-readiness-detectors.ts
-- backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts
-- backend/src/modules/seo-monitoring/seo-monitoring.module.ts
-- backend/src/modules/seo-monitoring/services/audit-findings.service.ts
-- backend/src/modules/seo-monitoring/services/crux-alerter.service.ts
+- backend/src/modules/seo-monitoring/processors/cwv-aggregation.processor.ts
 depends_on:
 - ConfigModule
 ---

--- a/.claude/knowledge/modules/seo-shadow-observatory.md
+++ b/.claude/knowledge/modules/seo-shadow-observatory.md
@@ -2,7 +2,7 @@
 module: seo-shadow-observatory
 sources:
 - backend/src/modules/seo-shadow-observatory
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/seo-shadow-observatory/env.schema.ts
 - backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,16 +2,16 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts
 - backend/src/modules/support/controllers/contact.controller.ts
 - backend/src/modules/support/controllers/faq.controller.ts
+- backend/src/modules/support/controllers/leads-admin.controller.ts
 - backend/src/modules/support/controllers/legal.controller.ts
 - backend/src/modules/support/controllers/quote.controller.ts
 - backend/src/modules/support/controllers/review.controller.ts
-- backend/src/modules/support/controllers/support-analytics.controller.ts
 depends_on:
 - ConfigModule
 - DatabaseModule

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicle-context.md
+++ b/.claude/knowledge/modules/vehicle-context.md
@@ -2,7 +2,7 @@
 module: vehicle-context
 sources:
 - backend/src/modules/vehicle-context
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/vehicle-context/vehicle-context.middleware.test.ts
 - backend/src/modules/vehicle-context/vehicle-context.middleware.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-24'
+last_scan: '2026-06-02'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -538,6 +538,11 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: medium
+  - glob: backend/supabase/migrations/*price_competitiveness*
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/supabase/migrations/*seo_snapshot*
     domain: D3
     owner: '@ak125/seo-team'

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -144,6 +144,14 @@ GA4_PRIVATE_KEY=
 # Property ID GA4 numérique (Admin → Property details)
 GA4_PROPERTY_ID=
 
+# Google Merchant Center — "Price competitiveness" (benchmark concurrent entrant)
+# Requis : l'ID du compte Merchant Center (Settings → Account ID).
+GMC_MERCHANT_ID=
+# Auth : par défaut le SA GSC ci-dessus est réutilisé (l'ajouter comme utilisateur
+# du compte Merchant Center suffit). Renseigner ci-dessous seulement pour un SA dédié.
+GMC_CLIENT_EMAIL=
+GMC_PRIVATE_KEY=
+
 # Kill-switch global pour fetchers SEO (set false pour bypass crons)
 SEO_MONITORING_ENABLED=false
 

--- a/backend/src/modules/merchant-center/controllers/price-competitiveness.controller.ts
+++ b/backend/src/modules/merchant-center/controllers/price-competitiveness.controller.ts
@@ -1,0 +1,45 @@
+/**
+ * PriceCompetitivenessController — admin (IsAdminGuard).
+ *
+ *   POST /api/admin/merchant-center/price-competitiveness/sync   → pull GMC benchmark
+ *   GET  /api/admin/merchant-center/price-competitiveness/gap    → over/under-market list
+ *
+ * OBSERVE-only: surfaces where we sit vs the market average. It never reprices.
+ */
+import { Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { IsAdminGuard } from '@auth/is-admin.guard';
+import {
+  PriceCompetitivenessService,
+  type PriceCompetitivenessSyncResult,
+} from '../services/price-competitiveness.service';
+
+@Controller('api/admin/merchant-center/price-competitiveness')
+@UseGuards(IsAdminGuard)
+export class PriceCompetitivenessController {
+  constructor(private readonly service: PriceCompetitivenessService) {}
+
+  /** Trigger a benchmark pull (idempotent per day). */
+  @Post('sync')
+  sync(
+    @Query('country') country = 'FR',
+  ): Promise<PriceCompetitivenessSyncResult> {
+    return this.service.sync(country);
+  }
+
+  /** List offers vs market: positive gap = above the market (candidate to lower). */
+  @Get('gap')
+  gap(
+    @Query('country') country = 'FR',
+    @Query('minGap') minGap?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ): Promise<unknown[]> {
+    const min = minGap != null && minGap !== '' ? Number(minGap) : null;
+    return this.service.gapReport(
+      country,
+      Number.isFinite(min as number) ? (min as number) : null,
+      limit ? Number(limit) : 200,
+      offset ? Number(offset) : 0,
+    );
+  }
+}

--- a/backend/src/modules/merchant-center/merchant-center.module.ts
+++ b/backend/src/modules/merchant-center/merchant-center.module.ts
@@ -10,11 +10,20 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../../database/database.module';
 import { MerchantCenterController } from './controllers/merchant-center.controller';
 import { MerchantCenterFeedService } from './services/merchant-center-feed.service';
+import { PriceCompetitivenessController } from './controllers/price-competitiveness.controller';
+import { PriceCompetitivenessService } from './services/price-competitiveness.service';
+import { GoogleCredentialsService } from '../seo-monitoring/services/google-credentials.service';
 
 @Module({
   imports: [DatabaseModule],
-  controllers: [MerchantCenterController],
-  providers: [MerchantCenterFeedService],
-  exports: [MerchantCenterFeedService],
+  controllers: [MerchantCenterController, PriceCompetitivenessController],
+  // GoogleCredentialsService is stateless (ConfigService only) — provided here to
+  // avoid importing the whole SeoMonitoringModule just for Content API auth.
+  providers: [
+    MerchantCenterFeedService,
+    PriceCompetitivenessService,
+    GoogleCredentialsService,
+  ],
+  exports: [MerchantCenterFeedService, PriceCompetitivenessService],
 })
 export class MerchantCenterModule {}

--- a/backend/src/modules/merchant-center/services/price-competitiveness.service.ts
+++ b/backend/src/modules/merchant-center/services/price-competitiveness.service.ts
@@ -1,0 +1,193 @@
+/**
+ * PriceCompetitivenessService — INBOUND competitor benchmark from Google.
+ *
+ * Pulls the Merchant Center "Price competitiveness" report (Merchant API →
+ * accounts.reports.search / PriceCompetitivenessProductView) and stores the
+ * per-offer market benchmark in `__price_competitiveness` via
+ * `upsert_price_competitiveness_v1`. INBOUND complement to
+ * MerchantCenterFeedService (which is OUTBOUND only).
+ *
+ * Auth reuses GoogleCredentialsService.getMerchantContentAuth() (scope
+ * `content`). Kill-switch: returns `disabled` if creds / merchantId absent.
+ *
+ * OBSERVE-only — the benchmark is Google's click-weighted competitor AVERAGE,
+ * never a named competitor. Per docs/pricing/economic-governance-system.md it is
+ * "signal bruité, jamais autorité": it flags over/under-market SKUs, it NEVER
+ * auto-reprices (forbidden anti-pattern). The no-loss floor stays in
+ * pricing-invariants.service.ts.
+ *
+ * Refs: migration 20260602_price_competitiveness.sql
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { merchantapi_reports_v1 } from 'googleapis';
+import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
+import { GoogleCredentialsService } from '../../seo-monitoring/services/google-credentials.service';
+
+export interface PriceCompetitivenessSyncResult {
+  status: 'ok' | 'disabled';
+  reason?: string;
+  country: string;
+  fetched: number;
+  upserted: number;
+  reportDate: string;
+}
+
+interface BenchmarkRow {
+  offer_id: string;
+  product_rest_id: string | null;
+  gtin: string | null;
+  title: string | null;
+  brand: string | null;
+  country: string;
+  our_price_eur: number;
+  benchmark_price_eur: number;
+  report_date: string;
+}
+
+const PAGE_SIZE = 1000;
+const UPSERT_CHUNK = 1000;
+const MICROS = 1_000_000;
+
+@Injectable()
+export class PriceCompetitivenessService extends SupabaseBaseService {
+  protected override readonly logger = new Logger(
+    PriceCompetitivenessService.name,
+  );
+
+  constructor(private readonly creds: GoogleCredentialsService) {
+    super();
+  }
+
+  /**
+   * Pull the FR price-competitiveness report and upsert benchmarks.
+   * Idempotent per (offer, country, report_date) — safe to run daily (cron/admin).
+   */
+  async sync(country = 'FR'): Promise<PriceCompetitivenessSyncResult> {
+    const reportDate = new Date().toISOString().slice(0, 10);
+    const auth = this.creds.getMerchantContentAuth();
+    const merchantId = this.creds.getMerchantId();
+
+    if (!auth || !merchantId) {
+      const reason = !merchantId
+        ? 'GMC_MERCHANT_ID manquant'
+        : 'credentials Merchant Center absentes';
+      this.logger.warn(`[PRICE_COMPETITIVENESS] sync désactivé — ${reason}`);
+      return {
+        status: 'disabled',
+        reason,
+        country,
+        fetched: 0,
+        upserted: 0,
+        reportDate,
+      };
+    }
+
+    const client = new merchantapi_reports_v1.Merchantapi({ auth });
+    const parent = `accounts/${merchantId}`;
+    const query = buildQuery(country);
+
+    const rows: BenchmarkRow[] = [];
+    let pageToken: string | undefined;
+    do {
+      const res = await client.accounts.reports.search({
+        parent,
+        requestBody: { query, pageSize: PAGE_SIZE, pageToken },
+      });
+      for (const r of res.data.results ?? []) {
+        const v = r.priceCompetitivenessProductView;
+        if (!v?.offerId || !v.benchmarkPrice?.amountMicros) continue;
+        const our = toEur(v.price?.amountMicros);
+        const bench = toEur(v.benchmarkPrice.amountMicros);
+        if (our == null || bench == null) continue;
+        rows.push({
+          offer_id: v.offerId,
+          product_rest_id: v.id ?? null,
+          gtin: null, // not exposed by this view; offer_id is the catalog key
+          title: v.title ?? null,
+          brand: v.brand ?? null,
+          country: v.reportCountryCode ?? country,
+          our_price_eur: our,
+          benchmark_price_eur: bench,
+          report_date: reportDate,
+        });
+      }
+      pageToken = res.data.nextPageToken ?? undefined;
+    } while (pageToken);
+
+    let upserted = 0;
+    for (let i = 0; i < rows.length; i += UPSERT_CHUNK) {
+      const slice = rows.slice(i, i + UPSERT_CHUNK);
+      const { data, error } = await this.callRpc<number>(
+        'upsert_price_competitiveness_v1',
+        { p_rows: slice },
+      );
+      if (error) {
+        this.logger.error(
+          `[PRICE_COMPETITIVENESS] upsert chunk@${i} failed: ${error.message}`,
+        );
+        throw error;
+      }
+      upserted += Number(data ?? 0);
+    }
+
+    this.logger.log(
+      `[PRICE_COMPETITIVENESS] sync ${country} date=${reportDate} fetched=${rows.length} upserted=${upserted}`,
+    );
+    return {
+      status: 'ok',
+      country,
+      fetched: rows.length,
+      upserted,
+      reportDate,
+    };
+  }
+
+  /** Read the over/under-market gap (delegates to the STABLE read RPC). */
+  async gapReport(
+    country = 'FR',
+    minGapPct: number | null = null,
+    limit = 200,
+    offset = 0,
+  ): Promise<unknown[]> {
+    const { data, error } = await this.callRpc<unknown[]>(
+      'get_price_competitiveness_gap_v1',
+      {
+        p_country: country,
+        p_min_gap_pct: minGapPct,
+        p_limit: limit,
+        p_offset: offset,
+      },
+    );
+    if (error) {
+      this.logger.error(
+        `[PRICE_COMPETITIVENESS] gapReport failed: ${error.message}`,
+      );
+      throw error;
+    }
+    return data ?? [];
+  }
+}
+
+function toEur(amountMicros: string | null | undefined): number | null {
+  if (amountMicros == null) return null;
+  const n = Number(amountMicros);
+  if (!Number.isFinite(n)) return null;
+  return Math.round((n / MICROS) * 100) / 100;
+}
+
+function buildQuery(country: string): string {
+  // Merchant API reports query language (snake_case view + fields), FR-scoped.
+  const c = country.replace(/[^A-Z]/g, '').slice(0, 2) || 'FR';
+  return [
+    'SELECT',
+    '  offer_id,',
+    '  id,',
+    '  title,',
+    '  brand,',
+    '  price,',
+    '  benchmark_price,',
+    '  report_country_code',
+    'FROM price_competitiveness_product_view',
+    `WHERE report_country_code = '${c}'`,
+  ].join('\n');
+}

--- a/backend/src/modules/seo-monitoring/services/google-credentials.service.ts
+++ b/backend/src/modules/seo-monitoring/services/google-credentials.service.ts
@@ -101,6 +101,48 @@ export class GoogleCredentialsService {
   }
 
   /**
+   * Merchant Center (Content API for Shopping) auth — scope `content`.
+   *
+   * Réutilise le MÊME service account que GSC par défaut (il suffit de
+   * l'ajouter comme utilisateur du compte Merchant Center) ; un SA dédié
+   * `GMC_CLIENT_EMAIL`/`GMC_PRIVATE_KEY` prend le dessus s'il est fourni.
+   * Sert à LIRE le benchmark concurrent (reports.search), jamais à écrire.
+   *
+   * @returns null si credentials manquantes (kill-switch implicite).
+   */
+  getMerchantContentAuth(): InstanceType<typeof google.auth.GoogleAuth> | null {
+    const clientEmail =
+      this.configService.get<string>('GMC_CLIENT_EMAIL') ||
+      this.configService.get<string>('GSC_CLIENT_EMAIL');
+    const privateKey =
+      this.configService.get<string>('GMC_PRIVATE_KEY') ||
+      this.configService.get<string>('GSC_PRIVATE_KEY');
+
+    if (!clientEmail || !privateKey) {
+      this.logger.warn(
+        '⚠️ Merchant Center credentials absentes (GMC_/GSC_CLIENT_EMAIL + PRIVATE_KEY) — sync compétitivité prix désactivé',
+      );
+      return null;
+    }
+
+    return new google.auth.GoogleAuth({
+      credentials: {
+        client_email: clientEmail,
+        private_key: privateKey.replace(/\\n/g, '\n'),
+      },
+      scopes: ['https://www.googleapis.com/auth/content'],
+    });
+  }
+
+  /**
+   * Merchant Center account id (`GMC_MERCHANT_ID`) — requis pour la Content API.
+   * Pas d'équivalent existant : c'est l'identifiant du compte GMC.
+   */
+  getMerchantId(): string | null {
+    return this.configService.get<string>('GMC_MERCHANT_ID') || null;
+  }
+
+  /**
    * Master kill-switch — désactive tout fetch côté schedulers.
    * Default false en prod tant que pipeline pas validée.
    */

--- a/backend/supabase/migrations/20260602_price_competitiveness.sql
+++ b/backend/supabase/migrations/20260602_price_competitiveness.sql
@@ -1,0 +1,141 @@
+-- 20260602_price_competitiveness.sql
+-- INBOUND competitor benchmark from Google Merchant Center "Price competitiveness".
+--
+-- Complement to the OUTBOUND feed (20260519_merchant_center_feed_v1.sql): that one
+-- PUSHES our catalog to Google Shopping; this one INGESTS back, per product, the
+-- click-weighted competitor benchmark price Google already computes from every
+-- retailer selling the same offer. No scraping, no 403 — Google's own auction data.
+--
+-- Source: Content API for Shopping reports.search / PriceCompetitivenessProductView
+--   (country-scoped, FR). Matching key = our offer_id (= g:id of the feed = piece id),
+--   gtin stored alongside for cross-check. Benchmark = market AVERAGE (no named
+--   competitor). Per docs/pricing/economic-governance-system.md: "concurrence = signal
+--   bruité, jamais autorité" — this is an OBSERVE-only signal, it NEVER auto-reprices.
+--
+-- Layers: table (storage) + upsert RPC (VOLATILE, write) + gap RPC (STABLE, read).
+
+-- ============================================================================
+-- STORAGE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.__price_competitiveness (
+  pc_id                bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  pc_offer_id          text        NOT NULL,            -- our g:id (= piece id), join key to catalog
+  pc_product_rest_id   text,                            -- full GMC REST product id (online:fr:FR:<offer>)
+  pc_gtin              text,                             -- EAN if present (cross-check)
+  pc_title             text,
+  pc_brand             text,
+  pc_country           text        NOT NULL DEFAULT 'FR',
+  pc_our_price_eur     numeric(12,2) NOT NULL,
+  pc_benchmark_price_eur numeric(12,2) NOT NULL,         -- market click-weighted average
+  -- positive => we are ABOVE the market (candidate to lower); negative => below.
+  pc_gap_pct           numeric(7,2)
+                         GENERATED ALWAYS AS (
+                           CASE WHEN pc_benchmark_price_eur > 0
+                                THEN round((pc_our_price_eur - pc_benchmark_price_eur)
+                                            / pc_benchmark_price_eur * 100, 2)
+                           END
+                         ) STORED,
+  pc_report_date       date        NOT NULL,
+  pc_fetched_at        timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_price_competitiveness UNIQUE (pc_offer_id, pc_country, pc_report_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pc_offer    ON public.__price_competitiveness (pc_offer_id);
+CREATE INDEX IF NOT EXISTS idx_pc_gap      ON public.__price_competitiveness (pc_country, pc_gap_pct DESC);
+CREATE INDEX IF NOT EXISTS idx_pc_date     ON public.__price_competitiveness (pc_report_date DESC);
+
+COMMENT ON TABLE public.__price_competitiveness IS
+  'GMC Price competitiveness benchmark per offer (OBSERVE-only competitor signal, never authority). Loaded by price-competitiveness.service.ts via Content API.';
+
+-- ============================================================================
+-- WRITE — bulk upsert (VOLATILE; service_role only). Idempotent per (offer,country,date).
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.upsert_price_competitiveness_v1(p_rows jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer := 0;
+BEGIN
+  INSERT INTO public.__price_competitiveness AS t (
+    pc_offer_id, pc_product_rest_id, pc_gtin, pc_title, pc_brand, pc_country,
+    pc_our_price_eur, pc_benchmark_price_eur, pc_report_date
+  )
+  SELECT
+    r->>'offer_id',
+    r->>'product_rest_id',
+    NULLIF(r->>'gtin',''),
+    r->>'title',
+    r->>'brand',
+    COALESCE(NULLIF(r->>'country',''),'FR'),
+    (r->>'our_price_eur')::numeric,
+    (r->>'benchmark_price_eur')::numeric,
+    (r->>'report_date')::date
+  FROM jsonb_array_elements(p_rows) AS r
+  WHERE r->>'offer_id' IS NOT NULL
+    AND (r->>'benchmark_price_eur') IS NOT NULL
+  ON CONFLICT (pc_offer_id, pc_country, pc_report_date) DO UPDATE SET
+    pc_product_rest_id     = EXCLUDED.pc_product_rest_id,
+    pc_gtin                = EXCLUDED.pc_gtin,
+    pc_title               = EXCLUDED.pc_title,
+    pc_brand               = EXCLUDED.pc_brand,
+    pc_our_price_eur       = EXCLUDED.pc_our_price_eur,
+    pc_benchmark_price_eur = EXCLUDED.pc_benchmark_price_eur,
+    pc_fetched_at          = now();
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+-- ============================================================================
+-- READ — latest benchmark per offer + gap, filterable (STABLE; PostgREST-safe).
+-- Positive gap_pct = we are above the market => candidate to lower (down to the
+-- break-even floor, never below — that gate stays in pricing-invariants).
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.get_price_competitiveness_gap_v1(
+  p_country     text    DEFAULT 'FR',
+  p_min_gap_pct numeric DEFAULT NULL,   -- e.g. 5 => only offers >=5% above market
+  p_limit       integer DEFAULT 200,
+  p_offset      integer DEFAULT 0
+)
+RETURNS TABLE (
+  offer_id            text,
+  title               text,
+  brand               text,
+  our_price_eur       numeric,
+  benchmark_price_eur numeric,
+  gap_pct             numeric,
+  report_date         date
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH latest AS (
+    SELECT DISTINCT ON (pc_offer_id)
+      pc_offer_id, pc_title, pc_brand, pc_our_price_eur,
+      pc_benchmark_price_eur, pc_gap_pct, pc_report_date
+    FROM public.__price_competitiveness
+    WHERE pc_country = p_country
+    ORDER BY pc_offer_id, pc_report_date DESC
+  )
+  SELECT pc_offer_id, pc_title, pc_brand, pc_our_price_eur,
+         pc_benchmark_price_eur, pc_gap_pct, pc_report_date
+  FROM latest
+  WHERE (p_min_gap_pct IS NULL OR pc_gap_pct >= p_min_gap_pct)
+  ORDER BY pc_gap_pct DESC NULLS LAST
+  LIMIT GREATEST(p_limit, 0) OFFSET GREATEST(p_offset, 0);
+$$;
+
+-- ============================================================================
+-- GRANTS — service_role only (anon/authenticated have no access; ADR-021).
+-- ============================================================================
+REVOKE ALL ON public.__price_competitiveness FROM anon, authenticated;
+REVOKE ALL ON FUNCTION public.upsert_price_competitiveness_v1(jsonb)    FROM anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_price_competitiveness_gap_v1(text, numeric, integer, integer) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.upsert_price_competitiveness_v1(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_price_competitiveness_gap_v1(text, numeric, integer, integer) TO service_role;

--- a/log.md
+++ b/log.md
@@ -562,3 +562,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/cwv-aggregation-flag-declare-2026-05-29`
 - **Décision** : fix(cwv): declare and enable aggregation scheduler flag
 - **Sortie** : PR #803 | commits 0caf28c0b
+
+## 2026-06-02 — feat/gmc-price-competitiveness (auto)
+
+- **Branche** : `feat/gmc-price-competitiveness`
+- **Décision** : feat(merchant-center): ingest GMC price-competitiveness benchmark (inbound)
+- **Sortie** : PR aucune | commits db17a343c


### PR DESCRIPTION
## But
Voir les prix concurrents **sans scraper** : ingère le rapport Google Merchant Center « Compétitivité des prix » (Merchant API — données d'enchère de Google, match par `offer_id` = `g:id` du flux) pour **détecter les pièces où on est au-dessus du marché** → aide à la **décision humaine**. Complément ENTRANT du flux sortant existant (`merchant-center.xml`).

## ⚠️ OBSERVE-only (par conception)
`GMC compétitivité → détecter au-dessus du benchmark → lister les écarts → décision humaine → JAMAIS de repricing auto.`

### Preuves demandées
| Garantie | Preuve dans le diff |
|---|---|
| **Aucune écriture sur les prix produit** | Seul write = `upsert_price_competitiveness_v1` → table `__price_competitiveness`. `pieces_price` jamais touché. |
| **Aucune modif PriceImport / PricingRules runtime** | Diff = nouveaux fichiers `merchant-center/` + extension `google-credentials`. `price-import.*`, `pricing-strategy.*`, `pricing_rules` **inchangés**. |
| **Endpoints admin protégés** | `@UseGuards(IsAdminGuard)` sur `price-competitiveness.controller.ts`. |
| **Sync manuel, pas de cron agressif** | Aucun `@Cron`/scheduler. Déclenché uniquement par `POST .../sync` (admin). |
| **`__price_competitiveness` = observation externe** | Table séparée, lue uniquement par l'endpoint admin `gap`. Aucun runtime pricing/produit ne la lit → **pas une source de vérité prix**. |
| **Rollback simple** | Kill-switch : creds / `GMC_MERCHANT_ID` absents → sync `disabled` (no-op). Ne pas appeler sync = rien ne se passe. Table droppable. |

## Contenu
- migration `__price_competitiveness` + RPC `upsert` (VOLATILE) / `gap` (STABLE)
- `PriceCompetitivenessService` (pull paginé Merchant API → upsert, kill-switch)
- endpoints admin `POST /sync`, `GET /gap`
- `GoogleCredentialsService.getMerchantContentAuth()` (scope `content`) + `getMerchantId()` — réutilise le SA GSC
- `.env.example` : `GMC_MERCHANT_ID` (+ SA dédié optionnel)

## Activation (rien ne tourne sans ça)
1. `GMC_MERCHANT_ID` = ID compte Merchant Center.
2. Autoriser le SA `GSC_CLIENT_EMAIL` comme utilisateur du compte Merchant Center.

Sans ça → `disabled`, no-op.

## Séquencement
**Draft volontaire** — à NE PAS merger avant **#819 / supplier-truth**. Outil d'observation commerciale, non prioritaire sur la vérité fournisseur.

## NO-GO (hors scope, interdits)
auto-reprice · modification prix runtime · règle de marge automatique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)