### PR TITLE
feat(supplier-truth): guarded one-shot ops runner (real sync owner-gated, dry-validated)

### DIFF
--- a/backend/src/workers/run-supplier-sync-once.guard.ts
+++ b/backend/src/workers/run-supplier-sync-once.guard.ts
@@ -1,0 +1,25 @@
+/**
+ * Explicit owner-gate for the REAL one-shot supplier sync.
+ *
+ * A real run performs actual CAL/DCA portal logins (real credentials) and writes
+ * to the shared production DB observation tables — that is a real supplier
+ * activation (even capped), so it is REFUSED unless an operator explicitly sets
+ * `SUPPLIER_SYNC_ONESHOT_CONFIRM=true`. Strict `=== 'true'`: any other value
+ * (unset, `'1'`, `'TRUE'`, `'yes'`) stays refused — fail-safe.
+ *
+ * Kept in its own tiny module so the guard can be unit-tested without importing
+ * the heavy `WorkerModule` graph the ops entrypoint boots.
+ */
+export const ONESHOT_CONFIRM_ENV = 'SUPPLIER_SYNC_ONESHOT_CONFIRM';
+
+export function isOneshotConfirmed(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env[ONESHOT_CONFIRM_ENV] === 'true';
+}
+
+export const ONESHOT_REFUSAL =
+  `REFUSING real supplier sync — set ${ONESHOT_CONFIRM_ENV}=true for an explicit, ` +
+  'owner-gated one-shot run (real CAL/DCA portal logins + writes to ' +
+  'supplier_inventory_snapshots / supplier_truth_projection on the shared prod DB). ' +
+  'Exiting now with NO portal login and NO DB write.';

--- a/backend/src/workers/run-supplier-sync-once.test.ts
+++ b/backend/src/workers/run-supplier-sync-once.test.ts
@@ -1,0 +1,36 @@
+import {
+  isOneshotConfirmed,
+  ONESHOT_CONFIRM_ENV,
+  ONESHOT_REFUSAL,
+} from './run-supplier-sync-once.guard';
+import { WorkerModule } from './worker.module';
+import { SupplierSyncRunner } from '../modules/supplier-truth/supplier-sync.runner';
+
+describe('one-shot guard — real supplier sync is owner-gated (fail-safe)', () => {
+  it('refuses by default; only an explicit "true" confirms a real run', () => {
+    expect(isOneshotConfirmed({})).toBe(false);
+    expect(isOneshotConfirmed({ [ONESHOT_CONFIRM_ENV]: 'false' })).toBe(false);
+    expect(isOneshotConfirmed({ [ONESHOT_CONFIRM_ENV]: '1' })).toBe(false);
+    expect(isOneshotConfirmed({ [ONESHOT_CONFIRM_ENV]: 'TRUE' })).toBe(false);
+    expect(isOneshotConfirmed({ [ONESHOT_CONFIRM_ENV]: 'yes' })).toBe(false);
+    expect(isOneshotConfirmed({ [ONESHOT_CONFIRM_ENV]: 'true' })).toBe(true);
+  });
+
+  it('the refusal message names the blocked real actions', () => {
+    expect(ONESHOT_REFUSAL).toContain('NO portal login');
+    expect(ONESHOT_REFUSAL).toContain('NO DB write');
+    expect(ONESHOT_REFUSAL).toContain(ONESHOT_CONFIRM_ENV);
+  });
+});
+
+describe('WorkerModule wires SupplierSyncRunner (the ops entrypoint app.get resolves)', () => {
+  it('declares SupplierSyncRunner as a provider', () => {
+    const providers = Reflect.getMetadata('providers', WorkerModule) ?? [];
+    const tokens = providers.map((p: unknown) =>
+      typeof p === 'object' && p !== null && 'provide' in p
+        ? (p as { provide: unknown }).provide
+        : p,
+    );
+    expect(tokens).toContain(SupplierSyncRunner);
+  });
+});

