### PR TITLE
fix(supplier-truth): DCA login waits for SPA auth state (login only)

### DIFF
--- a/backend/src/modules/supplier-truth/connectors/inoshop.connector.ts
+++ b/backend/src/modules/supplier-truth/connectors/inoshop.connector.ts
@@ -69,13 +69,26 @@ export class InoshopConnector implements SupplierConnector {
     await page.goto(`${this.baseUrl}/login`, { waitUntil: 'domcontentloaded' });
     await page.fill('input[name="login"]', creds.user);
     await page.fill('input[name="password"]', creds.password);
-    await Promise.all([
-      page.waitForLoadState('networkidle'),
-      page.click('button[type="submit"], [type="submit"]'),
-    ]);
+    await page.click('button[type="submit"], [type="submit"]');
 
-    // Authenticated iff a logout affordance exists (no login form).
-    const authed = (await page.locator('a[href*="logout"]').count()) > 0;
+    // The portal authenticates, then boots its SPA asynchronously (transient
+    // "Loading…" title), so the logout affordance renders a moment LATER than
+    // `networkidle`. Wait for a DETERMINISTIC authenticated state — off the
+    // /login route AND the logout link present — instead of checking too early
+    // (which yielded a false "no authenticated session"). LIVE_VERIFY 2026-06-02.
+    let authed = false;
+    try {
+      await page.waitForFunction(
+        () =>
+          !window.location.pathname.includes('/login') &&
+          document.querySelector('a[href*="logout"]') != null,
+        undefined,
+        { timeout: this.opts.navigationTimeoutMs },
+      );
+      authed = true;
+    } catch {
+      authed = false;
+    }
     await page.close();
     if (!authed) {
       throw new Error('inoshop login failed (no authenticated session)');


### PR DESCRIPTION
## Scope strict : login DCA uniquement
Corrige le faux négatif « no authenticated session » du connecteur inoshop (DistriCash / DCA, spl_id 71). **Login uniquement** — pas de `fetchAvailability`, pas de CAL, pas de refactor, pas d'activation.

## Le bug
`login()` vérifiait `a[href*="logout"]` **immédiatement** après `networkidle`, mais le portail boote sa SPA authentifiée **en asynchrone** (titre transitoire « Loading… ») → le lien logout n'existe pas encore → faux « login failed ».

## Le fix (déterministe, login only)
Après submit : `waitForFunction` jusqu'à un **état authentifié déterministe** — hors `/login` **ET** `a[href*="logout"]` présent — borné par `navigationTimeoutMs`. **Pas** de `waitForTimeout` arbitraire. Diff = 1 fichier, +20/-7.

## Preuve — LIVE_VERIFY 2026-06-02 (read-only, creds jamais loggés)
```
[login-only] creds chargés (user.len=6) — valeurs jamais affichées
[InoshopConnector] ✅ inoshop login ok (supplier 71)
[login-only] ✅ LOGIN DCA = PASS (4557ms)
[login-only] fetchAvailability = NOT_VERIFIED (hors scope ce PR)
```

## Critères d'acceptation
- [x] Login DCA passe en live (read-only)
- [x] Credentials jamais loggés (seul `user.len` affiché)
- [x] Logout link détecté **après** chargement SPA
- [x] Faux négatif « no authenticated session » supprimé
- [x] Aucun fetch produit ajouté
- [x] Aucun changement CAL
- [x] Aucun changement production / activation
- [x] PR petit, ciblé, sans refactor

## Test
Le changement est de l'**I/O navigateur** (non unit-testable sans mock Playwright lourd) → preuve = **run live read-only ci-dessus** (logs sanitizés), conformément au critère « sinon fournir une preuve live ».

## Hors scope (explicite)
**`fetchAvailability` = NOT_VERIFIED** — la recherche produit (widget JS) sera vérifiée/corrigée dans un PR suivant. **PR1b CAL reste BLOQUÉ** tant que DCA fetch n'est pas prouvé end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)