### PR TITLE
feat(command-center): Phase 2b — executor regen-artifact via PR draft (double-gardé, inerte)

### DIFF
--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -29,6 +29,7 @@ import {
   SHADOW_LEDGER,
 } from './services/command-center-orchestrator/orchestrator.service';
 import { RegenArtifactShadowPlanner } from './services/command-center-orchestrator/regen-artifact.planner';
+import { RegenArtifactExecutor } from './services/command-center-orchestrator/regen-artifact.executor';
 import { PrPropositionShadowPlanner } from './services/command-center-orchestrator/pr-proposition.planner';
 import { CommandCenterExecutionLedgerService } from './services/command-center-orchestrator/execution-ledger.service';
 import { ConfigurationController } from './controllers/configuration.controller';
@@ -220,6 +221,7 @@ import { SeoControlRefreshProcessor } from './processors/seo-control-refresh.pro
     CommandCenterReaderService,
     CommandCenterActionsService,
     CommandCenterOrchestratorService,
+    RegenArtifactExecutor, // Phase 2b : executor PR-based (double-gardé, inerte par défaut)
     RegenArtifactShadowPlanner, // shadow-2 ① planner regen-artifact (ADR-087)
     {
       // shadow-3 ② planner pr-proposition : réutilise le planner regen comme source

--- a/backend/src/modules/admin/controllers/command-center.controller.ts
+++ b/backend/src/modules/admin/controllers/command-center.controller.ts
@@ -7,6 +7,7 @@ import {
   NotFoundException,
   NotImplementedException,
   Post,
+  ServiceUnavailableException,
   UnprocessableEntityException,
   UseGuards,
   UseInterceptors,
@@ -31,6 +32,10 @@ import {
   RegenDryRunError,
   UnknownRegenTargetError,
 } from '../services/command-center-orchestrator/regen-artifact.planner';
+import {
+  ExecutorDisabledError,
+  ExecutorUnavailableError,
+} from '../services/command-center-orchestrator/regen-artifact.executor';
 import { UnknownPrPropositionError } from '../services/command-center-orchestrator/pr-proposition.planner';
 import {
   type ExecutionPlan,
@@ -214,6 +219,12 @@ export class CommandCenterController {
       }
       if (e instanceof NoExecutorError) {
         throw new NotImplementedException(e.message); // 501 : aucun executor (Phase 2a)
+      }
+      if (e instanceof ExecutorDisabledError) {
+        throw new ConflictException(e.message); // 409 : executor non activé (flag 2 off)
+      }
+      if (e instanceof ExecutorUnavailableError) {
+        throw new ServiceUnavailableException(e.message); // 503 : git/gh indispo/échec
       }
       throw e;
     }

--- a/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.executor.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.executor.ts
@@ -1,0 +1,186 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { type ExecutionReceipt } from './executable-action.contract';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Exécute git/gh sans shell (pas d'injection) avec timeout borné. Injectable pour les
+ * tests (qui passent un runner factice — aucune commande réelle lancée).
+ */
+export type CommandRunner = (
+  cmd: string,
+  args: string[],
+  cwd?: string,
+) => Promise<{ stdout: string }>;
+
+const defaultRunner: CommandRunner = async (cmd, args, cwd) => {
+  const { stdout } = await execFileAsync(cmd, args, {
+    cwd,
+    timeout: 120_000,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return { stdout };
+};
+
+/**
+ * Levée si l'executor réel n'est pas activé par le 2ᵉ flag explicite. Le mode `approved`
+ * (flag 1) ouvre le flux HITL ; OUVRIR une PR (flag 2 `COMMAND_CENTER_EXECUTOR=pr`) est une
+ * activation séparée — merger ce code ne change donc RIEN par défaut.
+ */
+export class ExecutorDisabledError extends Error {
+  constructor() {
+    super(
+      "Executor d'exécution non activé — poser COMMAND_CENTER_EXECUTOR=pr (DEV/PREPROD) pour autoriser l'ouverture de PR.",
+    );
+    this.name = 'ExecutorDisabledError';
+  }
+}
+
+/** Levée si git/gh est indisponible ou échoue (pas de succès fictif, pas d'état laissé). */
+export class ExecutorUnavailableError extends Error {
+  constructor(cause: string) {
+    super(`Exécution PR impossible (git/gh) : ${cause}`);
+    this.name = 'ExecutorUnavailableError';
+  }
+}
+
+/** Cible exécutable d'un regen-artifact (artefact + générateur + métadonnées PR). */
+export interface RegenExecTarget {
+  readonly action_id: string;
+  readonly committedRel: string;
+  readonly generatorRel: string;
+  readonly prTitle: string;
+  readonly commitMessage: string;
+  readonly base: string;
+  readonly branchPrefix: string;
+}
+
+/**
+ * Executor « regen-artifact » (Phase 2b) — exécute RÉELLEMENT une régénération approuvée
+ * en **ouvrant une PR draft**, le mécanisme le plus sûr (réversible = close PR ; gouverné
+ * = review + CI + **merge humain** ; rien n'atterrit sur `main` automatiquement).
+ *
+ * Double garde : (1) mode `approved` (géré par l'orchestrateur) + (2) flag explicite
+ * `COMMAND_CENTER_EXECUTOR=pr`. Isolation : travaille dans un **worktree git temporaire**
+ * (jamais le checkout runtime → 0 working tree sali). `execFile` (pas de shell). Échec
+ * git/gh → throw franc, worktree nettoyé en `finally`. PROD : l'orchestrateur force `off`.
+ */
+@Injectable()
+export class RegenArtifactExecutor {
+  private readonly logger = new Logger(RegenArtifactExecutor.name);
+  /** Identité de commit dédiée (pas l'opérateur ; traçable). */
+  private static readonly GIT_NAME = 'command-center-orchestrator';
+  private static readonly GIT_EMAIL = 'orchestrator@automecanik.local';
+
+  private readonly run: CommandRunner;
+
+  // `@Optional()` : aucun provider `CommandRunner` (c'est un type) → NestJS passe
+  // undefined ⇒ fallback `defaultRunner`. Les tests injectent un runner factice.
+  constructor(@Optional() run?: CommandRunner) {
+    this.run = run ?? defaultRunner;
+  }
+
+  /** 2ᵉ garde explicite : ouvrir des PR exige `COMMAND_CENTER_EXECUTOR=pr`. */
+  static isEnabled(): boolean {
+    return (
+      (process.env.COMMAND_CENTER_EXECUTOR || '').trim().toLowerCase() === 'pr'
+    );
+  }
+
+  /**
+   * Régénère l'artefact dans un worktree isolé, pousse une branche, ouvre une PR draft.
+   * `planHash` est porté dans le reçu (traçabilité de ce qui a été approuvé).
+   */
+  async execute(
+    target: RegenExecTarget,
+    repoRoot: string,
+    planHash: string,
+  ): Promise<ExecutionReceipt> {
+    if (!RegenArtifactExecutor.isEnabled()) throw new ExecutorDisabledError();
+
+    const branch = `${target.branchPrefix}-${planHash.slice(0, 12)}`;
+    const wt = mkdtempSync(join(tmpdir(), 'cc-regen-'));
+    try {
+      // worktree isolé sur origin/main (jamais le checkout runtime).
+      await this.run('git', [
+        '-C',
+        repoRoot,
+        'worktree',
+        'add',
+        '-b',
+        branch,
+        wt,
+        'origin/main',
+      ]);
+      // régénère l'artefact (le générateur écrit DANS le worktree temporaire).
+      await this.run('node', [join(wt, target.generatorRel)], wt);
+      await this.run('git', ['-C', wt, 'add', target.committedRel]);
+      await this.run('git', [
+        '-C',
+        wt,
+        '-c',
+        `user.name=${RegenArtifactExecutor.GIT_NAME}`,
+        '-c',
+        `user.email=${RegenArtifactExecutor.GIT_EMAIL}`,
+        'commit',
+        '-m',
+        target.commitMessage,
+      ]);
+      await this.run('git', ['-C', wt, 'push', '-u', 'origin', branch]);
+      const { stdout } = await this.run(
+        'gh',
+        [
+          'pr',
+          'create',
+          '--draft',
+          '--base',
+          target.base,
+          '--head',
+          branch,
+          '--title',
+          target.prTitle,
+          '--body',
+          `Régénération approuvée (HITL, ADR-087 Phase 2). plan_hash=${planHash}. À relire + merger humainement.`,
+        ],
+        wt,
+      );
+      const prUrl = stdout.trim();
+      this.logger.warn(`PR d'exécution ouverte (draft) : ${prUrl} [${branch}]`);
+      return {
+        action_id: target.action_id,
+        kind: 'regen-artifact',
+        applied: true,
+        plan_hash: planHash,
+        // Réversibilité de premier ordre : fermer la PR (rien n'a été mergé).
+        reverted_by: `gh pr close ${prUrl}`,
+        details: { pr_url: prUrl, branch, base: target.base },
+      };
+    } catch (e) {
+      throw new ExecutorUnavailableError((e as Error).message);
+    } finally {
+      // Nettoyage best-effort du worktree temporaire (jamais d'état laissé).
+      try {
+        await this.run('git', [
+          '-C',
+          repoRoot,
+          'worktree',
+          'remove',
+          '--force',
+          wt,
+        ]);
+      } catch {
+        /* worktree déjà absent / non créé */
+      }
+      try {
+        rmSync(wt, { recursive: true, force: true });
+      } catch {
+        /* déjà nettoyé */
+      }
+    }
+  }
+}

--- a/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.planner.ts
+++ b/backend/src/modules/admin/services/command-center-orchestrator/regen-artifact.planner.ts
@@ -2,12 +2,19 @@ import { execFile } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import {
+  computePlanHash,
   type ExecutableActionKind,
   type ExecutionPlan,
+  type ExecutionReceipt,
 } from './executable-action.contract';
 import { type ShadowPlanner } from './orchestrator.service';
+import {
+  ExecutorUnavailableError,
+  RegenArtifactExecutor,
+  type RegenExecTarget,
+} from './regen-artifact.executor';
 
 const execFileAsync = promisify(execFile);
 
@@ -26,6 +33,10 @@ interface RegenTarget {
   readonly generatorRel: string;
   /** résumé humain de l'effet would-be. */
   readonly summary: string;
+  /** métadonnées d'exécution réelle (Phase 2 : ouverture de PR). */
+  readonly prTitle: string;
+  readonly commitMessage: string;
+  readonly branchPrefix: string;
 }
 
 const REGEN_TARGETS: Readonly<Record<string, RegenTarget>> = {
@@ -35,6 +46,10 @@ const REGEN_TARGETS: Readonly<Record<string, RegenTarget>> = {
     generatorRel: 'scripts/governance/build-command-center-snapshot.js',
     summary:
       'Régénérer command-center-snapshot.json depuis agent-operating-map.yaml (projection déterministe).',
+    prTitle: 'chore(registry): refresh command-center-snapshot.json',
+    commitMessage:
+      'chore(registry): refresh command-center-snapshot.json (projection déterministe, HITL ADR-087)',
+    branchPrefix: 'cc-auto/regen-command-center-snapshot',
   },
 };
 
@@ -101,6 +116,13 @@ export class RegenArtifactShadowPlanner implements ShadowPlanner {
   private static readonly DRY_RUN_TIMEOUT_MS = 30_000;
   /** stdout du snapshot peut être volumineux (déterministe, mais large). */
   private static readonly DRY_RUN_MAX_BUFFER = 32 * 1024 * 1024;
+
+  /**
+   * Executor d'exécution réelle (Phase 2b) — OPTIONNEL. Absent (ex. tests shadow) ⇒
+   * `apply` indisponible (lève). Présent ⇒ `apply` ouvre une PR (double-gardé par le flag
+   * `COMMAND_CENTER_EXECUTOR=pr`, géré DANS l'executor).
+   */
+  constructor(@Optional() private readonly executor?: RegenArtifactExecutor) {}
 
   /** Liste des cibles regen connues (introspection / observabilité). */
   static knownTargets(): string[] {
@@ -182,5 +204,32 @@ export class RegenArtifactShadowPlanner implements ShadowPlanner {
       // Projection déterministe : l'inverse d'un regen est `git checkout <fichier>`.
       reversible: true,
     };
+  }
+
+  /**
+   * Exécution réelle (Phase 2b, HITL) : régénère + ouvre une PR draft via l'executor.
+   * `plan_hash` recalculé ici (déterministe ⇒ identique à celui approuvé) pour la
+   * traçabilité du reçu. Lève si l'executor n'est pas câblé (DI) ou si le flag executor
+   * n'est pas posé (géré DANS l'executor → `ExecutorDisabledError`). 0 écriture du checkout
+   * runtime : l'executor travaille en worktree git temporaire.
+   */
+  async apply(actionId: string): Promise<ExecutionReceipt> {
+    const target = REGEN_TARGETS[actionId];
+    if (!target) throw new UnknownRegenTargetError(actionId);
+    if (!this.executor) {
+      throw new ExecutorUnavailableError('executor regen non câblé (DI)');
+    }
+    const root = this.repoRoot();
+    const plan = await this.plan(actionId); // recalcul → plan_hash déterministe
+    const execTarget: RegenExecTarget = {
+      action_id: actionId,
+      committedRel: target.committedRel,
+      generatorRel: target.generatorRel,
+      prTitle: target.prTitle,
+      commitMessage: target.commitMessage,
+      base: 'main',
+      branchPrefix: target.branchPrefix,
+    };
+    return this.executor.execute(execTarget, root, computePlanHash(plan));
   }
 }

--- a/backend/tests/unit/command-center.controller.test.ts
+++ b/backend/tests/unit/command-center.controller.test.ts
@@ -9,6 +9,7 @@ import {
   ConflictException,
   NotFoundException,
   NotImplementedException,
+  ServiceUnavailableException,
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { CommandCenterController } from '../../src/modules/admin/controllers/command-center.controller';
@@ -22,6 +23,10 @@ import {
   RegenDryRunError,
   UnknownRegenTargetError,
 } from '../../src/modules/admin/services/command-center-orchestrator/regen-artifact.planner';
+import {
+  ExecutorDisabledError,
+  ExecutorUnavailableError,
+} from '../../src/modules/admin/services/command-center-orchestrator/regen-artifact.executor';
 import { type ExecutionPlan } from '../../src/modules/admin/services/command-center-orchestrator/executable-action.contract';
 
 const plan: ExecutionPlan = {
@@ -203,6 +208,26 @@ describe('CommandCenterController — approve (Phase 2a HITL)', () => {
     });
     await expect(c.approveExecution(okBody)).rejects.toBeInstanceOf(
       NotImplementedException,
+    );
+  });
+
+  it('executor non activé (flag 2 off) → 409', async () => {
+    const c = make({
+      executeApproved: jest.fn().mockRejectedValue(new ExecutorDisabledError()),
+    });
+    await expect(c.approveExecution(okBody)).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+  });
+
+  it('git/gh indisponible → 503', async () => {
+    const c = make({
+      executeApproved: jest
+        .fn()
+        .mockRejectedValue(new ExecutorUnavailableError('git not found')),
+    });
+    await expect(c.approveExecution(okBody)).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
     );
   });
 

--- a/backend/tests/unit/regen-artifact.executor.test.ts
+++ b/backend/tests/unit/regen-artifact.executor.test.ts
@@ -1,0 +1,99 @@
+/**
+ * RegenArtifactExecutor (Phase 2b) — exécution réelle via ouverture de PR draft.
+ * Prouve : double-garde (flag `COMMAND_CENTER_EXECUTOR=pr` requis), séquence git/gh
+ * attendue, reçu réversible (`gh pr close`), échec git/gh → ExecutorUnavailableError.
+ * Le runner est INJECTÉ et factice → AUCUNE commande réelle n'est lancée.
+ */
+import {
+  ExecutorDisabledError,
+  ExecutorUnavailableError,
+  RegenArtifactExecutor,
+  type RegenExecTarget,
+} from '../../src/modules/admin/services/command-center-orchestrator/regen-artifact.executor';
+
+const env = process.env as Record<string, string | undefined>;
+const SAVED = env.COMMAND_CENTER_EXECUTOR;
+afterEach(() => {
+  env.COMMAND_CENTER_EXECUTOR = SAVED;
+});
+
+const target: RegenExecTarget = {
+  action_id: 'regen:command-center-snapshot',
+  committedRel: 'audit/registry/command-center-snapshot.json',
+  generatorRel: 'scripts/governance/build-command-center-snapshot.js',
+  prTitle: 'chore(registry): refresh',
+  commitMessage: 'chore(registry): refresh (HITL)',
+  base: 'main',
+  branchPrefix: 'cc-auto/regen-command-center-snapshot',
+};
+
+describe('RegenArtifactExecutor', () => {
+  it('isEnabled reflète le 2ᵉ flag COMMAND_CENTER_EXECUTOR=pr', () => {
+    env.COMMAND_CENTER_EXECUTOR = 'pr';
+    expect(RegenArtifactExecutor.isEnabled()).toBe(true);
+    env.COMMAND_CENTER_EXECUTOR = '';
+    expect(RegenArtifactExecutor.isEnabled()).toBe(false);
+    env.COMMAND_CENTER_EXECUTOR = 'shadow'; // valeur autre → off
+    expect(RegenArtifactExecutor.isEnabled()).toBe(false);
+  });
+
+  it('flag off → ExecutorDisabledError, AUCUNE commande lancée', async () => {
+    env.COMMAND_CENTER_EXECUTOR = '';
+    const run = jest.fn();
+    const ex = new RegenArtifactExecutor(run);
+    await expect(ex.execute(target, '/repo', 'hash123')).rejects.toBeInstanceOf(
+      ExecutorDisabledError,
+    );
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('flag on → séquence git/gh + reçu PR draft réversible', async () => {
+    env.COMMAND_CENTER_EXECUTOR = 'pr';
+    const run = jest.fn().mockImplementation((cmd: string) => {
+      if (cmd === 'gh') {
+        return Promise.resolve({ stdout: 'https://github.com/a/b/pull/42\n' });
+      }
+      return Promise.resolve({ stdout: '' });
+    });
+    const ex = new RegenArtifactExecutor(run);
+    const receipt = await ex.execute(target, '/repo', 'abcdef0123456789');
+
+    expect(receipt.applied).toBe(true);
+    expect(receipt.kind).toBe('regen-artifact');
+    expect(receipt.plan_hash).toBe('abcdef0123456789');
+    expect(receipt.reverted_by).toBe(
+      'gh pr close https://github.com/a/b/pull/42',
+    );
+    expect(receipt.details).toMatchObject({
+      pr_url: 'https://github.com/a/b/pull/42',
+      base: 'main',
+    });
+
+    const calls = run.mock.calls as [string, string[], string?][];
+    // worktree isolé sur origin/main + branche dérivée du plan_hash
+    const wtAdd = calls.find(
+      (c) => c[0] === 'git' && c[1].includes('worktree') && c[1].includes('add'),
+    );
+    expect(wtAdd?.[1]).toEqual(expect.arrayContaining(['origin/main', '-b']));
+    expect(wtAdd?.[1].some((a) => a.includes('abcdef012345'))).toBe(true);
+    // PR draft
+    const gh = calls.find((c) => c[0] === 'gh');
+    expect(gh?.[1]).toEqual(
+      expect.arrayContaining(['pr', 'create', '--draft', '--base', 'main']),
+    );
+    // worktree nettoyé (remove --force)
+    const wtRemove = calls.find(
+      (c) => c[0] === 'git' && c[1].includes('worktree') && c[1].includes('remove'),
+    );
+    expect(wtRemove).toBeDefined();
+  });
+
+  it('git/gh échoue → ExecutorUnavailableError (pas de succès fictif)', async () => {
+    env.COMMAND_CENTER_EXECUTOR = 'pr';
+    const run = jest.fn().mockRejectedValue(new Error('git: command not found'));
+    const ex = new RegenArtifactExecutor(run);
+    await expect(ex.execute(target, '/repo', 'h')).rejects.toBeInstanceOf(
+      ExecutorUnavailableError,
+    );
+  });
+});

--- a/backend/tests/unit/regen-artifact.planner.test.ts
+++ b/backend/tests/unit/regen-artifact.planner.test.ts
@@ -12,6 +12,8 @@ import {
   UnknownRegenTargetError,
   summarizeDiff,
 } from '../../src/modules/admin/services/command-center-orchestrator/regen-artifact.planner';
+import { ExecutorUnavailableError } from '../../src/modules/admin/services/command-center-orchestrator/regen-artifact.executor';
+import { type ExecutionPlan } from '../../src/modules/admin/services/command-center-orchestrator/executable-action.contract';
 
 const env = process.env as Record<string, string | undefined>;
 const REGISTRY = env.REGISTRY_DIR;
@@ -44,6 +46,51 @@ describe('RegenArtifactShadowPlanner', () => {
     await expect(p.plan('regen:command-center-snapshot')).rejects.toBeInstanceOf(
       RegenDryRunError,
     );
+  });
+});
+
+describe('RegenArtifactShadowPlanner.apply (Phase 2b)', () => {
+  const fakePlan: ExecutionPlan = {
+    action_id: 'regen:command-center-snapshot',
+    kind: 'regen-artifact',
+    summary: 's',
+    would_change: true,
+    details: { a: 1 },
+    reversible: true,
+  };
+
+  it('apply délègue à l’executor (cible + plan_hash recalculé)', async () => {
+    const receipt = {
+      action_id: 'regen:command-center-snapshot',
+      kind: 'regen-artifact' as const,
+      applied: true,
+      plan_hash: 'h',
+      reverted_by: 'gh pr close X',
+      details: {},
+    };
+    const execute = jest.fn().mockResolvedValue(receipt);
+    const p = new RegenArtifactShadowPlanner({ execute } as never);
+    jest.spyOn(p, 'plan').mockResolvedValue(fakePlan); // évite le spawn générateur
+    const out = await p.apply('regen:command-center-snapshot');
+    expect(out).toEqual(receipt);
+    const [execTarget, , hash] = execute.mock.calls[0];
+    expect(execTarget.action_id).toBe('regen:command-center-snapshot');
+    expect(execTarget.base).toBe('main');
+    expect(typeof hash).toBe('string');
+  });
+
+  it('apply action_id inconnu → UnknownRegenTargetError', async () => {
+    const p = new RegenArtifactShadowPlanner({ execute: jest.fn() } as never);
+    await expect(p.apply('regen:nope')).rejects.toBeInstanceOf(
+      UnknownRegenTargetError,
+    );
+  });
+
+  it('apply sans executor câblé → ExecutorUnavailableError', async () => {
+    const p = new RegenArtifactShadowPlanner(); // pas d'executor injecté
+    await expect(
+      p.apply('regen:command-center-snapshot'),
+    ).rejects.toBeInstanceOf(ExecutorUnavailableError);
   });
 });
 


### PR DESCRIPTION
## Quoi

**Phase 2b** — **premier executor RÉEL** de la Phase 2 HITL (ADR-087). Mécanisme choisi : **ouvrir une PR draft**. C'est la voie d'exécution la **plus gouvernée et réversible** :
- **réversible** = `gh pr close <url>` (rien n'a été mergé) ;
- **gouverné** = la PR passe par review + CI + **merge HUMAIN** — rien n'atterrit sur `main` automatiquement.

Suite de #1021 (squelette HITL `approved` inerte). **INERTE par défaut** (2ᵉ flag requis).

## Comment

- `RegenArtifactExecutor.execute(target, root, planHash)` :
  - **worktree git temporaire** isolé sur `origin/main` (jamais le checkout runtime → 0 working-tree sali) ;
  - régénère l'artefact → commit (identité dédiée) → push branche → `gh pr create --draft` ;
  - `execFile` (**pas de shell**), args constants/validés (branche = `branchPrefix` + `plan_hash` hex, donc aucune injection) ; worktree nettoyé en `finally`.
  - Reçu : `applied:true`, `reverted_by: gh pr close <url>`, `details.pr_url`.
- **Double garde** : mode `approved` (flag 1, orchestrateur) **+** `COMMAND_CENTER_EXECUTOR=pr` (flag 2, dans l'executor) → `ExecutorDisabledError` sinon. **Merger ce code ne change RIEN par défaut.** PROD : l'orchestrateur force `off`.
- `RegenArtifactShadowPlanner.apply()` délègue à l'executor (injecté `@Optional`). `pr-proposition` n'a toujours pas d'`apply` → reste `NoExecutorError` (501).
- Controller `approve` : +2 mappings (`ExecutorDisabled`→**409**, `ExecutorUnavailable`→**503**).
- git/gh indisponible/échec → `ExecutorUnavailableError` (jamais de succès fictif).

## Chaîne de gardes complète (pour un vrai regen exécuté)

1. mode `approved` (flag 1) · 2. plan_hash == approuvé (**TOCTOU**, #1021) · 3. `would_change=true` (sinon no-op) · 4. `COMMAND_CENTER_EXECUTOR=pr` (flag 2) · 5. admin-only (guards) · 6. PR **draft** · 7. **merge humain**. Réversible à chaque étape.

## Pourquoi ce mécanisme (et pas l'autre)

Entre {ouvrir-une-PR, commit-direct}, la PR est retenue car **la plus gouvernée** (review obligatoire avant existence sur main ; merge humain ; close = revert). Le commit/écriture directe a été **écarté** (moins gouverné). Transparence : ceci introduit une capacité « le backend peut ouvrir des PR via `gh` » — volontairement **double-gardée + draft + human-merge** ; l'owner garde le veto au merge de cette PR.

## Vérifications

- ✅ jest **60/60** (executor : flag, séquence git/gh **mockée**, reçu réversible, échec→`ExecutorUnavailable` ; planner `apply` ; controller 409/503). **Aucune commande git/gh réelle en test.**
- ✅ ESLint clean · `tsc --noEmit` 0 erreur · ast-grep onModuleInit-guard pass.

## Déploiement

Backend-only, additif, **inerte par défaut** (2 flags off). Merge `main` → tag `:preprod`. **Pas de tag PROD.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
