### PR TITLE
chore(registry): dedup duplicate __gov_m7 migration ownership entry

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -1038,8 +1038,3 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: low
-  - glob: backend/supabase/migrations/20260614_gov_m7_stable_function_volatility_rpc*.sql
-    domain: D15
-    owner: '@ak125'
-    sourceConfidence: high
-    risk: low


### PR DESCRIPTION
## What
Removes a **duplicate `__gov_m7` migration ownership entry** in `.spec/00-canon/repository-registry/ownership.yaml` (L2 overlay).

PR #978 added the glob `backend/supabase/migrations/20260614_gov_m7_stable_function_volatility_rpc*.sql` **twice**:
- the canonical entry (with its descriptive comment, beside `__gov_m8`/`__gov_m9`) — **kept**
- a stray trailing copy after `docs/audit/**` — **removed**

Both were `domain: D15 / owner: '@ak125'`, so the duplicate was idempotent (no functional impact on ownership resolution), but a stray duplicate in a canonical registry shouldn't stand.

## Verification
- `npm run registry:validate` → ✓ all overlays valid (**185 entries**, 16 domains, 87.9% coverage)
- The `__gov_m7` glob still resolves to its **2 real migration files** → coverage retained.

## Scope note (intentional)
`audit/registry/canonical.json` is **not** regenerated in this PR. The L3 projection carries ~600 lines of **pre-existing drift** vs its L1 inventory (the freshness gate is warn-only, so it has accumulated independently of this change). Folding that regen in would be unrelated scope creep. The migration-glob string is not projected into `canonical.json` (0 occurrences), so this dedup does not affect it.

> Separate observation for the owner: the `canonical.json` warn-only freshness drift (~600 lines) is worth its own refresh PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)