### PR TITLE
fix(command-center): couverture repair pilotée par la priorité canon (P0), plus de liste figée

### DIFF
--- a/backend/src/modules/admin/services/command-center-action-rules/certification-action.rules.ts
+++ b/backend/src/modules/admin/services/command-center-action-rules/certification-action.rules.ts
@@ -13,6 +13,7 @@ interface DeptView {
   label: string;
   certification: string; // CERTIFIED|PARTIAL|UNKNOWN|BROKEN
   kpi_primary: string | null;
+  priority?: string | null; // P0|P1|P2|P3 (canon) — drives generic repair coverage
 }
 interface ChainView {
   id: string;
@@ -68,7 +69,20 @@ const REPAIR_PLAYBOOK: Record<
   },
 };
 
-const CRITICAL_DEPTS = new Set(Object.keys(REPAIR_PLAYBOOK));
+/**
+ * Conservative generic weights for a non-curated P0 department. Lower than the
+ * curated playbooks (so the funnel/supplier P0s stay on top) but high enough to
+ * surface — an uncertified P0 department must NEVER be invisible in the queue.
+ * 'governance' is the only valid catch-all source in the action contract enum
+ * (same fallback the wire rule already uses below).
+ */
+const GENERIC_P0_REPAIR = {
+  source: 'governance' as RawAction['source'],
+  impact: 6,
+  urgency: 6,
+  effort: 4,
+  risk: 2,
+};
 
 export function buildCertificationActions(
   departments: DeptView[],
@@ -76,29 +90,38 @@ export function buildCertificationActions(
 ): RawAction[] {
   const out: RawAction[] = [];
 
+  // Repair coverage is canon-priority-driven, NOT a hardcoded allowlist. Before,
+  // CRITICAL_DEPTS = Object.keys(REPAIR_PLAYBOOK) silently skipped every other
+  // uncertified P0 (audit 2026-06-11 angle mort: catalog, finance, logistics,
+  // support, governance had no action at all). Now: every uncertified department
+  // that is curated OR P0 gets a repair/certification action.
   for (const d of departments) {
-    if (!CRITICAL_DEPTS.has(d.id)) continue;
     if (d.certification === 'CERTIFIED') continue; // already trustworthy
 
     const pb = REPAIR_PLAYBOOK[d.id];
+    if (!pb && d.priority !== 'P0') continue; // curated always; generic only for P0
+    const w = pb ?? GENERIC_P0_REPAIR;
+
     out.push({
       id: `repair:${d.id}`,
       title: `Fiabiliser « ${d.label} » (source ${d.certification})`,
       department: d.id,
-      source: pb.source,
+      source: w.source,
       action_type: d.certification === 'BROKEN' ? 'repair' : 'certification',
-      impact: pb.impact,
-      urgency: pb.urgency,
+      impact: w.impact,
+      urgency: w.urgency,
       // canon is reliable about WHAT is broken → high confidence in the need to fix
       data_confidence: CONFIDENCE_BY_CERT.CERTIFIED,
-      effort: pb.effort,
-      risk: pb.risk,
+      effort: w.effort,
+      risk: w.risk,
       reason: `Le département est ${d.certification} dans la carte opérationnelle — ses signaux ne sont pas fiables tant qu'il n'est pas certifié.`,
       evidence: [
         '.spec/00-canon/ai-registry/agent-operating-map.yaml',
         `dept:${d.id}`,
       ],
-      next_step: pb.step,
+      next_step:
+        pb?.step ??
+        `Définir le verdict de fiabilité de « ${d.label} » (preuve + certification au canon) avant d'exploiter ses signaux.`,
     });
   }
 

--- a/backend/tests/unit/command-center-action-rules.test.ts
+++ b/backend/tests/unit/command-center-action-rules.test.ts
@@ -202,6 +202,96 @@ describe('certification rules — broken/partial sources → repair/certify, NOT
   });
 });
 
