### PR TITLE
fix(ops): sync-dev-runtime — débloque le ff-pull cron buté en boucle sur log.md

### DIFF
--- a/scripts/ops/sync-dev-runtime.sh
+++ b/scripts/ops/sync-dev-runtime.sh
@@ -113,6 +113,17 @@ if [ "$local_sha" = "$remote_sha" ]; then
 fi
 
 # 4. Fast-forward only (jamais reset --hard ; une divergence = réconciliation manuelle).
+# La garde l.96 "tolère" le bruit log.md dans le check de propreté, mais
+# `git merge --ff-only` butait QUAND MÊME dessus quand log.md a aussi avancé en
+# amont (refus d'écraser une modif locale) → le cron avortait en boucle ici =
+# drift silencieux (31 commits observés le 2026-06-16, violation no-silent-fallback).
+# On matérialise donc la tolérance : reset du SEUL log.md (régénéré par le hook
+# session-log) avant le ff. Sûr — la garde l.96-97 a déjà refusé tout autre fichier
+# sale ; jamais de `reset --hard`, seul ce fichier auto-généré est touché.
+if ! git diff --quiet -- log.md 2>/dev/null; then
+  git checkout --quiet -- log.md \
+    && log "bruit log.md local réinitialisé avant ff (toléré, régénéré par session-log)"
+fi
 git merge --ff-only origin/main || abort "non fast-forwardable (lignée divergente) — réconcilier main à la main"
 log "synced $local_sha → $remote_sha"
 


### PR DESCRIPTION
## Problème (cause racine, observé 2026-06-16)

Le checkout DEV (`/opt/automecanik/app`) était **31 commits derrière `origin/main`** alors que le cron `sync-dev-runtime.sh` tourne toutes les ~10 min → **DEV:3000 sert du code périmé**.

Cause : la garde l.96 filtre bien `log.md` du check de propreté (commentaire : « on tolère le bruit log.md du hook session-log »), **mais** `git merge --ff-only` (l.116) **refuse quand même** quand `log.md` a aussi avancé en amont — git n'écrase pas une modification locale non-commitée. Comme le hook session-log laisse en permanence un `M log.md` local et que l'upstream avance `log.md` (commits `chore(log)`), le **ff avorte à chaque tick** → drift silencieux qui s'accumule. C'est une violation du contrat *no-silent-fallback* du script lui-même (il prétend tolérer log.md, mais bute dessus).

## Fix

Matérialiser la tolérance déjà annoncée : avant le ff, `git checkout -- log.md` (reset du **seul** fichier auto-généré, régénéré par le hook session-log).

- **Sûr** : la garde l.96-97 a déjà **refusé tout autre fichier sale** → seul `log.md` peut être concerné ici.
- **Jamais `reset --hard`** (interdit l.116) — un seul fichier auto-généré est touché, jamais le code.
- `log.md` = timeline append-only régénérée par session-log ; sa version canonique vit en amont.

## Vérification

- **Reproduction (repo git jetable)** : sans le fix, `git merge --ff-only` **avorte** sur le bruit `log.md` (bug reproduit) ; avec le fix (`checkout log.md` + ff), le **ff réussit** et le commit de code upstream est appliqué (`app.txt → feat`). Branche `main` + `origin/main` asserts explicites (un premier essai avait faussement « réussi » sur une branche `master` — corrigé).
- `bash -n` OK (shellcheck non disponible sur le VPS).

## Impact / scope

- 1 fichier, +11 lignes, ops-tooling DEV uniquement. Aucune URL/migration/dépendance.
- **Une fois mergé, il faut un kick manuel unique** pour que le checkout DEV (bloqué) tire le fix : la resync 31-commits implique `npm install` (lockfile changé) + 14 migrations à revoir — **étapes owner-gated** que le script alerte sans auto-appliquer (axes 4-5). Le fix rend juste l'axe 1 (git ff) fiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)