### PR TITLE
fix(bot-guard): verified crawlers bypass geo/behavioral + rate-limit via FCrDNS (GSC 403)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -124,6 +124,13 @@ import { TrendSignalsModule } from './modules/trend-signals/trend-signals.module
         const ip = request.ip || request.connection?.remoteAddress;
         const user = request.user;
 
+        // Skip forward-confirmed search-engine crawlers (flag set upstream by
+        // BotGuardMiddleware via FCrDNS) — they must never hit the rate limiter
+        // and get a 429 mid-crawl.
+        if (request.isVerifiedBot === true) {
+          return true;
+        }
+
         // Skip for admin users (level >= 7)
         if (user?.isAdmin === true || parseInt(user?.level) >= 7) {
           return true;

--- a/backend/src/modules/bot-guard/bot-guard.controller.ts
+++ b/backend/src/modules/bot-guard/bot-guard.controller.ts
@@ -33,6 +33,7 @@ export class BotGuardController {
       enabled?: boolean;
       blockedCountries?: string[];
       suspicionThreshold?: number;
+      verifiedBotBypass?: boolean;
     },
   ) {
     await this.botGuardService.updateConfig(body);

--- a/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
@@ -1,0 +1,95 @@
+import { BotGuardMiddleware } from './bot-guard.middleware';
+
+type ServiceMock = Record<string, jest.Mock | (() => boolean)>;
+
+function makeMiddleware(overrides: ServiceMock = {}) {
+  const service = {
+    isEnabled: () => true,
+    isIpBlocked: jest.fn(async () => false),
+    isVerifiedSearchEngine: jest.fn(async () => false),
+    isCountryBlocked: jest.fn(async () => false),
+    calculateSuspicionScore: jest.fn(() => 0),
+    logBlocked: jest.fn(async () => undefined),
+    trackAllowed: jest.fn(async () => undefined),
+    ...overrides,
+  };
+  const middleware = new BotGuardMiddleware(service as never);
+  return { middleware, service };
+}
+
+function makeReqRes(
+  headers: Record<string, string> = {},
+  path = '/pieces/disque-de-frein-82/iveco-84/x-34297.html',
+) {
+  const req = {
+    path,
+    headers,
+    socket: { remoteAddress: '66.249.66.1' },
+  } as never;
+  const res = {
+    statusCode: 200,
+    body: null as unknown,
+    status(code: number) {
+      (this as { statusCode: number }).statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      (this as { body: unknown }).body = payload;
+      return this;
+    },
+  } as never;
+  const next = jest.fn();
+  return { req, res, next };
+}
+
+describe('BotGuardMiddleware ordering', () => {
+  it('lets a verified crawler through (next) and bypasses geo + behavioral', async () => {
+    const { middleware, service } = makeMiddleware({
+      isVerifiedSearchEngine: jest.fn(async () => true),
+      isCountryBlocked: jest.fn(async () => true), // would block if consulted
+    });
+    const { req, res, next } = makeReqRes({ 'cf-ipcountry': 'US' });
+
+    await middleware.use(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((req as { isVerifiedBot?: boolean }).isVerifiedBot).toBe(true);
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    // geo never consulted because the verified bypass returned first
+    expect(service.isCountryBlocked).not.toHaveBeenCalled();
+  });
+
+  it('still honors an explicit operator IP block even for a would-be verified crawler (ip_block wins, no DNS work)', async () => {
+    const verifySpy = jest.fn(async () => true);
+    const { middleware, res, next, req, service } = (() => {
+      const m = makeMiddleware({
+        isIpBlocked: jest.fn(async () => true),
+        isVerifiedSearchEngine: verifySpy,
+      });
+      const rr = makeReqRes({ 'cf-ipcountry': 'US' });
+      return { middleware: m.middleware, service: m.service, ...rr };
+    })();
+
+    await middleware.use(req, res, next);
+
+    expect((res as { statusCode: number }).statusCode).toBe(403);
+    expect((res as { body: { code: string } }).body.code).toBe('IP_BLOCKED');
+    expect(next).not.toHaveBeenCalled();
+    // ip_block short-circuits before any FCrDNS lookup
+    expect(service.isVerifiedSearchEngine).not.toHaveBeenCalled();
+  });
+
+  it('lets a verified crawler through even from a geo-blocked country', async () => {
+    const { middleware, service } = makeMiddleware({
+      isVerifiedSearchEngine: jest.fn(async () => true),
+      isCountryBlocked: jest.fn(async () => true),
+    });
+    const { req, res, next } = makeReqRes({ 'cf-ipcountry': 'CN' });
+
+    await middleware.use(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    expect(service.isCountryBlocked).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
@@ -20,11 +20,12 @@ function makeMiddleware(overrides: ServiceMock = {}) {
 function makeReqRes(
   headers: Record<string, string> = {},
   path = '/pieces/disque-de-frein-82/iveco-84/x-34297.html',
+  peer = '172.18.0.5', // immediate TCP peer = co-located Caddy (Docker-internal)
 ) {
   const req = {
     path,
     headers,
-    socket: { remoteAddress: '66.249.66.1' },
+    socket: { remoteAddress: peer },
   } as never;
   const res = {
     statusCode: 200,
@@ -48,7 +49,10 @@ describe('BotGuardMiddleware ordering', () => {
       isVerifiedSearchEngine: jest.fn(async () => true),
       isCountryBlocked: jest.fn(async () => true), // would block if consulted
     });
-    const { req, res, next } = makeReqRes({ 'cf-ipcountry': 'US' });
+    const { req, res, next } = makeReqRes({
+      'cf-ipcountry': 'US',
+      'cf-connecting-ip': '66.249.66.1',
+    });
 
     await middleware.use(req, res, next);
 
@@ -66,7 +70,10 @@ describe('BotGuardMiddleware ordering', () => {
         isIpBlocked: jest.fn(async () => true),
         isVerifiedSearchEngine: verifySpy,
       });
-      const rr = makeReqRes({ 'cf-ipcountry': 'US' });
+      const rr = makeReqRes({
+        'cf-ipcountry': 'US',
+        'cf-connecting-ip': '66.249.66.1',
+      });
       return { middleware: m.middleware, service: m.service, ...rr };
     })();
 
@@ -84,12 +91,55 @@ describe('BotGuardMiddleware ordering', () => {
       isVerifiedSearchEngine: jest.fn(async () => true),
       isCountryBlocked: jest.fn(async () => true),
     });
-    const { req, res, next } = makeReqRes({ 'cf-ipcountry': 'CN' });
+    const { req, res, next } = makeReqRes({
+      'cf-ipcountry': 'CN',
+      'cf-connecting-ip': '66.249.66.1',
+    });
 
     await middleware.use(req, res, next);
 
     expect(next).toHaveBeenCalledTimes(1);
     expect((res as { statusCode: number }).statusCode).toBe(200);
     expect(service.isCountryBlocked).not.toHaveBeenCalled();
+  });
+});
+
+describe('BotGuardMiddleware client-IP trust (anti-spoof)', () => {
+  it('IGNORES a spoofed cf-connecting-ip when the TCP peer is a public IP (direct-to-app) — verifies the real peer, not the header', async () => {
+    const { middleware, service } = makeMiddleware({
+      isVerifiedSearchEngine: jest.fn(async () => false),
+    });
+    // Attacker connects directly (public peer) and forges a real Googlebot IP.
+    const { req, res, next } = makeReqRes(
+      { 'cf-connecting-ip': '66.249.66.1', 'cf-ipcountry': 'US' },
+      '/pieces/x.html',
+      '203.0.113.50', // public peer = NOT our reverse proxy
+    );
+
+    await middleware.use(req, res, next);
+
+    // FCrDNS must run against the real peer, never the spoofed header.
+    expect(service.isVerifiedSearchEngine).toHaveBeenCalledWith(
+      '203.0.113.50',
+      expect.any(String),
+    );
+  });
+
+  it('TRUSTS cf-connecting-ip when the TCP peer is the internal reverse proxy', async () => {
+    const { middleware, service } = makeMiddleware({
+      isVerifiedSearchEngine: jest.fn(async () => false),
+    });
+    const { req, res, next } = makeReqRes(
+      { 'cf-connecting-ip': '66.249.66.1', 'cf-ipcountry': 'US' },
+      '/pieces/x.html',
+      '172.18.0.5', // internal peer (Caddy)
+    );
+
+    await middleware.use(req, res, next);
+
+    expect(service.isVerifiedSearchEngine).toHaveBeenCalledWith(
+      '66.249.66.1',
+      expect.any(String),
+    );
   });
 });

--- a/backend/src/modules/bot-guard/bot-guard.middleware.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.ts
@@ -30,10 +30,21 @@ export class BotGuardMiddleware implements NestMiddleware {
       return next();
     }
 
-    // 4. Country check via CF-IPCountry header (set by Cloudflare)
+    // 4. Country (Cloudflare CF-IPCountry header) + UA, read once for all checks.
     const country = (req.headers['cf-ipcountry'] as string)?.toUpperCase();
+    const userAgent = (req.headers['user-agent'] as string) || '';
 
     try {
+      // 5. Verified search-engine crawlers (FCrDNS) are NEVER blocked. They
+      // bypass geo + behavioral checks and the rate limiter (the flag below is
+      // read by ThrottlerGuard.skipIf in app.module.ts). UA is not trusted on
+      // its own — identity is proven by forward-confirmed reverse DNS.
+      if (await this.botGuardService.isVerifiedSearchEngine(ip, userAgent)) {
+        (req as Request & { isVerifiedBot?: boolean }).isVerifiedBot = true;
+        this.botGuardService.trackAllowed(country).catch(() => {});
+        return next();
+      }
+
       if (country && (await this.botGuardService.isCountryBlocked(country))) {
         await this.botGuardService.logBlocked(
           ip,
@@ -68,7 +79,6 @@ export class BotGuardMiddleware implements NestMiddleware {
       }
 
       // 6. Behavioral scoring
-      const userAgent = (req.headers['user-agent'] as string) || '';
       const suspicionScore = this.botGuardService.calculateSuspicionScore({
         ip,
         country,
@@ -106,6 +116,9 @@ export class BotGuardMiddleware implements NestMiddleware {
 
   private getClientIp(req: Request): string {
     return (
+      // Cloudflare's canonical true-client-IP header (the site sits behind CF),
+      // most reliable for both geo/IP checks and FCrDNS bot verification.
+      (req.headers['cf-connecting-ip'] as string)?.trim() ||
       (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
       (req.headers['x-real-ip'] as string) ||
       req.socket?.remoteAddress ||

--- a/backend/src/modules/bot-guard/bot-guard.middleware.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.ts
@@ -118,15 +118,27 @@ export class BotGuardMiddleware implements NestMiddleware {
   }
 
   private getClientIp(req: Request): string {
-    return (
-      // Cloudflare's canonical true-client-IP header (the site sits behind CF),
-      // most reliable for both geo/IP checks and FCrDNS bot verification.
-      (req.headers['cf-connecting-ip'] as string)?.trim() ||
-      (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
-      (req.headers['x-real-ip'] as string) ||
-      req.socket?.remoteAddress ||
-      'unknown'
-    );
+    const peer = req.socket?.remoteAddress || '';
+
+    // SECURITY: forwarding headers (cf-connecting-ip / x-forwarded-for /
+    // x-real-ip) are client-spoofable, so they are trusted ONLY when the
+    // immediate TCP peer is our own co-located reverse proxy (Caddy →
+    // loopback/Docker-internal). Caddy sits behind Cloudflare, which sets
+    // cf-connecting-ip and strips any inbound value, so that chain is authentic.
+    // A connection whose peer is a public IP reached the app directly (bypassing
+    // the edge): its headers are attacker-controlled and MUST be ignored — we
+    // use the socket address. Otherwise an attacker could set
+    // `cf-connecting-ip: <a real Googlebot IP>` and pass FCrDNS to bypass
+    // geo/behavioral blocking and the rate limiter.
+    if (this.isInternalIp(peer)) {
+      const forwarded =
+        (req.headers['cf-connecting-ip'] as string)?.trim() ||
+        (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ||
+        (req.headers['x-real-ip'] as string)?.trim();
+      if (forwarded) return forwarded;
+    }
+
+    return peer || 'unknown';
   }
 
   private isInternalIp(ip: string): boolean {

--- a/backend/src/modules/bot-guard/bot-guard.middleware.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.ts
@@ -35,33 +35,9 @@ export class BotGuardMiddleware implements NestMiddleware {
     const userAgent = (req.headers['user-agent'] as string) || '';
 
     try {
-      // 5. Verified search-engine crawlers (FCrDNS) are NEVER blocked. They
-      // bypass geo + behavioral checks and the rate limiter (the flag below is
-      // read by ThrottlerGuard.skipIf in app.module.ts). UA is not trusted on
-      // its own — identity is proven by forward-confirmed reverse DNS.
-      if (await this.botGuardService.isVerifiedSearchEngine(ip, userAgent)) {
-        (req as Request & { isVerifiedBot?: boolean }).isVerifiedBot = true;
-        this.botGuardService.trackAllowed(country).catch(() => {});
-        return next();
-      }
-
-      if (country && (await this.botGuardService.isCountryBlocked(country))) {
-        await this.botGuardService.logBlocked(
-          ip,
-          country,
-          'geo_block',
-          req.path,
-        );
-        this.logger.warn(
-          `Blocked: ip=${ip} country=${country} path=${req.path} reason=geo_block`,
-        );
-        res
-          .status(HttpStatus.FORBIDDEN)
-          .json({ error: 'Access denied', code: 'GEO_BLOCKED' });
-        return;
-      }
-
-      // 5. IP blocklist check
+      // 5. Explicit operator IP blocklist applies to EVERYONE — including
+      // verified crawlers. An admin IP block is a deliberate, observable action
+      // and must win; checked first so a blocked IP short-circuits before DNS.
       if (await this.botGuardService.isIpBlocked(ip)) {
         await this.botGuardService.logBlocked(
           ip,
@@ -78,7 +54,34 @@ export class BotGuardMiddleware implements NestMiddleware {
         return;
       }
 
-      // 6. Behavioral scoring
+      // 6. Verified search-engine crawlers (FCrDNS) bypass the AUTOMATIC blocks
+      // (geo + behavioral) and the rate limiter (req.isVerifiedBot is read by
+      // ThrottlerGuard.skipIf in app.module.ts). UA is not trusted on its own —
+      // identity is proven by forward-confirmed reverse DNS.
+      if (await this.botGuardService.isVerifiedSearchEngine(ip, userAgent)) {
+        (req as Request & { isVerifiedBot?: boolean }).isVerifiedBot = true;
+        this.botGuardService.trackAllowed(country).catch(() => {});
+        return next();
+      }
+
+      // 7. Geo block (Cloudflare CF-IPCountry header).
+      if (country && (await this.botGuardService.isCountryBlocked(country))) {
+        await this.botGuardService.logBlocked(
+          ip,
+          country,
+          'geo_block',
+          req.path,
+        );
+        this.logger.warn(
+          `Blocked: ip=${ip} country=${country} path=${req.path} reason=geo_block`,
+        );
+        res
+          .status(HttpStatus.FORBIDDEN)
+          .json({ error: 'Access denied', code: 'GEO_BLOCKED' });
+        return;
+      }
+
+      // 8. Behavioral scoring
       const suspicionScore = this.botGuardService.calculateSuspicionScore({
         ip,
         country,

--- a/backend/src/modules/bot-guard/bot-guard.service.test.ts
+++ b/backend/src/modules/bot-guard/bot-guard.service.test.ts
@@ -1,0 +1,212 @@
+import { BotGuardService } from './bot-guard.service';
+
+/**
+ * Builds a BotGuardService with in-memory mocks for ConfigService + CacheService.
+ * No real network/Redis is touched; DNS is stubbed per-test via spyOn.
+ */
+function makeService(configOverrides: Record<string, string> = {}) {
+  const configMap: Record<string, string> = {
+    BOT_GUARD_ENABLED: 'true',
+    BOT_GUARD_SUSPICION_THRESHOLD: '80',
+    BOT_GUARD_BLOCKED_COUNTRIES: 'CN',
+    BOT_GUARD_VERIFIED_BOT_BYPASS: 'true',
+    ...configOverrides,
+  };
+  const config = {
+    get: jest.fn((key: string, def?: string) =>
+      configMap[key] !== undefined ? configMap[key] : def,
+    ),
+  };
+  const store = new Map<string, unknown>();
+  const cache = {
+    get: jest.fn(async (key: string) =>
+      store.has(key) ? store.get(key) : null,
+    ),
+    set: jest.fn(async (key: string, value: unknown) => {
+      store.set(key, value);
+    }),
+  };
+  const service = new BotGuardService(config as never, cache as never);
+  return { service, config, cache, store };
+}
+
+const GOOGLEBOT_UA =
+  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+const BINGBOT_UA =
+  'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)';
+const CHROME_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+describe('BotGuardService.calculateSuspicionScore — Googlebot headroom', () => {
+  it('scores a real Googlebot on a deep, non-target-country page at 55 (< 80 default → only 25 pts of headroom)', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+
+    const score = service.calculateSuspicionScore({
+      ip: '66.249.66.1',
+      country: 'US', // Googlebot crawls mostly from the US (not a TARGET_COUNTRY)
+      userAgent: GOOGLEBOT_UA,
+      path: '/pieces/disque-de-frein-82/iveco-84/daily-iv/3-0-d-34297.html',
+      acceptLanguage: undefined, // Googlebot sends none → +30
+      hasSession: false, // no session on a deep page → +15
+    });
+
+    // +30 (no Accept-Language) +15 (no session, deep page) +10 (non-target country)
+    expect(score).toBe(55);
+  });
+});
+
+describe('BotGuardService.isVerifiedSearchEngine (FCrDNS)', () => {
+  it('returns false instantly for a normal browser UA — no DNS lookup at all', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+    const reverseSpy = jest.spyOn(
+      service as never,
+      'reverseDnsLookup' as never,
+    );
+
+    const result = await service.isVerifiedSearchEngine(
+      '203.0.113.5',
+      CHROME_UA,
+    );
+
+    expect(result).toBe(false);
+    expect(reverseSpy).not.toHaveBeenCalled();
+  });
+
+  it('verifies a genuine Googlebot: rDNS ends in .googlebot.com AND forward-resolves back to the same IP', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+    jest
+      .spyOn(service as never, 'reverseDnsLookup' as never)
+      .mockResolvedValue(['crawl-66-249-66-1.googlebot.com'] as never);
+    jest
+      .spyOn(service as never, 'forwardDnsLookup' as never)
+      .mockResolvedValue(['66.249.66.1'] as never);
+
+    expect(
+      await service.isVerifiedSearchEngine('66.249.66.1', GOOGLEBOT_UA),
+    ).toBe(true);
+  });
+
+  it('rejects a spoofer: UA claims Googlebot but rDNS is an unrelated domain (no forward lookup needed)', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+    jest
+      .spyOn(service as never, 'reverseDnsLookup' as never)
+      .mockResolvedValue(['host.evil-attacker.com'] as never);
+    const forwardSpy = jest.spyOn(
+      service as never,
+      'forwardDnsLookup' as never,
+    );
+
+    expect(
+      await service.isVerifiedSearchEngine('203.0.113.9', GOOGLEBOT_UA),
+    ).toBe(false);
+    expect(forwardSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a forged PTR: rDNS ends in .googlebot.com but forward-resolves to a DIFFERENT IP', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+    jest
+      .spyOn(service as never, 'reverseDnsLookup' as never)
+      .mockResolvedValue(['fake.googlebot.com'] as never);
+    jest
+      .spyOn(service as never, 'forwardDnsLookup' as never)
+      .mockResolvedValue(['10.20.30.40'] as never);
+
+    expect(
+      await service.isVerifiedSearchEngine('203.0.113.9', GOOGLEBOT_UA),
+    ).toBe(false);
+  });
+
+  it('does not fall for the substring trick: evilgooglebot.com must NOT match .googlebot.com', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+    jest
+      .spyOn(service as never, 'reverseDnsLookup' as never)
+      .mockResolvedValue(['evilgooglebot.com'] as never);
+    const forwardSpy = jest.spyOn(
+      service as never,
+      'forwardDnsLookup' as never,
+    );
+
+    expect(
+      await service.isVerifiedSearchEngine('203.0.113.9', GOOGLEBOT_UA),
+    ).toBe(false);
+    expect(forwardSpy).not.toHaveBeenCalled();
+  });
+
+  it('caches the verdict per IP — DNS is queried only once', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+    const reverseSpy = jest
+      .spyOn(service as never, 'reverseDnsLookup' as never)
+      .mockResolvedValue(['crawl.googlebot.com'] as never);
+    jest
+      .spyOn(service as never, 'forwardDnsLookup' as never)
+      .mockResolvedValue(['66.249.66.2'] as never);
+
+    await service.isVerifiedSearchEngine('66.249.66.2', GOOGLEBOT_UA);
+    await service.isVerifiedSearchEngine('66.249.66.2', GOOGLEBOT_UA);
+
+    expect(reverseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes IPv4-mapped IPv6 (::ffff:) before comparing forward-resolved IPs', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+    jest
+      .spyOn(service as never, 'reverseDnsLookup' as never)
+      .mockResolvedValue(['crawl.googlebot.com'] as never);
+    jest
+      .spyOn(service as never, 'forwardDnsLookup' as never)
+      .mockResolvedValue(['66.249.66.3'] as never);
+
+    expect(
+      await service.isVerifiedSearchEngine('::ffff:66.249.66.3', GOOGLEBOT_UA),
+    ).toBe(true);
+  });
+
+  it('returns false when the feature flag is off — even for a genuine Googlebot', async () => {
+    const { service } = makeService({ BOT_GUARD_VERIFIED_BOT_BYPASS: 'false' });
+    await service.onModuleInit();
+    const reverseSpy = jest.spyOn(
+      service as never,
+      'reverseDnsLookup' as never,
+    );
+
+    expect(
+      await service.isVerifiedSearchEngine('66.249.66.1', GOOGLEBOT_UA),
+    ).toBe(false);
+    expect(reverseSpy).not.toHaveBeenCalled();
+  });
+
+  it('verifies Bingbot via .search.msn.com', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+    jest
+      .spyOn(service as never, 'reverseDnsLookup' as never)
+      .mockResolvedValue(['msnbot-157-55-39-1.search.msn.com'] as never);
+    jest
+      .spyOn(service as never, 'forwardDnsLookup' as never)
+      .mockResolvedValue(['157.55.39.1'] as never);
+
+    expect(
+      await service.isVerifiedSearchEngine('157.55.39.1', BINGBOT_UA),
+    ).toBe(true);
+  });
+
+  it('is failsafe: a DNS resolution error yields false without throwing', async () => {
+    const { service } = makeService();
+    await service.onModuleInit();
+    jest
+      .spyOn(service as never, 'reverseDnsLookup' as never)
+      .mockRejectedValue(new Error('ENOTFOUND') as never);
+
+    expect(
+      await service.isVerifiedSearchEngine('203.0.113.9', GOOGLEBOT_UA),
+    ).toBe(false);
+  });
+});

--- a/backend/src/modules/bot-guard/bot-guard.service.ts
+++ b/backend/src/modules/bot-guard/bot-guard.service.ts
@@ -1,3 +1,4 @@
+import { promises as dns } from 'node:dns';
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { CacheService } from '@cache/cache.service';
@@ -28,6 +29,9 @@ export class BotGuardService implements OnModuleInit {
   private blockedIps: Set<string> = new Set();
   private enabled = true;
   private suspicionThreshold = 80;
+  // When true, forward-confirmed search-engine crawlers bypass geo/behavioral
+  // blocking (feature-flag for instant rollback). See isVerifiedSearchEngine().
+  private verifiedBotBypass = true;
   private lastConfigRefresh = 0;
   private readonly CONFIG_REFRESH_MS = 60_000;
 
@@ -58,7 +62,10 @@ export class BotGuardService implements OnModuleInit {
     'CM', // Francophone
   ]);
 
-  // Verified search engine bots (never block)
+  // Known-good crawler UA tokens — only used to *waive the UA-suspicion sub-score*.
+  // NOTE: a UA match alone NEVER exempts from geo/ip/behavioral blocking. Real
+  // "never block" for search engines is enforced by isVerifiedSearchEngine()
+  // below, which proves identity by IP (FCrDNS), not by the spoofable UA string.
   private readonly GOOD_BOTS = [
     'googlebot',
     'bingbot',
@@ -74,6 +81,58 @@ export class BotGuardService implements OnModuleInit {
     'pinterest',
     'semrushbot',
     'ahrefsbot',
+  ];
+
+  // IP-verifiable search engines. A crawler is trusted ONLY when its UA matches
+  // one of these families AND its reverse-DNS resolves to an allowed suffix AND
+  // that hostname forward-resolves back to the same IP (FCrDNS — Google's
+  // canonical verification method). Engines without stable reverse-DNS
+  // (e.g. SEMrush/Ahrefs) are intentionally absent: they fall through to scoring.
+  private readonly VERIFIED_BOT_RDNS: ReadonlyArray<{
+    name: string;
+    ua: string[];
+    suffixes: string[];
+  }> = [
+    {
+      name: 'Googlebot',
+      ua: [
+        'googlebot',
+        'google-inspectiontool',
+        'storebot-google',
+        'adsbot-google',
+        'mediapartners-google',
+        'apis-google',
+        'feedfetcher-google',
+        'googleother',
+        'google-extended',
+      ],
+      suffixes: ['.googlebot.com', '.google.com'],
+    },
+    {
+      name: 'Bingbot',
+      ua: ['bingbot', 'adidxbot', 'msnbot'],
+      suffixes: ['.search.msn.com'],
+    },
+    {
+      name: 'Applebot',
+      ua: ['applebot'],
+      suffixes: ['.applebot.apple.com'],
+    },
+    {
+      name: 'DuckDuckBot',
+      ua: ['duckduckbot', 'duckduckgo'],
+      suffixes: ['.duckduckgo.com'],
+    },
+    {
+      name: 'YandexBot',
+      ua: ['yandexbot', 'yandeximages', 'yandex.com/bots'],
+      suffixes: ['.yandex.com', '.yandex.net', '.yandex.ru'],
+    },
+    {
+      name: 'Yahoo',
+      ua: ['slurp'],
+      suffixes: ['.crawl.yahoo.net'],
+    },
   ];
 
   // Suspicious user-agent patterns
@@ -108,6 +167,9 @@ export class BotGuardService implements OnModuleInit {
     // Load initial config from env
     this.enabled =
       this.configService.get('BOT_GUARD_ENABLED', 'true') === 'true';
+    this.verifiedBotBypass =
+      this.configService.get('BOT_GUARD_VERIFIED_BOT_BYPASS', 'true') ===
+      'true';
     this.suspicionThreshold = parseInt(
       this.configService.get('BOT_GUARD_SUSPICION_THRESHOLD', '80'),
       10,
@@ -135,6 +197,7 @@ export class BotGuardService implements OnModuleInit {
         blockedCountries?: string[];
         blockedIps?: string[];
         suspicionThreshold?: number;
+        verifiedBotBypass?: boolean;
       }>('bot-guard:config');
 
       if (config) {
@@ -147,6 +210,9 @@ export class BotGuardService implements OnModuleInit {
         }
         if (config.suspicionThreshold) {
           this.suspicionThreshold = config.suspicionThreshold;
+        }
+        if (config.verifiedBotBypass !== undefined) {
+          this.verifiedBotBypass = config.verifiedBotBypass;
         }
       }
       this.lastConfigRefresh = Date.now();
@@ -163,6 +229,108 @@ export class BotGuardService implements OnModuleInit {
 
   isEnabled(): boolean {
     return this.enabled;
+  }
+
+  /**
+   * Forward-confirmed reverse DNS (FCrDNS) check for legitimate search-engine
+   * crawlers. Returns true only when ALL hold:
+   *   1. the UA matches a known crawler family (cheap prefilter — no UA = no DNS),
+   *   2. the IP's reverse-DNS hostname ends with an allowed suffix for that family,
+   *   3. that hostname forward-resolves back to the same IP.
+   *
+   * UA is never trusted on its own (trivially spoofable). The verdict is cached
+   * per-IP in Redis so a crawler costs at most one reverse + one forward lookup
+   * per IP per TTL; human traffic costs zero DNS (step 1 short-circuits).
+   *
+   * Failsafe: any DNS/cache error yields `false` (the request then falls through
+   * to the normal scoring path, which already lets default-config crawlers pass)
+   * — a verification failure must never *block* a crawler.
+   */
+  async isVerifiedSearchEngine(
+    ip: string,
+    userAgent: string,
+  ): Promise<boolean> {
+    if (!this.verifiedBotBypass) return false;
+
+    const ua = (userAgent || '').toLowerCase();
+    const family = this.VERIFIED_BOT_RDNS.find((f) =>
+      f.ua.some((token) => ua.includes(token)),
+    );
+    if (!family) return false;
+
+    const normIp = this.normalizeIp(ip);
+    if (!normIp) return false;
+
+    const cacheKey = `bot-guard:vbot:${normIp}`;
+    try {
+      const cached = await this.cacheService.get<boolean>(cacheKey);
+      if (cached !== null && cached !== undefined) return cached;
+    } catch {
+      // cache unavailable → verify live
+    }
+
+    let verified = false;
+    try {
+      const hosts = await this.reverseDnsLookup(normIp);
+      const match = hosts
+        .map((h) => h.toLowerCase().replace(/\.$/, ''))
+        .find((h) =>
+          family.suffixes.some(
+            (suffix) => h === suffix.slice(1) || h.endsWith(suffix),
+          ),
+        );
+      if (match) {
+        const forwardIps = await this.forwardDnsLookup(match);
+        verified = forwardIps.some((fip) => this.normalizeIp(fip) === normIp);
+      }
+    } catch (err) {
+      this.logger.debug(
+        `FCrDNS verification failed ip=${normIp} family=${family.name}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      verified = false;
+    }
+
+    try {
+      // Cache positives longer; recheck negatives sooner (an IP could be reassigned).
+      await this.cacheService.set(cacheKey, verified, verified ? 21600 : 3600);
+    } catch {
+      // non-blocking
+    }
+
+    if (verified) {
+      this.logger.debug(
+        `Verified search bot allowed: ip=${normIp} family=${family.name}`,
+      );
+    }
+    return verified;
+  }
+
+  /** Strip an IPv4-mapped IPv6 prefix so reverse/forward IPs compare equal. */
+  private normalizeIp(ip: string): string {
+    if (!ip) return '';
+    return ip
+      .replace(/^::ffff:/i, '')
+      .trim()
+      .toLowerCase();
+  }
+
+  /** Reverse-DNS lookup (overridable for tests). */
+  protected async reverseDnsLookup(ip: string): Promise<string[]> {
+    return dns.reverse(ip);
+  }
+
+  /** Forward A/AAAA lookup (overridable for tests). */
+  protected async forwardDnsLookup(host: string): Promise<string[]> {
+    const [v4, v6] = await Promise.allSettled([
+      dns.resolve4(host),
+      dns.resolve6(host),
+    ]);
+    const out: string[] = [];
+    if (v4.status === 'fulfilled') out.push(...v4.value);
+    if (v6.status === 'fulfilled') out.push(...v6.value);
+    return out;
   }
 
   async isCountryBlocked(country: string): Promise<boolean> {
@@ -329,6 +497,7 @@ export class BotGuardService implements OnModuleInit {
       blockedCountries: [...this.blockedCountries],
       blockedIps: [...this.blockedIps],
       suspicionThreshold: this.suspicionThreshold,
+      verifiedBotBypass: this.verifiedBotBypass,
       targetCountries: [...this.TARGET_COUNTRIES],
     };
   }
@@ -338,6 +507,7 @@ export class BotGuardService implements OnModuleInit {
     blockedCountries?: string[];
     blockedIps?: string[];
     suspicionThreshold?: number;
+    verifiedBotBypass?: boolean;
   }): Promise<void> {
     if (config.enabled !== undefined) this.enabled = config.enabled;
     if (config.blockedCountries) {
@@ -349,6 +519,9 @@ export class BotGuardService implements OnModuleInit {
     if (config.suspicionThreshold) {
       this.suspicionThreshold = config.suspicionThreshold;
     }
+    if (config.verifiedBotBypass !== undefined) {
+      this.verifiedBotBypass = config.verifiedBotBypass;
+    }
 
     // Persist to Redis
     await this.cacheService.set(
@@ -358,6 +531,7 @@ export class BotGuardService implements OnModuleInit {
         blockedCountries: [...this.blockedCountries],
         blockedIps: [...this.blockedIps],
         suspicionThreshold: this.suspicionThreshold,
+        verifiedBotBypass: this.verifiedBotBypass,
       },
       86400 * 30, // 30 days
     );

--- a/log.md
+++ b/log.md
@@ -448,3 +448,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/vehicle-issues-from-evidence-prc`
 - **Décision** : feat(content): (c) planner d'alimentation diagnostic engine kg_engine_families (DRY-RUN, 0 write) (+7 other commits)
 - **Sortie** : PR #965 | commits 8060413e4 cf1bb0f14 6d159eb76 b20f2cb0b a825c9c80 a93a8a507 849c17c84 b99a106ac
+
+## 2026-06-13 — fix/botguard-verified-bot-bypass (auto)
+
+- **Branche** : `fix/botguard-verified-bot-bypass`
+- **Décision** : fix(bot-guard): honor explicit ip_block before verified-bot bypass (+1 other commit)
+- **Sortie** : PR #967 | commits 003ce059f b857a0f36


### PR DESCRIPTION
## Problème (GSC)

Mail Search Console (12/06) : **« Bloquée en raison d'une interdiction d'accès (403) »** sur **148 URLs** (pages `/pieces/*` catalogue, fiches `/constructeurs/*`, etc.).

**Vérification runtime (live, ce jour)** : aucune des 148 ne renvoie 403 depuis une IP normale (UA Googlebot inclus) — 80×200, 54×410, 10×301, 3×404, 1×500, `cf-mitigated: none` partout. Le 403 est donc injecté par une couche de garde **au moment du crawl réel de Googlebot** (IP Google + débit), pas par le contenu.

## Cause racine (in-app)

`BotGuardMiddleware` (`forRoutes('*')`, monté `app.module.ts`) émet un **403** sur 3 chemins : `geo_block` (CF-IPCountry), `ip_block`, `behavioral` (score ≥ seuil). Le commentaire `// Verified search engine bots (never block)` sur `GOOD_BOTS` **n'était pas implémenté** : `GOOD_BOTS` n'annulait que les **+20** du sous-score UA, jamais `geo_block`/`ip_block` ni le reste du score.

Score d'un vrai Googlebot sur une page profonde : `+30` (pas d'Accept-Language) `+15` (pas de session) `+10` (pays hors `TARGET_COUNTRIES`, ex. US) = **55/80** → 25 pts de marge. Un seul tweak de config Redis/admin (seuil ↓, pays ajouté, IP blocklistée) ⇒ **désindexation silencieuse**. Le `ThrottlerGuard` global (100/min, 2000/h par IP) n'avait **aucune exemption verified-bot** non plus (429 sur burst de crawl).

## Correctif (robuste, FCrDNS — méthode canonique Google)

On implémente vraiment l'invariant « never block verified bots », **par l'IP** (jamais le UA, falsifiable) :

- **`isVerifiedSearchEngine(ip, ua)`** : prefilter UA (→ **0 DNS pour le trafic humain**) → reverse-DNS doit finir par un suffixe autorisé (`.googlebot.com`/`.google.com`, `.search.msn.com`, …) → **forward-confirm** (le host re-résout vers la même IP). Verdict caché par IP dans Redis (6 h positif / 1 h négatif). Spoof UA, PTR forgé et piège substring (`evilgooglebot.com`) rejetés.
- **Middleware** : un crawler vérifié bypass `geo_block` + behavioral, pose `req.isVerifiedBot = true`.
- **Throttler `skipIf`** : `req.isVerifiedBot` ⇒ pas de rate-limit (pas de 429 en plein crawl).
- **Feature flag** `BOT_GUARD_VERIFIED_BOT_BYPASS` (défaut `true`, rollback instantané) + toggle admin (`PUT /admin/bot-guard/config`) + log debug (observable).
- **`cf-connecting-ip`** comme vraie IP client derrière Cloudflare.

`ip_block` explicite reste honoré (action opérateur), mais geo/behavioral ne peuvent plus toucher un crawler forward-confirmé.

## Extension, pas de système parallèle

Étend `BotGuardService` (réutilise `CacheService` + `GOOD_BOTS`) et le `skipIf` throttler existant. Pas de nouveau module ; pas de couplage à `GooglebotDetectorService` (UA-only, SEO/Supabase). Aucune URL/route/canonical touchée.

## Tests & vérif

- **11 tests unitaires (TDD)** verts : caractérisation du score 55/80, FCrDNS verify Googlebot+Bingbot, rejet spoofer/PTR-forgé/substring, cache 1× DNS, IPv4-mapped, flag off, failsafe DNS error.
- `tsc --noEmit` backend : **0 erreur**. ESLint : clean. ast-grep `no-remote-io-in-onModuleInit` : non déclenché (le DNS est par-requête, pas dans `onModuleInit`).

## Hors scope (suivis owner séparés)

1. **Cloudflare WAF** (autre couche edge geo/bot, hors repo) — à vérifier côté dashboard (Security → Events, filtre Googlebot/403) ; et `GET /admin/bot-guard/recent-blocks` sur PROD pour confirmer si BotGuard a bien émis ces 403.
2. **500 persistant** sur `/pieces/filtre-a-air-8/nissan-119/navara-vi-pick-up-119383/2-3-dci-4x4-75203.html` (la page se rend, status erroné) — bug origine distinct.

## Déploiement

Merge `main` ⇒ build + tag `:preprod` (container CI). PROD = tag `v*` owner-gated (rien n'est déployé en PROD par ce merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
