### PR TITLE
feat(audit): runtime-truth rpc-overload-ambiguity runner + __gov_m10 RPC (PR-B0a-4)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -1042,6 +1042,14 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: low
+  # __gov_m10 read-only introspection RPC for the rpc-overload-ambiguity runtime-truth
+  # runner (Trust Ledger B0a-4; PGRST203 class, #993/#997). Additive, SECURITY DEFINER,
+  # service_role only. Glob exact (.sql + .down.sql of this migration).
+  - glob: backend/supabase/migrations/20260615_gov_m10_overload_ambiguity_rpc*.sql
+    domain: D15
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: low
   - glob: workspaces/ai-probe/**
     domain: D3
     owner: '@ak125/seo-team'

--- a/backend/supabase/migrations/20260615_gov_m10_overload_ambiguity_rpc.down.sql
+++ b/backend/supabase/migrations/20260615_gov_m10_overload_ambiguity_rpc.down.sql
@@ -1,0 +1,4 @@
+-- Rollback for 20260615_gov_m10_overload_ambiguity_rpc.sql
+-- Drops the read-only introspection RPC. The rpc-overload-ambiguity runner then
+-- reports health_status=UNKNOWN (RPC absent) instead of consuming stale data.
+drop function if exists public.__gov_m10_overload_ambiguity();

--- a/backend/supabase/migrations/20260615_gov_m10_overload_ambiguity_rpc.sql
+++ b/backend/supabase/migrations/20260615_gov_m10_overload_ambiguity_rpc.sql
@@ -1,0 +1,71 @@
+-- =====================================================
+-- __gov_m10_overload_ambiguity — read-only introspection RPC
+-- Date: 2026-06-15
+-- Refs: __gov_m1..m9 (governed introspection family — same pattern)
+--       .claude/skills/runtime-truth-audit/checks/rpc-overload-ambiguity.md (logic source)
+--       #993 (create_order_atomic PGRST203 → 24-day checkout outage), guard #997
+-- =====================================================
+--
+-- Why: the deterministic `rpc-overload-ambiguity` runner must detect PostgREST
+-- function-overload ambiguity (PGRST203 "could not choose the best candidate
+-- function") — the class that broke checkout for 24 days. pg_proc is not
+-- reachable via PostgREST, so we EXTEND the governed `__gov_*` family with one
+-- read-only function. Postgres is the source of truth for signatures (no
+-- SQL-text parsing). Extension-owned functions (pgvector/unaccent) are excluded.
+--
+-- Returns one row per public, non-extension function whose overloads are
+-- ambiguous for a PostgREST named-arg call:
+--   - subset_default : arg-names(A) ⊆ arg-names(B) and B's extra args are defaulted
+--   - type_only      : two overloads share identical arg-names, differ only by type
+--
+-- Security: EXECUTE restricted to service_role. Report-only; no mutation.
+
+set lock_timeout = '2s';
+set statement_timeout = '10s';
+
+create or replace function public.__gov_m10_overload_ambiguity()
+  returns table (function_name text, ambiguity_kind text, overload_count integer)
+  language sql
+  stable
+  security definer
+  set search_path to 'public'
+as $function$
+  with pub_fns as (
+    select p.oid, p.proname,
+           coalesce((select array_agg(an order by an)
+                     from unnest(p.proargnames[1:p.pronargs]) an), '{}'::text[]) as in_names,
+           p.pronargs, p.pronargdefaults
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.prokind = 'f'
+      and not exists (
+        select 1 from pg_depend d where d.objid = p.oid and d.deptype = 'e'
+      )
+  ),
+  overloaded as (
+    select proname from pub_fns group by proname having count(*) > 1
+  ),
+  ambiguous as (
+    select distinct a.proname,
+           case when a.in_names <@ b.in_names and b.in_names <@ a.in_names
+                then 'type_only' else 'subset_default' end as kind
+    from pub_fns a
+    join pub_fns b on a.proname = b.proname and a.oid < b.oid
+    where a.proname in (select proname from overloaded)
+      and (
+        (a.in_names <@ b.in_names and (b.pronargs - a.pronargs) <= b.pronargdefaults)
+        or (a.in_names <@ b.in_names and b.in_names <@ a.in_names)
+      )
+  )
+  select am.proname::text                          as function_name,
+         string_agg(distinct am.kind, ',' order by am.kind)::text as ambiguity_kind,
+         (select count(*)::int from pub_fns pf where pf.proname = am.proname) as overload_count
+  from ambiguous am
+  group by am.proname;
+$function$;
+
+revoke all on function public.__gov_m10_overload_ambiguity() from public;
+grant execute on function public.__gov_m10_overload_ambiguity() to service_role;
+
+comment on function public.__gov_m10_overload_ambiguity() is
+  'Read-only introspection (Trust Ledger B0a): public, non-extension functions with PostgREST-ambiguous overloads (PGRST203 class, #993). Consumed by scripts/audit/runtime-truth/rpc-overload-ambiguity.ts. service_role only.';

--- a/log.md
+++ b/log.md
@@ -490,3 +490,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/rpc-drift-silent-bugs`
 - **Décision** : fix(rpc-drift): repair advice view counter + drop execute_sql anti-pattern
 - **Sortie** : PR #982 | commits 4bf1dfdef
+
+## 2026-06-16 — feat/runtime-truth-overload-runner (auto)
+
+- **Branche** : `feat/runtime-truth-overload-runner`
+- **Décision** : feat(audit): runtime-truth rpc-overload-ambiguity runner + __gov_m10 RPC (PR-B0a-4)
+- **Sortie** : PR aucune | commits 4e659dfee

--- a/scripts/audit/runtime-truth/README.md
+++ b/scripts/audit/runtime-truth/README.md
@@ -21,6 +21,7 @@ supabase-js layer calling governed read-only `__gov_*` introspection RPCs — no
 | `pg-stable-write` | `__gov_m7_stable_function_volatility()` | critical | STABLE/IMMUTABLE functions that write (PostgREST read-only tx ⇒ silent 5xx, incident #693) |
 | `partition-cron-gap` | `__gov_m8_partition_coverage()` | critical | RANGE-partitioned tables about to exhaust partitions, no DEFAULT, no rotation cron ("no partition found", incidents #697/#698) |
 | `rpc-registry-drift` | `__gov_m9_callable_functions()` | medium | code calls `.rpc('x')` where `x` exists in no schema (silent feature breakage; found 7 live — incl. `increment_advice_views`, `execute_sql`) |
+| `rpc-overload-ambiguity` | `__gov_m10_overload_ambiguity()` | critical | public, non-extension functions with PostgREST-ambiguous overloads → PGRST203 "could not choose the best candidate" (the create_order_atomic 24-day checkout outage, #993; guard skill #997) |
 
 _Roadmap (same framework): `attribution-write-gap`, `nest-dead-services`, `orphan-runtime-flags`._
 

--- a/scripts/audit/runtime-truth/rpc-overload-ambiguity.test.ts
+++ b/scripts/audit/runtime-truth/rpc-overload-ambiguity.test.ts
@@ -1,0 +1,84 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyOverloadAmbiguity,
+  runRpcOverloadAmbiguity,
+  CHECK_NAME,
+  type OverloadRow,
+} from "./rpc-overload-ambiguity.ts";
+import { validateResult } from "./contract.ts";
+import { type RpcClient } from "./runner.ts";
+
+const NOW = "2026-06-15T20:00:00.000Z";
+const COMMIT = "abc1234";
+
+test("classifyOverloadAmbiguity: rows ⇒ sorted critical findings; empty ⇒ none", () => {
+  const rows: OverloadRow[] = [
+    { function_name: "get_cart_stats", ambiguity_kind: "type_only", overload_count: 3 },
+    {
+      function_name: "backfill_seo_keywords_type_ids",
+      ambiguity_kind: "subset_default",
+      overload_count: 2,
+    },
+  ];
+  const { findings, evidence } = classifyOverloadAmbiguity(rows);
+  assert.equal(findings.length, 2);
+  // sorted alphabetically → backfill first
+  assert.equal(findings[0].id, "overload-ambiguity:backfill_seo_keywords_type_ids");
+  assert.equal(findings[0].severity, "critical");
+  assert.equal(
+    (findings[1].detail as { function: string }).function,
+    "get_cart_stats",
+  );
+  assert.deepEqual(evidence, { ambiguous_functions: 2 });
+
+  assert.equal(classifyOverloadAmbiguity([]).findings.length, 0);
+});
+
+function stub(data: unknown, error: { message: string } | null = null): RpcClient {
+  return { rpc: async () => ({ data, error }) };
+}
+
+test("run: ambiguous overload ⇒ FAIL, contract-valid", async () => {
+  const r = await runRpcOverloadAmbiguity({
+    nowIso: NOW,
+    sourceCommit: COMMIT,
+    client: stub([
+      { function_name: "get_cart_stats", ambiguity_kind: "type_only", overload_count: 3 },
+    ]),
+  });
+  assert.ok(!("skipped" in r));
+  if ("skipped" in r) return;
+  assert.equal(r.result.check_name, CHECK_NAME);
+  assert.equal(r.result.coverage_status, "RECURRING");
+  assert.equal(r.result.health_status, "FAIL"); // critical ⇒ FAIL
+  assert.ok(validateResult(r.result).ok);
+});
+
+test("run: clean DB (no ambiguous overloads) ⇒ PASS", async () => {
+  const r = await runRpcOverloadAmbiguity({
+    nowIso: NOW,
+    sourceCommit: COMMIT,
+    client: stub([]),
+  });
+  if ("skipped" in r) return assert.fail("unexpected skip");
+  assert.equal(r.result.health_status, "PASS");
+  assert.equal(r.result.findings.length, 0);
+});
+
+test("run: no creds ⇒ skipped (PR lane)", async () => {
+  const r = await runRpcOverloadAmbiguity({ client: null });
+  assert.deepEqual(r, { skipped: "no-creds" });
+});
+
+test("run: RPC missing/error ⇒ UNKNOWN, no crash", async () => {
+  const r = await runRpcOverloadAmbiguity({
+    nowIso: NOW,
+    sourceCommit: COMMIT,
+    client: stub(null, { message: "function __gov_m10_overload_ambiguity() does not exist" }),
+  });
+  if ("skipped" in r) return assert.fail("unexpected skip");
+  assert.equal(r.result.health_status, "UNKNOWN");
+  assert.equal(r.result.findings.length, 0);
+  assert.ok(validateResult(r.result).ok);
+});

--- a/scripts/audit/runtime-truth/rpc-overload-ambiguity.ts
+++ b/scripts/audit/runtime-truth/rpc-overload-ambiguity.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env tsx
+/**
+ * rpc-overload-ambiguity — deterministic runtime-truth runner (Trust Ledger PR-B0a).
+ *
+ * Detects PostgREST function-overload ambiguity (PGRST203 "could not choose the
+ * best candidate function") — the root-cause class of the 24-day checkout outage
+ * (#993: create_order_atomic had two overloads, one a prefix of the other with a
+ * defaulted extra arg). Faithful deterministic port of
+ * `.claude/skills/runtime-truth-audit/checks/rpc-overload-ambiguity.md`.
+ *
+ * DB side via the governed read-only RPC `__gov_m10_overload_ambiguity()` —
+ * Postgres is the source of truth for signatures (no SQL-text parsing; extension
+ * functions excluded). Report-only. Pure classify is testable without a live DB.
+ *
+ * Severity is `critical`: a single .rpc() call against an ambiguous overload
+ * fails 100% with PGRST203 — a silent, total breakage of that surface.
+ */
+import {
+  getServiceClient,
+  gitSourceCommit,
+  makeResult,
+  writeResult,
+  type RpcClient,
+} from "./runner.ts";
+import {
+  healthFromFindings,
+  type RuntimeTruthFinding,
+  type RuntimeTruthResult,
+} from "./contract.ts";
+
+export const CHECK_NAME = "rpc-overload-ambiguity";
+const GOV_RPC = "__gov_m10_overload_ambiguity";
+
+/** One row returned by __gov_m10_overload_ambiguity(). */
+export interface OverloadRow {
+  function_name: string;
+  ambiguity_kind: string; // 'type_only' | 'subset_default' (or comma-joined)
+  overload_count: number;
+}
+
+/** PURE: map ambiguous-overload rows → critical findings. Deterministic, sorted. */
+export function classifyOverloadAmbiguity(rows: OverloadRow[]): {
+  findings: RuntimeTruthFinding[];
+  evidence: Record<string, unknown>;
+} {
+  const sorted = [...rows].sort((a, b) =>
+    a.function_name.localeCompare(b.function_name),
+  );
+  const findings: RuntimeTruthFinding[] = sorted.map((r) => ({
+    id: `overload-ambiguity:${r.function_name}`,
+    severity: "critical",
+    title: `public.${r.function_name} has ${r.overload_count} ambiguous overloads (${r.ambiguity_kind}) — any .rpc('${r.function_name}') call risks PGRST203 "could not choose the best candidate"`,
+    detail: {
+      function: r.function_name,
+      kind: r.ambiguity_kind,
+      overloads: r.overload_count,
+    },
+    fix_hint:
+      "verify internal SQL callers, then drop the obsolete overload (or rename params); see checks/rpc-overload-ambiguity.md",
+  }));
+  return { findings, evidence: { ambiguous_functions: sorted.length } };
+}
+
+export interface RunOpts {
+  repoRoot?: string;
+  nowIso?: string;
+  client?: RpcClient | null;
+  sourceCommit?: string;
+}
+
+export async function runRpcOverloadAmbiguity(
+  opts: RunOpts = {},
+): Promise<{ result: RuntimeTruthResult } | { skipped: "no-creds" }> {
+  const repoRoot = opts.repoRoot ?? process.env.REPO_ROOT ?? process.cwd();
+  const nowIso = opts.nowIso ?? new Date().toISOString();
+  const sourceCommit = opts.sourceCommit ?? gitSourceCommit(repoRoot);
+  const client = opts.client === undefined ? await getServiceClient() : opts.client;
+
+  if (!client) return { skipped: "no-creds" };
+
+  const { data, error } = await client.rpc(GOV_RPC);
+  if (error) {
+    return {
+      result: makeResult({
+        check_name: CHECK_NAME,
+        generated_at: nowIso,
+        source_commit: sourceCommit,
+        coverage_status: "RECURRING",
+        health_status: "UNKNOWN",
+        findings: [],
+        freshness: "live",
+        evidence: { error: error.message, hint: `apply migration adding ${GOV_RPC}()` },
+      }),
+    };
+  }
+
+  const rows = (Array.isArray(data) ? data : []) as OverloadRow[];
+  const { findings, evidence } = classifyOverloadAmbiguity(rows);
+  return {
+    result: makeResult({
+      check_name: CHECK_NAME,
+      generated_at: nowIso,
+      source_commit: sourceCommit,
+      coverage_status: "RECURRING",
+      health_status: healthFromFindings(findings),
+      findings,
+      freshness: "live",
+      evidence,
+    }),
+  };
+}
+
+// ── CLI entry ──────────────────────────────────────────────────────────────
+const isMain =
+  typeof process.argv[1] === "string" && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  runRpcOverloadAmbiguity()
+    .then((r) => {
+      if ("skipped" in r) {
+        console.error(`::warning::${CHECK_NAME} skipped (${r.skipped}) — no SUPABASE creds`);
+        process.exit(0);
+      }
+      const path = writeResult(process.env.REPO_ROOT ?? process.cwd(), r.result);
+      console.log(
+        `✓ ${CHECK_NAME}: health=${r.result.health_status} findings=${r.result.findings.length} → ${path}`,
+      );
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(`::warning::${CHECK_NAME} caught: ${err?.message}`);
+      process.exit(0);
+    });
+}


