### PR TITLE
feat(command-center): Phase 2 PR3 — SEO per-URL next_step (advisory)

### DIFF
--- a/backend/src/modules/admin/services/command-center-action-rules/seo-action.rules.ts
+++ b/backend/src/modules/admin/services/command-center-action-rules/seo-action.rules.ts
@@ -19,6 +19,7 @@ export interface GscOpportunityRow {
   page: string;
   impressions: number;
   clicks: number;
+  position?: number | null; // PR3: avg SERP position (rpc_seo_low_ctr_v1.avg_position)
 }
 
 type PageKind = 'product' | 'content' | 'other';
@@ -54,6 +55,50 @@ const KIND_META: Record<
   },
 };
 
+// SERP "ranked" cutoff — mirrors rpc_seo_low_ctr_v1's position bands
+// (top5 ≤ 5 + top15 ≤ 15 = ranked ; beyond > 15). Named (not magic): reuses the
+// governed RPC's own cutoff so the advisory stays consistent with the source.
+// NB: we re-derive the band from the NUMERIC position, NOT the RPC's position_band —
+// the RPC maps a NULL avg_position to 'beyond', so consuming it would fabricate a
+// "low position" diagnosis. Unknown must stay unknown (honest fallback below).
+const SERP_RANKED_MAX = 15;
+
+/**
+ * PR3 — advisory, deterministic per-URL editorial next_step. RULE-BASED ONLY: no
+ * content generation, no DB mutation, no meta/H1 edit — the operator acts manually.
+ * Honest fallback when the SERP position is unknown (no fabricated diagnosis):
+ *   - ranks (pos ≤ 15) but 0 clic → SERP appeal: title/meta + intent
+ *   - doesn't rank (pos > 15)     → authority/content: maillage / enrich + money link
+ */
+export function deriveUrlNextStep(
+  kind: PageKind,
+  position: number | null,
+): string {
+  if (position == null || !Number.isFinite(position) || position <= 0) {
+    // No ranking signal → generic recommendation, never a fake SERP claim.
+    if (kind === 'product')
+      return 'Vérifier title/meta + renforcer le maillage interne entrant (position SERP inconnue).';
+    if (kind === 'content')
+      return 'Vérifier title/meta + ajouter un lien vers une page produit (position SERP inconnue).';
+    return 'Vérifier title/meta + indexation (position SERP inconnue).';
+  }
+  const pos = position.toFixed(1);
+  if (position <= SERP_RANKED_MAX) {
+    // Ranks but zero-click → the SERP snippet/intent is the lever, not authority.
+    if (kind === 'product')
+      return `Optimiser title/meta + intention d'achat : ranke (pos. ${pos}) sans clic → attractivité SERP.`;
+    if (kind === 'content')
+      return `Améliorer title/meta + intro/intention : ranke (pos. ${pos}) sans clic → CTR à récupérer.`;
+    return `Vérifier title/meta + intention SERP : ranke (pos. ${pos}) sans clic.`;
+  }
+  // Beyond top15 → doesn't rank yet → authority/content first.
+  if (kind === 'product')
+    return `Renforcer le maillage interne entrant + vérifier l'indexation : position faible (pos. ${pos}).`;
+  if (kind === 'content')
+    return `Enrichir le contenu + ajouter un lien vers la page transactionnelle (money) : position faible (pos. ${pos}).`;
+  return `Vérifier l'indexation + enrichir le contenu : position faible (pos. ${pos}).`;
+}
+
 export function buildSeoOpportunityActions(
   rows: GscOpportunityRow[],
 ): RawAction[] {
@@ -74,16 +119,22 @@ export function buildSeoOpportunityActions(
     const totalImp = list.reduce((s, r) => s + r.impressions, 0);
     const sorted = [...list].sort((a, b) => b.impressions - a.impressions);
     const m = KIND_META[kind];
-    // PR2 drill-down: every page behind this action (already bounded by the RPC
-    // p_limit). ctr = clicks/impressions (~0 here, since the source filters to
-    // zero-click) — the frontend renders the per-URL table.
-    const details: SeoOpportunityDetail[] = sorted.map((r) => ({
-      url: r.page,
-      page_kind: kind,
-      impressions: r.impressions,
-      clicks: r.clicks,
-      ctr: r.impressions > 0 ? r.clicks / r.impressions : 0,
-    }));
+    // PR2 drill-down + PR3 per-URL advisory next_step. Every page behind this
+    // action (already bounded by the RPC p_limit). ctr = clicks/impressions (~0
+    // here, zero-click source). next_step is rule-derived from page kind + SERP
+    // position (honest fallback if position is unknown).
+    const details: SeoOpportunityDetail[] = sorted.map((r) => {
+      const position = r.position ?? null;
+      return {
+        url: r.page,
+        page_kind: kind,
+        impressions: r.impressions,
+        clicks: r.clicks,
+        ctr: r.impressions > 0 ? r.clicks / r.impressions : 0,
+        position,
+        next_step: deriveUrlNextStep(kind, position),
+      };
+    });
     out.push({
       id: `seo:opportunity:${kind}`,
       title: `${list.length} ${m.label} à fort potentiel SEO (impressions sans clic)`,

--- a/backend/src/modules/admin/services/command-center-actions.service.ts
+++ b/backend/src/modules/admin/services/command-center-actions.service.ts
@@ -71,6 +71,7 @@ export class CommandCenterActionsService extends SupabaseBaseService {
           page: string;
           impressions: number | string;
           clicks: number | string;
+          avg_position?: number | string | null;
         }>
       >('rpc_seo_low_ctr_v1', {
         p_window_days: CommandCenterActionsService.GSC_WINDOW_DAYS,
@@ -80,12 +81,18 @@ export class CommandCenterActionsService extends SupabaseBaseService {
       });
       if (error) throw error;
 
-      // RPC returns BIGINT sums as JSONB numbers; coerce defensively.
-      const rows: GscOpportunityRow[] = (data ?? []).map((r) => ({
-        page: r.page,
-        impressions: Number(r.impressions) || 0,
-        clicks: Number(r.clicks) || 0,
-      }));
+      // RPC returns BIGINT sums as JSONB numbers; coerce defensively. avg_position
+      // → position (PR3): only a real SERP position (>0) survives; 0/NaN/absent → null
+      // (explicit finite check, not a falsy-coerce) so the rule uses its honest fallback.
+      const rows: GscOpportunityRow[] = (data ?? []).map((r) => {
+        const pos = Number(r.avg_position);
+        return {
+          page: r.page,
+          impressions: Number(r.impressions) || 0,
+          clicks: Number(r.clicks) || 0,
+          position: Number.isFinite(pos) && pos > 0 ? pos : null,
+        };
+      });
       return buildSeoOpportunityActions(rows);
     } catch (e) {
       this.logger.warn(`[command-center-actions] SEO RPC failed: ${e}`);

--- a/backend/tests/unit/command-center-action-rules.test.ts
+++ b/backend/tests/unit/command-center-action-rules.test.ts
@@ -9,6 +9,7 @@ import { buildCertificationActions } from '../../src/modules/admin/services/comm
 import {
   buildSeoOpportunityActions,
   pageKindFromUrl,
+  deriveUrlNextStep,
 } from '../../src/modules/admin/services/command-center-action-rules/seo-action.rules';
 import { buildPricingRiskActions } from '../../src/modules/admin/services/command-center-action-rules/pricing-action.rules';
 
@@ -56,6 +57,8 @@ describe('score caps — honesty invariant', () => {
           impressions: 10,
           clicks: 0,
           ctr: 0,
+          position: 4,
+          next_step: 'x',
         },
       ],
     };
@@ -72,6 +75,8 @@ describe('score caps — honesty invariant', () => {
           impressions: 10,
           clicks: 0,
           ctr: 0,
+          position: 4,
+          next_step: 'x',
         },
       ],
     };
@@ -228,10 +233,20 @@ describe('SEO opportunity rules — real business actions (certified source)', (
     expect(buildSeoOpportunityActions([])).toEqual([]);
   });
 
-  it('PR2: emits a per-URL details payload (sorted desc; ctr = clicks/impressions)', () => {
+  it('PR2+PR3: per-URL details (sorted desc; ctr; position + advisory next_step)', () => {
     const out = buildSeoOpportunityActions([
-      { page: 'https://x/pieces/a.html', impressions: 200, clicks: 0 },
-      { page: 'https://x/pieces/b.html', impressions: 50, clicks: 5 },
+      {
+        page: 'https://x/pieces/a.html',
+        impressions: 200,
+        clicks: 0,
+        position: 4,
+      },
+      {
+        page: 'https://x/pieces/b.html',
+        impressions: 50,
+        clicks: 5,
+        position: 30,
+      },
     ]).map(finalizeAction);
     const product = out.find((a) => a.id === 'seo:opportunity:product')!;
     expect(product.details).toHaveLength(2);
@@ -241,8 +256,44 @@ describe('SEO opportunity rules — real business actions (certified source)', (
       impressions: 200,
       clicks: 0,
       ctr: 0,
+      position: 4,
+      next_step: expect.stringMatching(/title\/meta/i), // pos 4 ranked → SERP appeal
     });
     expect(product.details![1].ctr).toBeCloseTo(0.1, 5); // 5/50
+    expect(product.details![1].next_step).toMatch(/maillage/i); // pos 30 → authority
+  });
+
+  it('PR3: position=null + honest next_step when the RPC omits avg_position', () => {
+    const product = buildSeoOpportunityActions([
+      { page: 'https://x/pieces/a.html', impressions: 200, clicks: 0 },
+    ])
+      .map(finalizeAction)
+      .find((a) => a.id === 'seo:opportunity:product')!;
+    expect(product.details![0].position).toBeNull();
+    expect(product.details![0].next_step).toMatch(/inconnue/i);
+  });
+});
+
+describe('PR3: deriveUrlNextStep — deterministic, advisory, honest', () => {
+  it('ranked (pos ≤ 15) → title/meta + intent (SERP appeal)', () => {
+    expect(deriveUrlNextStep('product', 4)).toMatch(/title\/meta/i);
+    expect(deriveUrlNextStep('product', 4)).toMatch(/ranke/i);
+    expect(deriveUrlNextStep('content', 12)).toMatch(/title\/meta/i);
+    expect(deriveUrlNextStep('other', 8)).toMatch(/title\/meta/i);
+  });
+
+  it('not ranked (pos > 15) → maillage / enrich + money link', () => {
+    expect(deriveUrlNextStep('product', 40)).toMatch(/maillage/i);
+    expect(deriveUrlNextStep('content', 40)).toMatch(/transactionnelle/i);
+    expect(deriveUrlNextStep('content', 40)).toMatch(/enrichir/i);
+  });
+
+  it('honest fallback when position unknown — no fabricated SERP diagnosis', () => {
+    for (const pos of [null, 0]) {
+      const s = deriveUrlNextStep('product', pos);
+      expect(s).toMatch(/inconnue/i);
+      expect(s).not.toMatch(/ranke/i);
+    }
   });
 });
 

--- a/frontend/app/components/command-center/OwnerActionQueue.tsx
+++ b/frontend/app/components/command-center/OwnerActionQueue.tsx
@@ -162,9 +162,21 @@ export function OwnerActionQueue({ data }: { data: CommandCenterResponse }) {
                                     </th>
                                     <th
                                       scope="col"
-                                      className="py-1 text-right font-medium"
+                                      className="py-1 pr-3 text-right font-medium"
                                     >
                                       CTR
+                                    </th>
+                                    <th
+                                      scope="col"
+                                      className="py-1 pr-3 text-right font-medium"
+                                    >
+                                      Pos.
+                                    </th>
+                                    <th
+                                      scope="col"
+                                      className="py-1 font-medium"
+                                    >
+                                      Action SEO
                                     </th>
                                   </tr>
                                 </thead>
@@ -188,8 +200,16 @@ export function OwnerActionQueue({ data }: { data: CommandCenterResponse }) {
                                       <td className="py-1 pr-3 text-right tabular-nums">
                                         {d.clicks}
                                       </td>
-                                      <td className="py-1 text-right tabular-nums">
+                                      <td className="py-1 pr-3 text-right tabular-nums">
                                         {(d.ctr * 100).toFixed(2)}%
+                                      </td>
+                                      <td className="py-1 pr-3 text-right tabular-nums">
+                                        {d.position == null
+                                          ? "—"
+                                          : d.position.toFixed(1)}
+                                      </td>
+                                      <td className="py-1 text-muted-foreground">
+                                        {d.next_step}
                                       </td>
                                     </tr>
                                   ))}

--- a/packages/registry/src/command-center/snapshot.ts
+++ b/packages/registry/src/command-center/snapshot.ts
@@ -239,6 +239,8 @@ export const CcSeoDetailSchema = z
     impressions: z.number(),
     clicks: z.number(),
     ctr: z.number(), // clicks/impressions (0..1)
+    position: z.number().nullable(), // PR3: avg SERP position (rpc_seo_low_ctr_v1.avg_position); null if absent
+    next_step: z.string(), // PR3: advisory per-URL editorial action (deterministic, rule-based)
   })
   .strict();
 export type CcSeoDetail = z.infer<typeof CcSeoDetailSchema>;


