### PR TITLE
chore(claude): move agent-method-patterns rule to knowledge/ (−2.3K tokens/turn, on-demand)

### DIFF
--- a/.claude/knowledge/README.md
+++ b/.claude/knowledge/README.md
@@ -24,6 +24,7 @@ Si la réponse n'est pas dans REPO_MAP ni canonical, passer à la prose ci-desso
 4. `integrations/*.md` — pour Paybox, SystemPay, Supabase, catalogue fournisseur (parts-feed)
 5. `routes/*.md` — pour les routes Remix critiques
 6. `ops/*.md` — pour toute question sur **cleanup / refactor / suppression** (procédures, backlog, playbook cycles)
+7. [`agent-method-patterns.md`](agent-method-patterns.md) — patterns de méthode agent (phases DISCOVER→…, danger-zone, scope-freeze) ; **NON-CANON advisory / pointer-only**, renvoie aux guards/skills/vault. Relocalisé `.claude/rules/`→ici le 2026-06-07 (était auto-chargé chaque turn ; lu **on-demand** désormais).
 
 Si la question n'est pas couverte ici, lire `.claude/rules/*` puis grepper.
 

--- a/.claude/knowledge/agent-method-patterns.md
+++ b/.claude/knowledge/agent-method-patterns.md
@@ -31,7 +31,7 @@ existant, **sans installer gstack** ni créer de système parallèle.
 |---|---|---|
 | **DISCOVER** | cartographier avant de muter | [CLAUDE.md](../../CLAUDE.md) « analyser AVANT muter » → ordre `canonical.json → REPO_MAP → knowledge → ADR vault → grep` |
 | **DECIDE** | verdict `REUSE / IMPROVE / CREATE / STOP` | [continuous-improvement-global](../skills/continuous-improvement-global/SKILL.md) (`GO / GO_WITH_WATCH / FIX_AND_RETEST / OWNER_DECISION / STOP_*`) + CLAUDE.md « Prefer extension over creation » |
-| **PLAN** | scope borné, risques, rollback | CLAUDE.md « Discipline de périmètre » + branche dédiée / worktree ([deployment.md](deployment.md)) |
+| **PLAN** | scope borné, risques, rollback | CLAUDE.md « Discipline de périmètre » + branche dédiée / worktree ([deployment.md](../rules/deployment.md)) |
 | **PATCH** | modification minimale, blast radius réduit | CLAUDE.md « périmètre minimal » |
 | **VERIFY** | tests + preuves | champ *Test* de continuous-improvement + vérification runtime PRE-PR / POST-MERGE (CLAUDE.md §Runtime-awareness) |
 | **HANDOFF** | résumé owner, next action, no overclaim | [agent-exit-contract.md](../canon-mirrors/agent-exit-contract.md) (coverage manifest, verdict, anti-overclaim) |
@@ -59,9 +59,9 @@ doctrine mais **pas** intercepté par un guard — l'agent s'auto-discipline + d
 | `backend/src/modules/rm/` | **BLOCK** | pretool-file-guard.sh G5 |
 | `supabase.rpc` direct (commerce) / order-cart status writes | **BLOCK** *(code)* | ast-grep `commerce-*` |
 | `ALTER TABLE DROP COLUMN` / `CREATE TABLE` sans RLS | **WARN** | pretool-supabase-guard.sh G4-G5 |
-| `payments/` edits | **WARN** *(not BLOCK)* | pretool-file-guard.sh G3 + [payments.md](payments.md) |
+| `payments/` edits | **WARN** *(not BLOCK)* | pretool-file-guard.sh G3 + [payments.md](../rules/payments.md) |
 | `gh pr merge` → main | **GATED (CI)** | branch protection : checks stricts requis + `enforce_admins` (merge = PREPROD ; PROD reste tag-gated). Pas un gap de guard local. |
