### PR TITLE
feat(seo): selectV2Tier — câble validateV2Promotion (cut V2) dans les 2 calculateurs canoniques

### DIFF
--- a/backend/src/modules/admin/services/gamme-vlevel.service.ts
+++ b/backend/src/modules/admin/services/gamme-vlevel.service.ts
@@ -16,6 +16,7 @@ import {
   vLevelGroupKey,
   compareV3Champions,
   isKeywordEligibleForGamme,
+  selectV2Tier,
 } from '@repo/seo-roles';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 
@@ -239,27 +240,66 @@ export class GammeVLevelService extends SupabaseBaseService {
         }
       }
 
-      // 6. Promote top 10 V3 -> V2 (dedup by [model + energy])
-      // Même tie-break déterministe que l'in-group (cut V2 reproductible aux volumes ex-aequo).
+      // 6. Promote top-CAP V3 -> V2 via la SoT du cut (selectV2Tier, @repo/seo-roles).
+      // Même tie-break déterministe que l'in-group (cut V2 reproductible aux volumes ex-aequo)
+      // PUIS garde-fous objectifs validateV2Promotion : un champion type_id NULL ou à énergie
+      // incohérente (mot-clé gasoil ↔ véhicule essence) N'est PAS promu — il reste V3. Plafond
+      // sans backfill (« moins de V2 mais propres », owner 2026-06-08). Invariant V2 ⟹ V3.
       v3Champions.sort(compareV3Champions);
