### PR TITLE
docs(seo): add R-page excellence baseline and R3 filtre-a-air audit

### DIFF
--- a/audit/seo-r-page-excellence-baseline-doctrine-20260606.md
+++ b/audit/seo-r-page-excellence-baseline-doctrine-20260606.md
@@ -1,0 +1,49 @@
+# R-Page Excellence Baseline — doctrine (cited, not redefined)
+
+> **Cette PR ne définit pas l'excellence de toutes les pages R.** Elle démarre par **R3** (sujet
+> actif, voir la note pilote `seo-r3-eeat-baseline-filtre-a-air-20260606.md`). La doctrine devra être
+> déclinée **ensuite, un rôle à la fois**, pour R1, R2, R7, R8.
+>
+> **Reference projection — non-canon.** Ce document ne crée aucune règle ni aucun seuil : il **cite**
+> le canon et les barres gouvernées existantes. La vérité des rôles reste `.spec/00-canon/role-matrix.md`
+> (v5 figée) ; les barres restent les contrats + scorers nommés ci-dessous.
+
+## Principe directeur
+
+**L'excellence d'une page R = satisfaire excellemment la PROMESSE de son rôle (role-matrix), telle que
+mesurée par le contrat + le scorer gouvernés EXISTANTS de ce rôle — sans empiéter sur les rôles voisins.**
+
+Conséquences : même *objectif* (excellence), mais **rôle / sections / score / CTA différents** par page.
+Là où un rôle n'a **pas encore** de barre gouvernée, c'est un **gap noté** — jamais une grille inventée ici.
+
+## Définition par rôle (citations, paths)
+
+| Rôle | Promesse (role-matrix v5) | Barre / contrat cité | Scorer existant | Règle « ne pas bavurer » |
+|---|---|---|---|---|
+| **R1** router gamme/compat | trouver la bonne gamme pour le véhicule | `backend/src/config/page-contract-r1.{json,schema.ts}` ; `packages/seo-role-contracts/src/contracts/r1.ts` | `quality-scoring-engine.service.ts` (R1) | 0 prix/stock/panier (= R2) ; how-to → lien R3 |
+| **R2** produit/transactionnel | acheter la bonne référence | `backend/src/config/page-contract-r2.schema.ts` + données produit (prix/stock/compat) | (vérifier barre dédiée — gap si absente) | pas de conseil dominant (= R3/R4) ; **surface sensible catalogue/prix** |
+| **R3** conseil/pilier léger *(pilote)* | intervenir correctement sur la pièce | `backend/src/config/conseil-pack.constants.ts` → `PACK_DEFINITIONS.eeat` ; `page-contract-r3.{json,schema.ts}` ; `packages/seo-role-contracts/src/contracts/r3.ts` | `conseil-quality-scorer.service.ts` (section /100) ; `quality-scoring-engine.service.ts` (page) | S3 = compatibilité/critères (≠ « comment choisir » R6) ; pas d'encyclopédie (= R4) ; CTA **soft → R1** ; forbidden_dominant_signals R3 (`role-matrix.md` : buying_checklist, quality_tiers, transactional_listing, symptom_tree, deep_glossary) |
+| **R7** hub marque | explorer l'univers d'une marque | `backend/src/config/page-contract-r7.schema.ts` | (vérifier barre dédiée — gap si absente) | pas de générique ; pas de duplication R3 |
+| **R8** fiche véhicule | contexte véhicule → bonnes pièces | `backend/src/config/page-contract-r8.schema.ts` (+ règle noindex types 60000-83456) | `r8-diversity-check` (anti-duplicate sœurs) | pas de contenu constructeur générique ; canonical/index propres |
+
+Invariant transverse cité : les ancres de section sont **dérivées au runtime** (`slugifyTitle(titre)`,
+`backend/src/modules/blog/services/r3-guide.service.ts`) — donc fonction de l'éditorial, pas d'un set figé.
+
+## Statut des pilotes
+
+- **R3 — FAIT** : `audit/seo-r3-eeat-baseline-filtre-a-air-20260606.md` (pilote #1, read-only).
+- **R1 · R2 · R7 · R8 — DEFERRED** : non audités dans cette PR (voir §Extension future).
+
+## Extension future (NO-GO maintenant — gated, un rôle à la fois)
+
+- **Phase 2** : un pilote baseline **par rôle** (R1, puis R2, R7, R8), même forme que la note R3,
+  **citant le contrat + scorer de CE rôle**, **un seul rôle par PR**, read-only. R2 = catalogue/prix
+  → prudence accrue. Si un rôle n'a pas de scorer dédié, le pilote **note le gap** (n'invente pas de barre).
+- **Phase 3** : corrections ciblées par rôle via le pipeline gouverné (`/content-gen`), **jamais** de
+  génération massive ; toute 301/canonical reste owner-gated + ADR, **après** baseline du rôle prête.
+
+## Garde-fous de cette doctrine
+
+- **Citer, pas redéfinir** : aucun seuil/grille nouveau ici ; tout pointe `role-matrix` + les contrats/scorers nommés.
+- **Pas de vérité parallèle** : si une règle de rôle change, ça passe par son canon (vault ADR / contrat), pas par ce doc.
+- **Read-only** : ce document n'agit sur aucun runtime, aucune URL, aucun contenu.

