### PR TITLE
feat(pricing): governed catalog_gamme_display_activate — étape B1 gamme hub visibility (1330 only, NOT applied)

### DIFF
--- a/backend/src/modules/pricing/controllers/pricing-import.controller.ts
+++ b/backend/src/modules/pricing/controllers/pricing-import.controller.ts
@@ -9,6 +9,9 @@
  *   POST /api/admin/pricing/display/dry-run     → piece_display projection (no writes)
  *   POST /api/admin/pricing/display/commit      → flip piece_display false→true (confirm:true)
  *   POST /api/admin/pricing/display/rollback    → restore piece_display for a batch
+ *   POST /api/admin/pricing/display/gamme/dry-run  → pg_display projection, level-4 (no writes)
+ *   POST /api/admin/pricing/display/gamme/commit   → flip pg_display→'1' level-4 hubs (confirm:true)
+ *   POST /api/admin/pricing/display/gamme/rollback → restore pg_display for a gamme batch
  */
 import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { IsAdminGuard } from '@auth/is-admin.guard';
@@ -101,6 +104,31 @@ export class PricingImportController {
   @Post('display/rollback')
   displayRollback(@Body() body: { batchId: string; supplierId: string }) {
     return this.displayActivationService.rollback(
+      body.batchId,
+      body.supplierId,
+    );
+  }
+
+  /**
+   * Read-only GAMME visibility projection (étape B1, no writes). Returns the owner-gate
+   * values eligible(gammes)/refs(pieces)/gammeIds (NK expected: 1 / 11 / {1330}).
+   */
+  @Post('display/gamme/dry-run')
+  gammeDisplayDryRun(@Body() body: DisplayActivationRequest) {
+    return this.displayActivationService.gammeDryRun(body.supplierId);
+  }
+
+  /** Apply pg_display -> '1' for masked level-4 hub gammes — requires `confirm:true`. */
+  @Post('display/gamme/commit')
+  gammeDisplayCommit(
+    @Body() body: DisplayActivationRequest & { confirm?: boolean },
+  ) {
+    return this.displayActivationService.gammeCommit(body);
+  }
+
+  @Post('display/gamme/rollback')
+  gammeDisplayRollback(@Body() body: { batchId: string; supplierId: string }) {
+    return this.displayActivationService.gammeRollback(
       body.batchId,
       body.supplierId,
     );

--- a/backend/src/modules/pricing/services/catalog-display-activation.service.test.ts
+++ b/backend/src/modules/pricing/services/catalog-display-activation.service.test.ts
@@ -27,6 +27,21 @@ function makeRepo(
     displayRollback: jest
       .fn()
       .mockResolvedValue({ restored: 6431, batch_id: 'batch-1' }),
+    gammeDisplayActivate: jest.fn().mockResolvedValue({
+      dry_run: false,
+      supplier: '3410',
+      eligible: 1,
+      refs: 11,
+      displayed: 1,
+      gamme_ids: [1330],
+      batch_id: 'batch-1',
+    }),
+    gammeDisplayRollback: jest.fn().mockResolvedValue({
+      rolled_back: 1,
+      skipped_value_changed: 0,
+      skipped_missing_gamme: 0,
+      batch_id: 'batch-1',
+    }),
     ...overrides,
   } as unknown as PricingRepository;
 }
@@ -140,6 +155,137 @@ describe('CatalogDisplayActivationService', () => {
     it('rejects missing args', async () => {
       const svc = new CatalogDisplayActivationService(makeRepo());
       await expect(svc.rollback('', '3410')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+
+  // ── Étape B1 — gamme visibility (pg_display) ──────────────────────────────────────
+  describe('gammeDryRun', () => {
+    it('returns the owner-gate values (eligible/refs/gammeIds) and never opens a batch', async () => {
+      const repo = makeRepo({
+        gammeDisplayActivate: jest.fn().mockResolvedValue({
+          dry_run: true,
+          supplier: '3410',
+          eligible: 1,
+          refs: 11,
+          gamme_ids: [1330],
+        }),
+      });
+      const svc = new CatalogDisplayActivationService(repo);
+
+      const res = await svc.gammeDryRun('3410');
+
+      expect(res).toEqual({ eligible: 1, refs: 11, gammeIds: [1330] });
+      expect(repo.gammeDisplayActivate).toHaveBeenCalledWith({
+        batchId: null,
+        supplier: '3410',
+        operator: null,
+        dryRun: true,
+      });
+      expect(repo.createActivationBatch).not.toHaveBeenCalled();
+      expect(repo.setBatchStatus).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty supplierId', async () => {
+      const svc = new CatalogDisplayActivationService(makeRepo());
+      await expect(svc.gammeDryRun('')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('gammeCommit', () => {
+    it('refuses to write without confirm:true (no batch opened)', async () => {
+      const repo = makeRepo();
+      const svc = new CatalogDisplayActivationService(repo);
+
+      await expect(
+        svc.gammeCommit({ supplierId: '3410' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(repo.createActivationBatch).not.toHaveBeenCalled();
+      expect(repo.gammeDisplayActivate).not.toHaveBeenCalled();
+    });
+
+    it('opens a GAMME_DISPLAY_ACTIVATION batch, flips, marks COMMITTED, returns counts', async () => {
+      const repo = makeRepo();
+      const svc = new CatalogDisplayActivationService(repo);
+
+      const res = await svc.gammeCommit({
+        supplierId: '3410',
+        operator: 'owner',
+        confirm: true,
+      });
+
+      expect(res).toEqual({
+        batchId: 'batch-1',
+        eligible: 1,
+        refs: 11,
+        displayed: 1,
+        gammeIds: [1330],
+      });
+      expect(repo.createActivationBatch).toHaveBeenCalledWith({
+        supplierId: '3410',
+        operator: 'owner',
+        operation: 'GAMME_DISPLAY_ACTIVATION',
+      });
+      expect(repo.gammeDisplayActivate).toHaveBeenCalledWith({
+        batchId: 'batch-1',
+        supplier: '3410',
+        operator: 'owner',
+        dryRun: false,
+      });
+      expect(repo.setBatchStatus).toHaveBeenNthCalledWith(
+        2,
+        'batch-1',
+        'COMMITTED',
+        expect.objectContaining({ committed_rows: 1 }),
+      );
+    });
+
+    it('marks the batch FAILED and rethrows when the flip errors', async () => {
+      const repo = makeRepo({
+        gammeDisplayActivate: jest.fn().mockRejectedValue(new Error('boom')),
+      });
+      const svc = new CatalogDisplayActivationService(repo);
+
+      await expect(
+        svc.gammeCommit({ supplierId: '3410', confirm: true }),
+      ).rejects.toThrow('boom');
+      expect(repo.setBatchStatus).toHaveBeenNthCalledWith(
+        2,
+        'batch-1',
+        'FAILED',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('gammeRollback', () => {
+    it('delegates to gammeDisplayRollback and classifies skipped rows (value-changed vs missing)', async () => {
+      const repo = makeRepo({
+        gammeDisplayRollback: jest.fn().mockResolvedValue({
+          rolled_back: 0,
+          skipped_value_changed: 1,
+          skipped_missing_gamme: 0,
+          batch_id: 'batch-1',
+        }),
+      });
+      const svc = new CatalogDisplayActivationService(repo);
+
+      const res = await svc.gammeRollback('batch-1', '3410');
+
+      expect(res).toEqual({
+        rolledBack: 0,
+        skippedValueChanged: 1,
+        skippedMissingGamme: 0,
+      });
+      expect(repo.gammeDisplayRollback).toHaveBeenCalledWith('batch-1', '3410');
+    });
+
+    it('rejects missing args', async () => {
+      const svc = new CatalogDisplayActivationService(makeRepo());
+      await expect(svc.gammeRollback('', '3410')).rejects.toBeInstanceOf(
         BadRequestException,
       );
     });

--- a/backend/src/modules/pricing/services/catalog-display-activation.service.ts
+++ b/backend/src/modules/pricing/services/catalog-display-activation.service.ts
@@ -114,4 +114,123 @@ export class CatalogDisplayActivationService {
     );
     return { restored: res.restored };
   }
+
+  // ── Étape B1 — GAMME visibility (pieces_gamme.pg_display, level-4 hubs) ──────────────
+  // Mirrors the piece_display flow above at the gamme level, via the governed
+  // catalog_gamme_display_activate RPC. Distinct log prefix [CATALOG_GAMME_DISPLAY] and
+  // a self-describing batch operation marker so audits never confuse the two surfaces.
+
+  /**
+   * Read-only projection of the gamme-display activation. Returns the OWNER GATE values:
+   * eligible (number of level-4 gammes), refs (NK visible+sellable pieces inside them),
+   * and gammeIds. The owner commits only if these match the verified scope
+   * (NK expected: eligible=1, gammeIds={1330}, refs=11).
+   */
+  async gammeDryRun(
+    supplierId: string,
+  ): Promise<{ eligible: number; refs: number; gammeIds: number[] }> {
+    if (!supplierId) {
+      throw new BadRequestException('supplierId is required');
+    }
+    const res = await this.repo.gammeDisplayActivate({
+      batchId: null,
+      supplier: supplierId,
+      operator: null,
+      dryRun: true,
+    });
+    this.logger.log(
+      `[CATALOG_GAMME_DISPLAY] dry-run supplier=${supplierId} ` +
+        `eligible=${res.eligible} refs=${res.refs} gammes=[${res.gamme_ids.join(',')}]`,
+    );
+    return { eligible: res.eligible, refs: res.refs, gammeIds: res.gamme_ids };
+  }
+
+  /**
+   * Apply the gamme-display activation — requires `confirm:true` (owner-gated).
+   * Opens a governed batch tagged operation='GAMME_DISPLAY_ACTIVATION'.
+   */
+  async gammeCommit(
+    req: DisplayActivationRequest & { confirm?: boolean },
+  ): Promise<{
+    batchId: string;
+    eligible: number;
+    refs: number;
+    displayed: number;
+    gammeIds: number[];
+  }> {
+    if (!req.supplierId) {
+      throw new BadRequestException('supplierId is required');
+    }
+    if (req.confirm !== true) {
+      throw new BadRequestException(
+        'gamme display activation commit requires confirm:true',
+      );
+    }
+    const batchId = await this.repo.createActivationBatch({
+      supplierId: req.supplierId,
+      operator: req.operator ?? null,
+      operation: 'GAMME_DISPLAY_ACTIVATION',
+    });
+    await this.repo.setBatchStatus(batchId, 'COMMITTING'); // per-supplier mutex
+    try {
+      const res = await this.repo.gammeDisplayActivate({
+        batchId,
+        supplier: req.supplierId,
+        operator: req.operator ?? null,
+        dryRun: false,
+      });
+      await this.repo.setBatchStatus(batchId, 'COMMITTED', {
+        committed_rows: res.displayed ?? 0,
+        completed_at: new Date().toISOString(),
+      });
+      this.logger.log(
+        `[CATALOG_GAMME_DISPLAY] commit batchId=${batchId} supplier=${req.supplierId} ` +
+          `eligible=${res.eligible} refs=${res.refs} displayed=${res.displayed ?? 0} ` +
+          `gammes=[${res.gamme_ids.join(',')}]`,
+      );
+      return {
+        batchId,
+        eligible: res.eligible,
+        refs: res.refs,
+        displayed: res.displayed ?? 0,
+        gammeIds: res.gamme_ids,
+      };
+    } catch (e) {
+      await this.repo.setBatchStatus(batchId, 'FAILED', {
+        completed_at: new Date().toISOString(),
+      });
+      this.logger.error(
+        `[CATALOG_GAMME_DISPLAY] commit FAILED batchId=${batchId}: ${(e as Error).message}`,
+      );
+      throw e;
+    }
+  }
+
+  /**
+   * Restore the prior pg_display for a gamme-display batch (anti-conflict guarded).
+   * Anomaly-only in prod — never a routine step.
+   */
+  async gammeRollback(
+    batchId: string,
+    supplierId: string,
+  ): Promise<{
+    rolledBack: number;
+    skippedValueChanged: number;
+    skippedMissingGamme: number;
+  }> {
+    if (!batchId || !supplierId) {
+      throw new BadRequestException('batchId and supplierId are required');
+    }
+    const res = await this.repo.gammeDisplayRollback(batchId, supplierId);
+    this.logger.log(
+      `[CATALOG_GAMME_DISPLAY] rollback batchId=${batchId} ` +
+        `rolled_back=${res.rolled_back} skipped_value_changed=${res.skipped_value_changed} ` +
+        `skipped_missing_gamme=${res.skipped_missing_gamme}`,
+    );
+    return {
+      rolledBack: res.rolled_back,
+      skippedValueChanged: res.skipped_value_changed,
+      skippedMissingGamme: res.skipped_missing_gamme,
+    };
+  }
 }

--- a/backend/src/modules/pricing/services/pricing.repository.ts
+++ b/backend/src/modules/pricing/services/pricing.repository.ts
@@ -122,10 +122,15 @@ export class PricingRepository extends SupabaseBaseService {
     return data.chunk_id as string;
   }
 
-  /** Open a batch for a dispo-only ACTIVATION run (no raw import file). */
+  /**
+   * Open a batch for a no-file ACTIVATION run (dispo / display / gamme-display). The
+   * optional `operation` marker (e.g. 'GAMME_DISPLAY_ACTIVATION') is a self-describing
+   * audit tag on the shared price_import_batches table; null = legacy/unspecified.
+   */
   async createActivationBatch(input: {
     supplierId: string;
     operator: string | null;
+    operation?: string | null;
   }): Promise<string> {
     const { data, error } = await this.supabase
       .from('price_import_batches')
@@ -133,6 +138,7 @@ export class PricingRepository extends SupabaseBaseService {
         status: 'UPLOADED',
         supplier_id: input.supplierId,
         operator: input.operator,
+        ...(input.operation ? { operation: input.operation } : {}),
       })
       .select('batch_id')
       .single();
@@ -306,6 +312,81 @@ export class PricingRepository extends SupabaseBaseService {
     );
     if (error) throw error;
     return data as { restored: number; batch_id: string };
+  }
+
+  /**
+   * Set-based GAMME visibility activation (étape B1) via the governed server-side
+   * function. Flips pieces_gamme.pg_display -> '1' for masked LEVEL-4 hub gammes that
+   * already contain >=1 brand ref visible & sellable. Idempotent; `dryRun` projects
+   * without writing and returns eligible(gammes)/refs(pieces)/gamme_ids for the owner
+   * gate. Never touches pg_relfollow/pg_sitemap (gamme stays out of sitemap). Reversible
+   * via {@link gammeDisplayRollback}. See migration
+   * 20260607_pricing_catalog_gamme_display_activate.sql.
+   */
+  async gammeDisplayActivate(input: {
+    batchId: string | null; // required by the fn only for a commit
+    supplier: string; // pieces.piece_pm_id (brand-lock)
+    operator: string | null;
+    dryRun: boolean;
+  }): Promise<{
+    dry_run: boolean;
+    supplier: string;
+    eligible: number;
+    refs: number;
+    displayed?: number;
+    gamme_ids: number[];
+    batch_id?: string;
+  }> {
+    const { data, error } = await this.callRpc(
+      'catalog_gamme_display_activate',
+      {
+        p_batch_id: input.batchId,
+        p_supplier: input.supplier,
+        p_operator: input.operator,
+        p_dry_run: input.dryRun,
+      },
+    );
+    if (error) throw error;
+    return data as {
+      dry_run: boolean;
+      supplier: string;
+      eligible: number;
+      refs: number;
+      displayed?: number;
+      gamme_ids: number[];
+      batch_id?: string;
+    };
+  }
+
+  /**
+   * Reverse a gamme-display batch (restores prior pg_display) with the server-side
+   * anti-conflict guard (only restores gammes whose current pg_display still equals
+   * what the batch wrote). Returns rolled_back + skipped_value_changed (a later writer
+   * changed it) + skipped_missing_gamme (gamme deleted upstream), classified explicitly.
+   */
+  async gammeDisplayRollback(
+    batchId: string,
+    supplier: string,
+  ): Promise<{
+    rolled_back: number;
+    skipped_value_changed: number;
+    skipped_missing_gamme: number;
+    batch_id: string;
+  }> {
+    const { data, error } = await this.callRpc(
+      'catalog_gamme_display_rollback_batch',
+      {
+        p_batch_id: batchId,
+        p_supplier: supplier,
+      },
+    );
+    if (error) throw error;
+    return data as {
+      rolled_back: number;
+      skipped_value_changed: number;
+      skipped_missing_gamme: number;
+      batch_id: string;
+    };
   }
 
   async fetchProfiles(supplierId: string): Promise<SupplierPriceProfile[]> {

--- a/backend/supabase/migrations/20260607_pricing_catalog_gamme_display_activate.sql
+++ b/backend/supabase/migrations/20260607_pricing_catalog_gamme_display_activate.sql
@@ -1,0 +1,254 @@
+-- =====================================================
+-- Catalog Visibility Control Plane — catalog_gamme_display_activate (étape B1: gamme hub)
+-- Date: 2026-06-07
+-- Refs: 20260607_pricing_catalog_display_activate.sql (#880 — the piece_display sibling this
+--         mirrors at the GAMME level: same governance, dry-run, journal, owner gate),
+--       audit/nk-etape-b-vehicle-deferral-2026-06-07.md (B2 vehicle deferral),
+--       seo-indexability-policy.service.ts (runtime indexability authority — NOT duplicated),
+--       sitemap-v10-*.service.ts (all filter pg_relfollow='1' — proof pg_display alone is
+--         out-of-sitemap).
+--
+-- WHY (étape B1 — surface the masked level-4 hub gamme holding already-visible sellable refs):
+--   Étape A made the 6 431 sellable NK refs piece_display=true. A small tail stays invisible
+--   on its gamme hub because the GAMME is masked (pg_display != '1') even though the piece is
+--   visible & sellable. This flips pg_display '0'/NULL -> '1' for the LEVEL-4 hub gammes that
+--   already contain >=1 brand ref visible & sellable — the gamme-blocked subset of the tail.
+--
+-- SCOPE CORRECTION (verified read-only 2026-06-07, owner-gated):
+--   For NK ('3410') the eligibility predicate below returns EXACTLY one gamme:
+--     pg_id 1330 'Déflecteur disque de frein' (level 4), 11 NK visible+sellable refs, and
+--     0 collateral (its 3 407 other-brand pieces are ALL piece_display=false, so activating
+--     the gamme exposes only the 11 NK refs — distinct_brands_exposed = 1).
+--   The pg_level='4' filter is LOAD-BEARING: without it the predicate returns 23 gammes /
+--     1 460 refs (22 level-5 sub-gammes included). Level-5 extension is DEFERRED (NO-GO) until
+--     the hub-vs-listing visibility model is clarified. Gamme 2513 is NOT in scope (0 NK refs).
+--   OWNER GATE (enforced at apply, from the dry-run output — NOT hardcoded here to keep the
+--     function generic): commit ONLY if eligible == 1 AND gamme_ids == {1330} AND refs == 11.
+--     Any other result => STOP + analyse, no commit. The function stays brand-generic; the
+--     gate is the owner's dry-run check.
+--
+-- SCOPE. Writes EXACTLY pieces_gamme.pg_display. NEVER touches pg_relfollow, pg_sitemap,
+--   auto_type.type_display, pieces.piece_display, prices, or pri_dispo. pg_relfollow/pg_sitemap
+--   stay '0' => the gamme is VISIBLE (hub renders) but OUT of the sitemap (sitemap-v10-* filter
+--   pg_relfollow='1') => zero indexation push. A thin hub renders noindex,follow via the runtime
+--   policy (seo-indexability-policy.service.ts) — expected/correct, not duplicated as a pre-gate.
+--
+-- SAFETY INVARIANTS:
+--   - brand-locked by p_supplier on the piece existence check; the gamme set is derived from it;
+--   - level-4 ONLY (hub level) — set-based scope fully derived from the governed DB signal;
+--   - idempotent: only flips pg_display -> '1' for currently-masked gammes; re-run is a no-op;
+--   - pg_relfollow/pg_sitemap/type_display/piece_display/price NEVER mutated (the journal even
+--     snapshots old_relfollow/old_sitemap as proof they are untouched);
+--   - dry-run (p_dry_run=true, DEFAULT) computes the projection with ZERO writes, same predicate
+--     as the commit (within a call). Cross-call re-evaluation is by-design (same note as #880).
+--
+-- REVERSIBILITY. Each flip is journaled in pieces_gamme_display_history (old_display ->
+--   new_display='1', + control snapshot). catalog_gamme_display_rollback_batch restores
+--   pg_display to old_display for the batch, WITH AN ANTI-CONFLICT GUARD (only restores a gamme
+--   whose current pg_display still equals what this batch wrote — never clobbers a later change).
+--
+-- ADDITIF. Idempotent (CREATE OR REPLACE / ADD COLUMN IF NOT EXISTS / CREATE TABLE IF NOT
+-- EXISTS). Forward-only. NOT applied here — apply is owner-gated. No explicit BEGIN/COMMIT
+-- (squawk assume_in_transaction=true). SECURITY INVOKER (service-role caller bypasses RLS).
+--
+-- RLS: pieces_gamme_display_history is RLS-disabled, mirroring its sibling governed audit
+-- tables (pieces_display_history, pieces_price_history, price_import_batches are all RLS-off).
+-- Service-role-only internal rollback journal; no anon/frontend read path.
+-- =====================================================
+
+-- squawk-ignore-file prefer-bigint-over-int
+--   pieces_gamme_display_history.pg_id INTENTIONALLY mirrors pieces_gamme.pg_id, which is
+--   integer (int4) in the live schema. Matching int4 keeps the rollback join
+--   (pieces_gamme g JOIN pieces_gamme_display_history h ON g.pg_id = h.pg_id) aligned with the
+--   pieces_gamme int4 PK. Promoting to bigint would diverge from the source column type.
+
+set lock_timeout = '2s';
+set statement_timeout = '120s';
+
+-- ── Self-describing operation marker on the shared batch table (additive, nullable) ─────
+--   Legacy rows = NULL (zero backfill). The B1 batch carries operation='GAMME_DISPLAY_ACTIVATION'
+--   so audits distinguish it from the piece_display / dispo activations (same supplier, same
+--   cycle, same price_import_batches table). The dedicated journal already distinguishes by
+--   table; this column distinguishes inside the shared batch table.
+ALTER TABLE price_import_batches ADD COLUMN IF NOT EXISTS operation TEXT;
+
+COMMENT ON COLUMN price_import_batches.operation IS
+  'Self-describing op kind for a governed batch (e.g. GAMME_DISPLAY_ACTIVATION). NULL = legacy / unspecified. Additive marker; never drives logic, only audit/observability.';
+
+-- ── Rollback journal (per gamme, per batch; + control snapshot of relfollow/sitemap) ────
+CREATE TABLE IF NOT EXISTS pieces_gamme_display_history (
+  id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  batch_id      UUID        NOT NULL,
+  pg_id         INTEGER     NOT NULL,   -- mirrors pieces_gamme.pg_id (int4) — see squawk note
+  pm_id         TEXT        NOT NULL,   -- brand (p_supplier), e.g. '3410' (NK)
+  old_display   TEXT,                   -- pg_display can be NULL (not only '0') => NULLABLE
+  new_display   TEXT        NOT NULL,
+  old_relfollow TEXT,                   -- control snapshot (NOT modified) — proof of non-touch
+  old_sitemap   TEXT,                   -- control snapshot (NOT modified) — proof of non-touch
+  operator      TEXT,
+  changed_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- UNIQUE on (batch_id, pg_id): exactly one journal row per gamme per batch. Prevents a
+-- reused batch_id from double-journaling (which would corrupt the rollback skipped-count).
+-- Also serves batch_id lookups via the leftmost-prefix, so no separate batch index is needed.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_pieces_gamme_display_history_batch_pg
+  ON pieces_gamme_display_history (batch_id, pg_id);
+
+COMMENT ON TABLE pieces_gamme_display_history IS
+  'Rollback journal for catalog_gamme_display_activate: per-gamme old/new pg_display (+ control snapshot of pg_relfollow/pg_sitemap proving they are untouched), keyed by governed batch_id. Service-role-only (RLS-off like pieces_display_history).';
+
+-- ── Gamme visibility activation: pg_display -> '1', set-based, level-4, dry-run, gated ──
+CREATE OR REPLACE FUNCTION catalog_gamme_display_activate(
+  p_batch_id  UUID,          -- governed batch (price_import_batches); required for commit
+  p_supplier  TEXT,          -- pieces.piece_pm_id (brand), e.g. '3410' (NK). Brand-lock.
+  p_operator  TEXT,
+  p_dry_run   BOOLEAN DEFAULT true   -- safe default: project, do not write
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_eligible  BIGINT := 0;     -- number of GAMMES in scope (the gate's eligible)
+  v_refs      BIGINT := 0;     -- NK visible+sellable refs inside those gammes (gate cross-check)
+  v_displayed BIGINT := 0;     -- gammes actually flipped
+  v_gamme_ids INTEGER[];
+BEGIN
+  IF p_supplier IS NULL OR p_supplier = '' THEN
+    RAISE EXCEPTION 'catalog_gamme_display_activate: p_supplier (brand pm_id) is required';
+  END IF;
+  IF NOT p_dry_run AND p_batch_id IS NULL THEN
+    RAISE EXCEPTION 'catalog_gamme_display_activate: p_batch_id is required for a commit';
+  END IF;
+
+  PERFORM set_config('statement_timeout', '120s', true);
+  PERFORM set_config('lock_timeout', '5s', true);
+  -- DISTINCT lock namespace from étape A piece_display (hashtext(supplier)) so gamme-display and
+  -- piece-display ops on the SAME supplier never block each other.
+  PERFORM pg_advisory_xact_lock(hashtext(p_supplier || ':gamme-display'));
+
+  -- ELIGIBLE GAMMES (single source for dry-run + commit). A masked level-4 hub gamme that
+  -- already contains >=1 brand ref visible & sellable (storefront isSellable: dispo IN
+  -- '1','2','3' AND vente_ttc > 0).
+  CREATE TEMP TABLE _gamme_disp_eligible ON COMMIT DROP AS
+    SELECT g.pg_id,
+           g.pg_display   AS old_display,
+           g.pg_relfollow AS old_relfollow,
+           g.pg_sitemap   AS old_sitemap
+    FROM pieces_gamme g
+    WHERE g.pg_display IS DISTINCT FROM '1'   -- masked (robust vs NULL, not only '0')
+      AND g.pg_level = '4'                     -- indexable hub level ONLY (B1 scope; load-bearing)
+      AND EXISTS (
+        SELECT 1 FROM pieces p
+        WHERE p.piece_ga_id = g.pg_id
+          AND p.piece_pm_id::text = p_supplier
+          AND p.piece_display = true
+          AND EXISTS (
+            SELECT 1 FROM pieces_price pp
+            WHERE pp.pri_piece_id_i = p.piece_id
+              AND pp.pri_pm_id = p_supplier
+              AND pp.pri_dispo IN ('1', '2', '3')
+              AND pp.pri_vente_ttc_n > 0
+          )
+      );
+
+  SELECT count(*), array_agg(pg_id ORDER BY pg_id)
+    INTO v_eligible, v_gamme_ids
+    FROM _gamme_disp_eligible;
+
+  -- Ref cross-check: NK visible+sellable pieces inside the eligible gammes (lets the owner
+  -- gate on refs == 11 in addition to eligible == 1). eligible counts GAMMES, refs counts PIECES.
+  SELECT count(*)
+    INTO v_refs
+    FROM pieces p
+    JOIN _gamme_disp_eligible e ON e.pg_id = p.piece_ga_id
+    WHERE p.piece_pm_id::text = p_supplier
+      AND p.piece_display = true
+      AND EXISTS (
+        SELECT 1 FROM pieces_price pp
+        WHERE pp.pri_piece_id_i = p.piece_id
+          AND pp.pri_pm_id = p_supplier
+          AND pp.pri_dispo IN ('1', '2', '3')
+          AND pp.pri_vente_ttc_n > 0
+      );
+
+  IF p_dry_run THEN
+    RETURN jsonb_build_object(
+      'dry_run', true, 'supplier', p_supplier,
+      'eligible', v_eligible, 'refs', v_refs, 'gamme_ids', coalesce(v_gamme_ids, '{}')
+    );
+  END IF;
+
+  -- Journal (pg_display old -> '1') + control snapshot of relfollow/sitemap (NOT modified).
+  INSERT INTO pieces_gamme_display_history
+    (batch_id, pg_id, pm_id, old_display, new_display, old_relfollow, old_sitemap, operator)
+  SELECT p_batch_id, pg_id, p_supplier, old_display, '1', old_relfollow, old_sitemap, p_operator
+  FROM _gamme_disp_eligible;
+
+  -- Activation: pg_display ONLY. Never touches relfollow/sitemap/type_display/piece_display/price.
+  UPDATE pieces_gamme SET pg_display = '1'
+  WHERE pg_id IN (SELECT pg_id FROM _gamme_disp_eligible);
+  GET DIAGNOSTICS v_displayed = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'dry_run', false, 'supplier', p_supplier, 'batch_id', p_batch_id,
+    'eligible', v_eligible, 'refs', v_refs, 'displayed', v_displayed,
+    'gamme_ids', coalesce(v_gamme_ids, '{}')
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION catalog_gamme_display_activate(UUID, TEXT, TEXT, BOOLEAN) IS
+  'Catalog GAMME visibility activation (étape B1): flips pieces_gamme.pg_display -> ''1'' for masked LEVEL-4 hub gammes that already contain >=1 brand ref visible & sellable. Set-based + idempotent. pg_relfollow/pg_sitemap NEVER touched (gamme stays out of sitemap). p_dry_run=true (default) projects without writing; returns eligible(gammes)/refs(pieces)/gamme_ids for the owner gate (NK expected: eligible=1, gamme_ids={1330}, refs=11). Journals to pieces_gamme_display_history; reverse with catalog_gamme_display_rollback_batch. Owner-gated.';
+
+-- ── Rollback: restore prior pg_display for a batch, with anti-conflict guard ─────────────
+CREATE OR REPLACE FUNCTION catalog_gamme_display_rollback_batch(
+  p_batch_id UUID,
+  p_supplier TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_rolled_back           BIGINT := 0;
+  v_skipped_value_changed BIGINT := 0;   -- gamme still exists but pg_display was changed since
+  v_skipped_missing_gamme BIGINT := 0;   -- journaled gamme no longer exists (deleted upstream)
+BEGIN
+  IF p_batch_id IS NULL OR p_supplier IS NULL THEN
+    RAISE EXCEPTION 'catalog_gamme_display_rollback_batch: p_batch_id and p_supplier are required';
+  END IF;
+
+  PERFORM set_config('statement_timeout', '120s', true);
+  PERFORM set_config('lock_timeout', '5s', true);
+  PERFORM pg_advisory_xact_lock(hashtext(p_supplier || ':gamme-display'));
+
+  -- Classify the journaled rows BEFORE restoring (so just-restored rows are never mislabelled),
+  -- by EXPLICIT LEFT JOIN — NOT by (total - rolled_back) subtraction, which conflated a deleted
+  -- gamme with a value-conflict and mis-counted on a reused batch_id.
+  SELECT
+    count(*) FILTER (WHERE g.pg_id IS NOT NULL AND g.pg_display IS DISTINCT FROM h.new_display),
+    count(*) FILTER (WHERE g.pg_id IS NULL)
+  INTO v_skipped_value_changed, v_skipped_missing_gamme
+  FROM pieces_gamme_display_history h
+  LEFT JOIN pieces_gamme g ON g.pg_id = h.pg_id
+  WHERE h.batch_id = p_batch_id AND h.pm_id = p_supplier;
+
+  -- Restore ONLY gammes whose CURRENT pg_display still equals what this batch wrote
+  -- (new_display). If a later human/process changed it, skip — never clobber a newer state.
+  UPDATE pieces_gamme g SET pg_display = h.old_display
+  FROM pieces_gamme_display_history h
+  WHERE h.batch_id   = p_batch_id
+    AND h.pm_id      = p_supplier
+    AND g.pg_id      = h.pg_id
+    AND g.pg_display IS NOT DISTINCT FROM h.new_display;   -- anti-conflict guard
+  GET DIAGNOSTICS v_rolled_back = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'rolled_back', v_rolled_back,
+    'skipped_value_changed', v_skipped_value_changed,
+    'skipped_missing_gamme', v_skipped_missing_gamme,
+    'batch_id', p_batch_id
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION catalog_gamme_display_rollback_batch(UUID, TEXT) IS
+  'Reverses catalog_gamme_display_activate: restores pieces_gamme.pg_display to its journaled old value for the batch, brand-locked, ONLY where the current pg_display still equals what the batch wrote (anti-conflict guard — never clobbers a later change). Returns rolled_back + skipped_value_changed (a later writer changed it) + skipped_missing_gamme (gamme deleted upstream), classified by explicit LEFT JOIN (not subtraction); UNIQUE(batch_id,pg_id) prevents double-counting.';


### PR DESCRIPTION
## What

The governed **gamme-level** mirror of #880's `catalog_display_activate`: flips `pieces_gamme.pg_display` `'0'`/NULL → `'1'` for **masked level-4 hub gammes** that already contain ≥1 brand ref visible & sellable — surfacing the gamme-blocked tail of étape A on its hub.

**NOT applied.** `p_dry_run=true` default; apply is owner-gated.

## Scope (verified read-only, owner-corrected)

This PR ships **gamme 1330 only** after the plan's original scope was empirically refuted:

| Claim (original plan) | Verified |
|---|---|
| 2 gammes / 13 refs | ❌ → stated predicate = **23 gammes / 1 460 refs**; with `pg_level='4'` = **{1330} / 11** |
| `2513` = 2 NK refs | ❌ → gamme 2513 has **0 NK pieces** (and 0 piece_display=true) — **dropped** |
| `1330` = 11 NK, 0 collateral | ✅ → 11 NK refs; its 3 407 other-brand pieces are **all `piece_display=false`** → exposure = 11 NK only |

The **`pg_level='4'` filter is load-bearing** (without it: 22 extra level-5 sub-gammes). Level-5 is **deferred (NO-GO)** until the hub-vs-listing visibility model is clarified.

**Owner GATE (at apply, from the dry-run output — not hardcoded):** commit only if `eligible==1 AND gamme_ids=={1330} AND refs==11`. The function is brand-generic (for brand `1780` the same predicate returns 0); the gate is the owner's dry-run check.

## Guardrails

- ✅ Writes **only** `pieces_gamme.pg_display`. `pg_relfollow`/`pg_sitemap` are **snapshotted to the journal but never written** → gamme stays **out of the sitemap** (sitemap-v10-* require `pg_relfollow='1'`); the level-4 page is `noindex` via the runtime policy. No indexation push.
- ✅ Never touches `type_display` / `piece_display` / price / dispo. `pg_display` exposure is gated by `piece_display` per-piece (verified: all consumers AND `piece_display=true` independently).
- ✅ Distinct advisory lock (`hashtext(supplier||':gamme-display')` = 2083692129 vs étape A 1091097483) → never blocks étape A.
- ✅ Reversible: journals to `pieces_gamme_display_history` (RLS-off like `pieces_display_history`); `catalog_gamme_display_rollback_batch` restores with an **anti-conflict guard** (never clobbers a later change).
- 🔴 Apply is **owner-gated** — this PR ships the mechanism, not the mutation.

## Adversarial review (6 skeptics, read-only live-DB)

**5 SAFE + 1 medium — fixed.**

| Dimension | Verdict |
|---|---|
| Scope (`pg_level='4'` load-bearing) | ✅ SAFE — exactly {1330}/11; level filter proven necessary |
| Collateral exposure | ✅ SAFE — 0 non-NK exposed; `pg_display` never fans out pieces past `piece_display` |
| SEO-safety | ✅ SAFE — function never writes relfollow/sitemap; out of sitemap; level-4 page noindex |
| **Reversibility + count** | ⚠️ medium → **FIXED** |
| Scope & destructiveness | ✅ SAFE — only `pg_display`; additive `ADD COLUMN`; cascade-delete trigger is DELETE-only (unreachable) |
| Governance / no-bricolage | ✅ SAFE — no hardcoded 1330; `operation` is audit-only; reuses #880 lifecycle |

**The fix:** the rollback `skipped_conflict` was derived by `total − rolled_back`, which mis-counted on (a) a reused `batch_id` and (b) a deleted gamme. Now: **`UNIQUE(batch_id, pg_id)`** prevents double-journaling, and skipped rows are **classified explicitly** by LEFT JOIN into `skipped_value_changed` (a later writer changed it) vs `skipped_missing_gamme` (gamme deleted upstream) — never by subtraction.

## Surface

- `backend/supabase/migrations/20260607_pricing_catalog_gamme_display_activate.sql`
- `price_import_batches.operation` marker (additive, nullable, audit-only)
- `pieces_gamme_display_history` journal (+ `pg_relfollow`/`pg_sitemap` control snapshot)
- `catalog_gamme_display_activate` + `catalog_gamme_display_rollback_batch`
- Gamme triad on the étape A service/repo/controller: `gammeDryRun`/`gammeCommit`(confirm:true)/`gammeRollback`, `POST /api/admin/pricing/display/gamme/{dry-run,commit,rollback}`, batch tagged `operation='GAMME_DISPLAY_ACTIVATION'`, `[CATALOG_GAMME_DISPLAY]` log prefix
- Unit tests: **14/14**

## Apply sequence (after merge, owner-gated, NO-GO until dry-run conforme)

```jsonc
// dry-run — expect eligible=1, gamme_ids=[1330], refs=11
POST /api/admin/pricing/display/gamme/dry-run   { "supplierId": "3410" }
// commit ONLY if the gate holds exactly:
POST /api/admin/pricing/display/gamme/commit    { "supplierId": "3410", "operator": "<you>", "confirm": true }
// → batchId. QA the 1330 hub. Rollback (anomaly-only):
//   SELECT catalog_gamme_display_rollback_batch('<batchId>','3410');
```

**Deferred (NO-GO):** gamme 2513 · the 22 level-5 gammes · étape B2 (vehicle). The hub-vs-listing visibility question must be clarified before any extension beyond 1330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)