### PR TITLE
perf(blog): cache compatible vehicles with single-flight

### DIFF
--- a/backend/src/modules/blog/services/blog-article-relation.service.test.ts
+++ b/backend/src/modules/blog/services/blog-article-relation.service.test.ts
@@ -1,0 +1,154 @@
+import { BlogArticleRelationService } from './blog-article-relation.service';
+
+/**
+ * Unit coverage for the cache-aside + single-flight layer added on top of
+ * getCompatibleVehicles(). The heavy 5-7-query fan-out (computeCompatibleVehicles)
+ * is spied/stubbed so these tests assert ONLY the caching contract:
+ *   - miss → compute once → set with the right TTL
+ *   - hit → no recompute
+ *   - empty result → short negative-cache TTL
+ *   - single-flight → N concurrent cold-key callers share ONE compute
+ *   - best-effort set → a Redis write error never bubbles into the response
+ *   - key scoping → pg_id + limit + pg_alias each segment the cache
+ */
+
+/** Stateful in-memory CacheService double (get/set backed by a Map). */
+function makeCache(overrides: Partial<{ failSet: boolean }> = {}) {
+  const store = new Map<string, unknown>();
+  const get = jest.fn(async (key: string) =>
+    store.has(key) ? store.get(key) : null,
+  );
+  const set = jest.fn(async (key: string, val: unknown, _ttl?: number) => {
+    if (overrides.failSet) {
+      throw new Error('redis down');
+    }
+    store.set(key, val);
+  });
+  return { store, cache: { get, set } as any, get, set };
+}
+
+function makeService(cache: any) {
+  // supabase/transform deps are never reached: compute() is spied per-test.
+  return new BlogArticleRelationService({} as any, {} as any, cache);
+}
+
+const VEHICLES = [{ type_id: 1 }, { type_id: 2 }];
+
+describe('BlogArticleRelationService — getCompatibleVehicles cache layer', () => {
+  it('cache miss → computes once and stores with the 1h TTL (non-empty)', async () => {
+    const { cache, get, set } = makeCache();
+    const service = makeService(cache);
+    const compute = jest
+      .spyOn(service as any, 'computeCompatibleVehicles')
+      .mockResolvedValue(VEHICLES);
+
+    const result = await service.getCompatibleVehicles(42, 1000, 'filtre');
+
+    expect(result).toEqual(VEHICLES);
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledTimes(1);
+    const [key, value, ttl] = set.mock.calls[0];
+    expect(key).toBe('blog:compat-vehicles:v1:pg=42:lim=1000:alias=filtre');
+    expect(value).toEqual(VEHICLES);
+    expect(ttl).toBe(60 * 60);
+  });
+
+  it('cache hit → returns cached value WITHOUT recomputing', async () => {
+    const { cache, set } = makeCache();
+    const service = makeService(cache);
+    const compute = jest
+      .spyOn(service as any, 'computeCompatibleVehicles')
+      .mockResolvedValue(VEHICLES);
+
+    const first = await service.getCompatibleVehicles(42, 1000, 'filtre');
+    const second = await service.getCompatibleVehicles(42, 1000, 'filtre');
+
+    expect(first).toEqual(VEHICLES);
+    expect(second).toEqual(VEHICLES);
+    expect(compute).toHaveBeenCalledTimes(1); // 2nd call served from cache
+    expect(set).toHaveBeenCalledTimes(1); // only the miss writes
+  });
+
+  it('empty result → negative-cached with the short 5min TTL', async () => {
+    const { cache, set } = makeCache();
+    const service = makeService(cache);
+    jest
+      .spyOn(service as any, 'computeCompatibleVehicles')
+      .mockResolvedValue([]);
+
+    const result = await service.getCompatibleVehicles(99, 1000, '');
+
+    expect(result).toEqual([]);
+    const [, value, ttl] = set.mock.calls[0];
+    expect(value).toEqual([]);
+    expect(ttl).toBe(5 * 60);
+  });
+
+  it('single-flight → concurrent cold-key callers share ONE compute', async () => {
+    const { cache } = makeCache();
+    const service = makeService(cache);
+    let resolveCompute: (v: unknown[]) => void = () => {};
+    const compute = jest
+      .spyOn(service as any, 'computeCompatibleVehicles')
+      .mockImplementation(
+        () => new Promise((res) => (resolveCompute = res as any)),
+      );
+
+    const p1 = service.getCompatibleVehicles(7, 1000, 'frein');
+    const p2 = service.getCompatibleVehicles(7, 1000, 'frein');
+    const p3 = service.getCompatibleVehicles(7, 1000, 'frein');
+    // let both reach the inflight check before compute resolves
+    await Promise.resolve();
+    resolveCompute(VEHICLES);
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+    expect(compute).toHaveBeenCalledTimes(1);
+    expect(r1).toEqual(VEHICLES);
+    expect(r2).toEqual(VEHICLES);
+    expect(r3).toEqual(VEHICLES);
+  });
+
+  it('inflight slot is released → a later call recomputes on cold cache', async () => {
+    const { cache, get } = makeCache();
+    // simulate a non-persisting cache (get always misses) to prove the
+    // inflight Map does not pin a stale promise after completion
+    get.mockResolvedValue(null);
+    const service = makeService(cache);
+    const compute = jest
+      .spyOn(service as any, 'computeCompatibleVehicles')
+      .mockResolvedValue(VEHICLES);
+
+    await service.getCompatibleVehicles(7, 1000, 'frein');
+    await service.getCompatibleVehicles(7, 1000, 'frein');
+
+    expect(compute).toHaveBeenCalledTimes(2); // slot freed between calls
+  });
+
+  it('best-effort set → a Redis write error never bubbles into the response', async () => {
+    const { cache } = makeCache({ failSet: true });
+    const service = makeService(cache);
+    jest
+      .spyOn(service as any, 'computeCompatibleVehicles')
+      .mockResolvedValue(VEHICLES);
+
+    await expect(
+      service.getCompatibleVehicles(42, 1000, 'filtre'),
+    ).resolves.toEqual(VEHICLES);
+  });
+
+  it('cache key is segmented by pg_id + limit + pg_alias', async () => {
+    const { cache, set } = makeCache();
+    const service = makeService(cache);
+    jest
+      .spyOn(service as any, 'computeCompatibleVehicles')
+      .mockResolvedValue(VEHICLES);
+
+    await service.getCompatibleVehicles(1, 1000, 'a'); // by-gamme caller
+    await service.getCompatibleVehicles(1, 24, 'b'); // r3-guide caller
+
+    const keys = set.mock.calls.map((c) => c[0]);
+    expect(keys).toContain('blog:compat-vehicles:v1:pg=1:lim=1000:alias=a');
+    expect(keys).toContain('blog:compat-vehicles:v1:pg=1:lim=24:alias=b');
+  });
+});

