### PR TITLE
refactor(seo): remove dead brandLegacyMatch 301 branch (constructeurs catch-all)

### DIFF
--- a/frontend/app/routes/constructeurs.$.tsx
+++ b/frontend/app/routes/constructeurs.$.tsx
@@ -8,7 +8,6 @@
 // renvoie désormais 410 Gone + noindex (désindexation propre).
 
 import {
-  redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
 } from "@remix-run/node";
@@ -78,17 +77,11 @@ export async function loader({ params }: LoaderFunctionArgs) {
     );
   }
 
-  // Legacy : /constructeurs/{brand}-{id}.html (1-segment) → 301 vers la page marque.
-  // (En pratique servi par la route plus spécifique constructeurs.$brand[.]html.tsx ;
-  //  conservé tel quel — voir note de dette ADR-084 sur la cible sans id.)
-  const brandLegacyMatch = catchAll.match(/^([a-z0-9-]+)-(\d+)\.html$/i);
-  if (brandLegacyMatch) {
-    const [, brandSlug, brandId] = brandLegacyMatch;
-    logger.log("[ConstructeursCatchAll] Legacy brand URL:", brandSlug, brandId);
-    return redirect(`/constructeurs/${brandSlug}`, { status: 301 });
-  }
-
-  // URLs inconnues → 404
+  // Le 1-segment marque (/constructeurs/{brand}-{id}.html) est servi par la route plus
+  // spécifique constructeurs.$brand[.]html.tsx (précédence flat-routes) ; il n'atteint
+  // jamais ce catch-all. L'ancienne branche 301 legacy était donc morte (cible sans id
+  // qui 404 de toute façon) — retirée, ADR-084 suivi. Tout chemin restant → 404.
+  logger.log("[ConstructeursCatchAll] Unknown pattern, returning 404");
   logger.log("[ConstructeursCatchAll] Unknown pattern, returning 404");
   throw new Response("Not Found", { status: 404 });
 }


### PR DESCRIPTION
## Quoi

Retire la branche **morte** `brandLegacyMatch` (redirect 301) du catch-all `frontend/app/routes/constructeurs.$.tsx`, + l'import `redirect` devenu orphelin.

## Pourquoi (confirmé empiriquement)

La branche matchait un 1-segment `/constructeurs/{brand}-{id}.html` pour le 301-rediriger vers `/constructeurs/{brand}` (slug **sans id**). Deux problèmes — tous deux confirmés :
1. **Inatteignable** : la route plus spécifique `constructeurs.$brand[.]html.tsx` (R7) intercepte cette forme d'URL via la précédence flat-routes. Vérifié **live** : `bmw-33.html` → 200 (R7), `zzzfake-99999.html` → **404 via R7, jamais 301**. La branche du catch-all ne s'exécute donc jamais.
2. Sa cible (slug sans id) **404** de toute façon.

#973 l'avait consciemment laissée comme **dette documentée** (ADR-084). Ce PR fait le nettoyage.

## Périmètre / sûreté

- **Comportement runtime inchangé** (branche morte → suppression sans effet observable).
- **Ne change AUCUNE URL live ni redirect actif** : on retire un 301 mort, on ne retargette rien (`no_url_changes_ever` respecté — cf. classification SAFE du triage).
- Retrait de l'import `redirect` orphelin (sinon lint `no-unused-vars`).
- Réversible : revert PR.

## ⚠️ R-SEO-09 (url-immutability) — à surveiller

La canonical surface AST de la route (filename / default export / `meta` noindex statique / `handle` / `headers`) **ne change pas** → je n'attends **pas** de déclenchement. **Si** `url-immutability` rougit malgré tout, c'est le garde qui réagit au diff du loader : la résolution gouvernée = label owner `r-seo-09-override` + ce trade-off (suppression de code mort, 0 changement d'URL). **Je ne l'auto-applique jamais** — décision SEO owner (ADR-084 / #795).

## Vérification

- Local : 0 référence orpheline à `redirect`/`brandLegacyMatch`/`brandSlug` ; −12/+5 lignes.
- CI (gate) : build + tests + `url-immutability` → à confirmer avant merge.

Origine : triage des dettes signalées en suivi ADR-084 (#973).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
