### PR TITLE
docs(pricing): figer la routine supplier-load — séquence 7 gates, EAN-13, PENDING-by-default

### DIFF
--- a/.claude/knowledge/ops/supplier-brand-price-load-procedure.md
+++ b/.claude/knowledge/ops/supplier-brand-price-load-procedure.md
@@ -11,7 +11,7 @@ sources:
   - backend/src/modules/supplier-truth/connectors/inoshop-search-parse.ts  # bulk-search parser + activation classifier (brand-generic)
   - backend/src/modules/supplier-truth/connectors/supplier-registry.ts
   - /opt/automecanik/data/tecdoc/
-last_scan: 2026-06-08
+last_scan: 2026-06-10
 ---
 
 # Supplier Brand Price-Load Procedure
@@ -80,10 +80,11 @@ doit PAS rendre la pièce vendable tant que la dispo n'est pas vérifiée. Donc 
 - **Priorité de vérification** : les réfs **réellement affichables/vendables**
   (storefront), pas un top-N générique — pas besoin de couvrir 100 % du fichier.
 
-> ⚠️ **Le module gouverné active `pri_dispo='1'` au commit** (`pricing_commit_chunk`).
-> Pour respecter « import ≠ vendable », l'import doit pouvoir écrire en **pending**
-> (option d'activation paramétrable, défaut **non-activant**) — **changement
-> gouverné à livrer** (sinon : import puis demote immédiat des non-confirmées).
+> ✅ **Livré** (`ImportRequest.activate`, défaut **false** = PENDING — prouvé
+> MECAFILTER + VENEPORTE) : le commit écrit `pri_dispo='0'` + `pending_stock_check`
+> (INSERT) / préserve la dispo (UPDATE) → coût en base, **non vendable**.
+> `activate:true` reste owner-gated (réfs portal-CONFIRMED uniquement). Rendre
+> vendable = endpoint séparé `POST /api/admin/pricing/activate/{dry-run,commit,rollback}`.
 
 > ⚠️ **Dette storefront — traitée par #850** : `hasStockAvailable()` était hardcodé
 > `true` (« flux tendu ») → une pièce affichée sans prix vendable apparaissait à
@@ -120,6 +121,33 @@ Formule canon (module L1, en cents) : `achat = px_base×(1−remise)` ;
 `vente_ht = round(achat×(1+marge))` ; remise par (marque×sous-famille) ;
 grille = `MARGE_NEW_2021.xls`. ⚠️ **Valider l'unité `px_base`** (pack vs pièce).
 
+### 1bis — EAN-13 : reconstruire le check digit depuis la DB `[CRITICAL]`
+
+`pieces_ref_ean.pre_code_ean` stocke l'EAN-13 **SANS chiffre de contrôle** (12
+chars — constaté sur toutes les marques vérifiées : pm 3040, 3080, 4900). Or
+l'EAN-lock du parser (`inoshop-search-parse.ts`) est une **égalité stricte** avec
+le `data-ean` portail (13 chars) → un feed généré depuis la DB sans reconstruction
+**perd le verrou EAN** (tout retombe en REF_BRAND / REVIEW). Reconstruction
+(validée **0 mismatch sur 2 982 réfs** MECAFILTER DB↔xlsx, 2026-06-10) :
+
+```sql
+-- d13 = (10 − Σ(d_i × poids alterné 1/3) mod 10) mod 10
+SELECT pre_code_ean || (((10 - (
+  SELECT sum(substr(pre_code_ean,i,1)::int * CASE WHEN i % 2 = 1 THEN 1 ELSE 3 END)
+  FROM generate_series(1,12) i) % 10) % 10))::text AS ean13
+WHERE pre_code_ean ~ '^[0-9]{12}$';
+```
+
+Règles feed CSV (le parser du worker est un `split(',')` naïf) :
+
+- EAN absent → champ **VIDE non-quoté** (psql : laisser NULL — **jamais** `''`,
+  que `\copy` sort en `""` quoted, lu comme un EAN littéral de 2 chars).
+- `ORDER BY ref` (checkpoint resume stable). Gencode xlsx **prioritaire** quand un
+  fichier fournisseur existe ; EAN DB reconstruit en complément des manquants.
+- Deux sources de feed : **xlsx fournisseur** (actives = `c_arret_gamme='N'` +
+  `px_base>0`, clé `c_art_fourn`, `gencode`=EAN-13) ou **catalogue DB** (pas de
+  fichier : `piece_ref` + EAN reconstruit, périmètre `piece_pm_id`).
+
 ## 2 — Vérif live portail (lecture seule, owner-gated)
 Deux outils complémentaires, **génériques** (tout `SUPPLIER_SPL` + `BRAND_TOKENS`),
 read-only, ne touchent **jamais** `pieces_price` :
