### PR TITLE
feat(dev): robust DEV:3000 supervision — systemd (structural) + watcher reaper

### DIFF
--- a/scripts/ops/automecanik-dev.service
+++ b/scripts/ops/automecanik-dev.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=AutoMecanik Dev Server (DEV:3000, backend workspace)
+After=network.target
+
+[Service]
+Type=simple
+# backend workspace = the canonical DEV:3000 runtime (run-p dev:compile dev:watch).
+# Must be backend/ (not repo root, which would run `turbo dev` across all workspaces)
+# and so the app loads backend/.env relative to cwd.
+WorkingDirectory=/opt/automecanik/app/backend
+ExecStart=/usr/bin/npm run dev
+Restart=on-failure
+RestartSec=5
+# Kill the ENTIRE cgroup (npm, run-p, tsc --build --watch, tsc-alias --watch, nodemon,
+# wait-and-start.js) on stop/restart. Structural fix for the recurring 0-byte dist crash:
+# no watcher can be orphaned to init and race the next run's tsc-alias rewriting dist/*.js.
+# (control-group is systemd's default; explicit here for intent.)
+KillMode=control-group
+KillSignal=SIGTERM
+TimeoutStopSec=15
+SyslogIdentifier=automecanik-dev
+Environment=NODE_ENV=development
+Environment=NODE_OPTIONS=--max-old-space-size=4096
+
+[Install]
+WantedBy=default.target

