### PR TITLE
fix(seo): débloque R4 index + consolidation R5→R3 — 2 RPCs hors allowlist + cible 404 (3 bugs empilés)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -87,6 +87,14 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: low
+  # Migration corrective RPCs reference/diagnostic — fix R4 index vide (RPC Gate) +
+  # cible R5→R3 404 (owner GO en session 2026-06-10). Glob exact volontaire — les
+  # migrations ne sont PAS auto-couvertes (review d'ownership requise à chaque fois).
+  - glob: backend/supabase/migrations/20260610_fix_r5_redirect_target_align_reference_rpcs.sql
+    domain: D14
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: low
   - glob: scripts/governance/validate-authority-graph.js
     domain: D15
     owner: '@ak125'

--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 177,
+  "total": 179,
   "functions": [
     {
       "name": "__gov_m1_table_sizes",
@@ -463,6 +463,16 @@
       "name": "get_seo_quality_daily_stats",
       "volatility": "VOLATILE",
       "reason": "SELECT only"
+    },
+    {
+      "name": "get_all_seo_references",
+      "volatility": "STABLE",
+      "reason": "SELECT only — liste R4 /reference-auto (231 refs publiées) ; absent de l'allowlist → RpcBlockedError en PROD enforce P2 → index vide (fix 2026-06-10)"
+    },
+    {
+      "name": "get_r5_redirect_target",
+      "volatility": "STABLE",
+      "reason": "SELECT only — résout la redirection 301 détail R5 → R3 conseils#diagnostic-rapide (consolidation R5)"
     },
     {
       "name": "get_seo_reference_by_slug",

--- a/backend/supabase/migrations/20260610_fix_r5_redirect_target_align_reference_rpcs.sql
+++ b/backend/supabase/migrations/20260610_fix_r5_redirect_target_align_reference_rpcs.sql
@@ -24,6 +24,9 @@
 -- (pg_get_functiondef capturé) ; REVOKE EXECUTE pour annuler les grants.
 -- ============================================================================
 
+SET lock_timeout = '1s';
+SET statement_timeout = '5s';
+
 -- 1. Cible de redirection R5 → R3 corrigée (consolidation R5)
 CREATE OR REPLACE FUNCTION public.get_r5_redirect_target(p_slug text)
 RETURNS TABLE(redirect_to text, pg_alias text)

--- a/backend/supabase/migrations/20260610_fix_r5_redirect_target_align_reference_rpcs.sql
+++ b/backend/supabase/migrations/20260610_fix_r5_redirect_target_align_reference_rpcs.sql
@@ -1,0 +1,71 @@
+-- ============================================================================
+-- 20260610_fix_r5_redirect_target_align_reference_rpcs.sql
+-- ============================================================================
+-- Contexte (audit 2026-06-10, PR fix/r4-reference-list-rpc-gate) :
+--
+-- 1. get_r5_redirect_target (créée en Studio, jamais backportée au repo)
+--    construisait une cible 404 : '/blog-pieces-auto/conseil-' || pg_alias
+--    (route inexistante — la route R3 réelle est /blog-pieces-auto/conseils/).
+--    Le bug n'a jamais été observé en PROD car le RPC était simultanément
+--    bloqué par le RPC Gate (absent de rpc_allowlist.json) — deux bugs
+--    empilés qui se masquaient. Corrigé ici + durci (pg_alias NULL → hub).
+--
+-- 2. get_all_seo_references : la version repo (20260125_create_seo_reference.sql)
+--    référence une table inexistante `__products_gammes` (pg_label/pg_slug) ;
+--    la version déployée a été corrigée en Studio (pieces_gamme, pg_name/pg_alias)
+--    sans backport. Ce fichier aligne le repo sur la définition déployée
+--    (idempotent — CREATE OR REPLACE de la même définition).
+--
+-- 3. GRANT EXECUTE explicites : la recréation Studio a perdu le grant anon de
+--    get_all_seo_references (by_slug l'a, getAll non) — nécessaire pour le mode
+--    PREPROD READ_ONLY anon (ADR-028 Option D). Idempotents.
+--
+-- Rollback : les définitions antérieures sont dans l'historique de cette PR
+-- (pg_get_functiondef capturé) ; REVOKE EXECUTE pour annuler les grants.
+-- ============================================================================
+
+-- 1. Cible de redirection R5 → R3 corrigée (consolidation R5)
+CREATE OR REPLACE FUNCTION public.get_r5_redirect_target(p_slug text)
+RETURNS TABLE(redirect_to text, pg_alias text)
+LANGUAGE sql
+STABLE
+AS $function$
+  SELECT
+    CASE
+      WHEN array_length(so.related_gammes, 1) = 1 AND pg.pg_alias IS NOT NULL THEN
+        '/blog-pieces-auto/conseils/' || pg.pg_alias || '#diagnostic-rapide'
+      ELSE
+        '/diagnostic-auto'
+    END AS redirect_to,
+    pg.pg_alias
+  FROM __seo_observable so
+  LEFT JOIN pieces_gamme pg ON pg.pg_id = so.related_gammes[1]
+  WHERE so.slug = p_slug
+  LIMIT 1;
+$function$;
+
+-- 2. Alignement repo ↔ DB : définition déployée de get_all_seo_references
+--    (remplace la version repo cassée qui joignait __products_gammes, table inexistante)
+CREATE OR REPLACE FUNCTION public.get_all_seo_references()
+RETURNS TABLE(id integer, slug character varying, title character varying, meta_description character varying, definition text, pg_id integer, gamme_name character varying, gamme_slug character varying)
+LANGUAGE sql
+STABLE
+AS $function$
+  SELECT
+    r.id,
+    r.slug,
+    r.title,
+    r.meta_description,
+    LEFT(r.definition, 300) as definition,
+    r.pg_id,
+    g.pg_name as gamme_name,
+    g.pg_alias as gamme_slug
+  FROM __seo_reference r
+  LEFT JOIN pieces_gamme g ON g.pg_id = r.pg_id
+  WHERE r.is_published = true
+  ORDER BY r.title ASC;
+$function$;
+
+-- 3. Grants explicites (parité avec get_seo_reference_by_slug ; PREPROD anon)
+GRANT EXECUTE ON FUNCTION public.get_all_seo_references() TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_r5_redirect_target(text) TO anon, authenticated, service_role;

--- a/governance/rpc/rpc_allowlist.json
+++ b/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 157,
+  "total": 167,
   "functions": [
     {
       "name": "auth_email_exists",
@@ -423,6 +423,16 @@
       "name": "get_seo_quality_daily_stats",
       "volatility": "VOLATILE",
       "reason": "SELECT only"
+    },
+    {
+      "name": "get_all_seo_references",
+      "volatility": "STABLE",
+      "reason": "SELECT only — liste R4 /reference-auto (231 refs publiées) ; absent de l'allowlist → RpcBlockedError en PROD enforce P2 → index vide (fix 2026-06-10)"
+    },
+    {
+      "name": "get_r5_redirect_target",
+      "volatility": "STABLE",
+      "reason": "SELECT only — résout la redirection 301 détail R5 → R3 conseils#diagnostic-rapide (consolidation R5)"
     },
     {
       "name": "get_seo_reference_by_slug",

--- a/log.md
+++ b/log.md
@@ -418,3 +418,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `docs/vlevel-method-freeze`
 - **Décision** : docs(seo): vlevel — objectif top-vente (proxy recherche) + dispatch pages constructeur (+1 other commit)
 - **Sortie** : PR #898 | commits 1db293cf8 bd605b606
+
+## 2026-06-10 — fix/r4-reference-list-rpc-gate (auto)
+
+- **Branche** : `fix/r4-reference-list-rpc-gate`
+- **Décision** : chore(registry): glob ownership pour la migration 20260610 (D14, owner GO en session) (+3 other commits)
+- **Sortie** : PR #922 | commits f719e0d1f 5d5cf54c9 c62447acd 974ad3996

--- a/scripts/ci/check-rpc-allowlist-coverage.sh
+++ b/scripts/ci/check-rpc-allowlist-coverage.sh
@@ -59,7 +59,12 @@ root = sys.argv[1]
 def extract_calls(src: str):
     """Yield (rpc_name, has_api_source) per callRpc(...) invocation."""
     # Trouver toutes les positions de "callRpc"
-    for m in re.finditer(r"callRpc(?:<[^>]*>)?\s*\(", src):
+    # `<[^(]*` (et non `<[^>]*>`) : tolère les génériques imbriqués
+    # (`callRpc<Array<Record<string, unknown>>>(`) — l'ancien pattern s'arrêtait
+    # au premier `>` et rendait l'appel invisible au gate. Angle mort qui a
+    # laissé get_all_seo_references hors allowlist → RpcBlockedError en PROD
+    # (enforce P2) → index /reference-auto vide (« 0 références » sur 231).
+    for m in re.finditer(r"callRpc(?:<[^(]*)?\(", src):
         start = m.end()
         # Parcourir pour trouver la ) qui ferme, en comptant les (
         depth = 1


### PR DESCRIPTION
## Contexte

La demande owner « R4/R5/R6 en sections dans R3 ou redirection vers R3 » était en réalité **déjà construite** — mais cassée en PROD par trois bugs empilés qui se masquaient mutuellement :

1. **Angle mort du gate CI** : `check-rpc-allowlist-coverage.sh` ne voyait pas les appels `callRpc<Array<Record<string, unknown>>>(…)` (génériques imbriqués — le pattern s'arrêtait au premier `>`). 32 → **38 appels** détectés après fix.
2. **2 RPCs jamais allowlistés** (invisibles au gate) → `RpcBlockedError` en PROD (`RPC_GATE_MODE=enforce P2`), silencieusement avalé par les services (`return []` / `return null`) :
   - `get_all_seo_references` → index `/reference-auto` affichait « **0 références** » alors que **231 sont publiées** (détail + sitemap + sidebar R3 fonctionnaient — seule la liste était bloquée). C'est ce qui donnait l'impression « R4 supprimé ».
   - `get_r5_redirect_target` → la **consolidation R5→R3** (commentée dans le code : « R5→R3 consolidation: redirect sub-pages ») ne se déclenchait jamais : pages détail en 200 noindex au lieu du 301 prévu.
3. **Cible 404 dans la fonction R5** (créée en Studio, jamais backportée) : `'/blog-pieces-auto/conseil-' || pg_alias` — route inexistante (la vraie est `conseils/`). Jamais observé car le bug #2 l'empêchait de tirer.

Bonus découvert : la version repo de `get_all_seo_references` (migration 20260125) joint `__products_gammes` — table qui **n'a jamais existé** (convention inventée) ; la DB avait été corrigée en Studio sans backport. Drift aligné ici.

## Changements (4 commits, red→green)

1. `scripts/ci/check-rpc-allowlist-coverage.sh` — regex `<[^(]*` tolérante aux génériques imbriqués. Gate passe de « 32 couverts ✅ » à « 2 manquants ❌ » (red prouvé), même classe qu'INC-2026-006.
2. `rpc_allowlist.json` (backend runtime + copie racine) — les 2 entrées (STABLE, SELECT only, vérifiées en DB) + champs `total` corrigés (le total racine était déjà faux : 157 déclaré / 165 réel). Gate **vert** (38/38).
3. Migration `20260610_fix_r5_redirect_target_align_reference_rpcs.sql` — cible R5 corrigée (`conseils/` + durcissement `pg_alias NULL` → hub) ; backport définition déployée de `get_all_seo_references` ; GRANTs explicites (parité by_slug, PREPROD anon ADR-028). **Appliquée à la DB** via le canal MCP gouverné (2026-06-10, rollback = anciennes définitions capturées en PR + REVOKE).
4. Glob ownership D14 pour la migration (pattern V-Level #861, owner GO en session).

## Preuves runtime (PRE-PR, DEV:3000)

- `SELECT * FROM get_r5_redirect_target('bruit-amortisseur')` → `/blog-pieces-auto/conseils/amortisseur#diagnostic-rapide` ✅
- `curl DEV:3000/diagnostic-auto/bruit-amortisseur` → **301 → conseils/amortisseur#diagnostic-rapide** (première exécution réelle de la consolidation R5→R3) ✅
- `curl DEV:3000/api/seo/reference` → 231 références ✅ ; cible R3 `conseils/amortisseur` → 200 ✅

## Improvement Check (mode Full — DB + indexation)

- **Problem:** R4 index vide en PROD (231 refs invisibles, pages orphelines) + consolidation R5→R3 demandée par l'owner jamais active + gate CI aveugle aux génériques imbriqués.
- **Evidence before:** PROD `/api/seo/reference` = `{"references":[],"total":0}` ; détails R5 = 200 noindex (jamais 301) ; gate vert à tort (32 appels vus sur 38).
- **Expected gain:** index R4 vivant (maillage interne vers 231 refs sitemappées) ; ~10 pages détail R5 → 301 vers section diagnostic R3 (consolidation effective) ; classe de bug « RPC invisible au gate » fermée.
- **Risk:** fonctions SELECT-only, grants additifs, redirects = comportement déjà codé/commenté côté route ; réversible (anciennes définitions en PR, REVOKE, revert PR). Activation PROD = au prochain deploy (merge → `:preprod`, PROD au prochain tag `v*` — rien d'immédiat en PROD).
- **Test:** gate red(2 manquants)→green(38/38) ; SQL + 301 DEV prouvés ci-dessus.
- **Evidence after:** voir Preuves runtime ; POST-MERGE : vérifier PREPROD smoke puis, après tag, PROD `/reference-auto` (liste non vide) et un détail R5 (301).
- **Verdict:** GO
- **Next action:** merge owner ; au prochain tag PROD, spot-check les deux surfaces. Suivi hors-scope signalé : drift racine↔backend de `rpc_allowlist.json` (12 entrées) à resynchroniser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)