### PR TITLE
chore(hooks): pretool guards — block PROD tag push + raw DML on governed tables

### DIFF
--- a/scripts/claude-hooks/pretool-bash-guard.sh
+++ b/scripts/claude-hooks/pretool-bash-guard.sh
@@ -50,4 +50,12 @@ if echo "$COMMAND" | grep -qE 'npm\s+(install|uninstall|update|remove|add)\s'; t
   exit 2
 fi
 
+# Guard 6: Block version-tag create/push (v* = PROD deploy trigger, owner GO only)
+# Covers: git tag v1.2.3 / git tag -a v1.2.3 / git tag -s v1.2.3 / git push origin v1.2.3 / git push --tags
+# Rationale: tag v* promeut :preprod -> :production (voir .claude/rules/deployment.md).
+if echo "$COMMAND" | grep -qE 'git\s+tag\b.*\bv[0-9]+(\.[0-9]+){1,3}\b|git\s+push\b.*(--tags|\bv[0-9]+(\.[0-9]+){1,3}\b)'; then
+  echo "BLOCKED: tag v* = declencheur deploy PROD (voir .claude/rules/deployment.md). GO owner explicite requis." >&2
+  exit 2
+fi
+
 exit 0

--- a/scripts/claude-hooks/pretool-supabase-guard.sh
+++ b/scripts/claude-hooks/pretool-supabase-guard.sh
@@ -40,6 +40,15 @@ if echo "$QUERY_UPPER" | grep -qE 'TRUNCATE\s+'; then
   exit 2
 fi
 
+# Guard 6: Block raw DML on governed tables (BLOCK placed before the WARN guards
+# below so a combined statement cannot slip through on a WARN early-exit).
+# pieces / pieces_price = PricingModule gouverne ; __seo_* = pas de touch meta/H1 sans autorisation.
+# Une mutation legitime de ces surfaces passe par le module/RPC gouverne, pas du SQL brut en session.
+if echo "$QUERY_UPPER" | grep -qE '\b(UPDATE|DELETE\s+FROM)\s+(PUBLIC\.)?"?(PIECES_PRICE|PIECES|__SEO_[A-Z0-9_]+)\b'; then
+  echo "BLOCKED: DML brut (UPDATE/DELETE) sur pieces/pieces_price/__seo_*. Passer par le module/RPC gouverne (PricingModule / RPC), pas du SQL brut en session." >&2
+  exit 2
+fi
+
 # Guard 4: Warn on ALTER TABLE DROP COLUMN (data loss potential)
 if echo "$QUERY_UPPER" | grep -qE 'ALTER\s+TABLE.*DROP\s+COLUMN'; then
   echo "WARNING: ALTER TABLE DROP COLUMN detecte. Verifier qu'aucune donnee critique n'est perdue." >&2

--- a/scripts/test-claude-hooks.sh
+++ b/scripts/test-claude-hooks.sh
@@ -189,6 +189,55 @@ assert_exit "validate-top-priorities TOP>5 → exit 1" "1" "$?"
 assert_contains "validate-top-priorities flags TOP overflow" "TOP a 7" "$(cat /tmp/v3-out)"
 
 # ============================================================
