### PR TITLE
fix(seo): R2 noindex,follow quand 0 produit vendable (flag SEO_R2_SELLABLE_NOINDEX, OFF)

### DIFF
--- a/frontend/app/services/api/rm-api.service.ts
+++ b/frontend/app/services/api/rm-api.service.ts
@@ -123,6 +123,10 @@ export interface RmProductV2 extends RmProduct {
   image: string;
   filtre_gamme: string;
   is_accessory: boolean;
+  // Statut de stock dérivé de pri_dispo : '1'→IN_STOCK · '2'→LOW_STOCK ·
+  // '3'→PREORDER · sinon OUT_OF_STOCK. Sert au gate d'indexabilité R2
+  // (sellable = stock_status != OUT_OF_STOCK + price_ttc > 0).
+  stock_status: string;
 }
 
 export interface RmGroupedPiece {

--- a/frontend/app/utils/pieces-vehicle.loader.server.ts
+++ b/frontend/app/utils/pieces-vehicle.loader.server.ts
@@ -260,11 +260,11 @@ export async function piecesVehicleLoader({
     // long-TTL caching of a transient blip (canon: no silent fallback).
     type RmAlternativesResponse = {
       success: boolean;
-      version?: 'v2';
+      version?: "v2";
       etag?: string;
-      alternativeGammes: NoProductsData['alternativeGammes'];
-      alternativeVehicles: NoProductsData['alternativeVehicles'];
-      relatedModels: NoProductsData['relatedModels'];
+      alternativeGammes: NoProductsData["alternativeGammes"];
+      alternativeVehicles: NoProductsData["alternativeVehicles"];
+      relatedModels: NoProductsData["relatedModels"];
     };
     let alternativesData: RmAlternativesResponse | null = null;
     let alternativesFetchOk = false;
@@ -272,7 +272,7 @@ export async function piecesVehicleLoader({
       const altResp = await fetch(
         `http://127.0.0.1:3000/api/rm/alternatives?gamme_id=${gammeId}&type_id=${vehicleIds.typeId}&limit=12`,
         {
-          headers: { Accept: 'application/json' },
+          headers: { Accept: "application/json" },
           signal: AbortSignal.timeout(3000),
         },
       );
@@ -305,19 +305,19 @@ export async function piecesVehicleLoader({
       marqueName: vi?.marqueName ?? _marqueData.alias.replace(/-/g, " "),
       modeleName: vi?.modeleName ?? _modeleData.alias.replace(/-/g, " "),
       typeName: vi?.typeName ?? _typeData.alias.replace(/-/g, " "),
-      typeFuel: vi?.typeFuel ?? '',
-      typePowerPs: vi?.typePowerPs ?? '',
-      yearFrom: vi?.typeYearFrom ?? '',
-      yearTo: vi?.typeYearTo ?? '',
+      typeFuel: vi?.typeFuel ?? "",
+      typePowerPs: vi?.typePowerPs ?? "",
+      yearFrom: vi?.typeYearFrom ?? "",
+      yearTo: vi?.typeYearTo ?? "",
     };
 
     // Beacon télémétrie fire-and-forget (n'attend jamais)
-    void fetch('http://127.0.0.1:3000/api/rm/alternatives/track-soft-404', {
-      method: 'POST',
+    void fetch("http://127.0.0.1:3000/api/rm/alternatives/track-soft-404", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'user-agent': request.headers.get('user-agent') ?? '',
-        referer: request.headers.get('referer') ?? '',
+        "Content-Type": "application/json",
+        "user-agent": request.headers.get("user-agent") ?? "",
+        referer: request.headers.get("referer") ?? "",
       },
       body: JSON.stringify({ pg_id: gammeId, type_id: vehicleIds.typeId }),
     }).catch(() => {
@@ -328,7 +328,10 @@ export async function piecesVehicleLoader({
     const alternativeVehicles = alternativesData?.alternativeVehicles ?? [];
     const relatedModels = alternativesData?.relatedModels ?? [];
     const hasAlternatives =
-      alternativeGammes.length + alternativeVehicles.length + relatedModels.length > 0;
+      alternativeGammes.length +
+        alternativeVehicles.length +
+        relatedModels.length >
+      0;
 
     // Canon: cache TTL must reflect payload confidence — no silent fallback,
     // no long-TTL on error paths (feedback_no_long_ttl_cache_on_error_paths).
@@ -484,6 +487,17 @@ export async function piecesVehicleLoader({
         }
       : null;
 
+    // R2 indexabilité (flag SEO_R2_SELLABLE_NOINDEX, OFF par défaut) : nombre
+    // de produits VENDABLES = pri_dispo IN ('1','2','3') (→ stock_status !=
+    // OUT_OF_STOCK) + prix. Les vendables sont triés en tête (score dispo DESC),
+    // seul le tail OUT_OF_STOCK est tronqué par le LIMIT → sellableCount===0
+    // est fiable. Les produits compatibles restent affichés (UX) ; seule
+    // l'indexabilité bascule. Décision par-requête → auto-réparante.
+    const sellableCount = (rmV2Response.products ?? []).filter(
+      (p) => p.stock_status !== "OUT_OF_STOCK" && (p.price_ttc ?? 0) > 0,
+    ).length;
+    const sellableGateEnabled = process.env.SEO_R2_SELLABLE_NOINDEX === "on";
+
     // LCP OPTIMIZATION V6: defer() pour streamer donnees non-critiques
     // Donnees critiques (vehicle, pieces, seo) : retournees immediatement
     // Donnees non-critiques (relatedArticles, blogArticle) : streamees apres le first paint
@@ -542,6 +556,9 @@ export async function piecesVehicleLoader({
           rmDuration: rmV2Response.duration_ms,
         },
         dataQuality: rmV2Response.validation?.dataQuality?.quality ?? 0,
+        // R2 indexabilité (flag SEO_R2_SELLABLE_NOINDEX) — consommés par le robots meta
+        sellableCount,
+        sellableGateEnabled,
 
         // === DONNEES STREAMEES (non-bloquantes, chargees en background) ===
         // LCP: blogData deferred (below-fold, Googlebot execute JS)

--- a/frontend/app/utils/pieces-vehicle.meta.ts
+++ b/frontend/app/utils/pieces-vehicle.meta.ts
@@ -125,12 +125,15 @@ export function buildPiecesVehicleMeta(
     { property: "og:title", content: d.seo.title },
     { property: "og:description", content: d.seo.description },
     { property: "og:url", content: canonicalUrl },
-    // Robots: index si 2+ produits, OU si 1 produit avec qualite donnees suffisante
-    // Pages 2+ produits ont ~300 mots SSR (FAQ, guide, compatibilite)
+    // Robots: index si 2+ produits OU 1 produit avec qualite donnees suffisante,
+    // ET (flag SEO_R2_SELLABLE_NOINDEX) au moins 1 produit vendable
+    // (pri_dispo '1'|'2'|'3' → stock_status != OUT_OF_STOCK + prix). Flag OFF
+    // (defaut) → clause vendabilite neutre → robots identique a l'existant.
     {
       name: "robots",
       content:
-        d.count >= 2 || (d.count === 1 && (d.dataQuality ?? 0) >= 50)
+        (d.count >= 2 || (d.count === 1 && (d.dataQuality ?? 0) >= 50)) &&
+        (!d.sellableGateEnabled || (d.sellableCount ?? 0) >= 1)
           ? "index, follow"
           : "noindex, follow",
     },


### PR DESCRIPTION
## R2 : `noindex,follow` quand 0 produit vendable (flag `SEO_R2_SELLABLE_NOINDEX`, OFF par défaut)

**Flag OFF par défaut ⇒ robots byte-identique à l'existant. Zéro effet runtime tant que le flag n'est pas activé.** Frontend-only, aucune migration.

### Problème (vérifié, runtime + code)
La règle robots R2 (`frontend/app/utils/pieces-vehicle.meta.ts`) décidait `index,follow` ssi `count >= 2 || (count === 1 && dataQuality >= 50)`. Le `count` = **tous les produits compatibles non-pollués, sans filtre de stock** (le filtre stock a été retiré volontairement en `20260118_rm_remove_stock_filter.sql`, pour l'UX). **Aucune règle d'indexabilité basée sur la vendabilité.** → des pages R2 avec produits compatibles mais **0 vendable** (tous OUT_OF_STOCK / 0,00 €) restaient **indexées** (audit type 19052, Renault Clio III 1.5 dCi 86 ch : **14/115 gammes**).

### Fix
Le loader (`pieces-vehicle.loader.server.ts`) calcule `sellableCount` = produits avec `stock_status != OUT_OF_STOCK` (= `pri_dispo IN ('1','2','3')`) **et** `price_ttc > 0`, plus lit le flag `SEO_R2_SELLABLE_NOINDEX`. Le robots meta passe `noindex,follow` quand **0 vendable** — **sous le flag uniquement**.

- **PREORDER (`pri_dispo='3'`) compte comme vendable** (invariant commerce "PREORDER vendable si pri_dispo=3").
- **Les produits compatibles restent AFFICHÉS** (UX inchangée) ; seule l'indexabilité bascule.
- **Décision par-requête → auto-réparante** : la page re-passe `index,follow` automatiquement quand une pièce redevient vendable (sous réserve du TTL CDN, voir ci-dessous).
- Cible `noindex,**follow**` (convention soft-404 existante ; conserve l'équité de lien).

### Fichiers
- `services/api/rm-api.service.ts` : `stock_status: string` ajouté à `RmProductV2` (champ déjà présent dans le JSON RPC, non typé top-level ; type-only).
- `utils/pieces-vehicle.loader.server.ts` : calcul `sellableCount` + lecture `SEO_R2_SELLABLE_NOINDEX` + exposition dans les données loader.
- `utils/pieces-vehicle.meta.ts` : règle robots = `contentOk && (flagOFF || sellableCount>=1)`.

### Vérification
- ✅ **Logique vérifiée sur données runtime réelles** (`/api/rm/page-v2`, lecture seule) : `neiman` (pg 1367) → 4 produits tous OUT_OF_STOCK → `sellableCount=0` → noindex ; `filtre-a-huile` (pg 7) → 24 (IN_STOCK/LOW/PREORDER) → reste index.
- ⏳ Typecheck/lint/build frontend = **CI** (worktree sans node_modules).
- 🔒 **Flag OFF → aucun effet** ; vérification runtime flag-ON = étape post-merge (rollout étagé).

### Rollout étagé (owner-gated) + risques
- Blast radius **mesuré** : ~**12–15 %** des R2 indexables basculeraient en noindex (322/2200 sur Clio III berline) → **désindexation systémique délibérée** → activation étagée : DEV d'abord (curl les 14 URLs) → mesurer 2-3 modèles → PROD.
- **Cache CDN** `s-maxage=86400` → bascule **non instantanée** au edge (~25 h) + cadence re-crawl Google. Idem pour l'auto-ré-indexation. Purge CDN ciblée possible.
- **Rollback** : `SEO_R2_SELLABLE_NOINDEX=off` → comportement identique à aujourd'hui, sans redeploy.

### Hors-scope
Pas de masquage produit, pas de migration/RPC, pas de canonical/sitemap, pas d'activation de prix (chantier Pricing CP séparé). Suivi suggéré : test vitest de régression de la règle robots (non ajouté ici car non exécutable en worktree sans node_modules ; logique vérifiée sur données réelles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
