### PR TITLE
fix(seo): R8 owned-editorial gamme source from popular_parts/catalog (flag-gated, OFF)

### DIFF
--- a/backend/src/modules/admin/services/r8-owned-editorial.composer.test.ts
+++ b/backend/src/modules/admin/services/r8-owned-editorial.composer.test.ts
@@ -12,6 +12,7 @@ import {
   buildOwnedSelectionGuide,
   buildOwnedEntretien,
   buildOwnedFaq,
+  extractGammeSourceFromRpc,
   type GammeEditorial,
   type MotorisationFacts,
 } from './r8-owned-editorial.composer';
@@ -196,6 +197,81 @@ describe('buildOwnedFaq', () => {
     const g = gamme();
     g.purchaseGuide!.faq = [{ q: 'only one', a: 'answer' }];
     expect(buildOwnedFaq([g], facts, 'opener')).toBeNull();
+  });
+});
+
+describe('extractGammeSourceFromRpc', () => {
+  it('maps popular_parts (popularity-ranked) with proxy product_count desc', () => {
+    const out = extractGammeSourceFromRpc({
+      popular_parts: [
+        {
+          pg_id: 402,
+          pg_alias: 'plaquette-de-frein',
+          pg_name: 'Plaquettes de frein',
+        },
+        { pg_id: 8, pg_alias: 'filtre-a-air', pg_name: 'Filtre à air' },
+      ],
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({
+      pg_id: 402,
+      pg_alias: 'plaquette-de-frein',
+    });
+    expect(out[0].product_count).toBeGreaterThan(out[1].product_count);
+  });
+
+  it('falls back to catalog.families[].gammes when popular_parts empty', () => {
+    const out = extractGammeSourceFromRpc({
+      popular_parts: [],
+      catalog: {
+        families: [
+          {
+            mf_id: '1',
+            gammes: [
+              {
+                pg_id: 7,
+                pg_alias: 'filtre-a-huile',
+                pg_name: 'Filtre à huile',
+              },
+            ],
+          },
+          {
+            mf_id: '2',
+            gammes: [
+              {
+                pg_id: 9,
+                pg_alias: 'filtre-a-carburant',
+                pg_name: 'Filtre à carburant',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(out.map((g) => g.pg_id)).toEqual([7, 9]);
+  });
+
+  it('dedups by pg_id and skips rows missing id/alias/name', () => {
+    const out = extractGammeSourceFromRpc({
+      popular_parts: [
+        { pg_id: 7, pg_alias: 'filtre-a-huile', pg_name: 'Filtre à huile' },
+        { pg_id: 7, pg_alias: 'filtre-a-huile', pg_name: 'dup' },
+        { pg_id: 0, pg_alias: 'bad', pg_name: 'bad' },
+        { pg_id: 8, pg_alias: '', pg_name: 'no alias' },
+      ],
+    });
+    expect(out.map((g) => g.pg_id)).toEqual([7]);
+  });
+
+  it('uses real product_count when present, and returns [] for empty/garbage', () => {
+    expect(extractGammeSourceFromRpc(null)).toEqual([]);
+    expect(extractGammeSourceFromRpc({})).toEqual([]);
+    const out = extractGammeSourceFromRpc({
+      popular_parts: [
+        { pg_id: 5, pg_alias: 'x', pg_name: 'X', product_count: 42 },
+      ],
+    });
+    expect(out[0].product_count).toBe(42);
   });
 });
 

--- a/backend/src/modules/admin/services/r8-owned-editorial.composer.ts
+++ b/backend/src/modules/admin/services/r8-owned-editorial.composer.ts
@@ -35,6 +35,56 @@
 /** Min quality floor for owned editorial to be eligible (gatekeeper / conseil quality). */
 export const R8_OWNED_EDITORIAL_MIN_QUALITY = 75;
 
+// ── Gamme source (compatible gammes for owned editorial) ───────────────────
+
+/** Minimal gamme row consumed by `R8VehicleEnricherService.loadGammeEditorial()`. */
+export interface OwnedGammeSource {
+  pg_id: number;
+  pg_alias: string;
+  pg_name: string;
+  product_count: number;
+}
+
+/**
+ * Extract the compatible-gamme list for owned editorial from the cache RPC
+ * (`get_vehicle_page_data_cached`). The enricher's legacy `families` reads
+ * `compatible_families`, which the current RPC does NOT return — the gammes
+ * live under `popular_parts` (top, popularity-ranked) and, as a fallback,
+ * `catalog.families[].gammes[]`. Used ONLY by the flag-gated owned-editorial
+ * path; it does NOT touch the legacy `families` / catalog block. Pure +
+ * defensive: returns `[]` when neither source is present.
+ */
+export function extractGammeSourceFromRpc(
+  vehicleData: unknown,
+): OwnedGammeSource[] {
+  const vd = (vehicleData ?? {}) as Record<string, any>;
+  const popular = Array.isArray(vd.popular_parts) ? vd.popular_parts : [];
+  const catFamilies =
+    vd.catalog && Array.isArray(vd.catalog.families) ? vd.catalog.families : [];
+  const flattened = catFamilies.flatMap((f: any) =>
+    Array.isArray(f?.gammes) ? f.gammes : [],
+  );
+  const source = popular.length > 0 ? popular : flattened;
+  const out: OwnedGammeSource[] = [];
+  const seen = new Set<number>();
+  source.forEach((g: any, i: number) => {
+    const pgId = Number(g?.pg_id);
+    if (!Number.isFinite(pgId) || pgId <= 0 || seen.has(pgId)) return;
+    if (!g?.pg_alias || !g?.pg_name) return;
+    seen.add(pgId);
+    out.push({
+      pg_id: pgId,
+      pg_alias: String(g.pg_alias),
+      pg_name: String(g.pg_name),
+      // RPC carries no product_count here; preserve source order as a proxy
+      // (popular_parts is already popularity-ranked) so the anchor pick is stable.
+      product_count:
+        typeof g.product_count === 'number' ? g.product_count : 1000 - i,
+    });
+  });
+  return out;
+}
+
 // ── Inputs (plain data — the service maps DB rows into these) ──────────────
 
 export interface GammePurchaseGuide {

--- a/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
+++ b/backend/src/modules/admin/services/r8-vehicle-enricher.service.ts
@@ -44,6 +44,7 @@ import {
   buildOwnedSelectionGuide,
   buildOwnedEntretien,
   buildOwnedFaq,
+  extractGammeSourceFromRpc,
   type GammeEditorial,
   type MotorisationFacts,
 } from './r8-owned-editorial.composer';
@@ -252,9 +253,21 @@ export class R8VehicleEnricherService extends SupabaseBaseService {
       // editorial from the OWNED DB tables. OFF (default) → [] → existing path.
       const useOwnedEditorial =
         this.featureFlags?.r8OwnedEditorialEnabled ?? false;
+      // The cache RPC exposes compatible gammes under popular_parts /
+      // catalog.families[].gammes (NOT compatible_families), so legacy
+      // `families` is often empty. When so, source owned-editorial gammes from
+      // the RPC. Flag-gated only — never touches the legacy families/catalog block.
+      const ownedGammeSource =
+        useOwnedEditorial && topGammes.length === 0
+          ? extractGammeSourceFromRpc(vehicleData)
+          : topGammes;
       const gammeEditorials: GammeEditorial[] = useOwnedEditorial
         ? (
-            await Promise.all(topGammes.map((g) => this.loadGammeEditorial(g)))
+            await Promise.all(
+              ownedGammeSource
+                .slice(0, 5)
+                .map((g) => this.loadGammeEditorial(g)),
+            )
           ).filter((e): e is GammeEditorial => e !== null)
         : [];
 


### PR DESCRIPTION
## Fix B follow-up — owned editorial gamme source (flag-gated, OFF)

Follow-up to #906. **Flag `R8_OWNED_EDITORIAL_ENABLED` stays OFF by default** ⇒ zero runtime change. No DB migration, no queue drain, no URL/sitemap/canonical/noindex action, rollback by flag.

### Why (read-only pilot proof)

Ran the **real composer on real DB data** (read-only, no writes) for 5 Clio III types `19053, 11056, 19052, 26627, 19051`. Owned editorial produces **rich, real, per-sibling-distinct prose** (each motorisation anchors on a *different* top gamme → distinct content + FAQ, directly attacking Defect B).

But it never engaged through the enricher: the enricher reads `families` from `compatible_families`/`families`, which the cache RPC `get_vehicle_page_data_cached` **does not return** — compatible gammes live under `popular_parts` (popularity-ranked) + `catalog.families[].gammes[]`. So `families` is empty → owned editorial had no anchor → always fell back. **Pre-existing RPC-shape drift, not a Phase A defect** (also explains why current pages lack catalog/FAQ blocks).

### What

- **Pure** `extractGammeSourceFromRpc(vehicleData)` in the composer: `popular_parts` first, fallback `catalog.families[].gammes[]`; dedup by `pg_id`; skips rows missing id/alias/name; `product_count` proxy = source rank (RPC carries none here). +4 unit tests (**16 total, green**).
- Enricher: when `topGammes` (legacy `families`) is empty, source owned-editorial gammes from `extractGammeSourceFromRpc(vehicleData)`. **Flag-gated only** — computed solely when `R8_OWNED_EDITORIAL_ENABLED` is ON; never touches the legacy `families`/catalog block.

### Guardrails (unchanged from #906)

- Flag OFF default → dormant; rollback by flag.
- No DB write semantics changed (enricher still writes draft/REVIEW_REQUIRED unless gate ≥70 → INDEX, exactly as before).
- No migration, no queue drain, no sitemap/canonical/noindex/301 action.
- No invented facts — owned prose is sourced + gatekept; only frames it with real vehicle facts.

### Known follow-ups (non-blocking, surfaced by the proof)

- **Anchor scoring** : anchor = top `popular_parts` gamme (e.g. poulie-vilebrequin for 19053), not always freinage/filtration — may want a relevance/score bias later.
- **Source-data cleanup** : a few owned FAQ entries have messy formatting (`**3. Pompe a eau incluse?**`) and one `courroie d''accessoire` double-apostrophe — DB editorial cleanup, separate.

### Verify

- ✅ 16/16 composer unit tests (ts-jest).
- ⏳ Full backend typecheck/build = CI (worktree has no node_modules).
- 🔒 Flag OFF ⇒ no runtime effect. Pilot enrichment (writes shared `__seo_r8_pages`, which PROD overlays live for INDEX/REVIEW_REQUIRED) stays **owner-gated**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