-      const seenModelEnergy = new Set<string>();
-      const top10: VLevelKeywordRow[] = [];
-      for (const kw of v3Champions) {
-        // Même clé canonique que le groupement (plus de divergence group/dedup en casse).
-        const modelEnergy = vLevelGroupKey(kw.model, kw.energy, {
-          gammeUniverselle,
-        });
-        if (seenModelEnergy.has(modelEnergy)) continue;
-        seenModelEnergy.add(modelEnergy);
-        top10.push(kw);
-        if (top10.length >= VLEVEL_V2_CAP) break;
+
+      // Énergie réelle du véhicule (auto_type.type_fuel) pour détecter energy_mismatch au cut.
+      const championTypeIds = [
+        ...new Set(
+          v3Champions
+            .map((c) => c.type_id)
+            .filter(Boolean)
+            .map(Number),
+        ),
+      ];
+      const championFuelMap = new Map<number, string>();
+      for (let i = 0; i < championTypeIds.length; i += 100) {
+        const batch = championTypeIds.slice(i, i + 100);
+        const { data: types } = await this.supabase
+          .from('auto_type')
+          .select('type_id, type_fuel')
+          .in('type_id', batch.map(String));
+        if (types) {
+          for (const t of types) {
+            if (t.type_fuel)
+              championFuelMap.set(Number(t.type_id), t.type_fuel);
+          }
+        }
       }
-      const top10Ids = new Set(top10.map((c) => c.id));
+
+      const { v2: v2Champions, rejected: v2Rejected } = selectV2Tier(
+        v3Champions,
+        VLEVEL_V2_CAP,
+        (kw) => vLevelGroupKey(kw.model, kw.energy, { gammeUniverselle }),
+        (kw) => ({
+          isChampion: true, // par construction : kw provient de v3Champions (champion in-group)
+          typeId: kw.type_id,
+          keywordEnergy: kw.keyword, // hint énergie depuis le TEXTE du mot-clé (ex. « gasoil »)
+          vehicleEnergy: kw.type_id
+            ? (championFuelMap.get(Number(kw.type_id)) ?? null)
+            : null,
+        }),
+      );
+      const v2Ids = new Set(v2Champions.map((c) => c.id));
 
       for (const update of updates) {
-        if (top10Ids.has(update.id)) {
+        if (v2Ids.has(update.id)) {
           update.v_level = 'V2';
         }
+      }
+
+      if (v2Rejected.length > 0) {
+        // No silent fallback : on TRACE les champions élite recalés (restent V3, pas promus).
+        this.logger.log(
+          `V2 cut gamme ${pgId}: ${v2Rejected.length} champion(s) élite recalé(s) (restent V3) — ` +
+            v2Rejected
+              .map((r) => `"${r.champion.keyword}" [${r.violations.join(',')}]`)
+              .join('; '),
+        );
       }
 
       // 7. Non-vehicle + generic vehicle + cross-gamme keywords: clear v_level

--- a/packages/seo-roles/src/__tests__/vlevel-invariants.test.ts
+++ b/packages/seo-roles/src/__tests__/vlevel-invariants.test.ts
@@ -22,6 +22,7 @@ import {
   VLEVEL_PAGE_DISPATCH,
   VLEVEL_V2_PROMOTION,
   validateV2Promotion,
+  selectV2Tier,
   V_GROUP_KEY,
   vLevelGroupKey,
   compareV3Champions,
@@ -290,5 +291,90 @@ describe("Promotion V2 — invariant DUR « V2 ⟹ V3 » + affinage (on commence
     });
     assert.ok(!r.violations.includes("energy_mismatch"));
     assert.equal(r.ok, true);
+  });
+});
+
+describe("selectV2Tier — SoT du cut V2 (plafond sans backfill, V2 ⟹ V3 + garde-fous objectifs)", () => {
+  // Champion minimal tel que fourni par les 2 calculateurs canoniques (service recalc + pipeline).
+  type Champ = {
+    id: number;
+    keyword: string;
+    model: string;
+    energy: string;
+    type_id: string | number | null;
+    vehicleFuel: string | null; // auto_type.type_fuel, résolu par l'appelant (pas par selectV2Tier)
+  };
+  const groupKeyOf = (c: Champ) => vLevelGroupKey(c.model, c.energy);
+  // Miroir EXACT de la projection des calculateurs : keywordEnergy = TEXTE du mot-clé.
+  const toCandidate = (c: Champ) => ({
+    isChampion: true as const,
+    typeId: c.type_id,
+    keywordEnergy: c.keyword,
+    vehicleEnergy: c.vehicleFuel,
+  });
+  const champ = (over: Partial<Champ> & { id: number }): Champ => ({
+    keyword: `kw${over.id}`,
+    model: `model${over.id}`,
+    energy: "diesel",
+    type_id: String(1000 + over.id),
+    vehicleFuel: "Diesel",
+    ...over,
+  });
+
+  test("données propres : v2 = top-cap, aucun recalé (comportement préservé)", () => {
+    const champs = [champ({ id: 1 }), champ({ id: 2 }), champ({ id: 3 })];
+    const { v2, rejected } = selectV2Tier(champs, 10, groupKeyOf, toCandidate);
+    assert.deepEqual(v2.map((c) => c.id), [1, 2, 3]);
+    assert.equal(rejected.length, 0);
+  });
+
+  test("plafond, pas quota : invalide DANS le top-cap retiré SANS backfill (cap 3 → 2)", () => {
+    const champs = [
+      champ({ id: 1 }),
+      champ({ id: 2, type_id: null }), // unresolved_vehicle, dans le top-3
+      champ({ id: 3 }),
+      champ({ id: 4 }), // hors top-cap : ne doit PAS remonter combler le trou
+    ];
+    const { v2, rejected } = selectV2Tier(champs, 3, groupKeyOf, toCandidate);
+    assert.deepEqual(v2.map((c) => c.id), [1, 3], "v2 = valides du top-3, sans backfill de c4");
+    assert.equal(v2.length, 2, "« moins de V2 mais propres » (pas re-rempli à 3)");
+    assert.ok(!v2.some((c) => c.id === 4), "c4 (rang > cap) jamais promu");
+    assert.deepEqual(rejected.map((r) => r.champion.id), [2]);
+    assert.ok(rejected[0].violations.includes("unresolved_vehicle"));
+  });
+
+  test("energy_mismatch : « filtre a gasoil duster » sur véhicule essence → recalé (reste V3)", () => {
+    const duster = champ({
+      id: 9,
+      keyword: "filtre a gasoil duster",
+      model: "duster",
+      energy: "diesel",
+      type_id: "77163",
+      vehicleFuel: "Essence",
+    });
+    const { v2, rejected } = selectV2Tier([duster], 10, groupKeyOf, toCandidate);
+    assert.equal(v2.length, 0);
+    assert.equal(rejected.length, 1);
+    assert.ok(rejected[0].violations.includes("energy_mismatch"));
+  });
+
+  test("dédup défensive : 1 V2 max par groupe [model+energy]", () => {
+    const a = champ({ id: 1, model: "clio", energy: "diesel" });
+    const b = champ({ id: 2, model: "clio", energy: "diesel" }); // même groupe
+    const { v2 } = selectV2Tier([a, b], 10, groupKeyOf, toCandidate);
+    assert.deepEqual(v2.map((c) => c.id), [1], "le 2e du même groupe n'entre pas dans l'élite");
+  });
+
+  test("plafond respecté : jamais plus de cap V2, même avec surplus de champions valides", () => {
+    const champs = Array.from({ length: 15 }, (_, i) => champ({ id: i + 1 }));
+    const { v2 } = selectV2Tier(champs, VLEVEL_V2_CAP, groupKeyOf, toCandidate);
+    assert.equal(v2.length, VLEVEL_V2_CAP);
+  });
+
+  test("PURE : n'altère pas le tableau d'entrée", () => {
+    const champs = [champ({ id: 1 }), champ({ id: 2, type_id: null })];
+    const snapshot = champs.map((c) => c.id);
+    selectV2Tier(champs, 10, groupKeyOf, toCandidate);
+    assert.deepEqual(champs.map((c) => c.id), snapshot);
   });
 });

