### PR TITLE
fix(supplier): routine v2.2 — classify converge (REVIEW_PORTAL_TIMEOUT) + étape 8 quarantine R2-bruit

### DIFF
--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -19,7 +19,11 @@ depends_on:
 
 ## Rôle
 <!-- À compléter à la main : 1–3 phrases sur ce que fait ce module, pourquoi il existe. -->
-_Section à rédiger._
+`backend/src/modules/suppliers/` = **données maîtres fournisseur** (roster
+`___xtr_supplier`, liens marque `___xtr_supplier_link_pm`, stats) via `SuppliersService` —
+référentiel pur, **n'écrit aucune dispo/prix**. Le **domaine fournisseur** complet est plus
+large que ce module : voir la carte des 3 surfaces ci-dessous (§Pourquoi) — chacune a un
+métier distinct et partage les mêmes couches, **ne jamais en réinventer une**.
 
 <!-- AUTO-GENERATED (refresh-knowledge.py — ne pas éditer sous cette ligne) -->
 
@@ -42,12 +46,52 @@ _Section à rédiger._
 
 ## Pourquoi
 <!-- À compléter à la main : contraintes architecturales, décisions historiques, trade-offs. -->
-_Section à rédiger._
+
+### Carte du domaine fournisseur — 3 surfaces distinctes, couches partagées `[anti-redondance]`
+
+Vérifié à fond 2026-06-13 (audit read-only). **Trois** surfaces fournisseur coexistent,
+**métiers orthogonaux** — ce ne sont **pas** des doublons, et chaque session doit étendre
+celle qui correspond, **jamais en créer une parallèle** :
+
+| Surface | Fichier | Métier | Sortie | Cadence | Plateformes |
+|---|---|---|---|---|---|
+| **classify** | `backend/src/workers/supplier-availability-classify.ts` | full-feed pré-activation : quels refs peuvent devenir vendables | JSONL/CSV + **buckets d'activation** (CONFIRMED/BLOCK/REVIEW), read-only | on-demand (ops CLI) | **inoshop only** (route bulk `POST /search`) |
+| **supplier-sync** | `backend/src/modules/supplier-truth/supplier-sync.runner.ts` (+ scheduler/processor, `worker.module.ts`) | **observatoire** continu prix+dispo | écrit `supplier_offer_snapshot` (observations brutes + `parse_confidence`) | cron 4h, **DORMANT par défaut** (flag `SUPPLIER_TRUTH_SYNC_ENABLED`) | **DCA + CAL** (générique registry) |
+| **supplier-price-verify** | `backend/src/workers/supplier-price-verify.ts` | spot-check prix N-échantillon risque-pondéré avant import | verdict CONFIRMED/FIX_FEED/REVIEW/BLOCK | on-demand (ops CLI) | **inoshop + CAL** |
+
+**Couches PARTAGÉES (réutilisées par les 3, jamais dupliquées)** :
+- **Connecteurs** = couche portail unique : `connectors/supplier-registry.ts`
+  (générique par `spl_id`/platform/creds) + `inoshop.connector.ts` + `cal.connector.ts`
+  (login, token, jitter anti-ban, `fetchSearchRaw` bulk / `fetchAvailability` per-ref, close).
+- **Classification** : `connectors/inoshop-search-parse.ts` (`verdictForRef`/`ActivationBucket`) — pure, unique.
+- **Résilience** : `connectors/portal-classify-resilience.ts` (#960) — module **pur testé**
+  (bisection + budget par-ref + circuit-breaker + dead-letter `REVIEW_PORTAL_TIMEOUT`).
+  Réutilisable par classify **et** un futur supplier-sync.
+
+### Pourquoi classify ≠ DCA-only
+Générique via `SUPPLIER_SPL`+`BRAND_TOKENS`+registry. La limite `cfg.platform === 'inoshop'`
+est une **contrainte portail** (seul inoshop expose le bulk `/search`), **pas un hardcode** ;
+la dispo CAL passe par supplier-sync (per-ref) / supplier-price-verify.
 
 ## Gotchas
 <!-- À compléter à la main : pièges connus, bugs célèbres, invariants non évidents. -->
-_Section à rédiger._
+- **Ne pas confondre / dupliquer les 3 surfaces** (§Pourquoi). Avant d'ajouter une logique
+  dispo/prix/résilience fournisseur : étendre la surface + la couche partagée existante.
+- **`supplier_offer_snapshot` ≠ buckets d'activation.** L'observatoire stocke des
+  observations brutes (`parse_confidence` HIGH/AMBIGUOUS/…), **pas** CONFIRMED/BLOCK/REVIEW.
+  Le mapping refs→`pri_dispo` est le métier de classify, pas de supplier-sync.
+- **supplier-sync est DORMANT** (flag off, one-shot owner-gated `SUPPLIER_SYNC_ONESHOT_CONFIRM`).
+  Ne pas l'activer ni y câbler la résilience sans GO owner — c'est du code inactif.
+- **Pipeline supplier-sync WRITE câblé dans `worker.module.ts`** (Bull `forRoot`), jamais
+  re-provider ailleurs (sinon 2ᵉ `@Processor('supplier-sync')` = double-conso).
+- **Résilience = 1 seul module** (`portal-classify-resilience.ts`). Ne pas recréer un breaker
+  parallèle ; les breakers `CircuitBreakerService` (ai-content) / `RagCircuitBreakerService`
+  sont des **gates par-provider** d'un autre domaine — forme différente, ne pas coupler.
 
 ## Références
 <!-- À compléter à la main : liens vers `.claude/rules/`, vault ADRs, MEMORY.md entries. -->
-_Section à rédiger._
+- Runbook ops : [`.claude/knowledge/ops/supplier-brand-price-load-procedure.md`](../ops/supplier-brand-price-load-procedure.md) (séquence figée 8 gates).
+- Skill : [`supplier-price-load`](../../skills/supplier-price-load/SKILL.md).
+- PRs : #908 (consolidation classify) · #926 (méthode figée) · #960 (résilience module).
+- MEMORY : `project_supplier_verify_consolidation_20260608`,
+  `reference_supplier_pricing_via_governed_module`, `feedback_one_frozen_method_no_improvised_variants`.

--- a/.claude/knowledge/ops/supplier-brand-price-load-procedure.md
+++ b/.claude/knowledge/ops/supplier-brand-price-load-procedure.md
@@ -161,15 +161,17 @@ read-only, ne touchent **jamais** `pieces_price` :
   Invariant **no false in-stock** : CONFIRMED seulement si dispo-type **ET** icône verte
   concordent. `SUPPLIER_SPL=71 BRAND_TOKENS=NK,SBS FEED_PATH=… OUT_DIR=… npx tsx …`
   **Convergence `[CRITICAL]` (owner 2026-06-11)** : un portail lent peut 504 en boucle
-  sur certaines réfs (réfs numériques courtes = recherche lourde). Si un batch échoue
-  **alors que le portail vient de répondre** (≥1 succès récent), le worker l'**isole
-  ref-par-ref** : un ref qui échoue **seul** = problème portail/ref non pertinente →
-  bucket terminal **`REVIEW_PORTAL_TIMEOUT`** (checkpointé, plus jamais re-tenté, surfacé
-  en review). Une passe d'isolation **0 succès** = vraie panne portail → STOP **resumable
-  sans faux terminal** (les refs bufferisées retournent au retry). Garantit que le run
-  **CONVERGE** (9 647/9 647) au lieu de boucler. Réduire `BATCH` (ex. `BATCH=10`) allège
-  la recherche sur les plages lourdes. Re-checker les `REVIEW_PORTAL_TIMEOUT` plus tard =
-  les retirer du checkpoint et relancer.
+  sur certaines réfs (numériques courtes = recherche lourde). Le worker délègue la
+  résilience à un **module pur testé** (`portal-classify-resilience.ts`) qui applique le
+  pattern canonique : **bisection** d'un batch en échec (isole le ref fautif en ~log₂(n)
+  appels au lieu de n), **budget de tentatives par-ref** persistant (`attempts.json`,
+  cumulé inter-resume) → au-delà de `MAX_REF_ATTEMPTS` (déf. 3) le ref est **dead-letté**
+  bucket terminal **`REVIEW_PORTAL_TIMEOUT`** (le run **CONVERGE** au lieu de boucler), et
+  un **circuit-breaker** à fenêtre glissante (`BREAKER_WINDOW`, déf. 8) qui **OPEN** sur
+  échec soutenu → STOP **resumable, zéro faux terminal** (un retry d'un ref déjà
+  connu-mauvais n'alimente PAS le breaker, sinon la queue de réfs fautives ouvrirait
+  faussement le circuit). Réduire `BATCH` (ex. `BATCH=10`) allège les plages lourdes.
+  Re-checker les `REVIEW_PORTAL_TIMEOUT` = retirer leurs réfs du checkpoint + `attempts.json` et relancer.
 - **`supplier-price-verify.ts`** *(spot-check prix rapide)* — compare `achat fichier`
   vs `achat portail` sur un **échantillon** risque-pondéré (gros montants). Verdict
   **CONFIRMED / FIX_FEED / REVIEW / BLOCK**. ⚠️ recherche réf **floue** → re-vérifier

