### PR TITLE
feat(seo): additive R1 kw-promotion noindex→index (flag OFF)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -989,3 +989,9 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: low
+
+  - glob: backend/supabase/migrations/*seo_ready_gammes*
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -148,6 +148,19 @@ GA4_PROPERTY_ID=
 SEO_MONITORING_ENABLED=false
 
 # ─────────────────────────────────────────────────────────────────────────────
+# R1 gamme — promotion ADDITIVE noindex→index par mots-clés préparés (owner 2026-06-10)
+# Hub gamme /pieces/:gamme.html (gamme-response-builder).
+# `indexable = pg_level='1' OU seoReady(kw≥seuil)` — PROMOTION SEULEMENT : ne flippe
+#   que noindex→index, JAMAIS l'inverse (les gammes déjà indexées le restent).
+# Default OFF → aucun appel DB, robots legacy byte-identique. ON → auto-activation :
+#   dès qu'une gamme atteint le seuil de kw (table __seo_keywords) elle est promue.
+# N'utilise QUE le COMPTAGE des kw (pas les valeurs — mapping contaminé).
+# Requiert la fonction RPC rpc_seo_ready_gammes (migration 20260610) appliquée.
+# ─────────────────────────────────────────────────────────────────────────────
+SEO_R1_KW_PROMOTE_ENABLED=false
+SEO_R1_KW_MIN=50
+
+# ─────────────────────────────────────────────────────────────────────────────
 # PR-SBD-1 — SEO Business Control Dashboard (Phase A, default OFF)
 # Endpoint : GET /api/admin/seo-control/snapshot?range=7d|28d
 # Route   : /admin/seo-control (Remix SSR, 2 blocs visibles Phase A)

--- a/backend/src/modules/gamme-rest/gamme-rest.module.ts
+++ b/backend/src/modules/gamme-rest/gamme-rest.module.ts
@@ -13,6 +13,7 @@ import {
   GammeResponseBuilderService,
   GammePageDataService,
   BuyingGuideDataService,
+  SeoReadyGammeService,
 } from './services';
 import { R1RelatedResourcesService } from './services/r1-related-resources.service';
 
@@ -39,6 +40,7 @@ import { R1RelatedResourcesService } from './services/r1-related-resources.servi
     GammePageDataService,
     BuyingGuideDataService,
     R1RelatedResourcesService,
+    SeoReadyGammeService,
   ],
 })
 export class GammeRestModule {}

--- a/backend/src/modules/gamme-rest/services/__tests__/gamme-response-builder-seo-shadow.test.ts
+++ b/backend/src/modules/gamme-rest/services/__tests__/gamme-response-builder-seo-shadow.test.ts
@@ -59,6 +59,11 @@ describe('GammeResponseBuilderService — SEO chain shadow mode (PR-5)', () => {
     const chainFlags = new SeoFeatureFlagRegistry();
 
     const dummy = {} as never;
+    // SeoReadyGammeService stub — promotion OFF so the additive kw-path stays inert here.
+    const seoReadyGamme = {
+      isPromoteEnabled: () => false,
+      isSeoReady: async () => false,
+    } as never;
     return new GammeResponseBuilderService(
       dummy, // GammeDataTransformerService
       dummy, // GammeRpcService
@@ -68,6 +73,7 @@ describe('GammeResponseBuilderService — SEO chain shadow mode (PR-5)', () => {
       dummy, // R1RelatedResourcesService
       chainOrchestrator as never,
       chainFlags,
+      seoReadyGamme, // SeoReadyGammeService
     );
   }
 

--- a/backend/src/modules/gamme-rest/services/__tests__/seo-ready-gamme.service.test.ts
+++ b/backend/src/modules/gamme-rest/services/__tests__/seo-ready-gamme.service.test.ts
@@ -1,0 +1,91 @@
+import { SeoReadyGammeService } from '../seo-ready-gamme.service';
+
+/**
+ * Unit test the logic without the heavy SupabaseBaseService constructor:
+ * build the instance via Object.create and inject a mocked supabase client.
+ */
+function makeService(rpc: jest.Mock): SeoReadyGammeService {
+  const svc = Object.create(
+    SeoReadyGammeService.prototype,
+  ) as SeoReadyGammeService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (svc as any).logger = { error: jest.fn(), log: jest.fn(), warn: jest.fn() };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (svc as any).supabase = { rpc };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (svc as any).cache = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (svc as any).inflight = null;
+  return svc;
+}
+
+describe('SeoReadyGammeService', () => {
+  const OLD_ENV = process.env;
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+  });
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  describe('isPromoteEnabled — OFF by default, governed flag', () => {
+    it('false when unset', () => {
+      delete process.env.SEO_R1_KW_PROMOTE_ENABLED;
+      expect(makeService(jest.fn()).isPromoteEnabled()).toBe(false);
+    });
+    it('true only when exactly "true"', () => {
+      process.env.SEO_R1_KW_PROMOTE_ENABLED = 'true';
+      expect(makeService(jest.fn()).isPromoteEnabled()).toBe(true);
+      process.env.SEO_R1_KW_PROMOTE_ENABLED = '1';
+      expect(makeService(jest.fn()).isPromoteEnabled()).toBe(false);
+      process.env.SEO_R1_KW_PROMOTE_ENABLED = 'on';
+      expect(makeService(jest.fn()).isPromoteEnabled()).toBe(false);
+    });
+  });
+
+  describe('isSeoReady — cached kw-count set membership', () => {
+    it('true for a gamme in the ready set, false otherwise; RPC called once (cached)', async () => {
+      const rpc = jest
+        .fn()
+        .mockResolvedValue({ data: [{ pg_id: 7 }, { pg_id: 82 }], error: null });
+      const svc = makeService(rpc);
+      expect(await svc.isSeoReady(7)).toBe(true);
+      expect(await svc.isSeoReady(82)).toBe(true);
+      expect(await svc.isSeoReady(999)).toBe(false);
+      expect(rpc).toHaveBeenCalledTimes(1);
+      expect(rpc).toHaveBeenCalledWith('rpc_seo_ready_gammes', { p_min_kw: 50 });
+    });
+
+    it('honours SEO_R1_KW_MIN override', async () => {
+      process.env.SEO_R1_KW_MIN = '200';
+      const rpc = jest.fn().mockResolvedValue({ data: [], error: null });
+      await makeService(rpc).isSeoReady(7);
+      expect(rpc).toHaveBeenCalledWith('rpc_seo_ready_gammes', {
+        p_min_kw: 200,
+      });
+    });
+
+    it('falls back to the default threshold for an invalid override', async () => {
+      process.env.SEO_R1_KW_MIN = 'abc';
+      const rpc = jest.fn().mockResolvedValue({ data: [], error: null });
+      await makeService(rpc).isSeoReady(7);
+      expect(rpc).toHaveBeenCalledWith('rpc_seo_ready_gammes', { p_min_kw: 50 });
+    });
+
+    it('fail-safe: returns false on RPC error (legacy robots preserved, no throw)', async () => {
+      const rpc = jest
+        .fn()
+        .mockResolvedValue({ data: null, error: { message: 'boom' } });
+      await expect(makeService(rpc).isSeoReady(7)).resolves.toBe(false);
+    });
+
+    it('returns false for an invalid pgId without hitting the RPC', async () => {
+      const rpc = jest.fn();
+      const svc = makeService(rpc);
+      expect(await svc.isSeoReady(0)).toBe(false);
+      expect(await svc.isSeoReady(-5)).toBe(false);
+      expect(await svc.isSeoReady(NaN)).toBe(false);
+      expect(rpc).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/modules/gamme-rest/services/__tests__/seo-ready-gamme.service.test.ts
+++ b/backend/src/modules/gamme-rest/services/__tests__/seo-ready-gamme.service.test.ts
@@ -2,20 +2,19 @@ import { SeoReadyGammeService } from '../seo-ready-gamme.service';
 
 /**
  * Unit test the logic without the heavy SupabaseBaseService constructor:
- * build the instance via Object.create and inject a mocked supabase client.
+ * build the instance via Object.create and mock the inherited `callRpc` wrapper
+ * (the service calls `this.callRpc`, not `this.supabase.rpc` directly).
  */
-function makeService(rpc: jest.Mock): SeoReadyGammeService {
+function makeService(callRpc: jest.Mock): SeoReadyGammeService {
   const svc = Object.create(
     SeoReadyGammeService.prototype,
   ) as SeoReadyGammeService;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   (svc as any).logger = { error: jest.fn(), log: jest.fn(), warn: jest.fn() };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (svc as any).supabase = { rpc };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (svc as any).callRpc = callRpc;
   (svc as any).cache = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (svc as any).inflight = null;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
   return svc;
 }
 
@@ -45,15 +44,18 @@ describe('SeoReadyGammeService', () => {
 
   describe('isSeoReady — cached kw-count set membership', () => {
     it('true for a gamme in the ready set, false otherwise; RPC called once (cached)', async () => {
-      const rpc = jest
-        .fn()
-        .mockResolvedValue({ data: [{ pg_id: 7 }, { pg_id: 82 }], error: null });
+      const rpc = jest.fn().mockResolvedValue({
+        data: [{ pg_id: 7 }, { pg_id: 82 }],
+        error: null,
+      });
       const svc = makeService(rpc);
       expect(await svc.isSeoReady(7)).toBe(true);
       expect(await svc.isSeoReady(82)).toBe(true);
       expect(await svc.isSeoReady(999)).toBe(false);
       expect(rpc).toHaveBeenCalledTimes(1);
-      expect(rpc).toHaveBeenCalledWith('rpc_seo_ready_gammes', { p_min_kw: 50 });
+      expect(rpc).toHaveBeenCalledWith('rpc_seo_ready_gammes', {
+        p_min_kw: 50,
+      });
     });
 
     it('honours SEO_R1_KW_MIN override', async () => {
@@ -69,7 +71,9 @@ describe('SeoReadyGammeService', () => {
       process.env.SEO_R1_KW_MIN = 'abc';
       const rpc = jest.fn().mockResolvedValue({ data: [], error: null });
       await makeService(rpc).isSeoReady(7);
-      expect(rpc).toHaveBeenCalledWith('rpc_seo_ready_gammes', { p_min_kw: 50 });
+      expect(rpc).toHaveBeenCalledWith('rpc_seo_ready_gammes', {
+        p_min_kw: 50,
+      });
     });
 
     it('fail-safe: returns false on RPC error (legacy robots preserved, no throw)', async () => {

--- a/backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
+++ b/backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
@@ -26,6 +26,7 @@ import {
   type NormalizeResult,
 } from '../utils/r1-image-normalizer';
 import { R1RelatedResourcesService } from './r1-related-resources.service';
+import { SeoReadyGammeService } from './seo-ready-gamme.service';
 
 interface MotorizationRow {
   type_id: number;
@@ -81,6 +82,7 @@ export class GammeResponseBuilderService {
     private readonly relatedResources: R1RelatedResourcesService,
     private readonly chainOrchestrator: SeoChainOrchestratorService,
     private readonly chainFlags: SeoFeatureFlagRegistry,
+    private readonly seoReadyGamme: SeoReadyGammeService,
   ) {}
 
   /**
@@ -303,7 +305,24 @@ export class GammeResponseBuilderService {
     }) as { family_count: number; gamme_count: number };
     // pg_level est TEXT en BDD ('1' ou '2'), '1' = INDEX
     const isG1orG2 = String(pgLevel) === '1';
-    const pageRobots = isG1orG2 ? 'index, follow' : 'noindex, nofollow';
+    let pageRobots = isG1orG2 ? 'index, follow' : 'noindex, nofollow';
+
+    // 🔑 Promotion R1 ADDITIVE par mots-clés (owner 2026-06-10) — flag OFF par défaut.
+    // `indexable = pg_level='1' OU seoReady(kw préparé)`. PROMOTION SEULEMENT : on
+    // ne flippe que noindex→index, jamais l'inverse (les gammes déjà indexées le
+    // restent). Auto-activation : dès qu'une gamme reçoit du kw (≥ seuil) elle devient
+    // éligible. Flag OFF → aucun appel DB, comportement legacy byte-identique.
+    if (
+      !isG1orG2 &&
+      this.seoReadyGamme.isPromoteEnabled() &&
+      (await this.seoReadyGamme.isSeoReady(pgIdNum))
+    ) {
+      pageRobots = 'index, follow';
+      this.logger.log(
+        `[R1-KW-PROMOTE] pg_id=${pgIdNum} promu noindex→index (kw préparé)`,
+      );
+    }
+
     const canonicalLink = `pieces/${pgAlias}-${pgIdNum}.html`;
 
     // Traitement données
@@ -946,7 +965,7 @@ export class GammeResponseBuilderService {
         familyCount: seoValidation.family_count,
         gammeCount: seoValidation.gamme_count,
         relfollow: String(pgRelfollow) === '1' ? 1 : 0,
-        isIndexable: isG1orG2,
+        isIndexable: pageRobots === 'index, follow',
         robots: pageRobots,
         pgLevel: pageData.pg_level,
         pgRelfollow: pageData.pg_relfollow,

--- a/backend/src/modules/gamme-rest/services/index.ts
+++ b/backend/src/modules/gamme-rest/services/index.ts
@@ -3,3 +3,4 @@ export * from './gamme-rpc.service';
 export * from './gamme-response-builder.service';
 export * from './gamme-page-data.service';
 export * from './buying-guide-data.service';
+export * from './seo-ready-gamme.service';

--- a/backend/src/modules/gamme-rest/services/seo-ready-gamme.service.ts
+++ b/backend/src/modules/gamme-rest/services/seo-ready-gamme.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
+
+/**
+ * SEO-readiness signal for the ADDITIVE R1 keyword promotion (owner 2026-06-10).
+ *
+ * A gamme is "SEO-ready" when it has prepared keyword research, measured as
+ * `>= SEO_R1_KW_MIN` rows in `__seo_keywords` (existence/count only — NEVER the
+ * keyword VALUES, whose gamme mapping is contaminated). Used to PROMOTE a
+ * currently-noindex gamme hub to `index, follow`:
+ *
+ *     indexable = (pg_level='1')  OR  seoReady(gamme)
+ *
+ * Promotion only — it never demotes an already-indexed gamme. Gated by
+ * `SEO_R1_KW_PROMOTE_ENABLED` (default OFF → inert, no DB call). As the owner
+ * injects kw for new families, those gammes auto-become eligible (data-driven).
+ *
+ * The ready-set is loaded once via the read-only `rpc_seo_ready_gammes` RPC
+ * (avoids the supabase-js 1000-row cap) and cached in-process. On any failure
+ * the set is `null` → `isSeoReady` returns false → legacy behaviour (fail-safe).
+ */
+@Injectable()
+export class SeoReadyGammeService extends SupabaseBaseService {
+  protected readonly logger = new Logger(SeoReadyGammeService.name);
+
+  private static readonly DEFAULT_MIN_KW = 50;
+  private static readonly TTL_MS = 30 * 60 * 1000; // 30 min — set is very stable
+
+  private cache: { ids: Set<number>; at: number } | null = null;
+  private inflight: Promise<Set<number> | null> | null = null;
+
+  /** Additive R1 kw-promotion enabled? `SEO_R1_KW_PROMOTE_ENABLED=true`. Default OFF. */
+  isPromoteEnabled(): boolean {
+    return process.env.SEO_R1_KW_PROMOTE_ENABLED === 'true';
+  }
+
+  /** Minimum prepared kw rows to consider a gamme SEO-ready (filters contaminated noise). */
+  private minKw(): number {
+    const n = Number.parseInt(process.env.SEO_R1_KW_MIN ?? '', 10);
+    return Number.isInteger(n) && n > 0 ? n : SeoReadyGammeService.DEFAULT_MIN_KW;
+  }
+
+  /** True if the gamme has prepared keyword research (>= threshold). Fail-safe `false`. */
+  async isSeoReady(pgId: number): Promise<boolean> {
+    if (!Number.isInteger(pgId) || pgId <= 0) return false;
+    const ids = await this.loadReadySet();
+    return ids ? ids.has(pgId) : false;
+  }
+
+  /** Test-only: clear the in-process cache. */
+  resetCache(): void {
+    this.cache = null;
+    this.inflight = null;
+  }
+
+  private async loadReadySet(
+    now: number = Date.now(),
+  ): Promise<Set<number> | null> {
+    if (this.cache && now - this.cache.at < SeoReadyGammeService.TTL_MS) {
+      return this.cache.ids;
+    }
+    if (this.inflight) return this.inflight;
+
+    this.inflight = (async () => {
+      try {
+        const { data, error } = await this.supabase.rpc('rpc_seo_ready_gammes', {
+          p_min_kw: this.minKw(),
+        });
+        if (error) throw new Error(error.message);
+        const ids = new Set<number>();
+        for (const row of (data as Array<{ pg_id: number }> | null) ?? []) {
+          if (typeof row.pg_id === 'number') ids.add(row.pg_id);
+        }
+        this.cache = { ids, at: now };
+        return ids;
+      } catch (e) {
+        this.logger.error(
+          `seo-ready set load failed — R1 kw-promotion inert this call: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        );
+        return null;
+      } finally {
+        this.inflight = null;
+      }
+    })();
+
+    return this.inflight;
+  }
+}

--- a/backend/src/modules/gamme-rest/services/seo-ready-gamme.service.ts
+++ b/backend/src/modules/gamme-rest/services/seo-ready-gamme.service.ts
@@ -1,3 +1,5 @@
+// @role-purity-skip — ce service de plomberie référence R1 (hub gamme) dans sa
+// doc technique ; ce n'est pas du contenu R-role généré (cf. check-role-purity).
 import { Injectable, Logger } from '@nestjs/common';
 import { SupabaseBaseService } from '../../../database/services/supabase-base.service';
 
@@ -37,7 +39,9 @@ export class SeoReadyGammeService extends SupabaseBaseService {
   /** Minimum prepared kw rows to consider a gamme SEO-ready (filters contaminated noise). */
   private minKw(): number {
     const n = Number.parseInt(process.env.SEO_R1_KW_MIN ?? '', 10);
-    return Number.isInteger(n) && n > 0 ? n : SeoReadyGammeService.DEFAULT_MIN_KW;
+    return Number.isInteger(n) && n > 0
+      ? n
+      : SeoReadyGammeService.DEFAULT_MIN_KW;
   }
 
   /** True if the gamme has prepared keyword research (>= threshold). Fail-safe `false`. */
@@ -63,12 +67,14 @@ export class SeoReadyGammeService extends SupabaseBaseService {
 
     this.inflight = (async () => {
       try {
-        const { data, error } = await this.supabase.rpc('rpc_seo_ready_gammes', {
-          p_min_kw: this.minKw(),
-        });
+        // callRpc (not direct .rpc) — RPC Safety Gate + circuit breaker.
+        const { data, error } = await this.callRpc<Array<{ pg_id: number }>>(
+          'rpc_seo_ready_gammes',
+          { p_min_kw: this.minKw() },
+        );
         if (error) throw new Error(error.message);
         const ids = new Set<number>();
-        for (const row of (data as Array<{ pg_id: number }> | null) ?? []) {
+        for (const row of data ?? []) {
           if (typeof row.pg_id === 'number') ids.add(row.pg_id);
         }
         this.cache = { ids, at: now };

--- a/backend/supabase/migrations/20260610_rpc_seo_ready_gammes.sql
+++ b/backend/supabase/migrations/20260610_rpc_seo_ready_gammes.sql
@@ -15,6 +15,12 @@
 --
 -- Date: 2026-06-10
 -- ============================================================================
+
+-- squawk require-timeout-settings (pré-DDL ; CREATE FUNCTION est instantané mais
+-- le linter l'exige avant toute opération potentiellement lente).
+SET lock_timeout = '2s';
+SET statement_timeout = '60s';
+
 CREATE OR REPLACE FUNCTION rpc_seo_ready_gammes(p_min_kw integer DEFAULT 50)
 RETURNS TABLE (pg_id integer)
 LANGUAGE sql

--- a/backend/supabase/migrations/20260610_rpc_seo_ready_gammes.sql
+++ b/backend/supabase/migrations/20260610_rpc_seo_ready_gammes.sql
@@ -1,0 +1,31 @@
+-- ============================================================================
+-- rpc_seo_ready_gammes — pg_ids ayant >= p_min_kw lignes de mots-clés préparés.
+--
+-- Signal "SEO-ready" (recherche keyword préparée) consommé par la promotion R1
+-- ADDITIVE noindex→index (flag SEO_R1_KW_PROMOTE_ENABLED ; promotion seulement,
+-- JAMAIS de retrait d'index : `indexable = pg_level='1' OU seoReady`).
+--
+-- N'utilise QUE l'EXISTENCE/comptage des kw, jamais les VALEURS : le mapping
+-- keyword→gamme de __seo_keywords est contaminé (ex. pg 402 plaquette → top-kw
+-- « disque de frein »), cf. mémoire seo-keywords-table-contaminated. Le seuil
+-- de comptage filtre le bruit ; les valeurs ne sont jamais lues ici.
+--
+-- Lecture seule (STABLE) → exposable via PostgREST. Évite le cap 1000-lignes de
+-- supabase-js (agrégat GROUP BY/HAVING fait côté Postgres, ~19 lignes renvoyées).
+--
+-- Date: 2026-06-10
+-- ============================================================================
+CREATE OR REPLACE FUNCTION rpc_seo_ready_gammes(p_min_kw integer DEFAULT 50)
+RETURNS TABLE (pg_id integer)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT k.pg_id
+  FROM __seo_keywords k
+  WHERE k.pg_id IS NOT NULL
+  GROUP BY k.pg_id
+  HAVING count(*) >= GREATEST(p_min_kw, 1);
+$$;
+
+GRANT EXECUTE ON FUNCTION rpc_seo_ready_gammes(integer)
+  TO anon, authenticated, service_role;

--- a/backend/tests/unit/gamme-response-builder.service.test.ts
+++ b/backend/tests/unit/gamme-response-builder.service.test.ts
@@ -64,7 +64,10 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
   const makeRpcServiceMock = () =>
     ({
       getPageDataRpcV2: jest.fn(async () => makeBaseRpcPayload()),
-      getSeoFragmentsByTypeId: jest.fn(() => ({ fragment1: '', fragment2: '' })),
+      getSeoFragmentsByTypeId: jest.fn(() => ({
+        fragment1: '',
+        fragment2: '',
+      })),
       getTechnicalCodesByTypeIds: jest.fn(async () => []),
     }) as any;
 
@@ -156,14 +159,24 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
       buildAutoBuyingGuideV1: jest.fn(() => autoGuide),
     } as any;
 
-    const referenceService = { getByPgId: jest.fn().mockResolvedValue(null) } as any;
+    const referenceService = {
+      getByPgId: jest.fn().mockResolvedValue(null),
+    } as any;
     const seoTitleEngine = {
       resolve: jest.fn(() => ({
-        title: 'Test Title', description: 'Test Desc', keywords: '', h1: 'H1', content: '',
+        title: 'Test Title',
+        description: 'Test Desc',
+        keywords: '',
+        h1: 'H1',
+        content: '',
       })),
     } as any;
 
-    const relatedResources = { getRelatedResources: jest.fn(() => Promise.resolve({ links: [], blocks: [] })) } as any;
+    const relatedResources = {
+      getRelatedResources: jest.fn(() =>
+        Promise.resolve({ links: [], blocks: [] }),
+      ),
+    } as any;
     const chainOrchestrator = { run: jest.fn() } as any;
     const chainFlags = { mode: jest.fn(() => 'off') } as any;
     const service = new GammeResponseBuilderService(
@@ -175,11 +188,14 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
       relatedResources,
       chainOrchestrator,
       chainFlags,
+      { isPromoteEnabled: () => false, isSeoReady: async () => false } as never,
     );
 
     const result = await service.buildRpcV2Response('479');
 
-    expect(buyingGuideService.getBuyingGuideContractV1).toHaveBeenCalledWith('479');
+    expect(buyingGuideService.getBuyingGuideContractV1).toHaveBeenCalledWith(
+      '479',
+    );
     expect(buyingGuideService.toBuyingGuideV1).not.toHaveBeenCalled();
     expect(buyingGuideService.buildAutoBuyingGuideV1).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -194,7 +210,9 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
     expect(result.performance.buying_guide_available).toBe(1);
     expect(result.performance.buying_guide_fallback_used).toBe(1);
     expect(result.performance.buying_guide_gate_ok).toBe(0);
-    expect(result.performance).not.toHaveProperty('purchase_guide_v2_available');
+    expect(result.performance).not.toHaveProperty(
+      'purchase_guide_v2_available',
+    );
   });
 
   it('utilise le contrat guide DB quand il existe', async () => {
@@ -213,14 +231,24 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
       buildAutoBuyingGuideV1: jest.fn(),
     } as any;
 
-    const referenceService = { getByPgId: jest.fn().mockResolvedValue(null) } as any;
+    const referenceService = {
+      getByPgId: jest.fn().mockResolvedValue(null),
+    } as any;
     const seoTitleEngine = {
       resolve: jest.fn(() => ({
-        title: 'Test Title', description: 'Test Desc', keywords: '', h1: 'H1', content: '',
+        title: 'Test Title',
+        description: 'Test Desc',
+        keywords: '',
+        h1: 'H1',
+        content: '',
       })),
     } as any;
 
-    const relatedResources = { getRelatedResources: jest.fn(() => Promise.resolve({ links: [], blocks: [] })) } as any;
+    const relatedResources = {
+      getRelatedResources: jest.fn(() =>
+        Promise.resolve({ links: [], blocks: [] }),
+      ),
+    } as any;
     const chainOrchestrator = { run: jest.fn() } as any;
     const chainFlags = { mode: jest.fn(() => 'off') } as any;
     const service = new GammeResponseBuilderService(
@@ -232,15 +260,18 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
       relatedResources,
       chainOrchestrator,
       chainFlags,
+      { isPromoteEnabled: () => false, isSeoReady: async () => false } as never,
     );
 
     const result = await service.buildRpcV2Response('479');
 
-    expect(buyingGuideService.getBuyingGuideContractV1).toHaveBeenCalledWith('479');
-    expect(buyingGuideService.toBuyingGuideV1).toHaveBeenCalledWith(dbContract);
-    expect(buyingGuideService.passesBuyingGuideAntiWikiGate).toHaveBeenCalledWith(
-      mappedGuide,
+    expect(buyingGuideService.getBuyingGuideContractV1).toHaveBeenCalledWith(
+      '479',
     );
+    expect(buyingGuideService.toBuyingGuideV1).toHaveBeenCalledWith(dbContract);
+    expect(
+      buyingGuideService.passesBuyingGuideAntiWikiGate,
+    ).toHaveBeenCalledWith(mappedGuide);
     expect(buyingGuideService.buildAutoBuyingGuideV1).not.toHaveBeenCalled();
     expect(result.gammeBuyingGuide).toEqual(mappedGuide);
     expect(result.performance.buying_guide_fallback_used).toBe(0);
@@ -270,14 +301,24 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
       buildAutoBuyingGuideV1: jest.fn(() => fallbackGuide),
     } as any;
 
-    const referenceService = { getByPgId: jest.fn().mockResolvedValue(null) } as any;
+    const referenceService = {
+      getByPgId: jest.fn().mockResolvedValue(null),
+    } as any;
     const seoTitleEngine = {
       resolve: jest.fn(() => ({
-        title: 'Test Title', description: 'Test Desc', keywords: '', h1: 'H1', content: '',
+        title: 'Test Title',
+        description: 'Test Desc',
+        keywords: '',
+        h1: 'H1',
+        content: '',
       })),
     } as any;
 
-    const relatedResources = { getRelatedResources: jest.fn(() => Promise.resolve({ links: [], blocks: [] })) } as any;
+    const relatedResources = {
+      getRelatedResources: jest.fn(() =>
+        Promise.resolve({ links: [], blocks: [] }),
+      ),
+    } as any;
     const chainOrchestrator = { run: jest.fn() } as any;
     const chainFlags = { mode: jest.fn(() => 'off') } as any;
     const service = new GammeResponseBuilderService(
@@ -289,6 +330,7 @@ describe('GammeResponseBuilderService buying guide fallback', () => {
       relatedResources,
       chainOrchestrator,
       chainFlags,
+      { isPromoteEnabled: () => false, isSeoReady: async () => false } as never,
     );
 
     const result = await service.buildRpcV2Response('479');

--- a/log.md
+++ b/log.md
@@ -418,3 +418,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `docs/vlevel-method-freeze`
 - **Décision** : docs(seo): vlevel — objectif top-vente (proxy recherche) + dispatch pages constructeur (+1 other commit)
 - **Sortie** : PR #898 | commits 1db293cf8 bd605b606
+
+## 2026-06-10 — feat/seo-r1-kw-promote (auto)
+
+- **Branche** : `feat/seo-r1-kw-promote`
+- **Décision** : chore(registry): ownership glob D3 for rpc_seo_ready_gammes migration (ADR-058 PR-G) (+1 other commit)
+- **Sortie** : PR #917 | commits 09bbedb5b 5006024cd


### PR DESCRIPTION
## Pourquoi

Suite de l'indexabilité SEO (distinct de #916 qui traite R2 véhicule). L'owner veut, **au fur et à mesure** qu'une famille reçoit ses mots-clés préparés, **promouvoir** les hubs gamme R1 de `noindex` vers `index` — **sans jamais retirer** l'index des 123 gammes déjà indexées. Le kw est déjà injecté en DB pour **filtration + freinage**.

## Quoi

Règle **additive** au point de décision robots unique du hub gamme ([gamme-response-builder.service.ts:305](backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts#L305)) :

> `indexable = pg_level='1' OU seoReady(kw≥seuil)` — **promotion seulement** (flippe `noindex→index`), **jamais** l'inverse.

- **RPC read-only** `rpc_seo_ready_gammes(p_min_kw)` (migration `20260610`) : pg_ids ayant ≥ seuil de lignes dans `__seo_keywords`. Utilise le **COMPTAGE** seulement, **jamais les valeurs** (mapping contaminé — plaquette 402 → « disque de frein », cf. mémoire). Agrégat `GROUP BY/HAVING` côté Postgres → évite le cap 1000-lignes de supabase-js.
- **`SeoReadyGammeService`** : set cached in-process (TTL 30 min), **fail-safe** (RPC KO → `false` → robots legacy, jamais de promotion fantôme).
- **Promotion** branchée dans le builder ; court-circuit quand flag OFF (**aucun appel DB**, robots byte-identique au legacy). `isIndexable` debug aligné sur le robots servi.
- **Flags OFF par défaut** : `SEO_R1_KW_PROMOTE_ENABLED=false`, `SEO_R1_KW_MIN=50`.
- **15 tests jest** (logique service / cache / fail-safe / seuil + test builder existant mis à jour pour le nouveau dep).
- Ownership overlay `D3` ajouté (owner) pour la migration (gate ADR-058 PR-G).

## Activation (plus tard, owner-gated)

**Purement additif — ne retire jamais l'index des 123.** Pour activer : (1) appliquer le RPC `rpc_seo_ready_gammes` sur DEV (migrations non auto-appliquées, axe 4) ; (2) `SEO_R1_KW_PROMOTE_ENABLED=true` sur DEV ; (3) mesurer la cohorte promue (familles avec kw≥50 = filtration + freinage aujourd'hui) ; (4) GO owner → PROD (tag). Dès qu'une nouvelle famille reçoit du kw → promue automatiquement.

## Hors-scope

Pas de retrait d'index, pas de changement d'URL, pas de masquage produit, pas de contenu (les valeurs kw restent interdites en meta/contenu — contamination). R2 véhicule = #916.

## Improvement Check
- **Problem :** hubs gamme préparés (kw) restent `noindex` ; pas de promotion progressive.
- **Risk :** additif (n'enlève rien) ; flag OFF ; RPC read-only + fail-safe ; mesure DEV avant PROD. Rollback = flag `=false`.
- **Test :** 15 jest verts ; flag OFF = byte-identique legacy.
- **Verdict :** `GO_WITH_WATCH` (mesurer la cohorte promue sur DEV avant activation PROD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
