### PR TITLE
feat(supplier-truth): collect into the canonical supplier_offer_snapshot (no parallel table)

### DIFF
--- a/backend/src/modules/supplier-truth/supplier-sync.job.processor.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.job.processor.ts
@@ -18,7 +18,7 @@ export class SupplierSyncJobProcessor {
   async handle(): Promise<RunSummary> {
     const summary = await this.runner.runSync();
     this.logger.log(
-      `supplier-sync done: ${summary.suppliersRun} run / ${summary.suppliersFailed} failed / ${summary.suppliersSkipped} skipped, ${summary.refs} refs, ${summary.projectionsUpserted} projections`,
+      `supplier-sync done: ${summary.suppliersRun} run / ${summary.suppliersFailed} failed / ${summary.suppliersSkipped} skipped, ${summary.refs} refs, ${summary.offersInserted} offers`,
     );
     return summary;
   }

--- a/backend/src/modules/supplier-truth/supplier-sync.processor.test.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.processor.test.ts
@@ -1,13 +1,15 @@
 import { SupplierSyncProcessor } from './supplier-sync.processor';
-import type { SupplierTruthRepository } from './supplier-truth.repository';
+import type {
+  SupplierTruthRepository,
+  OfferSnapshotInsert,
+} from './supplier-truth.repository';
 import type {
   SupplierConnector,
   SupplierObservation,
 } from './connectors/supplier-connector.interface';
-import { AvailabilityState } from './domain/availability-state';
 
 const obs = (o: Partial<SupplierObservation>): SupplierObservation => ({
-  supplierId: '26',
+  supplierId: '71',
   rawRef: 'ELH4261',
   available: true,
   delayDays: null,
@@ -15,12 +17,14 @@ const obs = (o: Partial<SupplierObservation>): SupplierObservation => ({
   freshnessProvenance: 'CONNECTOR_FETCHED',
   parseError: false,
   priceBuyHt: null,
+  priceBaseHt: null,
+  remisePct: null,
   ...o,
 });
 
 function mockConnector(observations: SupplierObservation[]): SupplierConnector {
   return {
-    supplierId: '26',
+    supplierId: '71',
     platform: 'inoshop',
     login: jest.fn(async () => {}),
     fetchAvailability: jest.fn(async () => observations),
@@ -28,44 +32,21 @@ function mockConnector(observations: SupplierObservation[]): SupplierConnector {
 }
 
 function mockRepo() {
-  const inserted: unknown[] = [];
-  const upserted: { piece_id: number; state: string }[] = [];
+  const offers: OfferSnapshotInsert[] = [];
   const repo = {
     resolveRefToPieceIds: jest.fn(async (n: string) =>
       n === 'ELH4261' ? [123] : [],
     ),
-    insertSnapshot: jest.fn(async (s: unknown) => {
-      inserted.push(s);
+    insertOffer: jest.fn(async (o: OfferSnapshotInsert) => {
+      offers.push(o);
     }),
-    readRecentSnapshots: jest.fn(async (pieceId: number) => [
-      {
-        id: 1,
-        supplier_id: '26',
-        piece_id: pieceId,
-        raw_ref: 'ELH4261',
-        normalized_ref: 'ELH4261',
-        available: true,
-        delay_days: null,
-        parse_error: false,
-        fetched_at: new Date().toISOString(),
-        source_verified_at: null,
-        freshness_provenance: 'CONNECTOR_FETCHED',
-      },
-    ]),
-    getSupplierProfile: jest.fn(async () => null), // cold start
-    getProjection: jest.fn(async () => null),
-    upsertProjection: jest.fn(
-      async (row: { piece_id: number; state: string }) => {
-        upserted.push({ piece_id: row.piece_id, state: row.state });
-      },
-    ),
   } as unknown as SupplierTruthRepository;
-  return { repo, inserted, upserted };
+  return { repo, offers };
 }
 
-describe('SupplierSyncProcessor.syncRefs', () => {
-  it('inserts a snapshot per observation, emits unresolved, upserts resolved projections', async () => {
-    const { repo, inserted, upserted } = mockRepo();
+describe('SupplierSyncProcessor.syncRefs (canonical supplier_offer_snapshot ingestion)', () => {
+  it('writes one offer per RESOLVED observation; emits + skips unresolved (piece_id_i is NOT NULL)', async () => {
+    const { repo, offers } = mockRepo();
     const events: { name: string; payload: unknown }[] = [];
     const proc = new SupplierSyncProcessor(repo, (name, payload) =>
       events.push({ name, payload }),
@@ -78,36 +59,55 @@ describe('SupplierSyncProcessor.syncRefs', () => {
     const res = await proc.syncRefs(connector, ['ELH4261', 'NOPE']);
 
     expect(res.observations).toBe(2);
-    expect(res.snapshotsInserted).toBe(2);
-    expect(inserted).toHaveLength(2);
+    expect(res.offersInserted).toBe(1); // only the resolved ref is written
     expect(res.unresolved).toBe(1);
+    expect(offers).toHaveLength(1);
+    expect(offers[0].piece_id_i).toBe(123);
     expect(events.some((e) => e.name === 'supplier.ref.unresolved')).toBe(true);
-    // only the resolved piece (123) gets a projection
-    expect(res.projectionsUpserted).toBe(1);
-    expect(upserted).toHaveLength(1);
-    expect(upserted[0].piece_id).toBe(123);
   });
 
-  it('cold-start supplier (no profile) never yields VERIFIED_AVAILABLE', async () => {
-    const { repo, upserted } = mockRepo();
+  it('captures the FULL price triplet in integer cents (no data loss)', async () => {
+    const { repo, offers } = mockRepo();
     const proc = new SupplierSyncProcessor(repo);
-    await proc.syncRefs(mockConnector([obs({ rawRef: 'ELH4261' })]), [
-      'ELH4261',
-    ]);
-    expect(upserted[0].state).not.toBe(AvailabilityState.VERIFIED_AVAILABLE);
-    expect(upserted[0].state).toBe(AvailabilityState.SUPPLIER_PENDING);
+
+    await proc.syncRefs(
+      mockConnector([
+        obs({
+          rawRef: 'ELH4261',
+          priceBaseHt: 320.3, // public HT €
+          remisePct: 50,
+          priceBuyHt: 160.15, // achat HT €
+          delayDays: 3,
+        }),
+      ]),
+      ['ELH4261'],
+    );
+
+    expect(offers).toHaveLength(1);
+    expect(offers[0]).toMatchObject({
+      supplier_id: '71',
+      supplier_ref: 'ELH4261',
+      public_ht_cents: 32030,
+      remise_pct: 50,
+      achat_ht_cents: 16015,
+      available: true,
+      delay_days: 3,
+      parse_confidence: 'HIGH_CONFIDENCE',
+    });
   });
 
-  it('a parse-error observation is still snapshotted (append-only) but stays safe', async () => {
-    const { repo, inserted } = mockRepo();
+  it('a parse-error observation is stored with parse_confidence UNKNOWN', async () => {
+    const { repo, offers } = mockRepo();
     const proc = new SupplierSyncProcessor(repo);
+
     const res = await proc.syncRefs(
       mockConnector([
         obs({ rawRef: 'ELH4261', parseError: true, available: false }),
       ]),
       ['ELH4261'],
     );
-    expect(inserted).toHaveLength(1);
-    expect(res.projectionsUpserted).toBe(1);
+
+    expect(res.offersInserted).toBe(1);
+    expect(offers[0].parse_confidence).toBe('UNKNOWN');
   });
 });

--- a/backend/src/modules/supplier-truth/supplier-sync.processor.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.processor.ts
@@ -1,31 +1,25 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
   SupplierTruthRepository,
-  type SnapshotInsert,
-  type ProjectionRow,
-  type SupplierProfileRow,
+  type OfferSnapshotInsert,
 } from './supplier-truth.repository';
 import { resolvePieceId, type RefIndexLookup } from './domain/ref-resolver';
-import {
-  projectTruth,
-  ConnectorState,
-  type SupplierObservationInput,
-  type SupplierProfileInput,
-  type PrevProjection,
-} from './domain/truth-engine';
-import { AvailabilityState } from './domain/availability-state';
 import type {
   SupplierConnector,
   SupplierObservation,
 } from './connectors/supplier-connector.interface';
 
 /**
- * Sync processor (Layers 1→2→3 orchestration).
+ * Supplier-offer ingestion processor.
  *
- * connector.fetchAvailability → resolve ref→piece_id → APPEND snapshot →
- * re-project per piece via the pure Truth Engine → upsert canonical projection.
- * Emits degradation/observability events. Pure orchestration with injected deps
- * (repository + event sink) so it is unit-testable without DB/HTTP.
+ * connector.fetchAvailability → resolve ref→piece_id → APPEND the observed price
+ * triplet + availability into the canonical `supplier_offer_snapshot` (pricing
+ * H2, append-only). The availability-CONSENSUS projection (truth-engine →
+ * supplier_truth_projection) is DEFERRED (H3, not wired): V1 margin checks read
+ * the raw observed prices directly, no consensus state needed.
+ *
+ * Pure orchestration with injected deps (repository + event sink) so it is
+ * unit-testable without DB/HTTP.
  */
 
 export type EventSink = (
@@ -37,9 +31,13 @@ export const noopSink: EventSink = () => {};
 
 export interface SyncResult {
   observations: number;
-  snapshotsInserted: number;
+  offersInserted: number;
+  /**
+   * Observations whose ref did not resolve to a piece_id.
+   * `supplier_offer_snapshot.piece_id_i` is NOT NULL, so these can't be stored —
+   * emitted as an observable event, then skipped (no silent drop).
+   */
   unresolved: number;
-  projectionsUpserted: number;
 }
 
 @Injectable()
@@ -51,173 +49,70 @@ export class SupplierSyncProcessor {
     private readonly emit: EventSink = noopSink,
   ) {}
 
-  /** Sync a bounded working-set of refs through one connector. */
+  /** Ingest a bounded working-set of refs from one connector into supplier_offer_snapshot. */
   async syncRefs(
     connector: SupplierConnector,
     refs: string[],
-    now: Date = new Date(),
   ): Promise<SyncResult> {
     const observations = await connector.fetchAvailability(refs);
     const lookup: RefIndexLookup = (n) => this.repo.resolveRefToPieceIds(n);
 
-    const resolvedPieceIds = new Set<number>();
-    let snapshotsInserted = 0;
+    let offersInserted = 0;
     let unresolved = 0;
 
     for (const obs of observations) {
-      const { pieceId, reason, normalizedRef } = await resolvePieceId(
-        obs.rawRef,
-        lookup,
-      );
-      await this.repo.insertSnapshot(
-        toSnapshotInsert(obs, pieceId, normalizedRef),
-      );
-      snapshotsInserted++;
+      const { pieceId, reason } = await resolvePieceId(obs.rawRef, lookup);
       if (pieceId == null) {
+        // No silent drop: the canonical row requires a non-null piece_id_i, so an
+        // unresolved ref is surfaced as an observable event, then skipped.
         unresolved++;
         this.emit('supplier.ref.unresolved', {
           supplierId: obs.supplierId,
           rawRef: obs.rawRef,
           reason,
         });
-      } else {
-        resolvedPieceIds.add(pieceId);
+        continue;
       }
+      await this.repo.insertOffer(toOfferInsert(obs, pieceId));
+      offersInserted++;
     }
 
-    let projectionsUpserted = 0;
-    for (const pieceId of resolvedPieceIds) {
-      await this.reproject(pieceId, now);
-      projectionsUpserted++;
+    if (unresolved > 0) {
+      this.logger.warn(
+        `${observations.length} obs, ${offersInserted} offers written, ${unresolved} unresolved (skipped)`,
+      );
     }
 
     return {
       observations: observations.length,
-      snapshotsInserted,
+      offersInserted,
       unresolved,
-      projectionsUpserted,
     };
-  }
-
-  /** Recompute and persist the canonical projection for one piece. */
-  private async reproject(pieceId: number, now: Date): Promise<void> {
-    const snaps = await this.repo.readRecentSnapshots(pieceId);
-    const supplierIds = [...new Set(snaps.map((s) => s.supplier_id))];
-    const profiles = await Promise.all(
-      supplierIds.map((id) => this.repo.getSupplierProfile(id)),
-    );
-    const profileInputs = profiles
-      .map((p, i) => (p ? toProfileInput(p) : coldStartProfile(supplierIds[i])))
-      .filter(Boolean) as SupplierProfileInput[];
-
-    const obsInputs: SupplierObservationInput[] = snaps.map((s) => ({
-      supplierId: s.supplier_id,
-      available: s.available,
-      delayDays: s.delay_days,
-      parseError: s.parse_error,
-      fetchedAt: new Date(s.fetched_at),
-      sourceVerifiedAt: s.source_verified_at
-        ? new Date(s.source_verified_at)
-        : null,
-    }));
-
-    const prev = await this.repo.getProjection(pieceId);
-    const prevProjection: PrevProjection | null = prev
-      ? {
-          state: prev.state as AvailabilityState,
-          stateCounter: prev.state_counter,
-        }
-      : null;
-
-    const row = projectTruth(obsInputs, profileInputs, prevProjection, now);
-
-    const wasVerified = prev?.state === AvailabilityState.VERIFIED_AVAILABLE;
-    await this.repo.upsertProjection(toProjectionRow(pieceId, row, prev));
-
-    if (
-      row.state === AvailabilityState.HARD_CONFLICT ||
-      (wasVerified && row.state !== AvailabilityState.VERIFIED_AVAILABLE)
-    ) {
-      this.emit('supplier.truth.degraded', {
-        pieceId,
-        from: prev?.state ?? null,
-        to: row.state,
-        reason: row.projectionReasonCode,
-      });
-    }
   }
 }
 
-// ---- mappers (connector/db ↔ domain) ----
+// ---- mappers (connector observation → canonical offer row) ----
 
-function toSnapshotInsert(
+/** Euros → integer cents (no float drift); null stays null. */
+const eurosToCents = (v: number | null | undefined): number | null =>
+  v == null ? null : Math.round(v * 100);
+
+function toOfferInsert(
   obs: SupplierObservation,
-  pieceId: number | null,
-  normalizedRef: string,
-): SnapshotInsert {
+  pieceId: number,
+): OfferSnapshotInsert {
   return {
+    piece_id_i: pieceId,
     supplier_id: obs.supplierId,
-    piece_id: pieceId,
-    raw_ref: obs.rawRef,
-    normalized_ref: normalizedRef,
+    supplier_ref: obs.rawRef,
+    public_ht_cents: eurosToCents(obs.priceBaseHt),
+    remise_pct: obs.remisePct ?? null,
+    achat_ht_cents: eurosToCents(obs.priceBuyHt),
     available: obs.available,
     delay_days: obs.delayDays,
-    parse_error: obs.parseError,
+    parse_confidence: obs.parseError ? 'UNKNOWN' : 'HIGH_CONFIDENCE',
     source_verified_at: obs.sourceVerifiedAt
       ? obs.sourceVerifiedAt.toISOString()
       : null,
-    freshness_provenance: obs.freshnessProvenance,
-    price_buy_ht: obs.priceBuyHt ?? null,
-  };
-}
-
-function toProfileInput(p: SupplierProfileRow): SupplierProfileInput {
-  const reliability = p.reliability_score;
-  return {
-    supplierId: p.supplier_id,
-    reliabilityScore: reliability,
-    supplierStability: reliability != null ? reliability / 100 : 0,
-    mismatchRate: p.mismatch_rate,
-    timeoutRate: p.timeout_rate,
-    defaultTtlMinutes: p.default_ttl_minutes,
-    connectorState: p.connector_state as ConnectorState,
-  };
-}
-
-function coldStartProfile(supplierId: string): SupplierProfileInput {
-  return {
-    supplierId,
-    reliabilityScore: null, // cold start → never VERIFIED on zero history
-    supplierStability: 0,
-    mismatchRate: 0.5,
-    timeoutRate: 0,
-    defaultTtlMinutes: null,
-    connectorState: ConnectorState.ACTIVE,
-  };
-}
-
-function toProjectionRow(
-  pieceId: number,
-  row: ReturnType<typeof projectTruth>,
-  prev: ProjectionRow | null,
-): ProjectionRow {
-  const stateChanged = prev?.state !== row.state;
-  return {
-    piece_id: pieceId,
-    state: row.state,
-    confidence: row.confidence,
-    delay_days: row.delayDays,
-    source_supplier: row.sourceSupplierId,
-    conflict_kind: row.conflictKind,
-    state_since:
-      stateChanged || !prev?.state_since
-        ? new Date().toISOString()
-        : prev.state_since,
-    state_counter: row.stateCounter,
-    projected_at: new Date().toISOString(),
-    projection_reason_code: row.projectionReasonCode,
-    projection_metadata: { sourceSupplier: row.sourceSupplierId },
-    projection_inputs_hash: row.projectionInputsHash,
-    projection_version: 1,
   };
 }

--- a/backend/src/modules/supplier-truth/supplier-sync.runner.test.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.runner.test.ts
@@ -48,9 +48,8 @@ const processor = () =>
   ({
     syncRefs: jest.fn(async () => ({
       observations: 1,
-      snapshotsInserted: 1,
+      offersInserted: 1,
       unresolved: 0,
-      projectionsUpserted: 1,
     })),
   }) as unknown as SupplierSyncProcessor;
 
@@ -68,15 +67,14 @@ describe('SupplierSyncRunner.runSync', () => {
     const summary = await runner.runSync();
 
     expect(connector.login).toHaveBeenCalledWith({ user: 'u', password: 'p' });
-    expect(proc.syncRefs).toHaveBeenCalledWith(
-      connector,
-      ['ELH4261', 'SCL4123'],
-      expect.any(Date),
-    );
+    expect(proc.syncRefs).toHaveBeenCalledWith(connector, [
+      'ELH4261',
+      'SCL4123',
+    ]);
     expect(connector.close).toHaveBeenCalled(); // resources released
     expect(summary.suppliersRun).toBe(1);
     expect(summary.refs).toBe(2);
-    expect(summary.projectionsUpserted).toBe(1);
+    expect(summary.offersInserted).toBe(1);
   });
 
   it('skips a supplier with no credentials (never logs in)', async () => {
@@ -163,10 +161,6 @@ describe('SupplierSyncRunner.runSync', () => {
     await runner.runSync();
 
     // Only the first 2 carried refs hit the portal this run; R3-R5 wait for TTL refresh.
-    expect(proc.syncRefs).toHaveBeenCalledWith(
-      connector,
-      ['R1', 'R2'],
-      expect.any(Date),
-    );
+    expect(proc.syncRefs).toHaveBeenCalledWith(connector, ['R1', 'R2']);
   });
 });

--- a/backend/src/modules/supplier-truth/supplier-sync.runner.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.runner.ts
@@ -77,7 +77,8 @@ export interface RunSummary {
   /** Benign skip: no credentials configured, or none of the working-set brands carried. */
   suppliersSkipped: number;
   refs: number;
-  projectionsUpserted: number;
+  /** Rows appended to the canonical `supplier_offer_snapshot` this run. */
+  offersInserted: number;
 }
 
 @Injectable()
@@ -93,7 +94,7 @@ export class SupplierSyncRunner {
     private readonly maxRefsPerRun: number = envMaxRefsPerRun(),
   ) {}
 
-  async runSync(now: Date = new Date()): Promise<RunSummary> {
+  async runSync(): Promise<RunSummary> {
     const runId = randomUUID();
     const workingSet = await this.repo.getWorkingSet();
     const summary: RunSummary = {
@@ -101,7 +102,7 @@ export class SupplierSyncRunner {
       suppliersFailed: 0,
       suppliersSkipped: 0,
       refs: workingSet.length,
-      projectionsUpserted: 0,
+      offersInserted: 0,
     };
     if (workingSet.length === 0) return summary;
 
@@ -146,11 +147,11 @@ export class SupplierSyncRunner {
       const connector = this.connectorFactory(cfg);
       try {
         await connector.login(creds);
-        const res = await this.processor.syncRefs(connector, refs, now);
-        summary.projectionsUpserted += res.projectionsUpserted;
+        const res = await this.processor.syncRefs(connector, refs);
+        summary.offersInserted += res.offersInserted;
         summary.suppliersRun++;
         this.logger.log(
-          `synced ${cfg.supplierName}: ${res.snapshotsInserted} snapshots, ${res.projectionsUpserted} projections`,
+          `synced ${cfg.supplierName}: ${res.offersInserted} offers, ${res.unresolved} unresolved`,
         );
       } catch (e) {
         const message = (e as Error).message;

--- a/backend/src/modules/supplier-truth/supplier-sync.scheduler.test.ts
+++ b/backend/src/modules/supplier-truth/supplier-sync.scheduler.test.ts
@@ -91,11 +91,11 @@ describe('SupplierSyncJobProcessor', () => {
         suppliersFailed: 0,
         suppliersSkipped: 0,
         refs: 2,
-        projectionsUpserted: 2,
+        offersInserted: 2,
       })),
     } as unknown as SupplierSyncRunner;
     const summary = await new SupplierSyncJobProcessor(runner).handle();
     expect(runner.runSync).toHaveBeenCalled();
-    expect(summary.projectionsUpserted).toBe(2);
+    expect(summary.offersInserted).toBe(2);
   });
 });

--- a/backend/src/modules/supplier-truth/supplier-truth.repository.ts
+++ b/backend/src/modules/supplier-truth/supplier-truth.repository.ts
@@ -13,6 +13,13 @@ import { SupabaseBaseService } from '../../database/services/supabase-base.servi
 const T_SNAPSHOTS = 'supplier_inventory_snapshots';
 const T_PROJECTION = 'supplier_truth_projection';
 const T_PROFILE = 'supplier_runtime_profile';
+/**
+ * Canonical per-supplier price+availability observation timeline (pricing H2,
+ * 20260523 migration). Append-only (DB anti-mutation trigger), partitioned
+ * monthly by observed_at. This is the SoT observation store the live-portal
+ * connectors write to — NOT the (unapplied, parallel) supplier_inventory_snapshots.
+ */
+const T_OFFERS = 'supplier_offer_snapshot';
 
 export interface SnapshotInsert {
   supplier_id: string;
@@ -31,6 +38,29 @@ export interface SnapshotInsert {
 export interface SnapshotRow extends SnapshotInsert {
   id: number;
   fetched_at: string;
+}
+
+/**
+ * One row of `supplier_offer_snapshot` (canonical observation). All prices in
+ * integer cents (no float drift); `piece_id_i` is NOT NULL at the DB, so only
+ * RESOLVED observations are written. `offer_id` + `observed_at` are DB defaults.
+ */
+export interface OfferSnapshotInsert {
+  piece_id_i: number;
+  supplier_id: string;
+  supplier_ref: string;
+  public_ht_cents: number | null;
+  remise_pct: number | null;
+  achat_ht_cents: number | null;
+  available: boolean;
+  delay_days: number | null;
+  parse_confidence:
+    | 'HIGH_CONFIDENCE'
+    | 'AMBIGUOUS_MAPPING'
+    | 'FALLBACK_MATCH'
+    | 'EAN_FALLBACK'
+    | 'UNKNOWN';
+  source_verified_at: string | null;
 }
 
 export interface ProjectionRow {
@@ -74,7 +104,23 @@ export class SupplierTruthRepository extends SupabaseBaseService {
     super(configService);
   }
 
-  /** APPEND-ONLY. The only write into the snapshot log. */
+  /**
+   * APPEND-ONLY write into the canonical supplier-offer observation timeline
+   * (`supplier_offer_snapshot`). This is the live-portal collection target.
+   */
+  async insertOffer(offer: OfferSnapshotInsert): Promise<void> {
+    const { error } = await this.supabase.from(T_OFFERS).insert(offer);
+    if (error) {
+      throw new Error(`insertOffer failed: ${error.message}`);
+    }
+  }
+
+  /**
+   * APPEND-ONLY. Write into the (deferred-H3) availability-consensus snapshot log
+   * `supplier_inventory_snapshots`. NOT wired into the live collection path — that
+   * writes `supplier_offer_snapshot` via `insertOffer`. Kept for the future
+   * availability-consensus layer (truth-engine); its table is not yet applied.
+   */
   async insertSnapshot(snapshot: SnapshotInsert): Promise<void> {
     const { error } = await this.supabase.from(T_SNAPSHOTS).insert(snapshot);
     if (error) {


### PR DESCRIPTION
## Redirect supplier collection to the canonical store (kill the parallel system)

**Architecture fix found while preparing the CAL/DCA collection.** The supplier-truth pipeline (#831/#833/#834) writes to `supplier_inventory_snapshots` — a table whose migration (`20260520_supplier_truth_v1.sql`) was **never applied** and which **duplicates** the pricing module's canonical observatory `supplier_offer_snapshot` (created 2026-05-23, exists, empty). Writing there would have created a parallel supplier data model — the #1 forbidden pattern — and the prices would have landed where pricing can't use them.

This PR redirects the live-portal collection to write the **canonical** `supplier_offer_snapshot` instead.

### Why supplier_offer_snapshot is canonical
- Per-supplier price+availability **observation timeline**, append-only (DB anti-mutation trigger), partitioned monthly (migration `20260523_…:145-179`, comment: *"H2 — Per-supplier observation timeline… observatory"*).
- Has the **full price** schema: `public_ht_cents` + `remise_pct` + `achat_ht_cents` + `available` + `delay_days`.
- **Observation-only** (`lecture-zero-V1`): pricing margins read `pieces_price`, never this — so writing it has **zero client-price impact** (exactly the owner's "observation only, no client price change").
- Verified: **no code writes it** today (unused scaffold); `supplier_inventory_snapshots` migration is unapplied.

### What changed
- `supplier-truth.repository.ts`: `+ OfferSnapshotInsert` + `insertOffer()` → `supplier_offer_snapshot`.
- `supplier-sync.processor.ts`: ingests observations → `supplier_offer_snapshot`. **Fixes a data-loss bug** — the connectors fetch the full triplet (priceBase + remise + achat) but the old mapper persisted only achat; now all three are captured in integer cents. Unresolved refs (`piece_id_i` is NOT NULL) are emitted as an observable event + skipped (no silent drop). The availability-**consensus** projection (truth-engine → `supplier_truth_projection`) is **DEFERRED to H3** — not wired; V1 margin checks read raw observed prices.
- `supplier-sync.runner.ts`: `RunSummary.offersInserted` (was `projectionsUpserted`).
- tests rewritten for offer ingestion (full-triplet cents capture, parse_confidence, unresolved skip).

**No new migration** (`supplier_offer_snapshot` already exists). **`supplier_truth_v1.sql` stays unapplied** (no parallel tables). The truth-engine domain library + its tests are untouched (preserved for the H3 consensus layer).

### Phase B (next) margin verification data flow
`supplier_offer_snapshot.achat_ht_cents` (observed) vs `pieces_price.pri_achat_ht_n` (current cost) + `pricing_rules.margin_rate` → recompute `vente_HT` via `pricing-formula.service` → **KEEP / MODIFY / BLOCK / REVIEW**. No client-price write.

### Known follow-up (not in this PR)
The #831 read endpoint (`/api/admin/supplier-truth/projection/:pieceId`) still reads `supplier_truth_projection` (now unwritten) → returns `UNKNOWN`. Repointing it to the offer timeline is deferred with the H3 consensus layer. The endpoint is dormant/admin-only.

### Gates (local, green)
188 supplier-truth tests · prettier · eslint · `tsc --build` exit 0.

## Improvement Check
- **Problem:** the supplier pipeline wrote a parallel, unapplied table + discarded 2/3 of the fetched price data.
- **Evidence before:** `supplier_inventory_snapshots` not in DB (42P01); `toSnapshotInsert` kept only `price_buy_ht`; `supplier_offer_snapshot` empty + unwritten.
- **Expected gain:** supplier prices land in the canonical, margin-usable observatory with the full triplet; no parallel system.
- **Risk:** none live — observation-only table, no client price, no scheduler armed (#831 inert), no migration. Rollback = revert.
- **Test:** offer ingestion suite + full local gates.
- **Verdict:** GO — corrects the data model before any collection.
- **Next action:** owner review; then run the bounded CAL/DCA collection (still owner-gated via `SUPPLIER_SYNC_ONESHOT_CONFIRM`) into supplier_offer_snapshot, then Phase B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)