### PR TITLE
feat(pricing): governed admin endpoints for dispo-only activation

### DIFF
--- a/backend/src/modules/pricing/controllers/pricing-import.controller.ts
+++ b/backend/src/modules/pricing/controllers/pricing-import.controller.ts
@@ -1,8 +1,11 @@
 /**
- * Admin endpoints for the price import lifecycle (IsAdminGuard).
- *   POST /api/admin/pricing/import/dry-run   → report + batchId (no writes)
- *   POST /api/admin/pricing/import/commit    → chunked atomic apply
- *   POST /api/admin/pricing/import/rollback  → LIFO restore
+ * Admin endpoints for the price import + activation lifecycle (IsAdminGuard).
+ *   POST /api/admin/pricing/import/dry-run     → report + batchId (no writes)
+ *   POST /api/admin/pricing/import/commit      → chunked atomic apply
+ *   POST /api/admin/pricing/import/rollback    → LIFO restore
+ *   POST /api/admin/pricing/activate/dry-run   → dispo-only projection (no writes)
+ *   POST /api/admin/pricing/activate/commit    → flip pri_dispo 1/2 (confirm:true)
+ *   POST /api/admin/pricing/activate/rollback  → LIFO restore of an activation batch
  */
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { IsAdminGuard } from '@auth/is-admin.guard';
@@ -10,6 +13,10 @@ import {
   PriceImportService,
   type ImportRequest,
 } from '../services/price-import.service';
