### PR TITLE
fix(supplier): sanitize refs in classify HTML cache filename (slash refs → ENOENT)

### DIFF
--- a/backend/src/workers/supplier-availability-classify.ts
+++ b/backend/src/workers/supplier-availability-classify.ts
@@ -55,6 +55,9 @@ const sleep = (ms: number): Promise<void> =>
   new Promise((r) => setTimeout(r, ms));
 const pct = (n: number, d: number): string =>
   d ? ((n / d) * 100).toFixed(1) + '%' : '0%';
+// Supplier refs can contain `/` (e.g. VDO "2910000102400/483") — a raw ref in the
+// cache filename becomes a nested path and crashes writeFileSync (ENOENT).
+const fsSafe = (ref: string): string => ref.replace(/[^A-Za-z0-9._-]/g, '-');
 
 interface FeedRow {
   ref: string;
@@ -212,7 +215,7 @@ async function main(): Promise<void> {
     }
     consecutiveFails = 0;
     writeFileSync(
-      `${HTML_DIR}/${batch[0].ref}_${batch[batch.length - 1].ref}.html.gz`,
+      `${HTML_DIR}/${fsSafe(batch[0].ref)}_${fsSafe(batch[batch.length - 1].ref)}.html.gz`,
       gzipSync(r.html),
     );
     const lines = batch.map((b) =>


### PR DESCRIPTION
## Bug

Le worker `supplier-availability-classify.ts` compose le nom du fichier cache HTML gz à partir des réfs brutes du batch. Une réf contenant un slash — format réel VDO `2910000102400/483` — produit un chemin avec sous-dossier inexistant → `writeFileSync` **ENOENT**, crash du run complet.

**Constaté** : run VDO 2026-06-10, batch 5/26. Le design checkpoint a fonctionné comme prévu (batch en vol jamais checkpointé → 0 faux verdict, resume propre).

## Fix

`fsSafe()` : remplace tout caractère hors `[A-Za-z0-9._-]` dans les deux réfs du nom de fichier. 4 lignes, rien d'autre touché — le checkpoint JSONL et l'EAN-lock continuent d'utiliser la réf brute.

## Preuve

Run VDO repris avec la source corrigée — passe les batches `/483` sans erreur (resume en cours au moment de la PR ; je confirme le rapport final en commentaire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)