### PR TITLE
fix(db): guard jsonb_array_length dans get_page_quality_features (22023 → recompute débloqué)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -95,6 +95,13 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: low
+  # Fix get_page_quality_features 22023 (jsonb_array_length sur jsonb non-array) — débloque
+  # le recompute du quality-scoring (de-RAG v2.2 #935). Owner GO session 2026-06-11. Glob exact.
+  - glob: backend/supabase/migrations/20260611_fix_get_page_quality_features_jsonb_array_length_guard.sql
+    domain: D14
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: low
   - glob: scripts/governance/validate-authority-graph.js
     domain: D15
     owner: '@ak125'

--- a/backend/supabase/migrations/20260611_fix_get_page_quality_features_jsonb_array_length_guard.sql
+++ b/backend/supabase/migrations/20260611_fix_get_page_quality_features_jsonb_array_length_guard.sql
@@ -17,7 +17,10 @@
 -- version via un recreate DÉTERMINISTE depuis sa définition courante (pas de
 -- transcription manuelle fragile d'une fonction de ~9 100 caractères).
 --
--- Squawk : pas de BEGIN/COMMIT explicite (assume_in_transaction).
+-- Squawk : pas de BEGIN/COMMIT explicite (assume_in_transaction) + timeouts requis
+-- (require-timeout-settings, convention repo 2s/5s — DDL léger, swap de définition).
+set lock_timeout = '2s';
+set statement_timeout = '5s';
 
 -- 1) Helper type-guardé : 0 si non-array / null jsonb.
 CREATE OR REPLACE FUNCTION public.safe_jsonb_array_length(x jsonb)

--- a/backend/supabase/migrations/20260611_fix_get_page_quality_features_jsonb_array_length_guard.sql
+++ b/backend/supabase/migrations/20260611_fix_get_page_quality_features_jsonb_array_length_guard.sql
@@ -1,0 +1,62 @@
+-- Fix: get_page_quality_features() throws 22023 "cannot get array length of a non-array"
+--
+-- Root cause (vérifié 2026-06-11) : la fonction calcule les colonnes *_count via
+--   jsonb_array_length(COALESCE(sgpg_*, '[]'::jsonb))
+-- Le COALESCE ne garde que le SQL-NULL — PAS un jsonb dont le type est non-array
+-- (object/scalar). Données réelles de __seo_gamme_purchase_guide :
+--   sgpg_faq          = 237 array / 2 OBJECT / 2 null
+--   sgpg_brands_guide = 11 array / 213 OBJECT / 17 null   (un guide marques = objet, pas liste)
+-- → jsonb_array_length() sur les lignes OBJECT lève 22023. Le chemin app (PostgREST,
+--   SELECT *) déclenche l'erreur → fetchFeatures() reçoit [] → QualityScoringEngine
+--   score 0 page (silencieux depuis ~mars : la table __quality_page_scores est figée).
+--   Le `count(*)` SQL masquait (count n'évalue pas les colonnes projetées).
+--
+-- Fix (robuste, type-guarded — AUCUNE mutation de données) : router chaque
+-- jsonb_array_length(x) via un guard jsonb_typeof. La fonction avait été créée
+-- HORS migration (non-versionnée) — cette migration la remet sous contrôle de
+-- version via un recreate DÉTERMINISTE depuis sa définition courante (pas de
+-- transcription manuelle fragile d'une fonction de ~9 100 caractères).
+--
+-- Squawk : pas de BEGIN/COMMIT explicite (assume_in_transaction).
+
+-- 1) Helper type-guardé : 0 si non-array / null jsonb.
+CREATE OR REPLACE FUNCTION public.safe_jsonb_array_length(x jsonb)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $fn$
+  SELECT CASE WHEN jsonb_typeof(x) = 'array' THEN jsonb_array_length(x) ELSE 0 END;
+$fn$;
+
+COMMENT ON FUNCTION public.safe_jsonb_array_length(jsonb) IS
+  'jsonb_array_length type-guardé (ADR-data-integrity) : retourne 0 pour un jsonb non-array/null au lieu de lever 22023. Migration 20260611.';
+
+-- 2) Recreate get_page_quality_features() depuis sa définition COURANTE, en routant
+--    chaque appel `jsonb_array_length(` vers le helper guardé. Déterministe (zéro
+--    transcription) + idempotent : le guard `[^a-z_]` empêche de ré-emballer
+--    `safe_jsonb_array_length` à un second passage.
+DO $mig$
+DECLARE
+  d text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid) INTO d
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE p.proname = 'get_page_quality_features' AND n.nspname = 'public'
+  ORDER BY p.oid
+  LIMIT 1;
+
+  IF d IS NULL THEN
+    RAISE EXCEPTION 'get_page_quality_features() introuvable — migration abandonnée';
+  END IF;
+
+  d := regexp_replace(
+         d,
+         '([^a-z_])jsonb_array_length\(',
+         '\1public.safe_jsonb_array_length(',
+         'g'
+       );
+
+  EXECUTE d;
+END
+$mig$;


### PR DESCRIPTION
## RPC `get_page_quality_features` : guard `jsonb_array_length` (22023 → recompute débloqué)

**Découvert** en appliquant le de-RAG v2.2 (#935) : la RPC renvoie **HTTP 400 / PG 22023 `cannot get array length of a non-array`** via PostgREST → `QualityScoringEngine.fetchFeatures()` reçoit `[]` → **0 page scorée** (silencieux **depuis ~mars** → `__quality_page_scores` figée v2.1).

**Cause (vérifiée DB)** : `jsonb_array_length(COALESCE(sgpg_*, '[]'::jsonb))` — le COALESCE garde le SQL-null mais **pas** un jsonb non-array. Données réelles :
- `sgpg_faq` : 237 array / **2 object** / 2 null
- `sgpg_brands_guide` : 11 array / **213 object** / 17 null (un guide marques = objet, pas liste)

`count(*)` SQL masquait (n'évalue pas les colonnes projetées) ; `SELECT *` (REST) déclenche l'erreur.

**Fix (robuste, 0 mutation de données)** :
1. helper `safe_jsonb_array_length(jsonb)` type-guardé (0 si non-array/null) ;
2. recreate **déterministe** de `get_page_quality_features` depuis sa def courante (elle était **non-versionnée** — gap de gouvernance fermé ici), routant `jsonb_array_length(` → `safe_jsonb_array_length(` (regex `[^a-z_]` → idempotent). **Aucune transcription manuelle.**
3. glob ownership ajouté (owner GO 2026-06-11).

**Orthogonal au de-RAG** (#935) — bug pré-existant qui bloquait déjà tout recompute depuis mars.

### Séquence post-merge (owner-gated)
1. **Appliquer** la migration à la DB partagée (`apply_migration` / Studio) — DDL, ton GO.
2. Re-vérifier `SELECT * FROM get_page_quality_features()` → plus de 22023.
3. **Recompute** v2.2 → `__quality_page_scores` propre (sans RAG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
