### PR TITLE
fix(seo): recos Command Center véridiques — filtre GSC synthétique + enveloppe v2 honnête

### DIFF
--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 179,
+  "total": 181,
   "functions": [
     {
       "name": "__gov_m1_table_sizes",
@@ -813,6 +813,16 @@
       "name": "rm_get_page_complete_v2",
       "volatility": "VOLATILE",
       "reason": "Read-only cache (migrated from P2)"
+    },
+    {
+      "name": "rpc_seo_low_ctr_v1",
+      "volatility": "STABLE",
+      "reason": "SEO low-CTR aggregation read-only (Command Center + seo-control dashboard)"
+    },
+    {
+      "name": "rpc_seo_low_ctr_v2",
+      "volatility": "STABLE",
+      "reason": "SEO low-CTR v2 honest envelope read-only (Command Center owner-action queue)"
     },
     {
       "name": "search_pieces_fts",

--- a/backend/src/modules/admin/services/command-center-action-rules/seo-action.rules.ts
+++ b/backend/src/modules/admin/services/command-center-action-rules/seo-action.rules.ts
@@ -1,7 +1,9 @@
 /**
- * SEO opportunity rules — REAL business actions (source SEO/GSC is CERTIFIED).
+ * SEO opportunity rules — REAL business actions (source SEO/GSC, CERTIFIED
+ * seulement si la fraîcheur d'ingestion est vérifiée — sinon PARTIAL).
  * Input = GSC rows already filtered by the service to "high impressions, ~0 clicks"
- * (the clearest opportunity). Pure function (no I/O) → testable with fixtures.
+ * (the clearest opportunity) — requêtes synthétiques exclues côté RPC
+ * (_seo_is_synthetic_query). Pure function (no I/O) → testable with fixtures.
  *
  * Aggregated by PAGE KIND so the queue stays a prioritized list, not 500 rows.
  * NB: these are local opportunity-grouping buckets, NOT the governed SEO R* role
@@ -21,6 +23,29 @@ export interface GscOpportunityRow {
   clicks: number;
   position?: number | null; // PR3: avg SERP position (rpc_seo_low_ctr_v1.avg_position)
 }
+
+/**
+ * Méta d'honnêteté de la source GSC (enveloppe rpc_seo_low_ctr_v2) :
+ *   - total_qualifying : pages qualifiantes AVANT le cap p_limit (divulgue le cap),
+ *   - data_from/data_to : couverture réellement présente dans la fenêtre demandée
+ *     (remplace le « sur 120j » qui affirmait une couverture non vérifiée),
+ *   - freshness : 'fresh' = dernière ingestion dans le SLA ; 'stale'/'unknown'
+ *     dégradent la confiance à PARTIAL — jamais un CERTIFIED non vérifié.
+ */
+export interface GscOpportunityMeta {
+  total_qualifying: number | null;
+  data_from: string | null; // YYYY-MM-DD — première date réellement couverte
+  data_to: string | null; // YYYY-MM-DD — dernière date réellement couverte
+  freshness: 'fresh' | 'stale' | 'unknown';
+}
+
+/** Fallback honnête (RPC v1 sans enveloppe) : rien d'affirmé, confiance PARTIAL. */
+export const UNKNOWN_GSC_META: GscOpportunityMeta = {
+  total_qualifying: null,
+  data_from: null,
+  data_to: null,
+  freshness: 'unknown',
+};
 
 type PageKind = 'product' | 'content' | 'other';
 
@@ -101,8 +126,64 @@ export function deriveUrlNextStep(
 
 export function buildSeoOpportunityActions(
   rows: GscOpportunityRow[],
+  meta: GscOpportunityMeta = UNKNOWN_GSC_META,
 ): RawAction[] {
-  if (!rows.length) return [];
+  if (!rows.length) {
+    // 0 ligne + données fraîches et couvertes = vraie bonne nouvelle → rien.
+    // 0 ligne SANS fraîcheur/couverture vérifiée = indistinguable d'une panne
+    // d'ingestion : un signal de certification, jamais un silence ambigu.
+    if (meta.freshness === 'fresh' && meta.data_from) return [];
+    return [
+      {
+        id: 'seo:gsc-data-gap',
+        title:
+          'Données GSC absentes ou non fraîches — fiabiliser avant de conclure',
+        department: 'seo',
+        source: 'seo',
+        action_type: 'certification',
+        impact: 6,
+        urgency: 6,
+        // le constat « pas de donnée fraîche » est lui-même certain
+        data_confidence: CONFIDENCE_BY_CERT.CERTIFIED,
+        effort: 3,
+        risk: 1,
+        reason:
+          "0 page d'opportunité remontée, mais la fraîcheur/couverture GSC n'est pas vérifiée " +
+          `(fraîcheur : ${meta.freshness}${meta.data_from ? '' : ', couverture inconnue'}) — ` +
+          "impossible de distinguer « aucune opportunité » d'une ingestion arrêtée.",
+        evidence: ['__seo_gsc_daily (fenêtre interrogée vide ou non fraîche)'],
+        next_step:
+          "Vérifier l'ingestion GSC (gsc-daily-fetcher) et appliquer la migration rpc_seo_low_ctr_v2 si absente.",
+      },
+    ];
+  }
+
+  const sampleSize = rows.length;
+  const truncated =
+    meta.total_qualifying != null && meta.total_qualifying > sampleSize;
+  // CERTIFIED exige une fraîcheur vérifiée ; stale/unknown → PARTIAL (≥ floor 40 :
+  // l'action business survit mais l'UI la marque « prudence », pas de faux 90).
+  const confidence =
+    meta.freshness === 'fresh'
+      ? CONFIDENCE_BY_CERT.CERTIFIED
+      : CONFIDENCE_BY_CERT.PARTIAL;
+  // sampleSize/total_qualifying sont GLOBAUX (tous types de pages, cap p_limit
+  // partagé) alors que chaque action est émise PAR type — le wording le dit.
+  const scopeNote = truncated
+    ? `Échantillon global top ${sampleSize} par impact — ${meta.total_qualifying} pages qualifiantes (fortes impressions, ~0 clic) au total, tous types de pages confondus.`
+    : meta.total_qualifying != null
+      ? `Liste complète (${meta.total_qualifying} pages qualifiantes, tous types confondus).`
+      : `Échantillon top ${sampleSize} (toutes pages) — total qualifiant inconnu (RPC v1).`;
+  const coverageNote =
+    meta.data_from && meta.data_to
+      ? `Données GSC réellement couvertes du ${meta.data_from} au ${meta.data_to}`
+      : 'Couverture réelle des données GSC inconnue';
+  const freshnessNote =
+    meta.freshness === 'fresh'
+      ? ''
+      : meta.freshness === 'stale'
+        ? ' ; fraîcheur GSC dégradée (ingestion en retard)'
+        : ' ; fraîcheur GSC non vérifiée';
 
   const byKind = new Map<PageKind, GscOpportunityRow[]>();
   for (const r of rows) {
@@ -137,16 +218,16 @@ export function buildSeoOpportunityActions(
     });
     out.push({
       id: `seo:opportunity:${kind}`,
-      title: `${list.length} ${m.label} à fort potentiel SEO (impressions sans clic)`,
+      title: `${list.length} ${m.label} à fort potentiel SEO (impressions sans clic${truncated ? ` — top ${sampleSize} toutes pages` : ''})`,
       department: 'seo',
       source: 'seo',
       action_type: 'business',
       impact: m.impact,
       urgency: m.urgency,
-      data_confidence: CONFIDENCE_BY_CERT.CERTIFIED, // GSC certified
+      data_confidence: confidence,
       effort: kind === 'product' ? 4 : 3,
       risk: 1,
-      reason: `${list.length} ${m.label} cumulent ${totalImp} impressions sur 120j avec ~0 clic → CTR à récupérer.`,
+      reason: `${list.length} ${m.label} cumulent ${totalImp} impressions avec ~0 clic → CTR à récupérer. ${scopeNote} ${coverageNote}${freshnessNote}.`,
       evidence: sorted
         .slice(0, 3)
         .map((r) => `${r.page} (${r.impressions} imp, ${r.clicks} clic)`),

--- a/backend/src/modules/admin/services/command-center-actions.service.ts
+++ b/backend/src/modules/admin/services/command-center-actions.service.ts
@@ -8,6 +8,8 @@ import {
 } from './command-center-action-rules/certification-action.rules';
 import {
   buildSeoOpportunityActions,
+  UNKNOWN_GSC_META,
+  type GscOpportunityMeta,
   type GscOpportunityRow,
 } from './command-center-action-rules/seo-action.rules';
 import { buildPricingRiskActions } from './command-center-action-rules/pricing-action.rules';
@@ -20,12 +22,22 @@ import {
   type RawAction,
 } from './command-center-action-rules/score-action';
 
+/** Forme brute d'une ligne GSC renvoyée par rpc_seo_low_ctr_v1/v2 (JSONB). */
+interface RawGscRow {
+  page: string;
+  impressions: number | string;
+  clicks: number | string;
+  avg_position?: number | string | null;
+}
+
 /**
  * Command Center — live Owner Action Queue engine (Phase 2).
  * Combines:
  *   - certification/repair actions from the canon snapshot (no DB),
- *   - REAL SEO opportunity actions (GSC, certified — via the governed STABLE
- *     aggregation RPC rpc_seo_low_ctr_v1; server-side GROUP BY, no new RPC/migration),
+ *   - REAL SEO opportunity actions (GSC — via the governed STABLE aggregation
+ *     RPC rpc_seo_low_ctr_v2: synthetic queries filtered server-side, envelope
+ *     discloses the p_limit cap + real data coverage + ingestion freshness;
+ *     explicit logged fallback to v1 while the migration is not applied),
  *   - cautious pricing actions (missing purchase price via count; margin thresholds
  *     + runtime sell-at-loss kept as certification — no fake threshold).
  * Every source is graceful: a failed query yields a "source unavailable" certification
@@ -37,6 +49,8 @@ import {
 export class CommandCenterActionsService extends SupabaseBaseService {
   private static readonly GSC_WINDOW_DAYS = 120;
   private static readonly MIN_IMPRESSIONS = 50;
+  /** SLA fraîcheur GSC : lag normal ≈ 3 j ; au-delà de 7 j = stale → PARTIAL. */
+  private static readonly GSC_FRESH_MAX_LAG_DAYS = 7;
 
   constructor(configService: ConfigService) {
     super(configService);
@@ -59,32 +73,61 @@ export class CommandCenterActionsService extends SupabaseBaseService {
 
   private async seoOpportunities(): Promise<RawAction[]> {
     try {
-      // Reuse the governed STABLE aggregation RPC instead of reinventing GROUP BY
-      // client-side: it computes SUM(impressions)/SUM(clicks) GROUP BY page with
-      // HAVING impressions >= p_min_impressions AND ctr <= p_max_ctr, server-side.
-      // p_max_ctr: 0 → strictly zero-click. This avoids the supabase-js 1000-row
-      // cap and the unindexed client sort; STABLE = read-only (no mutation).
-      // Routed through callRpc (RPC Safety Gate) — internal admin context, not
-      // source:'api', so no allowlist entry is required.
-      const { data, error } = await this.callRpc<
-        Array<{
-          page: string;
-          impressions: number | string;
-          clicks: number | string;
-          avg_position?: number | string | null;
-        }>
-      >('rpc_seo_low_ctr_v1', {
+      // Governed STABLE aggregation, server-side GROUP BY + HAVING (avoids the
+      // supabase-js 1000-row cap). p_max_ctr: 0 → strictly zero-click. Routed
+      // through callRpc (RPC Safety Gate) — v1/v2 sont dans
+      // governance/rpc/rpc_allowlist.json (une fonction inconnue du gate est
+      // BLOCK en PROD enforce ; le « contexte interne » seul ne suffit pas).
+      // v2 = synthetic queries filtered + honest envelope {rows, total_qualifying,
+      // data_from, data_to, last_data_date}. v1 fallback is EXPLICIT and logged
+      // (migration not yet applied): meta stays 'unknown' → the rule degrades
+      // confidence to PARTIAL and the reason says the coverage is unknown —
+      // governed, observable, never a silent green.
+      const rpcParams = {
         p_window_days: CommandCenterActionsService.GSC_WINDOW_DAYS,
         p_min_impressions: CommandCenterActionsService.MIN_IMPRESSIONS,
         p_max_ctr: 0,
         p_limit: 50,
-      });
-      if (error) throw error;
+      };
+      const v2 = await this.callRpc<{
+        rows?: RawGscRow[];
+        total_qualifying?: number | string | null;
+        data_from?: string | null;
+        data_to?: string | null;
+        last_data_date?: string | null;
+      }>('rpc_seo_low_ctr_v2', rpcParams);
+
+      let rawRows: RawGscRow[];
+      let meta: GscOpportunityMeta;
+      if (!v2.error && v2.data && Array.isArray(v2.data.rows)) {
+        rawRows = v2.data.rows;
+        // null doit RESTER null (Number(null) === 0 fabriquerait « Liste
+        // complète (0 pages qualifiantes) » à côté de lignes non vides).
+        const rawTotal = v2.data.total_qualifying;
+        const total = rawTotal == null ? NaN : Number(rawTotal);
+        meta = {
+          total_qualifying: Number.isFinite(total) ? total : null,
+          data_from: v2.data.data_from ?? null,
+          data_to: v2.data.data_to ?? null,
+          freshness: this.gscFreshness(v2.data.last_data_date ?? null),
+        };
+      } else {
+        this.logger.warn(
+          `[command-center-actions] rpc_seo_low_ctr_v2 indisponible (${v2.error ?? 'enveloppe invalide'}) — fallback v1 : couverture/total inconnus, confiance dégradée`,
+        );
+        const v1 = await this.callRpc<RawGscRow[]>(
+          'rpc_seo_low_ctr_v1',
+          rpcParams,
+        );
+        if (v1.error) throw v1.error;
+        rawRows = v1.data ?? [];
+        meta = UNKNOWN_GSC_META;
+      }
 
       // RPC returns BIGINT sums as JSONB numbers; coerce defensively. avg_position
       // → position (PR3): only a real SERP position (>0) survives; 0/NaN/absent → null
       // (explicit finite check, not a falsy-coerce) so the rule uses its honest fallback.
-      const rows: GscOpportunityRow[] = (data ?? []).map((r) => {
+      const rows: GscOpportunityRow[] = rawRows.map((r) => {
         const pos = Number(r.avg_position);
         return {
           page: r.page,
@@ -93,13 +136,33 @@ export class CommandCenterActionsService extends SupabaseBaseService {
           position: Number.isFinite(pos) && pos > 0 ? pos : null,
         };
       });
-      return buildSeoOpportunityActions(rows);
+      return buildSeoOpportunityActions(rows, meta);
     } catch (e) {
       this.logger.warn(`[command-center-actions] SEO RPC failed: ${e}`);
       return [
         this.sourceUnavailable('seo', "Requête GSC d'opportunité indisponible"),
       ];
     }
+  }
+
+  /**
+   * Fraîcheur d'ingestion GSC : 'fresh' si la dernière date ingérée est dans le
+   * SLA (lag GSC normal ≈ 3 j) ; au-delà → 'stale' ; date absente/invalide →
+   * 'unknown'. Stale/unknown ⇒ la règle dégrade la confiance à PARTIAL — la
+   * constante « CERTIFIED 90 » n'est plus affichée sans vérification.
+   */
+  private gscFreshness(
+    lastDataDate: string | null,
+  ): 'fresh' | 'stale' | 'unknown' {
+    if (!lastDataDate) return 'unknown';
+    const last = Date.parse(lastDataDate);
+    if (!Number.isFinite(last)) return 'unknown';
+    // Jours calendaires entiers (floor) : 'YYYY-MM-DD' = minuit UTC, un lag
+    // fractionnaire ferait basculer la même date fresh→stale selon l'heure.
+    const lagDays = Math.floor((Date.now() - last) / 86_400_000);
+    return lagDays <= CommandCenterActionsService.GSC_FRESH_MAX_LAG_DAYS
+      ? 'fresh'
+      : 'stale';
   }
 
   private async pricingRisks(): Promise<RawAction[]> {

--- a/backend/supabase/migrations/20260611_seo_control_004_synthetic_filter.down.sql
+++ b/backend/supabase/migrations/20260611_seo_control_004_synthetic_filter.down.sql
@@ -1,0 +1,421 @@
+-- Down : restaure les définitions d'origine (sans filtre synthétique) des 4 RPC
+-- + helper, et supprime rpc_seo_low_ctr_v2 + _seo_is_synthetic_query.
+-- APPROVED: rollback only — down.sql is the inverse of the matching up.sql, never executed in normal flow
+-- Sources des corps restaurés : 20260518_seo_control_001_helpers.sql / 002_rpcs.sql.
+
+set lock_timeout = '2s';
+set statement_timeout = '5s';
+
+DROP FUNCTION IF EXISTS rpc_seo_low_ctr_v2(INT, TIMESTAMPTZ, INT, NUMERIC, INT);
+
+-- ─── RPC 1 : Traffic Window (définition d'origine) ───────────────
+CREATE OR REPLACE FUNCTION rpc_seo_traffic_v1(
+  p_window_days INT,
+  p_now TIMESTAMPTZ DEFAULT NOW()
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH bounds AS (
+    SELECT
+      (p_now::DATE - p_window_days) AS from_d,
+      p_now::DATE AS to_d,
+      (p_now::DATE - p_window_days * 2) AS prev_from_d,
+      (p_now::DATE - p_window_days) AS prev_to_d
+  ),
+  curr AS (
+    SELECT
+      COALESCE(SUM(clicks), 0)::BIGINT AS c,
+      COALESCE(SUM(impressions), 0)::BIGINT AS i,
+      AVG(position)::FLOAT8 AS pos,
+      COUNT(DISTINCT page)::BIGINT AS pc
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.from_d AND date < bounds.to_d
+  ),
+  prev AS (
+    SELECT
+      COALESCE(SUM(clicks), 0)::BIGINT AS c,
+      COALESCE(SUM(impressions), 0)::BIGINT AS i
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.prev_from_d AND date < bounds.prev_to_d
+  )
+  SELECT jsonb_build_object(
+    'impact_score_version', 'v1',
+    'clicks', curr.c,
+    'impressions', curr.i,
+    'ctr', CASE WHEN curr.i > 0
+                THEN ROUND((curr.c::NUMERIC / curr.i) * 100, 2)::FLOAT8
+                ELSE 0::FLOAT8 END,
+    'avg_position', COALESCE(ROUND(curr.pos::NUMERIC, 2)::FLOAT8, 0::FLOAT8),
+    'pages_count', curr.pc,
+    'delta_vs_previous', jsonb_build_object(
+      'clicks_pct', CASE WHEN prev.c > 0
+                         THEN ROUND(((curr.c - prev.c)::NUMERIC / prev.c) * 100, 1)::FLOAT8
+                         ELSE NULL END,
+      'impressions_pct', CASE WHEN prev.i > 0
+                              THEN ROUND(((curr.i - prev.i)::NUMERIC / prev.i) * 100, 1)::FLOAT8
+                              ELSE NULL END,
+      'direction', CASE
+        WHEN prev.c = 0 THEN 'unknown'
+        WHEN curr.c::NUMERIC > prev.c::NUMERIC * 1.05 THEN 'up'
+        WHEN curr.c::NUMERIC < prev.c::NUMERIC * 0.95 THEN 'down'
+        ELSE 'flat' END,
+      'change_severity', CASE
+        WHEN prev.c > 0 AND curr.c::NUMERIC < prev.c::NUMERIC * 0.80 THEN 'high'
+        WHEN prev.c > 0 AND curr.c::NUMERIC < prev.c::NUMERIC * 0.90 THEN 'medium'
+        ELSE 'info' END
+    )
+  ) FROM curr, prev;
+$$;
+COMMENT ON FUNCTION rpc_seo_traffic_v1(INT, TIMESTAMPTZ) IS
+  'PR-SBD-1 v1 — Aggregated GSC traffic over window + delta vs previous window. Deterministic via p_now. impact_score_version=v1.';
+
+-- ─── RPC 2 : Top Losers (définition d'origine) ───────────────────
+CREATE OR REPLACE FUNCTION rpc_seo_top_losers_v1(
+  p_window_days INT,
+  p_now TIMESTAMPTZ DEFAULT NOW(),
+  p_limit INT DEFAULT 20
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH bounds AS (
+    SELECT
+      (p_now::DATE - p_window_days) AS from_d,
+      p_now::DATE AS to_d,
+      (p_now::DATE - p_window_days * 2) AS prev_from_d,
+      (p_now::DATE - p_window_days) AS prev_to_d
+  ),
+  curr AS (
+    SELECT
+      page,
+      SUM(clicks)::BIGINT AS clicks,
+      SUM(impressions)::BIGINT AS impressions,
+      AVG(position)::FLOAT8 AS position
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.from_d AND date < bounds.to_d
+    GROUP BY page
+  ),
+  prev AS (
+    SELECT
+      page,
+      SUM(clicks)::BIGINT AS clicks,
+      AVG(position)::FLOAT8 AS position
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.prev_from_d AND date < bounds.prev_to_d
+    GROUP BY page
+  ),
+  joined AS (
+    SELECT
+      curr.page,
+      _seo_resolve_surface_key(curr.page) AS surface_key,
+      curr.clicks AS clicks_current,
+      COALESCE(prev.clicks, 0)::BIGINT AS clicks_previous,
+      (curr.clicks - COALESCE(prev.clicks, 0))::BIGINT AS delta_clicks,
+      CASE WHEN COALESCE(prev.clicks, 0) > 0
+           THEN ROUND(((curr.clicks - prev.clicks)::NUMERIC / prev.clicks) * 100, 1)::FLOAT8
+           ELSE NULL END AS delta_pct,
+      curr.impressions AS impressions_current,
+      COALESCE(ROUND(curr.position::NUMERIC, 2)::FLOAT8, NULL::FLOAT8) AS position_current,
+      ROUND(COALESCE(curr.position - prev.position, 0)::NUMERIC, 2)::FLOAT8 AS position_delta,
+      ROUND(
+        (ABS(curr.clicks - COALESCE(prev.clicks, 0))::NUMERIC
+        * GREATEST(0::NUMERIC, (11::NUMERIC - LEAST(COALESCE(curr.position, 50)::NUMERIC, 50::NUMERIC))) / 10.0::NUMERIC)::NUMERIC,
+        2
+      )::FLOAT8 AS business_impact_score,
+      CASE
+        WHEN curr.clicks::NUMERIC < COALESCE(prev.clicks, 0)::NUMERIC * 0.50 THEN 'critical'
+        WHEN curr.clicks::NUMERIC < COALESCE(prev.clicks, 0)::NUMERIC * 0.75 THEN 'high'
+        WHEN curr.clicks::NUMERIC < COALESCE(prev.clicks, 0)::NUMERIC * 0.90 THEN 'medium'
+        ELSE 'low' END AS severity
+    FROM curr LEFT JOIN prev USING (page)
+    WHERE curr.clicks < COALESCE(prev.clicks, 0)
+    ORDER BY business_impact_score DESC, delta_clicks ASC
+    LIMIT p_limit
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'page', j.page,
+        'surface_key', j.surface_key,
+        'clicks_current', j.clicks_current,
+        'clicks_previous', j.clicks_previous,
+        'delta_clicks', j.delta_clicks,
+        'delta_pct', j.delta_pct,
+        'impressions_current', j.impressions_current,
+        'position_current', j.position_current,
+        'position_delta', j.position_delta,
+        'business_impact_score', j.business_impact_score,
+        'impact_score_version', 'v1',
+        'severity', j.severity,
+        'top_queries_sample', _seo_top_queries_for_page_jsonb(j.page, p_window_days, p_now, 3)
+      )
+      ORDER BY j.business_impact_score DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM joined j;
+$$;
+COMMENT ON FUNCTION rpc_seo_top_losers_v1(INT, TIMESTAMPTZ, INT) IS
+  'PR-SBD-1 v1 — Top N pages losing clicks vs previous window. Each row : surface_key, business_impact_score (pos-weighted), severity, top_queries_sample (≤3 LATERAL).';
+
+-- ─── RPC 3 : Low CTR Opportunities (définition d'origine) ────────
+CREATE OR REPLACE FUNCTION rpc_seo_low_ctr_v1(
+  p_window_days INT,
+  p_now TIMESTAMPTZ DEFAULT NOW(),
+  p_min_impressions INT DEFAULT 100,
+  p_max_ctr NUMERIC DEFAULT 0.01,
+  p_limit INT DEFAULT 50
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH bounds AS (
+    SELECT
+      (p_now::DATE - p_window_days) AS from_d,
+      p_now::DATE AS to_d
+  ),
+  agg AS (
+    SELECT
+      page,
+      SUM(impressions)::BIGINT AS impressions,
+      SUM(clicks)::BIGINT AS clicks,
+      ROUND((SUM(clicks)::NUMERIC / NULLIF(SUM(impressions), 0)), 4)::FLOAT8 AS ctr,
+      ROUND(AVG(position)::NUMERIC, 2)::FLOAT8 AS avg_position
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.from_d AND date < bounds.to_d
+    GROUP BY page
+    HAVING SUM(impressions) >= p_min_impressions
+       AND (SUM(clicks)::NUMERIC / NULLIF(SUM(impressions), 0)) <= p_max_ctr
+  ),
+  scored AS (
+    SELECT
+      page,
+      _seo_resolve_surface_key(page) AS surface_key,
+      impressions,
+      clicks,
+      ctr,
+      avg_position,
+      CASE
+        WHEN avg_position <= 5 THEN 'top5'
+        WHEN avg_position <= 15 THEN 'top15'
+        ELSE 'beyond' END AS position_band,
+      ROUND(
+        (impressions::NUMERIC
+        * GREATEST(0::NUMERIC, (CASE
+            WHEN avg_position <= 5 THEN 0.05
+            WHEN avg_position <= 15 THEN 0.02
+            ELSE 0.005 END)::NUMERIC - ctr::NUMERIC))::NUMERIC,
+        2
+      )::FLOAT8 AS business_impact_score,
+      CASE
+        WHEN avg_position <= 5 AND ctr < 0.005 THEN 'critical'
+        WHEN avg_position <= 15 AND ctr < 0.005 THEN 'high'
+        ELSE 'medium' END AS severity
+    FROM agg
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'page', s.page,
+        'surface_key', s.surface_key,
+        'impressions', s.impressions,
+        'clicks', s.clicks,
+        'ctr', s.ctr,
+        'avg_position', s.avg_position,
+        'position_band', s.position_band,
+        'business_impact_score', s.business_impact_score,
+        'impact_score_version', 'v1',
+        'severity', s.severity
+      )
+      ORDER BY s.business_impact_score DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM (
+    SELECT * FROM scored ORDER BY business_impact_score DESC LIMIT p_limit
+  ) s;
+$$;
+COMMENT ON FUNCTION rpc_seo_low_ctr_v1(INT, TIMESTAMPTZ, INT, NUMERIC, INT) IS
+  'PR-SBD-1 v1 — Pages with impressions but low CTR. impact_score = potential clicks lost (impressions × (expected_ctr_by_band - actual_ctr)).';
+
+-- ─── RPC 4 : Alerts (définition 20260521 — état antérieur à 20260611) ──
+CREATE OR REPLACE FUNCTION rpc_seo_alerts_v1(
+  p_now TIMESTAMPTZ DEFAULT NOW(),
+  p_limit INT DEFAULT 50
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH unified AS (
+    -- Source A : audit findings unresolved (severity critical|high|medium)
+    SELECT
+      'audit_findings'::TEXT AS source,
+      audit_type::TEXT AS alert_type,
+      entity_url,
+      severity::TEXT AS severity,
+      detected_at,
+      COALESCE(
+        jsonb_strip_nulls(jsonb_build_object(
+          'reason', payload->>'reason',
+          'metric', payload->>'metric',
+          'expected', payload->'expected'
+        )),
+        '{}'::jsonb
+      ) AS payload_minimal
+    FROM __seo_audit_findings
+    WHERE resolved_at IS NULL
+      AND severity IN ('critical', 'high', 'medium')
+    UNION ALL
+    -- Source B : event log unresolved (severity critical|high, anomalies+ingestion failures)
+    SELECT
+      'event_log'::TEXT,
+      event_type::TEXT,
+      entity_url,
+      severity::TEXT,
+      created_at,
+      COALESCE(
+        jsonb_strip_nulls(jsonb_build_object(
+          'reason', payload->>'reason',
+          'source', payload->>'source',
+          'count', payload->'count'
+        )),
+        '{}'::jsonb
+      )
+    FROM __seo_event_log
+    WHERE resolved_at IS NULL
+      AND severity IN ('critical', 'high')
+      AND event_type IN ('anomaly_detected', 'alert_sent', 'ingestion_run_failed')
+    UNION ALL
+    -- Source C : sitemap freshness — alert on ABSENCE of a completion heartbeat >26h
+    -- (étape 2). Une seule ligne synthétique quand aucun `sitemap_generation_complete`
+    -- récent n'existe. Réutilise __seo_event_log (#601), aucune surface externe.
+    SELECT
+      'sitemap_freshness'::TEXT,
+      'SITEMAP_STALE_V1'::TEXT,
+      NULL::TEXT,
+      'high'::TEXT,
+      p_now,
+      jsonb_build_object(
+        'reason', 'no sitemap_generation_complete heartbeat in last 26h',
+        'threshold_hours', 26
+      )
+    WHERE NOT EXISTS (
+      SELECT 1 FROM __seo_event_log
+      WHERE event_type = 'sitemap_generation_complete'
+        AND created_at > p_now - INTERVAL '26 hours'
+    )
+  ),
+  enriched AS (
+    SELECT
+      u.source,
+      u.alert_type,
+      u.entity_url,
+      u.severity,
+      u.detected_at,
+      u.payload_minimal,
+      _seo_resolve_operational_domain(u.alert_type) AS operational_domain,
+      _seo_resolve_surface_key(u.entity_url) AS surface_key,
+      ROUND(
+        ((CASE u.severity
+          WHEN 'critical' THEN 10
+          WHEN 'high' THEN 5
+          WHEN 'medium' THEN 2
+          ELSE 1 END)::NUMERIC
+        * (1 + COALESCE(LOG(GREATEST(1, COALESCE(gsc.clicks_7d, 0))), 0))::NUMERIC)::NUMERIC,
+        2
+      )::FLOAT8 AS business_impact_score
+    FROM unified u
+    LEFT JOIN LATERAL (
+      SELECT SUM(clicks)::BIGINT AS clicks_7d
+      FROM __seo_gsc_daily
+      WHERE page = u.entity_url
+        AND date >= p_now::DATE - 7
+        AND date < p_now::DATE
+    ) gsc ON TRUE
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'source', e.source,
+        'alert_type', e.alert_type,
+        'entity_url', e.entity_url,
+        'surface_key', e.surface_key,
+        'operational_domain', e.operational_domain,
+        'severity', e.severity,
+        'detected_at', e.detected_at,
+        'payload_minimal', e.payload_minimal,
+        'business_impact_score', e.business_impact_score,
+        'impact_score_version', 'v1'
+      )
+      ORDER BY e.business_impact_score DESC, e.detected_at DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM (
+    SELECT *
+    FROM enriched
+    ORDER BY business_impact_score DESC, detected_at DESC
+    LIMIT p_limit
+  ) e;
+$$;
+COMMENT ON FUNCTION rpc_seo_alerts_v1(TIMESTAMPTZ, INT) IS
+  'PR-SBD-1 v1 + étape 2 — Unresolved alerts UNION (audit_findings + event_log + sitemap freshness absence SITEMAP_STALE_V1) with operational_domain + surface_key + business_impact_score (severity weighted by page traffic). payload_minimal ≤ 3 keys (anti-bloat).';
+
+-- CREATE OR REPLACE preserves privileges, but re-state them explicitly (canon 002_rpcs).
+REVOKE ALL ON FUNCTION rpc_seo_alerts_v1(TIMESTAMPTZ, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION rpc_seo_alerts_v1(TIMESTAMPTZ, INT) TO service_role;
+
+-- ─── Helper : top queries per page (définition d'origine) ────────
+CREATE OR REPLACE FUNCTION _seo_top_queries_for_page_jsonb(
+  p_page TEXT,
+  p_window_days INT,
+  p_now TIMESTAMPTZ,
+  p_limit INT DEFAULT 3
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH bounds AS (
+    SELECT
+      (p_now::DATE - p_window_days) AS from_d,
+      p_now::DATE AS to_d,
+      (p_now::DATE - p_window_days * 2) AS prev_from_d,
+      (p_now::DATE - p_window_days) AS prev_to_d
+  ),
+  curr AS (
+    SELECT
+      query,
+      SUM(clicks)::INT AS c,
+      SUM(impressions)::INT AS i,
+      AVG(position)::FLOAT8 AS pos
+    FROM __seo_gsc_daily, bounds
+    WHERE page = p_page
+      AND date >= bounds.from_d
+      AND date < bounds.to_d
+      AND query IS NOT NULL
+    GROUP BY query
+  ),
+  prev AS (
+    SELECT
+      query,
+      SUM(clicks)::INT AS c
+    FROM __seo_gsc_daily, bounds
+    WHERE page = p_page
+      AND date >= bounds.prev_from_d
+      AND date < bounds.prev_to_d
+      AND query IS NOT NULL
+    GROUP BY query
+  ),
+  joined AS (
+    SELECT
+      curr.query,
+      (curr.c - COALESCE(prev.c, 0))::INT AS clicks_delta,
+      ROUND(curr.pos::NUMERIC, 2)::FLOAT8 AS position_current
+    FROM curr
+    LEFT JOIN prev USING (query)
+    ORDER BY ABS(curr.c - COALESCE(prev.c, 0)) DESC
+    LIMIT p_limit
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'query', query,
+        'clicks_delta', clicks_delta,
+        'position_current', position_current
+      )
+      ORDER BY ABS(clicks_delta) DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM joined;
+$$;
+COMMENT ON FUNCTION _seo_top_queries_for_page_jsonb(TEXT, INT, TIMESTAMPTZ, INT) IS
+  'PR-SBD-1 v1 — Top N (default 3) queries delta clicks for a page over a window. Used by rpc_seo_top_losers_v1 to provide diagnostic context (ranking vs CTR vs cannibalisation).';
+
+DROP FUNCTION IF EXISTS _seo_is_synthetic_query(TEXT);

--- a/backend/supabase/migrations/20260611_seo_control_004_synthetic_filter.sql
+++ b/backend/supabase/migrations/20260611_seo_control_004_synthetic_filter.sql
@@ -1,0 +1,564 @@
+-- =====================================================
+-- SEO GSC — filtre des requêtes synthétiques internes (^ai[0-9]+$)
+-- Date: 2026-06-11
+-- Refs: 20260518_seo_control_001_helpers.sql / 002_rpcs.sql (définitions d'origine)
+--       20260521_seo_sitemap_freshness_001_alert_rpc.sql (baseline COURANTE de
+--         rpc_seo_alerts_v1 — sources A+B+C ; reproduire 20260518 ici effacerait
+--         silencieusement l'alerte SITEMAP_STALE_V1)
+--       MEMORY feedback_gsc_ai_type_id_synthetic_query_pattern (« filtrer ai\d+ avant CTR »)
+-- =====================================================
+--
+-- Problème mesuré (audit 2026-06-11) : __seo_gsc_daily contient des requêtes
+-- synthétiques internes (type_id, pattern ^ai[0-9]+$ — 0 clic, impressions non
+-- humaines). Aucune couche ne les filtrait : l'opportunité SEO n°1 du Command
+-- Center (2 283 impressions, « ranke pos. 5.2 ») était 100 % synthétique, et
+-- 5/50 pages de rpc_seo_low_ctr_v1 étaient des fantômes (+46 % d'impressions
+-- sur le bucket produit).
+--
+-- Fix structurel :
+--   1. _seo_is_synthetic_query(text) — prédicat unique (single source of truth).
+--   2. CREATE OR REPLACE des 4 RPC + 1 helper lisant __seo_gsc_daily : même
+--      corps, même signature, même forme de sortie — seul ajout = le filtre.
+--      (OR REPLACE préserve les GRANTs existants.)
+--   3. rpc_seo_low_ctr_v2 — enveloppe honnête {rows, total_qualifying,
+--      data_from, data_to, last_data_date} pour divulguer le cap p_limit et la
+--      couverture réelle des données (la v1 reste servie pour ses consommateurs).
+--
+-- La donnée brute reste intacte (aucune ligne supprimée) : le synthétique reste
+-- requêtable pour le monitoring interne ; il est exclu des agrégats DÉCISIONNELS.
+
+set lock_timeout = '2s';
+set statement_timeout = '5s';
+
+-- ─── Prédicat unique : requête GSC synthétique interne ───────────
+CREATE OR REPLACE FUNCTION _seo_is_synthetic_query(p_query TEXT)
+RETURNS BOOLEAN LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+  -- type_id internes émis par les sondes (ex. ai62935) — jamais une requête humaine.
+  -- NULL (ligne GSC anonymisée) = non-synthétique : on la garde.
+  SELECT COALESCE(p_query ~ '^ai[0-9]+$', FALSE);
+$$;
+COMMENT ON FUNCTION _seo_is_synthetic_query(TEXT) IS
+  'Prédicat unique requête GSC synthétique interne (^ai[0-9]+$, type_id sondes). Utilisé par les RPC d''agrégation __seo_gsc_daily pour exclure le trafic non humain des agrégats décisionnels. NULL → FALSE.';
+
+-- ─── RPC 1 : Traffic Window — + filtre synthétique ───────────────
+CREATE OR REPLACE FUNCTION rpc_seo_traffic_v1(
+  p_window_days INT,
+  p_now TIMESTAMPTZ DEFAULT NOW()
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH bounds AS (
+    SELECT
+      (p_now::DATE - p_window_days) AS from_d,
+      p_now::DATE AS to_d,
+      (p_now::DATE - p_window_days * 2) AS prev_from_d,
+      (p_now::DATE - p_window_days) AS prev_to_d
+  ),
+  curr AS (
+    SELECT
+      COALESCE(SUM(clicks), 0)::BIGINT AS c,
+      COALESCE(SUM(impressions), 0)::BIGINT AS i,
+      AVG(position)::FLOAT8 AS pos,
+      COUNT(DISTINCT page)::BIGINT AS pc
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.from_d AND date < bounds.to_d
+      AND NOT _seo_is_synthetic_query(query)
+  ),
+  prev AS (
+    SELECT
+      COALESCE(SUM(clicks), 0)::BIGINT AS c,
+      COALESCE(SUM(impressions), 0)::BIGINT AS i
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.prev_from_d AND date < bounds.prev_to_d
+      AND NOT _seo_is_synthetic_query(query)
+  )
+  SELECT jsonb_build_object(
+    'impact_score_version', 'v1',
+    'clicks', curr.c,
+    'impressions', curr.i,
+    'ctr', CASE WHEN curr.i > 0
+                THEN ROUND((curr.c::NUMERIC / curr.i) * 100, 2)::FLOAT8
+                ELSE 0::FLOAT8 END,
+    'avg_position', COALESCE(ROUND(curr.pos::NUMERIC, 2)::FLOAT8, 0::FLOAT8),
+    'pages_count', curr.pc,
+    'delta_vs_previous', jsonb_build_object(
+      'clicks_pct', CASE WHEN prev.c > 0
+                         THEN ROUND(((curr.c - prev.c)::NUMERIC / prev.c) * 100, 1)::FLOAT8
+                         ELSE NULL END,
+      'impressions_pct', CASE WHEN prev.i > 0
+                              THEN ROUND(((curr.i - prev.i)::NUMERIC / prev.i) * 100, 1)::FLOAT8
+                              ELSE NULL END,
+      'direction', CASE
+        WHEN prev.c = 0 THEN 'unknown'
+        WHEN curr.c::NUMERIC > prev.c::NUMERIC * 1.05 THEN 'up'
+        WHEN curr.c::NUMERIC < prev.c::NUMERIC * 0.95 THEN 'down'
+        ELSE 'flat' END,
+      'change_severity', CASE
+        WHEN prev.c > 0 AND curr.c::NUMERIC < prev.c::NUMERIC * 0.80 THEN 'high'
+        WHEN prev.c > 0 AND curr.c::NUMERIC < prev.c::NUMERIC * 0.90 THEN 'medium'
+        ELSE 'info' END
+    )
+  ) FROM curr, prev;
+$$;
+COMMENT ON FUNCTION rpc_seo_traffic_v1(INT, TIMESTAMPTZ) IS
+  'PR-SBD-1 v1 — Aggregated GSC traffic over window + delta vs previous window. Deterministic via p_now. impact_score_version=v1. 2026-06-11 : exclut les requêtes synthétiques (_seo_is_synthetic_query).';
+
+-- ─── RPC 2 : Top Losers — + filtre synthétique ───────────────────
+CREATE OR REPLACE FUNCTION rpc_seo_top_losers_v1(
+  p_window_days INT,
+  p_now TIMESTAMPTZ DEFAULT NOW(),
+  p_limit INT DEFAULT 20
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH bounds AS (
+    SELECT
+      (p_now::DATE - p_window_days) AS from_d,
+      p_now::DATE AS to_d,
+      (p_now::DATE - p_window_days * 2) AS prev_from_d,
+      (p_now::DATE - p_window_days) AS prev_to_d
+  ),
+  curr AS (
+    SELECT
+      page,
+      SUM(clicks)::BIGINT AS clicks,
+      SUM(impressions)::BIGINT AS impressions,
+      AVG(position)::FLOAT8 AS position
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.from_d AND date < bounds.to_d
+      AND NOT _seo_is_synthetic_query(query)
+    GROUP BY page
+  ),
+  prev AS (
+    SELECT
+      page,
+      SUM(clicks)::BIGINT AS clicks,
+      AVG(position)::FLOAT8 AS position
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.prev_from_d AND date < bounds.prev_to_d
+      AND NOT _seo_is_synthetic_query(query)
+    GROUP BY page
+  ),
+  joined AS (
+    SELECT
+      curr.page,
+      _seo_resolve_surface_key(curr.page) AS surface_key,
+      curr.clicks AS clicks_current,
+      COALESCE(prev.clicks, 0)::BIGINT AS clicks_previous,
+      (curr.clicks - COALESCE(prev.clicks, 0))::BIGINT AS delta_clicks,
+      CASE WHEN COALESCE(prev.clicks, 0) > 0
+           THEN ROUND(((curr.clicks - prev.clicks)::NUMERIC / prev.clicks) * 100, 1)::FLOAT8
+           ELSE NULL END AS delta_pct,
+      curr.impressions AS impressions_current,
+      COALESCE(ROUND(curr.position::NUMERIC, 2)::FLOAT8, NULL::FLOAT8) AS position_current,
+      ROUND(COALESCE(curr.position - prev.position, 0)::NUMERIC, 2)::FLOAT8 AS position_delta,
+      ROUND(
+        (ABS(curr.clicks - COALESCE(prev.clicks, 0))::NUMERIC
+        * GREATEST(0::NUMERIC, (11::NUMERIC - LEAST(COALESCE(curr.position, 50)::NUMERIC, 50::NUMERIC))) / 10.0::NUMERIC)::NUMERIC,
+        2
+      )::FLOAT8 AS business_impact_score,
+      CASE
+        WHEN curr.clicks::NUMERIC < COALESCE(prev.clicks, 0)::NUMERIC * 0.50 THEN 'critical'
+        WHEN curr.clicks::NUMERIC < COALESCE(prev.clicks, 0)::NUMERIC * 0.75 THEN 'high'
+        WHEN curr.clicks::NUMERIC < COALESCE(prev.clicks, 0)::NUMERIC * 0.90 THEN 'medium'
+        ELSE 'low' END AS severity
+    FROM curr LEFT JOIN prev USING (page)
+    WHERE curr.clicks < COALESCE(prev.clicks, 0)
+    ORDER BY business_impact_score DESC, delta_clicks ASC
+    LIMIT p_limit
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'page', j.page,
+        'surface_key', j.surface_key,
+        'clicks_current', j.clicks_current,
+        'clicks_previous', j.clicks_previous,
+        'delta_clicks', j.delta_clicks,
+        'delta_pct', j.delta_pct,
+        'impressions_current', j.impressions_current,
+        'position_current', j.position_current,
+        'position_delta', j.position_delta,
+        'business_impact_score', j.business_impact_score,
+        'impact_score_version', 'v1',
+        'severity', j.severity,
+        'top_queries_sample', _seo_top_queries_for_page_jsonb(j.page, p_window_days, p_now, 3)
+      )
+      ORDER BY j.business_impact_score DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM joined j;
+$$;
+COMMENT ON FUNCTION rpc_seo_top_losers_v1(INT, TIMESTAMPTZ, INT) IS
+  'PR-SBD-1 v1 — Top N pages losing clicks vs previous window. Each row : surface_key, business_impact_score (pos-weighted), severity, top_queries_sample (≤3 LATERAL). 2026-06-11 : exclut les requêtes synthétiques (_seo_is_synthetic_query).';
+
+-- ─── RPC 3 : Low CTR Opportunities — + filtre synthétique ────────
+CREATE OR REPLACE FUNCTION rpc_seo_low_ctr_v1(
+  p_window_days INT,
+  p_now TIMESTAMPTZ DEFAULT NOW(),
+  p_min_impressions INT DEFAULT 100,
+  p_max_ctr NUMERIC DEFAULT 0.01,
+  p_limit INT DEFAULT 50
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH bounds AS (
+    SELECT
+      (p_now::DATE - p_window_days) AS from_d,
+      p_now::DATE AS to_d
+  ),
+  agg AS (
+    SELECT
+      page,
+      SUM(impressions)::BIGINT AS impressions,
+      SUM(clicks)::BIGINT AS clicks,
+      ROUND((SUM(clicks)::NUMERIC / NULLIF(SUM(impressions), 0)), 4)::FLOAT8 AS ctr,
+      ROUND(AVG(position)::NUMERIC, 2)::FLOAT8 AS avg_position
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.from_d AND date < bounds.to_d
+      AND NOT _seo_is_synthetic_query(query)
+    GROUP BY page
+    HAVING SUM(impressions) >= p_min_impressions
+       AND (SUM(clicks)::NUMERIC / NULLIF(SUM(impressions), 0)) <= p_max_ctr
+  ),
+  scored AS (
+    SELECT
+      page,
+      _seo_resolve_surface_key(page) AS surface_key,
+      impressions,
+      clicks,
+      ctr,
+      avg_position,
+      CASE
+        WHEN avg_position <= 5 THEN 'top5'
+        WHEN avg_position <= 15 THEN 'top15'
+        ELSE 'beyond' END AS position_band,
+      ROUND(
+        (impressions::NUMERIC
+        * GREATEST(0::NUMERIC, (CASE
+            WHEN avg_position <= 5 THEN 0.05
+            WHEN avg_position <= 15 THEN 0.02
+            ELSE 0.005 END)::NUMERIC - ctr::NUMERIC))::NUMERIC,
+        2
+      )::FLOAT8 AS business_impact_score,
+      CASE
+        WHEN avg_position <= 5 AND ctr < 0.005 THEN 'critical'
+        WHEN avg_position <= 15 AND ctr < 0.005 THEN 'high'
+        ELSE 'medium' END AS severity
+    FROM agg
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'page', s.page,
+        'surface_key', s.surface_key,
+        'impressions', s.impressions,
+        'clicks', s.clicks,
+        'ctr', s.ctr,
+        'avg_position', s.avg_position,
+        'position_band', s.position_band,
+        'business_impact_score', s.business_impact_score,
+        'impact_score_version', 'v1',
+        'severity', s.severity
+      )
+      ORDER BY s.business_impact_score DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM (
+    SELECT * FROM scored ORDER BY business_impact_score DESC LIMIT p_limit
+  ) s;
+$$;
+COMMENT ON FUNCTION rpc_seo_low_ctr_v1(INT, TIMESTAMPTZ, INT, NUMERIC, INT) IS
+  'PR-SBD-1 v1 — Pages with impressions but low CTR. impact_score = potential clicks lost (impressions × (expected_ctr_by_band - actual_ctr)). 2026-06-11 : exclut les requêtes synthétiques (_seo_is_synthetic_query).';
+
+-- ─── RPC 3bis : Low CTR v2 — enveloppe honnête (cap + couverture) ─
+-- Même filtre/score que v1, mais la sortie divulgue ce que la v1 cache :
+--   total_qualifying  = nb de pages qualifiantes AVANT le LIMIT p_limit
+--   data_from/data_to = couverture réelle des données dans la fenêtre demandée
+--   last_data_date    = dernière date ingérée (check de fraîcheur consommateur)
+CREATE OR REPLACE FUNCTION rpc_seo_low_ctr_v2(
+  p_window_days INT,
+  p_now TIMESTAMPTZ DEFAULT NOW(),
+  p_min_impressions INT DEFAULT 100,
+  p_max_ctr NUMERIC DEFAULT 0.01,
+  p_limit INT DEFAULT 50
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH bounds AS (
+    SELECT
+      (p_now::DATE - p_window_days) AS from_d,
+      p_now::DATE AS to_d
+  ),
+  agg AS (
+    SELECT
+      page,
+      SUM(impressions)::BIGINT AS impressions,
+      SUM(clicks)::BIGINT AS clicks,
+      ROUND((SUM(clicks)::NUMERIC / NULLIF(SUM(impressions), 0)), 4)::FLOAT8 AS ctr,
+      ROUND(AVG(position)::NUMERIC, 2)::FLOAT8 AS avg_position
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.from_d AND date < bounds.to_d
+      AND NOT _seo_is_synthetic_query(query)
+    GROUP BY page
+    HAVING SUM(impressions) >= p_min_impressions
+       AND (SUM(clicks)::NUMERIC / NULLIF(SUM(impressions), 0)) <= p_max_ctr
+  ),
+  scored AS (
+    SELECT
+      page,
+      _seo_resolve_surface_key(page) AS surface_key,
+      impressions,
+      clicks,
+      ctr,
+      avg_position,
+      CASE
+        WHEN avg_position <= 5 THEN 'top5'
+        WHEN avg_position <= 15 THEN 'top15'
+        ELSE 'beyond' END AS position_band,
+      ROUND(
+        (impressions::NUMERIC
+        * GREATEST(0::NUMERIC, (CASE
+            WHEN avg_position <= 5 THEN 0.05
+            WHEN avg_position <= 15 THEN 0.02
+            ELSE 0.005 END)::NUMERIC - ctr::NUMERIC))::NUMERIC,
+        2
+      )::FLOAT8 AS business_impact_score,
+      CASE
+        WHEN avg_position <= 5 AND ctr < 0.005 THEN 'critical'
+        WHEN avg_position <= 15 AND ctr < 0.005 THEN 'high'
+        ELSE 'medium' END AS severity
+    FROM agg
+  ),
+  coverage AS (
+    SELECT MIN(date) AS data_from, MAX(date) AS data_to
+    FROM __seo_gsc_daily, bounds
+    WHERE date >= bounds.from_d AND date < bounds.to_d
+      AND NOT _seo_is_synthetic_query(query)
+  )
+  SELECT jsonb_build_object(
+    'rows', COALESCE(
+      (SELECT jsonb_agg(
+        jsonb_build_object(
+          'page', s.page,
+          'surface_key', s.surface_key,
+          'impressions', s.impressions,
+          'clicks', s.clicks,
+          'ctr', s.ctr,
+          'avg_position', s.avg_position,
+          'position_band', s.position_band,
+          'business_impact_score', s.business_impact_score,
+          'impact_score_version', 'v1',
+          'severity', s.severity
+        )
+        ORDER BY s.business_impact_score DESC
+      )
+      FROM (
+        SELECT * FROM scored ORDER BY business_impact_score DESC LIMIT p_limit
+      ) s),
+      '[]'::jsonb
+    ),
+    'total_qualifying', (SELECT COUNT(*) FROM agg),
+    'data_from', (SELECT data_from FROM coverage),
+    'data_to', (SELECT data_to FROM coverage),
+    -- Borné à la fenêtre (partition pruning) : ingestion arrêtée au-delà de la
+    -- fenêtre → NULL → freshness 'unknown' côté consommateur (dégradé, honnête).
+    'last_data_date', (
+      SELECT MAX(date) FROM __seo_gsc_daily, bounds
+      WHERE date >= bounds.from_d AND date < bounds.to_d
+    ),
+    'impact_score_version', 'v1'
+  );
+$$;
+COMMENT ON FUNCTION rpc_seo_low_ctr_v2(INT, TIMESTAMPTZ, INT, NUMERIC, INT) IS
+  '2026-06-11 — Low CTR v2 : mêmes filtres/score que v1 (synthétique exclu) + enveloppe honnête {rows, total_qualifying (avant LIMIT), data_from/data_to (couverture réelle), last_data_date (fraîcheur)}. Consommateur : Command Center owner-action queue.';
+
+REVOKE ALL ON FUNCTION rpc_seo_low_ctr_v2(INT, TIMESTAMPTZ, INT, NUMERIC, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION rpc_seo_low_ctr_v2(INT, TIMESTAMPTZ, INT, NUMERIC, INT) TO service_role;
+
+-- ─── RPC 4 : Alerts — + filtre synthétique (pondération trafic) ──
+-- Baseline = 20260521_seo_sitemap_freshness_001_alert_rpc.sql (sources A+B+C,
+-- définition la plus récente du repo — PAS 20260518 qui n'a que A+B).
+CREATE OR REPLACE FUNCTION rpc_seo_alerts_v1(
+  p_now TIMESTAMPTZ DEFAULT NOW(),
+  p_limit INT DEFAULT 50
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH unified AS (
+    -- Source A : audit findings unresolved (severity critical|high|medium)
+    SELECT
+      'audit_findings'::TEXT AS source,
+      audit_type::TEXT AS alert_type,
+      entity_url,
+      severity::TEXT AS severity,
+      detected_at,
+      COALESCE(
+        jsonb_strip_nulls(jsonb_build_object(
+          'reason', payload->>'reason',
+          'metric', payload->>'metric',
+          'expected', payload->'expected'
+        )),
+        '{}'::jsonb
+      ) AS payload_minimal
+    FROM __seo_audit_findings
+    WHERE resolved_at IS NULL
+      AND severity IN ('critical', 'high', 'medium')
+    UNION ALL
+    -- Source B : event log unresolved (severity critical|high, anomalies+ingestion failures)
+    SELECT
+      'event_log'::TEXT,
+      event_type::TEXT,
+      entity_url,
+      severity::TEXT,
+      created_at,
+      COALESCE(
+        jsonb_strip_nulls(jsonb_build_object(
+          'reason', payload->>'reason',
+          'source', payload->>'source',
+          'count', payload->'count'
+        )),
+        '{}'::jsonb
+      )
+    FROM __seo_event_log
+    WHERE resolved_at IS NULL
+      AND severity IN ('critical', 'high')
+      AND event_type IN ('anomaly_detected', 'alert_sent', 'ingestion_run_failed')
+    UNION ALL
+    -- Source C : sitemap freshness — alert on ABSENCE of a completion heartbeat >26h
+    -- (étape 2). Une seule ligne synthétique quand aucun `sitemap_generation_complete`
+    -- récent n'existe. Réutilise __seo_event_log (#601), aucune surface externe.
+    SELECT
+      'sitemap_freshness'::TEXT,
+      'SITEMAP_STALE_V1'::TEXT,
+      NULL::TEXT,
+      'high'::TEXT,
+      p_now,
+      jsonb_build_object(
+        'reason', 'no sitemap_generation_complete heartbeat in last 26h',
+        'threshold_hours', 26
+      )
+    WHERE NOT EXISTS (
+      SELECT 1 FROM __seo_event_log
+      WHERE event_type = 'sitemap_generation_complete'
+        AND created_at > p_now - INTERVAL '26 hours'
+    )
+  ),
+  enriched AS (
+    SELECT
+      u.source,
+      u.alert_type,
+      u.entity_url,
+      u.severity,
+      u.detected_at,
+      u.payload_minimal,
+      _seo_resolve_operational_domain(u.alert_type) AS operational_domain,
+      _seo_resolve_surface_key(u.entity_url) AS surface_key,
+      ROUND(
+        ((CASE u.severity
+          WHEN 'critical' THEN 10
+          WHEN 'high' THEN 5
+          WHEN 'medium' THEN 2
+          ELSE 1 END)::NUMERIC
+        * (1 + COALESCE(LOG(GREATEST(1, COALESCE(gsc.clicks_7d, 0))), 0))::NUMERIC)::NUMERIC,
+        2
+      )::FLOAT8 AS business_impact_score
+    FROM unified u
+    LEFT JOIN LATERAL (
+      SELECT SUM(clicks)::BIGINT AS clicks_7d
+      FROM __seo_gsc_daily
+      WHERE page = u.entity_url
+        AND date >= p_now::DATE - 7
+        AND date < p_now::DATE
+        AND NOT _seo_is_synthetic_query(query)
+    ) gsc ON TRUE
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'source', e.source,
+        'alert_type', e.alert_type,
+        'entity_url', e.entity_url,
+        'surface_key', e.surface_key,
+        'operational_domain', e.operational_domain,
+        'severity', e.severity,
+        'detected_at', e.detected_at,
+        'payload_minimal', e.payload_minimal,
+        'business_impact_score', e.business_impact_score,
+        'impact_score_version', 'v1'
+      )
+      ORDER BY e.business_impact_score DESC, e.detected_at DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM (
+    SELECT *
+    FROM enriched
+    ORDER BY business_impact_score DESC, detected_at DESC
+    LIMIT p_limit
+  ) e;
+$$;
+COMMENT ON FUNCTION rpc_seo_alerts_v1(TIMESTAMPTZ, INT) IS
+  'PR-SBD-1 v1 + étape 2 — Unresolved alerts UNION (audit_findings + event_log + sitemap freshness absence SITEMAP_STALE_V1) with operational_domain + surface_key + business_impact_score (severity weighted by page traffic). payload_minimal ≤ 3 keys (anti-bloat). 2026-06-11 : pondération trafic hors requêtes synthétiques (_seo_is_synthetic_query).';
+
+-- CREATE OR REPLACE preserves privileges, but re-state them explicitly (canon 002_rpcs).
+REVOKE ALL ON FUNCTION rpc_seo_alerts_v1(TIMESTAMPTZ, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION rpc_seo_alerts_v1(TIMESTAMPTZ, INT) TO service_role;
+
+-- ─── Helper : top queries per page — + filtre synthétique ────────
+CREATE OR REPLACE FUNCTION _seo_top_queries_for_page_jsonb(
+  p_page TEXT,
+  p_window_days INT,
+  p_now TIMESTAMPTZ,
+  p_limit INT DEFAULT 3
+) RETURNS JSONB LANGUAGE sql STABLE AS $$
+  WITH bounds AS (
+    SELECT
+      (p_now::DATE - p_window_days) AS from_d,
+      p_now::DATE AS to_d,
+      (p_now::DATE - p_window_days * 2) AS prev_from_d,
+      (p_now::DATE - p_window_days) AS prev_to_d
+  ),
+  curr AS (
+    SELECT
+      query,
+      SUM(clicks)::INT AS c,
+      SUM(impressions)::INT AS i,
+      AVG(position)::FLOAT8 AS pos
+    FROM __seo_gsc_daily, bounds
+    WHERE page = p_page
+      AND date >= bounds.from_d
+      AND date < bounds.to_d
+      AND query IS NOT NULL
+      AND NOT _seo_is_synthetic_query(query)
+    GROUP BY query
+  ),
+  prev AS (
+    SELECT
+      query,
+      SUM(clicks)::INT AS c
+    FROM __seo_gsc_daily, bounds
+    WHERE page = p_page
+      AND date >= bounds.prev_from_d
+      AND date < bounds.prev_to_d
+      AND query IS NOT NULL
+      AND NOT _seo_is_synthetic_query(query)
+    GROUP BY query
+  ),
+  joined AS (
+    SELECT
+      curr.query,
+      (curr.c - COALESCE(prev.c, 0))::INT AS clicks_delta,
+      ROUND(curr.pos::NUMERIC, 2)::FLOAT8 AS position_current
+    FROM curr
+    LEFT JOIN prev USING (query)
+    ORDER BY ABS(curr.c - COALESCE(prev.c, 0)) DESC
+    LIMIT p_limit
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'query', query,
+        'clicks_delta', clicks_delta,
+        'position_current', position_current
+      )
+      ORDER BY ABS(clicks_delta) DESC
+    ),
+    '[]'::jsonb
+  )
+  FROM joined;
+$$;
+COMMENT ON FUNCTION _seo_top_queries_for_page_jsonb(TEXT, INT, TIMESTAMPTZ, INT) IS
+  'PR-SBD-1 v1 — Top N queries (delta clicks) for a page. Private helper (no GRANT). 2026-06-11 : exclut les requêtes synthétiques (_seo_is_synthetic_query).';

--- a/backend/tests/unit/command-center-action-rules.test.ts
+++ b/backend/tests/unit/command-center-action-rules.test.ts
@@ -229,8 +229,23 @@ describe('SEO opportunity rules — real business actions (certified source)', (
     expect(out.find((a) => a.id === 'seo:opportunity:content')).toBeDefined();
   });
 
-  it('returns nothing on empty input', () => {
-    expect(buildSeoOpportunityActions([])).toEqual([]);
+  it('empty input + fraîcheur/couverture vérifiées → rien (vraie bonne nouvelle)', () => {
+    expect(
+      buildSeoOpportunityActions([], {
+        total_qualifying: 0,
+        data_from: '2026-04-01',
+        data_to: '2026-06-08',
+        freshness: 'fresh',
+      }),
+    ).toEqual([]);
+  });
+
+  it('empty input SANS fraîcheur vérifiée → action certification data-gap, jamais un silence ambigu', () => {
+    const out = buildSeoOpportunityActions([]).map(finalizeAction);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('seo:gsc-data-gap');
+    expect(out[0].action_type).toBe('certification');
+    expect(out[0].reason).toMatch(/ingestion/i);
   });
 
   it('PR2+PR3: per-URL details (sorted desc; ctr; position + advisory next_step)', () => {
@@ -294,6 +309,67 @@ describe('PR3: deriveUrlNextStep — deterministic, advisory, honest', () => {
       expect(s).toMatch(/inconnue/i);
       expect(s).not.toMatch(/ranke/i);
     }
+  });
+});
+
+describe('PR4: GSC meta honnêteté — cap divulgué, couverture réelle, fraîcheur', () => {
+  const rows = [
+    {
+      page: 'https://x/pieces/a.html',
+      impressions: 200,
+      clicks: 0,
+      position: 4,
+    },
+    { page: 'https://x/blog-pieces-auto/conseils/c', impressions: 100, clicks: 0 },
+  ];
+
+  it('fresh + cap dépassé → confiance CERTIFIED (90), cap dans le titre, couverture réelle dans la raison', () => {
+    const out = buildSeoOpportunityActions(rows, {
+      total_qualifying: 147,
+      data_from: '2026-04-01',
+      data_to: '2026-06-08',
+      freshness: 'fresh',
+    }).map(finalizeAction);
+    const product = out.find((a) => a.id === 'seo:opportunity:product')!;
+    expect(product.data_confidence).toBe(90);
+    expect(product.action_type).toBe('business');
+    expect(product.title).toMatch(/top 2/); // 147 qualifiantes > 2 affichées → cap divulgué
+    expect(product.reason).toMatch(/147 pages qualifiantes/);
+    expect(product.reason).toMatch(/2026-04-01 au 2026-06-08/);
+    expect(product.reason).not.toMatch(/120j/); // plus de claim de fenêtre non vérifiée
+  });
+
+  it('stale → PARTIAL (55) annoncé, l\'action business survit (≥ floor) marquée prudence', () => {
+    const out = buildSeoOpportunityActions(rows, {
+      total_qualifying: 2,
+      data_from: '2026-04-01',
+      data_to: '2026-05-01',
+      freshness: 'stale',
+    }).map(finalizeAction);
+    const product = out.find((a) => a.id === 'seo:opportunity:product')!;
+    expect(product.data_confidence).toBe(55);
+    expect(product.action_type).toBe('business');
+    expect(product.reason).toMatch(/fraîcheur GSC dégradée/i);
+  });
+
+  it('meta absente (fallback RPC v1) → PARTIAL + couverture et total annoncés inconnus', () => {
+    const out = buildSeoOpportunityActions(rows).map(finalizeAction);
+    const product = out.find((a) => a.id === 'seo:opportunity:product')!;
+    expect(product.data_confidence).toBe(55);
+    expect(product.reason).toMatch(/total qualifiant inconnu/i);
+    expect(product.reason).toMatch(/Couverture réelle des données GSC inconnue/);
+  });
+
+  it('liste complète (total ≤ échantillon) → pas de cap dans le titre, « Liste complète » dans la raison', () => {
+    const out = buildSeoOpportunityActions(rows, {
+      total_qualifying: 2,
+      data_from: '2026-04-01',
+      data_to: '2026-06-08',
+      freshness: 'fresh',
+    }).map(finalizeAction);
+    const product = out.find((a) => a.id === 'seo:opportunity:product')!;
+    expect(product.title).not.toMatch(/top \d/);
+    expect(product.reason).toMatch(/Liste complète \(2 pages qualifiantes/);
   });
 });
 

--- a/backend/tests/unit/command-center-actions.service.test.ts
+++ b/backend/tests/unit/command-center-actions.service.test.ts
@@ -101,3 +101,173 @@ describe('CommandCenterActionsService — honest by construction', () => {
     expect(supabase.from).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * A supabase whose table reads succeed (empty pricing) and whose rpc() is
+ * driven per-function — isolates the SEO v2/v1 path.
+ */
+function seoSupabase(
+  rpcImpl: (name: string) => { data: unknown; error: unknown },
+) {
+  const ok = { data: [], count: 0, error: null };
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    'from',
+    'select',
+    'eq',
+    'gt',
+    'or',
+    'limit',
+    'order',
+    'gte',
+  ]) {
+    chain[m] = jest.fn().mockReturnValue(chain);
+  }
+  chain.then = (resolve: (v: typeof ok) => unknown) => resolve(ok);
+  chain.rpc = jest
+    .fn()
+    .mockImplementation((name: string) => Promise.resolve(rpcImpl(name)));
+  return chain as ReturnType<typeof brokenSupabase>;
+}
+
+describe('PR4: rpc_seo_low_ctr_v2 envelope + explicit v1 fallback', () => {
+  const gscRow = {
+    page: '/pieces/filtre-a-air-8/x-1/y-2/z-3.html',
+    impressions: 200,
+    clicks: 0,
+    avg_position: 4.2,
+  };
+
+  it('v2 envelope → meta wired: fresh data = confidence 90, cap + real coverage in reason', async () => {
+    // last ingested date 2 days ago → within the 7-day freshness SLA
+    const freshDate = new Date(Date.now() - 2 * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const supabase = seoSupabase((name) =>
+      name === 'rpc_seo_low_ctr_v2'
+        ? {
+            data: {
+              rows: [gscRow],
+              total_qualifying: 147,
+              data_from: '2026-04-01',
+              data_to: freshDate,
+              last_data_date: freshDate,
+            },
+            error: null,
+          }
+        : { data: null, error: { message: `unexpected call to ${name}` } },
+    );
+    const service = makeService(supabase);
+    const queue = await service.computeActionQueue([], [], 'full');
+    const product = queue.find((a) => a.id === 'seo:opportunity:product');
+    expect(product).toBeDefined();
+    expect(product!.action_type).toBe('business');
+    expect(product!.data_confidence).toBe(90);
+    expect(product!.title).toMatch(/top 1/); // 147 qualifying > 1 shown → cap disclosed
+    expect(product!.reason).toMatch(/147 pages qualifiantes/);
+    expect(product!.reason).toMatch(new RegExp(`2026-04-01 au ${freshDate}`));
+  });
+
+  it('v2 stale ingestion → business action survives at PARTIAL (55), staleness said out loud', async () => {
+    const staleDate = new Date(Date.now() - 20 * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const supabase = seoSupabase((name) =>
+      name === 'rpc_seo_low_ctr_v2'
+        ? {
+            data: {
+              rows: [gscRow],
+              total_qualifying: 1,
+              data_from: '2026-04-01',
+              data_to: staleDate,
+              last_data_date: staleDate,
+            },
+            error: null,
+          }
+        : { data: null, error: { message: `unexpected call to ${name}` } },
+    );
+    const service = makeService(supabase);
+    const queue = await service.computeActionQueue([], [], 'full');
+    const product = queue.find((a) => a.id === 'seo:opportunity:product');
+    expect(product).toBeDefined();
+    expect(product!.data_confidence).toBe(55);
+    expect(product!.reason).toMatch(/fraîcheur GSC dégradée/i);
+  });
+
+  it('v2 unavailable → EXPLICIT v1 fallback: confidence degraded to 55, unknown coverage said out loud', async () => {
+    const supabase = seoSupabase((name) =>
+      name === 'rpc_seo_low_ctr_v1'
+        ? { data: [gscRow], error: null }
+        : {
+            data: null,
+            error: { message: 'function rpc_seo_low_ctr_v2 does not exist' },
+          },
+    );
+    const service = makeService(supabase);
+    const queue = await service.computeActionQueue([], [], 'full');
+    const product = queue.find((a) => a.id === 'seo:opportunity:product');
+    expect(product).toBeDefined();
+    expect(product!.action_type).toBe('business'); // 55 ≥ floor 40 — survives flagged « prudence »
+    expect(product!.data_confidence).toBe(55);
+    expect(product!.reason).toMatch(/total qualifiant inconnu/i);
+    expect(product!.reason).toMatch(/Couverture réelle des données GSC inconnue/);
+  });
+
+  it('v2 returns a v1-style ARRAY (invalid envelope) → explicit v1 fallback at PARTIAL', async () => {
+    const supabase = seoSupabase((name) =>
+      name === 'rpc_seo_low_ctr_v2'
+        ? { data: [gscRow], error: null } // array, no .rows envelope
+        : name === 'rpc_seo_low_ctr_v1'
+          ? { data: [gscRow], error: null }
+          : { data: null, error: { message: `unexpected call to ${name}` } },
+    );
+    const service = makeService(supabase);
+    const queue = await service.computeActionQueue([], [], 'full');
+    const product = queue.find((a) => a.id === 'seo:opportunity:product');
+    expect(product).toBeDefined();
+    expect(product!.data_confidence).toBe(55); // meta unknown → PARTIAL, no fake 90
+    expect(product!.reason).toMatch(/total qualifiant inconnu/i);
+  });
+
+  it('freshness boundary is calendar-day based: 7 days ago = fresh (90), 8 days ago = stale (55)', async () => {
+    const dateDaysAgo = (n: number) =>
+      new Date(Date.now() - n * 86_400_000).toISOString().slice(0, 10);
+    for (const [daysAgo, expected] of [
+      [7, 90],
+      [8, 55],
+    ] as const) {
+      const d = dateDaysAgo(daysAgo);
+      const supabase = seoSupabase((name) =>
+        name === 'rpc_seo_low_ctr_v2'
+          ? {
+              data: {
+                rows: [gscRow],
+                total_qualifying: 1,
+                data_from: '2026-04-01',
+                data_to: d,
+                last_data_date: d,
+              },
+              error: null,
+            }
+          : { data: null, error: { message: `unexpected call to ${name}` } },
+      );
+      const service = makeService(supabase);
+      const queue = await service.computeActionQueue([], [], 'full');
+      const product = queue.find((a) => a.id === 'seo:opportunity:product');
+      expect(product!.data_confidence).toBe(expected);
+    }
+  });
+
+  it('v2 AND v1 broken → honest sourceUnavailable certification, never business', async () => {
+    const supabase = seoSupabase(() => ({
+      data: null,
+      error: { message: 'boom' },
+    }));
+    const service = makeService(supabase);
+    const queue = await service.computeActionQueue([], [], 'full');
+    expect(queue.find((a) => a.id === 'unavailable:seo')).toBeDefined();
+    expect(
+      queue.some((a) => a.id.startsWith('seo:opportunity:')),
+    ).toBe(false);
+  });
+});

--- a/governance/rpc/rpc_allowlist.json
+++ b/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 167,
+  "total": 169,
   "functions": [
     {
       "name": "auth_email_exists",
@@ -743,6 +743,16 @@
       "name": "rm_get_page_complete_v2",
       "volatility": "VOLATILE",
       "reason": "Read-only cache (migrated from P2)"
+    },
+    {
+      "name": "rpc_seo_low_ctr_v1",
+      "volatility": "STABLE",
+      "reason": "SEO low-CTR aggregation read-only (Command Center + seo-control dashboard)"
+    },
+    {
+      "name": "rpc_seo_low_ctr_v2",
+      "volatility": "STABLE",
+      "reason": "SEO low-CTR v2 honest envelope read-only (Command Center owner-action queue)"
     },
     {
       "name": "search_pieces_fts",


### PR DESCRIPTION
## Problème (audit 2026-06-11, vérifié en SQL live)

Les recommandations SEO du Command Center étaient **trompeuses** :
- L'opportunité n°1 (`filtre-a-air Hyundai ix35`, 2 283 impressions, « ranke pos. 5.2 sans clic ») était **100 % fabriquée** par les requêtes synthétiques internes `^ai[0-9]+$` (360/360 requêtes, 0 impression humaine). 5/50 pages = fantômes purs ; bucket produit gonflé **+46 %**.
- Le cap `p_limit=50` était caché : « 24 fiches produit » affichées alors que **80 qualifient** (147 pages au total) — chantier sous-estimé ~3×.
- « sur 120j » : la table ne couvre que ~64 jours réels.
- `data_confidence=90` (« GSC certified ») : constante jamais vérifiée contre la fraîcheur d'ingestion.

## Fix structurel

**Migration `20260611_seo_control_004_synthetic_filter.sql`** (+ rollback `.down.sql` complet) :
- Prédicat unique `_seo_is_synthetic_query(text)` (IMMUTABLE) — single source of truth du pattern.
- Filtre appliqué aux **4 RPC** lisant `__seo_gsc_daily` (`traffic`, `top_losers`, `low_ctr`, `alerts` pondération) + helper `_seo_top_queries_for_page_jsonb`. Corps **byte-identiques** aux baselines vérifiées mécaniquement (diff modulo lignes de filtre).
- ⚠️ `rpc_seo_alerts_v1` basé sur **20260521** (sources A+B+C avec `SITEMAP_STALE_V1`), pas 20260518 — le premier jet l'aurait silencieusement effacée (attrapé par la review adversariale).
- **`rpc_seo_low_ctr_v2`** : enveloppe `{rows, total_qualifying, data_from, data_to, last_data_date}` — divulgue le cap, la couverture réelle, la fraîcheur. `last_data_date` borné à la fenêtre (partition pruning). La v1 garde sa forme (3 consommateurs intacts).

**Service** (`command-center-actions.service.ts`) :
- Appel v2 ; **fallback v1 explicite et loggé** tant que la migration n'est pas appliquée (couverture inconnue → confiance dégradée, jamais un silence).
- Fraîcheur GSC calendaire (SLA 7 j) : stale/unknown → confiance **PARTIAL 55** (badge « prudence » UI < 70), fini le 90 non vérifié.

**Règles** (`seo-action.rules.ts`) :
- Titre : « … — top 50 toutes pages » quand tronqué ; raison : total qualifiant + « Données GSC réellement couvertes du X au Y ».
- `rows=[]` sans fraîcheur vérifiée → action certification `seo:gsc-data-gap` (un 0 ambigu n'est plus indistinguable d'une ingestion arrêtée).

**Allowlist RPC** (les 2 copies) : `rpc_seo_low_ctr_v1`/`v2` ajoutés — une fonction inconnue du gate est BLOCK en PROD enforce ; le commentaire « internal context » était faux.

## Vérification

- **40/40 tests** jest (11 nouveaux : enveloppe v2, fallback explicite, frontière 7/8 j, data-gap, wording, v1+v2 cassés → sourceUnavailable).
- Build turbo 11/11 ✓, ESLint ✓.
- Reproduction SQL vérifiée mécaniquement (script diff) contre 20260518 + 20260521.
- Review adversariale 3 lentilles (SQL, TS, honnêteté) — BLOCKER + 2 MAJOR/MINORs corrigés.

## Post-merge (owner-gated, axe 4)

La migration n'est **pas auto-appliquée** à la DB partagée. Apply = `20260611_seo_control_004_synthetic_filter.sql` (réversible via `.down.sql`).

⚠️ **Drift préexistant découvert** : la DB live n'a PAS la source C de `rpc_seo_alerts_v1` (migration 20260521 mergée mais jamais appliquée — `pg_get_functiondef` vérifié). L'apply de cette migration réalignera la DB sur le repo (et activera enfin l'alerte `SITEMAP_STALE_V1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)