### PR TITLE
fix(seo): extend restoreAccents with freinage lexicon (read-time accents)

### DIFF
--- a/backend/src/config/fr-accent-map.test.ts
+++ b/backend/src/config/fr-accent-map.test.ts
@@ -1,0 +1,124 @@
+import { restoreAccents } from './fr-accent-map';
+
+/**
+ * Extension lexique freinage de restoreAccents() (read-time content quality gate).
+ * Couvre : correction métier + pluriel + frontière hyphen-aware (slugs/URLs/wikilinks),
+ * anglais/marques/JSON-LD intacts, ambigus exclus (cote/rainure), idempotence, non-régression.
+ *
+ * NB : restoreAccents s'applique au CONTENU HTML (sgc_content), jamais au frontmatter/clés YAML.
+ * Périmètre = additif (entrées existantes inchangées) ; les nouvelles entrées sont hyphen-aware.
+ */
+describe('restoreAccents — extension lexique freinage', () => {
+  describe('correction métier + casse + pluriel', () => {
+    it('corrige les termes métier freinage', () => {
+      const out = restoreAccents(
+        "l'energie cinetique du disque ventile, perfore ou rivete a l'arriere",
+      );
+      expect(out).toContain('cinétique');
+      expect(out).toContain('ventilé');
+      expect(out).toContain('perforé');
+      expect(out).toContain('arrière');
+    });
+
+    it('corrige aussi un terme capitalisé (sortie minuscule = comportement existant)', () => {
+      // restoreAccents historique replie la casse (cf. test EnricherTextUtils
+      // "case-insensitive"). Ce PR reste ADDITIF : il ne change pas ce contrat.
+      expect(restoreAccents('Diametre nominal')).toBe('diamètre nominal');
+      expect(restoreAccents('Etrier flottant')).toBe('étrier flottant');
+    });
+
+    it('préserve le pluriel', () => {
+      expect(restoreAccents('disques ventiles')).toBe('disques ventilés');
+      expect(restoreAccents('les etriers avant')).toBe('les étriers avant');
+      expect(restoreAccents('machoires usees')).toContain('mâchoires');
+    });
+
+    it('corrige etrier/machoire/pedale/diametre/epaisseur en prose', () => {
+      expect(restoreAccents("laisser l'etrier pendre")).toContain('étrier');
+      expect(restoreAccents('pulsation dans la pedale')).toContain('pédale');
+      expect(restoreAccents('frottement metallique')).toContain('métallique');
+    });
+  });
+
+  describe('anti-sur-correction — slugs / URLs / wikilinks (hyphen-aware)', () => {
+    it('ne touche pas un slug kebab même s’il contient un terme corrigé', () => {
+      expect(restoreAccents('etrier-de-frein')).toBe('etrier-de-frein');
+      expect(restoreAccents('machoires-de-frein')).toBe('machoires-de-frein');
+      expect(restoreAccents('kit-de-freins-arriere')).toBe(
+        'kit-de-freins-arriere',
+      );
+    });
+
+    it('les nouvelles entrées freinage ne cassent pas un slug dans un href', () => {
+      // NB scope : le chemin "/pieces/" est volontairement ABSENT ici. Son altération par
+      // l'entrée HISTORIQUE `pieces` (/\bpieces\b/) est un bug PRÉ-EXISTANT (cf. description PR),
+      // hors périmètre de ce correctif additif freinage — non corrigé ici volontairement.
+      const html = '<a href="etrier-de-frein-78.html">étrier de frein</a>';
+      expect(restoreAccents(html)).toBe(html);
+    });
+
+    it('ne touche pas un wikilink', () => {
+      const s = '[[disque-de-frein]] et [[machoires-de-frein]]';
+      expect(restoreAccents(s)).toBe(s);
+    });
+  });
+
+  describe('anti-sur-correction — anglais / marques / JSON-LD', () => {
+    it('ne touche pas les tokens techniques anglais (snake_case)', () => {
+      const s = 'requires_review NO_VEHICLE_EVIDENCE rag_recycled_candidate';
+      expect(restoreAccents(s)).toBe(s);
+    });
+
+    it('ne touche pas les marques équipementiers', () => {
+      const s = 'Brembo, ATE, Bosch, TRW, Textar, Ferodo, Valeo, NK, Delphi';
+      expect(restoreAccents(s)).toBe(s);
+    });
+
+    it('ne touche pas les clés JSON-LD (schema.org en contenu)', () => {
+      const s =
+        '{"@type":"Question","name":"Q","acceptedAnswer":{"@type":"Answer"}}';
+      expect(restoreAccents(s)).toBe(s);
+    });
+  });
+
+  describe('ambigus EXCLUS — laissés intacts (hors scope déterministe)', () => {
+    it('ne convertit pas "cote" (cotation ≠ côté)', () => {
+      expect(restoreAccents('respecter la cote constructeur')).toBe(
+        'respecter la cote constructeur',
+      );
+      expect(restoreAccents("le vehicule tire d'un cote")).toBe(
+        "le véhicule tire d'un cote",
+      );
+    });
+
+    it('ne convertit pas "rainure" (nom/adj ambigu)', () => {
+      expect(restoreAccents('des rainures profondes')).toBe(
+        'des rainures profondes',
+      );
+      expect(restoreAccents('rainure (sport)')).toBe('rainure (sport)');
+    });
+  });
+
+  describe('idempotence + non-régression', () => {
+    it('est idempotent (rejouer ne change rien)', () => {
+      const once = restoreAccents("l'energie cinetique du vehicule ventile");
+      expect(restoreAccents(once)).toBe(once);
+    });
+
+    it("n'altère pas un texte déjà correct", () => {
+      const s = "l'énergie cinétique du véhicule ventilé à l'arrière";
+      expect(restoreAccents(s)).toBe(s);
+    });
+
+    it('corrige toujours les entrées existantes (véhicule)', () => {
+      expect(restoreAccents('le vehicule et la securite')).toBe(
+        'le véhicule et la sécurité',
+      );
+    });
+
+    it('gère null/empty sans crash', () => {
+      expect(restoreAccents('')).toBe('');
+      expect(restoreAccents(undefined as unknown as string)).toBe(undefined);
+    });
+  });
+});

