### PR TITLE
feat(command-center): Phase 2a — squelette HITL approved (executeApproved, inerte)

### DIFF
--- a/backend/src/modules/admin/controllers/command-center.controller.ts
+++ b/backend/src/modules/admin/controllers/command-center.controller.ts
@@ -5,6 +5,7 @@ import {
   Controller,
   Get,
   NotFoundException,
+  NotImplementedException,
   Post,
   UnprocessableEntityException,
   UseGuards,
@@ -21,7 +22,9 @@ import {
 } from '../services/command-center-reader.service';
 import {
   CommandCenterOrchestratorService,
+  NoExecutorError,
   OrchestrationDisabledError,
+  PlanHashMismatchError,
   UnsupportedExecutableActionError,
 } from '../services/command-center-orchestrator/orchestrator.service';
 import {
@@ -31,6 +34,7 @@ import {
 import { UnknownPrPropositionError } from '../services/command-center-orchestrator/pr-proposition.planner';
 import {
   type ExecutionPlan,
+  type ExecutionReceipt,
   type OrchestrationMode,
 } from '../services/command-center-orchestrator/executable-action.contract';
 
@@ -39,6 +43,16 @@ const ShadowPlanRequestSchema = z
   .object({
     kind: z.enum(['regen-artifact', 'pr-proposition']),
     action_id: z.string().min(1),
+  })
+  .strict();
+
+/** Corps validé d'une exécution approuvée (HITL) : preview → approve avec le plan_hash. */
+const ApproveRequestSchema = z
+  .object({
+    kind: z.enum(['regen-artifact', 'pr-proposition']),
+    action_id: z.string().min(1),
+    /** hash du plan prévisualisé que l'humain approuve (garde TOCTOU). */
+    plan_hash: z.string().min(1),
   })
   .strict();
 
@@ -145,6 +159,61 @@ export class CommandCenterController {
       }
       if (e instanceof RegenDryRunError) {
         throw new UnprocessableEntityException(e.message); // 422 : dry-run impossible
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Exécute une action APPROUVÉE (Phase 2, HITL). Étape 2 du flux preview→approve :
+   * l'opérateur renvoie le `plan_hash` du plan qu'il a prévisualisé. Mapping HTTP :
+   * mode ≠ approved → 409 ; plan_hash périmé → 409 ; kind/cible inconnu → 400 ;
+   * dry-run KO → 422 ; aucun executor branché (Phase 2a) → 501 Not Implemented.
+   */
+  @Post('orchestration/approve')
+  async approveExecution(
+    @Body() body: unknown,
+    @User('email') actorEmail?: string,
+  ): Promise<ExecutionReceipt> {
+    this.assertExposed();
+
+    let parsed: z.infer<typeof ApproveRequestSchema>;
+    try {
+      parsed = ApproveRequestSchema.parse(body);
+    } catch (e) {
+      if (e instanceof ZodError) {
+        throw new BadRequestException(
+          `Requête invalide : ${e.issues.map((i) => i.message).join(', ')}`,
+        );
+      }
+      throw e;
+    }
+
+    try {
+      return await this.orchestrator.executeApproved(
+        parsed.kind,
+        parsed.action_id,
+        { actor: actorEmail ?? 'admin', plan_hash: parsed.plan_hash },
+      );
+    } catch (e) {
+      if (
+        e instanceof OrchestrationDisabledError ||
+        e instanceof PlanHashMismatchError
+      ) {
+        throw new ConflictException(e.message); // 409 : mode≠approved ou plan périmé
+      }
+      if (
+        e instanceof UnsupportedExecutableActionError ||
+        e instanceof UnknownRegenTargetError ||
+        e instanceof UnknownPrPropositionError
+      ) {
+        throw new BadRequestException(e.message); // 400 : kind/cible inconnu
+      }
+      if (e instanceof RegenDryRunError) {
+        throw new UnprocessableEntityException(e.message); // 422 : recalcul impossible
+      }
+      if (e instanceof NoExecutorError) {
+        throw new NotImplementedException(e.message); // 501 : aucun executor (Phase 2a)
       }
       throw e;
     }

--- a/backend/src/modules/admin/services/command-center-orchestrator/executable-action.contract.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/executable-action.contract.ts
@@ -56,6 +56,26 @@ export interface ExecutionLedgerEntry {
   /** hash déterministe du plan (dédup / idempotence). */
   plan_hash: string;
   would_change: boolean;
+  /** true = exécution réelle approuvée (Phase 2) ; absent/false = run shadow (Phase 1). */
+  executed?: boolean;
+}
+
+/**
+ * Reçu d'une exécution approuvée (Phase 2). Décrit ce qui A ÉTÉ fait (par opposition à
+ * `ExecutionPlan` = ce qui SERAIT fait) + comment l'annuler. `applied=false` ⇒ no-op
+ * (plan `would_change=false`). `reverted_by` porte l'inverse exact (réversibilité ADR-087).
+ */
+export interface ExecutionReceipt {
+  action_id: string;
+  kind: ExecutableActionKind;
+  /** une mutation a-t-elle réellement été appliquée ? false = no-op (rien à faire). */
+  applied: boolean;
+  /** hash du plan exécuté (= celui approuvé par l'humain ; traçabilité). */
+  plan_hash: string;
+  /** commande/inverse exact pour annuler (ex. `git checkout <fichier>`, `gh pr close N`). */
+  reverted_by: string | null;
+  /** détail structuré du résultat (ex. PR url, octets écrits). */
+  details: Record<string, unknown>;
 }
 
 /**
@@ -75,8 +95,10 @@ export function resolveOrchestrationMode(): OrchestrationMode {
     raw === 'auto' ||
     raw === 'off'
   ) {
-    // Phase 1 : seuls off|shadow sont implémentés ; approved|auto restent inertes ici.
-    return raw === 'approved' || raw === 'auto' ? 'off' : raw;
+    // Phase 2a : off|shadow|approved sont résolus ; `auto` (exécution sans humain)
+    // n'est PAS implémenté → reste inerte (→ off). Le mode `approved` est HITL : il ne
+    // mute qu'avec une approbation explicite + un executor branché (sinon throw).
+    return raw === 'auto' ? 'off' : raw;
   }
   return 'off';
 }

--- a/backend/src/modules/admin/services/command-center-orchestrator/execution-ledger.service.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/execution-ledger.service.ts
@@ -46,6 +46,8 @@ export class CommandCenterExecutionLedgerService extends SupabaseBaseService {
           mode: entry.mode,
           plan_hash: entry.plan_hash,
           would_change: entry.would_change,
+          // Phase 2 : distingue une exécution réelle approuvée d'un run shadow.
+          ...(entry.executed ? { executed: true } : {}),
         },
         aal_metadata: null,
       });

--- a/backend/src/modules/admin/services/command-center-orchestrator/orchestrator.service.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/orchestrator.service.ts
@@ -11,6 +11,7 @@ import {
   type ExecutableActionKind,
   type ExecutionLedgerEntry,
   type ExecutionPlan,
+  type ExecutionReceipt,
   type OrchestrationMode,
 } from './executable-action.contract';
 
@@ -54,12 +55,45 @@ export class UnsupportedExecutableActionError extends Error {
   }
 }
 
-/** Un planner calcule un ExecutionPlan *would-be* pour une action (0 mutation). */
+/**
+ * Levée si le `plan_hash` approuvé ne correspond plus au plan recalculé (Phase 2, HITL) :
+ * l'état a changé entre la prévisualisation et l'approbation → on REFUSE d'exécuter
+ * (garde TOCTOU — l'humain a approuvé un plan qui n'est plus à jour).
+ */
+export class PlanHashMismatchError extends Error {
+  constructor() {
+    super(
+      "Le plan a changé depuis l'approbation (plan_hash ≠) — exécution refusée, re-prévisualisez.",
+    );
+    this.name = 'PlanHashMismatchError';
+  }
+}
+
+/**
+ * Levée si une exécution approuvée est demandée mais que le planner n'expose aucun
+ * `apply` (Phase 2a : aucun executor branché → rien ne mute). No-silent-fallback.
+ */
+export class NoExecutorError extends Error {
+  constructor(kind: ExecutableActionKind) {
+    super(
+      `Aucun executor branché pour le kind « ${kind} » — exécution réelle indisponible (Phase 2a).`,
+    );
+    this.name = 'NoExecutorError';
+  }
+}
+
+/**
+ * Un planner calcule un ExecutionPlan *would-be* (0 mutation) et, en Phase 2, peut
+ * OPTIONNELLEMENT exposer `apply` pour exécuter réellement (HITL). Absence d'`apply` =
+ * pas d'exécution possible pour ce kind.
+ */
 export interface ShadowPlanner {
   readonly kind: ExecutableActionKind;
   plan(actionId: string): Promise<ExecutionPlan>;
   /** action_id que ce planner sait traiter (catalogue exposé à l'UI). Optionnel. */
   listActionIds?(): string[];
+  /** Phase 2 : exécute réellement l'action (mute). Absent = exécution indisponible. */
+  apply?(actionId: string): Promise<ExecutionReceipt>;
 }
 
 /** Une action exécutable disponible (kind + action_id) — catalogue pour l'UI. */
@@ -159,8 +193,9 @@ export class CommandCenterOrchestratorService implements OnModuleInit {
 
   /**
    * Calcule un plan *would-be* (0 mutation) PUIS le trace au ledger (append-only).
-   * Throws si l'orchestration n'est pas en `shadow`, ou si aucun planner n'existe pour
-   * ce kind — jamais de fallback silencieux.
+   * Autorisé en `shadow` ET `approved` (la prévisualisation précède toujours l'exécution).
+   * Throws si l'orchestration est `off`, ou si aucun planner n'existe pour ce kind —
+   * jamais de fallback silencieux.
    *
    * L'append ledger est best-effort-MAIS-surfacé : un échec de trace (READ_ONLY PREPROD,
    * erreur DB) n'invalide PAS le plan (le calcul a réussi) → on log un warn, on ne throw
@@ -172,7 +207,9 @@ export class CommandCenterOrchestratorService implements OnModuleInit {
     opts?: { actor?: string },
   ): Promise<ExecutionPlan> {
     const mode = this.getMode();
-    if (mode !== 'shadow') throw new OrchestrationDisabledError(mode);
+    if (mode !== 'shadow' && mode !== 'approved') {
+      throw new OrchestrationDisabledError(mode);
+    }
     const planner = this.planners.get(kind);
     if (!planner) throw new UnsupportedExecutableActionError(kind);
 
@@ -194,5 +231,79 @@ export class CommandCenterOrchestratorService implements OnModuleInit {
     }
 
     return plan;
+  }
+
+  /**
+   * Exécute RÉELLEMENT une action approuvée (Phase 2, HITL, mode `approved`). Suite de
+   * gardes, dans l'ordre (no-silent-fallback) :
+   *   1. mode === `approved` (sinon `OrchestrationDisabledError`) ;
+   *   2. planner existe (sinon `UnsupportedExecutableActionError`) ;
+   *   3. on RECALCULE le plan et on vérifie `plan_hash` ⇒ l'humain a approuvé CE plan
+   *      exact ; s'il a changé depuis (état muté) → `PlanHashMismatchError` (garde TOCTOU) ;
+   *   4. `would_change=false` ⇒ no-op : on renvoie un reçu `applied=false` SANS muter ;
+   *   5. le planner doit exposer `apply` (sinon `NoExecutorError` — Phase 2a n'en branche
+   *      AUCUN, donc rien ne mute tant qu'un executor n'est pas ajouté en Phase 2b).
+   * L'exécution réelle + son reçu sont tracés au ledger (`executed:true`).
+   */
+  async executeApproved(
+    kind: ExecutableActionKind,
+    actionId: string,
+    opts: { actor: string; plan_hash: string },
+  ): Promise<ExecutionReceipt> {
+    const mode = this.getMode();
+    if (mode !== 'approved') throw new OrchestrationDisabledError(mode);
+    const planner = this.planners.get(kind);
+    if (!planner) throw new UnsupportedExecutableActionError(kind);
+
+    // Recalcul + garde TOCTOU : l'approbation porte sur un plan figé (plan_hash).
+    const plan = await planner.plan(actionId);
+    if (computePlanHash(plan) !== opts.plan_hash) {
+      throw new PlanHashMismatchError();
+    }
+
+    // No-op : rien à appliquer (déjà à jour) → reçu applied=false, AUCUNE mutation.
+    if (!plan.would_change) {
+      const receipt: ExecutionReceipt = {
+        action_id: actionId,
+        kind,
+        applied: false,
+        plan_hash: opts.plan_hash,
+        reverted_by: null,
+        details: { reason: 'no-op (would_change=false)' },
+      };
+      await this.recordExecution(opts.actor, receipt, mode);
+      return receipt;
+    }
+
+    // Exécution réelle — requiert un executor (Phase 2a : aucun → throw, 0 mutation).
+    if (!planner.apply) throw new NoExecutorError(kind);
+    const receipt = await planner.apply(actionId);
+    this.logger.warn(
+      `EXÉCUTION approuvée appliquée : ${actionId} (applied=${receipt.applied}, revert=${receipt.reverted_by ?? 'n/a'})`,
+    );
+    await this.recordExecution(opts.actor, receipt, mode);
+    return receipt;
+  }
+
+  /** Trace une exécution approuvée au ledger (executed:true), échec surfacé. */
+  private async recordExecution(
+    actor: string,
+    receipt: ExecutionReceipt,
+    mode: OrchestrationMode,
+  ): Promise<void> {
+    if (!this.ledger) return;
+    const result = await this.ledger.record({
+      actor,
+      action_id: receipt.action_id,
+      mode,
+      plan_hash: receipt.plan_hash,
+      would_change: receipt.applied,
+      executed: true,
+    });
+    if (!result.recorded) {
+      this.logger.warn(
+        `exécution NON tracée (${receipt.action_id}) : ${result.reason ?? 'raison inconnue'}`,
+      );
+    }
   }
 }

--- a/backend/tests/unit/command-center-orchestrator.service.test.ts
+++ b/backend/tests/unit/command-center-orchestrator.service.test.ts
@@ -8,10 +8,13 @@ import {
   computePlanHash,
   resolveOrchestrationMode,
   type ExecutionPlan,
+  type ExecutionReceipt,
 } from '../../src/modules/admin/services/command-center-orchestrator/executable-action.contract';
 import {
   CommandCenterOrchestratorService,
+  NoExecutorError,
   OrchestrationDisabledError,
+  PlanHashMismatchError,
   UnsupportedExecutableActionError,
   type ShadowLedgerSink,
   type ShadowPlanner,
@@ -51,10 +54,15 @@ describe('resolveOrchestrationMode — défaut OFF, PROD toujours OFF', () => {
     expect(resolveOrchestrationMode()).toBe('off');
   });
 
-  it('approved/auto = off en Phase 1 (inerte, non implémentés)', () => {
+  it('approved résolu (Phase 2a, HITL) ; auto reste inerte → off', () => {
     setEnv('approved', 'development');
+    expect(resolveOrchestrationMode()).toBe('approved');
+    setEnv('AUTO', 'preprod'); // auto non implémenté → off
     expect(resolveOrchestrationMode()).toBe('off');
-    setEnv('auto', 'development');
+  });
+
+  it('PROD = off même si le flag dit approved', () => {
+    setEnv('approved', 'production');
     expect(resolveOrchestrationMode()).toBe('off');
   });
 
@@ -257,6 +265,106 @@ describe('computePlanHash — déterministe & sensible', () => {
     );
     expect(computePlanHash({ ...base, details: { a: 2 } })).not.toBe(
       computePlanHash(base),
+    );
+  });
+});
+
+describe('executeApproved — HITL Phase 2a (inerte : 0 executor branché)', () => {
+  const changingPlan: ExecutionPlan = {
+    action_id: 'regen:x',
+    kind: 'regen-artifact',
+    summary: 's',
+    would_change: true,
+    details: { a: 1 },
+    reversible: true,
+  };
+  const noopPlan: ExecutionPlan = { ...changingPlan, would_change: false };
+  const HASH = computePlanHash(changingPlan);
+
+  function plannerFor(
+    plan: ExecutionPlan,
+    apply?: ShadowPlanner['apply'],
+  ): ShadowPlanner {
+    return { kind: 'regen-artifact', plan: async () => plan, apply };
+  }
+  function svc(planner: ShadowPlanner, ledger?: ShadowLedgerSink) {
+    const s = new CommandCenterOrchestratorService([planner], ledger);
+    s.onModuleInit();
+    return s;
+  }
+
+  it('mode ≠ approved → OrchestrationDisabledError', async () => {
+    setEnv('shadow', 'development');
+    const s = svc(plannerFor(changingPlan));
+    await expect(
+      s.executeApproved('regen-artifact', 'regen:x', {
+        actor: 'a',
+        plan_hash: HASH,
+      }),
+    ).rejects.toBeInstanceOf(OrchestrationDisabledError);
+  });
+
+  it('plan_hash périmé → PlanHashMismatchError (garde TOCTOU)', async () => {
+    setEnv('approved', 'development');
+    const s = svc(plannerFor(changingPlan));
+    await expect(
+      s.executeApproved('regen-artifact', 'regen:x', {
+        actor: 'a',
+        plan_hash: 'stale-hash',
+      }),
+    ).rejects.toBeInstanceOf(PlanHashMismatchError);
+  });
+
+  it('would_change=false → no-op (applied:false), 0 executor appelé', async () => {
+    setEnv('approved', 'development');
+    const apply = jest.fn();
+    const s = svc(plannerFor(noopPlan, apply));
+    const receipt = await s.executeApproved('regen-artifact', 'regen:x', {
+      actor: 'a',
+      plan_hash: computePlanHash(noopPlan),
+    });
+    expect(receipt.applied).toBe(false);
+    expect(receipt.reverted_by).toBeNull();
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('would_change=true SANS apply → NoExecutorError (Phase 2a inerte)', async () => {
+    setEnv('approved', 'development');
+    const s = svc(plannerFor(changingPlan)); // pas d'apply
+    await expect(
+      s.executeApproved('regen-artifact', 'regen:x', {
+        actor: 'a',
+        plan_hash: HASH,
+      }),
+    ).rejects.toBeInstanceOf(NoExecutorError);
+  });
+
+  it('would_change=true AVEC apply → exécute + trace executed:true', async () => {
+    setEnv('approved', 'development');
+    const receiptOut: ExecutionReceipt = {
+      action_id: 'regen:x',
+      kind: 'regen-artifact',
+      applied: true,
+      plan_hash: HASH,
+      reverted_by: 'git checkout file',
+      details: {},
+    };
+    const apply = jest.fn().mockResolvedValue(receiptOut);
+    const record = jest.fn().mockResolvedValue({ recorded: true });
+    const s = svc(plannerFor(changingPlan, apply), { record });
+    const out = await s.executeApproved('regen-artifact', 'regen:x', {
+      actor: 'fafa',
+      plan_hash: HASH,
+    });
+    expect(out).toEqual(receiptOut);
+    expect(apply).toHaveBeenCalledWith('regen:x');
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: 'fafa',
+        mode: 'approved',
+        executed: true,
+        plan_hash: HASH,
+      }),
     );
   });
 });

--- a/backend/tests/unit/command-center.controller.test.ts
+++ b/backend/tests/unit/command-center.controller.test.ts
@@ -8,11 +8,14 @@ import {
   BadRequestException,
   ConflictException,
   NotFoundException,
+  NotImplementedException,
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { CommandCenterController } from '../../src/modules/admin/controllers/command-center.controller';
 import {
+  NoExecutorError,
   OrchestrationDisabledError,
+  PlanHashMismatchError,
   UnsupportedExecutableActionError,
 } from '../../src/modules/admin/services/command-center-orchestrator/orchestrator.service';
 import {
@@ -34,6 +37,7 @@ function make(opts: {
   mode?: 'full' | 'light' | 'disabled';
   orchMode?: string;
   planShadow?: jest.Mock;
+  executeApproved?: jest.Mock;
 }) {
   const reader = { getMode: () => opts.mode ?? 'full' } as never;
   const orchestrator = {
@@ -44,6 +48,16 @@ function make(opts: {
       { kind: 'regen-artifact', action_id: 'regen:command-center-snapshot' },
     ],
     planShadow: opts.planShadow ?? jest.fn().mockResolvedValue(plan),
+    executeApproved:
+      opts.executeApproved ??
+      jest.fn().mockResolvedValue({
+        action_id: 'regen:command-center-snapshot',
+        kind: 'regen-artifact',
+        applied: false,
+        plan_hash: 'h',
+        reverted_by: null,
+        details: {},
+      }),
   } as never;
   return new CommandCenterController(reader, orchestrator);
 }
@@ -143,6 +157,72 @@ describe('CommandCenterController — orchestration', () => {
       'pr-proposition',
       'pr:command-center-snapshot-refresh',
       { actor: 'admin' },
+    );
+  });
+});
+
+describe('CommandCenterController — approve (Phase 2a HITL)', () => {
+  const okBody = {
+    kind: 'regen-artifact',
+    action_id: 'regen:command-center-snapshot',
+    plan_hash: 'h',
+  };
+
+  it('body invalide (plan_hash manquant) → 400', async () => {
+    const c = make({});
+    await expect(
+      c.approveExecution({ kind: 'regen-artifact', action_id: 'x' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('mode ≠ approved → 409', async () => {
+    const c = make({
+      executeApproved: jest
+        .fn()
+        .mockRejectedValue(new OrchestrationDisabledError('shadow')),
+    });
+    await expect(c.approveExecution(okBody)).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+  });
+
+  it('plan_hash périmé → 409', async () => {
+    const c = make({
+      executeApproved: jest.fn().mockRejectedValue(new PlanHashMismatchError()),
+    });
+    await expect(c.approveExecution(okBody)).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+  });
+
+  it('aucun executor (Phase 2a) → 501 Not Implemented', async () => {
+    const c = make({
+      executeApproved: jest
+        .fn()
+        .mockRejectedValue(new NoExecutorError('regen-artifact')),
+    });
+    await expect(c.approveExecution(okBody)).rejects.toBeInstanceOf(
+      NotImplementedException,
+    );
+  });
+
+  it('succès → renvoie le reçu + propage actor + plan_hash', async () => {
+    const receipt = {
+      action_id: 'regen:command-center-snapshot',
+      kind: 'regen-artifact',
+      applied: false,
+      plan_hash: 'h',
+      reverted_by: null,
+      details: {},
+    };
+    const executeApproved = jest.fn().mockResolvedValue(receipt);
+    const c = make({ orchMode: 'approved', executeApproved });
+    const res = await c.approveExecution(okBody, 'fafa@automecanik.com');
+    expect(res).toEqual(receipt);
+    expect(executeApproved).toHaveBeenCalledWith(
+      'regen-artifact',
+      'regen:command-center-snapshot',
+      { actor: 'fafa@automecanik.com', plan_hash: 'h' },
     );
   });
 });


### PR DESCRIPTION
## Quoi

**Phase 2a** — première brique de la **Phase 2** d'ADR-087 (exécution réelle, HITL), sur **GO owner explicite**. C'est le **squelette `approved` INERTE** : il pose tout le contrat HITL (mode, approbation, garde anti-TOCTOU, ledger) **mais ne branche AUCUN executor → rien ne peut muter**.

C'est l'analogue, côté Phase 2, de ce que shadow-1 (#1010) était pour la Phase 1 : la fondation sûre d'abord, les exécuteurs ensuite.

## Comment (chaîne de gardes, no-silent-fallback)

- `resolveOrchestrationMode` : **`approved` devient résolvable** (flag-gated, **PROD forcé `off`**) ; `auto` (sans humain) reste **non implémenté → off**.
- `executeApproved(kind, action_id, { actor, plan_hash })` :
  1. `mode === approved` (sinon `OrchestrationDisabledError` → **409**) ;
  2. planner existe (sinon **400**) ;
  3. **garde TOCTOU** : on **recalcule** le plan et on exige `plan_hash` == celui approuvé ; s'il a changé depuis la prévisualisation (état muté) → `PlanHashMismatchError` → **409** ;
  4. `would_change=false` ⇒ **no-op** (`applied:false`, **0 mutation**) ;
  5. le planner doit exposer `apply` — **Phase 2a n'en branche AUCUN** → `NoExecutorError` → **501 Not Implemented**.
- `ExecutionReceipt` = ce qui **A** été fait + `reverted_by` (l'inverse exact pour annuler). Exécution réelle tracée au ledger `executed:true`.
- `planShadow` autorisé en `shadow` **ET** `approved` (le preview précède toujours l'approbation).
- Controller : `POST /api/admin/command-center/orchestration/approve`.

## Flux HITL (2 étapes)

1. **preview** : `POST .../orchestration/shadow` → `ExecutionPlan` + `plan_hash` (le client le calcule/affiche) ;
2. **approve** : l'humain renvoie `POST .../orchestration/approve { kind, action_id, plan_hash }` → exécution **uniquement si le plan n'a pas changé**.

## Garde-fous

- **Flag OFF par défaut, PROD forcé OFF**, `auto` non implémenté.
- **0 mutation possible** : sans executor, `executeApproved` throw toujours (501) pour tout `would_change=true`.
- Réversibilité de premier ordre (`reverted_by`) inscrite dans le contrat.

## Hors-scope (décision séparée)

Le **1er executor réel = Phase 2b**, après décision du **mécanisme d'exécution** : ouvrir une **PR** via git+`gh` (réversible = close PR, gouverné = review+CI) nécessite un token GitHub côté backend → **décision infra/owner distincte**. Je ne l'assume pas ici.

## Vérifications

- ✅ jest **51/51** (orchestrateur + controller + ledger + 2 planners).
- ✅ ESLint clean · `tsc --noEmit` 0 erreur · ast-grep onModuleInit-guard pass.

## Déploiement

Backend-only, additif. Aucune action runtime. Merge `main` → tag `:preprod`. **Pas de tag PROD.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
