### PR TITLE
feat(supplier-truth): read-only observability endpoint + inert-by-default scheduler gate

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -287,6 +287,12 @@ SENTRY_ALLOW_DEBUG_ENDPOINT=false
 # logs into districashv2.inoshop.net to read availability for working-set refs only
 # (NO order/cart/payment/piece_display writes). OPTIONAL: if absent, the connector is
 # skipped cleanly (RunSummary.suppliersSkipped++, no crash). Never commit real values.
+#
+# MASTER ACTIVATION SWITCH — INERT by default. The SupplierTruthModule is wired into
+# the app (observable status/projection endpoints) but the scheduler arms NO repeatable
+# job and NO connector ever logs in unless this is explicitly 'true'. Leave false until
+# activation is an explicit, owner-gated decision (then a separate runtime rollout).
+SUPPLIER_TRUTH_SYNC_ENABLED=false
 SUPPLIER_INOSHOP_DISTRICASH_USER=
 SUPPLIER_INOSHOP_DISTRICASH_PASSWORD=
 # CAL (Société CAL 92 / PF Préférence Seine) — ___xtr_supplier spl_id 19, ASP.NET

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,6 +38,7 @@ import { SeoModule } from './modules/seo/seo.module'; // 🔍 NOUVEAU - Module S
 import { SeoMonitoringModule } from './modules/seo-monitoring/seo-monitoring.module'; // 📊 Phase 1 — Observability GSC/GA4/CWV daily ingestion
 import { SeoControlPlaneModule } from './modules/seo-control-plane/seo-control-plane.module'; // 🤖 ADR-064 — SEO Production Control Plane (L1 synthetic crawler q15min)
 import { MerchantCenterModule } from './modules/merchant-center/merchant-center.module'; // 🛒 PR commerce-loop V1 step 5B — Google Shopping XML feed
+import { SupplierTruthModule } from './modules/supplier-truth/supplier-truth.module'; // 🔌 Supplier availability sentinel — INERT (SUPPLIER_TRUTH_SYNC_ENABLED=false by default)
 import { SearchModule } from './modules/search/search.module'; // 🔍 NOUVEAU - Module de recherche optimisé v3.0 !
 import { SystemModule } from './modules/system/system.module'; // ⚡ NOUVEAU - Module system monitoring !
 import { BlogModule } from './modules/blog/blog.module'; // 📚 NOUVEAU - Module blog avec tables __blog_* intégrées !
@@ -203,6 +204,7 @@ import { TrendSignalsModule } from './modules/trend-signals/trend-signals.module
     SeoMonitoringModule, // 📊 Phase 1 — Observability GSC/GA4/CWV daily ingestion (cf. ADR-025)
     SeoControlPlaneModule, // 🤖 ADR-064 — SEO Production Control Plane (L1 synthetic crawler q15min)
     MerchantCenterModule, // 🛒 PR commerce-loop V1 step 5B — Google Shopping XML feed /api/feed/merchant-center.xml
+    SupplierTruthModule, // 🔌 Supplier availability sentinel — runtime wiring, INERT by default (no sync armed unless SUPPLIER_TRUTH_SYNC_ENABLED=true); read-only /api/admin/supplier-truth/*
     SearchModule, // 🔍 NOUVEAU - Module de recherche optimisé v3.0 avec Meilisearch !
     BlogModule, // 📚 NOUVEAU - Module blog avec conseils, guides et glossaire intégrés !
     SystemModule, // ⚡ NOUVEAU - Module system monitoring et métriques !

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -38,7 +38,7 @@ import { SeoModule } from './modules/seo/seo.module'; // 🔍 NOUVEAU - Module S
 import { SeoMonitoringModule } from './modules/seo-monitoring/seo-monitoring.module'; // 📊 Phase 1 — Observability GSC/GA4/CWV daily ingestion
 import { SeoControlPlaneModule } from './modules/seo-control-plane/seo-control-plane.module'; // 🤖 ADR-064 — SEO Production Control Plane (L1 synthetic crawler q15min)
 import { MerchantCenterModule } from './modules/merchant-center/merchant-center.module'; // 🛒 PR commerce-loop V1 step 5B — Google Shopping XML feed
-import { SupplierTruthModule } from './modules/supplier-truth/supplier-truth.module'; // 🔌 Supplier availability sentinel — INERT (SUPPLIER_TRUTH_SYNC_ENABLED=false by default)
+import { SupplierTruthModule } from './modules/supplier-truth/supplier-truth.module'; // 🔌 Supplier-truth read-only observability endpoint (sync side lives in WorkerModule)
 import { SearchModule } from './modules/search/search.module'; // 🔍 NOUVEAU - Module de recherche optimisé v3.0 !
 import { SystemModule } from './modules/system/system.module'; // ⚡ NOUVEAU - Module system monitoring !
 import { BlogModule } from './modules/blog/blog.module'; // 📚 NOUVEAU - Module blog avec tables __blog_* intégrées !
@@ -204,7 +204,7 @@ import { TrendSignalsModule } from './modules/trend-signals/trend-signals.module
     SeoMonitoringModule, // 📊 Phase 1 — Observability GSC/GA4/CWV daily ingestion (cf. ADR-025)
     SeoControlPlaneModule, // 🤖 ADR-064 — SEO Production Control Plane (L1 synthetic crawler q15min)
     MerchantCenterModule, // 🛒 PR commerce-loop V1 step 5B — Google Shopping XML feed /api/feed/merchant-center.xml
