### PR TITLE
feat(command-center): shadow-2b — ledger admin_audit des runs shadow (append-only)

### DIFF
--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -26,8 +26,10 @@ import { CommandCenterActionsService } from './services/command-center-actions.s
 import {
   CommandCenterOrchestratorService,
   SHADOW_PLANNERS,
+  SHADOW_LEDGER,
 } from './services/command-center-orchestrator/orchestrator.service';
 import { RegenArtifactShadowPlanner } from './services/command-center-orchestrator/regen-artifact.planner';
+import { CommandCenterExecutionLedgerService } from './services/command-center-orchestrator/execution-ledger.service';
 import { ConfigurationController } from './controllers/configuration.controller';
 import { StockController } from './controllers/stock.controller'; // 🔥 Controller consolidé unique
 import { AdminController } from './controllers/admin.controller';
@@ -224,6 +226,12 @@ import { SeoControlRefreshProcessor } from './processors/seo-control-refresh.pro
       provide: SHADOW_PLANNERS,
       useFactory: (regen: RegenArtifactShadowPlanner) => [regen],
       inject: [RegenArtifactShadowPlanner],
+    },
+    CommandCenterExecutionLedgerService, // shadow-2b ledger admin_audit (ADR-087)
+    {
+      // Sink ledger injecté dans l'orchestrateur (append-only __admin_audit_log).
+      provide: SHADOW_LEDGER,
+      useExisting: CommandCenterExecutionLedgerService,
     },
     ConfigurationService,
     StockManagementService, // ✅ Service principal stock

--- a/backend/src/modules/admin/services/command-center-orchestrator/executable-action.contract.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/executable-action.contract.ts
@@ -22,6 +22,8 @@
  * shadow-2/3 ; l'exécution réelle (HITL) en Phase 2 (`approved`), gated séparément.
  */
 
+import { createHash } from 'node:crypto';
+
 /** Modes d'orchestration (ADR-087). Défaut OFF ; Phase 1 = off|shadow seulement. */
 export type OrchestrationMode = 'off' | 'shadow' | 'approved' | 'auto';
 
@@ -77,4 +79,20 @@ export function resolveOrchestrationMode(): OrchestrationMode {
     return raw === 'approved' || raw === 'auto' ? 'off' : raw;
   }
   return 'off';
+}
+
+/**
+ * Hash déterministe d'un plan, porté par `ExecutionLedgerEntry.plan_hash` (dédup /
+ * idempotence : deux runs shadow du même plan produisent le même hash). On ne hashe que
+ * les champs signifiants de l'effet would-be — `summary`/`reversible` sont dérivés et
+ * n'altèrent pas l'identité du changement décrit.
+ */
+export function computePlanHash(plan: ExecutionPlan): string {
+  const canonical = JSON.stringify({
+    action_id: plan.action_id,
+    kind: plan.kind,
+    would_change: plan.would_change,
+    details: plan.details,
+  });
+  return createHash('sha256').update(canonical).digest('hex');
 }

