### PR TITLE
feat(supplier-truth): cap per-supplier refs per run (anti-ban bound)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -293,6 +293,10 @@ SENTRY_ALLOW_DEBUG_ENDPOINT=false
 # job and NO connector ever logs in unless this is explicitly 'true'. Leave false until
 # activation is an explicit, owner-gated decision (then a separate runtime rollout).
 SUPPLIER_TRUTH_SYNC_ENABLED=false
+# Anti-ban: max references queried per supplier portal per run (each ref = one
+# authenticated portal query). Overlap can be large (100+ ordered refs ∩ carried
+# brands); this caps a single pass so refs cycle across runs via TTL. Default 50.
+SUPPLIER_SYNC_MAX_REFS_PER_RUN=50
 SUPPLIER_INOSHOP_DISTRICASH_USER=
 SUPPLIER_INOSHOP_DISTRICASH_PASSWORD=
 # CAL (Société CAL 92 / PF Préférence Seine) — ___xtr_supplier spl_id 19, ASP.NET

--- a/backend/src/modules/supplier-truth/supplier-sync.runner.test.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.runner.test.ts
@@ -147,4 +147,26 @@ describe('SupplierSyncRunner.runSync', () => {
     expect(summary.suppliersRun).toBe(0);
     expect(summary.suppliersSkipped).toBe(1);
   });
+
+  it('caps per-supplier refs to maxRefsPerRun (anti-ban) — extra refs deferred to later runs', async () => {
+    const connector = makeConnector();
+    const proc = processor();
+    const runner = new SupplierSyncRunner(
+      repo(['R1', 'R2', 'R3', 'R4', 'R5']),
+      proc,
+      () => connector,
+      () => ({ user: 'u', password: 'p' }),
+      undefined, // emit → default noopSink
+      2, // maxRefsPerRun
+    );
+
+    await runner.runSync();
+
+    // Only the first 2 carried refs hit the portal this run; R3-R5 wait for TTL refresh.
+    expect(proc.syncRefs).toHaveBeenCalledWith(
+      connector,
+      ['R1', 'R2'],
+      expect.any(Date),
+    );
+  });
 });

--- a/backend/src/modules/supplier-truth/supplier-sync.runner.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.runner.ts
@@ -57,6 +57,19 @@ export const envCredResolver: CredResolver = (cfg) => {
   return user && password ? { user, password } : null;
 };
 
+/**
+ * Per-supplier refs cap per run — anti-ban guard bounding how many references a
+ * single run queries against a supplier portal (each ref = one authenticated
+ * portal query). Env-overridable via `SUPPLIER_SYNC_MAX_REFS_PER_RUN`; the
+ * working-set is already bounded upstream, this caps the per-supplier slice so a
+ * large overlap can't hammer a portal in one pass (refs cycle across runs via TTL).
+ */
+const DEFAULT_MAX_REFS_PER_RUN = 50;
+export function envMaxRefsPerRun(): number {
+  const raw = Number(process.env.SUPPLIER_SYNC_MAX_REFS_PER_RUN);
+  return Number.isInteger(raw) && raw > 0 ? raw : DEFAULT_MAX_REFS_PER_RUN;
+}
+
 export interface RunSummary {
   suppliersRun: number;
   /** Connector threw (auth/site-down/anti-ban/crash) — a broken supplier, NOT idle. */
@@ -77,6 +90,7 @@ export class SupplierSyncRunner {
     private readonly connectorFactory: ConnectorFactory = defaultConnectorFactory,
     private readonly credResolver: CredResolver = envCredResolver,
     private readonly emit: EventSink = noopSink,
+    private readonly maxRefsPerRun: number = envMaxRefsPerRun(),
   ) {}
 
   async runSync(now: Date = new Date()): Promise<RunSummary> {
@@ -106,13 +120,21 @@ export class SupplierSyncRunner {
       const carriedBrands = new Set(
         await this.repo.getSupplierLinkedBrands(cfg.supplierId),
       );
-      const refs = [
+      const carriedRefs = [
         ...new Set(
           workingSet
             .filter((w) => w.pmId != null && carriedBrands.has(w.pmId))
             .map((w) => w.ref),
         ),
       ];
+      // Anti-ban: cap the per-supplier portal queries for this run; the rest
+      // refresh on subsequent runs (TTL-driven). No silent drop — logged.
+      const refs = carriedRefs.slice(0, this.maxRefsPerRun);
+      if (carriedRefs.length > refs.length) {
+        this.logger.log(
+          `${cfg.supplierName}: capping ${carriedRefs.length} carried refs to ${refs.length} this run (SUPPLIER_SYNC_MAX_REFS_PER_RUN=${this.maxRefsPerRun})`,
+        );
+      }
       if (refs.length === 0) {
         this.logger.log(
           `skip ${cfg.supplierName}: none of the working-set brands are carried`,


### PR DESCRIPTION
## Anti-ban refs cap — bound a run's portal load

Adds `SUPPLIER_SYNC_MAX_REFS_PER_RUN` (env, **default 50**). The supplier-sync runner now slices each supplier's *carried-refs overlap* (working-set ∩ `___xtr_supplier_link_pm` brands) to a bounded count per run.

### Why
A full run queries every overlapping ref against the supplier portal (one authenticated Playwright query per ref). **Live-measured overlap on the current working-set: 115 refs for DCA (spl 71), 176 for CAL (spl 19)** — ~291 portal queries in one pass. That's an anti-ban risk and far more than a "controlled" run. The cap bounds a single pass; capped refs cycle across subsequent runs via the existing TTL refresh. **No silent drop** — when capping happens it's logged (`capping N carried refs to M this run`).

### Scope (small, no behaviour change while dormant)
- `supplier-sync.runner.ts`: new `maxRefsPerRun` constructor param (defaults to `envMaxRefsPerRun()` reading `SUPPLIER_SYNC_MAX_REFS_PER_RUN`, fallback 50) + `carriedRefs.slice(0, cap)` + a log when capped. The default param means **WorkerModule's existing factory construction is unchanged** (no wiring touched).
- `.env.example`: documents `SUPPLIER_SYNC_MAX_REFS_PER_RUN=50`.
- test: 5 carried refs + cap 2 ⇒ `processor.syncRefs` receives only the first 2.

The sentinel stays **dormant** (`SUPPLIER_TRUTH_SYNC_ENABLED=false`, #831) — this changes nothing live. It (a) makes a future production activation anti-ban-safe by default, and (b) enables a small **controlled observation run** (cap=10) without hammering a portal.

### Gates (local, green)
188 supplier-truth tests (+1 cap) · prettier · eslint · `tsc --build` exit 0.

## Improvement Check
- **Problem:** an activated run would fire ~291 sequential portal queries (115 DCA + 176 CAL) — anti-ban risk, unbounded per-supplier load.
- **Evidence before:** runner queried the full `carriedRefs` overlap with no cap; live overlap counts measured via SQL on `___xtr_order_line` ∩ `___xtr_supplier_link_pm`.
- **Expected gain:** bounded, anti-ban-safe runs; controllable observation runs.
- **Risk:** behaviour change only when activated (dormant now). Capped refs deferred (not dropped) — cycle via TTL. Default 50 is conservative. Rollback = revert.
- **Test:** cap unit test + full suite + tsc build.
- **Verdict:** GO — small, reversible, needed before any controlled run.
- **Next action:** merge, then run a bounded controlled observation (cap=10, CAL first) and inspect the written observation rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)