### PR TITLE
feat(seo): consolidation R4→R3 inerte (flag OFF) — 301 self-gaté référence → conseils

### DIFF
--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -149,6 +149,24 @@ export class FeatureFlagsService {
     return this.bool('SEO_R6_CONSOLIDATION_ENABLED', false);
   }
 
+  // ── R4 Consolidation (référence → R3 conseils, décision owner 2026-06-10) ──
+
+  /**
+   * Gates the R4→R3 consolidation redirect path: when ON, R4 reference
+   * detail pages 301-redirect to the linked gamme's R3 conseils page — ONLY
+   * for references whose gamme has a live R3 article (self-gated: no pg_id
+   * or no live R3 → the standalone R4 page keeps serving — never a
+   * redirect-to-404). The R4 content stays served inside R3 (sidebar card,
+   * already live) and the data stays in `__seo_reference`.
+   * Mirrors the R5 (live) and R6 (#925) consolidations.
+   *
+   * Activation is owner-gated: same program as R6 (vault ADR + sitemap
+   * exclusion). Default: false (inert — zero behavior change).
+   */
+  get seoR4ConsolidationEnabled(): boolean {
+    return this.bool('SEO_R4_CONSOLIDATION_ENABLED', false);
+  }
+
   // ── Conseil Pack flags ──
 
   get conseilPackEnabled(): boolean {

--- a/backend/src/modules/seo/controllers/reference.controller.ts
+++ b/backend/src/modules/seo/controllers/reference.controller.ts
@@ -205,6 +205,22 @@ export class ReferenceController {
     };
   }
 
+  /**
+   * Cible de redirection 301 pour les pages R4 référence → R3 conseils
+   * (consolidation R4→R3, flag-gated OFF — mirror de R5 et R6 #925).
+   * Cache court : doit se propager vite quand l'owner active le flag.
+   * IMPORTANT : doit rester déclaré AVANT @Get(':slug') qui capture tout.
+   * GET /api/seo/reference/redirect/:slug
+   */
+  @Get('redirect/:slug')
+  @Header('Cache-Control', 'public, max-age=300')
+  async getRedirectTarget(
+    @Param('slug') slug: string,
+  ): Promise<{ redirect_to: string | null; pg_alias: string | null }> {
+    const result = await this.referenceService.getRedirectTarget(slug);
+    return result ?? { redirect_to: null, pg_alias: null };
+  }
+
   // ============================================
   // ROUTES AVEC :slug (sous-routes d'abord)
   // ============================================