### PR DESCRIPTION
## Pourquoi

4ᵉ runner déterministe de la famille `runtime-truth` — rend **récurrente** la garde PGRST203 (skill check #997), la classe qui a cassé le checkout 24 jours (#993). Complète la série `pg-stable-write` / `partition-cron-gap` / `rpc-registry-drift` (#978/#980/#981).

## Contenu

- **`__gov_m10_overload_ambiguity()`** — RPC introspection read-only (`SECURITY DEFINER`, `service_role` only). Postgres = source de vérité des signatures (`pg_proc` + `pg_depend`, fonctions d'extension exclues) ; **aucun parsing de texte SQL**. Encapsule le détecteur validé en live le 2026-06-15.
- **`rpc-overload-ambiguity.ts`** — consomme le RPC, classe les lignes → findings `critical`, émet le JSON contractuel. `classifyOverloadAmbiguity` pur, testé unitairement. RPC absent ⇒ `UNKNOWN` (no silent fallback). Report-only.

## Vérifié

- Tests runner **5/5** (`tsx --test`).
- **squawk 0 issue** sur la migration (préambule `lock/statement_timeout`, `down` = drop).
- SQL du RPC exécuté en live → **0 ligne** (toutes les mines PGRST203 ont été remédiées : `create_order_atomic` #993, + `get_cart_stats` / `evaluate_rule_condition` / `backfill_seo_keywords_type_ids` droppées).

## Activation (owner-gated, comme m7/m8/m9)

Additif. Appliquer la migration via le workflow gouverné « Apply Supabase migrations » → le runner passe de `UNKNOWN` à des résultats réels. Le câblage de la récurrence (CI planifié) est un livrable séparé (Livrable C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)