### PR TITLE
chore(config): garder uniquement le MCP supabase local (réfs claude_ai_Supabase mortes)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,6 @@
 {
 "permissions": {
-    "allow": [
-      "mcp__claude_ai_Supabase__execute_sql",
-      "mcp__claude_ai_Supabase__list_tables",
-      "mcp__claude_ai_Supabase__get_project",
-      "mcp__claude_ai_Supabase__get_project_url"
-    ]
+    "allow": []
   },
   "hooks": {
     "PreToolUse": [
@@ -28,7 +23,7 @@
         ]
       },
       {
-        "matcher": "mcp__supabase__apply_migration|mcp__supabase__execute_sql|mcp__claude_ai_Supabase__apply_migration|mcp__claude_ai_Supabase__execute_sql",
+        "matcher": "mcp__supabase__apply_migration|mcp__supabase__execute_sql",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Quoi

Nettoyage de `.claude/settings.json` : on garde **uniquement ce que la CLI utilise** (serveur MCP local `supabase`), on retire les références mortes au **connecteur compte claude.ai « Supabase »** — déconnecté côté claude.ai car il faisait **doublon** (≈30 noms d'outils dupliqués dans le contexte always-on).

## Diff (minimal, +2/−7)

- **`permissions.allow` → `[]`** : suppression des 4 pré-approbations `mcp__claude_ai_Supabase__*` (`execute_sql`, `list_tables`, `get_project`, `get_project_url`). Les approbations du `supabase` **local** vivent déjà dans `settings.local.json` (per-machine, gitignored) → aucune capacité CLI perdue.
- **matcher `pretool-supabase-guard.sh`** : retrait des moitiés `claude_ai_Supabase`, **conservation** du binding local `mcp__supabase__apply_migration|mcp__supabase__execute_sql`.

## Pourquoi

- `.mcp.json` ne déclare que `supabase` + `shadcn` (« Main = supabase + shadcn ») — c'est le serveur **gouverné** utilisé par la session DEV.
- Le connecteur `claude.ai Supabase` était un doublon au niveau **compte** → surconsommation de tokens (outils différés en double). Investigation surconsommation tokens.

## Sûreté / non-régression

- ✅ JSON valide (`jq empty`)
- ✅ supabase-guard **toujours** déclenché sur le serveur local (`apply_migration` / `execute_sql`)
- ✅ 0 réf `claude_ai_Supabase` restante
- ✅ Aucun guard affaibli (le matcher conserve le serveur réellement utilisé)
- ✅ Réversible (1 fichier, additif inverse trivial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)