### PR TITLE
feat(runtime-truth-audit): massdoc type_id invariant check (tripwire ADR-085)

### DIFF
--- a/.claude/skills/runtime-truth-audit/SKILL.md
+++ b/.claude/skills/runtime-truth-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: runtime-truth-audit
-description: Use when auditing runtime drift vs spec/registry (dead services, RPC drift, STABLE functions that write, partitions without rotation, attribution columns never written, orphan feature flags, PGRST203 overload ambiguity). Triggers — "audit runtime drift", "detect dead service", "check partition rotation", "verify attribution write path", "audit feature flags", "detect ambiguous RPC overloads". 7 atomic checks, each tied to a real PR incident or MEMORY reference. Informational only (autofixable=false strict V1).
+description: Use when auditing runtime drift vs spec/registry (dead services, RPC drift, STABLE functions that write, partitions without rotation, attribution columns never written, orphan feature flags, PGRST203 overload ambiguity, massdoc type_id invariant integrity). Triggers — "audit runtime drift", "detect dead service", "check partition rotation", "verify attribution write path", "audit feature flags", "detect ambiguous RPC overloads", "verify massdoc type_id invariant". 8 atomic checks, each tied to a real PR incident or MEMORY reference. Informational only (autofixable=false strict V1).
 type: technique
 status: experimental
 owners: ['@ak125']
@@ -43,7 +43,7 @@ Ce skill **ne fait que lire**. Il **ne modifie aucun fichier**, **ne crée
 aucune PR**, **n'écrit en DB que via supabase MCP read-only**. Output =
 rapport markdown structuré listant les findings par check.
 
-## Architecture atomique (7 checks)
+## Architecture atomique (8 checks)
 
 ```
 .claude/skills/runtime-truth-audit/
@@ -56,6 +56,7 @@ rapport markdown structuré listant les findings par check.
     attribution-write-gap.md        # colonnes attribution sans writer (#695)
     orphan-runtime-flags.md         # feature flags morts (préventif)
     rpc-overload-ambiguity.md       # overloads PostgREST ambigus → PGRST203 (#993)
+    massdoc-typeid-invariant.md     # invariant numérotation type_id Massdoc / ADR-085 (#998)
 ```
 
 **Un check = une responsabilité** (≤ 100 lignes). Pas de check "mega"
@@ -122,14 +123,14 @@ conditionnée à 6 mois de mesure + `FPR < 0.01` + autofix trivial.
 ## Procédure (orchestrateur)
 
 1. Si l'utilisateur demande "audit runtime drift" sans préciser :
