### PR TITLE
docs(claude): reduce [CRITICAL] markers 7→5 (P1 anti-dilution)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 
 ---
 
-## Contrat d'exécution (comportement de l'agent) `[CRITICAL]`
+## Contrat d'exécution (comportement de l'agent)
 
 Ce repo est **gouverné** : ADRs, contracts, registries déterministes, ratchets CI.
 L'assistant **ÉTEND** l'architecture existante — il ne crée **JAMAIS** de système
@@ -37,7 +37,7 @@ ADR-058/062. **L1** data auto (`audit/registry/*.json`) + **L2** overlay manuel
 `audit/registry/canonical.json` = projection générée, **jamais éditée**. L'enforcement
 (ratchets / CI / ast-grep) entoure ces 3 couches. Détail : `packages/registry/README.md`.
 
-`[CRITICAL]` **Generated artifacts are projections, never sources of truth** :
+`[HIGH]` **Generated artifacts are projections, never sources of truth** :
 ne jamais éditer un artefact généré (`canonical.json`, blocs
 `<!-- AUTO-GENERATED -->`, `REPO_MAP.md`, canon mirrors hash-lockés) — corriger
 L1+L2, puis rebuild.


### PR DESCRIPTION
## Quoi

**Phase 2** du dégraissage `CLAUDE.md` (roadmap P1 `project_memory_context_architecture` : *« 17 [CRITICAL] = 0 prioritaire »* — trop de marqueurs diluent la priorité). Réduit le **nombre** de `[CRITICAL]` de **7 → 5**. **Aucune règle retirée** — seul l'emphase change. Diff +2/−2.

## Les 5 `[CRITICAL]` conservés (les non-négociables)

1. NEVER invent architecture already governed elsewhere
2. Mode par défaut = analyser AVANT muter
3. Anti-bricolage & patterns interdits
4. No silent fallback
5. Sécurité opérationnelle

## 2 démotions de marqueur (règle + prose intactes)

- `## Contrat d'exécution [CRITICAL]` → marqueur **retiré du header de section** (redondant : les 5 sous-règles portent la criticité).
- `[CRITICAL] Generated artifacts are projections` → **`[HIGH]`** : la règle « ne jamais éditer un artefact généré » **reste**, toujours **enforced par file-guard + ast-grep** ; on abaisse l'emphase, pas l'enforcement.

## Sûreté

- ✅ `validate-agents-md.sh --diff origin/main` : PASS
- ✅ Aucune règle/garde supprimée · réversible (+2/−2)
- ⚠️ La sélection « le noyau » (quels 5) = **jugement agent** → **ajustable par toi en revue** (revert/swap trivial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)