### PR TITLE
docs(seo-batch): bannière LEGACY RAG-contenu → pointer workspaces/wiki

### DIFF
--- a/workspaces/seo-batch/README.md
+++ b/workspaces/seo-batch/README.md
@@ -1,5 +1,10 @@
 # SEO Batch Workspace
 
+> ⚠️ **LEGACY pour le CONTENU — pour PRODUIRE du contenu, utiliser `workspaces/wiki/`, pas ce workspace.**
+> Ici `content-gen` / `rag-ops` / `r*-content-batch` / `r7-brand-rag-generator` lisent `/opt/automecanik/rag/knowledge/` → DB : ce mode RAG-source-de-contenu est **abandonné** (canon vault ADR-031/046 ; garde ast-grep #923 `seo-no-rag-as-content-source`).
+> **Pipeline contenu MODERNE** = `workspaces/wiki/` (`wiki-proposal-writer`, ADR-033) → wiki-repo `_scripts/` (`build_exports_seo` ADR-059, `promote.py` ADR-083 auto-tiered) → `exports/seo` → DB → R.
+> Les skills **audit/QA** d'ici (`pollution-scanner`, `v5-guardian`, `seo-gamme-audit`, `kw-classify`, `r8-diversity-check`) restent valides. Dépréciation du RAG-contenu = programme owner-sponsorisé séparé (ne pas réécrire réactivement).
+
 Claude Code project root pour les campagnes SEO AutoMecanik. Charge uniquement les 39 agents R0-R8 et les 16 skills SEO, sans les charger dans le workspace dev daily.
 
 ## Pourquoi ce workspace existe


### PR DESCRIPTION
## Bannière LEGACY sur `workspaces/seo-batch/README.md` → pointer le pipeline contenu moderne

**Doc-only, additif (5 lignes), aucun code touché.**

### Constat (vérifié)
`workspaces/seo-batch/` est l'atelier **RAG-contenu legacy** : `content-gen/SKILL.md` lit `/opt/automecanik/rag/knowledge/gammes/*.md` → DB (lignes 3, 54, 196, 232), README se décrit « content gen, RAG enrich », `seo-batch.md` pose « RAG knowledge = source de vérité ». C'est le paradigme **abandonné** (canon vault ADR-031/046 ; garde ast-grep `seo-no-rag-as-content-source` #923). **0 référence** au pipeline moderne (exports/seo, build_exports_seo, ADR-059) dans tout seo-batch.

### Ce que fait la PR
Ajoute une bannière en tête du README qui :
- marque seo-batch **LEGACY pour le contenu** (référence le canon, n'invente rien) ;
- pointe le **pipeline moderne** : `workspaces/wiki/` (`wiki-proposal-writer`, ADR-033) → wiki-repo `_scripts/` (`build_exports_seo` ADR-059, `promote.py` ADR-083) → `exports/seo` → DB → R ;
- précise que les skills **audit/QA** (`pollution-scanner`, `v5-guardian`, `seo-gamme-audit`, `kw-classify`, `r8-diversity-check`) **restent valides**.

### Ce que la PR ne fait PAS
Aucune réécriture/suppression d'agents (la dépréciation du RAG-contenu = programme owner-sponsorisé séparé — même posture que #923 : marquer, pas bulldozer). Phrase RAG-source posée sur la même ligne que `ADR-031/046` (bypass `rag-scope-guard`). Lint preprod-vocabulary : 0 violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
