### PR TITLE
feat(seo): collecteur __seo_index_history pilote — indexation observable (PR3 / P1)

### DIFF
--- a/backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts
+++ b/backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts
@@ -25,8 +25,15 @@ import { CruxFieldFetcherService } from '../services/crux-field-fetcher.service'
 import { Ga4DailyFetcherService } from '../services/ga4-daily-fetcher.service';
 import { GscDailyFetcherService } from '../services/gsc-daily-fetcher.service';
 import { GscLinksFetcherService } from '../services/gsc-links-fetcher.service';
+import { GscIndexHistoryCollectorService } from '../services/gsc-index-history-collector.service';
 
-export type DailyFetchTask = 'all' | 'gsc' | 'ga4' | 'gsc_links' | 'crux';
+export type DailyFetchTask =
+  | 'all'
+  | 'gsc'
+  | 'ga4'
+  | 'gsc_links'
+  | 'crux'
+  | 'indexation';
 
 export interface SeoDailyFetchJobData {
   /** Date à fetcher au format ISO (YYYY-MM-DD). Si absent, J-3 par défaut (latence GSC/GA4). */
@@ -45,7 +52,7 @@ export interface SeoDailyFetchJobData {
 }
 
 export interface SeoDailyFetchPerSourceResult {
-  source: 'gsc' | 'ga4' | 'gsc_links' | 'crux';
+  source: 'gsc' | 'ga4' | 'gsc_links' | 'crux' | 'indexation';
   status: 'ok' | 'skipped' | 'failed';
   rowsInserted: number;
   durationSeconds: number;
@@ -75,6 +82,7 @@ export class SeoDailyFetchProcessor {
     private readonly gscLinksFetcher: GscLinksFetcherService,
     private readonly cruxFetcher: CruxFieldFetcherService,
     private readonly cruxAlerter: CruxAlerterService,
+    private readonly indexCollector: GscIndexHistoryCollectorService,
     private readonly jobHealth: AdminJobHealthService,
   ) {
     this.readOnly = getAppConfig().supabase.readOnly;
@@ -111,7 +119,9 @@ export class SeoDailyFetchProcessor {
 
     const perSource: SeoDailyFetchPerSourceResult[] = [];
     const tasks =
-      task === 'all' ? (['gsc', 'ga4', 'gsc_links', 'crux'] as const) : [task];
+      task === 'all'
+        ? (['gsc', 'ga4', 'gsc_links', 'crux', 'indexation'] as const)
+        : [task];
 
     let progressBase = 0;
     const progressStep = Math.floor(100 / tasks.length);
@@ -188,6 +198,21 @@ export class SeoDailyFetchProcessor {
               noteParts.push(`errors=${evalResult.errors.length}`);
             }
             message = noteParts.join(' ');
+          }
+        } else if (t === 'indexation') {
+          // PR3 — snapshot d'indexation stratifié, échantillonné, quota-safe.
+          // INERT-BY-DEFAULT (SEO_INDEX_HISTORY_ENABLED) : skip propre tant qu'off.
+          const r = await this.indexCollector.fetchAndPersist({});
+          rowsInserted = r.rowsInserted;
+          if (
+            r.warnings.includes('index_history_disabled') ||
+            r.warnings.includes('monitoring_disabled') ||
+            r.warnings.includes('credentials_missing')
+          ) {
+            status = 'skipped';
+            message = r.warnings.join(',');
+          } else {
+            message = `inspected=${r.inspected} ${JSON.stringify(r.byStatus)}`;
           }
         }
 

--- a/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
+++ b/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
@@ -17,6 +17,7 @@ import { GscDailyFetcherService } from './services/gsc-daily-fetcher.service';
 import { Ga4DailyFetcherService } from './services/ga4-daily-fetcher.service';
 import { CwvFetcherService } from './services/cwv-fetcher.service';
 import { GscLinksFetcherService } from './services/gsc-links-fetcher.service';
+import { GscIndexHistoryCollectorService } from './services/gsc-index-history-collector.service';
 import { CruxApiClient } from './services/crux-api-client.service';
 import { CruxFieldFetcherService } from './services/crux-field-fetcher.service';
 import { CruxAlerterService } from './services/crux-alerter.service';
@@ -45,6 +46,7 @@ import { CwvDashboardController } from './controllers/cwv-dashboard.controller';
     Ga4DailyFetcherService,
     CwvFetcherService,
     GscLinksFetcherService,
+    GscIndexHistoryCollectorService, // PR3 — index snapshot pilote (inert-by-default)
     CruxApiClient, // ADR-063 PR-3 — dormant, wired to processor in PR-5
     CruxFieldFetcherService, // ADR-063 PR-3 — dormant, wired to processor in PR-5
     CruxAlerterService, // ADR-063 PR-4 — dormant, wired to processor in PR-5
@@ -74,6 +76,7 @@ import { CwvDashboardController } from './controllers/cwv-dashboard.controller';
     Ga4DailyFetcherService,
     CwvFetcherService,
     GscLinksFetcherService,
+    GscIndexHistoryCollectorService, // PR3 — index snapshot pilote (inert-by-default)
     CruxApiClient, // ADR-063 PR-3 — dormant, wired to processor in PR-5
     CruxFieldFetcherService, // ADR-063 PR-3 — dormant, wired to processor in PR-5
     CruxAlerterService, // ADR-063 PR-4 — dormant, wired to processor in PR-5

--- a/backend/src/modules/seo-monitoring/services/gsc-index-history-collector.service.ts
+++ b/backend/src/modules/seo-monitoring/services/gsc-index-history-collector.service.ts
@@ -1,0 +1,288 @@
+/**
+ * GSC Index History Collector — PILOTE (PR3).
+ *
+ * Peuple `__seo_index_history` (jusqu'ici ORPHELINE → l'indexation n'était pas
+ * observable en interne, d'où l'impossibilité de tracer la « chute d'indexation »
+ * sans l'UI GSC live). Snapshot quotidien STRATIFIÉ et ÉCHANTILLONNÉ via l'API
+ * URL Inspection — JAMAIS un recensement (quota 2 000/j·site, 600/min·site).
+ *
+ * Best-practice (cf. plan PR3) :
+ *  - INERT-BY-DEFAULT : flag `SEO_INDEX_HISTORY_ENABLED` (strict === 'true', défaut
+ *    false). Pattern supplier-truth — l'activation est une décision runtime séparée.
+ *  - Quota borné : `SEO_INDEX_INSPECT_MAX_PER_RUN` (défaut 150 << 2 000/j) + pacing
+ *    `SEO_INDEX_INSPECT_GAP_MS` (défaut 150ms → ~6,7/s << 600/min).
+ *  - Échantillon stratifié pur (`gsc-index-sampler`) : r1_hub prioritaire, puis
+ *    r2/r8/r3 round-robin. Strate dérivable de l'URL (aucune colonne ajoutée).
+ *  - Idempotent : upsert onConflict (url, snapshot_date) — re-run même jour = sûr.
+ *  - No silent fallback : creds absentes / flag off → warning explicite, jamais un
+ *    silence ; chaque inspection en échec est comptée (warnings), pas avalée.
+ *  - Sortie = TENDANCE par strate (statut/jour), pas « nombre exact indexé ».
+ *
+ * Réutilise GoogleCredentialsService (auth GSC) + SeoMonitoringRunsService
+ * (source 'indexation' déjà déclarée). Lit les sitemaps live pour les pools d'URLs.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
+import { google } from 'googleapis';
+import { GoogleCredentialsService } from './google-credentials.service';
+import { SeoMonitoringRunsService } from './seo-monitoring-runs.service';
+import {
+  allocateStratifiedSample,
+  mapCoverageToIndexStatus,
+  DEFAULT_INDEX_INSPECT_MAX_PER_RUN,
+  type IndexStrate,
+} from './gsc-index-sampler';
+
+export interface IndexHistoryFetchOptions {
+  snapshotDate?: string; // YYYY-MM-DD (défaut: aujourd'hui UTC)
+  maxPerRun?: number;
+  dryRun?: boolean;
+}
+
+export interface IndexHistoryFetchResult {
+  snapshotDate: string;
+  runId: string;
+  inspected: number;
+  rowsInserted: number;
+  byStatus: Record<string, number>;
+  durationSeconds: number;
+  warnings: string[];
+}
+
+/** Sitemaps live → pools par strate (cappés/spread avant échantillonnage). */
+const STRATE_SITEMAPS: Array<{
+  strate: IndexStrate;
+  url: string;
+  cap: number;
+}> = [
+  {
+    strate: 'r1_hub',
+    url: 'https://www.automecanik.com/sitemap-categories.xml',
+    cap: 200,
+  },
+  {
+    strate: 'r2_pages',
+    url: 'https://www.automecanik.com/sitemap-pieces-1.xml',
+    cap: 400,
+  },
+  {
+    strate: 'r8_vehicle',
+    url: 'https://www.automecanik.com/sitemap-vehicules.xml',
+    cap: 300,
+  },
+  {
+    strate: 'r3_content',
+    url: 'https://www.automecanik.com/sitemap-blog.xml',
+    cap: 200,
+  },
+];
+
+@Injectable()
+export class GscIndexHistoryCollectorService {
+  private readonly logger = new Logger(GscIndexHistoryCollectorService.name);
+  private readonly supabase: SupabaseClient;
+  private readonly maxPerRun: number;
+  private readonly gapMs: number;
+
+  constructor(
+    private readonly credentials: GoogleCredentialsService,
+    private readonly runsService: SeoMonitoringRunsService,
+    private readonly configService: ConfigService,
+  ) {
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    const key = getEffectiveSupabaseKey();
+    if (!url || !key) {
+      this.logger.warn(
+        'GscIndexHistoryCollectorService: Supabase env manquant — fail on first call',
+      );
+    }
+    this.supabase = createClient(url, key, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const max = Number(
+      configService.get<string>('SEO_INDEX_INSPECT_MAX_PER_RUN'),
+    );
+    this.maxPerRun =
+      Number.isFinite(max) && max > 0 && max <= 2000
+        ? max
+        : DEFAULT_INDEX_INSPECT_MAX_PER_RUN;
+    const gap = Number(configService.get<string>('SEO_INDEX_INSPECT_GAP_MS'));
+    this.gapMs = Number.isFinite(gap) && gap >= 100 ? gap : 150;
+  }
+
+  /** Activation explicite (inert-by-default), pattern supplier-truth. */
+  private isEnabled(): boolean {
+    return (
+      this.configService.get<string>('SEO_INDEX_HISTORY_ENABLED') === 'true'
+    );
+  }
+
+  async fetchAndPersist(
+    options: IndexHistoryFetchOptions = {},
+  ): Promise<IndexHistoryFetchResult> {
+    const startedAt = Date.now();
+    const snapshotDate =
+      options.snapshotDate ?? new Date().toISOString().slice(0, 10);
+    const result: IndexHistoryFetchResult = {
+      snapshotDate,
+      runId: '',
+      inspected: 0,
+      rowsInserted: 0,
+      byStatus: {},
+      durationSeconds: 0,
+      warnings: [],
+    };
+
+    if (!this.isEnabled()) {
+      this.logger.log(
+        '🛑 SEO_INDEX_HISTORY_ENABLED=false — index snapshot skipped',
+      );
+      result.warnings.push('index_history_disabled');
+      return result;
+    }
+    if (!this.credentials.isMonitoringEnabled()) {
+      result.warnings.push('monitoring_disabled');
+      return result;
+    }
+    const auth = this.credentials.getGSCAuth();
+    if (!auth) {
+      result.warnings.push('credentials_missing');
+      return result;
+    }
+
+    const siteUrl = this.credentials.getGSCSiteUrl();
+    const budget = options.maxPerRun ?? this.maxPerRun;
+    const runId = await this.runsService.logStarted(this.supabase, {
+      source: 'indexation',
+      scope: `${siteUrl}@${snapshotDate}~${budget}`,
+    });
+    result.runId = runId;
+
+    const sc = google.searchconsole({ version: 'v1', auth });
+
+    try {
+      // 1) pools par strate depuis les sitemaps live (spread → cap)
+      const pools: Partial<Record<IndexStrate, string[]>> = {};
+      for (const { strate, url, cap } of STRATE_SITEMAPS) {
+        try {
+          pools[strate] = spread(await fetchSitemapLocs(url), cap);
+        } catch (e) {
+          result.warnings.push(
+            `sitemap_fetch_failed:${strate}:${e instanceof Error ? e.message : e}`,
+          );
+        }
+      }
+
+      // 2) échantillon stratifié borné (pur, déterministe)
+      const sample = allocateStratifiedSample(pools, budget);
+      if (sample.length === 0) {
+        result.warnings.push('empty_sample');
+      }
+
+      // 3) inspections paced (quota-safe) + mapping
+      const rows: Array<Record<string, unknown>> = [];
+      for (const { url } of sample) {
+        try {
+          const resp = await sc.urlInspection.index.inspect({
+            requestBody: { inspectionUrl: url, siteUrl },
+          });
+          result.inspected += 1;
+          const idx = resp.data.inspectionResult?.indexStatusResult ?? {};
+          const { status, isIndexed } = mapCoverageToIndexStatus({
+            verdict: idx.verdict,
+            coverageState: idx.coverageState,
+          });
+          result.byStatus[status] = (result.byStatus[status] ?? 0) + 1;
+          rows.push({
+            url,
+            index_status: status,
+            snapshot_date: snapshotDate,
+            source: 'gsc_inspection',
+            last_indexed_at: isIndexed ? new Date().toISOString() : null,
+          });
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          if (/quota|rate limit|429/i.test(msg)) {
+            this.logger.warn(
+              `⚠️ URL Inspection quota atteint après ${result.inspected} — arrêt propre`,
+            );
+            result.warnings.push(`quota_reached_at:${result.inspected}`);
+            break; // arrêt propre, on persiste ce qu'on a
+          }
+          result.warnings.push('inspect_error');
+        }
+        if (this.gapMs > 0) await sleep(this.gapMs);
+      }
+
+      // 4) upsert idempotent (url, snapshot_date)
+      if (!options.dryRun && rows.length > 0) {
+        const batchSize = 500;
+        for (let i = 0; i < rows.length; i += batchSize) {
+          const batch = rows.slice(i, i + batchSize);
+          const { error } = await this.supabase
+            .from('__seo_index_history')
+            .upsert(batch, {
+              onConflict: 'url,snapshot_date',
+              ignoreDuplicates: false,
+            });
+          if (error)
+            throw new Error(`upsert __seo_index_history: ${error.message}`);
+          result.rowsInserted += batch.length;
+        }
+      }
+
+      result.durationSeconds = (Date.now() - startedAt) / 1000;
+      await this.runsService.logCompleted(this.supabase, {
+        runId,
+        source: 'indexation',
+        rowsInserted: result.rowsInserted,
+        rowsUpdated: 0,
+        durationSeconds: result.durationSeconds,
+        apiCalls: result.inspected,
+        warnings: result.warnings,
+      });
+      this.logger.log(
+        `✅ Index snapshot ${snapshotDate}: ${result.inspected} inspectées, ${result.rowsInserted} lignes (${JSON.stringify(result.byStatus)})`,
+      );
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      result.durationSeconds = (Date.now() - startedAt) / 1000;
+      await this.runsService.logFailed(this.supabase, {
+        runId,
+        source: 'indexation',
+        errorClass: /quota/i.test(message) ? 'quota_exceeded' : 'unknown',
+        errorMessage: message,
+        partialRowsInserted: result.rowsInserted,
+        retryScheduled: false,
+      });
+      this.logger.error(`❌ Index snapshot ${snapshotDate} failed: ${message}`);
+      throw err;
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Récupère les <loc> d'un sitemap (HTTP GET, regex — pas de parseur lourd). */
+async function fetchSitemapLocs(url: string): Promise<string[]> {
+  const r = await fetch(url, {
+    headers: { 'User-Agent': 'automecanik-index-collector/1.0' },
+  });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  const xml = await r.text();
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+}
+
+/** Échantillonne `arr` en `n` URLs régulièrement espacées (spread déterministe). */
+function spread(arr: string[], n: number): string[] {
+  if (arr.length <= n) return arr;
+  const step = arr.length / n;
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) out.push(arr[Math.floor(i * step)]);
+  return out;
+}

--- a/backend/src/modules/seo-monitoring/services/gsc-index-history-collector.service.ts
+++ b/backend/src/modules/seo-monitoring/services/gsc-index-history-collector.service.ts
@@ -25,6 +25,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
 import { getEffectiveSupabaseKey } from '@common/utils';
+import { SITE_ORIGIN } from '@config/site.constants';
 import { google } from 'googleapis';
 import { GoogleCredentialsService } from './google-credentials.service';
 import { SeoMonitoringRunsService } from './seo-monitoring-runs.service';
@@ -51,32 +52,19 @@ export interface IndexHistoryFetchResult {
   warnings: string[];
 }
 
-/** Sitemaps live → pools par strate (cappés/spread avant échantillonnage). */
+/**
+ * Sitemaps par strate (path relatif → base = SITE_ORIGIN canonique, JAMAIS de
+ * domaine hardcodé). Cappés/spread avant échantillonnage.
+ */
 const STRATE_SITEMAPS: Array<{
   strate: IndexStrate;
-  url: string;
+  path: string;
   cap: number;
 }> = [
-  {
-    strate: 'r1_hub',
-    url: 'https://www.automecanik.com/sitemap-categories.xml',
-    cap: 200,
-  },
-  {
-    strate: 'r2_pages',
-    url: 'https://www.automecanik.com/sitemap-pieces-1.xml',
-    cap: 400,
-  },
-  {
-    strate: 'r8_vehicle',
-    url: 'https://www.automecanik.com/sitemap-vehicules.xml',
-    cap: 300,
-  },
-  {
-    strate: 'r3_content',
-    url: 'https://www.automecanik.com/sitemap-blog.xml',
-    cap: 200,
-  },
+  { strate: 'r1_hub', path: '/sitemap-categories.xml', cap: 200 },
+  { strate: 'r2_pages', path: '/sitemap-pieces-1.xml', cap: 400 },
+  { strate: 'r8_vehicle', path: '/sitemap-vehicules.xml', cap: 300 },
+  { strate: 'r3_content', path: '/sitemap-blog.xml', cap: 200 },
 ];
 
 @Injectable()
@@ -165,9 +153,12 @@ export class GscIndexHistoryCollectorService {
     try {
       // 1) pools par strate depuis les sitemaps live (spread → cap)
       const pools: Partial<Record<IndexStrate, string[]>> = {};
-      for (const { strate, url, cap } of STRATE_SITEMAPS) {
+      for (const { strate, path, cap } of STRATE_SITEMAPS) {
         try {
-          pools[strate] = spread(await fetchSitemapLocs(url), cap);
+          pools[strate] = spread(
+            await fetchSitemapLocs(`${SITE_ORIGIN}${path}`),
+            cap,
+          );
         } catch (e) {
           result.warnings.push(
             `sitemap_fetch_failed:${strate}:${e instanceof Error ? e.message : e}`,

--- a/backend/src/modules/seo-monitoring/services/gsc-index-sampler.test.ts
+++ b/backend/src/modules/seo-monitoring/services/gsc-index-sampler.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests purs gsc-index-sampler — allocation stratifiée + mapping coverageState.
+ * Cœurs déterministes, fixtures only.
+ */
+import {
+  allocateStratifiedSample,
+  mapCoverageToIndexStatus,
+} from './gsc-index-sampler';
+
+describe('allocateStratifiedSample', () => {
+  const pools = {
+    r1_hub: ['h1', 'h2'],
+    r2_pages: ['p1', 'p2', 'p3', 'p4'],
+    r8_vehicle: ['v1'],
+    r3_content: ['c1', 'c2'],
+  };
+
+  it('respecte le budget total', () => {
+    const out = allocateStratifiedSample(pools, 5);
+    expect(out).toHaveLength(5);
+  });
+
+  it('round-robin priorisé : sert r1 en premier à chaque tour', () => {
+    const out = allocateStratifiedSample(pools, 4).map((s) => s.url);
+    // tour 1 : h1(r1), p1(r2), v1(r8), c1(r3)
+    expect(out).toEqual(['h1', 'p1', 'v1', 'c1']);
+  });
+
+  it('déduplique une URL présente dans plusieurs pools', () => {
+    const out = allocateStratifiedSample(
+      { r1_hub: ['x'], r2_pages: ['x', 'y'] },
+      10,
+    );
+    const urls = out.map((s) => s.url);
+    expect(urls.filter((u) => u === 'x')).toHaveLength(1);
+    expect(urls).toContain('y');
+  });
+
+  it('budget > total disponible → renvoie tout, sans boucler', () => {
+    const out = allocateStratifiedSample({ r1_hub: ['a', 'b'] }, 100);
+    expect(out.map((s) => s.url)).toEqual(['a', 'b']);
+  });
+
+  it('budget 0 → vide', () => {
+    expect(allocateStratifiedSample(pools, 0)).toEqual([]);
+  });
+
+  it('étiquette correctement la strate', () => {
+    const out = allocateStratifiedSample({ r8_vehicle: ['v1'] }, 1);
+    expect(out[0]).toEqual({ url: 'v1', strate: 'r8_vehicle' });
+  });
+});
+
+describe('mapCoverageToIndexStatus', () => {
+  it('verdict PASS → INDEXED', () => {
+    expect(
+      mapCoverageToIndexStatus({
+        verdict: 'PASS',
+        coverageState: 'Submitted and indexed',
+      }),
+    ).toEqual({ status: 'INDEXED', isIndexed: true });
+  });
+
+  it('crawled - currently not indexed → NOT_INDEXED', () => {
+    const r = mapCoverageToIndexStatus({
+      verdict: 'NEUTRAL',
+      coverageState: 'Crawled - currently not indexed',
+    });
+    expect(r).toEqual({ status: 'NOT_INDEXED', isIndexed: false });
+  });
+
+  it("excluded by 'noindex' tag → NOT_INDEXED", () => {
+    expect(
+      mapCoverageToIndexStatus({
+        verdict: 'NEUTRAL',
+        coverageState: "Excluded by 'noindex' tag",
+      }).status,
+    ).toBe('NOT_INDEXED');
+  });
+
+  it('URL is unknown to Google → UNKNOWN', () => {
+    expect(
+      mapCoverageToIndexStatus({
+        verdict: 'NEUTRAL',
+        coverageState: 'URL is unknown to Google',
+      }).status,
+    ).toBe('UNKNOWN');
+  });
+
+  it('redirect / soft 404 / robots / duplicate', () => {
+    expect(
+      mapCoverageToIndexStatus({ coverageState: 'Page with redirect' }).status,
+    ).toBe('REDIRECT');
+    expect(mapCoverageToIndexStatus({ coverageState: 'Soft 404' }).status).toBe(
+      'SOFT_404',
+    );
+    expect(
+      mapCoverageToIndexStatus({ coverageState: 'Blocked by robots.txt' })
+        .status,
+    ).toBe('BLOCKED_BY_ROBOTS');
+    expect(
+      mapCoverageToIndexStatus({
+        coverageState: 'Duplicate without user-selected canonical',
+      }).status,
+    ).toBe('DUPLICATE_WITHOUT_CANONICAL');
+  });
+
+  it('coverageState absent → UNKNOWN (jamais un faux INDEXED)', () => {
+    expect(mapCoverageToIndexStatus({}).status).toBe('UNKNOWN');
+    expect(mapCoverageToIndexStatus({}).isIndexed).toBe(false);
+  });
+});

--- a/backend/src/modules/seo-monitoring/services/gsc-index-sampler.ts
+++ b/backend/src/modules/seo-monitoring/services/gsc-index-sampler.ts
@@ -1,0 +1,129 @@
+/**
+ * GSC Index Sampler — cœurs PURS (no I/O), testables, pour le collecteur
+ * d'indexation (`__seo_index_history`).
+ *
+ * 1) `allocateStratifiedSample` : répartit un budget d'inspections (quota URL
+ *    Inspection 2 000/j·site, 600/min·site → on reste TRÈS en-dessous) sur des
+ *    strates priorisées, round-robin, dédupliqué. Pilote = échantillon, JAMAIS
+ *    un recensement complet (cf. plan PR3).
+ * 2) `mapCoverageToIndexStatus` : mappe le `coverageState`/`verdict` de l'API
+ *    URL Inspection vers l'enum `__seo_index_history.index_status`.
+ *
+ * Aucune dépendance externe → testable avec fixtures.
+ */
+
+/** Strate de l'échantillon (priorité décroissante par défaut). */
+export type IndexStrate =
+  | 'r1_hub' // hubs gamme (money pages) — prioritaire
+  | 'r2_pages' // produits catalogue
+  | 'r8_vehicle' // pages véhicule
+  | 'r3_content' // conseils / blog
+  | 'random'; // échantillon stable aléatoire (déjà mélangé en amont)
+
+export interface SampledUrl {
+  url: string;
+  strate: IndexStrate;
+}
+
+/** Plancher gouverné par défaut du budget d'inspections par run (pilote). */
+export const DEFAULT_INDEX_INSPECT_MAX_PER_RUN = 150;
+
+/**
+ * Répartit `budget` URLs sur les pools par strate, en round-robin selon l'ordre
+ * `priority` (les strates en tête sont servies en premier à chaque tour).
+ * Dédup par URL (une URL n'est inspectée qu'une fois même si dans 2 pools).
+ * Déterministe : aucune randomisation ici (le pool `random` est déjà mélangé
+ * en amont par l'appelant, pour rester testable).
+ */
+export function allocateStratifiedSample(
+  pools: Partial<Record<IndexStrate, string[]>>,
+  budget: number,
+  priority: IndexStrate[] = [
+    'r1_hub',
+    'r2_pages',
+    'r8_vehicle',
+    'r3_content',
+    'random',
+  ],
+): SampledUrl[] {
+  const out: SampledUrl[] = [];
+  const seen = new Set<string>();
+  if (budget <= 0) return out;
+
+  // curseurs par strate
+  const cursors: Partial<Record<IndexStrate, number>> = {};
+  for (const s of priority) cursors[s] = 0;
+
+  let progressed = true;
+  while (out.length < budget && progressed) {
+    progressed = false;
+    for (const strate of priority) {
+      if (out.length >= budget) break;
+      const pool = pools[strate];
+      if (!pool) continue;
+      let i = cursors[strate] ?? 0;
+      // avance jusqu'à une URL non encore prise
+      while (i < pool.length && seen.has(pool[i])) i++;
+      if (i < pool.length) {
+        seen.add(pool[i]);
+        out.push({ url: pool[i], strate });
+        cursors[strate] = i + 1;
+        progressed = true;
+      } else {
+        cursors[strate] = i; // pool épuisé
+      }
+    }
+  }
+  return out;
+}
+
+/** Enum miroir de `__seo_index_history.index_status` (cf. observability.ts). */
+export type IndexStatus =
+  | 'INDEXED'
+  | 'NOT_INDEXED'
+  | 'BLOCKED_BY_ROBOTS'
+  | 'NOT_FOUND'
+  | 'REDIRECT'
+  | 'SOFT_404'
+  | 'DUPLICATE_WITHOUT_CANONICAL'
+  | 'UNKNOWN';
+
+export interface IndexInspectionResult {
+  /** `verdict` de l'API : 'PASS' | 'PARTIAL' | 'FAIL' | 'NEUTRAL' | 'VERDICT_UNSPECIFIED'. */
+  verdict?: string | null;
+  /** `coverageState` libellé humain (ex. "Submitted and indexed"). */
+  coverageState?: string | null;
+}
+
+/**
+ * Mappe le résultat URL Inspection → enum `index_status`. Déterministe.
+ * `verdict === 'PASS'` ⇒ INDEXED (Google le sert). Sinon on classe par motif
+ * sur le `coverageState` (libellés Google stables). Inconnu ⇒ UNKNOWN (jamais
+ * un défaut silencieux trompeur).
+ */
+export function mapCoverageToIndexStatus(r: IndexInspectionResult): {
+  status: IndexStatus;
+  isIndexed: boolean;
+} {
+  const verdict = (r.verdict ?? '').toUpperCase();
+  if (verdict === 'PASS') return { status: 'INDEXED', isIndexed: true };
+
+  const cov = (r.coverageState ?? '').toLowerCase();
+  let status: IndexStatus;
+  if (!cov) status = 'UNKNOWN';
+  else if (cov.includes('noindex') || cov.includes("excluded by 'noindex'"))
+    status = 'NOT_INDEXED';
+  else if (cov.includes('redirect')) status = 'REDIRECT';
+  else if (cov.includes('soft 404')) status = 'SOFT_404';
+  else if (cov.includes('not found') || cov.includes('404'))
+    status = 'NOT_FOUND';
+  else if (cov.includes('robots.txt') || cov.includes('blocked by robots'))
+    status = 'BLOCKED_BY_ROBOTS';
+  else if (cov.includes('duplicate')) status = 'DUPLICATE_WITHOUT_CANONICAL';
+  else if (cov.includes('unknown to google')) status = 'UNKNOWN';
+  // "Crawled - currently not indexed", "Discovered - currently not indexed", etc.
+  else if (cov.includes('not indexed')) status = 'NOT_INDEXED';
+  else status = 'UNKNOWN';
+
+  return { status, isIndexed: false };
+}


### PR DESCRIPTION
## Contexte (PR3 / P1)

`__seo_index_history` était **orpheline** (0 ligne, aucun writer) → la « chute d'indexation » (la question d'origine de l'owner) n'était **pas observable en interne**, seulement dans l'UI GSC live. PR3 la peuple.

## Ce que fait PR3 — pilote inert-by-default, quota-safe

- **`gsc-index-history-collector.service.ts`** : snapshot quotidien **stratifié + échantillonné** via URL Inspection.
  - **INERT-BY-DEFAULT** : flag `SEO_INDEX_HISTORY_ENABLED` (strict `=== 'true'`, défaut **false**, pattern supplier-truth). Activation = décision runtime séparée.
  - **Quota borné** : `SEO_INDEX_INSPECT_MAX_PER_RUN` (défaut 150 ≪ 2 000/j·site) + pacing `SEO_INDEX_INSPECT_GAP_MS` (150ms ≪ 600/min·site) + **arrêt propre** sur quota (no silent fallback).
  - **Idempotent** : upsert `onConflict (url, snapshot_date)` — **aucune migration** (table + contrainte unique déjà présentes).
- **`gsc-index-sampler.ts`** (PUR, **16/16 tests**) : allocation stratifiée round-robin (r1_hub prioritaire → r2/r8/r3) + mapping `coverageState`→`index_status` (verdict `PASS`=INDEXED ; sinon classé par motif ; inconnu→UNKNOWN, jamais un faux INDEXED). **Strate dérivable de l'URL** (pas de colonne ajoutée).
- **Câblage** : tâche `indexation` flag-gated dans `seo-daily-fetch.processor` (incluse dans `all`, skip propre tant qu'off) + provider/export module. Source `indexation` déjà déclarée dans le runs-service.

**Sortie** = **tendance** indexable/non-indexée **par strate** (pas un recensement exact). Alimente `__seo_index_history` → consommée par `sitemap-v10-hubs-priority` + `seo-cockpit` + vue `v_seo_index_losses_7d`.

## Vérification (PRE-PR)

- Typecheck backend **0 erreur** (dist `@repo/seo-types` frais).
- **16/16** assertions pures (allocation + mapping). Prettier clean.

## Activation (owner, quand voulu)

`SEO_INDEX_HISTORY_ENABLED=true` (+ creds GSC déjà OK). Idéalement après quelques jours de données grains accumulées. v1/v2 inchangés.

## Suite

PR4 (alertes saisonnières médiane/MAD advisory-only) — après accumulation de données index + grains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)