--- a/backend/src/modules/admin/services/command-center-orchestrator/execution-ledger.service.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/execution-ledger.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { type ExecutionLedgerEntry } from './executable-action.contract';
+
+/** Résultat SURFACÉ d'un append ledger — jamais de silence (no-silent-fallback). */
+export interface LedgerWriteResult {
+  recorded: boolean;
+  /** raison du non-enregistrement (`read_only`, message d'erreur DB…) si recorded=false. */
+  reason?: string;
+}
+
+/**
+ * Ledger d'orchestration shadow (ADR-087). Trace chaque run shadow dans la table
+ * existante `__admin_audit_log` (= « ledger admin_audit » du canon — on ÉTEND, on ne
+ * crée pas de table parallèle). Append-only : on n'écrit JAMAIS un artefact, seulement
+ * une ligne d'audit.
+ *
+ * En mode READ_ONLY (container PREPROD, ADR-028 Option D), l'append est court-circuité
+ * par le garde canonique `guardReadOnly` hérité de `SupabaseBaseService` → renvoie
+ * `{recorded:false, reason:'read_only'}` (le garde émet déjà un warn structuré LogQL).
+ * Toute autre erreur DB est loggée + surfacée — jamais avalée silencieusement.
+ */
+@Injectable()
+export class CommandCenterExecutionLedgerService extends SupabaseBaseService {
+  protected readonly logger = new Logger(
+    CommandCenterExecutionLedgerService.name,
+  );
+
+  /** Valeurs figées pour namespacer nos lignes dans la table d'audit partagée. */
+  private static readonly LEDGER_ACTION = 'cc_orchestration_shadow_plan';
+  private static readonly LEDGER_ENTITY_TYPE = 'cc_executable_action';
+
+  async record(entry: ExecutionLedgerEntry): Promise<LedgerWriteResult> {
+    // READ_ONLY (PREPROD) : court-circuit canonique, surfacé (pas de write tenté).
+    if (this.guardReadOnly('cc-orchestration-ledger', entry.action_id)) {
+      return { recorded: false, reason: 'read_only' };
+    }
+
+    try {
+      const { error } = await this.supabase.from('__admin_audit_log').insert({
+        aal_action: CommandCenterExecutionLedgerService.LEDGER_ACTION,
+        aal_entity_type: CommandCenterExecutionLedgerService.LEDGER_ENTITY_TYPE,
+        aal_entity_id: entry.action_id,
+        aal_user_id: entry.actor,
+        aal_new_value: {
+          mode: entry.mode,
+          plan_hash: entry.plan_hash,
+          would_change: entry.would_change,
+        },
+        aal_metadata: null,
+      });
+      if (error) {
+        this.logger.error(
+          `ledger append KO (${entry.action_id}): ${error.message}`,
+        );
+        return { recorded: false, reason: error.message };
+      }
+      return { recorded: true };
+    } catch (e) {
+      const reason = (e as Error).message;
+      this.logger.error(`ledger append a levé (${entry.action_id}): ${reason}`);
+      return { recorded: false, reason };
+    }
+  }
+}

--- a/backend/src/modules/admin/services/command-center-orchestrator/orchestrator.service.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/orchestrator.service.ts
@@ -6,8 +6,10 @@ import {
   type OnModuleInit,
 } from '@nestjs/common';
 import {
+  computePlanHash,
   resolveOrchestrationMode,
   type ExecutableActionKind,
+  type ExecutionLedgerEntry,
   type ExecutionPlan,
   type OrchestrationMode,
 } from './executable-action.contract';
