### PR TITLE
fix(rpc-drift): repair advice view counter + drop execute_sql anti-pattern

### DIFF
--- a/backend/src/modules/blog/services/advice.service.ts
+++ b/backend/src/modules/blog/services/advice.service.ts
@@ -511,11 +511,24 @@ export class AdviceService {
         advice_id: adviceId,
       });
     } catch {
-      // Fallback - mise a jour manuelle si la fonction RPC n'existe pas
-      await this.supabaseService.client
-        .from(TABLES.blog_advice)
-        .update({ ba_visit: 'ba_visit::int + 1' })
-        .eq('ba_id', adviceId);
+      // Fallback (non-atomic, best-effort) si la RPC increment_advice_views est absente.
+      // NB: supabase-js .update() écrit une valeur littérale — il faut donc lire puis
+      // réécrire le compteur (un `'ba_visit::int + 1'` littéral n'incrémentait rien).
+      try {
+        const { data } = await this.supabaseService.client
+          .from(TABLES.blog_advice)
+          .select('ba_visit')
+          .eq('ba_id', adviceId)
+          .maybeSingle();
+        const current = Number.parseInt(data?.ba_visit ?? '0', 10);
+        const next = (Number.isNaN(current) ? 0 : current) + 1;
+        await this.supabaseService.client
+          .from(TABLES.blog_advice)
+          .update({ ba_visit: String(next) })
+          .eq('ba_id', adviceId);
+      } catch {
+        // Comptage de vues non-critique — ne jamais casser la requête.
+      }
     }
   }
 

