### PR TITLE
feat(supplier-truth): wire CAL connector (read-only sentinel, spl_id 19)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -287,6 +287,10 @@ SENTRY_ALLOW_DEBUG_ENDPOINT=false
 # logs into districashv2.inoshop.net to read availability for working-set refs only
 # (NO order/cart/payment/piece_display writes). OPTIONAL: if absent, the connector is
 # skipped cleanly (RunSummary.suppliersSkipped++, no crash). Never commit real values.
-# (CAL connector vars CAL_USER/CAL_PASSWORD/CAL_BASE_URL come with PR1b.)
 SUPPLIER_INOSHOP_DISTRICASH_USER=
 SUPPLIER_INOSHOP_DISTRICASH_PASSWORD=
+# CAL (Société CAL 92 / PF Préférence Seine) — ___xtr_supplier spl_id 19, ASP.NET
+# WebForms portal https://siteweb.pfpreference-seine.fr/login.aspx (baseUrl lives in
+# supplier-registry.ts). Read-only sentinel; OPTIONAL (absent → connector skipped).
+CAL_USER=
+CAL_PASSWORD=

--- a/backend/src/modules/supplier-truth/connectors/cal-parse.ts
+++ b/backend/src/modules/supplier-truth/connectors/cal-parse.ts
@@ -1,0 +1,171 @@
+/**
+ * CAL (PF Préférence Seine, Société CAL 92) — pure parsing (Layer 1 logic, no I/O).
+ *
+ * Encodes the contract for what the connector extracts from a CAL product page
+ * (post-login):
+ *   - prixNetHt   : displayed "Prix net HT" (the value AutoMecanik pays after
+ *                   applying CAL's grid to Valeo's catalogue) — in €.
+ *   - dispoLabel  : human "Disponibilité" badge — "En stock", "Sur commande Xj",
+ *                   "Indisponible", or specific to CAL's UI (verified live).
+ *   - delayDays   : if the badge encodes a delay, parsed to int days.
+ *
+ * Pure mapping; the DOM adapter (connector class) only feeds these primitives in.
+ *
+ * NOTE: selector strings live in the connector. The parsers here are
+ * encoding-agnostic and unit-tested. Real CAL UI labels MUST be verified on the
+ * first live run; today's mapping is the safe-degradation default — unknown =
+ * parseError: true → never a false in-stock.
+ */
+
+import {
+  SupplierObservationSchema,
+  type SupplierObservation,
+} from './supplier-connector.interface';
+
+/** Parse a CAL price label like "12,15 €", "12.15 € HT", "Prix net : 12,15 €". */
+export function parseCalPriceHt(
+  text: string | null | undefined,
+): number | null {
+  if (!text) return null;
+  const m = text.match(/(\d+(?:[.,]\d+)?)\s*€/);
+  if (!m) return null;
+  const n = Number.parseFloat(m[1].replace(',', '.'));
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+/** Parse a CAL discount label like "50%", "50 %", "50% ". Returns 0..100 or null. */
+export function parseCalRemisePct(
+  text: string | null | undefined,
+): number | null {
+  if (!text) return null;
+  // Require start-of-string or a non-numeric char before the digits, so that
+  // strings like "-5%" or "1.50%" embedded in "1.51.50%" don't accidentally match.
+  const m = text.match(/(?:^|[^\d.,-])(\d+(?:[.,]\d+)?)\s*%/);
+  if (!m) return null;
+  const n = Number.parseFloat(m[1].replace(',', '.'));
+  return Number.isFinite(n) && n >= 0 && n <= 100 ? n : null;
+}
+
+/** Parse a delay badge like "Sur commande 3 j", "Délai 5 jours", "J+2". */
+export function parseCalDelayDays(
+  text: string | null | undefined,
+): number | null {
+  if (!text) return null;
+  const t = text.toLowerCase();
+  // "j+2", "j +2"
+  const jPlus = t.match(/\bj\s*\+\s*(\d+)/);
+  if (jPlus) return Number.parseInt(jPlus[1], 10);
+  // "5 jours", "3 j", "2j", "sous 4 jours"
+  const dj = t.match(/(\d+)\s*(?:j(?:our)?s?)\b/);
+  if (dj) return Number.parseInt(dj[1], 10);
+  return null;
+}
+
+export type CalDispoState = 'in_stock' | 'on_order' | 'unavailable' | 'unknown';
+
+/**
+ * Classify CAL's stock icon by `<img src>` filename. This is the AUTHORITATIVE
+ * stock signal on the article line (the red/green/orange puce). The legend is
+ * literally embedded in the page:
+ *   ico_dispo0.png = Sur commande / Indisponible   (red)
+ *   ico_dispo1.png = Disponible                    (green)
+ *   ico_dispo3.png = Disponible à J+1 / Call Center
+ * `puceRed.png` is the same red-state icon used elsewhere in the UI.
+ *
+ * The `qte` field returned by the autocomplete JSONP is NOT the available stock
+ * — it appears to be a packaging/min-order quantity. Always trust this icon
+ * instead. Verified live on 2026-05-23 (ref 715899 had ico_dispo0 = red).
+ */
+export type CalStockIcon =
+  | 'available'
+  | 'unavailable'
+  | 'on_order_j1'
+  | 'unknown';
+export function classifyCalStockIcon(
+  src: string | null | undefined,
+): CalStockIcon {
+  if (!src) return 'unknown';
+  if (/ico_dispo1\b/i.test(src)) return 'available';
+  if (/ico_dispo3\b/i.test(src)) return 'on_order_j1';
+  if (/ico_dispo0\b/i.test(src) || /puceRed/i.test(src)) return 'unavailable';
+  return 'unknown';
+}
+
+/** Classify a CAL availability badge to a coarse state. */
+export function classifyCalDispo(
+  text: string | null | undefined,
+): CalDispoState {
+  if (!text) return 'unknown';
+  const t = text.toLowerCase();
+  // Word boundaries so "indisponible" doesn't match "disponible" as a substring.
+  if (
+    /(\ben\s+stock\b|\bdisponible\b|\bdispo\b)/.test(t) &&
+    !/(non\s*disponible|\bindisponible\b)/.test(t)
+  ) {
+    return 'in_stock';
+  }
+  if (
+    /(sur\s+commande|commande|sous\s+\d+\s*j|\bj\s*\+|\d+\s*j(?:our)?s?\b|d[ée]lai)/.test(
+      t,
+    )
+  ) {
+    return 'on_order';
+  }
+  if (
+    /(rupture|indisponible|non\s*disponible|\bnd\b|épuis[ée]|non\s+r[ée]f[ée]renc)/.test(
+      t,
+    )
+  ) {
+    return 'unavailable';
+  }
+  return 'unknown';
+}
+
+/** Fields extracted from one CAL product page by the connector. */
+export interface CalProduct {
+  supplierId: string;
+  rawRef: string;
+  /** "Prix net HT" displayed on the product page, in €. */
+  prixNetHt: number | null;
+  /** "Prix de base" (public/list HT) displayed on the product page, in €. */
+  prixBaseHt?: number | null;
+  /** CAL-specific discount % displayed alongside the net (0..100). */
+  remisePct?: number | null;
+  /** Raw availability badge text (fallback, used when no icon found). */
+  dispoLabel: string | null;
+  /** Explicit delay text if present (sometimes alongside dispoLabel). */
+  delayLabel?: string | null;
+  /** Authoritative stock-icon `<img src>` (ico_dispo0/1/3 or puceRed). */
+  stockIconSrc?: string | null;
+}
+
+/** Map one CAL extracted product to a validated SupplierObservation. */
+export function calProductToObservation(p: CalProduct): SupplierObservation {
+  // The icon is authoritative — defer to text only when no icon was captured.
+  const icon = classifyCalStockIcon(p.stockIconSrc);
+  const textState = classifyCalDispo(p.dispoLabel);
+  const state: CalStockIcon | CalDispoState =
+    icon !== 'unknown' ? icon : textState;
+  const delayDays =
+    icon === 'on_order_j1'
+      ? 1
+      : parseCalDelayDays(p.delayLabel ?? p.dispoLabel);
+
+  const nothingExtracted = p.prixNetHt == null && state === 'unknown';
+  const available = state === 'available' || state === 'in_stock';
+
+  // delayDays only meaningful when not in stock; null when in stock or unknown.
+  const obs = {
+    supplierId: p.supplierId,
+    rawRef: p.rawRef,
+    available,
+    delayDays: available ? null : delayDays,
+    sourceVerifiedAt: null,
+    freshnessProvenance: 'CONNECTOR_FETCHED' as const,
+    parseError: nothingExtracted,
+    priceBuyHt: p.prixNetHt,
+    priceBaseHt: p.prixBaseHt ?? null,
+    remisePct: p.remisePct ?? null,
+  };
+  return SupplierObservationSchema.parse(obs);
+}

--- a/backend/src/modules/supplier-truth/connectors/cal.connector.test.ts
+++ b/backend/src/modules/supplier-truth/connectors/cal.connector.test.ts
@@ -1,0 +1,283 @@
+import {
+  calProductToObservation,
+  classifyCalDispo,
+  classifyCalStockIcon,
+  parseCalDelayDays,
+  parseCalPriceHt,
+  parseCalRemisePct,
+} from './cal-parse';
+import {
+  CalConnector,
+  isForbiddenPostbackTarget,
+  parsePriceFromText,
+} from './cal.connector';
+
+// Importing the connector here also proves the module loads WITHOUT playwright
+// at import-time (type-only imports are erased; the dynamic import is in login()).
+
+describe('parseCalPriceHt', () => {
+  it.each([
+    ['12,15 €', 12.15],
+    ['12.15 € HT', 12.15],
+    ['Prix net : 12,15 €', 12.15],
+    ['Prix net HT 320,30 €', 320.3],
+    ['0 €', 0],
+  ])('parses %j → %s', (input, expected) => {
+    expect(parseCalPriceHt(input)).toBe(expected);
+  });
+  it.each(['', null, undefined, 'non communiqué', 'sur devis'])(
+    'returns null on %j',
+    (input) => {
+      expect(parseCalPriceHt(input as string | null | undefined)).toBeNull();
+    },
+  );
+  it('parsePriceFromText (connector helper) behaves the same', () => {
+    expect(parsePriceFromText('12,15 €')).toBe(12.15);
+    expect(parsePriceFromText(null)).toBeNull();
+  });
+});
+
+describe('parseCalRemisePct', () => {
+  it.each([
+    ['50%', 50],
+    ['50 %', 50],
+    ['50% ', 50],
+    ['45,5%', 45.5],
+    ['0%', 0],
+    ['100%', 100],
+  ])('parses %j → %s', (input, expected) => {
+    expect(parseCalRemisePct(input)).toBe(expected);
+  });
+  it.each(['', null, undefined, '— %', '150%', '-5%'])(
+    'returns null on out-of-range/unparsable %j',
+    (input) => {
+      expect(parseCalRemisePct(input as string | null | undefined)).toBeNull();
+    },
+  );
+});
+
+describe('parseCalDelayDays', () => {
+  it.each([
+    ['J+2', 2],
+    ['j +5', 5],
+    ['Sur commande 3 j', 3],
+    ['Sous 4 jours', 4],
+    ['Délai 7 jours', 7],
+  ])('parses %j → %s days', (input, expected) => {
+    expect(parseCalDelayDays(input)).toBe(expected);
+  });
+  it.each(['En stock', 'Indisponible', null, ''])(
+    'returns null on %j',
+    (input) => {
+      expect(parseCalDelayDays(input as string | null)).toBeNull();
+    },
+  );
+});
+
+describe('classifyCalDispo', () => {
+  it.each([
+    ['En stock', 'in_stock'],
+    ['Disponible', 'in_stock'],
+    ['DISPO', 'in_stock'],
+    ['Sur commande', 'on_order'],
+    ['Sous 5 jours', 'on_order'],
+    ['Délai 7 jours', 'on_order'],
+    ['Rupture', 'unavailable'],
+    ['Indisponible', 'unavailable'],
+    ['Non disponible', 'unavailable'],
+    ['ND', 'unavailable'],
+  ])('classifies %j → %s', (input, expected) => {
+    expect(classifyCalDispo(input)).toBe(expected);
+  });
+  it.each(['', null, undefined, '???'])('unknown for %j', (input) => {
+    expect(classifyCalDispo(input as string | null | undefined)).toBe(
+      'unknown',
+    );
+  });
+});
+
+describe('calProductToObservation — pure mapper', () => {
+  const base = { supplierId: '19', rawRef: '715899' };
+
+  it('in stock → available=true, delayDays=null, parseError=false', () => {
+    const obs = calProductToObservation({
+      ...base,
+      prixNetHt: 12.15,
+      dispoLabel: 'En stock',
+    });
+    expect(obs.available).toBe(true);
+    expect(obs.delayDays).toBeNull();
+    expect(obs.priceBuyHt).toBe(12.15);
+    expect(obs.parseError).toBe(false);
+  });
+
+  it('on order with delay → available=false, delayDays set', () => {
+    const obs = calProductToObservation({
+      ...base,
+      prixNetHt: 12.15,
+      dispoLabel: 'Sur commande 3 jours',
+    });
+    expect(obs.available).toBe(false);
+    expect(obs.delayDays).toBe(3);
+  });
+
+  it('unavailable → available=false, no delay', () => {
+    const obs = calProductToObservation({
+      ...base,
+      prixNetHt: 12.15,
+      dispoLabel: 'Indisponible',
+    });
+    expect(obs.available).toBe(false);
+    expect(obs.delayDays).toBeNull();
+    expect(obs.parseError).toBe(false); // we have a price; not nothing
+  });
+
+  it('nothing extracted (no price + unknown dispo) → parseError=true, never available', () => {
+    const obs = calProductToObservation({
+      ...base,
+      prixNetHt: null,
+      dispoLabel: null,
+    });
+    expect(obs.available).toBe(false);
+    expect(obs.parseError).toBe(true);
+  });
+
+  it('price only (dispo unknown) → parseError=false but available=false (safe)', () => {
+    const obs = calProductToObservation({
+      ...base,
+      prixNetHt: 12.15,
+      dispoLabel: '???',
+    });
+    expect(obs.available).toBe(false);
+    expect(obs.parseError).toBe(false);
+    expect(obs.priceBuyHt).toBe(12.15);
+  });
+});
+
+describe('classifyCalStockIcon — authoritative stock signal', () => {
+  it.each([
+    [
+      'https://siteweb.pfpreference-seine.fr/app_themes/cyber_CAL92/img/ico_dispo0.png',
+      'unavailable',
+    ],
+    ['/app_themes/cyber_CAL92/img/ico_dispo1.png', 'available'],
+    ['/app_themes/cyber_CAL92/img/ico_dispo3.png', 'on_order_j1'],
+    ['/img/puceRed.png', 'unavailable'],
+  ])('classifies %s → %s', (src, expected) => {
+    expect(classifyCalStockIcon(src)).toBe(expected);
+  });
+  it.each(['', null, undefined, '/img/random.png'])('unknown for %j', (src) => {
+    expect(classifyCalStockIcon(src as string | null | undefined)).toBe(
+      'unknown',
+    );
+  });
+});
+
+describe('calProductToObservation — icon-driven path (authoritative)', () => {
+  const base = { supplierId: '19', rawRef: '715899', prixNetHt: 160.15 };
+
+  it('icon=ico_dispo0 → available=false even with a parsed price (red puce = unavailable)', () => {
+    const obs = calProductToObservation({
+      ...base,
+      dispoLabel: null,
+      stockIconSrc: '/img/ico_dispo0.png',
+    });
+    expect(obs.available).toBe(false);
+    expect(obs.priceBuyHt).toBe(160.15);
+    expect(obs.parseError).toBe(false);
+  });
+
+  it('carries priceBaseHt + remisePct when the connector extracted them (sampling)', () => {
+    const obs = calProductToObservation({
+      ...base,
+      prixBaseHt: 320.3,
+      remisePct: 50,
+      dispoLabel: null,
+      stockIconSrc: '/img/ico_dispo0.png',
+    });
+    expect(obs.priceBaseHt).toBe(320.3);
+    expect(obs.remisePct).toBe(50);
+    // Sanity: net ≈ base × (1 − %) (160.15 ≈ 320.3 × 0.5 ✓)
+    expect(obs.priceBuyHt).toBeCloseTo(320.3 * 0.5, 2);
+  });
+
+  it('priceBaseHt/remisePct default to null when not provided (other connectors)', () => {
+    const obs = calProductToObservation({
+      ...base,
+      dispoLabel: null,
+      stockIconSrc: '/img/ico_dispo1.png',
+    });
+    expect(obs.priceBaseHt).toBeNull();
+    expect(obs.remisePct).toBeNull();
+  });
+
+  it('icon=ico_dispo1 → available=true', () => {
+    const obs = calProductToObservation({
+      ...base,
+      dispoLabel: null,
+      stockIconSrc: '/img/ico_dispo1.png',
+    });
+    expect(obs.available).toBe(true);
+  });
+
+  it('icon=ico_dispo3 → available=false, delayDays=1 (J+1)', () => {
+    const obs = calProductToObservation({
+      ...base,
+      dispoLabel: null,
+      stockIconSrc: '/img/ico_dispo3.png',
+    });
+    expect(obs.available).toBe(false);
+    expect(obs.delayDays).toBe(1);
+  });
+
+  it('icon wins over text — ico_dispo0 overrides "En stock" label', () => {
+    const obs = calProductToObservation({
+      ...base,
+      dispoLabel: 'En stock',
+      stockIconSrc: '/img/ico_dispo0.png',
+    });
+    expect(obs.available).toBe(false);
+  });
+});
+
+describe('🚨 Anti-cart safety — postback deny-list (READ-ONLY contract)', () => {
+  it.each([
+    'ctl00$Cart$cmdAjouter',
+    'ctl00$Panier$cmdAdd',
+    'ctl00$lstArticles$ctl00$cmdAjouter',
+    'CtrlMonPanier1$cmdValidPanier',
+    'CtrlOrder$cmdValidOrder',
+    'CtrlIncart$cmdCde',
+    'ctl00$ContentPlaceHolder1$CtrlBasketAdd1$lnkAjouterAuPanier',
+  ])('refuses %s', (target) => {
+    expect(isForbiddenPostbackTarget(target)).toBe(true);
+  });
+  it.each([
+    'ctl00$CtrlHeaderSlidingTemplateSelector$ctl00$cmbShowPrices',
+    'ctl00$ContentPlaceHolder1$CtrlCatalogueTecdocV3$CtrlSearchVehiculesTemplateSelector1$ctl00$CtrlSearchArtByRef1$cmdSearByRef',
+    'ctl00$ContentPlaceHolder1$CtrlCatalogueTecdocV3$CtrlSearchVehiculesTemplateSelector1$ctl00$CtrlSearchArtByRef1$CtrlAutoComplete1$cmdFired',
+  ])('allows known read-only target: %s', (target) => {
+    expect(isForbiddenPostbackTarget(target)).toBe(false);
+  });
+});
+
+describe('CalConnector (construction, no I/O)', () => {
+  it('exposes platform + supplierId, normalizes baseUrl trailing slash', () => {
+    const c = new CalConnector({
+      supplierId: '19',
+      baseUrl: 'https://siteweb.pfpreference-seine.fr/',
+    });
+    expect(c.platform).toBe('cal');
+    expect(c.supplierId).toBe('19');
+  });
+
+  it('fetchAvailability before login throws (guard)', async () => {
+    const c = new CalConnector({ supplierId: '19', baseUrl: 'https://x' });
+    await expect(c.fetchAvailability(['REF'])).rejects.toThrow(/before login/);
+  });
+
+  it('close() is a no-op when never logged in', async () => {
+    const c = new CalConnector({ supplierId: '19', baseUrl: 'https://x' });
+    await expect(c.close()).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/modules/supplier-truth/connectors/cal.connector.ts
+++ b/backend/src/modules/supplier-truth/connectors/cal.connector.ts
@@ -1,0 +1,321 @@
+/**
+ * CAL (PF Préférence Seine, Société CAL 92) — Layer 1 I/O adapter.
+ *
+ * Live-verified flow (2026-05-23):
+ *  1) GET /login.aspx → fill visible username + password → press Enter.
+ *     The visible main form is selected; the hidden `CtrlLoginMini1` header
+ *     widget is skipped by `:visible`. WebForms VIEWSTATE/EVENTVALIDATION are
+ *     handled by the browser engine on form-submit.
+ *  2) After login, the catalogue hides prices behind a per-session toggle
+ *     `cmbShowPrices` (Ctrl+E in the UI). Triggered via __doPostBack since the
+ *     link is in a collapsed header slider (not visible to a click).
+ *  3) Per-ref lookup:
+ *     a) Call /CallWS.aspx?origine=autocomplete (JSONP, cookies preserved) →
+ *        returns { ref, marq, qte (stock), key (internal id) }.
+ *     b) Set txtRef + HiddenValue (the `key`) in the form, invoke __doPostBack
+ *        on `cmdFired` (the autocomplete-select hidden button).
+ *     c) Page now renders the article line with `.articlePrixBase` (public HT),
+ *        `.articlePrixRemise` (CAL discount %), `.articlePrixNet` (purchase HT).
+ *
+ * Anti-bricolage: one warm browser context; postbacks driven directly so we
+ * don't replay brittle UI animations; all selectors use stable CSS classes
+ * (not the cryptic ctl00$... ASP.NET IDs). Safe degradation → parseError.
+ */
+
+import { Logger } from '@nestjs/common';
+import type { Browser, BrowserContext, Page } from 'playwright';
+import {
+  type SupplierConnector,
+  type SupplierCredentials,
+  type SupplierObservation,
+} from './supplier-connector.interface';
+import {
+  calProductToObservation,
+  parseCalPriceHt,
+  parseCalRemisePct,
+} from './cal-parse';
+
+const AUTOCOMPLETE_ROOT =
+  'ctl00$ContentPlaceHolder1$CtrlCatalogueTecdocV3$CtrlSearchVehiculesTemplateSelector1$ctl00$CtrlSearchArtByRef1$CtrlAutoComplete1';
+const CMD_FIRED = `${AUTOCOMPLETE_ROOT}$cmdFired`;
+const ID_TXTREF = `${AUTOCOMPLETE_ROOT.replace(/\$/g, '_')}_txtRef`;
+const ID_HIDDEN_VALUE = `${AUTOCOMPLETE_ROOT.replace(/\$/g, '_')}_HiddenValue`;
+const ID_HIDDEN_MARQUE = `${AUTOCOMPLETE_ROOT.replace(/\$/g, '_')}_HiddenMarque`;
+const ID_HIDDEN_SESSION = `${AUTOCOMPLETE_ROOT.replace(/\$/g, '_')}_HiddenSession`;
+const SHOW_PRICES_POSTBACK =
+  'ctl00$CtrlHeaderSlidingTemplateSelector$ctl00$cmbShowPrices';
+
+/**
+ * 🚨 SAFETY — postback targets that MUST NEVER be invoked by this READ-ONLY
+ * connector. Adding an article to the CAL cart triggers a real, billable
+ * order. The deny-list is enforced inside `postback()` (throws on match) so
+ * even an accidental call upstream fails loud, never silently.
+ */
+const FORBIDDEN_POSTBACK =
+  /panier|cart|ajouter|incart|cmdcde|cmdadd|cmdAjout|commande|valid.*panier|order/i;
+
+/** Public guard — exported so the unit test pins the read-only contract. */
+export function isForbiddenPostbackTarget(target: string): boolean {
+  return FORBIDDEN_POSTBACK.test(target);
+}
+
+export interface CalConnectorOptions {
+  supplierId: string;
+  baseUrl: string;
+  minRequestIntervalMs?: number;
+  navigationTimeoutMs?: number;
+}
+
+const DEFAULTS = { minRequestIntervalMs: 1500, navigationTimeoutMs: 30000 };
+const USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36';
+
+export class CalConnector implements SupplierConnector {
+  readonly platform = 'cal';
+  readonly supplierId: string;
+  private readonly logger = new Logger(CalConnector.name);
+  private readonly baseUrl: string;
+  private readonly opts: Required<CalConnectorOptions>;
+  private browser?: Browser;
+  private context?: BrowserContext;
+  private catalogPage?: Page;
+  private loggedIn = false;
+
+  constructor(options: CalConnectorOptions) {
+    this.supplierId = options.supplierId;
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+    this.opts = { ...DEFAULTS, ...options } as Required<CalConnectorOptions>;
+  }
+
+  async login(creds: SupplierCredentials): Promise<void> {
+    const { chromium } = await import('playwright');
+    this.browser = await chromium.launch({ headless: true });
+    this.context = await this.browser.newContext({
+      locale: 'fr-FR',
+      userAgent: USER_AGENT,
+    });
+    const page = await this.context.newPage();
+    page.setDefaultNavigationTimeout(this.opts.navigationTimeoutMs);
+
+    await page.goto(`${this.baseUrl}/login.aspx`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page
+      .locator('input[type="text"]:visible, input[type="email"]:visible')
+      .first()
+      .fill(creds.user);
+    const pwd = page.locator('input[type="password"]:visible').first();
+    await pwd.fill(creds.password);
+    // Universal WebForms submit: Enter on the password field (cmdvalider is
+    // styled away on some pages, but Enter always posts the parent form).
+    await Promise.all([
+      page.waitForLoadState('networkidle'),
+      pwd.press('Enter'),
+    ]);
+
+    const url = page.url();
+    const leftLogin = !/\/login\.aspx/i.test(url);
+    if (!leftLogin) {
+      await page.close();
+      throw new Error(
+        'CAL login failed (still on login.aspx) — check credentials',
+      );
+    }
+    this.logger.log(`✅ CAL login ok (supplier ${this.supplierId})`);
+
+    // Enable prices for this session (per-session toggle, server-stored).
+    await this.postback(page, SHOW_PRICES_POSTBACK);
+
+    // Warm catalogue page; re-used by fetchAvailability to avoid one nav/ref.
+    await page.goto(`${this.baseUrl}/catalogue/1-pieces-auto.aspx`, {
+      waitUntil: 'domcontentloaded',
+    });
+    this.catalogPage = page;
+    this.loggedIn = true;
+  }
+
+  async fetchAvailability(refs: string[]): Promise<SupplierObservation[]> {
+    if (!this.loggedIn || !this.catalogPage || !this.context) {
+      throw new Error('CAL fetchAvailability called before login');
+    }
+    const out: SupplierObservation[] = [];
+    for (const ref of refs) {
+      try {
+        out.push(await this.lookupOne(ref));
+      } catch (e) {
+        this.logger.warn(`CAL lookup '${ref}' failed: ${(e as Error).message}`);
+        out.push(
+          calProductToObservation({
+            supplierId: this.supplierId,
+            rawRef: ref,
+            prixNetHt: null,
+            dispoLabel: null,
+          }),
+        );
+      }
+      await this.jitterDelay();
+    }
+    return out;
+  }
+
+  /** Per-ref lookup: autocomplete API → form select → parse the article line. */
+  private async lookupOne(ref: string): Promise<SupplierObservation> {
+    const page = this.catalogPage!;
+    const ctx = this.context!;
+
+    // (a) Resolve the article's `key` and stock via the JSONP autocomplete API.
+    const idsession =
+      (await page
+        .locator(`input[id="${ID_HIDDEN_SESSION}"]`)
+        .getAttribute('value')
+        .catch(() => null)) ?? '';
+    const hiddenMarque =
+      (await page
+        .locator(`input[id="${ID_HIDDEN_MARQUE}"]`)
+        .getAttribute('value')
+        .catch(() => '')) ?? '';
+    const params = new URLSearchParams({
+      featureClass: 'P',
+      style: 'full',
+      limit: '20',
+      name_startsWith: hiddenMarque + ref,
+      idsession,
+      succ: '01',
+      privatepwd: 'wz7yH5STyWM=',
+      interface: 'CYB',
+      mode: 'RefWithCat',
+      cattag: '',
+      callback: 'jsonpCb',
+    });
+    const url = `${this.baseUrl}/CallWS.aspx?origine=autocomplete&${params}`;
+    const resp = await ctx.request.get(url, {
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    });
+    if (!resp.ok()) throw new Error(`autocomplete HTTP ${resp.status()}`);
+    const body = (await resp.text())
+      .replace(/^[^(]*\(/, '')
+      .replace(/\);?\s*$/, '');
+    const parsed = JSON.parse(body) as {
+      result?: Array<{ ref: string; key: string; marq: string; qte: string }>;
+    };
+    const item =
+      (parsed.result ?? []).find((r) => r.ref === ref) ?? parsed.result?.[0];
+    if (!item) {
+      // No match → never had a tariff at CAL for this ref. Safe parseError.
+      return calProductToObservation({
+        supplierId: this.supplierId,
+        rawRef: ref,
+        prixNetHt: null,
+        dispoLabel: null,
+      });
+    }
+    // (b) Drive the autocomplete `select` callback: set txtRef + HiddenValue,
+    //     then fire cmdFired's __doPostBack. Loads the article line with prices.
+    await page.evaluate(
+      ([refStr, key, idTxt, idHidden]) => {
+        const t = document.getElementById(idTxt) as HTMLInputElement | null;
+        const h = document.getElementById(idHidden) as HTMLInputElement | null;
+        if (t) t.value = refStr;
+        if (h) h.value = key;
+      },
+      [ref, item.key, ID_TXTREF, ID_HIDDEN_VALUE],
+    );
+    await this.postback(page, CMD_FIRED);
+
+    // Race guard: networkidle alone is insufficient — the WebForms repeater
+    // can briefly display the PREVIOUS article while the new one re-renders,
+    // causing us to read stale prices. Wait until the article line carries the
+    // codart attribute matching THIS ref's key (verified live 2026-05-23).
+    await page
+      .locator(`.qteincart[codart="${item.key}"]`)
+      .first()
+      .waitFor({ state: 'attached', timeout: 10000 })
+      .catch(() => {
+        /* fallback: read whatever is there; race protection is best-effort */
+      });
+
+    // (c) Extract from stable CSS classes (article repeater template). The
+    // AUTHORITATIVE stock signal is the icon image src in ctrlStockStatus —
+    // owner-verified 2026-05-23: `qte` from the API is NOT actual stock.
+    const [prixNetText, prixBaseText, remiseText, stockIconSrc] =
+      await Promise.all([
+        page
+          .locator('.articlePrixNet')
+          .first()
+          .textContent()
+          .catch(() => null),
+        page
+          .locator('.articlePrixBase')
+          .first()
+          .textContent()
+          .catch(() => null),
+        page
+          .locator('.articlePrixRemise')
+          .first()
+          .textContent()
+          .catch(() => null),
+        page
+          .locator('[id*="ctrlStockStatus1_ImgDocStatus"] img')
+          .first()
+          .getAttribute('src')
+          .catch(() => null),
+      ]);
+
+    return calProductToObservation({
+      supplierId: this.supplierId,
+      rawRef: ref,
+      prixNetHt: parseCalPriceHt(prixNetText),
+      prixBaseHt: parseCalPriceHt(prixBaseText),
+      remisePct: parseCalRemisePct(remiseText),
+      dispoLabel: null, // icon is authoritative, no text needed
+      stockIconSrc,
+    });
+  }
+
+  /**
+   * Invoke ASP.NET WebForms __doPostBack and wait for the resulting cycle.
+   *
+   * 🚨 SAFETY: hard-rejects any target matching cart/order patterns
+   * (FORBIDDEN_POSTBACK). This connector is READ-ONLY by contract — adding to
+   * the CAL cart triggers real, billable orders. Fail loud, never silently.
+   */
+  private async postback(page: Page, target: string, arg = ''): Promise<void> {
+    if (FORBIDDEN_POSTBACK.test(target)) {
+      throw new Error(
+        `CAL connector refuses postback to forbidden target (cart/order): ${target}`,
+      );
+    }
+    await page.evaluate(
+      ([t, a]) =>
+        (
+          window as unknown as { __doPostBack: (t: string, a: string) => void }
+        ).__doPostBack(t, a),
+      [target, arg],
+    );
+    await page
+      .waitForLoadState('networkidle', { timeout: 20000 })
+      .catch(() => {});
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.catalogPage?.close();
+      await this.context?.close();
+    } finally {
+      await this.browser?.close();
+      this.browser = undefined;
+      this.context = undefined;
+      this.catalogPage = undefined;
+      this.loggedIn = false;
+    }
+  }
+
+  private async jitterDelay(): Promise<void> {
+    const base = this.opts.minRequestIntervalMs;
+    const jitter = Math.floor(Math.random() * base * 0.4);
+    await new Promise((r) => setTimeout(r, base + jitter));
+  }
+}
+
+/** Re-exported helper kept for unit tests (parses "12,15 €" / "12.15 €"). */
+export { parseCalPriceHt as parsePriceFromText } from './cal-parse';

--- a/backend/src/modules/supplier-truth/connectors/supplier-registry.ts
+++ b/backend/src/modules/supplier-truth/connectors/supplier-registry.ts
@@ -11,7 +11,7 @@
  * no hardcoded secrets). Values live in backend `.env`.
  */
 
-export type SupplierPlatform = 'inoshop';
+export type SupplierPlatform = 'inoshop' | 'cal';
 
 export interface SupplierConnectorConfig {
   /** `___xtr_supplier.spl_id`. */
@@ -41,6 +41,19 @@ const REGISTRY: readonly SupplierConnectorConfig[] = [
     credEnv: {
       userKey: 'SUPPLIER_INOSHOP_DISTRICASH_USER',
       passKey: 'SUPPLIER_INOSHOP_DISTRICASH_PASSWORD',
+    },
+  },
+  {
+    // CAL (Société CAL 92 / PF Préférence Seine) — portail ASP.NET WebForms,
+    // ___xtr_supplier spl_id 19. LIVE_VERIFY 2026-06-02 (read-only) : login +
+    // fetch ref 715899 → achat 160,15 / base 320,30 / remise 50% OK.
+    supplierId: '19',
+    supplierName: 'CAL',
+    platform: 'cal',
+    baseUrl: 'https://siteweb.pfpreference-seine.fr',
+    credEnv: {
+      userKey: 'CAL_USER',
+      passKey: 'CAL_PASSWORD',
     },
   },
 ];

--- a/backend/src/modules/supplier-truth/supplier-sync.runner.test.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.runner.test.ts
@@ -3,6 +3,24 @@ import type { SupplierTruthRepository } from './supplier-truth.repository';
 import type { SupplierSyncProcessor } from './supplier-sync.processor';
 import type { SupplierConnector } from './connectors/supplier-connector.interface';
 
+// These tests pin PER-SUPPLIER runner semantics — decouple them from the live
+// registry size so adding a 2nd connectable portal (e.g. CAL) never flips the
+// suppliersRun / suppliersSkipped counts.
+jest.mock('./connectors/supplier-registry', () => ({
+  listConnectableSuppliers: () => [
+    {
+      supplierId: '71',
+      supplierName: 'DISTRICASH (DCA)',
+      platform: 'inoshop',
+      baseUrl: 'https://districashv2.inoshop.net',
+      credEnv: {
+        userKey: 'SUPPLIER_INOSHOP_DISTRICASH_USER',
+        passKey: 'SUPPLIER_INOSHOP_DISTRICASH_PASSWORD',
+      },
+    },
+  ],
+}));
+
 function makeConnector(): jest.Mocked<SupplierConnector> & { closed: boolean } {
   const c = {
     supplierId: '71',

--- a/backend/src/modules/supplier-truth/supplier-sync.runner.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.runner.ts
@@ -15,6 +15,7 @@ import type {
   SupplierCredentials,
 } from './connectors/supplier-connector.interface';
 import { InoshopConnector } from './connectors/inoshop.connector';
+import { CalConnector } from './connectors/cal.connector';
 
 /**
  * Orchestrates one full sync cycle: bounded working-set → each connectable
@@ -36,6 +37,11 @@ export const defaultConnectorFactory: ConnectorFactory = (cfg) => {
   switch (cfg.platform) {
     case 'inoshop':
       return new InoshopConnector({
+        supplierId: cfg.supplierId,
+        baseUrl: cfg.baseUrl,
+      });
+    case 'cal':
+      return new CalConnector({
         supplierId: cfg.supplierId,
         baseUrl: cfg.baseUrl,
       });

--- a/log.md
+++ b/log.md
@@ -568,3 +568,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/cleanup-audit-artifacts`
 - **Décision** : docs(audit): refresh carte 24-départements avec deltas funnel 06-01 (+1 other commit)
 - **Sortie** : PR #820 | commits ed821a72d d88e707ca
+
+## 2026-06-02 — feat/supplier-cal-pr1b (auto)
+
+- **Branche** : `feat/supplier-cal-pr1b`
+- **Décision** : feat(supplier-truth): wire CAL connector (read-only sentinel, spl_id 19)
+- **Sortie** : PR #828 | commits 136941362


### PR DESCRIPTION
## PR1b CAL — connecteur CAL (lecture seule, spl_id 19)
Réintègre + câble le connecteur **CAL** existant (Société CAL 92 / PF Préférence Seine — portail **ASP.NET WebForms**) dans la sentinelle supplier-truth. Même patron que DCA/inoshop (#819/#826/#827).

## Contenu
- **Nouveaux** : `cal.connector.ts`, `cal-parse.ts`, `cal.connector.test.ts` (depuis la branche source `feat/supplier-cal-connector`)
- **Câblage** : `supplier-registry.ts` (platform `'cal'` + entrée spl_id 19, baseUrl hardcodé comme inoshop), `supplier-sync.runner.ts` (factory `case 'cal'`), `.env.example` (`CAL_USER`/`CAL_PASSWORD`)

## Flux CAL (ASP.NET WebForms)
`login.aspx` → toggle prix per-session `cmbShowPrices` (`__doPostBack`) → JSONP autocomplete `/CallWS.aspx` → set `txtRef`+`HiddenValue` + `__doPostBack cmdFired` → lecture `.articlePrixNet`/`.articlePrixBase`/`.articlePrixRemise` + **icône stock (signal autoritaire)**.

## Preuve — LIVE_VERIFY 2026-06-02 (read-only, creds jamais loggés)
```
✅ CAL login ok (supplier 19)
ref 715899       -> achatHT=160.15 · baseHT=320.30 · remise=50% · parseError=false (320,30 × 0,50 = 160,15 ✓)
ref ZZZ(inexist) -> parseError=true (dégradation safe, jamais de faux « en stock »)
```

## Garanties (read-only)
- **zéro** order / cart / payment / pricing / write
- **OPTIONAL** : creds CAL absents → connecteur **skippé proprement** (`RunSummary.suppliersSkipped++`, pas de crash)
- icône stock autoritaire → jamais de faux « en stock »
- **PAS d'activation** sentinelle prod (FAST-FOLLOW observabilité)

## Statut sentinelle
2 connecteurs prouvés end-to-end : **DCA/inoshop** (#826+#827 mergés) + **CAL** (ce PR). Reste dormant tant que pas activé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)