### PR TITLE
feat(ai-registry): wiki department (PR#3 seed 3)

### DIFF
--- a/.spec/00-canon/ai-registry/agent-operating-map.yaml
+++ b/.spec/00-canon/ai-registry/agent-operating-map.yaml
@@ -196,6 +196,15 @@ departments:
     capabilities: [observability, health, rpc-alerts]
     state: partial                   # observability live; commerce-runtime plane (RCOP) partial
 
+  - id: wiki
+    label: "Knowledge RAW & WIKI"
+    lead: wiki-lead
+    priority: P1                     # max criticality of repo_domains (D6 = P1)
+    kpi_primary: wiki_readiness
+    repo_domains: [D6]
+    capabilities: [wiki-proposal-writer, rag-knowledge-bootstrap]
+    state: partial                   # ADR-033 Phase 2 sas; readiness chain partial (wiki produces, consumers read)
+
 # Allowlist of capabilities that resolve to neither a registry skill nor a node
 # yet (modules/engines/services/signals). Keeps department.capabilities from being
 # ghost slugs; `owner` is the department id. Each commented with its real path.
@@ -211,6 +220,8 @@ declared_capabilities:
   - { id: observability,      type: module,  owner: runtime,  status: live }     # backend/src/modules/observability
   - { id: health,             type: module,  owner: runtime,  status: live }     # backend/src/modules/health
   - { id: rpc-alerts,         type: signal,  owner: runtime,  status: live }     # rpc_*_alerts_v1 (backend/src/modules/admin/services/seo-control.service.ts)
+  - { id: wiki-proposal-writer,    type: skill,  owner: wiki, status: partial }  # workspaces/wiki/.claude/skills/wiki-proposal-writer/SKILL.md (ADR-033)
+  - { id: rag-knowledge-bootstrap, type: module, owner: wiki, status: partial }  # backend/src/modules/rag-knowledge-bootstrap
 
 # Business handoffs (department→department), distinct from the pipeline `handoffs`
 # above. Communication by contract, not free discussion. `contract_ref` points to
@@ -264,3 +275,15 @@ department_handoffs:
     evidence:
       scripts:
         - backend/src/modules/seo-monitoring/services/funnel-events.service.ts
+
+  # wiki produces validated knowledge; seo (next seed) is its consumer (ADR-031/033).
+  - id: wiki-to-seo-readiness
+    from: wiki
+    to: seo
+    contract_ref: wiki-readiness-verdict.v1
+    contract_status: planned
+    purpose: "Autoriser la consommation SEO seulement quand la fiche WIKI est READY (ADR-033)"
+    gate: human_review_required
+    state: PARTIAL
+    evidence:
+      adr: ADR-033


### PR DESCRIPTION
Third progressive seed of the department layer, order **data → runtime → wiki** (seo/catalog next).

**Adds (additive, warn-only, +23):**
- `department: wiki` (Knowledge RAW & WIKI) — `wiki-proposal-writer` + `rag-knowledge-bootstrap` · D6 · kpi `wiki_readiness`
- 2 `declared_capabilities` grounded (workspaces/wiki skill + backend rag-knowledge-bootstrap)
- 1 handoff `wiki → seo` readiness gate (ADR-031/033) — seo is the next seed

**Doctrine:** wiki **produces** validated knowledge; consumers (seo, rag-proxy) read it — rag-proxy is the consumer layer, deliberately **not** a wiki capability.

**Validation:** self-test PASS · 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)