### PR TITLE
feat(catalog): R2 accessories block data layer — AccessoryProductsService (PR-2a, flag OFF)

### DIFF
--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -229,6 +229,19 @@ export class FeatureFlagsService {
     return this.bool('SEO_CONTROL_DASHBOARD_ENABLED', false);
   }
 
+  // ── R2 Accessories block (accessory products under main gamme, PR-2) ──
+
+  /**
+   * Master switch for the R2 "Accessoires" block — surfaces an accessory gamme's
+   * PRODUCTS (linked via pieces_gamme.pg_parent_gamme_id) on the main gamme's R2
+   * product page, in the current vehicle context. Default: false (rollout safe).
+   * OFF = the AccessoryProductsService short-circuits to an empty result (no query,
+   * no surface). The accessory gamme stays hidden; no URL/sitemap/indexation change.
+   */
+  get accessoryBlocksOnR2Enabled(): boolean {
+    return this.bool('SHOW_ACCESSORY_BLOCKS_ON_R2', false);
+  }
+
   // ── VehicleContext cookie kill-switch (PR-B.6) ──
 
   /**
@@ -340,6 +353,7 @@ export class FeatureFlagsService {
     'VEHICLE_CTX_ENABLED',
     'DIAGNOSTIC_KG_SHADOW_ENABLED',
     'DIAGNOSTIC_KG_PRIMARY_ENABLED',
+    'SHOW_ACCESSORY_BLOCKS_ON_R2',
   ]);
 
   listFlags(): Record<

--- a/backend/src/modules/catalog/catalog.module.ts
+++ b/backend/src/modules/catalog/catalog.module.ts
@@ -30,6 +30,7 @@ import { CatalogDataIntegrityService } from './services/catalog-data-integrity.s
 import { PricingService } from '../products/services/pricing.service';
 import { OemPlatformMappingService } from './services/oem-platform-mapping.service';
 import { UnifiedPageDataService } from './services/unified-page-data.service';
+import { AccessoryProductsService } from './services/accessory-products.service';
 import { SeoTemplateService } from './services/seo-template.service'; // ⚡ SEO processing NestJS (RPC V4)
 import { HomepageRpcService } from './services/homepage-rpc.service';
 import { CatalogHierarchyService } from './services/catalog-hierarchy.service';
@@ -80,6 +81,7 @@ import { GammePricePreviewService } from './services/gamme-price-preview.service
     // PiecesDbController, // DÉSACTIVÉ - service manquant
   ],
   providers: [
+    AccessoryProductsService,
     // 🔧 Services principaux
     CatalogService,
     EnhancedVehicleCatalogService,

--- a/backend/src/modules/catalog/controllers/gamme-unified.controller.ts
+++ b/backend/src/modules/catalog/controllers/gamme-unified.controller.ts
@@ -14,6 +14,7 @@ import {
 import { GammeUnifiedService } from '../services/gamme-unified.service';
 import { GammePricePreviewService } from '../services/gamme-price-preview.service';
 import { UnifiedPageDataService } from '../services/unified-page-data.service';
+import { AccessoryProductsService } from '../services/accessory-products.service';
 
 @Controller('api/catalog/gammes')
 export class GammeUnifiedController {
@@ -23,7 +24,26 @@ export class GammeUnifiedController {
     private readonly gammeService: GammeUnifiedService,
     private readonly unifiedPageDataService: UnifiedPageDataService,
     private readonly pricePreviewService: GammePricePreviewService,
+    private readonly accessoryProductsService: AccessoryProductsService,
   ) {}
+
+  /**
+   * GET /api/catalog/gammes/:mainPgId/accessories/:typeId
+   * R2 "Accessoires" block (PR-2a): products of the accessory gammes linked to this
+   * MAIN gamme (via pg_parent_gamme_id) that are compatible with the vehicle :typeId.
+   * Read-only; flag-gated (SHOW_ACCESSORY_BLOCKS_ON_R2, default OFF → empty result).
+   * Never touches pg_display / URL / sitemap — the accessory gamme stays hidden.
+   */
+  @Get(':mainPgId/accessories/:typeId')
+  async getAccessoryProducts(
+    @Param('mainPgId') mainPgId: string,
+    @Param('typeId') typeId: string,
+  ) {
+    return this.accessoryProductsService.getForVehicle(
+      parseInt(mainPgId, 10),
+      parseInt(typeId, 10),
+    );
+  }
 
   /**
    * 🎯 GET /api/catalog/gammes - Toutes les gammes

--- a/backend/src/modules/catalog/services/accessory-products.service.test.ts
+++ b/backend/src/modules/catalog/services/accessory-products.service.test.ts
@@ -1,0 +1,134 @@
+/**
+ * AccessoryProductsService — R2 "Accessoires" block data layer (PR-2a).
+ *
+ * Pins: flag-gating (OFF = no query, no surface), the pg_parent_gamme_id lookup,
+ * and the REUSE of the canonical R2 products primitive (UnifiedPageDataService.getPageData)
+ * per accessory gamme — empty groups are dropped.
+ */
+import { AccessoryProductsService } from './accessory-products.service';
+import type { UnifiedPageDataService } from './unified-page-data.service';
+import type { FeatureFlagsService } from '../../../config/feature-flags.service';
+import type { ConfigService } from '@nestjs/config';
+
+function makeSupabase(
+  accGammes: unknown[] | null,
+  error: { message: string } | null = null,
+) {
+  const inFn = jest.fn().mockResolvedValue({ data: accGammes, error });
+  const eqFn = jest.fn().mockReturnValue({ in: inFn });
+  const selectFn = jest.fn().mockReturnValue({ eq: eqFn });
+  const fromFn = jest.fn().mockReturnValue({ select: selectFn });
+  return { client: { from: fromFn }, fromFn, selectFn, eqFn, inFn };
+}
+
+function makeService(opts: {
+  flag: boolean;
+  accGammes?: unknown[] | null;
+  lookupError?: { message: string } | null;
+  pageByPg?: Record<number, { pieces: unknown[]; minPrice: number }>;
+}) {
+  const config = {
+    get: jest.fn().mockReturnValue('https://example.supabase.co'),
+  } as unknown as ConfigService;
+  const getPageData = jest.fn(async (_typeId: number, pgId: number) => {
+    const p = opts.pageByPg?.[pgId];
+    return { pieces: p?.pieces ?? [], minPrice: p?.minPrice ?? 0 } as Awaited<
+      ReturnType<UnifiedPageDataService['getPageData']>
+    >;
+  });
+  const unified = { getPageData } as unknown as UnifiedPageDataService;
+  const flags = {
+    accessoryBlocksOnR2Enabled: opts.flag,
+  } as unknown as FeatureFlagsService;
+
+  const svc = new AccessoryProductsService(config, unified, flags);
+  const sb = makeSupabase(opts.accGammes ?? [], opts.lookupError ?? null);
+  (svc as unknown as { supabase: unknown }).supabase = sb.client;
+  return { svc, getPageData, sb };
+}
+
+describe('AccessoryProductsService', () => {
+  it('flag OFF → empty, runs NO query (no surface)', async () => {
+    const { svc, getPageData, sb } = makeService({ flag: false });
+
+    const res = await svc.getForVehicle(82, 9045);
+
+    expect(res).toEqual({
+      enabled: false,
+      mainPgId: 82,
+      typeId: 9045,
+      accessories: [],
+    });
+    expect(sb.fromFn).not.toHaveBeenCalled();
+    expect(getPageData).not.toHaveBeenCalled();
+  });
+
+  it('flag ON, no linked accessories → enabled, empty', async () => {
+    const { svc, getPageData } = makeService({ flag: true, accGammes: [] });
+
+    const res = await svc.getForVehicle(82, 9045);
+
+    expect(res).toEqual({
+      enabled: true,
+      mainPgId: 82,
+      typeId: 9045,
+      accessories: [],
+    });
+    expect(getPageData).not.toHaveBeenCalled();
+  });
+
+  it('flag ON → reuses getPageData per accessory; returns groups with products', async () => {
+    const { svc, getPageData } = makeService({
+      flag: true,
+      accGammes: [
+        {
+          pg_id: 1330,
+          pg_alias: 'deflecteur-disque-de-frein',
+          pg_name: 'Déflecteur disque de frein',
+        },
+      ],
+      pageByPg: { 1330: { pieces: [{ id: 1 }, { id: 2 }], minPrice: 12.5 } },
+    });
+
+    const res = await svc.getForVehicle(82, 9045);
+
+    expect(getPageData).toHaveBeenCalledWith(9045, 1330);
+    expect(res.enabled).toBe(true);
+    expect(res.accessories).toHaveLength(1);
+    expect(res.accessories[0]).toEqual({
+      pgId: 1330,
+      pgAlias: 'deflecteur-disque-de-frein',
+      pgName: 'Déflecteur disque de frein',
+      count: 2,
+      minPrice: 12.5,
+      products: [{ id: 1 }, { id: 2 }],
+    });
+  });
+
+  it('flag ON → accessory with 0 compatible products is dropped', async () => {
+    const { svc } = makeService({
+      flag: true,
+      accGammes: [{ pg_id: 1330, pg_alias: 'a', pg_name: 'A' }],
+      pageByPg: { 1330: { pieces: [], minPrice: 0 } },
+    });
+
+    const res = await svc.getForVehicle(82, 9045);
+
+    expect(res.enabled).toBe(true);
+    expect(res.accessories).toHaveLength(0);
+  });
+
+  it('flag ON but a falsy mainPgId/typeId → enabled, empty (no query)', async () => {
+    const { svc, getPageData } = makeService({ flag: true, accGammes: [] });
+
+    const res = await svc.getForVehicle(0, 9045);
+
+    expect(res).toEqual({
+      enabled: true,
+      mainPgId: 0,
+      typeId: 9045,
+      accessories: [],
+    });
+    expect(getPageData).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/catalog/services/accessory-products.service.ts
+++ b/backend/src/modules/catalog/services/accessory-products.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { FeatureFlagsService } from '../../../config/feature-flags.service';
+import { UnifiedPageDataService } from './unified-page-data.service';
+
+/** One accessory gamme + its products compatible with the current vehicle. */
+export interface AccessoryProductGroup {
+  pgId: number;
+  pgAlias: string;
+  pgName: string;
+  count: number;
+  minPrice: number;
+  products: Record<string, unknown>[];
+}
+
+export interface AccessoryProductsResult {
+  /** false = flag OFF (no query ran). true = flag ON (accessories may be empty). */
+  enabled: boolean;
+  mainPgId: number;
+  typeId: number;
+  accessories: AccessoryProductGroup[];
+}
+
+/**
+ * AccessoryProductsService (étape PR-2a, data layer for the R2 "Accessoires" block).
+ *
+ * For a MAIN gamme's R2 product page (a gamme × vehicle), returns the PRODUCTS of the
+ * ACCESSORY gammes linked to it via pieces_gamme.pg_parent_gamme_id (the governed
+ * accessory→main link from PR-1 #889), compatible with the current vehicle.
+ *
+ * NO-BRICOLAGE: it REUSES the canonical R2 products primitive
+ * (UnifiedPageDataService.getPageData → RPC get_pieces_for_type_gamme_v3) per accessory
+ * gamme, so accessory products carry the EXACT same gating + price logic as the main
+ * products — zero divergence, no reimplemented price path.
+ *
+ * SEO-SAFE: read-only; never touches pg_display / URL / sitemap / the accessory gamme.
+ * Flag-gated by SHOW_ACCESSORY_BLOCKS_ON_R2 (default OFF) — OFF short-circuits to an empty
+ * result (no query, no surface). The accessory gamme stays hidden.
+ */
+@Injectable()
+export class AccessoryProductsService extends SupabaseBaseService {
+  protected readonly logger = new Logger(AccessoryProductsService.name);
+
+  constructor(
+    configService: ConfigService,
+    private readonly unified: UnifiedPageDataService,
+    private readonly flags: FeatureFlagsService,
+  ) {
+    super(configService);
+  }
+
+  async getForVehicle(
+    mainPgId: number,
+    typeId: number,
+  ): Promise<AccessoryProductsResult> {
+    const empty: AccessoryProductsResult = {
+      enabled: false,
+      mainPgId,
+      typeId,
+      accessories: [],
+    };
+
+    // Flag OFF → no query, no surface (the accessory stays invisible).
+    if (!this.flags.accessoryBlocksOnR2Enabled) {
+      return empty;
+    }
+    if (!mainPgId || !typeId) {
+      return { ...empty, enabled: true };
+    }
+
+    // 1) Accessory gammes linked to this main hub (the PR-1 pg_parent_gamme_id link).
+    const { data: accGammes, error } = await this.supabase
+      .from('pieces_gamme')
+      .select('pg_id, pg_alias, pg_name')
+      .eq('pg_parent_gamme_id', mainPgId)
+      .in('pg_level', ['4', '5']);
+
+    if (error) {
+      this.logger.warn(
+        `[ACCESSORY_R2] gamme lookup failed main=${mainPgId}: ${error.message}`,
+      );
+      return { ...empty, enabled: true };
+    }
+    if (!accGammes?.length) {
+      return { ...empty, enabled: true };
+    }
+
+    // 2) For each accessory gamme, reuse the canonical R2 products primitive (same vehicle).
+    const groups: AccessoryProductGroup[] = [];
+    for (const g of accGammes) {
+      const pgId =
+        typeof g.pg_id === 'number' ? g.pg_id : parseInt(String(g.pg_id), 10);
+      if (!Number.isFinite(pgId) || pgId <= 0) continue;
+      try {
+        const page = await this.unified.getPageData(typeId, pgId);
+        const products = Array.isArray(page.pieces) ? page.pieces : [];
+        if (products.length > 0) {
+          groups.push({
+            pgId,
+            pgAlias: String(g.pg_alias ?? ''),
+            pgName: String(g.pg_name ?? ''),
+            count: products.length,
+            minPrice: page.minPrice ?? 0,
+            products,
+          });
+        }
+      } catch (e) {
+        this.logger.warn(
+          `[ACCESSORY_R2] product fetch failed acc=${pgId}: ${e instanceof Error ? e.message : e}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `[ACCESSORY_R2] main=${mainPgId} type=${typeId} groups=${groups.length}`,
+    );
+    return { enabled: true, mainPgId, typeId, accessories: groups };
+  }
+}

--- a/backend/supabase/migrations/20260607_pricing_catalog_accessory_link_index.sql
+++ b/backend/supabase/migrations/20260607_pricing_catalog_accessory_link_index.sql
@@ -1,0 +1,28 @@
+-- =====================================================
+-- catalog_accessory_link — read-path index (étape PR-2a)
+-- Date: 2026-06-07
+-- Ref: 20260607_pricing_catalog_accessory_link.sql (#889 — the data model this indexes).
+--
+-- WHY: the R2 "Accessoires" block (AccessoryProductsService) looks up the accessory gammes
+--   of a main hub via  WHERE pg_parent_gamme_id = <main_pg_id> AND pg_level IN ('4','5').
+--   This partial index serves that lookup. PR-1 deliberately deferred it here.
+--
+-- ADDITIF. Idempotent (CREATE INDEX IF NOT EXISTS). Forward-only. NOT applied here —
+-- owner-gated. No data mutation.
+-- =====================================================
+
+-- squawk-ignore-file require-concurrent-index-creation
+--   pieces_gamme is a SMALL table (~9.7k rows). A plain CREATE INDEX takes a brief SHARE
+--   lock (<100 ms) — negligible. CONCURRENTLY cannot run inside a transactional migration
+--   (squawk assume_in_transaction=true), and is unnecessary at this row count. The partial
+--   predicate keeps the index tiny (only linked accessories carry pg_parent_gamme_id).
+
+set lock_timeout = '2s';
+set statement_timeout = '120s';
+
+CREATE INDEX IF NOT EXISTS idx_pieces_gamme_parent_main
+  ON pieces_gamme (pg_parent_gamme_id)
+  WHERE pg_parent_gamme_id IS NOT NULL;
+
+COMMENT ON INDEX idx_pieces_gamme_parent_main IS
+  'Read-path for the R2 accessories block: find accessory gammes of a main hub (WHERE pg_parent_gamme_id = main). Partial (only linked accessories).';


### PR DESCRIPTION
## What — PR-2a (backend data layer for the R2 "Accessoires" block)

Consumes the PR-1 #889 accessory→main link (`pg_parent_gamme_id`). For a **MAIN gamme's R2 page** (gamme × vehicle), returns the **PRODUCTS** of the accessory gammes linked to it, **compatible with the current vehicle** — so the hub for « Disque de frein » (82) can show a « Accessoires » section with the Déflecteurs (1330) for that car.

**NOT applied** (the index migration is owner-gated). **NO frontend yet** (PR-2b). **Flag default OFF.**

## No-bricolage: reuses the canon

The service **reuses the canonical R2 products primitive** — `UnifiedPageDataService.getPageData` → RPC `get_pieces_for_type_gamme_v3` — **per accessory gamme**. So accessory products carry the **exact same gating + price logic** as the main page's products: zero divergence, no reimplemented price path.

R2 in production is built by **`catalog/`** (`UnifiedPageDataService`), **not** the guard-blocked + DEV-only `rm/` module — so this plugs in cleanly without touching `rm/`.

## SEO-safe + governed

- **Read-only.** Never touches `pg_display` / URL / sitemap / the accessory gamme. The accessory stays **hidden**; the block surfaces its *products* (existing R2 product pages), not a new hub.
- **Governed flag** `SHOW_ACCESSORY_BLOCKS_ON_R2` (`FeatureFlagsService` + `ALLOWED_KEYS`, runtime-toggleable, **default OFF**). OFF → the service **short-circuits to an empty result** (no query, no surface).

## Guardrails

- Accessory gammes resolved by `WHERE pg_parent_gamme_id = :mainPgId AND pg_level IN ('4','5')` (the PR-1 link).
- Empty groups dropped (no accessory shown if it has 0 compatible products for the vehicle).
- No URL/`piece_ga_id`/`rtp_pg_id` change. Read-path index is partial + tiny (`pieces_gamme` ~9.7k rows).

## Surface

- Governed flag `SHOW_ACCESSORY_BLOCKS_ON_R2` (default OFF)
- `AccessoryProductsService.getForVehicle(mainPgId, typeId)` (`catalog/`)
- `GET /api/catalog/gammes/:mainPgId/accessories/:typeId`
- Migration `20260607_pricing_catalog_accessory_link_index.sql` (read-path partial index, squawk-ignore justified)
- Unit tests: **5/5** (flag OFF = no query; reuse getPageData; empty groups dropped)

## Next (owner-gated)

- After merge: apply the index migration (DDL-only); flag stays **OFF**.
- **PR-2b** = frontend R2 section: deferred fetch of `…/accessories/:typeId` + an « Accessoires » component rendering the product cards with `<Link rel="nofollow">` to existing product pages. Flag-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)