--- a/.claude/knowledge/ops/supplier-brand-price-load-procedure.md
+++ b/.claude/knowledge/ops/supplier-brand-price-load-procedure.md
@@ -160,6 +160,16 @@ read-only, ne touchent **jamais** `pieces_price` :
   **reprenable** ; un batch en échec n'est jamais checkpointé (pas de faux NOT_FOUND).
   Invariant **no false in-stock** : CONFIRMED seulement si dispo-type **ET** icône verte
   concordent. `SUPPLIER_SPL=71 BRAND_TOKENS=NK,SBS FEED_PATH=… OUT_DIR=… npx tsx …`
+  **Convergence `[CRITICAL]` (owner 2026-06-11)** : un portail lent peut 504 en boucle
+  sur certaines réfs (réfs numériques courtes = recherche lourde). Si un batch échoue
+  **alors que le portail vient de répondre** (≥1 succès récent), le worker l'**isole
+  ref-par-ref** : un ref qui échoue **seul** = problème portail/ref non pertinente →
+  bucket terminal **`REVIEW_PORTAL_TIMEOUT`** (checkpointé, plus jamais re-tenté, surfacé
+  en review). Une passe d'isolation **0 succès** = vraie panne portail → STOP **resumable
+  sans faux terminal** (les refs bufferisées retournent au retry). Garantit que le run
+  **CONVERGE** (9 647/9 647) au lieu de boucler. Réduire `BATCH` (ex. `BATCH=10`) allège
+  la recherche sur les plages lourdes. Re-checker les `REVIEW_PORTAL_TIMEOUT` plus tard =
+  les retirer du checkpoint et relancer.
 - **`supplier-price-verify.ts`** *(spot-check prix rapide)* — compare `achat fichier`
   vs `achat portail` sur un **échantillon** risque-pondéré (gros montants). Verdict
   **CONFIRMED / FIX_FEED / REVIEW / BLOCK**. ⚠️ recherche réf **floue** → re-vérifier
@@ -271,7 +281,8 @@ prix vendable reste sur le grid mais à prix 0 → le gate `can_sell` l'affiche
 | 4 | Dry-run import | `POST import/dry-run` (fileRows = `confirmed.csv` : `ref,ean,achat_ht=portalPrix`) | **GO owner** | 0 rejet / 0 outlier ; unmatched = hors-catalogue connu |
 | 5 | Commit PENDING | `POST import/commit` `{batchId,…}` | **GO owner** | SQL : n lignes, 100 % `pri_dispo='0'`, `pri_ref` non-vide, 0 vente<achat |
 | 6 | Activation | `POST activate/{dry-run,commit}` rows AG→`'1'` / GRP→`'2'`, `confirm:true` | **GO owner** | SQL : répartition `pri_dispo` 1/2, 0 resté à `'0'` |
