### PR TITLE
feat(hooks): garde-taille MEMORY.md au SessionStart (alert-only, sœur de rotate-log.sh)

### DIFF
--- a/scripts/claude-hooks/check-memory-size.sh
+++ b/scripts/claude-hooks/check-memory-size.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# check-memory-size.sh — ALERT-ONLY guard on MEMORY.md (Layer 0) size.
+#
+# Sister script of rotate-log.sh, but ALERT-ONLY: it NEVER mutates MEMORY.md.
+# Re-compaction requires judgment (trim verbose hooks → linked atomic file, with
+# ZERO pointer loss); auto-trimming would risk dropping pointers, so this guard
+# only SURFACES the drift and leaves the fix to a human/agent.
+#
+# Why this exists: MEMORY.md (auto-loaded Layer 0) silently regrew 19.4KB → 24.8KB
+# and crossed the ~24.4KB truncation line — making part of the pointer index
+# invisible without any signal. This converts that silent regrowth into a visible
+# SessionStart warning (PULL→PUSH). Ref: memory project_memory_context_architecture
+# (P0 compaction target ≤20KiB, P4 observe).
+#
+# Behaviour (deterministic, no LLM, no git, idempotent):
+#   - Under threshold  → no output, exit 0 (silent no-op).
+#   - Over threshold   → ONE warning line to stdout, exit 0 (never blocks).
+#   - Missing file / any error → exit 0 (fail-open, like the other SessionStart hook).
+#
+# Usage:
+#   check-memory-size.sh [MEMORY_FILE] [SOFT_LIMIT_BYTES]
+# Defaults: MEMORY_FILE derived from $HOME + canonical project path; 20480 (20 KiB).
+# The caller (sessionstart-workspace-context.sh) passes the resolved path so this
+# stays worktree-agnostic and free of hardcoded user/infra paths.
+
+set -uo pipefail
+
+# Rollback rapide (cohérent avec les autres hooks).
+[ "${CLAUDE_HOOKS_DISABLE:-0}" = "1" ] && exit 0
+
+MEM="${1:-${HOME}/.claude/projects/-opt-automecanik-app/memory/MEMORY.md}"
+SOFT="${2:-20480}"   # 20 KiB — cible P0 (sous le seuil de troncature observé ~24,4KB)
+
+[ -f "$MEM" ] || exit 0
+BYTES=$(wc -c < "$MEM" 2>/dev/null || echo 0)
+[ "$BYTES" -gt "$SOFT" ] 2>/dev/null || exit 0
+
+printf '⚠️ MEMORY.md = %s o > %s (20 KiB, cible P0) — re-compacter Layer 0 (trim hooks → fichier lié, 0 pointeur perdu). Réf project_memory_context_architecture P0/P4.\n' "$BYTES" "$SOFT"
+exit 0

--- a/scripts/claude-hooks/sessionstart-workspace-context.sh
+++ b/scripts/claude-hooks/sessionstart-workspace-context.sh
@@ -117,6 +117,12 @@ extract_section() {
   echo "_Source : .claude/top-priorities.md — mise à jour max 1×/sem_"
 } > /tmp/sessionstart-output.txt
 
+# Garde-taille MEMORY.md (Layer 0) — alerte ALERT-ONLY si re-gonflement >20KiB.
+# Émise hors du manifest borné (ligne courte, rare, jamais bloquante). Sœur de
+# rotate-log.sh. Réf project_memory_context_architecture (P0 ≤20KiB / P4 observe).
+MEM_FILE="${HOME}/.claude/projects/$(printf '%s' "$REPO_ROOT_CANON" | tr '/' '-')/memory/MEMORY.md"
+bash "$REPO_ROOT/scripts/claude-hooks/check-memory-size.sh" "$MEM_FILE" 2>/dev/null || true
+
 # Borne taille : sortie ≤ 2000 bytes (~500 tokens). Si dépasse → fail silencieux (exit 0)
 # avec message stderr ; ne JAMAIS bloquer la session sur ce défaut.
 SIZE=$(wc -c < /tmp/sessionstart-output.txt)


### PR DESCRIPTION
## Problème

`MEMORY.md` (Layer 0, auto-loaded chaque session) a **re-gonflé silencieusement** 19,4→24,8KB et franchi la ligne de troncature ~24,4KB → une partie de l'index de pointeurs devient invisible **sans aucun signal**. (Re-démontré ce jour : édition externe → 20 817 o, repassé > cible.)

## Fix — un guard mécanique, pas un framework

Ajoute `scripts/claude-hooks/check-memory-size.sh`, **sœur de `rotate-log.sh`** mais **ALERT-ONLY** :
- **ne mute JAMAIS** MEMORY.md (le recompactage exige du jugement : trim hooks → fichier lié, **0 pointeur perdu** ; un auto-trim risquerait de droper des pointeurs) ;
- déterministe, idempotent, **fail-open** (toute erreur → exit 0) ;
- sous seuil → silencieux ; au-dessus de 20480 o (20 KiB, cible P0) → **une** ligne de warning.

Câblé via le hook **SessionStart existant** (`sessionstart-workspace-context.sh`) — **extension, pas un nouveau câblage** (CLAUDE.md « prefer extension over creation ») : la dérive surgit comme warning visible au démarrage = moment actionnable (PULL→PUSH). Path dérivé de `REPO_ROOT_CANON` (aucun path hardcodé), émis **hors** du manifest borné, `|| true`.

## Test

- sous seuil → silencieux (exit 0) ;
- au-dessus (fichier réel **20 817 o**) → alerte, **y compris e2e via le hook SessionStart** ;
- seuil paramétrable vérifié ; kill-switch `CLAUDE_HOOKS_DISABLE=1` → silencieux ;
- **non-régression** : le manifest SessionStart est toujours émis, exit 0.

## Impact / sûreté

- Merge `main` → **PREPROD CI uniquement** (jamais PROD). Effet DEV après resync.
- Additif (+46 l, 1 nouveau script + 5 l dans le hook existant). Réversible (`CLAUDE_HOOKS_DISABLE=1` ou revert).
- ALERT-ONLY : ne touche jamais MEMORY.md → aucun risque de perte de pointeur.

Réf : mémoire `project_memory_context_architecture_20260602` (P0 cible ≤20KiB / P4 observe). Complète le rétablissement PULL→PUSH (hook UserPromptSubmit + #909 wiper non-destructif).

🤖 Generated with [Claude Code](https://claude.com/claude-code)