### PR TITLE
feat(seo): GA4 fetcher lit keyEvents (API moderne) — corrige conversions=0 (PR2)

### DIFF
--- a/backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.service.ts
+++ b/backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.service.ts
@@ -97,10 +97,18 @@ export class Ga4DailyFetcherService {
     const rowLimit = options.rowLimit ?? 100000;
     const allRows: Array<Record<string, unknown>> = [];
 
+    // GA4 moderne : la métrique `conversions` est remplacée par `keyEvents`
+    // (rename Google 2024). On lit `keyEvents` et on l'écrit dans la colonne
+    // `conversions` (compat — sémantique = nombre de key events). Fallback
+    // gracieux + loggué vers la métrique legacy `conversions` si la propriété
+    // rejette `keyEvents` (no silent fallback). NB NON-RÉTROACTIF : un event
+    // marqué key event aujourd'hui n'alimente que les jours suivants.
+    let keyEventsFallback = false;
+
     try {
       for (const pattern of segments) {
         result.apiCalls += 1;
-        const [resp] = await client.runReport({
+        const mkReq = (metric: string) => ({
           property,
           dateRanges: [{ startDate: options.date, endDate: options.date }],
           dimensions: [
@@ -109,7 +117,7 @@ export class Ga4DailyFetcherService {
           ],
           metrics: [
             { name: 'sessions' },
-            { name: 'conversions' },
+            { name: metric },
             { name: 'bounceRate' },
             { name: 'averageSessionDuration' },
           ],
@@ -117,12 +125,38 @@ export class Ga4DailyFetcherService {
             ? {
                 filter: {
                   fieldName: 'pagePath',
-                  stringFilter: { matchType: 'CONTAINS', value: pattern },
+                  stringFilter: {
+                    matchType: 'CONTAINS' as const,
+                    value: pattern,
+                  },
                 },
               }
             : undefined,
           limit: rowLimit,
         });
+
+        let resp;
+        try {
+          [resp] = await client.runReport(
+            mkReq(keyEventsFallback ? 'conversions' : 'keyEvents'),
+          );
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          if (
+            !keyEventsFallback &&
+            /keyevents|valid metric|metric/i.test(msg)
+          ) {
+            this.logger.warn(
+              `[ga4] métrique keyEvents rejetée (${msg}) — fallback legacy conversions`,
+            );
+            result.warnings.push('keyEvents_unavailable_fallback_conversions');
+            keyEventsFallback = true;
+            result.apiCalls += 1;
+            [resp] = await client.runReport(mkReq('conversions'));
+          } else {
+            throw e;
+          }
+        }
 
         for (const row of resp.rows ?? []) {
           const dims = row.dimensionValues ?? [];
@@ -132,6 +166,7 @@ export class Ga4DailyFetcherService {
             page: dims[0]?.value ?? '',
             channel: (dims[1]?.value ?? 'organic').toLowerCase(),
             sessions: parseInt(mets[0]?.value ?? '0', 10),
+            // colonne `conversions` = nb de GA4 key events (source : metric keyEvents).
             conversions: parseInt(mets[1]?.value ?? '0', 10),
             bounce_rate: mets[2]?.value ? parseFloat(mets[2].value) : null,
             avg_session_duration: mets[3]?.value


### PR DESCRIPTION
## Contexte (PR2 — dernier morceau code P0)

`__seo_ga4_daily.conversions = 0` sur toute la fenêtre (vérifié live 2026-06-13) → la couche de réaction commerce est aveugle. Cause : le fetcher GA4 demande la métrique **`conversions`**, que Google a **remplacée par `keyEvents`** (rename GA4 2024). 

## Ce que fait PR2

- `ga4-daily-fetcher.service.ts` lit désormais la métrique **`keyEvents`** (API actuelle) au lieu de `conversions`.
- Valeur écrite dans la colonne **`conversions`** existante (compat — sémantique documentée = nombre de GA4 key events ; pas de migration, pas de nouveau gate).
- **Fallback gracieux + loggué** vers la métrique legacy `conversions` si la propriété rejette `keyEvents` (no silent fallback : `logger.warn` + warning `keyEvents_unavailable_fallback_conversions`).
- 1 seul fichier modifié. Typecheck backend **0 erreur** ; prettier clean.

## ⚠️ Dépendance owner + non-rétroactif

`keyEvents` ne remonte `> 0` que si des **key events sont configurés dans GA4 Admin** (purchase / add_to_cart / begin_checkout / generate_lead…). Et le marquage **n'est pas rétroactif** : seuls les jours **suivant** la config sont alimentés (l'historique GA4 n'est pas recalculé).

**Vérif post-config** : `SELECT SUM(conversions) FROM __seo_ga4_daily WHERE date > '<jour-config>'` > 0 (sur jours postérieurs, ou via un key event déjà existant comme `purchase`).

## Indépendance

Indépendante de #968/#969 (touche uniquement le fetcher GA4 ; la table `__seo_ga4_daily` existe déjà). Base = `main`.

## Suite (hors P0)

PR3 (indexation pilote `__seo_index_history`, quota-safe) · PR4 (alertes saisonnières advisory-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)