--- a/backend/src/modules/cart/services/abandoned-cart-data.service.ts
+++ b/backend/src/modules/cart/services/abandoned-cart-data.service.ts
@@ -227,7 +227,9 @@ export class AbandonedCartDataService extends SupabaseBaseService {
     };
     try {
       const countNotNull = async (col?: string): Promise<number> => {
-        let q = this.supabase.from(TABLE).select('*', { count: 'exact', head: true });
+        let q = this.supabase
+          .from(TABLE)
+          .select('*', { count: 'exact', head: true });
         if (col) q = q.not(col, 'is', null);
         const { count, error } = await q;
         if (error) throw error;
@@ -259,7 +261,10 @@ export class AbandonedCartDataService extends SupabaseBaseService {
       if (revErr) throw revErr;
       const revenue_recovered = (recoveredRows ?? []).reduce(
         (sum, r) =>
-          sum + Number((r as { cart_subtotal: number | string | null }).cart_subtotal ?? 0),
+          sum +
+          Number(
+            (r as { cart_subtotal: number | string | null }).cart_subtotal ?? 0,
+          ),
         0,
       );
       return {

--- a/backend/src/modules/cart/services/abandoned-cart-data.service.ts
+++ b/backend/src/modules/cart/services/abandoned-cart-data.service.ts
@@ -212,45 +212,71 @@ export class AbandonedCartDataService extends SupabaseBaseService {
     recovered: number;
     revenue_recovered: number;
   }> {
-    const { data, error } = await this.supabase.rpc('execute_sql', {
-      query: `
-        SELECT
-          count(*) as total_detected,
-          count(email_1h_sent_at) as emails_sent_1h,
-          count(email_24h_sent_at) as emails_sent_24h,
-          count(email_72h_sent_at) as emails_sent_72h,
-          count(email_opened_at) as opened,
-          count(email_clicked_at) as clicked,
-          count(recovered_at) as recovered,
-          coalesce(sum(case when recovered_at is not null then cart_subtotal else 0 end), 0) as revenue_recovered
-        FROM ${TABLE}
-      `,
-    });
-
-    if (error || !data?.[0]) {
-      this.logger.error(`Stats query failed: ${error?.message}`);
-      return {
-        total_detected: 0,
-        emails_sent_1h: 0,
-        emails_sent_24h: 0,
-        emails_sent_72h: 0,
-        opened: 0,
-        clicked: 0,
-        recovered: 0,
-        revenue_recovered: 0,
-      };
-    }
-
-    const row = data[0];
-    return {
-      total_detected: Number(row.total_detected),
-      emails_sent_1h: Number(row.emails_sent_1h),
-      emails_sent_24h: Number(row.emails_sent_24h),
-      emails_sent_72h: Number(row.emails_sent_72h),
-      opened: Number(row.opened),
-      clicked: Number(row.clicked),
-      recovered: Number(row.recovered),
-      revenue_recovered: Number(row.revenue_recovered),
+    // Counts via PostgREST head-count, remplaçant un RPC générique `execute_sql`
+    // inexistant (les stats retournaient toujours 0 + un log d'erreur ; `execute_sql`
+    // = anti-pattern SQL arbitraire). Pas de RPC dédiée : la table est dormante.
+    const zero = {
+      total_detected: 0,
+      emails_sent_1h: 0,
+      emails_sent_24h: 0,
+      emails_sent_72h: 0,
+      opened: 0,
+      clicked: 0,
+      recovered: 0,
+      revenue_recovered: 0,
     };
+    try {
+      const countNotNull = async (col?: string): Promise<number> => {
+        let q = this.supabase.from(TABLE).select('*', { count: 'exact', head: true });
+        if (col) q = q.not(col, 'is', null);
+        const { count, error } = await q;
+        if (error) throw error;
+        return count ?? 0;
+      };
+      const [
+        total_detected,
+        emails_sent_1h,
+        emails_sent_24h,
+        emails_sent_72h,
+        opened,
+        clicked,
+        recovered,
+      ] = await Promise.all([
+        countNotNull(),
+        countNotNull('email_1h_sent_at'),
+        countNotNull('email_24h_sent_at'),
+        countNotNull('email_72h_sent_at'),
+        countNotNull('email_opened_at'),
+        countNotNull('email_clicked_at'),
+        countNotNull('recovered_at'),
+      ]);
+      // Revenu récupéré : somme de cart_subtotal sur les paniers récupérés
+      // (sous-ensemble restreint des paniers récupérés).
+      const { data: recoveredRows, error: revErr } = await this.supabase
+        .from(TABLE)
+        .select('cart_subtotal')
+        .not('recovered_at', 'is', null);
+      if (revErr) throw revErr;
+      const revenue_recovered = (recoveredRows ?? []).reduce(
+        (sum, r) =>
+          sum + Number((r as { cart_subtotal: number | string | null }).cart_subtotal ?? 0),
+        0,
+      );
+      return {
+        total_detected,
+        emails_sent_1h,
+        emails_sent_24h,
+        emails_sent_72h,
+        opened,
+        clicked,
+        recovered,
+        revenue_recovered,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Stats query failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return zero;
+    }
   }
 }

--- a/log.md
+++ b/log.md
@@ -484,3 +484,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/trust-ledger-rpc-registry-drift`
 - **Décision** : feat(audit): runtime-truth rpc-registry-drift runner + __gov_m9 RPC (PR-B0a-3)
 - **Sortie** : PR #981 | commits 72ab73fd6
+
+## 2026-06-15 — fix/rpc-drift-silent-bugs (auto)
+
+- **Branche** : `fix/rpc-drift-silent-bugs`
+- **Décision** : fix(rpc-drift): repair advice view counter + drop execute_sql anti-pattern
+- **Sortie** : PR #982 | commits 4bf1dfdef


### PR DESCRIPTION
## Fix 2 silent bugs surfaced by `rpc-registry-drift` (#981)

Code-only, **no migration, no owner-gated step.** Both bugs are RPC calls to functions that don't exist — the runtime-truth runner found them.

### 1. Blog advice view counter (live: 85 articles, 62,982 views)
`increment_advice_views` RPC is absent **and** the fallback wrote the literal string `'ba_visit::int + 1'` instead of incrementing → **new views were not counted.** Fixed to a correct read-modify-write (non-atomic, best-effort, wrapped so a counter failure never breaks the request).

### 2. Abandoned-cart `getStats()` — `execute_sql` anti-pattern
Called a non-existent generic `execute_sql(query)` RPC → always errored → returned zeros + logged an error each call. Replaced with **native PostgREST head-counts** + a small revenue sum. Removes the arbitrary-SQL anti-pattern; no migration.

> ⚠️ **Honest scope note:** `__abandoned_cart_emails` is **empty (0 rows)** — so stats stay 0 until the abandoned-cart detection/email pipeline actually populates it. That dormant pipeline is a **deeper commerce-loop issue (your #1)**, out of scope for this fix. This PR fixes the *broken call*, not the empty data.

### Verification
- Both changes follow existing patterns (`this.supabase.from(TABLE)` already used for `.insert()` in the same file; `.maybeSingle()` used 10× in the advice service).
- CI TypeScript / ESLint / Backend Tests are the authoritative gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
