### PR TITLE
fix(infra): cloudflare origin ca cert for prod tls (no more acme)

### DIFF
--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -30,12 +30,17 @@
 
 # ===== REDIRECTION .FR VERS .COM =====
 automecanik.fr, www.automecanik.fr {
+    # TLS via Cloudflare Origin CA — plus d'ACME/expiration (incident 2026-06-08)
+    tls /etc/caddy/origin/origin.pem /etc/caddy/origin/origin.key
     redir https://www.automecanik.com{uri} permanent
 }
 
 # ===== SITE PRINCIPAL .COM =====
 automecanik.com, www.automecanik.com {
-    
+
+    # TLS via Cloudflare Origin CA — plus d'ACME/expiration (incident 2026-06-08, cert LE expiré)
+    tls /etc/caddy/origin/origin.pem /etc/caddy/origin/origin.key
+
     # Redirection apex vers www
     @apex host automecanik.com
     redir @apex https://www.automecanik.com{uri} permanent

--- a/docker-compose.caddy.yml
+++ b/docker-compose.caddy.yml
@@ -11,6 +11,11 @@ services:
       # Configuration
       - ./config/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
 
+      # Cloudflare Origin CA cert (15 ans, hors ACME) — fichiers déposés sur le serveur,
+      # JAMAIS committés (.gitignored). Incident 2026-06-08 : cert LE expiré, renouvellement
+      # ACME impossible car origine firewall-locked aux IPs Cloudflare.
+      - ./config/caddy/origin:/etc/caddy/origin:ro
+
       # Données persistantes (certificats SSL)
       - caddy_data:/data
       - caddy_config:/config


### PR DESCRIPTION
## Incident

PROD (`www.automecanik.com`) returned **HTTP 526** for ~22h: the origin Let's Encrypt cert expired **2026-06-07 13:03 UTC** and could not auto-renew.

**Root cause:** Caddy renews via ACME HTTP-01/TLS-ALPN-01, but the origin firewall only allows Cloudflare IPs (`config/caddy/Caddyfile` line ~201), so Let's Encrypt's validation servers can't reach Caddy → renewal impossible → cert expired. Cloudflare (Full-strict) then rejects the expired origin cert → 526.

**Detection:** the post-PROD **edge** test (`https://www.automecanik.com`). Green CI + `prod-smoke-tests` missed it because they test the origin, not the Cloudflare edge.

## Fix

Serve an explicit **Cloudflare Origin CA** certificate (15-year, trusted by Cloudflare in Full-strict) instead of ACME — removes the renewal/expiry failure class entirely for this Cloudflare-only origin. No `xcaddy` plugin, no API token, no renewal cron.

- `config/caddy/Caddyfile`: `tls` directive on the `.com` and `.fr` site blocks
- `docker-compose.caddy.yml`: mount `./config/caddy/origin` (cert files are placed on the server out-of-band and are **gitignored — never committed**)

## Not auto-applied

Caddy runs from `docker-compose.caddy.yml` (managed manually on the server, **not** in the `deploy-prod` pipeline). Merging this PR does **not** restart PROD Caddy. Application = owner SSH runbook on `49.12.233.2`:
1. Generate Origin CA cert in Cloudflare dashboard (hostnames: `automecanik.com, *.automecanik.com, automecanik.fr, *.automecanik.fr`).
2. Place `origin.pem` + `origin.key` in `config/caddy/origin/` (key `0600`).
3. `git fetch origin && git checkout origin/main -- config/caddy/Caddyfile docker-compose.caddy.yml`
4. `caddy validate` → `docker compose -f docker-compose.caddy.yml up -d` → verify origin + edge → revert Cloudflare to **Full (strict)**.

## Validation

`caddy validate` (with cert files mounted) → **Valid configuration**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