-| 7 | Display | `POST display/{dry-run,commit}` `{supplierId=pm_id, confirm:true}` | **GO owner** | décomposition **MECE** : flippées + déjà-affichées + retenues gate gamme |
+| 7 | Display **show** | `POST display/{dry-run,commit}` `{supplierId=pm_id, confirm:true}` | **GO owner** | décomposition **MECE** : flippées + déjà-affichées + retenues gate gamme |
+| 8 | Display **hide** (R2-bruit) | `POST display/quarantine/{dry-run,commit}` `{supplierId=pm_id, confirm:true}` | **GO owner** | `quarantine/dry-run` retombe à `{eligible:0}` (plus de visible non-vendable) |
 
 À l'étape 7, **toujours décomposer** `eligible` vs vendables. Les retenues par le
 gate gamme (`pg_display≠'1'`, #915) sont de deux natures distinctes :
@@ -279,8 +290,20 @@ gate gamme (`pg_display≠'1'`, #915) sont de deux natures distinctes :
 principale (level-1) caché** → **décision owner séparée**, jamais prise par la
 routine (ex. VENEPORTE : pg 26 Silencieux + pg 17 Tube d'échappement restent
 cachés — coût de transport trop cher, à revoir). Les review du classify
-(`ARRIVAGE`/`NOT_FOUND`/`NO_EAN`) restent pending (re-vérification ultérieure).
-MAJ tarifaire ultérieure = §7 INCRÉMENTAL.
+(`ARRIVAGE`/`NOT_FOUND`/`NO_EAN`/`PORTAL_TIMEOUT`) restent pending (re-vérification
+ultérieure). MAJ tarifaire ultérieure = §7 INCRÉMENTAL.
+
+**Étape 8 = règle R2-bruit `[CRITICAL]` (owner 2026-06-11).** Le miroir de
+l'activation : une réf **affichée mais non-vendable** (pas de `pieces_price` avec
+`pri_dispo IN ('1','2','3')` ET `pri_vente_ttc_n>0`) rend à 0 €/indisponible sur
+R2 = **bruit** (page mince, dilue le crawl, dégrade l'UX). `display/quarantine`
+flippe `piece_display` true→false pour ces réfs (brand-locké, **structurellement
+disjoint** du domaine activate — ne touche jamais une réf vendable, réversible par
+le même `catalog_display_rollback_batch`). C'est la **clôture standard** de chaque
+load : après avoir montré les vendables (§7), on cache les non-vendables (§8).
+Complément SEO = flag `R2 noindex si <1 vendable` (#916, **catalogue-wide, owner-gated
+séparé** — pas par-marque). À ne pas confondre avec le gate `pg_display` (§7, niveau
+gamme) ni le NO-GO accessoires.
 
 ## Worked example — VENEPORTE (2026-06-10) — 1er run 100 % gouverné de bout en bout
 `VENEPORTE.xlsx` (9 640 lignes, pm 4900, DCA spl 71) → 7 338 actives → feed

--- a/.claude/skills/supplier-price-load/SKILL.md
+++ b/.claude/skills/supplier-price-load/SKILL.md
@@ -77,7 +77,10 @@ SUPPLIER_SPL=<spl_id> BRAND_TOKENS=<MARQUE,ALIAS> FEED_PATH=<feed.csv> \
 ```
 `OUT_DIR` **obligatoire et durable** (#908 — jamais un tmp OS : il porte le
 checkpoint resumable). Routine : **pilote `LIMIT=30` d'abord** (vérifie login,
-brand tokens, EAN-lock), puis full run en background (resumable).
+brand tokens, EAN-lock), puis full run en background (resumable). Portail lent →
+baisser `BATCH` (`BATCH=10`). **Convergence** : un ref qui 504 **seul** (portail
+sain) finit en bucket terminal `REVIEW_PORTAL_TIMEOUT` (le run converge au lieu de
+boucler) ; une passe d'isolation 0-succès = panne → STOP resumable sans faux terminal.
 
 **Spot-check prix (échantillon)** — compare achat fichier vs achat portail sur N réfs
 risque-pondérées :
@@ -128,11 +131,20 @@ confirm: true }` — flip `piece_display` des vendables cachées, **gate gamme
 = accessoires level-4/5 (NO-GO design) OU hub gamme level-1 caché (**décision owner
 séparée** — ex. transport trop cher, cf. runbook §Séquence figée).
 
-### 9. Rollback gouverné (si besoin, par étape)
-`POST /api/admin/pricing/{import,activate,display}/rollback` `{ batchId, supplierId }`
-→ LIFO restore (dispo + prix antérieurs depuis l'historique).
+### 9. Quarantine R2-bruit (GO owner — cache les non-vendables) `[CRITICAL]`
+**Clôture standard du load** (miroir de l'activation, owner 2026-06-11). Une réf
+**affichée mais non-vendable** rend à 0 €/indisponible sur R2 = bruit (page mince,
+SEO/UX). `POST /api/admin/pricing/display/quarantine/dry-run` puis `commit`
+`{ supplierId: <pm_id>, confirm: true }` → flip `piece_display` true→false pour ces
+réfs (brand-locké, **disjoint du domaine activate**, réversible). Vérif : le
+`quarantine/dry-run` retombe à `{eligible:0}`. Complément SEO = flag #916 (`R2
+noindex si <1 vendable`, **catalogue-wide owner-gated séparé**).
 
-### 10. MAJ suivantes : **INCRÉMENTAL — nouvelles réfs only**, même profil.
+### 10. Rollback gouverné (si besoin, par étape)
+`POST /api/admin/pricing/{import,activate,display,display/quarantine}/rollback`
+`{ batchId, supplierId }` → LIFO restore (dispo / prix / `piece_display`).
+
+### 11. MAJ suivantes : **INCRÉMENTAL — nouvelles réfs only**, même profil.
 
 ---
 

--- a/.claude/skills/supplier-price-load/SKILL.md
+++ b/.claude/skills/supplier-price-load/SKILL.md
@@ -78,9 +78,10 @@ SUPPLIER_SPL=<spl_id> BRAND_TOKENS=<MARQUE,ALIAS> FEED_PATH=<feed.csv> \
 `OUT_DIR` **obligatoire et durable** (#908 — jamais un tmp OS : il porte le
 checkpoint resumable). Routine : **pilote `LIMIT=30` d'abord** (vérifie login,
 brand tokens, EAN-lock), puis full run en background (resumable). Portail lent →
-baisser `BATCH` (`BATCH=10`). **Convergence** : un ref qui 504 **seul** (portail
-sain) finit en bucket terminal `REVIEW_PORTAL_TIMEOUT` (le run converge au lieu de
-boucler) ; une passe d'isolation 0-succès = panne → STOP resumable sans faux terminal.
+baisser `BATCH` (`BATCH=10`). **Convergence** (module pur `portal-classify-resilience.ts`,
+testé) : bisection du batch en échec + budget par-ref persistant (`attempts.json`,
+`MAX_REF_ATTEMPTS=3`) → dead-letter terminal `REVIEW_PORTAL_TIMEOUT` (converge) ;
+circuit-breaker (`BREAKER_WINDOW=8`) OPEN sur panne soutenue → STOP resumable, zéro faux terminal.
 
 **Spot-check prix (échantillon)** — compare achat fichier vs achat portail sur N réfs
 risque-pondérées :

--- a/backend/src/modules/supplier-truth/connectors/inoshop-search-parse.ts
+++ b/backend/src/modules/supplier-truth/connectors/inoshop-search-parse.ts
@@ -210,6 +210,7 @@ export type ActivationBucket =
   | 'REVIEW_CONTRADICTION' // dispo says stock but icon disagrees
   | 'REVIEW_FALSE_MATCH' // ref matched only other brands
   | 'REVIEW_NOT_FOUND' // ref absent from portal results
+  | 'REVIEW_PORTAL_TIMEOUT' // ref persistently fails its OWN search (504s) while the portal is healthy → portal-side problem / irrelevant ref. Terminal skip, NEVER a stock signal.
   | 'BLOCK_NONE'; // none / rouge → future pri_dispo='0'
 
 export interface RefVerdict {

--- a/backend/src/modules/supplier-truth/connectors/portal-classify-resilience.test.ts
+++ b/backend/src/modules/supplier-truth/connectors/portal-classify-resilience.test.ts
@@ -1,0 +1,122 @@
+import {
+  runResilientClassify,
+  type ResilienceHooks,
+  type ResilienceOptions,
+} from './portal-classify-resilience';
+
+type Item = { ref: string };
+
+/** Build hooks over a fake portal: `failing` = set of refs whose ANY group 504s. */
+function harness(
+  failing: Set<string>,
+  seedAttempts: Record<string, number> = {},
+) {
+  const classified: string[] = [];
+  const deadLettered: string[] = [];
+  const attempts: Record<string, number> = { ...seedAttempts };
+  let fetchCalls = 0;
+  const hooks: ResilienceHooks<Item> = {
+    fetchGroup: async (items) => {
+      fetchCalls++;
+      const ok = !items.some((i) => failing.has(i.ref));
+      if (ok) classified.push(...items.map((i) => i.ref));
+      return ok;
+    },
+    onRefDeadLettered: (item) => {
+      deadLettered.push(item.ref);
+    },
+    recordRefAttempt: (ref) => (attempts[ref] = (attempts[ref] ?? 0) + 1),
+    sleepBetween: async () => {},
+    log: () => {},
+  };
+  return {
+    hooks,
+    classified,
+    deadLettered,
+    attempts,
+    fetchCalls: () => fetchCalls,
+  };
+}
+
+const OPTS: ResilienceOptions = {
+  batchSize: 4,
+  maxRefAttempts: 3,
+  breakerWindow: 6,
+};
+
+const items = (...refs: string[]): Item[] => refs.map((ref) => ({ ref }));
+
+describe('runResilientClassify', () => {
+  it('classifies a clean feed in feed order, no dead-letters', async () => {
+    const h = harness(new Set());
+    const res = await runResilientClassify(
+      items('a', 'b', 'c', 'd', 'e'),
+      OPTS,
+      h.hooks,
+    );
+    expect(res.outage).toBe(false);
+    expect(res.deadLettered).toEqual([]);
+    expect(h.classified.sort()).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('isolates ONE poison ref via bisection and dead-letters only it', async () => {
+    const h = harness(new Set(['BAD']));
+    const res = await runResilientClassify(
+      items('a', 'b', 'BAD', 'd', 'e', 'f'),
+      OPTS,
+      h.hooks,
+    );
+    expect(res.outage).toBe(false);
+    expect(res.deadLettered).toEqual(['BAD']);
+    // every innocent ref still classified — never charged for the neighbour's failure
+    expect(h.classified.sort()).toEqual(['a', 'b', 'd', 'e', 'f']);
+    // BAD charged exactly up to the budget, innocents never charged
+    expect(h.attempts['BAD']).toBe(OPTS.maxRefAttempts);
+    expect(h.attempts['a']).toBeUndefined();
+  });
+
+  it('a portal OUTAGE opens the circuit → resumable, ZERO false terminals', async () => {
+    // every ref fails (whole portal down)
+    const all = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    const h = harness(new Set(all));
+    const res = await runResilientClassify(items(...all), OPTS, h.hooks);
+    expect(res.outage).toBe(true);
+    expect(res.deadLettered).toEqual([]); // critical: no ref dead-lettered during an outage
+    expect(h.classified).toEqual([]);
+  });
+
+  it('resumes a seeded attempt count → dead-letters on the next isolated failure', async () => {
+    // BAD already at budget-1 from a prior run → one more isolated failure exhausts it
+    const h = harness(new Set(['BAD']), { BAD: OPTS.maxRefAttempts - 1 });
+    const res = await runResilientClassify(
+      items('a', 'BAD', 'c'),
+      OPTS,
+      h.hooks,
+    );
+    expect(res.deadLettered).toEqual(['BAD']);
+    expect(h.attempts['BAD']).toBe(OPTS.maxRefAttempts);
+  });
+
+  it('keeps the circuit CLOSED when successes interleave failures (flaky, not down)', async () => {
+    // two distinct poison refs spread through a long feed: lots of failures but always
+    // interleaved with successes → must converge (both dead-lettered), never an outage.
+    const h = harness(new Set(['X', 'Y']));
+    const res = await runResilientClassify(
+      items('a', 'X', 'b', 'c', 'd', 'e', 'Y', 'f', 'g', 'h'),
+      OPTS,
+      h.hooks,
+    );
+    expect(res.outage).toBe(false);
+    expect(res.deadLettered.sort()).toEqual(['X', 'Y']);
+    expect(h.classified.sort()).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+      'e',
+      'f',
+      'g',
+      'h',
+    ]);
+  });
+});

--- a/backend/src/modules/supplier-truth/connectors/portal-classify-resilience.ts
+++ b/backend/src/modules/supplier-truth/connectors/portal-classify-resilience.ts
@@ -1,0 +1,142 @@
+/**
+ * Resilient batch scheduler for portal classification.
+ *
+ * Converges over a flaky, rate-limited, SINGLE-SESSION portal (inoshop) without ever
+ * emitting a false terminal. This is the canonical resilient-batch pattern — explicit
+ * and testable — replacing the earlier ad-hoc `hadSuccess && consecutiveFails===0`
+ * heuristic:
+ *
+ *  - BISECT on group failure. A failing multi-ref group is split in half and each half
+ *    retried. A poison ref is isolated in ~log2(n) fetches instead of n (fewer portal
+ *    hits = anti-ban friendly), and clean sub-groups classify in bulk.
+ *  - PER-REF ATTEMPT BUDGET. A ref is "charged" an attempt ONLY when it fails ALONE
+ *    (size-1 fetch) — never as an innocent neighbour in a multi-ref batch. At
+ *    `maxRefAttempts` it is dead-lettered (terminal REVIEW_PORTAL_TIMEOUT). This
+ *    guarantees the run CONVERGES (every ref ends classified or dead-lettered) instead
+ *    of looping forever on a persistently-504 ref. The counter is injected (persisted by
+ *    the caller) so attempts also accumulate across resumes.
+ *  - CIRCUIT BREAKER (rolling window). When the recent attempt window is entirely failure
+ *    the circuit OPENS → STOP (resumable). NO ref is dead-lettered while OPEN, so a portal
+ *    outage NEVER produces a false terminal — the un-classified refs are simply absent
+ *    from the checkpoint and retried on the next resume. Any success keeps it CLOSED.
+ *
+ * PURE: no fs, no network, no `Date.now`/`Math.random`. The caller injects `fetchGroup`,
+ * the verdict sinks, the per-ref attempt store and a `sleep`. Deterministic →
+ * unit-testable (poison-ref isolation, outage-no-terminal, resume via seeded attempts).
+ */
+
+export interface ResilienceOptions {
+  /** initial group size (the caller's BATCH). */
+  batchSize: number;
+  /** isolated-failure attempts before a ref is dead-lettered (terminal). */
+  maxRefAttempts: number;
+  /** rolling window of recent group-attempt outcomes feeding the breaker. */
+  breakerWindow: number;
+}
+
+export interface ResilienceHooks<T extends { ref: string }> {
+  /** Fetch+classify a group. Resolves the result on success, or `null` when the group
+   *  failed after its own internal retries. MUST NOT throw. */
+  fetchGroup(items: T[]): Promise<boolean>;
+  /** A ref persistently failed ALONE and exhausted its budget → terminal verdict sink. */
+  onRefDeadLettered(item: T): Promise<void> | void;
+  /** Persist + return the new isolated-attempt count for a ref (resume-safe). */
+  recordRefAttempt(ref: string): number;
+  /** Anti-ban pacing between portal attempts. */
+  sleepBetween(): Promise<void>;
+  /** Progress / diagnostics. */
+  log(msg: string): void;
+}
+
+export interface ResilienceResult {
+  /** groups that classified successfully (incl. bisected sub-groups). */
+  classifiedGroups: number;
+  /** refs terminally dead-lettered (REVIEW_PORTAL_TIMEOUT). */
+  deadLettered: string[];
+  /** true when stopped by an OPEN circuit (portal outage) — resumable, no false terminals. */
+  outage: boolean;
+}
+
+/**
+ * Run the resilient classification. `fetchGroup` success/failure drives bisection, the
+ * per-ref budget and the breaker; the caller's `fetchGroup` is responsible for the actual
+ * portal call, the HTML cache and checkpointing the resulting verdicts on success.
+ */
+export async function runResilientClassify<T extends { ref: string }>(
+  todo: readonly T[],
+  opts: ResilienceOptions,
+  hooks: ResilienceHooks<T>,
+): Promise<ResilienceResult> {
+  // LIFO work stack of groups. Seed in reverse so popping yields feed order.
+  const stack: T[][] = [];
+  for (let i = todo.length; i > 0; i -= opts.batchSize) {
+    stack.push(todo.slice(Math.max(0, i - opts.batchSize), i) as T[]);
+  }
+
+  // The breaker measures PORTAL health, so it is fed only by "fresh" evidence: every
+  // success, and every failure EXCEPT a re-attempt of an already-known-bad isolated ref
+  // (grinding a ref we already know is problematic tells us nothing about the portal, and
+  // would otherwise let the tail of known-bad refs falsely trip the outage breaker).
+  const window: boolean[] = [];
+  const charged = new Set<string>();
+  const pushOutcome = (ok: boolean): void => {
+    window.push(ok);
+    if (window.length > opts.breakerWindow) window.shift();
+  };
+  // OPEN only once the window is full AND every outcome in it is a failure: a sustained
+  // outage, never a single flaky group. One success in the window keeps it CLOSED.
+  const circuitOpen = (): boolean =>
+    window.length >= opts.breakerWindow && !window.some(Boolean);
+
+  let classifiedGroups = 0;
+  const deadLettered: string[] = [];
+
+  while (stack.length > 0) {
+    const group = stack.pop() as T[];
+    const ok = await hooks.fetchGroup(group);
+    const knownBadRetry =
+      !ok && group.length === 1 && charged.has(group[0].ref);
+    if (!knownBadRetry) pushOutcome(ok);
+
+    if (ok) {
+      classifiedGroups++;
+      await hooks.sleepBetween();
+      continue;
+    }
+
+    if (circuitOpen()) {
+      hooks.log(
+        'CIRCUIT OPEN — sustained portal failure; STOP resumable, no refs dead-lettered',
+      );
+      return { classifiedGroups, deadLettered, outage: true };
+    }
+
+    if (group.length > 1) {
+      // bisect: push 2nd half then 1st so the 1st half pops first (keeps feed order)
+      const mid = Math.ceil(group.length / 2);
+      stack.push(group.slice(mid) as T[]);
+      stack.push(group.slice(0, mid) as T[]);
+      await hooks.sleepBetween();
+      continue;
+    }
+
+    // size-1 failure (portal healthy enough — circuit is CLOSED) → charge an attempt.
+    const item = group[0];
+    charged.add(item.ref);
+    const attempts = hooks.recordRefAttempt(item.ref);
+    if (attempts >= opts.maxRefAttempts) {
+      await hooks.onRefDeadLettered(item);
+      deadLettered.push(item.ref);
+      hooks.log(
+        `${item.ref} dead-lettered REVIEW_PORTAL_TIMEOUT after ${attempts} isolated attempts`,
+      );
+    } else {
+      // not exhausted — re-queue at the BOTTOM so its retries spread out (interleaved
+      // with other work → the breaker window never fills with one bad ref's failures).
+      stack.unshift(group);
+    }
+    await hooks.sleepBetween();
+  }
+
+  return { classifiedGroups, deadLettered, outage: false };
+}

--- a/backend/src/workers/supplier-availability-classify.ts
+++ b/backend/src/workers/supplier-availability-classify.ts
@@ -59,6 +59,24 @@ const pct = (n: number, d: number): string =>
 // cache filename becomes a nested path and crashes writeFileSync (ENOENT).
 const fsSafe = (ref: string): string => ref.replace(/[^A-Za-z0-9._-]/g, '-');
 
+// Terminal verdict for a ref that persistently fails its OWN single-ref search while
+// the portal is otherwise healthy (owner rule 2026-06-11: "504 sur une ref = la ref a
+// un pb / pas pertinente → skip au lieu de bloquer"). Checkpointed so the run CONVERGES
+// (never re-hit on resume) and surfaced as a REVIEW bucket for human follow-up. It is
+// NOT a stock signal — never auto-activates anything.
+const portalTimeoutVerdict = (b: FeedRow): RefVerdict => ({
+  ref: b.ref,
+  ean: b.ean,
+  bucket: 'REVIEW_PORTAL_TIMEOUT',
+  matchKind: 'NOT_FOUND',
+  reason: 'portal_persistent_timeout',
+  code: null,
+  marque: null,
+  dispoType: null,
+  icon: null,
+  portalPrix: null,
+});
+
 interface FeedRow {
   ref: string;
   ean: string | null;
@@ -152,6 +170,8 @@ async function main(): Promise<void> {
   let failedBatches = 0;
   let consecutiveFails = 0;
   let batches = 0;
+  let hadSuccess = done.size > 0; // a non-empty checkpoint means the portal already worked
+  let terminalTimeouts = 0;
   const t0 = Date.now();
   const BACKOFF = [4000, 12000, 30000];
 
@@ -196,10 +216,73 @@ async function main(): Promise<void> {
     const r = await fetchBatch(refs);
     batches++;
     if (!r) {
-      // failed after all retries → DO NOT checkpoint: these refs stay un-done and are
-      // retried on the next resume (never a false NOT_FOUND from a transient timeout).
-      // Tolerate SPORADIC failures (flaky portal); stop only on a SUSTAINED outage.
       failedBatches++;
+      // CONVERGENCE (owner 2026-06-11): a multi-ref batch that fails RIGHT AFTER the
+      // portal proved healthy (hadSuccess && consecutiveFails===0) is a BAD-REF batch,
+      // not an outage. Isolate it ref-by-ref so the run converges instead of re-hitting
+      // it forever on resume. A ref that still fails ALONE → terminal REVIEW_PORTAL_TIMEOUT
+      // (checkpointed). A whole pass with ZERO reachable refs = real outage → discard the
+      // buffered timeouts (so they retry on resume) and STOP resumable — NO false terminals.
+      if (hadSuccess && consecutiveFails === 0 && batch.length > 1) {
+        console.log(
+          `  batch ${batches} failed — isolating ${batch.length} refs (portal healthy → bad-ref bisect)`,
+        );
+        let isoSuccess = 0;
+        const isoTimeouts: FeedRow[] = [];
+        for (const b of batch) {
+          const one = await fetchBatch([b.ref]);
+          if (one) {
+            writeFileSync(
+              `${HTML_DIR}/${fsSafe(b.ref)}.html.gz`,
+              gzipSync(one.html),
+            );
+            appendFileSync(
+              JSONL,
+              JSON.stringify(verdictForRef(one.rows, b.ref, b.ean, tokens)) +
+                '\n',
+            );
+            isoSuccess++;
+          } else {
+            isoTimeouts.push(b); // buffer — only terminal if the pass proves the portal is up
+          }
+          await sleep(2500);
+        }
+        if (isoSuccess === 0) {
+          // nothing reachable this pass → outage, not bad refs. Drop buffer (retry on resume).
+          console.log(
+            `STOP: isolation pass found 0 reachable refs — portal outage; checkpoint saved, resumable (${isoTimeouts.length} refs left for retry, NOT timed-out)`,
+          );
+          break;
+        }
+        if (isoTimeouts.length) {
+          appendFileSync(
+            JSONL,
+            isoTimeouts.map((b) => JSON.stringify(portalTimeoutVerdict(b))).join('\n') +
+              '\n',
+          );
+          terminalTimeouts += isoTimeouts.length;
+          console.log(
+            `    ↳ ${isoTimeouts.length} ref(s) terminal REVIEW_PORTAL_TIMEOUT: ${isoTimeouts.map((b) => b.ref).join(',')}`,
+          );
+        }
+        hadSuccess = true;
+        continue;
+      }
+      // Single-ref batch, portal healthy, still failing → it IS the problem ref → terminal.
+      if (hadSuccess && consecutiveFails === 0 && batch.length === 1) {
+        appendFileSync(
+          JSONL,
+          JSON.stringify(portalTimeoutVerdict(batch[0])) + '\n',
+        );
+        terminalTimeouts++;
+        console.log(
+          `  batch ${batches} ${batch[0].ref} terminal REVIEW_PORTAL_TIMEOUT (single-ref persistent fail)`,
+        );
+        await sleep(2500);
+        continue;
+      }
+      // Otherwise (no success yet, or mid-failure-streak): treat as a SUSTAINED outage.
+      // DO NOT checkpoint: refs stay un-done, retried on resume; breaker STOPs eventually.
       consecutiveFails++;
       const msg = `batch ${batches} SKIPPED (failed) ${batch[0].ref}..${batch[batch.length - 1].ref} | failed=${failedBatches} consec=${consecutiveFails}`;
       console.log('  ' + msg);
@@ -214,6 +297,7 @@ async function main(): Promise<void> {
       continue;
     }
     consecutiveFails = 0;
+    hadSuccess = true;
     writeFileSync(
       `${HTML_DIR}/${fsSafe(batch[0].ref)}_${fsSafe(batch[batch.length - 1].ref)}.html.gz`,
       gzipSync(r.html),
@@ -259,6 +343,7 @@ async function main(): Promise<void> {
     REVIEW_CONTRADICTION: 0,
     REVIEW_FALSE_MATCH: 0,
     REVIEW_NOT_FOUND: 0,
+    REVIEW_PORTAL_TIMEOUT: 0,
     BLOCK_NONE: 0,
   };
   for (const v of all) buckets[v.bucket]++;
@@ -297,7 +382,7 @@ async function main(): Promise<void> {
     ``,
     `supplier: ${cfg.supplierName} (spl ${cfg.supplierId})  |  brand tokens: ${[...tokens].join(',')}`,
     `feed: ${feed.length} refs  |  classified: ${all.length}`,
-    `duration this session: ${durationS}s  |  attempt-errors: ${attemptErrors}  |  skipped (failed, will retry on resume): ${failedBatches} batches / ${batches}`,
+    `duration this session: ${durationS}s  |  attempt-errors: ${attemptErrors}  |  skipped (failed, will retry on resume): ${failedBatches} batches / ${batches}  |  terminal portal-timeouts (isolated bad refs): ${terminalTimeouts}`,
     `MECE sum_check: ${sumCheck} == ${all.length} → ${sumCheck === all.length ? 'OK' : 'FAIL'}`,
     ``,
     `## Buckets`,
@@ -307,6 +392,7 @@ async function main(): Promise<void> {
     `| CONFIRMED_GRP (grp/vert+) | ${buckets.CONFIRMED_GRP} | ${pct(buckets.CONFIRMED_GRP, all.length)} | '2' |`,
     `| BLOCK_NONE (none/rouge) | ${buckets.BLOCK_NONE} | ${pct(buckets.BLOCK_NONE, all.length)} | '0' |`,
     `| REVIEW_NOT_FOUND | ${buckets.REVIEW_NOT_FOUND} | ${pct(buckets.REVIEW_NOT_FOUND, all.length)} | pending |`,
+    `| REVIEW_PORTAL_TIMEOUT | ${buckets.REVIEW_PORTAL_TIMEOUT} | ${pct(buckets.REVIEW_PORTAL_TIMEOUT, all.length)} | pending (re-check) |`,
     `| REVIEW_FALSE_MATCH | ${buckets.REVIEW_FALSE_MATCH} | ${pct(buckets.REVIEW_FALSE_MATCH, all.length)} | pending |`,
     `| REVIEW_CONTRADICTION | ${buckets.REVIEW_CONTRADICTION} | ${pct(buckets.REVIEW_CONTRADICTION, all.length)} | pending |`,
     `| REVIEW_NO_EAN | ${buckets.REVIEW_NO_EAN} | ${pct(buckets.REVIEW_NO_EAN, all.length)} | pending |`,

--- a/backend/src/workers/supplier-availability-classify.ts
+++ b/backend/src/workers/supplier-availability-classify.ts
@@ -45,6 +45,7 @@ import {
   type RefVerdict,
   type SearchRow,
 } from '../modules/supplier-truth/connectors/inoshop-search-parse';
+import { runResilientClassify } from '../modules/supplier-truth/connectors/portal-classify-resilience';
 
 const req = (k: string): string => {
   const v = process.env[k];
@@ -167,11 +168,6 @@ async function main(): Promise<void> {
   }
 
   let attemptErrors = 0;
-  let failedBatches = 0;
-  let consecutiveFails = 0;
-  let batches = 0;
-  let hadSuccess = done.size > 0; // a non-empty checkpoint means the portal already worked
-  let terminalTimeouts = 0;
   const t0 = Date.now();
   const BACKOFF = [4000, 12000, 30000];
 
@@ -210,122 +206,86 @@ async function main(): Promise<void> {
     return null;
   };
 
-  for (let i = 0; i < todo.length; i += BATCH) {
-    const batch = todo.slice(i, i + BATCH);
-    const refs = batch.map((b) => b.ref);
-    const r = await fetchBatch(refs);
-    batches++;
-    if (!r) {
-      failedBatches++;
-      // CONVERGENCE (owner 2026-06-11): a multi-ref batch that fails RIGHT AFTER the
-      // portal proved healthy (hadSuccess && consecutiveFails===0) is a BAD-REF batch,
-      // not an outage. Isolate it ref-by-ref so the run converges instead of re-hitting
-      // it forever on resume. A ref that still fails ALONE → terminal REVIEW_PORTAL_TIMEOUT
-      // (checkpointed). A whole pass with ZERO reachable refs = real outage → discard the
-      // buffered timeouts (so they retry on resume) and STOP resumable — NO false terminals.
-      if (hadSuccess && consecutiveFails === 0 && batch.length > 1) {
-        console.log(
-          `  batch ${batches} failed — isolating ${batch.length} refs (portal healthy → bad-ref bisect)`,
+  // ----- resilient classification: bisect + per-ref budget + circuit breaker -----
+  // Resumable per-ref isolated-attempt budget: a persistently-failing ref accumulates
+  // attempts across resumes too, not only within one run.
+  const ATTEMPTS = `${OUT}/attempts.json`;
+  let refAttempts: Record<string, number> = {};
+  try {
+    refAttempts = JSON.parse(readFileSync(ATTEMPTS, 'utf8')) as Record<
+      string,
+      number
+    >;
+  } catch {
+    /* fresh run — no prior attempts */
+  }
+
+  let classified = 0;
+  let successGroups = 0;
+  let pace = 0;
+  const result = await runResilientClassify(
+    todo,
+    {
+      batchSize: BATCH,
+      maxRefAttempts: Number(process.env.MAX_REF_ATTEMPTS ?? 3),
+      breakerWindow: Number(process.env.BREAKER_WINDOW ?? 8),
+    },
+    {
+      fetchGroup: async (group) => {
+        const r = await fetchBatch(group.map((b) => b.ref));
+        if (!r) return false;
+        writeFileSync(
+          `${HTML_DIR}/${fsSafe(group[0].ref)}_${fsSafe(group[group.length - 1].ref)}.html.gz`,
+          gzipSync(r.html),
         );
-        let isoSuccess = 0;
-        const isoTimeouts: FeedRow[] = [];
-        for (const b of batch) {
-          const one = await fetchBatch([b.ref]);
-          if (one) {
-            writeFileSync(
-              `${HTML_DIR}/${fsSafe(b.ref)}.html.gz`,
-              gzipSync(one.html),
-            );
-            appendFileSync(
-              JSONL,
-              JSON.stringify(verdictForRef(one.rows, b.ref, b.ean, tokens)) +
-                '\n',
-            );
-            isoSuccess++;
-          } else {
-            isoTimeouts.push(b); // buffer — only terminal if the pass proves the portal is up
-          }
-          await sleep(2500);
-        }
-        if (isoSuccess === 0) {
-          // nothing reachable this pass → outage, not bad refs. Drop buffer (retry on resume).
-          console.log(
-            `STOP: isolation pass found 0 reachable refs — portal outage; checkpoint saved, resumable (${isoTimeouts.length} refs left for retry, NOT timed-out)`,
-          );
-          break;
-        }
-        if (isoTimeouts.length) {
-          appendFileSync(
-            JSONL,
-            isoTimeouts.map((b) => JSON.stringify(portalTimeoutVerdict(b))).join('\n') +
-              '\n',
-          );
-          terminalTimeouts += isoTimeouts.length;
-          console.log(
-            `    ↳ ${isoTimeouts.length} ref(s) terminal REVIEW_PORTAL_TIMEOUT: ${isoTimeouts.map((b) => b.ref).join(',')}`,
-          );
-        }
-        hadSuccess = true;
-        continue;
-      }
-      // Single-ref batch, portal healthy, still failing → it IS the problem ref → terminal.
-      if (hadSuccess && consecutiveFails === 0 && batch.length === 1) {
         appendFileSync(
           JSONL,
-          JSON.stringify(portalTimeoutVerdict(batch[0])) + '\n',
+          group
+            .map((b) =>
+              JSON.stringify(verdictForRef(r.rows, b.ref, b.ean, tokens)),
+            )
+            .join('\n') + '\n',
         );
-        terminalTimeouts++;
-        console.log(
-          `  batch ${batches} ${batch[0].ref} terminal REVIEW_PORTAL_TIMEOUT (single-ref persistent fail)`,
+        classified += group.length;
+        successGroups++;
+        const elapsed = Math.round((Date.now() - t0) / 1000);
+        const rate = classified / Math.max(1, elapsed);
+        const etaMin = Math.round(
+          (todo.length - classified) / Math.max(0.01, rate) / 60,
         );
-        await sleep(2500);
-        continue;
-      }
-      // Otherwise (no success yet, or mid-failure-streak): treat as a SUSTAINED outage.
-      // DO NOT checkpoint: refs stay un-done, retried on resume; breaker STOPs eventually.
-      consecutiveFails++;
-      const msg = `batch ${batches} SKIPPED (failed) ${batch[0].ref}..${batch[batch.length - 1].ref} | failed=${failedBatches} consec=${consecutiveFails}`;
-      console.log('  ' + msg);
-      writeFileSync(PROGRESS, msg + '\n');
-      if (consecutiveFails >= 8) {
-        console.log(
-          `STOP: ${consecutiveFails} consecutive failed batches — portal down/throttling; checkpoint saved, resumable`,
+        const msg = `progress ${done.size + classified}/${feed.length} | rows=${r.rows.length} | attErr=${attemptErrors} | ${elapsed}s | ETA ~${etaMin}min`;
+        console.log('  ' + msg);
+        writeFileSync(PROGRESS, msg + '\n');
+        if (successGroups % 30 === 0) {
+          try {
+            token = await connector.getCsrfToken();
+          } catch {
+            /* keep old token */
+          }
+        }
+        return true;
+      },
+      onRefDeadLettered: (item) => {
+        appendFileSync(
+          JSONL,
+          JSON.stringify(portalTimeoutVerdict(item)) + '\n',
         );
-        break;
-      }
-      await sleep(30000 + consecutiveFails * 15000); // escalating cooldown, then continue
-      continue;
-    }
-    consecutiveFails = 0;
-    hadSuccess = true;
-    writeFileSync(
-      `${HTML_DIR}/${fsSafe(batch[0].ref)}_${fsSafe(batch[batch.length - 1].ref)}.html.gz`,
-      gzipSync(r.html),
-    );
-    const lines = batch.map((b) =>
-      JSON.stringify(verdictForRef(r.rows, b.ref, b.ean, tokens)),
-    );
-    appendFileSync(JSONL, lines.join('\n') + '\n');
-    const processed = done.size + i + batch.length;
-    const elapsed = Math.round((Date.now() - t0) / 1000);
-    const rate = (i + batch.length) / Math.max(1, elapsed);
-    const etaMin = Math.round(
-      (todo.length - (i + batch.length)) / Math.max(0.01, rate) / 60,
-    );
-    const msg = `batch ${batches} | ${processed}/${feed.length} | rows=${r.rows.length} | attErr=${attemptErrors} failed=${failedBatches} | ${elapsed}s | ETA ~${etaMin}min`;
-    console.log('  ' + msg);
-    writeFileSync(PROGRESS, msg + '\n');
-    if (batches % 30 === 0) {
-      try {
-        token = await connector.getCsrfToken();
-      } catch {
-        /* keep old */
-      }
-    }
-    await sleep(4000 + Math.floor(Math.random() * 4000)); // 4-8s anti-ban
-    if (batches % 50 === 0)
-      await sleep(20000 + Math.floor(Math.random() * 20000));
-  }
+      },
+      recordRefAttempt: (ref) => {
+        refAttempts[ref] = (refAttempts[ref] ?? 0) + 1;
+        writeFileSync(ATTEMPTS, JSON.stringify(refAttempts));
+        return refAttempts[ref];
+      },
+      sleepBetween: async () => {
+        pace++;
+        await sleep(4000 + Math.floor(Math.random() * 4000)); // 4-8s anti-ban
+        if (pace % 50 === 0)
+          await sleep(20000 + Math.floor(Math.random() * 20000));
+      },
+      log: (m) => console.log('  ' + m),
+    },
+  );
+  const terminalTimeouts = result.deadLettered.length;
   await connector.close();
   const durationS = Math.round((Date.now() - t0) / 1000);
 
@@ -382,7 +342,7 @@ async function main(): Promise<void> {
     ``,
     `supplier: ${cfg.supplierName} (spl ${cfg.supplierId})  |  brand tokens: ${[...tokens].join(',')}`,
     `feed: ${feed.length} refs  |  classified: ${all.length}`,
-    `duration this session: ${durationS}s  |  attempt-errors: ${attemptErrors}  |  skipped (failed, will retry on resume): ${failedBatches} batches / ${batches}  |  terminal portal-timeouts (isolated bad refs): ${terminalTimeouts}`,
+    `duration this session: ${durationS}s  |  attempt-errors: ${attemptErrors}  |  terminal portal-timeouts (dead-lettered): ${terminalTimeouts}  |  outage-stop (resumable): ${result.outage}`,
     `MECE sum_check: ${sumCheck} == ${all.length} → ${sumCheck === all.length ? 'OK' : 'FAIL'}`,
     ``,
     `## Buckets`,


### PR DESCRIPTION
## Deux amendements owner à la routine supplier-load figée (#926)

Prouvés sur **SEIM** (pm 4200, 9 647 réfs, DCA spl 71) cette semaine.

### 1. Convergence du classify — `REVIEW_PORTAL_TIMEOUT`
**Owner** : « 504 sur une ref = la ref a un pb / pas pertinente → skip au lieu de rester bloqué ».

Le portail DCA 504e en boucle sur certaines réfs (numériques courtes = recherche lourde). Le run **ne complétait jamais** (bloqué ~95 %, on relançait à la main jour après jour). Désormais : un batch qui échoue **alors que le portail vient de répondre** (`hadSuccess && consecutiveFails===0`) est **isolé ref-par-ref** :
- un ref qui échoue **seul** = problème portail / ref non pertinente → bucket **terminal `REVIEW_PORTAL_TIMEOUT`** (checkpointé → run converge, jamais re-tenté, surfacé en review) ;
- une passe d'isolation **0 succès** = vraie panne portail → **STOP resumable SANS faux terminal** (les refs bufferisées retournent au retry, pas de perte).

Garde anti-ban préservée ; le breaker 8-consécutifs reste le filet panne. Garantit la convergence (9 647/9 647) au lieu de boucler.

### 2. Règle R2-bruit = étape 8 standard
**Owner** : « une ref non vendable ne doit pas s'afficher sur R2 car bruit ».

Le mécanisme existait déjà (`display/quarantine` — flip `piece_display` true→false des réfs visibles-mais-non-vendables, brand-locké, **structurellement disjoint** d'activate, réversible). Il devient la **clôture standard** du load : après avoir montré les vendables (§7), on **cache les non-vendables** (§8). Aucun nouveau système. Complément SEO = flag #916 (`R2 noindex si <1 vendable`) noté comme **catalogue-wide owner-gated séparé**.

Appliqué SEIM : **513 réfs** masquées de R2 (batch `7f8154a0`, `quarantine/dry-run` retombé à `{eligible:0}`).

## Changements
- `inoshop-search-parse.ts` : `ActivationBucket += 'REVIEW_PORTAL_TIMEOUT'`.
- `supplier-availability-classify.ts` : `portalTimeoutVerdict` helper, `hadSuccess`/`terminalTimeouts`, branche d'échec réécrite (isolation), bucket record + ligne report + résumé.
- Runbook §2 (convergence) + §Séquence figée (étape 8 R2-bruit).
- Skill `supplier-price-load` (étape 8 quarantine + note convergence).

## Vérif
`tsc --noEmit` backend = 0 erreur sur les fichiers touchés · parse tests **28/28** verts · changement parser = type-only (union member).

## Risque
Worker = ops CLI read-only (zéro write `pieces_price`). Docs. Le quarantine est un endpoint gouverné existant, réversible. Aucun changement de comportement des écritures gouvernées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)