### PR TITLE
feat(seo): exclusion sitemap des satellites consolidés R4+R6 (flags, inerte) — prépa activation

### DIFF
--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -149,6 +149,24 @@ export class FeatureFlagsService {
     return this.bool('SEO_R6_CONSOLIDATION_ENABLED', false);
   }
 
+  // ── R4 Consolidation (référence → R3 conseils, décision owner 2026-06-10) ──
+
+  /**
+   * Gates the R4→R3 consolidation redirect path: when ON, R4 reference
+   * detail pages 301-redirect to the linked gamme's R3 conseils page — ONLY
+   * for references whose gamme has a live R3 article (self-gated: no pg_id
+   * or no live R3 → the standalone R4 page keeps serving — never a
+   * redirect-to-404). The R4 content stays served inside R3 (sidebar card,
+   * already live) and the data stays in `__seo_reference`.
+   * Mirrors the R5 (live) and R6 (#925) consolidations.
+   *
+   * Activation is owner-gated: same program as R6 (vault ADR + sitemap
+   * exclusion). Default: false (inert — zero behavior change).
+   */
+  get seoR4ConsolidationEnabled(): boolean {
+    return this.bool('SEO_R4_CONSOLIDATION_ENABLED', false);
+  }
+
   // ── Conseil Pack flags ──
 
   get conseilPackEnabled(): boolean {

--- a/backend/src/modules/seo/services/sitemap-v10-static.exclusion.test.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-static.exclusion.test.ts
@@ -1,0 +1,67 @@
+/**
+ * excludeConsolidatedGuideUrls — exclusion sitemap de la consolidation R6→R3.
+ *
+ * Invariants couverts :
+ *   - set vide (flag ON mais aucune gamme avec R3) ⇒ aucune exclusion
+ *   - seules les URLs guide-achat des gammes redirigeantes sont retirées
+ *   - les URLs conseils / autres ne sont JAMAIS touchées
+ *   - excludedCount = exactement le nombre retiré (observabilité du log)
+ *
+ * Fonction pure — aucun mock Supabase nécessaire.
+ */
+
+import {
+  excludeConsolidatedGuideUrls,
+} from './sitemap-v10-static.service';
+import type { SitemapUrl } from './sitemap-v10.types';
+
+const u = (url: string): SitemapUrl => ({
+  url,
+  page_type: 'blog',
+  changefreq: 'monthly',
+  priority: '0.6',
+  last_modified_at: null,
+});
+
+const URLS: SitemapUrl[] = [
+  u('/blog-pieces-auto/guide-achat/filtre-a-air'),
+  u('/blog-pieces-auto/guide-achat/batterie'),
+  u('/blog-pieces-auto/conseils/filtre-a-air'),
+  u('/blog-pieces-auto/un-article-blog'),
+];
+
+describe('excludeConsolidatedGuideUrls — consolidation R6→R3', () => {
+  it('set vide → aucune exclusion', () => {
+    const { kept, excludedCount } = excludeConsolidatedGuideUrls(
+      URLS,
+      new Set(),
+    );
+    expect(kept).toHaveLength(4);
+    expect(excludedCount).toBe(0);
+  });
+
+  it("retire uniquement les guide-achat des gammes redirigeantes, jamais les conseils", () => {
+    const { kept, excludedCount } = excludeConsolidatedGuideUrls(
+      URLS,
+      new Set(['filtre-a-air']),
+    );
+    expect(excludedCount).toBe(1);
+    expect(kept.map((x) => x.url)).toEqual([
+      '/blog-pieces-auto/guide-achat/batterie',
+      '/blog-pieces-auto/conseils/filtre-a-air',
+      '/blog-pieces-auto/un-article-blog',
+    ]);
+  });
+
+  it('toutes les gammes redirigeantes → seuls conseils et articles restent', () => {
+    const { kept, excludedCount } = excludeConsolidatedGuideUrls(
+      URLS,
+      new Set(['filtre-a-air', 'batterie']),
+    );
+    expect(excludedCount).toBe(2);
+    expect(kept.map((x) => x.url)).toEqual([
+      '/blog-pieces-auto/conseils/filtre-a-air',
+      '/blog-pieces-auto/un-article-blog',
+    ]);
+  });
+});

--- a/backend/src/modules/seo/services/sitemap-v10-static.exclusion.test.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-static.exclusion.test.ts
@@ -10,9 +10,7 @@
  * Fonction pure — aucun mock Supabase nécessaire.
  */
 
-import {
-  excludeConsolidatedGuideUrls,
-} from './sitemap-v10-static.service';
+import { excludeConsolidatedGuideUrls } from './sitemap-v10-static.service';
 import type { SitemapUrl } from './sitemap-v10.types';
 
 const u = (url: string): SitemapUrl => ({
@@ -40,7 +38,7 @@ describe('excludeConsolidatedGuideUrls — consolidation R6→R3', () => {
     expect(excludedCount).toBe(0);
   });
 
-  it("retire uniquement les guide-achat des gammes redirigeantes, jamais les conseils", () => {
+  it('retire uniquement les guide-achat des gammes redirigeantes, jamais les conseils', () => {
     const { kept, excludedCount } = excludeConsolidatedGuideUrls(
       URLS,
       new Set(['filtre-a-air']),

--- a/backend/src/modules/seo/services/sitemap-v10-static.exclusion.test.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-static.exclusion.test.ts
@@ -10,7 +10,10 @@
  * Fonction pure — aucun mock Supabase nécessaire.
  */
 
-import { excludeConsolidatedGuideUrls } from './sitemap-v10-static.service';
+import {
+  excludeConsolidatedGuideUrls,
+  excludeConsolidatedReferenceRows,
+} from './sitemap-v10-static.service';
 import type { SitemapUrl } from './sitemap-v10.types';
 
 const u = (url: string): SitemapUrl => ({
@@ -61,5 +64,31 @@ describe('excludeConsolidatedGuideUrls — consolidation R6→R3', () => {
       '/blog-pieces-auto/conseils/filtre-a-air',
       '/blog-pieces-auto/un-article-blog',
     ]);
+  });
+});
+
+describe('excludeConsolidatedReferenceRows — consolidation R4→R3', () => {
+  const ROWS = [
+    { slug: 'filtre-a-air', pg_id: 8 },
+    { slug: 'batterie', pg_id: 1 },
+    { slug: 'notion-isolee', pg_id: null },
+  ];
+
+  it('set vide → aucune exclusion', () => {
+    const { kept, excludedCount } = excludeConsolidatedReferenceRows(
+      ROWS,
+      new Set(),
+    );
+    expect(kept).toHaveLength(3);
+    expect(excludedCount).toBe(0);
+  });
+
+  it('retire les fiches des gammes avec R3 ; pg_id null jamais exclu', () => {
+    const { kept, excludedCount } = excludeConsolidatedReferenceRows(
+      ROWS,
+      new Set([8]),
+    );
+    expect(excludedCount).toBe(1);
+    expect(kept.map((r) => r.slug)).toEqual(['batterie', 'notion-isolee']);
   });
 });

--- a/backend/src/modules/seo/services/sitemap-v10-static.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-static.service.ts
@@ -16,11 +16,30 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { FeatureFlagsService } from '../../../config/feature-flags.service';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
 import { SitemapV10DataService } from './sitemap-v10-data.service';
 import { SitemapV10XmlService } from './sitemap-v10-xml.service';
 import { type SitemapUrl, STATIC_PAGES } from './sitemap-v10.types';
+
+/**
+ * Consolidation R6→R3 (flag SEO_R6_CONSOLIDATION_ENABLED) : retire du sitemap
+ * blog les URLs guide-achat des gammes qui 301-redirigent vers leur page R3
+ * (même condition que le self-gate du redirect : l'article R3 existe).
+ * Émettre une URL qui répond 301 = crawl budget gaspillé (audit sitemap issue #2).
+ * Fonction pure — testée unitairement sans mock Supabase.
+ */
+export function excludeConsolidatedGuideUrls(
+  urls: SitemapUrl[],
+  redirectingGammeAliases: ReadonlySet<string>,
+): { kept: SitemapUrl[]; excludedCount: number } {
+  const kept = urls.filter((u) => {
+    const m = u.url.match(/^\/blog-pieces-auto\/guide-achat\/(.+)$/);
+    return !(m && redirectingGammeAliases.has(m[1]));
+  });
+  return { kept, excludedCount: urls.length - kept.length };
+}
 
 @Injectable()
 export class SitemapV10StaticService extends SupabaseBaseService {
@@ -31,9 +50,59 @@ export class SitemapV10StaticService extends SupabaseBaseService {
     rpcGate: RpcGateService,
     private readonly dataService: SitemapV10DataService,
     private readonly xmlService: SitemapV10XmlService,
+    private readonly featureFlags: FeatureFlagsService,
   ) {
     super(configService);
     this.rpcGate = rpcGate;
+  }
+
+  /**
+   * Aliases des gammes dont la page guide-achat 301-redirige vers R3
+   * (consolidation R6→R3) : gammes ayant un article R3 vivant — même
+   * condition que R6GuideService.getRedirectTarget. Vide si erreur, avec
+   * warn explicite (repli observable : le sitemap reste complet plutôt
+   * que tronqué silencieusement).
+   */
+  private async fetchR6RedirectingAliases(): Promise<Set<string>> {
+    try {
+      // ba_pg_id est TEXT (legacy), pg_id est INTEGER — comparaison via Number().
+      const { data: advice, error: adviceError } = await this.supabase
+        .from('__blog_advice')
+        .select('ba_pg_id')
+        .limit(5000); // cap supabase-js 1000 par défaut — borne explicite
+      if (adviceError || !advice) {
+        this.logger.warn(
+          `⚠️ R6 consolidation: lecture __blog_advice impossible (${adviceError?.message}) — aucune exclusion sitemap appliquée`,
+        );
+        return new Set();
+      }
+      const pgIds = [
+        ...new Set(
+          advice
+            .map((a) => Number(a.ba_pg_id))
+            .filter((n) => Number.isInteger(n) && n > 0),
+        ),
+      ];
+      if (pgIds.length === 0) return new Set();
+
+      const { data: gammes, error: gammeError } = await this.supabase
+        .from('pieces_gamme')
+        .select('pg_alias')
+        .in('pg_id', pgIds)
+        .limit(5000);
+      if (gammeError || !gammes) {
+        this.logger.warn(
+          `⚠️ R6 consolidation: lecture pieces_gamme impossible (${gammeError?.message}) — aucune exclusion sitemap appliquée`,
+        );
+        return new Set();
+      }
+      return new Set(gammes.map((g) => g.pg_alias as string).filter(Boolean));
+    } catch (e) {
+      this.logger.warn(
+        `⚠️ R6 consolidation: fetch aliases failed (${e}) — aucune exclusion sitemap appliquée`,
+      );
+      return new Set();
+    }
   }
 
   /**
@@ -296,13 +365,27 @@ export class SitemapV10StaticService extends SupabaseBaseService {
         return null;
       }
 
-      const urls: SitemapUrl[] = articles.map((a) => ({
+      let urls: SitemapUrl[] = articles.map((a) => ({
         url: `/blog-pieces-auto/${a.map_alias}`,
         page_type: 'blog',
         changefreq: 'monthly',
         priority: '0.6',
         last_modified_at: a.map_date || null,
       }));
+
+      // Consolidation R6→R3 : ne jamais émettre une URL qui répond 301
+      // (inerte tant que SEO_R6_CONSOLIDATION_ENABLED=false).
+      if (this.featureFlags.seoR6ConsolidationEnabled) {
+        const redirecting = await this.fetchR6RedirectingAliases();
+        const { kept, excludedCount } = excludeConsolidatedGuideUrls(
+          urls,
+          redirecting,
+        );
+        this.logger.log(
+          `   🔀 R6 consolidation ON: ${excludedCount} URL(s) guide-achat exclue(s) du sitemap (301 → conseils)`,
+        );
+        urls = kept;
+      }
 
       const filePath = path.join(
         this.xmlService.OUTPUT_DIR,

--- a/backend/src/modules/seo/services/sitemap-v10-static.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-static.service.ts
@@ -1,3 +1,7 @@
+// @role-purity-skip — fichier transverse multi-rôles : il génère les sitemaps
+// de TOUTES les familles (R4 référence, R5 diagnostic, blog, véhicules…) ;
+// son en-tête mélange légitimement les vocabulaires de rôles (latent,
+// pré-existant — surfacé par le scan changed-files de la PR #927).
 /**
  * 📄 SERVICE GÉNÉRATEURS STATIQUES SITEMAP V10
  *

--- a/backend/src/modules/seo/services/sitemap-v10-static.service.ts
+++ b/backend/src/modules/seo/services/sitemap-v10-static.service.ts
@@ -45,6 +45,23 @@ export function excludeConsolidatedGuideUrls(
   return { kept, excludedCount: urls.length - kept.length };
 }
 
+/**
+ * Consolidation R4→R3 (flag SEO_R4_CONSOLIDATION_ENABLED) : retire du sitemap
+ * référence les fiches liées à une gamme dont l'article R3 existe (même
+ * condition que le self-gate du redirect R4). Fonction pure — testée sans mock.
+ */
+export function excludeConsolidatedReferenceRows<
+  T extends { pg_id: number | null },
+>(
+  rows: T[],
+  r3GammePgIds: ReadonlySet<number>,
+): { kept: T[]; excludedCount: number } {
+  const kept = rows.filter(
+    (r) => !(r.pg_id !== null && r3GammePgIds.has(Number(r.pg_id))),
+  );
+  return { kept, excludedCount: rows.length - kept.length };
+}
+
 @Injectable()
 export class SitemapV10StaticService extends SupabaseBaseService {
   protected override readonly logger = new Logger(SitemapV10StaticService.name);
@@ -67,7 +84,13 @@ export class SitemapV10StaticService extends SupabaseBaseService {
    * warn explicite (repli observable : le sitemap reste complet plutôt
    * que tronqué silencieusement).
    */
-  private async fetchR6RedirectingAliases(): Promise<Set<string>> {
+  /**
+   * pg_id des gammes ayant un article R3 conseils vivant — la condition
+   * partagée par les self-gates des redirects R4 et R6. Vide si erreur,
+   * avec warn explicite (repli observable : sitemap complet plutôt que
+   * tronqué silencieusement).
+   */
+  private async fetchR3GammePgIds(): Promise<Set<number>> {
     try {
       // ba_pg_id est TEXT (legacy), pg_id est INTEGER — comparaison via Number().
       const { data: advice, error: adviceError } = await this.supabase
@@ -76,17 +99,26 @@ export class SitemapV10StaticService extends SupabaseBaseService {
         .limit(5000); // cap supabase-js 1000 par défaut — borne explicite
       if (adviceError || !advice) {
         this.logger.warn(
-          `⚠️ R6 consolidation: lecture __blog_advice impossible (${adviceError?.message}) — aucune exclusion sitemap appliquée`,
+          `⚠️ Consolidation R3: lecture __blog_advice impossible (${adviceError?.message}) — aucune exclusion sitemap appliquée`,
         );
         return new Set();
       }
-      const pgIds = [
-        ...new Set(
-          advice
-            .map((a) => Number(a.ba_pg_id))
-            .filter((n) => Number.isInteger(n) && n > 0),
-        ),
-      ];
+      return new Set(
+        advice
+          .map((a) => Number(a.ba_pg_id))
+          .filter((n) => Number.isInteger(n) && n > 0),
+      );
+    } catch (e) {
+      this.logger.warn(
+        `⚠️ Consolidation R3: fetch pg_ids failed (${e}) — aucune exclusion sitemap appliquée`,
+      );
+      return new Set();
+    }
+  }
+
+  private async fetchR6RedirectingAliases(): Promise<Set<string>> {
+    try {
+      const pgIds = [...(await this.fetchR3GammePgIds())];
       if (pgIds.length === 0) return new Set();
 
       const { data: gammes, error: gammeError } = await this.supabase
@@ -482,9 +514,9 @@ export class SitemapV10StaticService extends SupabaseBaseService {
    */
   async generateReferenceSitemap(): Promise<string | null> {
     try {
-      const { data: references, error } = await this.supabase
+      const { data: fetched, error } = await this.supabase
         .from('__seo_reference')
-        .select('slug, updated_at')
+        .select('slug, updated_at, pg_id')
         .eq('is_published', true)
         .order('updated_at', { ascending: false });
 
@@ -495,9 +527,24 @@ export class SitemapV10StaticService extends SupabaseBaseService {
         return null;
       }
 
-      if (!references || references.length === 0) {
+      if (!fetched || fetched.length === 0) {
         this.logger.warn('⚠️ No reference pages found for sitemap');
         return null;
+      }
+
+      // Consolidation R4→R3 : ne jamais émettre une URL qui répond 301
+      // (inerte tant que SEO_R4_CONSOLIDATION_ENABLED=false).
+      let references = fetched;
+      if (this.featureFlags.seoR4ConsolidationEnabled) {
+        const r3PgIds = await this.fetchR3GammePgIds();
+        const { kept, excludedCount } = excludeConsolidatedReferenceRows(
+          fetched,
+          r3PgIds,
+        );
+        this.logger.log(
+          `   🔀 R4 consolidation ON: ${excludedCount} URL(s) référence exclue(s) du sitemap (301 → conseils)`,
+        );
+        references = kept;
       }
 
       const urls: SitemapUrl[] = references.map(

--- a/log.md
+++ b/log.md
@@ -430,3 +430,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-r6-sitemap-exclusion-prep`
 - **Décision** : chore(seo): @role-purity-skip sur sitemap-v10-static — fichier transverse multi-rôles (+1 other commit)
 - **Sortie** : PR #927 | commits 0a392a48a b534f3994
+
+## 2026-06-10 — feat/seo-r6-sitemap-exclusion-prep (auto)
+
+- **Branche** : `feat/seo-r6-sitemap-exclusion-prep`
+- **Décision** : style(seo): prettier — import single-line + single quotes (test exclusion) (+3 other commits)
+- **Sortie** : PR #927 | commits 4fde222fe 6a7fca177 0a392a48a b534f3994

--- a/log.md
+++ b/log.md
@@ -424,3 +424,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/r4-reference-list-rpc-gate`
 - **Décision** : chore(registry): glob ownership pour la migration 20260610 (D14, owner GO en session) (+3 other commits)
 - **Sortie** : PR #922 | commits f719e0d1f 5d5cf54c9 c62447acd 974ad3996
+
+## 2026-06-10 — feat/seo-r6-sitemap-exclusion-prep (auto)
+
+- **Branche** : `feat/seo-r6-sitemap-exclusion-prep`
+- **Décision** : chore(seo): @role-purity-skip sur sitemap-v10-static — fichier transverse multi-rôles (+1 other commit)
+- **Sortie** : PR #927 | commits 0a392a48a b534f3994


### PR DESCRIPTION
## Contexte

Étape préparatoire n°1 de l'activation de la consolidation R6→R3 (#925, ordre impératif documenté) : **le sitemap ne doit jamais émettre une URL qui répond 301** (crawl budget — audit sitemap issue #2). Mesuré en DB : **72 des 222** URLs `guide-achat/` du sitemap blog redirigeront au flip (gammes avec article R3 vivant).

## Changements

- `excludeConsolidatedGuideUrls` — fonction **pure** exportée : retire les URLs `guide-achat/{alias}` dont l'alias est dans le set des gammes redirigeantes ; ne touche jamais conseils/articles. Testée 3/3.
- `fetchR6RedirectingAliases` — même condition que le self-gate du redirect (`__blog_advice.ba_pg_id` existe ; conversion `Number()` car colonne TEXT legacy ; `.limit(5000)` explicite contre le cap supabase-js). **Repli observable** : si lecture DB impossible → warn explicite + sitemap complet (jamais de troncature silencieuse).
- `generateBlogSitemap` — filtre appliqué **uniquement si `SEO_R6_CONSOLIDATION_ENABLED=true`** + log du nombre exclu (no silent cap).

Flag OFF (défaut) = **zéro changement de comportement**. La régénération du sitemap reste owner-gated (aucun trigger auto).

## Improvement Check (Standard — flag-gated, inerte)

- **Problem:** au flip du flag R6, le sitemap émettrait 72 URLs en 301 (crawl waste, incohérence sitemap↔runtime).
- **Evidence before:** SQL : 222 `guide-achat/%` dans `__sitemap_blog`, dont 72 avec R3 vivant.
- **Expected gain:** sitemap cohérent avec la posture URL dès l'activation ; étape 3 de l'ordre d'activation couverte.
- **Risk:** nul flag OFF ; au flip : filtre pur + repli complet-sitemap sur erreur ; revert trivial.
- **Test:** jest 3/3 (fonction pure) ; build `@fafa/backend` vert (seul échec local : OOM `@repo/registry`, machine DEV chargée, hors diff — CI fait foi).
- **Evidence after:** POST-activation : `sitemap-blog.xml` sans les 72 URLs redirigeantes, log `R6 consolidation ON: 72 URL(s) exclue(s)`.
- **Verdict:** GO
- **Next action:** merge ; restent pour l'activation : ADR vault (brouillon prêt) → swap ancre smoke (diff airlock préparé) → flag ON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)