### PR TITLE
feat(seo): consolidation R6→R3 inerte (flag OFF) — 301 self-gaté guide-achat → conseils

### DIFF
--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -132,6 +132,23 @@ export class FeatureFlagsService {
     return this.bool('R8_OWNED_EDITORIAL_ENABLED', false);
   }
 
+  // ── R6 Consolidation (guide d'achat → R3 conseils, décision owner 2026-06-10) ──
+
+  /**
+   * Gates the R6→R3 consolidation redirect path: when ON, R6 guide-achat
+   * detail pages 301-redirect to the gamme's R3 conseils page — ONLY for
+   * gammes whose R3 article exists (self-gated per gamme: no live R3 → no
+   * redirect, the standalone R6 page keeps serving — never a redirect-to-404).
+   * Mirrors the R5→R3 consolidation (diagnostic-auto sub-pages → conseils).
+   *
+   * Activation is owner-gated: requires the vault ADR amending role-matrix v5
+   * (R6 standalone page → R3 section) + smoke-test anchor swap (airlock) +
+   * sitemap exclusion of folded gammes. Default: false (inert — zero change).
+   */
+  get seoR6ConsolidationEnabled(): boolean {
+    return this.bool('SEO_R6_CONSOLIDATION_ENABLED', false);
+  }
+
   // ── Conseil Pack flags ──
 
   get conseilPackEnabled(): boolean {

--- a/backend/src/modules/blog/controllers/r6-guide.controller.ts
+++ b/backend/src/modules/blog/controllers/r6-guide.controller.ts
@@ -3,7 +3,7 @@
  * GET /api/r6-guide/:pg_alias → R6GuidePayload
  */
 
-import { Controller, Get, Param, Logger } from '@nestjs/common';
+import { Controller, Get, Header, Param, Logger } from '@nestjs/common';
 import { R6GuideService } from '../services/r6-guide.service';
 import {
   DomainNotFoundException,
@@ -16,6 +16,22 @@ export class R6GuideController {
   private readonly logger = new Logger(R6GuideController.name);
 
   constructor(private readonly r6GuideService: R6GuideService) {}
+
+  /**
+   * Cible de redirection 301 pour les pages R6 guide-achat → R3 conseils
+   * (consolidation R6→R3, flag-gated OFF — mirror de /api/seo/diagnostic/redirect).
+   * Cache court : doit se propager vite quand l'owner active le flag.
+   * IMPORTANT : doit rester déclaré AVANT @Get(':pg_alias') qui capture tout.
+   * GET /api/r6-guide/redirect/:pg_alias
+   */
+  @Get('redirect/:pg_alias')
+  @Header('Cache-Control', 'public, max-age=300')
+  async getRedirectTarget(
+    @Param('pg_alias') pgAlias: string,
+  ): Promise<{ redirect_to: string | null; pg_alias: string | null }> {
+    const result = await this.r6GuideService.getRedirectTarget(pgAlias);
+    return result ?? { redirect_to: null, pg_alias: null };
+  }
 
   /**
    * GET /api/r6-guide/:pg_alias

--- a/backend/src/modules/blog/services/r6-guide.service.redirect.test.ts
+++ b/backend/src/modules/blog/services/r6-guide.service.redirect.test.ts
@@ -1,0 +1,81 @@
+/**
+ * R6GuideService.getRedirectTarget — consolidation R6→R3 (flag-gated).
+ *
+ * Invariants couverts :
+ *   - flag OFF (défaut) ⇒ null, AUCUNE requête DB (chemin inerte)
+ *   - flag ON + gamme inconnue ⇒ null
+ *   - flag ON + gamme sans article R3 ⇒ null (self-gate — jamais de redirect-vers-404)
+ *   - flag ON + article R3 vivant ⇒ cible /blog-pieces-auto/conseils/{alias}
+ *
+ * Pas d'I/O réseau ; mocks minimaux (mirror du style r3-guide.service.test.ts).
+ */
+
+import { R6GuideService } from './r6-guide.service';
+
+type Row = Record<string, unknown> | null;
+
+function makeService(
+  flagOn: boolean,
+  rows: { gamme: Row; advice: Row },
+): { service: R6GuideService; tablesQueried: string[] } {
+  const tablesQueried: string[] = [];
+  const client = {
+    from(table: string) {
+      tablesQueried.push(table);
+      const data = table === 'pieces_gamme' ? rows.gamme : rows.advice;
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        limit: () => builder,
+        single: async () => ({
+          data,
+          error: data ? null : { code: 'PGRST116' },
+        }),
+      };
+      return builder;
+    },
+  };
+  const service = new R6GuideService(
+    { client } as never,
+    {} as never,
+    {} as never,
+    { seoR6ConsolidationEnabled: flagOn } as never,
+  );
+  return { service, tablesQueried };
+}
+
+describe('R6GuideService.getRedirectTarget — consolidation R6→R3', () => {
+  it('flag OFF (défaut) → null sans aucune requête DB', async () => {
+    const { service, tablesQueried } = makeService(false, {
+      gamme: { pg_id: 8 },
+      advice: { ba_pg_id: 8 },
+    });
+    await expect(service.getRedirectTarget('filtre-a-air')).resolves.toBeNull();
+    expect(tablesQueried).toHaveLength(0);
+  });
+
+  it('flag ON + gamme inconnue → null', async () => {
+    const { service } = makeService(true, { gamme: null, advice: null });
+    await expect(service.getRedirectTarget('inconnue')).resolves.toBeNull();
+  });
+
+  it('flag ON + gamme sans article R3 → null (self-gate, pas de redirect-vers-404)', async () => {
+    const { service, tablesQueried } = makeService(true, {
+      gamme: { pg_id: 8 },
+      advice: null,
+    });
+    await expect(service.getRedirectTarget('filtre-a-air')).resolves.toBeNull();
+    expect(tablesQueried).toEqual(['pieces_gamme', '__blog_advice']);
+  });
+
+  it('flag ON + article R3 vivant → cible /blog-pieces-auto/conseils/{alias}', async () => {
+    const { service } = makeService(true, {
+      gamme: { pg_id: 8 },
+      advice: { ba_pg_id: 8 },
+    });
+    await expect(service.getRedirectTarget('filtre-a-air')).resolves.toEqual({
+      redirect_to: '/blog-pieces-auto/conseils/filtre-a-air',
+      pg_alias: 'filtre-a-air',
+    });
+  });
+});

--- a/backend/src/modules/blog/services/r6-guide.service.ts
+++ b/backend/src/modules/blog/services/r6-guide.service.ts
@@ -7,6 +7,7 @@
  */
 
 import { Injectable, Logger } from '@nestjs/common';
+import { FeatureFlagsService } from '../../../config/feature-flags.service';
 import { SupabaseIndexationService } from '../../search/services/supabase-indexation.service';
 import { BlogArticleTransformService } from './blog-article-transform.service';
 import { InternalLinkingService } from '../../seo/internal-linking.service';
@@ -46,7 +47,42 @@ export class R6GuideService {
     private readonly supabaseService: SupabaseIndexationService,
     private readonly transformService: BlogArticleTransformService,
     private readonly internalLinkingService: InternalLinkingService,
+    private readonly featureFlags: FeatureFlagsService,
   ) {}
+
+  /**
+   * R6→R3 consolidation redirect target (mirror du pattern R5,
+   * DiagnosticService.getRedirectTarget). Auto-gaté par gamme : retourne une
+   * cible UNIQUEMENT si la gamme a un article R3 conseils vivant — sinon null
+   * et la page R6 standalone continue de servir (jamais de redirect-vers-404).
+   * Inerte tant que SEO_R6_CONSOLIDATION_ENABLED=false (défaut).
+   */
+  async getRedirectTarget(
+    pgAlias: string,
+  ): Promise<{ redirect_to: string; pg_alias: string } | null> {
+    if (!this.featureFlags.seoR6ConsolidationEnabled) return null;
+
+    const { data: gamme } = await this.supabaseService.client
+      .from('pieces_gamme')
+      .select('pg_id')
+      .eq('pg_alias', pgAlias)
+      .single();
+    if (!gamme) return null;
+
+    // Self-gate : ne rediriger que si la page R3 de la gamme existe
+    const { data: advice } = await this.supabaseService.client
+      .from('__blog_advice')
+      .select('ba_pg_id')
+      .eq('ba_pg_id', gamme.pg_id)
+      .limit(1)
+      .single();
+    if (!advice) return null;
+
+    return {
+      redirect_to: `/blog-pieces-auto/conseils/${pgAlias}`,
+      pg_alias: pgAlias,
+    };
+  }
 
   /**
    * Resolve a non-canonical slug to the canonical pg_alias.

--- a/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
@@ -141,6 +141,28 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     throw json({ message: "Alias manquant" }, { status: 404 });
   }
 
+  try {
+    // R6→R3 consolidation (flag-gated côté serveur, inerte par défaut) :
+    // 301 vers la page R3 conseils de la gamme quand le flag est ON ET que
+    // la page R3 existe (self-gate backend — jamais de redirect-vers-404).
+    // Mirror du pattern R5 (diagnostic-auto.$slug → conseils).
+    const redirectProbeUrl = getInternalApiUrlFromRequest(
+      `/api/r6-guide/redirect/${pg_alias}`,
+      request,
+    );
+    const redirectRes = await fetch(redirectProbeUrl, {
+      headers: { Accept: "application/json" },
+    });
+    if (redirectRes.ok) {
+      const target = await redirectRes.json();
+      if (target?.redirect_to) {
+        return redirect(target.redirect_to, 301);
+      }
+    }
+  } catch {
+    // probe réseau en échec → rendu normal de la page R6 (comportement actuel)
+  }
+
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 12000);
 


### PR DESCRIPTION
## Contexte

Décision owner 2026-06-10 (en session) : **les règles évoluent — R6 rejoint la consolidation satellites→R3**, même posture que R5 (dont la chaîne 301 vient d'être réparée en #922 : RPC débloqué + cible 404 corrigée).

Cette PR livre la mécanique **entièrement inerte** (flag OFF par défaut, zéro changement de comportement) ; l'**activation reste un acte owner** gouverné par l'ADR vault (voir « Activation » plus bas).

## Mécanique (mirror exact du pattern R5)

- `FeatureFlags.seoR6ConsolidationEnabled` — `SEO_R6_CONSOLIDATION_ENABLED`, défaut `false` (même pattern que `R8_OWNED_EDITORIAL_ENABLED` #906/#907).
- `R6GuideService.getRedirectTarget(pgAlias)` — cible `/blog-pieces-auto/conseils/{alias}` **uniquement si l'article R3 de la gamme existe** (`__blog_advice.ba_pg_id`) : self-gate par gamme, jamais de redirect-vers-404, rollout naturellement borné par le contenu R3 disponible (pas de table de lots à gérer).
- `GET /api/r6-guide/redirect/:pg_alias` — déclaré **avant** le catch-all `:pg_alias`, `Cache-Control 300s` (propagation rapide au flip du flag, contrairement aux 86400s du endpoint R5).
- Loader `blog-pieces-auto.guide-achat.$pg_alias.tsx` — probe redirect en tête, fallback rendu normal sur erreur réseau (comportement identique à la route R5).
- **Aucun RPC ni migration** : deux selects idiomatiques du service (le pattern R5 utilisait un RPC ; ici la logique tient en requêtes existantes — moins de couches).

## Tests

`r6-guide.service.redirect.test.ts` — jest 4/4 ✅ :
- flag OFF → null **sans aucune requête DB** (chemin inerte prouvé)
- gamme inconnue → null
- gamme sans article R3 → null (self-gate)
- article R3 vivant → cible conseils

Build `@fafa/backend` vert. Build frontend local impossible sur la machine DEV (incident actif connu `web-vitals-attribution-unstable` : `Rollup failed to resolve web-vitals/attribution` — antérieur à cette PR) → validation frontend = CI.

## Activation (owner, hors de cette PR — ordre impératif)

1. **ADR vault** amendant role-matrix v5 (R6 standalone → consolidé R3) — brouillon préparé, à soumettre signé G3.
2. **Swap ancre smoke-test** `/blog-pieces-auto/guide-achat/roulement-de-roue` (`.github/` = airlock owner) — sinon le smoke casse au flip.
3. **Exclusion sitemap** des gammes repliées (sinon le sitemap émet des 301 — crawl waste, cf. audit sitemap issue #2).
4. `SEO_R6_CONSOLIDATION_ENABLED=true` + surveillance GSC.

## Improvement Check (Standard — feature flag-gated, zéro comportement)

- **Problem:** décision owner « R6 → sections/301 R3 » sans mécanique d'exécution (R5 l'avait, R6 non).
- **Evidence before:** aucun chemin de consolidation R6 ; 155 guides standalone, ~0-1 clic GSC/90j (matrice #866).
- **Expected gain:** mécanique prête, activation à coût marginal nul post-ADR ; self-gate = qualité garantie par construction.
- **Risk:** nul tant que flag OFF (prouvé par test « zéro requête DB ») ; au flip : réversible instantanément (flag OFF), redirects bornés aux gammes avec R3 vivant.
- **Test:** jest 4/4 + build backend vert (voir ci-dessus).
- **Evidence after:** POST-activation : échantillon de pages guide-achat → 301 conseils ; GSC impressions transférées.
- **Verdict:** GO (merge sûr — inerte) ; activation = OWNER_DECISION post-ADR.
- **Next action:** merge ; soumettre l'ADR vault ; puis étapes 2-4 dans l'ordre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)