--- a/packages/seo-roles/src/index.ts
+++ b/packages/seo-roles/src/index.ts
@@ -104,6 +104,8 @@ export {
   type V2PromotionCandidate,
   type V2Violation,
   validateV2Promotion,
+  type V2TierSelection,
+  selectV2Tier,
   V_GROUP_KEY,
   vLevelGroupKey,
   compareV3Champions,

--- a/packages/seo-roles/src/vlevel-invariants.ts
+++ b/packages/seo-roles/src/vlevel-invariants.ts
@@ -204,6 +204,70 @@ export function validateV2Promotion(c: V2PromotionCandidate): {
   return { ok: violations.length === 0, violations };
 }
 
+/** Résultat de la sélection du tier V2 — cf. {@link selectV2Tier}. */
+export interface V2TierSelection<T> {
+  /** Champions promus V2 : sous-ensemble VALIDE des top-`cap` champions élite. */
+  readonly v2: readonly T[];
+  /**
+   * Champions élite (dans le top-`cap`) REJETÉS de V2 et leurs violations. Ils restent
+   * V3 (ils demeurent le champion de leur groupe) — la démotion en V4 + ré-élection est
+   * un job de recalc séparé, owner-gated. Exposé pour l'observabilité (log/decision-pack).
+   */
+  readonly rejected: ReadonlyArray<{
+    readonly champion: T;
+    readonly violations: readonly V2Violation[];
+  }>;
+}
+
+/**
+ * Sélectionne le tier V2 = sous-ensemble VALIDE des top-`cap` champions élite.
+ *
+ * SoT UNIQUE du cut V2 : les calculateurs canoniques (`gamme-vlevel.service` recalc admin +
+ * `scripts/seo/vlevel-v3-pipeline` reelection-pack) l'appellent au lieu de dupliquer la boucle
+ * — ils ne peuvent donc plus diverger. Applique l'invariant `V2 ⟹ V3` + les garde-fous OBJECTIFS
+ * ({@link validateV2Promotion}) AU MOMENT DE LA PROMOTION.
+ *
+ * `cap` = PLAFOND, PAS quota : on prend les top-`cap` champions élite (dédupliqués par groupe),
+ * PUIS on retire ceux qui échouent {@link validateV2Promotion}. AUCUN backfill par des champions
+ * de rang inférieur (« moins de V2 mais propres », règle owner 2026-06-08 : air 10→8). Un champion
+ * rejeté RESTE V3 (cf. {@link V2TierSelection.rejected}).
+ *
+ * Pré-condition : `sortedChampions` DOIT être trié par {@link compareV3Champions} (volume DESC →
+ * longueur ASC → keyword ASC) — l'appelant le garantit (même tie-break que l'élection in-group).
+ * PURE & déterministe. NE MUTE RIEN. NE LIT PAS la DB (l'appelant fournit `toCandidate`).
+ *
+ * @param sortedChampions champions V3 (1 par groupe) déjà triés canoniquement.
+ * @param cap plafond du tier V2 ({@link VLEVEL_V2_CAP}).
+ * @param groupKeyOf clé de groupe `[modèle+énergie]` ({@link vLevelGroupKey}) — dédup défensive.
+ * @param toCandidate projette un champion en {@link V2PromotionCandidate} (isChampion=true).
+ */
+export function selectV2Tier<T>(
+  sortedChampions: readonly T[],
+  cap: number,
+  groupKeyOf: (champion: T) => string,
+  toCandidate: (champion: T) => V2PromotionCandidate,
+): V2TierSelection<T> {
+  // 1. Pool élite = top-`cap` champions dédupliqués par groupe (1 V2 max / [modèle+énergie]).
+  const seenGroup = new Set<string>();
+  const elite: T[] = [];
+  for (const champion of sortedChampions) {
+    const key = groupKeyOf(champion);
+    if (seenGroup.has(key)) continue;
+    seenGroup.add(key);
+    elite.push(champion);
+    if (elite.length >= cap) break;
+  }
+  // 2. V2 = sous-ensemble VALIDE du pool élite. Pas de backfill (plafond, pas quota).
+  const v2: T[] = [];
+  const rejected: Array<{ champion: T; violations: readonly V2Violation[] }> = [];
+  for (const champion of elite) {
+    const { ok, violations } = validateV2Promotion(toCandidate(champion));
+    if (ok) v2.push(champion);
+    else rejected.push({ champion, violations });
+  }
+  return { v2, rejected };
+}
+
 /**
  * Classement V-Level (figé 2026-06-08, owner-validé).
  *
@@ -355,7 +419,7 @@ export const V_LEVEL_KNOWN_GAPS: readonly VLevelKnownGap[] = [
   {
     id: "v2-promotion-not-affined",
     description:
-      "Le cut V2 = top-N volume brut, sans les garde-fous d'affinage (validateV2Promotion) : il remplit le cap avec des entrées type_id NULL, à énergie incohérente (mot-clé gasoil → véhicule essence) ou à volume-plancher. Observé sur filtre-à-carburant 2026-06-08 (Duster essence 2025 en V2). Câbler validateV2Promotion dans l'élection + recalc owner-gated before/after.",
+      "CÂBLÉ (selectV2Tier, SoT unique du cut V2) dans les 2 calculateurs canoniques (gamme-vlevel.service recalc + vlevel-v3-pipeline reelection-pack) : le cut applique désormais validateV2Promotion (type_id résolu + énergie cohérente), plafond sans backfill. RESTE owner-gated : (a) recalc before/after pour appliquer aux données existantes (ex. filtre-carburant Duster essence 2025) ; (b) scripts/insert-missing-keywords.ts (import CSV) garde tri/dedup NON-canoniques (énergie brute) — sa convergence est data-affecting, liée au gap v2-dedup-...-normalization.",
     gate: "G3",
   },
 ] as const;

--- a/scripts/seo/vlevel-v3-pipeline.ts
+++ b/scripts/seo/vlevel-v3-pipeline.ts
@@ -20,7 +20,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 // invariants V-Level canoniques (SoT) — mirrorés par reelection-pack, JAMAIS réinventés.
-import { VLEVEL_V2_CAP, vLevelGroupKey, compareV3Champions, modelMatchKey } from '@repo/seo-roles';
+import { VLEVEL_V2_CAP, vLevelGroupKey, compareV3Champions, modelMatchKey, selectV2Tier } from '@repo/seo-roles';
 
 const ROOT = process.cwd();
 const AUDIT_DIR = path.join(ROOT, 'audit'); // sortie runtime (decision-packs), non versionnée par défaut
@@ -582,15 +582,21 @@ async function reelectionPack(pgId: number): Promise<void> {
     for (let i = 1; i < group.length; i++) proposed.set(group[i].id, 'V4');
   }
   v3Champs.sort(compareV3Champions); // même tie-break déterministe → composition du cut V2 reproductible
-  const seen = new Set<string>();
-  let promoted = 0;
-  for (const c of v3Champs) {
-    const key = vLevelGroupKey(c.model, energyOf(c));
-    if (seen.has(key)) continue;
-    seen.add(key);
-    proposed.set(c.id, 'V2');
-    if (++promoted >= VLEVEL_V2_CAP) break;
-  }
+  // Cut V2 via la SoT unique (selectV2Tier, @repo/seo-roles) — MIROIR EXACT de gamme-vlevel.service.
+  // Plafond + validateV2Promotion (type_id résolu + énergie cohérente), sans backfill. Un champion
+  // recalé reste V3 (déjà posé ci-dessus) ; seuls les valides sont surclassés V2.
+  const { v2: v2Champs } = selectV2Tier(
+    v3Champs,
+    VLEVEL_V2_CAP,
+    (c) => vLevelGroupKey(c.model, energyOf(c)),
+    (c) => ({
+      isChampion: true, // par construction : c provient de v3Champs (champion in-group)
+      typeId: c.type_id,
+      keywordEnergy: c.keyword, // hint énergie depuis le TEXTE du mot-clé (ex. « gasoil »)
+      vehicleEnergy: c.type_id ? fuelMap.get(String(c.type_id)) ?? null : null,
+    }),
+  );
+  for (const c of v2Champs) proposed.set(c.id, 'V2');
 
   const rows = candidates.map((k) => {
     const np = proposed.get(k.id)!;


### PR DESCRIPTION
## Quoi
Câble l'invariant **V2 ⟹ V3 + garde-fous objectifs** (`validateV2Promotion`, #898) **dans le runtime de l'élection**, pas seulement dans la doc. Hoiste le cut V2 — aujourd'hui **dupliqué** dans les 2 calculateurs canoniques — en **une fonction pure SoT** `selectV2Tier()` que les deux appellent.

> ⛓️ **Stacké sur #898** (base = `docs/vlevel-method-freeze`). `validateV2Promotion` y est ajouté ; cette PR le consomme. À rebaser sur `main` quand #898 merge.

## Pourquoi (le gap)
`v2-promotion-not-affined` (G3, déclaré dans `vlevel-invariants.ts`) : le cut V2 = top-N volume brut, **remplit le cap** avec des entrées `type_id` NULL ou à énergie incohérente (mot-clé « gasoil » → véhicule essence). Observé 2026-06-08 sur filtre-carburant (Duster essence 2025 promu V2).

## Comment (design — zéro bricolage)
- **`@repo/seo-roles` : `selectV2Tier()`** — pure, générique, déterministe. Top-`cap` champions dédupliqués par `[modèle+énergie]` **PUIS** filtrés par `validateV2Promotion`. **Plafond, PAS quota → aucun backfill** par des champions de rang inférieur (« moins de V2 mais propres », règle owner : air 10→8). Un champion recalé **reste V3** (il demeure le champion de son groupe) ; il est exposé dans `rejected` pour l'observabilité.
- **`gamme-vlevel.service.ts`** (recalc admin runtime) : appelle `selectV2Tier` ; construit `championFuelMap` (`auto_type.type_fuel`) pour détecter `energy_mismatch` au cut ; **log** des recalés (no silent fallback).
- **`vlevel-v3-pipeline.ts` → `reelectionPack`** (read-only) : appelle `selectV2Tier` (miroir exact — `fuelMap` déjà présent).
- **6 tests unitaires** : Duster `energy_mismatch`, `type_id` NULL, no-backfill (cap 3→2), dédup groupe, plafond, pureté.

Les 2 calculateurs ne peuvent désormais **plus diverger** sur le cut V2 (SoT unique).

## Périmètre & sécurité
- **Réversible. Ne mute AUCUNE donnée.** Le service ne réécrit la DB que sur appel explicite du recalc admin ; le pipeline est read-only.
- **Reste owner-gated** (PAS dans cette PR) : lancer le **recalc before/after** pour appliquer aux V2 existants.
- **Hors scope assumé** : `scripts/insert-missing-keywords.ts` (import CSV) garde son tri/dedup **non-canoniques** (énergie brute) — sa convergence est *data-affecting*, liée au gap `v2-dedup-…-normalization` (G3). Tracé dans le gap, pas touché ici.

## Vérif locale
- `@repo/seo-roles` build (`tsc`) : ✅ 0 erreur
- `@repo/seo-roles` tests : ✅ **284 tests, 0 fail** (7 todo = gaps connus, count préservé)
- `@fafa/backend` typecheck (`tsc --noEmit`, résolu vers le seo-roles du worktree) : ✅ **0 erreur**

🤖 Generated with [Claude Code](https://claude.com/claude-code)