-| `git tag v*` / `push --tags` / deploy-prod | **BLOCK** | pretool-bash-guard.sh G6 (#879) — tag = décision opérateur ([deployment.md](deployment.md)) |
+| `git tag v*` / `push --tags` / deploy-prod | **BLOCK** | pretool-bash-guard.sh G6 (#879) — tag = décision opérateur ([deployment.md](../rules/deployment.md)) |
 | `UPDATE`/`DELETE` `pieces` / `pieces_price` / `__seo_*` via execute_sql | **BLOCK** | pretool-supabase-guard.sh G6 (#879) — passer par module/RPC gouverné |
 
 > Gaps `tag v*` et DML gouverné **fermés par #879** (Guard 6 ×2, durcissement owner-gated —
@@ -74,7 +74,7 @@ doctrine mais **pas** intercepté par un guard — l'agent s'auto-discipline + d
 
 Discipline existante : CLAUDE.md « Discipline de périmètre » + ownership 992 globs
 ([ownership.yaml](../../.spec/00-canon/repository-registry/ownership.yaml)) + travail en worktree
-dédié ([deployment.md](deployment.md)). Rituel à poser en tête de tâche :
+dédié ([deployment.md](../rules/deployment.md)). Rituel à poser en tête de tâche :
 
 ```
 Allowed:   <chemins du bounded-context concerné>
@@ -142,7 +142,7 @@ Doctrine **déjà en place** (rien à construire) :
 | DB | vérité runtime |
 | RAG | consultation seulement |
 
-Voir [agent-doc-search.md](agent-doc-search.md) : « pas de nouvel index, pas de couche RAG
+Voir [agent-doc-search.md](../rules/agent-doc-search.md) : « pas de nouvel index, pas de couche RAG
 parallèle, pas de vérité parallèle ». Une mémoire agent n'est **jamais** source de vérité.
 
 ---
@@ -172,9 +172,9 @@ agent-operating-map.yaml, owner-gated)* :
 
 | Refusé | Pourquoi |
 |---|---|
-| `/ship`, `/land-and-deploy` auto | PROD owner-gated : tag `v*` = décision opérateur ([deployment.md](deployment.md)) |
+| `/ship`, `/land-and-deploy` auto | PROD owner-gated : tag `v*` = décision opérateur ([deployment.md](../rules/deployment.md)) |
 | team-required mode | aucune imposition d'outil tiers dans le repo |
-| brain / mémoire externe comme canon | vérité = vault / DB / WIKI, jamais une mémoire agent ([agent-doc-search.md](agent-doc-search.md)) |
+| brain / mémoire externe comme canon | vérité = vault / DB / WIKI, jamais une mémoire agent ([agent-doc-search.md](../rules/agent-doc-search.md)) |
 | browser agent mutant sans garde-fou | toute mutation passe par les gates existants |
 | continuous checkpoint push | déclenche CI / PROD ; le push est une action gouvernée |
 


### PR DESCRIPTION
## Problème
`.claude/rules/*.md` sont **auto-chargés comme project instructions à chaque turn**. Les 8 rules pèsent ~29KB/turn (~7 360 tokens), plus que CLAUDE.md. Le plus gros, [`agent-method-patterns.md`](.claude/rules/agent-method-patterns.md) (~9,4KB ≈ 2 350 tok/turn), se déclare lui-même **`NON-CANON · ADVISORY · POINTER-ONLY · NO AUTHORITY`** — il ne fait que pointer vers les guards/skills/vault existants. Ce n'est pas un garde-fou ; il n'a pas besoin d'être en contexte à chaque turn.

## Fix (structurel, pas de bricolage)
Déplacement `.claude/rules/` (auto-chargé) → `.claude/knowledge/` (on-demand, comme `REPO_MAP.md`). Même principe Layer-0/Layer-1 que la compaction `MEMORY.md` faite en parallèle.

- `git mv` → **rename préservé** (R095, historique git intact)
- 7 liens sibling réparés (`deployment.md` / `payments.md` / `agent-doc-search.md` → `../rules/…`) ; tous les autres liens `../` / `../../` restent valides (même profondeur)
- Indexé dans [`.claude/knowledge/README.md`](.claude/knowledge/README.md) (§ Prose détaillée) pour discoverability on-demand
- **0 référence ailleurs dans le repo** (grep-vérifié : aucun guard / CI / ast-grep / skill ne le cible par chemin)
- **Aucun changement de contenu** ; entièrement réversible

## Impact
−~2 350 tokens/turn de contexte auto-chargé, sans perte de gouvernance (contenu advisory redondant avec CLAUDE.md + guards, désormais lu à la demande).

## Non inclus (volontaire)
Les autres rules restent auto-chargées : `deployment.md` / `payments.md` sont des **guards critiques** (à garder), les autres sont petites ou activement utiles. Ne pas rogner des garde-fous pour des tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)