-    SupplierTruthModule, // 🔌 Supplier availability sentinel — runtime wiring, INERT by default (no sync armed unless SUPPLIER_TRUTH_SYNC_ENABLED=true); read-only /api/admin/supplier-truth/*
+    SupplierTruthModule, // 🔌 Read-only observability for the supplier-truth sentinel (admin status + projection); the inert-gated sync runtime lives in WorkerModule
     SearchModule, // 🔍 NOUVEAU - Module de recherche optimisé v3.0 avec Meilisearch !
     BlogModule, // 📚 NOUVEAU - Module blog avec conseils, guides et glossaire intégrés !
     SystemModule, // ⚡ NOUVEAU - Module system monitoring et métriques !

--- a/backend/src/modules/supplier-truth/supplier-sync.flag.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.flag.ts
@@ -1,0 +1,17 @@
+import type { ConfigService } from '@nestjs/config';
+
+/**
+ * Single source of truth for the supplier-sync activation flag.
+ *
+ * The sentinel is INERT unless this env var is exactly `'true'`. Both the
+ * scheduler (which arms the BullMQ repeatable job) and the read-only
+ * observability controller (which reports the mode) read it through this helper,
+ * so the gate semantics live in ONE place — no magic string duplicated, no risk
+ * of the controller reporting "active" while the scheduler stays inert (or vice
+ * versa). Strict `=== 'true'`: any other value (`'1'`, `'TRUE'`, unset) is inert.
+ */
+export const SUPPLIER_TRUTH_SYNC_ENABLED = 'SUPPLIER_TRUTH_SYNC_ENABLED';
+
+export function isSupplierSyncEnabled(config: ConfigService): boolean {
+  return config.get<string>(SUPPLIER_TRUTH_SYNC_ENABLED) === 'true';
+}

--- a/backend/src/modules/supplier-truth/supplier-sync.scheduler.test.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.scheduler.test.ts
@@ -1,6 +1,7 @@
 import { SupplierSyncScheduler } from './supplier-sync.scheduler';
 import { SupplierSyncJobProcessor } from './supplier-sync.job.processor';
 import type { SupplierSyncRunner } from './supplier-sync.runner';
