### PR TITLE
fix(seo-roles): wire V-Level invariants without recalculation

### DIFF
--- a/backend/src/modules/admin/services/gamme-vlevel.service.ts
+++ b/backend/src/modules/admin/services/gamme-vlevel.service.ts
@@ -11,6 +11,7 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
+import { VLEVEL_V2_CAP, vLevelGroupKey } from '@repo/seo-roles';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 
 interface VLevelKeywordRow {
@@ -184,9 +185,10 @@ export class GammeVLevelService extends SupabaseBaseService {
       // 4. Group CSV vehicle keywords by [model+energy] or [model] if universelle
       const byModelEnergy = new Map<string, VLevelKeywordRow[]>();
       for (const kw of csvVehicleKws) {
-        const key = gammeUniverselle
-          ? `${kw.model || '_no_model'}`
-          : `${kw.model || '_no_model'}|${kw.energy || 'unknown'}`;
+        // Clé de groupe canonique partagée (@repo/seo-roles) — lowercase, fallbacks
+        // `_no_model`/`unknown`. Neutre ici : la donnée live est déjà lowercase et le
+        // service utilise déjà `energy||'unknown'` (cf. probe G2).
+        const key = vLevelGroupKey(kw.model, kw.energy, { gammeUniverselle });
         if (!byModelEnergy.has(key)) byModelEnergy.set(key, []);
         byModelEnergy.get(key)!.push(kw);
       }
@@ -231,11 +233,12 @@ export class GammeVLevelService extends SupabaseBaseService {
       const seenModelEnergy = new Set<string>();
       const top10: VLevelKeywordRow[] = [];
       for (const kw of v3Champions) {
-        const modelEnergy = `${(kw.model || '').toLowerCase()}|${(kw.energy || '').toLowerCase()}`;
+        // Même clé canonique que le groupement (plus de divergence group/dedup en casse).
+        const modelEnergy = vLevelGroupKey(kw.model, kw.energy, { gammeUniverselle });
         if (seenModelEnergy.has(modelEnergy)) continue;
         seenModelEnergy.add(modelEnergy);
         top10.push(kw);
-        if (top10.length >= 10) break;
+        if (top10.length >= VLEVEL_V2_CAP) break;
       }
       const top10Ids = new Set(top10.map((c) => c.id));
 

--- a/backend/src/modules/admin/services/gamme-vlevel.service.ts
+++ b/backend/src/modules/admin/services/gamme-vlevel.service.ts
@@ -234,7 +234,9 @@ export class GammeVLevelService extends SupabaseBaseService {
       const top10: VLevelKeywordRow[] = [];
       for (const kw of v3Champions) {
         // Même clé canonique que le groupement (plus de divergence group/dedup en casse).
-        const modelEnergy = vLevelGroupKey(kw.model, kw.energy, { gammeUniverselle });
+        const modelEnergy = vLevelGroupKey(kw.model, kw.energy, {
+          gammeUniverselle,
+        });
         if (seenModelEnergy.has(modelEnergy)) continue;
         seenModelEnergy.add(modelEnergy);
         top10.push(kw);

--- a/log.md
+++ b/log.md
@@ -394,3 +394,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `vlevel-doctrine-lock`
 - **Décision** : feat(seo-roles): V-Level doctrine — invariants ref + DB-only capture (lock-before-fix) ; + fixes squawk migration + overlay ownership D14
 - **Sortie** : PR #861 | commits 07141fcc4 4f037916a a599763f8 525cfa21d
+
+## 2026-06-05 — g2-vlevel-invariants-runtime-wiring (auto)
+
+- **Branche** : `g2-vlevel-invariants-runtime-wiring`
+- **Décision** : fix(seo-roles): wire V-Level invariants without recalculation
+- **Sortie** : PR #863 | commits 58af79a1f

--- a/packages/seo-roles/package.json
+++ b/packages/seo-roles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/seo-roles",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Single source of truth for canonical SEO page roles (R0..R8). Normalization, display labels, badge colors, branded CanonicalRoleId type, Zod schemas. Legacy accepted in input, canon mandatory in output.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/seo-roles/src/__tests__/vlevel-invariants.test.ts
+++ b/packages/seo-roles/src/__tests__/vlevel-invariants.test.ts
@@ -19,6 +19,7 @@ import {
   V_LEVEL_IDS,
   VLEVEL_V2_CAP,
   V_GROUP_KEY,
+  vLevelGroupKey,
   V_LEVEL_INVARIANTS,
   V_PROPAGATE,
   V_LEVEL_KNOWN_GAPS,
@@ -56,6 +57,50 @@ describe("V-Level invariants — cohérence (gelé, vert aujourd'hui)", () => {
     assert.equal(V_PROPAGATE.fillsOnlyNull, true);
     assert.equal(V_PROPAGATE.preservesAssigned, true);
     assert.deepEqual([...V_PROPAGATE.priorityOrder], ["V2", "V3", "V4", "V5"]);
+  });
+});
+
+describe("vLevelGroupKey — clé canonique partagée (G2, service)", () => {
+  test("groupe [model|energy] en lowercase", () => {
+    assert.equal(vLevelGroupKey("clio", "diesel"), "clio|diesel");
+  });
+
+  test("case-insensitive (résout le mismatch group/dedup côté service)", () => {
+    assert.equal(vLevelGroupKey("Clio", "Diesel"), vLevelGroupKey("clio", "diesel"));
+    assert.equal(vLevelGroupKey("CLIO", "DIESEL"), "clio|diesel");
+  });
+
+  test("gamme universelle → énergie ignorée", () => {
+    assert.equal(vLevelGroupKey("clio", "diesel", { gammeUniverselle: true }), "clio");
+  });
+
+  test("fallbacks _no_model / unknown (sémantique service energy||'unknown')", () => {
+    assert.equal(vLevelGroupKey(null, null), "_no_model|unknown");
+    assert.equal(vLevelGroupKey("clio", null), "clio|unknown");
+    assert.equal(vLevelGroupKey("", ""), "_no_model|unknown");
+  });
+
+  test("même clé pour groupe ET dedup (ne peuvent plus diverger)", () => {
+    assert.equal(vLevelGroupKey("clio", "diesel"), vLevelGroupKey("clio", "diesel"));
+  });
+});
+
+describe("V-Level gaps — résolution G2 (7 → 6)", () => {
+  test("propagate-comment-false retiré (résolu en G2)", () => {
+    const ids = V_LEVEL_KNOWN_GAPS.map((g) => g.id);
+    assert.ok(!ids.includes("propagate-comment-false"), "gap résolu encore présent");
+  });
+
+  test("dedup case-mismatch transformé en gap script-energy (G3)", () => {
+    const g = V_LEVEL_KNOWN_GAPS.find(
+      (x) => x.id === "v2-dedup-case-mismatch-and-script-energy-normalization",
+    );
+    assert.ok(g, "gap transformé absent");
+    assert.equal(g?.gate, "G3");
+  });
+
+  test("6 écarts restants (était 7)", () => {
+    assert.equal(V_LEVEL_KNOWN_GAPS.length, 6);
   });
 });
 

--- a/packages/seo-roles/src/index.ts
+++ b/packages/seo-roles/src/index.ts
@@ -98,6 +98,7 @@ export {
   type VLevelId,
   VLEVEL_V2_CAP,
   V_GROUP_KEY,
+  vLevelGroupKey,
   type VLevelInvariant,
   V_LEVEL_INVARIANTS,
   V_PROPAGATE,

--- a/packages/seo-roles/src/vlevel-invariants.ts
+++ b/packages/seo-roles/src/vlevel-invariants.ts
@@ -40,6 +40,28 @@ export const V_GROUP_KEY = {
 } as const;
 
 /**
+ * Clé de groupe/dedup canonique `[modèle(+énergie)]` — lowercase, fallbacks `_no_model` /
+ * `unknown`, énergie ignorée si gamme universelle. À utiliser pour le groupement V3 ET la
+ * dedup V2 d'un MÊME calculateur, afin qu'ils ne puissent plus diverger en casse.
+ *
+ * ⚠️ Sémantique `energy || 'unknown'` (null == 'unknown'). Le calculateur d'import CLI
+ * (`scripts/insert-missing-keywords.ts`) utilise l'énergie BRUTE (null ≠ 'unknown') et la
+ * donnée live contient les deux → le brancher ici serait DATA-AFFECTING (fusion de groupes,
+ * change l'élection V3/V4). C'est donc différé à G3 (dry-run before/after). En G2 ce helper
+ * n'est câblé QUE dans le service admin (`gamme-vlevel.service.ts`), où il est neutre.
+ */
+export function vLevelGroupKey(
+  model: string | null | undefined,
+  energy: string | null | undefined,
+  opts?: { gammeUniverselle?: boolean },
+): string {
+  const m = (model ?? "").toLowerCase() || "_no_model";
+  if (opts?.gammeUniverselle) return m;
+  const e = (energy ?? "").toLowerCase() || "unknown";
+  return `${m}|${e}`;
+}
+
+/**
  * Définition de chaque niveau (intention owner figée 2026-06-05).
  * `persisted` = présent en DB aujourd'hui ; `built` = produit par le pipeline aujourd'hui.
  */
@@ -134,16 +156,10 @@ export const V_LEVEL_KNOWN_GAPS: readonly VLevelKnownGap[] = [
     gate: "G1",
   },
   {
-    id: "v2-dedup-case-mismatch",
+    id: "v2-dedup-case-mismatch-and-script-energy-normalization",
     description:
-      "Clé groupe V3 non-lowercase vs clé dedup V2 lowercase. INERTE aujourd'hui (198/198 modèles déjà lowercase) → code smell, normaliser.",
-    gate: "G2",
-  },
-  {
-    id: "propagate-comment-false",
-    description:
-      "Commentaire insert-missing-keywords.ts:1037-1039 décrit une règle (champion→V2, autres→V3, héritage total) qui NE correspond PAS à la fonction DB réelle (backfill-NULL-only). Corriger le commentaire.",
-    gate: "G2",
+      "Service side is neutralized via shared lowercase helper (vLevelGroupKey). CLI script still uses raw energy; live data has NULL and 'unknown', so switching it to the canonical helper is data-affecting and deferred to G3 with before/after proof.",
+    gate: "G3",
   },
   {
     id: "count-vehicles-no-gamme-absent",

--- a/scripts/insert-missing-keywords.ts
+++ b/scripts/insert-missing-keywords.ts
@@ -29,6 +29,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createClient } from '@supabase/supabase-js';
 import * as dotenv from 'dotenv';
+import { VLEVEL_V2_CAP } from '@repo/seo-roles';
 
 // Load env
 dotenv.config({ path: path.join(__dirname, '../backend/.env') });
@@ -442,11 +443,13 @@ function assignVLevels(keywords: KeywordRecord[], gammeUniverselle: boolean = fa
     const seenModelEnergy = new Set<string>();
     const top10: KeywordRecord[] = [];
     for (const kw of v3Champions) {
+      // NB: clé dedup du script INCHANGÉE en G2 (énergie brute : null ≠ 'unknown').
+      // La converger vers vLevelGroupKey (@repo/seo-roles) est data-affecting → G3.
       const dedupKey = `${(kw.model || '').toLowerCase()}|${kw.energy}`;
       if (seenModelEnergy.has(dedupKey)) continue;
       seenModelEnergy.add(dedupKey);
       top10.push(kw);
-      if (top10.length >= 10) break;
+      if (top10.length >= VLEVEL_V2_CAP) break;
     }
     for (const kw of top10) {
       kw.v_level = 'V2';
@@ -1034,9 +1037,11 @@ Examples:
   // ── Phase V-PROPAGATE: Un V-level par type_id ──────────────────────────────
   console.log(`\n⚙️  Phase V-PROPAGATE: Uniformisation V-level par véhicule...`);
 
-  // For each type_id, propagate the best V-level to all its keywords
-  // V2 vehicles: champion keyword stays V2, others get V3 (unique constraint)
-  // V3/V4/V5 vehicles: all keywords inherit the vehicle's level
+  // propagate_vlevel_per_typeid (fonction DB versionnée dans
+  // backend/supabase/migrations/20260605_vlevel_capture_db_only_functions.sql) :
+  // pour chaque type_id, remplit UNIQUEMENT les keywords dont v_level est NULL avec le
+  // meilleur niveau du véhicule (V2>V3>V4>V5) et PRÉSERVE tout niveau déjà assigné
+  // (backfill non destructif). Ne rétrograde PAS et ne force PAS d'héritage.
   const { data: propResult, error: propError } = await supabase.rpc('propagate_vlevel_per_typeid', {
     p_pg_id: pgId
   });


### PR DESCRIPTION
## G2 — runtime/test only, zéro recalcul DB

G2 runtime-neutral wiring:
- replace duplicated V2 cap with `VLEVEL_V2_CAP`
- add shared `vLevelGroupKey` helper
- use same group/dedup key in admin **service only**
- fix misleading `propagate` comment
- add conformance tests
- **no DB mutation, no recalculation, no V5/data changes**

> **G2 intentionally wires the shared group-key helper only into the admin service.
> The CLI script key remains unchanged because live data contains both NULL and `'unknown'`
> energies; normalizing them would merge groups and change V3/V4 election. That belongs to
> G3 with a dry-run before/after.**

## Neutralité (condition #1 — probe read-only AVANT toute édition)
- `lower(model) <> model = 0` ✅
- `lower(energy) <> energy = 0` ✅
- **Découverte** : `energy` live = 444 `NULL` + 603 `'unknown'` (kw véhicule). Le **service** fait déjà `energy||'unknown'` (merge au group stage → dedup neutre). Le **script** fait `${kw.energy}` brut (null ≠ 'unknown') → converger sa clé serait **data-affecting** → différé G3.

## Périmètre exact
| Action | Fichier | Statut |
|---|---|---|
| `vLevelGroupKey()` (data, pas moteur) | `packages/seo-roles/src/vlevel-invariants.ts` | ajouté |
| Helper group + dedup | `gamme-vlevel.service.ts` | câblé (neutre) |
| `VLEVEL_V2_CAP` (remplace `10`) | service + script | câblé |
| Commentaire `propagate` corrigé | `scripts/insert-missing-keywords.ts:1037-1039` | doc-only |
| Clé du script → helper | — | **différé G3** (énergie data-affecting) |

## Écarts connus 7 → 6
- `propagate-comment-false` → **résolu** (retiré).
- `v2-dedup-case-mismatch` → **transformé** en `v2-dedup-case-mismatch-and-script-energy-normalization` (gate **G3**) : *Service side is neutralized via shared lowercase helper. CLI script still uses raw energy; live data has NULL and 'unknown', so switching it to the canonical helper is data-affecting and deferred to G3 with before/after proof.*

## Vérification
- `@repo/seo-roles` : `tsc --noEmit` ✅ · `node:test` **16 pass / 0 fail / 6 todo** (était 7) · golden baseline **inchangé**.
- Backend : `tsc --noEmit` ✅ (résolu vers le package frais ; `turbo typecheck` a `dependsOn ^build`).
- Clé `dedupKey` du script **intacte** (énergie brute préservée).

Réf : doctrine `audit/levels-doctrine-cgc-vs-vlevel-2026-06-04.md` · suite plan G3 (recalcul V5 union + énergie, before/after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)