--- a/backend/src/config/fr-accent-map.ts
+++ b/backend/src/config/fr-accent-map.ts
@@ -48,6 +48,46 @@ const ACCENT_MAP: Array<[RegExp, string]> = [
   [/\bdelai\b/gi, 'délai'],
   [/\bdepose\b/gi, 'dépose'],
   [/\brepose\b/gi, 'repose'], // correct, no accent
+  // --- freinage lexicon (PR fix/restoreaccents-freinage-lexicon-2026-06-02) ---
+  // Frontière HYPHEN-AWARE (?<![\w-])…(?![\w-]) pour ces entrées : ne matche jamais
+  // à l'intérieur d'un token kebab → protège slugs / wikilinks / URLs
+  // (ex. "etrier-de-frein" intact, mais "l'etrier" corrigé). Sortie minuscule = comportement
+  // historique inchangé (cf. test EnricherTextUtils "case-insensitive") — PR strictement additif.
+  // Ambigus VOLONTAIREMENT exclus (laissés cassés) : cote (côté/cotation), rainure (nom/adj),
+  // estime/perces (adj/verbe) — hors scope de ce correctif déterministe.
+  [/(?<![\w-])cinetiques?(?![\w-])/gi, 'cinétique'],
+  [/(?<![\w-])repetables?(?![\w-])/gi, 'répétable'],
+  [/(?<![\w-])difficultes?(?![\w-])/gi, 'difficulté'],
+  [/(?<![\w-])experiences?(?![\w-])/gi, 'expérience'],
+  [/(?<![\w-])deformations?(?![\w-])/gi, 'déformation'],
+  [/(?<![\w-])kilometres?(?![\w-])/gi, 'kilomètre'],
+  [/(?<![\w-])capacites?(?![\w-])/gi, 'capacité'],
+  [/(?<![\w-])cles?(?![\w-])/gi, 'clé'],
+  [/(?<![\w-])memes?(?![\w-])/gi, 'même'],
+  [/(?<![\w-])etriers?(?![\w-])/gi, 'étrier'],
+  [/(?<![\w-])machoires?(?![\w-])/gi, 'mâchoire'],
+  [/(?<![\w-])pedales?(?![\w-])/gi, 'pédale'],
+  [/(?<![\w-])metalliques?(?![\w-])/gi, 'métallique'],
+  [/(?<![\w-])allongees?(?![\w-])/gi, 'allongée'],
+  [/(?<![\w-])bleutees?(?![\w-])/gi, 'bleutée'],
+  [/(?<![\w-])creusees?(?![\w-])/gi, 'creusée'],
+  [/(?<![\w-])immediats?(?![\w-])/gi, 'immédiat'],
+  [/(?<![\w-])elevees?(?![\w-])/gi, 'élevée'],
+  [/(?<![\w-])integrees?(?![\w-])/gi, 'intégrée'],
+  [/(?<![\w-])diametres?(?![\w-])/gi, 'diamètre'],
+  [/(?<![\w-])epaisseurs?(?![\w-])/gi, 'épaisseur'],
+  [/(?<![\w-])stabilites?(?![\w-])/gi, 'stabilité'],
+  [/(?<![\w-])arrieres?(?![\w-])/gi, 'arrière'],
+  [/(?<![\w-])ventiles?(?![\w-])/gi, 'ventilé'],
+  [/(?<![\w-])perfores?(?![\w-])/gi, 'perforé'],
+  [/(?<![\w-])pressees?(?![\w-])/gi, 'pressée'],
+  [/(?<![\w-])rivetees?(?![\w-])/gi, 'rivetée'],
+  [/(?<![\w-])collees?(?![\w-])/gi, 'collée'],
+  [/(?<![\w-])echauffements?(?![\w-])/gi, 'échauffement'],
+  [/(?<![\w-])majorites?(?![\w-])/gi, 'majorité'],
+  [/(?<![\w-])qualites?(?![\w-])/gi, 'qualité'],
+  [/(?<![\w-])mecaniques?(?![\w-])/gi, 'mécanique'],
+  [/(?<![\w-])numeros?(?![\w-])/gi, 'numéro'],
 ];
 
 /**


### PR DESCRIPTION
## Quoi

**Correctif read-time strictement additif** : étend le correcteur d'accents de **contenu** `restoreAccents()` (`backend/src/config/fr-accent-map.ts`) avec **33 termes du lexique freinage**.

Corrige le **français métier cassé** sur le contenu **R3 conseil live** (`__seo_gamme_conseil`, lu au read-time par `BlogSeoService.sanitizeConseilContent`) : `cinetique → cinétique`, `ventile → ventilé`, `perfore → perforé`, `arriere → arrière`, `diametre → diamètre`, `epaisseur → épaisseur`, `etrier → étrier`, `machoire → mâchoire`, `pedale → pédale`, etc. — termes que le dictionnaire actuel (37 entrées) ne couvrait pas.

Origine : audit couverture R-rôles freinage (workflow `wwp96282x`) — dette qualité #1 = accents métier non rattrapés au read-time, sur 13/15 gammes R3.

## Scope STRICT

✅ **1 fichier** : `fr-accent-map.ts` (+ test). **Additif** : les 37 entrées existantes **et le callback** sont **inchangés** — la sortie reste **minuscule** (contrat existant `EnricherTextUtils "case-insensitive"`). *(La préservation de casse a été retirée pour ne pas casser ce contrat partagé par tous les consommateurs de `restoreAccents` — sujet d'un autre PR si voulu.)*
✅ Nouvelles entrées **hyphen-aware** `(?<![\w-])…(?![\w-])` → ne matchent **jamais** dans un token kebab ⇒ **slugs / wikilinks / URLs protégés** (`etrier-de-frein` intact, `l'etrier` corrigé).
✅ Ambigus **exclus** (laissés intacts) : `cote` (côté/cotation), `rainure` (nom/adj), `estime`/`perces`.

❌ **Aucun changement d'URL / route / slug / canonical / sitemap.**
❌ Aucune écriture DB, aucune régénération de contenu, aucun changement `blog-seo.service.ts`, aucun tag PROD.

## Tests — 16/16 ✅ (jest, vérifiés en local + le test existant `EnricherTextUtils` repasse)

`fr-accent-map.test.ts` : correction métier + pluriel ; **anti-sur-correction** (slugs, wikilinks, href, marques Brembo/ATE/Bosch…, tokens anglais, clés JSON-LD intacts) ; ambigus exclus ; idempotence ; non-régression des entrées existantes.

## ℹ️ Quirk PRÉ-EXISTANT détecté par le test — **NON corrigé ici volontairement**

`restoreAccents` **actuel** (sans ce PR) altérerait `/pieces/` → `/pièces/` **si** on lui passe un href littéral (entrée **historique** `/\bpieces\b/` + `blog-seo.service.ts:247` applique `restoreAccents` au HTML complet).

**Vérif live read-only (2026-06-03) → severity FAIBLE, PAS P0 :**
- Pages R3 conseil live = liens **`/pieces/` CORRECTS** rendus (**0 `/pièces/`**) ⇒ ne se manifeste pas à l'affichage.
- `/pièces/plaquette-de-frein-402.html` → **301 → `/pieces/…`** (pas de 404).

→ Quirk fonctionnel latent, hors périmètre. **Ce PR ne le corrige pas et ne l'aggrave pas** (entrée `pieces` intacte). Suivi : `audit/pieces-restoreAccents-latent-quirk-2026-06-03.md`.

## Déploiement

Merge `main` = **container PREPROD CI uniquement**. **PROD reste derrière un tag `v*` séparé.** Réversible : `git revert` (1 fichier additif, zéro donnée mutée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