-   exécuter les 6 checks dans l'ordre listé ci-dessus, agréger les findings.
+   exécuter les 8 checks dans l'ordre listé ci-dessus, agréger les findings.
 2. Si l'utilisateur cite un check spécifique (ex: "check partition rotation") :
    exécuter uniquement ce check.
 3. Format de sortie attendu :
    ```markdown
    # Runtime Truth Audit Report
    Date : YYYY-MM-DD
-   Checks exécutés : N/6
+   Checks exécutés : N/8
 
    ## Findings par severity
    - critical : X

--- a/.claude/skills/runtime-truth-audit/checks/massdoc-typeid-invariant.md
+++ b/.claude/skills/runtime-truth-audit/checks/massdoc-typeid-invariant.md
@@ -1,0 +1,90 @@
+---
+check: massdoc-typeid-invariant
+severity: high
+confidence: high
+expected_false_positive_rate: 0.01
+autofixable: false
+sources:
+  - auto_type (type_id_i) via supabase MCP
+  - tecdoc_map.type_id_remap (old_id, new_id) via supabase MCP
+  - tecdoc_map.type_id_seq (last_value, is_called) via supabase MCP
+incidents_proven:
+  - "#998 / vault #319 (2026-06-15, ADR-085) — allocateur gouverné type_id ; bug setval/MINVALUE attrapé à l'apply"
+risk_documented:
+  - ADR-085 (governance-vault) — invariant numérotation interne véhicule Massdoc-séquentiel
+  - backend/supabase/migrations/20260615_massdoc_type_id_allocator.sql
+---
+
+# Check : Intégrité de l'invariant de numérotation interne véhicule (Massdoc, ADR-085)
+
+## Pattern audité
+
+L'invariant canon ADR-085 : `auto_type.type_id` = séquence globale Massdoc ; le KTYPNR TecDoc est une **clé
+source** (dans `tecdoc_map.type_id_remap.old_id`), jamais adopté comme id ; aucune réutilisation des trous legacy ;
+aucune renumérotation. L'**unique** voie d'allocation gouvernée est `tecdoc_map.allocate_massdoc_type_id`.
+
+Ce check détecte une **dérive d'intégrité** : un véhicule inséré dans `auto_type` **hors** de la voie gouvernée
+(ex. INSERT manuel, ré-exécution du script déprécié `fix-vehicles-massdoc.py`), qui adopterait un KTYPNR comme id,
+bypasserait l'allocateur, casserait le pont remap, ou désynchroniserait la séquence.
+
+**Impact** : collision d'ids / URLs véhicule cassées (URLs keyées `type_id`) / 301 perdus / duplicate-content —
+silencieux (aucune erreur runtime tant que personne ne tombe sur la page). D'où la détection proactive.
+
+## Origine
+
+PR #998 (migration) + vault PR #319 (ADR-085), 2026-06-15. L'allocateur remplace le script ad-hoc. Cet allocateur
+est **inerte tant qu'aucune vague ne l'appelle** ; ce check est la **tripwire** qui garantit que, le jour où une
+vague (ou un INSERT manuel) tourne, toute violation de l'invariant remonte au lieu de corrompre en silence.
+
+## Méthode (4 sous-invariants, chacun doit retourner 0 / OK)
+
+```sql
+-- A. KTYPNR source adopté comme id interne (doit être 0)
+SELECT count(*) FROM auto_type WHERE type_id_i IN (SELECT old_id FROM tecdoc_map.type_id_remap);
+
+-- B. type_id >= 60000 hors gouvernance = bypass allocateur (pas dans remap.new_id) (doit être 0)
+SELECT count(*) FROM auto_type
+ WHERE type_id_i >= 60000 AND type_id_i NOT IN (SELECT new_id FROM tecdoc_map.type_id_remap);
+
+-- C. remap orphelin : new_id absent de auto_type (doit être 0)
+SELECT count(*) FROM tecdoc_map.type_id_remap r
+ WHERE NOT EXISTS (SELECT 1 FROM auto_type a WHERE a.type_id_i = r.new_id);
+
+-- D. séquence désynchronisée : un id >= prochain-allouable sans avoir avancé la séquence (doit être OK)
+SELECT (SELECT last_value FROM tecdoc_map.type_id_seq) AS seq_last,
+       (SELECT max(type_id_i) FROM auto_type)          AS max_id;   -- DRIFT si seq_last <= max_id (is_called=false)
+```
+
+Baseline vérifiée 2026-06-15 : A=0, B=0, C=0, D=OK (seq 83457 > max 83456). Toute déviation = finding.
+
+## Sortie attendue (JSON)
+
+```json
+{
+  "check": "massdoc-typeid-invariant",
+  "pass": true,
+  "findings": [],
+  "summary": { "A_ktypnr_adopted": 0, "B_allocator_bypass": 0, "C_remap_orphan": 0, "D_seq_sync": "OK" }
+}
+```
+
+Un `pass: false` liste le(s) sous-invariant(s) violé(s) avec le compte. Exemple de finding :
+`{ "invariant": "B", "drift_count": 3, "severity": "high", "fix_hint": "véhicules ajoutés hors allocateur — remapper via tecdoc_map.allocate_massdoc_type_id (owner-gated), ne PAS renuméroter" }`.
+
+## Faux positifs connus
+
+- **Legacy 0–59999** où `type_id == KTYPNR` (grandfathered) : exclus par design (A teste l'overlap avec
+  `remap.old_id` qui est ≥100001 ; B ne teste que ≥60000). Pas de FP attendu.
+- Fenêtre transactionnelle pendant une vague gouvernée en cours (allocate → INSERT non encore committé) : lire en
+  dehors d'une vague active, ou tolérer un écart transitoire.
+
+## Limites
+
+- Détection d'**état**, pas de l'auteur : signale la dérive, pas qui l'a causée (volontaire — pas de surveillance d'identité).
+- Ne couvre pas les codes moteur (`auto_type_motor_code`) — périmètre = numérotation `type_id` uniquement (un check = une responsabilité).
+
+## Action recommandée pour les findings
+
+- **Aucune auto-correction** (autofixable=false, doctrine no-silent-fallback). Tout fix = **owner-gated** :
+  re-router les ids hors-gouvernance via `tecdoc_map.allocate_massdoc_type_id`, **jamais** renuméroter l'existant
+  (no URL changes). Rollback allocateur = `DROP FUNCTION/SEQUENCE` (additif). Voir ADR-085.


### PR DESCRIPTION
8e check atomique du skill `runtime-truth-audit` : tripwire read-only de l'invariant de numérotation interne véhicule (canon ADR-085).

Détecte 4 dérives : KTYPNR adopté comme id · bypass de l'allocateur gouverné · remap orphelin · désync séquence. **autofixable=false** (détection seule, jamais d'auto-fix — doctrine no-silent-fallback). Vérifié vert sur la DB 2026-06-15 (A=0, B=0, C=0, D=OK).

Répond à « comment suis-je notifié si l'invariant casse » : `runtime-truth-audit` surface le finding. Étend l'existant (zéro nouveau système), respecte les 6 critères d'admission du skill. SKILL.md count 7→8.