### PR TITLE
fix(seo-scoring): découple le quality-scoring du RAG (v2.2) — RAG = chatbot only

### DIFF
--- a/backend/src/config/scoring-profiles.config.spec.ts
+++ b/backend/src/config/scoring-profiles.config.spec.ts
@@ -1,0 +1,33 @@
+import { CONFIDENCE_SIGNALS, SCORING_VERSION } from './scoring-profiles.config';
+
+/**
+ * v2.2 — Découplage RAG du scoring SEO.
+ * RAG = chatbot only (ADR-031/046) → ne doit JAMAIS être un signal de qualité SEO.
+ * Ces invariants pinnent le retrait + la cohérence des poids (somme = 100).
+ */
+describe('scoring-profiles config — v2.2 (RAG hors-scoring)', () => {
+  it('SCORING_VERSION bumpé à v2.2 (recompute distinguable du v2.1 RAG-pollué)', () => {
+    expect(SCORING_VERSION).toBe('v2.2');
+  });
+
+  it('CONFIDENCE_SIGNALS : poids somment à 100', () => {
+    const sum = CONFIDENCE_SIGNALS.reduce((acc, s) => acc + s.weight, 0);
+    expect(sum).toBe(100);
+  });
+
+  it('CONFIDENCE_SIGNALS : AUCUN signal RAG (chatbot only)', () => {
+    const ids = CONFIDENCE_SIGNALS.map((s) => s.id);
+    expect(ids).not.toContain('rag_available');
+    expect(ids).not.toContain('truth_level_high');
+    expect(ids.some((id) => /rag|truth_level/i.test(id))).toBe(false);
+  });
+
+  it('CONFIDENCE_SIGNALS : ne garde que des signaux RÉELS de la page', () => {
+    const ids = CONFIDENCE_SIGNALS.map((s) => s.id).sort();
+    expect(ids).toEqual([
+      'data_completeness',
+      'pipeline_recent',
+      'source_verified',
+    ]);
+  });
+});

--- a/backend/src/config/scoring-profiles.config.ts
+++ b/backend/src/config/scoring-profiles.config.ts
@@ -7,7 +7,11 @@
  * Git-versioned — changes require code review.
  */
 
-export const SCORING_VERSION = 'v2.1';
+// v2.2 (2026-06-11): RAG retiré du scoring SEO (RAG = chatbot only, ADR-031/046).
+// Les poids des ex-signaux RAG (contenu + truth) sont ré-ancrés sur le contenu
+// RÉEL de la page (sg_content, provenance vérifiée, complétude). Décalage de score
+// attendu = correction (dé-pollution), pas régression.
+export const SCORING_VERSION = 'v2.2';
 
 // ── Types ──
 
@@ -171,15 +175,14 @@ export const SEO_THRESHOLDS = {
   desc_min: 120,
   desc_max: 165,
   h1_min: 10,
-  content_min: 800, // page content length
-  rag_content_min: 1500, // RAG file length
+  content_min: 800, // page content length (v2.2: rag_content_min retiré — RAG ≠ signal SEO)
 };
 
 /** Trust & Evidence: thresholds */
 export const TRUST_THRESHOLDS = {
   pipeline_quality_min: 70,
   pipeline_quality_good: 85,
-  rag_truth_level_good: ['L1', 'L2'], // high confidence levels
+  // v2.2: rag_truth_level_good retiré — la confiance s'ancre sur provenance + pipeline réels.
 };
 
 /** Freshness: days since update thresholds per page type */
@@ -394,31 +397,24 @@ export interface ConfidenceSignal {
   description: string;
 }
 
+// v2.2: signaux RAG (rag_available, truth_level_high) RETIRÉS — RAG = chatbot only
+// (ADR-031/046). Leurs 35 pts redistribués sur les signaux RÉELS (provenance + complétude).
+// Somme = 100 (40 + 25 + 35).
 export const CONFIDENCE_SIGNALS: ConfidenceSignal[] = [
   {
     id: 'source_verified',
-    weight: 25,
+    weight: 40,
     description: 'Source provenance verifiee',
   },
   {
     id: 'pipeline_recent',
-    weight: 20,
+    weight: 25,
     description: 'Pipeline execute < 30 jours',
   },
   {
-    id: 'rag_available',
-    weight: 20,
-    description: 'Fichier RAG present et substantiel',
-  },
-  {
     id: 'data_completeness',
-    weight: 20,
+    weight: 35,
     description: 'Majorite des features presentes',
-  },
-  {
-    id: 'truth_level_high',
-    weight: 15,
-    description: 'RAG truth level L1 ou L2',
   },
 ];
 

