### PR TITLE
fix(supplier-truth): DCA fetchAvailability drives the real search flow

### DIFF
--- a/backend/src/modules/supplier-truth/connectors/inoshop.connector.ts
+++ b/backend/src/modules/supplier-truth/connectors/inoshop.connector.ts
@@ -138,25 +138,41 @@ export class InoshopConnector implements SupplierConnector {
     ref: string,
   ): Promise<SupplierObservation[]> {
     await page.goto(`${this.baseUrl}/`, { waitUntil: 'domcontentloaded' });
-    // type in the reference autocomplete (tagsinput) and submit
-    const input = page.locator(
-      '#autocompletion-invoker input[data-role="tagsinput"]',
-    );
-    await input.fill(ref);
-    await input.press('Enter');
-    await page.waitForLoadState('networkidle');
+    // The reference field is a tagsinput widget whose <input> is HIDDEN — you
+    // click the styled invoker, type the ref, Tab to commit the tag, Enter to
+    // submit, which NAVIGATES to /search where the .ARTICLE rows render.
+    // (The old `input.fill()` hit the hidden node → "element not visible" → no
+    // rows → every ref degraded to parseError.) LIVE_VERIFY 2026-06-02.
+    await page.locator('#autocompletion-invoker').click();
+    await page.keyboard.type(ref);
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Enter');
+    await page
+      .waitForURL((u) => u.toString().includes('/search'), {
+        timeout: this.opts.navigationTimeoutMs,
+      })
+      .catch(() => undefined);
+    await page
+      .waitForLoadState('networkidle', {
+        timeout: this.opts.navigationTimeoutMs,
+      })
+      .catch(() => undefined);
 
     // extract each rendered .ARTICLE row's data attributes (verified-on-first-run)
     const articles = (await page.$$eval('.ARTICLE', (nodes) =>
       nodes.map((n) => {
         const ds = (k: string) => n.getAttribute(k);
-        const priceText =
-          n.querySelector('[class*="prix-achat"], [class*="price-buy"]')
-            ?.textContent ?? '';
+        // Net purchase price (achat HT) is a data-attribute, not row text.
+        const priceText = ds('data-filtreprixachat') ?? ds('data-prix') ?? '';
         const icon =
           n.querySelector('img[src*="/stock/"]')?.getAttribute('src') ?? null;
         return {
-          rawRef: ds('data-filtrecodearticle') || ds('data-ref') || '',
+          // supplier/searched ref (e.g. 314772), not the internal code (SBS314772)
+          rawRef:
+            ds('data-filtrecodearticlefournisseur') ||
+            ds('data-filtrecodearticle') ||
+            ds('data-ref') ||
+            '',
           codeArticle: ds('data-filtrecodearticle'),
           stockRaw: ds('data-stock'),
           dispoType: ds('data-dispo-type'),


### PR DESCRIPTION
## Scope strict : recherche dispo DCA uniquement
Corrige `fetchAvailability` (login déjà acquis via #826). Pas d'order/cart/payment/pricing, pas de CAL, pas d'activation.

## Le bug
`searchOne` tapait dans un tagsinput **caché** sur la home, puis lisait `.ARTICLE` (jamais rendu là) → toute réf dégradait en `parseError` (0 donnée).

## Le vrai flux (reverse-engineered en live)
1. Cliquer le div `#autocompletion-invoker`
2. Taper la réf → `POST /search/auto-complete`
3. **Tab** (valide le tag) + **Enter** → navigue vers `/search`
4. Lignes `<TR class="ARTICLE ARTICLE_CONTENT">` → `data-filtrecodearticlefournisseur` (314772), `data-filtreprixachat` (72.71), `data-stock`, `data-dispo-type`, icône stock, `data-filtreremise1/2` (56/3)

## Le fix (search only, 1 fichier)
- interaction : click invoker + type + Tab + Enter + `waitForURL('/search')`
- parse : achat net depuis `data-filtreprixachat` ; réf depuis `data-filtrecodearticlefournisseur`

## Preuve — LIVE_VERIFY 2026-06-02 (run compilé, read-only, creds jamais loggés)
```
✅ inoshop login ok (supplier 71)
ref 314772        -> achatHT=72.71 · parseError=false (dispo=false, icône stock rouge)
ref ZZZ(inexist)  -> parseError=true (dégradation safe, jamais de faux « en stock »)
=> 4/5 réfs avec données réelles
```

## Critères d'acceptation
- [x] réf réelle connue → données réelles (achat 72.71)
- [x] produit non trouvé → parseError (jamais faux stock)
- [x] timeout propre (waitForURL/networkidle bornés + `.catch`)
- [x] logs sanitizés (creds jamais affichés)
- [x] **zéro commande / zéro panier / zéro write**
- [x] pas de CAL, pas d'activation
- [x] diff petit (1 fichier, +27/-11)

## Note technique
Vérif via la **voie compilée** (tsc → node), fidèle au runtime/CI. `tsx` injecte un helper esbuild `__name` qui casse les callbacks `$$eval` dans le navigateur — artefact du harness de test, **pas** du connecteur (compilé en prod).

## Statut DCA
login = PASS (#826) · **fetch = PASS (ce PR)** → **connecteur DCA prouvé end-to-end**. Débloque **PR1b CAL** (même patron) après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)