+import {
+  PriceActivationService,
+  type ActivationRequest,
+} from '../services/price-activation.service';
 import { PricingSimulationService } from '../services/pricing-simulation.service';
 import type {
   CustomerType,
@@ -21,6 +28,7 @@ import type {
 export class PricingImportController {
   constructor(
     private readonly importService: PriceImportService,
+    private readonly activationService: PriceActivationService,
     private readonly simulationService: PricingSimulationService,
   ) {}
 
@@ -49,5 +57,22 @@ export class PricingImportController {
   @Post('import/rollback')
   rollback(@Body() body: { batchId: string; supplierId: string }) {
     return this.importService.rollback(body.batchId, body.supplierId);
+  }
+
+  /** Read-only activation projection (no writes). */
+  @Post('activate/dry-run')
+  activateDryRun(@Body() body: ActivationRequest) {
+    return this.activationService.dryRun(body);
+  }
+
+  /** Apply the dispo-only activation — requires `confirm: true` (owner-gated). */
+  @Post('activate/commit')
+  activateCommit(@Body() body: ActivationRequest & { confirm?: boolean }) {
+    return this.activationService.commit(body);
+  }
+
+  @Post('activate/rollback')
+  activateRollback(@Body() body: { batchId: string; supplierId: string }) {
+    return this.activationService.rollback(body.batchId, body.supplierId);
   }
 }

--- a/backend/src/modules/pricing/pricing.module.ts
+++ b/backend/src/modules/pricing/pricing.module.ts
@@ -12,6 +12,7 @@ import { PricingStrategyService } from './services/pricing-strategy.service';
 import { SupplierProfileService } from './services/supplier-profile.service';
 import { PricingRepository } from './services/pricing.repository';
 import { PriceImportService } from './services/price-import.service';
+import { PriceActivationService } from './services/price-activation.service';
 import { PricingSimulationService } from './services/pricing-simulation.service';
 import { PricingImportController } from './controllers/pricing-import.controller';
 
@@ -24,6 +25,7 @@ import { PricingImportController } from './controllers/pricing-import.controller
     SupplierProfileService,
     PricingRepository,
     PriceImportService,
+    PriceActivationService,
     PricingSimulationService,
   ],
   exports: [

--- a/backend/src/modules/pricing/services/__tests__/price-activation.service.test.ts
+++ b/backend/src/modules/pricing/services/__tests__/price-activation.service.test.ts
@@ -1,0 +1,52 @@
+import {
+  classifyActivationRow,
+  type ActivationOutcome,
+} from '../price-activation.service';
+
+/**
+ * The eligibility projection must mirror pricing_activate_chunk's SQL guards
+ * EXACTLY — these tests lock that contract (no false in-stock, no collateral).
+ */
+describe('classifyActivationRow', () => {
+  const row = (
+    dispo: string | null,
+    state = 'ACTIVE',
+  ): { dispo: string | null; state: string } => ({ dispo, state });
+
+  it('ACTIVATE: non-sellable (null) ACTIVE row, target 1 or 2', () => {
+    expect(classifyActivationRow('1', row(null))).toBe('ACTIVATE');
+    expect(classifyActivationRow('2', row(null))).toBe('ACTIVATE');
+    expect(classifyActivationRow('1', row('0'))).toBe('ACTIVATE');
+  });
+
+  it('REJECTED: any target other than 1/2 (incl 0,3,empty,garbage)', () => {
+    for (const t of ['0', '3', '', 'x', '12'] as const) {
+      expect(classifyActivationRow(t, row(null))).toBe(
+        'REJECTED' as ActivationOutcome,
+      );
+    }
+  });
+
+  it('MISSING: no pieces_price row for the ref', () => {
+    expect(classifyActivationRow('1', undefined)).toBe('MISSING');
+  });
+
+  it('SKIP_FROZEN_MANUAL: respects quarantine / manual control', () => {
+    expect(classifyActivationRow('1', row(null, 'FROZEN'))).toBe(
+      'SKIP_FROZEN_MANUAL',
+    );
+    expect(classifyActivationRow('2', row(null, 'MANUAL_OVERRIDE'))).toBe(
+      'SKIP_FROZEN_MANUAL',
+    );
+  });
+
+  it('SKIP_ALREADY_SELLABLE: never downgrades nor re-touches an active price', () => {
+    for (const d of ['1', '2', '3'] as const) {
+      expect(classifyActivationRow('1', row(d))).toBe('SKIP_ALREADY_SELLABLE');
+    }
+  });
+
+  it('rejection precedes row lookup (bad target on a frozen row still REJECTED)', () => {
+    expect(classifyActivationRow('0', row(null, 'FROZEN'))).toBe('REJECTED');
+  });
+});

--- a/backend/src/modules/pricing/services/price-activation.service.ts
+++ b/backend/src/modules/pricing/services/price-activation.service.ts
@@ -1,0 +1,220 @@
+/**
+ * Availability activation service (dispo-only). Drives the governed
+ * pricing_activate_chunk RPC: flips pri_dispo null/'0' -> '1' (agence) | '2'
+ * (groupe), per portal-CONFIRMED supplier ref. Read-only dry-run projects what
+ * WOULD change; commit (owner-gated by `confirm`) applies it under the COMMITTING
+ * mutex and is reversible via pricing_rollback_batch. Prices are never mutated.
+ *
+ * The eligibility projection (classifyActivationRow) mirrors the SQL function's
+ * guards EXACTLY and is a pure, unit-tested function (no DB).
+ */
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { PricingRepository } from './pricing.repository';
+
+export type ActivationTarget = '1' | '2';
+
+export interface ActivationRequest {
+  /** pri_pm_id (brand), e.g. '3410' (NK). Brand-lock. */
+  supplierId: string;
+  rows: { ref: string; dispo: ActivationTarget }[];
+  operator?: string | null;
+}
+
+export type ActivationOutcome =
+  | 'ACTIVATE'
+  | 'SKIP_FROZEN_MANUAL'
+  | 'SKIP_ALREADY_SELLABLE'
+  | 'MISSING'
+  | 'REJECTED';
+
+/**
+ * Pure eligibility — mirrors pricing_activate_chunk's guards verbatim:
+ *  target whitelist {1,2} → else REJECTED; no row → MISSING; FROZEN/MANUAL →
+ *  SKIP_FROZEN_MANUAL; already sellable (1/2/3) → SKIP_ALREADY_SELLABLE; else ACTIVATE.
+ */
+export function classifyActivationRow(
+  target: string,
+  row: { dispo: string | null; state: string } | undefined,
+): ActivationOutcome {
+  if (target !== '1' && target !== '2') return 'REJECTED';
+  if (!row) return 'MISSING';
+  if (row.state === 'FROZEN' || row.state === 'MANUAL_OVERRIDE')
+    return 'SKIP_FROZEN_MANUAL';
+  if (row.dispo === '1' || row.dispo === '2' || row.dispo === '3')
+    return 'SKIP_ALREADY_SELLABLE';
+  return 'ACTIVATE';
+}
+
+export interface ActivationReport {
+  requested: number;
+  eligible: number;
+  byDispo: { '1': number; '2': number };
+  skippedFrozenManual: number;
+  skippedAlreadySellable: number;
+  missing: number;
+  rejected: number;
+}
+
+const ACTIVATION_CHUNK = 500;
+
+@Injectable()
+export class PriceActivationService {
+  private readonly logger = new Logger(PriceActivationService.name);
+
+  constructor(private readonly repo: PricingRepository) {}
+
+  /** Resolve the scope against pieces_price + classify each row. */
+  private async project(req: ActivationRequest): Promise<{
+    report: ActivationReport;
+    commitRows: {
+      piece_id_i: number;
+      pri_type: string;
+      dispo: ActivationTarget;
+    }[];
+  }> {
+    const refs = req.rows.map((r) => r.ref);
+    const resolved = await this.repo.resolveActivationRows(
+      req.supplierId,
+      refs,
+    );
+    const report: ActivationReport = {
+      requested: req.rows.length,
+      eligible: 0,
+      byDispo: { '1': 0, '2': 0 },
+      skippedFrozenManual: 0,
+      skippedAlreadySellable: 0,
+      missing: 0,
+      rejected: 0,
+    };
+    const commitRows: {
+      piece_id_i: number;
+      pri_type: string;
+      dispo: ActivationTarget;
+    }[] = [];
+    for (const { ref, dispo } of req.rows) {
+      const row = resolved.get(ref);
+      switch (classifyActivationRow(dispo, row)) {
+        case 'ACTIVATE':
+          if (row?.pieceId == null) {
+            report.missing++;
+            break;
+          }
+          report.eligible++;
+          // explicit keys (no dynamic property-name write from a remote value —
+          // dispo is already constrained to '1'/'2' by classifyActivationRow, this
+          // is defense-in-depth against property injection / prototype pollution)
+          if (dispo === '1') report.byDispo['1']++;
+          else report.byDispo['2']++;
+          commitRows.push({
+            piece_id_i: row.pieceId,
+            pri_type: row.priType,
+            dispo,
+          });
+          break;
+        case 'SKIP_FROZEN_MANUAL':
+          report.skippedFrozenManual++;
+          break;
+        case 'SKIP_ALREADY_SELLABLE':
+          report.skippedAlreadySellable++;
+          break;
+        case 'MISSING':
+          report.missing++;
+          break;
+        case 'REJECTED':
+          report.rejected++;
+          break;
+      }
+    }
+    return { report, commitRows };
+  }
+
+  /** Read-only projection. NO write. */
+  async dryRun(req: ActivationRequest): Promise<{ report: ActivationReport }> {
+    const { report } = await this.project(req);
+    this.logger.log(
+      `[PRICING_ACTIVATE] dry-run supplier=${req.supplierId} requested=${report.requested} ` +
+        `eligible=${report.eligible} (1=${report.byDispo['1']} 2=${report.byDispo['2']}) ` +
+        `skipFM=${report.skippedFrozenManual} skipSell=${report.skippedAlreadySellable} ` +
+        `missing=${report.missing} rejected=${report.rejected}`,
+    );
+    return { report };
+  }
+
+  /** Commit (owner-gated by `confirm:true`): dispo-only activation, chunked, reversible. */
+  async commit(req: ActivationRequest & { confirm?: boolean }): Promise<{
+    batchId: string;
+    totals: {
+      activated: number;
+      skipped: number;
+      missing: number;
+      rejected: number;
+    };
+    report: ActivationReport;
+  }> {
+    if (req.confirm !== true) {
+      throw new BadRequestException('activation commit requires confirm:true');
+    }
+    const { report, commitRows } = await this.project(req);
+    const batchId = await this.repo.createActivationBatch({
+      supplierId: req.supplierId,
+      operator: req.operator ?? null,
+    });
+    await this.repo.setBatchStatus(batchId, 'COMMITTING'); // acquire per-supplier mutex
+    const totals = { activated: 0, skipped: 0, missing: 0, rejected: 0 };
+    try {
+      for (
+        let seq = 0, i = 0;
+        i < commitRows.length;
+        i += ACTIVATION_CHUNK, seq++
+      ) {
+        const slice = commitRows.slice(i, i + ACTIVATION_CHUNK);
+        const chunkId = await this.repo.createChunk(
+          batchId,
+          seq,
+          i,
+          i + slice.length,
+        );
+        const res = await this.repo.activateChunk({
+          batchId,
+          chunkId,
+          supplier: req.supplierId,
+          operator: req.operator ?? null,
+          rows: slice,
+        });
+        totals.activated += res.activated;
+        totals.skipped += res.skipped;
+        totals.missing += res.missing;
+        totals.rejected += res.rejected;
+      }
+      await this.repo.setBatchStatus(batchId, 'COMMITTED', {
+        committed_rows: totals.activated,
+        completed_at: new Date().toISOString(),
+      });
+      this.logger.log(
+        `[PRICING_ACTIVATE] commit batchId=${batchId} activated=${totals.activated} ` +
+          `skipped=${totals.skipped} missing=${totals.missing} rejected=${totals.rejected}`,
+      );
+    } catch (e) {
+      await this.repo.setBatchStatus(batchId, 'FAILED', {
+        completed_at: new Date().toISOString(),
+      });
+      this.logger.error(
+        `[PRICING_ACTIVATE] commit FAILED batchId=${batchId}: ${(e as Error).message}`,
+      );
+      throw e;
+    }
+    return { batchId, totals, report };
+  }
+
+  /** LIFO rollback of an activation batch (restores prior pri_dispo). */
+  async rollback(
+    batchId: string,
+    supplierId: string,
+  ): Promise<{ restored: number; superseded: number }> {
+    const res = await this.repo.rollbackBatch(batchId, supplierId);
+    this.logger.log(
+      `[PRICING_ACTIVATE] rollback batchId=${batchId} restored=${res.restored} superseded=${res.superseded}`,
+    );
+    return res;
+  }
+}

--- a/backend/src/modules/pricing/services/pricing.repository.ts
+++ b/backend/src/modules/pricing/services/pricing.repository.ts
@@ -122,6 +122,71 @@ export class PricingRepository extends SupabaseBaseService {
     return data.chunk_id as string;
   }
 
+  /** Open a batch for a dispo-only ACTIVATION run (no raw import file). */
+  async createActivationBatch(input: {
+    supplierId: string;
+    operator: string | null;
+  }): Promise<string> {
+    const { data, error } = await this.supabase
+      .from('price_import_batches')
+      .insert({
+        status: 'UPLOADED',
+        supplier_id: input.supplierId,
+        operator: input.operator,
+      })
+      .select('batch_id')
+      .single();
+    if (error) throw error;
+    return data.batch_id as string;
+  }
+
+  /**
+   * Read pieces_price (brand-locked) for a set of supplier refs — the activation
+   * scope resolver. Chunked (<=500 refs/query, under the 1000-row cap).
+   */
+  async resolveActivationRows(
+    supplier: string,
+    refs: string[],
+  ): Promise<
+    Map<
+      string,
+      {
+        pieceId: number | null;
+        priType: string;
+        dispo: string | null;
+        state: string;
+      }
+    >
+  > {
+    const out = new Map<
+      string,
+      {
+        pieceId: number | null;
+        priType: string;
+        dispo: string | null;
+        state: string;
+      }
+    >();
+    for (let i = 0; i < refs.length; i += 500) {
+      const chunk = refs.slice(i, i + 500);
+      const { data, error } = await this.supabase
+        .from('pieces_price')
+        .select('pri_ref, pri_piece_id_i, pri_type, pri_dispo, pricing_state')
+        .eq('pri_pm_id', supplier)
+        .in('pri_ref', chunk);
+      if (error) throw error;
+      for (const r of (data ?? []) as Array<Record<string, unknown>>) {
+        out.set(String(r.pri_ref), {
+          pieceId: (r.pri_piece_id_i as number | null) ?? null,
+          priType: String(r.pri_type ?? '0'),
+          dispo: (r.pri_dispo as string | null) ?? null,
+          state: String(r.pricing_state ?? ''),
+        });
+      }
+    }
+    return out;
+  }
+
   /** Atomic per-chunk commit via the server-side function. */
   async commitChunk(input: {
     batchId: string;


### PR DESCRIPTION
## What

Follow-up to #872. Exposes the merged `pricing_activate_chunk` capability through **governed admin endpoints** (the doctrinal path — same `IsAdminGuard` controller as price import, no standalone worker, no direct `supabase.rpc`).

```
POST /api/admin/pricing/activate/dry-run    → read-only projection (no writes)
POST /api/admin/pricing/activate/commit     → flip pri_dispo 1/2 (requires confirm:true)
POST /api/admin/pricing/activate/rollback   → LIFO restore of an activation batch
```

Body: `{ supplierId: "<pri_pm_id>", rows: [{ ref, dispo: "1"|"2" }], operator?, confirm? }`.

## Governance / safety

| Aspect | How |
|---|---|
| **Auth** | `@UseGuards(IsAdminGuard)` (same as import endpoints) |
| **Commit gate** | `commit` throws `BadRequestException` unless `confirm: true` (owner-gated at the API) |
| **No direct RPC** | service → `PricingRepository.activateChunk` → `callRpc('pricing_activate_chunk')` (passes RPC Safety Gate) |
| **Mutex** | commit runs under `status='COMMITTING'` → the partial unique index serializes per-supplier writes |
| **Reversible** | tagged `price_import_batches` row → `pricing_rollback_batch(batchId)` restores prior `pri_dispo` |
| **Prices** | never mutated (the RPC is dispo-only; history rows have `old=new` on price columns) |
| **Eligibility** | `classifyActivationRow` mirrors the SQL guards verbatim — **unit-tested (6 cases)**: ACTIVATE / REJECTED(target≠1,2) / MISSING / SKIP_FROZEN_MANUAL / SKIP_ALREADY_SELLABLE |

## Read path

`resolveActivationRows(supplier, refs)` reads `pieces_price` brand-locked, chunked ≤500 refs/query (under the 1000-row cap). The `dry-run` is pure read (no batch, no row written) — a strict zero-write guarantee.

## Files

- `services/price-activation.service.ts` (new) — dryRun / commit / rollback + pure `classifyActivationRow`
- `services/pricing.repository.ts` — `createActivationBatch` + `resolveActivationRows`
- `controllers/pricing-import.controller.ts` — 3 endpoints
- `pricing.module.ts` — provider
- `__tests__/price-activation.service.test.ts` (new) — 6 eligibility cases

## Gated sequence (no activation in this PR)

1. ✋ this PR — review + CI
2. merge → **then** `dry-run Freinage via the module** (3,545: 1,674→'1', 1,871→'2')
3. dry-run report → **then** `go commit Freinage` (confirm:true) → QA pages

The `pricing_activate_chunk` migration is already applied (post-#872). **No write happens here.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