--- a/backend/src/modules/admin/services/quality-scoring-engine.service.ts
+++ b/backend/src/modules/admin/services/quality-scoring-engine.service.ts
@@ -879,7 +879,9 @@ export class QualityScoringEngineService extends SupabaseBaseService {
       actions.push('Ajouter une meta description');
     // v2.2: action ré-ancrée sur le contenu RÉEL de la page (source RAW→WIKI), plus le RAG.
     if (row.seo_content_length < 800)
-      actions.push('Enrichir le contenu éditorial de la page (source RAW→WIKI)');
+      actions.push(
+        'Enrichir le contenu éditorial de la page (source RAW→WIKI)',
+      );
 
     return actions;
   }

--- a/backend/src/modules/admin/services/quality-scoring-engine.service.ts
+++ b/backend/src/modules/admin/services/quality-scoring-engine.service.ts
@@ -533,10 +533,9 @@ export class QualityScoringEngineService extends SupabaseBaseService {
         else reasons.push('Image hero (pg_pic) manquante');
         if (row.has_pg_wall) score += 10;
         if (row.has_blog_advice) score += 10;
-        // v2.1: check contenu SEO (description gamme)
-        score += continuousScore(row.seo_content_length, 800, 20);
-        // v2.1: check RAG
-        score += continuousScore(row.rag_content_length, 1500, 10);
+        // v2.2: contenu RÉEL (sg_content). Absorbe les 10 pts de l'ex-signal RAG
+        // (retiré : RAG = chatbot only). 20+15+15+10+10+30 = 100.
+        score += continuousScore(row.seo_content_length, 800, 30);
         return decimalClamp(score);
       }
 
@@ -581,27 +580,19 @@ export class QualityScoringEngineService extends SupabaseBaseService {
     else reasons.push('H1 absent ou trop court');
 
     // Content length (for R4 use content_html, for others use seo_content)
+    // v2.2: contenu RÉEL de la page (sg_content). Absorbe les 15 pts de l'ex-signal
+    // RAG (retiré : RAG = chatbot only, ADR-031/046). 25+25+15+35 = 100.
     const contentLen =
       pageType === 'R4_reference'
         ? row.ref_content_html_length
         : row.seo_content_length;
-    if (contentLen >= t.content_min) score += 20;
+    if (contentLen >= t.content_min) score += 35;
     else if (contentLen > 0) {
-      score += 8;
+      score += 14;
       reasons.push(
         `Contenu page trop court (${contentLen} chars, min ${t.content_min})`,
       );
     } else reasons.push('Contenu page absent');
-
-    // RAG file (shared across types) — continuous
-    const ragPts = continuousScore(
-      row.rag_content_length,
-      t.rag_content_min,
-      15,
-    );
-    score += ragPts;
-    if (ragPts < 7.5)
-      reasons.push(`Fichier RAG court (${row.rag_content_length} chars)`);
 
     return decimalClamp(score);
   }
@@ -610,27 +601,22 @@ export class QualityScoringEngineService extends SupabaseBaseService {
     let score = 0;
 
     // Source verified (guide-specific but important for all)
-    if (row.guide_source_verified) score += 30;
+    // v2.2: +10 pts (absorbe une partie de l'ex-signal "RAG truth" retiré).
+    if (row.guide_source_verified) score += 40;
     else reasons.push('Source non verifiee');
 
-    // Pipeline quality
+    // Pipeline quality — v2.2: +10 pts (absorbe le reste de l'ex-signal RAG).
     const pq = row.pipeline_quality_score;
-    if (pq >= TRUST_THRESHOLDS.pipeline_quality_good) score += 25;
-    else if (pq >= TRUST_THRESHOLDS.pipeline_quality_min) score += 15;
+    if (pq >= TRUST_THRESHOLDS.pipeline_quality_good) score += 35;
+    else if (pq >= TRUST_THRESHOLDS.pipeline_quality_min) score += 25;
     else if (pq > 0) {
-      score += 5;
+      score += 10;
       reasons.push(`Pipeline quality faible (${pq})`);
     }
 
-    // RAG truth level
-    if (
-      row.rag_truth_level &&
-      TRUST_THRESHOLDS.rag_truth_level_good.includes(row.rag_truth_level)
-    ) {
-      score += 20;
-    } else if (row.rag_content_length > 0) {
-      score += 10;
-    }
+    // (ex-signal "RAG truth level" RETIRÉ : RAG = chatbot only, ADR-031/046.
+    //  La confiance s'ancre sur la provenance vérifiée + le pipeline réels.)
+    // Max inchangé : 40 + 35 + 15 = 90 (+10 canonical R4) = identique à l'ex 30+25+20+15.
 
     // Hard gate results (pipeline)
     const hgr = row.pipeline_hard_gate_results;
@@ -780,18 +766,12 @@ export class QualityScoringEngineService extends SupabaseBaseService {
             else if (days <= 180) score += signal.weight * 0.2;
           }
           break;
-        case 'rag_available':
-          score += continuousScore(row.rag_content_length, 1000, signal.weight);
-          break;
+        // v2.2: cases 'rag_available' + 'truth_level_high' RETIRÉES (RAG = chatbot only).
         case 'data_completeness': {
           const featuresPct = this.countPresentFeatures(row, _pageType);
           score += (featuresPct / 100) * signal.weight;
           break;
         }
-        case 'truth_level_high':
-          if (row.rag_truth_level && ['L1', 'L2'].includes(row.rag_truth_level))
-            score += signal.weight;
-          break;
       }
     }
 
