### PR TITLE
fix(ssr): bound deferred blog cascade to one total budget (stop bot render abort on /pieces)

### DIFF
--- a/frontend/app/services/pieces/pieces-route.service.ts
+++ b/frontend/app/services/pieces/pieces-route.service.ts
@@ -30,6 +30,15 @@ const BACKEND_URL =
       "http://localhost:3000"
     : "";
 
+// ⏱️ Budget temps TOTAL (ms) pour la cascade blog différée `blogData` (below-fold).
+// `blogData` est consommée côté bot via le chemin onAllReady de `entry.server.tsx`,
+// qui attend TOUTES les frontières <Suspense> avant d'émettre le HTML, sous un
+// `ABORT_DELAY` global de 5 s. Un timeout PAR endpoint (4 × 2 s = 8 s cumulés)
+// dépassait cette fenêtre → tout le rendu bot avortait ("render was aborted by the
+// server without a reason", Googlebot inclus). Ce budget borne la cascade ENTIÈRE
+// sous l'abort ; il doit rester strictement < ABORT_DELAY (entry.server.tsx).
+const BLOG_FETCH_BUDGET_MS = 2500;
+
 // ✅ Migration /img/* : Utiliser le proxy Caddy au lieu d'URLs Supabase directes
 function normalizeImageUrl(url: string | null | undefined): string {
   if (!url || typeof url !== "string") return "";
@@ -390,11 +399,16 @@ export async function fetchBlogArticleWithRelated(
     `${BACKEND_URL}/api/blog/homepage`,
   ];
 
+  // Deadline UNIQUE partagée par tous les endpoints (et non par-endpoint) :
+  // la cascade entière est bornée à BLOG_FETCH_BUDGET_MS, pas N × timeout.
+  // L'ordre de préférence des endpoints est préservé ; on s'arrête dès que le
+  // budget est épuisé et on retourne le fallback (toujours résolu, jamais rejeté).
+  const budget = AbortSignal.timeout(BLOG_FETCH_BUDGET_MS);
+
   for (const endpoint of endpoints) {
+    if (budget.aborted) break; // budget épuisé → ne pas lancer un fetch voué à l'abort
     try {
-      const response = await fetch(endpoint, {
-        signal: AbortSignal.timeout(2000),
-      });
+      const response = await fetch(endpoint, { signal: budget });
 
       if (!response.ok) continue;
 
@@ -436,7 +450,10 @@ export async function fetchBlogArticleWithRelated(
 
       return { article, relatedArticles };
     } catch {
-      // Continuer vers le prochain endpoint
+      // Deadline atteinte pendant un fetch → arrêter la cascade (les endpoints
+      // suivants partageraient le même signal déjà aborté). Sinon (erreur réseau
+      // ponctuelle sur cet endpoint) → essayer le suivant.
+      if (budget.aborted) break;
     }
   }
 


### PR DESCRIPTION
## Problème (Sentry PROD)

`Error: The render was aborted by the server without a reason.` — récurrent sur `/pieces/<gamme>/<marque>/<modele>/<type>.html` (ex. `bras-de-suspension-273/hyundai-76/...`, `plaquette-de-frein-402/volkswagen-173/...`), UA `AutoMecanikSyntheticBot` **et Googlebot réel** (`isbot()` = true pour les deux → chemin bot).

## Cause racine (prouvée)

- `entry.server.tsx` rend les **bots** via `renderToPipeableStream` **`onAllReady`** : React attend **toutes** les frontières `<Suspense>` avant d'émettre le moindre HTML, sous un `setTimeout(abort, ABORT_DELAY=5000)` global. (Les **navigateurs** utilisent `onShellReady` → immunisés, ils streament le shell immédiatement.)
- La donnée différée `blogData` (`pieces-vehicle.loader.server.ts:581`) appelle `fetchBlogArticleWithRelated`, qui boucle sur **4 endpoints en séquentiel**, chacun avec son propre `AbortSignal.timeout(2000)` → **jusqu'à 8 s cumulés**. La plupart des pages gamme×véhicule n'ont pas d'article blog → la boucle parcourt les 4 endpoints.
- `8 s > 5 s` → le **rendu bot entier** avorte (pas seulement la section blog below-fold). Le `.catch()` du loader n'attrape qu'un rejet, **pas la latence cumulée**.
- Cet abort existait silencieusement depuis longtemps ; **#970** (mergé le 13/06, `onError → Sentry.captureException`) l'a **correctement rendu observable** → d'où les alertes Sentry apparues le 14/06.

## Correctif (structurel, minimal)

Une **deadline unique partagée** sur toute la cascade au lieu d'un timeout par-endpoint :

```ts
const BLOG_FETCH_BUDGET_MS = 2500;               // < ABORT_DELAY (5 s)
const budget = AbortSignal.timeout(BLOG_FETCH_BUDGET_MS);
for (const endpoint of endpoints) {
  if (budget.aborted) break;
  const response = await fetch(endpoint, { signal: budget });
  ...
}
```

- Cascade bornée à **~2,5 s** (≪ 5 s) → la frontière `<Suspense>` `blogData` se résout **toujours** avant l'abort → plus d'abort bot.
- **Ordre de préférence des endpoints préservé** (séquentiel inchangé).
- Contrat **fallback toujours résolu** `{article:null, relatedArticles:[]}` conservé (timeout = résout le fallback, ne rejette pas) → dégrade gracieusement (`PiecesVehicleContent.tsx:522-539` rend `null` si vide).
- C'est le **même pattern** déjà utilisé correctement ailleurs dans le repo (`r4Reference`, `blog-pieces-auto.conseils.$pg_alias.tsx` — AbortController à deadline unique partagée).

## Hors-scope (volontaire)

- **`entry.server.tsx` non touché** — #970 a déjà câblé l'observabilité ; le faire taire serait une régression. Le but est que le rendu **n'avorte plus**, donc l'alerte disparaît pour la bonne raison.
- `fetchFromEndpointChain` + `fetchBlogArticle` + `fetchRelatedArticlesForGamme` (même pattern latent) = **code mort** (0 usage live) → non touchés.
- **Aucun** changement d'URL / meta / H1 / canonical / cache-control.

## Classe résiduelle (suivi séparé, non bloquant)

Audit exhaustif (12 sites `defer()`) : 3 autres clés différées **sans timeout** (`cart` root.tsx ; `belowFold` + `faqs` _index.tsx) pourraient avorter le stream bot **sous stall backend** (latent, pas par construction comme blog). Candidat PR de durcissement séparée — pas dans le scope de cet incident.

## Vérification

- **PRE-PR** : `tsc` — 0 erreur sur `pieces-route.service.ts` (5 erreurs résiduelles = `node_modules` worktree absent pour `@tiptap/*`/`web-vitals`, sans rapport, vertes en CI).
- **POST-MERGE (LIVE)** : `curl -A "AutoMecanikSyntheticBot/1.0" https://www.automecanik.com/pieces/plaquette-de-frein-402/volkswagen-173/...` → HTML shell complet, plus d'abort ; surveiller la disparition de l'issue Sentry `automecanik-backend-prod`.

## Rollback

Revert de ce commit (1 fichier, +21/-4). Aucun effet de bord runtime (cache/queues/flags inchangés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)