### PR TITLE
docs(departments): backlink map → machine-readable agent-operating-map (#787)

### DIFF
--- a/audit/automecanik-departments-map.md
+++ b/audit/automecanik-departments-map.md
@@ -8,6 +8,15 @@
 > Il route les capacités existantes vers les départements, clarifie leur mode de maturité, et définit le
 > rapport attendu pour permettre le pilotage par scoring.**
 
+> **Projection machine-readable (warn-only, PR #787).** Un sous-ensemble *commerce-loop* de ces départements
+> (Achats & Fournisseurs → `supplier`, Commercial & Ventes → `sales`, Pricing → `pricing`) + leurs handoffs
+> métier (`supplier→sales` dispo, `pricing→sales` marge) est formalisé, en **slugs**, dans
+> [`agent-operating-map.yaml`](../.spec/00-canon/ai-registry/agent-operating-map.yaml) (blocs `departments:` /
+> `department_handoffs:`, ai-registry). Pont vers les domaines techniques D1-D16 via `repo_domains`.
+> **Autorité par champ** : ce markdown reste la **SoT narrative** (Vue 1/5/6 + format rapport) ; le yaml est la
+> **SoT machine** des champs structurés (`id`, `lead`, `repo_domains`, `state`, handoffs). Linker, pas recopier
+> — ne pas dupliquer le contenu entre les deux (cf. règle d'or ci-dessus).
+
 ## Doctrine opérationnelle — 6 règles concrètes
 1. **Toyota Gate** — stop sur défaut, corrige à la source. 8 gates : RAW→WIKI · WIKI→PAGE · PAGE→PUBLISH · FAFA→PUBLISH · DEMANDE→DEVIS · DEVIS→PAIEMENT · **PRODUIT→PANIER (dispo !)** · AGENT→OUTPUT.
 2. **Amazon Owner** — chaque département possède **un résultat (KPI)**, pas une activité.


### PR DESCRIPTION
Adds a pointer from `audit/automecanik-departments-map.md` to the machine-readable department layer landed in #787 (`agent-operating-map.yaml` `departments:` / `department_handoffs:` blocks).

**Authority-per-field** (anti-drift): the markdown stays the **narrative SoT** (Vue 1/5/6 + report format); the yaml is the **machine SoT** for structured fields (id, lead, repo_domains, state, handoffs). A pointer, **not** a content copy — the two views can't drift on content.

- Additive, docs-only (+9 lines), reversible.
- Vocabulary lint: 0 violations (604 files).
- Completes the markdown→yaml direction (yaml→markdown already in #787).

🤖 Generated with [Claude Code](https://claude.com/claude-code)