--- a/audit/seo-r3-eeat-baseline-filtre-a-air-20260606.md
+++ b/audit/seo-r3-eeat-baseline-filtre-a-air-20260606.md
@@ -1,0 +1,83 @@
+# R3 EEAT Baseline — filtre-a-air (pg_id 8) — 2026-06-06
+
+> Pilote #1 de la doctrine `seo-r-page-excellence-baseline-doctrine-20260606.md`.
+
+## 1. Scope
+
+Audit **read-only**. Aucune génération · aucune action URL · aucun changement contrat/role-matrix ·
+aucune 301/canonical · aucun nouveau scorer. Une note Markdown, point.
+
+## 2. Canon cited, not redefined
+
+- **Barre d'excellence R3** = `PACK_DEFINITIONS.eeat` — `backend/src/config/conseil-pack.constants.ts:49-67` :
+  requiredSections `[S1,S2,S2_DIAG,S3,S4_DEPOSE,S5,S_GARAGE,S6,S8]` · optional `[S4_REPOSE,S7,META]` ·
+  `minSectionScore=75` · `minPackScore=85` · `minFaqCount=6`.
+- **Scorers** : `backend/src/modules/admin/services/conseil-quality-scorer.service.ts` (`sgc_quality_score`
+  /100 par section) ; `quality-scoring-engine.service.ts` (page). **Non ré-exécutés** ici — on lit les
+  `sgc_quality_score` déjà persistés (read-only).
+- **Ancres** : invariant `slugifyTitle(sgc_title)` — `backend/src/modules/blog/services/r3-guide.service.ts:434`.
+- **Garde-fou rôle** : `role-matrix.md` R3 `forbidden_dominant_signals` (buying_checklist, quality_tiers,
+  transactional_listing, symptom_tree, deep_glossary) ; **S3 = compatibilité/critères** (≠ « comment choisir » = R6) ;
+  **CTA soft → R1** uniquement (le runtime strippe déjà le prix + no-cart).
+
+> **Cet audit n'introduit aucune formule de score nouvelle. La vue /100 côté owner est une *projection*
+> des scores section/page existants + les 3 checks de gap observés.**
+
+## 3. Live state — filtre-a-air (DB `__seo_gamme_conseil`, sgc_pg_id='8', read-only)
+
+| Section | order | len | `sgc_quality_score` | source (RAG) | eeat |
+|---|---|---|---|---|---|
+| S1 (rôle) | 10 | 845 | **100** | domain.role | req ✓ |
+| S2 (quand changer) | 20 | 321 | 85 | maintenance.interval | req ✓ |
+| S2_DIAG (#diagnostic) | 25 | 1128 | 85 | diagnostic.symptoms | req ✓ |
+| S3 (compatibilité*) | 30 | 617 | **100** | selection.criteria | req ✓ |
+| S4_DEPOSE | 40 | 542 | 85 | diagnostic.causes | req ✓ |
+| S5 (erreurs) | 60 | **108** | 85 | selection.anti_mistakes | req ✓ (len anormale) |
+| S6 (vérifs après) | 65 | 2363 | **100** | maintenance.good_practices | req ✓ |
+| **S_GARAGE** (pro) | 67 | 374 | **70** | installation.difficulty | **req ✗ (<75)** |
+| S8 (FAQ) | 85 | 1114 | **100** | rendering.faq | req ✓ |
+| S4_REPOSE | 50 | 1668 | 76 | installation.steps | opt ✓ |
+| S7 (pièces liées) | 80 | 2031 | **100** | domain.related_parts | opt ✓ |
+| META | 99 | 282 | 80 | domain.role+ | opt ✓ |
+
+`*` S3 titre = « Comment choisir vos filtre à air » **mais source = `selection.criteria`** ⇒ contenu
+**compatibilité-light (role-safe)** ; seul le *libellé* flirte avec le vocabulaire R6.
+
+- **9/9 sections requises eeat présentes** ; pack moyenne (requises) ≈ **90 ≥ 85** ✓.
+- **Toutes les 12 sections sourcées RAG** (`gammes/filtre-a-air.md`) ✓.
+
+## 4. Thin gap checks (observés, non scorés par un nouvel engine)
+
+- **Ancres canoniques** : ⚠️ les ancres sont des **slugs de titres complets** (`fonction-du-filtre-a-air`,
+  `diagnostic-rapide-du-filtre-a-air`, `comment-choisir-vos-filtre-a-air`…), **pas** le set propre
+  `#role/#diagnostic-rapide/#comment-choisir/#compatibilite/#faq`. Gap d'ancres = réel (titres ≠ ancres figées).
+- **CTA → R1/pièces** : chemin de rendu `SoftCTA → /pieces/{alias}-{id}.html` (`ConseilSections.tsx`) — soft,
+  canon-OK ; **non re-vérifié live** dans cette baseline (observation, pas mesure).
+- **Provenance RAW/WIKI** : `sgc_sources` non-vide ET référence `gammes/filtre-a-air.md` (RAW) pour 12/12 ✓.
+
+## 5. Verdict
+
+**EEAT-baseline compatible with known soft spots.** 9/9 sections requises présentes, pack ≈ 90 ≥ 85,
+100 % sourcé RAG. **NON « excellent » tant que** : (a) **S_GARAGE = 70 < `minSectionScore` 75** (seul
+manquement au plancher par-section eeat) ; (b) **S5 anormalement court (108 c)** malgré un score 85
+(angle mort du scorer sur la longueur) ; (c) **`minFaqCount` eeat = 6 non vérifié** sur S8 ; (d) **ancres
+canoniques non confirmées** (slugs de titres).
+
+> **Correction des soft spots présumés** : la donnée DB montre que le manquement au plancher eeat est
+> **S_GARAGE (70)**, **pas** S4_REPOSE (76, optionnel, ≥75 → passe). S5 reste un point faible *de longueur*
+> (108 c), pas de score. ⇒ le `next_action` cible S_GARAGE + S5, pas « S5 + S4_REPOSE ».
+
+## 6. Next action (étroit, owner-gated)
+
+Refresh contenu gouverné limité à **S_GARAGE + S5 uniquement** via `/content-gen --r3` (seo-batch), si l'owner approuve :
+- **S_GARAGE** : remonter à `sgc_quality_score ≥ 75` (plancher eeat) ;
+- **S5** : étoffer à une longueur utile (108 c → contenu réel « erreur → risque → correctif ») ;
+- **vérifier** `S8` FAQ count ≥ 6 (`minFaqCount` eeat) ;
+- **préserver** S1/S2_DIAG/S3/S6/S7/S8 (déjà 100/85) ; **aucune** action URL R4/R6 ; **aucune** 301/canonical ; **aucune** régénération complète.
+- (Optionnel, séparé) clarifier le *libellé* S3 « comment choisir » → « critères de compatibilité » pour lever l'ambiguïté R6 (contenu déjà role-safe).
+
+## 7. 301 posture
+
+**NO-GO maintenant.** Cross-link `#866` (`seo-r3-pillar-consolidation-evidence` : `OBSERVE 10/10`,
+R4/R6 = KEEP — l'évidence ne soutient pas un fold massif). 301 chirurgicale plus tard, owner-gated + ADR,
+par lot ≤5 + surveillance GSC, **après** R3 prête.


### PR DESCRIPTION
## Summary

Adds two **read-only** SEO audit notes:

- **R-Page Excellence Baseline doctrine** across R1/R2/R3/R7/R8
- **R3 EEAT baseline audit** for `filtre-a-air`

This does **not** redefine the canon. It **cites** existing role-matrix promises, governed contracts, scorers and anti-bleed rules. It is pilot #1 of a per-role doctrine; R1/R2/R7/R8 are explicitly deferred (doctrine only, no audit).

## Finding

`filtre-a-air` R3 is **EEAT-baseline compatible, but not yet "excellent"**.

- 9/9 required EEAT sections present
- all 12 sections RAG-sourced
- pack average ≈ 90 ≥ 85
- real per-section-floor miss: **`S_GARAGE` 70 < 75** (not `S4_REPOSE` 76, which is optional and passes)
- `S5` is anomalously short (108 chars) despite score 85
- `minFaqCount` (eeat = 6) and live CTA/canonical anchors still need verification

## Next action (owner-gated only)

- refresh **`S_GARAGE` + `S5`** via governed `/content-gen --r3`
- verify FAQ ≥ 6
- preserve all other sections

## Out of scope

No content generation · no R1/R2/R7/R8 audit · no URL action · no canonical · no 301 · no R4/R6 runtime fold. 301 posture = NO-GO now (cross-link #866 `OBSERVE 10/10`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
