### PR TITLE
feat(command-center): COMMAND_CENTER_MODE exposure flag (full DEV/PREPROD · restricted PROD) (PR4)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -304,3 +304,13 @@ SUPPLIER_INOSHOP_DISTRICASH_PASSWORD=
 # supplier-registry.ts). Read-only sentinel; OPTIONAL (absent → connector skipped).
 CAL_USER=
 CAL_PASSWORD=
+
+# ── Command Center cockpit exposure (ADR follow-up 2026-06-04) ──
+# Controls /api/admin/command-center + /admin/command-center exposure.
+#   full      = complete cockpit (departments, capabilities, handoffs, actions)
+#   light     = top-line health only (no internal agent/department detail)
+#   disabled  = endpoint 404s, route shows a "disabled" notice
+# Unset → SAFE DEFAULT: 'disabled' when NODE_ENV=production (PROD), else 'full'
+# (DEV=development, PREPROD=preprod → full). The Docker REGISTRY_DIR fix that
+# repairs /admin/control-plane is INDEPENDENT of this flag and active everywhere.
+COMMAND_CENTER_MODE=full

--- a/backend/src/modules/admin/controllers/command-center.controller.ts
+++ b/backend/src/modules/admin/controllers/command-center.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, UseGuards, UseInterceptors } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
 import { AuthenticatedGuard } from '@auth/authenticated.guard';
 import { IsAdminGuard } from '@auth/is-admin.guard';
 import { AdminResponseInterceptor } from '../../../common/interceptors/admin-response.interceptor';
@@ -12,6 +18,10 @@ import {
  * Surfaces the deterministic AI Operating Map projection
  * (audit/registry/command-center-snapshot.json) + live envelope (stale/validation/
  * global_status/health_score_current). Read-only — no mutation, no DB write.
+ *
+ * Exposure gated by COMMAND_CENTER_MODE (full/light/disabled; prod-safe default
+ * = disabled in PROD). `disabled` → 404 (reduces surface, does not reveal data);
+ * `light` → top-line health only (the reader strips internal detail).
  */
 @Controller('api/admin/command-center')
 @UseGuards(AuthenticatedGuard, IsAdminGuard)
@@ -21,6 +31,11 @@ export class CommandCenterController {
 
   @Get()
   async getSummary(): Promise<CommandCenterResponse> {
+    if (this.reader.getMode() === 'disabled') {
+      throw new NotFoundException(
+        'Command Center is disabled in this environment',
+      );
+    }
     return this.reader.getCommandCenter();
   }
 }

--- a/backend/src/modules/admin/services/command-center-reader.service.ts
+++ b/backend/src/modules/admin/services/command-center-reader.service.ts
@@ -60,25 +60,32 @@ export class CommandCenterReaderService {
     }
   }
 
-  /** Cache-aside aggregate. Degraded results get a short TTL. */
+  /** Resolved exposure mode (full / light / disabled). */
+  getMode(): CommandCenterMode {
+    return resolveCommandCenterMode();
+  }
+
+  /** Cache-aside aggregate. Degraded results get a short TTL. Mode-aware key. */
   async getCommandCenter(): Promise<CommandCenterResponse> {
-    const cached = await this.cacheService.get<CommandCenterResponse>(
-      CommandCenterReaderService.CACHE_KEY,
-    );
+    const mode = resolveCommandCenterMode();
+    const cacheKey = `${CommandCenterReaderService.CACHE_KEY}:${mode}`;
+    const cached = await this.cacheService.get<CommandCenterResponse>(cacheKey);
     if (cached) return cached;
 
-    const summary = this.build();
+    const built = this.build();
+    const result: CommandCenterResponse =
+      mode === 'light' ? toLightResponse(built) : { ...built, mode };
     await this.cacheService.set(
-      CommandCenterReaderService.CACHE_KEY,
-      summary,
-      summary.degraded
+      cacheKey,
+      result,
+      result.degraded
         ? CommandCenterReaderService.TTL_DEGRADED
         : CommandCenterReaderService.TTL_OK,
     );
-    return summary;
+    return result;
   }
 