@@ -149,15 +177,15 @@ read-only, ne touchent **jamais** `pieces_price` :
 par EAN** → corriger le fichier (ou exclure du 1er commit, repris en contrôle 30 j).
 
 ## 5 — Import gouverné (owner GO) — coût d'abord, activation ensuite
-`POST /api/admin/pricing/import/commit` `{ batchId }` → chunks atomiques 5000,
-écrit `pieces_price_history`, batch `COMMITTED`. **Met le coût en base.**
-⚠️ Le module met `pri_dispo='1'` au commit ; pour respecter « import ≠ vendable »
-(§Garde-fou storefront), soit l'import écrit en **pending** (option non-activante,
-**à livrer**), soit on **demote** immédiatement les non-confirmées (→ pending /
-`'0'` + `pricing_state_reason`) — l'activation **vendable** (`'1'` en stock, `'2'`
-stock faible, `'3'` sur commande) ne reste que sur les réfs **CONFIRMED** (étape 2),
-selon leur statut réel. **Rollback** : `POST .../rollback`
-`{ batchId, supplierId }` (LIFO `pricing_rollback_batch`, restaure prix + dispo).
+`POST /api/admin/pricing/import/commit` `{ batchId, ...ImportRequest }` (le corps
+reprend les mêmes `fileRows`) → chunks atomiques 5000, écrit `pieces_price_history`,
+batch `COMMITTED`. **Met le coût en base, en PENDING par défaut** (`activate:false`
+→ `pri_dispo='0'`, non vendable ; **`pri_ref` persisté** depuis #913 — c'est la clé
+de l'activation). L'activation **vendable** (`'1'` en stock, `'2'` stock faible,
+`'3'` sur commande) ne porte que sur les réfs **CONFIRMED** (étape 2), via
+`activate/{dry-run,commit}` (rows `{ref,dispo}`, `confirm:true`, brand-lock
+`supplierId=pm_id`). **Rollback** : `POST .../rollback` `{ batchId, supplierId }`
+(LIFO `pricing_rollback_batch`, restaure prix + dispo).
 
 ## 6 — Post-commit (étalé 30 j la 1ère fois)
 Dispo tenue à jour par la sentinelle (capée `SUPPLIER_SYNC_MAX_REFS_PER_RUN`,
@@ -232,6 +260,38 @@ prix vendable reste sur le grid mais à prix 0 → le gate `can_sell` l'affiche
 | Plateforme connecteur (CAL ≠ DCA) | `platform` du registry |
 | Dérivation prix | profil `DIRECT_NET` / `REMISE_ON_BRUT` / … |
 | `brand pm_id` cible | scope du profil + du match |
+
+## Séquence figée (routine standard — prouvée de bout en bout VENEPORTE 2026-06-10)
+
+| # | Étape | Endpoint / commande | Gate | Vérif après |
+|---|---|---|---|---|
+| 1 | Feed (§1/§1bis) | psql `\copy` → `data/tecdoc/<fourn>-<marque>-<AAAAMM>-feed.csv` | — | longueurs EAN ∈ {13, 0}, zéro `"` |
+| 2 | Pilote classify | worker §2, `LIMIT=30` | **GO owner** (login portail) | 0 FALSE_MATCH, CONFIRMED EAN-locked |
+| 3 | Full classify | worker sans LIMIT (background, resumable) | couvert par le GO pilote | `MECE sum_check`, buckets, 0 batch failed |
+| 4 | Dry-run import | `POST import/dry-run` (fileRows = `confirmed.csv` : `ref,ean,achat_ht=portalPrix`) | **GO owner** | 0 rejet / 0 outlier ; unmatched = hors-catalogue connu |
+| 5 | Commit PENDING | `POST import/commit` `{batchId,…}` | **GO owner** | SQL : n lignes, 100 % `pri_dispo='0'`, `pri_ref` non-vide, 0 vente<achat |
+| 6 | Activation | `POST activate/{dry-run,commit}` rows AG→`'1'` / GRP→`'2'`, `confirm:true` | **GO owner** | SQL : répartition `pri_dispo` 1/2, 0 resté à `'0'` |
+| 7 | Display | `POST display/{dry-run,commit}` `{supplierId=pm_id, confirm:true}` | **GO owner** | décomposition **MECE** : flippées + déjà-affichées + retenues gate gamme |
+
+À l'étape 7, **toujours décomposer** `eligible` vs vendables. Les retenues par le
+gate gamme (`pg_display≠'1'`, #915) sont de deux natures distinctes :
+**accessoires level-4/5** → NO-GO permanent (cachés par design) ; **hub de gamme
+principale (level-1) caché** → **décision owner séparée**, jamais prise par la
+routine (ex. VENEPORTE : pg 26 Silencieux + pg 17 Tube d'échappement restent
+cachés — coût de transport trop cher, à revoir). Les review du classify
+(`ARRIVAGE`/`NOT_FOUND`/`NO_EAN`) restent pending (re-vérification ultérieure).
+MAJ tarifaire ultérieure = §7 INCRÉMENTAL.
+
+## Worked example — VENEPORTE (2026-06-10) — 1er run 100 % gouverné de bout en bout
+`VENEPORTE.xlsx` (9 640 lignes, pm 4900, DCA spl 71) → 7 338 actives → feed
+`dca-veneporte-202606-feed.csv` (6 865 EAN-13 dont 8 complétés depuis la DB, 473
+vides nets) → pilote 30 réfs (0 NOT_FOUND = preuve empirique que DCA porte la
+marque) → full classify 47 min, 0 erreur : **1 449 CONFIRMED tous EAN-locked**
+(791 AG + 658 GRP), 5 850 ruptures, 39 review → dry-run batch `85c26ac0`
+(1 411 INSERT / 38 unmatched / 0 rejet) → commit PENDING 1 411 (`pri_ref` 100 %)
+→ activation batch `f3f18443` (778×`'1'` + 633×`'2'`) → display batch `9969fcd9` :
+**332 visibles** (Catalyseur 163, Joint d'échappement 105, FAP 57, SCR 7) ;
+1 078 vendables retenues hubs pg 26/17 (owner : transport) + 1 accessoire level-4.
 
 ## Worked example — 1er run NK (2026-06-04) + remédiation
 Marque **NK** (= `SBS.xlsx`, « SBS = NK »), fournisseur **DCA** (spl 71), feed

--- a/.claude/skills/supplier-price-load/SKILL.md
+++ b/.claude/skills/supplier-price-load/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: supplier-price-load
-description: Use when loading a supplier/brand tariff into pieces_price — drives the GOVERNED Pricing Control Plane import (portal verification → supplier profile → dry-run → commit → rollback), never a standalone INSERT. Triggers — "charger les tarifs de <marque>", "importer le tarif <fournisseur>", "mettre à jour les prix d'achat de <marque>", or any prepared supplier feed destined for pieces_price.
+description: Use when loading a supplier/brand tariff into pieces_price — drives the GOVERNED Pricing Control Plane import (feed + EAN-13 → portal classify → supplier profile → dry-run → commit PENDING → activation → display → rollback), never a standalone INSERT. Triggers — "charger les tarifs de <marque>", "importer le tarif <fournisseur>", "mettre à jour les prix d'achat de <marque>", or any prepared supplier feed destined for pieces_price.
 type: discipline
 status: stable
 owners: ['@ak125']
 domain: D15
 runtime_class: privileged
 llm_safe: false
-last_verified: '2026-06-04'
+last_verified: '2026-06-10'
 license: Internal - Automecanik
 compatibility: Designed for Claude Code in the AutoMecanik monorepo. Stack — Supabase + PostgreSQL + Playwright supplier connectors + the governed PricingModule (Pricing Control Plane V1). Touches pieces_price (live client cost) via the governed import API only. Privileged — drives prod price writes + does real supplier-portal logins.
 tags: [pricing, supplier, pieces_price, tariff, import, pricing-control-plane, dca, governance]
 metadata:
-  version: "2.0"
+  version: "2.1"
   argument-hint: "[brand] [supplier]"
   disable-model-invocation: true
   spec: agentskills.io/specification v1
@@ -33,12 +33,14 @@ PR #707/#709), de façon vérifiée et réversible. Doctrine = runbook
 > parallèle interdit** (anti-bricolage). Le run réel exige un **GO owner par
 > étape**.
 
-> **Invariant dispo `[CRITICAL]`** : importer un tarif **active** la pièce —
-> `pricing_commit_chunk` met `pri_dispo='1'` (= vendable). Tous les chemins de
-> lecture de prix filtrent `pri_dispo='1'` (R2 RPC, search, products). Donc
-> **`pri_dispo=null` rend le prix INVISIBLE partout** — ne jamais charger un prix
-> qu'on veut voir avec `dispo` null. La nuance « rupture » se gère **après** via
-> le toggle admin `working-stock` / la sentinelle, pas en laissant le prix muet.
+> **Invariant dispo `[CRITICAL]`** : le commit gouverné écrit en **PENDING par
+> défaut** (`ImportRequest.activate:false` → `pri_dispo='0'` +
+> `pending_stock_check`, non vendable ; **`pri_ref` persisté** #913 = clé de
+> l'activation). Tous les chemins de lecture filtrent `pri_dispo IN ('1','2','3')`
+> → un prix pending/null est **INVISIBLE partout** (0,00 €). Rendre vendable =
+> étape séparée `activate/{dry-run,commit}` sur les seules réfs
+> **portal-CONFIRMED** (AG→`'1'`, GRP→`'2'`), puis visible = `display/commit`
+> (gate gamme `pg_display` #915). Chaque étape = **GO owner** + rollback batch.
 
 ## Quand proposer ce skill
 
@@ -52,10 +54,13 @@ PR #707/#709), de façon vérifiée et réversible. Doctrine = runbook
 
 ## Workflow (OBLIGATOIRE — chaque étape gated)
 
-### 1. Localiser le fichier fournisseur
+### 1. Localiser / générer le feed
 Feed préparé sous `/opt/automecanik/data/tecdoc/`, nommage générique
 `<fournisseur>-<marque>-<AAAAMM>-feed.csv`. ⚠️ **Valider l'unité `px_base`**
-(pack vs pièce) — risque d'erreur ×N.
+(pack vs pièce) — risque d'erreur ×N. ⚠️ **EAN depuis la DB = reconstruire le
+check digit** (`pieces_ref_ean` stocke 12 chars ; EAN-lock parser = égalité
+stricte EAN-13) ; EAN absent = champ vide **non-quoté** (jamais `""`) — SQL +
+règles dans le runbook §1bis.
 
 ### 2. Vérif live portail (login RÉEL, lecture seule — GO owner)
 Deux outils **génériques** (tout `SUPPLIER_SPL` + `BRAND_TOKENS`), read-only, ne
@@ -66,9 +71,13 @@ touchent jamais `pieces_price`. C'est la **seule** brique hors-module (le
 route bulk `POST /search` (~0,2 s/réf), buckets `CONFIRMED_AG`/`CONFIRMED_GRP`/
 `BLOCK_NONE`/`REVIEW_*`, cache + checkpoint reprenable, invariant *no false in-stock* :
 ```bash
-SUPPLIER_SPL=<spl_id> BRAND_TOKENS=NK,SBS FEED_PATH=<feed.csv> OUT_DIR=/tmp/<run> \
+SUPPLIER_SPL=<spl_id> BRAND_TOKENS=<MARQUE,ALIAS> FEED_PATH=<feed.csv> \
+  OUT_DIR=/opt/automecanik/data/tecdoc/<fournisseur>-<marque> [LIMIT=30] \
   npx tsx -r dotenv/config backend/src/workers/supplier-availability-classify.ts dotenv_config_path=backend/.env
 ```
+`OUT_DIR` **obligatoire et durable** (#908 — jamais un tmp OS : il porte le
+checkpoint resumable). Routine : **pilote `LIMIT=30` d'abord** (vérifie login,
+brand tokens, EAN-lock), puis full run en background (resumable).
 
 **Spot-check prix (échantillon)** — compare achat fichier vs achat portail sur N réfs
 risque-pondérées :
@@ -100,15 +109,30 @@ DSL caché**. Profil = donnée gouvernée, à confirmer avec l'owner.
 0 `VENTE_BELOW_ACHAT`, examiner `DELTA_EXCEEDS_MAX` (outliers), rejets, comptes
 INSERT vs UPDATE. **Présenter à l'owner.**
 
-### 6. Commit gouverné (GO owner explicite — écrit `pieces_price`)
-`POST /api/admin/pricing/import/commit` `{ batchId }` → chunks atomiques 5000,
-`pri_dispo='1'`, écrit `pieces_price_history`, batch `COMMITTED`.
+### 6. Commit gouverné PENDING (GO owner explicite — écrit `pieces_price`)
+`POST /api/admin/pricing/import/commit` `{ batchId, ...ImportRequest }` → chunks
+atomiques 5000, **`pri_dispo='0'` PENDING** (défaut `activate:false`), `pri_ref`
+persisté, écrit `pieces_price_history`, batch `COMMITTED`. **Vérif SQL** : n lignes,
+100 % `'0'`, `pri_ref` non-vide, 0 vente<achat.
 
-### 7. Rollback gouverné (si besoin)
-`POST /api/admin/pricing/import/rollback` `{ batchId, supplierId }` → LIFO restore
-via `pricing_rollback_batch` (restaure dispo + prix antérieurs depuis l'historique).
+### 7. Activation dispo (GO owner — rend les prix lisibles)
+`POST /api/admin/pricing/activate/dry-run` puis `commit` `{ supplierId: <pm_id>,
+rows: [{ref, dispo}], confirm: true }` — rows depuis `confirmed.csv` du classify :
+AG→`'1'`, GRP→`'2'`. Missing attendu = hors-catalogue du dry-run import.
+**Vérif SQL** : répartition `pri_dispo`, 0 resté à `'0'`.
 
-### 8. MAJ suivantes : **INCRÉMENTAL — nouvelles réfs only**, même profil.
+### 8. Display (GO owner — rend les pièces visibles/achetables)
+`POST /api/admin/pricing/display/dry-run` puis `commit` `{ supplierId: <pm_id>,
+confirm: true }` — flip `piece_display` des vendables cachées, **gate gamme
+`pg_display='1'` (#915)**. **Décomposer TOUJOURS** eligible vs vendables : retenues
+= accessoires level-4/5 (NO-GO design) OU hub gamme level-1 caché (**décision owner
+séparée** — ex. transport trop cher, cf. runbook §Séquence figée).
+
+### 9. Rollback gouverné (si besoin, par étape)
+`POST /api/admin/pricing/{import,activate,display}/rollback` `{ batchId, supplierId }`
+→ LIFO restore (dispo + prix antérieurs depuis l'historique).
+
+### 10. MAJ suivantes : **INCRÉMENTAL — nouvelles réfs only**, même profil.
 
 ---
 


### PR DESCRIPTION
## Quoi

La méthode de chargement tarif fournisseur est **prouvée de bout en bout sur 3 marques** (NK remédiation, MECAFILTER, VENEPORTE 100 % gouverné, 2026-06-10 : 1 449 CONFIRMED → 1 411 importées → 332 en ligne). Cette PR la **fige** dans ses deux supports canoniques existants — aucun nouveau système.

## Runbook `.claude/knowledge/ops/supplier-brand-price-load-procedure.md`

- **§1bis EAN-13 `[CRITICAL]`** : `pieces_ref_ean.pre_code_ean` stocke l'EAN-13 **sans chiffre de contrôle** (12 chars, toutes marques vérifiées) ; l'EAN-lock du parser étant une égalité stricte, tout feed DB doit reconstruire le check digit (SQL fourni, **validé 0 mismatch / 2 982 réfs** MECAFILTER DB↔xlsx). Règles CSV pour le parser naïf (champ vide non-quoté, jamais `""`).
- **§Séquence figée** : routine standard en 7 gates owner (feed → pilote 30 → full classify → dry-run → commit PENDING → activation → display) avec vérification SQL après chaque étape, et doctrine de **décomposition MECE au display** : accessoires level-4/5 = NO-GO design ; **hub gamme level-1 caché = décision owner séparée** (ex. VENEPORTE pg 26/17 : transport trop cher), jamais prise par la routine.
- **2 passages obsolètes corrigés** : le mode « import pending à livrer » est **livré** (`ImportRequest.activate`, défaut false → `pri_dispo='0'` ; `pri_ref` persisté #913) — le runbook décrivait encore l'ancien comportement `pri_dispo='1'` au commit.
- Worked example VENEPORTE (chaîne de chiffres complète + batchs).

## Skill `supplier-price-load` v2.0 → v2.1

- Invariant dispo réécrit : **PENDING par défaut**, activation/display = étapes séparées owner-gated.
- `OUT_DIR` **durable obligatoire** (#908) — l'exemple `/tmp/<run>` contredisait le worker.
- Workflow complété : étapes 7 (activation `rows AG→'1'/GRP→'2'`) et 8 (display + gate gamme #915), rollback par étape.

## Risque

Docs-only. Aucun changement de code ni de comportement runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)