### PR TITLE
fix(hooks): clean-settings-local.sh non-destructif (préserve hooks + additionalDirectories)

### DIFF
--- a/scripts/claude-hooks/clean-settings-local.sh
+++ b/scripts/claude-hooks/clean-settings-local.sh
@@ -56,8 +56,12 @@ done <<< "$NON_BASH_PERMS"
 # Build JSON
 JSON_ARRAY=$(printf '%s\n' "${ALLOW_ENTRIES[@]}" | jq -R . | jq -s .)
 
-# Write new settings
-jq -n --argjson allow "$JSON_ARRAY" '{"permissions": {"allow": $allow}}' > "$SETTINGS_FILE"
+# Write new settings — NON-DESTRUCTIVE merge.
+# Ne réécrit QUE .permissions.allow (normalisé en wildcards). Préserve TOUTES les
+# autres clés (.permissions.additionalDirectories, .hooks, et toute clé future).
+# tmp + mv obligatoire : on lit $SETTINGS_FILE, donc pas de redirect direct dedans.
+jq --argjson allow "$JSON_ARRAY" '.permissions.allow = $allow' "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp" \
+  && mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
 
 echo "=== After:  $(wc -l < "$SETTINGS_FILE") lines / $(wc -c < "$SETTINGS_FILE") bytes ==="
 echo "Cleaned! Reduced from $LINE_COUNT lines to $(wc -l < "$SETTINGS_FILE") lines"


### PR DESCRIPTION
## Problème

Le cron `0 3 * * 0` lance `scripts/claude-hooks/clean-settings-local.sh` qui réécrit `.claude/settings.local.json` via `jq -n '{"permissions":{"allow":$allow}}'` — il ne garde QUE `permissions.allow` et **détruit toute autre clé** chaque dimanche 03:00 :
- `hooks` (ex. le hook `UserPromptSubmit` PULL→PUSH câblé en local — meurt chaque semaine)
- `permissions.additionalDirectories` (**perte silencieuse existante** — viole "no silent fallback")

## Fix

Remplace le rewrite destructif par un **merge non-destructif** :
```bash
jq --argjson allow "$JSON_ARRAY" '.permissions.allow = $allow' "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp" && mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
```
→ normalise UNIQUEMENT `permissions.allow` (Bash spécifiques → wildcards), préserve toutes les autres clés présentes et futures. `tmp + mv` car on lit le fichier source.

## Test (sans toucher le vrai fichier)

Échantillon 142 lignes (`hooks` + `additionalDirectories` + 122 perms Bash) :
- `allow` normalisé 122 → 4 wildcards ✅
- `hooks.UserPromptSubmit` préservé ✅
- `permissions.additionalDirectories` préservé ✅
- JSON valide ✅
- Ancien comportement sur le même échantillon : `hooks` **détruit** (régression confirmée)

## Impact / sûreté

- Merge `main` → **PREPROD CI uniquement** (jamais PROD).
- Effet réel sur DEV après resync (`sync-dev-runtime.sh` ff-pull main).
- Réversible (1 fichier, +6/−2). Comportement de nettoyage des permissions inchangé.

Réf : mémoire `project_memory_context_architecture_20260602` (P2 — hook PULL→PUSH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)