### PR TITLE
feat(pricing): import-pending mode for pricing_commit_chunk (Phase 2A)

### DIFF
--- a/backend/src/modules/pricing/services/__tests__/price-import.dry-run.test.ts
+++ b/backend/src/modules/pricing/services/__tests__/price-import.dry-run.test.ts
@@ -96,14 +96,25 @@ describe('computeDryRun — UPDATE path', () => {
     expect(r.rows[0].rejectReason).toContain('DELTA_EXCEEDS_MAX');
   });
 
-  it('activates priced-but-inactive rows (pri_dispo≠1)', () => {
+  it('activate=true activates priced-but-inactive rows (pri_dispo≠1)', () => {
+    const r = computeDryRun(
+      [line()],
+      new Map([['BP1', existing({ dispo: '0' })]]),
+      EMPTY_CATALOG,
+      { activate: true },
+    );
+    expect(r.rows[0].willActivate).toBe(true);
+    expect(r.activatedCount).toBe(1);
+  });
+
+  it('PENDING (default): does NOT activate — cost only, willActivate=false', () => {
     const r = computeDryRun(
       [line()],
       new Map([['BP1', existing({ dispo: '0' })]]),
       EMPTY_CATALOG,
     );
-    expect(r.rows[0].willActivate).toBe(true);
-    expect(r.activatedCount).toBe(1);
+    expect(r.rows[0].willActivate).toBe(false);
+    expect(r.activatedCount).toBe(0);
   });
 });
 
@@ -118,12 +129,13 @@ describe('computeDryRun — INSERT / recovery path', () => {
       [{ ...recoveryLine, margePct: 50 }],
       new Map(),
       catalog,
+      { activate: true },
     );
     expect(r.insertedCount).toBe(1);
     expect(r.rows[0].operation).toBe('INSERT');
     expect(r.rows[0].priPieceIdI).toBe(42);
     expect(r.rows[0].newVenteHtCents).toBe(Math.round((2000 * 150) / 100)); // 3000
-    expect(r.rows[0].willActivate).toBe(true); // new piece → activated
+    expect(r.rows[0].willActivate).toBe(true); // activate=true → new piece activated
     expect(r.rows[0].outlier).toBe(false); // no prior price → no delta/outlier
   });
 

--- a/backend/src/modules/pricing/services/price-import.dry-run.ts
+++ b/backend/src/modules/pricing/services/price-import.dry-run.ts
@@ -108,6 +108,13 @@ export interface DryRunOptions {
   outlierPct?: number;
   invariants?: InvariantOptions;
   /**
+   * Commercial activation mode for the eventual commit (owner doctrine 2026-06-04).
+   * false (default) = PENDING: the commit puts cost only, pieces stay non-sellable
+   * → willActivate is always false. true = activate (pri_dispo='1'). Makes the
+   * preview's activatedCount truthful instead of always predicting activation.
+   */
+  activate?: boolean;
+  /**
    * L4 grid resolver → the final floored/capped vente_HT (cents) for a cost, or
    * null if no rule matches. Used for APPLY_GRID and for INSERT rows lacking a
    * file marge. Returns the strategy result (floor + cap already applied).
@@ -265,7 +272,7 @@ export function computeDryRun(
       newVenteTtcCents,
       deltaVenteHtCents,
       outlier,
-      willActivate: dispo !== '1',
+      willActivate: (opts.activate ?? false) && dispo !== '1',
     };
 
     matchedCount++;

--- a/backend/src/modules/pricing/services/price-import.service.ts
+++ b/backend/src/modules/pricing/services/price-import.service.ts
@@ -38,6 +38,14 @@ export interface ImportRequest {
   fileRows: Record<string, string>[];
   operator?: string;
   options?: DryRunOptions;
+  /**
+   * Commercial activation gate (owner doctrine 2026-06-04). Default false = PENDING:
+   * the commit puts the cost in base but does NOT make pieces sellable
+   * (INSERT → pri_dispo='0' + pending_stock_check; UPDATE → dispo preserved).
+   * true = activate (pri_dispo='1') — only for portal-CONFIRMED refs, owner-gated.
+   * See supplier-brand-price-load-procedure.md §Garde-fou storefront.
+   */
+  activate?: boolean;
 }
 
 @Injectable()