--- a/scripts/ops/clean-stale-watchers.sh
+++ b/scripts/ops/clean-stale-watchers.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# clean-stale-watchers.sh — reap stale/orphaned `npm run dev` watcher processes
+# for THIS repo before a fresh `npm run dev` starts.
+#
+# Wire it as the backend `predev` hook so every `npm run dev` begins from a clean
+# slate (npm runs `predev` to completion before `dev`):
+#
+#     "predev": "bash ../scripts/ops/clean-stale-watchers.sh",
+#
+# WHY THIS EXISTS
+# ---------------
+# A previous `npm run dev` whose top-level npm / terminal was killed (closed tab,
+# SIGHUP, crash) can leave its children orphaned — reparented to init (PPID=1):
+# `run-p`, `tsc --build --watch`, `tsc-alias -p tsconfig.json --watch`, `nodemon`,
+# `wait-and-start.js`. The dangerous one is a *second* `tsc-alias --watch`: two
+# `tsc-alias` processes rewrite the SAME `dist/*.js` in place, and when one reads a
+# file the other (or `tsc`) is mid-emit, the file is truncated to 0 bytes. NestJS
+# then boots into a misleading
+#
+#     A circular dependency has been detected inside <Module>
+#
+# because a provider/controller in the module's providers[]/controllers[] array
+# resolves to `undefined` (require() of the 0-byte .js returns `{}`). This 0-byte
+# truncation crash was observed 4 times in 16 days (2026-05-22, 2026-06-05,
+# 2026-06-07, 2026-06-13), each traced to duplicate watcher processes racing the
+# same dist.
+#
+# This script enforces the single-watcher invariant on the DEV box: kill any
+# pre-existing repo watcher so the incoming `npm run dev` is the only writer.
+#
+# SAFETY
+# ------
+#   * Repo-scoped: only matches watchers launched from THIS repo's node_modules/.bin
+#     (and `wait-and-start.js` whose cwd is under this repo). It never touches the
+#     VS Code tsserver, other projects' watchers, or unrelated node processes.
+#   * DEV-only by construction: CI and Docker run `build` / `start:prod`, never `dev`,
+#     so this hook is inert there.
+#   * Idempotent: a clean machine (no prior watchers) is a no-op clean exit.
+#   * `--dry-run` lists what would be killed without sending any signal.
+#
+# Usage: clean-stale-watchers.sh [--dry-run]
+
+set -uo pipefail
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+# Repo root = two levels up from this script (scripts/ops/ -> repo root).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN="${REPO_ROOT}/node_modules/.bin"
+SELF=$$
+
+log() { echo "[clean-stale-watchers] $*"; }
+
+candidates=()
+
+# (1) run-p / tsc / tsc-alias / nodemon launched from THIS repo's node_modules/.bin
+while IFS= read -r pid; do
+  [ -n "$pid" ] || continue
+  [ "$pid" = "$SELF" ] && continue
+  candidates+=("$pid")
+done < <(pgrep -f "${BIN}/(run-p|tsc|tsc-alias|nodemon)" 2>/dev/null || true)
+
+# (2) wait-and-start.js whose working directory is under this repo
+while IFS= read -r pid; do
+  [ -n "$pid" ] || continue
+  [ "$pid" = "$SELF" ] && continue
+  cwd="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
+  case "$cwd" in
+    "$REPO_ROOT" | "$REPO_ROOT"/*) candidates+=("$pid") ;;
+  esac
+done < <(pgrep -f 'wait-and-start\.js' 2>/dev/null || true)
+
+# Dedup. Guard against empty array under `set -u`.
+pids=()
+if [ "${#candidates[@]}" -gt 0 ]; then
+  mapfile -t pids < <(printf '%s\n' "${candidates[@]}" | sort -un)
+fi
+
+if [ "${#pids[@]}" -eq 0 ]; then
+  log "no stale repo watchers found — clean start."
+  exit 0
+fi
+
+log "found ${#pids[@]} stale repo watcher process(es):"
+for pid in "${pids[@]}"; do
+  printf '  pid=%-8s ppid=%-8s start=%s :: %s\n' \
+    "$pid" \
+    "$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')" \
+    "$(ps -o lstart= -p "$pid" 2>/dev/null)" \
+    "$(ps -o args= -p "$pid" 2>/dev/null | cut -c1-90)"
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  log "(--dry-run) no processes killed."
+  exit 0
+fi
+
+# Graceful SIGTERM, then SIGKILL any straggler.
+for pid in "${pids[@]}"; do kill "$pid" 2>/dev/null || true; done
+sleep 2
+for pid in "${pids[@]}"; do
+  if kill -0 "$pid" 2>/dev/null; then
+    log "SIGKILL straggler $pid"
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+done
+
+log "cleaned ${#pids[@]} stale watcher(s) — proceeding to a single-watcher start."
+exit 0

--- a/scripts/ops/install-dev-service.sh
+++ b/scripts/ops/install-dev-service.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# install-dev-service.sh — make systemd the canonical supervisor of DEV:3000.
+#
+# Run once on the DEV box (46.224.118.55) as the deploy user. Idempotent.
+#
+#     bash scripts/ops/install-dev-service.sh
+#
+# WHY (structural fix)
+# --------------------
+# DEV:3000 is `npm run dev` (run-p -> tsc --build --watch + tsc-alias --watch + nodemon).
+# When that command is launched from a terminal that later closes, its children are
+# reparented to init (orphaned). A second `npm run dev` then runs alongside the orphans,
+# and two `tsc-alias --watch` processes rewrite the SAME dist/*.js in place, truncating
+# files to 0 bytes mid-emit. NestJS then crashes at boot with a misleading
+# "A circular dependency has been detected inside <Module>". Seen 4x in 16 days.
+#
+# systemd runs the whole tree in one cgroup and `KillMode=control-group` tears the entire
+# cgroup down on stop/restart — so a watcher can never be orphaned. `Restart=on-failure`
+# also auto-recovers a crash. This makes the failure mode structurally impossible instead
+# of merely cleaned-up after the fact.
+#
+# Cutover is brief (~15s :3000 downtime) and reversible:
+#   systemctl --user stop automecanik-dev   # then `cd backend && npm run dev` to go manual again
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+UNIT_SRC="${REPO_ROOT}/scripts/ops/automecanik-dev.service"
+UNIT_DST="${HOME}/.config/systemd/user/automecanik-dev.service"
+
+log() { echo "[install-dev-service] $*"; }
+
+[ -f "$UNIT_SRC" ] || { echo "missing $UNIT_SRC" >&2; exit 1; }
+
+mkdir -p "$(dirname "$UNIT_DST")"
+install -m 0644 "$UNIT_SRC" "$UNIT_DST"
+log "installed unit -> $UNIT_DST"
+
+systemctl --user daemon-reload
+loginctl enable-linger "$(id -un)" >/dev/null 2>&1 || true   # service survives logout
+
+# Clean cutover, no restart-fight:
+#  (1) stop any systemd-managed instance (clean stop disables Restart),
+#  (2) reap any manual/orphaned watchers still on the box,
+#  (3) start fresh under systemd as the single instance.
+systemctl --user stop automecanik-dev.service 2>/dev/null || true
+bash "${REPO_ROOT}/scripts/ops/clean-stale-watchers.sh" || true
+systemctl --user enable --now automecanik-dev.service
+log "service enabled + started"
+
+for i in $(seq 1 20); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 http://localhost:3000/health 2>/dev/null || echo 000)"
+  log "/health=${code} (try ${i})"
+  if [ "$code" = "200" ]; then
+    log "DEV:3000 is now supervised by systemd. Logs: journalctl --user -u automecanik-dev -f"
+    exit 0
+  fi
+  sleep 4
+done
+
+log "WARNING: /health not 200 after ~80s — inspect: journalctl --user -u automecanik-dev -n 80 --no-pager" >&2
+exit 1


### PR DESCRIPTION
## Problème (cause racine structurelle)

DEV:3000 crashe périodiquement au boot sur :

```
A circular dependency has been detected inside AdminModule
```

Message **trompeur** : pas un cycle de code. Une entrée du `providers[]`/`controllers[]` vaut `undefined` car le `.js` compilé est **à 0 octet** (`require()` d'un `.js` vide → `{}`).

**Cause racine de fond** : le poste DEV a **déjà** un service systemd `automecanik-dev.service` (enabled, linger) censé superviser le dev server — mais il était **mort et mal configuré** (`WorkingDirectory` = racine → `turbo dev`, alors que le runtime canonique est le `npm run dev` **backend**). Du coup l'équipe lance `npm run dev` dans des **terminaux VSCode**, qui en se fermant **orphelinent** leurs watchers (run-p, `tsc --build --watch`, `tsc-alias --watch`, nodemon → reparentés à init). Un second run fait alors coexister **deux `tsc-alias --watch`** qui réécrivent le **même `dist/*.js` in-place** → troncature 0 octet. Constaté **4× en 16 j** (2026-05-22, 06-05, 06-07, 06-13).

## Correctif — le mieux : prévention structurelle (systemd), pas mitigation

### 1. `scripts/ops/automecanik-dev.service` (corrigé, version-contrôlé)
- `WorkingDirectory=/opt/automecanik/app/backend` → supervise **exactement** le runtime backend actuel (aucun changement de comportement) + l'app charge `backend/.env`.
- **`KillMode=control-group`** → systemd tue **tout le cgroup** à l'arrêt/restart : un watcher ne peut **jamais** être orphelin → le race 0-octet devient **structurellement impossible** (pas juste nettoyé après coup).
- `Restart=on-failure` → auto-récupère un crash comme celui d'aujourd'hui.

### 2. `scripts/ops/install-dev-service.sh` (cutover idempotent)
Installe l'unit, active linger, stoppe proprement toute instance, **reape** les watchers manuels/orphelins, `enable --now`, puis vérifie `/health`. Bascule ~15 s, réversible.

### 3. `scripts/ops/clean-stale-watchers.sh` (reaper, défense-en-profondeur)
Reaper repo-scopé (idempotent, `--dry-run`, n'effleure ni tsserver VS Code ni autres projets). Utilisé par l'installer pour le cutover ; **wireable** en `predev` backend si un `npm run dev` manuel est encore lancé.

## Activation (action owner — persistance systemd, le harness me bloque l'auto-activation)

```bash
bash scripts/ops/install-dev-service.sh    # sur le poste DEV, user deploy
```

Le fichier unit live a déjà été corrigé + `daemon-reload` ; il ne reste que l'activation (stop manuel → `systemctl --user enable --now`), que l'installer fait proprement.

## Validation
- `systemd-analyze --user verify` : unit valide.
- `clean-stale-watchers.sh --dry-run` testé contre les process vivants : ciblage exact, tsserver exclu, 0 tué.
- Incident du 13/06 déjà résolu manuellement (kill orphelins) ; cette PR **empêche la récurrence à la source**.

## Blast radius
- Poste DEV uniquement. **Aucun** impact PREPROD/PROD (qui n'exécutent jamais `npm run dev`). Aucune route, aucune table, aucun code applicatif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)