### PR TITLE
fix(orders): pass a UUID to create_order_atomic p_correlation_id (P0 checkout)

### DIFF
--- a/backend/src/modules/orders/services/orders.service.ts
+++ b/backend/src/modules/orders/services/orders.service.ts
@@ -407,7 +407,12 @@ export class OrdersService extends SupabaseBaseService {
       // p_correlation_id is explicit (instead of relying on PG DEFAULT gen_random_uuid()) to
       // satisfy ast-grep `commerce-correlation-id-required-on-mutations` and to preserve
       // causality lineage from day 1 (Vault #301 canon, Operational Knowledge Graph prep).
-      const correlationId = orderData.idempotencyKey ?? randomUUID();
+      // MUST be a UUID (p_correlation_id is typed `uuid`). The idempotency key (ik-<ts>-<rand>)
+      // is a DIFFERENT identifier — NOT a uuid — and is handled separately by the controller
+      // (checkIdempotency / order_idempotency dedup). Wiring it here raised
+      // "invalid input syntax for type uuid". One fresh uuid per creation, matching the
+      // `?? randomUUID()` convention used elsewhere (updateOrder L638, order-status.service).
+      const correlationId = randomUUID();
       const { error: rpcError } = await this.callRpc(
         'create_order_atomic',
         {


### PR DESCRIPTION
## P0 — la création de commande échoue toujours

Après le fix de l'ambiguïté d'overload (drop du `create_order_atomic(jsonb,jsonb)`), la fonction est désormais atteinte — et révèle un **2ᵉ défaut introduit par le même changement #301** :

```
Échec création commande: invalid input syntax for type uuid: "ik-1781539584991-g7xkle"
```

`OrdersService.createOrder` passait `orderData.idempotencyKey` dans `p_correlation_id`, qui est typé **`uuid`**. La clé d'idempotence (`ik-<ts>-<rand>`) est un **identifiant différent**, **pas un uuid**, et est déjà gérée séparément par le contrôleur (`checkIdempotency` / table `order_idempotency`).

L'ambiguïté d'overload (PGRST203) **masquait** ce bug : l'appel n'atteignait jamais la validation des arguments. Routing réparé → le mauvais argument apparaît.

## Correctif (1 ligne)

```diff
-const correlationId = orderData.idempotencyKey ?? randomUUID();
+const correlationId = randomUUID();
```

- `p_correlation_id` reste un **uuid valide** (lineage event-stream).
- Reprend la convention `?? randomUUID()` déjà utilisée partout ailleurs ([orders.service.ts:638](backend/src/modules/orders/services/orders.service.ts#L638), [order-status.service.ts:62](backend/src/modules/orders/services/order-status.service.ts#L62)).
- `p_correlation_id` reste **présent** → règle ast-grep `commerce-correlation-id-required-on-mutations` satisfaite.
- La déduplication d'idempotence (contrôleur) est **inchangée**.

## Vérification

- `ast-grep scan` sur le fichier : aucune violation.
- Build backend : mon fichier compile sans erreur. Les 6 erreurs `@repo/seo-types` du build local sont des **fantômes de dist périmée en worktree** (source `packages/seo-types/src/observability.ts` exporte bien ces symboles ; module `seo-monitoring` non touché par ce diff) — CI build à neuf, vert attendu.

## Périmètre

`backend/src/modules/orders/services/orders.service.ts` uniquement. Module `payments/` **non touché**. Aucun changement DB.

> ⚠️ **Déploiement** : merge `main` = PREPROD. Pour rétablir le checkout en **PROD**, il faut un **tag `v*`** (décision opérateur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)