+import type { ConfigService } from '@nestjs/config';
 
 function mockQueue() {
   return {
@@ -8,16 +9,61 @@ function mockQueue() {
   } as unknown as import('bull').Queue;
 }
 
+/** ConfigService stub returning a fixed SUPPLIER_TRUTH_SYNC_ENABLED value. */
+function mockConfig(enabled: boolean): ConfigService {
+  return {
+    get: jest.fn((key: string) =>
+      key === 'SUPPLIER_TRUTH_SYNC_ENABLED'
+        ? enabled
+          ? 'true'
+          : 'false'
+        : undefined,
+    ),
+  } as unknown as ConfigService;
+}
+
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
 describe('SupplierSyncScheduler', () => {
   it('onModuleInit is SYNCHRONOUS (returns void, defers work) — CLAUDE.md non-blocking rule', () => {
-    const s = new SupplierSyncScheduler(mockQueue());
+    const s = new SupplierSyncScheduler(mockQueue(), mockConfig(true));
     const ret = s.onModuleInit();
     expect(ret).toBeUndefined(); // not a Promise
   });
 
+  it('INERT by default: flag!=true ⇒ onModuleInit arms NO repeatable job (no queue.add ever)', async () => {
+    const q = mockQueue();
+    new SupplierSyncScheduler(q, mockConfig(false)).onModuleInit();
+    await flushMicrotasks(); // even if work were deferred, give it a tick
+    expect(q.add).not.toHaveBeenCalled();
+  });
+
+  it('isSyncEnabled reflects the flag', () => {
+    expect(
+      new SupplierSyncScheduler(mockQueue(), mockConfig(false)).isSyncEnabled(),
+    ).toBe(false);
+    expect(
+      new SupplierSyncScheduler(mockQueue(), mockConfig(true)).isSyncEnabled(),
+    ).toBe(true);
+  });
+
+  it('flag=true ⇒ onModuleInit arms the repeatable cron job', async () => {
+    const q = mockQueue();
+    new SupplierSyncScheduler(q, mockConfig(true)).onModuleInit();
+    await flushMicrotasks(); // configureRepeatable is deferred with void
+    expect(q.add).toHaveBeenCalledWith(
+      'sync',
+      {},
+      expect.objectContaining({
+        repeat: { cron: '0 */4 * * *' },
+        jobId: 'supplier-sync-repeatable',
+      }),
+    );
+  });
+
   it('configureRepeatable enqueues a repeatable cron job with a fixed jobId (idempotent)', async () => {
     const q = mockQueue();
-    await new SupplierSyncScheduler(q).configureRepeatable();
+    await new SupplierSyncScheduler(q, mockConfig(true)).configureRepeatable();
     expect(q.add).toHaveBeenCalledWith(
       'sync',
       {},
@@ -30,7 +76,7 @@ describe('SupplierSyncScheduler', () => {
 
   it('triggerNow enqueues a one-off job (no repeat)', async () => {
     const q = mockQueue();
-    await new SupplierSyncScheduler(q).triggerNow();
+    await new SupplierSyncScheduler(q, mockConfig(true)).triggerNow();
     const call = (q.add as jest.Mock).mock.calls[0];
     expect(call[0]).toBe('sync');
     expect(call[2].repeat).toBeUndefined();

--- a/backend/src/modules/supplier-truth/supplier-sync.scheduler.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.scheduler.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectQueue } from '@nestjs/bull';
 import type { Queue } from 'bull';
 
@@ -23,9 +24,26 @@ export class SupplierSyncScheduler implements OnModuleInit {
 
   constructor(
     @InjectQueue(SUPPLIER_SYNC_QUEUE) private readonly queue: Queue,
+    private readonly config: ConfigService,
   ) {}
 
+  /**
+   * Activation flag — INERT by default (owner-gated). The sentinel NEVER syncs
+   * unless `SUPPLIER_TRUTH_SYNC_ENABLED` is explicitly `'true'`. Off → no
+   * repeatable job is ever armed → the @Processor never receives work → no
+   * connector login / portal hit / DB write.
+   */
+  isSyncEnabled(): boolean {
+    return this.config.get<string>('SUPPLIER_TRUTH_SYNC_ENABLED') === 'true';
+  }
+
   onModuleInit(): void {
+    if (!this.isSyncEnabled()) {
+      this.logger.log(
+        '⏸️ supplier-sync INERT — SUPPLIER_TRUTH_SYNC_ENABLED!=true: scheduler present, NO repeatable job armed, no portal hit',
+      );
+      return;
+    }
     this.logger.log(
       '🚀 init — deferring repeatable supplier-sync setup (non-blocking)',
     );

--- a/backend/src/modules/supplier-truth/supplier-sync.scheduler.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.scheduler.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectQueue } from '@nestjs/bull';
 import type { Queue } from 'bull';
+import { isSupplierSyncEnabled } from './supplier-sync.flag';
 
 /**
  * Schedules the recurring supplier sync (Task 12) via Bull.
@@ -34,7 +35,7 @@ export class SupplierSyncScheduler implements OnModuleInit {
    * connector login / portal hit / DB write.
    */
   isSyncEnabled(): boolean {
-    return this.config.get<string>('SUPPLIER_TRUTH_SYNC_ENABLED') === 'true';
+    return isSupplierSyncEnabled(this.config);
   }
 
   onModuleInit(): void {

--- a/backend/src/modules/supplier-truth/supplier-truth.controller.ts
+++ b/backend/src/modules/supplier-truth/supplier-truth.controller.ts
@@ -5,12 +5,13 @@ import {
   ParseIntPipe,
   UseGuards,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { IsAdminGuard } from '@auth/is-admin.guard';
 import {
   SupplierTruthService,
   type AvailabilityView,
 } from './supplier-truth.service';
-import { SupplierSyncScheduler } from './supplier-sync.scheduler';
+import { isSupplierSyncEnabled } from './supplier-sync.flag';
 import {
   listConnectableSuppliers,
   type SupplierPlatform,
@@ -30,7 +31,7 @@ import {
 export class SupplierTruthController {
   constructor(
     private readonly service: SupplierTruthService,
-    private readonly scheduler: SupplierSyncScheduler,
+    private readonly config: ConfigService,
   ) {}
 
   /** Activation + wiring status. Read-only; no connector login, no DB write. */
@@ -44,7 +45,7 @@ export class SupplierTruthController {
       platform: SupplierPlatform;
     }>;
   } {
-    const syncEnabled = this.scheduler.isSyncEnabled();
+    const syncEnabled = isSupplierSyncEnabled(this.config);
     return {
       mode: syncEnabled ? 'ACTIVE' : 'OBSERVABLE_DORMANT',
       syncEnabled,

--- a/backend/src/modules/supplier-truth/supplier-truth.controller.ts
+++ b/backend/src/modules/supplier-truth/supplier-truth.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+} from '@nestjs/common';
+import { IsAdminGuard } from '@auth/is-admin.guard';
+import {
+  SupplierTruthService,
+  type AvailabilityView,
+} from './supplier-truth.service';
+import { SupplierSyncScheduler } from './supplier-sync.scheduler';
+import {
+  listConnectableSuppliers,
+  type SupplierPlatform,
+} from './connectors/supplier-registry';
+
+/**
+ * Read-only observability surface for the supplier-truth sentinel (admin-only).
+ *
+ * Strictly READ: `status` reflects the activation flag + the connectable-supplier
+ * registry (no portal hit); `projection/:pieceId` reads the canonical projection
+ * via the service (UNKNOWN when not yet verified). No endpoint triggers a sync,
+ * mutates pricing/orders, or writes anything. There is intentionally NO trigger
+ * route — activation stays an env-flag decision, not an HTTP action.
+ */
+@Controller('api/admin/supplier-truth')
+@UseGuards(IsAdminGuard)
+export class SupplierTruthController {
+  constructor(
+    private readonly service: SupplierTruthService,
+    private readonly scheduler: SupplierSyncScheduler,
+  ) {}
+
+  /** Activation + wiring status. Read-only; no connector login, no DB write. */
+  @Get('status')
+  status(): {
+    mode: 'ACTIVE' | 'OBSERVABLE_DORMANT';
+    syncEnabled: boolean;
+    connectableSuppliers: Array<{
+      supplierId: string;
+      supplierName: string;
+      platform: SupplierPlatform;
+    }>;
+  } {
+    const syncEnabled = this.scheduler.isSyncEnabled();
+    return {
+      mode: syncEnabled ? 'ACTIVE' : 'OBSERVABLE_DORMANT',
+      syncEnabled,
+      connectableSuppliers: listConnectableSuppliers().map((c) => ({
+        supplierId: c.supplierId,
+        supplierName: c.supplierName,
+        platform: c.platform,
+      })),
+    };
+  }
+
+  /** Canonical availability for one piece; UNKNOWN until verified. Read-only. */
+  @Get('projection/:pieceId')
+  projection(
+    @Param('pieceId', ParseIntPipe) pieceId: number,
+  ): Promise<AvailabilityView> {
+    return this.service.getProjection(pieceId);
+  }
+}

--- a/backend/src/modules/supplier-truth/supplier-truth.module.test.ts
+++ b/backend/src/modules/supplier-truth/supplier-truth.module.test.ts
@@ -1,101 +1,42 @@
-import { BullModule } from '@nestjs/bull';
+import type { ConfigService } from '@nestjs/config';
 import { SupplierTruthModule } from './supplier-truth.module';
 import { SupplierTruthController } from './supplier-truth.controller';
+import { SupplierTruthReadModule } from './supplier-truth-read.module';
 import { SupplierTruthService } from './supplier-truth.service';
-import { SupplierTruthRepository } from './supplier-truth.repository';
-import { SupplierTruthEventSink } from './supplier-truth-event-sink';
-import { SupplierSyncProcessor } from './supplier-sync.processor';
-import { SupplierSyncRunner } from './supplier-sync.runner';
-import { SupplierSyncJobProcessor } from './supplier-sync.job.processor';
-import { SupplierSyncScheduler } from './supplier-sync.scheduler';
-import { DatabaseModule } from '../../database/database.module';
 import { AvailabilityState } from './domain/availability-state';
 
-/** Token of a provider entry, whether a plain class or a `{ provide, useFactory }`. */
-function providerToken(p: unknown): unknown {
-  return typeof p === 'object' && p !== null && 'provide' in p
-    ? (p as { provide: unknown }).provide
-    : p;
-}
-
-describe('SupplierTruthModule wiring (structural — no infra boot)', () => {
+describe('SupplierTruthModule wiring (read-only API — no sync duplication)', () => {
   const imports = Reflect.getMetadata('imports', SupplierTruthModule) ?? [];
   const controllers =
     Reflect.getMetadata('controllers', SupplierTruthModule) ?? [];
   const providers = Reflect.getMetadata('providers', SupplierTruthModule) ?? [];
-  const exportsMeta = Reflect.getMetadata('exports', SupplierTruthModule) ?? [];
-  const providerTokens = providers.map(providerToken);
 
-  it('registers the supplier-sync BullMQ queue + DatabaseModule', () => {
-    expect(imports).toContain(DatabaseModule);
-    expect(
-      imports.some(
-        (m: unknown) =>
-          typeof m === 'object' &&
-          m !== null &&
-          (m as { module?: unknown }).module === BullModule,
-      ),
-    ).toBe(true);
-  });
-
-  it('declares the read-only controller', () => {
+  it('reuses the shared read slice + declares the read-only controller', () => {
+    expect(imports).toContain(SupplierTruthReadModule);
     expect(controllers).toEqual([SupplierTruthController]);
   });
 
-  it('wires every sentinel component (repo, service, REAL sink, processor, runner, job, scheduler)', () => {
-    for (const token of [
-      SupplierTruthRepository,
-      SupplierTruthService,
-      SupplierTruthEventSink,
-      SupplierSyncProcessor,
-      SupplierSyncRunner,
-      SupplierSyncJobProcessor,
-      SupplierSyncScheduler,
-    ]) {
-      expect(providerTokens).toContain(token);
-    }
-  });
-
-  it('injects the REAL event sink into the processor + runner factories (not noopSink)', () => {
-    const runnerProvider = providers.find(
-      (p: unknown) => providerToken(p) === SupplierSyncRunner,
-    );
-    const processorProvider = providers.find(
-      (p: unknown) => providerToken(p) === SupplierSyncProcessor,
-    );
-    expect(runnerProvider.inject).toContain(SupplierTruthEventSink);
-    expect(processorProvider.inject).toContain(SupplierTruthEventSink);
-  });
-
-  it('exports only the read service (funnel entry point)', () => {
-    expect(exportsMeta).toEqual([SupplierTruthService]);
+  it('does NOT re-provide the sync runtime (queue/scheduler/processor/runner live in WorkerModule)', () => {
+    // Anti-parallel-system guard: this module adds ONLY the read endpoint. Re-
+    // providing the scheduler/@Processor here would create a second consumer on
+    // the same BullMQ queue (double processing once active) + a duplicate armer.
+    expect(providers).toHaveLength(0);
   });
 });
 
-describe('SupplierTruthEventSink is injectable + writes no DB (logs only)', () => {
-  it('constructs and emits without throwing and without any DB client', () => {
-    const sink = new SupplierTruthEventSink();
-    expect(typeof sink.emit).toBe('function');
-    // No supabase/db member — degradation events route to logs, never a write.
-    expect(
-      (sink as unknown as { supabase?: unknown }).supabase,
-    ).toBeUndefined();
-    expect(() =>
-      sink.emit('supplier.truth.degraded', { supplierId: '71' }),
-    ).not.toThrow();
-  });
-});
+function mockConfig(value: string): ConfigService {
+  return { get: jest.fn(() => value) } as unknown as ConfigService;
+}
 
 describe('SupplierTruthController is strictly read-only', () => {
-  const inertScheduler = {
-    isSyncEnabled: () => false,
-  } as unknown as SupplierSyncScheduler;
-
-  it('status reports OBSERVABLE_DORMANT + connectable suppliers, no portal hit', () => {
+  it('status reports OBSERVABLE_DORMANT + connectable suppliers, no DB hit', () => {
     const service = {
       getProjection: jest.fn(),
     } as unknown as SupplierTruthService;
-    const controller = new SupplierTruthController(service, inertScheduler);
+    const controller = new SupplierTruthController(
+      service,
+      mockConfig('false'),
+    );
 
     const status = controller.status();
 
@@ -104,6 +45,20 @@ describe('SupplierTruthController is strictly read-only', () => {
     const ids = status.connectableSuppliers.map((s) => s.supplierId).sort();
     expect(ids).toEqual(['19', '71']); // CAL + DistriCash
     expect(service.getProjection).not.toHaveBeenCalled(); // status hits no DB
+  });
+
+  it('reports ACTIVE only when the flag is exactly "true" (conservative)', () => {
+    const service = {
+      getProjection: jest.fn(),
+    } as unknown as SupplierTruthService;
+    expect(
+      new SupplierTruthController(service, mockConfig('true')).status().mode,
+    ).toBe('ACTIVE');
+    // any other value (e.g. '1', 'TRUE') stays dormant — fail-safe
+    expect(
+      new SupplierTruthController(service, mockConfig('1')).status()
+        .syncEnabled,
+    ).toBe(false);
   });
 
   it('projection delegates to the read service (UNKNOWN when unverified)', async () => {
@@ -116,7 +71,10 @@ describe('SupplierTruthController is strictly read-only', () => {
     const service = {
       getProjection: jest.fn(async () => view),
     } as unknown as SupplierTruthService;
-    const controller = new SupplierTruthController(service, inertScheduler);
+    const controller = new SupplierTruthController(
+      service,
+      mockConfig('false'),
+    );
 
     await expect(controller.projection(123)).resolves.toBe(view);
     expect(service.getProjection).toHaveBeenCalledWith(123);

--- a/backend/src/modules/supplier-truth/supplier-truth.module.test.ts
+++ b/backend/src/modules/supplier-truth/supplier-truth.module.test.ts
@@ -1,0 +1,124 @@
+import { BullModule } from '@nestjs/bull';
+import { SupplierTruthModule } from './supplier-truth.module';
+import { SupplierTruthController } from './supplier-truth.controller';
+import { SupplierTruthService } from './supplier-truth.service';
+import { SupplierTruthRepository } from './supplier-truth.repository';
+import { SupplierTruthEventSink } from './supplier-truth-event-sink';
+import { SupplierSyncProcessor } from './supplier-sync.processor';
+import { SupplierSyncRunner } from './supplier-sync.runner';
+import { SupplierSyncJobProcessor } from './supplier-sync.job.processor';
+import { SupplierSyncScheduler } from './supplier-sync.scheduler';
+import { DatabaseModule } from '../../database/database.module';
+import { AvailabilityState } from './domain/availability-state';
+
+/** Token of a provider entry, whether a plain class or a `{ provide, useFactory }`. */
+function providerToken(p: unknown): unknown {
+  return typeof p === 'object' && p !== null && 'provide' in p
+    ? (p as { provide: unknown }).provide
+    : p;
+}
+
+describe('SupplierTruthModule wiring (structural — no infra boot)', () => {
+  const imports = Reflect.getMetadata('imports', SupplierTruthModule) ?? [];
+  const controllers =
+    Reflect.getMetadata('controllers', SupplierTruthModule) ?? [];
+  const providers = Reflect.getMetadata('providers', SupplierTruthModule) ?? [];
+  const exportsMeta = Reflect.getMetadata('exports', SupplierTruthModule) ?? [];
+  const providerTokens = providers.map(providerToken);
+
+  it('registers the supplier-sync BullMQ queue + DatabaseModule', () => {
+    expect(imports).toContain(DatabaseModule);
+    expect(
+      imports.some(
+        (m: unknown) =>
+          typeof m === 'object' &&
+          m !== null &&
+          (m as { module?: unknown }).module === BullModule,
+      ),
+    ).toBe(true);
+  });
+
+  it('declares the read-only controller', () => {
+    expect(controllers).toEqual([SupplierTruthController]);
+  });
+
+  it('wires every sentinel component (repo, service, REAL sink, processor, runner, job, scheduler)', () => {
+    for (const token of [
+      SupplierTruthRepository,
+      SupplierTruthService,
+      SupplierTruthEventSink,
+      SupplierSyncProcessor,
+      SupplierSyncRunner,
+      SupplierSyncJobProcessor,
+      SupplierSyncScheduler,
+    ]) {
+      expect(providerTokens).toContain(token);
+    }
+  });
+
+  it('injects the REAL event sink into the processor + runner factories (not noopSink)', () => {
+    const runnerProvider = providers.find(
+      (p: unknown) => providerToken(p) === SupplierSyncRunner,
+    );
+    const processorProvider = providers.find(
+      (p: unknown) => providerToken(p) === SupplierSyncProcessor,
+    );
+    expect(runnerProvider.inject).toContain(SupplierTruthEventSink);
+    expect(processorProvider.inject).toContain(SupplierTruthEventSink);
+  });
+
+  it('exports only the read service (funnel entry point)', () => {
+    expect(exportsMeta).toEqual([SupplierTruthService]);
+  });
+});
+
+describe('SupplierTruthEventSink is injectable + writes no DB (logs only)', () => {
+  it('constructs and emits without throwing and without any DB client', () => {
+    const sink = new SupplierTruthEventSink();
+    expect(typeof sink.emit).toBe('function');
+    // No supabase/db member — degradation events route to logs, never a write.
+    expect(
+      (sink as unknown as { supabase?: unknown }).supabase,
+    ).toBeUndefined();
+    expect(() =>
+      sink.emit('supplier.truth.degraded', { supplierId: '71' }),
+    ).not.toThrow();
+  });
+});
+
+describe('SupplierTruthController is strictly read-only', () => {
+  const inertScheduler = {
+    isSyncEnabled: () => false,
+  } as unknown as SupplierSyncScheduler;
+
+  it('status reports OBSERVABLE_DORMANT + connectable suppliers, no portal hit', () => {
+    const service = {
+      getProjection: jest.fn(),
+    } as unknown as SupplierTruthService;
+    const controller = new SupplierTruthController(service, inertScheduler);
+
+    const status = controller.status();
+
+    expect(status.mode).toBe('OBSERVABLE_DORMANT');
+    expect(status.syncEnabled).toBe(false);
+    const ids = status.connectableSuppliers.map((s) => s.supplierId).sort();
+    expect(ids).toEqual(['19', '71']); // CAL + DistriCash
+    expect(service.getProjection).not.toHaveBeenCalled(); // status hits no DB
+  });
+
+  it('projection delegates to the read service (UNKNOWN when unverified)', async () => {
+    const view = {
+      state: AvailabilityState.UNKNOWN,
+      confidence: 0,
+      delayDays: null,
+      sourceSupplier: null,
+    };
+    const service = {
+      getProjection: jest.fn(async () => view),
+    } as unknown as SupplierTruthService;
+    const controller = new SupplierTruthController(service, inertScheduler);
+
+    await expect(controller.projection(123)).resolves.toBe(view);
+    expect(service.getProjection).toHaveBeenCalledWith(123);
+  });
+});

--- a/backend/src/modules/supplier-truth/supplier-truth.module.ts
+++ b/backend/src/modules/supplier-truth/supplier-truth.module.ts
@@ -1,79 +1,25 @@
 /**
- * SupplierTruthModule — runtime wiring of the supplier availability sentinel.
+ * SupplierTruthModule — read-only observability surface for the sentinel.
  *
- * INERT MODE by default (owner-gated). This module instantiates the sentinel's
- * components (connectors registry + runner + processor + BullMQ scheduler/job +
- * the REAL event sink) and exposes a read-only observability endpoint — but it
- * runs NO sync: the scheduler arms its repeatable job ONLY when
- * `SUPPLIER_TRUTH_SYNC_ENABLED=true`. Off (default) → no job armed → the
- * @Processor never receives work → no connector login / portal hit / DB write.
+ * IMPORTANT (CQRS + no-duplication): the supplier-sync WRITE/SYNC side (queue +
+ * scheduler + processor + runner + real event sink) is ALREADY wired in
+ * `WorkerModule` (where Bull `forRoot` lives) and runs at app root. This module
+ * does NOT re-provide any of that — re-registering the queue / scheduler /
+ * @Processor here would create a parallel system + a second consumer on the same
+ * BullMQ queue. It adds ONLY the admin read endpoint, reusing the shared read
+ * slice (`SupplierTruthReadModule`) and reading the activation flag via
+ * `ConfigService` (global) — no coupling to the Bull runtime.
  *
- * Status: PARTIAL_READY → OBSERVABLE_DORMANT. The components are live-verified
- * (DCA #826/#827, CAL #828); this PR makes them instantiated + observable, not
- * active. Activation (flag ON) stays a separate, owner-gated decision.
+ * Inert-by-default is enforced where the job is armed — in the scheduler's
+ * `onModuleInit` gate (`SUPPLIER_TRUTH_SYNC_ENABLED`), inside WorkerModule. This
+ * endpoint only REPORTS that mode; it never arms, syncs, or mutates anything.
  */
 import { Module } from '@nestjs/common';
-import { BullModule } from '@nestjs/bull';
-import { DatabaseModule } from '../../database/database.module';
-import { SupplierTruthRepository } from './supplier-truth.repository';
-import { SupplierTruthService } from './supplier-truth.service';
-import { SupplierTruthEventSink } from './supplier-truth-event-sink';
-import { SupplierSyncProcessor } from './supplier-sync.processor';
-import {
-  SupplierSyncRunner,
-  defaultConnectorFactory,
-  envCredResolver,
-} from './supplier-sync.runner';
-import { SupplierSyncJobProcessor } from './supplier-sync.job.processor';
-import {
-  SupplierSyncScheduler,
-  SUPPLIER_SYNC_QUEUE,
-} from './supplier-sync.scheduler';
+import { SupplierTruthReadModule } from './supplier-truth-read.module';
 import { SupplierTruthController } from './supplier-truth.controller';
 
 @Module({
-  imports: [
-    DatabaseModule,
-    BullModule.registerQueue({ name: SUPPLIER_SYNC_QUEUE }),
-  ],
+  imports: [SupplierTruthReadModule],
   controllers: [SupplierTruthController],
-  providers: [
-    SupplierTruthRepository,
-    SupplierTruthService,
-    SupplierTruthEventSink,
-    // Processor + runner get the REAL event sink (not noopSink) via factory, so
-    // degradation/observability events are actually emitted once active.
-    {
-      provide: SupplierSyncProcessor,
-      useFactory: (
-        repo: SupplierTruthRepository,
-        sink: SupplierTruthEventSink,
-      ) => new SupplierSyncProcessor(repo, sink.emit),
-      inject: [SupplierTruthRepository, SupplierTruthEventSink],
-    },
-    {
-      provide: SupplierSyncRunner,
-      useFactory: (
-        repo: SupplierTruthRepository,
-        processor: SupplierSyncProcessor,
-        sink: SupplierTruthEventSink,
-      ) =>
-        new SupplierSyncRunner(
-          repo,
-          processor,
-          defaultConnectorFactory,
-          envCredResolver,
-          sink.emit,
-        ),
-      inject: [
-        SupplierTruthRepository,
-        SupplierSyncProcessor,
-        SupplierTruthEventSink,
-      ],
-    },
-    SupplierSyncJobProcessor,
-    SupplierSyncScheduler,
-  ],
-  exports: [SupplierTruthService],
 })
 export class SupplierTruthModule {}

--- a/backend/src/modules/supplier-truth/supplier-truth.module.ts
+++ b/backend/src/modules/supplier-truth/supplier-truth.module.ts
@@ -1,0 +1,79 @@
+/**
+ * SupplierTruthModule — runtime wiring of the supplier availability sentinel.
+ *
+ * INERT MODE by default (owner-gated). This module instantiates the sentinel's
+ * components (connectors registry + runner + processor + BullMQ scheduler/job +
+ * the REAL event sink) and exposes a read-only observability endpoint — but it
+ * runs NO sync: the scheduler arms its repeatable job ONLY when
+ * `SUPPLIER_TRUTH_SYNC_ENABLED=true`. Off (default) → no job armed → the
+ * @Processor never receives work → no connector login / portal hit / DB write.
+ *
+ * Status: PARTIAL_READY → OBSERVABLE_DORMANT. The components are live-verified
+ * (DCA #826/#827, CAL #828); this PR makes them instantiated + observable, not
+ * active. Activation (flag ON) stays a separate, owner-gated decision.
+ */
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bull';
+import { DatabaseModule } from '../../database/database.module';
+import { SupplierTruthRepository } from './supplier-truth.repository';
+import { SupplierTruthService } from './supplier-truth.service';
+import { SupplierTruthEventSink } from './supplier-truth-event-sink';
+import { SupplierSyncProcessor } from './supplier-sync.processor';
+import {
+  SupplierSyncRunner,
+  defaultConnectorFactory,
+  envCredResolver,
+} from './supplier-sync.runner';
+import { SupplierSyncJobProcessor } from './supplier-sync.job.processor';
+import {
+  SupplierSyncScheduler,
+  SUPPLIER_SYNC_QUEUE,
+} from './supplier-sync.scheduler';
+import { SupplierTruthController } from './supplier-truth.controller';
+
+@Module({
+  imports: [
+    DatabaseModule,
+    BullModule.registerQueue({ name: SUPPLIER_SYNC_QUEUE }),
+  ],
+  controllers: [SupplierTruthController],
+  providers: [
+    SupplierTruthRepository,
+    SupplierTruthService,
+    SupplierTruthEventSink,
+    // Processor + runner get the REAL event sink (not noopSink) via factory, so
+    // degradation/observability events are actually emitted once active.
+    {
+      provide: SupplierSyncProcessor,
+      useFactory: (
+        repo: SupplierTruthRepository,
+        sink: SupplierTruthEventSink,
+      ) => new SupplierSyncProcessor(repo, sink.emit),
+      inject: [SupplierTruthRepository, SupplierTruthEventSink],
+    },
+    {
+      provide: SupplierSyncRunner,
+      useFactory: (
+        repo: SupplierTruthRepository,
+        processor: SupplierSyncProcessor,
+        sink: SupplierTruthEventSink,
+      ) =>
+        new SupplierSyncRunner(
+          repo,
+          processor,
+          defaultConnectorFactory,
+          envCredResolver,
+          sink.emit,
+        ),
+      inject: [
+        SupplierTruthRepository,
+        SupplierSyncProcessor,
+        SupplierTruthEventSink,
+      ],
+    },
+    SupplierSyncJobProcessor,
+    SupplierSyncScheduler,
+  ],
+  exports: [SupplierTruthService],
+})
+export class SupplierTruthModule {}

--- a/log.md
+++ b/log.md
@@ -574,3 +574,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/supplier-cal-pr1b`
 - **Décision** : feat(supplier-truth): wire CAL connector (read-only sentinel, spl_id 19)
 - **Sortie** : PR #828 | commits 136941362
+
+## 2026-06-03 — feat/supplier-truth-runtime-wiring (auto)
+
+- **Branche** : `feat/supplier-truth-runtime-wiring`
+- **Décision** : feat(supplier-truth): runtime wiring (inert mode, scheduler OFF default)
+- **Sortie** : PR #831 | commits 268efea6c


### PR DESCRIPTION
## supplier-truth — read-only observability + inert-by-default scheduler

**No supplier sync activation. No scheduled job armed by default. No pricing/order mutation. Read-only observability endpoint only.** Doctrine: `PARTIAL_READY → OBSERVABLE_DORMANT`.

### ⚠️ Final-review correction (important — diff redesigned vs first cut)
The first cut assumed the sentinel was dead code and created a new module wiring queue+scheduler+processor+runner. **That was wrong**: the supplier-sync write/sync side is **already wired in `WorkerModule`** (`backend/src/workers/worker.module.ts:102-183`, imported in `app.module.ts:234`) and runs at app root. The first cut **duplicated** it → a parallel system + a **second `@Processor('supplier-sync')` consumer** on the same BullMQ queue (latent double-processing once active). Unit/structural tests don't boot the app, so CI didn't catch it. Redesigned to the minimal, non-duplicating form below.

### What this PR actually does
1. **Inert-by-default scheduler gate** (the real safety win) — `supplier-sync.scheduler.ts` `onModuleInit` now gates on `SUPPLIER_TRUTH_SYNC_ENABLED` (default false). **This is a runtime behaviour change to the EXISTING WorkerModule scheduler**, which previously armed the 4h repeatable job **unconditionally on every boot** (effectively no-op only because supplier creds are optional/absent → connectors skip). Now: flag off ⇒ logs `⏸️ INERT` and returns before arming.
2. **Read-only observability controller** (the genuinely-new surface) — `SupplierTruthController`, admin-guarded: `GET /api/admin/supplier-truth/status` (flag + connectable suppliers, no portal hit) and `GET /api/admin/supplier-truth/projection/:pieceId` (canonical projection, `UNKNOWN` until verified). **No trigger route.**
3. **`SupplierTruthModule` = controller-only** — `imports: [SupplierTruthReadModule]` (reuse the shared read slice) + `controllers: [SupplierTruthController]`. **Zero providers** — no queue, scheduler, or processor re-provided.
4. **Single source for the flag** — `supplier-sync.flag.ts` (`SUPPLIER_TRUTH_SYNC_ENABLED` + `isSupplierSyncEnabled`). The scheduler gate and the controller status both read it through this helper (strict `=== 'true'`).
5. **`.env.example`** — `SUPPLIER_TRUTH_SYNC_ENABLED=false` (master switch, inert by default).

### Safety contract (proven by tests)
`SUPPLIER_TRUTH_SYNC_ENABLED != 'true'` ⇒ scheduler present but **arms NO repeatable job** (`queue.add` never called) ⇒ `@Processor` never receives work ⇒ **no connector login · no portal hit · no pricing/order/DB mutation**. Controller is strictly read-only. `supplier-truth.module.test.ts` locks the **anti-duplication invariant** (module providers length 0) + flag-variant fail-safe (`'1'` → dormant).

### Local gates (green on the corrected design)
187 supplier-truth tests · prettier · eslint · `tsc --build` exit 0 · ast-grep onModuleInit guard. Adversarial multi-agent review (28 agents) on the diff: 0 real defects on the master invariant.

### Out of scope / NO-GO
Flag ON by default · active scheduler · real sync · any supplier/pricing/order mutation · merge without tests/gates. Activation (`flag → true`) stays a separate, owner-gated runtime decision with its own rollout.

## Improvement Check
- **Problem:** the supplier-sync scheduler (live in WorkerModule) armed the 4h job unconditionally on every boot, with zero read-side observability into the sentinel.
- **Evidence before:** `git show origin/main:.../supplier-sync.scheduler.ts` → `onModuleInit` calls `void configureRepeatable()` with no gate; no `/api/admin/supplier-truth/*` endpoint.
- **Expected gain:** scheduler inert by default (owner-gated activation) + a read-only status/projection endpoint — no parallel system.
- **Risk:** behaviour change to a live component (scheduler stops arming by default) — intended + safe (flag-gated, reversible by revert). Endpoint read-only + admin-guarded. Rollback = revert PR (no schema/data change).
- **Test:** inert scheduler test + controller/module tests + anti-duplication lock + full local gate suite.
- **Evidence after:** flag off proven to arm nothing; flag=true still arms (gated); 187 tests green; tsc --build exit 0; providers length 0.
- **Verdict:** GO_WITH_WATCH — keeps the sentinel dormant; watch boot logs for the `⏸️ INERT` line on PREPROD.
- **Next action:** owner re-reads the corrected runtime diff; on merge, confirm PREPROD boot shows the INERT line. Activation = separate owner GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)