### PR TITLE
feat(content): raw-evidence-inventory 3 types + encyclopedia-coverage (baseline)

### DIFF
--- a/audit/content/raw-evidence/accessoires-de-machoire.raw-evidence.json
+++ b/audit/content/raw-evidence/accessoires-de-machoire.raw-evidence.json
@@ -1,0 +1,96 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (0)",
+        "domain.must_be_true < 2 (0)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_C",
+  "pg_id": 1502,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:330431d5cade5eb0c46fbaa4cfcd40c939c857f1960a79d798259e8eaeb19885",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/accessoires-de-machoire.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "accessoires-de-machoire"
+}

--- a/audit/content/raw-evidence/accessoires-de-plaquette.raw-evidence.json
+++ b/audit/content/raw-evidence/accessoires-de-plaquette.raw-evidence.json
@@ -1,0 +1,96 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (0)",
+        "domain.must_be_true < 2 (0)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_C",
+  "pg_id": 1164,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:e9be856bc220c7d5fa1bdb0319216262dfd6d915e14cfc4c9ba9f6de9a1183ef",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/accessoires-de-plaquette.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "accessoires-de-plaquette"
+}

--- a/audit/content/raw-evidence/accumulateur-de-pression-de-carburant.raw-evidence.json
+++ b/audit/content/raw-evidence/accumulateur-de-pression-de-carburant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1303,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1fe203dc8e1a34563a2e18a03134c9452ff921f7703af64894eb0085ddd91e9d",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/accumulateur-de-pression-de-carburant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "accumulateur-de-pression-de-carburant"
+}

--- a/audit/content/raw-evidence/accumulateur-de-pression.raw-evidence.json
+++ b/audit/content/raw-evidence/accumulateur-de-pression.raw-evidence.json
@@ -1,0 +1,123 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range missing"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 1064,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:48648cfa39c1fbc7b129dda311451d686b825e0dc9513c03513da06c2d65ffa2",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/accumulateur-de-pression.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "accumulateur-de-pression"
+}

--- a/audit/content/raw-evidence/agregat-de-freinage.raw-evidence.json
+++ b/audit/content/raw-evidence/agregat-de-freinage.raw-evidence.json
@@ -1,0 +1,117 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (43 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 415,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:e2e842c20b2cba8233f50fb847a19d8f8b0074badda78d387b351414e7f107fe",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/agregat-de-freinage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "agregat-de-freinage"
+}

--- a/audit/content/raw-evidence/alternateur.raw-evidence.json
+++ b/audit/content/raw-evidence/alternateur.raw-evidence.json
@@ -1,0 +1,136 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 4,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b9c019442d8448e110de05a69c5a1dabc96c4355c5de9cfd482922c0b850c8d8",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/alternateur.yml"
+      },
+      {
+        "content_hash": "sha256:0267e8b332d4221204ebcf310b5c105c2b7667ded99e98765d6753d4484f1edb",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/alternateur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "alternateur"
+}

--- a/audit/content/raw-evidence/amortisseur-de-direction.raw-evidence.json
+++ b/audit/content/raw-evidence/amortisseur-de-direction.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (50 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 130,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:8881e1e4cb83a80b66c7af51c470182c7b4966a7b2921ceb8a606b541699c154",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/amortisseur-de-direction.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "amortisseur-de-direction"
+}

--- a/audit/content/raw-evidence/amortisseur.raw-evidence.json
+++ b/audit/content/raw-evidence/amortisseur.raw-evidence.json
@@ -1,0 +1,123 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (46-651)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 854,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:93ee5db6fced183fc915b04d7aa6644f132913062fa81f8f30ef538b01dc9332",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/amortisseur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "amortisseur"
+}

--- a/audit/content/raw-evidence/ampoule-eclairage-interieur.raw-evidence.json
+++ b/audit/content/raw-evidence/ampoule-eclairage-interieur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (59 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 117,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1b8ed0d07fbaec8eb4dc722e485277c2003d996bdaba214ea221b0b3c1f71341",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ampoule-eclairage-interieur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ampoule-eclairage-interieur"
+}

--- a/audit/content/raw-evidence/ampoule-feu-arriere.raw-evidence.json
+++ b/audit/content/raw-evidence/ampoule-feu-arriere.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (68 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 115,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d483ec466473f8d5c9accc705ba14bbb50967bdf36b57ccd302feb28a28f2bd5",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ampoule-feu-arriere.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ampoule-feu-arriere"
+}

--- a/audit/content/raw-evidence/ampoule-feu-avant.raw-evidence.json
+++ b/audit/content/raw-evidence/ampoule-feu-avant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (60 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 107,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:99c2aa49abb74d501c16102775e926a5b0020fab73f15e6e2665c21f9c1ec525",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ampoule-feu-avant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ampoule-feu-avant"
+}

--- a/audit/content/raw-evidence/ampoule-feu-clignotant.raw-evidence.json
+++ b/audit/content/raw-evidence/ampoule-feu-clignotant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (75 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 105,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:58ae982646859d203fc0ba53ac8720a56c15f1bfe3c859b0d84521749a69efd9",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ampoule-feu-clignotant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ampoule-feu-clignotant"
+}

--- a/audit/content/raw-evidence/ampoule-feu-de-position.raw-evidence.json
+++ b/audit/content/raw-evidence/ampoule-feu-de-position.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (75 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2126,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:a4807cb8fcd367c721b3ea4630097aabbfdcb5c4e9e3f2a86b5fd18026ee235f",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ampoule-feu-de-position.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ampoule-feu-de-position"
+}

--- a/audit/content/raw-evidence/ampoule-feu-de-recul.raw-evidence.json
+++ b/audit/content/raw-evidence/ampoule-feu-de-recul.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 114,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:ddae2ea9be797305d5c984e065069523bfdefcd28311a2fffb44f6888c2ebfa0",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ampoule-feu-de-recul.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ampoule-feu-de-recul"
+}

--- a/audit/content/raw-evidence/ampoule-feu-eclaireur-de-plaque.raw-evidence.json
+++ b/audit/content/raw-evidence/ampoule-feu-eclaireur-de-plaque.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (60 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 112,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:06a5a841308cc49149ae797a3f47ecb1d5590d8a182af8f3f44e0e45c95ad562",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ampoule-feu-eclaireur-de-plaque.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ampoule-feu-eclaireur-de-plaque"
+}

--- a/audit/content/raw-evidence/ampoule-feu-stop.raw-evidence.json
+++ b/audit/content/raw-evidence/ampoule-feu-stop.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (56 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 111,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:dfe71eaa0b329119888a8c505fa39459783f18d151831c89b44c50faf74974cf",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ampoule-feu-stop.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ampoule-feu-stop"
+}

--- a/audit/content/raw-evidence/arbre-a-came.raw-evidence.json
+++ b/audit/content/raw-evidence/arbre-a-came.raw-evidence.json
@@ -1,0 +1,32 @@
+{
+  "coverage": [],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [],
+  "inventory_status": "RAW_PARSE_ERROR",
+  "next_action": "FIX_RAW_FRONTMATTER (yaml_parse_error: duplicated mapping key (193:5)\n\n 190 |     source_ref: corpus RAG web OEM\n 191 |   technical_notes:\n 192 |     val_2_a: '2 A'\n 193 |     val_2_a: '2 a'\n-----------^\n 194 |     val_7_6_litres: '7,6 litres'\n 195 |     val_800_v: '800 V')",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": null,
+    "sources": [
+      {
+        "content_hash": "sha256:c905118c7b442239413fb8d0ef0020917894f126fd04e89ff7352e7bc256f1cc",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/arbre-a-came.md"
+      }
+    ],
+    "truth_level": null,
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": null
+  },
+  "raw_verdict": "RAW_PARSE_ERROR",
+  "schema_version": "raw-evidence.v1",
+  "subject": "arbre-a-came"
+}

--- a/audit/content/raw-evidence/attelage.raw-evidence.json
+++ b/audit/content/raw-evidence/attelage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (46 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 39,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:16395f212fe272cb1a8fb1a0ce0b89ac08ec68cfd6104751bdd886cc25a60a4c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/attelage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "attelage"
+}

--- a/audit/content/raw-evidence/avertisseur-sonore.raw-evidence.json
+++ b/audit/content/raw-evidence/avertisseur-sonore.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (53 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 297,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d0c86de2d3a39e72504ab6c399367946c718db3fb66f00001aba7a6237f82fda",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/avertisseur-sonore.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "avertisseur-sonore"
+}

--- a/audit/content/raw-evidence/bague-d-etancheite-boite-automatique.raw-evidence.json
+++ b/audit/content/raw-evidence/bague-d-etancheite-boite-automatique.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 626,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4ed43118234d4d2ad4dafdd3360b040f4fd29d29fd36f18baefb3113f6f6a6a2",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bague-d-etancheite-boite-automatique.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bague-d-etancheite-boite-automatique"
+}

--- a/audit/content/raw-evidence/bague-d-etancheite-cardan.raw-evidence.json
+++ b/audit/content/raw-evidence/bague-d-etancheite-cardan.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (59 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 624,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6c5e759d952e4591f3a3975c40d251098741d9057a6c09ca176b397b3d9632e8",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bague-d-etancheite-cardan.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bague-d-etancheite-cardan"
+}

--- a/audit/content/raw-evidence/bagues-d-etancheite-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/bagues-d-etancheite-moteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 3874,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:89b6c5e6cbe4a5ccb78bad58406295ccf0458dac421de672d922a1e643c05605",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bagues-d-etancheite-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bagues-d-etancheite-moteur"
+}

--- a/audit/content/raw-evidence/balais-d-essuie-glace.raw-evidence.json
+++ b/audit/content/raw-evidence/balais-d-essuie-glace.raw-evidence.json
@@ -1,0 +1,122 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "achat",
+    "diagnostic",
+    "entretien"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 298,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b9b50115fadb61af25784fc55be0db02a0834186cbbf8f4dbfbb7380fc712d58",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/balais-d-essuie-glace.yml"
+      },
+      {
+        "content_hash": "sha256:7903f5fd8b369474f8c07fc53c539fcb8a85ace5e1eb5846078e46a9fb13d4cb",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/balais-d-essuie-glace.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "balais-d-essuie-glace"
+}

--- a/audit/content/raw-evidence/ballast-a-lampe-xenon.raw-evidence.json
+++ b/audit/content/raw-evidence/ballast-a-lampe-xenon.raw-evidence.json
@@ -1,0 +1,32 @@
+{
+  "coverage": [],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [],
+  "inventory_status": "RAW_PARSE_ERROR",
+  "next_action": "FIX_RAW_FRONTMATTER (yaml_parse_error: duplicated mapping key (219:5)\n\n 216 |     val_2_kw: '2 kW'\n 217 |     val_220_v: '220 v'\n 218 |     val_25_a: '25 A'\n 219 |     val_25_a: '25 a'\n-----------^\n 220 |     val_30_a: '30 a'\n 221 |     val_7_kw: '7 kW')",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": null,
+    "sources": [
+      {
+        "content_hash": "sha256:f848a5e7db938e972e68c46ed9a9aaa97959db6a5997b998ef8fa5d1d4e228e4",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ballast-a-lampe-xenon.md"
+      }
+    ],
+    "truth_level": null,
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": null
+  },
+  "raw_verdict": "RAW_PARSE_ERROR",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ballast-a-lampe-xenon"
+}

--- a/audit/content/raw-evidence/barre-de-direction.raw-evidence.json
+++ b/audit/content/raw-evidence/barre-de-direction.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 285,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:02bd82cc0a0e6afed5e96cbb6feaf42e71dd8b8f5151823b8add055b49ae2dae",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/barre-de-direction.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "barre-de-direction"
+}

--- a/audit/content/raw-evidence/barre-stabilisatrice.raw-evidence.json
+++ b/audit/content/raw-evidence/barre-stabilisatrice.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (3-147)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 274,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:c84f620cd422c3f689428e7320829e61269b21ee034e1cad877eae750c0ee62a",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/barre-stabilisatrice.yml"
+      },
+      {
+        "content_hash": "sha256:a2feb8c4dbf237195736ce264d9be4b47ffe72d3e2891245e974253d987581a5",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/barre-stabilisatrice.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "barre-stabilisatrice"
+}

--- a/audit/content/raw-evidence/batterie.raw-evidence.json
+++ b/audit/content/raw-evidence/batterie.raw-evidence.json
@@ -1,0 +1,32 @@
+{
+  "coverage": [],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [],
+  "inventory_status": "RAW_PARSE_ERROR",
+  "next_action": "FIX_RAW_FRONTMATTER (yaml_parse_error: duplicated mapping key (252:5)\n\n 249 |     val_115_nm: '115 Nm'\n 250 |     val_12_v: '12 V'\n 251 |     val_12_a: '12 a'\n 252 |     val_12_v: '12 v'\n-----------^\n 253 | conseil_v5:\n 254 |   _sync_source: __seo_gamme_conseil)",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": null,
+    "sources": [
+      {
+        "content_hash": "sha256:599e82f29ae97b1142daf6722d11dbea381f6389345f17ed191594243e20a153",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/batterie.md"
+      }
+    ],
+    "truth_level": null,
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": null
+  },
+  "raw_verdict": "RAW_PARSE_ERROR",
+  "schema_version": "raw-evidence.v1",
+  "subject": "batterie"
+}

--- a/audit/content/raw-evidence/biellette-de-barre-stabilisatrice.raw-evidence.json
+++ b/audit/content/raw-evidence/biellette-de-barre-stabilisatrice.raw-evidence.json
@@ -1,0 +1,133 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (46 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3230,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:71db52782c60b8b3a2a53f5dd7d8643199f37e1ccfbb3b473df3508b77b6dddb",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/biellette-de-barre-stabilisatrice.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "biellette-de-barre-stabilisatrice"
+}

--- a/audit/content/raw-evidence/bobine-d-allumage.raw-evidence.json
+++ b/audit/content/raw-evidence/bobine-d-allumage.raw-evidence.json
@@ -1,0 +1,37 @@
+{
+  "coverage": [],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [],
+  "inventory_status": "RAW_PARSE_ERROR",
+  "next_action": "FIX_RAW_FRONTMATTER (yaml_parse_error: duplicated mapping key (228:5)\n\n 225 |     source_ref: corpus RAG web OEM\n 226 |   technical_notes:\n 227 |     val_000_v: '000 V'\n 228 |     val_000_v: '000 v'\n-----------^\n 229 |     val_100_a: '100 a'\n 230 |     val_12_v: '12 V')",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": null,
+    "sources": [
+      {
+        "content_hash": "sha256:f0261fdcf47c13dc2ce93ea29e38ce150be50c497ba53a33791c0ab6375000a3",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/bobine-d-allumage.yml"
+      },
+      {
+        "content_hash": "sha256:9d890e96c9c7b775973661099a394460d8f6dd8a14d305c534afa727819e60e7",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bobine-d-allumage.md"
+      }
+    ],
+    "truth_level": null,
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": null
+  },
+  "raw_verdict": "RAW_PARSE_ERROR",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bobine-d-allumage"
+}

--- a/audit/content/raw-evidence/boitier-de-prechauffage.raw-evidence.json
+++ b/audit/content/raw-evidence/boitier-de-prechauffage.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (15-200)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 1750,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:67b1f0b3cc80af0dcd6f9f923a28a376c053a61250513ebbc279e5cb75885c4d",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/boitier-de-prechauffage.yml"
+      },
+      {
+        "content_hash": "sha256:005e0edb4a20f6e8f6a9a4020035656a1c620af17a2db4ec7bf582f7475e1b41",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/boitier-de-prechauffage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "boitier-de-prechauffage"
+}

--- a/audit/content/raw-evidence/bouchon-d-huile-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/bouchon-d-huile-moteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range missing"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 597,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6ec965fbc5aa3144f0b7b84fe1bcfd322e52301ea49378ca515897236431a58c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bouchon-d-huile-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bouchon-d-huile-moteur"
+}

--- a/audit/content/raw-evidence/bouchon-de-radiateur.raw-evidence.json
+++ b/audit/content/raw-evidence/bouchon-de-radiateur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (53 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 548,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:23619ff59304fd6a41a2adf89def3d1e8dca2051107c35989ffdcda97f26a6aa",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bouchon-de-radiateur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bouchon-de-radiateur"
+}

--- a/audit/content/raw-evidence/bouchon-de-vidange.raw-evidence.json
+++ b/audit/content/raw-evidence/bouchon-de-vidange.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (25 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 593,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b8cc5b374f1ad47f74944bddfc750c529702d5529f9e898df13f36a367f1c30e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bouchon-de-vidange.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bouchon-de-vidange"
+}

--- a/audit/content/raw-evidence/bouchon-reservoir-de-carburant.raw-evidence.json
+++ b/audit/content/raw-evidence/bouchon-reservoir-de-carburant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (46 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 602,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6c754e4fddad22fda414b553542e83e270ec00f54d4b67219945bfd846af23c6",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bouchon-reservoir-de-carburant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bouchon-reservoir-de-carburant"
+}

--- a/audit/content/raw-evidence/bouchon-vase-d-expansion.raw-evidence.json
+++ b/audit/content/raw-evidence/bouchon-vase-d-expansion.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 56,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:576260602839a621bed1238c3283a0e6f9d0ae0cd4ad78697f681017dbda6334",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bouchon-vase-d-expansion.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bouchon-vase-d-expansion"
+}

--- a/audit/content/raw-evidence/bougie-d-allumage.raw-evidence.json
+++ b/audit/content/raw-evidence/bougie-d-allumage.raw-evidence.json
@@ -1,0 +1,32 @@
+{
+  "coverage": [],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [],
+  "inventory_status": "RAW_PARSE_ERROR",
+  "next_action": "FIX_RAW_FRONTMATTER (yaml_parse_error: duplicated mapping key (233:5)\n\n 230 |     source_ref: corpus RAG web OEM\n 231 |   technical_notes:\n 232 |     val_000_v: '000 V'\n 233 |     val_000_v: '000 v'\n-----------^\n 234 |     val_000__c: '000 °C'\n 235 |     val_100_a: '100 a')",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": null,
+    "sources": [
+      {
+        "content_hash": "sha256:dfddf215a4af2562210ab0d9f8ae71de18e948e81baa3f61df20a9a3bd44e74b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bougie-d-allumage.md"
+      }
+    ],
+    "truth_level": null,
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": null
+  },
+  "raw_verdict": "RAW_PARSE_ERROR",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bougie-d-allumage"
+}

--- a/audit/content/raw-evidence/bougie-de-prechauffage.raw-evidence.json
+++ b/audit/content/raw-evidence/bougie-de-prechauffage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 243,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:93da0c78e6bd00fbcaa81f0152eafe8451eea73a538faea05fbed773da7e9d8d",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bougie-de-prechauffage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bougie-de-prechauffage"
+}

--- a/audit/content/raw-evidence/boulon-de-roue.raw-evidence.json
+++ b/audit/content/raw-evidence/boulon-de-roue.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (37 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 657,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:7f0133b9b1629ef9a8ea7accdcd1e1d1d3a9475478450439d3c8fd2572d944e1",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/boulon-de-roue.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "boulon-de-roue"
+}

--- a/audit/content/raw-evidence/bouteille-deshydratante.raw-evidence.json
+++ b/audit/content/raw-evidence/bouteille-deshydratante.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (39 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 851,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:a29c43f90246d1ce3e0b731110909504020c87a8ee577e61729852973d0934c9",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bouteille-deshydratante.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bouteille-deshydratante"
+}

--- a/audit/content/raw-evidence/bras-d-essuie-glace.raw-evidence.json
+++ b/audit/content/raw-evidence/bras-d-essuie-glace.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (51 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 301,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:a28d88104b4986f08ce6f8dd801a99f63a5dfc15277fe92ba1bd4db9e2d8749f",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bras-d-essuie-glace.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bras-d-essuie-glace"
+}

--- a/audit/content/raw-evidence/bras-de-suspension.raw-evidence.json
+++ b/audit/content/raw-evidence/bras-de-suspension.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (9-95)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 273,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4207d1b19330617428ace13342bfee9dd165395d93c2b2c8cd841bb6720fbaa3",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/bras-de-suspension.yml"
+      },
+      {
+        "content_hash": "sha256:a75bcb8743dc9e2dc5b44e6b0cb2afea09e6565e31cfd5436638da7801f1b07f",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bras-de-suspension.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bras-de-suspension"
+}