+describe('repair coverage — canon-priority-driven (audit 2026-06-11 angle mort)', () => {
+  it('an uncertified P0 department WITHOUT a curated playbook still gets a repair action (no silent skip)', () => {
+    const out = buildCertificationActions(
+      [
+        {
+          id: 'finance',
+          label: 'Finance',
+          certification: 'PARTIAL',
+          kpi_primary: 'k',
+          priority: 'P0',
+        },
+      ],
+      [],
+    ).map(finalizeAction);
+    const fin = out.find((a) => a.id === 'repair:finance');
+    expect(fin).toBeDefined(); // before the fix: finance was invisible
+    expect(fin!.action_type).toBe('certification');
+    expect(fin!.source).toBe('governance'); // catch-all source (enum-valid)
+    expect(fin!.department).toBe('finance'); // real department shown in UI
+    expect(fin!.next_step).toMatch(/verdict de fiabilité/i); // generic honest step
+  });
+
+  it('a curated P0 keeps its specific playbook weights/step (not the generic ones)', () => {
+    const out = buildCertificationActions(
+      [
+        {
+          id: 'sales',
+          label: 'Ventes',
+          certification: 'PARTIAL',
+          kpi_primary: 'k',
+          priority: 'P0',
+        },
+      ],
+      [],
+    ).map(finalizeAction);
+    const sales = out.find((a) => a.id === 'repair:sales')!;
+    expect(sales.impact).toBe(10); // curated, not generic 6
+    expect(sales.next_step).toMatch(/funnel/i); // curated step preserved
+  });
+
+  it('a non-P0 department without a curated playbook is NOT covered (conservative scope)', () => {
+    const out = buildCertificationActions(
+      [
+        {
+          id: 'media',
+          label: 'Média',
+          certification: 'PARTIAL',
+          kpi_primary: 'k',
+          priority: 'P2',
+        },
+      ],
+      [],
+    );
+    expect(out.find((a) => a.id === 'repair:media')).toBeUndefined();
+  });
+
+  it('a CERTIFIED P0 department gets no action even via the generic path', () => {
+    const out = buildCertificationActions(
+      [
+        {
+          id: 'finance',
+          label: 'Finance',
+          certification: 'CERTIFIED',
+          kpi_primary: 'k',
+          priority: 'P0',
+        },
+      ],
+      [],
+    );
+    expect(out.find((a) => a.id === 'repair:finance')).toBeUndefined();
+  });
+
+  it('a generic P0 that is BROKEN escalates to a repair action', () => {
+    const out = buildCertificationActions(
+      [
+        {
+          id: 'support',
+          label: 'Support',
+          certification: 'BROKEN',
+          kpi_primary: 'k',
+          priority: 'P0',
+        },
+      ],
+      [],
+    ).map(finalizeAction);
+    const sup = out.find((a) => a.id === 'repair:support')!;
+    expect(sup.action_type).toBe('repair');
+  });
+});
+
 describe('SEO opportunity rules — real business actions (certified source)', () => {
   it('classifies URLs by page kind', () => {
     expect(pageKindFromUrl('https://x/pieces/filtre/a/b.html')).toBe('product');


### PR DESCRIPTION
## Problème (audit câblage 2026-06-11)

`CRITICAL_DEPTS = Object.keys(REPAIR_PLAYBOOK)` (sales/supplier/data/runtime) **ignorait silencieusement** tout autre département **P0 non-certifié** → angle mort : **catalog, finance, logistics, support** (et governance avant sa résolution par #1003) ne généraient **aucune action**, invisibles dans la queue malgré leur criticité P0.

## Fix structurel

`buildCertificationActions` devient **piloté par la priorité canon**, plus une allowlist figée :
- chaque département **non-CERTIFIED** émet une action s'il est **curated** (playbook spécifique conservé : poids + step) **OU** **P0** ;
- P0 sans playbook → poids génériques **conservateurs** (6/6/4/2, sous les curated), source `governance` (catch-all enum-valide, déjà utilisé par la règle wire), `next_step` honnête (« définir le verdict de fiabilité ») ;
- `BROKEN` → `repair`, sinon `certification` ;
- **périmètre conservateur** : P0 uniquement (les 5 départements de l'angle mort) — les non-P0 sans playbook restent non couverts (pas de bruit) ;
- `DeptView` : champ `priority?` (déjà porté par le snapshot via le reader, **zéro plumbing** supplémentaire).

## Vérification

- Tests **45/45** (+5 : P0 sans playbook désormais couvert ; curated garde ses poids/step ; non-P0 non couvert ; CERTIFIED P0 = rien ; BROKEN P0 → repair).
- ESLint propre. Build backend = gate CI autoritaire (fresh).
- Indépendant de #1003 (fonction pure) ; composent correctement (après #1003 governance=CERTIFIED → plus de repair:governance).

## Scope / risques

Surface admin (cockpit `disabled` en PROD par défaut), advisory, réversible. **Changement de comportement assumé** : des actions apparaissent pour des P0 non-certifiés jusque-là invisibles (c'est le but — surfacer l'angle mort). Aucune URL/migration. Merge = PREPROD (pas de tag `v*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)