### PR TITLE
feat(command-center): shadow-2a — planner regen-artifact (would-be diff, 0 écriture)

### DIFF
--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -23,7 +23,11 @@ import { RegistryReaderService } from './services/registry-reader.service';
 import { CommandCenterController } from './controllers/command-center.controller';
 import { CommandCenterReaderService } from './services/command-center-reader.service';
 import { CommandCenterActionsService } from './services/command-center-actions.service';
-import { CommandCenterOrchestratorService } from './services/command-center-orchestrator/orchestrator.service';
+import {
+  CommandCenterOrchestratorService,
+  SHADOW_PLANNERS,
+} from './services/command-center-orchestrator/orchestrator.service';
+import { RegenArtifactShadowPlanner } from './services/command-center-orchestrator/regen-artifact.planner';
 import { ConfigurationController } from './controllers/configuration.controller';
 import { StockController } from './controllers/stock.controller'; // 🔥 Controller consolidé unique
 import { AdminController } from './controllers/admin.controller';
@@ -213,6 +217,14 @@ import { SeoControlRefreshProcessor } from './processors/seo-control-refresh.pro
     CommandCenterReaderService,
     CommandCenterActionsService,
     CommandCenterOrchestratorService,
+    RegenArtifactShadowPlanner, // shadow-2 ① planner regen-artifact (ADR-087)
+    {
+      // Liste des planners shadow auto-enregistrés au boot de l'orchestrateur.
+      // shadow-3 ajoutera ici le planner pr-proposition.
+      provide: SHADOW_PLANNERS,
+      useFactory: (regen: RegenArtifactShadowPlanner) => [regen],
+      inject: [RegenArtifactShadowPlanner],
+    },
     ConfigurationService,
     StockManagementService, // ✅ Service principal stock
     WorkingStockService, // ✅ Service complémentaire (search, export, stats)

--- a/backend/src/modules/admin/services/command-center-orchestrator/orchestrator.service.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/orchestrator.service.ts
@@ -1,10 +1,23 @@
-import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  Optional,
+  type OnModuleInit,
+} from '@nestjs/common';
 import {
   resolveOrchestrationMode,
   type ExecutableActionKind,
   type ExecutionPlan,
   type OrchestrationMode,
 } from './executable-action.contract';
