### PR TITLE
chore(rules): démote agent-method-patterns.md hors always-on (on-demand)

### DIFF
--- a/.claude/knowledge/agent-method-patterns.md
+++ b/.claude/knowledge/agent-method-patterns.md
@@ -14,7 +14,7 @@ Vocabulaire de lecture/sortie — **PAS** un orchestrateur, PAS un gate CI, PAS 
 |---|---|
 | **DISCOVER** | [CLAUDE.md](../../CLAUDE.md) « analyser AVANT muter » → `canonical.json → REPO_MAP → knowledge → ADR vault → grep` |
 | **DECIDE** | [continuous-improvement-global](../skills/continuous-improvement-global/SKILL.md) + CLAUDE.md « Prefer extension over creation » |
-| **PLAN** | CLAUDE.md « Discipline de périmètre » + worktree dédié ([deployment.md](deployment.md)) |
+| **PLAN** | CLAUDE.md « Discipline de périmètre » + worktree dédié ([deployment.md](../rules/deployment.md)) |
 | **PATCH** | CLAUDE.md « périmètre minimal » |
 | **VERIFY** | champ *Test* de continuous-improvement + vérification runtime PRE-PR / POST-MERGE |
 | **HANDOFF** | [agent-exit-contract.md](../canon-mirrors/agent-exit-contract.md) (coverage manifest, anti-overclaim) |
@@ -36,9 +36,9 @@ Niveaux : **BLOCK** (refusé, guard local) · **WARN** (averti, autorisé) · **
 | `backend/src/modules/rm/` | **BLOCK** | file-guard G5 |
 | `supabase.rpc` direct (commerce) / order-cart status writes | **BLOCK** *(code)* | ast-grep `commerce-*` |
 | `ALTER TABLE DROP COLUMN` / `CREATE TABLE` sans RLS | **WARN** | supabase-guard G4-G5 |
-| `payments/` edits | **WARN** | file-guard G3 + [payments.md](payments.md) |
+| `payments/` edits | **WARN** | file-guard G3 + [payments.md](../rules/payments.md) |
 | `gh pr merge` → main | **GATED (CI)** | branch protection : checks stricts + `enforce_admins` (merge = PREPROD ; PROD tag-gated) |
-| `git tag v*` / `push --tags` / deploy-prod | **BLOCK** | bash-guard G6 (#879) — tag = décision opérateur ([deployment.md](deployment.md)) |
+| `git tag v*` / `push --tags` / deploy-prod | **BLOCK** | bash-guard G6 (#879) — tag = décision opérateur ([deployment.md](../rules/deployment.md)) |
 | `UPDATE`/`DELETE` `pieces` / `pieces_price` / `__seo_*` via execute_sql | **BLOCK** | supabase-guard G6 (#879) — passer par module/RPC gouverné |
 
 > #879 = durcissement owner-gated — **renforcer, jamais affaiblir** un guard.
@@ -77,7 +77,7 @@ cassé ? `DONE` sur-déclaré alors que `PARTIAL` ?
 ## 6. Mémoire & routing — pointers
 
 - Mémoire = aide au rappel, **jamais** source de vérité — couches `MEMORY.md` / `CLAUDE.md` /
-  vault / WIKI / DB / RAG : voir [agent-doc-search.md](agent-doc-search.md).
+  vault / WIKI / DB / RAG : voir [agent-doc-search.md](../rules/agent-doc-search.md).
 - Routing autoritaire = [agent-operating-map.yaml](../../.spec/00-canon/ai-registry/agent-operating-map.yaml)
   + [role-matrix.md](../../.spec/00-canon/role-matrix.md) + [departments-map](../../audit/automecanik-departments-map.md).
 


### PR DESCRIPTION
## Quoi

Sort `agent-method-patterns.md` de `.claude/rules/` (auto-chargé à **chaque tour** par le harness) vers `.claude/knowledge/` (lu **on-demand** via Read / hook PUSH / grep).

## Pourquoi

- `.claude/rules/*.md` = ~24,5 KB injectés **chaque tour** (~6,6K tok). Ce fichier pèse **5 554 o (~1 500 tok/tour)** et porte son propre en-tête : `NON-CANON · ADVISORY · POINTER-ONLY · NO AUTHORITY` → il n'a pas sa place en always-on.
- Levier de réduction de surconsommation tokens (suite du fil mémoire/MCP). = **P3** de `project_memory_context_architecture` (« dégraisser → noyau »).

## Sûreté / périmètre minimal

- ✅ **Seul ce fichier déplacé** : aucune référence entrante (grep repo), **absent** du registry `canonical.json` → pas de drift, pas de rebuild.
- ✅ `agent-doc-search.md` **NON touché** : il est référencé par le registry **+ 6 `agents/*/AGENTS.md`** gouvernés → démotion = blast radius large, **décision séparée** (pas bundlée ici).
- ✅ **Aucun rail sécurité/canon retiré** : `payments.md`, `deployment.md` restent always-on.
- ✅ Profondeur identique (`.claude/rules/` ↔ `.claude/knowledge/`, depth-2) → liens `../../` intacts ; **3 liens same-dir** corrigés vers `../rules/`. **18/18 liens résolvent**.
- ✅ Réversible (`git mv` inverse). CLAUDE.md **non modifié**.

## Gain

~1 500 tok/tour retirés de l'always-on.

## Note découvrabilité

Le fichier reste git-tracké et atteignable (Read/grep/PUSH). Si tu veux un pointeur explicite dans CLAUDE.md, c'est un follow-up trivial (volontairement non inclus pour garder CLAUDE.md intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)