### PR TITLE
feat(content): add deterministic RAW evidence inventory

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -274,6 +274,13 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: low
+  # RAW evidence inventory (read-only diagnostic upstream of promote-raw-gammes-to-wiki.py).
+  # D3 / @ak125/seo-team — same SEO content pipeline family (RAW → WIKI → consumers, ADR-031).
+  - glob: audit/content/raw-evidence/**
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: low
   # ADR-082 Phase 1 — continuous improvement doctrine pilots + cross-validation
   # (rangés à plat sous audit/ par convention historique, cf. audit/seo-*.md).
   - glob: audit/pilot-*.md

--- a/audit/content/raw-evidence/README.md
+++ b/audit/content/raw-evidence/README.md
@@ -1,0 +1,56 @@
+# RAW evidence inventory — `audit/content/raw-evidence/`
+
+Read-only, deterministic diagnostic answering **« le RAW a-t-il le droit de devenir un
+wiki/une page ? »** for a gamme subject. It measures per-block **coverage** + **provenance**
+of `automecanik-raw/recycled/rag-knowledge/` and emits an evidence artefact. It is the
+diagnostic step immediately **upstream** of `scripts/wiki-generators/promote-raw-gammes-to-wiki.py`.
+
+> **Read-only & advisory.** No fact extraction, no LLM, no generation, no DB/wiki/RAG write,
+> no URL/canonical/redirect, no publication. The only files written live under this folder.
+> Builder + schema live in [`scripts/wiki-generators/`](../../../scripts/wiki-generators/).
+
+## Run
+
+```bash
+npx tsx scripts/wiki-generators/raw-evidence-inventory.ts filtre-a-air        # human-readable
+npx tsx scripts/wiki-generators/raw-evidence-inventory.ts filtre-a-air --json # machine output (also writes the artefact)
+npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --all               # every gamme subject
+npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --emit-schema       # regenerate the JSON Schema projection
+npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --check             # fail if the committed schema drifted from Zod
+npx tsx --test scripts/wiki-generators/__tests__/raw-evidence-inventory.test.ts
+```
+
+Source root is `${AUTOMECANIK_RAW_PATH:-/opt/automecanik/automecanik-raw}`.
+
+## Contract
+
+`raw-evidence.schema.ts` (Zod) is the **single source of truth**; `raw-evidence.schema.json`
+is a **generated projection — never edit it by hand** (regenerate with `--emit-schema`,
+`--check` enforces no drift). Output is **deterministic + idempotent** (sorted keys via the
+shared `writeDeterministicJson`, `content_hash` = sha256 of source bytes, **no builder timestamp**).
+
+- `coverage[]` — v4 canon blocks **A.domain / B.selection / C.diagnostic / D.maintenance /
+  E.installation** (`PRESENT` / `PARTIAL` / `MISSING`, WARN-gaps in `warnings[]`), plus the
+  `schema_version 5.0` superset blocks recensés as `NOT_MAPPED` (never silently dropped), plus
+  `compatibility` = `BLOCKED_CATALOG_REQUIRED` (catalogue/DB only, never a RAW blocker).
+- `provenance.sources[]` — gamme `.md` + `_raw/evidence/<slug>.yml` (slug-equal) + an explicitly
+  mapped guide (`GUIDE_MAP`; guides carry no `pg_id` link, so they are never slug-guessed).
+- `next_action` — `SOURCE_FIRST` (no RAW) · `FIX_RAW_FRONTMATTER` (parse error) ·
+  `ENRICH_RAW_<BLOCK>` (a block incomplete, deterministic priority) · `PROMOTE_RAW_TO_WIKI`
+  (all A–E present). **Owner-gated** — this tool never runs the next step.
+
+## Role-fold annotation (`fold_readiness` / `fold_status`)
+
+`fold_readiness` separates **« RAW coverage OK »** from **« fold R4/R6→R3 authorised in prod »** :
+
+- `R5_to_R3 = READY_ADR_027` — R5 already folded into R3 (`S2_DIAG #diagnostic-rapide`, ADR-027, live).
+- `R4_to_R3 = BLOCKED_PENDING_ADR`, `R6_to_R3 = BLOCKED_PENDING_ADR` — the owner-desired R4/R6→R3
+  fold is **not canon**; it requires a vault ADR extending ADR-027 + role-matrix v6 + redirect RPCs.
+  The `r3_section` field is a **forward-compatible annotation only** — it authorises nothing.
+
+## Downstream (deferred, not in this PR)
+
+The intended next step is to wire this as an **upstream `raw` dimension** of
+[`scripts/seo/seo-readiness.ts`](../../../scripts/seo/seo-readiness.ts) (so its worst-case
+`NEXT_ACTION` stops presuming the RAW is ready). That wiring, fact/claim extraction, and the
+R4/R6→R3 runtime fold all remain **owner-gated follow-ups**.

--- a/audit/content/raw-evidence/filtre-a-air.raw-evidence.json
+++ b/audit/content/raw-evidence/filtre-a-air.raw-evidence.json
@@ -1,0 +1,143 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:key_visual_features",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 8,
+  "provenance": {
+    "completeness_profile": "filtration",
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:27eab1f7b226f863267e0d121fb02a7dc128063ca3bd5d804a0f7040804fb787",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/filtre-a-air.yml"
+      },
+      {
+        "content_hash": "sha256:09e4d5bef4f79c7f45ab1c56b0172a8d8ab4f006b4d766d99eea501a465574d0",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/filtre-a-air.md"
+      },
+      {
+        "content_hash": "sha256:5db34aaf345a4c97b5cc4329a8453309d2351609edcacc81ac0fe546f2595a3b",
+        "kind": "guide",
+        "path": "recycled/rag-knowledge/guides/choisir-filtre-air.md"
+      }
+    ],
+    "truth_level": "L3",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "filtre-a-air"
+}

--- a/log.md
+++ b/log.md
@@ -394,3 +394,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `vlevel-doctrine-lock`
 - **Décision** : feat(seo-roles): V-Level doctrine — invariants ref + DB-only capture (lock-before-fix) ; + fixes squawk migration + overlay ownership D14
 - **Sortie** : PR #861 | commits 07141fcc4 4f037916a a599763f8 525cfa21d
+
+## 2026-06-05 — feat/content-raw-evidence-inventory (auto)
+
+- **Branche** : `feat/content-raw-evidence-inventory`
+- **Décision** : feat(content): read-only deterministic RAW evidence inventory (pilote filtre-a-air)
+- **Sortie** : PR aucune | commits a9a042483

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
     "governance:command-center": "node scripts/governance/build-command-center-snapshot.js",
     "governance:command-center:check": "node scripts/governance/build-command-center-snapshot.js --check",
     "governance:test:command-center": "tsx --test scripts/governance/__tests__/build-command-center-snapshot.test.ts",
+    "content:raw-evidence:schema-check": "tsx scripts/wiki-generators/raw-evidence-inventory.ts --check",
+    "content:test:raw-evidence": "tsx --test scripts/wiki-generators/__tests__/raw-evidence-inventory.test.ts",
     "architecture:build": "npm -w @repo/registry run build:architecture",
     "architecture:test": "tsx --test tests/registry/architecture-generator.test.ts",
     "depcruise:integrity-test": "tsx --test tests/registry/depcruise-integrity.test.ts",

--- a/scripts/wiki-generators/__tests__/raw-evidence-inventory.test.ts
+++ b/scripts/wiki-generators/__tests__/raw-evidence-inventory.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for scripts/wiki-generators/raw-evidence-inventory.ts
+ *
+ * Run: npx tsx --test scripts/wiki-generators/__tests__/raw-evidence-inventory.test.ts
+ *
+ * Covers (TDD):
+ *   - pilot output validates against the generated JSON Schema (Ajv)
+ *   - golden pilot assertions (READY, A–E PRESENT, fold_readiness, 3 sources)
+ *   - 5.0 superset blocks recensés (no silent drop)
+ *   - fold_status: R5 LIVE, R4/R6 PENDING_ADR
+ *   - determinism (build ×2 deep-equal)
+ *   - NO_RAW path validates + SOURCE_FIRST
+ *   - the committed pilot artefact validates against the schema
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { buildEvidence } from '../raw-evidence-inventory';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const SCHEMA = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'raw-evidence.schema.json'), 'utf8'));
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+const validate = ajv.compile(SCHEMA);
+
+test('pilot filtre-a-air validates against the generated schema', () => {
+  const ev = buildEvidence('filtre-a-air');
+  assert.ok(validate(ev), JSON.stringify(validate.errors));
+});
+
+test('pilot golden: READY, A–E PRESENT, fold_readiness, 3 sources', () => {
+  const ev = buildEvidence('filtre-a-air');
+  assert.equal(ev.inventory_status, 'DIAGNOSTIC_READY');
+  assert.equal(ev.raw_verdict, 'READY');
+  assert.equal(ev.next_action, 'PROMOTE_RAW_TO_WIKI');
+  const abcde = ev.coverage.filter((c) => /^[A-E]\./.test(c.block));
+  assert.equal(abcde.length, 5);
+  assert.ok(abcde.every((c) => c.status === 'PRESENT'), 'A–E must all be PRESENT');
+  assert.equal(ev.fold_readiness.R5_to_R3, 'READY_ADR_027');
+  assert.equal(ev.fold_readiness.R4_to_R3, 'BLOCKED_PENDING_ADR');
+  assert.equal(ev.fold_readiness.R6_to_R3, 'BLOCKED_PENDING_ADR');
+  assert.equal(ev.provenance.sources.length, 3);
+  assert.equal(ev.pg_id, 8);
+});
+
+test('5.0 superset blocks are recensés (no silent drop)', () => {
+  const ev = buildEvidence('filtre-a-air');
+  const sup = ev.coverage.filter((c) => c.block.startsWith('5.0:')).map((c) => c.block);
+  for (const b of ['5.0:variants', '5.0:conseil_v5', '5.0:diagnostic.depose_steps']) {
+    assert.ok(sup.includes(b), `missing recensé block ${b}`);
+  }
+  assert.ok(
+    ev.coverage.filter((c) => c.block.startsWith('5.0:')).every((c) => c.status === 'NOT_MAPPED'),
+    '5.0 blocks must be NOT_MAPPED',
+  );
+});
+
+test('fold_status per block: R5 LIVE, R4/R6 PENDING_ADR', () => {
+  const ev = buildEvidence('filtre-a-air');
+  const byBlock = Object.fromEntries(ev.coverage.map((c) => [c.block, c]));
+  assert.equal(byBlock['C.diagnostic'].fold_status, 'LIVE');
+  assert.equal(byBlock['A.domain'].fold_status, 'PENDING_ADR');
+  assert.equal(byBlock['B.selection'].fold_status, 'PENDING_ADR');
+  assert.equal(byBlock['compatibility'].status, 'BLOCKED_CATALOG_REQUIRED');
+});
+
+test('deterministic: build ×2 deep-equal', () => {
+  assert.deepEqual(buildEvidence('filtre-a-air'), buildEvidence('filtre-a-air'));
+});
+
+test('NO_RAW path validates and yields SOURCE_FIRST', () => {
+  const ev = buildEvidence('__subject_does_not_exist__');
+  assert.ok(validate(ev), JSON.stringify(validate.errors));
+  assert.equal(ev.inventory_status, 'NO_RAW');
+  assert.equal(ev.raw_verdict, 'NO_RAW');
+  assert.equal(ev.next_action, 'SOURCE_FIRST');
+});
+
+test('committed pilot artefact validates against the schema', () => {
+  const p = path.join(ROOT, 'audit', 'content', 'raw-evidence', 'filtre-a-air.raw-evidence.json');
+  const committed = JSON.parse(fs.readFileSync(p, 'utf8'));
+  assert.ok(validate(committed), JSON.stringify(validate.errors));
+});

--- a/scripts/wiki-generators/raw-block-schema.ts
+++ b/scripts/wiki-generators/raw-block-schema.ts
@@ -1,0 +1,156 @@
+/**
+ * RAW evidence block taxonomy.
+ * Blocks A–E are the CANONICAL v4 schema
+ * (.spec/00-canon/gamme-md-schema.md, "v4 — Architecture 5 blocs", truth_level L1|L2).
+ * Live RAW carries schema_version 5.0 — a SUPERSET of v4 (truth_level L3 + extra
+ * blocks: depose_steps, variants, location_on_vehicle, key_visual_features,
+ * purchase_guardrails, conseil_v5). This file reconciles v4 canon + 5.0 superset.
+ *
+ * A–E thresholds REUSE / reference validate-gamme-schema.ts (the same v4 blocks):
+ * do NOT re-duplicate them here. Converging that validator onto this module is
+ * intentionally deferred (P-later). This is an extension v4→5.0, not legacy-vs-target.
+ *
+ * BLOCK-severity vs WARN-severity below mirror scripts/validate-gamme-schema.ts:64-118.
+ */
+
+export type BlockStatus =
+  | 'PRESENT'
+  | 'PARTIAL'
+  | 'MISSING'
+  | 'NOT_APPLICABLE'
+  | 'NOT_MAPPED'
+  | 'BLOCKED_CATALOG_REQUIRED';
+
+export interface BlockDef {
+  id: string; // 'A.domain'
+  key: string; // frontmatter key
+  canon_role: string;
+  r3_section: string | null;
+  fold_status: 'PENDING_ADR' | 'LIVE' | 'NATIVE' | 'NOT_FOLDED';
+}
+
+/** v4 canon blocks A–E, with their canonical role + (annotated) R3 target section. */
+export const BLOCK_DEFS: readonly BlockDef[] = [
+  { id: 'A.domain', key: 'domain', canon_role: 'R4', r3_section: 'reference', fold_status: 'PENDING_ADR' },
+  { id: 'B.selection', key: 'selection', canon_role: 'R6', r3_section: 'guide-achat', fold_status: 'PENDING_ADR' },
+  { id: 'C.diagnostic', key: 'diagnostic', canon_role: 'R5', r3_section: 'diagnostic-rapide', fold_status: 'LIVE' },
+  { id: 'D.maintenance', key: 'maintenance', canon_role: 'R3', r3_section: 'maintenance', fold_status: 'NATIVE' },
+  { id: 'E.installation', key: 'installation', canon_role: 'R3', r3_section: 'installation', fold_status: 'NATIVE' },
+] as const;
+
+/** schema_version 5.0 superset blocks (top-level keys), recensés so populated data is never silently dropped. */
+export const SUPERSET_BLOCKS_5_0: readonly string[] = [
+  'variants',
+  'location_on_vehicle',
+  'key_visual_features',
+  'purchase_guardrails',
+  'conseil_v5',
+] as const;
+
+/**
+ * Explicit guide mapping (subject slug → guide slug under recycled/rag-knowledge/guides/).
+ * Guides carry NO pg_id / gamme frontmatter field, so they CANNOT be auto-linked by
+ * slug-equality (e.g. `choisir-filtre-air` ≠ `filtre-a-air`). Auto-discovery would be
+ * non-deterministic; the mapping is therefore explicit (seeded per pilot). Subjects
+ * absent from this map record `unlinked_source_types: ['guide']` (honest, not silent).
+ */
+export const GUIDE_MAP: Readonly<Record<string, string>> = {
+  'filtre-a-air': 'choisir-filtre-air',
+};
+
+const len = (v: unknown): number => (Array.isArray(v) ? v.length : 0);
+
+export interface BlockAssessment {
+  status: BlockStatus;
+  warnings: string[];
+}
+
+/**
+ * Assess a v4 block's coverage from the parsed RAW frontmatter.
+ * Returns PRESENT/PARTIAL/MISSING + WARN-severity gaps in `warnings`.
+ * Thresholds mirror validate-gamme-schema.ts (v4) — see header.
+ */
+export function assessBlock(blockKey: string, fm: any): BlockAssessment {
+  const node = fm?.[blockKey];
+  if (node === undefined || node === null) return { status: 'MISSING', warnings: [] };
+  const warnings: string[] = [];
+
+  switch (blockKey) {
+    case 'domain': {
+      const role = typeof node.role === 'string' ? node.role : '';
+      // BLOCK-severity (validate-gamme-schema.ts:64-67): role >= 80 chars, non-generic.
+      if (role.length < 80) return { status: 'PARTIAL', warnings: [`domain.role too short (${role.length} < 80)`] };
+      // WARN-severity.
+      if (len(node.confusion_with) < 2) warnings.push(`domain.confusion_with < 2 (${len(node.confusion_with)})`);
+      if (len(node.must_be_true) < 2) warnings.push(`domain.must_be_true < 2 (${len(node.must_be_true)})`);
+      return { status: 'PRESENT', warnings };
+    }
+    case 'selection': {
+      // BLOCK-severity: cost_range present + not suspect (max <= 10*min).
+      const cr = node.cost_range;
+      if (!cr) return { status: 'PARTIAL', warnings: ['selection.cost_range missing'] };
+      if (cr.min > 0 && cr.max > 10 * cr.min) {
+        return { status: 'PARTIAL', warnings: [`selection.cost_range suspect (${cr.min}-${cr.max})`] };
+      }
+      // WARN-severity.
+      if (len(node.criteria) < 3) warnings.push(`selection.criteria < 3 (${len(node.criteria)})`);
+      if (len(node.checklist) < 3) warnings.push(`selection.checklist < 3 (${len(node.checklist)})`);
+      if (len(node.anti_mistakes) < 3) warnings.push(`selection.anti_mistakes < 3 (${len(node.anti_mistakes)})`);
+      return { status: 'PRESENT', warnings };
+    }
+    case 'diagnostic': {
+      // No BLOCK-severity in C — all WARN.
+      if (len(node.symptoms) < 3) warnings.push(`diagnostic.symptoms < 3 (${len(node.symptoms)})`);
+      if (len(node.causes) < 2) warnings.push(`diagnostic.causes < 2 (${len(node.causes)})`);
+      if (len(node.quick_checks) < 2) warnings.push(`diagnostic.quick_checks < 2 (${len(node.quick_checks)})`);
+      return { status: 'PRESENT', warnings };
+    }
+    case 'maintenance': {
+      // WARN-severity: interval + note ; usage_factors required only when unit != km.
+      if (!node.interval || !node.interval.note) warnings.push('maintenance.interval or note missing');
+      if (node.interval && node.interval.unit !== 'km' && len(node.usage_factors) === 0) {
+        warnings.push('maintenance.usage_factors required when unit != km');
+      }
+      return { status: 'PRESENT', warnings };
+    }
+    case 'installation': {
+      // INFO-only in the v4 validator ; steps >= 3 is informational.
+      if (len(node.steps) < 3) warnings.push(`installation.steps < 3 (${len(node.steps)})`);
+      return { status: 'PRESENT', warnings };
+    }
+    default:
+      return { status: 'MISSING', warnings: [] };
+  }
+}
+
+/**
+ * Deterministic next_action when one or more A–E blocks are MISSING/PARTIAL.
+ * Priority: (1) blocks required by intent_targets first, then (2) fixed order C>A>B>D>E.
+ * `compatibility` (catalog) is informational and never the RAW next_action.
+ */
+const INTENT_BLOCKS: Readonly<Record<string, string[]>> = {
+  diagnostic: ['C.diagnostic'],
+  achat: ['B.selection'],
+  compatibilite: ['A.domain'],
+};
+const FIXED_PRIORITY = ['C.diagnostic', 'A.domain', 'B.selection', 'D.maintenance', 'E.installation'];
+
+export function pickNextAction(
+  coverage: { block: string; status: BlockStatus }[],
+  intentTargets: string[],
+): string {
+  const incomplete = new Set(
+    coverage.filter((c) => c.status === 'MISSING' || c.status === 'PARTIAL').map((c) => c.block),
+  );
+  if (incomplete.size === 0) return 'PROMOTE_RAW_TO_WIKI';
+
+  const intentFirst = intentTargets.flatMap((t) => INTENT_BLOCKS[t] ?? []);
+  const ordered = [...intentFirst, ...FIXED_PRIORITY];
+  for (const block of ordered) {
+    if (incomplete.has(block)) {
+      const letter = block.split('.')[0].toUpperCase();
+      return `ENRICH_RAW_${letter}`;
+    }
+  }
+  return 'ENRICH_RAW';
+}

