### PR TITLE
fix(seo-monitor): scope repeatable-job prune to owned jobs (fixes CWV job eviction)

### DIFF
--- a/backend/src/workers/services/seo-monitor-scheduler.service.test.ts
+++ b/backend/src/workers/services/seo-monitor-scheduler.service.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Anti-régression : `cleanOldRepeatableJobs()` ne doit supprimer QUE les jobs
+ * possédés par SeoMonitorSchedulerService sur la queue mutualisée `seo-monitor`.
+ *
+ * Incident 2026-05-30 : le prune total (sans allowlist) effaçait les repeatables
+ * `cwv-aggregation-*` enregistrés par CwvAggregationSchedulerService sur la même
+ * queue → `__seo_cwv_hourly` jamais peuplé (effacement non-déterministe au boot).
+ */
+import { SeoMonitorSchedulerService } from './seo-monitor-scheduler.service';
+
+type RepeatableJob = { name: string; key: string };
+
+/**
+ * Fabrique une fausse Bull `Queue` exposant uniquement la surface utilisée par
+ * `cleanOldRepeatableJobs()` : getRepeatableJobs + removeRepeatableByKey.
+ * Les `add` (setup*) sont mockés no-op pour pouvoir appeler le configurateur si besoin.
+ */
+function makeQueueMock(existing: RepeatableJob[]) {
+  const remaining = [...existing];
+  const removedKeys: string[] = [];
+  return {
+    removedKeys,
+    queue: {
+      // Renvoie une COPIE — comme Bull, qui ne retourne pas le tableau interne
+      // que le code itère (sinon le splice ci-dessous muterait l'itération).
+      getRepeatableJobs: jest.fn(async () => [...remaining]),
+      removeRepeatableByKey: jest.fn(async (key: string) => {
+        removedKeys.push(key);
+        const i = remaining.findIndex((j) => j.key === key);
+        if (i >= 0) remaining.splice(i, 1);
+      }),
+      add: jest.fn(async () => ({ id: 'mock' })),
+    },
+  };
+}
+
+/** Accède à la méthode privée sans `any` étalé partout. */
+function cleanOldRepeatableJobs(svc: SeoMonitorSchedulerService): Promise<void> {
+  return (
+    svc as unknown as { cleanOldRepeatableJobs: () => Promise<void> }
+  ).cleanOldRepeatableJobs();
+}
+
+describe('SeoMonitorSchedulerService.cleanOldRepeatableJobs (allowlist prune)', () => {
+  const OWNED: RepeatableJob[] = [
+    { name: 'check-pages', key: 'check-pages:critical-urls-monitoring:::*/30 * * * *' },
+    { name: 'check-pages', key: 'check-pages:random-sample-monitoring:::0 */6 * * *' },
+    { name: 'daily-fetch', key: 'daily-fetch:seo-daily-fetch:::0 4 * * *' },
+  ];
+  const FOREIGN_CWV: RepeatableJob[] = [
+    { name: 'cwv-aggregation-hourly', key: 'cwv-aggregation-hourly:cwv-agg-hourly-repeat::UTC:5 * * * *' },
+    { name: 'cwv-aggregation-daily', key: 'cwv-aggregation-daily:cwv-agg-daily-repeat::UTC:15 3 * * *' },
+  ];
+
+  it('supprime les jobs possédés (check-pages, daily-fetch)', async () => {
+    const { queue, removedKeys } = makeQueueMock([...OWNED]);
+    const svc = new SeoMonitorSchedulerService(queue as never);
+
+    await cleanOldRepeatableJobs(svc);
+
+    expect(removedKeys.sort()).toEqual(OWNED.map((j) => j.key).sort());
+    expect(queue.removeRepeatableByKey).toHaveBeenCalledTimes(OWNED.length);
+  });
+
+  it("NE supprime PAS les jobs d'un autre scheduler (cwv-aggregation-*)", async () => {
+    const { queue, removedKeys } = makeQueueMock([...OWNED, ...FOREIGN_CWV]);
+    const svc = new SeoMonitorSchedulerService(queue as never);
+
+    await cleanOldRepeatableJobs(svc);
+
+    // Les jobs CWV ne doivent jamais être passés à removeRepeatableByKey.
+    for (const cwv of FOREIGN_CWV) {
+      expect(removedKeys).not.toContain(cwv.key);
+    }
+    // Seuls les jobs possédés sont supprimés.
+    expect(removedKeys.sort()).toEqual(OWNED.map((j) => j.key).sort());
+  });
+
+  it('ne fait jamais de prune total de la queue partagée', async () => {
+    const { queue, removedKeys } = makeQueueMock([...OWNED, ...FOREIGN_CWV]);
+    const svc = new SeoMonitorSchedulerService(queue as never);
+
+    await cleanOldRepeatableJobs(svc);
+
+    // Régression historique : tout supprimer (5) au lieu des seuls possédés (3).
+    expect(removedKeys.length).toBe(OWNED.length);
+    expect(removedKeys.length).toBeLessThan(OWNED.length + FOREIGN_CWV.length);
+  });
+
+  it('no-op quand seuls des jobs étrangers existent', async () => {
+    const { queue, removedKeys } = makeQueueMock([...FOREIGN_CWV]);
+    const svc = new SeoMonitorSchedulerService(queue as never);
+
+    await cleanOldRepeatableJobs(svc);
+
+    expect(removedKeys).toHaveLength(0);
+    expect(queue.removeRepeatableByKey).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/workers/services/seo-monitor-scheduler.service.test.ts
+++ b/backend/src/workers/services/seo-monitor-scheduler.service.test.ts
@@ -35,7 +35,9 @@ function makeQueueMock(existing: RepeatableJob[]) {
 }
 
 /** Accède à la méthode privée sans `any` étalé partout. */
-function cleanOldRepeatableJobs(svc: SeoMonitorSchedulerService): Promise<void> {
+function cleanOldRepeatableJobs(
+  svc: SeoMonitorSchedulerService,
+): Promise<void> {
   return (
     svc as unknown as { cleanOldRepeatableJobs: () => Promise<void> }
   ).cleanOldRepeatableJobs();
@@ -43,13 +45,25 @@ function cleanOldRepeatableJobs(svc: SeoMonitorSchedulerService): Promise<void> 
 
 describe('SeoMonitorSchedulerService.cleanOldRepeatableJobs (allowlist prune)', () => {
   const OWNED: RepeatableJob[] = [
-    { name: 'check-pages', key: 'check-pages:critical-urls-monitoring:::*/30 * * * *' },
-    { name: 'check-pages', key: 'check-pages:random-sample-monitoring:::0 */6 * * *' },
+    {
+      name: 'check-pages',
+      key: 'check-pages:critical-urls-monitoring:::*/30 * * * *',
+    },
+    {
+      name: 'check-pages',
+      key: 'check-pages:random-sample-monitoring:::0 */6 * * *',
+    },
     { name: 'daily-fetch', key: 'daily-fetch:seo-daily-fetch:::0 4 * * *' },
   ];
   const FOREIGN_CWV: RepeatableJob[] = [
-    { name: 'cwv-aggregation-hourly', key: 'cwv-aggregation-hourly:cwv-agg-hourly-repeat::UTC:5 * * * *' },
-    { name: 'cwv-aggregation-daily', key: 'cwv-aggregation-daily:cwv-agg-daily-repeat::UTC:15 3 * * *' },
+    {
+      name: 'cwv-aggregation-hourly',
+      key: 'cwv-aggregation-hourly:cwv-agg-hourly-repeat::UTC:5 * * * *',
+    },
+    {
+      name: 'cwv-aggregation-daily',
+      key: 'cwv-aggregation-daily:cwv-agg-daily-repeat::UTC:15 3 * * *',
+    },
   ];
 
   it('supprime les jobs possédés (check-pages, daily-fetch)', async () => {

--- a/backend/src/workers/services/seo-monitor-scheduler.service.ts
+++ b/backend/src/workers/services/seo-monitor-scheduler.service.ts
@@ -11,6 +11,27 @@ import { Queue } from 'bull';
 import { DatabaseException, ErrorCodes } from '@common/exceptions';
 import { getErrorMessage } from '@common/utils/error.utils';
 
+/**
+ * Repeatable job names OWNED by this scheduler on the shared `seo-monitor` queue.
+ *
+ * La queue `seo-monitor` est MUTUALISÉE : d'autres schedulers y enregistrent
+ * leurs propres repeatables (ex. `cwv-aggregation-hourly` / `cwv-aggregation-daily`
+ * via `CwvAggregationSchedulerService`). `cleanOldRepeatableJobs()` ne doit donc
+ * supprimer QUE les jobs possédés par CE service — un prune total efface, de
+ * façon non-déterministe au boot, les jobs des autres schedulers (incident
+ * 2026-05-30 : le prune total effaçait `cwv-aggregation-*` → `__seo_cwv_hourly`
+ * jamais peuplé).
+ *
+ * Même discipline d'allowlist que `CwvAggregationSchedulerService.removeStaleRepeatables()`
+ * et `sitemap-v10-scheduler.service.ts` (suppression filtrée par nom de job).
+ *
+ * Jobs possédés : `check-pages` (critical-urls + random-sample) et `daily-fetch`.
+ */
+const OWNED_REPEATABLE_JOB_NAMES: ReadonlySet<string> = new Set([
+  'check-pages',
+  'daily-fetch',
+]);
+
 @Injectable()
 export class SeoMonitorSchedulerService implements OnModuleInit {
   private readonly logger = new Logger(SeoMonitorSchedulerService.name);
@@ -62,12 +83,19 @@ export class SeoMonitorSchedulerService implements OnModuleInit {
   }
 
   /**
-   * 🗑️ Nettoie les anciens jobs répétitifs
+   * 🗑️ Nettoie les anciens jobs répétitifs POSSÉDÉS par ce scheduler.
+   *
+   * Filtre par `OWNED_REPEATABLE_JOB_NAMES` : la queue `seo-monitor` est
+   * mutualisée, supprimer un repeatable non-possédé (ex. `cwv-aggregation-*`)
+   * casserait un autre scheduler de façon non-déterministe au boot.
    */
   private async cleanOldRepeatableJobs() {
     const repeatableJobs = await this.seoMonitorQueue.getRepeatableJobs();
 
     for (const job of repeatableJobs) {
+      if (!OWNED_REPEATABLE_JOB_NAMES.has(job.name)) {
+        continue; // job d'un autre scheduler sur la queue partagée — ne pas toucher
+      }
       await this.seoMonitorQueue.removeRepeatableByKey(job.key);
       this.logger.log(`🗑️ Ancien job répétitif supprimé: ${job.name}`);
     }


### PR DESCRIPTION
## Problème (mesuré)

En activant `SEO_CWV_AGGREGATION_ENABLED=true` en DEV (2026-05-30), les jobs `cwv-aggregation-hourly/daily` apparaissaient puis disparaissaient de façon non-déterministe : `__seo_cwv_hourly` restait à **0 rows**.

**Root cause** : `SeoMonitorSchedulerService.cleanOldRepeatableJobs()` faisait un **prune TOTAL** de la queue mutualisée `seo-monitor` :

```ts
for (const job of repeatableJobs) {
  await this.seoMonitorQueue.removeRepeatableByKey(job.key); // supprime TOUT
}
```

Or `CwvAggregationSchedulerService` enregistre `cwv-aggregation-*` sur **la même queue `seo-monitor`**. Les deux `onModuleInit` tournent au même boot dans le même process (WorkerModule), ordre non garanti → le scheduler legacy effaçait les jobs CWV de l'autre scheduler.

## Fix (minimal, structurel)

Allowlist explicite des jobs **possédés** par ce scheduler ; le prune ne touche qu'eux :

```ts
const OWNED_REPEATABLE_JOB_NAMES = new Set(['check-pages', 'daily-fetch']);
// ...
if (!OWNED_REPEATABLE_JOB_NAMES.has(job.name)) continue; // ne pas toucher les jobs d'autrui
```

C'est **exactement la discipline déjà utilisée** par `CwvAggregationScheduler.removeStaleRepeatables()` (filtre ses 2 jobs) et `sitemap-v10-scheduler.service.ts` (filtre `=== SITEMAP_REGENERATE_JOB_NAME`) — on étend un pattern existant, on n'invente rien.

## Preuves

- `npx jest src/workers/services/seo-monitor-scheduler.service.test.ts` → **4/4 verts** :
  - supprime les jobs possédés (check-pages ×2, daily-fetch)
  - **NE supprime PAS** `cwv-aggregation-*` (anti-régression cœur)
  - ne fait jamais de prune total (3 supprimés sur 5, pas 5)
  - no-op si seuls des jobs étrangers existent
- `npx tsc --noEmit` backend → **exit 0**

## Périmètre (strict)

- 1 fichier modifié + 1 test. **Cadences inchangées**, **pas de nouvelle queue**, **pas de migration**, **pas de modif du scheduler CWV**.
- **Pas d'activation PROD** : ce fix débloque l'activation future, il ne l'active pas. `SEO_CWV_AGGREGATION_ENABLED` reste OFF partout (DEV rollbacké).

## Suite (hors PR)

Après merge + vérif : ré-activer `SEO_CWV_AGGREGATION_ENABLED` en DEV → confirmer que **hourly ET daily** survivent au boot → puis décision PROD séparée (owner-gated).

## Definition of Done

- [x] **DoD1** Tests verts (jest 4/4 + tsc exit 0)
- [x] **DoD2** Ownership : worker BullMQ scheduler (bounded context seo-monitoring)
- [x] **DoD3** Rollback : revert PR (changement purement additif + 1 guard clause)
- [ ] **DoD4** Observabilité : N/A — log existant `🗑️ supprimé` conservé, pas de nouvelle surface
- [x] **DoD5** Drift zéro : fix aligne le comportement sur les 2 autres schedulers de la queue
- [x] **DoD6** Docs : commentaire `OWNED_REPEATABLE_JOB_NAMES` + corps PR
- [ ] **DoD7** Monitoring : N/A
- [x] **DoD8** No TODO
- [x] **DoD9** No silent skip : le `continue` est documenté (job d'un autre scheduler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
