### PR TITLE
fix(seo): guard R4 reference against cross-family pollution

### DIFF
--- a/backend/src/modules/seo/services/r4-family-guard.test.ts
+++ b/backend/src/modules/seo/services/r4-family-guard.test.ts
@@ -1,0 +1,181 @@
+import {
+  isBareSlug,
+  classifyPartFamily,
+  filterOffFamilyParts,
+  detectOffFamilyArtifacts,
+} from './r4-family-guard';
+
+/**
+ * R4 cross-family pollution guard — pure logic.
+ * Family key = mf_id (catalog_family). Conservative: only KNOWN-and-different families
+ * are OFF_FAMILY; prose / unknown slug / unknown target ⇒ kept.
+ *
+ * Fixture: target gamme = brake family (mf_id 10). Map mixes brake parts (10),
+ * electrical (20), cooling (30) — arbitrary ids prove there is NO hardcoded denylist:
+ * the verdict comes purely from the injected slug→mf_id map.
+ */
+const TARGET_BRAKE = 10;
+const SLUG_MF: ReadonlyMap<string, number> = new Map([
+  ['disque-de-frein', 10],
+  ['plaquette-de-frein', 10],
+  ['etrier-de-frein', 10],
+  ['alternateur', 20],
+  ['batterie', 20],
+  ['poulie-d-alternateur', 20],
+  ['radiateur-de-refroidissement', 30],
+  ['pompe-a-eau', 30],
+]);
+
+describe('r4-family-guard — isBareSlug', () => {
+  it('recognises kebab slugs', () => {
+    expect(isBareSlug('disque-de-frein')).toBe(true);
+    expect(isBareSlug('alternateur')).toBe(true);
+    expect(isBareSlug('poulie-d-alternateur')).toBe(true);
+  });
+
+  it('rejects prose phrases (spaces / punctuation / parentheses)', () => {
+    expect(isBareSlug('Plaquettes de frein (a controler)')).toBe(false);
+    expect(isBareSlug('Disque ventile')).toBe(false);
+    expect(isBareSlug('codes p2452 p2453')).toBe(false);
+  });
+});
+
+describe('r4-family-guard — classifyPartFamily', () => {
+  it('SAME family is accepted', () => {
+    expect(
+      classifyPartFamily('plaquette-de-frein', TARGET_BRAKE, SLUG_MF),
+    ).toBe('SAME');
+    expect(classifyPartFamily('etrier-de-frein', TARGET_BRAKE, SLUG_MF)).toBe(
+      'SAME',
+    );
+  });
+
+  it('OFF-FAMILY (known but different mf_id) is refused', () => {
+    expect(classifyPartFamily('alternateur', TARGET_BRAKE, SLUG_MF)).toBe(
+      'OFF_FAMILY',
+    );
+    expect(
+      classifyPartFamily('radiateur-de-refroidissement', TARGET_BRAKE, SLUG_MF),
+    ).toBe('OFF_FAMILY');
+  });
+
+  it('UNKNOWN slug (not in the family map) is accepted — no false positive', () => {
+    expect(classifyPartFamily('liquide-de-frein', TARGET_BRAKE, SLUG_MF)).toBe(
+      'UNKNOWN',
+    );
+  });
+
+  it('prose entry is accepted (cannot resolve a family)', () => {
+    expect(
+      classifyPartFamily(
+        'Plaquettes de frein (a controler)',
+        TARGET_BRAKE,
+        SLUG_MF,
+      ),
+    ).toBe('UNKNOWN');
+  });
+
+  it('UNKNOWN target family ⇒ never OFF_FAMILY (no false positive)', () => {
+    expect(classifyPartFamily('alternateur', null, SLUG_MF)).toBe('UNKNOWN');
+  });
+
+  it('verdict comes from the map, not a denylist (arbitrary slug, same mf as target = SAME)', () => {
+    const customMap = new Map([['totally-made-up-part', TARGET_BRAKE]]);
+    expect(
+      classifyPartFamily('totally-made-up-part', TARGET_BRAKE, customMap),
+    ).toBe('SAME');
+  });
+});
+
+describe('r4-family-guard — filterOffFamilyParts', () => {
+  it('keeps SAME + UNKNOWN, drops OFF_FAMILY, reports dropped', () => {
+    const composition = [
+      'plaquette-de-frein', // SAME
+      'etrier-de-frein', // SAME
+      'liquide-de-frein', // UNKNOWN (kept)
+      'Disques de frein (a controler)', // prose UNKNOWN (kept)
+      'alternateur', // OFF
+      'batterie', // OFF
+      'poulie-d-alternateur', // OFF
+    ];
+    const { kept, dropped } = filterOffFamilyParts(
+      composition,
+      TARGET_BRAKE,
+      SLUG_MF,
+    );
+    expect(kept).toEqual([
+      'plaquette-de-frein',
+      'etrier-de-frein',
+      'liquide-de-frein',
+      'Disques de frein (a controler)',
+    ]);
+    expect(dropped).toEqual([
+      'alternateur',
+      'batterie',
+      'poulie-d-alternateur',
+    ]);
+  });
+
+  it('null / empty input ⇒ empty result, no crash', () => {
+    expect(filterOffFamilyParts(null, TARGET_BRAKE, SLUG_MF)).toEqual({
+      kept: [],
+      dropped: [],
+    });
+    expect(filterOffFamilyParts(undefined, TARGET_BRAKE, SLUG_MF)).toEqual({
+      kept: [],
+      dropped: [],
+    });
+    expect(filterOffFamilyParts([], TARGET_BRAKE, SLUG_MF)).toEqual({
+      kept: [],
+      dropped: [],
+    });
+  });
+
+  it('is idempotent (re-filtering kept output drops nothing)', () => {
+    const composition = ['plaquette-de-frein', 'alternateur'];
+    const once = filterOffFamilyParts(composition, TARGET_BRAKE, SLUG_MF);
+    const twice = filterOffFamilyParts(once.kept, TARGET_BRAKE, SLUG_MF);
+    expect(twice.dropped).toEqual([]);
+    expect(twice.kept).toEqual(once.kept);
+  });
+
+  it('unknown target family ⇒ keeps everything (no destructive false positive)', () => {
+    const composition = ['alternateur', 'plaquette-de-frein'];
+    const { kept, dropped } = filterOffFamilyParts(composition, null, SLUG_MF);
+    expect(dropped).toEqual([]);
+    expect(kept).toEqual(composition);
+  });
+});
+
+describe('r4-family-guard — detectOffFamilyArtifacts (guard flag)', () => {
+  it('flags off-family slugs across multiple arrays (composition + symptomes)', () => {
+    const composition = ['plaquette-de-frein', 'alternateur'];
+    const symptomes = ['poulie-d-alternateur', 'Pedale spongieuse']; // 1 off-family slug + 1 prose
+    const found = detectOffFamilyArtifacts(
+      [composition, symptomes],
+      TARGET_BRAKE,
+      SLUG_MF,
+    );
+    expect(found.sort()).toEqual(['alternateur', 'poulie-d-alternateur']);
+  });
+
+  it('returns [] when everything is same/unknown (clean page)', () => {
+    const composition = [
+      'plaquette-de-frein',
+      'etrier-de-frein',
+      'liquide-de-frein',
+    ];
+    expect(
+      detectOffFamilyArtifacts([composition], TARGET_BRAKE, SLUG_MF),
+    ).toEqual([]);
+  });
+
+  it('deduplicates a slug repeated across arrays', () => {
+    const found = detectOffFamilyArtifacts(
+      [['alternateur'], ['alternateur']],
+      TARGET_BRAKE,
+      SLUG_MF,
+    );
+    expect(found).toEqual(['alternateur']);
+  });
+});

