### PR TITLE
fix(seo): guard url-compatibility diagnostic endpoints (AuthenticatedGuard parity)

### DIFF
--- a/backend/src/modules/seo/seo.controller.ts
+++ b/backend/src/modules/seo/seo.controller.ts
@@ -273,6 +273,7 @@ export class SeoController {
    * Vérifie que les URLs générées sont identiques à l'ancien format nginx
    */
   @Get('url-compatibility/report')
+  @UseGuards(AuthenticatedGuard)
   async getUrlCompatibilityReport() {
     try {
       const report =
@@ -298,6 +299,7 @@ export class SeoController {
    * Query params: type (gammes|constructeurs|modeles|all), sampleSize (number)
    */
   @Get('url-compatibility/verify')
+  @UseGuards(AuthenticatedGuard)
   async verifyUrlCompatibility(
     @Query('type') type?: 'gammes' | 'constructeurs' | 'modeles' | 'all',
     @Query('sampleSize') sampleSize?: number,
@@ -328,6 +330,7 @@ export class SeoController {
    * Query params: limit, offset
    */
   @Get('url-compatibility/gammes')
+  @UseGuards(AuthenticatedGuard)
   async getGammeUrls(
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
@@ -358,6 +361,7 @@ export class SeoController {
    * GET /seo/url-compatibility/constructeurs - Liste toutes les URLs de constructeurs
    */
   @Get('url-compatibility/constructeurs')
+  @UseGuards(AuthenticatedGuard)
   async getConstructeurUrls(
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
@@ -388,6 +392,7 @@ export class SeoController {
    * GET /seo/url-compatibility/modeles - Liste toutes les URLs de modèles
    */
   @Get('url-compatibility/modeles')
+  @UseGuards(AuthenticatedGuard)
   async getModeleUrls(
     @Query('limit') limit?: number,
     @Query('offset') offset?: number,
@@ -425,6 +430,7 @@ export class SeoController {
    * Pour vérifier le format : /pieces/{pg_alias}-{pg_id}/{marque}-{id}/{modele}-{id}/{type}-{id}.html
    */
   @Get('url-compatibility/test-vehicule')
+  @UseGuards(AuthenticatedGuard)
   async testVehiculeUrl(
     @Query('pgId') pgId?: number,
     @Query('pgAlias') pgAlias?: string,
@@ -505,6 +511,7 @@ export class SeoController {
    * GET /seo/url-compatibility/test-constructeur - Tester génération URL constructeur+type
    */
   @Get('url-compatibility/test-constructeur')
+  @UseGuards(AuthenticatedGuard)
   async testConstructeurUrl(
     @Query('marqueId') marqueId?: number,
     @Query('marqueAlias') marqueAlias?: string,


### PR DESCRIPTION
## Quoi

Ajoute `@UseGuards(AuthenticatedGuard)` aux **7 endpoints `@Get /api/seo/url-compatibility/*`** (`report`, `verify`, `gammes`, `constructeurs`, `modeles`, `test-vehicule`, `test-constructeur`) dans `backend/src/modules/seo/seo.controller.ts`.

## Pourquoi

C'étaient les **seuls** endpoints non-guardés du contrôleur. Leurs frères diagnostics **dans le même fichier** sont déjà guardés (`@Get('analytics')`, `pages-without-seo`, `@Put('metadata')`, `@Post('batch-update')` → `@UseGuards(AuthenticatedGuard)`). Ces endpoints exposent des diagnostics SEO internes (rapport de couverture, fixtures de test) qui appartiennent derrière auth comme leurs frères.

## Périmètre / sûreté

- **Additif pur** : 7 décorateurs, guard **déjà importé** (ligne 13), 0 nouvel import.
- **0 changement d'URL / route / canonical** → `no_url_changes_ever` non engagé.
- **0 appelant** du endpoint dans le repo (frontend + backend) → non-breaking.
- Service sous-jacent `url-compatibility.service.ts` strictement **read-only** (`.select()` only).
- Réversible : revert PR.

## Vérification

- Local : 11 `@UseGuards(AuthenticatedGuard)` au total (4 existants + 7 ajoutés), chaque route `url-compatibility` suivie de son guard.
- CI (gate) : build turbo + tests + lint → à confirmer verts avant merge.

Origine : triage des dettes signalées en suivi ADR-084 (#973).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
