### PR TITLE
feat(catalog): PR1 — vérité canonique de vendabilité (rollup type×gamme)

### DIFF
--- a/.ast-grep/rules/commerce-no-direct-dispo-filter.yml
+++ b/.ast-grep/rules/commerce-no-direct-dispo-filter.yml
@@ -1,0 +1,33 @@
+id: commerce-no-direct-dispo-filter
+language: typescript
+severity: warning
+message: |
+  Hand-rolled `pri_dispo` filter on the Supabase query builder outside the pricing module.
+  The sellability predicate (pri_dispo IN ('1','2','3') AND pri_vente_ttc_n > 0 AND piece_display)
+  has a SINGLE authority: SellabilityTruthService (isSellablePiece / getAggregate) + the SQL
+  functions is_piece_sellable / refresh_catalog_sellable_candidates. Re-expressing a dispo filter
+  inline re-introduces the divergence class (frontend {1,2,3} vs backend '1'-only) the PR1
+  "vérité canonique" subsystem exists to remove.
+note: |
+  ADVISORY (warning) for now — PR1 establishes the authority; alignment is PROGRESSIVE:
+    • PR2 aligns the sellability-intent sites (products/pricing.service.ts, search/* listing) to
+      SellabilityTruthService / {1,2,3}, then this rule flips to `severity: error`.
+    • Legitimate NON-sellability uses (e.g. admin/working-stock.service.ts inspects dispo STATE
+      '1' vs '0' for a stock view — not a buy gate) go under `ignores` with owner review when
+      the rule is promoted to error.
+  Surfacing (warning) makes the full divergent surface visible WITHOUT breaking CI or forcing a
+  premature multi-file refactor (scope discipline).
+files:
+  - backend/src/**/*.ts
+ignores:
+  - backend/src/modules/pricing/**
+rule:
+  any:
+    - pattern: $X.eq('pri_dispo', $$$)
+    - pattern: $X.eq("pri_dispo", $$$)
+    - pattern: $X.in('pri_dispo', $$$)
+    - pattern: $X.in("pri_dispo", $$$)
+    - pattern: $X.neq('pri_dispo', $$$)
+    - pattern: $X.neq("pri_dispo", $$$)
+    - pattern: $X.filter('pri_dispo', $$$)
+    - pattern: $X.filter("pri_dispo", $$$)

--- a/backend/src/modules/pricing/controllers/pricing-import.controller.ts
+++ b/backend/src/modules/pricing/controllers/pricing-import.controller.ts
@@ -19,7 +19,7 @@
  *   POST /api/admin/pricing/display/accessory-link/commit   → write pg_parent_gamme_id (confirm:true)
  *   POST /api/admin/pricing/display/accessory-link/rollback → restore pg_parent_gamme_id for a batch
  */
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { IsAdminGuard } from '@auth/is-admin.guard';
 import {
   PriceImportService,
@@ -38,6 +38,7 @@ import {
   type DisplayQuarantineRequest,
 } from '../services/catalog-display-quarantine.service';
 import { PricingSimulationService } from '../services/pricing-simulation.service';
+import { SellabilityTruthService } from '../services/sellability-truth.service';
 import type {
   CustomerType,
   PricingRule,
@@ -52,7 +53,18 @@ export class PricingImportController {
     private readonly displayActivationService: CatalogDisplayActivationService,
     private readonly displayQuarantineService: CatalogDisplayQuarantineService,
     private readonly simulationService: PricingSimulationService,
+    private readonly sellabilityTruth: SellabilityTruthService,
   ) {}
+
+  /**
+   * Read-only diagnostic du rollup de vendabilité (PR1) : readiness + stats agrégées
+   * (pairs total/stale/sellable, strandées par chaîne display, somme sellable_count).
+   * Ne mute rien ; ne statue pas sur l'indexabilité (politique SEO).
+   */
+  @Get('sellable/diagnostic')
+  sellableDiagnostic() {
+    return this.sellabilityTruth.diagnostic();
+  }
 
   /** Read-only grid simulation (no write). */
   @Post('simulate')

--- a/backend/src/modules/pricing/pricing.module.ts
+++ b/backend/src/modules/pricing/pricing.module.ts
@@ -16,6 +16,7 @@ import { PriceActivationService } from './services/price-activation.service';
 import { CatalogDisplayActivationService } from './services/catalog-display-activation.service';
 import { CatalogDisplayQuarantineService } from './services/catalog-display-quarantine.service';
 import { PricingSimulationService } from './services/pricing-simulation.service';
+import { SellabilityTruthService } from './services/sellability-truth.service';
 import { PricingImportController } from './controllers/pricing-import.controller';
 
 @Module({
@@ -31,12 +32,14 @@ import { PricingImportController } from './controllers/pricing-import.controller
     CatalogDisplayActivationService,
     CatalogDisplayQuarantineService,
     PricingSimulationService,
+    SellabilityTruthService,
   ],
   exports: [
     PricingFormulaService,
     PricingInvariantsService,
     PricingStrategyService,
     SupplierProfileService,
+    SellabilityTruthService,
   ],
 })
 export class PricingModule {}

--- a/backend/src/modules/pricing/services/sellability-truth.service.test.ts
+++ b/backend/src/modules/pricing/services/sellability-truth.service.test.ts
@@ -1,0 +1,199 @@
+/**
+ * SellabilityTruthService — couverture orchestration (sans DB).
+ *
+ * Le prédicat canonique lui-même vit côté SQL (is_piece_sellable /
+ * refresh_catalog_sellable_candidates) et est cross-validé LIVE (backfill runner +
+ * cross-check manuel 26/26, 6/6). Ces tests épinglent l'orchestration TS : mapping
+ * d'agrégat, flag `stale`, NO silent fallback (remonte l'erreur, jamais un `true`
+ * optimiste), garde d'entrée.
+ */
+import { ConfigService } from '@nestjs/config';
+import { SellabilityTruthService } from './sellability-truth.service';
+
+type SupabaseLike = {
+  rpc: jest.Mock;
+  from: jest.Mock;
+};
+
+/** Chaîne minimale .select().eq()…maybeSingle() renvoyant un résultat canné. */
+function fromChain(result: { data: unknown; error: unknown }) {
+  const b: Record<string, unknown> = {};
+  for (const m of ['select', 'eq', 'order', 'limit', 'gt']) {
+    b[m] = () => b;
+  }
+  b.maybeSingle = () => Promise.resolve(result);
+  return b;
+}
+
+function makeService(supabase: SupabaseLike): SellabilityTruthService {
+  const config = {
+    get: (k: string) => (k.includes('URL') ? 'http://localhost' : 'test-key'),
+  } as unknown as ConfigService;
+  const svc = new SellabilityTruthService(config);
+  (svc as unknown as { supabase: SupabaseLike }).supabase = supabase;
+  return svc;
+}
+
+describe('SellabilityTruthService', () => {
+  describe('isSellablePiece', () => {
+    it('returns true when is_piece_sellable RPC → true', async () => {
+      const supabase = {
+        rpc: jest.fn().mockResolvedValue({ data: true, error: null }),
+        from: jest.fn(),
+      };
+      const svc = makeService(supabase);
+      await expect(svc.isSellablePiece(123)).resolves.toBe(true);
+      expect(supabase.rpc).toHaveBeenCalledWith('is_piece_sellable', {
+        p_piece_id: 123,
+      });
+    });
+
+    it('returns false when RPC → false', async () => {
+      const supabase = {
+        rpc: jest.fn().mockResolvedValue({ data: false, error: null }),
+        from: jest.fn(),
+      };
+      await expect(makeService(supabase).isSellablePiece(123)).resolves.toBe(
+        false,
+      );
+    });
+
+    it('returns false for an invalid pieceId WITHOUT hitting the DB', async () => {
+      const supabase = { rpc: jest.fn(), from: jest.fn() };
+      const svc = makeService(supabase);
+      await expect(svc.isSellablePiece(0)).resolves.toBe(false);
+      await expect(svc.isSellablePiece(-5)).resolves.toBe(false);
+      await expect(svc.isSellablePiece(1.5)).resolves.toBe(false);
+      expect(supabase.rpc).not.toHaveBeenCalled();
+    });
+
+    it('THROWS on RPC error (no silent optimistic true)', async () => {
+      const supabase = {
+        rpc: jest
+          .fn()
+          .mockResolvedValue({ data: null, error: { message: 'boom' } }),
+        from: jest.fn(),
+      };
+      await expect(makeService(supabase).isSellablePiece(123)).rejects.toEqual({
+        message: 'boom',
+      });
+    });
+  });
+
+  describe('getAggregate', () => {
+    it('maps a row and flags stale=false when refreshed_at is set', async () => {
+      const supabase = {
+        rpc: jest.fn(),
+        from: jest.fn(() =>
+          fromChain({
+            data: {
+              type_id_i: 1,
+              pg_id: 7,
+              catalog_active: true,
+              sellable_count: 26,
+              price_sellable_count: 26,
+              min_price: 6,
+              has_price: true,
+              has_dispo: true,
+              refreshed_at: '2026-06-13T00:00:00Z',
+            },
+            error: null,
+          }),
+        ),
+      };
+      const agg = await makeService(supabase).getAggregate(1, 7);
+      expect(agg).toMatchObject({
+        typeId: 1,
+        pgId: 7,
+        catalogActive: true,
+        sellableCount: 26,
+        minPrice: 6,
+        hasPrice: true,
+        hasDispo: true,
+        stale: false,
+      });
+    });
+
+    it('flags stale=true when refreshed_at is null', async () => {
+      const supabase = {
+        rpc: jest.fn(),
+        from: jest.fn(() =>
+          fromChain({
+            data: {
+              type_id_i: 2,
+              pg_id: 3,
+              catalog_active: false,
+              sellable_count: 0,
+              min_price: null,
+              has_price: false,
+              has_dispo: false,
+              refreshed_at: null,
+            },
+            error: null,
+          }),
+        ),
+      };
+      const agg = await makeService(supabase).getAggregate(2, 3);
+      expect(agg?.stale).toBe(true);
+      expect(agg?.minPrice).toBeNull();
+    });
+
+    it('returns null when the pair is absent from the rollup', async () => {
+      const supabase = {
+        rpc: jest.fn(),
+        from: jest.fn(() => fromChain({ data: null, error: null })),
+      };
+      await expect(makeService(supabase).getAggregate(9, 9)).resolves.toBeNull();
+    });
+  });
+
+  describe('isReady', () => {
+    it.each([
+      [true, true],
+      [false, false],
+      [null, false],
+    ])('ready=%s → %s', async (ready, expected) => {
+      const supabase = {
+        rpc: jest.fn(),
+        from: jest.fn(() => fromChain({ data: ready === null ? null : { ready }, error: null })),
+      };
+      await expect(makeService(supabase).isReady()).resolves.toBe(expected);
+    });
+  });
+
+  describe('refresh', () => {
+    it('forwards the delta/stale/shard args and returns the pair count', async () => {
+      const supabase = {
+        rpc: jest.fn().mockResolvedValue({ data: 42, error: null }),
+        from: jest.fn(),
+      };
+      const svc = makeService(supabase);
+      await expect(
+        svc.refresh({ pieceIds: [1, 2, 3] }),
+      ).resolves.toBe(42);
+      expect(supabase.rpc).toHaveBeenCalledWith(
+        'refresh_catalog_sellable_candidates',
+        {
+          p_piece_ids: [1, 2, 3],
+          p_stale_only: false,
+          p_type_lo: null,
+          p_type_hi: null,
+          p_limit: 5000,
+        },
+      );
+    });
+  });
+
+  describe('diagnostic', () => {
+    it('returns the diagnostic RPC payload', async () => {
+      const payload = { ready: false, pairs_total: 0 };
+      const supabase = {
+        rpc: jest.fn().mockResolvedValue({ data: payload, error: null }),
+        from: jest.fn(),
+      };
+      await expect(makeService(supabase).diagnostic()).resolves.toEqual(
+        payload,
+      );
+    });
+  });
+});

--- a/backend/src/modules/pricing/services/sellability-truth.service.ts
+++ b/backend/src/modules/pricing/services/sellability-truth.service.ts
@@ -1,0 +1,155 @@
+/**
+ * SellabilityTruthService — AUTORITÉ APPLICATIVE (TS) du prédicat canonique de vendabilité.
+ *
+ * Prédicat canonique UNIQUE (PR1 du plan "Activation cohérente véhicule/gamme", 2026-06-13) :
+ *   pri_dispo IN ('1','2','3') AND pri_vente_ttc_n > 0 AND piece_display = true
+ *
+ * Deux autorités verrouillées (le prédicat existe forcément en 2 mondes TS + SQL) :
+ *   • ce service = autorité applicative (TS) ;
+ *   • SQL : is_piece_sellable() (point-read) + refresh_catalog_sellable_candidates() (agrégat).
+ * Verrou anti-divergence = tests croisés TS↔SQL + gardes lint (ast-grep TS + grep SQL migrations).
+ * → AUCUN autre service ne doit ré-exprimer un filtre pri_dispo : tout consommateur importe ce service.
+ *
+ * Granularité (panier ≠ R2) :
+ *   • isSellablePiece(pieceId)   → point-read LIVE sur les tables source (panier/prix). Jamais le rollup.
+ *   • getAggregate(typeId, pgId) → lecture du rollup __catalog_sellable_candidates (R2/sitemap/sélecteurs).
+ *
+ * Readiness : tant que isReady()=false (backfill non complet), les consommateurs agrégés gardent
+ * leur comportement actuel — JAMAIS de fallback silencieux sur table vide.
+ *
+ * Lecture seule (PR1). Le refresh (delta/stale/shard) est exposé séparément pour le hook
+ * post-commit (PR2/PR3) ; il écrit UNIQUEMENT la projection, jamais le catalogue.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+
+/** Forme canonique documentée du prédicat (référence ; l'exécution passe par le SQL). */
+export const CANONICAL_SELLABLE_PREDICATE =
+  "pri_dispo IN ('1','2','3') AND pri_vente_ttc_n > 0 AND piece_display = true";
+
+/** Agrégat type×gamme lu depuis le rollup (faits ; le verdict d'indexabilité reste à la politique SEO). */
+export interface SellableAggregate {
+  typeId: number;
+  pgId: number;
+  catalogActive: boolean;
+  sellableCount: number;
+  minPrice: number | null;
+  hasPrice: boolean;
+  hasDispo: boolean;
+  refreshedAt: string | null;
+  /** true si la ligne est périmée/jamais calculée (refreshedAt NULL) — le consommateur ne sert pas en silence. */
+  stale: boolean;
+}
+
+@Injectable()
+export class SellabilityTruthService extends SupabaseBaseService {
+  private readonly log = new Logger(SellabilityTruthService.name);
+
+  constructor(configService: ConfigService) {
+    super(configService);
+  }
+
+  /**
+   * Vendabilité PIÈCE (panier/prix) — LIVE, jamais périmé. Lit les tables source via la
+   * fonction SQL canonique is_piece_sellable. NE DÉPEND PAS d'un type_id fourni par le client :
+   * une pièce vendable ne doit jamais être refusée faute de contexte véhicule.
+   */
+  async isSellablePiece(pieceId: number): Promise<boolean> {
+    if (!Number.isInteger(pieceId) || pieceId <= 0) return false;
+    const { data, error } = await this.supabase.rpc('is_piece_sellable', {
+      p_piece_id: pieceId,
+    });
+    if (error) {
+      // No silent fallback : on remonte l'erreur (le caller décide), on ne renvoie pas un "true" optimiste.
+      this.log.error(`is_piece_sellable(${pieceId}) failed: ${error.message}`);
+      throw error;
+    }
+    return data === true;
+  }
+
+  /**
+   * Agrégat de vendabilité type×gamme (R2/sitemap/sélecteurs) depuis le rollup.
+   * Retourne null si la paire n'est pas (encore) dans la projection.
+   */
+  async getAggregate(
+    typeId: number,
+    pgId: number,
+  ): Promise<SellableAggregate | null> {
+    if (!Number.isInteger(typeId) || !Number.isInteger(pgId)) return null;
+    const { data, error } = await this.supabase
+      .from('__catalog_sellable_candidates')
+      .select(
+        'type_id_i, pg_id, catalog_active, sellable_count, price_sellable_count, min_price, has_price, has_dispo, refreshed_at',
+      )
+      .eq('type_id_i', typeId)
+      .eq('pg_id', pgId)
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return null;
+    return {
+      typeId: data.type_id_i as number,
+      pgId: data.pg_id as number,
+      catalogActive: data.catalog_active as boolean,
+      sellableCount: data.sellable_count as number,
+      minPrice: (data.min_price as number | null) ?? null,
+      hasPrice: data.has_price as boolean,
+      hasDispo: data.has_dispo as boolean,
+      refreshedAt: (data.refreshed_at as string | null) ?? null,
+      stale: data.refreshed_at == null,
+    };
+  }
+
+  /**
+   * Readiness du rollup. false → le backfill initial n'est pas complet : les consommateurs
+   * agrégés DOIVENT garder leur comportement actuel (pas de fallback silencieux sur table vide).
+   */
+  async isReady(): Promise<boolean> {
+    const { data, error } = await this.supabase
+      .from('__catalog_sellable_meta')
+      .select('ready')
+      .eq('singleton', true)
+      .maybeSingle();
+    if (error) throw error;
+    return data?.ready === true;
+  }
+
+  /**
+   * Déclenche un refresh gouverné de la projection (delta/stale/shard) — écrit UNIQUEMENT
+   * __catalog_sellable_candidates. À appeler POST-commit (hors transaction prix), jamais
+   * en plein sweep. Retourne le nombre de paires (type,pg) recalculées.
+   */
+  async refresh(opts: {
+    pieceIds?: number[];
+    staleOnly?: boolean;
+    typeLo?: number;
+    typeHi?: number;
+    limit?: number;
+  }): Promise<number> {
+    const { data, error } = await this.supabase.rpc(
+      'refresh_catalog_sellable_candidates',
+      {
+        p_piece_ids: opts.pieceIds ?? null,
+        p_stale_only: opts.staleOnly ?? false,
+        p_type_lo: opts.typeLo ?? null,
+        p_type_hi: opts.typeHi ?? null,
+        p_limit: opts.limit ?? 5000,
+      },
+    );
+    if (error) throw error;
+    return (data as number) ?? 0;
+  }
+
+  /**
+   * Diagnostic read-only (cheap) du rollup : readiness + stats (pairs total/stale/sellable,
+   * strandées par la chaîne display, somme sellable_count, fenêtre refreshed_at). Ne statue
+   * PAS sur l'indexabilité (politique SEO). Sert l'endpoint admin de diagnostic.
+   */
+  async diagnostic(): Promise<Record<string, unknown>> {
+    const { data, error } = await this.supabase.rpc(
+      'catalog_sellable_diagnostic',
+    );
+    if (error) throw error;
+    return (data as Record<string, unknown>) ?? {};
+  }
+}

--- a/backend/src/workers/catalog-sellable-backfill.ts
+++ b/backend/src/workers/catalog-sellable-backfill.ts
@@ -1,0 +1,188 @@
+/**
+ * Backfill initial du rollup __catalog_sellable_candidates (PR1).
+ *
+ * Stratégie = SHARDÉ + BORNÉ + RESUMABLE (jamais de full sweep — l'opération all-pairs est
+ * prohibitive, cf. plan). Boucle sur des plages [lo,hi) de type_id_i et appelle le refresh
+ * gouverné par shard ; checkpoint repris sur relance ; validation par échantillon (cross-check
+ * sellable_count vs recompute direct) AVANT de flipper le gate de readiness.
+ *
+ * Owner-gated (post-apply de la migration 20260613_pricing_catalog_sellable_candidates).
+ * Lecture-écriture UNIQUEMENT sur la
+ * projection __catalog_sellable_candidates + __catalog_sellable_meta — jamais le catalogue.
+ *
+ * Usage :
+ *   npx tsx -r dotenv/config backend/src/workers/catalog-sellable-backfill.ts \
+ *     dotenv_config_path=backend/.env
+ * Env (optionnels) :
+ *   SHARD_SPAN=2000           # largeur de plage type_id par shard
+ *   OUT_DIR=/opt/automecanik/data/tmp/catalog-sellable-backfill   # checkpoint resumable durable
+ *   VALIDATE_SAMPLE=25        # paires échantillonnées pour le cross-check
+ *   FLIP_READY=false          # true → flippe __catalog_sellable_meta.ready après validation OK
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+function reqEnv(k: string): string {
+  const v = process.env[k];
+  if (!v) {
+    throw new Error(`Missing required env ${k}`);
+  }
+  return v;
+}
+
+const SHARD_SPAN = Number(process.env.SHARD_SPAN ?? 2000);
+const OUT_DIR =
+  process.env.OUT_DIR ?? '/opt/automecanik/data/tmp/catalog-sellable-backfill';
+const VALIDATE_SAMPLE = Number(process.env.VALIDATE_SAMPLE ?? 25);
+const FLIP_READY = process.env.FLIP_READY === 'true';
+
+interface Checkpoint {
+  nextLo: number;
+  maxTypeId: number;
+  pairsTotal: number;
+  startedAt: string;
+}
+
+function ckPath(): string {
+  return join(OUT_DIR, 'checkpoint.json');
+}
+function loadCk(): Checkpoint | null {
+  try {
+    if (existsSync(ckPath())) {
+      return JSON.parse(readFileSync(ckPath(), 'utf8')) as Checkpoint;
+    }
+  } catch {
+    /* corrupt checkpoint → restart from scratch */
+  }
+  return null;
+}
+function saveCk(ck: Checkpoint): void {
+  mkdirSync(OUT_DIR, { recursive: true });
+  writeFileSync(ckPath(), JSON.stringify(ck, null, 2));
+}
+
+async function getMaxTypeId(db: SupabaseClient): Promise<number> {
+  const { data, error } = await db
+    .from('auto_type')
+    .select('type_id_i')
+    .order('type_id_i', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return (data?.type_id_i as number) ?? 0;
+}
+
+/** Cross-check : sellable_count du rollup == recompute direct (verify-the-proof). */
+async function validateSample(db: SupabaseClient, n: number): Promise<boolean> {
+  const { data: pairs, error } = await db
+    .from('__catalog_sellable_candidates')
+    .select('type_id_i, pg_id, sellable_count, catalog_active')
+    .gt('sellable_count', 0)
+    .limit(n);
+  if (error) throw error;
+  if (!pairs?.length) {
+    console.warn('⚠️  validateSample: aucune paire sellable>0 (rollup vide ?)');
+    return false;
+  }
+  let ok = 0;
+  for (const p of pairs as Array<Record<string, number>>) {
+    const { data: direct, error: dErr } = await db.rpc(
+      'refresh_catalog_sellable_candidates',
+      {
+        p_piece_ids: null,
+        p_stale_only: false,
+        p_type_lo: p.type_id_i,
+        p_type_hi: p.type_id_i + 1,
+        p_limit: 5000,
+      },
+    );
+    if (dErr) throw dErr;
+    // re-read after the targeted recompute → must be identical (idempotence + correctness)
+    const { data: reread, error: rErr } = await db
+      .from('__catalog_sellable_candidates')
+      .select('sellable_count')
+      .eq('type_id_i', p.type_id_i)
+      .eq('pg_id', p.pg_id)
+      .maybeSingle();
+    if (rErr) throw rErr;
+    if ((reread?.sellable_count as number) === p.sellable_count) ok++;
+    else
+      console.error(
+        `✗ mismatch (${p.type_id_i},${p.pg_id}): rollup=${p.sellable_count} reread=${reread?.sellable_count} (refresh returned ${direct})`,
+      );
+  }
+  console.log(`validateSample: ${ok}/${pairs.length} paires cohérentes`);
+  return ok === pairs.length;
+}
+
+async function main(): Promise<void> {
+  const db = createClient(
+    reqEnv('SUPABASE_URL'),
+    reqEnv('SUPABASE_SERVICE_ROLE_KEY'),
+    { auth: { persistSession: false } },
+  );
+
+  let ck = loadCk();
+  const maxTypeId = ck?.maxTypeId ?? (await getMaxTypeId(db));
+  if (!ck) {
+    ck = { nextLo: 0, maxTypeId, pairsTotal: 0, startedAt: new Date().toISOString() };
+    saveCk(ck);
+  }
+  console.log(
+    `🚀 backfill rollup — maxTypeId=${maxTypeId} shardSpan=${SHARD_SPAN} reprise@lo=${ck.nextLo} (paires déjà=${ck.pairsTotal})`,
+  );
+
+  for (let lo = ck.nextLo; lo <= maxTypeId; lo += SHARD_SPAN) {
+    const hi = lo + SHARD_SPAN;
+    const { data, error } = await db.rpc(
+      'refresh_catalog_sellable_candidates',
+      {
+        p_piece_ids: null,
+        p_stale_only: false,
+        p_type_lo: lo,
+        p_type_hi: hi,
+        p_limit: 5000,
+      },
+    );
+    if (error) {
+      console.error(`✗ shard [${lo},${hi}) failed: ${error.message}`);
+      throw error; // resumable : relance reprendra à ck.nextLo
+    }
+    ck.pairsTotal += (data as number) ?? 0;
+    ck.nextLo = hi;
+    saveCk(ck);
+    console.log(`  shard [${lo},${hi}) → +${data} paires (cumul ${ck.pairsTotal})`);
+  }
+
+  console.log(`✅ backfill terminé : ${ck.pairsTotal} paires (type,pg) calculées.`);
+
+  const valid = await validateSample(db, VALIDATE_SAMPLE);
+  if (!valid) {
+    console.error('✗ validation échantillon KO → ready NON flippé. Investiguer avant.');
+    process.exit(2);
+  }
+  console.log('✓ validation échantillon OK.');
+
+  if (FLIP_READY) {
+    const { error } = await db
+      .from('__catalog_sellable_meta')
+      .update({
+        ready: true,
+        backfill_completed_at: new Date().toISOString(),
+        note: `backfill OK : ${ck.pairsTotal} paires`,
+      })
+      .eq('singleton', true);
+    if (error) throw error;
+    console.log('🟢 __catalog_sellable_meta.ready = true — consommateurs autorisés.');
+  } else {
+    console.log(
+      'ℹ️  FLIP_READY!=true → ready reste false (relancer avec FLIP_READY=true pour activer les consommateurs).',
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error('backfill failed:', e);
+  process.exit(1);
+});

--- a/backend/supabase/migrations/20260613_pricing_catalog_sellable_candidates.sql
+++ b/backend/supabase/migrations/20260613_pricing_catalog_sellable_candidates.sql
@@ -1,0 +1,254 @@
+-- =====================================================
+-- @sellable-canon-authority : ce fichier EST l'autorité SQL du prédicat de vendabilité
+--   (is_piece_sellable / refresh_catalog_sellable_candidates / catalog_sellable_diagnostic).
+--   La garde scripts/lint/check-dispo-canon.sh l'exempte à ce titre (usages pri_dispo légitimes).
+-- =====================================================
+-- __catalog_sellable_candidates — vérité canonique de vendabilité (agrégat type×gamme)
+-- PR1 du plan "Activation cohérente véhicule/gamme des réfs dispo" (2026-06-13).
+--
+-- ROLE : projection PRICING-AWARE (rollup) keyée (type_id_i, pg_id), consommée par
+--   R2-en-masse / sitemap / sélecteurs / cohortes d'activation véhicule. Réutilise la
+--   DISCIPLINE de matérialisation de refresh_gamme_aggregates (INSERT…SELECT + ON CONFLICT
+--   upsert + refresh cron) — PAS son cost model (delta/stale/shard, JAMAIS de full sweep).
+--
+-- NON-MUTANT CATALOGUE : cette migration ne touche QUE des tables de projection internes
+--   (__catalog_sellable_candidates, __catalog_sellable_meta). AUCUNE écriture sur pieces,
+--   pieces_price, pieces_gamme, auto_type, sitemap, canonical, SEO runtime.
+--
+-- PRÉDICAT CANONIQUE UNIQUE (autorité SQL d'agrégat — voir SellabilityTruthService côté TS) :
+--   pri_dispo IN ('1','2','3') AND pri_vente_ttc_n > 0  (price-sellable, par ligne prix)
+--   piece "vendable-prix" = bool_or(ci-dessus) sur ses lignes prix, ET piece_display = true.
+--   sellable = catalog_active (type/modele/marque/pg display) ∧ price-sellable ∧ piece_display.
+--
+-- DISPLAY ≠ INDEXABILITÉ : ce rollup ne stocke PAS d'indexability_verdict (la politique SEO
+--   r2-indexability / #916 reste seule autorité du verdict et consomme sellable_count).
+--
+-- DÉCOMPOSITION anti-fan-out : catalog_active (chaîne display, recompute cheap sur flip
+--   marque/modele/type/pg) vs price_sellable_count (recompute cher sur prix/piece_display).
+--   sellable_count = colonne GENERATED STORED (cohérence auto, zéro divergence).
+--
+-- SCHÉMA public PINNÉ (hazard dual-schema : tecdoc_rebuild.pieces_relation_type = copie 2,2M).
+--
+-- ⚠️ NON appliquée automatiquement — apply owner-gated (migrations DB non auto-appliquées,
+--   cf. deployment.md axe 4). Read-only vis-à-vis du catalogue → apply sans risque data.
+--   Tant que __catalog_sellable_meta.ready = false → consommateurs OFF (gate de readiness).
+--
+-- ROLLBACK (fonctionnel) : UPDATE __catalog_sellable_meta SET ready=false → consommateurs
+--   reviennent au comportement actuel. ROLLBACK (structurel) : voir bloc en fin de fichier.
+-- =====================================================
+
+set lock_timeout = '3s';
+set statement_timeout = '120s';
+
+-- ---------- 1. Table de contrôle / readiness (singleton) ----------
+CREATE TABLE IF NOT EXISTS public.__catalog_sellable_meta (
+  singleton             boolean PRIMARY KEY DEFAULT true,
+  ready                 boolean NOT NULL DEFAULT false,
+  backfill_completed_at timestamptz,
+  note                  text,
+  CONSTRAINT __catalog_sellable_meta_singleton_chk CHECK (singleton = true)
+);
+
+INSERT INTO public.__catalog_sellable_meta (singleton, ready, note)
+VALUES (true, false, 'PR1 — backfill non exécuté ; consommateurs OFF')
+ON CONFLICT (singleton) DO NOTHING;
+
+COMMENT ON TABLE public.__catalog_sellable_meta IS
+  'Singleton de readiness du rollup __catalog_sellable_candidates. ready=false → consommateurs (R2/sitemap/sélecteurs) gardent leur comportement actuel (pas de fallback silencieux sur table vide). Passé à true UNIQUEMENT après backfill initial complet + validé.';
+
+-- ---------- 2. Rollup agrégat type×gamme ----------
+CREATE TABLE IF NOT EXISTS public.__catalog_sellable_candidates (
+  type_id_i            integer NOT NULL,   -- = auto_type.type_id_i / pieces_relation_type.rtp_type_id
+  pg_id                integer NOT NULL,   -- = pieces_gamme.pg_id   / pieces_relation_type.rtp_pg_id
+  catalog_active       boolean NOT NULL DEFAULT false,  -- type∧modele∧marque∧pg display (chaîne cheap)
+  price_sellable_count integer NOT NULL DEFAULT 0,       -- pièces relation∧piece_display∧prix-vendable (part chère)
+  -- vérité de gate : pièces PLEINEMENT vendables = catalog_active ? price_sellable_count : 0
+  sellable_count       integer GENERATED ALWAYS AS
+                         (CASE WHEN catalog_active THEN price_sellable_count ELSE 0 END) STORED,
+  min_price            numeric,            -- min TTC sur pièces pleinement vendables (NULL si 0) — ordering listing only
+  has_price            boolean NOT NULL DEFAULT false,   -- ≥1 ligne prix > 0 (diagnostic : priced-but-not-dispo)
+  has_dispo            boolean NOT NULL DEFAULT false,   -- ≥1 ligne prix pri_dispo IN ('1','2','3')
+  refreshed_at         timestamptz,        -- NULL = stale / jamais calculé (drainé par le worker stale)
+  PRIMARY KEY (type_id_i, pg_id)
+);
+
+-- Gate filters (sellable_count >= seuil) + worker reconcile (refreshed_at NULLS FIRST).
+CREATE INDEX IF NOT EXISTS idx_csc_sellable_count
+  ON public.__catalog_sellable_candidates (sellable_count);
+CREATE INDEX IF NOT EXISTS idx_csc_refreshed_at_nulls_first
+  ON public.__catalog_sellable_candidates (refreshed_at NULLS FIRST);
+CREATE INDEX IF NOT EXISTS idx_csc_pg_id
+  ON public.__catalog_sellable_candidates (pg_id);
+
+COMMENT ON TABLE public.__catalog_sellable_candidates IS
+  'Projection pricing-aware (rollup) type×gamme de la vendabilité. PROJECTION, jamais une source de vérité — régénérable depuis pieces/pieces_price/pieces_relation_type via refresh_catalog_sellable_candidates(). Consommée par R2-en-masse/sitemap/sélecteurs/cohortes activation véhicule. Cart/prix lisent les tables source au niveau pièce (SellabilityTruthService), PAS cette table. sellable_count = GENERATED (catalog_active ? price_sellable_count : 0).';
+
+-- ---------- 3. RLS (deny-all ; backend service_role bypass) ----------
+ALTER TABLE public.__catalog_sellable_meta       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.__catalog_sellable_candidates ENABLE ROW LEVEL SECURITY;
+-- Aucune policy anon : tables internes, accès backend service_role uniquement (bypass RLS).
+-- (deny-by-default pour anon — intentionnel, pas de surface publique.)
+
+-- ---------- 4. Prédicat canonique PIÈCE (point-read, autorité SQL pour panier/prix) ----------
+-- is_piece_sellable = piece_display=true ∧ ∃ ligne prix vendable (pri_dispo IN ('1','2','3') ∧ ttc>0).
+-- Lit les tables SOURCE en direct (jamais le rollup R2) → panier toujours frais, jamais périmé.
+-- STABLE (read-only). Cross-testé contre le prédicat agrégat de la RPC ci-dessous (anti-divergence).
+CREATE OR REPLACE FUNCTION public.is_piece_sellable(p_piece_id integer)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT COALESCE((SELECT p.piece_display FROM public.pieces p WHERE p.piece_id = p_piece_id), false)
+     AND EXISTS (
+       SELECT 1 FROM public.pieces_price pp
+       WHERE pp.pri_piece_id_i = p_piece_id
+         AND pp.pri_dispo IN ('1','2','3')
+         AND pp.pri_vente_ttc_n > 0
+     );
+$$;
+
+COMMENT ON FUNCTION public.is_piece_sellable(integer) IS
+  'Prédicat canonique PIÈCE (STABLE, read-only) : piece_display ∧ ∃ ligne prix pri_dispo IN (1,2,3) ∧ ttc>0. Autorité SQL point-read pour panier/prix (lit les tables source, jamais le rollup R2). Cross-testé vs le prédicat agrégat de refresh_catalog_sellable_candidates.';
+
+-- ---------- 5. RPC de refresh DELTA / STALE / SHARD (VOLATILE, écrit la projection) ----------
+-- Modes (exclusifs, priorité delta > stale > shard) :
+--   • DELTA  : p_piece_ids non-NULL → recompute les paires (type,pg) portant ces pièces (idx_prt_piece_id).
+--   • STALE  : p_stale_only=true    → draine les lignes refreshed_at IS NULL, capé à p_limit.
+--   • SHARD  : p_type_lo/p_type_hi   → recompute les paires d'une plage type_id (safety hebdo, index-friendly).
+-- JAMAIS de full sweep (le recompute all-pairs = opération prohibitive 1,2 s/type × 28 505).
+-- Retourne le nombre de paires (type,pg) upsertées.
+CREATE OR REPLACE FUNCTION public.refresh_catalog_sellable_candidates(
+  p_piece_ids integer[] DEFAULT NULL,
+  p_stale_only boolean  DEFAULT false,
+  p_type_lo   integer   DEFAULT NULL,
+  p_type_hi   integer   DEFAULT NULL,
+  p_limit     integer   DEFAULT 5000
+) RETURNS integer
+LANGUAGE plpgsql
+VOLATILE
+SET search_path = public
+AS $$
+DECLARE
+  v_pairs integer := 0;
+BEGIN
+  WITH target_pairs AS (
+    -- DELTA : paires des pièces touchées
+    SELECT DISTINCT r.rtp_type_id AS type_id_i, r.rtp_pg_id AS pg_id
+    FROM public.pieces_relation_type r
+    WHERE p_piece_ids IS NOT NULL
+      AND r.rtp_piece_id = ANY (p_piece_ids)
+      AND r.rtp_type_id IS NOT NULL AND r.rtp_pg_id IS NOT NULL
+    UNION
+    -- STALE : lignes déjà marquées stale (refreshed_at IS NULL), capé
+    SELECT s.type_id_i, s.pg_id
+    FROM (
+      SELECT c.type_id_i, c.pg_id
+      FROM public.__catalog_sellable_candidates c
+      WHERE p_stale_only AND c.refreshed_at IS NULL
+      ORDER BY c.type_id_i, c.pg_id
+      LIMIT GREATEST(p_limit, 0)
+    ) s
+    UNION
+    -- SHARD : plage type_id (safety reconcile borné, index composite rtp_type_id)
+    SELECT DISTINCT r.rtp_type_id, r.rtp_pg_id
+    FROM public.pieces_relation_type r
+    WHERE p_type_lo IS NOT NULL AND p_type_hi IS NOT NULL
+      AND r.rtp_type_id >= p_type_lo AND r.rtp_type_id < p_type_hi
+      AND r.rtp_type_id IS NOT NULL AND r.rtp_pg_id IS NOT NULL
+  ),
+  computed AS (
+    SELECT
+      tp.type_id_i,
+      tp.pg_id,
+      -- chaîne display (cheap) : type ∧ modele ∧ marque ∧ pg
+      ( COALESCE(at.type_display, '') = '1'
+        AND COALESCE(am.modele_display, 0) = 1
+        AND COALESCE(amq.marque_display, 0) = 1
+        AND COALESCE(pg.pg_display, '') = '1' )                         AS catalog_active,
+      COALESCE(agg.sellable_pieces, 0)                                  AS price_sellable_count,
+      agg.min_price,
+      COALESCE(agg.has_price, false)                                   AS has_price,
+      COALESCE(agg.has_dispo, false)                                   AS has_dispo
+    FROM target_pairs tp
+    LEFT JOIN public.auto_type   at  ON at.type_id_i = tp.type_id_i
+    LEFT JOIN public.auto_modele am  ON am.modele_id = NULLIF(at.type_modele_id, '')::int
+    LEFT JOIN public.auto_marque amq ON amq.marque_id = am.modele_marque_id
+    LEFT JOIN public.pieces_gamme pg ON pg.pg_id = tp.pg_id
+    LEFT JOIN LATERAL (
+      SELECT
+        COUNT(*) FILTER (WHERE px.is_sellable)                          AS sellable_pieces,
+        MIN(px.min_ttc) FILTER (WHERE px.is_sellable)                  AS min_price,
+        bool_or(px.row_has_price)                                      AS has_price,
+        bool_or(px.row_has_dispo)                                      AS has_dispo
+      FROM public.pieces_relation_type r2
+      JOIN public.pieces p ON p.piece_id = r2.rtp_piece_id
+      LEFT JOIN LATERAL (
+        SELECT
+          bool_or(pp.pri_vente_ttc_n > 0)                                            AS row_has_price,
+          bool_or(pp.pri_dispo IN ('1','2','3'))                                      AS row_has_dispo,
+          bool_or(pp.pri_dispo IN ('1','2','3') AND pp.pri_vente_ttc_n > 0)
+            AND p.piece_display                                                       AS is_sellable,
+          MIN(pp.pri_vente_ttc_n) FILTER (WHERE pp.pri_dispo IN ('1','2','3') AND pp.pri_vente_ttc_n > 0) AS min_ttc
+        FROM public.pieces_price pp
+        WHERE pp.pri_piece_id_i = p.piece_id
+      ) px ON true
+      WHERE r2.rtp_type_id = tp.type_id_i AND r2.rtp_pg_id = tp.pg_id
+    ) agg ON true
+  ),
+  upserted AS (
+    INSERT INTO public.__catalog_sellable_candidates AS t
+      (type_id_i, pg_id, catalog_active, price_sellable_count, min_price, has_price, has_dispo, refreshed_at)
+    SELECT c.type_id_i, c.pg_id, c.catalog_active, c.price_sellable_count, c.min_price, c.has_price, c.has_dispo, now()
+    FROM computed c
+    ON CONFLICT (type_id_i, pg_id) DO UPDATE SET
+      catalog_active       = EXCLUDED.catalog_active,
+      price_sellable_count = EXCLUDED.price_sellable_count,
+      min_price            = EXCLUDED.min_price,
+      has_price            = EXCLUDED.has_price,
+      has_dispo            = EXCLUDED.has_dispo,
+      refreshed_at         = EXCLUDED.refreshed_at
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_pairs FROM upserted;
+
+  RETURN v_pairs;
+END;
+$$;
+
+COMMENT ON FUNCTION public.refresh_catalog_sellable_candidates(integer[], boolean, integer, integer, integer) IS
+  'Refresh DELTA/STALE/SHARD (VOLATILE) du rollup __catalog_sellable_candidates. Modes exclusifs : DELTA (p_piece_ids → paires des pièces touchées), STALE (p_stale_only → draine refreshed_at IS NULL capé p_limit), SHARD (p_type_lo/p_type_hi → plage type_id, safety hebdo). Prédicat canonique inline = autorité SQL d''agrégat (aligné SellabilityTruthService TS). JAMAIS de full sweep. Schéma public pinné.';
+
+-- ---------- 6. RPC diagnostic read-only (cheap : stats du rollup + readiness) ----------
+CREATE OR REPLACE FUNCTION public.catalog_sellable_diagnostic()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'ready',                     (SELECT ready FROM public.__catalog_sellable_meta WHERE singleton),
+    'backfill_completed_at',     (SELECT backfill_completed_at FROM public.__catalog_sellable_meta WHERE singleton),
+    'pairs_total',               (SELECT count(*) FROM public.__catalog_sellable_candidates),
+    'pairs_stale',               (SELECT count(*) FROM public.__catalog_sellable_candidates WHERE refreshed_at IS NULL),
+    'pairs_sellable',            (SELECT count(*) FROM public.__catalog_sellable_candidates WHERE sellable_count > 0),
+    -- pièces prix-vendables mais page éteinte par la chaîne display (catalog_active=false) = strandées
+    'pairs_stranded_by_display', (SELECT count(*) FROM public.__catalog_sellable_candidates WHERE price_sellable_count > 0 AND NOT catalog_active),
+    'sum_sellable_count',        (SELECT COALESCE(sum(sellable_count), 0) FROM public.__catalog_sellable_candidates),
+    'refreshed_at_min',          (SELECT min(refreshed_at) FROM public.__catalog_sellable_candidates),
+    'refreshed_at_max',          (SELECT max(refreshed_at) FROM public.__catalog_sellable_candidates)
+  );
+$$;
+
+COMMENT ON FUNCTION public.catalog_sellable_diagnostic() IS
+  'Diagnostic read-only (STABLE) du rollup __catalog_sellable_candidates : ready, pairs_total/stale/sellable, pairs_stranded_by_display (price_sellable_count>0 ∧ NOT catalog_active), sum_sellable_count, fenêtre refreshed_at. Cheap (agrège le rollup, pas le catalogue). NE statue PAS sur l''indexabilité (politique SEO).';
+
+-- =====================================================
+-- ROLLBACK (structurel) — owner-gated, ordre inverse :
+--   DROP FUNCTION IF EXISTS public.catalog_sellable_diagnostic();
+--   DROP FUNCTION IF EXISTS public.refresh_catalog_sellable_candidates(integer[], boolean, integer, integer, integer);
+--   DROP FUNCTION IF EXISTS public.is_piece_sellable(integer);
+--   DROP TABLE IF EXISTS public.__catalog_sellable_candidates;
+--   DROP TABLE IF EXISTS public.__catalog_sellable_meta;
+-- (projection régénérable — aucune perte de donnée catalogue.)
+-- =====================================================

--- a/scripts/lint/check-dispo-canon.sh
+++ b/scripts/lint/check-dispo-canon.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Block-new : interdit toute NOUVELLE divergence du prédicat de vendabilité `pri_dispo`.
+#
+# Why: le prédicat canonique (pri_dispo IN ('1','2','3') AND pri_vente_ttc_n > 0 AND
+# piece_display = true) a UNE autorité — SellabilityTruthService (TS) + is_piece_sellable /
+# refresh_catalog_sellable_candidates (SQL). Ré-exprimer un filtre `pri_dispo` ailleurs
+# réintroduit la classe de divergence (front {1,2,3} vs backend '1'-only) que le sous-système
+# "vérité canonique" (PR1) supprime. Cf. plan catalog-sellable-truth 2026-06-13.
+#
+# Stratégie = BLOCK-NEW DIFF-SCOPED (pattern ratchet du repo) :
+#   • on ne scanne QUE les lignes AJOUTÉES dans le diff vs la base (origin/main) → l'historique
+#     (16 sites legacy + migrations pricing gouvernées) est grandfather, jamais retrofit ;
+#   • error (exit 1) sur toute nouvelle ligne divergente non exemptée ;
+#   • EXEMPTÉ : fichiers sous backend/src/modules/pricing/** (le module autorité) ET toute ligne
+#     portant l'annotation explicite `@sellable-canon` (SQL `-- @sellable-canon`, TS `// @sellable-canon`).
+#
+# Complémentaire à la règle ast-grep `commerce-no-direct-dispo-filter` (severity warning) qui,
+# elle, rend visible le BACKLOG des 16 sites existants (IDE + lint advisory).
+#
+# Used by: CI lint job (gates) — base = origin/main ; override via DISPO_CANON_BASE.
+#          Exit 0 = OK, 1 = nouvelle divergence non annotée détectée.
+set -euo pipefail
+
+BASE_REF="${DISPO_CANON_BASE:-origin/main}"
+if git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  BASE="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")"
+else
+  # Base introuvable (ex. shallow clone sans origin/main) → fallback dernier commit.
+  BASE="$(git rev-parse HEAD~1 2>/dev/null || echo HEAD)"
+fi
+
+# Motif divergence : query-builder TS (.eq/.in/.neq/.filter('pri_dispo'…)) OU filtre SQL (pri_dispo = / IN).
+PATTERN="(\.(eq|in|neq|filter)\([[:space:]]*['\"]pri_dispo['\"]|pri_dispo[[:space:]]*(=|IN))"
+
+violations=0
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  # Scope : TS backend + migrations SQL.
+  if [[ "$f" == backend/src/*.ts || "$f" == backend/supabase/migrations/*.sql ]]; then :; else continue; fi
+  # Exemption : module autorité (chemin) OU fichier déclaré autorité (marqueur header).
+  if [[ "$f" == backend/src/modules/pricing/* ]]; then continue; fi
+  if [ -f "$f" ] && grep -q '@sellable-canon-authority' "$f" 2>/dev/null; then continue; fi
+
+  # Lignes AJOUTÉES uniquement (diff working-tree vs base, on retire le '+').
+  while IFS= read -r line; do
+    content="${line#+}"
+    case "$content" in *"@sellable-canon"*) continue ;; esac
+    if printf '%s\n' "$content" | grep -qE "$PATTERN"; then
+      echo "  ✗ $f : ${content#"${content%%[![:space:]]*}"}"
+      violations=$((violations + 1))
+    fi
+  done < <(git diff --unified=0 "$BASE" -- "$f" 2>/dev/null | grep -E '^\+[^+]' || true)
+done < <(git diff --name-only --diff-filter=AMR "$BASE" -- backend/src backend/supabase/migrations 2>/dev/null || true)
+
+if [ "$violations" -gt 0 ]; then
+  cat >&2 <<'EOF'
+
+✗ check-dispo-canon : nouvelle(s) divergence(s) du prédicat `pri_dispo` détectée(s) ci-dessus.
+  → Consommer l'autorité unique au lieu d'inliner un filtre :
+      TS  : SellabilityTruthService.isSellablePiece() / getAggregate()
+      SQL : is_piece_sellable() / refresh_catalog_sellable_candidates()
+  → Exception légitime (usage NON-vendabilité, ex. vue stock admin) : annoter la ligne
+      `-- @sellable-canon: <raison>` (SQL) ou `// @sellable-canon: <raison>` (TS), owner-revu.
+EOF
+  exit 1
+fi
+
+echo "✓ check-dispo-canon : aucune nouvelle divergence pri_dispo (base $BASE)."


### PR DESCRIPTION
## PR1 — vérité canonique de vendabilité (non-mutant catalogue)

Première PR du plan *« Activation cohérente véhicule/gamme des réfs dispo »* (conçu via 2 passes adversariales read-only : fact-check + tournoi d'architecture). **DRAFT** : apply migration + backfill + flip `ready` sont owner-gated ; l'alignement des 16 sites `pri_dispo` = PRs suivants.

### Contenu
- **Migration `20260613_pricing_catalog_sellable_candidates.sql`** (Pricing Control Plane) :
  - rollup `__catalog_sellable_candidates(type_id_i, pg_id)` ; `sellable_count` = colonne **GENERATED STORED** `catalog_active ? price_sellable_count : 0` (cohérence auto, anti-divergence) ;
  - décomposition anti-fan-out : `catalog_active` (chaîne display type→modèle→marque→pg, recompute *cheap*) vs `price_sellable_count` (relation∧piece_display∧prix-vendable, recompute *cher*) ;
  - `__catalog_sellable_meta` (gate `ready`, **anti-fallback-silencieux**) ;
  - `is_piece_sellable(piece_id)` STABLE = autorité SQL **point-read** (panier/prix, lit les sources, jamais le rollup) ;
  - `refresh_catalog_sellable_candidates(delta/stale/shard)` VOLATILE, **jamais de full sweep**, schéma `public` pinné ;
  - `catalog_sellable_diagnostic()` ; RLS deny-all.
- **`SellabilityTruthService`** = autorité applicative TS unique (`isSellablePiece`/`getAggregate`/`isReady`/`refresh`/`diagnostic`), **no silent fallback** ; export pour consommateurs (panier PR2).
- **Endpoint** `GET /api/admin/pricing/sellable/diagnostic` (IsAdminGuard, read-only).
- **Verrou prédicat (2 couches)** : `commerce-no-direct-dispo-filter` (ast-grep, `warning`, backlog 16 sites) + `scripts/lint/check-dispo-canon.sh` (**block-new diff-scoped**, `error`, TS+SQL, exemption module pricing + annotation `@sellable-canon`).
- **Backfill worker** `catalog-sellable-backfill.ts` : sharded/borné/**resumable** + validation échantillon (cross-check `sellable_count` vs recompute) **avant** flip `ready`.

### Vérifié (preuves)
- Agrégation **cross-validée live** : (1,7)=26 / (1,2)=6 identiques au comptage naïf direct ; `catalog_active` gate bien (pg1 : 2 prix-vendables → `sellable_count=0`) ; `is_piece_sellable` vendable→true / dispo0→false.
- Gardes validées : ast-grep **16 sites** flaggés (hors pricing) ; `check-dispo-canon.sh` positive+négative (détecte un `pri_dispo` injecté → exit 1).
- **tsc clean** (service, worker, controller, module). `jest` (tests unitaires) + build turbo + lint = **cette CI**.

### Owner-gated (hors cette PR)
1. Appliquer la migration (DDL ; read-only catalogue → sans risque data).
2. Backfill (`FLIP_READY=true` après validation échantillon) → `ready=true` = consommateurs autorisés.
3. PR2 : aligner les sites `pri_dispo` intent-vendabilité + ré-activer la sécurité panier (flag, log-only) ; PR3 : activation véhicule gouvernée.

### Découverte
Divergence `pri_dispo` = **16 sites TS** (pas 2) hors module pricing → PR2 plus large que prévu ; la garde le matérialise sans casser la CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)