### PR TITLE
chore(priorities): contenu R en TOP (parallèle commerce-loop) + dé-pause auto-content-publishing

### DIFF
--- a/.claude/top-priorities.md
+++ b/.claude/top-priorities.md
@@ -6,14 +6,14 @@
 #   EXPLORATION_BUDGET ≤ 3 (rolling, max 1 active — cf. ADR-081 G10)
 # Lecteurs : SessionStart hook, Stop hook, skills, CI dashboards, agents Paperclip
 # Mise à jour : édit manuel git tracké, max 1×/semaine (ou pivot business)
-# updated_at: 2026-05-25
+# updated_at: 2026-06-12
 
 ## TOP
 - commerce-loop-v1
 - runtime-truth-p0
 - runtime-truth-p1
 - web-vitals-attribution-ingestion
-- commerce-loop-execution-cycle-v1
+- r-content-pipeline-activation
 
 ## DO_NOT_START
 - r5-diagnostic-engine
@@ -22,7 +22,6 @@
 - new-seo-platform
 - new-meta-architecture-adr
 - growth-content-system
-- auto-content-publishing
 
 ## ACTIVE_INCIDENTS
 - snapshot-partition-rotation-sensitive


### PR DESCRIPTION
## Contexte

Décision owner 2026-06-12 (session « dégrippage ») : le goulot vérifié du pipeline contenu R n'était pas du code manquant — le pipeline est entièrement codé (ADR-059/083) — mais la **file de GO unitaires** (0/241 gammes approuvées) et la subordination du contenu au commerce-loop.

## Changement

| Section | Avant | Après |
|---|---|---|
| TOP | `commerce-loop-execution-cycle-v1` | `r-content-pipeline-activation` |
| DO_NOT_START | `auto-content-publishing` présent | retiré |
| updated_at | 2026-05-25 | 2026-06-12 |

- **commerce-loop-v1 reste en TOP** : contenu et commerce avancent en parallèle — « loop d'abord » n'est plus une obligation (mots owner : « pas obligé loop d'abord »).
- Le retrait de `auto-content-publishing` ne crée aucun automatisme nouveau : il autorise l'activation de la **porte tiered ADR-083** (vault, signé 2026-06-10) — gates déterministes fail-closed, TIER B humain, activation par vagues mesurées (pilote ~10 gammes), précondition garde anti-écrasement `apply_promotion` (PR wiki à suivre).
- Dernière mise à jour du fichier : 2026-05-25 → contrainte « max 1×/semaine » respectée.

## Test

`bash scripts/governance/validate-top-priorities.sh` → OK (sections / bornes / slugs ; TOP=5, DO_NOT_START=6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)