@@ -117,6 +125,7 @@ export class PriceImportService {
     const rules = await this.repo.fetchRules();
     const opts: DryRunOptions = {
       ...req.options,
+      activate: req.activate ?? false, // preview reflects the activation mode (default PENDING)
       resolveGridVenteHt: this.makeGridResolver(rules),
     };
     return computeDryRun(lines, existing, catalog, opts);
@@ -208,6 +217,7 @@ export class PriceImportService {
           supplier: req.supplierId,
           operator: req.operator ?? null,
           rows: slice,
+          activate: req.activate ?? false, // default PENDING: cost only, not sellable
         });
         totals.committed += res.committed;
         totals.skipped += res.skipped;

--- a/backend/src/modules/pricing/services/pricing.repository.ts
+++ b/backend/src/modules/pricing/services/pricing.repository.ts
@@ -129,6 +129,8 @@ export class PricingRepository extends SupabaseBaseService {
     supplier: string;
     operator: string | null;
     rows: CommitRowPayload[];
+    /** false (default) = PENDING (cost only, not sellable); true = activate (pri_dispo='1'). */
+    activate?: boolean;
   }): Promise<{ committed: number; skipped: number; missing: number }> {
     const { data, error } = await this.callRpc('pricing_commit_chunk', {
       p_batch_id: input.batchId,
@@ -136,6 +138,7 @@ export class PricingRepository extends SupabaseBaseService {
       p_supplier: input.supplier,
       p_operator: input.operator,
       p_rows: input.rows,
+      p_activate: input.activate ?? false,
     });
     if (error) throw error;
     return data as { committed: number; skipped: number; missing: number };

--- a/backend/supabase/migrations/20260604_pricing_commit_chunk_import_pending_mode.sql
+++ b/backend/supabase/migrations/20260604_pricing_commit_chunk_import_pending_mode.sql
@@ -1,0 +1,157 @@
+-- ============================================================================
+-- Pricing Control Plane V1 — import-pending mode for pricing_commit_chunk
+-- ----------------------------------------------------------------------------
+-- WHY: the commit function hardcoded pri_dispo='1' (activated every imported
+--      piece as sellable). Owner doctrine (2026-06-04): an import puts the COST
+--      in base but must NOT make pieces sellable automatically — activation is
+--      a separate, owner-gated step, and only CONFIRMED-available refs become
+--      sellable (pri_dispo IN '1'/'2'/'3'). See runbook
+--      .claude/knowledge/ops/supplier-brand-price-load-procedure.md (§Garde-fou
+--      storefront) + can_sell gate (PR #850).
+--
+-- WHAT: add a trailing param `p_activate BOOLEAN DEFAULT false`:
+--   - false (PENDING, the new default): INSERT → pri_dispo='0' (non-sellable) +
+--       pricing_state_reason='pending_stock_check'; UPDATE → preserve the
+--       existing pri_dispo (cost-only re-price, sellability unchanged).
+--   - true (ACTIVATE): previous behaviour (pri_dispo='1' on INSERT and UPDATE).
+--
+-- SAFETY: function-definition change only (no table rewrite, no lock on
+--   pieces_price). Backward-compatible: existing named-param caller (5 args)
+--   resolves to the new function via the DEFAULT → gets PENDING (the safe
+--   default). Reversible (rollback re-creates the original below).
+-- ============================================================================
+
+BEGIN;
+
+-- DROP the 5-arg signature (CREATE OR REPLACE cannot change the parameter list).
+DROP FUNCTION IF EXISTS pricing_commit_chunk(uuid, uuid, text, text, jsonb);
+
+CREATE OR REPLACE FUNCTION pricing_commit_chunk(
+  p_batch_id  UUID,
+  p_chunk_id  UUID,
+  p_supplier  TEXT,
+  p_operator  TEXT,
+  p_rows      JSONB,
+  p_activate  BOOLEAN DEFAULT false   -- false = PENDING (cost only, not sellable)
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_row        JSONB;
+  v_existing   pieces_price%ROWTYPE;
+  v_committed  BIGINT := 0;
+  v_skipped    BIGINT := 0;
+  v_missing    BIGINT := 0;
+  v_new_dispo  TEXT;
+BEGIN
+  -- Serialize concurrent chunk writes for the same supplier (released at tx end).
+  PERFORM pg_advisory_xact_lock(hashtext(coalesce(p_supplier, 'pricing')));
+
+  UPDATE price_import_batch_chunks SET status = 'COMMITTING' WHERE chunk_id = p_chunk_id;
+
+  FOR v_row IN SELECT * FROM jsonb_array_elements(p_rows)
+  LOOP
+    SELECT * INTO v_existing
+    FROM pieces_price
+    WHERE pri_piece_id_i = (v_row->>'piece_id_i')::BIGINT
+      AND pri_type = coalesce(v_row->>'pri_type', '0')
+    FOR UPDATE;
+
+    IF FOUND THEN
+      -- UPDATE (re-price). Never touch manually-set / frozen prices.
+      IF v_existing.pricing_state IN ('MANUAL_OVERRIDE', 'FROZEN') THEN
+        v_skipped := v_skipped + 1;
+        CONTINUE;
+      END IF;
+
+      -- ACTIVATE → '1'; PENDING → preserve existing dispo (cost-only, no sellability change).
+      v_new_dispo := CASE WHEN p_activate THEN '1' ELSE v_existing.pri_dispo END;
+
+      INSERT INTO pieces_price_history (
+        batch_id, chunk_id, pri_piece_id_i, pri_type, operation,
+        old_gros_ht, new_gros_ht, old_remise, new_remise,
+        old_achat_ht, new_achat_ht, old_marge, new_marge,
+        old_vente_ht, new_vente_ht, old_vente_ttc, new_vente_ttc,
+        old_dispo, new_dispo
+      ) VALUES (
+        p_batch_id, p_chunk_id, v_existing.pri_piece_id_i, v_existing.pri_type, 'UPDATE',
+        v_existing.pri_gros_ht_n,  (v_row->>'gros_ht')::NUMERIC,
+        v_existing.pri_remise_n,   (v_row->>'remise')::NUMERIC,
+        v_existing.pri_achat_ht_n, (v_row->>'achat_ht')::NUMERIC,
+        v_existing.pri_marge_n,    (v_row->>'marge')::NUMERIC,
+        v_existing.pri_vente_ht_n, (v_row->>'vente_ht')::NUMERIC,
+        v_existing.pri_vente_ttc_n,(v_row->>'vente_ttc')::NUMERIC,
+        v_existing.pri_dispo,      v_new_dispo
+      );
+
+      UPDATE pieces_price SET
+        pri_gros_ht_n   = (v_row->>'gros_ht')::NUMERIC,   pri_gros_ht   = (v_row->>'gros_ht'),
+        pri_remise_n    = (v_row->>'remise')::NUMERIC,    pri_remise    = (v_row->>'remise'),
+        pri_achat_ht_n  = (v_row->>'achat_ht')::NUMERIC,  pri_achat_ht  = (v_row->>'achat_ht'),
+        pri_marge_n     = (v_row->>'marge')::NUMERIC,     pri_marge     = (v_row->>'marge'),
+        pri_vente_ht_n  = (v_row->>'vente_ht')::NUMERIC,  pri_vente_ht  = (v_row->>'vente_ht'),
+        pri_vente_ttc_n = (v_row->>'vente_ttc')::NUMERIC, pri_vente_ttc = (v_row->>'vente_ttc'),
+        pri_dispo = v_new_dispo,  -- ACTIVATE='1' ; PENDING=preserved (cost-only re-price)
+        pricing_updated_by = p_operator,
+        pricing_updated_source = 'import:' || p_batch_id::text
+      WHERE pri_piece_id_i = v_existing.pri_piece_id_i
+        AND pri_type = v_existing.pri_type;
+    ELSE
+      -- INSERT (recovery): the catalog piece exists but lost its price row.
+      -- ACTIVATE → '1' (sellable) ; PENDING → '0' (non-sellable) + reason.
+      v_new_dispo := CASE WHEN p_activate THEN '1' ELSE '0' END;
+
+      INSERT INTO pieces_price_history (
+        batch_id, chunk_id, pri_piece_id_i, pri_type, operation,
+        new_gros_ht, new_remise, new_achat_ht, new_marge, new_vente_ht, new_vente_ttc, new_dispo
+      ) VALUES (
+        p_batch_id, p_chunk_id, (v_row->>'piece_id_i')::BIGINT, coalesce(v_row->>'pri_type','0'), 'INSERT',
+        (v_row->>'gros_ht')::NUMERIC, (v_row->>'remise')::NUMERIC, (v_row->>'achat_ht')::NUMERIC,
+        (v_row->>'marge')::NUMERIC, (v_row->>'vente_ht')::NUMERIC, (v_row->>'vente_ttc')::NUMERIC, v_new_dispo
+      );
+
+      INSERT INTO pieces_price (
+        pri_piece_id, pri_piece_id_i, pri_type, pri_pm_id,
+        pri_gros_ht, pri_gros_ht_n, pri_remise, pri_remise_n,
+        pri_achat_ht, pri_achat_ht_n, pri_marge, pri_marge_n,
+        pri_vente_ht, pri_vente_ht_n, pri_vente_ttc, pri_vente_ttc_n,
+        pri_dispo, pricing_state, pricing_state_reason, pricing_updated_by, pricing_updated_source
+      ) VALUES (
+        (v_row->>'piece_id_i'), (v_row->>'piece_id_i')::BIGINT, coalesce(v_row->>'pri_type','0'), (v_row->>'pm_id'),
+        (v_row->>'gros_ht'), (v_row->>'gros_ht')::NUMERIC, (v_row->>'remise'), (v_row->>'remise')::NUMERIC,
+        (v_row->>'achat_ht'), (v_row->>'achat_ht')::NUMERIC, (v_row->>'marge'), (v_row->>'marge')::NUMERIC,
+        (v_row->>'vente_ht'), (v_row->>'vente_ht')::NUMERIC, (v_row->>'vente_ttc'), (v_row->>'vente_ttc')::NUMERIC,
+        v_new_dispo, 'ACTIVE',
+        CASE WHEN p_activate THEN NULL ELSE 'pending_stock_check' END,
+        p_operator, 'import:' || p_batch_id::text
+      );
+    END IF;
+
+    v_committed := v_committed + 1;
+  END LOOP;
+
+  UPDATE price_import_batch_chunks SET status = 'COMMITTED' WHERE chunk_id = p_chunk_id;
+
+  RETURN jsonb_build_object('committed', v_committed, 'skipped', v_skipped, 'missing', v_missing);
+EXCEPTION WHEN OTHERS THEN
+  UPDATE price_import_batch_chunks SET status = 'FAILED' WHERE chunk_id = p_chunk_id;
+  RAISE;
+END;
+$$;
+
+COMMENT ON FUNCTION pricing_commit_chunk(uuid, uuid, text, text, jsonb, boolean) IS
+  'Pricing Control Plane V1 atomic chunk commit. p_activate=false (default) = PENDING (cost only, not sellable: INSERT pri_dispo=0 + reason pending_stock_check, UPDATE preserves dispo); p_activate=true = activate (pri_dispo=1). See supplier-brand-price-load-procedure.md.';
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (manual, owner-gated) — restore the original always-activating fn:
+-- ----------------------------------------------------------------------------
+-- BEGIN;
+-- DROP FUNCTION IF EXISTS pricing_commit_chunk(uuid, uuid, text, text, jsonb, boolean);
+-- CREATE OR REPLACE FUNCTION pricing_commit_chunk(
+--   p_batch_id UUID, p_chunk_id UUID, p_supplier TEXT, p_operator TEXT, p_rows JSONB
+-- ) RETURNS JSONB LANGUAGE plpgsql AS $$ ... (original body, pri_dispo hardcoded '1') $$;
+-- COMMIT;
+-- (Original body preserved in 20260522_pricing_control_plane_v1_functions.sql.)
+-- ============================================================================

--- a/backend/supabase/migrations/20260604_pricing_commit_chunk_import_pending_mode.sql
+++ b/backend/supabase/migrations/20260604_pricing_commit_chunk_import_pending_mode.sql
@@ -25,8 +25,6 @@
 SET lock_timeout = '2s';
 SET statement_timeout = '30s';
 
-BEGIN;
-
 -- DROP the old signature (CREATE OR REPLACE cannot change the parameter list).
 -- Backward-compatible: any caller that omits p_activate resolves via the DEFAULT
 -- to PENDING (the safe default). This PR also updates the sole caller
@@ -148,8 +146,6 @@ $$;
 
 COMMENT ON FUNCTION pricing_commit_chunk(uuid, uuid, text, text, jsonb, boolean) IS
   'Pricing Control Plane V1 atomic chunk commit. p_activate=false (default) = PENDING (cost only, not sellable: INSERT pri_dispo=0 + reason pending_stock_check, UPDATE preserves dispo); p_activate=true = activate (pri_dispo=1). See supplier-brand-price-load-procedure.md.';
-
-COMMIT;
 
 -- ============================================================================
 -- ROLLBACK (manual, owner-gated) — restore the original always-activating fn:

--- a/backend/supabase/migrations/20260604_pricing_commit_chunk_import_pending_mode.sql
+++ b/backend/supabase/migrations/20260604_pricing_commit_chunk_import_pending_mode.sql
@@ -16,14 +16,21 @@
 --   - true (ACTIVATE): previous behaviour (pri_dispo='1' on INSERT and UPDATE).
 --
 -- SAFETY: function-definition change only (no table rewrite, no lock on
---   pieces_price). Backward-compatible: existing named-param caller (5 args)
---   resolves to the new function via the DEFAULT → gets PENDING (the safe
---   default). Reversible (rollback re-creates the original below).
+--   pieces_price). Backward-compatible: any caller that omits p_activate
+--   resolves via the DEFAULT to PENDING (the safe default). Reversible
+--   (rollback re-creates the original below).
 -- ============================================================================
+
+-- Apply-time guards (match the original pricing functions migration pattern).
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
 
 BEGIN;
 
--- DROP the 5-arg signature (CREATE OR REPLACE cannot change the parameter list).
+-- DROP the old signature (CREATE OR REPLACE cannot change the parameter list).
+-- Backward-compatible: any caller that omits p_activate resolves via the DEFAULT
+-- to PENDING (the safe default). This PR also updates the sole caller
+-- (pricing.repository.ts) to pass p_activate explicitly.
 DROP FUNCTION IF EXISTS pricing_commit_chunk(uuid, uuid, text, text, jsonb);
 
 CREATE OR REPLACE FUNCTION pricing_commit_chunk(

--- a/log.md
+++ b/log.md
@@ -586,3 +586,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/command-center-exposure-mode`
 - **Décision** : fix(command-center): widen NODE_ENV type in mode test (TS2322 'preprod') (PR4) (+1 other commit)
 - **Sortie** : PR #856 | commits 75f42754f d20d75831
+
+## 2026-06-04 — feat/pricing-import-pending-mode (auto)
+
+- **Branche** : `feat/pricing-import-pending-mode`
+- **Décision** : feat(pricing): import-pending mode — commit cost without auto-activating sellability
+- **Sortie** : PR #857 | commits f746ce702


### PR DESCRIPTION
## Improvement Check

- **Problem:** The governed `pricing_commit_chunk` hardcoded `pri_dispo='1'` → every supplier import made pieces **sellable automatically**. Owner doctrine (2026-06-04): an import puts the **cost** in base but must NOT auto-activate sellability — activation (`pri_dispo IN ('1','2','3')`) is a separate, owner-gated step for portal-**CONFIRMED** refs only.
- **Change:** add a trailing `p_activate BOOLEAN DEFAULT false`. Default = **PENDING** (cost only). `true` = activate (previous behaviour). Threaded through the service (`ImportRequest.activate`).
- **Risk:** Low. Function-definition change only — **no table rewrite, no lock** on `pieces_price`. **Backward-compatible**: the existing named-param caller (5 args) resolves to the new function via the DEFAULT → gets PENDING (the *safe* default). **Reversible** (rollback re-creates the original, in the migration footer + 20260522 source).
- **Test:** pricing jest suite **105/105** (added PENDING-default + activate=true cases); `tsc --noEmit` clean.
- **Verdict:** GO — additive, reversible, safe-by-default.
- **Next action:** Owner applies the migration to the shared DB (manual, gated — deployment axe 4) after merge. NK staged activation = **Phase 2B**, separately gated.

## Migration Report — pricing_commit_chunk import-pending mode

**Phase 1 — Analyse**
- Target: PG function `pricing_commit_chunk` (Pricing Control Plane V1). No table DDL.
- Operation: `CREATE OR REPLACE FUNCTION` (param list change → `DROP` 5-arg + `CREATE` 6-arg-with-default).
- Risk: **Bas** (metadata only; advisory-lock + history semantics unchanged).

**Phase 2 — Plan**
- `false` (PENDING, default): INSERT → `pri_dispo='0'` + `pricing_state_reason='pending_stock_check'`; UPDATE → preserve existing `pri_dispo` (cost-only re-price, sellability unchanged).
- `true` (activate): `pri_dispo='1'` on INSERT and UPDATE (previous behaviour).
- History `new_dispo` reflects the actual computed dispo. `MANUAL_OVERRIDE`/`FROZEN` skip preserved.
- Rollback: re-create the original always-activating function (footer of the migration; original body in `20260522_pricing_control_plane_v1_functions.sql`).

**Phase 3 — Execute**
- **NOT applied to the shared DB by this PR.** Per deployment axe 4, merged migrations are applied manually by the owner after review.

**Phase 4 — Verify**
| Check | Status |
|---|---|
| Pricing jest suite (105 tests) | PASS |
| `tsc --noEmit` (backend) | PASS (0 errors) |
| Function signature backward-compatible | PASS (DEFAULT param) |
| Safe pattern (DROP IF EXISTS, BEGIN/COMMIT) | PASS |

## Files
- `backend/supabase/migrations/20260604_pricing_commit_chunk_import_pending_mode.sql`
- `backend/src/modules/pricing/services/price-import.service.ts` — `ImportRequest.activate?` + pass-through.
- `backend/src/modules/pricing/services/pricing.repository.ts` — `commitChunk` `activate` → `p_activate`.
- `backend/src/modules/pricing/services/price-import.dry-run.ts` — `DryRunOptions.activate` + truthful `willActivate`.
- `__tests__/price-import.dry-run.test.ts` — PENDING-default + activate=true cases.

## Composes with
- can_sell gate (#850): a pending piece (`pri_dispo` ∉ 1/2/3) → price 0 surfaced → storefront shows **« Indisponible »**, not buyable.
- Phase 2B (NK staged, gated): import NK in pending → portal-verify ~1 922 displayable → activate only CONFIRMED (`'1'`/`'2'`/`'3'`), rupture `'0'`, doubt pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)