--- a/audit/content/raw-evidence/bride-de-liquide-de-refroidissement.raw-evidence.json
+++ b/audit/content/raw-evidence/bride-de-liquide-de-refroidissement.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (52 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (15-200)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 3219,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:ee5ed781affe010b4ba0fef0ea83158b68091f49205d7a256b04946401bee6a6",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/bride-de-liquide-de-refroidissement.yml"
+      },
+      {
+        "content_hash": "sha256:dfeffd8beed912a399bba252885aba6ecf07dd1ff8f859b2fae937f2ebe5f212",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/bride-de-liquide-de-refroidissement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bride-de-liquide-de-refroidissement"
+}

--- a/audit/content/raw-evidence/butee-d-embrayage.raw-evidence.json
+++ b/audit/content/raw-evidence/butee-d-embrayage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (62 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 48,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6471e9a522548e0be2a22c233a2b0ed19cf8c48f23d003b8c13bdc11a6c2e351",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/butee-d-embrayage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "butee-d-embrayage"
+}

--- a/audit/content/raw-evidence/butee-elastique-d-amortisseur.raw-evidence.json
+++ b/audit/content/raw-evidence/butee-elastique-d-amortisseur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (52 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1182,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:11f944ce3ab904271fc92d47893e6e1d52e92941cdb3ced65e66aaae77e85dfd",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/butee-elastique-d-amortisseur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "butee-elastique-d-amortisseur"
+}

--- a/audit/content/raw-evidence/cable-d-accelerateur.raw-evidence.json
+++ b/audit/content/raw-evidence/cable-d-accelerateur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (60 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 618,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:ed116e0f2d7420af36abb3ba844dd5ba2e425b1979e19be28f009bf772e8c0a3",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/cable-d-accelerateur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "cable-d-accelerateur"
+}

--- a/audit/content/raw-evidence/cable-d-embrayage.raw-evidence.json
+++ b/audit/content/raw-evidence/cable-d-embrayage.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (62 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (8-102)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 478,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2f3fd4bc727ee1c5a4e844d7337917752de234a7b24d4c2f2dfd3c19e79d27ae",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/cable-d-embrayage.yml"
+      },
+      {
+        "content_hash": "sha256:97f9207490ac5dfe1144e2afd96373302cf028e2330a6adc693d39df04c06ed2",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/cable-d-embrayage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "cable-d-embrayage"
+}

--- a/audit/content/raw-evidence/cable-de-capot-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/cable-de-capot-moteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (60 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1238,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:55e7a8ea1117ade48fca48df5e737739a143bf3a637aa2df2bb59d3152f3a256",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/cable-de-capot-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "cable-de-capot-moteur"
+}

--- a/audit/content/raw-evidence/cable-de-compteur-de-vitesse.raw-evidence.json
+++ b/audit/content/raw-evidence/cable-de-compteur-de-vitesse.raw-evidence.json
@@ -1,0 +1,131 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 1150,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0e684a677e6d1ed88198c1ff83fa721307442846e3f890e52a666729d10b491f",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/cable-de-compteur-de-vitesse.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "cable-de-compteur-de-vitesse"
+}

--- a/audit/content/raw-evidence/cable-de-frein-a-main.raw-evidence.json
+++ b/audit/content/raw-evidence/cable-de-frein-a-main.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (46 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 124,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:ad23f0979835deb4194eaca7ace8b951c43f1dcfcdf9e164eff5415948803bff",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/cable-de-frein-a-main.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "cable-de-frein-a-main"
+}

--- a/audit/content/raw-evidence/capteur-abs.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-abs.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 412,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:30fe78cd7f49024cd74e9678226f9912fc6039248413d46e333dbc14836ab978",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-abs.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-abs"
+}

--- a/audit/content/raw-evidence/capteur-controle-de-pression-des-pneus.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-controle-de-pression-des-pneus.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (56 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2232,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d1e5cd1eb3818d216e58cece25b34599639a6a920f62667eb7070f9c525076ad",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-controle-de-pression-des-pneus.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-controle-de-pression-des-pneus"
+}

--- a/audit/content/raw-evidence/capteur-d-allumage.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-d-allumage.raw-evidence.json
@@ -1,0 +1,96 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (0)",
+        "domain.must_be_true < 2 (0)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_C",
+  "pg_id": 834,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:e2f4720cf23947f9b7cb0d78a49ba5536ab17146a725ec5a411b286ace4e3206",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-d-allumage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-d-allumage"
+}

--- a/audit/content/raw-evidence/capteur-d-arbre-a-cames.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-d-arbre-a-cames.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range missing"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 3946,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:095d6a03276a1aa501026143a1781a8bc4a55712026c0bf91fe6ae30edf0c832",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-d-arbre-a-cames.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-d-arbre-a-cames"
+}

--- a/audit/content/raw-evidence/capteur-de-cognement.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-de-cognement.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 3921,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4059b525e7f7e2436f2074349d9ccd3dd5882e61dcc7e6a82b3bd1dbf6dc9d91",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-de-cognement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-de-cognement"
+}

--- a/audit/content/raw-evidence/capteur-de-pedale-d-accelerateur.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-de-pedale-d-accelerateur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 3908,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:166dbad37ee8361975ea8b057845935e2e9f903e85ce183a76f2619a252370bf",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-de-pedale-d-accelerateur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-de-pedale-d-accelerateur"
+}

--- a/audit/content/raw-evidence/capteur-de-pluie.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-de-pluie.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 2275,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:ebf71585b783f4a76e2766fd4592f56dfb5d6ed147f48e258db902ef7218b770",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-de-pluie.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-de-pluie"
+}

--- a/audit/content/raw-evidence/capteur-de-pression-common-rail.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-de-pression-common-rail.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 3996,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d887d7c5c88e745f568d2e446387bbca67dab811cffa9505651bf57d7f3b8e4c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-de-pression-common-rail.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-de-pression-common-rail"
+}

--- a/audit/content/raw-evidence/capteur-de-pression-turbo.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-de-pression-turbo.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (68 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3553,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:f402e4a897e8b4e7469ba4adb6b90d11092052e997ad89cef5288d074fdcaddc",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-de-pression-turbo.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-de-pression-turbo"
+}

--- a/audit/content/raw-evidence/capteur-impulsion.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-impulsion.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (60 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 4813,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:8f3ebe4f695a84f189b01c52478c7eda4919f117b0bb52555fdd5f201cda4e6a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-impulsion.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-impulsion"
+}

--- a/audit/content/raw-evidence/capteur-niveau-d-huile-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-niveau-d-huile-moteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 1289,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:700d8333afaff32394459e6298429da8ada35022b7519b5d062de920d227d266",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-niveau-d-huile-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-niveau-d-huile-moteur"
+}

--- a/audit/content/raw-evidence/capteur-niveau-de-liquide-de-refroidissement.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-niveau-de-liquide-de-refroidissement.raw-evidence.json
@@ -1,0 +1,131 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range missing"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 1288,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:7d54827df9d3bfdf5b5e3590f098a974d5d979f91ce365ff5807fa14a1484a84",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-niveau-de-liquide-de-refroidissement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-niveau-de-liquide-de-refroidissement"
+}

--- a/audit/content/raw-evidence/capteur-parctronic.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-parctronic.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (54 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2623,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:a5fdd2e1a5e63fe1894df6a2154e08b0ac1a71c11dc5decd90e50282baae32b5",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-parctronic.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-parctronic"
+}

--- a/audit/content/raw-evidence/capteur-position-papillon.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-position-papillon.raw-evidence.json
@@ -1,0 +1,123 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range missing"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 3940,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:57a74dc6cb525f3d61a319308cf639a31a555c7b563090a1952bac1d2a21555c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-position-papillon.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-position-papillon"
+}

--- a/audit/content/raw-evidence/capteur-pression-d-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-pression-d-huile.raw-evidence.json
@@ -1,0 +1,96 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (0)",
+        "domain.must_be_true < 2 (0)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_C",
+  "pg_id": 162,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:cd00125ab49e587c56b7bd71b51f9981b21e5b54d106b03918079c375156d1ae",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-pression-d-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-pression-d-huile"
+}

--- a/audit/content/raw-evidence/capteur-pression-de-carburant.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-pression-de-carburant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 817,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:8e4f3fb95c26acd32333e240c197b151a6e9fe229a2635bb91fbf0145b15f98b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-pression-de-carburant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-pression-de-carburant"
+}

--- a/audit/content/raw-evidence/capteur-pression-de-gaz-d-echappement.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-pression-de-gaz-d-echappement.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (15-200)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 4272,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:057b754ad67d51f33bfc0f40f3549a6d194167c106b6bff313e758d4dc047bf0",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-pression-de-gaz-d-echappement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-pression-de-gaz-d-echappement"
+}

--- a/audit/content/raw-evidence/capteur-pression-du-tuyau-d-admission.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-pression-du-tuyau-d-admission.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (50 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (15-200)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 3947,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:69153f7740eea5a33af26e1bb9174b6236b8c790dfab73ba2c3f340aeae33d1e",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/capteur-pression-du-tuyau-d-admission.yml"
+      },
+      {
+        "content_hash": "sha256:b848464179b385e210ccb9a791042a0670ae8e8db512a5c904bc5ef5adae7661",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-pression-du-tuyau-d-admission.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-pression-du-tuyau-d-admission"
+}

--- a/audit/content/raw-evidence/capteur-pression-et-temperature-d-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-pression-et-temperature-d-huile.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (52 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (15-200)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 4175,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:33885e991c871be757bf4197cf78c69029a18c97b52dc6da5b39ae3356f0b4ad",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/capteur-pression-et-temperature-d-huile.yml"
+      },
+      {
+        "content_hash": "sha256:ea585de21eb2204af776b7e4b533642fbe151fbdeb4a014727aee4706c5105e0",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-pression-et-temperature-d-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-pression-et-temperature-d-huile"
+}

--- a/audit/content/raw-evidence/capteur-temperature-d-air-admission.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-temperature-d-air-admission.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 3939,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2d510f384c2aa20b06c1e2845e99594ef782aaaab6d495b65d55b460ebe655f5",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-temperature-d-air-admission.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-temperature-d-air-admission"
+}

--- a/audit/content/raw-evidence/capteur-temperature-d-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-temperature-d-huile.raw-evidence.json
@@ -1,0 +1,123 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range missing"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 829,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:916861f25869ecdd1164db7a5e76e21ba4b0bf9598a40d63c48586edfda828c8",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-temperature-d-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-temperature-d-huile"
+}

--- a/audit/content/raw-evidence/capteur-temperature-de-carburant.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-temperature-de-carburant.raw-evidence.json
@@ -1,0 +1,96 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (0)",
+        "domain.must_be_true < 2 (0)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_C",
+  "pg_id": 3943,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1ee2d2cb12b6a0bed33beefd134588f4b853c70eee8ea916c13362e74634f3ce",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-temperature-de-carburant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-temperature-de-carburant"
+}

--- a/audit/content/raw-evidence/capteur-temperature-de-climatisation.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-temperature-de-climatisation.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2054,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:5dfe7c601879c3b1ea5f58181b91f26fb4ca934e5808371472955cd6d032d657",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-temperature-de-climatisation.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-temperature-de-climatisation"
+}

--- a/audit/content/raw-evidence/capteur-temperature-interieure.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-temperature-interieure.raw-evidence.json
@@ -1,0 +1,96 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (0)",
+        "domain.must_be_true < 2 (0)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_C",
+  "pg_id": 832,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:184db1d3ae61275c2476007a79c813c1bd6863cefa9e16d275a7cb3fc2db6eae",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-temperature-interieure.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-temperature-interieure"
+}

--- a/audit/content/raw-evidence/capteur-vilebrequin.raw-evidence.json
+++ b/audit/content/raw-evidence/capteur-vilebrequin.raw-evidence.json
@@ -1,0 +1,123 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range missing"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 833,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:39c3de2ffd9cdd1aafe69019bec0d46d2cfddb10f0fef0b8064bd1c5935607f0",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/capteur-vilebrequin.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "capteur-vilebrequin"
+}

--- a/audit/content/raw-evidence/cardan.raw-evidence.json
+++ b/audit/content/raw-evidence/cardan.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 13,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:ee6a8e239b1f8d23eebc15f291d26abaf3d395be69b188bbd0406f44c0f40706",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/cardan.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "cardan"
+}

--- a/audit/content/raw-evidence/carter-d-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/carter-d-huile.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (23 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 592,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:58cc4ccd838af74d92434413c5242a945ac551e7ffdf01a5c9ced629766cef2c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/carter-d-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "carter-d-huile"
+}

--- a/audit/content/raw-evidence/catalyseur.raw-evidence.json
+++ b/audit/content/raw-evidence/catalyseur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 429,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0b7a66906464fefda4444d147ad357ecbc9f5dbca041b14d08e066eb72fbd825",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/catalyseur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "catalyseur"
+}

--- a/audit/content/raw-evidence/chaine-de-distribution.raw-evidence.json
+++ b/audit/content/raw-evidence/chaine-de-distribution.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 1123,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:390cf6ee966273905386f00a4278d490090f6960603fe58dbbf75e4dd7186438",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/chaine-de-distribution.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "chaine-de-distribution"
+}

--- a/audit/content/raw-evidence/collecteur-d-echappement.raw-evidence.json
+++ b/audit/content/raw-evidence/collecteur-d-echappement.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 1543,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:3c2780e4d82863b4294c65b099bb5651e58ea55b79370be492788c5f43da6da8",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/collecteur-d-echappement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "collecteur-d-echappement"
+}

--- a/audit/content/raw-evidence/colonne-de-direction.raw-evidence.json
+++ b/audit/content/raw-evidence/colonne-de-direction.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 1211,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:27499394639785da6c8d794874606afaa9eeeb874b5c2ea8d08dc2d92c17c90a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/colonne-de-direction.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "colonne-de-direction"
+}

--- a/audit/content/raw-evidence/commande-correcteur-de-portee.raw-evidence.json
+++ b/audit/content/raw-evidence/commande-correcteur-de-portee.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 1432,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4f813ddd3eaba24d12c1f44cb8c549aab1d67e9a4f49533acd08a0e95742f0f4",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/commande-correcteur-de-portee.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "commande-correcteur-de-portee"
+}

--- a/audit/content/raw-evidence/commande-d-eclairage.raw-evidence.json
+++ b/audit/content/raw-evidence/commande-d-eclairage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (40 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 809,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d5e70d2c0681c0a79d21e954a266f045dbfa0f03e2a98989fbc22d2756bca2e3",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/commande-d-eclairage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "commande-d-eclairage"
+}

--- a/audit/content/raw-evidence/commande-d-essuie-glace.raw-evidence.json
+++ b/audit/content/raw-evidence/commande-d-essuie-glace.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (69 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 751,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:c57b9c61a1700126ae9ec89d2b8933553e0c3508b0bec7467d9473a98a37a16e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/commande-d-essuie-glace.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "commande-d-essuie-glace"
+}

--- a/audit/content/raw-evidence/commande-de-ventilation.raw-evidence.json
+++ b/audit/content/raw-evidence/commande-de-ventilation.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (47 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (30-400)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 1385,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6e58117f15ef77dc94a60d8633d9f9e5713d09a3ff7cc9ddd82693eea1008868",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/commande-de-ventilation.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "commande-de-ventilation"
+}

--- a/audit/content/raw-evidence/compresseur-de-climatisation.raw-evidence.json
+++ b/audit/content/raw-evidence/compresseur-de-climatisation.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 447,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:af98e64054dd92e475c1e8bc996f430248b0e199eebc667b9486c201921efeae",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/compresseur-de-climatisation.yml"
+      },
+      {
+        "content_hash": "sha256:92844a0912a1e931267e5e01393a99bbaffca9b37079febd6df8663791c05288",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/compresseur-de-climatisation.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "compresseur-de-climatisation"
+}

--- a/audit/content/raw-evidence/condenseur-de-climatisation.raw-evidence.json
+++ b/audit/content/raw-evidence/condenseur-de-climatisation.raw-evidence.json
@@ -1,0 +1,139 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)",
+        "domain.must_be_true < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 448,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:849696c92edde0186ed91b24797b1e71a8e5091882f0032e833450f74ed135d8",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/condenseur-de-climatisation.yml"
+      },
+      {
+        "content_hash": "sha256:ad5d48297ec827ccc28a44c4e8429c57bd7e1b516ac916ddedad5197d5330c28",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/condenseur-de-climatisation.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "condenseur-de-climatisation"
+}

--- a/audit/content/raw-evidence/conduite-a-haute-pression-d-injection.raw-evidence.json
+++ b/audit/content/raw-evidence/conduite-a-haute-pression-d-injection.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (57 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3916,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2c7d93f52c0f7d764e4106962a654deab5daf7a1a4085ba35bf8d92e54f86445",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/conduite-a-haute-pression-d-injection.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "conduite-a-haute-pression-d-injection"
+}

--- a/audit/content/raw-evidence/conduite-de-climatisation.raw-evidence.json
+++ b/audit/content/raw-evidence/conduite-de-climatisation.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (52 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2094,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:dad5dca9da192a15d11793279278c232a29a30c5213cffa6d2430146a360c3c1",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/conduite-de-climatisation.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "conduite-de-climatisation"
+}

--- a/audit/content/raw-evidence/contacteur-de-feu-de-recul.raw-evidence.json
+++ b/audit/content/raw-evidence/contacteur-de-feu-de-recul.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (42 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 807,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:32b6cd6ebd6e0770e92c1aadabd06e73e6c0af9ff2f688e3bcb6ab34b3539c65",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/contacteur-de-feu-de-recul.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "contacteur-de-feu-de-recul"
+}

--- a/audit/content/raw-evidence/contacteur-demarreur.raw-evidence.json
+++ b/audit/content/raw-evidence/contacteur-demarreur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (43 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 682,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:26b5a71b419e40e66b8096d9d5c8120316af32c7f2b5c456fdec5e1bee417620",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/contacteur-demarreur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "contacteur-demarreur"
+}

--- a/audit/content/raw-evidence/corps-papillon.raw-evidence.json
+++ b/audit/content/raw-evidence/corps-papillon.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 158,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:9ba86130f99fadd9c20ad2de7a9c4648c2ae9565b8ef94ff60df1a093ce31075",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/corps-papillon.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "corps-papillon"
+}

--- a/audit/content/raw-evidence/correcteur-de-portee.raw-evidence.json
+++ b/audit/content/raw-evidence/correcteur-de-portee.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (74 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 700,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0efa33b68c0b52a0e4dcd61d375b7f5c1421bd5d144f4887cc96d8c14a739fef",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/correcteur-de-portee.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "correcteur-de-portee"
+}

--- a/audit/content/raw-evidence/courroie-d-accessoire.raw-evidence.json
+++ b/audit/content/raw-evidence/courroie-d-accessoire.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (31 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (7-181)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 10,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6cd7d766756c97d748f77740d05f96f9ac6f61a4befb0dea1689d9d761f796a8",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/courroie-d-accessoire.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "courroie-d-accessoire"
+}

--- a/audit/content/raw-evidence/courroie-de-distribution.raw-evidence.json
+++ b/audit/content/raw-evidence/courroie-de-distribution.raw-evidence.json
@@ -1,0 +1,123 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 306,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0040ccd208e07425fb5e1aa9cddfed02547d864a5c00c45b0141f87d4108c4ad",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/courroie-de-distribution.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "courroie-de-distribution"
+}

--- a/audit/content/raw-evidence/cremailliere-de-direction.raw-evidence.json
+++ b/audit/content/raw-evidence/cremailliere-de-direction.raw-evidence.json
@@ -1,0 +1,131 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (7-2087)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 286,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d79d4ead4057ff7714fcea1eca28e70b07694bf6e0e97503446d3f336420330b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/cremailliere-de-direction.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "reviewed"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "cremailliere-de-direction"
+}

--- a/audit/content/raw-evidence/culbuteur.raw-evidence.json
+++ b/audit/content/raw-evidence/culbuteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (56 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 432,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4effc41efdf85e56d76da753a1ec43878e54bd9f7d8cef00e572d4cba5e04b88",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/culbuteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "culbuteur"
+}

--- a/audit/content/raw-evidence/cylindre-de-roue.raw-evidence.json
+++ b/audit/content/raw-evidence/cylindre-de-roue.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (49 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 277,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:22881c9aa281ac16642e0f1579076bce7e07deff4d31b315cd09d06c41df265c",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/cylindre-de-roue.yml"
+      },
+      {
+        "content_hash": "sha256:e14e29bc5931a1f039e4436687e05d7ab0bce3c1716f7321e325e8cb2fb8e327",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/cylindre-de-roue.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "cylindre-de-roue"
+}