@@ -18,6 +20,23 @@ import {
  * de test peut construire l'orchestrateur sans (defaut `[]`) → reste découplé.
  */
 export const SHADOW_PLANNERS = Symbol('CC_SHADOW_PLANNERS');
+
+/** Token DI pour le sink ledger (optionnel — l'unité de test construit sans). */
+export const SHADOW_LEDGER = Symbol('CC_SHADOW_LEDGER');
+
+/** Résultat d'un append ledger, surfacé (no-silent-fallback). */
+export interface ShadowLedgerResult {
+  recorded: boolean;
+  reason?: string;
+}
+
+/**
+ * Abstraction du ledger : l'orchestrateur ne dépend QUE de cette interface, pas du
+ * service Supabase concret (découplage + testabilité sans DB).
+ */
+export interface ShadowLedgerSink {
+  record(entry: ExecutionLedgerEntry): Promise<ShadowLedgerResult>;
+}
 
 /** Levée quand on tente un plan alors que l'orchestration n'est pas en mode `shadow`. */
 export class OrchestrationDisabledError extends Error {
@@ -62,6 +81,9 @@ export class CommandCenterOrchestratorService implements OnModuleInit {
     @Optional()
     @Inject(SHADOW_PLANNERS)
     private readonly injectedPlanners: ShadowPlanner[] = [],
+    @Optional()
+    @Inject(SHADOW_LEDGER)
+    private readonly ledger?: ShadowLedgerSink,
   ) {}
 
   /**
@@ -113,17 +135,41 @@ export class CommandCenterOrchestratorService implements OnModuleInit {
   }
 
   /**
-   * Calcule un plan *would-be* (0 mutation). Throws si l'orchestration n'est pas en
-   * `shadow`, ou si aucun planner n'existe pour ce kind — jamais de fallback silencieux.
+   * Calcule un plan *would-be* (0 mutation) PUIS le trace au ledger (append-only).
+   * Throws si l'orchestration n'est pas en `shadow`, ou si aucun planner n'existe pour
+   * ce kind — jamais de fallback silencieux.
+   *
+   * L'append ledger est best-effort-MAIS-surfacé : un échec de trace (READ_ONLY PREPROD,
+   * erreur DB) n'invalide PAS le plan (le calcul a réussi) → on log un warn, on ne throw
+   * pas. `actor` par défaut = `system` (un appelant Phase 2 passera l'opérateur réel).
    */
   async planShadow(
     kind: ExecutableActionKind,
     actionId: string,
+    opts?: { actor?: string },
   ): Promise<ExecutionPlan> {
     const mode = this.getMode();
     if (mode !== 'shadow') throw new OrchestrationDisabledError(mode);
     const planner = this.planners.get(kind);
     if (!planner) throw new UnsupportedExecutableActionError(kind);
-    return planner.plan(actionId);
+
+    const plan = await planner.plan(actionId);
+
+    if (this.ledger) {
+      const result = await this.ledger.record({
+        actor: opts?.actor ?? 'system',
+        action_id: actionId,
+        mode,
+        plan_hash: computePlanHash(plan),
+        would_change: plan.would_change,
+      });
+      if (!result.recorded) {
+        this.logger.warn(
+          `shadow run NON tracé (${actionId}) : ${result.reason ?? 'raison inconnue'}`,
+        );
+      }
+    }
+
+    return plan;
   }
 }

--- a/backend/tests/unit/command-center-orchestrator.service.test.ts
+++ b/backend/tests/unit/command-center-orchestrator.service.test.ts
@@ -5,6 +5,7 @@
  * fallback silencieux (throws explicites), jamais de mutation.
  */
 import {
+  computePlanHash,
   resolveOrchestrationMode,
   type ExecutionPlan,
 } from '../../src/modules/admin/services/command-center-orchestrator/executable-action.contract';
@@ -12,6 +13,7 @@ import {
   CommandCenterOrchestratorService,
   OrchestrationDisabledError,
   UnsupportedExecutableActionError,
+  type ShadowLedgerSink,
   type ShadowPlanner,
 } from '../../src/modules/admin/services/command-center-orchestrator/orchestrator.service';
 
@@ -143,5 +145,100 @@ describe('CommandCenterOrchestratorService — squelette inerte', () => {
     expect(s.supportedKinds()).toEqual([]); // pas encore : onModuleInit non appelé
     s.onModuleInit();
     expect(s.supportedKinds()).toEqual(['regen-artifact']);
+  });
+});
+
+describe('planShadow — trace ledger (shadow-2b)', () => {
+  const fakePlan: ExecutionPlan = {
+    action_id: 'regen:x',
+    kind: 'regen-artifact',
+    summary: 'fake',
+    would_change: true,
+    details: { a: 1 },
+    reversible: true,
+  };
+  const fakePlanner: ShadowPlanner = {
+    kind: 'regen-artifact',
+    plan: async () => fakePlan,
+  };
+
+  it('trace au ledger l’entrée attendue (actor défaut=system, plan_hash, would_change)', async () => {
+    setEnv('shadow', 'development');
+    const record = jest.fn().mockResolvedValue({ recorded: true });
+    const ledger: ShadowLedgerSink = { record };
+    const s = new CommandCenterOrchestratorService([fakePlanner], ledger);
+    s.onModuleInit();
+    await s.planShadow('regen-artifact', 'regen:x');
+    expect(record).toHaveBeenCalledTimes(1);
+    expect(record).toHaveBeenCalledWith({
+      actor: 'system',
+      action_id: 'regen:x',
+      mode: 'shadow',
+      plan_hash: computePlanHash(fakePlan),
+      would_change: true,
+    });
+  });
+
+  it('actor explicite propagé', async () => {
+    setEnv('shadow', 'development');
+    const record = jest.fn().mockResolvedValue({ recorded: true });
+    const s = new CommandCenterOrchestratorService([fakePlanner], { record });
+    s.onModuleInit();
+    await s.planShadow('regen-artifact', 'regen:x', { actor: 'fafa' });
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ actor: 'fafa' }),
+    );
+  });
+
+  it('échec ledger (recorded:false) → warn, mais le plan est renvoyé (pas de throw)', async () => {
+    setEnv('shadow', 'development');
+    const record = jest
+      .fn()
+      .mockResolvedValue({ recorded: false, reason: 'read_only' });
+    const s = new CommandCenterOrchestratorService([fakePlanner], { record });
+    s.onModuleInit();
+    const warn = jest.spyOn((s as never)['logger'], 'warn').mockImplementation();
+    const plan = await s.planShadow('regen-artifact', 'regen:x');
+    expect(plan).toEqual(fakePlan);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('read_only'));
+  });
+
+  it('sans ledger injecté → planShadow marche quand même (0 trace)', async () => {
+    setEnv('shadow', 'development');
+    const s = new CommandCenterOrchestratorService([fakePlanner]);
+    s.onModuleInit();
+    await expect(s.planShadow('regen-artifact', 'regen:x')).resolves.toEqual(
+      fakePlan,
+    );
+  });
+});
+
+describe('computePlanHash — déterministe & sensible', () => {
+  const base: ExecutionPlan = {
+    action_id: 'regen:x',
+    kind: 'regen-artifact',
+    summary: 's',
+    would_change: false,
+    details: { a: 1 },
+    reversible: true,
+  };
+
+  it('même plan signifiant → même hash (idempotence)', () => {
+    expect(computePlanHash(base)).toBe(computePlanHash({ ...base }));
+  });
+
+  it('summary/reversible n’altèrent PAS le hash (champs dérivés)', () => {
+    expect(computePlanHash({ ...base, summary: 'autre', reversible: false })).toBe(
+      computePlanHash(base),
+    );
+  });
+
+  it('would_change ou details différents → hash différent', () => {
+    expect(computePlanHash({ ...base, would_change: true })).not.toBe(
+      computePlanHash(base),
+    );
+    expect(computePlanHash({ ...base, details: { a: 2 } })).not.toBe(
+      computePlanHash(base),
+    );
   });
 });

