### PR TITLE
feat(command-center): shadow-3 — planner pr-proposition (brouillon PR would-be, 0 mutation)

### DIFF
--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -29,6 +29,7 @@ import {
   SHADOW_LEDGER,
 } from './services/command-center-orchestrator/orchestrator.service';
 import { RegenArtifactShadowPlanner } from './services/command-center-orchestrator/regen-artifact.planner';
+import { PrPropositionShadowPlanner } from './services/command-center-orchestrator/pr-proposition.planner';
 import { CommandCenterExecutionLedgerService } from './services/command-center-orchestrator/execution-ledger.service';
 import { ConfigurationController } from './controllers/configuration.controller';
 import { StockController } from './controllers/stock.controller'; // 🔥 Controller consolidé unique
@@ -221,11 +222,21 @@ import { SeoControlRefreshProcessor } from './processors/seo-control-refresh.pro
     CommandCenterOrchestratorService,
     RegenArtifactShadowPlanner, // shadow-2 ① planner regen-artifact (ADR-087)
     {
-      // Liste des planners shadow auto-enregistrés au boot de l'orchestrateur.
-      // shadow-3 ajoutera ici le planner pr-proposition.
-      provide: SHADOW_PLANNERS,
-      useFactory: (regen: RegenArtifactShadowPlanner) => [regen],
+      // shadow-3 ② planner pr-proposition : réutilise le planner regen comme source
+      // du would-be (composition). Fourni via factory car son ctor prend un ShadowPlanner.
+      provide: PrPropositionShadowPlanner,
+      useFactory: (regen: RegenArtifactShadowPlanner) =>
+        new PrPropositionShadowPlanner(regen),
       inject: [RegenArtifactShadowPlanner],
+    },
+    {
+      // Liste des planners shadow auto-enregistrés au boot de l'orchestrateur.
+      provide: SHADOW_PLANNERS,
+      useFactory: (
+        regen: RegenArtifactShadowPlanner,
+        prProp: PrPropositionShadowPlanner,
+      ) => [regen, prProp],
+      inject: [RegenArtifactShadowPlanner, PrPropositionShadowPlanner],
     },
     CommandCenterExecutionLedgerService, // shadow-2b ledger admin_audit (ADR-087)
     {

--- a/backend/src/modules/admin/services/command-center-orchestrator/pr-proposition.planner.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/pr-proposition.planner.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  type ExecutableActionKind,
+  type ExecutionPlan,
+} from './executable-action.contract';
+import { type ShadowPlanner } from './orchestrator.service';
+
+/**
+ * Gabarit de proposition de PR. shadow-3 n'en déclare qu'UN, adossé à une action
+ * mécanique & gouvernée : rafraîchir le snapshot Command Center. La proposition
+ * RÉUTILISE le planner regen-artifact comme source de l'effet would-be (composition,
+ * pas duplication) → `would_change` reflète l'état RÉEL de l'artefact (on ne propose un
+ * PR que s'il y a vraiment un diff — jamais de filler).
+ */
+interface PrTemplate {
+  readonly id: string;
+  /** action_id regen sous-jacent qui décide du would_change + porte le diff. */
+  readonly regenActionId: string;
+  readonly prTitle: string;
+  readonly commitMessage: string;
+  readonly base: string;
+  readonly files: readonly string[];
+  readonly rationale: string;
+}
+
+const PR_TEMPLATES: Readonly<Record<string, PrTemplate>> = {
+  'pr:command-center-snapshot-refresh': {
+    id: 'pr:command-center-snapshot-refresh',
+    regenActionId: 'regen:command-center-snapshot',
+    prTitle: 'chore(registry): refresh command-center-snapshot.json',
+    commitMessage:
+      'chore(registry): refresh command-center-snapshot.json (projection déterministe)',
+    base: 'main',
+    files: ['audit/registry/command-center-snapshot.json'],
+    rationale:
+      'Le snapshot est une projection déterministe de agent-operating-map.yaml ; le régénérer réaligne la projection committée sur la source.',
+  },
+};
+
+/** Levée si l'action_id ne correspond à aucun gabarit de PR connu (jamais de faux PR). */
+export class UnknownPrPropositionError extends Error {
+  constructor(actionId: string) {
+    super(
+      `Aucun gabarit de PR pour « ${actionId} » (gabarits: ${Object.keys(PR_TEMPLATES).join(', ')}).`,
+    );
+    this.name = 'UnknownPrPropositionError';
+  }
+}
+
+/** Compose un corps de PR markdown déterministe (aucune I/O, aucun appel gh). */
+function composePrBody(
+  tpl: PrTemplate,
+  wouldChange: boolean,
+  diff: unknown,
+): string {
+  const lines = [
+    `## Proposition (shadow — non créée)`,
+    ``,
+    tpl.rationale,
+    ``,
+    `- **Base** : \`${tpl.base}\``,
+    `- **Fichiers** : ${tpl.files.map((f) => `\`${f}\``).join(', ')}`,
+    `- **Commit** : \`${tpl.commitMessage}\``,
+    `- **Changement réel ?** : ${wouldChange ? 'OUI — diff ci-dessous' : 'NON — déjà à jour (aucun PR nécessaire)'}`,
+  ];
+  if (wouldChange && diff) {
+    lines.push('', '```json', JSON.stringify(diff, null, 2), '```');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Planner shadow ② « pr-proposition » (ADR-087, Phase 1 shadow-3).
+ *
+ * Pendant *human-reviewable* de `regen-artifact` : compose le BROUILLON de PR (titre,
+ * body, commit, fichiers) qu'un opérateur ouvrirait pour appliquer le changement — SANS
+ * créer de branche ni de PR (0 appel `gh`, 0 mutation, 0 réseau). `would_change` et le
+ * diff proviennent du planner regen sous-jacent (composition) → honnête par construction.
+ * `reversible=true` : une PR est revue + revert-able.
+ */
+@Injectable()
+export class PrPropositionShadowPlanner implements ShadowPlanner {
+  readonly kind: ExecutableActionKind = 'pr-proposition';
+  private readonly logger = new Logger(PrPropositionShadowPlanner.name);
+
+  /** Réutilise le planner regen comme source du would-be (injecté par DI). */
+  constructor(private readonly regen: ShadowPlanner) {}
+
+  static knownTemplates(): string[] {
+    return Object.keys(PR_TEMPLATES);
+  }
+
+  async plan(actionId: string): Promise<ExecutionPlan> {
+    const tpl = PR_TEMPLATES[actionId];
+    if (!tpl) throw new UnknownPrPropositionError(actionId);
+
+    // Source de vérité du changement : le planner regen sous-jacent (0 mutation).
+    const regenPlan = await this.regen.plan(tpl.regenActionId);
+    const wouldChange = regenPlan.would_change;
+    const diff = (regenPlan.details as { diff?: unknown }).diff ?? null;
+
+    this.logger.log(
+      `shadow pr-proposition ${actionId} → would_change=${wouldChange}`,
+    );
+
+    return {
+      action_id: actionId,
+      kind: this.kind,
+      summary: wouldChange
+        ? `Proposer une PR : ${tpl.prTitle}`
+        : `Aucune PR nécessaire (${tpl.files.join(', ')} déjà à jour)`,
+      would_change: wouldChange,
+      details: {
+        pr_title: tpl.prTitle,
+        commit_message: tpl.commitMessage,
+        base: tpl.base,
+        files: [...tpl.files],
+        pr_body: composePrBody(tpl, wouldChange, diff),
+        underlying_action: tpl.regenActionId,
+      },
+      // Une PR est revue par un humain puis revert-able → réversible.
+      reversible: true,
+    };
+  }
+}

--- a/backend/tests/unit/pr-proposition.planner.test.ts
+++ b/backend/tests/unit/pr-proposition.planner.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Planner shadow ② « pr-proposition » (ADR-087 shadow-3). Pendant human-reviewable de
+ * regen-artifact : compose un BROUILLON de PR à partir de l'effet would-be du planner
+ * regen sous-jacent — 0 appel `gh`, 0 mutation. `would_change` vient du regen (honnête).
+ */
+import {
+  PrPropositionShadowPlanner,
+  UnknownPrPropositionError,
+} from '../../src/modules/admin/services/command-center-orchestrator/pr-proposition.planner';
+import {
+  type ExecutionPlan,
+} from '../../src/modules/admin/services/command-center-orchestrator/executable-action.contract';
+import { type ShadowPlanner } from '../../src/modules/admin/services/command-center-orchestrator/orchestrator.service';
+
+function regenStub(plan: Partial<ExecutionPlan>): ShadowPlanner {
+  return {
+    kind: 'regen-artifact',
+    plan: async () => ({
+      action_id: 'regen:command-center-snapshot',
+      kind: 'regen-artifact',
+      summary: 'regen',
+      would_change: false,
+      details: {},
+      reversible: true,
+      ...plan,
+    }),
+  };
+}
+
+const TARGET = 'pr:command-center-snapshot-refresh';
+
+describe('PrPropositionShadowPlanner', () => {
+  it('kind = pr-proposition et expose ses gabarits', () => {
+    const p = new PrPropositionShadowPlanner(regenStub({}));
+    expect(p.kind).toBe('pr-proposition');
+    expect(PrPropositionShadowPlanner.knownTemplates()).toContain(TARGET);
+  });
+
+  it('action_id inconnu → UnknownPrPropositionError', async () => {
+    const p = new PrPropositionShadowPlanner(regenStub({}));
+    await expect(p.plan('pr:nope')).rejects.toBeInstanceOf(
+      UnknownPrPropositionError,
+    );
+  });
+
+  it('regen would_change=true → brouillon de PR complet + diff intégré', async () => {
+    const p = new PrPropositionShadowPlanner(
+      regenStub({ would_change: true, details: { diff: { added: 3 } } }),
+    );
+    const plan = await p.plan(TARGET);
+    expect(plan.kind).toBe('pr-proposition');
+    expect(plan.would_change).toBe(true);
+    expect(plan.reversible).toBe(true);
+    const d = plan.details as Record<string, unknown>;
+    expect(d.pr_title).toBe('chore(registry): refresh command-center-snapshot.json');
+    expect(d.files).toEqual(['audit/registry/command-center-snapshot.json']);
+    expect(d.underlying_action).toBe('regen:command-center-snapshot');
+    expect(String(d.pr_body)).toContain('OUI');
+    expect(String(d.pr_body)).toContain('"added": 3'); // diff sous-jacent intégré
+  });
+
+  it('regen would_change=false → no-op honnête (aucune PR nécessaire)', async () => {
+    const p = new PrPropositionShadowPlanner(regenStub({ would_change: false }));
+    const plan = await p.plan(TARGET);
+    expect(plan.would_change).toBe(false);
+    expect(plan.summary).toContain('Aucune PR nécessaire');
+    expect(String((plan.details as Record<string, unknown>).pr_body)).toContain(
+      'NON — déjà à jour',
+    );
+  });
+});


### PR DESCRIPTION
## Quoi

**shadow-3** — **dernier planner** de la Phase 1 « shadow » (ADR-087, ② `pr-proposition`). C'est le **pendant *human-reviewable*** de `regen-artifact` : il compose le **brouillon de PR** qu'un opérateur ouvrirait pour appliquer un changement, **sans jamais créer de branche ni de PR**.

Suite de #1010 (fondation), #1013 (regen-artifact), #1014 (ledger). **Clôt la Phase 1.**

## Comment (composition > duplication, honnête par construction)

- `PrPropositionShadowPlanner.plan(actionId)` compose : `pr_title`, `pr_body` (markdown), `commit_message`, `files`, `base` — **0 appel `gh`, 0 mutation, 0 réseau**.
- **`would_change` + le diff proviennent du planner `regen-artifact` sous-jacent** (injecté). Donc :
  - le planner ne propose une PR **que s'il y a un vrai changement** ;
  - sinon → **no-op explicite** : `would_change=false`, summary « Aucune PR nécessaire (… déjà à jour) ». Pas de filler, pas de PR fantôme.
- Cible Phase 1 = **UNE** : `pr:command-center-snapshot-refresh`, adossée à `regen:command-center-snapshot`. `action_id` inconnu → `UnknownPrPropositionError`.
- `reversible: true` (une PR est revue par un humain puis revert-able).

## Distinction avec regen-artifact (pourquoi 2 kinds)

| | `regen-artifact` (#1013) | `pr-proposition` (ce PR) |
|---|---|---|
| Sortie | le **diff** would-be | le **brouillon de PR** (titre + body + commit) |
| Consommateur Phase 2 | auto-apply (`auto`) | **humain** ouvre/approuve (`approved`) |

## Wiring DI

`PrPropositionShadowPlanner` fourni via **factory** (son ctor prend un `ShadowPlanner` → réutilise le regen), puis ajouté au tableau `SHADOW_PLANNERS` → auto-enregistré au boot de l'orchestrateur, à côté du regen.

## Garde-fous (inchangés)

- Flag `COMMAND_CENTER_ORCHESTRATION` **OFF par défaut**, **PROD forcé OFF**.
- `planShadow` throws hors `shadow`. Append-only ledger (#1014) trace chaque run.
- **0 mutation**, 0 réseau, 0 appel `gh`.

## Vérifications

- ✅ jest **31/31** (4 suites : orchestrateur + ledger + 2 planners).
- ✅ ESLint clean · `tsc --noEmit` 0 erreur (projet entier) · ast-grep onModuleInit-guard pass.

## Bilan Phase 1 « shadow » (ADR-087) — complète après ce merge

- modes `off|shadow` (approved|auto inertes, PROD forcé off) ;
- planners ① `regen-artifact` + ② `pr-proposition` ;
- ledger `__admin_audit_log` append-only (READ_ONLY-safe).

La **Phase 2** (`approved`, HITL, exécution réelle) reste une décision owner séparée (ADR-087).

## Déploiement

Aucune action runtime. Merge `main` → tag `:preprod` (CI). **Pas de tag PROD.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