+
+/**
+ * Token DI pour la liste des planners shadow à auto-enregistrer au boot. Le module
+ * fournit ce tableau (regen-artifact en shadow-2, pr-proposition en shadow-3) ; l'unité
+ * de test peut construire l'orchestrateur sans (defaut `[]`) → reste découplé.
+ */
+export const SHADOW_PLANNERS = Symbol('CC_SHADOW_PLANNERS');
 
 /** Levée quand on tente un plan alors que l'orchestration n'est pas en mode `shadow`. */
 export class OrchestrationDisabledError extends Error {
@@ -45,12 +58,23 @@ export class CommandCenterOrchestratorService implements OnModuleInit {
   private readonly logger = new Logger(CommandCenterOrchestratorService.name);
   private readonly planners = new Map<ExecutableActionKind, ShadowPlanner>();
 
+  constructor(
+    @Optional()
+    @Inject(SHADOW_PLANNERS)
+    private readonly injectedPlanners: ShadowPlanner[] = [],
+  ) {}
+
   /**
-   * Boot : log SYNC (aucune I/O distante) du mode UNIQUEMENT s'il est ≠ off, pour
-   * qu'un opérateur qui pose `COMMAND_CENTER_ORCHESTRATION=shadow` voie que le flag a
-   * pris effet. Silencieux par défaut (off) → ne pollue pas les logs en nominal.
+   * Boot : (1) enregistre les planners injectés (DI), puis (2) log SYNC (aucune I/O
+   * distante) du mode UNIQUEMENT s'il est ≠ off, pour qu'un opérateur qui pose
+   * `COMMAND_CENTER_ORCHESTRATION=shadow` voie que le flag a pris effet. Silencieux par
+   * défaut (off). L'enregistrement est inoffensif même en off : `planShadow` throws tant
+   * que le mode ≠ shadow.
    */
   onModuleInit(): void {
+    for (const planner of this.injectedPlanners) {
+      this.registerPlanner(planner);
+    }
     const mode = this.getMode();
     if (mode !== 'off') {
       this.logger.warn(

--- a/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.planner.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.planner.ts
@@ -1,0 +1,181 @@
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  type ExecutableActionKind,
+  type ExecutionPlan,
+} from './executable-action.contract';
+import { type ShadowPlanner } from './orchestrator.service';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Cible de régénération déterministe connue. Phase 1 (shadow-2) n'en déclare qu'UNE :
+ * le snapshot Command Center — seul générateur du repo avec (a) un dry-run propre
+ * (`--json` écrit sur stdout puis `return` AVANT toute écriture fichier, vérifié) et
+ * (b) une garantie de déterminisme byte-identique sur un même checkout.
+ */
+interface RegenTarget {
+  /** action_id stable porté par l'ExecutionPlan (clé de la map). */
+  readonly id: string;
+  /** chemin (relatif au repo root) du fichier committé à comparer. */
+  readonly committedRel: string;
+  /** script générateur (relatif au repo root) lançable en dry-run `--json`. */
+  readonly generatorRel: string;
+  /** résumé humain de l'effet would-be. */
+  readonly summary: string;
+}
+
+const REGEN_TARGETS: Readonly<Record<string, RegenTarget>> = {
+  'regen:command-center-snapshot': {
+    id: 'regen:command-center-snapshot',
+    committedRel: 'audit/registry/command-center-snapshot.json',
+    generatorRel: 'scripts/governance/build-command-center-snapshot.js',
+    summary:
+      'Régénérer command-center-snapshot.json depuis agent-operating-map.yaml (projection déterministe).',
+  },
+};
+
+/** Levée si l'action_id ne correspond à aucune cible regen connue (jamais de faux plan). */
+export class UnknownRegenTargetError extends Error {
+  constructor(actionId: string) {
+    super(
+      `Aucune cible regen connue pour « ${actionId} » (cibles: ${Object.keys(REGEN_TARGETS).join(', ')}).`,
+    );
+    this.name = 'UnknownRegenTargetError';
+  }
+}
+
+/** Levée si le dry-run ne peut pas produire de sortie (générateur absent, crash, timeout). */
+export class RegenDryRunError extends Error {
+  constructor(actionId: string, cause: string) {
+    super(`Dry-run regen impossible pour « ${actionId} » : ${cause}`);
+    this.name = 'RegenDryRunError';
+  }
+}
+
+/** Résumé déterministe & borné du diff would-be (pas de dépendance externe). */
+export interface RegenDiffSummary {
+  lines_committed: number;
+  lines_would_be: number;
+  first_diff_line: number;
+  preview_committed: string[];
+  preview_would_be: string[];
+}
+
+export function summarizeDiff(
+  committed: string,
+  wouldBe: string,
+): RegenDiffSummary {
+  const a = committed.split('\n');
+  const b = wouldBe.split('\n');
+  let prefix = 0;
+  while (prefix < a.length && prefix < b.length && a[prefix] === b[prefix]) {
+    prefix += 1;
+  }
+  return {
+    lines_committed: a.length,
+    lines_would_be: b.length,
+    first_diff_line: prefix + 1,
+    preview_committed: a.slice(prefix, prefix + 5),
+    preview_would_be: b.slice(prefix, prefix + 5),
+  };
+}
+
+/**
+ * Planner shadow ① « regen-artifact » (ADR-087, Phase 1 shadow-2).
+ *
+ * Calcule l'effet *would-be* d'une régénération d'artefact déterministe SANS écrire :
+ * il lance le vrai générateur en dry-run (`node <script> --json` → stdout), compare au
+ * fichier committé, et renvoie un ExecutionPlan décrivant le diff. `reversible=true` :
+ * une régénération de projection déterministe a pour inverse un simple `git checkout`
+ * du fichier. AUCUNE mutation de l'artefact, AUCUN accès DB, AUCun réseau.
+ */
+@Injectable()
+export class RegenArtifactShadowPlanner implements ShadowPlanner {
+  readonly kind: ExecutableActionKind = 'regen-artifact';
+  private readonly logger = new Logger(RegenArtifactShadowPlanner.name);
+  /** Borne le dry-run : un générateur qui pend ne doit pas bloquer l'appelant. */
+  private static readonly DRY_RUN_TIMEOUT_MS = 30_000;
+  /** stdout du snapshot peut être volumineux (déterministe, mais large). */
+  private static readonly DRY_RUN_MAX_BUFFER = 32 * 1024 * 1024;
+
+  /** Liste des cibles regen connues (introspection / observabilité). */
+  static knownTargets(): string[] {
+    return Object.keys(REGEN_TARGETS);
+  }
+
+  /**
+   * Repo root, ancré EXACTEMENT comme `CommandCenterReaderService` (REGISTRY_DIR/../..),
+   * pour éviter le piège cwd=backend/ en Docker (start.sh fait `cd backend`).
+   */
+  private repoRoot(): string {
+    const registryDir =
+      process.env.REGISTRY_DIR || join(process.cwd(), 'audit', 'registry');
+    return join(registryDir, '..', '..');
+  }
+
+  async plan(actionId: string): Promise<ExecutionPlan> {
+    const target = REGEN_TARGETS[actionId];
+    if (!target) throw new UnknownRegenTargetError(actionId);
+
+    const root = this.repoRoot();
+    const committedPath = join(root, target.committedRel);
+    const generatorPath = join(root, target.generatorRel);
+
+    if (!existsSync(generatorPath)) {
+      // Pas de faux plan : si le générateur n'est pas là (image Docker sans scripts/),
+      // on échoue franchement plutôt que d'inventer un diff.
+      throw new RegenDryRunError(
+        actionId,
+        `générateur introuvable: ${target.generatorRel}`,
+      );
+    }
+
+    let wouldBe: string;
+    try {
+      // execFile (PAS de shell) + args constants → zéro surface d'injection.
+      // `--json` = dry-run pur : stdout = contenu would-be, 0 écriture (vérifié L383-385).
+      const { stdout } = await execFileAsync(
+        'node',
+        [generatorPath, '--json'],
+        {
+          cwd: root,
+          timeout: RegenArtifactShadowPlanner.DRY_RUN_TIMEOUT_MS,
+          maxBuffer: RegenArtifactShadowPlanner.DRY_RUN_MAX_BUFFER,
+        },
+      );
+      wouldBe = stdout;
+    } catch (e) {
+      throw new RegenDryRunError(actionId, (e as Error).message);
+    }
+
+    const committed = existsSync(committedPath)
+      ? readFileSync(committedPath, 'utf-8')
+      : null;
+    const wouldChange = committed !== wouldBe;
+
+    this.logger.log(
+      `shadow regen ${actionId} → would_change=${wouldChange} (committed=${committed?.length ?? 0}b, would_be=${wouldBe.length}b)`,
+    );
+
+    return {
+      action_id: actionId,
+      kind: this.kind,
+      summary: target.summary,
+      would_change: wouldChange,
+      details: {
+        artifact: target.committedRel,
+        generator: target.generatorRel,
+        committed_present: committed !== null,
+        bytes_committed: committed?.length ?? 0,
+        bytes_would_be: wouldBe.length,
+        diff: wouldChange ? summarizeDiff(committed ?? '', wouldBe) : null,
+      },
+      // Projection déterministe : l'inverse d'un regen est `git checkout <fichier>`.
+      reversible: true,
+    };
+  }
+}

--- a/backend/tests/unit/command-center-orchestrator.service.test.ts
+++ b/backend/tests/unit/command-center-orchestrator.service.test.ts
@@ -133,4 +133,15 @@ describe('CommandCenterOrchestratorService — squelette inerte', () => {
     expect(() => on.onModuleInit()).not.toThrow();
     expect(warnOn).toHaveBeenCalledTimes(1);
   });
+
+  it('onModuleInit enregistre les planners injectés par DI (shadow-2 wiring)', () => {
+    setEnv(undefined, 'development');
+    // sans injection (défaut) → toujours vide (rétro-compat shadow-1)
+    expect(new CommandCenterOrchestratorService().supportedKinds()).toEqual([]);
+    // avec injection → enregistrés au boot
+    const s = new CommandCenterOrchestratorService([fakePlanner]);
+    expect(s.supportedKinds()).toEqual([]); // pas encore : onModuleInit non appelé
+    s.onModuleInit();
+    expect(s.supportedKinds()).toEqual(['regen-artifact']);
+  });
 });

--- a/backend/tests/unit/regen-artifact.planner.test.ts
+++ b/backend/tests/unit/regen-artifact.planner.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Planner shadow ① « regen-artifact » (ADR-087 shadow-2a).
+ * Prouve : zéro faux plan (unknown id throw), échec franc si générateur absent
+ * (RegenDryRunError, pas de diff inventé), et résumé de diff déterministe & borné.
+ * Le chemin nominal (spawn du vrai générateur) est volontairement hors du unit test
+ * hermétique — couvert par le calcul `summarizeDiff` testé directement.
+ */
+import { join } from 'node:path';
+import {
+  RegenArtifactShadowPlanner,
+  RegenDryRunError,
+  UnknownRegenTargetError,
+  summarizeDiff,
+} from '../../src/modules/admin/services/command-center-orchestrator/regen-artifact.planner';
+
+const env = process.env as Record<string, string | undefined>;
+const REGISTRY = env.REGISTRY_DIR;
+afterEach(() => {
+  env.REGISTRY_DIR = REGISTRY;
+});
+
+describe('RegenArtifactShadowPlanner', () => {
+  it('kind = regen-artifact et expose ses cibles connues', () => {
+    const p = new RegenArtifactShadowPlanner();
+    expect(p.kind).toBe('regen-artifact');
+    expect(RegenArtifactShadowPlanner.knownTargets()).toContain(
+      'regen:command-center-snapshot',
+    );
+  });
+
+  it('action_id inconnu → UnknownRegenTargetError (jamais de faux plan)', async () => {
+    const p = new RegenArtifactShadowPlanner();
+    await expect(p.plan('regen:does-not-exist')).rejects.toBeInstanceOf(
+      UnknownRegenTargetError,
+    );
+  });
+
+  it('générateur absent → RegenDryRunError (échec franc, pas de diff inventé)', async () => {
+    // REGISTRY_DIR bidon → repoRoot = /tmp/.../no-scripts → script introuvable.
+    env.REGISTRY_DIR = join('/tmp', 'cc-regen-test-absent', 'audit', 'registry');
+    const p = new RegenArtifactShadowPlanner();
+    await expect(p.plan('regen:command-center-snapshot')).rejects.toBeInstanceOf(
+      RegenDryRunError,
+    );
+  });
+});
+
+describe('summarizeDiff — déterministe et borné', () => {
+  it('identiques → first_diff_line au-delà de la fin, previews vides', () => {
+    const s = summarizeDiff('a\nb\nc', 'a\nb\nc');
+    expect(s.lines_committed).toBe(3);
+    expect(s.lines_would_be).toBe(3);
+    expect(s.first_diff_line).toBe(4); // prefix=3 → 3+1
+    expect(s.preview_committed).toEqual([]);
+    expect(s.preview_would_be).toEqual([]);
+  });
+
+  it('1re ligne divergente repérée + previews bornés à 5', () => {
+    const committed = ['l1', 'l2', 'x', 'l4', 'l5', 'l6', 'l7'].join('\n');
+    const wouldBe = ['l1', 'l2', 'y', 'l4', 'l5', 'l6', 'l7'].join('\n');
+    const s = summarizeDiff(committed, wouldBe);
+    expect(s.first_diff_line).toBe(3);
+    expect(s.preview_committed).toHaveLength(5);
+    expect(s.preview_committed[0]).toBe('x');
+    expect(s.preview_would_be[0]).toBe('y');
+  });
+});


### PR DESCRIPTION
## Quoi

**shadow-2a** — premier planner shadow de l'orchestration Command Center : **① `regen-artifact`** (ADR-087 Phase 1). Calcule l'effet **would-be** d'une régénération d'artefact déterministe **sans rien écrire**.

Suite de #1010 (fondation inerte). Le planner branche enfin une capacité concrète dans le point d'extension `registerPlanner` posé par shadow-1.

## Comment (et pourquoi c'est sûr)

- `RegenArtifactShadowPlanner.plan(actionId)` :
  1. lance le **vrai générateur** en dry-run : `node <script> --json` → stdout ;
  2. compare au fichier committé ;
  3. renvoie un `ExecutionPlan` `{ would_change, details.diff (borné), reversible: true }`.
- **0 écriture vérifiée empiriquement** : dans `build-command-center-snapshot.js`, `--json` écrit sur stdout puis `return 0` **avant** `writeDeterministicJson` (L383-385). Test live : sha du snapshot committé **inchangé** avant/après, sortie déterministe (`would-be == committed`).
- **0 injection** : `execFile` (pas de shell) + args constants. Timeout 30 s + maxBuffer bornés.
- **Jamais de faux plan** : générateur absent → `RegenDryRunError` ; `action_id` inconnu → `UnknownRegenTargetError` (no silent fallback).
- **Réversibilité** : regen d'une projection déterministe → inverse = `git checkout <fichier>` → `reversible: true`.
- **Cible Phase 1 = UNE seule** : `regen:command-center-snapshot` (seul générateur du repo avec dry-run propre **et** déterminisme byte-identique garanti). Root ancré comme `CommandCenterReaderService` (`REGISTRY_DIR/../..`, piège `cwd=backend/` en Docker).

## Wiring DI

Token `SHADOW_PLANNERS` (factory → `[regen]`), auto-enregistré au boot via `onModuleInit`. Le constructeur de l'orchestrateur reste **no-arg-compatible** (`@Optional`, défaut `[]`) → rétro-compat totale des tests shadow-1. shadow-3 ajoutera le planner `pr-proposition` au même tableau.

## Périmètre & garde-fous (inchangés depuis shadow-1)

- Flag `COMMAND_CENTER_ORCHESTRATION` **OFF par défaut**, **PROD forcé OFF**.
- `planShadow` throws tant que le mode ≠ `shadow` → le planner enregistré ne tourne pas en nominal.
- **0 mutation** d'artefact, **0 DB**, **0 réseau**. Additif pur.

## Hors-scope (suite)

Le **write ledger `__admin_audit_log`** est délibérément déféré à **shadow-2b** — il exige de vérifier le schéma réel de la table (jamais écrire sur des colonnes déduites) + gérer `READ_ONLY=true` en PREPROD. Déféré ≠ abandonné.

## Vérifications

- ✅ jest **17/17** (12 orchestrateur dont nouveau test wiring DI + 5 planner).
- ✅ ESLint clean · `tsc --noEmit` 0 erreur (projet entier).
- ✅ ast-grep `backend-no-remote-io-in-onmoduleinit` : pass (onModuleInit = register sync only).
- ✅ Dry-run réel : snapshot committé non muté (sha identique).

## Déploiement

Aucune action runtime. Merge `main` → tag `:preprod` (CI). **Pas de tag PROD.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
