### PR TITLE
fix(ssr): surface silent Googlebot 500s (entry.server onError → log + Sentry)

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -107,12 +107,15 @@ function handleBotRequest(
         },
         onError(error: unknown) {
           responseStatusCode = 500;
-          // Log streaming rendering errors from inside the shell.  Don't log
-          // errors encountered during initial shell rendering since they'll
-          // reject and get logged in handleDocumentRequest.
-          if (shellRendered) {
-            logger.error(error);
-          }
+          // Surface ALL streaming render errors. On the bot path (onAllReady)
+          // `shellRendered` only flips at the very end, so a render error that
+          // React recovers from (via an ErrorBoundary) — or a render that hits
+          // the ABORT_DELAY timeout — would otherwise be SILENT: a Googlebot-only
+          // 500 with no log and no Sentry event. Non-shell errors never
+          // double-log (true shell errors go through onShellError -> reject ->
+          // handleError).
+          logger.error("[SSR onError]", error);
+          Sentry.captureException(error);
         },
       },
     );
@@ -174,9 +177,9 @@ function handleBrowserRequest(
         },
         onError(error: unknown) {
           responseStatusCode = 500;
-          if (shellRendered) {
-            logger.error(error);
-          }
+          // Same rationale as the bot path: never swallow a render error silently.
+          logger.error("[SSR onError]", error);
+          Sentry.captureException(error);
         },
       },
     );


### PR DESCRIPTION
## Problème
Le 500 PROD-only sur certaines pages R2 `/pieces/.../*.html` (ex. filtre-a-air nissan navara …75203) rend le **vrai contenu + statut 500** sous UA Googlebot, mais **aucune trace** : ni log, ni Sentry. Cause : `entry.server.tsx` `onError` ne logge que `if (shellRendered)`. Sur le **chemin bot** (`handleBotRequest`/`onAllReady`), `shellRendered` ne passe à `true` qu'à la toute fin → une erreur de rendu récupérée par un ErrorBoundary (ou un `abort` au timeout 5 s) fixe le 500 **silencieusement**. C'est une violation **"no silent fallback"** spécifique à Googlebot (le pire cas SEO).

## Correctif
Les deux `onError` (bot + browser) loggent désormais **inconditionnellement** (`logger.error("[SSR onError]", error)`) **et** `Sentry.captureException(error)`. Plus aucune erreur de rendu SSR n'est avalée silencieusement.

- Pas de double-log : les vraies erreurs de shell passent par `onShellError → reject → handleError` (séparé).
- Imports déjà présents (`Sentry` l.14, `logger` l.17). Aucune nouvelle dépendance/env.

## Suite (après déploiement)
Une fois live, la stack du 500 navara (et de tout autre 500 SSR bot) apparaît dans les logs + Sentry → je corrige le throw précis (composant/donnée) en TDD. **Aucune URL touchée.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)