### PR TITLE
feat(command-center): expose le catalogue d'actions shadow via l'API

### DIFF
--- a/backend/src/modules/admin/controllers/command-center.controller.ts
+++ b/backend/src/modules/admin/controllers/command-center.controller.ts
@@ -46,6 +46,8 @@ interface OrchestrationStatus {
   mode: OrchestrationMode;
   shadow_enabled: boolean;
   supported_kinds: string[];
+  /** Catalogue (kind × action_id) prévisualisable — backend SoT, l'UI consomme. */
+  available_actions: { kind: string; action_id: string }[];
 }
 
 /**
@@ -97,6 +99,7 @@ export class CommandCenterController {
       mode: this.orchestrator.getMode(),
       shadow_enabled: this.orchestrator.isShadowEnabled(),
       supported_kinds: this.orchestrator.supportedKinds(),
+      available_actions: this.orchestrator.availableActions(),
     };
   }
 

--- a/backend/src/modules/admin/services/command-center-orchestrator/orchestrator.service.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/orchestrator.service.ts
@@ -58,6 +58,14 @@ export class UnsupportedExecutableActionError extends Error {
 export interface ShadowPlanner {
   readonly kind: ExecutableActionKind;
   plan(actionId: string): Promise<ExecutionPlan>;
+  /** action_id que ce planner sait traiter (catalogue exposé à l'UI). Optionnel. */
+  listActionIds?(): string[];
+}
+
+/** Une action exécutable disponible (kind + action_id) — catalogue pour l'UI. */
+export interface AvailableAction {
+  kind: ExecutableActionKind;
+  action_id: string;
 }
 
 /**
@@ -132,6 +140,21 @@ export class CommandCenterOrchestratorService implements OnModuleInit {
   /** Liste des kinds actuellement supportés (vide en shadow-1). */
   supportedKinds(): ExecutableActionKind[] {
     return [...this.planners.keys()];
+  }
+
+  /**
+   * Catalogue des actions disponibles (kind × action_id), agrégé depuis les planners
+   * enregistrés — le backend est SoT, l'UI consomme (pas de liste dupliquée côté front).
+   * Un planner sans `listActionIds` n'expose aucune action (mais reste appelable par id).
+   */
+  availableActions(): AvailableAction[] {
+    const out: AvailableAction[] = [];
+    for (const planner of this.planners.values()) {
+      for (const action_id of planner.listActionIds?.() ?? []) {
+        out.push({ kind: planner.kind, action_id });
+      }
+    }
+    return out;
   }
 
   /**

--- a/backend/src/modules/admin/services/command-center-orchestrator/pr-proposition.planner.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/pr-proposition.planner.ts
@@ -90,6 +90,11 @@ export class PrPropositionShadowPlanner implements ShadowPlanner {
     return Object.keys(PR_TEMPLATES);
   }
 
+  /** Catalogue exposé à l'orchestrateur (ShadowPlanner.listActionIds). */
+  listActionIds(): string[] {
+    return PrPropositionShadowPlanner.knownTemplates();
+  }
+
   async plan(actionId: string): Promise<ExecutionPlan> {
     const tpl = PR_TEMPLATES[actionId];
     if (!tpl) throw new UnknownPrPropositionError(actionId);

--- a/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.planner.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.planner.ts
@@ -107,6 +107,11 @@ export class RegenArtifactShadowPlanner implements ShadowPlanner {
     return Object.keys(REGEN_TARGETS);
   }
 
+  /** Catalogue exposé à l'orchestrateur (ShadowPlanner.listActionIds). */
+  listActionIds(): string[] {
+    return RegenArtifactShadowPlanner.knownTargets();
+  }
+
   /**
    * Repo root, ancré EXACTEMENT comme `CommandCenterReaderService` (REGISTRY_DIR/../..),
    * pour éviter le piège cwd=backend/ en Docker (start.sh fait `cd backend`).

--- a/backend/tests/unit/command-center-orchestrator.service.test.ts
+++ b/backend/tests/unit/command-center-orchestrator.service.test.ts
@@ -117,6 +117,24 @@ describe('CommandCenterOrchestratorService — squelette inerte', () => {
     expect(() => s.registerPlanner(fakePlanner)).toThrow(/déjà enregistré/);
   });
 
+  it('availableActions agrège listActionIds des planners (vide si non implémenté)', () => {
+    // fakePlanner n'a PAS listActionIds → aucune action exposée
+    const s0 = new CommandCenterOrchestratorService();
+    s0.registerPlanner(fakePlanner);
+    expect(s0.availableActions()).toEqual([]);
+    // planner avec catalogue → agrégé
+    const s1 = new CommandCenterOrchestratorService();
+    s1.registerPlanner({
+      kind: 'regen-artifact',
+      plan: async () => fakePlan,
+      listActionIds: () => ['regen:a', 'regen:b'],
+    });
+    expect(s1.availableActions()).toEqual([
+      { kind: 'regen-artifact', action_id: 'regen:a' },
+      { kind: 'regen-artifact', action_id: 'regen:b' },
+    ]);
+  });
+
   it('onModuleInit : sync, ne throw jamais ; silencieux en off, log en shadow', () => {
     // off (défaut) → aucun log de confirmation
     setEnv(undefined, 'development');

--- a/backend/tests/unit/command-center.controller.test.ts
+++ b/backend/tests/unit/command-center.controller.test.ts
@@ -40,18 +40,24 @@ function make(opts: {
     getMode: () => opts.orchMode ?? 'off',
     isShadowEnabled: () => (opts.orchMode ?? 'off') === 'shadow',
     supportedKinds: () => ['regen-artifact', 'pr-proposition'],
+    availableActions: () => [
+      { kind: 'regen-artifact', action_id: 'regen:command-center-snapshot' },
+    ],
     planShadow: opts.planShadow ?? jest.fn().mockResolvedValue(plan),
   } as never;
   return new CommandCenterController(reader, orchestrator);
 }
 
 describe('CommandCenterController — orchestration', () => {
-  it('getOrchestrationStatus reporte mode + kinds (même en off)', () => {
+  it('getOrchestrationStatus reporte mode + kinds + catalogue (même en off)', () => {
     const c = make({ orchMode: 'off' });
     expect(c.getOrchestrationStatus()).toEqual({
       mode: 'off',
       shadow_enabled: false,
       supported_kinds: ['regen-artifact', 'pr-proposition'],
+      available_actions: [
+        { kind: 'regen-artifact', action_id: 'regen:command-center-snapshot' },
+      ],
     });
   });
 

--- a/backend/tests/unit/pr-proposition.planner.test.ts
+++ b/backend/tests/unit/pr-proposition.planner.test.ts
@@ -34,6 +34,7 @@ describe('PrPropositionShadowPlanner', () => {
     const p = new PrPropositionShadowPlanner(regenStub({}));
     expect(p.kind).toBe('pr-proposition');
     expect(PrPropositionShadowPlanner.knownTemplates()).toContain(TARGET);
+    expect(p.listActionIds()).toContain(TARGET);
   });
 
   it('action_id inconnu → UnknownPrPropositionError', async () => {

--- a/backend/tests/unit/regen-artifact.planner.test.ts
+++ b/backend/tests/unit/regen-artifact.planner.test.ts
@@ -26,6 +26,8 @@ describe('RegenArtifactShadowPlanner', () => {
     expect(RegenArtifactShadowPlanner.knownTargets()).toContain(
       'regen:command-center-snapshot',
     );
+    // listActionIds (catalogue orchestrateur) = mêmes cibles
+    expect(p.listActionIds()).toContain('regen:command-center-snapshot');
   });
 
   it('action_id inconnu → UnknownRegenTargetError (jamais de faux plan)', async () => {


### PR DESCRIPTION
## Quoi

Le statut orchestration (`GET /api/admin/command-center/orchestration`) renvoie désormais **`available_actions`** — la liste `(kind × action_id)` prévisualisable, **agrégée depuis les planners enregistrés**. Le **backend devient SoT du catalogue**.

**Pourquoi** : le panel cockpit (#1017) utilise aujourd'hui un champ `action_id` en texte libre + des exemples affichés en *hint* (légère duplication). Exposer le catalogue par l'API permet à l'UI de le **consommer** (menu déroulant) sans dupliquer la liste côté front. C'est un correctif structurel (single SoT), pas juste cosmétique.

## Comment (réutilise l'existant)

- `ShadowPlanner.listActionIds?(): string[]` (optionnel) + `AvailableAction { kind, action_id }` + `CommandCenterOrchestratorService.availableActions()` qui agrège les planners.
- `regen-artifact` / `pr-proposition` implémentent `listActionIds()` en **déléguant** à leurs cibles/gabarits existants (`knownTargets()` / `knownTemplates()`) — aucune nouvelle source.
- Un planner sans `listActionIds` n'expose rien (mais reste appelable par id) → rétro-compat.
- `GET …/orchestration` ajoute `available_actions` (additif).

## Garde-fous

- **Additif pur**, 0 mutation, périmètre shadow inchangé (flag OFF défaut, PROD off, mode-gated).
- Read-only (introspection).

## Vérifications

- ✅ jest **40/40** (orchestrateur + 2 planners + controller + ledger).
- ✅ ESLint clean · `tsc --noEmit` 0 erreur (projet entier).

## Suite

Frontend follow-up : remplacer le champ texte libre du panel par un `<select>` alimenté par `available_actions` (consomme ce catalogue).

## Déploiement

Backend-only. Aucune action runtime. Merge `main` → tag `:preprod` (CI). **Pas de tag PROD.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
