### PR TITLE
feat(guard): commerce-no-direct-pieces-price-write — invariant pricing rendu mécanique

### DIFF
--- a/.ast-grep/rules/commerce-no-direct-pieces-price-write.yml
+++ b/.ast-grep/rules/commerce-no-direct-pieces-price-write.yml
@@ -1,0 +1,28 @@
+id: commerce-no-direct-pieces-price-write
+language: typescript
+severity: error
+message: |
+  Direct write to `pieces_price` via the query builder is FORBIDDEN.
+  Canon: ADR-084 (supplier tariff governance) — pieces_price is written ONLY through the
+  governed PricingModule (RPC pricing_commit_chunk / pricing_activate_chunk), never a raw
+  .from('pieces_price').insert/update/upsert/delete. Use the governed endpoints
+  POST /api/admin/pricing/import|activate|display/* (invariants L2, history, rollback).
+note: |
+  Prevents the regression class behind the NK incident (a standalone worker INSERT into
+  pieces_price with pri_dispo=null → 30 621 invisible prices, no invariants/history/rollback).
+  All current writes go through RPC, so this rule has zero false positives today.
+  Legitimate exception (future): add the file under `ignores` ONLY with owner review.
+files:
+  - backend/src/**/*.ts
+ignores:
+  - backend/src/modules/pricing/**
+rule:
+  any:
+    - pattern: $X.from('pieces_price').insert($$$)
+    - pattern: $X.from("pieces_price").insert($$$)
+    - pattern: $X.from('pieces_price').update($$$)
+    - pattern: $X.from("pieces_price").update($$$)
+    - pattern: $X.from('pieces_price').upsert($$$)
+    - pattern: $X.from("pieces_price").upsert($$$)
+    - pattern: $X.from('pieces_price').delete($$$)
+    - pattern: $X.from("pieces_price").delete($$$)


### PR DESCRIPTION
## Trou d'enforcement réel (découvert en revue ADR-084)

L'invariant « **`pieces_price` écrit UNIQUEMENT via le PricingModule gouverné** » était **doctrine-only** :
- `supabase-guard G6` (#879) ne bloque que le **`UPDATE/DELETE` brut via MCP `execute_sql`** — **pas `INSERT`, ni le code worker/service** (`supabase.from('pieces_price').insert()`).
- **Aucune règle ast-grep** ne ciblait `pieces_price`.
- L'**incident NK** (`feed-commit-nk.ts` INSERT direct → **30 621 prix invisibles**, `pri_dispo=null` filtré partout) **prouve** que le trou était exploitable.

## Fix (réutilise le pattern existant, zéro bricolage)

Règle calquée sur `commerce-no-direct-order-status-write.yml` : bannit `.from('pieces_price').{insert,update,upsert,delete}` **hors `backend/src/modules/pricing/`**.

## Zéro faux positif — vérifié

- Les **seules** écritures `pieces_price` du code passent par **RPC** (`pricing_commit_chunk` / `pricing_activate_chunk`).
- Les **9** `from('pieces_price')` du backend sont tous des **`.select`** (lectures) — vérifiés un par un.
- `ast-grep scan backend/src` = **0 violation** (severity `error` safe).
- Cas test synthétique sous `backend/src` = **catché** (insert + update) ; même violation dans `modules/pricing/` = **ignorée**.

## Limite assumée

Comme les règles `commerce-*` existantes : capte le `.from().mutation()` chaîné direct (l'idiome standard + le pattern de l'incident), pas le split multi-statement. Pas de règle relationnelle complexe (over-engineering évité).

## Lien

Rend mécanique l'invariant #1 de l'ADR-084 (gouvernance tarif fournisseur, draft owner-gated vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)