### PR TITLE
feat(cwv): pg_cron for RUM aggregation — decouple from dead DEV worker

### DIFF
--- a/audit/web-vitals-attribution-ingestion-phase0-diagnostic-2026-06-03.md
+++ b/audit/web-vitals-attribution-ingestion-phase0-diagnostic-2026-06-03.md
@@ -1,0 +1,118 @@
+# Web-Vitals Attribution Ingestion — Phase 0 Diagnostic (READ-ONLY)
+
+**Date :** 2026-06-03
+**TOP priority :** `web-vitals-attribution-ingestion`
+**Incident bordé :** `web-vitals-attribution-unstable` (actif)
+**Mode :** lecture seule. Supabase MCP read-only (projet `cxpojprgwgubzjyqzmoq`), grep code, registry. **Zéro mutation** : aucune table, aucun backfill, aucun flag, aucun cron, aucun DEV relancé.
+**Doctrine :** Phase 0 empirique avant tout plan (`feedback_empirical_phase_0_first`) · CWV stack existe déjà, ne pas reconstruire (`feedback_cwv_rum_stack_already_exists`) · vérifier l'existant (`feedback_verify_existing_first`).
+
+---
+
+## Verdict global
+
+**`DIAGNOSTIC_READY` — la priorité est très majoritairement DÉJÀ LIVRÉE, pas un chantier neuf.** Le pipeline d'ingestion + attribution existe, est gouverné, et **collecte en live**. Mais une **dérive runtime active** (l'incident) provoque une **perte de données imminente** : l'agrégation `raw → hourly → daily_rum` est arrêtée depuis ~2 jours alors que le raw (TTL ~48h) continue d'affluer.
+
+- **NE PAS** construire d'ingestion/beacon/table : tout existe (RCOP 6 blocs mergés 05-24→05-29, #803/#811 résiduels mergés 06-01).
+- **Cause racine architecturale** : l'agrégation tourne dans un **worker BullMQ piloté par un flag DEV-only** (`SEO_CWV_AGGREGATION_ENABLED=true` seulement dans `backend/.env`), sur une **machine DEV actuellement hung**. Une chaîne de données PROD dépend du poste DEV = anti-pattern `deployment.md`. → fix robuste = **pg_cron** appelant les RPC `aggregate_cwv_*` existantes (découplé de l'app), pas un replay manuel.
+- **1 garde anti-perte (#811) mergée mais NON appliquée** au live (drift axe #4 deployment.md) → le filet qui aurait dû alerter est lui-même absent.
+- **Fenêtre de perte ouverte** : 2 022 échantillons humains (48 h) à sauver par replay avant purge TTL — stopgap, pas le fix.
+
+---
+
+## État de la chaîne (vérité live, mesurée)
+
+Topologie (canon mémoire) : `sendBeacon /api/seo/cwv/beacon → __seo_cwv_raw` (jour, TTL ~48h, human-only) `→ aggregate_cwv_hourly() → __seo_cwv_hourly` (TTL 14j) `→ aggregate_cwv_daily_rum() → __seo_cwv_daily_rum` (SoT field).
+
+| Tier | rows | newest | oldest | Lecture |
+|---|---|---|---|---|
+| `__seo_cwv_raw` (human) | 2 570 | **2026-06-03 16:14** (frais) | 2026-06-01 00:34 | ✅ collecte vivante |
+| `__seo_cwv_hourly` | 871 | **2026-06-01 13:00** | 2026-05-30 00:00 | ⛔ **figé ~2 j** |
+| `__seo_cwv_daily_rum` | 118 | **2026-06-01** | 2026-05-30 | ⛔ **figé ~2 j** |
+
+> Le beacon (ingestion) **marche** : raw frais à l'heure du probe. L'**agrégation** est l'étage cassé — exactement le symptôme `web-vitals-attribution-unstable`.
+
+**Attribution (dimension éponyme) — saine côté collecte**, sur raw < 24 h (1 022 lignes) :
+- `funnel_step` renseigné : **1022/1022** (100 %)
+- `attribution` jsonb peuplé : **478/1022** (~47 % — normal : web-vitals n'attache l'attribution que sur une partie des métriques/navigations)
+- surfaces distinctes : 4 · échantillons **R2 `/pieces`** : **631** · échantillons **INP** : 75
+- → la donnée d'attribution arrive bien ; elle est juste **bloquée à l'étage agrégation** avant d'atteindre le SoT field.
+
+---
+
+## Findings
+
+### Finding 1 — `critical` · agrégation figée + perte de données imminente (= l'incident)
+
+**Mesuré :** 48 heures de raw humain présentes mais **jamais agrégées** dans `__seo_cwv_hourly`.
+
+| Métrique | Valeur |
+|---|---|
+| heures manquantes | **48** |
+| échantillons humains non agrégés | **2 022** |
+| plus ancienne heure manquante | 2026-06-01 14:00 UTC |
+| plus récente heure manquante | 2026-06-03 13:00 UTC |
+
+**Fenêtre de perte :** le raw a un TTL ~48 h. Les échantillons du 06-01 14:00 seront **purgés vers le 06-03 ~14:00+** sans avoir été agrégés → **perte définitive**. Le backfill n'est possible que **tant que le raw n'est pas purgé** (les RPC `aggregate_cwv_*` lisent le raw).
+
+**Cause racine — ARCHITECTURALE, pas une valeur de flag (chaîne de preuve) :**
+1. L'agrégation est un **job répétable BullMQ** enregistré dans le **process worker** (`CwvAggregationSchedulerService` dans `backend/src/workers/worker.module.ts:135`, boot via `backend/src/workers/main.ts`), `onModuleInit` gardé par `isEnabled()`.
+2. `SEO_CWV_AGGREGATION_ENABLED=true` existe **uniquement dans `backend/.env:287` (DEV)**. `.env.example:223=false`, `preprod.schema.ts:61` optional/default-false (#803). → **PROD/PREPROD n'agrègent jamais**.
+3. Le **process worker n'est pas en cours d'exécution** (aucun `dist/workers/main.js` dans `ps`), et `npm run dev` ne démarre que l'API (`dist/main.js`), **pas** le worker.
+4. La machine **DEV elle-même est hung** : `curl localhost:3000/health` → `http=000` (timeout), `npm run dev` bloqué depuis le 31/05.
+
+→ **Une chaîne de données PROD (beacon→raw tourne sur PROD) dépend d'un flag DEV-only + d'un process worker DEV.** C'est l'anti-pattern explicite de `deployment.md` : **DEV = poste opérateur, PAS un host runtime**. L'agrégation s'est arrêtée à 06-01 13:00 = quand le worker DEV a cessé. Un replay manuel **re-cassera** au prochain hang DEV → ce serait du bricolage.
+
+**Solution robuste recommandée (structurelle, owner-gated) — découpler l'agrégation du process applicatif :**
+- **Cible : pg_cron appelant directement `aggregate_cwv_hourly()` + `aggregate_cwv_daily_rum()`** (RPC VOLATILE déjà existantes) **dans la DB**, là où vit la donnée — toujours-actif, zéro dépendance app/worker/flag/DEV, survit aux restarts. C'est le pattern canon des autres rotations (`feedback_partitioned_snapshot_tables_need_premake_cron`) et ça élimine la cause racine au lieu de la replâtrer. Aujourd'hui : **aucun pg_cron `aggregate_cwv*`** (mesuré, Finding 2).
+- *Alternative si on garde BullMQ* : faire tourner le worker sur le **runtime PROD** (49.12.233.2) avec le flag gouverné en env PROD — mais ça garde une dépendance process vs la robustesse pg_cron.
+
+**Stopgap urgent (owner, fenêtre TTL qui se ferme, NON le fix) :** replay idempotent `aggregate_cwv_hourly(<hour>)` × 48 (06-01 14:00 → 06-03 13:00) + `aggregate_cwv_daily_rum(<date>)` × 3, AVANT purge raw. À ne faire **que** comme sauvetage des 2 022 échantillons ; la vraie correction = pg_cron ci-dessus.
+
+### Finding 2 — `high` · garde anti-perte #811 mergée mais NON appliquée au live
+
+**Mesuré :**
+- `detect_cwv_aggregation_coverage_gap()` dans `pg_proc` : **0** (fonction absente du live)
+- pg_cron pour ce détecteur : **NONE**
+- pg_cron `aggregate_cwv%` : **NONE**
+- alertes `cwv_aggregation_coverage_gap` ouvertes : **0**
+
+**Lecture :** la migration `20260601_seo_cwv_aggregation_coverage_alert.sql` (#811, mergée 06-01) est **écrite mais pas appliquée** à la DB live — drift axe #4 `deployment.md` (migrations mergées ≠ auto-appliquées). C'est précisément pour ça que **Finding 1 est passé silencieux** : le filet conçu pour alerter sur ce trou n'existe pas encore côté runtime. De plus, **aucun pg_cron `aggregate_cwv*`** n'est planifié → l'agrégation ne dépend que du scheduler BullMQ (Finding 1), sans filet cron.
+
+**Action owner (owner-gated, additif réversible) :** appliquer l'additif `20260601_*` au live (Studio SQL, tx propre) pour activer le détecteur + son pg_cron. Aligne le runtime sur le code mergé et arme le filet anti-perte.
+
+---
+
+## Non-findings (vérifiés, écartés)
+
+- **« Il faut construire l'ingestion CWV »** : faux. Beacon + raw + hourly + daily_rum + taxonomie `@repo/cwv-taxonomy` + dashboard RPCs existent et sont mergés (RCOP #728/#731/#732/#733/#734 ; #803/#811). Reconstruire = triple duplication (canon).
+- **« L'attribution n'est pas collectée »** : faux. `funnel_step` 100 %, `attribution` jsonb 47 % (attendu), R2 `/pieces` bien représenté (631/24 h).
+- **`__seo_cwv_daily` (CrUX/PSI) vide** : connu, exclusion gouvernée V0.A (`CwvFetcherService` sans call site) — **hors scope** de ce TOP (RUM ≠ CrUX). Ne pas confondre avec `__seo_cwv_daily_rum` (le vrai SoT field, lui peuplé jusqu'au 06-01).
+
+---
+
+## Verdict & sortie
+
+| Verdict | Issue |
+|---|---|
+| `DIAGNOSTIC_READY` | **← retenu.** Chaîne existante + 2 dérives runtime localisées + chiffres actionnables. |
+| `BUILD` ingestion | **NON** — tout est déjà livré (anti-bricolage). |
+| `OWNER_DECISION` runtime | **← Finding 1 & 2.** Fix structurel = **pg_cron `aggregate_cwv_*`** (découple l'agrégation du worker/flag/DEV) + apply migration #811 (filet d'alerte). Stopgap = replay 48 h avant purge TTL. Tout owner-gated (Studio / runtime READ_ONLY=false), **hors de ce que je dois muter** (no DEV bricolé, no flag flip, no cron créé, no backfill par moi). |
+
+**Pas de PR code applicative à ouvrir.** Le code (RPC `aggregate_cwv_hourly/daily_rum`, beacon, schéma) est **complet et correct** ; le gap est **architectural/ops** : l'orchestration de l'agrégation est mal placée (worker DEV-only au lieu d'un pg_cron DB-side). Le fix robuste est une **migration pg_cron** (DDL additif réversible) + l'application de #811 — owner-gated.
+
+Ce que je peux préparer **sans exécuter** (pour relecture owner) :
+1. la **migration pg_cron** `aggregate_cwv_*` (schedule horaire @ :05 + daily @ 00:15 UTC, idempotente, pattern canon) — DDL, pas d'exécution ;
+2. le **script de replay borné** `/tmp` des 48 h (stopgap, sauvetage des 2 022 échantillons).
+Aucune mutation runtime/DB par moi sans GO nominatif.
+
+---
+
+## Annexe — requêtes (toutes READ-ONLY, reproductibles)
+
+1. schéma colonnes (`information_schema.columns`) des 3 tiers
+2. flow+freshness : `count/max/min` par tier
+3. migration-applied : `pg_proc` / `cron.job` / `__seo_event_log` open alerts
+4. quantif perte : raw-hours LEFT JOIN hourly-hours, `ua_class='human'`, grâce 2 h
+5. attribution : `attribution IS NOT NULL`, `funnel_step`, surfaces, R2, INP sur raw < 24 h
+
+Projet Supabase `cxpojprgwgubzjyqzmoq`. Aucune donnée mutée. DEV:3000 non sollicité (instable, hors-scope).

--- a/backend/supabase/migrations/20260603_seo_cwv_aggregation_cron.down.sql
+++ b/backend/supabase/migrations/20260603_seo_cwv_aggregation_cron.down.sql
@@ -1,0 +1,9 @@
+-- Rollback : retire les 2 cron d'agrégation CWV RUM (20260603_seo_cwv_aggregation_cron).
+-- Idempotent : unschedule seulement si le job existe (pas d'erreur sinon).
+-- N'affecte PAS les RPC aggregate_cwv_* (20260527) ni les cron de rotation.
+
+SELECT cron.unschedule('cwv-hourly-aggregation')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'cwv-hourly-aggregation');
+
+SELECT cron.unschedule('cwv-daily-rum-aggregation')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'cwv-daily-rum-aggregation');

--- a/backend/supabase/migrations/20260603_seo_cwv_aggregation_cron.sql
+++ b/backend/supabase/migrations/20260603_seo_cwv_aggregation_cron.sql
@@ -1,0 +1,82 @@
+-- Migration : pg_cron pour l'agrégation CWV RUM (raw → hourly → daily_rum).
+--
+-- PROBLÈME (mesuré 2026-06-03, audit runtime-truth Phase 0) :
+--   __seo_cwv_raw afflue en continu (beacon sur PROD), mais __seo_cwv_hourly /
+--   __seo_cwv_daily_rum sont FIGÉS depuis 2026-06-01 13:00 → 48 h / 2022
+--   échantillons humains non agrégés, à risque de purge (raw TTL ~48 h).
+--
+-- CAUSE RACINE (architecturale, pas une valeur de flag) :
+--   L'agrégation était un job répétable BullMQ dans le PROCESS WORKER
+--   (CwvAggregationSchedulerService, workers/worker.module.ts), gardé par
+--   SEO_CWV_AGGREGATION_ENABLED — flag à 'true' UNIQUEMENT dans backend/.env
+--   (DEV). Le worker DEV est mort + DEV est un poste opérateur, pas un host
+--   runtime (deployment.md). Une chaîne de données PROD ne doit pas dépendre
+--   du poste DEV. Le bloc 20260527 a déjà mis les rotations de partitions sous
+--   pg_cron mais PAS l'agrégation elle-même — ce trou est comblé ici.
+--
+-- SOLUTION (robuste, découplée de l'app) :
+--   Planifier les RPC VOLATILE existantes aggregate_cwv_hourly() /
+--   aggregate_cwv_daily_rum() directement via pg_cron, là où vit la donnée.
+--   Toujours-actif, survit aux restarts/déploiements, zéro dépendance
+--   worker/flag/DEV. Pattern IDENTIQUE aux cron déjà dans 20260527
+--   (cwv-hourly-rotation, cwv-daily-rum-rotation) : cron.schedule + WHERE NOT
+--   EXISTS idempotent.
+--
+-- AUTO-HEAL : l'hourly réagrège les 3 dernières heures complètes (pas juste la
+--   précédente). Les RPC sont des UPSERT idempotents → réagréger une heure déjà
+--   faite est un no-op sûr, et une exécution manquée se rattrape seule au tick
+--   suivant tant que le raw n'est pas purgé (TTL 48 h). Robuste contre un tick
+--   raté, sans backfill manuel.
+--
+-- SÉCURITÉ / SCOPE :
+--   - Additif pur. Aucune table, aucune RPC modifiée. Réutilise les RPC
+--     existantes (20260527) + pg_cron 1.6 déjà actif.
+--   - Idempotent : WHERE NOT EXISTS sur cron.job (re-run = no-op).
+--   - 100 % réversible (down = cron.unschedule).
+--   - Ne touche PAS le worker BullMQ ni le flag SEO_CWV_AGGREGATION_ENABLED.
+--     Si un jour le worker tourne sur un vrai runtime, les double-runs restent
+--     sûrs (UPSERT idempotent) — mais le SoT d'orchestration devient pg_cron.
+--   - N'effectue AUCUN backfill des 48 h déjà en retard : sauvetage = action
+--     OWNER séparée (aggregate_cwv_hourly(<h>) sur la fenêtre, avant purge).
+--
+-- Anti-régression PR #697 : cron ATOMIQUES, idempotents (WHERE NOT EXISTS).
+-- Horaires choisis pour NE PAS chevaucher les rotations de partitions
+-- (cwv-*-rotation @ 02:55/03:00/03:10) : agrégation à :05 (hourly) et 00:15 (daily).
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+-- =============================================================================
+-- 1. Cron agrégation HORAIRE : toutes les heures à HH:05 UTC.
+--    Réagrège les 3 dernières heures complètes (auto-heal d'un tick raté).
+--    Exclut l'heure courante (incomplète) : offsets 1, 2, 3 heures.
+-- =============================================================================
+SELECT cron.schedule(
+  'cwv-hourly-aggregation',
+  '5 * * * *',
+  $cron$
+    SELECT public.aggregate_cwv_hourly(date_trunc('hour', now()) - make_interval(hours => h))
+    FROM generate_series(1, 3) AS h;
+  $cron$
+)
+WHERE NOT EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'cwv-hourly-aggregation'
+);
+
+-- =============================================================================
+-- 2. Cron agrégation JOURNALIÈRE : tous les jours à 00:15 UTC.
+--    Réagrège hier + avant-hier (auto-heal). Idempotent (UPSERT).
+--    00:15 > toutes les rotations (≤ 03:10) et > l'hourly :05 → l'hourly de la
+--    veille a eu le temps de tourner avant le rollup journalier.
+-- =============================================================================
+SELECT cron.schedule(
+  'cwv-daily-rum-aggregation',
+  '15 0 * * *',
+  $cron$
+    SELECT public.aggregate_cwv_daily_rum((now() - make_interval(days => d))::date)
+    FROM generate_series(1, 2) AS d;
+  $cron$
+)
+WHERE NOT EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'cwv-daily-rum-aggregation'
+);


### PR DESCRIPTION
## Improvement Check

- **Problem:** Agrégation CWV RUM figée depuis 2026-06-01 13:00 (incident `web-vitals-attribution-unstable`). 48 h / 2022 échantillons humains non agrégés, à risque de purge (raw TTL ~48 h).
- **Evidence before:** Phase 0 runtime-truth read-only (Supabase live) → `__seo_cwv_raw` frais (newest 06-03 16:14) mais `hourly`/`daily_rum` bloqués au 06-01 13:00. `agg_cron = NONE`. Détail : `audit/web-vitals-attribution-ingestion-phase0-diagnostic-2026-06-03.md`.
- **Root cause (architectural):** l'agrégation vivait dans un job BullMQ du **process worker**, gardé par `SEO_CWV_AGGREGATION_ENABLED='true'` présent **uniquement dans `backend/.env` (DEV)**. Worker DEV mort + DEV = poste opérateur, pas un host runtime (`deployment.md`). Une chaîne PROD dépendait du poste DEV.
- **Fix:** planifier les RPC VOLATILE **existantes** `aggregate_cwv_hourly()` / `aggregate_cwv_daily_rum()` via **pg_cron** (déjà 1.6, déjà utilisé pour `cwv-*-rotation`). Découplé app/worker/flag/DEV. Pattern identique à `20260527` (le bloc avait planifié les rotations de partitions mais **pas** l'agrégation — trou comblé ici).
- **Expected gain:** agrégation toujours-active, survit restarts/déploiements ; auto-heal d'un tick raté (UPSERT idempotents, fenêtre glissante). Plus de dépendance au poste DEV.
- **Risk:** faible. Additif pur, idempotent (`WHERE NOT EXISTS`), 100% réversible (`.down` = `cron.unschedule`). Ne touche ni worker, ni flag, ni RPC, ni tables. **Aucun backfill** des 48 h en retard (sauvetage = action owner séparée).
- **Test (dry, read-only):** payloads cron résolvent aux bonnes cibles (hourly = 3 dernières heures complètes ; daily = J-1, J-2) ; signatures RPC résolvent live. Zéro write exécuté.
- **Verdict:** `OWNER_DECISION` (migration NON appliquée — Studio/owner, drift axe #4).
- **Next action (owner):**
  1. **Stopgap urgent** (fenêtre TTL) : sauver les 2022 échantillons — `SELECT aggregate_cwv_hourly(date_trunc('hour',now()) - make_interval(hours=>h)) FROM generate_series(1,48) h;` puis `aggregate_cwv_daily_rum` pour 06-01/02/03, **avant purge raw**.
  2. **Fix durable** : appliquer cette migration via Studio (les 2 `cron.schedule`).
  3. Optionnel : appliquer aussi `20260601_*` (#811, détecteur coverage-gap) — le filet d'alerte, lui aussi non appliqué au live.

## Scope

✅ 2 migrations (up + down) + 1 diagnostic. 🚫 Aucun code app · aucun worker · aucun flag · aucune RPC/table modifiée · aucune exécution sur runtime mutant.

Additif, idempotent, réversible. Non appliqué au live par cette PR.
