### PR TITLE
feat(command-center): onglet cockpit Orchestration (statut + preview shadow, read-only)

### DIFF
--- a/frontend/app/components/command-center/OrchestrationPanel.tsx
+++ b/frontend/app/components/command-center/OrchestrationPanel.tsx
@@ -1,0 +1,208 @@
+/**
+ * OrchestrationPanel — onglet « Orchestration » du Command Center (ADR-087, shadow).
+ *
+ * Read-only + preview. Affiche le mode d'orchestration courant (off|shadow|…) et les
+ * kinds supportés, et permet de PRÉVISUALISER un plan *would-be* (POST .../shadow) —
+ * 0 mutation d'artefact. Le backend reste la source de vérité : l'action_id est en
+ * texte libre, validé côté serveur (400 si inconnu, 409 si mode ≠ shadow, 422 si
+ * dry-run KO) — pas de catalogue dupliqué ici.
+ */
+import { Form, useNavigation } from "@remix-run/react";
+import {
+  Activity,
+  PlayCircle,
+  AlertTriangle,
+  CheckCircle2,
+} from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+
+export interface OrchestrationStatus {
+  mode: "off" | "shadow" | "approved" | "auto";
+  shadow_enabled: boolean;
+  supported_kinds: string[];
+}
+
+export interface ShadowPlanView {
+  action_id: string;
+  kind: string;
+  summary: string;
+  would_change: boolean;
+  reversible: boolean;
+  details: Record<string, unknown>;
+}
+
+export type OrchestrationActionData =
+  | { ok: true; plan: ShadowPlanView }
+  | { ok: false; error: string };
+
+function modeBadgeVariant(
+  mode: OrchestrationStatus["mode"],
+): "secondary" | "success" {
+  return mode === "shadow" ? "success" : "secondary";
+}
+
+export function OrchestrationPanel({
+  status,
+  result,
+}: {
+  status: OrchestrationStatus | null;
+  result?: OrchestrationActionData;
+}) {
+  const navigation = useNavigation();
+  const submitting = navigation.state === "submitting";
+
+  if (!status) {
+    return (
+      <Alert
+        variant="info"
+        icon={<AlertTriangle className="h-5 w-5" aria-hidden />}
+      >
+        <AlertTitle>Orchestration indisponible</AlertTitle>
+        <AlertDescription>
+          L&apos;API d&apos;orchestration n&apos;est pas exposée dans cet
+          environnement (Command Center désactivé, ou backend antérieur à
+          ADR-087).
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Activity className="h-4 w-4" aria-hidden /> Orchestration (ADR-087)
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="text-muted-foreground">Mode :</span>
+            <Badge variant={modeBadgeVariant(status.mode)}>{status.mode}</Badge>
+            {status.shadow_enabled ? (
+              <span className="text-muted-foreground">
+                — calcul <em>would-be</em> uniquement, 0 mutation
+                d&apos;artefact.
+              </span>
+            ) : (
+              <span className="text-muted-foreground">
+                — inactif (défaut). Active via{" "}
+                <code className="text-xs">
+                  COMMAND_CENTER_ORCHESTRATION=shadow
+                </code>{" "}
+                en DEV/PREPROD ; PROD est forcé{" "}
+                <code className="text-xs">off</code>.
+              </span>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="text-muted-foreground">Kinds supportés :</span>
+            {status.supported_kinds.length > 0 ? (
+              status.supported_kinds.map((k) => (
+                <Badge key={k} variant="outline">
+                  {k}
+                </Badge>
+              ))
+            ) : (
+              <span className="text-muted-foreground">aucun</span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <PlayCircle className="h-4 w-4" aria-hidden /> Prévisualiser un plan
+            (shadow)
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Form
+            method="post"
+            className="flex flex-col gap-3 sm:flex-row sm:items-end"
+          >
+            <div className="flex flex-col gap-1">
+              <label htmlFor="orch-kind" className="text-sm font-medium">
+                Kind
+              </label>
+              <select
+                id="orch-kind"
+                name="kind"
+                className="h-9 rounded-md border bg-background px-3 text-sm"
+                defaultValue={status.supported_kinds[0] ?? "regen-artifact"}
+              >
+                {status.supported_kinds.map((k) => (
+                  <option key={k} value={k}>
+                    {k}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-1 flex-col gap-1">
+              <label htmlFor="orch-action-id" className="text-sm font-medium">
+                action_id
+              </label>
+              <input
+                id="orch-action-id"
+                name="action_id"
+                required
+                placeholder="regen:command-center-snapshot"
+                className="h-9 rounded-md border bg-background px-3 text-sm"
+              />
+            </div>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Calcul…" : "Prévisualiser"}
+            </Button>
+          </Form>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Exemples : <code>regen:command-center-snapshot</code>{" "}
+            (regen-artifact) · <code>pr:command-center-snapshot-refresh</code>{" "}
+            (pr-proposition). Le backend valide l&apos;action_id
+            (404/400/409/422 surfacés).
+          </p>
+
+          {result ? (
+            <div className="mt-4">
+              {result.ok ? (
+                <Alert
+                  variant={result.plan.would_change ? "warning" : "success"}
+                  icon={
+                    result.plan.would_change ? (
+                      <AlertTriangle className="h-5 w-5" aria-hidden />
+                    ) : (
+                      <CheckCircle2 className="h-5 w-5" aria-hidden />
+                    )
+                  }
+                >
+                  <AlertTitle>
+                    {result.plan.would_change
+                      ? "Changement détecté (would-be)"
+                      : "Aucun changement (déjà à jour)"}
+                  </AlertTitle>
+                  <AlertDescription>
+                    <p className="mb-2">{result.plan.summary}</p>
+                    <pre className="max-h-80 overflow-auto rounded-md bg-muted p-3 text-xs">
+                      {JSON.stringify(result.plan.details, null, 2)}
+                    </pre>
+                  </AlertDescription>
+                </Alert>
+              ) : (
+                <Alert
+                  variant="error"
+                  icon={<AlertTriangle className="h-5 w-5" aria-hidden />}
+                >
+                  <AlertTitle>Prévisualisation refusée</AlertTitle>
+                  <AlertDescription>{result.error}</AlertDescription>
+                </Alert>
+              )}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/routes/admin.command-center.tsx
+++ b/frontend/app/routes/admin.command-center.tsx
@@ -7,15 +7,25 @@
  * global_status/health_score_current). Never throws on a data error — renders a
  * degraded banner so the page is always reachable (the backend already returns
  * 200 + degraded:true when the snapshot file is absent).
+ *
+ * Onglet « Orchestration » (ADR-087) : statut read-only + preview d'un plan shadow
+ * *would-be* (action POST → backend). 0 mutation d'artefact ; le backend valide.
  */
 import {
+  type ActionFunctionArgs,
   type LoaderFunctionArgs,
   json,
   type MetaFunction,
 } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
+import { useActionData, useLoaderData } from "@remix-run/react";
 import { type CommandCenterResponse } from "@repo/registry";
-import { AlertTriangle, Boxes, GitBranch, FileWarning } from "lucide-react";
+import {
+  AlertTriangle,
+  Boxes,
+  GitBranch,
+  FileWarning,
+  Workflow,
+} from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Badge } from "~/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
@@ -36,6 +46,12 @@ import { GlobalHealthBar } from "~/components/command-center/GlobalHealthBar";
 import { OwnerActionQueue } from "~/components/command-center/OwnerActionQueue";
 import { ModuleGrid } from "~/components/command-center/ModuleGrid";
 import { CertBadge } from "~/components/command-center/badges";
+import {
+  OrchestrationPanel,
+  type OrchestrationActionData,
+  type OrchestrationStatus,
+  type ShadowPlanView,
+} from "~/components/command-center/OrchestrationPanel";
 
 export const meta: MetaFunction = () =>
   createNoIndexMeta("Command Center — Admin");
@@ -74,6 +90,34 @@ function degraded(
   };
 }
 
+/** Best-effort fetch du statut orchestration (null si indisponible — surfacé dans l'UI). */
+async function fetchOrchestration(
+  request: Request,
+): Promise<OrchestrationStatus | null> {
+  try {
+    const res = await fetch(
+      getInternalApiUrlFromRequest(
+        "/api/admin/command-center/orchestration",
+        request,
+      ),
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: request.headers.get("Cookie") || "",
+        },
+      },
+    );
+    if (!res.ok) return null;
+    const body = (await res.json()) as {
+      data?: OrchestrationStatus;
+    } & OrchestrationStatus;
+    return body.data ?? (body as OrchestrationStatus);
+  } catch (e) {
+    logger.warn(`[command-center] orchestration status failed: ${e}`);
+    return null;
+  }
+}
+
 export async function loader({ request, context }: LoaderFunctionArgs) {
   await requireAdmin({ context }); // 401/403 → redirect (auth errors are NOT degraded)
 
@@ -89,30 +133,87 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     );
     if (res.status === 404) {
       // COMMAND_CENTER_MODE=disabled (prod-safe default) → endpoint 404s.
-      return json(
-        degraded(
+      return json({
+        cc: degraded(
           "Command Center désactivé dans cet environnement.",
           "disabled",
         ),
-      );
+        orchestration: null as OrchestrationStatus | null,
+      });
     }
     if (!res.ok) {
       logger.warn(`[command-center] API ${res.status} — rendering degraded`);
-      return json(degraded(`backend API ${res.status}`));
+      return json({
+        cc: degraded(`backend API ${res.status}`),
+        orchestration: null as OrchestrationStatus | null,
+      });
     }
     const body = (await res.json()) as {
       data?: CommandCenterResponse;
     } & CommandCenterResponse;
     // AdminResponseInterceptor wraps as { success, data, meta }.
-    return json(body.data ?? (body as CommandCenterResponse));
+    const cc = body.data ?? (body as CommandCenterResponse);
+    const orchestration =
+      cc.mode === "disabled" ? null : await fetchOrchestration(request);
+    return json({ cc, orchestration });
   } catch (e) {
     logger.error(`[command-center] fetch failed: ${e}`);
-    return json(degraded("backend unreachable"));
+    return json({
+      cc: degraded("backend unreachable"),
+      orchestration: null as OrchestrationStatus | null,
+    });
+  }
+}
+
+export async function action({
+  request,
+  context,
+}: ActionFunctionArgs): Promise<
+  ReturnType<typeof json<OrchestrationActionData>>
+> {
+  await requireAdmin({ context });
+  const form = await request.formData();
+  const kind = String(form.get("kind") ?? "");
+  const action_id = String(form.get("action_id") ?? "");
+
+  try {
+    const res = await fetch(
+      getInternalApiUrlFromRequest(
+        "/api/admin/command-center/orchestration/shadow",
+        request,
+      ),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: request.headers.get("Cookie") || "",
+        },
+        body: JSON.stringify({ kind, action_id }),
+      },
+    );
+    const body = (await res.json().catch(() => ({}))) as {
+      data?: ShadowPlanView;
+      message?: string | string[];
+    } & ShadowPlanView;
+    if (!res.ok) {
+      const msg = Array.isArray(body.message)
+        ? body.message.join(", ")
+        : (body.message ?? `Erreur backend ${res.status}`);
+      return json({ ok: false, error: msg }, { status: res.status });
+    }
+    const plan = body.data ?? (body as ShadowPlanView);
+    return json({ ok: true, plan });
+  } catch (e) {
+    logger.error(`[command-center] shadow preview failed: ${e}`);
+    return json({ ok: false, error: "Backend injoignable." }, { status: 502 });
   }
 }
 
 export default function AdminCommandCenter() {
-  const data = useLoaderData<typeof loader>() as CommandCenterResponse;
+  const { cc, orchestration } = useLoaderData<typeof loader>();
+  const result = useActionData<typeof action>() as
+    | OrchestrationActionData
+    | undefined;
 
   return (
     <div className="space-y-6 p-4 sm:p-6">
@@ -120,13 +221,13 @@ export default function AdminCommandCenter() {
         <h1 className="text-2xl font-bold tracking-tight">AI Command Center</h1>
         <p className="text-sm text-muted-foreground">
           Projection lecture-seule de la carte opérationnelle IA —{" "}
-          {data.summary.departments_total} départements ·{" "}
-          {data.summary.capabilities_certified}/
-          {data.summary.capabilities_total} capacités certifiées
+          {cc.summary.departments_total} départements ·{" "}
+          {cc.summary.capabilities_certified}/{cc.summary.capabilities_total}{" "}
+          capacités certifiées
         </p>
       </header>
 
-      {data.mode === "disabled" ? (
+      {cc.mode === "disabled" ? (
         <Alert
           variant="info"
           icon={<AlertTriangle className="h-5 w-5" aria-hidden />}
@@ -137,22 +238,22 @@ export default function AdminCommandCenter() {
             Le correctif Docker registry reste actif partout.
           </AlertDescription>
         </Alert>
-      ) : data.degraded ? (
+      ) : cc.degraded ? (
         <Alert
           variant="error"
           icon={<AlertTriangle className="h-5 w-5" aria-hidden />}
         >
           <AlertTitle>Command Center indisponible</AlertTitle>
           <AlertDescription>
-            {data.global_status.reasons[0] ??
+            {cc.global_status.reasons[0] ??
               "Snapshot absent. Générez-le (npm run governance:command-center) puis rechargez."}
           </AlertDescription>
         </Alert>
       ) : (
         <>
-          <GlobalHealthBar data={data} />
+          <GlobalHealthBar data={cc} />
 
-          {data.mode === "light" ? (
+          {cc.mode === "light" ? (
             <p className="text-sm text-muted-foreground">
               Mode light — synthèse de santé uniquement. Le détail
               (départements, capacités, handoffs, actions) est disponible en
@@ -165,22 +266,30 @@ export default function AdminCommandCenter() {
                 <TabsTrigger value="departments">Départements</TabsTrigger>
                 <TabsTrigger value="handoffs">Handoffs</TabsTrigger>
                 <TabsTrigger value="capabilities">Capacités</TabsTrigger>
+                <TabsTrigger value="orchestration">
+                  <Workflow className="mr-1 h-4 w-4" aria-hidden />
+                  Orchestration
+                </TabsTrigger>
               </TabsList>
 
               <TabsContent value="actions" className="mt-4">
-                <OwnerActionQueue data={data} />
+                <OwnerActionQueue data={cc} />
               </TabsContent>
 
               <TabsContent value="departments" className="mt-4">
-                <ModuleGrid data={data} />
+                <ModuleGrid data={cc} />
               </TabsContent>
 
               <TabsContent value="handoffs" className="mt-4">
-                <HandoffList data={data} />
+                <HandoffList data={cc} />
               </TabsContent>
 
               <TabsContent value="capabilities" className="mt-4">
-                <CapabilityTable data={data} />
+                <CapabilityTable data={cc} />
+              </TabsContent>
+
+              <TabsContent value="orchestration" className="mt-4">
+                <OrchestrationPanel status={orchestration} result={result} />
               </TabsContent>
             </Tabs>
           )}


### PR DESCRIPTION
## Quoi

Rend la capacité **shadow** (ADR-087) **visible et utilisable** dans le cockpit `/admin/command-center`. Le backend exposait déjà les endpoints (#1016) ; ce PR ajoute la **moitié UI** : un onglet « Orchestration ». **Étend** la route + les composants `command-center/` existants — aucune route parallèle.

## Contenu

- **`OrchestrationPanel.tsx`** *(new)* :
  - **Statut** : mode (`off`/`shadow`/…), `shadow_enabled`, `kinds` supportés. Explique comment activer (`COMMAND_CENTER_ORCHESTRATION=shadow` en DEV/PREPROD ; PROD forcé `off`).
  - **Preview** : formulaire (kind + action_id) → affiche le plan **would-be** : `would_change`, summary, détails (diff / corps de PR) dans un `<pre>`.
- **route** :
  - loader : fetch additionnel `GET …/orchestration` (best-effort → `null` si indispo, **surfacé** « indisponible » ; jamais de crash) ;
  - `action` Remix : `POST …/orchestration/shadow` → renvoie le plan ou l'**erreur backend** (400/409/422 surfacés dans l'UI).

## Pas de bricolage

- **`action_id` en texte libre validé côté serveur** → pas de catalogue dupliqué côté front (le backend reste SoT ; 400 si inconnu). Exemples montrés en hint, pas en registre parallèle.
- shadcn/ui + Tailwind + lucide-react uniquement, pas d'import `React`, pas d'inline-style (conventions `frontend.md`).
- a11y : `<label htmlFor>`, `aria-hidden` sur icônes, `<caption className="sr-only">` (hérité). Responsive `flex-col → sm:flex-row`.
- **0 mutation d'artefact** (preview = calcul would-be ; trace ledger en shadow, gouverné). **Pas de Phase 2.**

## Vérifications

- ✅ `tsc --noEmit` : **0 erreur sur mes fichiers** (seul subsiste `web-vitals/attribution`, **pré-existant sur `main`**, hors périmètre — artefact résolu en CI).
- ✅ Prettier : conforme.
- ⚠️ ESLint local non exécutable (config Remix transitive absente du symlink worktree) → **CI fait foi**.
- ⚠️ Smoke runtime live = **post-merge** (resync DEV) — DEV:3000 sert `main`, règle no-alt-port.

## Déploiement

Frontend-only. Aucune action runtime. Merge `main` → tag `:preprod` (CI). **Pas de tag PROD.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
