### PR TITLE
fix(seo): guard R4 secondary writer (seo-generator) against cross-family pollution

### DIFF
--- a/backend/src/modules/seo/services/r4-family-guard.test.ts
+++ b/backend/src/modules/seo/services/r4-family-guard.test.ts
@@ -179,3 +179,45 @@ describe('r4-family-guard — detectOffFamilyArtifacts (guard flag)', () => {
     expect(found).toEqual(['alternateur']);
   });
 });
+
+describe('r4-family-guard — anti-reintroduction (shared by both R4 writers)', () => {
+  // Both ReferenceService.refreshSingleGamme (primary) and SeoGeneratorService.buildR4FromRag
+  // (secondary) route frontmatter.composition through filterOffFamilyParts before persisting.
+  // This is the single point preventing re-introduction of the cross-family pollution.
+  it('drops the off-family bare-slug tail from a frontmatter-style composition, keeps prose + same-family', () => {
+    const frontmatterComposition = [
+      'Disque de frein (plateau en fonte GG25)', // prose → kept
+      'Plaquettes de frein (garnitures sacrificielles)', // prose → kept
+      'etrier-de-frein', // SAME family slug → kept
+      'alternateur', // OFF-FAMILY → dropped
+      'batterie', // OFF-FAMILY → dropped
+      'poulie-d-alternateur', // OFF-FAMILY → dropped
+    ];
+    const { kept, dropped } = filterOffFamilyParts(
+      frontmatterComposition,
+      TARGET_BRAKE,
+      SLUG_MF,
+    );
+    expect(dropped).toEqual([
+      'alternateur',
+      'batterie',
+      'poulie-d-alternateur',
+    ]);
+    expect(kept).toEqual([
+      'Disque de frein (plateau en fonte GG25)',
+      'Plaquettes de frein (garnitures sacrificielles)',
+      'etrier-de-frein',
+    ]);
+  });
+
+  it('a clean frontmatter composition passes through unchanged (no false drop)', () => {
+    const clean = ['disque-de-frein', 'plaquette-de-frein', 'etrier-de-frein'];
+    const { kept, dropped } = filterOffFamilyParts(
+      clean,
+      TARGET_BRAKE,
+      SLUG_MF,
+    );
+    expect(dropped).toEqual([]);
+    expect(kept).toEqual(clean);
+  });
+});