@@ -817,7 +797,7 @@ export class QualityScoringEngineService extends SupabaseBaseService {
     check(row.seo_title_length, 0);
     check(row.seo_desc_length, 0);
     check(row.seo_h1_length, 0);
-    check(row.rag_content_length, 0);
+    // v2.2: rag_content_length retiré des features de complétude (RAG = chatbot only).
     check(row.pipeline_quality_score, 0);
 
     switch (pageType) {
@@ -897,8 +877,9 @@ export class QualityScoringEngineService extends SupabaseBaseService {
       actions.push('Ajouter un titre SEO');
     if (row.seo_desc_length === 0 && row.ref_meta_desc_length === 0)
       actions.push('Ajouter une meta description');
-    if (row.rag_content_length < 1500)
-      actions.push('Enrichir le fichier RAG (>1500 chars)');
+    // v2.2: action ré-ancrée sur le contenu RÉEL de la page (source RAW→WIKI), plus le RAG.
+    if (row.seo_content_length < 800)
+      actions.push('Enrichir le contenu éditorial de la page (source RAW→WIKI)');
 
     return actions;
   }


### PR DESCRIPTION
## Découple le quality-scoring du RAG (v2.2) — RAG = chatbot only

### Problème (vérifié runtime + DB)
`QualityScoringEngineService` notait la **qualité ET la confiance SEO** à partir de `__rag_knowledge` (table RAG **figée au 2026-04-11**, contenu migré vers RAW). C'est une **erreur de catégorie** : le RAG sert **uniquement au chatbot** (ADR-031/046), il ne doit jamais être un signal de qualité SEO. Vestige de l'ère « RAG = source de contenu » (abandonnée).

### Sites RAG retirés (6) + ré-ancrage sur le contenu RÉEL
| Site | Avant (RAG) | Après (réel) |
|---|---|---|
| `scoreSeoTechnical` | RAG 15pts | contenu `sg_content` 20→**35** |
| `scoreContentDepth` R1 | RAG 10pts | `seo_content_length` 20→**30** |
| `scoreTrustEvidence` | RAG truth 20pts | `source_verified` 30→**40** + pipeline 25→**35** |
| `CONFIDENCE_SIGNALS` | `rag_available`(20) + `truth_level_high`(15) | `source_verified` 25→**40**, `pipeline_recent` 20→**25**, `data_completeness` 20→**35** |
| `countPresentFeatures` | `rag_content_length` | retiré |
| `deriveActions` | « Enrichir le fichier RAG » | « Enrichir le contenu éditorial (RAW→WIKI) » |

**Sommes préservées à 100** par dimension (vérifié inline + test). `SCORING_VERSION` v2.1→**v2.2**.

### Invariant testé
`scoring-profiles.config.spec.ts` : `CONFIDENCE_SIGNALS` Σ=100 + **0 signal RAG** + version v2.2.

### Ce qui reste (volontaire)
`rag_content_length`/`rag_truth_level` restent en **métadonnée d'audit** (jsonb `features`) + type `FeatureRow` (la RPC `get_page_quality_features` les renvoie encore — la retirer = migration DB séparée). **Plus jamais scorés.**

### Effet / rollout
- **Décalage de score attendu = CORRECTION** (dé-pollution RAG), pas régression.
- Prend effet **au prochain recompute** (`POST /api/internal/buying-guides/compute-quality-scores`) = **écriture shared DB, owner-gated**. **No-op tant que pas recomputé.**
- Périmètre : rôles scorés (R1/R3/R4) ; R4/R5/R6 « de côté » non touchés ; R2/R7/R8 toujours non calculés (extension séparée).
- Local : non-typecheckable en worktree (pas de node_modules) → **CI valide la compile + le test**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
