### PR TITLE
fix(seo): model-name match key (accent + roman↔arabic) — parser only

### DIFF
--- a/packages/seo-roles/src/__tests__/model-match-key.test.ts
+++ b/packages/seo-roles/src/__tests__/model-match-key.test.ts
@@ -1,0 +1,62 @@
+/**
+ * modelMatchKey — match robuste keyword ↔ catalogue (accents, roman↔arabe, espaces/tirets).
+ *
+ * Cause racine SCÉNIC (blocked-plan 2026-06-07) : « scenic 2 » (keyword) ne matchait pas
+ * « SCÉNIC II » (auto_modele.modele_name) → champion BLOCKED en PARSER_MISS. Ces tests gèlent
+ * la normalisation GÉNÉRIQUE (pas un hardcode Scénic).
+ *
+ * @see ../text-normalize.ts (modelMatchKey)
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { modelMatchKey } from "../index";
+
+const match = (a: string, b: string) => modelMatchKey(a) === modelMatchKey(b);
+
+describe("modelMatchKey — roman↔arabe + accents (générique)", () => {
+  test("scenic 2 ↔ SCÉNIC II", () => {
+    assert.ok(match("scenic 2", "SCÉNIC II"));
+    assert.equal(modelMatchKey("SCÉNIC II"), "scenic 2");
+  });
+
+  test("scenic 3 ↔ SCÉNIC III", () => {
+    assert.ok(match("scenic 3", "SCÉNIC III"));
+  });
+
+  test("scenic 1 ↔ SCÉNIC I", () => {
+    assert.ok(match("scenic 1", "SCÉNIC I"));
+  });
+
+  test("c4 picasso reste C4 Picasso (pas de faux roman sur c4)", () => {
+    assert.ok(match("c4 picasso", "C4 Picasso"));
+    assert.equal(modelMatchKey("C4 Picasso"), "c4 picasso");
+  });
+
+  test("clio 2 ↔ Clio II", () => {
+    assert.ok(match("clio 2", "Clio II"));
+  });
+
+  test("clio 3 ↔ Clio III", () => {
+    assert.ok(match("clio 3", "Clio III"));
+  });
+
+  test("générique : pas de hardcode — golf v ↔ GOLF 5, mégane iii ↔ MEGANE 3", () => {
+    assert.ok(match("golf v", "GOLF 5"));
+    assert.ok(match("mégane iii", "MEGANE 3"));
+    assert.ok(match("208 i", "208 I"));
+  });
+
+  test("tirets/espaces unifiés : c4-picasso ↔ C4 PICASSO", () => {
+    assert.ok(match("c4-picasso", "C4 PICASSO"));
+  });
+
+  test("ne convertit PAS un sous-mot romain (vti, tdi restent)", () => {
+    assert.equal(modelMatchKey("clio iii 1.5 dci"), "clio 3 1 5 dci");
+    assert.equal(modelMatchKey("a3 vti"), "a3 vti"); // 'vti' n'est pas un token romain pur
+  });
+
+  test("idempotent", () => {
+    const k = modelMatchKey("SCÉNIC III");
+    assert.equal(modelMatchKey(k), k);
+  });
+});

--- a/packages/seo-roles/src/index.ts
+++ b/packages/seo-roles/src/index.ts
@@ -78,6 +78,7 @@ export {
   type SupportedLocale,
   normalizeSeoText,
   normalizePhrase,
+  modelMatchKey,
   tokenize,
   stem,
   tokenizeAndStem,

--- a/packages/seo-roles/src/text-normalize.ts
+++ b/packages/seo-roles/src/text-normalize.ts
@@ -57,6 +57,36 @@ export function normalizePhrase(text: string): string {
 }
 
 /**
+ * Numéraux romains de génération de modèle (I..X) → arabe, pour un MATCH robuste
+ * keyword ↔ catalogue. `normalizeSeoText` gère déjà accents + tirets + espaces, mais pas
+ * `II` ↔ `2`. Seuls les tokens romains PURS sont convertis (`ii`→`2`), jamais un sous-mot
+ * (`vti`, `c4` restent). Mapping consistant des DEUX côtés → l'exactitude sémantique n'importe
+ * pas (ex. « classe v » et « CLASSE V » donnent tous deux `classe 5` → ils matchent).
+ */
+const MODEL_ROMAN_TO_ARABIC: Readonly<Record<string, string>> = {
+  i: "1", ii: "2", iii: "3", iv: "4", v: "5",
+  vi: "6", vii: "7", viii: "8", ix: "9", x: "10",
+};
+
+/**
+ * Clé canonique de MATCHING d'un nom de modèle véhicule (keyword libre ↔ `auto_modele.modele_name`).
+ *
+ * Pipeline : {@link normalizeSeoText} (lowercase, accents, tirets/ponctuation → espace, collapse)
+ * puis génération romaine → arabe par token. Déterministe & idempotent.
+ *
+ * Exemples : `"scenic 2"` et `"SCÉNIC II"` → `"scenic 2"` ; `"C4 Picasso"` → `"c4 picasso"` ;
+ * `"Clio III"` et `"clio 3"` → `"clio 3"`. Usage : résolution de candidat modèle (blocked-plan)
+ * et groupement V-Level — JAMAIS pour de l'affichage (clé interne uniquement).
+ */
+export function modelMatchKey(modelName: string): string {
+  return normalizeSeoText(modelName)
+    .split(" ")
+    .map((tok) => MODEL_ROMAN_TO_ARABIC[tok] ?? tok)
+    .join(" ")
+    .trim();
+}
+
+/**
  * Tokenise text into matchable units.
  *
  * Drops tokens shorter than {@link MIN_TOKEN_LEN} chars and FR stopwords.


### PR DESCRIPTION
## Cause racine

`blocked-plan` (2026-06-07) a classé **5 champions V3 Scénic en `PARSER_MISS`** : le modèle keyword `scenic ii` ne matchait pas le catalogue `SCÉNIC II` (**accent**), et `scenic 2` ne matcherait pas `SCÉNIC II` (**roman**). Le système croyait avoir un champion mais ne pouvait pas résoudre le modèle → pas de candidat → page /pieces impossible.

C'est un bug de **mécanisme (parser)**, pas de données. On corrige le parser **avant** de toucher les données (ta consigne).

## Le fix (générique, pas hardcodé)

`modelMatchKey()` ajouté à `text-normalize.ts` — **étend** l'existant :
- réutilise `normalizeSeoText` (déjà : lowercase, accents NFD, tirets/ponctuation → espace, collapse)
- + mapping **roman→arabe générique** sur les tokens numéraux purs (`i`..`x`). Jamais un sous-mot (`vti`, `c4` restent). Consistant des deux côtés.

`"scenic 2"` et `"SCÉNIC II"` → `"scenic 2"` · `"Clio III"` → `"clio 3"` · `"C4 Picasso"` → `"c4 picasso"`.

## Tests (tes 5 cas + bord) — **10/10 verts** (254 package)

- ✅ scenic 2 ↔ SCÉNIC II · scenic 3 ↔ SCÉNIC III · scenic 1 ↔ SCÉNIC I
- ✅ c4 picasso reste C4 Picasso · clio 2 ↔ Clio II · clio 3 ↔ Clio III
- ✅ générique : golf v ↔ GOLF 5, mégane iii ↔ MEGANE 3 · tirets unifiés · sous-mot romain (`vti`) intact · idempotent

**Preuve runtime** (read-only) : sur les vraies valeurs DB, `modelMatchKey` résout les 3 générations Scénic (scenic i/ii/iii → SCÉNIC I/II/III).

## Périmètre strict (respecté)

✅ parser uniquement · tests unitaires · **NO UPDATE · NO recalcul · NO apply DB**.
Le câblage dans `blocked-plan` (résolution de candidat) **converge en follow-up** qui importe cet export — après merge, le re-run `blocked:plan` montrera les 5 Scénic sortir de PARSER_MISS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)