--- a/backend/src/modules/seo/services/r4-family-guard.ts
+++ b/backend/src/modules/seo/services/r4-family-guard.ts
@@ -1,0 +1,102 @@
+/**
+ * R4 cross-family pollution guard — pure functions, zero NestJS/DB dependency.
+ *
+ * Problem (read-only audit 2026-06-03): R4 reference content
+ * (`__seo_reference.composition` / `symptomes_associes`) was polluted with bare-slug
+ * "related parts" belonging to OTHER product families (e.g. electrical slugs in a
+ * brake gamme), copied verbatim from an earlier RAG corpus. The legacy guard
+ * (`validateReferenceQuality`) only checked cross-ROLE procedure terms, never
+ * cross-FAMILY, so `contamination_flags` stayed empty on 239/239 rows.
+ *
+ * Authoritative family key = `mf_id` (catalog_family), resolved per gamme via
+ * `__seo_family_gamme_car_switch` (pg_id → mf_id). We compare `mf_id` directly — no
+ * fragile keyword/name matching, no denylist. A related-part bare-slug is OFF_FAMILY
+ * iff its resolved `mf_id` is KNOWN and differs from the target gamme's `mf_id`. Prose
+ * entries and unknown slugs are kept (conservative: never drop on uncertainty).
+ *
+ * Shared by:
+ *  - ReferenceService.refreshSingleGamme()  (write-time prevention: filter composition)
+ *  - ReferenceService.validateReferenceQuality() / auditAllReferences()  (detection flag)
+ */
+
+export type FamilyVerdict = 'SAME' | 'UNKNOWN' | 'OFF_FAMILY';
+
+/** A bare slug = kebab token: lowercase alnum + hyphens, no spaces/punctuation. */
+const BARE_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** True if `value` is a bare kebab-slug (a resolvable part reference, not prose). */
+export function isBareSlug(value: string): boolean {
+  return BARE_SLUG_RE.test(value.trim().toLowerCase());
+}
+
+/**
+ * Classify a single related-part entry against the target gamme's family.
+ *
+ * @param entry      related-part value (bare slug or prose phrase)
+ * @param targetMfId mf_id of the gamme owning the page (null = unknown → never OFF_FAMILY)
+ * @param slugToMfId resolved map: bare-slug → mf_id
+ *
+ * Conservative contract: only a bare-slug whose family is KNOWN *and* differs from the
+ * target is OFF_FAMILY. Prose, unresolved slugs, or unknown target family ⇒ UNKNOWN (kept).
+ */
+export function classifyPartFamily(
+  entry: string,
+  targetMfId: number | null,
+  slugToMfId: ReadonlyMap<string, number>,
+): FamilyVerdict {
+  const slug = entry.trim().toLowerCase();
+  if (!isBareSlug(slug)) return 'UNKNOWN'; // prose phrase → cannot resolve a family
+  const mf = slugToMfId.get(slug);
+  if (mf == null || targetMfId == null) return 'UNKNOWN';
+  return mf === targetMfId ? 'SAME' : 'OFF_FAMILY';
+}
+
+export interface FamilyFilterResult {
+  kept: string[];
+  dropped: string[];
+}
+
+/**
+ * Filter related-part entries: keep SAME + UNKNOWN, drop OFF_FAMILY.
+ * Returns `{ kept, dropped }` — the caller MUST log `dropped` (never a silent skip).
+ */
+export function filterOffFamilyParts(
+  parts: readonly string[] | null | undefined,
+  targetMfId: number | null,
+  slugToMfId: ReadonlyMap<string, number>,
+): FamilyFilterResult {
+  const kept: string[] = [];
+  const dropped: string[] = [];
+  for (const part of parts ?? []) {
+    if (classifyPartFamily(part, targetMfId, slugToMfId) === 'OFF_FAMILY') {
+      dropped.push(part);
+    } else {
+      kept.push(part);
+    }
+  }
+  return { kept, dropped };
+}
+
+/**
+ * Detect off-family bare-slug artifacts across any content arrays (audit/guard use).
+ * Returns the DISTINCT off-family slugs found (lowercased) — non-empty ⇒ flag R4_OFF_GAMME.
+ *
+ * Scope note: this catches the bare-slug pollution vector (e.g. `alternateur` in a brake
+ * gamme). Prose symptom blocks (free text, no slug) are NOT family-resolvable here and are
+ * covered by the cross-row audit sweep, not this per-row detector.
+ */
+export function detectOffFamilyArtifacts(
+  arrays: ReadonlyArray<readonly string[] | null | undefined>,
+  targetMfId: number | null,
+  slugToMfId: ReadonlyMap<string, number>,
+): string[] {
+  const found = new Set<string>();
+  for (const arr of arrays) {
+    for (const entry of arr ?? []) {
+      if (classifyPartFamily(entry, targetMfId, slugToMfId) === 'OFF_FAMILY') {
+        found.add(entry.trim().toLowerCase());
+      }
+    }
+  }
+  return [...found];
+}