--- a/audit/content/raw-evidence/debitmetre-d-air.raw-evidence.json
+++ b/audit/content/raw-evidence/debitmetre-d-air.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 3927,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:57504245d3e8aa22ac3ff52c2ff42f0ca52d37157292c3f01956a12f9b0696b6",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/debitmetre-d-air.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "debitmetre-d-air"
+}

--- a/audit/content/raw-evidence/demarreur.raw-evidence.json
+++ b/audit/content/raw-evidence/demarreur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (70 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:eef6e697736e00a735ef15fb356a16a757756ce1079ca3b6cfd1c54890d3d569",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/demarreur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "demarreur"
+}

--- a/audit/content/raw-evidence/detecteur-de-l-angle-de-braquage.raw-evidence.json
+++ b/audit/content/raw-evidence/detecteur-de-l-angle-de-braquage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3252,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:540c9bffd0356f951aa056311fbb49afe1ea749923fd2355653013c6d20abfd3",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/detecteur-de-l-angle-de-braquage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "detecteur-de-l-angle-de-braquage"
+}

--- a/audit/content/raw-evidence/detendeur-de-climatisation.raw-evidence.json
+++ b/audit/content/raw-evidence/detendeur-de-climatisation.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 183,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1e5655f54541cd92c2afd156d466de39229077a3e3782d0366cdf7446958b102",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/detendeur-de-climatisation.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "detendeur-de-climatisation"
+}

--- a/audit/content/raw-evidence/diagnostic/alternateur-diagnostic-mahle.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/alternateur-diagnostic-mahle.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:b7b7b59b521f61fa6f2dba25801dedd9e046e13171e61a308b615dcbf34536e6",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/alternateur-diagnostic-mahle.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "unverified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "alternateur-diagnostic-mahle",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/amortisseurs.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/amortisseurs.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:a3e840739281f4429745caa1b9fdacc5c384e00b88ebdd38000e772d22d738e3",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/amortisseurs.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "amortisseurs",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/bosch-freinage-brochure-reparation-fad-2020-fr.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/bosch-freinage-brochure-reparation-fad-2020-fr.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:aaa3744f6a6f3d89637ffa039c563257382c6ddec263479ee7caae00043b1ac1",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/bosch-freinage-brochure-reparation-fad-2020-fr.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "unverified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bosch-freinage-brochure-reparation-fad-2020-fr",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/bruits-freinage.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/bruits-freinage.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:f3be062b152e1c7ff7c8868f1358f2042d7019335b927662b8db01c15456e54e",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/bruits-freinage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "bruits-freinage",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/climatisation.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/climatisation.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:55e9e50eb6d3305624cde3d9c3ff3dfcefea8014af963b2f1770f8737046db25",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/climatisation.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "climatisation",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/demarrage-batterie.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/demarrage-batterie.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:0fe6af2786132ac0da558e33e0c5333ef24e82ca8edd197b612cf812f8a45f60",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/demarrage-batterie.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "demarrage-batterie",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/direction-cremaillere.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/direction-cremaillere.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:871c74f527742d1ef040687202342bacd397b28e4751f81155e5ed8feae687bf",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/direction-cremaillere.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "direction-cremaillere",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/disque-de-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/disque-de-frein.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:bcae6733936441fb32dc66e0395cfa7502f848872a678be4b2c7a64e49193b63",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/disque-de-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "disque-de-frein",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/distribution-courroie.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/distribution-courroie.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:48da60581511aa6ccdf0ef1cd4c3f4a4e8c5373a8b1c54d6c0a77cfa0cacf5a8",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/distribution-courroie.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "distribution-courroie",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/echappement-catalyseur.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/echappement-catalyseur.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:f78c47eee23da20c4df253971c117d7cb73970c4a3ad309dc4427562df70a349",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/echappement-catalyseur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "echappement-catalyseur",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/eclairage-voyants.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/eclairage-voyants.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:4b0f9efcc4211962caa56341cc5d76c28f338c7098ceb7185fda29b7d2d66869",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/eclairage-voyants.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "eclairage-voyants",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/embrayage.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/embrayage.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:2b6174f8d046b4541d0a7a645d869aaea2a1e827847e64c6495d7c2d87d6c8cf",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/embrayage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "embrayage",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/filtre-a-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/filtre-a-huile.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:74de714624a3841185722d32c363cd8d2215bebc369b5faca03fbf570ad07f38",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/filtre-a-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "filtre-a-huile",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/injecteurs-pompe.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/injecteurs-pompe.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:f1291d8d85e82677ad9273c20605e76eeb1a2298a7f212090e212deec42b398e",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/injecteurs-pompe.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "injecteurs-pompe",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/refroidissement.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/refroidissement.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:d4a0289e8efa232b9a396758fa5bc7f2bae624d17fb5ac9b105b9fa89bd3101a",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/refroidissement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "refroidissement",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/temoins-tableau-bord.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/temoins-tableau-bord.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:5e989b89d0121ee00182ee9d5269801ae47a9f953917d1d4cfa867eb93e9e90d",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/temoins-tableau-bord.md"
+      }
+    ],
+    "truth_level": "L1",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "temoins-tableau-bord",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/diagnostic/transmission-boite.raw-evidence.json
+++ b/audit/content/raw-evidence/diagnostic/transmission-boite.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "diagnostic",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "diagnostic",
+    "sources": [
+      {
+        "content_hash": "sha256:aca75b9d8697c3dc34000f8ed90b7cef2baf5870cddbddbd50efa59340999d3c",
+        "kind": "diagnostic",
+        "path": "recycled/rag-knowledge/diagnostic/transmission-boite.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "transmission-boite",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/disque-de-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/disque-de-frein.raw-evidence.json
@@ -1,0 +1,123 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "reference",
+    "entretien"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 82,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:76a08ef816be854960a6fb27a2ad82bddc7f945473bc1bc650dce387545b1a5f",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/disque-de-frein.yml"
+      },
+      {
+        "content_hash": "sha256:9796fe063018f9b23c5e9ac47598ae3e73ba011b6f82f5d081ba138d0fdc4494",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/disque-de-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "disque-de-frein"
+}

--- a/audit/content/raw-evidence/distributeur-d-allumage.raw-evidence.json
+++ b/audit/content/raw-evidence/distributeur-d-allumage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (63 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 683,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:c38b3d3e323b64961ad8907e92d70235b69873f340bc61ad2172ad9ebf5428de",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/distributeur-d-allumage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "distributeur-d-allumage"
+}

--- a/audit/content/raw-evidence/durite-de-refroidissement.raw-evidence.json
+++ b/audit/content/raw-evidence/durite-de-refroidissement.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (69 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 475,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:256eba38853644f065d3afab480b1518340e2ee8eed0bedb9c60687bbddabeec",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/durite-de-refroidissement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "durite-de-refroidissement"
+}

--- a/audit/content/raw-evidence/electrovanne.raw-evidence.json
+++ b/audit/content/raw-evidence/electrovanne.raw-evidence.json
@@ -1,0 +1,32 @@
+{
+  "coverage": [],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [],
+  "inventory_status": "RAW_PARSE_ERROR",
+  "next_action": "FIX_RAW_FRONTMATTER (yaml_parse_error: duplicated mapping key (203:5)\n\n 200 |     source_ref: corpus RAG web OEM\n 201 |   technical_notes:\n 202 |     val_2_v: '2 V'\n 203 |     val_2_v: '2 v'\n-----------^\n 204 |     val_3_v: '3 v'\n 205 |     val_4_v: '4 v')",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": null,
+    "sources": [
+      {
+        "content_hash": "sha256:267d23ee31d7a9f9b21b15c34dee137e1162a376eb47ab0c668afd0c108e972d",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/electrovanne.md"
+      }
+    ],
+    "truth_level": null,
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": null
+  },
+  "raw_verdict": "RAW_PARSE_ERROR",
+  "schema_version": "raw-evidence.v1",
+  "subject": "electrovanne"
+}

--- a/audit/content/raw-evidence/emetteur-d-embrayage.raw-evidence.json
+++ b/audit/content/raw-evidence/emetteur-d-embrayage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (66 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 234,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:cc712780fac8314cbf27f4d05cf6030e9f4a1613390f3a995905b2bf20e11221",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/emetteur-d-embrayage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "emetteur-d-embrayage"
+}

--- a/audit/content/raw-evidence/encyclopedia-coverage.json
+++ b/audit/content/raw-evidence/encyclopedia-coverage.json
@@ -1,0 +1,2147 @@
+{
+  "by_family": {
+    "__uncategorized__": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 6,
+        "OR": 0
+      },
+      "total": 6
+    },
+    "accessoires": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 26,
+        "OR": 0
+      },
+      "total": 26
+    },
+    "alimentation": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 21,
+        "OR": 0
+      },
+      "total": 21
+    },
+    "allumage": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 6,
+        "OR": 0
+      },
+      "total": 6
+    },
+    "capteurs": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 17,
+        "OR": 0
+      },
+      "total": 17
+    },
+    "climatisation": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 13,
+        "OR": 0
+      },
+      "total": 13
+    },
+    "direction": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 14,
+        "OR": 0
+      },
+      "total": 14
+    },
+    "distribution": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 13,
+        "OR": 0
+      },
+      "total": 13
+    },
+    "echappement": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 6,
+        "OR": 0
+      },
+      "total": 6
+    },
+    "eclairage": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 17,
+        "OR": 0
+      },
+      "total": 17
+    },
+    "electrique": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 4,
+        "OR": 0
+      },
+      "total": 4
+    },
+    "embrayage": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 9,
+        "OR": 0
+      },
+      "total": 9
+    },
+    "filtration": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 5,
+        "OR": 0
+      },
+      "total": 5
+    },
+    "freinage": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 20,
+        "OR": 0
+      },
+      "total": 20
+    },
+    "gestion-moteur": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 3,
+        "OR": 0
+      },
+      "total": 3
+    },
+    "moteur": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 30,
+        "OR": 0
+      },
+      "total": 30
+    },
+    "refroidissement": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 11,
+        "OR": 0
+      },
+      "total": 11
+    },
+    "support_moteur": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 2,
+        "OR": 0
+      },
+      "total": 2
+    },
+    "suspension": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 5,
+        "OR": 0
+      },
+      "total": 5
+    },
+    "tableau-de-bord": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 1,
+        "OR": 0
+      },
+      "total": 1
+    },
+    "transmission": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 7,
+        "OR": 0
+      },
+      "total": 7
+    },
+    "turbo": {
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 5,
+        "OR": 0
+      },
+      "total": 5
+    }
+  },
+  "by_type": {
+    "diagnostic": {
+      "parse_errors": 0,
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 17,
+        "OR": 0
+      },
+      "total": 17
+    },
+    "gamme": {
+      "parse_errors": 6,
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 241,
+        "OR": 0
+      },
+      "total": 241
+    },
+    "vehicle": {
+      "parse_errors": 0,
+      "tiers": {
+        "ARGENT": 0,
+        "BRONZE": 0,
+        "NONE": 0,
+        "NOT_CONFIGURED": 8,
+        "OR": 0
+      },
+      "total": 8
+    }
+  },
+  "fiches": [
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "alternateur-diagnostic-mahle",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "amortisseurs",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "bosch-freinage-brochure-reparation-fad-2020-fr",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "bruits-freinage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "climatisation",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "demarrage-batterie",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "direction-cremaillere",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "disque-de-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "distribution-courroie",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "echappement-catalyseur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "eclairage-voyants",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "embrayage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "filtre-a-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "injecteurs-pompe",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "refroidissement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "temoins-tableau-bord",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "diagnostic",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "transmission-boite",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "accessoires-de-machoire",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "accessoires-de-plaquette",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "accumulateur-de-pression",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "accumulateur-de-pression-de-carburant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "agregat-de-freinage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "electrique",
+      "missing_for_next_tier": [],
+      "subject": "alternateur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "suspension",
+      "missing_for_next_tier": [],
+      "subject": "amortisseur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "amortisseur-de-direction",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "ampoule-eclairage-interieur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "ampoule-feu-arriere",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "ampoule-feu-avant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "ampoule-feu-clignotant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "ampoule-feu-de-position",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "ampoule-feu-de-recul",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "ampoule-feu-eclaireur-de-plaque",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "ampoule-feu-stop",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "arbre-a-came",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "attelage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "avertisseur-sonore",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "bague-d-etancheite-boite-automatique",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "transmission",
+      "missing_for_next_tier": [],
+      "subject": "bague-d-etancheite-cardan",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "bagues-d-etancheite-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "balais-d-essuie-glace",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "ballast-a-lampe-xenon",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "barre-de-direction",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "barre-stabilisatrice",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "batterie",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "biellette-de-barre-stabilisatrice",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "bobine-d-allumage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "allumage",
+      "missing_for_next_tier": [],
+      "subject": "boitier-de-prechauffage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "bouchon-d-huile-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "bouchon-de-radiateur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "bouchon-de-vidange",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "bouchon-reservoir-de-carburant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "bouchon-vase-d-expansion",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "bougie-d-allumage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "allumage",
+      "missing_for_next_tier": [],
+      "subject": "bougie-de-prechauffage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "boulon-de-roue",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "bouteille-deshydratante",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "bras-d-essuie-glace",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "bras-de-suspension",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "bride-de-liquide-de-refroidissement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "embrayage",
+      "missing_for_next_tier": [],
+      "subject": "butee-d-embrayage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "suspension",
+      "missing_for_next_tier": [],
+      "subject": "butee-elastique-d-amortisseur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "cable-d-accelerateur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "embrayage",
+      "missing_for_next_tier": [],
+      "subject": "cable-d-embrayage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "cable-de-capot-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "tableau-de-bord",
+      "missing_for_next_tier": [],
+      "subject": "cable-de-compteur-de-vitesse",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "cable-de-frein-a-main",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-abs",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "capteur-controle-de-pression-des-pneus",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "allumage",
+      "missing_for_next_tier": [],
+      "subject": "capteur-d-allumage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "capteur-d-arbre-a-cames",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-de-cognement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-de-pedale-d-accelerateur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "capteur-de-pluie",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-de-pression-common-rail",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "turbo",
+      "missing_for_next_tier": [],
+      "subject": "capteur-de-pression-turbo",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-impulsion",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-niveau-d-huile-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "capteur-niveau-de-liquide-de-refroidissement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "capteur-parctronic",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "capteur-position-papillon",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "gestion-moteur",
+      "missing_for_next_tier": [],
+      "subject": "capteur-pression-d-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-pression-de-carburant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-pression-de-gaz-d-echappement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-pression-du-tuyau-d-admission",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-pression-et-temperature-d-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "capteur-temperature-d-air-admission",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "capteur-temperature-d-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "gestion-moteur",
+      "missing_for_next_tier": [],
+      "subject": "capteur-temperature-de-carburant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "capteur-temperature-de-climatisation",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "capteur-temperature-interieure",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "capteur-vilebrequin",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "transmission",
+      "missing_for_next_tier": [],
+      "subject": "cardan",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "carter-d-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "echappement",
+      "missing_for_next_tier": [],
+      "subject": "catalyseur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "chaine-de-distribution",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "echappement",
+      "missing_for_next_tier": [],
+      "subject": "collecteur-d-echappement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "colonne-de-direction",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "commande-correcteur-de-portee",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "commande-d-eclairage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "commande-d-essuie-glace",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "commande-de-ventilation",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "compresseur-de-climatisation",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "condenseur-de-climatisation",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "conduite-a-haute-pression-d-injection",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "conduite-de-climatisation",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "contacteur-de-feu-de-recul",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "electrique",
+      "missing_for_next_tier": [],
+      "subject": "contacteur-demarreur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "corps-papillon",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "correcteur-de-portee",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "courroie-d-accessoire",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "courroie-de-distribution",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "cremailliere-de-direction",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "culbuteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "cylindre-de-roue",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "debitmetre-d-air",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "electrique",
+      "missing_for_next_tier": [],
+      "subject": "demarreur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "detecteur-de-l-angle-de-braquage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "detendeur-de-climatisation",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "disque-de-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "allumage",
+      "missing_for_next_tier": [],
+      "subject": "distributeur-d-allumage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "durite-de-refroidissement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "electrovanne",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "embrayage",
+      "missing_for_next_tier": [],
+      "subject": "emetteur-d-embrayage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "etrier-de-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "evaporateur-de-climatisation",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "allumage",
+      "missing_for_next_tier": [],
+      "subject": "faisceau-d-allumage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "faisceau-d-attelage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "echappement",
+      "missing_for_next_tier": [],
+      "subject": "fap",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "feu-arriere",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "feu-avant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "feu-clignotant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "filtration",
+      "missing_for_next_tier": [],
+      "subject": "filtre-a-air",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "filtration",
+      "missing_for_next_tier": [],
+      "subject": "filtre-a-carburant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "filtration",
+      "missing_for_next_tier": [],
+      "subject": "filtre-a-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "filtration",
+      "missing_for_next_tier": [],
+      "subject": "filtre-d-habitacle",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "filtration",
+      "missing_for_next_tier": [],
+      "subject": "filtre-de-boite-auto",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "flexible-de-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "embrayage",
+      "missing_for_next_tier": [],
+      "subject": "fourchette-d-embrayage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "turbo",
+      "missing_for_next_tier": [],
+      "subject": "gaine-de-turbo",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "galet-enrouleur-de-courroie-d-accessoire",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "galet-enrouleur-de-courroie-de-distribution",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "galet-tendeur-de-courroie-d-accessoire",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "galet-tendeur-de-courroie-de-distribution",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "gicleur-detendeur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "embrayage",
+      "missing_for_next_tier": [],
+      "subject": "guide-d-embrayage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "guide-de-soupape",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "injecteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "turbo",
+      "missing_for_next_tier": [],
+      "subject": "intercooler",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "interrupteur-des-feux-de-freins",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "interrupteur-position-de-marche",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "interrupteur-verrouilage-des-portes",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "jauge-de-niveau-d-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "transmission",
+      "missing_for_next_tier": [],
+      "subject": "joint-arbre-longitudinal",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "joint-carter-de-distribution",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "joint-chemise-de-cylindre",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "echappement",
+      "missing_for_next_tier": [],
+      "subject": "joint-d-echappement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "joint-d-injecteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "joint-de-boite-vitesse",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "joint-de-cache-culbuteurs",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "joint-de-carter-d-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "joint-de-collecteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "joint-de-culasse",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "joint-de-pompe-d-injection",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "joint-tige-de-soupape",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "embrayage",
+      "missing_for_next_tier": [],
+      "subject": "kit-d-embrayage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "suspension",
+      "missing_for_next_tier": [],
+      "subject": "kit-de-butee-de-suspension",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "kit-de-chaine-de-distribution",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "kit-de-distribution",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "kit-de-freins-arriere",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "kit-de-poussoir-culbuteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "leve-vitre",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "machoires-de-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "maitre-cylindre-de-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "mecatronique-boite-automatique",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "allumage",
+      "missing_for_next_tier": [],
+      "subject": "module-d-allumage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "moteur-d-essuie-glace",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "moteur-electrique-de-ventilateur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "moyeu-de-roue",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "electrique",
+      "missing_for_next_tier": [],
+      "subject": "neiman",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "transmission",
+      "missing_for_next_tier": [],
+      "subject": "palier-d-arbre-de-transmission",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "palpeur-de-regime-gestion-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "parctronic",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "phares-antibrouillard",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "plaquette-de-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "pochette-joints-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "poignee-de-porte",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "pompe-a-air",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "pompe-a-carburant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "pompe-a-eau",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "pompe-a-haute-pression",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "pompe-a-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "pompe-a-injection",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "pompe-a-vide-de-freinage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "pompe-d-amorcage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "pompe-de-direction-assistee",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "pompe-hydraulique-systeme-de-freinage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "pompe-nettoyage-des-phares",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "pompe-nettoyage-des-vitres",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "poulie-d-alternateur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "poulie-d-arbre-a-came",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "distribution",
+      "missing_for_next_tier": [],
+      "subject": "poulie-vilebrequin",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "poussoir-de-soupape",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "pressostat-d-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "pressostat-de-climatisation",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "pulseur-d-air-d-habitacle",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "radiateur-d-huile",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "radiateur-de-chauffage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "radiateur-de-refroidissement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "embrayage",
+      "missing_for_next_tier": [],
+      "subject": "recepteur-d-embrayage",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "refroidisseur-de-carburant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "regulateur-de-pression-carburant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "eclairage",
+      "missing_for_next_tier": [],
+      "subject": "relais-de-clignotant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "repartiteur-de-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "suspension",
+      "missing_for_next_tier": [],
+      "subject": "ressort-de-suspension",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "retroviseur-exterieur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "rotule-de-direction",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "rotule-de-suspension",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "roulement-de-roue",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "serrure-de-porte",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "servo-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "echappement",
+      "missing_for_next_tier": [],
+      "subject": "silencieux",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "sonde-de-refroidissement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "sonde-lambda",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "transmission",
+      "missing_for_next_tier": [],
+      "subject": "soufflet-de-cardan",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "direction",
+      "missing_for_next_tier": [],
+      "subject": "soufflet-de-direction",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "soupape-d-admission",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "soupape-d-air-secondaire",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "soupape-d-aspiration-d-air-secondaire",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "soupape-d-echappement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "soupape-de-rampe-commune-d-injection",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "soupape-reaspiration-des-gaz-d-echappement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "suspension",
+      "missing_for_next_tier": [],
+      "subject": "sphere-de-suspension",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "support_moteur",
+      "missing_for_next_tier": [],
+      "subject": "support-de-boite-vitesse",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "support_moteur",
+      "missing_for_next_tier": [],
+      "subject": "support-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "transmission",
+      "missing_for_next_tier": [],
+      "subject": "suspension-boite-vitesse-automatique",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "tambour-de-frein",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "temoin-d-usure",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "thermostat",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "transmission",
+      "missing_for_next_tier": [],
+      "subject": "trepied-arbre-de-commande",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "embrayage",
+      "missing_for_next_tier": [],
+      "subject": "tringle-de-vitesses",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "tringlerie-d-essuie-glace",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "echappement",
+      "missing_for_next_tier": [],
+      "subject": "tube-d-echappement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "tube-de-distributeur-carburant",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "turbo",
+      "missing_for_next_tier": [],
+      "subject": "turbo",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "tuyau-carburant-de-fuite",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "gestion-moteur",
+      "missing_for_next_tier": [],
+      "subject": "tuyau-ventilation-de-carter-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "capteurs",
+      "missing_for_next_tier": [],
+      "subject": "valve-de-reglage-du-ralenti",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "turbo",
+      "missing_for_next_tier": [],
+      "subject": "valve-de-turbo",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "climatisation",
+      "missing_for_next_tier": [],
+      "subject": "valve-magnetique",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "alimentation",
+      "missing_for_next_tier": [],
+      "subject": "vanne-egr",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "vase-d-expansion",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "refroidissement",
+      "missing_for_next_tier": [],
+      "subject": "ventilateur-de-refroidissement",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "verin-capot-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "verin-de-coffre",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "accessoires",
+      "missing_for_next_tier": [],
+      "subject": "verin-vitre-arriere",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "moteur",
+      "missing_for_next_tier": [],
+      "subject": "vis-de-culasse",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "freinage",
+      "missing_for_next_tier": [],
+      "subject": "vis-de-disque",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "gamme",
+      "family": "embrayage",
+      "missing_for_next_tier": [],
+      "subject": "volant-moteur",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "vehicle",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "citroen-c3",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "vehicle",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "ford-focus-3",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "vehicle",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "peugeot-206",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "vehicle",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "renault",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "vehicle",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "renault-clio-3",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "vehicle",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "renault-clio-iii",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "vehicle",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "renault-megane-3",
+      "tier": "NOT_CONFIGURED"
+    },
+    {
+      "entity_type": "vehicle",
+      "family": null,
+      "missing_for_next_tier": [],
+      "subject": "volkswagen-golf-6",
+      "tier": "NOT_CONFIGURED"
+    }
+  ],
+  "profiles": {
+    "diagnostic": {
+      "content_hash": null,
+      "path": "_schemas/completeness/diagnostic.yaml",
+      "reason": "profile file absent (_schemas/completeness/diagnostic.yaml)",
+      "status": "NOT_CONFIGURED",
+      "warnings": []
+    },
+    "gamme": {
+      "content_hash": null,
+      "path": "_schemas/completeness/gamme.yaml",
+      "reason": "profile file absent (_schemas/completeness/gamme.yaml)",
+      "status": "NOT_CONFIGURED",
+      "warnings": []
+    },
+    "vehicle": {
+      "content_hash": null,
+      "path": "_schemas/completeness/vehicle.yaml",
+      "reason": "profile file absent (_schemas/completeness/vehicle.yaml)",
+      "status": "NOT_CONFIGURED",
+      "warnings": []
+    }
+  },
+  "schema_version": "encyclopedia-coverage.v1"
+}