--- a/backend/src/modules/seo/services/reference.service.redirect.test.ts
+++ b/backend/src/modules/seo/services/reference.service.redirect.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ReferenceService.getRedirectTarget — consolidation R4→R3 (flag-gated).
+ *
+ * Invariants couverts :
+ *   - flag OFF (défaut) ⇒ null, AUCUNE requête DB (chemin inerte)
+ *   - référence sans pg_id ⇒ null
+ *   - gamme liée sans article R3 ⇒ null (self-gate — jamais de redirect-vers-404)
+ *   - chaîne complète ⇒ cible /blog-pieces-auto/conseils/{pg_alias}
+ *
+ * Pas d'I/O réseau ; instanciation directe + mock du client supabase hérité
+ * (pattern rm-soft404-tracker / r6-guide.service.redirect).
+ */
+
+import { ReferenceService } from './reference.service';
+
+type Row = Record<string, unknown> | null;
+
+function makeService(
+  flagOn: boolean,
+  rows: { ref: Row; advice: Row; gamme: Row },
+): { service: ReferenceService; tablesQueried: string[] } {
+  const tablesQueried: string[] = [];
+  const client = {
+    from(table: string) {
+      tablesQueried.push(table);
+      const data =
+        table === '__seo_reference'
+          ? rows.ref
+          : table === '__blog_advice'
+            ? rows.advice
+            : rows.gamme;
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        limit: () => builder,
+        single: async () => ({
+          data,
+          error: data ? null : { code: 'PGRST116' },
+        }),
+      };
+      return builder;
+    },
+  };
+  const service = new ReferenceService(
+    { evaluate: () => ({ allowed: true }) } as never,
+    undefined,
+    { seoR4ConsolidationEnabled: flagOn } as never,
+  );
+  Object.defineProperty(service, 'supabase', { value: client });
+  return { service, tablesQueried };
+}
+
+describe('ReferenceService.getRedirectTarget — consolidation R4→R3', () => {
+  it('flag OFF (défaut) → null sans aucune requête DB', async () => {
+    const { service, tablesQueried } = makeService(false, {
+      ref: { pg_id: 8 },
+      advice: { ba_pg_id: '8' },
+      gamme: { pg_alias: 'filtre-a-air' },
+    });
+    await expect(service.getRedirectTarget('filtre-a-air')).resolves.toBeNull();
+    expect(tablesQueried).toHaveLength(0);
+  });
+
+  it('référence sans pg_id → null', async () => {
+    const { service } = makeService(true, {
+      ref: { pg_id: null },
+      advice: null,
+      gamme: null,
+    });
+    await expect(service.getRedirectTarget('notion-isolee')).resolves.toBeNull();
+  });
+
+  it('gamme sans article R3 → null (self-gate, pas de redirect-vers-404)', async () => {
+    const { service, tablesQueried } = makeService(true, {
+      ref: { pg_id: 8 },
+      advice: null,
+      gamme: { pg_alias: 'filtre-a-air' },
+    });
+    await expect(service.getRedirectTarget('filtre-a-air')).resolves.toBeNull();
+    expect(tablesQueried).toEqual(['__seo_reference', '__blog_advice']);
+  });
+
+  it('chaîne complète → cible /blog-pieces-auto/conseils/{alias}', async () => {
+    const { service } = makeService(true, {
+      ref: { pg_id: 8 },
+      advice: { ba_pg_id: '8' },
+      gamme: { pg_alias: 'filtre-a-air' },
+    });
+    await expect(service.getRedirectTarget('filtre-a-air')).resolves.toEqual({
+      redirect_to: '/blog-pieces-auto/conseils/filtre-a-air',
+      pg_alias: 'filtre-a-air',
+    });
+  });
+});

--- a/backend/src/modules/seo/services/reference.service.ts
+++ b/backend/src/modules/seo/services/reference.service.ts
@@ -233,6 +233,49 @@ export class ReferenceService extends SupabaseBaseService {
   }
 
   /**
+   * R4→R3 consolidation redirect target (mirror des patterns R5 et R6 #925).
+   * Auto-gaté : retourne une cible UNIQUEMENT si la référence est liée à une
+   * gamme (pg_id) dont l'article R3 conseils existe — sinon null et la page
+   * R4 standalone continue de servir (jamais de redirect-vers-404).
+   * Inerte tant que SEO_R4_CONSOLIDATION_ENABLED=false (défaut).
+   */
+  async getRedirectTarget(
+    slug: string,
+  ): Promise<{ redirect_to: string; pg_alias: string } | null> {
+    if (!this.featureFlags?.seoR4ConsolidationEnabled) return null;
+
+    const { data: ref } = await this.supabase
+      .from('__seo_reference')
+      .select('pg_id')
+      .eq('slug', slug)
+      .eq('is_published', true)
+      .single();
+    if (!ref?.pg_id) return null;
+
+    // Self-gate : ne rediriger que si la page R3 de la gamme existe
+    // (ba_pg_id est TEXT legacy — comparaison via chaîne).
+    const { data: advice } = await this.supabase
+      .from('__blog_advice')
+      .select('ba_pg_id')
+      .eq('ba_pg_id', String(ref.pg_id))
+      .limit(1)
+      .single();
+    if (!advice) return null;
+
+    const { data: gamme } = await this.supabase
+      .from('pieces_gamme')
+      .select('pg_alias')
+      .eq('pg_id', ref.pg_id)
+      .single();
+    if (!gamme?.pg_alias) return null;
+
+    return {
+      redirect_to: `/blog-pieces-auto/conseils/${gamme.pg_alias}`,
+      pg_alias: gamme.pg_alias as string,
+    };
+  }
+
+  /**
    * Récupère toutes les références publiées
    * @returns Liste des références (version légère)
    */

