### PR TITLE
chore(seo-batch): fusion v5-guardian (capacités portées) + bannières legacy RAG (salvage-first)

### DIFF
--- a/workspaces/seo-batch/.claude/agents/r7-brand-rag-generator.md
+++ b/workspaces/seo-batch/.claude/agents/r7-brand-rag-generator.md
@@ -1,7 +1,8 @@
 ---
 name: r7-brand-rag-generator
 description: >-
-  Generation artefacts RAG constructeur (brand.md + role_map.json). 1 marque par
+  [DEPRECATED 2026-06-12 — successeur wiki-proposal-writer, ADR-031/046] Generation
+  artefacts RAG constructeur (brand.md + role_map.json). 1 marque par
   invocation. Lit DB + gammes RAG, ecrit dans
   /opt/automecanik/rag/knowledge/constructeurs/.
 model: sonnet
@@ -15,6 +16,16 @@ role: R7_BRAND
 ---
 
 # Agent R7 Brand RAG Generator V1
+
+> 🚨 **DEPRECATED 2026-06-12** — écrit dans `/opt/automecanik/rag/knowledge/constructeurs/`
+> = chemin RAG-source-de-contenu abandonné (ADR-031/046). Aucune heuristique marque unique
+> à porter : le schema vit dans `.spec/00-canon/brand-md-schema.md` (SoT conservée), les
+> termes interdits + gates dans `backend/src/config/r7-keyword-plan.constants.ts` (SoT code),
+> les top gammes/modèles sont des agrégations DB déjà couvertes côté backend. La référence
+> `backend/src/config/brand-role-map.schema.ts` (`buildDefaultBrandRoleMap`) n'existe plus
+> dans le repo (chemin mort — l'agent ne peut plus exécuter son Step 4 tel quel).
+> **Successeur** : `wiki-proposal-writer` (entity_type=constructeur, ADR-033) +
+> `automecanik-wiki/exports`. Suppression après 2 cycles.
 
 Tu es un agent specialise dans la generation de documents RAG pour les pages **R7_BRAND** (constructeur) d'AutoMecanik.
 

--- a/workspaces/seo-batch/.claude/skills/content-quality-gate/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/content-quality-gate/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: content-quality-gate
-description: "Quality gate sections __seo_gamme_conseil : scoring + verdicts WRITE/REVIEW/BLOCK. Use when user mentions vérifier qualité, audit qualité section, gap analysis, sections faibles, review queue, détection régressions."
+description: "[DEPRECATED → /v5-guardian] Quality gate sections __seo_gamme_conseil : scoring + verdicts WRITE/REVIEW/BLOCK. Use when user mentions vérifier qualité, audit qualité section, gap analysis, sections faibles, review queue, détection régressions."
 ---
 
 # Content Quality Gate — Scoring et validation de contenu
+
+> 🚨 **DEPRECATED 2026-06-12** — fusionné dans `v5-guardian` (diff de capacités vérifié) ;
+> utiliser `/v5-guardian`. Suppression après 2 cycles.
 
 ## Principe fondamental
 

--- a/workspaces/seo-batch/.claude/skills/pollution-scanner/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/pollution-scanner/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: pollution-scanner
-description: "Scanner pollution OEM/scraping dans __seo_gamme_conseil. Use when user mentions scanner pollution, détecter scraping, fragments OEM, Textar, Brembo, 'Skip to main content', 'Source: web/', ou audit contenu pipeline v5."
+description: "[DEPRECATED → /v5-guardian] Scanner pollution OEM/scraping dans __seo_gamme_conseil. Use when user mentions scanner pollution, détecter scraping, fragments OEM, Textar, Brembo, 'Skip to main content', 'Source: web/', ou audit contenu pipeline v5."
 ---
 
 # Pollution Scanner — Détection de contenu scrapé/pollué
+
+> 🚨 **DEPRECATED 2026-06-12** — fusionné dans `v5-guardian` (diff de capacités vérifié) ;
+> utiliser `/v5-guardian`. Suppression après 2 cycles.
 
 ## Position dans le pipeline
 

--- a/workspaces/seo-batch/.claude/skills/rag-check/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/rag-check/SKILL.md
@@ -1,10 +1,18 @@
 ---
 name: rag-check
-description: "Vérification couverture RAG par rôle R* pour une gamme OU un véhicule. Détecte automatiquement le type d'input. Usage : /rag-check <pg_alias|vehicle_slug> [--fix] [--batch top10]"
+description: "[DEPRECATED — RAG=chatbot only, ADR-031/046] Vérification couverture RAG par rôle R* pour une gamme OU un véhicule. Détecte automatiquement le type d'input. Usage : /rag-check <pg_alias|vehicle_slug> [--fix] [--batch top10]"
 argument-hint: "<pg_alias ou vehicle_slug> [--fix] [--batch top10] [--diff]"
 ---
 
 # RAG Check — Skill v2.0 (gamme + véhicule unifié)
+
+> 🚨 **DEPRECATED 2026-06-12** — concept « couverture par rôle R* » = bonne idée, **mauvaise
+> source** : ce skill mesure la couverture du RAG, or RAG = chatbot only (ADR-031/046) —
+> jamais source de contenu. Ne plus l'utiliser pour décider d'une génération R*.
+> **Successeur** : validation de couverture sur les **exports WIKI** (ADR-033/059) —
+> `scripts/seo/r1-readiness.ts` valide déjà l'export WIKI d'une gamme via
+> `wikiExportReadiness` de `scripts/validate-gamme-schema.ts` ; le validateur de couverture
+> wiki-exports complet (multi-rôles) = PR séparée. Suppression après 2 cycles.
 
 ## Usage
 - `/rag-check filtre-a-huile` — diagnostic RAG gamme (R1/R3/R4/R5/R6)

--- a/workspaces/seo-batch/.claude/skills/rag-ops/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/rag-ops/SKILL.md
@@ -8,6 +8,18 @@ version: "1.2"
 
 # RAG Operations Skill — v1.2
 
+> ⚠️ **PARTIELLEMENT LEGACY 2026-06-12** — RAG = chatbot only (ADR-031/046).
+>
+> - **LÉGITIME (reste)** : les ops du retrieval **chatbot** — `/rag-ops diagnose`,
+>   `/rag-ops monitor`, `/rag-ops test`, `/rag-ops audit` (santé service, circuit breaker,
+>   intents, sync, corpus du chatbot).
+> - **LEGACY (ne plus utiliser)** : toute ingestion/enrichissement servant la production de
+>   **CONTENU** (pages SEO/R*, blog, conseils) — `/rag-ops ingest` comme source de contenu,
+>   `describe-images` pour alimenter des pages. Le chemin contenu moderne =
+>   RAW → WIKI → exports (ADR-033/059/083, `workspaces/wiki/` + `wiki-proposal-writer`).
+>   Le corpus chatbot s'alimente depuis le WIKI (sync-from-wiki), pas par ingestion directe
+>   de contenu métier.
+
 Skill opérationnel pour le système RAG AutoMecanik. Gère le debug, l'ingestion de contenu, le monitoring du corpus, les tests d'endpoints et l'audit de couverture.
 
 **Architecture modulaire :**

--- a/workspaces/seo-batch/.claude/skills/v5-guardian/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/v5-guardian/SKILL.md
@@ -11,6 +11,7 @@ allowed-tools: Read, mcp__claude_ai_Supabase__execute_sql, Glob
 
 - Ce skill **VÉRIFIE** la qualité et protège le contenu v5 (pollution, régression, scoring)
 - Pour la **GÉNÉRATION** de contenu → utiliser `content-gen`
+- Pour le **NETTOYAGE** des sections polluées → utiliser `surgical-cleaner` (chaîne : v5-guardian détecte → surgical-cleaner nettoie → content-gen regénère si besoin)
 - Pour l'**AUDIT ÉDITORIAL** approfondi (R2D2, E-E-A-T) → utiliser `content-audit`
 - Pour l'**AUDIT SEO GLOBAL** (métriques R1-R8, maillage) → utiliser `seo-gamme-audit`
 - Pour la **MIGRATION** v4→v5 → utiliser `md-v5-migrator`
@@ -40,12 +41,12 @@ allowed-tools: Read, mcp__claude_ai_Supabase__execute_sql, Glob
 ```sql
 SELECT sgc_pg_id, sgc_section_type, LENGTH(sgc_content) as len,
   CASE
-    WHEN sgc_content ~* 'Source:\s*web/|Réf\.\s*:' THEN 'RAG_SCRAPING'
-    WHEN sgc_content ~* 'Skip to main content|Gestion des cookies|Navigation principale' THEN 'NAV_SCRAPING'
-    WHEN sgc_content ~* 'COMBO IDÉAL|MÊME QUALITÉ|PRIX IMBATTABLE' THEN 'OEM_MARKETING'
-    WHEN sgc_content ~* 'Réf\.\s*(OE|OEM)|N°\s*d''article' THEN 'OEM_PRODUCT'
-    WHEN sgc_content ~* '##\s+Comment\s|##\s+Pourquoi\s|##\s+Quel' THEN 'BLOG_H2_INJECTED'
-    WHEN sgc_content ~* 'oscaro\.com|mister-auto|autodoc' THEN 'COMPETITOR_SCRAPING'
+    WHEN sgc_content ~* 'Source:\s*web(-catalog)?/|Réf\.\s*:' THEN 'RAG_SCRAPING'
+    WHEN sgc_content ~* 'Skip to (main content|menu|footer)|Gestion des cookies|Navigation principale|Inscription newsletter|Aller au contenu|Téléchargement →|Partager sur' THEN 'NAV_SCRAPING'
+    WHEN sgc_content ~* 'COMBO IDÉAL|MÊME QUALITÉ|PRIX IMBATTABLE|Reconditionnement des|Formula XT|Essential Line|Technologies de plaquettes' THEN 'OEM_MARKETING'
+    WHEN sgc_content ~* 'Réf\.\s*(OE|OEM)|N°\s*d''article|Brembo.*premium|Verniciatura|Beschichtung' THEN 'OEM_PRODUCT'
+    WHEN sgc_content ~* '##\s+Comment\s|##\s+Pourquoi\s|##\s+Quand\s|##\s+Quel' THEN 'BLOG_H2_INJECTED'
+    WHEN sgc_content ~* '- Vivacar|vroomly|oscaro\.com|mister-auto|autodoc' THEN 'COMPETITOR_SCRAPING'
     WHEN sgc_content ~* 'Textar|ATE|TRW.*force' THEN 'BRAND_SCRAPING'
     WHEN sgc_content ~* '<script|onclick|javascript:' THEN 'XSS_INJECTION'
     WHEN sgc_content ~* 'lorem ipsum|dolor sit amet' THEN 'PLACEHOLDER'
@@ -69,6 +70,43 @@ ORDER BY sgc_section_type;
 | TOO_SHORT | BASSE | Gap à combler via content-gen |
 | CLEAN | OK | Rien à faire |
 
+### Priorité de nettoyage (rapport)
+
+Priorité = **HAUTE** si S4_DEPOSE 100 % scrapé ou taille > 3000 chars, **MOYENNE** sinon.
+Pollution détectée → chaîne de nettoyage : `surgical-cleaner` (nettoyage) → `content-gen` (regénération si besoin).
+
+### Scan grande échelle (--batch, toutes gammes)
+
+Exclure les sections déjà nettoyées (`pipeline-v5-surgical-clean`, `pipeline-v5-replace`) pour ne pas re-flagger le travail validé :
+
+```sql
+SELECT pollution_type, COUNT(*) as section_count, COUNT(DISTINCT sgc_pg_id) as gamme_count
+FROM (
+  SELECT sgc_pg_id,
+    CASE
+      WHEN sgc_content ~* 'Source:\s*web(-catalog)?/' THEN 'RAG_SCRAPING'
+      WHEN sgc_content ~* 'Skip to (main content|menu|footer)|Inscription newsletter|Aller au contenu|Gestion des cookies|Téléchargement →|Partager sur' THEN 'NAV_SCRAPING'
+      WHEN sgc_content ~* 'COMBO IDÉAL|MÊME QUALITÉ|Reconditionnement des|Formula XT|Essential Line|Technologies de plaquettes' THEN 'OEM_MARKETING'
+      WHEN sgc_content ~* 'Textar équipées|Brembo.*premium|Verniciatura|Beschichtung' THEN 'OEM_PRODUCT'
+      WHEN sgc_content ~* '##\s+Comment\s|##\s+Pourquoi\s|##\s+Quand\s|##\s+Quel' THEN 'BLOG_H2_INJECTED'
+      WHEN sgc_content ~* '- Vivacar|vroomly|oscaro\.com|mister-auto' THEN 'COMPETITOR_SCRAPING'
+      ELSE 'CLEAN'
+    END as pollution_type
+  FROM "__seo_gamme_conseil"
+  WHERE sgc_enriched_by IS DISTINCT FROM 'pipeline-v5-surgical-clean'
+    AND sgc_enriched_by IS DISTINCT FROM 'pipeline-v5-replace'
+) sub
+GROUP BY pollution_type
+ORDER BY section_count DESC;
+```
+
+Pour le détail des sections polluées (pg_id, section, preview), reprendre la même clause `WHERE sgc_enriched_by IS DISTINCT FROM …` + le filtre `OR` des patterns ci-dessus.
+
+### Faux positifs connus
+
+- **pg_id=1164 (Accessoires plaquettes) S3** : le regex capte « Brembo » dans un contexte technique légitime de compatibilité étrier. Ce n'est PAS de la pollution.
+- Le contenu technique qui mentionne des marques dans un contexte de comparaison ou de compatibilité est légitime (vaut aussi pour `Textar|ATE|TRW` du pattern BRAND_SCRAPING).
+
 ---
 
 ## Module 2 : Scoring qualité (ex content-quality-gate)
@@ -84,6 +122,38 @@ ORDER BY sgc_section_type;
 | **Cohérence section** | 0-15 | Contenu correspond au type S1/S2/S3/etc. |
 | **Français correct** | 0-15 | Pas de fragments étrangers, phrases complètes |
 
+### Critères spécifiques par type de section (bonus/malus)
+
+| Section | Bonus/Malus spécifiques |
+|---------|------------------------|
+| S1 (fonction) | +10 si explique le rôle mécanique concret, -10 si copié de Wikipedia |
+| S2 (quand changer) | +10 si liste de symptômes concrets, -10 si générique "consultez un pro" |
+| S3 (comment choisir) | +10 si critères d'achat spécifiques (marques, specs), -10 si marketing |
+| S4_DEPOSE | +10 si étapes numérotées avec outils, -10 si blog scrapé |
+| S5 (erreurs) | +10 si erreurs spécifiques au composant, -10 si "ne pas oublier de vérifier" |
+| S6 (vérifications) | +10 si méthode de diagnostic concrète, -10 si conseil vague |
+
+### Requête SQL de scoring rapide
+
+```sql
+SELECT sgc_pg_id, sgc_section_type,
+  LENGTH(sgc_content) as len,
+  sgc_enriched_by,
+  -- Indicateurs pollution
+  CASE WHEN sgc_content ~* 'Source:\s*web(-catalog)?/' THEN 1 ELSE 0 END as has_rag_scraping,
+  CASE WHEN sgc_content ~* 'Skip to main content|Gestion des cookies' THEN 1 ELSE 0 END as has_nav_scraping,
+  CASE WHEN sgc_content ~* 'COMBO IDÉAL|MÊME QUALITÉ' THEN 1 ELSE 0 END as has_oem_marketing,
+  CASE WHEN sgc_content ~* '##\s+Comment\s|##\s+Pourquoi\s' THEN 1 ELSE 0 END as has_blog_h2,
+  -- Indicateurs qualité
+  CASE WHEN LENGTH(sgc_content) BETWEEN 150 AND 1500 THEN 'OK'
+       WHEN LENGTH(sgc_content) < 50 THEN 'VIDE'
+       WHEN LENGTH(sgc_content) > 3000 THEN 'SUSPECT'
+       ELSE 'COURT' END as length_verdict
+FROM "__seo_gamme_conseil"
+WHERE sgc_pg_id = '{pg_id}'
+ORDER BY sgc_section_type;
+```
+
 ### Verdicts
 
 | Score | Verdict | Action |
@@ -91,6 +161,23 @@ ORDER BY sgc_section_type;
 | ≥ 70 | **WRITE** | Prêt pour écriture (avec confirmation rapide) |
 | 40-69 | **REVIEW** | Examen humain requis |
 | < 40 | **BLOCK** | Ne pas écrire, chercher meilleure source |
+
+Principe fondamental : **3 niveaux de vérification, jamais de write automatique** (scorer → comparer → décider). Tout verdict BLOCK ou REVIEW stoppe le pipeline jusqu'à validation humaine.
+
+### Matrice de décision vs existant (anti-régression L2)
+
+Avant toute modification, comparer le contenu proposé avec l'existant. **BLOCK si le nouveau contenu est inférieur à l'existant** (score inférieur, plus court ET moins spécifique, pollué, ou existant déjà nettoyé `pipeline-v5-*`).
+
+| Existant | Nouveau proposé | Verdict |
+|----------|-----------------|---------|
+| Vide / <50 chars | Score >= 70 | WRITE |
+| Vide / <50 chars | Score 40-69 | REVIEW |
+| Vide / <50 chars | Score < 40 | BLOCK |
+| Court (<300) générique | Score >= 70 + spécifique | WRITE |
+| Court (<300) générique | Score 40-69 | REVIEW |
+| Bon (>300, propre) | Score >= 80 + nettement supérieur | REVIEW (validation manuelle) |
+| Bon (>300, propre) | Score < 80 | BLOCK (pas de régression) |
+| Déjà nettoyé (v5-*) | Tout | BLOCK (sauf si score > 90 + REVIEW) |
 
 ### Check claims numériques non sourcés (plafonne le verdict)
 
@@ -113,6 +200,22 @@ les espaces, virgule → point, lowercase, trim.
 autoritaire (facts/sources WIKI `exports/seo` de la gamme, ou donnée DB autoritaire citée) ⇒
 **verdict plafonné à REVIEW** (jamais WRITE direct), avec la liste des claims non sourcés
 dans le rapport. Ne jamais inventer ni « corriger » une valeur — signaler uniquement.
+
+### Check vocabulaire cross-rôle R1 (plafonne le verdict)
+
+> Origine : salvage du script archivé `generate-content-r1.py` (PR #954). La liste vit dans
+> un seul fichier — **pointer, pas duplication**.
+
+Pour du contenu destiné à une page **R1** (routage gamme) : scanner contre les listes
+**FORBIDDEN VOCABULARY** (anglicismes interdits + vocabulaire cross-rôle R3/R4/R5/R6 +
+jargon accepté à ne pas flagger) définies dans
+`.claude/prompts/R1_ROUTER/editorial.md` §FORBIDDEN VOCABULARY (racine monorepo ;
+depuis ce workspace : `../../.claude/prompts/R1_ROUTER/editorial.md`). Ne PAS recopier
+la liste ici — la lire à chaque run (SoT unique).
+
+**Règle** : tout terme interdit détecté ⇒ **verdict plafonné à REVIEW**, avec les termes
+trouvés et leur rôle d'origine (R3 how-to, R5 diagnostic, R4 référence, R6 guide d'achat)
+dans le rapport. Les termes de la section « Jargon technique accepté » ne sont jamais flaggés.
 
 ---
 

--- a/workspaces/seo-batch/README.md
+++ b/workspaces/seo-batch/README.md
@@ -3,7 +3,7 @@
 > ⚠️ **LEGACY pour le CONTENU — pour PRODUIRE du contenu, utiliser `workspaces/wiki/`, pas ce workspace.**
 > Ici `content-gen` / `rag-ops` / `r*-content-batch` / `r7-brand-rag-generator` lisent `/opt/automecanik/rag/knowledge/` → DB : ce mode RAG-source-de-contenu est **abandonné** (canon vault ADR-031/046 ; garde ast-grep #923 `seo-no-rag-as-content-source`).
 > **Pipeline contenu MODERNE** = `workspaces/wiki/` (`wiki-proposal-writer`, ADR-033) → wiki-repo `_scripts/` (`build_exports_seo` ADR-059, `promote.py` ADR-083 auto-tiered) → `exports/seo` → DB → R.
-> Les skills **audit/QA** d'ici (`pollution-scanner`, `v5-guardian`, `seo-gamme-audit`, `kw-classify`, `r8-diversity-check`) restent valides. Dépréciation du RAG-contenu = programme owner-sponsorisé séparé (ne pas réécrire réactivement).
+> Les skills **audit/QA** d'ici (`v5-guardian` — qui fusionne `pollution-scanner` + `content-quality-gate` depuis 2026-06-12 —, `seo-gamme-audit`, `kw-classify`, `r8-diversity-check`) restent valides. Dépréciation du RAG-contenu = programme owner-sponsorisé séparé (ne pas réécrire réactivement).
 
 Claude Code project root pour les campagnes SEO AutoMecanik. Charge uniquement les 39 agents R0-R8 et les 16 skills SEO, sans les charger dans le workspace dev daily.
 
@@ -38,7 +38,7 @@ cd /opt/automecanik/app && claude
 
 ### Skills SEO inclus
 
-`content-audit`, `content-gen`, `content-quality-gate`, `keyword-planner`, `kw-classify`, `legacy-recycler`, `pipeline-orchestrator`, `pollution-scanner`, `r8-diversity-check`, `rag-check`, `rag-ops`, `seo-content-architect`, `seo-gamme-audit`, `seo-vault-verify`, `surgical-cleaner`, `v5-guardian`.
+`content-audit`, `content-gen`, `content-quality-gate` (🚨 deprecated 2026-06-12, fusionné dans `v5-guardian`), `keyword-planner`, `kw-classify`, `legacy-recycler`, `pipeline-orchestrator`, `pollution-scanner` (🚨 deprecated 2026-06-12, fusionné dans `v5-guardian`), `r8-diversity-check`, `rag-check` (🚨 deprecated 2026-06-12, successeur = validation exports WIKI), `rag-ops` (⚠️ chatbot-ops only ; ingestion contenu = legacy ADR-031/046), `seo-content-architect`, `seo-gamme-audit`, `seo-vault-verify`, `surgical-cleaner`, `v5-guardian` (survivant renforcé).
 
 ### Skills DEV restés en monorepo racine
 


### PR DESCRIPTION
## Contexte

PR « cleanup-seo-batch-surface » du plan dégrippage (audit 2026-06-12, doctrine owner SALVAGE-FIRST). RAG = chatbot only (ADR-031/046) ; chemin contenu moderne = RAW→WIKI→exports (ADR-033/059/083) ; `workspaces/seo-batch` marqué LEGACY pour le routage contenu (#932). Part de la version origin/main de `v5-guardian` enrichie par #945 (check claims numériques).

## Tâche 1 — Diff de capacités v5-guardian vs pollution-scanner + content-quality-gate

La claim « Remplace pollution-scanner + content-quality-gate combinés » a été vérifiée capacité par capacité. Résultat : **9 capacités manquantes portées**, le reste était déjà couvert.

| Capacité | Source | Statut |
|---|---|---|
| Patterns `Source:\s*web-catalog/` (RAG_SCRAPING) | pollution-scanner | **PORTÉE** (Module 1 CASE) |
| Patterns `Skip to menu/footer`, `Inscription newsletter`, `Aller au contenu`, `Téléchargement →`, `Partager sur` (NAV_SCRAPING) | pollution-scanner | **PORTÉE** |
| Patterns `Reconditionnement des`, `Formula XT`, `Essential Line`, `Technologies de plaquettes` (OEM_MARKETING) | pollution-scanner | **PORTÉE** |
| Patterns `Brembo.*premium`, `Verniciatura`, `Beschichtung` (OEM_PRODUCT) | pollution-scanner | **PORTÉE** |
| Pattern `##\s+Quand\s` (BLOG_H2_INJECTED) | pollution-scanner | **PORTÉE** |
| Patterns `- Vivacar`, `vroomly` (COMPETITOR_SCRAPING) | pollution-scanner | **PORTÉE** |
| SQL scan grande échelle agrégé par type + exclusion sections `pipeline-v5-surgical-clean`/`-replace` | pollution-scanner §2-3 | **PORTÉE** (nouvelle section --batch) |
| Heuristique priorité (HAUTE si S4_DEPOSE 100 % scrapé ou >3000c) | pollution-scanner | **PORTÉE** |
| Faux positifs connus (pg_id=1164 Brembo contexte compatibilité) | pollution-scanner | **PORTÉE** (étendue à `Textar|ATE|TRW`) |
| Chaîne nettoyage → `surgical-cleaner` → `content-gen` | pollution-scanner | **PORTÉE** (Démarcation) |
| Critères spécifiques par section S1-S6 (bonus/malus ±10) | content-quality-gate | **PORTÉE** (Module 2) |
| SQL scoring rapide (indicateurs booléens + length_verdict VIDE/COURT/OK/SUSPECT) | content-quality-gate | **PORTÉE** (Module 2) |
| Matrice de décision L2 vs existant (8 lignes, incl. « v5-* → BLOCK sauf score >90 + REVIEW ») | content-quality-gate | **PORTÉE** (Module 2) |
| Principe « 3 niveaux, jamais de write automatique » | content-quality-gate | **PORTÉE** (1 ligne, Module 2) |
| CASE pollution principal (RAG/NAV/OEM/BLOG/COMPETITOR/XSS/PLACEHOLDER/TOO_SHORT…) | les deux | déjà couverte |
| Verdict pollution par sévérité | pollution-scanner | déjà couverte |
| Scoring universel 0-100 (6 critères) | content-quality-gate | déjà couverte (identique) |
| Verdicts WRITE/REVIEW/BLOCK + seuils | content-quality-gate | déjà couverte |
| Guard anti-régression 4 règles + tags protégés + requête pre-write | content-quality-gate L2 (partiel) | déjà couverte (Module 3, plus riche) |
| Gap detection + sections attendues + priorisation | les deux | déjà couverte (Module 4) |
| Requête de comparaison section courante | content-quality-gate | déjà couverte (pre-write = superset) |
| Coverage manifest + Attention SQL (sgc_pg_id TEXT, etc.) | les deux | déjà couverte |
| Démarcation avec content-audit / seo-gamme-audit / seo-content-architect | content-quality-gate | déjà couverte |

**Capacité supplémentaire (salvage `generate-content-r1.py`, PR #954)** : nouveau check « vocabulaire cross-rôle R1 » qui plafonne le verdict à REVIEW — **pointe** vers `.claude/prompts/R1_ROUTER/editorial.md` §FORBIDDEN VOCABULARY (pointer, pas duplication ; SoT unique).

## Verdicts par fichier

| Fichier | Verdict |
|---|---|
| `v5-guardian/SKILL.md` | **SURVIVANT RENFORCÉ** — 9 capacités portées + check vocabulaire cross-rôle R1 (pointer) |
| `pollution-scanner/SKILL.md` | **DEPRECATED** — bannière + préfixe description ; fusionné dans v5-guardian (diff vérifié) ; fichier conservé, suppression après 2 cycles |
| `content-quality-gate/SKILL.md` | **DEPRECATED** — idem |
| `rag-check/SKILL.md` | **DEPRECATED** — bonne idée (couverture par rôle R*), mauvaise source (RAG) ; successeur = validation de couverture sur les exports WIKI (ADR-033/059, cf. `scripts/seo/r1-readiness.ts` → `wikiExportReadiness` de `scripts/validate-gamme-schema.ts`) ; validateur complet = PR séparée (non créé ici) |
| `rag-ops/SKILL.md` | **PARTIELLEMENT LEGACY** (bannière nuancée) — chatbot-ops (`diagnose`/`monitor`/`test`/`audit`) = LÉGITIME et reste ; ingestion/enrichissement CONTENU (`ingest` comme source de contenu, `describe-images` pour pages) = legacy ADR-031/046 |
| `agents/r7-brand-rag-generator.md` | **DEPRECATED** — aucune heuristique marque unique : schema = `.spec/00-canon/brand-md-schema.md` (SoT conservée), gates/termes interdits = `r7-keyword-plan.constants.ts` (SoT code), top gammes/modèles = agrégations DB couvertes backend ; successeur = `wiki-proposal-writer` (entity_type=constructeur) + `automecanik-wiki/exports` |
| `README.md` | liste des skills annotée (deprecated/fusion) + ligne « skills audit/QA » mise à jour |

## Anomalie relevée

- `r7-brand-rag-generator.md` référence `backend/src/config/brand-role-map.schema.ts` (`buildDefaultBrandRoleMap`) qui **n'existe plus dans le repo** — l'agent ne pouvait déjà plus exécuter son Step 4 tel quel (chemin mort, signalé dans la bannière).

## Validation

- 6 frontmatters YAML valides (parse `yaml.safe_load` OK)
- 6 chemins pointés vérifiés existants (`editorial.md`, `r1-readiness.ts`, `validate-gamme-schema.ts`, `brand-md-schema.md`, `r7-keyword-plan.constants.ts`, `wiki-proposal-writer/SKILL.md`)
- `scripts/lint/check-preprod-vocabulary.sh` : 618 fichiers, 0 violations
- Scope strict respecté : 7 fichiers `workspaces/seo-batch/` uniquement, aucun fichier supprimé

🤖 Generated with [Claude Code](https://claude.com/claude-code)