--- a/audit/content/raw-evidence/etrier-de-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/etrier-de-frein.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (52 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 78,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:03082abfa687ab6530a0ed93579084ae866e151607392d5a3c520613b604bdc3",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/etrier-de-frein.yml"
+      },
+      {
+        "content_hash": "sha256:e67d3a3c9f89546bdf9095186abe6e3f6f9ae2c42666c70d75ed6df9b33adf5d",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/etrier-de-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "etrier-de-frein"
+}

--- a/audit/content/raw-evidence/evaporateur-de-climatisation.raw-evidence.json
+++ b/audit/content/raw-evidence/evaporateur-de-climatisation.raw-evidence.json
@@ -1,0 +1,139 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)",
+        "domain.must_be_true < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 471,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4f94ac471c586154a001ba93599720dca7e426ed8de039c0d463656e59ff1aef",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/evaporateur-de-climatisation.yml"
+      },
+      {
+        "content_hash": "sha256:e16c1c09fb939aae26db57926b6484a80ae89cd8af33865a65ab977808db63c3",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/evaporateur-de-climatisation.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "evaporateur-de-climatisation"
+}

--- a/audit/content/raw-evidence/faisceau-d-allumage.raw-evidence.json
+++ b/audit/content/raw-evidence/faisceau-d-allumage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (75 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 685,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:64aae212e3fa12eafdc534a7eafd1fb2943930c11bd2fdf12bc468d7a03b2413",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/faisceau-d-allumage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "faisceau-d-allumage"
+}

--- a/audit/content/raw-evidence/faisceau-d-attelage.raw-evidence.json
+++ b/audit/content/raw-evidence/faisceau-d-attelage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (63 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 179,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:5354ac7fe6daff7bcbfd1e4ca5f85b70b6c23051b039154f2199f894667e424a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/faisceau-d-attelage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "faisceau-d-attelage"
+}

--- a/audit/content/raw-evidence/fap.raw-evidence.json
+++ b/audit/content/raw-evidence/fap.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (67 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1256,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b67255fca16602da55fddd441c4c5fd4d732dc1525db790ee8731362a95cb70e",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/fap.yml"
+      },
+      {
+        "content_hash": "sha256:064931507b1c21202c49cd309abaa04f647f1810b6b1d1ede7d6416a4b543468",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/fap.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "fap"
+}

--- a/audit/content/raw-evidence/feu-arriere.raw-evidence.json
+++ b/audit/content/raw-evidence/feu-arriere.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (46 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 290,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2126441fa395918ad3651af634e4db802ed27083cd9f8af14c1984b2b1663282",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/feu-arriere.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "feu-arriere"
+}

--- a/audit/content/raw-evidence/feu-avant.raw-evidence.json
+++ b/audit/content/raw-evidence/feu-avant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (35 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 259,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:48c5a3d316453babaaf47082c13e28a195c6163f9d6da347def2779ec1d3fe8d",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/feu-avant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "feu-avant"
+}

--- a/audit/content/raw-evidence/feu-clignotant.raw-evidence.json
+++ b/audit/content/raw-evidence/feu-clignotant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (36 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 62,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2ee319ffc369defc6140e4e91fac7937572a94ef4852fd1cbbed23a40ffe79aa",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/feu-clignotant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "feu-clignotant"
+}

--- a/audit/content/raw-evidence/filtre-a-carburant.raw-evidence.json
+++ b/audit/content/raw-evidence/filtre-a-carburant.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 9,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:e1b2dc1f441a1bb153c80ebf72bebb011bc2fa104eb326a0892f56498cb773e4",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/filtre-a-carburant.yml"
+      },
+      {
+        "content_hash": "sha256:c8b09f47e767c19fb432f1bd8348560fee38ca5d5370f60218046c09f9ba3eca",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/filtre-a-carburant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "filtre-a-carburant"
+}

--- a/audit/content/raw-evidence/filtre-a-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/filtre-a-huile.raw-evidence.json
@@ -1,0 +1,142 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:key_visual_features",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 7,
+  "provenance": {
+    "completeness_profile": "filtration",
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:df7f365c5d6ad51846e79d6b56624f02c24ab0ec6d95ac24e20ed7be10115343",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/filtre-a-huile.yml"
+      },
+      {
+        "content_hash": "sha256:07be8662dc4af805ef87d8d1f106a13e2d5f47e7c41b3ba76fdee3215c08b930",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/filtre-a-huile.md"
+      }
+    ],
+    "truth_level": "L3",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "filtre-a-huile"
+}

--- a/audit/content/raw-evidence/filtre-d-habitacle.raw-evidence.json
+++ b/audit/content/raw-evidence/filtre-d-habitacle.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 424,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:872a589baa382b200dc0a9b52ad6a5bebd714d5f898e1fc48f324c5fc8f9e51d",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/filtre-d-habitacle.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "filtre-d-habitacle"
+}

--- a/audit/content/raw-evidence/filtre-de-boite-auto.raw-evidence.json
+++ b/audit/content/raw-evidence/filtre-de-boite-auto.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (39 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 416,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:fc2da9d2fef25d5f321f77f97b150df413b1480fd327b691718fa13d83110b9b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/filtre-de-boite-auto.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "filtre-de-boite-auto"
+}

--- a/audit/content/raw-evidence/flexible-de-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/flexible-de-frein.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (62 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 83,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:eaf9dd7e7b5f66ad9b067aa02002a092a6c03581d8aa2503446c80e5ad95384c",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/flexible-de-frein.yml"
+      },
+      {
+        "content_hash": "sha256:2774119b68ebd8747506eb0da1f13085ec2cbbc55f98b2e2de5b564afb6dfb08",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/flexible-de-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "flexible-de-frein"
+}

--- a/audit/content/raw-evidence/fourchette-d-embrayage.raw-evidence.json
+++ b/audit/content/raw-evidence/fourchette-d-embrayage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (46 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3419,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6c9b893c88609bb284183b91d3dcc8ec783df83cbbf9d19ee707ee8b733d70ae",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/fourchette-d-embrayage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "fourchette-d-embrayage"
+}

--- a/audit/content/raw-evidence/gaine-de-turbo.raw-evidence.json
+++ b/audit/content/raw-evidence/gaine-de-turbo.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (52 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3314,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:cced1039943bacbbf55cd029501bf84808292e0ae7b104924ad8875241920155",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/gaine-de-turbo.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "gaine-de-turbo"
+}

--- a/audit/content/raw-evidence/galet-enrouleur-de-courroie-d-accessoire.raw-evidence.json
+++ b/audit/content/raw-evidence/galet-enrouleur-de-courroie-d-accessoire.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (30 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 312,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:8c2350eb963cc8cab51f8908e317fa8c2920c46e14ba890fee79509ba4857f71",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/galet-enrouleur-de-courroie-d-accessoire.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "galet-enrouleur-de-courroie-d-accessoire"
+}

--- a/audit/content/raw-evidence/galet-enrouleur-de-courroie-de-distribution.raw-evidence.json
+++ b/audit/content/raw-evidence/galet-enrouleur-de-courroie-de-distribution.raw-evidence.json
@@ -1,0 +1,133 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (52 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 313,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:c36d0df96d2d12dbb32e48df466ac084731f310f7615de331858c43e5808f3e6",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/galet-enrouleur-de-courroie-de-distribution.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "galet-enrouleur-de-courroie-de-distribution"
+}

--- a/audit/content/raw-evidence/galet-tendeur-de-courroie-d-accessoire.raw-evidence.json
+++ b/audit/content/raw-evidence/galet-tendeur-de-courroie-d-accessoire.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 310,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:52973338cff6e0b06c8264c79dee77d85a4fb231648c69c89c0f77291303f915",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/galet-tendeur-de-courroie-d-accessoire.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "galet-tendeur-de-courroie-d-accessoire"
+}

--- a/audit/content/raw-evidence/galet-tendeur-de-courroie-de-distribution.raw-evidence.json
+++ b/audit/content/raw-evidence/galet-tendeur-de-courroie-de-distribution.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (51 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 308,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0865418540e590dee9a0c39019235f2dfdc1bc821e16af3c7834f93b7cdcf065",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/galet-tendeur-de-courroie-de-distribution.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "galet-tendeur-de-courroie-de-distribution"
+}

--- a/audit/content/raw-evidence/gicleur-detendeur.raw-evidence.json
+++ b/audit/content/raw-evidence/gicleur-detendeur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (50 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2408,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:40e14379ddcc0389a96d78c3111231e6d41bba1b7e84c7950a35c916ec39fde1",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/gicleur-detendeur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "gicleur-detendeur"
+}

--- a/audit/content/raw-evidence/guide-d-embrayage.raw-evidence.json
+++ b/audit/content/raw-evidence/guide-d-embrayage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (45 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 4688,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1db735f977294a89f6c73a62a66453f6d40c643567e89bc63b67d94f9e9bc6ee",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/guide-d-embrayage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "guide-d-embrayage"
+}

--- a/audit/content/raw-evidence/guide-de-soupape.raw-evidence.json
+++ b/audit/content/raw-evidence/guide-de-soupape.raw-evidence.json
@@ -1,0 +1,96 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (0)",
+        "domain.must_be_true < 2 (0)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_C",
+  "pg_id": 1644,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:c1e539f7ed32292fc76587700fa558c9213c0d8eeec57f138c6f25912588e472",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/guide-de-soupape.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "guide-de-soupape"
+}

--- a/audit/content/raw-evidence/injecteur.raw-evidence.json
+++ b/audit/content/raw-evidence/injecteur.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 3902,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:3f4ff4f0fbb9d772c5e728cc3f112c80c208d778e7f7d94e8c8c31f874785086",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/injecteur.yml"
+      },
+      {
+        "content_hash": "sha256:401c13adc88a9f6833c4d2da6e40ae56ade73415f5fa66799b5371a5bfb7a6cd",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/injecteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "injecteur"
+}

--- a/audit/content/raw-evidence/intercooler.raw-evidence.json
+++ b/audit/content/raw-evidence/intercooler.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (37 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 468,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:93e328904d63a398731777a53b942f00ac2804c121b27953713591d66af0a8b5",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/intercooler.yml"
+      },
+      {
+        "content_hash": "sha256:9630af4cf775e67cda772a611f5489e3e09c9feeaa938d69fc94d0dbcf3df2ed",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/intercooler.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "intercooler"
+}

--- a/audit/content/raw-evidence/interrupteur-des-feux-de-freins.raw-evidence.json
+++ b/audit/content/raw-evidence/interrupteur-des-feux-de-freins.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (65 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 806,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6e18b7073ae5569461d2206d68e66bab0a793034050ad7360ef84a02e437de14",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/interrupteur-des-feux-de-freins.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "interrupteur-des-feux-de-freins"
+}

--- a/audit/content/raw-evidence/interrupteur-position-de-marche.raw-evidence.json
+++ b/audit/content/raw-evidence/interrupteur-position-de-marche.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 2197,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2de2c291c46c12ea0f83b8427c1bc42f985068895754e05df0ddf9ccfbee4010",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/interrupteur-position-de-marche.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "interrupteur-position-de-marche"
+}

--- a/audit/content/raw-evidence/interrupteur-verrouilage-des-portes.raw-evidence.json
+++ b/audit/content/raw-evidence/interrupteur-verrouilage-des-portes.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (61 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 864,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:a8b6768fd54e97aa4dc89eec1138dd8821ad96acd27fdc472d129680cc682113",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/interrupteur-verrouilage-des-portes.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "interrupteur-verrouilage-des-portes"
+}

--- a/audit/content/raw-evidence/jauge-de-niveau-d-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/jauge-de-niveau-d-huile.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (34 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 599,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d121ca304f5e5b57a58564b98e7874d3bb300e91f850fa4139dad578324d37d7",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/jauge-de-niveau-d-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "jauge-de-niveau-d-huile"
+}

--- a/audit/content/raw-evidence/joint-arbre-longitudinal.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-arbre-longitudinal.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (56 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1427,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1cb4c880d7603e1397758cc69734b65d89241fe49d41091e1ec4ea8c3d6e73e8",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-arbre-longitudinal.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-arbre-longitudinal"
+}

--- a/audit/content/raw-evidence/joint-carter-de-distribution.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-carter-de-distribution.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (70 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 568,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:844558b4cc0175c1544f6561e58493b118cfe82191e936cc9bb9a1cbc89db569",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-carter-de-distribution.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-carter-de-distribution"
+}

--- a/audit/content/raw-evidence/joint-chemise-de-cylindre.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-chemise-de-cylindre.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (5-200)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 128,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:ecd5bf06647e1487b3fdbbbe641a34e11108e86db7340a5e5600c3dc70981852",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/joint-chemise-de-cylindre.yml"
+      },
+      {
+        "content_hash": "sha256:c1b8b81a544d76115ea64f671b8254b50e91ce6c01ef508df303437bdb68d44b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-chemise-de-cylindre.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-chemise-de-cylindre"
+}

--- a/audit/content/raw-evidence/joint-d-echappement.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-d-echappement.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (64 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 138,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0969a5e50cb283a00e840a31497785ffd48c29bb7cc1515efcb5569d5f037d5e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-d-echappement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-d-echappement"
+}

--- a/audit/content/raw-evidence/joint-d-injecteur.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-d-injecteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (72 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3894,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:5af95df6d03bd8cb989caf7748b48859964767645601deedc6ada8455fd7c67e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-d-injecteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-d-injecteur"
+}

--- a/audit/content/raw-evidence/joint-de-boite-vitesse.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-de-boite-vitesse.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (70 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 146,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d103e4f42bfe9618d551200b0fe64d6ec3c1f903607c2032aa781861a1db4664",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-de-boite-vitesse.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-de-boite-vitesse"
+}

--- a/audit/content/raw-evidence/joint-de-cache-culbuteurs.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-de-cache-culbuteurs.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (69 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 321,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6383a7591531b84306623ae5f1f2aa22dc5b18653907467c63134f80d519229a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-de-cache-culbuteurs.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-de-cache-culbuteurs"
+}

--- a/audit/content/raw-evidence/joint-de-carter-d-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-de-carter-d-huile.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (62 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 455,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:c35241a3194ab7fb1b595a95bf42650cba150c32879c360e0384969f0113134e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-de-carter-d-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-de-carter-d-huile"
+}

--- a/audit/content/raw-evidence/joint-de-collecteur.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-de-collecteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (54 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 40,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1a3d32fedbddf5632691745efa0a43972316295eb58c31ee2f36e2b851d5444b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-de-collecteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-de-collecteur"
+}

--- a/audit/content/raw-evidence/joint-de-culasse.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-de-culasse.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 318,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6ebbf59ebfcdc129ec56c5a88c16db176fd73b6d8ea134b838c2300c44f89ee5",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-de-culasse.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-de-culasse"
+}

--- a/audit/content/raw-evidence/joint-de-pompe-d-injection.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-de-pompe-d-injection.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (60 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3893,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2cd4b0b6432325e49157e8eb3ff503eb9882e5f6a3571a94c5beb7ab2e9d15ef",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-de-pompe-d-injection.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-de-pompe-d-injection"
+}

--- a/audit/content/raw-evidence/joint-tige-de-soupape.raw-evidence.json
+++ b/audit/content/raw-evidence/joint-tige-de-soupape.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (59 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 322,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:99efbc1afa5e8992433909afa2927c2e3b7d0450614920d0a2a63fe66103b629",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/joint-tige-de-soupape.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "joint-tige-de-soupape"
+}

--- a/audit/content/raw-evidence/kit-d-embrayage.raw-evidence.json
+++ b/audit/content/raw-evidence/kit-d-embrayage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (76-1070)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 479,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:5561b6508e2fa0506d07270fe8acbcbc82a586e49d905867e477a24d3413f735",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/kit-d-embrayage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "kit-d-embrayage"
+}