### PR DESCRIPTION
## Phase 2 PR3 — SEO per-URL next_step (advisory editorial recommendation)

Each per-URL row in the `seo:opportunity:*` drill-down now carries its **SERP position** + an **advisory `next_step`** — a deterministic, rule-based editorial recommendation telling the operator what to do for that exact URL. Read-only; the operator acts manually.

### Logic (deterministic, explainable — no AI / free generation)
Derived from **page kind × SERP position band** (the band mirrors `rpc_seo_low_ctr_v1`'s own `top5≤5 / top15≤15 / beyond` cutoffs):
- **ranks (pos ≤ 15) but zero-click** → `title/meta` + search intent (SERP appeal is the lever, not authority).
- **doesn't rank (pos > 15)** → product: internal linking + indexation ; content: enrich + link to the transactional (money) page.
- **position unknown** → honest generic recommendation, **never a fabricated SERP diagnosis** ("position SERP inconnue").

### Changes
- `seo-action.rules.ts` — `deriveUrlNextStep(page_kind, position)` pure fn. Re-derives the band from the numeric position, **not** the RPC `position_band` (which maps NULL → `beyond` and would fabricate a low-position claim).
- `command-center-actions.service.ts` — maps the RPC `avg_position` → `position` (explicit finite>0 check; 0/NaN/absent → null). **Reuses `rpc_seo_low_ctr_v1` — no new query.**
- `@repo/registry` — `CcSeoDetail` + `position` (nullable) + `next_step`. SoT alias → backend `SeoOpportunityDetail` inherits it; frontend consumes it.
- frontend `OwnerActionQueue` — drill-down table gains **Pos.** + **Action SEO** columns.
- tests — `deriveUrlNextStep` matrix (ranked / beyond / unknown) + end-to-end details + honest fallback.

### Guardrails
**Advisory only** — NO content generation, NO meta/title/H1 mutation, NO DB write, NO sitemap trigger. NO new route/table/migration/RPC/heavy lib/sub-cockpit. Downgraded business→certification actions still strip `details` (PR2 guard intact). Reviewed across **3 adversarial lenses → ship, 0 blocking** (2 nit clarity items folded in: explicit finite-check on `avg_position`, comment on why we don't consume the RPC `position_band`). `COMMAND_CENTER_MODE` stays **disabled by default in production**. **No `v*` PROD tag.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