--- a/backend/tests/unit/execution-ledger.service.test.ts
+++ b/backend/tests/unit/execution-ledger.service.test.ts
@@ -1,0 +1,93 @@
+/**
+ * CommandCenterExecutionLedgerService — append au ledger `__admin_audit_log` (ADR-087
+ * shadow-2b). Prouve : READ_ONLY court-circuite l'insert (recorded:false, reason:read_only)
+ * SANS toucher la DB ; insert OK → recorded:true avec les colonnes aal_* attendues ;
+ * erreur DB → surfacée (recorded:false), jamais avalée.
+ */
+import { CommandCenterExecutionLedgerService } from '../../src/modules/admin/services/command-center-orchestrator/execution-ledger.service';
+import { type ExecutionLedgerEntry } from '../../src/modules/admin/services/command-center-orchestrator/executable-action.contract';
+
+const mockConfigService = {
+  get: jest.fn().mockImplementation((key: string) => {
+    const map: Record<string, string> = {
+      SUPABASE_URL: 'https://test.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'test-service-role-key-placeholder',
+    };
+    return map[key] ?? 'mock-value';
+  }),
+  getOrThrow: jest.fn().mockReturnValue('mock-value'),
+};
+
+function createService(): CommandCenterExecutionLedgerService {
+  const Ctor = CommandCenterExecutionLedgerService as unknown as new (
+    cfg: unknown,
+  ) => CommandCenterExecutionLedgerService;
+  return new Ctor(mockConfigService);
+}
+
+const entry: ExecutionLedgerEntry = {
+  actor: 'system',
+  action_id: 'regen:command-center-snapshot',
+  mode: 'shadow',
+  plan_hash: 'abc123',
+  would_change: true,
+};
+
+describe('CommandCenterExecutionLedgerService', () => {
+  it('READ_ONLY → court-circuit (recorded:false, reason:read_only), 0 insert tenté', async () => {
+    const svc = createService();
+    const insert = jest.fn();
+    Object.defineProperty(svc, 'supabase', {
+      get: () => ({ from: () => ({ insert }) }),
+      configurable: true,
+    });
+    Object.defineProperty(svc, 'isReadOnlyMode', {
+      get: () => true,
+      configurable: true,
+    });
+    const res = await svc.record(entry);
+    expect(res).toEqual({ recorded: false, reason: 'read_only' });
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('insert OK → recorded:true avec les colonnes aal_* attendues', async () => {
+    const svc = createService();
+    const insert = jest.fn().mockResolvedValue({ error: null });
+    Object.defineProperty(svc, 'supabase', {
+      get: () => ({ from: jest.fn().mockReturnValue({ insert }) }),
+      configurable: true,
+    });
+    Object.defineProperty(svc, 'isReadOnlyMode', {
+      get: () => false,
+      configurable: true,
+    });
+    const res = await svc.record(entry);
+    expect(res).toEqual({ recorded: true });
+    expect(insert).toHaveBeenCalledWith({
+      aal_action: 'cc_orchestration_shadow_plan',
+      aal_entity_type: 'cc_executable_action',
+      aal_entity_id: 'regen:command-center-snapshot',
+      aal_user_id: 'system',
+      aal_new_value: { mode: 'shadow', plan_hash: 'abc123', would_change: true },
+      aal_metadata: null,
+    });
+  });
+
+  it('erreur DB → surfacée (recorded:false, reason), jamais avalée', async () => {
+    const svc = createService();
+    const insert = jest
+      .fn()
+      .mockResolvedValue({ error: { message: 'permission denied' } });
+    Object.defineProperty(svc, 'supabase', {
+      get: () => ({ from: () => ({ insert }) }),
+      configurable: true,
+    });
+    Object.defineProperty(svc, 'isReadOnlyMode', {
+      get: () => false,
+      configurable: true,
+    });
+    jest.spyOn((svc as never)['logger'], 'error').mockImplementation();
+    const res = await svc.record(entry);
+    expect(res).toEqual({ recorded: false, reason: 'permission denied' });
+  });
+});


### PR DESCRIPTION
## Quoi

**shadow-2b** — branche le **« ledger admin_audit »** du canon ADR-087 (délibérément déféré depuis shadow-1). Chaque **run shadow** est tracé dans la table **existante** `__admin_audit_log` (on **étend** l'audit-log, pas de table parallèle). **0 mutation d'artefact** — seulement une ligne d'audit append-only.

Suite de #1010 (fondation) et #1013 (planner regen-artifact).

## Comment (robuste, réutilise l'existant)

- `CommandCenterExecutionLedgerService extends SupabaseBaseService` → `record(entry)` :
  - **READ_ONLY (PREPROD)** : réutilise le **garde canonique hérité** `guardReadOnly` (ADR-028 Option D) → l'insert est court-circuité → `{ recorded: false, reason: 'read_only' }`. Le garde émet déjà un **warn structuré LogQL** (`readonly.skipped`). Aucune écriture tentée.
  - **Erreur DB** → loggée (`logger.error`) **+ surfacée** dans le résultat. **Jamais de silence** (no-silent-fallback).
  - Colonnes `aal_*` **vérifiées contre le schéma réel** de la table (introspection `information_schema`), pas déduites. NOT NULL (`aal_action`/`aal_entity_type`/`aal_entity_id`) tous fournis ; `aal_id`/`aal_created_at` auto.
  - Lignes namespacées : `aal_action='cc_orchestration_shadow_plan'`, `aal_entity_type='cc_executable_action'`.
- `computePlanHash(plan)` (dans le contrat, sha256 **déterministe**) : ne hashe que les champs signifiants (`action_id`/`kind`/`would_change`/`details`) → idempotence ; `summary`/`reversible` (dérivés) n'altèrent pas l'identité du changement.
- `planShadow(kind, actionId, { actor })` : calcule le plan **puis** trace. Un échec de trace **n'invalide pas** le plan (le calcul a réussi) → `warn`, pas de `throw`. `actor` défaut = `system`.

## Wiring DI

Ledger injecté via token `SHADOW_LEDGER` (`@Optional`, `useExisting`) → l'orchestrateur ne dépend que de l'interface `ShadowLedgerSink`, **pas** du service Supabase concret. Le constructeur reste compatible sans ledger → tests hermétiques sans DB.

## Garde-fous (inchangés)

- Flag `COMMAND_CENTER_ORCHESTRATION` **OFF par défaut**, **PROD forcé OFF**.
- `planShadow` throws hors `shadow` → aucune trace en nominal.
- Append-only : **jamais** de mutation d'artefact, jamais de write en READ_ONLY.

## Vérifications

- ✅ jest **27/27** (3 suites : orchestrateur + ledger + planner).
- ✅ ESLint clean · `tsc --noEmit` 0 erreur (projet entier) · ast-grep onModuleInit-guard pass.
- ✅ Schéma `__admin_audit_log` confirmé par introspection ; colonnes d'insert unit-testées au exact.
- ⚠️ **Insert live NON exécuté volontairement** — pour ne pas polluer l'audit-log partagé (DB DEV = DB partagée). Validité prouvée par : schéma vérifié + colonnes unit-testées + **pattern identique** au writer prod éprouvé `order-audit.listener` (`.from('__admin_audit_log').insert({ aal_* })`).

## Déploiement

Aucune action runtime. Merge `main` → tag `:preprod` (CI). **Pas de tag PROD.**

## Suite

shadow-3 = planner ② `pr-proposition` (corps de PR *would-be*, 0 mutation) — réutilisera ce même ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