--- a/backend/src/modules/seo/services/r4-family-guard.ts
+++ b/backend/src/modules/seo/services/r4-family-guard.ts
@@ -1,3 +1,7 @@
+// @role-purity-skip
+// Cross-cutting FAMILY guard: legitimately references both the R4 `composition` and
+// the `symptomes_associes` columns it protects — it is a guard, not R4 content. The
+// role-overlap rule targets role content comments, not protective utilities.
 /**
  * R4 cross-family pollution guard — pure functions, zero NestJS/DB dependency.
  *

--- a/backend/src/modules/seo/services/reference.service.ts
+++ b/backend/src/modules/seo/services/reference.service.ts
@@ -10,6 +10,11 @@ import * as path from 'path';
 import * as yaml from 'js-yaml';
 import { SITE_ORIGIN } from '../../../config/app.config';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
+import {
+  isBareSlug,
+  filterOffFamilyParts,
+  detectOffFamilyArtifacts,
+} from './r4-family-guard';
 
 // ── V4 Schema Types ──
 
@@ -533,10 +538,21 @@ export class ReferenceService extends SupabaseBaseService {
           : null;
 
     // v4: Build composition from related_parts
-    const composition =
+    const compositionRaw =
       v4Data && v4Data.domain.relatedParts.length > 0
         ? v4Data.domain.relatedParts
         : null;
+
+    // R4 cross-family guard (write-time prevention): drop related_parts that belong
+    // to ANOTHER product family (e.g. electrical slugs in a brake gamme). Family key =
+    // mf_id (catalog_family) via __seo_family_gamme_car_switch. Conservative: only a
+    // bare-slug whose family is KNOWN and differs from this gamme's is dropped; prose,
+    // unmapped slugs, or an unmapped target gamme are kept (UNKNOWN). Drops are logged.
+    const composition = await this.filterCompositionByFamily(
+      pgAlias,
+      gamme.id,
+      compositionRaw,
+    );
 
     if (existing) {
       // 5a. Update existing entry — refresh content but keep is_published
@@ -660,6 +676,112 @@ export class ReferenceService extends SupabaseBaseService {
       qualityScore: quality.score,
       qualityFlags: quality.flags,
     };
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // R4 cross-family guard helpers — pure logic lives in ./r4-family-guard.ts.
+  // Family key = mf_id (catalog_family) resolved via __seo_family_gamme_car_switch.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Memoized pg_id → mf_id (catalog family) map. ~104 gammes are mapped; the rest
+   * resolve to UNKNOWN and are therefore never dropped/flagged by the guard.
+   * Paginated read (sfgcs has ~3790 rows, up to 295/pg → a plain `.in()` would hit
+   * the supabase-js 1000-row cap), first mf_id per gamme wins.
+   */
+  private r4GammeFamilyMap: Map<string, number> | null = null;
+
+  private async getGammeFamilyMap(): Promise<Map<string, number>> {
+    if (this.r4GammeFamilyMap) return this.r4GammeFamilyMap;
+    const map = new Map<string, number>();
+    const PAGE = 1000;
+    for (let from = 0; from < 100_000; from += PAGE) {
+      const { data, error } = await this.supabase
+        .from('__seo_family_gamme_car_switch')
+        .select('sfgcs_pg_id, sfgcs_mf_id')
+        .range(from, from + PAGE - 1);
+      if (error || !data || data.length === 0) break;
+      for (const row of data as Array<{
+        sfgcs_pg_id: string | number;
+        sfgcs_mf_id: string | number;
+      }>) {
+        const pid = String(row.sfgcs_pg_id);
+        if (!map.has(pid)) map.set(pid, Number(row.sfgcs_mf_id));
+      }
+      if (data.length < PAGE) break;
+    }
+    this.r4GammeFamilyMap = map;
+    return map;
+  }
+
+  /**
+   * Resolve bare-slug → mf_id for the given entries (slug → pg_id via pieces_gamme,
+   * pg_id → mf_id via the family map). Non bare-slug / unmapped entries are absent.
+   */
+  private async resolveSlugFamilies(
+    entries: readonly string[],
+  ): Promise<Map<string, number>> {
+    const out = new Map<string, number>();
+    const bare = [
+      ...new Set(
+        entries.filter((s) => isBareSlug(s)).map((s) => s.trim().toLowerCase()),
+      ),
+    ];
+    if (bare.length === 0) return out;
+    const famMap = await this.getGammeFamilyMap();
+    const slugToPgId = new Map<string, string>();
+    for (let i = 0; i < bare.length; i += 200) {
+      const { data } = await this.supabase
+        .from('pieces_gamme')
+        .select('pg_id, pg_alias')
+        .in('pg_alias', bare.slice(i, i + 200));
+      for (const g of (data ?? []) as Array<{
+        pg_id: string | number;
+        pg_alias: string;
+      }>) {
+        slugToPgId.set(String(g.pg_alias).toLowerCase(), String(g.pg_id));
+      }
+    }
+    for (const [slug, pgId] of slugToPgId) {
+      const mf = famMap.get(pgId);
+      if (mf != null) out.set(slug, mf);
+    }
+    return out;
+  }
+
+  /**
+   * Drop related_parts that belong to another family (mf_id) before write.
+   * Returns the kept list (null if empty). Dropped items are logged — never silent.
+   * Fail-safe: on any resolution error the raw list is kept (content is never lost).
+   */
+  private async filterCompositionByFamily(
+    pgAlias: string,
+    targetPgId: number,
+    parts: string[] | null,
+  ): Promise<string[] | null> {
+    if (!parts || parts.length === 0) return parts;
+    try {
+      const famMap = await this.getGammeFamilyMap();
+      const targetMfId = famMap.get(String(targetPgId)) ?? null;
+      if (targetMfId == null) return parts; // unmapped gamme → cannot judge → keep
+      const slugToMfId = await this.resolveSlugFamilies(parts);
+      const { kept, dropped } = filterOffFamilyParts(
+        parts,
+        targetMfId,
+        slugToMfId,
+      );
+      if (dropped.length > 0) {
+        this.logger.warn(
+          `R4 family guard: dropped ${dropped.length} off-family related_parts from "${pgAlias}" (mf_id ${targetMfId}): ${dropped.join(', ')}`,
+        );
+      }
+      return kept.length > 0 ? kept : null;
+    } catch (e) {
+      this.logger.warn(
+        `R4 family guard skipped for "${pgAlias}" (resolution error, content kept): ${(e as Error).message}`,
+      );
+      return parts;
+    }
   }
 
   /**
@@ -1474,7 +1596,13 @@ export class ReferenceService extends SupabaseBaseService {
    * - MISSING_ROLE_NEGATIF, MISSING_REGLES_METIER, MISSING_SCOPE
    * - MISSING_ACCENTS, TITLE_FORMAT
    */