--- a/frontend/app/routes/reference-auto.$slug.tsx
+++ b/frontend/app/routes/reference-auto.$slug.tsx
@@ -11,6 +11,7 @@
 
 import {
   json,
+  redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
 } from "@remix-run/node";
@@ -322,6 +323,25 @@ export async function loader({ params }: LoaderFunctionArgs) {
 
   if (!slug || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
     throw new Response("Slug invalide", { status: 400 });
+  }
+
+  try {
+    // R4→R3 consolidation (flag-gated côté serveur, inerte par défaut) :
+    // 301 vers la page R3 conseils de la gamme liée quand le flag est ON ET
+    // que la page R3 existe (self-gate backend — jamais de redirect-vers-404).
+    // Mirror des patterns R5 (diagnostic-auto.$slug) et R6 (guide-achat).
+    const redirectRes = await fetch(
+      `${getInternalApiUrl("")}/api/seo/reference/redirect/${slug}`,
+      { headers: { Accept: "application/json" } },
+    );
+    if (redirectRes.ok) {
+      const target = await redirectRes.json();
+      if (target?.redirect_to) {
+        return redirect(target.redirect_to, 301);
+      }
+    }
+  } catch {
+    // probe réseau en échec → rendu normal de la page R4 (comportement actuel)
   }
 
   try {


### PR DESCRIPTION
## Contexte

Décision owner 2026-06-10 : **R4 doit être intégré dans R3** — R4 rejoint le programme satellites→R3 (R5 = live depuis #922, R6 = #925). Le contenu R4 est **déjà intégré dans R3** (encadré « fiche technique » par gamme, avec fallback glossaire) ; cette PR ajoute la posture URL : 301 des pages standalone, self-gaté.

Périmètre mesuré en DB : **73 des 231 fiches publiées** redirigeront (gammes liées avec article R3 vivant) ; 158 continueront de servir (self-gate — dont la seule fiche sans `pg_id`).

## Mécanique (mirror exact de R5/R6)

- `FeatureFlags.seoR4ConsolidationEnabled` — `SEO_R4_CONSOLIDATION_ENABLED`, défaut `false`.
- `ReferenceService.getRedirectTarget(slug)` — cible `/blog-pieces-auto/conseils/{pg_alias}` **uniquement si** la référence a un `pg_id` ET que l'article R3 de la gamme existe (`__blog_advice.ba_pg_id`, TEXT legacy → `String()`). Jamais de redirect-vers-404.
- `GET /api/seo/reference/redirect/:slug` — déclaré **avant** le catch-all `:slug`, `Cache-Control 300s`.
- Loader `reference-auto.$slug.tsx` — probe redirect en tête, fallback rendu normal (mirror R5/R6).
- **La donnée n'est jamais supprimée** : `__seo_reference` continue d'alimenter l'encadré R4 des pages R3.

## Tests

`reference.service.redirect.test.ts` — jest **4/4** ✅ : flag OFF → null **sans aucune requête DB** / sans pg_id → null / self-gate sans R3 → null / chaîne complète → cible. Build `@fafa/backend` vert (seul échec local : OOM `@repo/registry`, machine chargée, hors diff).

## Improvement Check (Standard — flag-gated, inerte)

- **Problem:** décision owner « R4 intégré dans R3 » sans posture URL ; 231 pages standalone à ~0 clic dispersent le pilier.
- **Evidence before:** SQL : 231 publiées / 230 avec gamme / 73 avec R3 vivant.
- **Expected gain:** au flip : 73 fiches consolidées vers leur pilier R3 (l'encadré y sert déjà le contenu) ; 158 restent servies en attendant leur R3.
- **Risk:** nul flag OFF (prouvé « zéro requête DB ») ; au flip : self-gaté, réversible instantanément.
- **Test:** jest 4/4 + build backend vert.
- **Evidence after:** POST-activation : échantillon `/reference-auto/{slug}` → 301 conseils ; les 158 sans R3 → 200.
- **Verdict:** GO (merge sûr — inerte) ; activation = même programme owner que R6 (ADR vault couvrant R4+R6 + exclusion sitemap).
- **Next action:** merge ; l'exclusion sitemap R4 arrive dans #927 (même sujet) ; ADR draft mis à jour pour couvrir R4+R6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)