### PR TITLE
feat(admin): lien Command Center dans Accès Rapides du dashboard

### DIFF
--- a/frontend/app/routes/admin._index.tsx
+++ b/frontend/app/routes/admin._index.tsx
@@ -27,6 +27,7 @@ import {
   Truck,
   Palette,
   Sparkles,
+  LayoutDashboard,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Alert } from "~/components/ui/alert";
@@ -996,6 +997,21 @@ export default function AdminDashboard() {
 
         {/* Ligne 2 : Fonctionnalités avancées */}
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <Link
+            to="/admin/command-center"
+            className="block p-4 rounded-lg border-2 border-cyan-200 hover:border-cyan-400 hover:bg-muted transition-all group"
+          >
+            <div className="flex items-center gap-3">
+              <LayoutDashboard className="h-6 w-6 text-cyan-600 group-hover:text-cyan-700" />
+              <div>
+                <p className="font-medium text-gray-900">Command Center</p>
+                <p className="text-sm text-gray-500">
+                  Cockpit IA — santé départements & actions
+                </p>
+              </div>
+            </div>
+          </Link>
+
           <Link
             to="/admin/ai-content"
             className="block p-4 rounded-lg border-2 border-gradient-to-r to-pink-200 hover:border-purple-400 hover:bg-gradient-to-r hover: hover:to-pink-50 transition-all group relative overflow-hidden"


### PR DESCRIPTION
## Quoi

Carte d'accès rapide **Command Center** sur la page `/admin` (section « Accès Rapides », ligne Fonctionnalités avancées), pointant vers `/admin/command-center`.

La sidebar expose déjà ce lien mais enterré sous « Système » — le cockpit méritait un accès direct depuis le dashboard d'accueil.

## Comment

- `frontend/app/routes/admin._index.tsx` uniquement : +1 icône `LayoutDashboard` (lucide) + 1 carte `<Link>` au même pattern que les cartes voisines (border-2, hover, Tailwind only).
- Libellé/description alignés sur l'entrée sidebar existante (« Cockpit IA — santé départements & actions »).

## Scope / risques

- Front-only, dashboard-only, 16 lignes additives, zéro backend, zéro flag touché (`COMMAND_CENTER_MODE` reste `disabled` en prod — ce lien mène à la page existante qui gère déjà son propre état).
- Aucune URL publique/SEO touchée (route admin noindex).
- Rollback : revert du commit.

## Vérification

- ESLint OK sur le fichier modifié.
- Merge = GO owner (DEV/PREPROD seulement, pas de tag `v*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)