--- a/backend/src/modules/blog/services/blog-article-relation.service.ts
+++ b/backend/src/modules/blog/services/blog-article-relation.service.ts
@@ -3,6 +3,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { SupabaseIndexationService } from '../../search/services/supabase-indexation.service';
 import { BlogArticleTransformService } from './blog-article-transform.service';
 import { normalizeTypeAlias } from '../../../common/utils/url-builder.utils';
+import { CacheService } from '@cache/cache.service';
 
 /**
  * 🔗 BlogArticleRelationService - Relations et véhicules compatibles
@@ -17,23 +18,131 @@ import { normalizeTypeAlias } from '../../../common/utils/url-builder.utils';
  *
  * Extrait de BlogService pour réduire la complexité (SRP)
  */
+
+/**
+ * TTL fenêtre fraîche (secondes) pour les véhicules compatibles. Donnée de
+ * référence stable (`__cross_gamme_car_new` + `auto_*`), mutée sur import
+ * catalogue, PAS sur publication d'article → invalidation = expiration TTL.
+ */
+const COMPAT_VEHICLES_CACHE_TTL_SECONDS = 60 * 60;
+
+/**
+ * TTL court pour résultat vide (négative-cache). Évite de relancer le fan-out
+ * 5-7 requêtes à chaque hit de crawl sur une gamme non couverte, sans staleness
+ * longue si la couverture est ajoutée par un import ultérieur.
+ */
+const COMPAT_VEHICLES_EMPTY_TTL_SECONDS = 5 * 60;
+
+/**
+ * Préfixe de clé versionné — bumper `v1` → `v2` force une invalidation globale
+ * (pas de source d'événement par-item pour la donnée de compatibilité).
+ */
+const COMPAT_VEHICLES_CACHE_PREFIX = 'blog:compat-vehicles:v1:';
+
 @Injectable()
 export class BlogArticleRelationService {
   private readonly logger = new Logger(BlogArticleRelationService.name);
 
+  /**
+   * Single-flight in-memory dedup (pattern R3GuideService). N requêtes
+   * concurrentes en cache miss sur la même clé partagent un seul compute —
+   * casse le thundering-herd du crawl concurrent sur clé froide. Dedup local
+   * par replica ; le store Redis partagé visibilise le résultat aux autres.
+   */
+  private readonly inflight = new Map<string, Promise<any[]>>();
+
   constructor(
     private readonly supabaseService: SupabaseIndexationService,
     private readonly transformService: BlogArticleTransformService,
+    private readonly cacheService: CacheService,
   ) {}
 
   /**
-   * 🚗 Charger les véhicules compatibles avec une gamme de pièce
-   * Version simplifiée : requête directe sans multiples étapes
+   * 🚗 Charger les véhicules compatibles avec une gamme de pièce.
+   *
+   * Cache-aside + single-flight au-dessus du fan-out 5-7 requêtes Supabase
+   * (cause racine du pic CPU sous crawl concurrent). Réutilise le `CacheService`
+   * global gouverné — partagé avec sessions/paiements, donc on ne consomme que
+   * son API publique (`get`/`set`), jamais ses internes.
+   *
    * @param pg_id - ID de la pièce générique
    * @param limit - Nombre max de véhicules (défaut: 1000 = quasi illimité)
    * @param pg_alias - Alias de la gamme pour construire l'URL
    */
   async getCompatibleVehicles(
+    pg_id: number,
+    limit = 1000,
+    pg_alias = '',
+  ): Promise<any[]> {
+    // Clé versionnée incluant pg_id + limit + pg_alias : les callers passent des
+    // limites différentes (1000 vs 24) et pg_alias change le `catalog_url`
+    // assemblé — une clé partagée servirait un mauvais payload.
+    const cacheKey = `${COMPAT_VEHICLES_CACHE_PREFIX}pg=${pg_id}:lim=${limit}:alias=${pg_alias}`;
+    const startedAt = Date.now();
+
+    const cached = await this.cacheService.get<any[]>(cacheKey);
+    if (cached !== null) {
+      this.logger.debug(
+        `[compat-cache] hit key=${cacheKey} count=${cached.length} duration_ms=${Date.now() - startedAt}`,
+      );
+      return cached;
+    }
+
+    const existing = this.inflight.get(cacheKey);
+    if (existing) {
+      this.logger.debug(`[compat-cache] coalesced key=${cacheKey}`);
+      return existing;
+    }
+
+    const promise = (async () => {
+      const computeStart = Date.now();
+      try {
+        const vehicles = await this.computeCompatibleVehicles(
+          pg_id,
+          limit,
+          pg_alias,
+        );
+        // Écriture best-effort : un blip Redis sur le `set` ne doit JAMAIS
+        // transformer un compute réussi en 500 (CacheService.set rethrow).
+        try {
+          await this.cacheService.set(
+            cacheKey,
+            vehicles,
+            vehicles.length > 0
+              ? COMPAT_VEHICLES_CACHE_TTL_SECONDS
+              : COMPAT_VEHICLES_EMPTY_TTL_SECONDS,
+          );
+        } catch (cacheErr) {
+          this.logger.error(
+            `[compat-cache] set-failed key=${cacheKey} — résultat retourné non caché`,
+            cacheErr instanceof Error ? cacheErr.stack : String(cacheErr),
+          );
+        }
+        this.logger.log(
+          `[compat-cache] miss key=${cacheKey} count=${vehicles.length} duration_ms=${Date.now() - computeStart}`,
+        );
+        return vehicles;
+      } finally {
+        // Toujours libérer le slot single-flight, même si le compute rejette
+        // (il ne rejette pas aujourd'hui — catch interne → []), pour ne pas
+        // figer une promesse rejetée dans la Map.
+        this.inflight.delete(cacheKey);
+      }
+    })();
+
+    this.inflight.set(cacheKey, promise);
+    return promise;
+  }
+
+  /**
+   * Fan-out réel (extrait verbatim, logique inchangée) — 5-7 requêtes Supabase
+   * séquentielles + assemblage JS. Toujours invoqué via
+   * {@link getCompatibleVehicles} (couche cache-aside + single-flight).
+   * @param pg_id - ID de la pièce générique
+   * @param limit - Nombre max de véhicules (défaut: 1000 = quasi illimité)
+   * @param pg_alias - Alias de la gamme pour construire l'URL
+   */
+  private async computeCompatibleVehicles(
     pg_id: number,
     limit = 1000,
     pg_alias = '',


### PR DESCRIPTION
## Summary

Adds cache-aside + single-flight protection around blog compatible vehicle computation.

## Why

The endpoint can become expensive under concurrent crawl/load. Baseline DEV runtime showed repeated uncached calls with similar latency, and saturation can amplify the cost.

## What changed

- Adds Redis cache-aside for compatible vehicles
- TTL:
  - positive result: 1h
  - empty result: 5min negative cache
- Adds single-flight coalescing so concurrent identical requests share one computation
- Redis set failure is best-effort and does not break the response
- Cache key is segmented by pg_id, limit and alias

## Tests

- Jest: blog-article-relation.service.test.ts — 7/7 PASS
- tsc --noEmit: PASS
- ESLint: 0 errors
- Prettier: PASS
- ast-grep: PASS

## Validation limits

The patched behavior cannot be validated on the real DEV endpoint before merge because DEV:3000 serves main and alt-port is blocked.

Post-merge validation must be done on PREPROD first:
- check logs: [compat-cache] miss | hit | coalesced | set-failed
- compare latency/CPU against baseline
- confirm no functional regression on blog compatible vehicles

PROD remains gated by explicit v* tag only.

## Definition of Done (self-evaluation)

- [x] **DoD1** Tests verts — jest 7/7 + tsc + ESLint(0 err) + Prettier + ast-grep
- [x] **DoD2** Ownership — `backend/src/modules/blog` (bounded context respecté, 1 service + son test)
- [x] **DoD3** Rollback: revert PR — additif, 1 fichier service ; `git revert` du commit perf
- [x] **DoD4** Observabilité — logs `[compat-cache] hit | miss | coalesced | set-failed`
- [x] **DoD5** Drift zéro — aucun changement registry/canon/schema/contrat fonctionnel
- [x] **DoD6** Docs — JSDoc sur méthodes + PR body (problème, design, limites de validation)
- [ ] **DoD7** Monitoring : N/A ce PR — réutilise les logs CacheService existants, pas de nouvelle alerte
- [x] **DoD8** No TODO — aucun TODO/FIXME introduit
- [x] **DoD9** No silent skip — pas de fallback silencieux ; `set` best-effort loggé ERROR, `get`→null dégrade vers compute (by design, loggé), négative-cache explicite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