--- a/backend/src/workers/run-supplier-sync-once.ts
+++ b/backend/src/workers/run-supplier-sync-once.ts
@@ -1,0 +1,51 @@
+/**
+ * One-shot controlled supplier-sync run (ops entrypoint) — SAFE BY DEFAULT.
+ *
+ * Boots the REAL production DI (`WorkerModule`) and invokes the existing
+ * `SupplierSyncRunner.runSync()` exactly ONCE — no scheduler armed, no 4h cron,
+ * one-shot. Bounded by `SUPPLIER_SYNC_MAX_REFS_PER_RUN` (set it small for a first
+ * run). Reuses the real wiring — no parallel construction.
+ *
+ * REFUSES to do anything real unless `SUPPLIER_SYNC_ONESHOT_CONFIRM=true` is set
+ * (see `./run-supplier-sync-once.guard`). A real run performs CAL/DCA portal
+ * logins with real credentials and writes the (funnel-dormant) observation tables
+ * `supplier_inventory_snapshots` / `supplier_truth_projection` on the shared prod
+ * DB — a real, owner-gated supplier activation. Without the flag it exits with no
+ * portal login and no DB write.
+ *
+ * Run (only after an explicit owner GO), from backend/, COMPILED (not tsx, which
+ * breaks Playwright `$eval`):
+ *   SUPPLIER_SYNC_ONESHOT_CONFIRM=true SUPPLIER_SYNC_MAX_REFS_PER_RUN=10 \
+ *     node dist/workers/run-supplier-sync-once.js
+ */
+import { NestFactory } from '@nestjs/core';
+import { WorkerModule } from './worker.module';
+import { SupplierSyncRunner } from '../modules/supplier-truth/supplier-sync.runner';
+import {
+  isOneshotConfirmed,
+  ONESHOT_REFUSAL,
+} from './run-supplier-sync-once.guard';
+
+async function main(): Promise<void> {
+  if (!isOneshotConfirmed()) {
+    // eslint-disable-next-line no-console
+    console.error(ONESHOT_REFUSAL);
+    process.exit(2);
+  }
+  const app = await NestFactory.createApplicationContext(WorkerModule, {
+    logger: ['error', 'warn', 'log'],
+  });
+  const runner = app.get(SupplierSyncRunner);
+  const summary = await runner.runSync();
+  // eslint-disable-next-line no-console
+  console.log('SUPPLIER_SYNC_ONESHOT_SUMMARY ' + JSON.stringify(summary));
+  // Hard-exit to skip onModuleDestroy — avoids touching the shared Bull
+  // repeatables the long-running worker process owns.
+  process.exit(0);
+}
+
+// Only run when invoked directly (`node …`), never on import (keeps the guard
+// unit-testable + prevents accidental execution).
+if (require.main === module) {
+  void main();
+}


### PR DESCRIPTION
## Guarded one-shot ops runner — real supplier sync stays owner-gated

Adds the controlled one-shot supplier-sync ops entrypoint, **SAFE BY DEFAULT**. It does **nothing real** unless `SUPPLIER_SYNC_ONESHOT_CONFIRM=true` is set explicitly. A real run performs CAL/DCA **portal logins (real credentials)** and writes the funnel-dormant observation tables on the **shared prod DB** — a real, owner-gated supplier activation — so it stays blocked behind the explicit flag.

This PR **does not run any sync**. It is dry-validated only (jest): **no portal login, no credentials, no DB write**.

### Files
- `run-supplier-sync-once.guard.ts` — `isOneshotConfirmed()` (strict `=== 'true'`, fail-safe) + the refusal message. Tiny standalone module so the guard is unit-testable without importing the heavy `WorkerModule` graph.
- `run-supplier-sync-once.ts` — boots the REAL `WorkerModule` DI + runs `SupplierSyncRunner.runSync()` **once** (reuse, no parallel wiring), bounded by `SUPPLIER_SYNC_MAX_REFS_PER_RUN` (#833), guarded by the confirm flag, and only executes when invoked directly (`require.main`) — never on import.
- `run-supplier-sync-once.test.ts` — guard refuses by default / only `'true'` confirms; refusal names the blocked real actions; `WorkerModule` structurally wires `SupplierSyncRunner` (so the `app.get` resolves).

### Satisfies the dry-run checklist
- ✅ compile ops-runner (ts-jest + tsc)
- ✅ verify WorkerModule DI wires the runner (structural, no boot)
- ✅ verify the runner refuses to execute without the explicit flag
- ✅ cap=10 + sink + fake connector already covered by `supplier-sync.runner.test.ts` (#833) + `supplier-truth-event-sink.test.ts`
- ✅ no credentials, no portal request, no shared DB write

### How a real run is unlocked (later, separate explicit GO)
```
SUPPLIER_SYNC_ONESHOT_CONFIRM=true SUPPLIER_SYNC_MAX_REFS_PER_RUN=10 \
  node dist/workers/run-supplier-sync-once.js
```
The sentinel stays **OBSERVABLE_DORMANT**. A real run remains a separate, explicit owner GO (real portal logins + prod-DB writes).

## Improvement Check
- **Problem:** the ops one-shot had no guard — running it would do a real sync (portal logins + prod-DB writes) with no explicit confirmation.
- **Evidence before:** `runSync()` / the @Processor run regardless of the dormancy flag; no confirm gate on a manual one-shot.
- **Expected gain:** a fail-safe gate so a real run is impossible without an explicit owner flag; the controlled-run tool is dry-validated + reviewable.
- **Risk:** none live — guarded, refuses by default, nothing runs on merge. Rollback = revert.
- **Test:** guard refuses/allows + DI structural + full local gates (188+ supplier-truth tests, prettier, eslint, tsc --build).
- **Verdict:** GO_WITH_WATCH — merge adds only a safe-by-default tool; a real run needs a separate explicit GO.
- **Next action:** owner reviews; the real bounded run waits for an explicit, scoped GO phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)