--- a/audit/content/raw-evidence/kit-de-butee-de-suspension.raw-evidence.json
+++ b/audit/content/raw-evidence/kit-de-butee-de-suspension.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1632,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:445037c5edebad6672269adc1f975799836eb67cb69b355af7322bb2ebc5053a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/kit-de-butee-de-suspension.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "kit-de-butee-de-suspension"
+}

--- a/audit/content/raw-evidence/kit-de-chaine-de-distribution.raw-evidence.json
+++ b/audit/content/raw-evidence/kit-de-chaine-de-distribution.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (43 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (11-160)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 1389,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6eab75ac1eff15b7f0545b134b2638d8ad3321e719ca45240de8372ef6f03b3c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/kit-de-chaine-de-distribution.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "kit-de-chaine-de-distribution"
+}

--- a/audit/content/raw-evidence/kit-de-distribution.raw-evidence.json
+++ b/audit/content/raw-evidence/kit-de-distribution.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 307,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:7c0ad263ac817e0310d868080ec3acdd8cf9c311d6a98a950955dc5c84369f7f",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/kit-de-distribution.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "kit-de-distribution"
+}

--- a/audit/content/raw-evidence/kit-de-freins-arriere.raw-evidence.json
+++ b/audit/content/raw-evidence/kit-de-freins-arriere.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (36 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3859,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b1cdfa632f094a4862d183c83bf09f81eec7444e3e242fd478f80e1b80aa3673",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/kit-de-freins-arriere.yml"
+      },
+      {
+        "content_hash": "sha256:acdccbb471cf62862dbdc1f5c852fbc6a90502112fa9b5bd496df5a4578aa32b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/kit-de-freins-arriere.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "kit-de-freins-arriere"
+}

--- a/audit/content/raw-evidence/kit-de-poussoir-culbuteur.raw-evidence.json
+++ b/audit/content/raw-evidence/kit-de-poussoir-culbuteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (56 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3320,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b32b8937bd8d3f59fe23390a32f2dd0c6f31445c91f717df5b4de0f4d102b0b6",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/kit-de-poussoir-culbuteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "kit-de-poussoir-culbuteur"
+}

--- a/audit/content/raw-evidence/leve-vitre.raw-evidence.json
+++ b/audit/content/raw-evidence/leve-vitre.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (40 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1561,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:94161f66aa6ae2b964d764bf5765678acd1cd39331eb5c52e8c9984914d71bfa",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/leve-vitre.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "leve-vitre"
+}

--- a/audit/content/raw-evidence/machoires-de-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/machoires-de-frein.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (42 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 70,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d08f21add41848acf9171a92d77b1603bd3440e66e3210c9e65ee9c0668b1547",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/machoires-de-frein.yml"
+      },
+      {
+        "content_hash": "sha256:c0a46ac843df25f3ca5eecaa7cf4960f8bdf3a33b5fc2daab8cc6dc4a94f79bd",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/machoires-de-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "machoires-de-frein"
+}

--- a/audit/content/raw-evidence/maitre-cylindre-de-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/maitre-cylindre-de-frein.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (57 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 258,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6457fe038befd466bfb315cf374ae5a2c89e16537e3a602a04e52c5d23f0d857",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/maitre-cylindre-de-frein.yml"
+      },
+      {
+        "content_hash": "sha256:d81a0344f4cf198446858e73715d88d6c4d10d6d8cbca57e7b3a0ea0f54d095e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/maitre-cylindre-de-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "maitre-cylindre-de-frein"
+}

--- a/audit/content/raw-evidence/mecatronique-boite-automatique.raw-evidence.json
+++ b/audit/content/raw-evidence/mecatronique-boite-automatique.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (49 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3072,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:e8f26c26e5286b513486b19cd28892cd0f963722d3485af051ab739b6524a435",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/mecatronique-boite-automatique.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "mecatronique-boite-automatique"
+}

--- a/audit/content/raw-evidence/module-d-allumage.raw-evidence.json
+++ b/audit/content/raw-evidence/module-d-allumage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (47 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1218,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1c3cfbd98e787e39ce1a94179009f678a668e0599af83cdda6a823b389034cb5",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/module-d-allumage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "module-d-allumage"
+}

--- a/audit/content/raw-evidence/moteur-d-essuie-glace.raw-evidence.json
+++ b/audit/content/raw-evidence/moteur-d-essuie-glace.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (50 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 295,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:33c6635df3ab2c3c20899d94ab047c4e8b1245ebacc413a0b3f26e6599644d72",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/moteur-d-essuie-glace.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "moteur-d-essuie-glace"
+}

--- a/audit/content/raw-evidence/moteur-electrique-de-ventilateur.raw-evidence.json
+++ b/audit/content/raw-evidence/moteur-electrique-de-ventilateur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (53 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 792,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:05f0cb414a2200d963977992d6ef74b258327adb0de72dc183ccb30fe6ee83d2",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/moteur-electrique-de-ventilateur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "moteur-electrique-de-ventilateur"
+}

--- a/audit/content/raw-evidence/moyeu-de-roue.raw-evidence.json
+++ b/audit/content/raw-evidence/moyeu-de-roue.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (72 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 653,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:784f9f81840e9d193b8f123398de650c7a46c94a48ddb6699d3a86130c946d4a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/moyeu-de-roue.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "moyeu-de-roue"
+}

--- a/audit/content/raw-evidence/neiman.raw-evidence.json
+++ b/audit/content/raw-evidence/neiman.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (62 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1367,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:a9c821b0f10bc6230b4e072c41f6e16e58c68c96752353f1ae184d4148ec2281",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/neiman.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "neiman"
+}

--- a/audit/content/raw-evidence/palier-d-arbre-de-transmission.raw-evidence.json
+++ b/audit/content/raw-evidence/palier-d-arbre-de-transmission.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2109,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6b6e7ecc49f339afd3167754d49fcbad45ee76297442eb610fff530647bdbefa",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/palier-d-arbre-de-transmission.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "palier-d-arbre-de-transmission"
+}

--- a/audit/content/raw-evidence/palpeur-de-regime-gestion-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/palpeur-de-regime-gestion-moteur.raw-evidence.json
@@ -1,0 +1,123 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range missing"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 3896,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b5e92e0a6990de4d0a3a2d2a8071932b63c362af3f13083badec9a957ebc52d8",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/palpeur-de-regime-gestion-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "palpeur-de-regime-gestion-moteur"
+}

--- a/audit/content/raw-evidence/parctronic.raw-evidence.json
+++ b/audit/content/raw-evidence/parctronic.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1209,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:df442f81a5a2d971501c36e56358b0f8919811f05a5bed40553c98bd1bb83d18",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/parctronic.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "parctronic"
+}

--- a/audit/content/raw-evidence/phares-antibrouillard.raw-evidence.json
+++ b/audit/content/raw-evidence/phares-antibrouillard.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 289,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:f685c2e8ab34dd499beb05e7232f00dc23efd5054754eb9fd83fcde73c0901b1",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/phares-antibrouillard.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "phares-antibrouillard"
+}

--- a/audit/content/raw-evidence/plaquette-de-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/plaquette-de-frein.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "reference",
+    "entretien"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 402,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b38b2c3d08bbfb030eb5e4ea54a742b061b47438187e482bafa681e6553ce751",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/plaquette-de-frein.yml"
+      },
+      {
+        "content_hash": "sha256:879313a0c660e40f20ebc3c2efc351656a4b0707ca1162c91769c79784646e3e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/plaquette-de-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "plaquette-de-frein"
+}

--- a/audit/content/raw-evidence/pochette-joints-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/pochette-joints-moteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 560,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:67933a917792c482b98e59aee9903df2d8c33647def792ce5c7e4e667ec7dfb2",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pochette-joints-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pochette-joints-moteur"
+}

--- a/audit/content/raw-evidence/poignee-de-porte.raw-evidence.json
+++ b/audit/content/raw-evidence/poignee-de-porte.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (64 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1373,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:e6b494afced1453fa4272d27408a4463fcd98b84550ee10373337824de0b93b0",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/poignee-de-porte.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "poignee-de-porte"
+}

--- a/audit/content/raw-evidence/pompe-a-air.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-a-air.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 903,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:f1a10b778ae675c2c0e373f6bf2a18a55202ce10f461adbb350f4877ee2308e5",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-a-air.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-a-air"
+}

--- a/audit/content/raw-evidence/pompe-a-carburant.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-a-carburant.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 458,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0e904762ee8f8143668630a0f2236f8aed4e6ff8fcd7c4b146ecffc8831785c7",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/pompe-a-carburant.yml"
+      },
+      {
+        "content_hash": "sha256:01fde3590224a9fb19f7d302942464b14283d527cc899ac0279bb29a5927c1d7",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-a-carburant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-a-carburant"
+}

--- a/audit/content/raw-evidence/pompe-a-eau.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-a-eau.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (67 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1260,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:63964535295b08a3adc6cdb58a451b6150322709a75b79771de6c64befaabb1a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-a-eau.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-a-eau"
+}

--- a/audit/content/raw-evidence/pompe-a-haute-pression.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-a-haute-pression.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (69 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3918,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:75a55553882a4aa2feda871133e524af8f7dec5835ef77acb6bc6cc683e1b685",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-a-haute-pression.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-a-haute-pression"
+}

--- a/audit/content/raw-evidence/pompe-a-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-a-huile.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (60 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 596,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2de78b01f479039cf1b6d94f2f44aa64432d83c6148cb691260918033b57cfe3",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-a-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-a-huile"
+}

--- a/audit/content/raw-evidence/pompe-a-injection.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-a-injection.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (69 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3904,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:e03ec90634e6d7b8bbbdb4dbd7bbd1d1fdf374fd92f8f4535131d9f04e942c1a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-a-injection.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-a-injection"
+}

--- a/audit/content/raw-evidence/pompe-a-vide-de-freinage.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-a-vide-de-freinage.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (54 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (15-200)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 387,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:13cdb0d4655db6d57083f75842915eb91e25fd990275459bb38a30f685144e3e",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/pompe-a-vide-de-freinage.yml"
+      },
+      {
+        "content_hash": "sha256:185da846d1eef1f70c23f481b245ac79972c77bf0ef5f8fbf16170355ca44a5c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-a-vide-de-freinage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-a-vide-de-freinage"
+}

--- a/audit/content/raw-evidence/pompe-d-amorcage.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-d-amorcage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (54 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 862,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4db1952687eccc2e1d2039d2194ec1e1e01ee3908f9ca4250f3b9b1b49cc9f1a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-d-amorcage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-d-amorcage"
+}

--- a/audit/content/raw-evidence/pompe-de-direction-assistee.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-de-direction-assistee.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 12,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:9a42177e421780b9c977bdbcd9559003800e58bc0af56d77c435476164d7f0c7",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-de-direction-assistee.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-de-direction-assistee"
+}

--- a/audit/content/raw-evidence/pompe-hydraulique-systeme-de-freinage.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-hydraulique-systeme-de-freinage.raw-evidence.json
@@ -1,0 +1,96 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (0)",
+        "domain.must_be_true < 2 (0)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_C",
+  "pg_id": 1115,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:811b0336d9d109e495e1ee89422996826a842a4a6b0767176a4de58745044f11",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-hydraulique-systeme-de-freinage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-hydraulique-systeme-de-freinage"
+}

--- a/audit/content/raw-evidence/pompe-nettoyage-des-phares.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-nettoyage-des-phares.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (59 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 795,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:624b82a86a8752a7a598caf025d39396d8e95ac2ed220283a3be920e2af62f61",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-nettoyage-des-phares.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-nettoyage-des-phares"
+}

--- a/audit/content/raw-evidence/pompe-nettoyage-des-vitres.raw-evidence.json
+++ b/audit/content/raw-evidence/pompe-nettoyage-des-vitres.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 794,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:12b5f457a65f5ad8708a945455484345901797a6b7057913b0ffb7efee1929a6",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pompe-nettoyage-des-vitres.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pompe-nettoyage-des-vitres"
+}

--- a/audit/content/raw-evidence/poulie-d-alternateur.raw-evidence.json
+++ b/audit/content/raw-evidence/poulie-d-alternateur.raw-evidence.json
@@ -1,0 +1,133 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (37 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1108,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:628e14f95bf8253a07567b4f9fbacdc46f38612e706e7fe3a10645f23cba19ed",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/poulie-d-alternateur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "poulie-d-alternateur"
+}

--- a/audit/content/raw-evidence/poulie-d-arbre-a-came.raw-evidence.json
+++ b/audit/content/raw-evidence/poulie-d-arbre-a-came.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (64 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1067,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0b780d76882ac3a277852a2bd6bef624ce87dd3d383c339751a00da865ab8cc3",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/poulie-d-arbre-a-came.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "poulie-d-arbre-a-came"
+}

--- a/audit/content/raw-evidence/poulie-vilebrequin.raw-evidence.json
+++ b/audit/content/raw-evidence/poulie-vilebrequin.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (52 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3213,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:90b035fc877d1c4b4d34177d62184e7c1b660ea8318ae54f4079399d46383e9c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/poulie-vilebrequin.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "poulie-vilebrequin"
+}

--- a/audit/content/raw-evidence/poussoir-de-soupape.raw-evidence.json
+++ b/audit/content/raw-evidence/poussoir-de-soupape.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (56 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1216,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:8e0b6a7f31e64be74475917c9a90b1e5e97bce502a39fa73d933e04a503bdf5c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/poussoir-de-soupape.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "poussoir-de-soupape"
+}

--- a/audit/content/raw-evidence/pressostat-d-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/pressostat-d-huile.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 805,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:3adde06ea9ad23db4496850d122ca7de6e0f4236c157d207b23d070903f63509",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pressostat-d-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pressostat-d-huile"
+}

--- a/audit/content/raw-evidence/pressostat-de-climatisation.raw-evidence.json
+++ b/audit/content/raw-evidence/pressostat-de-climatisation.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (56 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1360,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4b913320dc2f486b9a6fbc69b2ad75e7a3770361de69c5075570261e79015537",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pressostat-de-climatisation.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pressostat-de-climatisation"
+}

--- a/audit/content/raw-evidence/pulseur-d-air-d-habitacle.raw-evidence.json
+++ b/audit/content/raw-evidence/pulseur-d-air-d-habitacle.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 2669,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:274e9b3a8ab432e35c1ebda569dceb15f93caadd21ff041bb7ebd18234033ae0",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/pulseur-d-air-d-habitacle.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "pulseur-d-air-d-habitacle"
+}

--- a/audit/content/raw-evidence/radiateur-d-huile.raw-evidence.json
+++ b/audit/content/raw-evidence/radiateur-d-huile.raw-evidence.json
@@ -1,0 +1,131 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (25-350)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 469,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:547ba840fe6d440378b033b3649a2184e949f5eefed76447371addb49ada4f1b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/radiateur-d-huile.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "radiateur-d-huile"
+}

--- a/audit/content/raw-evidence/radiateur-de-chauffage.raw-evidence.json
+++ b/audit/content/raw-evidence/radiateur-de-chauffage.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 467,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:65c0496c55ac9e0e599c9d8942cee9f062b55db218b18d5daf4b3321e19bc005",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/radiateur-de-chauffage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "radiateur-de-chauffage"
+}

--- a/audit/content/raw-evidence/radiateur-de-refroidissement.raw-evidence.json
+++ b/audit/content/raw-evidence/radiateur-de-refroidissement.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (70 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 470,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:35c6160237d4c435849abe4ce967245b65e046ad45c6fd476b87dc39e9591914",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/radiateur-de-refroidissement.yml"
+      },
+      {
+        "content_hash": "sha256:c0a09b28d61b6bb3f86e216424878657bdd677f06a4fb7004769f14d8b78267a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/radiateur-de-refroidissement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "radiateur-de-refroidissement"
+}

--- a/audit/content/raw-evidence/recepteur-d-embrayage.raw-evidence.json
+++ b/audit/content/raw-evidence/recepteur-d-embrayage.raw-evidence.json
@@ -1,0 +1,133 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (71 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 620,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:bc5054344935eb456f0a1d45cf58447376d3e38d1946c0eb3f8de9651091b147",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/recepteur-d-embrayage.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "recepteur-d-embrayage"
+}

--- a/audit/content/raw-evidence/refroidisseur-de-carburant.raw-evidence.json
+++ b/audit/content/raw-evidence/refroidisseur-de-carburant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (59 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3640,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4c851ab0e978280b37cba1324f1408bf15505ac7c04f00e323da16a2f6e6be8b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/refroidisseur-de-carburant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "refroidisseur-de-carburant"
+}

--- a/audit/content/raw-evidence/regulateur-de-pression-carburant.raw-evidence.json
+++ b/audit/content/raw-evidence/regulateur-de-pression-carburant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (58 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 168,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:883dbae37ff6c1d8897fac22464576a45cad906ad600b0605a0bc21109f9c10b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/regulateur-de-pression-carburant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "regulateur-de-pression-carburant"
+}

--- a/audit/content/raw-evidence/relais-de-clignotant.raw-evidence.json
+++ b/audit/content/raw-evidence/relais-de-clignotant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (59 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 61,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:14f3cc7ffb0817b54ba02eaa1daed1831a88284b9b006f20897f32179d6dc754",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/relais-de-clignotant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "relais-de-clignotant"
+}

--- a/audit/content/raw-evidence/repartiteur-de-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/repartiteur-de-frein.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (50 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (15-200)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 73,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:482bc7f41433af6644972e94bfd00aabc53cda933377c0e561e217b8bfe880da",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/repartiteur-de-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "repartiteur-de-frein"
+}

--- a/audit/content/raw-evidence/ressort-de-suspension.raw-evidence.json
+++ b/audit/content/raw-evidence/ressort-de-suspension.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 188,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:96a3df31378960f74ec6766f9f0b2f7fc431d82a042793113c35d86dc379b57f",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ressort-de-suspension.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ressort-de-suspension"
+}

--- a/audit/content/raw-evidence/retroviseur-exterieur.raw-evidence.json
+++ b/audit/content/raw-evidence/retroviseur-exterieur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (36 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 50,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b7d62643f848d34afcb53d65eaf719faa555044cefa8ef9b72957ec58eea6e2b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/retroviseur-exterieur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "retroviseur-exterieur"
+}

--- a/audit/content/raw-evidence/rotule-de-direction.raw-evidence.json
+++ b/audit/content/raw-evidence/rotule-de-direction.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 2066,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4ad1567339b9d027f99d1bc5f88fde3d9b214d2b5d278f764170cd5e4bfcdc71",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/rotule-de-direction.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "rotule-de-direction"
+}

--- a/audit/content/raw-evidence/rotule-de-suspension.raw-evidence.json
+++ b/audit/content/raw-evidence/rotule-de-suspension.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 2462,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0e28d6f84ffc5f4e674e2144dca54cc7611544bed9f482142c065ff663501e70",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/rotule-de-suspension.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "rotule-de-suspension"
+}

--- a/audit/content/raw-evidence/roulement-de-roue.raw-evidence.json
+++ b/audit/content/raw-evidence/roulement-de-roue.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 655,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:7d3ff09e976457dc41f3271380c4da45039d80662632f672ca966dd9b2eb0fcb",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/roulement-de-roue.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "roulement-de-roue"
+}

--- a/audit/content/raw-evidence/serrure-de-porte.raw-evidence.json
+++ b/audit/content/raw-evidence/serrure-de-porte.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (47 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1361,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:5a679e0d91e041a1636987ce4a0e2164434b4b0242d1f46e5f38b0281ad1161b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/serrure-de-porte.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "serrure-de-porte"
+}

--- a/audit/content/raw-evidence/servo-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/servo-frein.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (59 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 74,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:35612a1e43361195b4815f6963fcc8c609f3b446b647856f1a8bd70f89f79c18",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/servo-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "servo-frein"
+}

--- a/audit/content/raw-evidence/silencieux.raw-evidence.json
+++ b/audit/content/raw-evidence/silencieux.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 26,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:76c6a8b9f45d25536f236013c1fa8025c3c98043069432d513f7cfa3cfa41e2b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/silencieux.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "silencieux"
+}

