### PR TITLE
feat(pricing): governed catalog_display_quarantine — hide non-vendable refs (inverse of #880, NOT applied)

### DIFF
--- a/backend/src/modules/pricing/controllers/pricing-import.controller.ts
+++ b/backend/src/modules/pricing/controllers/pricing-import.controller.ts
@@ -114,10 +114,13 @@ export class PricingImportController {
     );
   }
 
-  /** Read-only quarantine projection — how many visible-but-non-vendable refs (no writes). */
+  /**
+   * Read-only quarantine projection — how many visible-but-non-vendable refs (no writes).
+   * Optional `gammeIds` (pieces.piece_ga_id) scopes the projection to a cohort.
+   */
   @Post('display/quarantine/dry-run')
   displayQuarantineDryRun(@Body() body: DisplayQuarantineRequest) {
-    return this.displayQuarantineService.dryRun(body.supplierId);
+    return this.displayQuarantineService.dryRun(body.supplierId, body.gammeIds);
   }
 
   /** Apply piece_display true→false for non-vendable refs — requires `confirm:true`. */

--- a/backend/src/modules/pricing/controllers/pricing-import.controller.ts
+++ b/backend/src/modules/pricing/controllers/pricing-import.controller.ts
@@ -9,6 +9,9 @@
  *   POST /api/admin/pricing/display/dry-run     → piece_display projection (no writes)
  *   POST /api/admin/pricing/display/commit      → flip piece_display false→true (confirm:true)
  *   POST /api/admin/pricing/display/rollback    → restore piece_display for a batch
+ *   POST /api/admin/pricing/display/quarantine/dry-run → non-vendable hide projection (no writes)
+ *   POST /api/admin/pricing/display/quarantine/commit  → flip piece_display true→false (confirm:true)
+ *   POST /api/admin/pricing/display/quarantine/rollback → restore piece_display for a quarantine batch
  */
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { IsAdminGuard } from '@auth/is-admin.guard';
@@ -24,6 +27,10 @@ import {
   CatalogDisplayActivationService,
   type DisplayActivationRequest,
 } from '../services/catalog-display-activation.service';