--- a/scripts/wiki-generators/raw-evidence-inventory.ts
+++ b/scripts/wiki-generators/raw-evidence-inventory.ts
@@ -1,0 +1,302 @@
+/**
+ * raw-evidence-inventory.ts — READ-ONLY, DETERMINISTIC RAW evidence inventory.
+ *
+ * Answers « le RAW a-t-il le droit de devenir un wiki/une page ? » for a gamme
+ * subject, by measuring per-block coverage (v4 canon A–E + 5.0 superset) and
+ * provenance against `automecanik-raw/recycled/rag-knowledge/`. It is the diagnostic
+ * step immediately UPSTREAM of promote-raw-gammes-to-wiki.py (hence this dir).
+ *
+ * STRICTLY read-only of the RAW repo ; writes only the evidence artefact under
+ * `audit/content/raw-evidence/`. No fact extraction, no LLM, no generation, no
+ * DB/wiki/RAG write, no URL/canonical/redirect. Deterministic + idempotent: same
+ * RAW → bit-identical artefact (writeDeterministicJson, content_hash from source
+ * bytes, no builder timestamp).
+ *
+ * Pattern: build-command-center-snapshot.js (deterministic builder) + diag-canon
+ * Zod→JSON projection. seo-readiness.ts borrowed only for verdict/NEXT_ACTION shape.
+ *
+ * Usage:
+ *   npx tsx scripts/wiki-generators/raw-evidence-inventory.ts <subject> [--json]
+ *   npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --all
+ *   npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --emit-schema   # regenerate JSON Schema projection
+ *   npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --check         # fail if committed schema drifted
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { load as loadYaml } from 'js-yaml';
+import { zodToJsonSchema as _zodToJsonSchema } from 'zod-to-json-schema';
+
+import { RawEvidenceSchema, type RawEvidence } from './raw-evidence.schema';
+import {
+  BLOCK_DEFS,
+  SUPERSET_BLOCKS_5_0,
+  GUIDE_MAP,
+  assessBlock,
+  pickNextAction,
+  type BlockStatus,
+} from './raw-block-schema';
+
+const require = createRequire(import.meta.url);
+// Reuse the shared deterministic writer (sortKeysDeep + 2-space + trailing \n + sha256).
+const { writeDeterministicJson, sortKeysDeep } = require('../registry/lib/utils.js');
+
+// Type-erased cast (TS2589 mitigation), mirroring diag-canon-jsonschema.ts.
+const zodToJsonSchema = _zodToJsonSchema as (schema: unknown, options?: unknown) => object;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MONOREPO_ROOT = path.resolve(__dirname, '..', '..');
+const RAW_ROOT = process.env.AUTOMECANIK_RAW_PATH || '/opt/automecanik/automecanik-raw';
+const KB = path.join(RAW_ROOT, 'recycled', 'rag-knowledge');
+const GAMMES_DIR = path.join(KB, 'gammes');
+const GUIDES_DIR = path.join(KB, 'guides');
+const EVIDENCE_DIR = path.join(KB, '_raw', 'evidence');
+const OUT_DIR = path.join(MONOREPO_ROOT, 'audit', 'content', 'raw-evidence');
+const SCHEMA_PATH = path.join(__dirname, 'raw-evidence.schema.json');
+
+const FOLD_READINESS = {
+  R4_to_R3: 'BLOCKED_PENDING_ADR',
+  R5_to_R3: 'READY_ADR_027',
+  R6_to_R3: 'BLOCKED_PENDING_ADR',
+} as const;
+const FOLD_NOTE =
+  'R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).';
+
+type Source = { path: string; kind: 'gamme' | 'guide' | 'evidence'; content_hash: string };
+
+function sha256File(absPath: string): string {
+  return 'sha256:' + crypto.createHash('sha256').update(fs.readFileSync(absPath)).digest('hex');
+}
+
+function relToRaw(absPath: string): string {
+  return path.relative(RAW_ROOT, absPath).split(path.sep).join('/');
+}
+
+/** Parse YAML frontmatter from a `---`-delimited markdown file. Never throws. */
+function parseFrontmatter(raw: string): { fm: any | null; error: string | null } {
+  if (!raw.startsWith('---')) return { fm: null, error: 'no_frontmatter_delimiter' };
+  const end = raw.indexOf('\n---', 3);
+  if (end === -1) return { fm: null, error: 'unterminated_frontmatter' };
+  try {
+    return { fm: loadYaml(raw.slice(3, end)) ?? null, error: null };
+  } catch (e) {
+    return { fm: null, error: 'yaml_parse_error: ' + String((e as Error).message || e) };
+  }
+}
+
+function discoverSources(subject: string): { sources: Source[]; unlinked: string[] } {
+  const sources: Source[] = [];
+  const gammePath = path.join(GAMMES_DIR, `${subject}.md`);
+  if (fs.existsSync(gammePath)) {
+    sources.push({ path: relToRaw(gammePath), kind: 'gamme', content_hash: sha256File(gammePath) });
+  }
+  const evidencePath = path.join(EVIDENCE_DIR, `${subject}.yml`);
+  if (fs.existsSync(evidencePath)) {
+    sources.push({ path: relToRaw(evidencePath), kind: 'evidence', content_hash: sha256File(evidencePath) });
+  }
+  const unlinked: string[] = [];
+  const guideSlug = GUIDE_MAP[subject];
+  if (guideSlug) {
+    const guidePath = path.join(GUIDES_DIR, `${guideSlug}.md`);
+    if (fs.existsSync(guidePath)) {
+      sources.push({ path: relToRaw(guidePath), kind: 'guide', content_hash: sha256File(guidePath) });
+    }
+  } else {
+    // No deterministic guide link (guides carry no pg_id/gamme field) — honest, not silent.
+    unlinked.push('guide');
+  }
+  sources.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return { sources, unlinked };
+}
+
+type CoverageEntry = {
+  block: string;
+  status: BlockStatus;
+  canon_role: string;
+  r3_section: string | null;
+  fold_status: 'PENDING_ADR' | 'LIVE' | 'NATIVE' | 'NOT_FOLDED';
+  warnings: string[];
+};
+
+function buildCoverage(fm: any): CoverageEntry[] {
+  const coverage: CoverageEntry[] = [];
+  // v4 canon blocks A–E.
+  for (const def of BLOCK_DEFS) {
+    const { status, warnings } = assessBlock(def.key, fm);
+    coverage.push({
+      block: def.id,
+      status,
+      canon_role: def.canon_role,
+      r3_section: def.r3_section,
+      fold_status: def.fold_status,
+      warnings,
+    });
+  }
+  // 5.0 superset blocks — recensés (present → NOT_MAPPED), never silently dropped.
+  for (const key of SUPERSET_BLOCKS_5_0) {
+    if (fm?.[key] !== undefined && fm?.[key] !== null) {
+      coverage.push({ block: `5.0:${key}`, status: 'NOT_MAPPED', canon_role: '—', r3_section: null, fold_status: 'NOT_FOLDED', warnings: [] });
+    }
+  }
+  if (fm?.diagnostic?.depose_steps !== undefined && fm?.diagnostic?.depose_steps !== null) {
+    coverage.push({ block: '5.0:diagnostic.depose_steps', status: 'NOT_MAPPED', canon_role: '—', r3_section: null, fold_status: 'NOT_FOLDED', warnings: [] });
+  }
+  // Compatibility — catalog/DB only, never in RAW, never a RAW blocker.
+  coverage.push({ block: 'compatibility', status: 'BLOCKED_CATALOG_REQUIRED', canon_role: 'R1/R2', r3_section: null, fold_status: 'NOT_FOLDED', warnings: [] });
+  return coverage;
+}
+
+function rawVerdict(coverage: CoverageEntry[]): RawEvidence['raw_verdict'] {
+  const abcde = coverage.filter((c) => /^[A-E]\./.test(c.block));
+  if (abcde.every((c) => c.status === 'PRESENT')) return 'READY';
+  return 'PARTIAL_READY';
+}
+
+/** Build the (deterministic) evidence artefact for one subject. Read-only; no write. */
+export function buildEvidence(subject: string): RawEvidence {
+  const gammePath = path.join(GAMMES_DIR, `${subject}.md`);
+  const base = {
+    schema_version: 'raw-evidence.v1' as const,
+    subject,
+    fold_readiness: FOLD_READINESS,
+    fold_note: FOLD_NOTE,
+  };
+
+  if (!fs.existsSync(gammePath)) {
+    return RawEvidenceSchema.parse({
+      ...base,
+      pg_id: null,
+      inventory_status: 'NO_RAW',
+      intent_targets: [],
+      provenance: { source_type: null, truth_level: null, verification_status: null, completeness_profile: null, sources: [], unlinked_source_types: [] },
+      coverage: [],
+      raw_verdict: 'NO_RAW',
+      next_action: 'SOURCE_FIRST',
+    });
+  }
+
+  const { sources, unlinked } = discoverSources(subject);
+  const { fm, error } = parseFrontmatter(fs.readFileSync(gammePath, 'utf8'));
+
+  if (error || !fm) {
+    return RawEvidenceSchema.parse({
+      ...base,
+      pg_id: null,
+      inventory_status: 'RAW_PARSE_ERROR',
+      intent_targets: [],
+      provenance: { source_type: null, truth_level: null, verification_status: null, completeness_profile: null, sources, unlinked_source_types: unlinked },
+      coverage: [],
+      raw_verdict: 'RAW_PARSE_ERROR',
+      next_action: `FIX_RAW_FRONTMATTER (${error ?? 'empty_frontmatter'})`,
+    });
+  }
+
+  const coverage = buildCoverage(fm);
+  const intentTargets = Array.isArray(fm.intent_targets) ? fm.intent_targets.map(String) : [];
+  const pgIdRaw = Number(fm.pg_id);
+  const pg_id = Number.isFinite(pgIdRaw) ? pgIdRaw : null;
+
+  return RawEvidenceSchema.parse({
+    ...base,
+    pg_id,
+    inventory_status: 'DIAGNOSTIC_READY',
+    intent_targets: intentTargets,
+    provenance: {
+      source_type: fm.source_type ?? null,
+      truth_level: fm.truth_level ?? null,
+      verification_status: fm.verification_status ?? null,
+      completeness_profile: fm.completeness_profile ?? null,
+      sources,
+      unlinked_source_types: unlinked,
+    },
+    coverage,
+    raw_verdict: rawVerdict(coverage),
+    next_action: pickNextAction(
+      coverage.map((c) => ({ block: c.block, status: c.status })),
+      intentTargets,
+    ),
+  });
+}
+
+function buildSchemaJson(): object {
+  return zodToJsonSchema(RawEvidenceSchema, { target: 'jsonSchema7', $refStrategy: 'none' });
+}
+
+function serialize(obj: unknown): string {
+  return JSON.stringify(sortKeysDeep(obj), null, 2) + '\n';
+}
+
+function listSubjects(): string[] {
+  return fs
+    .readdirSync(GAMMES_DIR)
+    .filter((f) => f.endsWith('.md')) // excludes *.manifest.yaml / *.html
+    .map((f) => f.slice(0, -3))
+    .sort();
+}
+
+function writeArtefact(ev: RawEvidence): string {
+  const out = path.join(OUT_DIR, `${ev.subject}.raw-evidence.json`);
+  return writeDeterministicJson(out, ev);
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--emit-schema')) {
+    const sha = writeDeterministicJson(SCHEMA_PATH, buildSchemaJson());
+    process.stdout.write(`emitted ${path.relative(MONOREPO_ROOT, SCHEMA_PATH)} (sha256:${sha})\n`);
+    return;
+  }
+
+  if (args.includes('--check')) {
+    const expected = serialize(buildSchemaJson());
+    const actual = fs.existsSync(SCHEMA_PATH) ? fs.readFileSync(SCHEMA_PATH, 'utf8') : '';
+    if (actual !== expected) {
+      process.stderr.write('raw-evidence.schema.json DRIFTED from the Zod source. Run --emit-schema.\n');
+      process.exit(1);
+    }
+    process.stdout.write('raw-evidence.schema.json is in sync with the Zod source.\n');
+    return;
+  }
+
+  if (args.includes('--all')) {
+    const subjects = listSubjects();
+    for (const subject of subjects) {
+      const ev = buildEvidence(subject);
+      const sha = writeArtefact(ev);
+      process.stdout.write(`${subject}: ${ev.inventory_status} · ${ev.raw_verdict} · ${ev.next_action} (sha256:${sha})\n`);
+    }
+    process.stdout.write(`\n${subjects.length} subjects.\n`);
+    return;
+  }
+
+  const subject = args.find((a) => !a.startsWith('--'));
+  if (!subject) {
+    process.stderr.write('Usage: raw-evidence-inventory.ts <subject> [--json] | --all | --emit-schema | --check\n');
+    process.exit(2);
+  }
+
+  const ev = buildEvidence(subject!);
+  const sha = writeArtefact(ev);
+
+  if (args.includes('--json')) {
+    process.stdout.write(serialize(ev));
+    return;
+  }
+  process.stdout.write(`\nRAW_EVIDENCE ${subject} — read-only\n`);
+  process.stdout.write(`  inventory_status: ${ev.inventory_status}\n`);
+  process.stdout.write(`  raw_verdict:      ${ev.raw_verdict}\n`);
+  for (const c of ev.coverage) {
+    const w = c.warnings.length ? `  warnings:[${c.warnings.join('; ')}]` : '';
+    process.stdout.write(`  ${c.block.padEnd(28)} ${c.status}${w}\n`);
+  }
+  process.stdout.write(`  fold_readiness:   R4=${ev.fold_readiness.R4_to_R3} R5=${ev.fold_readiness.R5_to_R3} R6=${ev.fold_readiness.R6_to_R3}\n`);
+  process.stdout.write(`  next_action:      ${ev.next_action}   (owner-gated)\n`);
+  process.stdout.write(`  artefact:         audit/content/raw-evidence/${subject}.raw-evidence.json (sha256:${sha})\n`);
+}
+
+const invokedDirect =
+  !!process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirect) main();