--- a/audit/content/raw-evidence/sonde-de-refroidissement.raw-evidence.json
+++ b/audit/content/raw-evidence/sonde-de-refroidissement.raw-evidence.json
@@ -1,0 +1,138 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 830,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:0317bd05f8ab07aa0d9ce1d946d47df1cf435f1bce7b7b8bbf25c83c4f977da0",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/sonde-de-refroidissement.yml"
+      },
+      {
+        "content_hash": "sha256:f8420a97ba864179ae8c28b9c9dcaaedaacb40a9cc27260374f8ff4dbe270e5e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/sonde-de-refroidissement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "sonde-de-refroidissement"
+}

--- a/audit/content/raw-evidence/sonde-lambda.raw-evidence.json
+++ b/audit/content/raw-evidence/sonde-lambda.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 3922,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:3963e46bdb65def648481bb9ba0814b636ef7387145707d5b16e1a396aabe2a2",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/sonde-lambda.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "sonde-lambda"
+}

--- a/audit/content/raw-evidence/soufflet-de-cardan.raw-evidence.json
+++ b/audit/content/raw-evidence/soufflet-de-cardan.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (65 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 193,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:cf42e5bbaabba070b5987f486732ce381d686371733d2b51ef67f434d09eef3d",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/soufflet-de-cardan.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "soufflet-de-cardan"
+}

--- a/audit/content/raw-evidence/soufflet-de-direction.raw-evidence.json
+++ b/audit/content/raw-evidence/soufflet-de-direction.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 191,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d037ac684492dff7af2d09151f6410e1d8004046347d5793218ec9b8802503b6",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/soufflet-de-direction.yml"
+      },
+      {
+        "content_hash": "sha256:3a290854f4abc7b582f4ff802f439dbf99dba97d1d8ce8fc579a05121a1458b7",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/soufflet-de-direction.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "soufflet-de-direction"
+}

--- a/audit/content/raw-evidence/soupape-d-admission.raw-evidence.json
+++ b/audit/content/raw-evidence/soupape-d-admission.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (47 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1269,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b5b895eeeccca04aa4cae3104e85b1e9ec67911b72a87994dbe7c00b5717e564",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/soupape-d-admission.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "soupape-d-admission"
+}

--- a/audit/content/raw-evidence/soupape-d-air-secondaire.raw-evidence.json
+++ b/audit/content/raw-evidence/soupape-d-air-secondaire.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (57 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 904,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:d99fd73d249c76a8c5346761b70dbe2ddf634b36134e67356371c9be5152fe0e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/soupape-d-air-secondaire.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "soupape-d-air-secondaire"
+}

--- a/audit/content/raw-evidence/soupape-d-aspiration-d-air-secondaire.raw-evidence.json
+++ b/audit/content/raw-evidence/soupape-d-aspiration-d-air-secondaire.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (53 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1136,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4282d186904286f93d1ae6b214de956a9bf6cafc13ed668b6f9816bc29b0d1a5",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/soupape-d-aspiration-d-air-secondaire.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "soupape-d-aspiration-d-air-secondaire"
+}

--- a/audit/content/raw-evidence/soupape-d-echappement.raw-evidence.json
+++ b/audit/content/raw-evidence/soupape-d-echappement.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (49 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1270,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:6c6e7a4daad734f76a7d30d58d5da7cf78bb362664da585ebf3fb46b6c6a75c5",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/soupape-d-echappement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "soupape-d-echappement"
+}

--- a/audit/content/raw-evidence/soupape-de-rampe-commune-d-injection.raw-evidence.json
+++ b/audit/content/raw-evidence/soupape-de-rampe-commune-d-injection.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (64 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 5656,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:58714c00ce37b03a41a19e3dcc96d01ad478ae9dbafc6d3a9da3986c0be9cd32",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/soupape-de-rampe-commune-d-injection.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "soupape-de-rampe-commune-d-injection"
+}

--- a/audit/content/raw-evidence/soupape-reaspiration-des-gaz-d-echappement.raw-evidence.json
+++ b/audit/content/raw-evidence/soupape-reaspiration-des-gaz-d-echappement.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (60 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (20-300)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 1137,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1935583396b5c8eff08fcd8561571b4ac649642a70cba8e7b40157d9a5a8262f",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/soupape-reaspiration-des-gaz-d-echappement.yml"
+      },
+      {
+        "content_hash": "sha256:f462333681786de55a7d9d3ee3429d36e1cfa9391491f8acc098b92bbeb59adb",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/soupape-reaspiration-des-gaz-d-echappement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "soupape-reaspiration-des-gaz-d-echappement"
+}

--- a/audit/content/raw-evidence/sphere-de-suspension.raw-evidence.json
+++ b/audit/content/raw-evidence/sphere-de-suspension.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 1718,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:e017b2a1926c162bbd5f42d9ed26a68d6d4173b731728f072624447d8727c7e6",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/sphere-de-suspension.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "sphere-de-suspension"
+}

--- a/audit/content/raw-evidence/support-de-boite-vitesse.raw-evidence.json
+++ b/audit/content/raw-evidence/support-de-boite-vitesse.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (50 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 249,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:f7279bfbbe41839d6df5d14aae99a86ac408f5ba80f9913851cad519dffa60ec",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/support-de-boite-vitesse.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "support-de-boite-vitesse"
+}

--- a/audit/content/raw-evidence/support-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/support-moteur.raw-evidence.json
@@ -1,0 +1,131 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (34 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:diagnostic.depose_steps",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 247,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:44e8f45e28af0daed2e16317c883e99981a14c462ad8e675c2ad067ca5190499",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/support-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "support-moteur"
+}

--- a/audit/content/raw-evidence/suspension-boite-vitesse-automatique.raw-evidence.json
+++ b/audit/content/raw-evidence/suspension-boite-vitesse-automatique.raw-evidence.json
@@ -1,0 +1,123 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range missing"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 248,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b368d13c0ebe1b902f5957a247e165507210950a5f4d0885bbdfa43c91198ec2",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/suspension-boite-vitesse-automatique.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "suspension-boite-vitesse-automatique"
+}

--- a/audit/content/raw-evidence/tambour-de-frein.raw-evidence.json
+++ b/audit/content/raw-evidence/tambour-de-frein.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 123,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:daa4f7d8807a0a057ffc3f8c4400268f3e8f5c1eaa7df51722134ad7f7db0822",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/tambour-de-frein.yml"
+      },
+      {
+        "content_hash": "sha256:b40b1d2514689d73ca7c9bcaf3d6d506a1067d4d930c97e0a96f702e530c8ce4",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/tambour-de-frein.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "tambour-de-frein"
+}

--- a/audit/content/raw-evidence/temoin-d-usure.raw-evidence.json
+++ b/audit/content/raw-evidence/temoin-d-usure.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (39 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 407,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:92d2d7ec5af4b2c814f18804365b6cc13e5b85fbb38c71e05ecfa3e8e7572759",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/temoin-d-usure.yml"
+      },
+      {
+        "content_hash": "sha256:69804c185c9658e8dff55a61a04b13d2e4fff40e53aa5b5703893ad0724cec18",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/temoin-d-usure.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "temoin-d-usure"
+}

--- a/audit/content/raw-evidence/thermostat.raw-evidence.json
+++ b/audit/content/raw-evidence/thermostat.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (73 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (3-59)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 316,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:01db4db2c594e3a6b6c112731d2c77431fd41bc6ef406c92a1caa5e3a53c90e4",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/thermostat.yml"
+      },
+      {
+        "content_hash": "sha256:2645a147393ddbc1f7f0425d9a0f4c35d55abc81beb8c5069f8b84d56f6e2936",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/thermostat.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "thermostat"
+}

--- a/audit/content/raw-evidence/trepied-arbre-de-commande.raw-evidence.json
+++ b/audit/content/raw-evidence/trepied-arbre-de-commande.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1147,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:bfef13ca0cac690c926c1df6d41f4e7998e833df926932d55c4a4293d6b377c1",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/trepied-arbre-de-commande.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "trepied-arbre-de-commande"
+}

--- a/audit/content/raw-evidence/tringle-de-vitesses.raw-evidence.json
+++ b/audit/content/raw-evidence/tringle-de-vitesses.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1650,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:fb8a274cc44f73bd607e2d1526a44bb79dbf4dc79f8a5ac54d5008fd88ecd41e",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/tringle-de-vitesses.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "tringle-de-vitesses"
+}

--- a/audit/content/raw-evidence/tringlerie-d-essuie-glace.raw-evidence.json
+++ b/audit/content/raw-evidence/tringlerie-d-essuie-glace.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 300,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:5e435eaf61b0701a91756a7317e6eaa117bc33552468407c8a5a21e89ca193f3",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/tringlerie-d-essuie-glace.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "tringlerie-d-essuie-glace"
+}

--- a/audit/content/raw-evidence/tube-d-echappement.raw-evidence.json
+++ b/audit/content/raw-evidence/tube-d-echappement.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (65 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 17,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:a68770652e43be8666e22c1596f70a18d127ba3ca0aa32a174a1a96636ff6f4b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/tube-d-echappement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "tube-d-echappement"
+}

--- a/audit/content/raw-evidence/tube-de-distributeur-carburant.raw-evidence.json
+++ b/audit/content/raw-evidence/tube-de-distributeur-carburant.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (55 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3964,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:e4dae99eeb2fddb8a5aa88667f3859558e3802739ad0550e02da0e3a03e833e2",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/tube-de-distributeur-carburant.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "tube-de-distributeur-carburant"
+}

--- a/audit/content/raw-evidence/turbo.raw-evidence.json
+++ b/audit/content/raw-evidence/turbo.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (54 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2234,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:bebdf7b8c130d4e32cab4883d30c27a61b95c8ff6c41ff452ca9bce89a5c8d8c",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/turbo.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "turbo"
+}

--- a/audit/content/raw-evidence/tuyau-carburant-de-fuite.raw-evidence.json
+++ b/audit/content/raw-evidence/tuyau-carburant-de-fuite.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (66 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 3937,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:1154b7eb9e138e3fdd93e09ecf7eb3a3ee88df8c93094c193aff3038343b856f",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/tuyau-carburant-de-fuite.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "tuyau-carburant-de-fuite"
+}

--- a/audit/content/raw-evidence/tuyau-ventilation-de-carter-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/tuyau-ventilation-de-carter-moteur.raw-evidence.json
@@ -1,0 +1,96 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (0)",
+        "domain.must_be_true < 2 (0)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "MISSING",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_C",
+  "pg_id": 1600,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:75bcbe5831a6a12cf4fe92c4af2c97e275bc00a74b3d4228b96e57297061104a",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/tuyau-ventilation-de-carter-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "tuyau-ventilation-de-carter-moteur"
+}

--- a/audit/content/raw-evidence/valve-de-reglage-du-ralenti.raw-evidence.json
+++ b/audit/content/raw-evidence/valve-de-reglage-du-ralenti.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 1298,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:ef01466f00468e71666a26af2a278738d3d37b19b5e2b4664885d253fe57c05b",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/valve-de-reglage-du-ralenti.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "valve-de-reglage-du-ralenti"
+}

--- a/audit/content/raw-evidence/valve-de-turbo.raw-evidence.json
+++ b/audit/content/raw-evidence/valve-de-turbo.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (72 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 4314,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:4c1ffd1acefd9c22fd18a2c05dcb8ecced214172a764932c3059d71703653290",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/valve-de-turbo.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "valve-de-turbo"
+}

--- a/audit/content/raw-evidence/valve-magnetique.raw-evidence.json
+++ b/audit/content/raw-evidence/valve-magnetique.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (54 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PARTIAL",
+      "warnings": [
+        "selection.cost_range suspect (30-500)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_B",
+  "pg_id": 2073,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b34f2f24c1a8cd318446fea66a8d8e8af505347b424fd8aa7e47c8ffa230dbdc",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/valve-magnetique.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "valve-magnetique"
+}

--- a/audit/content/raw-evidence/vanne-egr.raw-evidence.json
+++ b/audit/content/raw-evidence/vanne-egr.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 1145,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:b98d9a3eca5b32eaf35439813c5284f4bea1a5abb1a1c703027c9f8debb00796",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/vanne-egr.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "vanne-egr"
+}

--- a/audit/content/raw-evidence/vase-d-expansion.raw-evidence.json
+++ b/audit/content/raw-evidence/vase-d-expansion.raw-evidence.json
@@ -1,0 +1,127 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (64 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": [
+        "diagnostic.quick_checks < 2 (1)"
+      ]
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 397,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:f2e213090731bf7cfdd6abe48f9d2390c9d110db4362f0b7bffb0a9c09834b1d",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/vase-d-expansion.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "vase-d-expansion"
+}