--- a/backend/src/modules/seo/services/reference.service.ts
+++ b/backend/src/modules/seo/services/reference.service.ts
@@ -753,8 +753,10 @@ export class ReferenceService extends SupabaseBaseService {
    * Drop related_parts that belong to another family (mf_id) before write.
    * Returns the kept list (null if empty). Dropped items are logged — never silent.
    * Fail-safe: on any resolution error the raw list is kept (content is never lost).
+   * Public: reused as-is by SeoGeneratorService.buildR4FromRag (2nd R4 writer) — same filter,
+   * no duplicated resolution logic, no behaviour change to this primary writer.
    */
-  private async filterCompositionByFamily(
+  async filterCompositionByFamily(
     pgAlias: string,
     targetPgId: number,
     parts: string[] | null,

--- a/backend/src/modules/seo/services/seo-generator.service.ts
+++ b/backend/src/modules/seo/services/seo-generator.service.ts
@@ -19,6 +19,8 @@ import {
 
 // Import du service AI Content pour enrichissement LLM
 import { AiContentService } from '../../ai-content/ai-content.service';
+// R4 cross-family guard: reuse the primary writer's family filter (no duplicated logic)
+import { ReferenceService } from './reference.service';
 
 // Import des templates SEO
 import {
@@ -130,6 +132,7 @@ export class SeoGeneratorService {
 
   constructor(
     private readonly configService: ConfigService,
+    private readonly referenceService: ReferenceService,
     @Optional() private readonly qualityValidator?: QualityValidatorService,
     @Optional() private readonly aiContentService?: AiContentService,
   ) {
@@ -480,6 +483,15 @@ Retourne UNIQUEMENT le texte reformulé, sans commentaires.`;
     const url = `${SITE_ORIGIN}/reference-auto/${slug}`;
     const schemaOrg = buildR4SchemaOrg(templated.title, definition, url);
 
+    // R4 cross-family guard (parity with the primary writer ReferenceService.refreshSingleGamme):
+    // drop related_parts belonging to another product family before persisting. Reuses the exact
+    // same merged, mf_id-based filter — no duplicated logic, no behaviour change to the primary writer.
+    const composition = await this.referenceService.filterCompositionByFamily(
+      slug,
+      pgId,
+      frontmatter.composition || null,
+    );
+
     return {
       slug,
       title: templated.title,
@@ -487,7 +499,7 @@ Retourne UNIQUEMENT le texte reformulé, sans commentaires.`;
       definition,
       role_mecanique: roleMecanique,
       role_negatif: roleNegatif,
-      composition: frontmatter.composition || null,
+      composition,
       confusions_courantes: frontmatter.confusions_courantes || null,
       symptomes_associes: symptomesAssocies,
       regles_metier: mechanicalRules.must_be_true || null,

--- a/backend/src/modules/seo/services/seo-generator.service.ts
+++ b/backend/src/modules/seo/services/seo-generator.service.ts
@@ -115,6 +115,9 @@ export interface GenerateResult {
   validation?: ValidationResult;
 }
 
+// @role-purity-skip
+// Multi-role generator: produces R4 Reference AND R5 Diagnostics (saveR4Draft / saveR5Draft);
+// its docstring legitimately names both roles. Not single-role content.
 /**
  * Service pour générer du contenu SEO depuis les fichiers RAG
  *


### PR DESCRIPTION
## Fast-follow à #836 — fermer le 2ᵉ chemin de réintroduction

#836 a guardé le **writer primaire** R4 (`ReferenceService.refreshSingleGamme`). Mais `SeoGeneratorService.buildR4FromRag` (endpoint admin `seo-generator.controller.ts:187` → `saveR4Draft`) est un **2ᵉ writer vivant** qui persiste aussi `composition` depuis `frontmatter.related_parts` — **sans filtre famille**. Tant qu'il n'est pas guardé, il reste un chemin possible de **réintroduction** de la pollution cross-family nettoyée en DB.

## Fix (meilleure approche : zéro duplication, primary writer inchangé)

- **Injection** de `ReferenceService` dans `SeoGeneratorService` ; `buildR4FromRag` route `composition` à travers **le même** filtre mf_id (`filterCompositionByFamily`, rendue **`public`**).
- **Zéro logique dupliquée** : on réutilise la résolution famille (`__seo_family_gamme_car_switch` → `mf_id`) + le helper pur déjà mergés et testés en prod.
- **Writer primaire inchangé** : le seul diff sur `reference.service.ts` = `private`→`public` sur une méthode (visibilité). `refreshSingleGamme` se comporte **exactement** comme avant.

## Garanties (scope owner respecté)

- **Conservateur** : seuls les bare-slugs de famille **connue ET différente** sont retirés ; prose, slug non-mappé, gamme cible non-mappée ⇒ **gardés** (UNKNOWN).
- **Ne touche PAS** : `symptomes_associes`, `is_published`, URLs, ni aucune **donnée existante** (ce PR ne modifie que le flux de génération futur).
- **Ne nettoie PAS l'UNKNOWN** (ex. `batterie` non mappé) — résidu owner-gated séparé.
- **Fail-safe** hérité : sur erreur de résolution, le contenu brut est conservé (jamais de perte), drops loggés.

## Tests anti-réintroduction
2 nouveaux tests sur le filtre pur partagé par les 2 writers (drop du tail off-family d'une `composition` frontmatter-style, prose+same-family conservés ; composition propre inchangée). **17/17 verts.**

## Vérifs locales
`tsc --noEmit` 0 erreur · ESLint propre · jest 17/17 · role-purity ✓ (skip gouverné sur le générateur multi-rôles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)