+import {
+  CatalogDisplayQuarantineService,
+  type DisplayQuarantineRequest,
+} from '../services/catalog-display-quarantine.service';
 import { PricingSimulationService } from '../services/pricing-simulation.service';
 import type {
   CustomerType,
@@ -37,6 +44,7 @@ export class PricingImportController {
     private readonly importService: PriceImportService,
     private readonly activationService: PriceActivationService,
     private readonly displayActivationService: CatalogDisplayActivationService,
+    private readonly displayQuarantineService: CatalogDisplayQuarantineService,
     private readonly simulationService: PricingSimulationService,
   ) {}
 
@@ -101,6 +109,30 @@ export class PricingImportController {
   @Post('display/rollback')
   displayRollback(@Body() body: { batchId: string; supplierId: string }) {
     return this.displayActivationService.rollback(
+      body.batchId,
+      body.supplierId,
+    );
+  }
+
+  /** Read-only quarantine projection — how many visible-but-non-vendable refs (no writes). */
+  @Post('display/quarantine/dry-run')
+  displayQuarantineDryRun(@Body() body: DisplayQuarantineRequest) {
+    return this.displayQuarantineService.dryRun(body.supplierId);
+  }
+
+  /** Apply piece_display true→false for non-vendable refs — requires `confirm:true`. */
+  @Post('display/quarantine/commit')
+  displayQuarantineCommit(
+    @Body() body: DisplayQuarantineRequest & { confirm?: boolean },
+  ) {
+    return this.displayQuarantineService.commit(body);
+  }
+
+  @Post('display/quarantine/rollback')
+  displayQuarantineRollback(
+    @Body() body: { batchId: string; supplierId: string },
+  ) {
+    return this.displayQuarantineService.rollback(
       body.batchId,
       body.supplierId,
     );

--- a/backend/src/modules/pricing/pricing.module.ts
+++ b/backend/src/modules/pricing/pricing.module.ts
@@ -14,6 +14,7 @@ import { PricingRepository } from './services/pricing.repository';
 import { PriceImportService } from './services/price-import.service';
 import { PriceActivationService } from './services/price-activation.service';
 import { CatalogDisplayActivationService } from './services/catalog-display-activation.service';
+import { CatalogDisplayQuarantineService } from './services/catalog-display-quarantine.service';
 import { PricingSimulationService } from './services/pricing-simulation.service';
 import { PricingImportController } from './controllers/pricing-import.controller';
 
@@ -28,6 +29,7 @@ import { PricingImportController } from './controllers/pricing-import.controller
     PriceImportService,
     PriceActivationService,
     CatalogDisplayActivationService,
+    CatalogDisplayQuarantineService,
     PricingSimulationService,
   ],
   exports: [

--- a/backend/src/modules/pricing/services/catalog-display-quarantine.service.test.ts
+++ b/backend/src/modules/pricing/services/catalog-display-quarantine.service.test.ts
@@ -52,9 +52,30 @@ describe('CatalogDisplayQuarantineService', () => {
         supplier: '3410',
         operator: null,
         dryRun: true,
+        gammeIds: null,
       });
       expect(repo.createActivationBatch).not.toHaveBeenCalled();
       expect(repo.setBatchStatus).not.toHaveBeenCalled();
+    });
+
+    it('forwards a cohort gamme scope (staged dry-run)', async () => {
+      const repo = makeRepo({
+        displayQuarantine: jest
+          .fn()
+          .mockResolvedValue({ dry_run: true, supplier: '3410', eligible: 862 }),
+      });
+      const svc = new CatalogDisplayQuarantineService(repo);
+
+      const res = await svc.dryRun('3410', [2, 4, 13, 188, 286, 1145]);
+
+      expect(res).toEqual({ eligible: 862 });
+      expect(repo.displayQuarantine).toHaveBeenCalledWith({
+        batchId: null,
+        supplier: '3410',
+        operator: null,
+        dryRun: true,
+        gammeIds: [2, 4, 13, 188, 286, 1145],
+      });
     });
 
     it('rejects an empty supplierId', async () => {
@@ -95,6 +116,7 @@ describe('CatalogDisplayQuarantineService', () => {
         supplier: '3410',
         operator: 'owner',
         dryRun: false,
+        gammeIds: null,
       });
       expect(repo.setBatchStatus).toHaveBeenNthCalledWith(
         1,

--- a/backend/src/modules/pricing/services/catalog-display-quarantine.service.test.ts
+++ b/backend/src/modules/pricing/services/catalog-display-quarantine.service.test.ts
@@ -60,9 +60,11 @@ describe('CatalogDisplayQuarantineService', () => {
 
     it('forwards a cohort gamme scope (staged dry-run)', async () => {
       const repo = makeRepo({
-        displayQuarantine: jest
-          .fn()
-          .mockResolvedValue({ dry_run: true, supplier: '3410', eligible: 862 }),
+        displayQuarantine: jest.fn().mockResolvedValue({
+          dry_run: true,
+          supplier: '3410',
+          eligible: 862,
+        }),
       });
       const svc = new CatalogDisplayQuarantineService(repo);
 

--- a/backend/src/modules/pricing/services/catalog-display-quarantine.service.test.ts
+++ b/backend/src/modules/pricing/services/catalog-display-quarantine.service.test.ts
@@ -1,0 +1,148 @@
+/**
+ * CatalogDisplayQuarantineService — orchestration coverage (inverse of the
+ * activation service).
+ *
+ * The eligibility predicate itself lives server-side (catalog_display_quarantine
+ * SQL function) and is empirically proven (1 925 == NK visible-non-vendable set,
+ * overlap=0 with the activated 6 431). These tests pin the TS orchestration that
+ * surrounds it: the owner-gated confirm, the governed batch lifecycle
+ * (COMMITTING → COMMITTED / FAILED), and the dry-run/rollback wiring.
+ */
+import { BadRequestException } from '@nestjs/common';
+import { CatalogDisplayQuarantineService } from './catalog-display-quarantine.service';
+import type { PricingRepository } from './pricing.repository';
+
+function makeRepo(
+  overrides: Partial<PricingRepository> = {},
+): PricingRepository {
+  return {
+    createActivationBatch: jest.fn().mockResolvedValue('batch-q1'),
+    setBatchStatus: jest.fn().mockResolvedValue(undefined),
+    displayQuarantine: jest.fn().mockResolvedValue({
+      dry_run: false,
+      supplier: '3410',
+      eligible: 1925,
+      hidden: 1925,
+      batch_id: 'batch-q1',
+    }),
+    displayRollback: jest
+      .fn()
+      .mockResolvedValue({ restored: 1925, batch_id: 'batch-q1' }),
+    ...overrides,
+  } as unknown as PricingRepository;
+}
+
+describe('CatalogDisplayQuarantineService', () => {
+  describe('dryRun', () => {
+    it('calls the fn with dryRun:true and never opens a batch', async () => {
+      const repo = makeRepo({
+        displayQuarantine: jest.fn().mockResolvedValue({
+          dry_run: true,
+          supplier: '3410',
+          eligible: 1925,
+        }),
+      });
+      const svc = new CatalogDisplayQuarantineService(repo);
+
+      const res = await svc.dryRun('3410');
+
+      expect(res).toEqual({ eligible: 1925 });
+      expect(repo.displayQuarantine).toHaveBeenCalledWith({
+        batchId: null,
+        supplier: '3410',
+        operator: null,
+        dryRun: true,
+      });
+      expect(repo.createActivationBatch).not.toHaveBeenCalled();
+      expect(repo.setBatchStatus).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty supplierId', async () => {
+      const svc = new CatalogDisplayQuarantineService(makeRepo());
+      await expect(svc.dryRun('')).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('commit', () => {
+    it('refuses to write without confirm:true (no batch opened)', async () => {
+      const repo = makeRepo();
+      const svc = new CatalogDisplayQuarantineService(repo);
+
+      await expect(svc.commit({ supplierId: '3410' })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(repo.createActivationBatch).not.toHaveBeenCalled();
+      expect(repo.displayQuarantine).not.toHaveBeenCalled();
+    });
+
+    it('opens a batch, flips (dryRun:false), marks COMMITTED, returns counts', async () => {
+      const repo = makeRepo();
+      const svc = new CatalogDisplayQuarantineService(repo);
+
+      const res = await svc.commit({
+        supplierId: '3410',
+        operator: 'owner',
+        confirm: true,
+      });
+
+      expect(res).toEqual({
+        batchId: 'batch-q1',
+        eligible: 1925,
+        hidden: 1925,
+      });
+      expect(repo.displayQuarantine).toHaveBeenCalledWith({
+        batchId: 'batch-q1',
+        supplier: '3410',
+        operator: 'owner',
+        dryRun: false,
+      });
+      expect(repo.setBatchStatus).toHaveBeenNthCalledWith(
+        1,
+        'batch-q1',
+        'COMMITTING',
+      );
+      expect(repo.setBatchStatus).toHaveBeenNthCalledWith(
+        2,
+        'batch-q1',
+        'COMMITTED',
+        expect.objectContaining({ committed_rows: 1925 }),
+      );
+    });
+
+    it('marks the batch FAILED and rethrows when the flip errors', async () => {
+      const repo = makeRepo({
+        displayQuarantine: jest.fn().mockRejectedValue(new Error('boom')),
+      });
+      const svc = new CatalogDisplayQuarantineService(repo);
+
+      await expect(
+        svc.commit({ supplierId: '3410', confirm: true }),
+      ).rejects.toThrow('boom');
+      expect(repo.setBatchStatus).toHaveBeenNthCalledWith(
+        2,
+        'batch-q1',
+        'FAILED',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('rollback', () => {
+    it('delegates to the generic displayRollback', async () => {
+      const repo = makeRepo();
+      const svc = new CatalogDisplayQuarantineService(repo);
+
+      const res = await svc.rollback('batch-q1', '3410');
+
+      expect(res).toEqual({ restored: 1925 });
+      expect(repo.displayRollback).toHaveBeenCalledWith('batch-q1', '3410');
+    });
+
+    it('rejects missing args', async () => {
+      const svc = new CatalogDisplayQuarantineService(makeRepo());
+      await expect(svc.rollback('', '3410')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/backend/src/modules/pricing/services/catalog-display-quarantine.service.ts
+++ b/backend/src/modules/pricing/services/catalog-display-quarantine.service.ts
@@ -27,6 +27,8 @@ export interface DisplayQuarantineRequest {
   /** pieces.piece_pm_id (brand), e.g. '3410' (NK). Brand-lock. */
   supplierId: string;
   operator?: string | null;
+  /** optional cohort scope (pieces.piece_ga_id); omitted/null = whole brand */
+  gammeIds?: number[] | null;
 }
 
 @Injectable()
@@ -35,8 +37,14 @@ export class CatalogDisplayQuarantineService {
 
   constructor(private readonly repo: PricingRepository) {}
 
-  /** Read-only projection of how many visible-but-non-vendable refs WOULD be hidden. */
-  async dryRun(supplierId: string): Promise<{ eligible: number }> {
+  /**
+   * Read-only projection of how many visible-but-non-vendable refs WOULD be hidden.
+   * `gammeIds` (optional, pieces.piece_ga_id) scopes the projection to a cohort.
+   */
+  async dryRun(
+    supplierId: string,
+    gammeIds?: number[] | null,
+  ): Promise<{ eligible: number }> {
     if (!supplierId) {
       throw new BadRequestException('supplierId is required');
     }
@@ -45,9 +53,11 @@ export class CatalogDisplayQuarantineService {
       supplier: supplierId,
       operator: null,
       dryRun: true,
+      gammeIds: gammeIds ?? null,
     });
     this.logger.log(
-      `[CATALOG_DISPLAY] quarantine dry-run supplier=${supplierId} eligible=${res.eligible}`,
+      `[CATALOG_DISPLAY] quarantine dry-run supplier=${supplierId} ` +
+        `gammes=${gammeIds?.length ?? 'all'} eligible=${res.eligible}`,
     );
     return { eligible: res.eligible };
   }
@@ -78,6 +88,7 @@ export class CatalogDisplayQuarantineService {
         supplier: req.supplierId,
         operator: req.operator ?? null,
         dryRun: false,
+        gammeIds: req.gammeIds ?? null,
       });
       await this.repo.setBatchStatus(batchId, 'COMMITTED', {
         committed_rows: res.hidden ?? 0,
@@ -85,7 +96,7 @@ export class CatalogDisplayQuarantineService {
       });
       this.logger.log(
         `[CATALOG_DISPLAY] quarantine commit batchId=${batchId} supplier=${req.supplierId} ` +
-          `eligible=${res.eligible} hidden=${res.hidden ?? 0}`,
+          `gammes=${req.gammeIds?.length ?? 'all'} eligible=${res.eligible} hidden=${res.hidden ?? 0}`,
       );
       return {
         batchId,

--- a/backend/src/modules/pricing/services/catalog-display-quarantine.service.ts
+++ b/backend/src/modules/pricing/services/catalog-display-quarantine.service.ts
@@ -1,0 +1,123 @@
+/**
+ * Catalog visibility quarantine service (piece_display only) — the inverse of
+ * {@link CatalogDisplayActivationService}.
+ *
+ * Drives the governed catalog_display_quarantine RPC: flips pieces.piece_display
+ * true -> false for the brand's refs that are currently visible AND non-vendable
+ * per the storefront isSellable gate (no pieces_price row with pri_dispo IN
+ * '1','2','3' AND pri_vente_ttc_n > 0). These are the refs that render at 0 € /
+ * OUT_OF_STOCK in R2 listings: visually present but not buyable (listing-quality
+ * drag). Hiding them is the mirror-image of the activation flow.
+ *
+ * SET-BASED + IDEMPOTENT: the scope is derived from the governed DB signal, not
+ * from a passed id list. dryRun projects what WOULD hide with ZERO writes; commit
+ * (owner-gated by `confirm:true`) applies it under a per-supplier batch and is
+ * reversible via the SAME generic catalog_display_rollback_batch. The eligibility
+ * predicate lives once, server-side, so dry-run and commit can never drift.
+ *
+ * SCOPE GUARDRAILS (enforced in the SQL function, mirrored here for intent):
+ *   brand-locked · STRUCTURALLY DISJOINT from the activate domain (never touches a
+ *   ref with a sellable-dispo price) · gated on the inverse-isSellable predicate ·
+ *   never touches gamme/vehicle/price/dispo · only true -> false.
+ */
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { PricingRepository } from './pricing.repository';
+
+export interface DisplayQuarantineRequest {
+  /** pieces.piece_pm_id (brand), e.g. '3410' (NK). Brand-lock. */
+  supplierId: string;
+  operator?: string | null;
+}
+
+@Injectable()
+export class CatalogDisplayQuarantineService {
+  private readonly logger = new Logger(CatalogDisplayQuarantineService.name);
+
+  constructor(private readonly repo: PricingRepository) {}
+
+  /** Read-only projection of how many visible-but-non-vendable refs WOULD be hidden. */
+  async dryRun(supplierId: string): Promise<{ eligible: number }> {
+    if (!supplierId) {
+      throw new BadRequestException('supplierId is required');
+    }
+    const res = await this.repo.displayQuarantine({
+      batchId: null,
+      supplier: supplierId,
+      operator: null,
+      dryRun: true,
+    });
+    this.logger.log(
+      `[CATALOG_DISPLAY] quarantine dry-run supplier=${supplierId} eligible=${res.eligible}`,
+    );
+    return { eligible: res.eligible };
+  }
+
+  /**
+   * Apply the visibility quarantine — requires `confirm:true` (owner-gated).
+   * Opens a governed batch, runs the set-based flip, marks the batch COMMITTED.
+   */
+  async commit(
+    req: DisplayQuarantineRequest & { confirm?: boolean },
+  ): Promise<{ batchId: string; eligible: number; hidden: number }> {
+    if (!req.supplierId) {
+      throw new BadRequestException('supplierId is required');
+    }
+    if (req.confirm !== true) {
+      throw new BadRequestException(
+        'display quarantine commit requires confirm:true',
+      );
+    }
+    const batchId = await this.repo.createActivationBatch({
+      supplierId: req.supplierId,
+      operator: req.operator ?? null,
+    });
+    await this.repo.setBatchStatus(batchId, 'COMMITTING'); // per-supplier mutex
+    try {
+      const res = await this.repo.displayQuarantine({
+        batchId,
+        supplier: req.supplierId,
+        operator: req.operator ?? null,
+        dryRun: false,
+      });
+      await this.repo.setBatchStatus(batchId, 'COMMITTED', {
+        committed_rows: res.hidden ?? 0,
+        completed_at: new Date().toISOString(),
+      });
+      this.logger.log(
+        `[CATALOG_DISPLAY] quarantine commit batchId=${batchId} supplier=${req.supplierId} ` +
+          `eligible=${res.eligible} hidden=${res.hidden ?? 0}`,
+      );
+      return {
+        batchId,
+        eligible: res.eligible,
+        hidden: res.hidden ?? 0,
+      };
+    } catch (e) {
+      await this.repo.setBatchStatus(batchId, 'FAILED', {
+        completed_at: new Date().toISOString(),
+      });
+      this.logger.error(
+        `[CATALOG_DISPLAY] quarantine commit FAILED batchId=${batchId}: ${(e as Error).message}`,
+      );
+      throw e;
+    }
+  }
+
+  /**
+   * Restore the prior piece_display for a batch (reverses a quarantine commit).
+   * Delegates to the SAME generic rollback as the activation flow.
+   */
+  async rollback(
+    batchId: string,
+    supplierId: string,
+  ): Promise<{ restored: number }> {
+    if (!batchId || !supplierId) {
+      throw new BadRequestException('batchId and supplierId are required');
+    }
+    const res = await this.repo.displayRollback(batchId, supplierId);
+    this.logger.log(
+      `[CATALOG_DISPLAY] quarantine rollback batchId=${batchId} restored=${res.restored}`,
+    );
+    return { restored: res.restored };
+  }
+}

--- a/backend/src/modules/pricing/services/pricing.repository.ts
+++ b/backend/src/modules/pricing/services/pricing.repository.ts
@@ -292,7 +292,49 @@ export class PricingRepository extends SupabaseBaseService {
     };
   }
 
-  /** Reverse a display activation batch (restores prior piece_display). */
+  /**
+   * Set-based CATALOG VISIBILITY quarantine via the governed server-side function —
+   * the inverse of {@link displayActivate}. Flips pieces.piece_display true -> false
+   * for brand-locked refs that are currently visible AND non-vendable per the
+   * storefront isSellable gate (no pieces_price row with pri_dispo IN '1','2','3'
+   * AND pri_vente_ttc_n > 0). Structurally disjoint from the activate domain.
+   * Idempotent; `dryRun` projects without writing. Reversible via the SAME generic
+   * {@link displayRollback} (restores old_display). Never touches gamme/vehicle/
+   * price/dispo. See migration 20260607_pricing_catalog_display_quarantine.sql.
+   */
+  async displayQuarantine(input: {
+    batchId: string | null; // required by the fn only for a commit
+    supplier: string; // pieces.piece_pm_id (brand-lock)
+    operator: string | null;
+    dryRun: boolean;
+  }): Promise<{
+    dry_run: boolean;
+    supplier: string;
+    eligible: number;
+    hidden?: number;
+    batch_id?: string;
+  }> {
+    const { data, error } = await this.callRpc('catalog_display_quarantine', {
+      p_batch_id: input.batchId,
+      p_supplier: input.supplier,
+      p_operator: input.operator,
+      p_dry_run: input.dryRun,
+    });
+    if (error) throw error;
+    return data as {
+      dry_run: boolean;
+      supplier: string;
+      eligible: number;
+      hidden?: number;
+      batch_id?: string;
+    };
+  }
+
+  /**
+   * Reverse a display batch (restores prior piece_display). Generic: reverses BOTH a
+   * {@link displayActivate} batch (restores false) and a {@link displayQuarantine}
+   * batch (restores true), since the journal records old_display per piece.
+   */
   async displayRollback(
     batchId: string,
     supplier: string,

--- a/backend/src/modules/pricing/services/pricing.repository.ts
+++ b/backend/src/modules/pricing/services/pricing.repository.ts
@@ -307,18 +307,22 @@ export class PricingRepository extends SupabaseBaseService {
     supplier: string; // pieces.piece_pm_id (brand-lock)
     operator: string | null;
     dryRun: boolean;
+    /** optional cohort scope (pieces.piece_ga_id); null/undefined = whole brand */
+    gammeIds?: number[] | null;
   }): Promise<{
     dry_run: boolean;
     supplier: string;
     eligible: number;
     hidden?: number;
     batch_id?: string;
+    gamme_ids?: number[] | null;
   }> {
     const { data, error } = await this.callRpc('catalog_display_quarantine', {
       p_batch_id: input.batchId,
       p_supplier: input.supplier,
       p_operator: input.operator,
       p_dry_run: input.dryRun,
+      p_gamme_ids: input.gammeIds ?? null,
     });
     if (error) throw error;
     return data as {
@@ -327,6 +331,7 @@ export class PricingRepository extends SupabaseBaseService {
       eligible: number;
       hidden?: number;
       batch_id?: string;
+      gamme_ids?: number[] | null;
     };
   }
 

--- a/backend/supabase/migrations/20260607_pricing_catalog_display_quarantine.sql
+++ b/backend/supabase/migrations/20260607_pricing_catalog_display_quarantine.sql
@@ -31,6 +31,9 @@
 -- SCOPE. Touches EXACTLY pieces.piece_display. NEVER touches pieces_gamme.pg_display,
 --   auto_type.type_display, prices, pri_dispo, the sitemap, indexation, or any page row.
 --   Gamme/véhicule visibility is out of scope (a separate, SEO-gated concern).
+--   p_gamme_ids (optional) only RESTRICTS which pieces are considered (a pieces.piece_ga_id
+--   row-filter, for staged per-cohort commits) — it NEVER mutates pg_display or any gamme
+--   row; gamme visibility stays out of scope.
 --
 -- SAFETY INVARIANTS:
 --   - brand-locked by p_supplier (pieces.piece_pm_id): never touches a non-brand piece;
@@ -87,7 +90,8 @@ CREATE OR REPLACE FUNCTION catalog_display_quarantine(
   p_batch_id  UUID,          -- governed batch (price_import_batches); required for commit
   p_supplier  TEXT,          -- pieces.piece_pm_id (brand), e.g. '3410' (NK). Brand-lock.
   p_operator  TEXT,
-  p_dry_run   BOOLEAN DEFAULT true   -- safe default: project, do not write
+  p_dry_run   BOOLEAN DEFAULT true,   -- safe default: project, do not write
+  p_gamme_ids INTEGER[] DEFAULT NULL  -- optional cohort scope (pieces.piece_ga_id); NULL = whole brand
 ) RETURNS JSONB
 LANGUAGE plpgsql
 AS $$
@@ -136,13 +140,21 @@ BEGIN
           AND pp.pri_pm_id = p_supplier
           AND pp.pri_dispo IN ('1', '2', '3')
           AND pp.pri_vente_ttc_n > 0
-      );
+      )
+      -- (3) optional cohort scope. NULL = the whole brand (all candidate refs). When the
+      --     owner passes a gamme-id list (pieces.piece_ga_id), the action is restricted to
+      --     those gammes — this only NARROWS the set, so every safety invariant above
+      --     (brand-lock, activate-domain disjointness, storefront non-vendability,
+      --     reversibility) holds unchanged on the subset. Enables staged commits
+      --     (e.g. pure-dead gammes first, then mixed) with clean per-batch rollback.
+      AND (p_gamme_ids IS NULL OR p.piece_ga_id = ANY(p_gamme_ids));
 
   SELECT count(*) INTO v_eligible FROM _disp_quarantine_eligible;
 
   IF p_dry_run THEN
     RETURN jsonb_build_object(
-      'dry_run', true, 'supplier', p_supplier, 'eligible', v_eligible
+      'dry_run', true, 'supplier', p_supplier, 'eligible', v_eligible,
+      'gamme_ids', p_gamme_ids
     );
   END IF;
 
@@ -158,10 +170,10 @@ BEGIN
 
   RETURN jsonb_build_object(
     'dry_run', false, 'supplier', p_supplier, 'batch_id', p_batch_id,
-    'eligible', v_eligible, 'hidden', v_hidden
+    'eligible', v_eligible, 'hidden', v_hidden, 'gamme_ids', p_gamme_ids
   );
 END;
 $$;
 
-COMMENT ON FUNCTION catalog_display_quarantine(UUID, TEXT, TEXT, BOOLEAN) IS
-  'Catalog visibility quarantine (inverse of catalog_display_activate): flips pieces.piece_display true -> false for brand-locked refs that are currently visible AND non-vendable per the storefront isSellable gate (no pieces_price row with pri_dispo IN 1,2,3 AND pri_vente_ttc_n > 0). Structurally disjoint from the activate domain (excludes any pri_dispo IN 1,2 ref). Set-based + idempotent. p_dry_run=true (default) projects without writing. Never touches gamme/vehicle/price/dispo. Journals to pieces_display_history; reverse with catalog_display_rollback_batch. Owner-gated.';
+COMMENT ON FUNCTION catalog_display_quarantine(UUID, TEXT, TEXT, BOOLEAN, INTEGER[]) IS
+  'Catalog visibility quarantine (inverse of catalog_display_activate): flips pieces.piece_display true -> false for brand-locked refs that are currently visible AND non-vendable per the storefront isSellable gate (no pieces_price row with pri_dispo IN 1,2,3 AND pri_vente_ttc_n > 0). Structurally disjoint from the activate domain (excludes any pri_dispo IN 1,2 ref). Optional p_gamme_ids (pieces.piece_ga_id) narrows the action to a cohort for staged commits (NULL = whole brand). Set-based + idempotent. p_dry_run=true (default) projects without writing. Never touches gamme/vehicle/price/dispo. Journals to pieces_display_history; reverse with catalog_display_rollback_batch. Owner-gated.';

--- a/backend/supabase/migrations/20260607_pricing_catalog_display_quarantine.sql
+++ b/backend/supabase/migrations/20260607_pricing_catalog_display_quarantine.sql
@@ -1,0 +1,167 @@
+-- =====================================================
+-- Catalog Visibility Control Plane — catalog_display_quarantine (inverse of étape A)
+-- Date: 2026-06-07
+-- Refs: 20260607_pricing_catalog_display_activate.sql (the SIBLING this mirrors in
+--         reverse — same governance, same journal, same generic rollback),
+--       frontend/app/utils/stock.utils.ts:43-58 (isSellable gate this predicate is the
+--         EXACT inverse of: can_sell = pri_vente_ttc_n > 0 AND pri_dispo IN '1','2','3'),
+--       20260118_rm_remove_stock_filter.sql (R2 listing build gates on piece_display=true
+--         — piece_display IS the visibility gate; hiding a ref removes it from listings),
+--       audit/nk-quarantine-dryrun-2026-06-07.md (the read-only DRY-RUN that scoped this:
+--         1 925 NK visible-but-non-vendable refs, overlap=0 with the 6 431 activated).
+--
+-- WHY (the inverse of catalog_display_activate):
+--   catalog_display_activate made the 6 431 sellable NK refs VISIBLE (piece_display
+--   false -> true). Post-activation QA surfaced a PRE-EXISTING condition (NOT caused by
+--   the activation): NK refs that were ALREADY piece_display = true but are NON-VENDABLE
+--   (no price row with a sellable dispo). They render in R2 listings at 0 € /
+--   OUT_OF_STOCK — blocked by the storefront buy-gate (isSellable requires
+--   pri_vente_ttc_n > 0 AND pri_dispo IN '1','2','3'), so NOT buyable, but visually
+--   present (listing-quality / conversion drag). This function HIDES exactly those refs
+--   (piece_display true -> false), the mirror-image action of the activation.
+--
+-- WHY SET-BASED (not a passed list of ids), same as the sibling:
+--   The action is uniform (true -> false) and the scope is FULLY derivable from the
+--   governed DB signal — a ref is in scope iff it is brand-locked, currently visible, and
+--   has NO sellable price for the brand. Deriving the scope from the DB (single source of
+--   truth) is idempotent and REPEATABLE: re-running after any future tariff/TecDoc import
+--   re-quarantines exactly the refs that became non-vendable again, with no external
+--   artifact to drift. Empirically (audit 2026-06-07) the predicate == the 1 925 set.
+--
+-- SCOPE. Touches EXACTLY pieces.piece_display. NEVER touches pieces_gamme.pg_display,
+--   auto_type.type_display, prices, pri_dispo, the sitemap, indexation, or any page row.
+--   Gamme/véhicule visibility is out of scope (a separate, SEO-gated concern).
+--
+-- SAFETY INVARIANTS:
+--   - brand-locked by p_supplier (pieces.piece_pm_id): never touches a non-brand piece;
+--   - DISJOINT FROM THE ACTIVATE DOMAIN BY CONSTRUCTION. The first NOT EXISTS excludes any
+--     ref that has a sellable-dispo price row (pri_dispo IN '1','2') — the exact set
+--     catalog_display_activate operates on — EVEN IF that ref is mispriced (price 0/NULL).
+--     A mispriced-but-sellable-dispo ref is a PRICING fix, never a display quarantine.
+--     Result: this function can NEVER hide a ref the activation made (or would make)
+--     visible. Verified: with this guard the eligible set is IDENTICAL to the pure
+--     storefront predicate (1 925 == 1 925) and overlap with the activate domain = 0 —
+--     the structural invariant equals the empirical one, no edge ref exists;
+--   - GATE: only ever HIDES a ref that is BOTH currently visible AND non-vendable per the
+--     storefront isSellable gate (no priced row with pri_dispo IN '1','2','3'). Priced
+--     PREORDER (pri_dispo '3', pri_vente_ttc_n > 0) IS sellable -> excluded, stays visible;
+--   - idempotent: only flips piece_display true -> false; already-hidden refs are not
+--     re-touched; re-running is a no-op once everything non-vendable is hidden;
+--   - prices, dispo, gamme, vehicle are NEVER mutated — display-only;
+--   - dry-run (p_dry_run = true, the DEFAULT) computes the projection with ZERO writes,
+--     using the EXACT same predicate as the commit — WITHIN a single call there is no
+--     dry-run/commit divergence (same as the sibling activate).
+--
+-- OPERATIONAL NOTE (cross-call re-evaluation, by-design — surfaced by adversarial review):
+--   A dry-run and a LATER commit are SEPARATE transactions (the temp table is
+--   ON COMMIT DROP, not a frozen id list), so the commit RE-EVALUATES the predicate at
+--   commit time. This is intentional and SAFE-by-construction: the commit can never hide
+--   a ref that is sellable AT COMMIT TIME. If an NK price/dispo import runs between the
+--   dry-run and the commit, the committed count may differ from the preview — the
+--   AUTHORITATIVE count is the commit's returned `hidden`, and the journal is always exact.
+--   Commit promptly after the dry-run (or pause NK imports for the window) to keep the
+--   preview and the commit aligned. Mirrors catalog_display_activate's behaviour exactly.
+--
+-- REVERSIBILITY. Each flip is journaled in pieces_display_history (old_display = true ->
+--   new_display = false) under the run's batch_id. The EXISTING generic
+--   catalog_display_rollback_batch(batch_id, supplier) restores the prior piece_display
+--   for the whole batch, brand-locked — it restores old_display, so it reverses BOTH
+--   directions (activation and quarantine). NO new rollback code is needed.
+--
+-- ADDITIF. Idempotent (CREATE OR REPLACE). Forward-only. NOT applied to the shared DB
+-- here — governed apply step is owner-gated. SECURITY INVOKER (service-role caller
+-- bypasses RLS). No explicit BEGIN/COMMIT (squawk assume_in_transaction=true).
+--
+-- DEPENDENCY. pieces_display_history (the shared journal) and
+-- catalog_display_rollback_batch (the shared rollback) are created by the sibling
+-- migration 20260607_pricing_catalog_display_activate.sql, which sorts BEFORE this one
+-- ("activate" < "quarantine") and therefore runs first. This migration deliberately does
+-- NOT redeclare them (no schema duplication) — it only adds the inverse function.
+-- =====================================================
+
+set lock_timeout = '2s';
+set statement_timeout = '120s';
+
+-- ── Quarantine: piece_display true -> false, set-based, dry-run-capable, gated ───────
+CREATE OR REPLACE FUNCTION catalog_display_quarantine(
+  p_batch_id  UUID,          -- governed batch (price_import_batches); required for commit
+  p_supplier  TEXT,          -- pieces.piece_pm_id (brand), e.g. '3410' (NK). Brand-lock.
+  p_operator  TEXT,
+  p_dry_run   BOOLEAN DEFAULT true   -- safe default: project, do not write
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_eligible BIGINT := 0;
+  v_hidden   BIGINT := 0;
+BEGIN
+  IF p_supplier IS NULL OR p_supplier = '' THEN
+    RAISE EXCEPTION 'catalog_display_quarantine: p_supplier (brand pm_id) is required';
+  END IF;
+  IF NOT p_dry_run AND p_batch_id IS NULL THEN
+    RAISE EXCEPTION 'catalog_display_quarantine: p_batch_id is required for a commit';
+  END IF;
+
+  -- Give this run its own runtime budget, and serialize it against concurrent runs for
+  -- the SAME supplier — crucially including catalog_display_activate, which shares this
+  -- exact lock key (hashtext(supplier)). Activation and quarantine on the same brand can
+  -- never interleave (lock released at tx end).
+  PERFORM set_config('statement_timeout', '120s', true);
+  PERFORM set_config('lock_timeout', '5s', true);
+  PERFORM pg_advisory_xact_lock(hashtext(coalesce(p_supplier, 'catalog-display')));
+
+  -- SINGLE SOURCE OF THE ELIGIBILITY PREDICATE (captured once, used by both dry-run and
+  -- commit). Eligible = brand-locked piece, currently VISIBLE, NOT in the activate domain,
+  -- and NON-VENDABLE per the storefront gate.
+  CREATE TEMP TABLE _disp_quarantine_eligible ON COMMIT DROP AS
+    SELECT p.piece_id, p.piece_display AS old_display
+    FROM pieces p
+    WHERE p.piece_pm_id::text = p_supplier   -- brand-lock
+      AND p.piece_display = true             -- only flip visible -> hidden
+      -- (1) structural disjointness from catalog_display_activate: exclude ANY ref with a
+      --     sellable-dispo price (pri_dispo IN '1','2'), at ANY price. Such a ref belongs
+      --     to the activation domain; if mispriced, that is a pricing fix, not a hide.
+      AND NOT EXISTS (
+        SELECT 1 FROM pieces_price pp
+        WHERE pp.pri_piece_id_i = p.piece_id
+          AND pp.pri_pm_id = p_supplier
+          AND pp.pri_dispo IN ('1', '2')
+      )
+      -- (2) storefront non-vendable: inverse of isSellable (stock.utils.ts) — no priced row
+      --     with a sellable dispo. Priced PREORDER (dispo '3', price > 0) IS sellable and
+      --     is therefore EXCLUDED here (stays visible).
+      AND NOT EXISTS (
+        SELECT 1 FROM pieces_price pp
+        WHERE pp.pri_piece_id_i = p.piece_id
+          AND pp.pri_pm_id = p_supplier
+          AND pp.pri_dispo IN ('1', '2', '3')
+          AND pp.pri_vente_ttc_n > 0
+      );
+
+  SELECT count(*) INTO v_eligible FROM _disp_quarantine_eligible;
+
+  IF p_dry_run THEN
+    RETURN jsonb_build_object(
+      'dry_run', true, 'supplier', p_supplier, 'eligible', v_eligible
+    );
+  END IF;
+
+  -- Journal (true -> false) so the generic rollback restores the prior value.
+  INSERT INTO pieces_display_history (batch_id, piece_id, pm_id, old_display, new_display, operator)
+  SELECT p_batch_id, piece_id, p_supplier, old_display, false, p_operator
+  FROM _disp_quarantine_eligible;
+
+  -- Quarantine: piece_display ONLY. Never touches gamme/vehicle/price/dispo.
+  UPDATE pieces SET piece_display = false
+  WHERE piece_id IN (SELECT piece_id FROM _disp_quarantine_eligible);
+  GET DIAGNOSTICS v_hidden = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'dry_run', false, 'supplier', p_supplier, 'batch_id', p_batch_id,
+    'eligible', v_eligible, 'hidden', v_hidden
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION catalog_display_quarantine(UUID, TEXT, TEXT, BOOLEAN) IS
+  'Catalog visibility quarantine (inverse of catalog_display_activate): flips pieces.piece_display true -> false for brand-locked refs that are currently visible AND non-vendable per the storefront isSellable gate (no pieces_price row with pri_dispo IN 1,2,3 AND pri_vente_ttc_n > 0). Structurally disjoint from the activate domain (excludes any pri_dispo IN 1,2 ref). Set-based + idempotent. p_dry_run=true (default) projects without writing. Never touches gamme/vehicle/price/dispo. Journals to pieces_display_history; reverse with catalog_display_rollback_batch. Owner-gated.';


### PR DESCRIPTION
## What

The governed **inverse** of #880's `catalog_display_activate`. A set-based, brand-locked function that flips `pieces.piece_display` **true → false** for refs that are **visible but non-vendable** — the refs that render at **0 € / OUT_OF_STOCK** in R2 listings (visually present, not buyable; listing-quality / conversion drag).

Scoped from `audit/nk-quarantine-dryrun-2026-06-07.md`: **1 925** NK (`pm_id='3410'`) refs across 20 gammes, **overlap=0** with the 6 431 activated by #880.

**NOT applied.** `p_dry_run=true` is the default; apply is owner-gated (dry-run → commit).

## Why this design (no bricolage)

Extends the merged #880 pattern instead of inventing a parallel one:

- **Same governance** — set-based (scope derived from the DB signal), idempotent, `p_dry_run=true` default, `confirm:true` to commit, governed batch lifecycle.
- **No new table** — journals to the existing `pieces_display_history`.
- **No new rollback** — reversed by the existing generic `catalog_display_rollback_batch` (restores `old_display`, reverses *both* directions).
- **Shared advisory-lock key** (`1091097483` for NK) so activate / quarantine / rollback can **never interleave** per supplier.

## Predicate (mirrors the real storefront gate)

Exact inverse of `isSellable` (`frontend/app/utils/stock.utils.ts:43-58` — `price>0 AND pri_dispo IN '1','2','3'`):

```
piece_pm_id = supplier AND piece_display = true
AND NOT EXISTS (pieces_price: pri_dispo IN '1','2')                      -- (1) structural disjointness from activate
AND NOT EXISTS (pieces_price: pri_dispo IN '1','2','3' AND vente_ttc>0)  -- (2) storefront non-vendable
AND (p_gamme_ids IS NULL OR piece_ga_id = ANY(p_gamme_ids))             -- (3) optional cohort scope
```

Clause (1) makes overlap=0 **structural**. **Verified live:** guarded==storefront==**1 925**, overlap with the 6 431 == **0**.

## Cohort scope (`p_gamme_ids`) — enables the staged 2-batch apply

`p_gamme_ids INTEGER[] DEFAULT NULL` (NULL = whole brand, fully backward-compatible) only **narrows** the eligible set, so every safety invariant holds on the subset. Per-batch rollback stays clean (batch-keyed). The 1 925 split by gamme (`piece_ga_id`):

**Batch 1 — pure-dead (6 gammes, 862)** · `gammeIds: [2,4,13,188,286,1145]`
Démarreur (286), Alternateur (198), Ressort de suspension (148), Vanne EGR (141), Cardan (87 ⚠), Crémaillière de direction (2).

**Batch 2 — mixte (14 gammes, 1 063)** · `gammeIds: [78,82,83,123,124,247,249,273,402,407,412,478,854,2462]`
Étrier (440), Flexible (207), Câble frein main (151), Amortisseur (112), Disque (59), Support moteur (28), Bras (17), Plaquette (17), Capteur ABS (12), Rotule (9), Tambour (5), Témoin usure (3), Câble embrayage (2), Support boîte (1).

> ⚠ **Cardan (gamme 13)** sits in pure-dead here vs *mixte* in the audit: its 1 "sellable" NK ref is a `dispo '1'/'2'` ref priced 0/NULL → in the **activate domain** (protected from quarantine, renders 0 €), not storefront-sellable. This classification uses the **same** sellability definition as the quarantine gate. Move gamme 13 to batch 2 if you prefer the audit grouping — the function takes explicit ids.

## Adversarial review (6 skeptics, read-only live-DB)

5 SAFE + 1 UNCERTAIN (low) · zero UNSAFE/high/critical. Disjointness (tautological, overlap=0 any data state), reversibility (1 925/1 925 restored), scope (only `piece_display`), governance (identical lock key, no dup DDL), predicate correctness (replicated the authoritative `best_prices` RPC → **0 false positives**). The one finding: dry-run count is an **estimate**, commit **re-evaluates** at commit-time (safe-by-design — can never hide a ref sellable at commit-time; the returned `hidden` is authoritative). Documented in the migration header.

## Guardrails

- ✅ Only `pieces.piece_display` — never `pg_display`/`type_display`/price/dispo/gamme/vehicle (`p_gamme_ids` is a row-filter, not a gamme mutation).
- ✅ Never the 6 431 activated refs (overlap=0 by construction).
- ✅ No deletion · no sitemap · no SEO · no indexation. Reversible (journaled). Cache self-heals via 1 h TTL.
- 🔴 Apply is **owner-gated** — this PR ships the mechanism, not the mutation.

## Surface

- `backend/supabase/migrations/20260607_pricing_catalog_display_quarantine.sql`
- `CatalogDisplayQuarantineService` (`dryRun` / `commit` confirm:true / `rollback`)
- `PricingRepository.displayQuarantine()` (+ `gammeIds`)
- `POST /api/admin/pricing/display/quarantine/{dry-run,commit,rollback}` (`IsAdminGuard`)
- Unit test: **8/8 pass**

## Staged apply sequence (after merge, owner-gated, NO-GO until dry-run conforme)

```jsonc
// BATCH 1 — pure-dead (expect eligible = 862)
POST /api/admin/pricing/display/quarantine/dry-run
  { "supplierId": "3410", "gammeIds": [2,4,13,188,286,1145] }
// verify: eligible≈862, overlap=0, scope piece_display-only → then:
POST /api/admin/pricing/display/quarantine/commit
  { "supplierId": "3410", "operator": "<you>", "confirm": true, "gammeIds": [2,4,13,188,286,1145] }
// → batchId B1. QA impacted pages. Rollback: SELECT catalog_display_rollback_batch('<B1>','3410');

// BATCH 2 — mixte (expect eligible = 1063), only after batch-1 QA OK
POST /api/admin/pricing/display/quarantine/dry-run
  { "supplierId": "3410", "gammeIds": [78,82,83,123,124,247,249,273,402,407,412,478,854,2462] }
POST /api/admin/pricing/display/quarantine/commit
  { "supplierId": "3410", "operator": "<you>", "confirm": true, "gammeIds": [78,82,83,123,124,247,249,273,402,407,412,478,854,2462] }
// → batchId B2. Rollback: SELECT catalog_display_rollback_batch('<B2>','3410');
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)