### PR TITLE
feat(seo): resolve NULL-type_id champions in V3 decision-pack (seed-driven)

### DIFF
--- a/scripts/seo/vlevel-v3-pipeline.ts
+++ b/scripts/seo/vlevel-v3-pipeline.ts
@@ -105,11 +105,18 @@ async function decisionPack(pgId: number): Promise<void> {
   }
   const champs = [...byTid.values(), ...nulls];
 
-  // 2. resolve type_id -> type -> modele -> marque
-  const tids = champs.map((c) => c.type_id).filter(Boolean) as string[];
+  // résolution des champions type_id NULL via seed data-driven (keyword -> {modele_id,type_id,...})
+  // -> pas de parsing fragile, curé manuellement (investigation web), reproductible.
+  const nrSeed: Record<string, any> = seed.null_resolution_by_keyword || {};
+  const nrOf = (c: Champ) => (c.type_id ? null : nrSeed[c.keyword] || null);
+  const nrTypeIds = champs.map((c) => nrOf(c)?.type_id).filter(Boolean).map(String);
+  const nrModeleIds = champs.map((c) => nrOf(c)?.modele_id).filter(Boolean).map(String);
+
+  // 2. resolve type_id -> type -> modele -> marque (champions + résolutions NULL du seed)
+  const tids = [...new Set([...(champs.map((c) => c.type_id).filter(Boolean) as string[]), ...nrTypeIds])];
   const types = await selectIn<any>(s, 'auto_type', 'type_id,type_modele_id,type_name,type_fuel,type_display,type_alias,type_power_ps', 'type_id', tids);
   const typeMap = new Map(types.map((t) => [String(t.type_id), t]));
-  const modeleIds = [...new Set(types.map((t) => t.type_modele_id).filter(Boolean))].map(String);
+  const modeleIds = [...new Set([...types.map((t) => String(t.type_modele_id)).filter((x) => x && x !== 'null'), ...nrModeleIds])];
   const modeles = await selectIn<any>(s, 'auto_modele', 'modele_id,modele_name,modele_alias,modele_marque_id', 'modele_id', modeleIds);
   const modMap = new Map(modeles.map((m) => [String(m.modele_id), m]));
   const marqueIds = [...new Set(modeles.map((m) => String(m.modele_marque_id)))];
@@ -156,7 +163,19 @@ async function decisionPack(pgId: number): Promise<void> {
     } else if (c.type_id && !renderable) {
       decision = 'DEFER_REMAP'; reason = 'orphan / non rendable (type_id absent auto_type ou type_display!=1)'; risk = 'page non rendable';
     } else if (!c.type_id) {
-      decision = 'REVIEW_OWNER'; reason = 'type_id NULL — investigation requise (voir resolution-queue)'; risk = 'non mappé';
+      const nr = nrOf(c);
+      if (nr) {
+        const rt = typeMap.get(String(nr.type_id));
+        const rm = rt ? modMap.get(String(rt.type_modele_id)) : modMap.get(String(nr.modele_id));
+        const rmq = rm ? mqMap.get(String(rm.modele_marque_id)) : null;
+        recId = String(nr.type_id); recLabel = nr.label || ''; conf = nr.confidence || 0; source = nr.source || 'seed';
+        v3type = 'DIESEL_DEFAULT_RESOLVED_NULL';
+        if (rt && rt.type_display === '1' && rm && rmq) recUrl = url(rt.type_alias, rm.modele_alias, rm.modele_id, rmq.marque_alias, rmq.marque_id, recId);
+        decision = conf >= 78 && recUrl ? 'APPROVE_CANDIDATE' : 'REVIEW_OWNER';
+        reason = 'type_id NULL résolu via seed (investigation web curée)';
+      } else {
+        decision = 'REVIEW_OWNER'; reason = 'type_id NULL — investigation requise (voir resolution-queue)'; risk = 'non mappé';
+      }
     } else if (ek) {
       recId = ek.type_id; v3type = ek.v3_type; conf = ek.confidence; source = 'web(explicit)'; reason = ek.reason;
       recUrl = renderable && t.type_alias ? url(t.type_alias, m.modele_alias, m.modele_id, mq.marque_alias, mq.marque_id, recId) : curUrl;

--- a/scripts/seo/vlevel-v3-web-evidence.json
+++ b/scripts/seo/vlevel-v3-web-evidence.json
@@ -16,6 +16,10 @@
     "disque 308 gti": { "type_id": "33864", "v3_type": "EXPLICIT_PETROL_PERFORMANCE", "owner_hint": "APPROVE_DISTINCT", "confidence": 75, "reason": "keyword sportif essence explicite -> V3 distinct, hors diesel-default; volume500 niche" },
     "plaquette de frein clio 3 1.5 dci": { "type_id": "34746", "v3_type": "DIESEL_EXPLICIT", "owner_hint": "REVIEW", "confidence": 73, "reason": "conflit: clio 3 générique->86 (19052) vs explicite 1.5 dci->88 (34746)" }
   },
+  "null_resolution_by_keyword": {
+    "$note": "Champions type_id NULL résolus via investigation web curée (resolution-queue). Seulement les cas confirmés ; les NULL ambigus (motorisation/génération inconnue) restent volontairement absents -> REVIEW par défaut. Jamais de devinette.",
+    "disque arriere scenic 3": { "modele_id": "140089", "type_id": "5853", "label": "Scénic III 1.5 dCi 110", "confidence": 82, "source": "web:fiches-auto,largus" }
+  },
   "review_keyword": {
     "disque de frein 206": "essence-vs-diesel: diesel défaut 1.4 HDi 69 (30091) mais 206 essence 1.4 75 best-seller -> trancher demande réelle"
   },


### PR DESCRIPTION
## Quoi

Suivi de #869. Le générateur de decision-pack laissait les champions **type_id NULL** sans `recommended_type_id` → `validate-pack` les bloquait à juste titre (APPROVE sans cible). **Solution structurelle, pas de hand-patch CSV.**

- résolution NULL **data-driven** via seed `null_resolution_by_keyword` (étend le pattern `web-evidence`, curé manuellement, **jamais de parsing fragile ni scraping auto**)
- le générateur fetch les `type_id`/`modele_id` de résolution → construit l'URL `/pieces/` + propose `APPROVE_CANDIDATE` si confiance ≥ 78, sinon `REVIEW_OWNER`
- les NULL ambigus (motorisation/génération inconnue) restent **volontairement absents du seed** → `REVIEW` par défaut (zéro devinette)

## Exemple

`disque arriere scenic 3` (V2 **vol500**, type_id NULL) → **Scénic III 1.5 dCi 110 (5853)** :
`avant : (aucune)` → `après : /pieces/disque-de-frein-82/renault-140/scenic-iii-140089/1-5-dci-5853.html`

## Effet sur le pilote disque (read-only, vérifié)

| | avant ce PR | après |
|---|---|---|
| `validate-pack` (verdict owner 9 lignes) | ❌ scenic 3 bloqué (NULL sans cible) | ✅ 9 applicables, contrôles OK |
| `apply-pack --dry-run` | 6 changements | **7 changements** (scenic 3 NULL→5853 inclus) |

## Inchangé
READ-ONLY + DRY-RUN : aucune mutation, `--apply` toujours **refusé** (exit 2). 2 fichiers `scripts/seo/` modifiés (couverts ownership). Pas de runtime backend/frontend touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)