-  private build(): CommandCenterResponse {
+  private build(): Omit<CommandCenterResponse, 'mode'> {
     const now = new Date();
     const gitSha = process.env.GIT_SHA || process.env.SOURCE_COMMIT || null;
     const snapshot = this.readJson<SnapshotFile>(
@@ -327,11 +334,64 @@ interface SnapshotFile {
   owner_actions: unknown[];
 }
 
+export type CommandCenterMode = 'full' | 'light' | 'disabled';
+
+/**
+ * Exposure mode for the Command Center cockpit (owner decision 2026-06-04):
+ * full in DEV/PREPROD, restricted in PROD. Explicit `COMMAND_CENTER_MODE` wins;
+ * otherwise SAFE DEFAULT = `disabled` when NODE_ENV=production (PROD), else `full`
+ * (DEV runs `development`, PREPROD runs `preprod`). The Docker REGISTRY_DIR fix is
+ * independent of this flag and stays active in every environment.
+ */
+export function resolveCommandCenterMode(): CommandCenterMode {
+  const raw = (process.env.COMMAND_CENTER_MODE || '').trim().toLowerCase();
+  if (raw === 'full' || raw === 'light' || raw === 'disabled') return raw;
+  return process.env.NODE_ENV === 'production' ? 'disabled' : 'full';
+}
+
+/**
+ * Light projection: top-line health only. Strips ALL internal detail
+ * (departments, capabilities, chains, alerts, owner_actions, evidence paths,
+ * canon_path, git_sha, global_status.reasons) so PROD can show "is it healthy?"
+ * without leaking the agent/department map. `summary` aggregate counts are kept
+ * (numbers, no internal identifiers).
+ */
+function toLightResponse(
+  full: Omit<CommandCenterResponse, 'mode'>,
+): CommandCenterResponse {
+  return {
+    degraded: full.degraded,
+    schema_version: full.schema_version,
+    source_truth: {
+      canon_path: '',
+      last_verified: full.source_truth.last_verified,
+    },
+    summary: full.summary,
+    executive_kpis: [],
+    departments: [],
+    capabilities: [],
+    chains: [],
+    alerts: [],
+    owner_actions: [],
+    generated_at: full.generated_at,
+    git_sha: null,
+    stale_status: full.stale_status,
+    validation_status: full.validation_status,
+    global_status: {
+      level: full.global_status.level,
+      verdict: full.global_status.verdict,
+      reasons: [],
+    },
+    mode: 'light',
+  };
+}
+
 export interface CommandCenterResponse extends Omit<
   SnapshotFile,
   'departments'
 > {
   degraded: boolean;
+  mode: CommandCenterMode;
   departments: Array<
     SnapshotFile['departments'][number] & {
       health_score_current: number;

--- a/backend/tests/unit/command-center-reader.service.test.ts
+++ b/backend/tests/unit/command-center-reader.service.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import {
   CommandCenterReaderService,
+  resolveCommandCenterMode,
   type CommandCenterResponse,
 } from '../../src/modules/admin/services/command-center-reader.service';
 
@@ -112,6 +113,54 @@ describe('CommandCenterReaderService', () => {
       const result = await service.getCommandCenter();
       expect(result).toBe(cached);
       expect(cache.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exposure mode (COMMAND_CENTER_MODE)', () => {
+    const ENV = {
+      mode: process.env.COMMAND_CENTER_MODE,
+      node: process.env.NODE_ENV,
+    };
+    afterEach(() => {
+      process.env.COMMAND_CENTER_MODE = ENV.mode;
+      process.env.NODE_ENV = ENV.node;
+    });
+
+    it('explicit COMMAND_CENTER_MODE wins (full/light/disabled)', () => {
+      for (const m of ['full', 'light', 'disabled'] as const) {
+        process.env.COMMAND_CENTER_MODE = m;
+        expect(resolveCommandCenterMode()).toBe(m);
+      }
+    });
+
+    it('safe default: disabled in production, full elsewhere', () => {
+      delete process.env.COMMAND_CENTER_MODE;
+      process.env.NODE_ENV = 'production';
+      expect(resolveCommandCenterMode()).toBe('disabled');
+      process.env.NODE_ENV = 'preprod';
+      expect(resolveCommandCenterMode()).toBe('full');
+      process.env.NODE_ENV = 'development';
+      expect(resolveCommandCenterMode()).toBe('full');
+    });
+
+    it('light mode strips internal detail but keeps top-line health', async () => {
+      process.env.COMMAND_CENTER_MODE = 'light';
+      const { service } = makeService('full');
+      const res = await service.getCommandCenter();
+      expect(res.mode).toBe('light');
+      expect(res.departments).toEqual([]);
+      expect(res.capabilities).toEqual([]);
+      expect(res.chains).toEqual([]);
+      expect(res.owner_actions).toEqual([]);
+      expect(res.global_status.reasons).toEqual([]);
+      expect(res.source_truth.canon_path).toBe('');
+      expect(res.stale_status).toBe('STALE');
+    });
+
+    it('getMode() reflects the resolver', () => {
+      process.env.COMMAND_CENTER_MODE = 'disabled';
+      const { service } = makeService('full');
+      expect(service.getMode()).toBe('disabled');
     });
   });
 });

--- a/backend/tests/unit/command-center-reader.service.test.ts
+++ b/backend/tests/unit/command-center-reader.service.test.ts
@@ -134,12 +134,14 @@ describe('CommandCenterReaderService', () => {
     });
 
     it('safe default: disabled in production, full elsewhere', () => {
-      delete process.env.COMMAND_CENTER_MODE;
-      process.env.NODE_ENV = 'production';
+      // NODE_ENV is type-narrowed in the backend; widen for the 'preprod' literal.
+      const env = process.env as Record<string, string | undefined>;
+      delete env.COMMAND_CENTER_MODE;
+      env.NODE_ENV = 'production';
       expect(resolveCommandCenterMode()).toBe('disabled');
-      process.env.NODE_ENV = 'preprod';
+      env.NODE_ENV = 'preprod';
       expect(resolveCommandCenterMode()).toBe('full');
-      process.env.NODE_ENV = 'development';
+      env.NODE_ENV = 'development';
       expect(resolveCommandCenterMode()).toBe('full');
     });
 

--- a/frontend/app/routes/admin.command-center.tsx
+++ b/frontend/app/routes/admin.command-center.tsx
@@ -40,9 +40,13 @@ import { CertBadge } from "~/components/command-center/badges";
 export const meta: MetaFunction = () =>
   createNoIndexMeta("Command Center — Admin");
 
-function degraded(reason: string): CommandCenterResponse {
+function degraded(
+  reason: string,
+  mode: "full" | "disabled" = "full",
+): CommandCenterResponse {
   return {
     degraded: true,
+    mode,
     schema_version: "command-center.v1",
     source_truth: { canon_path: "", last_verified: null },
     summary: {
@@ -82,6 +86,15 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         },
       },
     );
+    if (res.status === 404) {
+      // COMMAND_CENTER_MODE=disabled (prod-safe default) → endpoint 404s.
+      return json(
+        degraded(
+          "Command Center désactivé dans cet environnement.",
+          "disabled",
+        ),
+      );
+    }
     if (!res.ok) {
       logger.warn(`[command-center] API ${res.status} — rendering degraded`);
       return json(degraded(`backend API ${res.status}`));
@@ -112,7 +125,18 @@ export default function AdminCommandCenter() {
         </p>
       </header>
 
-      {data.degraded ? (
+      {data.mode === "disabled" ? (
+        <Alert
+          variant="info"
+          icon={<AlertTriangle className="h-5 w-5" aria-hidden />}
+        >
+          <AlertTitle>Command Center désactivé</AlertTitle>
+          <AlertDescription>
+            Le cockpit complet est réservé à DEV/PREPROD (COMMAND_CENTER_MODE).
+            Le correctif Docker registry reste actif partout.
+          </AlertDescription>
+        </Alert>
+      ) : data.degraded ? (
         <Alert
           variant="error"
           icon={<AlertTriangle className="h-5 w-5" aria-hidden />}
@@ -127,30 +151,38 @@ export default function AdminCommandCenter() {
         <>
           <GlobalHealthBar data={data} />
 
-          <Tabs defaultValue="actions">
-            <TabsList className="flex flex-wrap">
-              <TabsTrigger value="actions">Actions</TabsTrigger>
-              <TabsTrigger value="departments">Départements</TabsTrigger>
-              <TabsTrigger value="handoffs">Handoffs</TabsTrigger>
-              <TabsTrigger value="capabilities">Capacités</TabsTrigger>
-            </TabsList>
+          {data.mode === "light" ? (
+            <p className="text-sm text-muted-foreground">
+              Mode light — synthèse de santé uniquement. Le détail
+              (départements, capacités, handoffs, actions) est disponible en
+              DEV/PREPROD.
+            </p>
+          ) : (
+            <Tabs defaultValue="actions">
+              <TabsList className="flex flex-wrap">
+                <TabsTrigger value="actions">Actions</TabsTrigger>
+                <TabsTrigger value="departments">Départements</TabsTrigger>
+                <TabsTrigger value="handoffs">Handoffs</TabsTrigger>
+                <TabsTrigger value="capabilities">Capacités</TabsTrigger>
+              </TabsList>
 
-            <TabsContent value="actions" className="mt-4">
-              <OwnerActionQueue data={data} />
-            </TabsContent>
+              <TabsContent value="actions" className="mt-4">
+                <OwnerActionQueue data={data} />
+              </TabsContent>
 
-            <TabsContent value="departments" className="mt-4">
-              <ModuleGrid data={data} />
-            </TabsContent>
+              <TabsContent value="departments" className="mt-4">
+                <ModuleGrid data={data} />
+              </TabsContent>
 
-            <TabsContent value="handoffs" className="mt-4">
-              <HandoffList data={data} />
-            </TabsContent>
+              <TabsContent value="handoffs" className="mt-4">
+                <HandoffList data={data} />
+              </TabsContent>
 
-            <TabsContent value="capabilities" className="mt-4">
-              <CapabilityTable data={data} />
-            </TabsContent>
-          </Tabs>
+              <TabsContent value="capabilities" className="mt-4">
+                <CapabilityTable data={data} />
+              </TabsContent>
+            </Tabs>
+          )}
         </>
       )}
     </div>

--- a/log.md
+++ b/log.md
@@ -580,3 +580,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/supplier-truth-runtime-wiring`
 - **Décision** : feat(supplier-truth): runtime wiring (inert mode, scheduler OFF default)
 - **Sortie** : PR #831 | commits 268efea6c
+
+## 2026-06-04 — feat/command-center-exposure-mode (auto)
+
+- **Branche** : `feat/command-center-exposure-mode`
+- **Décision** : fix(command-center): widen NODE_ENV type in mode test (TS2322 'preprod') (PR4) (+1 other commit)
+- **Sortie** : PR #856 | commits 75f42754f d20d75831

--- a/packages/registry/src/command-center/snapshot.ts
+++ b/packages/registry/src/command-center/snapshot.ts
@@ -20,11 +20,27 @@
  */
 import { z } from "zod";
 
-export const CertificationSchema = z.enum(["CERTIFIED", "PARTIAL", "UNKNOWN", "BROKEN"]);
+export const CertificationSchema = z.enum([
+  "CERTIFIED",
+  "PARTIAL",
+  "UNKNOWN",
+  "BROKEN",
+]);
 export type Certification = z.infer<typeof CertificationSchema>;
 
-export const CapabilityStatusSchema = z.enum(["live", "partial", "dormant", "broken", "duplicate"]);
-export const DepartmentFamilySchema = z.enum(["Business", "Growth", "Operations", "AI-Governance"]);
+export const CapabilityStatusSchema = z.enum([
+  "live",
+  "partial",
+  "dormant",
+  "broken",
+  "duplicate",
+]);
+export const DepartmentFamilySchema = z.enum([
+  "Business",
+  "Growth",
+  "Operations",
+  "AI-Governance",
+]);
 export const HandoffStateSchema = z.enum(["EXISTS", "PARTIAL", "ASPIRATIONAL"]);
 
 export const CcEvidenceSchema = z
@@ -39,7 +55,15 @@ export const CcEvidenceSchema = z
 export const CcCapabilitySchema = z
   .object({
     id: z.string(),
-    type: z.enum(["skill", "agent", "service", "module", "engine", "pipeline", "signal"]),
+    type: z.enum([
+      "skill",
+      "agent",
+      "service",
+      "module",
+      "engine",
+      "pipeline",
+      "signal",
+    ]),
     owner: z.string(),
     status: CapabilityStatusSchema,
     certification: CertificationSchema,
@@ -82,7 +106,12 @@ export const CcChainSchema = z
   .strict();
 export type CcChain = z.infer<typeof CcChainSchema>;
 
-export const CcAlertCodeSchema = z.enum(["BROKEN_EVIDENCE", "OVERCLAIM_RISK", "P0_NO_KPI", "HANDOFF_INCOMPLETE"]);
+export const CcAlertCodeSchema = z.enum([
+  "BROKEN_EVIDENCE",
+  "OVERCLAIM_RISK",
+  "P0_NO_KPI",
+  "HANDOFF_INCOMPLETE",
+]);
 export const CcAlertSchema = z
   .object({
     code: CcAlertCodeSchema,
@@ -121,9 +150,22 @@ export const CcExecutiveKpiSchema = z
 export const CcSummarySchema = z
   .object({
     departments_total: z.number().int().min(0),
-    by_priority: z.object({ P0: z.number().int(), P1: z.number().int(), P2: z.number().int(), P3: z.number().int() }).strict(),
+    by_priority: z
+      .object({
+        P0: z.number().int(),
+        P1: z.number().int(),
+        P2: z.number().int(),
+        P3: z.number().int(),
+      })
+      .strict(),
     by_state: z
-      .object({ live: z.number().int(), partial: z.number().int(), dormant: z.number().int(), broken: z.number().int(), duplicate: z.number().int() })
+      .object({
+        live: z.number().int(),
+        partial: z.number().int(),
+        dormant: z.number().int(),
+        broken: z.number().int(),
+        duplicate: z.number().int(),
+      })
       .strict(),
     capabilities_total: z.number().int().min(0),
     capabilities_certified: z.number().int().min(0),
@@ -137,7 +179,12 @@ export const CcSummarySchema = z
 export const CommandCenterSnapshotSchema = z
   .object({
     schema_version: z.literal("command-center.v1"),
-    source_truth: z.object({ canon_path: z.string().min(1), last_verified: z.string().nullable() }).strict(),
+    source_truth: z
+      .object({
+        canon_path: z.string().min(1),
+        last_verified: z.string().nullable(),
+      })
+      .strict(),
     summary: CcSummarySchema,
     executive_kpis: z.array(CcExecutiveKpiSchema),
     departments: z.array(CcDepartmentSchema),
@@ -151,8 +198,18 @@ export type CommandCenterSnapshot = z.infer<typeof CommandCenterSnapshotSchema>;
 
 // ── Live response envelope (computed by the backend reader at request time) ──
 
-export const StaleStatusSchema = z.enum(["FRESH", "WARNING", "STALE", "UNKNOWN"]);
-export const ValidationStatusSchema = z.enum(["VALIDATED", "WARN_ONLY", "STRICT_FAIL", "UNKNOWN"]);
+export const StaleStatusSchema = z.enum([
+  "FRESH",
+  "WARNING",
+  "STALE",
+  "UNKNOWN",
+]);
+export const ValidationStatusSchema = z.enum([
+  "VALIDATED",
+  "WARN_ONLY",
+  "STRICT_FAIL",
+  "UNKNOWN",
+]);
 
 export const GlobalStatusSchema = z
   .object({
@@ -171,8 +228,12 @@ export const CcDepartmentLiveSchema = CcDepartmentSchema.extend({
 export type CcDepartmentLive = z.infer<typeof CcDepartmentLiveSchema>;
 
 /** What GET /api/admin/command-center returns (data wrapped by AdminResponseInterceptor). */
+export const CommandCenterModeSchema = z.enum(["full", "light", "disabled"]);
+export type CommandCenterMode = z.infer<typeof CommandCenterModeSchema>;
+
 export const CommandCenterResponseSchema = CommandCenterSnapshotSchema.extend({
   degraded: z.boolean(),
+  mode: CommandCenterModeSchema,
   generated_at: z.string(),
   git_sha: z.string().nullable(),
   stale_status: StaleStatusSchema,

--- a/packages/registry/src/index.ts
+++ b/packages/registry/src/index.ts
@@ -29,7 +29,10 @@ export { DeletePolicySchema, type DeletePolicy } from "./shared/delete-policy";
 export { DerivedFromSchema, type DerivedFrom } from "./shared/derived-from";
 export { OwnerIdSchema, type OwnerId } from "./shared/owner";
 export { FamilyIdSchema, type FamilyId } from "./shared/family";
-export { AccessSurfaceSchema, type AccessSurface } from "./shared/access-surface";
+export {
+  AccessSurfaceSchema,
+  type AccessSurface,
+} from "./shared/access-surface";
 
 // ── Layer 1 entries (auto-generated) ──
 export { FileEntrySchema, type FileEntry } from "./entries/file-entry";
@@ -171,6 +174,7 @@ export {
 export {
   CommandCenterSnapshotSchema,
   CommandCenterResponseSchema,
+  CommandCenterModeSchema,
   CertificationSchema,
   GlobalStatusSchema,
   StaleStatusSchema,
@@ -183,6 +187,7 @@ export {
   CcOwnerActionSchema,
   type CommandCenterSnapshot,
   type CommandCenterResponse,
+  type CommandCenterMode,
   type Certification,
   type GlobalStatus,
   type CcDepartment,


### PR DESCRIPTION
## Improvement Check

- **Problem:** the full cockpit shouldn't be a PROD-public/critical surface (attack surface, internal-map leakage, runtime cost) — but the Docker `REGISTRY_DIR` fix in #854 (which repairs `/admin/control-plane`) **must** stay in PROD.
- **Evidence before:** #854 ships the full cockpit + the Docker fix together, with no exposure control.
- **Expected gain:** one governed env flag separates the two: cockpit full in DEV/PREPROD, restricted in PROD by default; Docker fix everywhere.
- **Risk:** read-only, additive; **prod-safe by default** (restricted even if the var is never set). Rollback = revert.
- **Test:** backend Jest — resolver default (prod→disabled, else full), explicit override, light strips internal detail; backend ESLint/TypeScript green locally.
- **Verdict:** `GO`
- **Next:** owner picks `COMMAND_CENTER_MODE` for PROD (`disabled` strict, or `light`) before any `v*` tag.

## What (owner decision 2026-06-04)

`COMMAND_CENTER_MODE = full | light | disabled`, resolved by `resolveCommandCenterMode()`:
explicit env wins; **SAFE DEFAULT = `disabled` when `NODE_ENV=production`** (PROD), else `full`
(DEV=`development`, PREPROD=`preprod`). So PROD is restricted automatically — **no deploy-env edit needed**.

- **Backend** — controller **404s** on `disabled` (reduces surface, reveals nothing); reader builds a
  **light** payload = top-line health only (`degraded`/`stale_status`/`validation_status`/`global_status`
  level+verdict + `summary` counts) and **strips all internal detail** (departments, capabilities, chains,
  alerts, owner_actions, evidence, `canon_path`, `git_sha`, `reasons`). Mode-aware cache key. `mode` added
  to the response + the `@repo/registry` Zod contract.
- **Frontend** — `/admin/command-center` renders a **"désactivé"** notice (on 404), a **light** summary
  (GlobalHealthBar only), or the **full** hub — by `mode`.
- **Governance** — `backend/.env.example` documents the flag (not ad-hoc).

**The Docker `REGISTRY_DIR` fix from #854 is unaffected by this flag — it repairs control-plane in PROD too.**

> No `v*` PROD tag should set `COMMAND_CENTER_MODE` without an explicit owner choice (disabled vs light).

🤖 Generated with [Claude Code](https://claude.com/claude-code)