--- a/audit/content/raw-evidence/vehicles/citroen-c3.raw-evidence.json
+++ b/audit/content/raw-evidence/vehicles/citroen-c3.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "vehicle",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "vehicle",
+    "sources": [
+      {
+        "content_hash": "sha256:1f22f0f374224b8781d2e957cd3a823cddc2c6251c6f94646b700ccc68a24982",
+        "kind": "vehicle",
+        "path": "recycled/rag-knowledge/vehicles/citroen-c3.md"
+      }
+    ],
+    "truth_level": "L1",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "citroen-c3",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/vehicles/ford-focus-3.raw-evidence.json
+++ b/audit/content/raw-evidence/vehicles/ford-focus-3.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "vehicle",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "vehicle",
+    "sources": [
+      {
+        "content_hash": "sha256:cd91d689971638f7df402b3c2d1b5499837de61e58a0d7f6f729a7ab85754dd8",
+        "kind": "vehicle",
+        "path": "recycled/rag-knowledge/vehicles/ford-focus-3.md"
+      }
+    ],
+    "truth_level": "L1",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ford-focus-3",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/vehicles/peugeot-206.raw-evidence.json
+++ b/audit/content/raw-evidence/vehicles/peugeot-206.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "vehicle",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "vehicle",
+    "sources": [
+      {
+        "content_hash": "sha256:d84af4c80eb95ed0067a0ecda4c8d7c7bce2c39e387f7e0770c883b099a97ace",
+        "kind": "vehicle",
+        "path": "recycled/rag-knowledge/vehicles/peugeot-206.md"
+      }
+    ],
+    "truth_level": "L1",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "peugeot-206",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/vehicles/renault-clio-3.raw-evidence.json
+++ b/audit/content/raw-evidence/vehicles/renault-clio-3.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "vehicle",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "vehicle",
+    "sources": [
+      {
+        "content_hash": "sha256:00ab8c0252808d8e1e385a24e93217fd21de3842b24529908cca5c72eef7cf0b",
+        "kind": "vehicle",
+        "path": "recycled/rag-knowledge/vehicles/renault-clio-3.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "renault-clio-3",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/vehicles/renault-clio-iii.raw-evidence.json
+++ b/audit/content/raw-evidence/vehicles/renault-clio-iii.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "vehicle",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "vehicle",
+    "sources": [
+      {
+        "content_hash": "sha256:af3f051be83365af0437a789bbf0eb65e012a7aaaf067706b93939f2580c82d0",
+        "kind": "vehicle",
+        "path": "recycled/rag-knowledge/vehicles/renault-clio-iii.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "renault-clio-iii",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/vehicles/renault-megane-3.raw-evidence.json
+++ b/audit/content/raw-evidence/vehicles/renault-megane-3.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "vehicle",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "vehicle",
+    "sources": [
+      {
+        "content_hash": "sha256:0367e904ea1c6faf89113afd9da409fb8f720e943a0864a19311b3d0d6cc7154",
+        "kind": "vehicle",
+        "path": "recycled/rag-knowledge/vehicles/renault-megane-3.md"
+      }
+    ],
+    "truth_level": "L1",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "renault-megane-3",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/vehicles/renault.raw-evidence.json
+++ b/audit/content/raw-evidence/vehicles/renault.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "vehicle",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "vehicle",
+    "sources": [
+      {
+        "content_hash": "sha256:45b7c53794d4824b8f5e12cd30bacff5013a8a2ea747a53aaa236a3d15d4f6ce",
+        "kind": "vehicle",
+        "path": "recycled/rag-knowledge/vehicles/renault.md"
+      }
+    ],
+    "truth_level": "L1",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "renault",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/vehicles/volkswagen-golf-6.raw-evidence.json
+++ b/audit/content/raw-evidence/vehicles/volkswagen-golf-6.raw-evidence.json
@@ -1,0 +1,27 @@
+{
+  "coverage": [],
+  "entity_type": "vehicle",
+  "intent_targets": [],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "missing_for_next_tier": [],
+  "next_action": "CONFIGURE_COMPLETENESS_PROFILE",
+  "pg_id": null,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "vehicle",
+    "sources": [
+      {
+        "content_hash": "sha256:fb239ba57765ea1f12ca559fab9489b6c3a725044a64a65d496aa3ccb857f3db",
+        "kind": "vehicle",
+        "path": "recycled/rag-knowledge/vehicles/volkswagen-golf-6.md"
+      }
+    ],
+    "truth_level": "L1",
+    "unlinked_source_types": [],
+    "verification_status": "verified"
+  },
+  "raw_verdict": "NOT_CONFIGURED",
+  "schema_version": "raw-evidence.v1",
+  "subject": "volkswagen-golf-6",
+  "tier": "NOT_CONFIGURED"
+}

--- a/audit/content/raw-evidence/ventilateur-de-refroidissement.raw-evidence.json
+++ b/audit/content/raw-evidence/ventilateur-de-refroidissement.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 508,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2d6ab81a8d4b8826043366059992da01f1aa5225fdbc3da9df2c4d8074d1811e",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/ventilateur-de-refroidissement.yml"
+      },
+      {
+        "content_hash": "sha256:0a6f5a5c42b3691f9a3d8f4c48cfbfcf070c1a10068a4948d476802fdafda3dd",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/ventilateur-de-refroidissement.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "ventilateur-de-refroidissement"
+}

--- a/audit/content/raw-evidence/verin-capot-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/verin-capot-moteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (45 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 514,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:314be35c87f722eb60ab5af46ed25d38bdd159acbb2300a38a0d6d39382ab2b4",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/verin-capot-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "verin-capot-moteur"
+}

--- a/audit/content/raw-evidence/verin-de-coffre.raw-evidence.json
+++ b/audit/content/raw-evidence/verin-de-coffre.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (48 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 5032,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:2b6739abe7f6212587713e97c44c0896cac0aff1a842ea05d0ebcb19f581723d",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/verin-de-coffre.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "verin-de-coffre"
+}

--- a/audit/content/raw-evidence/verin-vitre-arriere.raw-evidence.json
+++ b/audit/content/raw-evidence/verin-vitre-arriere.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (58 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 2454,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:c96a7abba2747fc8ba5d26578e891b5bed0227fe462f8dbf47f2b5edc8f3a0c4",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/verin-vitre-arriere.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "verin-vitre-arriere"
+}

--- a/audit/content/raw-evidence/vis-de-culasse.raw-evidence.json
+++ b/audit/content/raw-evidence/vis-de-culasse.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (68 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 1533,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:70afd9434809093e87d550b5f1ee620f4d24a137e0872f8b319f532aa8ff07c0",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/vis-de-culasse.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "vis-de-culasse"
+}

--- a/audit/content/raw-evidence/vis-de-disque.raw-evidence.json
+++ b/audit/content/raw-evidence/vis-de-disque.raw-evidence.json
@@ -1,0 +1,130 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PARTIAL",
+      "warnings": [
+        "domain.role too short (45 < 80)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "ENRICH_RAW_A",
+  "pg_id": 54,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:89531d4983f24845dee6e46837521417d3021e09ec3b0b661dccf40d1d9e2956",
+        "kind": "evidence",
+        "path": "recycled/rag-knowledge/_raw/evidence/vis-de-disque.yml"
+      },
+      {
+        "content_hash": "sha256:465acbe27910876c8e86197e9955286457681719b7259bcb4879a7748d039575",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/vis-de-disque.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "PARTIAL_READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "vis-de-disque"
+}

--- a/audit/content/raw-evidence/volant-moteur.raw-evidence.json
+++ b/audit/content/raw-evidence/volant-moteur.raw-evidence.json
@@ -1,0 +1,125 @@
+{
+  "coverage": [
+    {
+      "block": "A.domain",
+      "canon_role": "R4",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "reference",
+      "status": "PRESENT",
+      "warnings": [
+        "domain.confusion_with < 2 (1)"
+      ]
+    },
+    {
+      "block": "B.selection",
+      "canon_role": "R6",
+      "fold_status": "PENDING_ADR",
+      "r3_section": "guide-achat",
+      "status": "PRESENT",
+      "warnings": [
+        "selection.checklist < 3 (0)"
+      ]
+    },
+    {
+      "block": "C.diagnostic",
+      "canon_role": "R5",
+      "fold_status": "LIVE",
+      "r3_section": "diagnostic-rapide",
+      "status": "PRESENT",
+      "warnings": []
+    },
+    {
+      "block": "D.maintenance",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "maintenance",
+      "status": "PRESENT",
+      "warnings": [
+        "maintenance.usage_factors required when unit != km"
+      ]
+    },
+    {
+      "block": "E.installation",
+      "canon_role": "R3",
+      "fold_status": "NATIVE",
+      "r3_section": "installation",
+      "status": "PRESENT",
+      "warnings": [
+        "installation.steps < 3 (0)"
+      ]
+    },
+    {
+      "block": "5.0:variants",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:location_on_vehicle",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:purchase_guardrails",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "5.0:conseil_v5",
+      "canon_role": "—",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "NOT_MAPPED",
+      "warnings": []
+    },
+    {
+      "block": "compatibility",
+      "canon_role": "R1/R2",
+      "fold_status": "NOT_FOLDED",
+      "r3_section": null,
+      "status": "BLOCKED_CATALOG_REQUIRED",
+      "warnings": []
+    }
+  ],
+  "fold_note": "R4/R6→R3 = direction owner souhaitée, PENDING_ADR (étend ADR-027) ; pas canon. R5 déjà replié (ADR-027).",
+  "fold_readiness": {
+    "R4_to_R3": "BLOCKED_PENDING_ADR",
+    "R5_to_R3": "READY_ADR_027",
+    "R6_to_R3": "BLOCKED_PENDING_ADR"
+  },
+  "intent_targets": [
+    "diagnostic",
+    "achat",
+    "compatibilite"
+  ],
+  "inventory_status": "DIAGNOSTIC_READY",
+  "next_action": "PROMOTE_RAW_TO_WIKI",
+  "pg_id": 577,
+  "provenance": {
+    "completeness_profile": null,
+    "source_type": "gamme",
+    "sources": [
+      {
+        "content_hash": "sha256:9215708ce528c7a2fe3426f74f4e52d7b33829b6d485e5a81e1843fa79f4e676",
+        "kind": "gamme",
+        "path": "recycled/rag-knowledge/gammes/volant-moteur.md"
+      }
+    ],
+    "truth_level": "L2",
+    "unlinked_source_types": [
+      "guide"
+    ],
+    "verification_status": "draft"
+  },
+  "raw_verdict": "READY",
+  "schema_version": "raw-evidence.v1",
+  "subject": "volant-moteur"
+}

--- a/scripts/wiki-generators/completeness-tiers.ts
+++ b/scripts/wiki-generators/completeness-tiers.ts
@@ -1,0 +1,318 @@
+/**
+ * completeness-tiers.ts — loader + evaluator for the RAW completeness profiles.
+ *
+ * Profiles live in the automecanik-raw repo (PR-A of the « RAW Encyclopédie »
+ * plan, owner 2026-06-12) under `_schemas/completeness/{gamme,vehicle,diagnostic}.yaml`
+ * and follow `_schemas/completeness/completeness-profile.schema.json` :
+ *   - tiers cumulatifs BRONZE → ARGENT → OR (ARGENT suppose BRONZE, OR suppose ARGENT)
+ *   - component `where` : `frontmatter:<dot.path>` ('.'=racine) | `body:h2`
+ *     (titres dans required_fields) | `file:<path>` (`<slug>` interpolé)
+ *   - component `check` : present_non_empty | items_have_required_fields |
+ *     sections_present | min_two_distinct_source_kinds | file_exists |
+ *     covers_db_set | all_resolved
+ *
+ * READ-ONLY + deterministic (fs reads only, no DB, no LLM, no network). Warn-only :
+ * un profil mesure, il ne bloque rien. Fallbacks explicites — JAMAIS de crash,
+ * JAMAIS de skip silencieux :
+ *   - profil absent      → status NOT_CONFIGURED (compté dans le rapport agrégé)
+ *   - profil illisible   → status PROFILE_PARSE_ERROR (raison conservée)
+ *   - check inconnu      → composant fail-closed + warning au chargement
+ *   - covers_db_set      → l'ensemble de référence DB (SELECT only) n'est PAS
+ *     accessible à cet inventaire filesystem-only : évalué depuis l'ensemble
+ *     fiche-local (`motorizations[]` → engine_code, cf. notes du profil vehicle)
+ *     quand présent, sinon dégradé en present_non_empty + warning explicite.
+ *
+ * Section H2 « non-vide » = contenu ≥ 20 caractères utiles (hors espaces),
+ * conformément au contrat PR-B du plan.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import { load as loadYaml } from 'js-yaml';
+
+export const TIERS_ORDER = ['BRONZE', 'ARGENT', 'OR'] as const;
+export type TierName = (typeof TIERS_ORDER)[number];
+
+/** Tier reached by a fiche (NONE = BRONZE not met ; NOT_CONFIGURED = no usable profile). */
+export type TierResult = 'NONE' | TierName | 'NOT_CONFIGURED';
+
+const KNOWN_CHECKS = new Set([
+  'present_non_empty',
+  'items_have_required_fields',
+  'sections_present',
+  'min_two_distinct_source_kinds',
+  'file_exists',
+  'covers_db_set',
+  'all_resolved',
+]);
+
+export interface ProfileComponent {
+  id: string;
+  where: string;
+  check: string;
+  required_fields?: string[];
+}
+
+export interface CompletenessProfile {
+  entity_type: string;
+  tiers: Record<TierName, { components: ProfileComponent[] }>;
+}
+
+export type ProfileLoad =
+  | { status: 'OK'; profile: CompletenessProfile; content_hash: string; warnings: string[] }
+  | { status: 'NOT_CONFIGURED'; reason: string }
+  | { status: 'PROFILE_PARSE_ERROR'; reason: string; content_hash: string | null };
+
+export interface FicheContext {
+  slug: string;
+  /** Parsed YAML frontmatter (null on parse error — frontmatter checks then fail, body checks still run). */
+  fm: unknown;
+  /** Markdown body AFTER the frontmatter block. */
+  body: string;
+  /** Absolute RAW repo root (for file: checks). */
+  rawRoot: string;
+}
+
+export interface TierEvaluation {
+  tier: TierResult;
+  /** Failing component ids of the tier ABOVE the one reached ([] at OR). */
+  missing_for_next_tier: string[];
+}
+
+/**
+ * Load `_schemas/completeness/<entityType>.yaml` from the RAW repo root.
+ * Never throws ; absence and unreadability are explicit statuses.
+ */
+export function loadCompletenessProfile(rawRoot: string, entityType: string): ProfileLoad {
+  const rel = path.join('_schemas', 'completeness', `${entityType}.yaml`);
+  const abs = path.join(rawRoot, rel);
+  if (!fs.existsSync(abs)) {
+    return { status: 'NOT_CONFIGURED', reason: `profile file absent (${rel.split(path.sep).join('/')})` };
+  }
+  const bytes = fs.readFileSync(abs);
+  const content_hash = 'sha256:' + crypto.createHash('sha256').update(bytes).digest('hex');
+
+  let doc: unknown;
+  try {
+    doc = loadYaml(bytes.toString('utf8'));
+  } catch (e) {
+    return { status: 'PROFILE_PARSE_ERROR', reason: 'yaml_parse_error: ' + String((e as Error).message || e), content_hash };
+  }
+  if (!isPlainObject(doc)) {
+    return { status: 'PROFILE_PARSE_ERROR', reason: 'profile is not a YAML mapping', content_hash };
+  }
+
+  const warnings: string[] = [];
+  if (doc.entity_type !== entityType) {
+    warnings.push(`entity_type mismatch: profile says '${String(doc.entity_type)}', expected '${entityType}'`);
+  }
+  const tiersNode = (doc as Record<string, unknown>).tiers;
+  if (!isPlainObject(tiersNode)) {
+    return { status: 'PROFILE_PARSE_ERROR', reason: "missing or invalid 'tiers' mapping", content_hash };
+  }
+
+  const tiers = {} as CompletenessProfile['tiers'];
+  for (const tierName of TIERS_ORDER) {
+    const node = (tiersNode as Record<string, unknown>)[tierName];
+    const componentsRaw = isPlainObject(node) ? (node as Record<string, unknown>).components : undefined;
+    if (!Array.isArray(componentsRaw) || componentsRaw.length === 0) {
+      return { status: 'PROFILE_PARSE_ERROR', reason: `tier ${tierName} missing or has no components`, content_hash };
+    }
+    const components: ProfileComponent[] = [];
+    for (const c of componentsRaw) {
+      if (!isPlainObject(c) || typeof c.id !== 'string' || !c.id || typeof c.where !== 'string' || typeof c.check !== 'string') {
+        return { status: 'PROFILE_PARSE_ERROR', reason: `invalid component in tier ${tierName} (id/where/check required)`, content_hash };
+      }
+      if (!KNOWN_CHECKS.has(c.check)) {
+        warnings.push(`unknown check '${c.check}' on ${tierName}/${c.id} — fail-closed`);
+      }
+      if (c.check === 'covers_db_set') {
+        warnings.push(
+          `covers_db_set on ${tierName}/${c.id}: DB reference set (SELECT only) not available in this ` +
+            `filesystem-only inventory — evaluated from fiche-local motorizations[] when present, else degraded to present_non_empty`,
+        );
+      }
+      if (c.check === 'sections_present' && !Array.isArray(c.required_fields)) {
+        warnings.push(`sections_present on ${tierName}/${c.id} has no required_fields (section titles) — fail-closed`);
+      }
+      components.push({
+        id: c.id,
+        where: c.where,
+        check: c.check,
+        required_fields: Array.isArray(c.required_fields) ? c.required_fields.map(String) : undefined,
+      });
+    }
+    tiers[tierName] = { components };
+  }
+
+  return { status: 'OK', profile: { entity_type: entityType, tiers }, content_hash, warnings };
+}
+
+/**
+ * Evaluate the cumulative tiers of a fiche against a loaded profile.
+ * Tier T is reached iff every component of every tier ≤ T passes.
+ */
+export function evaluateTiers(profile: CompletenessProfile, ctx: FicheContext): TierEvaluation {
+  const failedByTier = {} as Record<TierName, string[]>;
+  for (const tierName of TIERS_ORDER) {
+    failedByTier[tierName] = profile.tiers[tierName].components
+      .filter((c) => !checkComponent(c, ctx))
+      .map((c) => c.id);
+  }
+  let reachedIdx = -1;
+  for (let i = 0; i < TIERS_ORDER.length; i++) {
+    if (failedByTier[TIERS_ORDER[i]].length === 0) reachedIdx = i;
+    else break;
+  }
+  const tier: TierResult = reachedIdx === -1 ? 'NONE' : TIERS_ORDER[reachedIdx];
+  const nextTier = TIERS_ORDER[reachedIdx + 1];
+  return { tier, missing_for_next_tier: nextTier ? failedByTier[nextTier] : [] };
+}
+
+/** Evaluate one profile component. Unknown check / unknown where → fail-closed. */
+export function checkComponent(c: ProfileComponent, ctx: FicheContext): boolean {
+  if (c.check === 'file_exists') {
+    if (!c.where.startsWith('file:')) return false;
+    const rel = c.where.slice('file:'.length).split('<slug>').join(ctx.slug);
+    return fs.existsSync(path.join(ctx.rawRoot, rel));
+  }
+  if (c.check === 'sections_present') {
+    if (c.where !== 'body:h2' || !c.required_fields || c.required_fields.length === 0) return false;
+    const sections = extractH2Sections(ctx.body);
+    return c.required_fields.every((title) => {
+      const content = sections.get(normalizeTitle(title));
+      return content !== undefined && usefulLength(content) >= 20;
+    });
+  }
+
+  if (!c.where.startsWith('frontmatter:')) return false;
+  const node = resolveFmPath(ctx.fm, c.where.slice('frontmatter:'.length));
+
+  switch (c.check) {
+    case 'present_non_empty': {
+      if (c.required_fields && c.required_fields.length > 0) {
+        if (!isPlainObject(node)) return false;
+        return c.required_fields.every((f) => isNonEmpty((node as Record<string, unknown>)[f]));
+      }
+      return isNonEmpty(node);
+    }
+    case 'items_have_required_fields': {
+      if (!Array.isArray(node) || node.length === 0) return false;
+      const required = c.required_fields ?? [];
+      return node.every((item) => isPlainObject(item) && required.every((f) => isNonEmpty((item as Record<string, unknown>)[f])));
+    }
+    case 'min_two_distinct_source_kinds': {
+      if (!Array.isArray(node)) return false;
+      const kinds = new Set(
+        node
+          .map((item) => (isPlainObject(item) ? String((item as Record<string, unknown>).type ?? (item as Record<string, unknown>).kind ?? '') : ''))
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0),
+      );
+      return kinds.size >= 2;
+    }
+    case 'all_resolved': {
+      // « aucune entrée ouverte » : absent / vide = rien d'ouvert → pass ;
+      // toute entrée non explicitement resolved/closed = ouverte → fail.
+      if (node === undefined || node === null) return true;
+      if (!Array.isArray(node)) return false;
+      return node.every(
+        (item) =>
+          isPlainObject(item) &&
+          typeof (item as Record<string, unknown>).status === 'string' &&
+          ['resolved', 'closed'].includes(((item as Record<string, unknown>).status as string).toLowerCase()),
+      );
+    }
+    case 'covers_db_set': {
+      // Filesystem-only : pas de SELECT. Ensemble de référence fiche-local
+      // (motorizations[].engine_code) quand présent ; sinon dégradé non-vide
+      // (warning émis au chargement du profil — jamais silencieux).
+      if (!Array.isArray(node) || node.length === 0) return false;
+      const ref = engineCodes((ctx.fm as Record<string, unknown> | null)?.motorizations);
+      if (ref.length > 0) {
+        const got = new Set(engineCodes(node));
+        return ref.every((code) => got.has(code));
+      }
+      return true;
+    }
+    default:
+      return false; // unknown check — fail-closed (warning emitted at profile load)
+  }
+}
+
+/** Extract H2 sections of a markdown body → Map<normalized title, content until next H1/H2>. */
+export function extractH2Sections(body: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  const lines = body.split('\n');
+  let currentTitle: string | null = null;
+  let buffer: string[] = [];
+  const flush = () => {
+    if (currentTitle !== null && !sections.has(currentTitle)) sections.set(currentTitle, buffer.join('\n'));
+    buffer = [];
+  };
+  for (const line of lines) {
+    const h2 = /^##\s+(.*)$/.exec(line);
+    if (h2) {
+      flush();
+      currentTitle = normalizeTitle(h2[1]);
+      continue;
+    }
+    if (/^#\s/.test(line)) {
+      flush();
+      currentTitle = null;
+      continue;
+    }
+    if (currentTitle !== null) buffer.push(line);
+  }
+  flush();
+  return sections;
+}
+
+/** Normalize an H2 title for matching: straight apostrophes, collapsed spaces, lowercase. */
+export function normalizeTitle(title: string): string {
+  return title.replace(/[’ʼ‘]/g, "'").replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/** Useful character count of a section: everything except whitespace. */
+export function usefulLength(content: string): number {
+  return content.replace(/\s+/g, '').length;
+}
+
+/** Resolve a dot-path inside the frontmatter ('.' = root). */
+function resolveFmPath(fm: unknown, dotPath: string): unknown {
+  if (fm === null || fm === undefined) return undefined;
+  if (dotPath === '.' || dotPath === '') return fm;
+  let node: unknown = fm;
+  for (const key of dotPath.split('.')) {
+    if (!isPlainObject(node)) return undefined;
+    node = (node as Record<string, unknown>)[key];
+  }
+  return node;
+}
+
+/** Non-empty: trimmed string, non-empty array, non-empty object, finite number, boolean. */
+function isNonEmpty(v: unknown): boolean {
+  if (v === null || v === undefined) return false;
+  if (typeof v === 'string') return v.trim().length > 0;
+  if (Array.isArray(v)) return v.length > 0;
+  if (typeof v === 'number') return Number.isFinite(v);
+  if (typeof v === 'boolean') return true;
+  if (isPlainObject(v)) return Object.keys(v).length > 0;
+  return false;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Distinct non-empty engine_code values of an array of items (order preserved). */
+function engineCodes(items: unknown): string[] {
+  if (!Array.isArray(items)) return [];
+  const out: string[] = [];
+  for (const item of items) {
+    if (!isPlainObject(item)) continue;
+    const code = (item as Record<string, unknown>).engine_code;
+    if (typeof code === 'string' && code.trim().length > 0 && !out.includes(code.trim())) out.push(code.trim());
+  }
+  return out;
+}

--- a/scripts/wiki-generators/raw-evidence-inventory.ts
+++ b/scripts/wiki-generators/raw-evidence-inventory.ts
@@ -15,9 +15,17 @@
  * Pattern: build-command-center-snapshot.js (deterministic builder) + diag-canon
  * Zod→JSON projection. seo-readiness.ts borrowed only for verdict/NEXT_ACTION shape.
  *
+ * 3-types extension (plan « RAW Encyclopédie » PR-B, owner 2026-06-12) : `--all-types`
+ * evaluates gamme + vehicle + diagnostic fiches against the completeness profiles
+ * (`${RAW_ROOT}/_schemas/completeness/*.yaml`, PR-A) → tier NONE/BRONZE/ARGENT/OR per
+ * fiche + aggregate `audit/content/raw-evidence/encyclopedia-coverage.json`. Profile
+ * absent → NOT_CONFIGURED (counted, never a crash/silent skip). Legacy gamme modes and
+ * artefact bytes are untouched.
+ *
  * Usage:
  *   npx tsx scripts/wiki-generators/raw-evidence-inventory.ts <subject> [--json]
  *   npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --all
+ *   npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --all-types     # 3 types (gamme+vehicle+diagnostic) + encyclopedia-coverage.json
  *   npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --emit-schema   # regenerate JSON Schema projection
  *   npx tsx scripts/wiki-generators/raw-evidence-inventory.ts --check         # fail if committed schema drifted
  */
@@ -29,7 +37,13 @@ import { createRequire } from 'node:module';
 import { load as loadYaml } from 'js-yaml';
 import { zodToJsonSchema as _zodToJsonSchema } from 'zod-to-json-schema';
 
-import { RawEvidenceSchema, type RawEvidence } from './raw-evidence.schema';
+import {
+  RawEvidenceSchema,
+  EncyclopediaCoverageSchema,
+  TIER,
+  type RawEvidence,
+  type EncyclopediaCoverage,
+} from './raw-evidence.schema';
 import {
   BLOCK_DEFS,
   SUPERSET_BLOCKS_5_0,
@@ -38,6 +52,12 @@ import {
   pickNextAction,
   type BlockStatus,
 } from './raw-block-schema';
+import {
+  loadCompletenessProfile,
+  evaluateTiers,
+  type ProfileLoad,
+  type TierResult,
+} from './completeness-tiers';
 
 const require = createRequire(import.meta.url);
 // Reuse the shared deterministic writer (sortKeysDeep + 2-space + trailing \n + sha256).
@@ -53,8 +73,26 @@ const KB = path.join(RAW_ROOT, 'recycled', 'rag-knowledge');
 const GAMMES_DIR = path.join(KB, 'gammes');
 const GUIDES_DIR = path.join(KB, 'guides');
 const EVIDENCE_DIR = path.join(KB, '_raw', 'evidence');
+const VEHICLES_DIR = path.join(KB, 'vehicles');
+const DIAGNOSTIC_DIR = path.join(KB, 'diagnostic');
 const OUT_DIR = path.join(MONOREPO_ROOT, 'audit', 'content', 'raw-evidence');
+const COVERAGE_PATH = path.join(OUT_DIR, 'encyclopedia-coverage.json');
 const SCHEMA_PATH = path.join(__dirname, 'raw-evidence.schema.json');
+
+// 3 tiered entity types (plan « RAW Encyclopédie » PR-B). Gamme per-fiche artefacts keep
+// their legacy location + byte-identical format ; vehicle/diagnostic artefacts live in
+// sub-directories (slug collisions exist, e.g. disque-de-frein in gammes/ AND diagnostic/).
+const TIERED_ENTITY_TYPES = ['gamme', 'vehicle', 'diagnostic'] as const;
+type TieredEntityType = (typeof TIERED_ENTITY_TYPES)[number];
+const ENTITY_SRC_DIR: Record<TieredEntityType, string> = {
+  gamme: GAMMES_DIR,
+  vehicle: VEHICLES_DIR,
+  diagnostic: DIAGNOSTIC_DIR,
+};
+const ENTITY_OUT_DIR: Record<'vehicle' | 'diagnostic', string> = {
+  vehicle: path.join(OUT_DIR, 'vehicles'),
+  diagnostic: path.join(OUT_DIR, 'diagnostic'),
+};
 
 const FOLD_READINESS = {
   R4_to_R3: 'BLOCKED_PENDING_ADR',
@@ -220,6 +258,202 @@ export function buildEvidence(subject: string): RawEvidence {
   });
 }
 
+// ————————————————————————————————————————————————————————————————————————————
+// 3-types extension — completeness tiers (plan « RAW Encyclopédie » PR-B).
+// Profiles (PR-A) live in `${RAW_ROOT}/_schemas/completeness/{gamme,vehicle,diagnostic}.yaml`.
+// Profile absent → tier NOT_CONFIGURED (never a crash, never a silent skip — counted
+// in the aggregate report). Legacy gamme modes/artefacts are untouched (byte-identical).
+// ————————————————————————————————————————————————————————————————————————————
+
+/** Markdown body AFTER the `---`-delimited frontmatter block ('' if unterminated). */
+function splitBody(raw: string): string {
+  if (!raw.startsWith('---')) return raw;
+  const end = raw.indexOf('\n---', 3);
+  if (end === -1) return '';
+  const eol = raw.indexOf('\n', end + 4);
+  return eol === -1 ? '' : raw.slice(eol + 1);
+}
+
+interface TieredFiche {
+  subject: string;
+  family: string | null; // gamme frontmatter `category` ; null otherwise
+  tier: TierResult;
+  missing_for_next_tier: string[];
+  parse_error: boolean;
+  fm: any | null;
+  parse_error_msg: string | null;
+}
+
+/** Parse + tier-evaluate one fiche (any entity type). Read-only ; never throws. */
+function evaluateFiche(entityType: TieredEntityType, subject: string, profileLoad: ProfileLoad): TieredFiche {
+  const srcPath = path.join(ENTITY_SRC_DIR[entityType], `${subject}.md`);
+  const raw = fs.readFileSync(srcPath, 'utf8');
+  const { fm, error } = parseFrontmatter(raw);
+  const body = splitBody(raw);
+  const tierEval =
+    profileLoad.status === 'OK'
+      ? evaluateTiers(profileLoad.profile, { slug: subject, fm, body, rawRoot: RAW_ROOT })
+      : { tier: 'NOT_CONFIGURED' as TierResult, missing_for_next_tier: [] as string[] };
+  const family =
+    entityType === 'gamme' && typeof fm?.category === 'string' && fm.category.trim().length > 0
+      ? fm.category.trim()
+      : null;
+  return {
+    subject,
+    family,
+    tier: tierEval.tier,
+    missing_for_next_tier: tierEval.missing_for_next_tier,
+    parse_error: !!error || !fm,
+    fm,
+    parse_error_msg: error ?? (fm ? null : 'empty_frontmatter'),
+  };
+}
+
+function tierVerdict(fiche: TieredFiche): RawEvidence['raw_verdict'] {
+  if (fiche.parse_error) return 'RAW_PARSE_ERROR';
+  if (fiche.tier === 'NOT_CONFIGURED') return 'NOT_CONFIGURED';
+  // ARGENT+ = éligible WIKI candidate (porte ADR-083 ensuite) — BRONZE ≠ publication.
+  return fiche.tier === 'ARGENT' || fiche.tier === 'OR' ? 'READY' : 'PARTIAL_READY';
+}
+
+function tierNextAction(fiche: TieredFiche): string {
+  if (fiche.parse_error) return `FIX_RAW_FRONTMATTER (${fiche.parse_error_msg})`;
+  switch (fiche.tier) {
+    case 'NOT_CONFIGURED':
+      return 'CONFIGURE_COMPLETENESS_PROFILE';
+    case 'NONE':
+      return 'ENRICH_RAW_TO_BRONZE';
+    case 'BRONZE':
+      return 'ENRICH_RAW_TO_ARGENT';
+    default:
+      return 'PROMOTE_RAW_TO_WIKI'; // ARGENT/OR — owner-gated (porte ADR-083)
+  }
+}
+
+/** Build the deterministic per-fiche artefact for a vehicle/diagnostic subject. */
+export function buildEntityEvidence(
+  entityType: 'vehicle' | 'diagnostic',
+  subject: string,
+  profileLoad: ProfileLoad,
+): RawEvidence {
+  const srcPath = path.join(ENTITY_SRC_DIR[entityType], `${subject}.md`);
+  const fiche = evaluateFiche(entityType, subject, profileLoad);
+  return RawEvidenceSchema.parse({
+    schema_version: 'raw-evidence.v1' as const,
+    subject,
+    entity_type: entityType,
+    pg_id: null,
+    inventory_status: fiche.parse_error ? 'RAW_PARSE_ERROR' : 'DIAGNOSTIC_READY',
+    intent_targets: [],
+    provenance: {
+      source_type: fiche.fm?.source_type ?? null,
+      truth_level: fiche.fm?.truth_level ?? null,
+      verification_status: fiche.fm?.verification_status ?? null,
+      completeness_profile: fiche.fm?.completeness_profile ?? null,
+      sources: [{ path: relToRaw(srcPath), kind: entityType, content_hash: sha256File(srcPath) }],
+      unlinked_source_types: [],
+    },
+    coverage: [], // v4 A–E blocks are gamme-specific — tier evaluation carries the signal here
+    tier: fiche.tier,
+    missing_for_next_tier: fiche.missing_for_next_tier,
+    raw_verdict: tierVerdict(fiche),
+    next_action: tierNextAction(fiche),
+  });
+}
+
+function emptyTierCounts(): Record<(typeof TIER)[number], number> {
+  return { NONE: 0, BRONZE: 0, ARGENT: 0, OR: 0, NOT_CONFIGURED: 0 };
+}
+
+function profileState(entityType: TieredEntityType, load: ProfileLoad): EncyclopediaCoverage['profiles']['gamme'] {
+  return {
+    path: `_schemas/completeness/${entityType}.yaml`,
+    status: load.status,
+    content_hash: load.status === 'NOT_CONFIGURED' ? null : load.content_hash,
+    reason: load.status === 'OK' ? null : load.reason,
+    warnings: load.status === 'OK' ? load.warnings : [],
+  };
+}
+
+/** Run the 3-types inventory : per-fiche artefacts (vehicle/diagnostic) + legacy gamme artefacts + aggregate. */
+function runAllTypes(): void {
+  const loads = {
+    gamme: loadCompletenessProfile(RAW_ROOT, 'gamme'),
+    vehicle: loadCompletenessProfile(RAW_ROOT, 'vehicle'),
+    diagnostic: loadCompletenessProfile(RAW_ROOT, 'diagnostic'),
+  } as const;
+
+  const byType = {} as EncyclopediaCoverage['by_type'];
+  const byFamily: EncyclopediaCoverage['by_family'] = {};
+  const fiches: EncyclopediaCoverage['fiches'] = [];
+
+  for (const entityType of TIERED_ENTITY_TYPES) {
+    const subjects = listSubjectsIn(ENTITY_SRC_DIR[entityType]);
+    const tiers = emptyTierCounts();
+    let parseErrors = 0;
+
+    for (const subject of subjects) {
+      const fiche = evaluateFiche(entityType, subject, loads[entityType]);
+      tiers[fiche.tier] += 1;
+      if (fiche.parse_error) parseErrors += 1;
+      fiches.push({
+        entity_type: entityType,
+        subject,
+        family: fiche.family,
+        tier: fiche.tier,
+        missing_for_next_tier: fiche.missing_for_next_tier,
+      });
+      if (entityType === 'gamme') {
+        const familyKey = fiche.family ?? '__uncategorized__';
+        byFamily[familyKey] ??= { total: 0, tiers: emptyTierCounts() };
+        byFamily[familyKey].total += 1;
+        byFamily[familyKey].tiers[fiche.tier] += 1;
+        // Legacy per-fiche artefact — byte-identical to the historic gamme format (`--all`).
+        writeArtefact(buildEvidence(subject));
+      } else {
+        const ev = buildEntityEvidence(entityType, subject, loads[entityType]);
+        writeDeterministicJson(path.join(ENTITY_OUT_DIR[entityType], `${subject}.raw-evidence.json`), ev);
+      }
+    }
+
+    byType[entityType] = { total: subjects.length, parse_errors: parseErrors, tiers };
+    const profileNote = loads[entityType].status === 'OK' ? 'profile OK' : `profile ${loads[entityType].status}`;
+    process.stdout.write(
+      `${entityType}: ${subjects.length} fiches · ${profileNote} · ` +
+        `NONE=${tiers.NONE} BRONZE=${tiers.BRONZE} ARGENT=${tiers.ARGENT} OR=${tiers.OR} NOT_CONFIGURED=${tiers.NOT_CONFIGURED}` +
+        (parseErrors ? ` · parse_errors=${parseErrors}` : '') +
+        '\n',
+    );
+  }
+
+  fiches.sort((a, b) =>
+    a.entity_type < b.entity_type ? -1 : a.entity_type > b.entity_type ? 1 : a.subject < b.subject ? -1 : a.subject > b.subject ? 1 : 0,
+  );
+
+  const coverage = EncyclopediaCoverageSchema.parse({
+    schema_version: 'encyclopedia-coverage.v1' as const,
+    profiles: {
+      gamme: profileState('gamme', loads.gamme),
+      vehicle: profileState('vehicle', loads.vehicle),
+      diagnostic: profileState('diagnostic', loads.diagnostic),
+    },
+    by_type: byType,
+    by_family: byFamily,
+    fiches,
+  });
+  const sha = writeDeterministicJson(COVERAGE_PATH, coverage);
+  process.stdout.write(`\nencyclopedia-coverage: ${path.relative(MONOREPO_ROOT, COVERAGE_PATH)} (sha256:${sha})\n`);
+}
+
+function listSubjectsIn(dir: string): string[] {
+  if (!fs.existsSync(dir)) return []; // honest empty set — counted as total: 0 in the aggregate
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.md')) // excludes *.manifest.yaml / *.html
+    .map((f) => f.slice(0, -3))
+    .sort();
+}
+
 function buildSchemaJson(): object {
   return zodToJsonSchema(RawEvidenceSchema, { target: 'jsonSchema7', $refStrategy: 'none' });
 }
@@ -229,11 +463,7 @@ function serialize(obj: unknown): string {
 }
 
 function listSubjects(): string[] {
-  return fs
-    .readdirSync(GAMMES_DIR)
-    .filter((f) => f.endsWith('.md')) // excludes *.manifest.yaml / *.html
-    .map((f) => f.slice(0, -3))
-    .sort();
+  return listSubjectsIn(GAMMES_DIR);
 }
 
 function writeArtefact(ev: RawEvidence): string {
@@ -272,9 +502,14 @@ function main(): void {
     return;
   }
 
+  if (args.includes('--all-types')) {
+    runAllTypes();
+    return;
+  }
+
   const subject = args.find((a) => !a.startsWith('--'));
   if (!subject) {
-    process.stderr.write('Usage: raw-evidence-inventory.ts <subject> [--json] | --all | --emit-schema | --check\n');
+    process.stderr.write('Usage: raw-evidence-inventory.ts <subject> [--json] | --all | --all-types | --emit-schema | --check\n');
     process.exit(2);
   }
 

--- a/scripts/wiki-generators/raw-evidence.schema.json
+++ b/scripts/wiki-generators/raw-evidence.schema.json
@@ -58,6 +58,14 @@
       },
       "type": "array"
     },
+    "entity_type": {
+      "enum": [
+        "gamme",
+        "vehicle",
+        "diagnostic"
+      ],
+      "type": "string"
+    },
     "fold_note": {
       "type": "string"
     },
@@ -107,6 +115,12 @@
       ],
       "type": "string"
     },