+# Guard : pretool-bash-guard.sh — Guard 6 (tag v* = PROD deploy trigger)
+# ============================================================
+
+echo ""
+echo "=== pretool-bash-guard.sh (Guard 6 tag PROD) ==="
+
+run_bash_guard() {
+  echo "{\"command\":\"$1\"}" | bash scripts/claude-hooks/pretool-bash-guard.sh >/dev/null 2>&1
+  echo $?
+}
+
+# BLOCK : créations/pushes de tag v* (déclencheur deploy PROD)
+assert_exit "bash-guard: git tag v1.2.3 → BLOCK"           "2" "$(run_bash_guard 'git tag v1.2.3')"
+assert_exit "bash-guard: git tag -a v1.2.3 -m rel → BLOCK" "2" "$(run_bash_guard 'git tag -a v1.2.3 -m rel')"
+assert_exit "bash-guard: git tag -s v2.0.0 → BLOCK"        "2" "$(run_bash_guard 'git tag -s v2.0.0')"
+assert_exit "bash-guard: git push origin v1.2.3 → BLOCK"   "2" "$(run_bash_guard 'git push origin v1.2.3')"
+assert_exit "bash-guard: git push --tags → BLOCK"          "2" "$(run_bash_guard 'git push --tags')"
+# ALLOW : pas de faux positif sur les usages git courants
+assert_exit "bash-guard: git tag (list) → allow"           "0" "$(run_bash_guard 'git tag')"
+assert_exit "bash-guard: push feature branch → allow"      "0" "$(run_bash_guard 'git push origin feat/foo')"
+assert_exit "bash-guard: git status → allow"               "0" "$(run_bash_guard 'git status')"
+# Sanity : guard existant (Guard 1) toujours actif
+assert_exit "bash-guard: git push origin main → BLOCK (G1)" "2" "$(run_bash_guard 'git push origin main')"
+
+# ============================================================
+# Guard : pretool-supabase-guard.sh — Guard 6 (DML direct sur tables gouvernées)
+# ============================================================
+
+echo ""
+echo "=== pretool-supabase-guard.sh (Guard 6 DML) ==="
+
+run_sql_guard() {
+  echo "{\"query\":\"$1\"}" | bash scripts/claude-hooks/pretool-supabase-guard.sh >/dev/null 2>&1
+  echo $?
+}
+
+# BLOCK : DML brut sur pieces / pieces_price / __seo_*
+assert_exit "sql-guard: UPDATE pieces_price → BLOCK"           "2" "$(run_sql_guard 'UPDATE pieces_price SET pri_dispo=1')"
+assert_exit "sql-guard: UPDATE pieces → BLOCK"                 "2" "$(run_sql_guard 'UPDATE pieces SET x=1 WHERE id=1')"
+assert_exit "sql-guard: DELETE FROM __seo_keywords → BLOCK"    "2" "$(run_sql_guard 'DELETE FROM __seo_keywords WHERE id=1')"
+assert_exit "sql-guard: lowercase update public.pieces_price → BLOCK" "2" "$(run_sql_guard 'update public.pieces_price set x=1')"
+# ALLOW : pas de faux positif (autre table pieces_*, SELECT, INSERT hors scope owner)
+assert_exit "sql-guard: UPDATE pieces_relation_type → allow"  "0" "$(run_sql_guard 'UPDATE pieces_relation_type SET x=1')"
+assert_exit "sql-guard: SELECT FROM pieces → allow"           "0" "$(run_sql_guard 'SELECT * FROM pieces')"
+assert_exit "sql-guard: INSERT pieces_price → allow (scope=UPDATE/DELETE)" "0" "$(run_sql_guard 'INSERT INTO pieces_price (id) VALUES (1)')"
+# Sanity : guard existant (Guard 1) toujours actif
+assert_exit "sql-guard: DROP TABLE foo (no IF EXISTS) → BLOCK (G1)" "2" "$(run_sql_guard 'DROP TABLE foo')"
+
+# ============================================================
 # Résumé
 # ============================================================
 


### PR DESCRIPTION
## Pourquoi

Durcissement **owner-gated** des PreToolUse guards : convertir 2 des 3 gaps `DOCTRINE_ONLY` (interdits par doctrine mais non mécanisés) en **BLOCK mécanique**. Renforce une doctrine déjà écrite — **additif, strengthen-only, jamais affaiblir, réversible**. Zéro nouvelle couche : on étend les guards bash existants (même mécanisme, même style).

Contexte : suite à l'extraction des patterns gstack (#877), 3 gaps `DOCTRINE_ONLY` avaient été documentés. Cette PR en mécanise 2 ; le 3e (`gh pr merge`) est volontairement laissé sans guard (voir ci-dessous).

## Quoi

**1. [pretool-bash-guard.sh](scripts/claude-hooks/pretool-bash-guard.sh) — Guard 6 (tag PROD)**
Bloque `git tag v1.2.3`, `git tag -a|-s v1.2.3`, `git push origin v1.2.3`, `git push --tags`.
Raison : tag `v*` promeut `:preprod → :production` ([deployment.md](.claude/rules/deployment.md)) = déclencheur PROD, GO owner explicite requis. Aucun usage agent légitime.

**2. [pretool-supabase-guard.sh](scripts/claude-hooks/pretool-supabase-guard.sh) — Guard 6 (DML gouverné)**
Bloque `UPDATE`/`DELETE` brut sur `pieces`, `pieces_price`, `__seo_*` via execute_sql.
Raison : ces surfaces se mutent par **module/RPC gouverné** (PricingModule), pas du SQL brut en session. **Placé avant les guards WARN** pour que la précédence BLOCK l'emporte (un statement combiné ne peut pas passer via un early-exit WARN).

**3. [test-claude-hooks.sh](scripts/test-claude-hooks.sh)** — +17 cas (BLOCK + anti-faux-positif + sanity guards existants). **36/36 verts** en local.

## `gh pr merge` — délibérément NON gardé

La vérification de la branch protection `main` montre : **13 checks stricts requis + `enforce_admins: true`**. Merger vers main est donc **déjà gated par la CI** (et `merge=PREPROD` only ; PROD reste tag-gated). Un guard regex local serait redondant + casserait `gh pr merge --auto --squash`. **FYI owner** : `main` n'exige **pas** de review PR (`required_pull_request_reviews: null`) — décision de politique branch-protection, hors scope de cette PR.

## Garanties (scope strict)

- ✅ guards + tests **uniquement** · ❌ pas de doc · ❌ pas de #877 touché · ❌ pas de nouvelle couche/CI-wiring
- Additif : +66 lignes, 0 suppression · réversible (`CLAUDE_HOOKS_DISABLE=1` déjà supporté)
- Faux-positifs vérifiés : `pieces_relation_type`, `SELECT`, `INSERT`, `git tag` (list), push de branche feature → **allow**

## Vérification

```
bash scripts/test-claude-hooks.sh   # 36 passed / 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)