### PR TITLE
feat(pricing): catalog activation plan (T1) — read-only orphan/activation classifier

### DIFF
--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -32,6 +32,16 @@ export class FeatureFlagsService {
     return this.bool('SAFE_FALLBACK_ENABLED', false);
   }
 
+  /**
+   * Kill-switch for the auto-apply at tariff commit (T3). Default OFF → the commit
+   * runs the activation verification + a display-activation DRY-RUN only (no mutation).
+   * ON → the brand's vendable-but-hidden pieces are auto-activated (piece_display) via
+   * the governed catalog_display_activate primitive (#880, respects FROZEN / quarantine).
+   */
+  get catalogAutoActivateEnabled(): boolean {
+    return this.bool('CATALOG_AUTO_ACTIVATE', false);
+  }
+
   get canaryGammes(): string[] {
     return this.csv('CANARY_GAMMES');
   }
@@ -316,6 +326,7 @@ export class FeatureFlagsService {
     'HARD_GATES_ENABLED',
     'AUTO_REPAIR_ENABLED',
     'SAFE_FALLBACK_ENABLED',
+    'CATALOG_AUTO_ACTIVATE',
     'CANARY_GAMMES',
     'R1_CONTENT_PIPELINE_ENABLED',
     'BRIEF_GATES_ENABLED',

--- a/backend/src/modules/pricing/controllers/pricing-import.controller.ts
+++ b/backend/src/modules/pricing/controllers/pricing-import.controller.ts
@@ -38,6 +38,7 @@ import {
   type DisplayQuarantineRequest,
 } from '../services/catalog-display-quarantine.service';
 import { PricingSimulationService } from '../services/pricing-simulation.service';
+import { CatalogActivationPlanService } from '../services/catalog-activation-plan.service';
 import type {
   CustomerType,
   PricingRule,
@@ -52,7 +53,18 @@ export class PricingImportController {
     private readonly displayActivationService: CatalogDisplayActivationService,
     private readonly displayQuarantineService: CatalogDisplayQuarantineService,
     private readonly simulationService: PricingSimulationService,
+    private readonly activationPlanService: CatalogActivationPlanService,
   ) {}
+
+  /**
+   * Read-only activation plan for a tariff batch (brand). T1 — NO writes.
+   * Classifies sellable-priced pieces (visible / display-gated / accessory /
+   * gamme-inactive / orphan) + proposes universal-section candidates.
+   */
+  @Post('activation/plan')
+  activationPlan(@Body() body: { brandPmId: number }) {
+    return this.activationPlanService.plan(body.brandPmId);
+  }
 
   /** Read-only grid simulation (no write). */
   @Post('simulate')

--- a/backend/src/modules/pricing/pricing.module.ts
+++ b/backend/src/modules/pricing/pricing.module.ts
@@ -16,6 +16,7 @@ import { PriceActivationService } from './services/price-activation.service';
 import { CatalogDisplayActivationService } from './services/catalog-display-activation.service';
 import { CatalogDisplayQuarantineService } from './services/catalog-display-quarantine.service';
 import { PricingSimulationService } from './services/pricing-simulation.service';
+import { CatalogActivationPlanService } from './services/catalog-activation-plan.service';
 import { PricingImportController } from './controllers/pricing-import.controller';
 
 @Module({
@@ -31,6 +32,7 @@ import { PricingImportController } from './controllers/pricing-import.controller
     CatalogDisplayActivationService,
     CatalogDisplayQuarantineService,
     PricingSimulationService,
+    CatalogActivationPlanService,
   ],
   exports: [
     PricingFormulaService,

--- a/backend/src/modules/pricing/services/catalog-activation-plan.service.test.ts
+++ b/backend/src/modules/pricing/services/catalog-activation-plan.service.test.ts
@@ -1,0 +1,60 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  CatalogActivationPlanService,
+  type ActivationPlan,
+} from './catalog-activation-plan.service';
+import { PricingRepository } from './pricing.repository';
+
+const samplePlan: ActivationPlan = {
+  brand_pm_id: 730,
+  sellable_priced: 21417,
+  categories: {
+    already_visible: 16373,
+    display_gated: 285,
+    accessory: 309,
+    gamme_inactive: 407,
+    orphan_with_oem: 2454,
+    orphan_no_source: 2181,
+  },
+  universal_candidates: [{ pg_id: 3357, pg_name: 'Liquide de frein', pieces: 42 }],
+};
+
+function makeService(planImpl?: jest.Mock) {
+  const repo = {
+    catalogActivationPlan:
+      planImpl ?? jest.fn().mockResolvedValue(samplePlan),
+  } as unknown as PricingRepository;
+  return { service: new CatalogActivationPlanService(repo), repo };
+}
+
+describe('CatalogActivationPlanService', () => {
+  it('returns the dry-run plan from the repository unchanged', async () => {
+    const { service, repo } = makeService();
+    const out = await service.plan(730);
+    expect(out).toEqual(samplePlan);
+    expect(repo.catalogActivationPlan).toHaveBeenCalledWith(730);
+  });
+
+  it.each([0, -1, 1.5, NaN])(
+    'rejects non-positive-integer brandPmId (%p) without touching the repo',
+    async (bad) => {
+      const repoCall = jest.fn();
+      const { service } = makeService(repoCall);
+      await expect(service.plan(bad as number)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(repoCall).not.toHaveBeenCalled();
+    },
+  );
+
+  it('never mutates: the service only reads via the RPC-backed repo method', async () => {
+    const repoCall = jest.fn().mockResolvedValue(samplePlan);
+    const { service } = makeService(repoCall);
+    await service.plan(730);
+    // single read call, no commit/activate/display method exists on this service
+    expect(repoCall).toHaveBeenCalledTimes(1);
+    expect(
+      (service as unknown as Record<string, unknown>).commit,
+    ).toBeUndefined();
+  });
+});

--- a/backend/src/modules/pricing/services/catalog-activation-plan.service.test.ts
+++ b/backend/src/modules/pricing/services/catalog-activation-plan.service.test.ts
@@ -16,7 +16,9 @@ const samplePlan: ActivationPlan = {
     orphan_with_oem: 2454,
     orphan_no_source: 2181,
   },
-  universal_candidates: [{ pg_id: 3357, pg_name: 'Liquide de frein', pieces: 42 }],
+  orphan_no_source_by_gamme: [
+    { pg_id: 82, pg_name: 'Disque de frein', pieces: 3 },
+  ],
 };
 
 function makeService(planImpl?: jest.Mock) {

--- a/backend/src/modules/pricing/services/catalog-activation-plan.service.ts
+++ b/backend/src/modules/pricing/services/catalog-activation-plan.service.ts
@@ -1,0 +1,77 @@
+/**
+ * Catalog activation plan (T1 — READ-ONLY scaffold of the governed activation pipeline).
+ *
+ * For a tariff batch (= a brand, `pieces.piece_pm_id`), classifies the sellable-priced
+ * pieces and emits a DRY-RUN plan — the same dry-run-first pattern as the price import.
+ * It NEVER writes (no price/dispo/display/relation mutation): the actual activation
+ * (universal section, display flip, accessory parent, OEM fitment) are SEPARATE
+ * owner-gated steps (T2-T4 of the design).
+ *
+ * Drives the read-only RPC `catalog_activation_plan` (STABLE). The plan also proposes
+ * `universal_candidates` (orphan + no-OEM gammes) so the universal list is curated
+ * incrementally at each tariff update — "au fur et à mesure".
+ *
+ * Design: audit/orphan-price-and-universal-section-design-2026-06-08.md §5/§5bis.
+ */
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { PricingRepository } from './pricing.repository';
+
+/** Per-category counts of the brand's sellable-priced pieces. */
+export interface ActivationPlanCategories {
+  /** has gamme×vehicle link + piece_display=true + gamme active → already on a page. */
+  already_visible: number;
+  /** has link but piece_display=false → safe to activate (correct fitment, display-gated). */
+  display_gated: number;
+  /** piece_pg_pid ≠ piece_pg_id → accessory attached to a parent gamme. */
+  accessory: number;
+  /** has link but its gamme is inactive (pg_display≠'1') → activate the gamme. */
+  gamme_inactive: number;
+  /** orphan (no link) but carries OEM refs → vehicle fitment re-derivable (validated sub-project). */
+  orphan_with_oem: number;
+  /** orphan (no link) + no OEM → no authoritative fitment source (universal candidate or blocked; never fabricate). */
+  orphan_no_source: number;
+}
+
+/** A gamme proposed as "universal section" candidate (orphan + no-OEM), for owner confirmation. */
+export interface UniversalCandidate {
+  pg_id: number;
+  pg_name: string | null;
+  pieces: number;
+}
+
+export interface ActivationPlan {
+  brand_pm_id: number;
+  sellable_priced: number;
+  categories: ActivationPlanCategories;
+  universal_candidates: UniversalCandidate[];
+}
+
+@Injectable()
+export class CatalogActivationPlanService {
+  private readonly logger = new Logger(CatalogActivationPlanService.name);
+
+  constructor(private readonly repo: PricingRepository) {}
+
+  /**
+   * Read-only activation plan for a brand batch. No writes.
+   * @param brandPmId pieces_marque.pm_id (the tariff brand).
+   */
+  async plan(brandPmId: number): Promise<ActivationPlan> {
+    if (!Number.isInteger(brandPmId) || brandPmId <= 0) {
+      throw new BadRequestException(
+        'brandPmId must be a positive integer (pieces_marque.pm_id)',
+      );
+    }
+
+    const data = await this.repo.catalogActivationPlan(brandPmId);
+
+    const c = data.categories;
+    this.logger.log(
+      `[ACTIVATION_PLAN] brand=${brandPmId} sellable=${data.sellable_priced} ` +
+        `visible=${c.already_visible} display_gated=${c.display_gated} accessory=${c.accessory} ` +
+        `gamme_inactive=${c.gamme_inactive} orphan_oem=${c.orphan_with_oem} orphan_no_source=${c.orphan_no_source} ` +
+        `universal_candidates=${data.universal_candidates.length}`,
+    );
+    return data;
+  }
+}

--- a/backend/src/modules/pricing/services/catalog-activation-plan.service.ts
+++ b/backend/src/modules/pricing/services/catalog-activation-plan.service.ts
@@ -32,8 +32,13 @@ export interface ActivationPlanCategories {
   orphan_no_source: number;
 }
 
-/** A gamme proposed as "universal section" candidate (orphan + no-OEM), for owner confirmation. */
-export interface UniversalCandidate {
+/**
+ * A gamme grouping the brand's orphan + no-OEM pieces (no fitment source).
+ * NOT auto-universal: a genuinely universal gamme is a CATALOG-level property
+ * (curated registry: ~0 vehicle fitment + consumable nature), detected separately —
+ * not inferred per-brand from "orphan + no OEM". This list is a follow-up hint only.
+ */
+export interface OrphanGammeGroup {
   pg_id: number;
   pg_name: string | null;
   pieces: number;
@@ -43,7 +48,7 @@ export interface ActivationPlan {
   brand_pm_id: number;
   sellable_priced: number;
   categories: ActivationPlanCategories;
-  universal_candidates: UniversalCandidate[];
+  orphan_no_source_by_gamme: OrphanGammeGroup[];
 }
 
 @Injectable()
@@ -70,7 +75,7 @@ export class CatalogActivationPlanService {
       `[ACTIVATION_PLAN] brand=${brandPmId} sellable=${data.sellable_priced} ` +
         `visible=${c.already_visible} display_gated=${c.display_gated} accessory=${c.accessory} ` +
         `gamme_inactive=${c.gamme_inactive} orphan_oem=${c.orphan_with_oem} orphan_no_source=${c.orphan_no_source} ` +
-        `universal_candidates=${data.universal_candidates.length}`,
+        `orphan_no_source_gammes=${data.orphan_no_source_by_gamme.length}`,
     );
     return data;
   }

--- a/backend/src/modules/pricing/services/price-import.service.ts
+++ b/backend/src/modules/pricing/services/price-import.service.ts
@@ -31,6 +31,8 @@ import {
   CatalogActivationPlanService,
   type ActivationPlan,
 } from './catalog-activation-plan.service';
+import { CatalogDisplayActivationService } from './catalog-display-activation.service';
+import { FeatureFlagsService } from '../../../config/feature-flags.service';
 
 const CHUNK_SIZE = 5000;
 
@@ -59,6 +61,8 @@ export class PriceImportService {
   constructor(
     private readonly repo: PricingRepository,
     private readonly activationPlan: CatalogActivationPlanService,
+    private readonly displayActivation: CatalogDisplayActivationService,
+    private readonly flags: FeatureFlagsService,
   ) {}
 
   private hashRows(rows: Record<string, string>[]): string {
@@ -180,6 +184,7 @@ export class PriceImportService {
     skipped: number;
     missing: number;
     activationPlan: ActivationPlan | null;
+    displayActivation: { eligible: number; applied: boolean } | null;
   }> {
     const lines = await this.buildLines(req);
     const linesByKey = new Map(lines.map((l) => [l.key, l]));
@@ -260,6 +265,7 @@ export class PriceImportService {
     // commit: the price commit already succeeded, so a verification error is logged only
     // (no silent fallback) and returns a null plan.
     let activationPlan: ActivationPlan | null = null;
+    let displayActivation: { eligible: number; applied: boolean } | null = null;
     const brandPmIdNum = Number(req.brandPmId);
     if (Number.isInteger(brandPmIdNum) && brandPmIdNum > 0) {
       try {
@@ -269,13 +275,40 @@ export class PriceImportService {
           `[PRICING_IMPORT] activation verification failed batchId=${batchId} brand=${req.brandPmId}: ${(e as Error).message}`,
         );
       }
+
+      // T3 — AUTO-APPLY (governed kill-switch CATALOG_AUTO_ACTIVATE, default OFF).
+      // ALWAYS dry-run the display activation (read-only: what WOULD become visible).
+      // Only when the flag is ON do we COMMIT it — flip piece_display for the brand's
+      // vendable-but-hidden refs via the governed catalog_display_activate primitive
+      // (#880, respects FROZEN / quarantine #884). Never fails the commit (price already
+      // committed); a failure is logged (no silent fallback) and leaves applied=false.
+      try {
+        const dry = await this.displayActivation.dryRun(req.brandPmId);
+        let applied = false;
+        if (this.flags.catalogAutoActivateEnabled && dry.eligible > 0) {
+          await this.displayActivation.commit({
+            supplierId: req.brandPmId,
+            operator: req.operator ?? null,
+            confirm: true,
+          });
+          applied = true;
+          this.logger.log(
+            `[PRICING_IMPORT] auto-activate APPLIED batchId=${batchId} brand=${req.brandPmId} eligible=${dry.eligible}`,
+          );
+        }
+        displayActivation = { eligible: dry.eligible, applied };
+      } catch (e) {
+        this.logger.error(
+          `[PRICING_IMPORT] auto-activate failed batchId=${batchId} brand=${req.brandPmId}: ${(e as Error).message}`,
+        );
+      }
     } else {
       this.logger.warn(
         `[PRICING_IMPORT] activation verification skipped batchId=${batchId}: brandPmId="${req.brandPmId}" is not a positive integer`,
       );
     }
 
-    return { ...totals, activationPlan };
+    return { ...totals, activationPlan, displayActivation };
   }
 
   async rollback(

--- a/backend/src/modules/pricing/services/price-import.service.ts
+++ b/backend/src/modules/pricing/services/price-import.service.ts
@@ -27,6 +27,10 @@ import {
   type PricingRule,
 } from './pricing-strategy.service';
 import { PricingRepository, type CommitRowPayload } from './pricing.repository';
+import {
+  CatalogActivationPlanService,
+  type ActivationPlan,
+} from './catalog-activation-plan.service';
 
 const CHUNK_SIZE = 5000;
 
@@ -52,7 +56,10 @@ export interface ImportRequest {
 export class PriceImportService {
   private readonly logger = new Logger(PriceImportService.name);
 
-  constructor(private readonly repo: PricingRepository) {}
+  constructor(
+    private readonly repo: PricingRepository,
+    private readonly activationPlan: CatalogActivationPlanService,
+  ) {}
 
   private hashRows(rows: Record<string, string>[]): string {
     return createHash('sha256').update(JSON.stringify(rows)).digest('hex');
@@ -168,7 +175,12 @@ export class PriceImportService {
   async commit(
     batchId: string,
     req: ImportRequest,
-  ): Promise<{ committed: number; skipped: number; missing: number }> {
+  ): Promise<{
+    committed: number;
+    skipped: number;
+    missing: number;
+    activationPlan: ActivationPlan | null;
+  }> {
     const lines = await this.buildLines(req);
     const linesByKey = new Map(lines.map((l) => [l.key, l]));
     const report = await this.computeReport(req, lines);
@@ -239,7 +251,31 @@ export class PriceImportService {
       );
       throw e;
     }
-    return totals;
+
+    // AUTO catalog-activation verification (read-only) — runs at EVERY tariff commit
+    // ("au fur et à mesure des mises à jour tarif"). Classifies the just-committed brand:
+    // what's recoverable (display-gated / accessory / gamme-inactive / orphan) +
+    // orphan-no-source gammes. READ-ONLY: no catalog mutation here (the actual activation
+    // — display flip, universal section, fitment — are governed steps). Never fails the
+    // commit: the price commit already succeeded, so a verification error is logged only
+    // (no silent fallback) and returns a null plan.
+    let activationPlan: ActivationPlan | null = null;
+    const brandPmIdNum = Number(req.brandPmId);
+    if (Number.isInteger(brandPmIdNum) && brandPmIdNum > 0) {
+      try {
+        activationPlan = await this.activationPlan.plan(brandPmIdNum);
+      } catch (e) {
+        this.logger.error(
+          `[PRICING_IMPORT] activation verification failed batchId=${batchId} brand=${req.brandPmId}: ${(e as Error).message}`,
+        );
+      }
+    } else {
+      this.logger.warn(
+        `[PRICING_IMPORT] activation verification skipped batchId=${batchId}: brandPmId="${req.brandPmId}" is not a positive integer`,
+      );
+    }
+
+    return { ...totals, activationPlan };
   }
 
   async rollback(

--- a/backend/src/modules/pricing/services/pricing.repository.ts
+++ b/backend/src/modules/pricing/services/pricing.repository.ts
@@ -12,6 +12,7 @@ import type { CatalogPiece, ExistingPriceRow } from './price-import.dry-run';
 import type { SupplierPriceProfile } from './supplier-profile.service';
 import type { PricingRule } from './pricing-strategy.service';
 import type { CostBucketAggregate } from './pricing-simulation.core';
+import type { ActivationPlan } from './catalog-activation-plan.service';
 
 const PAGE = 1000; // supabase-js caps a single select at 1000 rows → paginate
 
@@ -32,6 +33,20 @@ export interface CommitRowPayload {
 export class PricingRepository extends SupabaseBaseService {
   constructor(configService: ConfigService) {
     super(configService);
+  }
+
+  /**
+   * READ-ONLY activation plan for a brand batch (T1). Drives the STABLE RPC
+   * `catalog_activation_plan` — classifies sellable-priced pieces + proposes
+   * universal candidates. No writes. See migration
+   * 20260608_pricing_catalog_activation_plan.sql.
+   */
+  async catalogActivationPlan(brandPmId: number): Promise<ActivationPlan> {
+    const { data, error } = await this.callRpc('catalog_activation_plan', {
+      p_brand_pm_id: brandPmId,
+    });
+    if (error) throw error;
+    return data as ActivationPlan;
   }
 
   /** Idempotency: an identical file (same hash) already imported? */

--- a/backend/supabase/migrations/20260608_pricing_catalog_activation_plan.sql
+++ b/backend/supabase/migrations/20260608_pricing_catalog_activation_plan.sql
@@ -1,0 +1,80 @@
+-- =====================================================
+-- catalog_activation_plan — passe d'activation catalogue (T1, READ-ONLY / dry-run)
+-- Date: 2026-06-08
+--
+-- ROLE: classifieur read-only de la « passe d'activation » du pipeline tarif (design
+--   audit/orphan-price-and-universal-section-design-2026-06-08.md §5bis). Pour un
+--   batch tarif (= marque `pieces.piece_pm_id`), classe les pièces PRIX-VENDABLE
+--   (pieces_price : pri_dispo IN '1','2','3' AND pri_vente_ttc>0) en :
+--     already_visible / display_gated / accessory / gamme_inactive /
+--     orphan_with_oem / orphan_no_source
+--   et propose des `universal_candidates` (gammes orphelines sans OEM = candidates
+--   « section universelle », à confirmer par l'owner — construction au fur et à mesure).
+--
+-- AUCUNE écriture (STABLE). Émet seulement un PLAN. Les mutations (activation display,
+--   tag universel, fitment) sont des étapes SÉPARÉES owner-gated (T2-T4). Casts/guards
+--   alignés sur get_listing_products_extended (live) + validés sur marque réelle.
+--
+-- ⚠️ NON appliquée automatiquement — owner-gated. Read-only, donc apply sans risque
+--   data ; à appliquer pour exposer l'endpoint /api/admin/pricing/activation/plan.
+-- =====================================================
+
+set lock_timeout = '2s';
+set statement_timeout = '60s';
+
+CREATE OR REPLACE FUNCTION catalog_activation_plan(p_brand_pm_id integer)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+AS $$
+  WITH brand_pieces AS (
+    SELECT p.piece_id, p.piece_pg_id, p.piece_pg_pid, p.piece_has_oem, p.piece_display
+    FROM pieces p
+    WHERE NULLIF(p.piece_pm_id::text, '')::int = p_brand_pm_id
+  ),
+  sellable AS (
+    SELECT bp.*
+    FROM brand_pieces bp
+    WHERE EXISTS (
+      SELECT 1 FROM pieces_price pr
+      WHERE NULLIF(pr.pri_piece_id, '')::int = bp.piece_id
+        AND pr.pri_dispo IN ('1', '2', '3')
+        AND NULLIF(TRIM(pr.pri_vente_ttc), '')::numeric > 0
+    )
+  ),
+  classified AS (
+    SELECT s.piece_id, s.piece_pg_id, s.piece_pg_pid, s.piece_has_oem, s.piece_display,
+           EXISTS (SELECT 1 FROM pieces_relation_type r WHERE r.rtp_piece_id = s.piece_id) AS has_link,
+           g.pg_display AS gd
+    FROM sellable s
+    LEFT JOIN pieces_gamme g ON g.pg_id = s.piece_pg_id
+  ),
+  cand AS (
+    SELECT c.piece_pg_id, gg.pg_name, count(*) AS n
+    FROM classified c
+    LEFT JOIN pieces_gamme gg ON gg.pg_id = c.piece_pg_id
+    WHERE NOT c.has_link AND NOT c.piece_has_oem
+    GROUP BY c.piece_pg_id, gg.pg_name
+    ORDER BY count(*) DESC
+    LIMIT 50
+  )
+  SELECT jsonb_build_object(
+    'brand_pm_id', p_brand_pm_id,
+    'sellable_priced', (SELECT count(*) FROM classified),
+    'categories', jsonb_build_object(
+      'already_visible',   (SELECT count(*) FROM classified WHERE has_link AND piece_display AND gd = '1'),
+      'display_gated',     (SELECT count(*) FROM classified WHERE has_link AND NOT piece_display),
+      'accessory',         (SELECT count(*) FROM classified WHERE piece_pg_pid IS NOT NULL AND piece_pg_pid <> 0 AND piece_pg_pid <> piece_pg_id),
+      'gamme_inactive',    (SELECT count(*) FROM classified WHERE has_link AND gd IS DISTINCT FROM '1'),
+      'orphan_with_oem',   (SELECT count(*) FROM classified WHERE NOT has_link AND piece_has_oem),
+      'orphan_no_source',  (SELECT count(*) FROM classified WHERE NOT has_link AND NOT piece_has_oem)
+    ),
+    'universal_candidates', COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object('pg_id', piece_pg_id, 'pg_name', pg_name, 'pieces', n)) FROM cand),
+      '[]'::jsonb
+    )
+  );
+$$;
+
+COMMENT ON FUNCTION catalog_activation_plan(integer) IS
+  'READ-ONLY (STABLE) activation/orphan-recovery classifier for a brand batch (pieces.piece_pm_id). Classes sellable-priced pieces into already_visible/display_gated/accessory/gamme_inactive/orphan_with_oem/orphan_no_source + proposes universal_candidates (orphan + no-OEM gammes). NO writes — emits a dry-run plan only. Feeds the governed activation pipeline (T1). Mutations are separate owner-gated steps.';

--- a/backend/supabase/migrations/20260608_pricing_catalog_activation_plan.sql
+++ b/backend/supabase/migrations/20260608_pricing_catalog_activation_plan.sql
@@ -69,7 +69,7 @@ AS $$
       'orphan_with_oem',   (SELECT count(*) FROM classified WHERE NOT has_link AND piece_has_oem),
       'orphan_no_source',  (SELECT count(*) FROM classified WHERE NOT has_link AND NOT piece_has_oem)
     ),
-    'universal_candidates', COALESCE(
+    'orphan_no_source_by_gamme', COALESCE(
       (SELECT jsonb_agg(jsonb_build_object('pg_id', piece_pg_id, 'pg_name', pg_name, 'pieces', n)) FROM cand),
       '[]'::jsonb
     )

--- a/backend/supabase/migrations/20260608_pricing_catalog_universal_gammes.sql
+++ b/backend/supabase/migrations/20260608_pricing_catalog_universal_gammes.sql
@@ -1,0 +1,49 @@
+-- =====================================================
+-- catalog_universal_gammes — set des gammes UNIVERSELLES (T2a, READ-ONLY)
+-- Date: 2026-06-08
+--
+-- ROLE: source de la « section Produits universels ». Retourne les gammes
+--   universelles = SANS aucun fitment véhicule (`pieces_relation_type` vide) + ayant
+--   des pièces VENDABLES (prix+dispo) + de NATURE consommable/visserie/fluide/joint.
+--   Ce sont des produits vendus SANS véhicule (≈86 gammes, ≈3 531 pièces vendables
+--   aujourd'hui invisibles). Les gammes sans fitment mais véhicule-spécifiques
+--   (capteur, rotor, électrovanne… = avec OEM, à fitter) sont EXCLUES.
+--
+-- AUCUNE écriture (STABLE). « Curation au fur et à mesure » = la règle classe
+--   automatiquement à chaque appel ; un futur override owner (table/flag, quand le
+--   glob ownership sera ouvert) viendra raffiner les exceptions et SUPERSEDER cette
+--   heuristique de nom (V1 documentée — PAS un magic-constant runtime définitif).
+--
+-- ⚠️ NON appliquée automatiquement — owner-gated. Read-only → apply data-safe.
+-- =====================================================
+
+set lock_timeout = '2s';
+set statement_timeout = '60s';
+
+CREATE OR REPLACE FUNCTION catalog_universal_gammes()
+RETURNS TABLE(pg_id integer, pg_name text, pg_alias text, pg_display text, sellable_pieces bigint)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT g.pg_id, g.pg_name, g.pg_alias, g.pg_display,
+    count(p.piece_id) FILTER (
+      WHERE EXISTS (SELECT 1 FROM pieces_price pr
+        WHERE NULLIF(pr.pri_piece_id, '')::int = p.piece_id
+          AND pr.pri_dispo IN ('1','2','3') AND NULLIF(TRIM(pr.pri_vente_ttc), '')::numeric > 0)
+    ) AS sellable_pieces
+  FROM pieces_gamme g
+  JOIN pieces p ON p.piece_pg_id = g.pg_id
+  WHERE NOT EXISTS (SELECT 1 FROM pieces_relation_type r WHERE r.rtp_pg_id = g.pg_id)
+    -- nature consommable / visserie / fluide / joint (V1 seed heuristic, owner-overridable)
+    AND LOWER(g.pg_name) ~ '(liquide|antigel|additif|nettoyant|graisse|lubrifiant|spray|entretien|substance|[ée]tanch|colle|silicone|fluide|bague|joint|vis|[eé]crou|rondelle|collier|clip|rivet|ressort|fusible|cosse|douille|manchon|raccord|bouchon|capuchon|connecteur|fiche|relais|goupille|circlip|durite|tuyau|gaine|assortiment|patte|attache)'
+  GROUP BY g.pg_id, g.pg_name, g.pg_alias, g.pg_display
+  HAVING count(p.piece_id) FILTER (
+      WHERE EXISTS (SELECT 1 FROM pieces_price pr
+        WHERE NULLIF(pr.pri_piece_id, '')::int = p.piece_id
+          AND pr.pri_dispo IN ('1','2','3') AND NULLIF(TRIM(pr.pri_vente_ttc), '')::numeric > 0)
+    ) > 0
+  ORDER BY sellable_pieces DESC;
+$$;
+
+COMMENT ON FUNCTION catalog_universal_gammes() IS
+  'READ-ONLY (STABLE) set of UNIVERSAL gammes for the "Produits universels" section: no vehicle fitment + sellable pieces (prix+dispo) + consumable/hardware/fluid nature. Sold without a vehicle. V1 seed heuristic (name-based), owner-overridable later (no fabricated fitment). Feeds the universal section + the governed activation pipeline.';

--- a/log.md
+++ b/log.md
@@ -412,3 +412,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-r3-consolidation-evidence`
 - **Décision** : feat(seo): read-only GSC-backed R3 consolidation evidence matrix (10-gamme pilot)
 - **Sortie** : PR aucune | commits ca0232d4c
+
+## 2026-06-08 — feat/catalog-activation-plan (auto)
+
+- **Branche** : `feat/catalog-activation-plan`
+- **Décision** : feat(pricing): catalog activation plan (T1) — read-only orphan/activation classifier
+- **Sortie** : PR #901 | commits 11b8a77b8

--- a/log.md
+++ b/log.md
@@ -424,3 +424,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/catalog-activation-plan`
 - **Décision** : feat(pricing): auto-run activation verification at each tariff commit (+2 other commits)
 - **Sortie** : PR #901 | commits 327c43402 12ded3a7b 11b8a77b8
+
+## 2026-06-08 — feat/catalog-activation-plan (auto)
+
+- **Branche** : `feat/catalog-activation-plan`
+- **Décision** : feat(pricing): catalog_universal_gammes() — read-only universal-section source (T2a) (+4 other commits)
+- **Sortie** : PR #901 | commits 978bf889d 2601ab61b 327c43402 12ded3a7b 11b8a77b8

--- a/log.md
+++ b/log.md
@@ -418,3 +418,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/catalog-activation-plan`
 - **Décision** : feat(pricing): catalog activation plan (T1) — read-only orphan/activation classifier
 - **Sortie** : PR #901 | commits 11b8a77b8
+
+## 2026-06-08 — feat/catalog-activation-plan (auto)
+
+- **Branche** : `feat/catalog-activation-plan`
+- **Décision** : feat(pricing): auto-run activation verification at each tariff commit (+2 other commits)
+- **Sortie** : PR #901 | commits 327c43402 12ded3a7b 11b8a77b8


### PR DESCRIPTION
## Pourquoi

Premier maillon (read-only) du **pipeline d'activation catalogue gouverné** qui récupère, **au fur et à mesure des mises à jour tarif**, le stock payé mais invisible (prix existant non rattaché / caché). Design complet : `audit/orphan-price-and-universal-section-design-2026-06-08.md`.

Le pipeline tarif pose déjà `pri_dispo='1'` au commit, mais ne crée pas le lien gamme×véhicule, ne gère pas les universelles, n'active pas la gamme. Audit MECE (vérifié) : **431 125** pièces prix-vendable → **29 576 orphelines** (aucun lien) + **8 951** cachées malgré prix. La gamme est **toujours** connue (`piece_pg_id`) ; le gap = véhicule + affichage.

## Ce que fait cette PR (T1 — 0 mutation)

Pour un batch tarif (= une marque `pieces.piece_pm_id`), classe les pièces prix-vendable et émet un **plan dry-run** :

| catégorie | sens | action (tranche ultérieure) |
|---|---|---|
| `already_visible` | lien + display + gamme active | — |
| `display_gated` | lien OK, `piece_display=false` | activer display (T3) |
| `accessory` | `piece_pg_pid ≠ piece_pg_id` | rattacher parent (natif) |
| `gamme_inactive` | gamme `pg_display≠1` | activer gamme (T3) |
| `orphan_with_oem` | orphelin + OEM | fitment OEM→véhicule (T4, validé) |
| `orphan_no_source` | orphelin sans OEM | universel candidat / bloqué |

+ `universal_candidates` (gammes orphelines sans OEM) → la liste de la **section universelle** se cure **incrémentalement**, pas en gros batch manuel.

## Contenu

- **Migration** `20260608_pricing_catalog_activation_plan.sql` : RPC `catalog_activation_plan(p_brand_pm_id)` **STABLE (read-only)** → jsonb. squawk **0 issue**. **NON appliquée** (owner-gated ; read-only donc apply sans risque data). Casts/guards alignés sur `get_listing_products_extended` live.
- **Service** `CatalogActivationPlanService` + `PricingRepository.catalogActivationPlan` (via `callRpc`).
- **Endpoint** `POST /api/admin/pricing/activation/plan { brandPmId }` (`IsAdminGuard`).
- **Test** unitaire (repo mocké) **6/6**.

## Vérifs

- **SQL validé live** sur marque réelle (BOSCH pm_id 730) : 21 417 prix-vendable → 16 373 visible / 285 gated / 309 accessory / 407 gamme-inactive / 4 635 orphelins (2 454 OEM, 2 181 sans source).
- `tsc --noEmit` : **0 erreur**. squawk : **0**. jest : **6/6**.

## Invariants / NO-GO

- **Aucune écriture** — émet seulement un plan. Mutations = tranches **T2-T4 owner-gated**.
- **Jamais de fitment inventé** (OEM/TecDoc source obligatoire). Jamais de flip display en aveugle (respect quarantaine #884).
- Réutilise les primitives gouvernées existantes — **pas de système parallèle**.

## Apply

La RPC est **read-only** : à appliquer (owner-gated, data-safe) pour que l'endpoint réponde. Tant qu'elle n'est pas appliquée, l'endpoint admin renverra une erreur RPC inexistante (aucun impact runtime public).

🤖 Generated with [Claude Code](https://claude.com/claude-code)