+    "missing_for_next_tier": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "next_action": {
       "minLength": 1,
       "type": "string"
@@ -148,7 +162,9 @@
                 "enum": [
                   "gamme",
                   "guide",
-                  "evidence"
+                  "evidence",
+                  "vehicle",
+                  "diagnostic"
                 ],
                 "type": "string"
               },
@@ -201,7 +217,8 @@
         "PARTIAL_READY",
         "BLOCKED",
         "NO_RAW",
-        "RAW_PARSE_ERROR"
+        "RAW_PARSE_ERROR",
+        "NOT_CONFIGURED"
       ],
       "type": "string"
     },
@@ -211,6 +228,16 @@
     },
     "subject": {
       "minLength": 1,
+      "type": "string"
+    },
+    "tier": {
+      "enum": [
+        "NONE",
+        "BRONZE",
+        "ARGENT",
+        "OR",
+        "NOT_CONFIGURED"
+      ],
       "type": "string"
     }
   },
@@ -222,10 +249,8 @@
     "intent_targets",
     "provenance",
     "coverage",
-    "fold_readiness",
     "raw_verdict",
-    "next_action",
-    "fold_note"
+    "next_action"
   ],
   "type": "object"
 }

--- a/scripts/wiki-generators/raw-evidence.schema.ts
+++ b/scripts/wiki-generators/raw-evidence.schema.ts
@@ -29,12 +29,22 @@ export const FOLD_READINESS = ['BLOCKED_PENDING_ADR', 'READY_ADR_027'] as const;
 
 export const INVENTORY_STATUS = ['DIAGNOSTIC_READY', 'NO_RAW', 'RAW_PARSE_ERROR'] as const;
 
-export const RAW_VERDICT = ['READY', 'PARTIAL_READY', 'BLOCKED', 'NO_RAW', 'RAW_PARSE_ERROR'] as const;
+/** NOT_CONFIGURED = no usable completeness profile for the entity type (additive, plan « RAW Encyclopédie » PR-B). */
+export const RAW_VERDICT = ['READY', 'PARTIAL_READY', 'BLOCKED', 'NO_RAW', 'RAW_PARSE_ERROR', 'NOT_CONFIGURED'] as const;
+
+/** Tiered entity types of the RAW encyclopedia (recycled/rag-knowledge/{gammes,vehicles,diagnostic}/). */
+export const ENTITY_TYPE = ['gamme', 'vehicle', 'diagnostic'] as const;
+
+/** Completeness tier reached (profiles `_schemas/completeness/*.yaml`, cumulative BRONZE → ARGENT → OR). */
+export const TIER = ['NONE', 'BRONZE', 'ARGENT', 'OR', 'NOT_CONFIGURED'] as const;
+
+/** Status of a completeness profile load (absent profile is explicit, never a silent skip). */
+export const PROFILE_STATUS = ['OK', 'NOT_CONFIGURED', 'PROFILE_PARSE_ERROR'] as const;
 
 const SourceSchema = z
   .object({
     path: z.string().min(1), // relative to the automecanik-raw repo root
-    kind: z.enum(['gamme', 'guide', 'evidence']),
+    kind: z.enum(['gamme', 'guide', 'evidence', 'vehicle', 'diagnostic']),
     content_hash: z.string().regex(/^sha256:[0-9a-f]{64}$/),
   })
   .strict();
@@ -68,17 +78,86 @@ export const RawEvidenceSchema = z
       })
       .strict(),
     coverage: z.array(CoverageEntrySchema),
+    // Gamme-only fold annotations — optional since the 3-types extension (omitted on
+    // vehicle/diagnostic artefacts ; still always emitted for gammes — additive change).
     fold_readiness: z
       .object({
         R4_to_R3: z.enum(FOLD_READINESS),
         R5_to_R3: z.enum(FOLD_READINESS),
         R6_to_R3: z.enum(FOLD_READINESS),
       })
-      .strict(),
+      .strict()
+      .optional(),
     raw_verdict: z.enum(RAW_VERDICT),
     next_action: z.string().min(1),
-    fold_note: z.string(),
+    fold_note: z.string().optional(),
+    // ——— 3-types extension (plan « RAW Encyclopédie » PR-B) — ADDITIVE, optional ———
+    // Absent on legacy gamme artefacts (byte-identical output preserved) ; populated on
+    // vehicle/diagnostic artefacts. Tier evaluation = completeness profiles (PR-A).
+    entity_type: z.enum(ENTITY_TYPE).optional(),
+    tier: z.enum(TIER).optional(),
+    missing_for_next_tier: z.array(z.string()).optional(),
   })
   .strict();
 
 export type RawEvidence = z.infer<typeof RawEvidenceSchema>;
+
+// ————————————————————————————————————————————————————————————————————————————
+// Aggregate encyclopedia coverage report (audit/content/raw-evidence/encyclopedia-coverage.json).
+// Deterministic projection over the 3 tiered entity types — counts per type × tier,
+// per famille (gammes only), plus the per-fiche tier rows. No timestamp, no absolute path.
+// ————————————————————————————————————————————————————————————————————————————
+
+const TierCountsSchema = z
+  .object({
+    NONE: z.number().int().nonnegative(),
+    BRONZE: z.number().int().nonnegative(),
+    ARGENT: z.number().int().nonnegative(),
+    OR: z.number().int().nonnegative(),
+    NOT_CONFIGURED: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const ProfileStateSchema = z
+  .object({
+    path: z.string().min(1), // relative to the automecanik-raw repo root
+    status: z.enum(PROFILE_STATUS),
+    content_hash: z.string().regex(/^sha256:[0-9a-f]{64}$/).nullable(),
+    reason: z.string().nullable(), // why NOT_CONFIGURED / PROFILE_PARSE_ERROR (never silent)
+    warnings: z.array(z.string()), // load-time degradations (unknown check, covers_db_set sans DB…)
+  })
+  .strict();
+
+const TypeCoverageSchema = z
+  .object({
+    total: z.number().int().nonnegative(),
+    parse_errors: z.number().int().nonnegative(), // fiches whose frontmatter failed to parse (still tier-evaluated body-only)
+    tiers: TierCountsSchema,
+  })
+  .strict();
+
+export const EncyclopediaCoverageSchema = z
+  .object({
+    schema_version: z.literal('encyclopedia-coverage.v1'),
+    profiles: z
+      .object({ gamme: ProfileStateSchema, vehicle: ProfileStateSchema, diagnostic: ProfileStateSchema })
+      .strict(),
+    by_type: z
+      .object({ gamme: TypeCoverageSchema, vehicle: TypeCoverageSchema, diagnostic: TypeCoverageSchema })
+      .strict(),
+    by_family: z.record(z.string(), z.object({ total: z.number().int().nonnegative(), tiers: TierCountsSchema }).strict()),
+    fiches: z.array(
+      z
+        .object({
+          entity_type: z.enum(ENTITY_TYPE),
+          subject: z.string().min(1),
+          family: z.string().nullable(), // gamme frontmatter `category` ; null for vehicle/diagnostic
+          tier: z.enum(TIER),
+          missing_for_next_tier: z.array(z.string()),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+export type EncyclopediaCoverage = z.infer<typeof EncyclopediaCoverageSchema>;


### PR DESCRIPTION
## Contexte
PR-B du plan RAW Encyclopédie. Étend le contrat de richesse existant `raw-evidence-inventory.ts` (gammes-only) aux types **vehicle** et **diagnostic**, et produit le rapport agrégé `encyclopedia-coverage.json` = **baseline AVANT enrichissement**.

## Approche (extension, pas réécriture)
- Pattern existant préservé : déterministe (sha256, 2 runs identiques vérifiés), idempotent, read-only sur `AUTOMECANIK_RAW_PATH`, écrit uniquement `audit/content/raw-evidence/`.
- Lit les profils `_schemas/completeness/{gamme,vehicle,diagnostic}.yaml` (PR-A raw#23) ; **fallback `NOT_CONFIGURED`** si absent — jamais de crash ni silent skip (compté dans le rapport).
- Mode gamme existant **intact** (rétro-compat).

## Baseline mesurée (profils PR-A pas encore mergés → NOT_CONFIGURED attendu)
| Type | Fiches |
|---|---|
| gammes | 241 |
| vehicles | 8 |
| diagnostic | 17 |

Re-run après merge de raw#23 produira la vraie baseline BRONZE/ARGENT/OR — c'est le `PR-B rerun` du plan.

## Vérification
- Déterminisme : 2 runs → sha256 identique du coverage. ✓
- Rétro-compat : `filtre-a-air.raw-evidence.json` conserve le schéma gamme existant + champs additifs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)