### PR TITLE
chore(registry): resync dep-governance L2 vs L1 (tsx 4.22.4, turbo 2.9.16)

### DIFF
--- a/.spec/00-canon/repository-registry/dep-governance.yaml
+++ b/.spec/00-canon/repository-registry/dep-governance.yaml
@@ -113,13 +113,13 @@ dependencies:
     owner: "@ak125"
 
   # ── build-tooling (2 entries — D13) ──
-  - id: "npm:tsx@^4.22.3"
+  - id: "npm:tsx@^4.22.4"
     name: "tsx"
     family: build-tooling
     domain: D13
     owner: "@ak125"
-    notes: "tsx unified at ^4.22.3 across frontend + 5 workspace packages (L1 deps.json). Contract was pinned ^4.20.6 while package.json already declared ^4.22.3 — main's committed deps.json was stale (warn-only freshness, Phase 1); resynced to L1 truth here."
-  - id: "npm:turbo@^2.9.12"
+    notes: "tsx unified at ^4.22.4 across frontend + workspace packages (L1 deps.json). Contract resynced ^4.22.3→^4.22.4 to match L1 after a Dependabot patch bump (manual L2 overlay lagged L1 auto-gen)."
+  - id: "npm:turbo@^2.9.16"
     name: "turbo"
     family: build-tooling
     domain: D13


### PR DESCRIPTION
## Problème (découvert via la CI de #989)

Le check **`🛡️ Deterministic gates`** échoue sur `main` — step `📋 @repo/registry contract tests (BLOCKING)` :
```
not ok 2  — every contract dependency.id appears in L1 deps.json (subset)   expected 0, actual 2
not ok 20 — §4.2 cross-contract L1 — every contract id exists in audit/registry/deps.json
# fail 1
```
2 `dependency.id` du contrat **L2 manuel** (`.spec/00-canon/repository-registry/dep-governance.yaml`) absents de **L1** (`audit/registry/deps.json`, auto-généré).

## Cause racine

Un bump **Dependabot patch déjà mergé** a mis à jour `package.json` + régénéré L1, mais l'overlay **manuel L2** est resté sur les anciennes versions :
| Contrat L2 (avant) | L1 / `package.json` (réel) |
|---|---|
| `npm:tsx@^4.22.3` | `npm:tsx@^4.22.4` (frontend + 8 packages) |
| `npm:turbo@^2.9.12` | `npm:turbo@^2.9.16` (root) |

Dérive overlay↔données, **pas** une régression de code. (Surfacé sur la CI de #989 mais **non-requis** là-bas → n'a pas bloqué le merge SSR.)

## Correctif

Aligner les 2 `id:` du contrat sur la vérité L1 (+ note tsx mise à jour pour cohérence). **Aucun changement de version de dépendance** (les versions réelles sont déjà 4.22.4 / 2.9.16 sur `main`), aucun changement de comportement, aucun fichier généré édité.

## Vérification (PRE-PR)

```
$ node -v        # v22.22.2 (≥22 requis pour @repo/registry)
$ npm -w @repo/registry test
ok 2  - every contract dependency.id appears in L1 deps.json (subset)
ok 20 - §4.2 cross-contract L1 — every contract id exists in audit/registry/deps.json
# tests 216 # pass 216 # fail 0
```

## Scope / gouvernance

1 fichier, +3/-3. `.spec/00-canon/**` est owner-gated → édité **sur autorisation owner explicite** (cette session). Le gate `Block-new (owner + domain required)` couvre D13/D14 ownership. Diff = uniquement l'overlay L2 dépendances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)