### PR TITLE
feat(catalog): 'Produits universels' section (T2b, flag OFF, noindex)

### DIFF
--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -32,6 +32,11 @@ export class FeatureFlagsService {
     return this.bool('SAFE_FALLBACK_ENABLED', false);
   }
 
+  /** "Produits universels" section (T2b). Default OFF — owner enables when validated. */
+  get universalSectionEnabled(): boolean {
+    return this.bool('SHOW_UNIVERSAL_SECTION', false);
+  }
+
   get canaryGammes(): string[] {
     return this.csv('CANARY_GAMMES');
   }
@@ -316,6 +321,7 @@ export class FeatureFlagsService {
     'HARD_GATES_ENABLED',
     'AUTO_REPAIR_ENABLED',
     'SAFE_FALLBACK_ENABLED',
+    'SHOW_UNIVERSAL_SECTION',
     'CANARY_GAMMES',
     'R1_CONTENT_PIPELINE_ENABLED',
     'BRIEF_GATES_ENABLED',

--- a/backend/src/modules/catalog/catalog.module.ts
+++ b/backend/src/modules/catalog/catalog.module.ts
@@ -15,6 +15,7 @@ import { PiecesDiagnosticController } from './controllers/pieces-diagnostic.cont
 import { CatalogIntegrityController } from './controllers/catalog-integrity.controller';
 import { VehicleHierarchyController } from './controllers/vehicle-hierarchy.controller'; // 🚗 API hiérarchie véhicules
 import { CompatibilityController } from './controllers/compatibility.controller'; // 🎯 API compatibilité pièce/véhicule
+import { UniversalCatalogController } from './controllers/universal-catalog.controller'; // 🧴 Section "Produits universels" (T2b)
 // import { PiecesDbController } from '../../pieces/pieces-db.controller'; // DÉSACTIVÉ - service manquant
 
 // ========================================
@@ -38,6 +39,7 @@ import { CacheWarmingService } from './services/cache-warming.service';
 import { CompatibilityService } from './services/compatibility.service'; // 🎯 Service compatibilité pièce/véhicule
 import { PopularGammesService } from './services/popular-gammes.service'; // 🔗 Service maillage SEO (découplage Catalog↔Vehicles)
 import { GammePricePreviewService } from './services/gamme-price-preview.service'; // 💰 Prix indicatifs gamme (conversion P0)
+import { UniversalCatalogService } from './services/universal-catalog.service'; // 🧴 Section "Produits universels" (T2b)
 
 /**
  * 📂 MODULE CATALOGUE CONSOLIDÉ
@@ -78,6 +80,7 @@ import { GammePricePreviewService } from './services/gamme-price-preview.service
     CatalogIntegrityController, // 🛡️ VALIDATION de l'intégrité des données
     VehicleHierarchyController, // 🚗 API hiérarchie véhicules pour pages motorisation
     CompatibilityController, // 🎯 API compatibilité pièce/véhicule (Pack Confiance V2)
+    UniversalCatalogController, // 🧴 Section "Produits universels" (T2b)
     // PiecesDbController, // DÉSACTIVÉ - service manquant
   ],
   providers: [
@@ -110,6 +113,8 @@ import { GammePricePreviewService } from './services/gamme-price-preview.service
     PopularGammesService,
     // 💰 PRICE PREVIEW SERVICE - Prix indicatifs sans véhicule (conversion P0)
     GammePricePreviewService,
+    // 🧴 UNIVERSAL CATALOG - Section "Produits universels" (T2b, flag-gated)
+    UniversalCatalogService,
     // Alias pour compatibilité
     { provide: 'PricingServiceV5UltimateFinal', useClass: PricingService },
   ],

--- a/backend/src/modules/catalog/controllers/universal-catalog.controller.ts
+++ b/backend/src/modules/catalog/controllers/universal-catalog.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get } from '@nestjs/common';
+import { UniversalCatalogService } from '../services/universal-catalog.service';
+
+/**
+ * Read-only API for the "Produits universels" section (T2b).
+ * GET /api/catalog/universal/section → universal gammes + product previews (no vehicle).
+ * Flag-gated by SHOW_UNIVERSAL_SECTION (default OFF → { enabled:false, gammes:[] }).
+ */
+@Controller('api/catalog/universal')
+export class UniversalCatalogController {
+  constructor(private readonly universal: UniversalCatalogService) {}
+
+  @Get('section')
+  getSection() {
+    return this.universal.getSection();
+  }
+}

--- a/backend/src/modules/catalog/services/universal-catalog.service.ts
+++ b/backend/src/modules/catalog/services/universal-catalog.service.ts
@@ -1,0 +1,93 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { FeatureFlagsService } from '../../../config/feature-flags.service';
+import {
+  GammePricePreviewService,
+  type GammePricePreview,
+} from './gamme-price-preview.service';
+
+/** One universal gamme + a preview of its sellable products (no vehicle). */
+export interface UniversalGammeSection {
+  pgId: number;
+  pgName: string;
+  pgAlias: string | null;
+  sellablePieces: number;
+  preview: GammePricePreview | null;
+}
+
+export interface UniversalSectionResult {
+  /** false = flag OFF (no query ran). true = flag ON (gammes may be empty). */
+  enabled: boolean;
+  gammes: UniversalGammeSection[];
+}
+
+/**
+ * UniversalCatalogService (T2b) — data layer for the "Produits universels" section.
+ *
+ * Universal gammes = sold WITHOUT a vehicle (fluids / hardware / consumables): no vehicle
+ * fitment + sellable pieces + consumable nature. The set comes from the governed read-only
+ * function `catalog_universal_gammes()` (auto-classified, owner-overridable). Per gamme, the
+ * products are the EXISTING `GammePricePreviewService.getPricePreview` (RPC
+ * get_gamme_price_preview, vehicle-agnostic, cached) — zero new product path, no divergence.
+ *
+ * SEO-SAFE / read-only: never touches pg_display / URL / sitemap / price. Flag-gated by
+ * SHOW_UNIVERSAL_SECTION (default OFF → empty result, no query). No fabricated fitment.
+ */
+@Injectable()
+export class UniversalCatalogService extends SupabaseBaseService {
+  protected readonly logger = new Logger(UniversalCatalogService.name);
+
+  constructor(
+    configService: ConfigService,
+    private readonly flags: FeatureFlagsService,
+    private readonly pricePreview: GammePricePreviewService,
+  ) {
+    super(configService);
+  }
+
+  /**
+   * The universal section: top universal gammes + a product preview each.
+   * @param limit max gammes (bounded; default 24).
+   */
+  async getSection(limit = 24): Promise<UniversalSectionResult> {
+    if (!this.flags.universalSectionEnabled) {
+      return { enabled: false, gammes: [] };
+    }
+
+    const { data, error } = await this.callRpc('catalog_universal_gammes', {});
+    if (error) {
+      this.logger.warn(`[UNIVERSAL] gamme set lookup failed: ${error.message}`);
+      return { enabled: true, gammes: [] };
+    }
+    const rows = (Array.isArray(data) ? data : []).slice(0, Math.max(1, limit));
+
+    const gammes: UniversalGammeSection[] = [];
+    for (const r of rows) {
+      const row = r as Record<string, unknown>;
+      const pgId =
+        typeof row.pg_id === 'number'
+          ? row.pg_id
+          : parseInt(String(row.pg_id), 10);
+      if (!Number.isFinite(pgId) || pgId <= 0) continue;
+      let preview: GammePricePreview | null = null;
+      try {
+        preview = await this.pricePreview.getPricePreview(pgId, 4);
+      } catch (e) {
+        this.logger.warn(
+          `[UNIVERSAL] preview failed pg=${pgId}: ${e instanceof Error ? e.message : e}`,
+        );
+      }
+      gammes.push({
+        pgId,
+        pgName: String(row.pg_name ?? ''),
+        pgAlias: row.pg_alias ? String(row.pg_alias) : null,
+        sellablePieces: Number(row.sellable_pieces ?? 0),
+        preview,
+      });
+    }
+
+    this.logger.log(`[UNIVERSAL] section gammes=${gammes.length}`);
+    return { enabled: true, gammes };
+  }
+}

--- a/frontend/app/routes/pieces.produits-universels.tsx
+++ b/frontend/app/routes/pieces.produits-universels.tsx
@@ -1,0 +1,133 @@
+/**
+ * Route : /pieces/produits-universels
+ * Section « Produits universels » (T2b) — gammes sans véhicule (consommables /
+ * visserie / fluides / joints), vendables mais invisibles ailleurs.
+ *
+ * Data : GET /api/catalog/universal/section (flag SHOW_ACCESSORY… → ici
+ * SHOW_UNIVERSAL_SECTION, défaut OFF → { enabled:false } → rien d'affiché).
+ * Source produits = get_gamme_price_preview (sans véhicule), réutilisée.
+ *
+ * SEO : noindex/nofollow tant que la section n'est pas validée par l'owner.
+ */
+import {
+  json,
+  type LoaderFunctionArgs,
+  type MetaFunction,
+} from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { Boxes } from "lucide-react";
+import { formatPrice } from "~/utils/format";
+import { logger } from "~/utils/logger";
+
+interface PreviewProduct {
+  piece_id: number;
+  name: string;
+  ref: string;
+  price: number;
+  brand_name: string;
+}
+interface UniversalGamme {
+  pgId: number;
+  pgName: string;
+  pgAlias: string | null;
+  sellablePieces: number;
+  preview: { min_price: number | null; products: PreviewProduct[] } | null;
+}
+interface SectionData {
+  enabled: boolean;
+  gammes: UniversalGamme[];
+}
+
+export async function loader(_args: LoaderFunctionArgs) {
+  let section: SectionData = { enabled: false, gammes: [] };
+  try {
+    const res = await fetch(
+      "http://127.0.0.1:3000/api/catalog/universal/section",
+      { headers: { Accept: "application/json" }, signal: AbortSignal.timeout(5000) },
+    );
+    if (res.ok) {
+      section = (await res.json()) as SectionData;
+    } else {
+      logger.warn(`[UNIVERSAL_SECTION] API non-ok: ${res.status}`);
+    }
+  } catch (e) {
+    // fail-soft observable (no silent fallback): logged, renders an empty section.
+    logger.warn(
+      `[UNIVERSAL_SECTION] fetch failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+  return json(section);
+}
+
+// noindex tant que la section n'est pas validée (nouvelle URL publique).
+export const headers = () => ({
+  "X-Robots-Tag": "noindex, nofollow",
+  "Cache-Control": "public, max-age=300, s-maxage=600",
+});
+
+export const meta: MetaFunction = () => [
+  { title: "Produits universels | Automecanik" },
+  { name: "robots", content: "noindex, nofollow" },
+];
+
+export default function ProduitsUniversels() {
+  const { enabled, gammes } = useLoaderData<typeof loader>();
+
+  if (!enabled || gammes.length === 0) {
+    return (
+      <main className="container mx-auto px-4 py-12">
+        <p className="text-gray-500">Section produits universels indisponible.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <header className="mb-8 flex items-center gap-3">
+        <Boxes className="h-8 w-8 text-amber-600" aria-hidden="true" />
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Produits universels</h1>
+          <p className="text-sm text-gray-600">
+            Consommables, visserie, joints et fluides — vendus sans véhicule.
+          </p>
+        </div>
+      </header>
+
+      <div className="space-y-10">
+        {gammes.map((g) => (
+          <section key={g.pgId}>
+            <h2 className="mb-3 text-xl font-semibold text-gray-900">
+              {g.pgName}{" "}
+              <span className="text-sm font-normal text-gray-500">
+                ({g.sellablePieces} réf.
+                {g.preview?.min_price ? ` · dès ${formatPrice(g.preview.min_price)}` : ""})
+              </span>
+            </h2>
+            {g.preview?.products?.length ? (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+                {g.preview.products.map((p) => (
+                  <div
+                    key={p.piece_id}
+                    className="rounded-xl border border-gray-200 bg-white p-3 shadow-sm"
+                  >
+                    <div className="line-clamp-2 text-sm font-medium text-gray-900">
+                      {p.name}
+                    </div>
+                    <div className="mt-0.5 text-xs text-gray-500">
+                      {p.brand_name} · {p.ref}
+                    </div>
+                    <div className="mt-2 font-semibold text-gray-900">
+                      {formatPrice(p.price)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400">Produits bientôt disponibles.</p>
+            )}
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Pourquoi

T2b du programme orphan-price/universel : rendre visibles les **produits universels** (consommables / visserie / fluides / joints) — vendables mais **invisibles** car sans rattachement véhicule. **~86 gammes / ~3 531 pièces vendables** aujourd'hui cachées. Voir `audit/orphan-price-and-universal-section-design-2026-06-08.md` + `audit/universal-gammes-candidate-list-2026-06-08.md`.

## Ce que fait cette PR

- **`UniversalCatalogService.getSection()`** — **flag-gated** `SHOW_UNIVERSAL_SECTION` (défaut **OFF** → `{enabled:false, gammes:[]}`, aucune requête). Lit `catalog_universal_gammes()` (auto-curation, #901) pour le set de gammes + **réutilise `GammePricePreviewService.getPricePreview`** (RPC `get_gamme_price_preview`, sans véhicule, caché) pour les produits → **zéro nouveau chemin produit**, pas de fitment inventé, ne touche jamais `pg_display`/URL/sitemap.
- **`GET /api/catalog/universal/section`** — nouveau `UniversalCatalogController` (PAS d'édition de `GammeUnifiedController` → évite le conflit avec le revert #900).
- **Route frontend `/pieces/produits-universels`** : liste les gammes universelles + aperçus produits. **noindex/nofollow** (nouvelle URL publique, indexation après validation owner). Fail-soft + loggé (no silent fallback). Réutilise `formatPrice`.
- Flag ajouté à `FeatureFlagsService` + `ALLOWED_KEYS` (override runtime).

## Sûreté / invariants

- **Flag défaut OFF** → rien de visible tant que GO owner.
- **noindex** tant que la section n'est pas validée (nouvelle URL).
- Lecture seule, aucune mutation catalogue. Réutilise les primitives existantes (pas de système parallèle).

## Dépendance

Dépend de **#901** (`catalog_universal_gammes()` RPC — appliquée read-only). À merger après #901.

## Vérifs

- `tsc --noEmit` backend **0**, frontend **0**.
- Registry block-new gate : `backend/src/modules/catalog/**` (D1) + `frontend/app/routes/**` (D8) → couvert.
- RPC `catalog_universal_gammes()` validée live (86 gammes / 3 531 pièces).

## Activation (owner, plus tard)

`SHOW_UNIVERSAL_SECTION=true` (env ou override admin) → la section répond ; retirer `noindex` quand validé. Raffinement universel (overrides) = suit quand le glob `.spec` est ouvert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)