-  validateReferenceQuality(ref: SeoReference): ReferenceQualityResult {
+  validateReferenceQuality(
+    ref: SeoReference,
+    familyCtx?: {
+      targetMfId: number | null;
+      slugToMfId: ReadonlyMap<string, number>;
+    },
+  ): ReferenceQualityResult {
     const flags: string[] = [];
 
     // --- BLOQUANTS ---
@@ -1559,6 +1687,8 @@ export class ReferenceService extends SupabaseBaseService {
       ...(ref.composition || []),
       ...(ref.reglesMetier || []),
       ...(ref.confusionsCourantes || []),
+      ...(ref.symptomesAssocies || []),
+      ...(ref.takeaways || []),
     ]
       .filter(Boolean)
       .join(' ')
@@ -1566,6 +1696,26 @@ export class ReferenceService extends SupabaseBaseService {
 
     if (R4_FORBIDDEN.some((term) => allText.includes(term))) {
       flags.push('R4_CONTAMINATED');
+    }
+
+    // 9b. Cross-FAMILY contamination: related-part slugs that belong to another
+    // product family (e.g. electrical slugs in a brake reference). Family-aware via
+    // mf_id (catalog_family), no denylist. Only runs when a family context is supplied
+    // (auditAllReferences); skipped otherwise to keep backward-compatible callers pure.
+    if (familyCtx) {
+      const offFamily = detectOffFamilyArtifacts(
+        [
+          ref.composition,
+          ref.symptomesAssocies,
+          ref.confusionsCourantes,
+          ref.takeaways,
+        ],
+        familyCtx.targetMfId,
+        familyCtx.slugToMfId,
+      );
+      if (offFamily.length > 0) {
+        flags.push('R4_OFF_GAMME');
+      }
     }
 
     // 10. Règles métier = mots-clés au lieu de phrases
@@ -1594,6 +1744,7 @@ export class ReferenceService extends SupabaseBaseService {
       'NO_NUMBERS_IN_DEFINITION',
       'GENERIC_COMPOSITION',
       'R4_CONTAMINATED',
+      'R4_OFF_GAMME',
     ];
     const blockingCount = flags.filter((f) => blockingFlags.includes(f)).length;
     const warningCount = flags.filter((f) => !blockingFlags.includes(f)).length;
@@ -1612,8 +1763,32 @@ export class ReferenceService extends SupabaseBaseService {
    */
   async auditAllReferences(): Promise<ReferenceAuditResult> {
     const allRefs = await this.getAllFull();
+
+    // Pre-resolve the family context once for cross-family (R4_OFF_GAMME) detection:
+    // pg_id → mf_id map + bare-slug → mf_id for every slug appearing in any ref array.
+    const famMap = await this.getGammeFamilyMap();
+    const allSlugs = new Set<string>();
+    for (const ref of allRefs) {
+      for (const arr of [
+        ref.composition,
+        ref.symptomesAssocies,
+        ref.confusionsCourantes,
+        ref.takeaways,
+      ]) {
+        for (const v of arr ?? []) {
+          if (isBareSlug(v)) allSlugs.add(v.trim().toLowerCase());
+        }
+      }
+    }
+    const slugToMfId = await this.resolveSlugFamilies([...allSlugs]);
+
     const details: ReferenceAuditDetail[] = allRefs.map((ref) => {
-      const quality = this.validateReferenceQuality(ref);
+      const familyCtx = {
+        targetMfId:
+          ref.pgId != null ? (famMap.get(String(ref.pgId)) ?? null) : null,
+        slugToMfId,
+      };
+      const quality = this.validateReferenceQuality(ref, familyCtx);
       return {
         slug: ref.slug,
         title: ref.title,
@@ -1628,7 +1803,11 @@ export class ReferenceService extends SupabaseBaseService {
     const real = details.filter((d) => d.isPublishable).length;
 
     // Persist contamination flags in DB (Phase 5B)
-    const PERSIST_FLAGS = ['R4_CONTAMINATED', 'RULES_ARE_KEYWORDS'];
+    const PERSIST_FLAGS = [
+      'R4_CONTAMINATED',
+      'RULES_ARE_KEYWORDS',
+      'R4_OFF_GAMME',
+    ];
     for (const ref of allRefs) {
       const detail = details.find((d) => d.slug === ref.slug);
       if (!detail) continue;


### PR DESCRIPTION
## Problème (analyse read-only 2026-06-03, workflows internes)

Le contenu R4 « reference » (`__seo_reference.composition` / `symptomes_associes`) est pollué par des **slugs « pièces liées » d'AUTRES familles** (ex. slugs électriques `alternateur`/`batterie` dans une gamme freinage), copiés verbatim depuis un corpus RAG antérieur. Le garde-fou existant (`validateReferenceQuality`) ne testait que la contamination cross-**RÔLE** (termes procédure R3/R5), jamais cross-**FAMILLE** → `contamination_flags` **vide sur 239/239 lignes** alors que le balayage structurel read-only en détecte **≥44 sur 16 familles** (vecteur composition high-confidence = 23 lignes).

## Cause racine (high-confidence)

`ReferenceService.refreshSingleGamme` (`reference.service.ts:536-547`) écrit `composition ← domain.relatedParts` et `symptomes_associes ← diagnostic.symptoms` du frontmatter `.md` **sans aucun filtre de famille**. Les `.md` courants sont propres → la DB est figée depuis une version antérieure polluée (~2026-04-21, non traçable mais non-bloquant : le filtre au write boundary est correct quel que soit l'historique).

## Fix (structurel, en EXTENSION — aucun système parallèle)

- **`r4-family-guard.ts`** — classifieur de famille **pur** (zéro DB/NestJS), clé = **`mf_id` (catalog_family)**. **Conservateur** : un slug n'est `OFF_FAMILY` que si sa famille est **connue ET différente** de la gamme cible ; prose, slug non-mappé, ou gamme cible non-mappée ⇒ **`UNKNOWN` (gardé)**. **Aucune denylist.**
- **`refreshSingleGamme`** — filtre `composition` **au write boundary** (drops **loggés**, jamais silencieux ; **fail-safe** : sur erreur de résolution, le contenu brut est conservé — jamais de perte).
- **`validateReferenceQuality` / `auditAllReferences`** — le scan inclut désormais `symptomes_associes` + `takeaways` ; nouveau flag **family-aware `R4_OFF_GAMME`** (bloquant + persisté) → l'audit **voit enfin** la contamination.

Clé famille = `mf_id` via `__seo_family_gamme_car_switch` (chargement **paginé + dedup** → évite le cap supabase-js 1000 lignes ; 3790 lignes, max 295/pg). **15 tests unitaires** sur la logique pure (SAME accepté / UNKNOWN accepté / OFF-FAMILY refusé / symptômes bare-slug hors-famille flaggés / verdict par map pas denylist / pas de faux-positif sur famille inconnue).

## Périmètre (honnête)

- ✅ **Writer primaire** : `refreshSingleGamme` (chemin par défaut via `ExecutionRouter`).
- ⏳ **Fast-follow** : `seo-generator.buildR4FromRag` (endpoint admin, 2ᵉ writer) — réutilisera le **même helper pur** ; différé ici pour éviter un couplage DI cross-service dans cette PR.
- 🚫 **Aucune mutation DB de contenu** : nettoyer les ≥44 lignes existantes est une étape **séparée owner-gated (N3)**, à exécuter **APRÈS** ce garde-fou (sinon la source pourrait réécrire). Peupler `contamination_flags` via `auditAllReferences` = action admin owner-déclenchée.
- Couverture filtre : ~104/240 gammes sont mappées dans `sfgcs` → les gammes/slugs non mappés restent `UNKNOWN` (gardés, par design) ; ces cas sont couverts par le sweep audit + le cleanup N3.

## Vérifs locales (worktree)
- `tsc --noEmit` : **0 erreur**.
- ESLint (3 fichiers) : **propre**.
- `jest r4-family-guard.test.ts` : **15/15 PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)