### PR TITLE
feat(audit): runtime-truth rpc-registry-drift runner + __gov_m9 RPC (PR-B0a-3)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -1020,6 +1020,14 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: low
+  # __gov_m9 read-only introspection RPC for the rpc-registry-drift runtime-truth
+  # runner (Trust Ledger B0a, owner GO 2026-06-14, "A"). Additive, SECURITY DEFINER,
+  # service_role only. Glob exact (.sql + .down.sql of this migration).
+  - glob: backend/supabase/migrations/20260614_gov_m9_callable_functions_rpc*.sql
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   - glob: workspaces/ai-probe/**
     domain: D3
     owner: '@ak125/seo-team'

--- a/backend/supabase/migrations/20260614_gov_m9_callable_functions_rpc.down.sql
+++ b/backend/supabase/migrations/20260614_gov_m9_callable_functions_rpc.down.sql
@@ -1,0 +1,2 @@
+-- Rollback for 20260614_gov_m9_callable_functions_rpc.sql
+drop function if exists public.__gov_m9_callable_functions();

--- a/backend/supabase/migrations/20260614_gov_m9_callable_functions_rpc.sql
+++ b/backend/supabase/migrations/20260614_gov_m9_callable_functions_rpc.sql
@@ -1,0 +1,42 @@
+-- =====================================================
+-- __gov_m9_callable_functions — read-only introspection RPC
+-- Date: 2026-06-14
+-- Refs: __gov_m1..m8 (governed introspection family — same pattern)
+--       .claude/skills/runtime-truth-audit/checks/rpc-registry-drift.md (logic source)
+--       Plan: Trust Ledger PR-B0a rpc-registry-drift runner
+-- =====================================================
+--
+-- Why: the deterministic `rpc-registry-drift` runner scans backend/src for
+-- literal `.rpc('<name>')` calls and must verify each name exists as a
+-- PostgREST-callable function. supabase-js `.rpc()` resolves against the
+-- `public` schema, so a called RPC absent from public FAILS at runtime
+-- (silent feature breakage — verified: 5 such calls today, e.g.
+-- increment_advice_views, execute_sql). pg_proc is not reachable via PostgREST,
+-- so we EXTEND the governed `__gov_*` family with one read-only function.
+--
+-- Returns the distinct names of all functions in the `public` schema (the set
+-- `.rpc()` can resolve). The runner diffs code-called names against this set.
+--
+-- Security: EXECUTE restricted to service_role. Report-only; no mutation.
+
+set lock_timeout = '2s';
+set statement_timeout = '10s';
+
+create or replace function public.__gov_m9_callable_functions()
+  returns table (function_name text)
+  language sql
+  stable
+  security definer
+  set search_path to 'public'
+as $function$
+  select distinct p.proname::text
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public';
+$function$;
+
+revoke all on function public.__gov_m9_callable_functions() from public;
+grant execute on function public.__gov_m9_callable_functions() to service_role;
+
+comment on function public.__gov_m9_callable_functions() is
+  'Read-only introspection (Trust Ledger B0a): distinct names of all public-schema functions (the set supabase-js .rpc() can resolve). Consumed by scripts/audit/runtime-truth/rpc-registry-drift.ts to detect code calling a non-existent RPC. service_role only.';

--- a/log.md
+++ b/log.md
@@ -478,3 +478,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/trust-ledger-b0a`
 - **Décision** : feat(audit): runtime-truth pg-stable-write deterministic runner + __gov_m7 RPC (PR-B0a)
 - **Sortie** : PR #978 | commits f8c27b88b
+
+## 2026-06-14 — feat/trust-ledger-rpc-registry-drift (auto)
+
+- **Branche** : `feat/trust-ledger-rpc-registry-drift`
+- **Décision** : feat(audit): runtime-truth rpc-registry-drift runner + __gov_m9 RPC (PR-B0a-3)
+- **Sortie** : PR #981 | commits 72ab73fd6

--- a/scripts/audit/runtime-truth/README.md
+++ b/scripts/audit/runtime-truth/README.md
@@ -20,8 +20,9 @@ supabase-js layer calling governed read-only `__gov_*` introspection RPCs — no
 |---|---|---|---|
 | `pg-stable-write` | `__gov_m7_stable_function_volatility()` | critical | STABLE/IMMUTABLE functions that write (PostgREST read-only tx ⇒ silent 5xx, incident #693) |
 | `partition-cron-gap` | `__gov_m8_partition_coverage()` | critical | RANGE-partitioned tables about to exhaust partitions, no DEFAULT, no rotation cron ("no partition found", incidents #697/#698) |
+| `rpc-registry-drift` | `__gov_m9_callable_functions()` | medium | code calls `.rpc('x')` where `x` exists in no schema (silent feature breakage; found 7 live — incl. `increment_advice_views`, `execute_sql`) |
 
-_Roadmap (same framework): `rpc-registry-drift`, `attribution-write-gap`, `nest-dead-services`, `orphan-runtime-flags`._
+_Roadmap (same framework): `attribution-write-gap`, `nest-dead-services`, `orphan-runtime-flags`._
 
 ## Run
 

--- a/scripts/audit/runtime-truth/rpc-registry-drift.test.ts
+++ b/scripts/audit/runtime-truth/rpc-registry-drift.test.ts
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  extractRpcCalls,
+  classifyRpcDrift,
+  scanRpcCalls,
+  runRpcRegistryDrift,
+  CHECK_NAME,
+  type RpcCallSite,
+} from "./rpc-registry-drift.ts";
+import { validateResult } from "./contract.ts";
+import { type RpcClient } from "./runner.ts";
+
+const NOW = "2026-06-14T21:00:00.000Z";
+const COMMIT = "abc1234";
+
+test("extractRpcCalls: literal single/double/backtick quotes", () => {
+  const src = `a.rpc('foo', {x:1}); b.rpc("bar"); c.rpc(\`baz\`); d.rpc(dynamic);`;
+  assert.deepEqual(extractRpcCalls(src), ["foo", "bar", "baz"]);
+});
+
+test("classifyRpcDrift: missing RPCs ⇒ medium findings; present ⇒ none", () => {
+  const calls: RpcCallSite[] = [
+    { name: "exists_a", files: ["x.ts"] },
+    { name: "missing_b", files: ["y.ts", "z.ts"] },
+  ];
+  const { findings, evidence } = classifyRpcDrift(calls, ["exists_a", "other"]);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, "medium");
+  assert.equal(findings[0].id, "rpc-drift:missing_b");
+  assert.deepEqual((findings[0].detail as { call_sites: string[] }).call_sites, ["y.ts", "z.ts"]);
+  assert.deepEqual(evidence, { scanned_calls: 2, missing: 1, db_functions: 2 });
+
+  assert.equal(classifyRpcDrift(calls, ["exists_a", "missing_b"]).findings.length, 0);
+});
+
+test("scanRpcCalls: walks tree, ignores tests/.d.ts/node_modules", () => {
+  const root = mkdtempSync(join(tmpdir(), "rpcdrift-"));
+  mkdirSync(join(root, "sub/node_modules"), { recursive: true });
+  writeFileSync(join(root, "a.ts"), "x.rpc('alpha'); y.rpc('beta');");
+  writeFileSync(join(root, "sub/b.ts"), "z.rpc('alpha');");
+  writeFileSync(join(root, "a.test.ts"), "q.rpc('should_be_ignored');");
+  writeFileSync(join(root, "types.d.ts"), "w.rpc('also_ignored');");
+  writeFileSync(join(root, "sub/node_modules/c.ts"), "n.rpc('vendor_ignored');");
+  const calls = scanRpcCalls(root);
+  const names = calls.map((c) => c.name);
+  assert.deepEqual(names, ["alpha", "beta"]); // sorted, dedup, tests/d.ts/node_modules excluded
+  assert.equal(calls.find((c) => c.name === "alpha")!.files.length, 2);
+});
+
+function stub(data: unknown, error: { message: string } | null = null): RpcClient {
+  return { rpc: async () => ({ data, error }) };
+}
+
+test("run: a missing RPC ⇒ FAIL (medium findings), contract-valid", async () => {
+  const calls: RpcCallSite[] = [
+    { name: "increment_advice_views", files: ["blog/advice.service.ts"] },
+    { name: "resolve_gamme_alias", files: ["x.ts"] },
+  ];
+  const r = await runRpcRegistryDrift({
+    calls,
+    client: stub([{ function_name: "resolve_gamme_alias" }]),
+    nowIso: NOW,
+    sourceCommit: COMMIT,
+  });
+  assert.ok("result" in r);
+  assert.equal(r.result.check_name, CHECK_NAME);
+  assert.equal(r.result.health_status, "WARN"); // medium ⇒ WARN
+  assert.equal(r.result.findings.length, 1);
+  assert.equal(r.result.findings[0].id, "rpc-drift:increment_advice_views");
+  assert.ok(validateResult(r.result).ok);
+});
+
+test("run: all present ⇒ PASS", async () => {
+  const calls: RpcCallSite[] = [{ name: "ok_rpc", files: ["x.ts"] }];
+  const r = await runRpcRegistryDrift({ calls, client: stub([{ function_name: "ok_rpc" }]), nowIso: NOW, sourceCommit: COMMIT });
+  assert.ok("result" in r);
+  assert.equal(r.result.health_status, "PASS");
+});
+
+test("run: RPC error ⇒ UNKNOWN; no client ⇒ skipped", async () => {
+  const err = await runRpcRegistryDrift({ calls: [], client: stub(null, { message: "nope" }), nowIso: NOW, sourceCommit: COMMIT });
+  assert.ok("result" in err);
+  assert.equal(err.result.health_status, "UNKNOWN");
+  const sk = await runRpcRegistryDrift({ calls: [], client: null, nowIso: NOW, sourceCommit: COMMIT });
+  assert.ok("skipped" in sk);
+});

--- a/scripts/audit/runtime-truth/rpc-registry-drift.ts
+++ b/scripts/audit/runtime-truth/rpc-registry-drift.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env tsx
+/**
+ * rpc-registry-drift — deterministic runtime-truth runner (Trust Ledger PR-B0a).
+ *
+ * Scans backend/src for literal `.rpc('<name>')` calls and flags any whose
+ * function does NOT exist in the PostgREST-callable `public` schema — i.e. code
+ * calling an RPC that was never created or was dropped (silent feature breakage,
+ * e.g. increment_advice_views / execute_sql). Faithful deterministic port of
+ * `.claude/skills/runtime-truth-audit/checks/rpc-registry-drift.md`.
+ *
+ * DB side via the governed read-only RPC `__gov_m9_callable_functions()`.
+ * Report-only. Pure logic (extract + classify) is testable without a live DB.
+ *
+ * Note: only LITERAL `.rpc('x')` calls are statically checkable (dynamic
+ * `.rpc(var)` is out of scope). A call routed through `.schema('other')` may be
+ * a false positive — flagged at `medium` so a human triages (some sites have an
+ * intentional fallback when the RPC is absent).
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+  getServiceClient,
+  gitSourceCommit,
+  makeResult,
+  writeResult,
+  type RpcClient,
+} from "./runner.ts";
+import {
+  healthFromFindings,
+  type RuntimeTruthFinding,
+  type RuntimeTruthResult,
+} from "./contract.ts";
+
+export const CHECK_NAME = "rpc-registry-drift";
+const GOV_RPC = "__gov_m9_callable_functions";
+
+const RPC_CALL_RE = /\.rpc\(\s*['"`]([a-zA-Z_][a-zA-Z0-9_]*)['"`]/g;
+
+/** PURE: extract literal `.rpc('name')` call names from a source string. */
+export function extractRpcCalls(source: string): string[] {
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  RPC_CALL_RE.lastIndex = 0;
+  while ((m = RPC_CALL_RE.exec(source)) !== null) names.push(m[1]);
+  return names;
+}
+
+export interface RpcCallSite {
+  name: string;
+  files: string[];
+}
+
+/** Walk a directory tree collecting literal `.rpc()` call names → call sites. */
+export function scanRpcCalls(rootDir: string): RpcCallSite[] {
+  const byName = new Map<string, Set<string>>();
+  const walk = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e === "node_modules" || e === "dist" || e.startsWith(".")) continue;
+      const p = join(dir, e);
+      let st;
+      try {
+        st = statSync(p);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) walk(p);
+      else if (e.endsWith(".ts") && !e.endsWith(".d.ts") && !e.endsWith(".test.ts") && !e.endsWith(".spec.ts")) {
+        for (const name of extractRpcCalls(readFileSync(p, "utf8"))) {
+          if (!byName.has(name)) byName.set(name, new Set());
+          byName.get(name)!.add(p);
+        }
+      }
+    }
+  };
+  walk(rootDir);
+  return Array.from(byName.entries())
+    .map(([name, files]) => ({ name, files: Array.from(files).sort() }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** PURE: flag called RPCs absent from the DB-callable set. Deterministic. */
+export function classifyRpcDrift(
+  calls: RpcCallSite[],
+  dbFunctionNames: string[],
+): { findings: RuntimeTruthFinding[]; evidence: Record<string, unknown> } {
+  const dbSet = new Set(dbFunctionNames);
+  const missing = calls.filter((c) => !dbSet.has(c.name));
+  const findings: RuntimeTruthFinding[] = missing.map((c) => ({
+    id: `rpc-drift:${c.name}`,
+    severity: "medium",
+    title: `code calls .rpc('${c.name}') — no such function in the public schema (runtime failure or silent fallback)`,
+    detail: { rpc: c.name, call_sites: c.files },
+    fix_hint: `create public.${c.name}(...) via a governed migration, or remove/replace the call`,
+  }));
+  return {
+    findings,
+    evidence: {
+      scanned_calls: calls.length,
+      missing: missing.length,
+      db_functions: dbFunctionNames.length,
+    },
+  };
+}
+
+export interface RunOpts {
+  repoRoot?: string;
+  nowIso?: string;
+  client?: RpcClient | null;
+  sourceCommit?: string;
+  /** Inject scan results for tests (skips the file walk). */
+  calls?: RpcCallSite[];
+}
+
+export async function runRpcRegistryDrift(
+  opts: RunOpts = {},
+): Promise<{ result: RuntimeTruthResult } | { skipped: "no-creds" }> {
+  const repoRoot = opts.repoRoot ?? process.env.REPO_ROOT ?? process.cwd();
+  const nowIso = opts.nowIso ?? new Date().toISOString();
+  const sourceCommit = opts.sourceCommit ?? gitSourceCommit(repoRoot);
+  const client = opts.client === undefined ? await getServiceClient() : opts.client;
+
+  if (!client) return { skipped: "no-creds" };
+
+  const calls = opts.calls ?? scanRpcCalls(join(repoRoot, "backend/src"));
+
+  const { data, error } = await client.rpc(GOV_RPC);
+  if (error) {
+    return {
+      result: makeResult({
+        check_name: CHECK_NAME,
+        generated_at: nowIso,
+        source_commit: sourceCommit,
+        coverage_status: "RECURRING",
+        health_status: "UNKNOWN",
+        findings: [],
+        freshness: "live",
+        evidence: { error: error.message, hint: `apply migration adding ${GOV_RPC}()` },
+      }),
+    };
+  }
+
+  const dbNames = (Array.isArray(data) ? data : []).map(
+    (r) => (r as { function_name: string }).function_name,
+  );
+  const { findings, evidence } = classifyRpcDrift(calls, dbNames);
+  return {
+    result: makeResult({
+      check_name: CHECK_NAME,
+      generated_at: nowIso,
+      source_commit: sourceCommit,
+      coverage_status: "RECURRING",
+      health_status: healthFromFindings(findings),
+      findings,
+      freshness: "live",
+      evidence,
+    }),
+  };
+}
+
+// ── CLI entry ──────────────────────────────────────────────────────────────
+const isMain =
+  typeof process.argv[1] === "string" && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  runRpcRegistryDrift()
+    .then((r) => {
+      if ("skipped" in r) {
+        console.error(`::warning::${CHECK_NAME} skipped (${r.skipped}) — no SUPABASE creds`);
+        process.exit(0);
+      }
+      const path = writeResult(process.env.REPO_ROOT ?? process.cwd(), r.result);
+      console.log(
+        `✓ ${CHECK_NAME}: health=${r.result.health_status} findings=${r.result.findings.length} → ${path}`,
+      );
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(`::warning::${CHECK_NAME} caught: ${err?.message}`);
+      process.exit(0);
+    });
+}

--- a/scripts/audit/runtime-truth/rpc-registry-drift.ts
+++ b/scripts/audit/runtime-truth/rpc-registry-drift.ts
@@ -16,7 +16,7 @@
  * a false positive — flagged at `medium` so a human triages (some sites have an
  * intentional fallback when the RPC is absent).
  */
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   getServiceClient,
@@ -54,24 +54,33 @@ export interface RpcCallSite {
 export function scanRpcCalls(rootDir: string): RpcCallSite[] {
   const byName = new Map<string, Set<string>>();
   const walk = (dir: string): void => {
-    let entries: string[];
+    // withFileTypes: Dirent carries isDirectory()/isFile() — no separate statSync,
+    // so no time-of-check-to-time-of-use file race (CodeQL js/file-system-race).
+    let entries: import("node:fs").Dirent[];
     try {
-      entries = readdirSync(dir);
+      entries = readdirSync(dir, { withFileTypes: true });
     } catch {
       return;
     }
-    for (const e of entries) {
+    for (const ent of entries) {
+      const e = ent.name;
       if (e === "node_modules" || e === "dist" || e.startsWith(".")) continue;
       const p = join(dir, e);
-      let st;
-      try {
-        st = statSync(p);
-      } catch {
-        continue;
-      }
-      if (st.isDirectory()) walk(p);
-      else if (e.endsWith(".ts") && !e.endsWith(".d.ts") && !e.endsWith(".test.ts") && !e.endsWith(".spec.ts")) {
-        for (const name of extractRpcCalls(readFileSync(p, "utf8"))) {
+      if (ent.isDirectory()) walk(p);
+      else if (
+        ent.isFile() &&
+        e.endsWith(".ts") &&
+        !e.endsWith(".d.ts") &&
+        !e.endsWith(".test.ts") &&
+        !e.endsWith(".spec.ts")
+      ) {
+        let src: string;
+        try {
+          src = readFileSync(p, "utf8");
+        } catch {
+          continue;
+        }
+        for (const name of extractRpcCalls(src)) {
           if (!byName.has(name)) byName.set(name, new Set());
           byName.get(name)!.add(p);
         }


### PR DESCRIPTION
## Runtime-truth `rpc-registry-drift` runner + `__gov_m9` RPC (PR-B0a-3)

Third runtime-truth runner (top-priority *runtime-truth-p1*) — **the first to find real drift.** Report-only.

### What
Scans `backend/src` for literal `.rpc('<name>')` calls and flags any whose function exists in **no schema** — i.e. code calling an RPC that was never created or was dropped → **silent feature breakage** (no static check catches this).

### Live finding (verified, triaged — verify-the-proof, no overclaim)
18 `.rpc()` calls scanned, **7 missing from the DB**:

**❌ Real silent bugs (2):**
- `increment_advice_views` (blog) — fallback writes the literal string `'ba_visit::int + 1'` instead of incrementing → **view counts broken**.
- `execute_sql` (abandoned-cart stats) — generic SQL-exec RPC never created → **cart-recovery analytics broken** (+ security anti-pattern).

**✅ By design (3):** `__admin_job_health_success`, `get_keyword_import_history`, `get_table_names` — intentional `if(error)`/try-catch fallbacks.

**🔍 To triage (2):** `count_distinct_crawled_urls`, `get_conseil_priority_queue`.

Payment RPC `mark_order_paid_atomic` correctly **present** (not flagged) — the check discriminates.

### Architecture / verification
- Reuses the B0a framework; DB side via governed read-only `__gov_m9_callable_functions()` (extends `__gov_*`, `service_role` only). Pure scan + classify (testable without a live DB).
- **6 tests** green · `tsc --strict` clean · **squawk 0 issues** · live end-to-end validated.
- Severity `medium` (some sites have fallbacks) → a human triages; the runner surfaces all drift recurrently.

### Owner-gated
1. Apply read-only migration `20260614_gov_m9_callable_functions_rpc.sql`.
2. Ownership glob added (owner GO "A").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
