### PR TITLE
feat(command-center): expose orchestration shadow en read-only (GET statut + POST preview)

### DIFF
--- a/backend/src/modules/admin/controllers/command-center.controller.ts
+++ b/backend/src/modules/admin/controllers/command-center.controller.ts
@@ -1,17 +1,52 @@
 import {
+  BadRequestException,
+  Body,
+  ConflictException,
   Controller,
   Get,
   NotFoundException,
+  Post,
+  UnprocessableEntityException,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
+import { z, ZodError } from 'zod';
 import { AuthenticatedGuard } from '@auth/authenticated.guard';
 import { IsAdminGuard } from '@auth/is-admin.guard';
+import { User } from '../../../common/decorators/user.decorator';
 import { AdminResponseInterceptor } from '../../../common/interceptors/admin-response.interceptor';
 import {
   CommandCenterReaderService,
   CommandCenterResponse,
 } from '../services/command-center-reader.service';
+import {
+  CommandCenterOrchestratorService,
+  OrchestrationDisabledError,
+  UnsupportedExecutableActionError,
+} from '../services/command-center-orchestrator/orchestrator.service';
+import {
+  RegenDryRunError,
+  UnknownRegenTargetError,
+} from '../services/command-center-orchestrator/regen-artifact.planner';
+import { UnknownPrPropositionError } from '../services/command-center-orchestrator/pr-proposition.planner';
+import {
+  type ExecutionPlan,
+  type OrchestrationMode,
+} from '../services/command-center-orchestrator/executable-action.contract';
+
+/** Corps validé du preview shadow (kind aligné sur ExecutableActionKind). */
+const ShadowPlanRequestSchema = z
+  .object({
+    kind: z.enum(['regen-artifact', 'pr-proposition']),
+    action_id: z.string().min(1),
+  })
+  .strict();
+
+interface OrchestrationStatus {
+  mode: OrchestrationMode;
+  shadow_enabled: boolean;
+  supported_kinds: string[];
+}
 
 /**
  * Read-only admin endpoint backing the `/admin/command-center` cockpit.
@@ -22,20 +57,93 @@ import {
  * Exposure gated by COMMAND_CENTER_MODE (full/light/disabled; prod-safe default
  * = disabled in PROD). `disabled` → 404 (reduces surface, does not reveal data);
  * `light` → top-line health only (the reader strips internal detail).
+ *
+ * Orchestration (ADR-087) : deux endpoints additionnels exposent le mode `shadow`
+ * (introspection + preview du plan would-be). PROD = double-gardé : COMMAND_CENTER_MODE
+ * `disabled` → 404, ET orchestration `off` (forcée en PROD) → 409. Aucune mutation
+ * d'artefact ; le preview shadow trace au ledger admin_audit (comportement gouverné).
  */
 @Controller('api/admin/command-center')
 @UseGuards(AuthenticatedGuard, IsAdminGuard)
 @UseInterceptors(AdminResponseInterceptor)
 export class CommandCenterController {
-  constructor(private readonly reader: CommandCenterReaderService) {}
+  constructor(
+    private readonly reader: CommandCenterReaderService,
+    private readonly orchestrator: CommandCenterOrchestratorService,
+  ) {}
 
-  @Get()
-  async getSummary(): Promise<CommandCenterResponse> {
+  private assertExposed(): void {
     if (this.reader.getMode() === 'disabled') {
       throw new NotFoundException(
         'Command Center is disabled in this environment',
       );
     }
+  }
+
+  @Get()
+  async getSummary(): Promise<CommandCenterResponse> {
+    this.assertExposed();
     return this.reader.getCommandCenter();
+  }
+
+  /**
+   * Statut orchestration (introspection read-only) : mode courant + kinds supportés.
+   * Utile même en `off` (reporte « off »). Gardé sur COMMAND_CENTER_MODE disabled → 404.
+   */
+  @Get('orchestration')
+  getOrchestrationStatus(): OrchestrationStatus {
+    this.assertExposed();
+    return {
+      mode: this.orchestrator.getMode(),
+      shadow_enabled: this.orchestrator.isShadowEnabled(),
+      supported_kinds: this.orchestrator.supportedKinds(),
+    };
+  }
+
+  /**
+   * Preview d'un plan shadow *would-be* (ADR-087) : calcule l'effet sans muter l'artefact.
+   * Mode-gated : `planShadow` throw `OrchestrationDisabledError` hors `shadow` → 409.
+   * Validation Zod → 400 ; cible/kind inconnu → 400 ; dry-run générateur KO → 422.
+   */
+  @Post('orchestration/shadow')
+  async previewShadowPlan(
+    @Body() body: unknown,
+    @User('email') actorEmail?: string,
+  ): Promise<ExecutionPlan> {
+    this.assertExposed();
+
+    let parsed: z.infer<typeof ShadowPlanRequestSchema>;
+    try {
+      parsed = ShadowPlanRequestSchema.parse(body);
+    } catch (e) {
+      if (e instanceof ZodError) {
+        throw new BadRequestException(
+          `Requête invalide : ${e.issues.map((i) => i.message).join(', ')}`,
+        );
+      }
+      throw e;
+    }
+
+    try {
+      return await this.orchestrator.planShadow(parsed.kind, parsed.action_id, {
+        actor: actorEmail ?? 'admin',
+      });
+    } catch (e) {
+      // Mapping HTTP explicite — jamais de 500 opaque sur un cas attendu.
+      if (e instanceof OrchestrationDisabledError) {
+        throw new ConflictException(e.message); // 409 : orchestration ≠ shadow
+      }
+      if (
+        e instanceof UnsupportedExecutableActionError ||
+        e instanceof UnknownRegenTargetError ||
+        e instanceof UnknownPrPropositionError
+      ) {
+        throw new BadRequestException(e.message); // 400 : kind/cible inconnu
+      }
+      if (e instanceof RegenDryRunError) {
+        throw new UnprocessableEntityException(e.message); // 422 : dry-run impossible
+      }
+      throw e;
+    }
   }
 }

--- a/backend/tests/unit/command-center.controller.test.ts
+++ b/backend/tests/unit/command-center.controller.test.ts
@@ -1,0 +1,142 @@
+/**
+ * CommandCenterController — endpoints orchestration shadow (ADR-087, exposition read-only).
+ * Prouve : gate COMMAND_CENTER_MODE disabled → 404 ; mapping HTTP explicite des erreurs
+ * orchestrateur (off→409, kind/cible inconnu→400, dry-run KO→422, Zod→400) ; succès →
+ * renvoie le plan would-be. Aucun appel réel — orchestrateur + reader mockés.
+ */
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { CommandCenterController } from '../../src/modules/admin/controllers/command-center.controller';
+import {
+  OrchestrationDisabledError,
+  UnsupportedExecutableActionError,
+} from '../../src/modules/admin/services/command-center-orchestrator/orchestrator.service';
+import {
+  RegenDryRunError,
+  UnknownRegenTargetError,
+} from '../../src/modules/admin/services/command-center-orchestrator/regen-artifact.planner';
+import { type ExecutionPlan } from '../../src/modules/admin/services/command-center-orchestrator/executable-action.contract';
+
+const plan: ExecutionPlan = {
+  action_id: 'regen:command-center-snapshot',
+  kind: 'regen-artifact',
+  summary: 'ok',
+  would_change: false,
+  details: {},
+  reversible: true,
+};
+
+function make(opts: {
+  mode?: 'full' | 'light' | 'disabled';
+  orchMode?: string;
+  planShadow?: jest.Mock;
+}) {
+  const reader = { getMode: () => opts.mode ?? 'full' } as never;
+  const orchestrator = {
+    getMode: () => opts.orchMode ?? 'off',
+    isShadowEnabled: () => (opts.orchMode ?? 'off') === 'shadow',
+    supportedKinds: () => ['regen-artifact', 'pr-proposition'],
+    planShadow: opts.planShadow ?? jest.fn().mockResolvedValue(plan),
+  } as never;
+  return new CommandCenterController(reader, orchestrator);
+}
+
+describe('CommandCenterController — orchestration', () => {
+  it('getOrchestrationStatus reporte mode + kinds (même en off)', () => {
+    const c = make({ orchMode: 'off' });
+    expect(c.getOrchestrationStatus()).toEqual({
+      mode: 'off',
+      shadow_enabled: false,
+      supported_kinds: ['regen-artifact', 'pr-proposition'],
+    });
+  });
+
+  it('COMMAND_CENTER_MODE disabled → 404 sur status ET preview', async () => {
+    const c = make({ mode: 'disabled' });
+    expect(() => c.getOrchestrationStatus()).toThrow(NotFoundException);
+    await expect(
+      c.previewShadowPlan({ kind: 'regen-artifact', action_id: 'x' }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('body invalide (Zod) → 400', async () => {
+    const c = make({});
+    await expect(c.previewShadowPlan({ kind: 'nope' })).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    await expect(c.previewShadowPlan({})).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('orchestration off → OrchestrationDisabledError → 409', async () => {
+    const planShadow = jest
+      .fn()
+      .mockRejectedValue(new OrchestrationDisabledError('off'));
+    const c = make({ planShadow });
+    await expect(
+      c.previewShadowPlan({ kind: 'regen-artifact', action_id: 'x' }),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('kind/cible inconnu → 400', async () => {
+    const c1 = make({
+      planShadow: jest
+        .fn()
+        .mockRejectedValue(new UnsupportedExecutableActionError('regen-artifact')),
+    });
+    await expect(
+      c1.previewShadowPlan({ kind: 'regen-artifact', action_id: 'x' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    const c2 = make({
+      planShadow: jest.fn().mockRejectedValue(new UnknownRegenTargetError('x')),
+    });
+    await expect(
+      c2.previewShadowPlan({ kind: 'regen-artifact', action_id: 'x' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('dry-run générateur KO → 422', async () => {
+    const c = make({
+      planShadow: jest
+        .fn()
+        .mockRejectedValue(new RegenDryRunError('x', 'introuvable')),
+    });
+    await expect(
+      c.previewShadowPlan({ kind: 'regen-artifact', action_id: 'x' }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityException);
+  });
+
+  it('succès → renvoie le plan + propage actor (email)', async () => {
+    const planShadow = jest.fn().mockResolvedValue(plan);
+    const c = make({ orchMode: 'shadow', planShadow });
+    const res = await c.previewShadowPlan(
+      { kind: 'regen-artifact', action_id: 'regen:command-center-snapshot' },
+      'fafa@automecanik.com',
+    );
+    expect(res).toEqual(plan);
+    expect(planShadow).toHaveBeenCalledWith(
+      'regen-artifact',
+      'regen:command-center-snapshot',
+      { actor: 'fafa@automecanik.com' },
+    );
+  });
+
+  it('actor absent → défaut « admin »', async () => {
+    const planShadow = jest.fn().mockResolvedValue(plan);
+    const c = make({ orchMode: 'shadow', planShadow });
+    await c.previewShadowPlan({
+      kind: 'pr-proposition',
+      action_id: 'pr:command-center-snapshot-refresh',
+    });
+    expect(planShadow).toHaveBeenCalledWith(
+      'pr-proposition',
+      'pr:command-center-snapshot-refresh',
+      { actor: 'admin' },
+    );
+  });
+});


### PR DESCRIPTION
## Quoi

Rend la capacité **shadow** (ADR-087, mergée via #1010→#1015) **utilisable et observable** côté admin. Jusqu'ici l'orchestrateur, les planners et le ledger existaient mais **rien n'appelait `planShadow`** — aucune surface. Ce PR **étend le controller Command Center existant** (pas de nouveau module) avec deux endpoints read-only.

## Endpoints (admin-only, guards inchangés)

- **`GET /api/admin/command-center/orchestration`** — introspection : `{ mode, shadow_enabled, supported_kinds }`. Utile même en `off` (reporte « off »).
- **`POST /api/admin/command-center/orchestration/shadow`** `{ kind, action_id }` — calcule le **plan would-be** via `planShadow`. **0 mutation d'artefact** ; en shadow le preview trace au ledger `admin_audit` (comportement gouverné). `actor` = email admin (`@User`).

## Garde-fous & mapping HTTP explicite

Jamais de 500 opaque sur un cas attendu :

| Situation | Code |
|---|---|
| `COMMAND_CENTER_MODE=disabled` (défaut PROD) | **404** (double-garde, sur les 2 endpoints) |
| Orchestration ≠ `shadow` (off / PROD forcé) → `OrchestrationDisabledError` | **409** |
| Body invalide (Zod `.strict()`) ou kind/cible inconnu | **400** |
| Dry-run générateur impossible (`RegenDryRunError`) | **422** |
| Succès | **200** + `ExecutionPlan` would-be |

**PROD double-gardé** : `COMMAND_CENTER_MODE` disabled → 404, ET orchestration forcée `off` → 409. Rien d'exécutable, 0 mutation.

## Réutilise l'existant (pas de bricolage)

- Controller, guards (`AuthenticatedGuard`+`IsAdminGuard`), `AdminResponseInterceptor` : **étendus**, pas recréés.
- `@User('email')` (`common/decorators/user.decorator.ts`) pour l'actor.
- Validation Zod `.parse()` → `BadRequestException` (pattern `seo-control.controller`).
- `planShadow(kind, action_id, {actor})` (mergé) inchangé.

## Vérifications

- ✅ jest **8/8** (gate disabled→404, mapping 409/400/422, succès + propagation actor).
- ✅ ESLint clean · `tsc --noEmit` 0 erreur.
- ⚠️ **Smoke runtime live = post-merge** (resync DEV) : DEV:3000 sert `main` et la règle no-alt-port interdit un repro sur port alternatif. Couvert d'ici là par les unit tests (mapping HTTP complet) + l'E2E Smoke CI.

## Périmètre

Backend-only (l'endpoint = l'enabler). Une carte cockpit frontend (affichage du plan would-be) serait un follow-up séparé pour garder le blast radius minimal. **Pas de Phase 2** : ceci reste du shadow read-only (0 mutation d'artefact).

## Déploiement

Aucune action runtime. Merge `main` → tag `:preprod` (CI). **Pas de tag PROD.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
