### PR TITLE
feat(pricing): governed catalog_display_activate — réf-level visibility (étage A, design/NOT applied)

### DIFF
--- a/backend/src/modules/pricing/controllers/pricing-import.controller.ts
+++ b/backend/src/modules/pricing/controllers/pricing-import.controller.ts
@@ -6,6 +6,9 @@
  *   POST /api/admin/pricing/activate/dry-run   → dispo-only projection (no writes)
  *   POST /api/admin/pricing/activate/commit    → flip pri_dispo 1/2 (confirm:true)
  *   POST /api/admin/pricing/activate/rollback  → LIFO restore of an activation batch
+ *   POST /api/admin/pricing/display/dry-run     → piece_display projection (no writes)
+ *   POST /api/admin/pricing/display/commit      → flip piece_display false→true (confirm:true)
+ *   POST /api/admin/pricing/display/rollback    → restore piece_display for a batch
  */
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { IsAdminGuard } from '@auth/is-admin.guard';
@@ -17,6 +20,10 @@ import {
   PriceActivationService,
   type ActivationRequest,
 } from '../services/price-activation.service';
+import {
+  CatalogDisplayActivationService,
+  type DisplayActivationRequest,
+} from '../services/catalog-display-activation.service';
 import { PricingSimulationService } from '../services/pricing-simulation.service';
 import type {
   CustomerType,
@@ -29,6 +36,7 @@ export class PricingImportController {
   constructor(
     private readonly importService: PriceImportService,
     private readonly activationService: PriceActivationService,
+    private readonly displayActivationService: CatalogDisplayActivationService,
     private readonly simulationService: PricingSimulationService,
   ) {}
 
@@ -74,5 +82,27 @@ export class PricingImportController {
   @Post('activate/rollback')
   activateRollback(@Body() body: { batchId: string; supplierId: string }) {
     return this.activationService.rollback(body.batchId, body.supplierId);
+  }
+
+  /** Read-only visibility projection — how many hidden-but-sellable refs (no writes). */
+  @Post('display/dry-run')
+  displayDryRun(@Body() body: DisplayActivationRequest) {
+    return this.displayActivationService.dryRun(body.supplierId);
+  }
+
+  /** Apply piece_display false→true for sellable refs — requires `confirm:true`. */
+  @Post('display/commit')
+  displayCommit(
+    @Body() body: DisplayActivationRequest & { confirm?: boolean },
+  ) {
+    return this.displayActivationService.commit(body);
+  }
+
+  @Post('display/rollback')
+  displayRollback(@Body() body: { batchId: string; supplierId: string }) {
+    return this.displayActivationService.rollback(
+      body.batchId,
+      body.supplierId,
+    );
   }
 }

--- a/backend/src/modules/pricing/pricing.module.ts
+++ b/backend/src/modules/pricing/pricing.module.ts
@@ -13,6 +13,7 @@ import { SupplierProfileService } from './services/supplier-profile.service';
 import { PricingRepository } from './services/pricing.repository';
 import { PriceImportService } from './services/price-import.service';
 import { PriceActivationService } from './services/price-activation.service';
+import { CatalogDisplayActivationService } from './services/catalog-display-activation.service';
 import { PricingSimulationService } from './services/pricing-simulation.service';
 import { PricingImportController } from './controllers/pricing-import.controller';
 
@@ -26,6 +27,7 @@ import { PricingImportController } from './controllers/pricing-import.controller
     PricingRepository,
     PriceImportService,
     PriceActivationService,
+    CatalogDisplayActivationService,
     PricingSimulationService,
   ],
   exports: [

--- a/backend/src/modules/pricing/services/catalog-display-activation.service.test.ts
+++ b/backend/src/modules/pricing/services/catalog-display-activation.service.test.ts
@@ -1,0 +1,147 @@
+/**
+ * CatalogDisplayActivationService — orchestration coverage.
+ *
+ * The eligibility predicate itself lives server-side (catalog_display_activate
+ * SQL function) and is empirically proven (6 431 == NK CONFIRMED set). These
+ * tests pin the TS orchestration that surrounds it: the owner-gated confirm,
+ * the governed batch lifecycle (COMMITTING → COMMITTED / FAILED), and the
+ * dry-run/rollback wiring.
+ */
+import { BadRequestException } from '@nestjs/common';
+import { CatalogDisplayActivationService } from './catalog-display-activation.service';
+import type { PricingRepository } from './pricing.repository';
+
+function makeRepo(
+  overrides: Partial<PricingRepository> = {},
+): PricingRepository {
+  return {
+    createActivationBatch: jest.fn().mockResolvedValue('batch-1'),
+    setBatchStatus: jest.fn().mockResolvedValue(undefined),
+    displayActivate: jest.fn().mockResolvedValue({
+      dry_run: false,
+      supplier: '3410',
+      eligible: 6431,
+      displayed: 6431,
+      batch_id: 'batch-1',
+    }),
+    displayRollback: jest
+      .fn()
+      .mockResolvedValue({ restored: 6431, batch_id: 'batch-1' }),
+    ...overrides,
+  } as unknown as PricingRepository;
+}
+
+describe('CatalogDisplayActivationService', () => {
+  describe('dryRun', () => {
+    it('calls the fn with dryRun:true and never opens a batch', async () => {
+      const repo = makeRepo({
+        displayActivate: jest.fn().mockResolvedValue({
+          dry_run: true,
+          supplier: '3410',
+          eligible: 6431,
+        }),
+      });
+      const svc = new CatalogDisplayActivationService(repo);
+
+      const res = await svc.dryRun('3410');
+
+      expect(res).toEqual({ eligible: 6431 });
+      expect(repo.displayActivate).toHaveBeenCalledWith({
+        batchId: null,
+        supplier: '3410',
+        operator: null,
+        dryRun: true,
+      });
+      expect(repo.createActivationBatch).not.toHaveBeenCalled();
+      expect(repo.setBatchStatus).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty supplierId', async () => {
+      const svc = new CatalogDisplayActivationService(makeRepo());
+      await expect(svc.dryRun('')).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('commit', () => {
+    it('refuses to write without confirm:true (no batch opened)', async () => {
+      const repo = makeRepo();
+      const svc = new CatalogDisplayActivationService(repo);
+
+      await expect(svc.commit({ supplierId: '3410' })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(repo.createActivationBatch).not.toHaveBeenCalled();
+      expect(repo.displayActivate).not.toHaveBeenCalled();
+    });
+
+    it('opens a batch, flips (dryRun:false), marks COMMITTED, returns counts', async () => {
+      const repo = makeRepo();
+      const svc = new CatalogDisplayActivationService(repo);
+
+      const res = await svc.commit({
+        supplierId: '3410',
+        operator: 'owner',
+        confirm: true,
+      });
+
+      expect(res).toEqual({
+        batchId: 'batch-1',
+        eligible: 6431,
+        displayed: 6431,
+      });
+      expect(repo.displayActivate).toHaveBeenCalledWith({
+        batchId: 'batch-1',
+        supplier: '3410',
+        operator: 'owner',
+        dryRun: false,
+      });
+      expect(repo.setBatchStatus).toHaveBeenNthCalledWith(
+        1,
+        'batch-1',
+        'COMMITTING',
+      );
+      expect(repo.setBatchStatus).toHaveBeenNthCalledWith(
+        2,
+        'batch-1',
+        'COMMITTED',
+        expect.objectContaining({ committed_rows: 6431 }),
+      );
+    });
+
+    it('marks the batch FAILED and rethrows when the flip errors', async () => {
+      const repo = makeRepo({
+        displayActivate: jest.fn().mockRejectedValue(new Error('boom')),
+      });
+      const svc = new CatalogDisplayActivationService(repo);
+
+      await expect(
+        svc.commit({ supplierId: '3410', confirm: true }),
+      ).rejects.toThrow('boom');
+      expect(repo.setBatchStatus).toHaveBeenNthCalledWith(
+        2,
+        'batch-1',
+        'FAILED',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('rollback', () => {
+    it('delegates to displayRollback', async () => {
+      const repo = makeRepo();
+      const svc = new CatalogDisplayActivationService(repo);
+
+      const res = await svc.rollback('batch-1', '3410');
+
+      expect(res).toEqual({ restored: 6431 });
+      expect(repo.displayRollback).toHaveBeenCalledWith('batch-1', '3410');
+    });
+
+    it('rejects missing args', async () => {
+      const svc = new CatalogDisplayActivationService(makeRepo());
+      await expect(svc.rollback('', '3410')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/backend/src/modules/pricing/services/catalog-display-activation.service.ts
+++ b/backend/src/modules/pricing/services/catalog-display-activation.service.ts
@@ -1,0 +1,117 @@
+/**
+ * Catalog visibility activation service (piece_display only — étape A, réf-level).
+ *
+ * Drives the governed catalog_display_activate RPC: flips pieces.piece_display
+ * false -> true for the brand's pieces that are ALREADY sellable
+ * (pieces_price.pri_dispo IN '1','2') and currently hidden. This is the
+ * visibility step of the supplier activation flow that PriceActivationService
+ * (dispo activation) started — sellability first, then visibility.
+ *
+ * SET-BASED + IDEMPOTENT: the scope is derived from the governed DB signal, not
+ * from a passed id list. dryRun projects what WOULD flip with ZERO writes;
+ * commit (owner-gated by `confirm:true`) applies it under a per-supplier batch
+ * and is reversible via catalog_display_rollback_batch. The eligibility predicate
+ * lives once, server-side, so dry-run and commit can never drift.
+ *
+ * SCOPE GUARDRAILS (enforced in the SQL function, mirrored here for intent):
+ *   brand-locked · gated on pri_dispo IN '1','2' (REVIEW/BLOCK excluded) ·
+ *   never touches gamme/vehicle/price/dispo · only false -> true.
+ */
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { PricingRepository } from './pricing.repository';
+
+export interface DisplayActivationRequest {
+  /** pieces.piece_pm_id (brand), e.g. '3410' (NK). Brand-lock. */
+  supplierId: string;
+  operator?: string | null;
+}
+
+@Injectable()
+export class CatalogDisplayActivationService {
+  private readonly logger = new Logger(CatalogDisplayActivationService.name);
+
+  constructor(private readonly repo: PricingRepository) {}
+
+  /** Read-only projection of how many hidden-but-sellable refs WOULD be shown. */
+  async dryRun(supplierId: string): Promise<{ eligible: number }> {
+    if (!supplierId) {
+      throw new BadRequestException('supplierId is required');
+    }
+    const res = await this.repo.displayActivate({
+      batchId: null,
+      supplier: supplierId,
+      operator: null,
+      dryRun: true,
+    });
+    this.logger.log(
+      `[CATALOG_DISPLAY] dry-run supplier=${supplierId} eligible=${res.eligible}`,
+    );
+    return { eligible: res.eligible };
+  }
+
+  /**
+   * Apply the visibility activation — requires `confirm:true` (owner-gated).
+   * Opens a governed batch, runs the set-based flip, marks the batch COMMITTED.
+   */
+  async commit(
+    req: DisplayActivationRequest & { confirm?: boolean },
+  ): Promise<{ batchId: string; eligible: number; displayed: number }> {
+    if (!req.supplierId) {
+      throw new BadRequestException('supplierId is required');
+    }
+    if (req.confirm !== true) {
+      throw new BadRequestException(
+        'display activation commit requires confirm:true',
+      );
+    }
+    const batchId = await this.repo.createActivationBatch({
+      supplierId: req.supplierId,
+      operator: req.operator ?? null,
+    });
+    await this.repo.setBatchStatus(batchId, 'COMMITTING'); // per-supplier mutex
+    try {
+      const res = await this.repo.displayActivate({
+        batchId,
+        supplier: req.supplierId,
+        operator: req.operator ?? null,
+        dryRun: false,
+      });
+      await this.repo.setBatchStatus(batchId, 'COMMITTED', {
+        committed_rows: res.displayed ?? 0,
+        completed_at: new Date().toISOString(),
+      });
+      this.logger.log(
+        `[CATALOG_DISPLAY] commit batchId=${batchId} supplier=${req.supplierId} ` +
+          `eligible=${res.eligible} displayed=${res.displayed ?? 0}`,
+      );
+      return {
+        batchId,
+        eligible: res.eligible,
+        displayed: res.displayed ?? 0,
+      };
+    } catch (e) {
+      await this.repo.setBatchStatus(batchId, 'FAILED', {
+        completed_at: new Date().toISOString(),
+      });
+      this.logger.error(
+        `[CATALOG_DISPLAY] commit FAILED batchId=${batchId}: ${(e as Error).message}`,
+      );
+      throw e;
+    }
+  }
+
+  /** Restore the prior piece_display for a batch (reverses a commit). */
+  async rollback(
+    batchId: string,
+    supplierId: string,
+  ): Promise<{ restored: number }> {
+    if (!batchId || !supplierId) {
+      throw new BadRequestException('batchId and supplierId are required');
+    }
+    const res = await this.repo.displayRollback(batchId, supplierId);
+    this.logger.log(
+      `[CATALOG_DISPLAY] rollback batchId=${batchId} restored=${res.restored}`,
+    );
+    return { restored: res.restored };
+  }
+}

--- a/backend/src/modules/pricing/services/pricing.repository.ts
+++ b/backend/src/modules/pricing/services/pricing.repository.ts
@@ -256,6 +256,58 @@ export class PricingRepository extends SupabaseBaseService {
     return data as { restored: number; superseded: number };
   }
 
+  /**
+   * Set-based CATALOG VISIBILITY activation via the governed server-side
+   * function. Flips pieces.piece_display false -> true for brand-locked pieces
+   * that are ALREADY sellable (pieces_price.pri_dispo IN '1','2') and currently
+   * hidden. Idempotent; `dryRun` projects without writing. Reversible via
+   * {@link displayRollback}. Never touches gamme/vehicle/price/dispo. See
+   * migration 20260607_pricing_catalog_display_activate.sql.
+   */
+  async displayActivate(input: {
+    batchId: string | null; // required by the fn only for a commit
+    supplier: string; // pieces.piece_pm_id (brand-lock)
+    operator: string | null;
+    dryRun: boolean;
+  }): Promise<{
+    dry_run: boolean;
+    supplier: string;
+    eligible: number;
+    displayed?: number;
+    batch_id?: string;
+  }> {
+    const { data, error } = await this.callRpc('catalog_display_activate', {
+      p_batch_id: input.batchId,
+      p_supplier: input.supplier,
+      p_operator: input.operator,
+      p_dry_run: input.dryRun,
+    });
+    if (error) throw error;
+    return data as {
+      dry_run: boolean;
+      supplier: string;
+      eligible: number;
+      displayed?: number;
+      batch_id?: string;
+    };
+  }
+
+  /** Reverse a display activation batch (restores prior piece_display). */
+  async displayRollback(
+    batchId: string,
+    supplier: string,
+  ): Promise<{ restored: number; batch_id: string }> {
+    const { data, error } = await this.callRpc(
+      'catalog_display_rollback_batch',
+      {
+        p_batch_id: batchId,
+        p_supplier: supplier,
+      },
+    );
+    if (error) throw error;
+    return data as { restored: number; batch_id: string };
+  }
+
   async fetchProfiles(supplierId: string): Promise<SupplierPriceProfile[]> {
     const { data, error } = await this.supabase
       .from('supplier_price_profiles')

--- a/backend/supabase/migrations/20260607_pricing_catalog_display_activate.sql
+++ b/backend/supabase/migrations/20260607_pricing_catalog_display_activate.sql
@@ -1,0 +1,179 @@
+-- =====================================================
+-- Catalog Visibility Control Plane — catalog_display_activate (étape A: réf-only)
+-- Date: 2026-06-07
+-- Refs: 20260606_pricing_activate_chunk.sql (sibling dispo activation, same governance),
+--       20260522_pricing_control_plane_v1_functions.sql (price_import_batches lifecycle),
+--       20260118_rm_remove_stock_filter.sql (get_listing_products_for_build gates the R2
+--         listing on pieces.piece_display = true — the stock/dispo filter was REMOVED, so
+--         piece_display IS the visibility gate),
+--       audit/supplier-nk-dca-availability-2026-06-06 (NK CONFIRMED-available set).
+--
+-- WHY (étape A — make sellable NK refs visible, réf-only):
+--   pricing_activate_chunk already flipped the 6 431 NK CONFIRMED refs to SELLABLE
+--   (pri_dispo '1'/'2', batch 2f7f7762-...). They are STILL invisible: the R2 listing
+--   build includes a piece ONLY when pieces.piece_display = true, and all 6 431 are
+--   piece_display = false. This function flips piece_display false -> true for the NK
+--   pieces that are ALREADY sellable. It is the visibility (réf) step of the supplier
+--   activation flow that pricing_activate_chunk started (sellability).
+--
+-- WHY SET-BASED (not a passed list of ids):
+--   The action is uniform (false -> true) and the scope is FULLY derivable from the
+--   governed DB signal — a piece is in scope iff it has a sellable price row for the
+--   brand and is currently hidden. Deriving the scope from the DB (single source of
+--   truth) is more robust than re-feeding an external id list: it is idempotent and
+--   REPEATABLE — re-running after any future tariff/TecDoc import activates exactly the
+--   newly-sellable-but-hidden refs, with no external artifact to drift. Empirically the
+--   gate (pri_pm_id='3410' AND pri_dispo IN '1','2' AND piece_display=false) == the
+--   6 431 CONFIRMED set, with 0 orphan prices and 0 brand mismatch.
+--
+-- SCOPE (étape A — réf ONLY). Touches EXACTLY pieces.piece_display. NEVER touches
+--   pieces_gamme.pg_display, auto_type.type_display, prices, pri_dispo, the sitemap, or
+--   indexation. Gamme/véhicule visibility (étage B) is a separate, SEO-gated step.
+--
+-- SAFETY INVARIANTS:
+--   - brand-locked by p_supplier (pieces.piece_pm_id): never touches a non-brand piece;
+--   - GATE: only ever exposes a piece that ALREADY has a sellable pieces_price row for
+--     the brand (pri_dispo '1'/'2'). REVIEW/BLOCK refs (dispo null/'0') are excluded by
+--     construction — visibility follows sellability, never the reverse;
+--   - idempotent: only flips piece_display false -> true; already-visible pieces are not
+--     re-touched; re-running is a no-op once everything sellable is visible;
+--   - prices, dispo, gamme, vehicle are NEVER mutated — display-only;
+--   - dry-run (p_dry_run = true, the DEFAULT) computes the projection with ZERO writes,
+--     sharing the EXACT same eligibility set as the commit (no dry-run/commit drift).
+--
+-- REVERSIBILITY. Each flip is journaled in pieces_display_history (old_display ->
+--   new_display); catalog_display_rollback_batch(batch_id, supplier) restores the prior
+--   piece_display for the whole batch, brand-locked.
+--
+-- ADDITIF. Idempotent (CREATE OR REPLACE / IF NOT EXISTS). Forward-only. NOT applied to
+-- the shared DB here — governed apply step is owner-gated. SECURITY INVOKER (service-role
+-- caller bypasses RLS). No explicit BEGIN/COMMIT (squawk assume_in_transaction=true).
+--
+-- RLS: pieces_display_history is RLS-disabled to mirror its sibling governed audit tables
+-- (pieces_price_history, price_import_batches, price_import_batch_chunks are all RLS-off).
+-- Service-role-only internal rollback journal; no anon/frontend read path.
+-- =====================================================
+
+set lock_timeout = '2s';
+set statement_timeout = '120s';
+
+-- ── Rollback journal (old_display -> new_display, per piece, per batch) ──────────────
+CREATE TABLE IF NOT EXISTS pieces_display_history (
+  id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  batch_id    UUID        NOT NULL,
+  piece_id    INTEGER     NOT NULL,
+  pm_id       TEXT        NOT NULL,   -- brand (p_supplier), e.g. '3410' (NK)
+  old_display BOOLEAN     NOT NULL,
+  new_display BOOLEAN     NOT NULL,
+  operator    TEXT,
+  changed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pieces_display_history_batch
+  ON pieces_display_history (batch_id);
+
+COMMENT ON TABLE pieces_display_history IS
+  'Rollback journal for catalog_display_activate: per-piece old/new piece_display, keyed by governed batch_id. Service-role-only (RLS-off like pieces_price_history).';
+
+-- ── Activation: piece_display false -> true, set-based, dry-run-capable, gated ───────
+CREATE OR REPLACE FUNCTION catalog_display_activate(
+  p_batch_id  UUID,          -- governed batch (price_import_batches); required for commit
+  p_supplier  TEXT,          -- pieces.piece_pm_id (brand), e.g. '3410' (NK). Brand-lock.
+  p_operator  TEXT,
+  p_dry_run   BOOLEAN DEFAULT true   -- safe default: project, do not write
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_eligible  BIGINT := 0;
+  v_displayed BIGINT := 0;
+BEGIN
+  IF p_supplier IS NULL OR p_supplier = '' THEN
+    RAISE EXCEPTION 'catalog_display_activate: p_supplier (brand pm_id) is required';
+  END IF;
+  IF NOT p_dry_run AND p_batch_id IS NULL THEN
+    RAISE EXCEPTION 'catalog_display_activate: p_batch_id is required for a commit';
+  END IF;
+
+  -- Give this run its own runtime budget (the set UPDATE on a large table), and
+  -- serialize concurrent runs for the same supplier (lock released at tx end).
+  PERFORM set_config('statement_timeout', '120s', true);
+  PERFORM set_config('lock_timeout', '5s', true);
+  PERFORM pg_advisory_xact_lock(hashtext(coalesce(p_supplier, 'catalog-display')));
+
+  -- SINGLE SOURCE OF THE ELIGIBILITY PREDICATE (captured once, used by both dry-run and
+  -- commit). Driven from pieces_price (the small, filtered sellable set) then PK-joined
+  -- to pieces. Eligible = brand-locked piece, currently hidden, with a SELLABLE price.
+  CREATE TEMP TABLE _disp_eligible ON COMMIT DROP AS
+    SELECT p.piece_id, p.piece_display AS old_display
+    FROM pieces p
+    JOIN (
+      SELECT DISTINCT pri_piece_id_i AS piece_id
+      FROM pieces_price
+      WHERE pri_pm_id = p_supplier
+        AND pri_dispo IN ('1', '2')
+    ) s ON s.piece_id = p.piece_id
+    WHERE p.piece_pm_id::text = p_supplier   -- brand-lock (defense-in-depth)
+      AND p.piece_display = false;           -- only flip hidden -> visible
+
+  SELECT count(*) INTO v_eligible FROM _disp_eligible;
+
+  IF p_dry_run THEN
+    RETURN jsonb_build_object(
+      'dry_run', true, 'supplier', p_supplier, 'eligible', v_eligible
+    );
+  END IF;
+
+  -- Journal (false -> true) so rollback restores the prior value.
+  INSERT INTO pieces_display_history (batch_id, piece_id, pm_id, old_display, new_display, operator)
+  SELECT p_batch_id, piece_id, p_supplier, old_display, true, p_operator
+  FROM _disp_eligible;
+
+  -- Activation: piece_display ONLY. Never touches gamme/vehicle/price/dispo.
+  UPDATE pieces SET piece_display = true
+  WHERE piece_id IN (SELECT piece_id FROM _disp_eligible);
+  GET DIAGNOSTICS v_displayed = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'dry_run', false, 'supplier', p_supplier, 'batch_id', p_batch_id,
+    'eligible', v_eligible, 'displayed', v_displayed
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION catalog_display_activate(UUID, TEXT, TEXT, BOOLEAN) IS
+  'Catalog visibility activation (réf-only): flips pieces.piece_display false -> true for brand-locked pieces that are ALREADY sellable (pieces_price.pri_dispo IN 1,2) and currently hidden. Set-based + idempotent. p_dry_run=true (default) projects without writing. Never touches gamme/vehicle/price/dispo. Journals to pieces_display_history; reverse with catalog_display_rollback_batch. Owner-gated.';
+
+-- ── Rollback: restore the prior piece_display for an entire batch (brand-locked) ─────
+CREATE OR REPLACE FUNCTION catalog_display_rollback_batch(
+  p_batch_id UUID,
+  p_supplier TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_restored BIGINT := 0;
+BEGIN
+  IF p_batch_id IS NULL OR p_supplier IS NULL THEN
+    RAISE EXCEPTION 'catalog_display_rollback_batch: p_batch_id and p_supplier are required';
+  END IF;
+
+  PERFORM set_config('statement_timeout', '120s', true);
+  PERFORM set_config('lock_timeout', '5s', true);
+  PERFORM pg_advisory_xact_lock(hashtext(coalesce(p_supplier, 'catalog-display')));
+
+  -- Restore each journaled piece to its old_display (brand-locked, set-based).
+  UPDATE pieces p SET piece_display = h.old_display
+  FROM pieces_display_history h
+  WHERE h.batch_id = p_batch_id
+    AND h.pm_id    = p_supplier
+    AND p.piece_id = h.piece_id
+    AND p.piece_pm_id::text = p_supplier;
+  GET DIAGNOSTICS v_restored = ROW_COUNT;
+
+  RETURN jsonb_build_object('restored', v_restored, 'batch_id', p_batch_id);
+END;
+$$;
+
+COMMENT ON FUNCTION catalog_display_rollback_batch(UUID, TEXT) IS
+  'Reverses catalog_display_activate: restores pieces.piece_display to its journaled old value for every piece in the batch, brand-locked. Idempotent.';

--- a/backend/supabase/migrations/20260607_pricing_catalog_display_activate.sql
+++ b/backend/supabase/migrations/20260607_pricing_catalog_display_activate.sql
@@ -54,6 +54,13 @@
 -- Service-role-only internal rollback journal; no anon/frontend read path.
 -- =====================================================
 
+-- squawk-ignore-file prefer-bigint-over-int
+--   pieces_display_history.piece_id INTENTIONALLY mirrors pieces.piece_id, which is
+--   integer (int4) in the live schema. The type is dictated by the FK relationship,
+--   not a free choice: matching int4 keeps the rollback join
+--   (pieces p JOIN pieces_display_history h ON p.piece_id = h.piece_id) aligned with
+--   the pieces int4 PK. Promoting to bigint would diverge from the source column type.
+
 set lock_timeout = '2s';
 set statement_timeout = '120s';
 


### PR DESCRIPTION
## Étage A — make the SELLABLE-but-hidden NK refs visible (réf-only)

**Design/PR only — the migration is NOT applied to the shared DB** (owner-gated apply step). No prod write performed by this PR.

### Why
`pricing_activate_chunk` (#872) already flipped the **6 431** NK CONFIRMED refs to sellable (`pri_dispo` 1/2, batch `2f7f7762-…`). They are still **invisible** on the storefront: the R2 listing build (`get_listing_products_for_build`) gates inclusion on `pieces.piece_display = true` (the stock/dispo filter was removed in `20260118_rm_remove_stock_filter.sql`), and all 6 431 are `piece_display = false`. This PR adds the governed mechanism to flip `piece_display` false→true for the refs that are **already sellable**.

### Why set-based (not a passed id list) — robustness / no parallel SoT
- The action is uniform (false→true); the scope is fully derivable from the **governed DB signal** — a piece is in scope iff it has a sellable price row for the brand and is currently hidden. Re-feeding an external `verdicts.jsonl` list would be a parallel source of truth; `pieces_price.pri_dispo` is the SoT.
- **Idempotent + repeatable**: re-running after any future tariff/TecDoc import activates exactly the newly-sellable-but-hidden refs — the owner's standing rule *"si une ref a un prix et une dispo → piece_display devient true"*.
- **Empirically proven** (read-only): `(pri_pm_id='3410' AND pri_dispo IN '1','2' AND piece_display=false)` == **6 431**, with **0** orphan prices and **0** brand mismatch. The DB-derived gate == the owner's "scope CONFIRMED disponibles".

### Scope guardrails (enforced in SQL — étage A = réf ONLY)
| Guardrail | How |
|---|---|
| marque NK only (`pm_id=3410`) | `p_supplier` brand-lock on `pieces.piece_pm_id` |
| scope = CONFIRMED disponibles | gate `pri_dispo IN ('1','2')` (== proven 6 431) |
| REVIEW / BLOCK never touched | their dispo is null/'0' → excluded by construction |
| prix jamais modifié | function writes only `pieces.piece_display` |
| gamme / véhicule jamais activé | never touches `pg_display` / `type_display` |
| rollback | `pieces_display_history` + `catalog_display_rollback_batch` restore prior value |
| dry-run obligatoire | `p_dry_run=true` (DEFAULT) projects with **zero writes**, same predicate as commit |

**Explicitly NOT in this PR (étage B, deferred, SEO-gated):** `pg_display` 0→1, `type_display` 0→1, sitemap, indexation, new pages.

### Surface (extends the existing Pricing Control Plane activation flow)
- **Migration** `20260607_pricing_catalog_display_activate.sql` — `pieces_display_history` (RLS-off like its sibling `pieces_price_history` / `price_import_batches`) + `catalog_display_activate(p_batch_id, p_supplier, p_operator, p_dry_run)` + `catalog_display_rollback_batch(p_batch_id, p_supplier)`. Named `..._pricing_...` = Pricing Control Plane bounded context (existing owner glob).
- **CatalogDisplayActivationService** — `dryRun` / `commit`(`confirm:true`) / `rollback`, reusing the `price_import_batches` lifecycle + per-supplier advisory mutex.
- **PricingRepository** — `displayActivate` / `displayRollback` via `callRpc` (RPC safety gate; no direct `supabase.rpc`).
- **Endpoints** `POST /api/admin/pricing/display/{dry-run,commit,rollback}` (`IsAdminGuard`).
- **Unit test** (7 cases, green) pins the owner-gated confirm + batch lifecycle (COMMITTING→COMMITTED/FAILED) + rollback wiring.

### Owner-gated apply sequence (after review + green CI)
1. owner applies the migration · 2. `display/dry-run` (expect eligible=6 431) · 3. `display/commit` `{supplierId:'3410', confirm:true}` · 4. targeted cache invalidation (Freinage/Embrayage/Suspension/Roulement/Supports) · 5. QA NK pages.
Reverse anytime: `SELECT catalog_display_rollback_batch('<batch>','3410');`

## Improvement Check
- **Problem:** 6 431 sellable NK refs invisible (`piece_display=false`) → never enter any listing.
- **Evidence before:** read-only proof above (6 431 == gate, 0 orphan, 0 brand leak).
- **Expected gain:** sellable NK refs become listable once owner applies + commits.
- **Risk:** low — display-only, brand-locked, gated on sellability, reversible, dry-run-first. Migration NOT applied here.
- **Test:** 7 unit tests green; ESLint clean; eligibility predicate empirically verified.
- **Verdict:** GO for review (apply remains owner-gated).
- **Next action:** owner review + CI; then the apply sequence above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)