--- a/scripts/wiki-generators/raw-evidence.schema.json
+++ b/scripts/wiki-generators/raw-evidence.schema.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "coverage": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "block": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "canon_role": {
+            "type": "string"
+          },
+          "fold_status": {
+            "enum": [
+              "PENDING_ADR",
+              "LIVE",
+              "NATIVE",
+              "NOT_FOLDED"
+            ],
+            "type": "string"
+          },
+          "r3_section": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "enum": [
+              "PRESENT",
+              "PARTIAL",
+              "MISSING",
+              "NOT_APPLICABLE",
+              "NOT_MAPPED",
+              "BLOCKED_CATALOG_REQUIRED"
+            ],
+            "type": "string"
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "block",
+          "status",
+          "canon_role",
+          "r3_section",
+          "fold_status",
+          "warnings"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "fold_note": {
+      "type": "string"
+    },
+    "fold_readiness": {
+      "additionalProperties": false,
+      "properties": {
+        "R4_to_R3": {
+          "enum": [
+            "BLOCKED_PENDING_ADR",
+            "READY_ADR_027"
+          ],
+          "type": "string"
+        },
+        "R5_to_R3": {
+          "enum": [
+            "BLOCKED_PENDING_ADR",
+            "READY_ADR_027"
+          ],
+          "type": "string"
+        },
+        "R6_to_R3": {
+          "enum": [
+            "BLOCKED_PENDING_ADR",
+            "READY_ADR_027"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "R4_to_R3",
+        "R5_to_R3",
+        "R6_to_R3"
+      ],
+      "type": "object"
+    },
+    "intent_targets": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "inventory_status": {
+      "enum": [
+        "DIAGNOSTIC_READY",
+        "NO_RAW",
+        "RAW_PARSE_ERROR"
+      ],
+      "type": "string"
+    },
+    "next_action": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "pg_id": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "provenance": {
+      "additionalProperties": false,
+      "properties": {
+        "completeness_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sources": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "content_hash": {
+                "pattern": "^sha256:[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "kind": {
+                "enum": [
+                  "gamme",
+                  "guide",
+                  "evidence"
+                ],
+                "type": "string"
+              },
+              "path": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "path",
+              "kind",
+              "content_hash"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "truth_level": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unlinked_source_types": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verification_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "source_type",
+        "truth_level",
+        "verification_status",
+        "completeness_profile",
+        "sources",
+        "unlinked_source_types"
+      ],
+      "type": "object"
+    },
+    "raw_verdict": {
+      "enum": [
+        "READY",
+        "PARTIAL_READY",
+        "BLOCKED",
+        "NO_RAW",
+        "RAW_PARSE_ERROR"
+      ],
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "raw-evidence.v1",
+      "type": "string"
+    },
+    "subject": {
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "subject",
+    "pg_id",
+    "inventory_status",
+    "intent_targets",
+    "provenance",
+    "coverage",
+    "fold_readiness",
+    "raw_verdict",
+    "next_action",
+    "fold_note"
+  ],
+  "type": "object"
+}

--- a/scripts/wiki-generators/raw-evidence.schema.ts
+++ b/scripts/wiki-generators/raw-evidence.schema.ts
@@ -1,0 +1,84 @@
+/**
+ * raw-evidence.schema.ts — Zod SOURCE OF TRUTH for the RAW evidence inventory artefact.
+ *
+ * The Zod schema is the single source of truth. The JSON Schema
+ * (`raw-evidence.schema.json`) is a GENERATED PROJECTION — never edit it by hand
+ * (principe L3 « generated artifacts are projections » de CLAUDE.md ; précédent
+ * Zod→JSON : backend/src/config/diag-canon.schema.ts → diag-canon-jsonschema.ts).
+ *
+ * Read-only diagnostic artefact : « le RAW a-t-il le droit de devenir un wiki ? ».
+ * Measures coverage + provenance only — no fact extraction, no generation, no DB/wiki write.
+ */
+import { z } from 'zod';
+
+/** Per-block coverage status. */
+export const BLOCK_STATUS = [
+  'PRESENT', // block present, all BLOCK-severity thresholds met (WARN gaps → warnings[])
+  'PARTIAL', // block present but a BLOCK-severity threshold fails
+  'MISSING', // block key absent
+  'NOT_APPLICABLE',
+  'NOT_MAPPED', // present in RAW (schema_version 5.0 superset) but not mapped to a canonical role
+  'BLOCKED_CATALOG_REQUIRED', // data lives in the catalogue/DB, never in RAW (never a RAW blocker)
+] as const;
+
+/** R4/R6→R3 fold status of a block's target section. */
+export const FOLD_STATUS = ['PENDING_ADR', 'LIVE', 'NATIVE', 'NOT_FOLDED'] as const;
+
+/** Per-role fold readiness — separates "RAW coverage OK" from "fold authorised in prod". */
+export const FOLD_READINESS = ['BLOCKED_PENDING_ADR', 'READY_ADR_027'] as const;
+
+export const INVENTORY_STATUS = ['DIAGNOSTIC_READY', 'NO_RAW', 'RAW_PARSE_ERROR'] as const;
+
+export const RAW_VERDICT = ['READY', 'PARTIAL_READY', 'BLOCKED', 'NO_RAW', 'RAW_PARSE_ERROR'] as const;
+
+const SourceSchema = z
+  .object({
+    path: z.string().min(1), // relative to the automecanik-raw repo root
+    kind: z.enum(['gamme', 'guide', 'evidence']),
+    content_hash: z.string().regex(/^sha256:[0-9a-f]{64}$/),
+  })
+  .strict();
+
+const CoverageEntrySchema = z
+  .object({
+    block: z.string().min(1), // 'A.domain' … 'E.installation', '5.0:variants', 'compatibility'
+    status: z.enum(BLOCK_STATUS),
+    canon_role: z.string(), // 'R4' | 'R6' | 'R5' | 'R3' | 'R1/R2' | '—'
+    r3_section: z.string().nullable(),
+    fold_status: z.enum(FOLD_STATUS),
+    warnings: z.array(z.string()), // WARN-severity sub-gaps (no silent drop), [] if none
+  })
+  .strict();
+
+export const RawEvidenceSchema = z
+  .object({
+    schema_version: z.literal('raw-evidence.v1'),
+    subject: z.string().min(1),
+    pg_id: z.number().int().nullable(),
+    inventory_status: z.enum(INVENTORY_STATUS),
+    intent_targets: z.array(z.string()),
+    provenance: z
+      .object({
+        source_type: z.string().nullable(),
+        truth_level: z.string().nullable(),
+        verification_status: z.string().nullable(),
+        completeness_profile: z.string().nullable(),
+        sources: z.array(SourceSchema), // deterministically discovered set (sorted by path)
+        unlinked_source_types: z.array(z.string()), // e.g. ['guide'] when no deterministic link exists
+      })
+      .strict(),
+    coverage: z.array(CoverageEntrySchema),
+    fold_readiness: z
+      .object({
+        R4_to_R3: z.enum(FOLD_READINESS),
+        R5_to_R3: z.enum(FOLD_READINESS),
+        R6_to_R3: z.enum(FOLD_READINESS),
+      })
+      .strict(),
+    raw_verdict: z.enum(RAW_VERDICT),
+    next_action: z.string().min(1),
+    fold_note: z.string(),
+  })
+  .strict();
+
+export type RawEvidence = z.infer<typeof RawEvidenceSchema>;


### PR DESCRIPTION
## Summary

Adds a deterministic, **read-only** RAW evidence inventory for the `filtre-a-air` pilot — a repo-native RAW evidence layer **before** wiki promotion (the diagnostic step immediately upstream of `promote-raw-gammes-to-wiki.py`).

- Zod schema-as-code as the single source of truth (`raw-evidence.schema.ts`)
- generated JSON Schema projection (`--emit-schema` / `--check`, never hand-edited)
- deterministic builder reusing the shared `writeDeterministicJson` (sorted keys, sha256 content hashes, no builder timestamp)
- block taxonomy reconciles the **v4 canon** (`.spec/00-canon/gamme-md-schema.md`, blocks A–E) with the live RAW **`schema_version 5.0` superset** (extension v4→5.0, not v5-vs-legacy)
- `node:test` + Ajv validation (7 tests)
- pilot artefact under `audit/content/raw-evidence/`
- provenance with sha256 content hashes (gamme + evidence + explicitly-mapped guide)
- fold-readiness annotations for R4/R5/R6 → R3 **without enabling any runtime fold**

## Scope — read-only diagnostic only

- ❌ No DB write · ❌ no wiki write · ❌ no RAG write
- ❌ No content generation · ❌ no LLM
- ❌ No `seo-readiness.ts` change
- ❌ No URL / canonical / redirect / sitemap change
- ❌ No new GitHub Action (CI test-wiring deferred — see Deferred)

## Pilot result — `filtre-a-air`

- `inventory_status: DIAGNOSTIC_READY`
- `raw_verdict: READY` → `next_action: PROMOTE_RAW_TO_WIKI` (owner-gated)
- A–E coverage: `PRESENT` (B carries a `selection.checklist` WARN — surfaced, not hidden)
- `schema_version 5.0` superset blocks recensés `NOT_MAPPED` (no silent drop)
- `compatibility: BLOCKED_CATALOG_REQUIRED` (catalogue/DB only, never a RAW blocker)
- `fold_readiness`: `R5_to_R3: READY_ADR_027` · `R4_to_R3: BLOCKED_PENDING_ADR` · `R6_to_R3: BLOCKED_PENDING_ADR`

## Verification

- `npm run content:test:raw-evidence` → 7/7 pass (`npx tsx --test`)
- `npm run content:raw-evidence:schema-check` → schema projection in sync with the Zod source
- deterministic output verified across two runs (bit-identical)
- `NO_RAW` → `SOURCE_FIRST` ; missing / no-`schema_version` frontmatter does not crash
- read-only proven: no `.insert/.update/.upsert`, no `createClient`/`fetch`; writes only under `audit/content/raw-evidence/`

## Role-fold posture (no canon change)

`fold_readiness` separates **« RAW coverage OK »** from **« fold R4/R6→R3 authorised in prod »**. R5 is already folded into R3 (`S2_DIAG #diagnostic-rapide`, ADR-027 — live). The owner-desired R4/R6→R3 fold is **`PENDING_ADR`** and **not canon**: it would require a vault ADR extending ADR-027 + role-matrix v6 + redirect RPCs. The `r3_section` field is a forward-compatible annotation only — it authorises nothing.

## Deferred (out of scope — owner-gated / ADR-gated)

- `raw` dimension in `seo-readiness.ts`
- `raw-facts` extraction / claim checking
- R4/R6 → R3 **runtime fold** (vault ADR + role-matrix v6 + redirect RPCs + sitemap)
- page generation / publishing
- CI test-wiring — the only existing gate on `scripts/wiki-generators/**` (`rag-permissions-audit.yml`) is a blocking guard, not a test-runner; extending it would change its nature, so `content:test:raw-evidence` runs locally meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
