### PR TITLE
feat(seo-observability): boucle OBSERVE — attribution + mesure + restitution (DRAFT, owner-gated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
 
             # Known bypass files (debug/internal)
             BYPASS_COUNT=$(echo "$DIRECT_RPC_FILES" | \
-              grep -c "googlebot-detector\|enhanced-config\|products.service\|products-catalog.service\|advice.service\|content-refresh.service\|admin-job-health\|conseil-priority.service\|rag-knowledge.service\|rag-image-management\|rm-builder.service\|buying-guide-data.service\|payment-data.service\|orders.service\|r1-keyword-plan-batch\|admin-keyword-planner.controller\|abandoned-cart-data.service\|gamme-rpc.service\|admin-supplier-stats.service\|quality-history-snapshot.service\|cwv-aggregation.service\|cwv-dashboard.service" || echo "0")
+              grep -c "googlebot-detector\|enhanced-config\|products.service\|products-catalog.service\|advice.service\|content-refresh.service\|admin-job-health\|conseil-priority.service\|rag-knowledge.service\|rag-image-management\|rm-builder.service\|buying-guide-data.service\|payment-data.service\|orders.service\|r1-keyword-plan-batch\|admin-keyword-planner.controller\|abandoned-cart-data.service\|gamme-rpc.service\|admin-supplier-stats.service\|quality-history-snapshot.service\|cwv-aggregation.service\|cwv-dashboard.service\|seo-action-outcome.service" || echo "0")
 
             UNEXPECTED=$((DIRECT_RPC - BYPASS_COUNT))
 

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -652,6 +652,11 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: medium
+  - glob: backend/supabase/migrations/*seo_action_*
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/supabase/migrations/*seo_event_funnel*
     domain: D3
     owner: '@ak125/seo-team'

--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 181,
+  "total": 182,
   "functions": [
     {
       "name": "__gov_m1_table_sizes",
@@ -828,6 +828,11 @@
       "name": "rpc_seo_low_ctr_v3",
       "volatility": "STABLE",
       "reason": "SEO low-CTR v3 read-only — grain pages (__seo_gsc_daily_pages, sans query) + coverage envelope (Command Center owner-action queue)"
+    },
+    {
+      "name": "rpc_seo_action_outcomes_v1",
+      "volatility": "STABLE",
+      "reason": "SEO action outcomes read-only (boucle OBSERVE PR-2) — lit __seo_action_outcome (table projetee), jamais __admin_audit_log ; anon-safe ; enveloppe honnete + disclaimer OBSERVATIONNEL"
     },
     {
       "name": "search_pieces_fts",

--- a/backend/src/modules/admin/services/command-center-actions.service.ts
+++ b/backend/src/modules/admin/services/command-center-actions.service.ts
@@ -170,6 +170,33 @@ export class CommandCenterActionsService extends SupabaseBaseService {
   }
 
   /**
+   * PR-3 — Outcomes SEO matérialisés (boucle OBSERVE), lecture additive.
+   * Enveloppe honnête via le RPC STABLE allowlisté `rpc_seo_action_outcomes_v1`
+   * (lit la table projetée, JAMAIS l'audit-log). Gracieux : indisponibilité
+   * SURFACÉE (`source_unavailable`), jamais un faux-vert.
+   */
+  async seoActionOutcomes(): Promise<Record<string, unknown>> {
+    try {
+      const res = await this.callRpc<Record<string, unknown>>(
+        'rpc_seo_action_outcomes_v1',
+        { p_lookback_days: 90, p_limit: 100 },
+      );
+      if (res.error || !res.data) {
+        this.logger.warn(
+          `[command-center-actions] rpc_seo_action_outcomes_v1 indisponible (${res.error ?? 'donnée absente'})`,
+        );
+        return { rows: [], source_unavailable: true };
+      }
+      return res.data;
+    } catch (e) {
+      this.logger.warn(
+        `[command-center-actions] SEO outcomes RPC failed: ${e}`,
+      );
+      return { rows: [], source_unavailable: true };
+    }
+  }
+
+  /**
    * Fraîcheur d'ingestion GSC : 'fresh' si la dernière date ingérée est dans le
    * SLA (lag GSC normal ≈ 3 j) ; au-delà → 'stale' ; date absente/invalide →
    * 'unknown'. Stale/unknown ⇒ la règle dégrade la confiance à PARTIAL — la

--- a/backend/src/modules/admin/services/command-center-reader.service.ts
+++ b/backend/src/modules/admin/services/command-center-reader.service.ts
@@ -95,7 +95,12 @@ export class CommandCenterReaderService {
             built.chains,
             mode,
           );
-      result = { ...built, mode, action_queue };
+      // PR-3 boucle OBSERVE : champ additif, full mode + flag ON uniquement.
+      const seo_outcomes =
+        !built.degraded && mode === 'full' && isSeoOutcomesEnabled()
+          ? await this.actions.seoActionOutcomes()
+          : null;
+      result = { ...built, mode, action_queue, seo_outcomes };
     }
     await this.cacheService.set(
       cacheKey,
@@ -107,7 +112,10 @@ export class CommandCenterReaderService {
     return result;
   }
 
-  private build(): Omit<CommandCenterResponse, 'mode' | 'action_queue'> {
+  private build(): Omit<
+    CommandCenterResponse,
+    'mode' | 'action_queue' | 'seo_outcomes'
+  > {
     const now = new Date();
     const gitSha = process.env.GIT_SHA || process.env.SOURCE_COMMIT || null;
     const snapshot = this.readJson<SnapshotFile>(
@@ -372,6 +380,19 @@ export function resolveCommandCenterMode(): CommandCenterMode {
 }
 
 /**
+ * PR-3 boucle OBSERVE — flag du champ additif `seo_outcomes`. Défaut OFF ;
+ * **PROD toujours OFF** (mirror resolveOrchestrationMode, ADR-087). Hors-prod,
+ * `COMMAND_CENTER_SEO_OUTCOMES=true` explicite requis.
+ */
+export function isSeoOutcomesEnabled(): boolean {
+  if (process.env.NODE_ENV === 'production') return false;
+  return (
+    (process.env.COMMAND_CENTER_SEO_OUTCOMES || '').trim().toLowerCase() ===
+    'true'
+  );
+}
+
+/**
  * Light projection: top-line health only. Strips ALL internal detail
  * (departments, capabilities, chains, alerts, owner_actions, evidence paths,
  * canon_path, git_sha, global_status.reasons) so PROD can show "is it healthy?"
@@ -379,7 +400,7 @@ export function resolveCommandCenterMode(): CommandCenterMode {
  * (numbers, no internal identifiers).
  */
 function toLightResponse(
-  full: Omit<CommandCenterResponse, 'mode' | 'action_queue'>,
+  full: Omit<CommandCenterResponse, 'mode' | 'action_queue' | 'seo_outcomes'>,
 ): CommandCenterResponse {
   return {
     degraded: full.degraded,
@@ -406,6 +427,7 @@ function toLightResponse(
     },
     mode: 'light',
     action_queue: [],
+    seo_outcomes: null,
   };
 }
 
@@ -416,6 +438,8 @@ export interface CommandCenterResponse extends Omit<
   degraded: boolean;
   mode: CommandCenterMode;
   action_queue: OwnerActionV2[];
+  /** PR-3 boucle OBSERVE — outcomes SEO (flag COMMAND_CENTER_SEO_OUTCOMES, full mode) ; null sinon. */
+  seo_outcomes: Record<string, unknown> | null;
   departments: Array<
     SnapshotFile['departments'][number] & {
       health_score_current: number;

--- a/backend/src/modules/seo-monitoring/controllers/seo-action-attribution.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/seo-action-attribution.controller.ts
@@ -2,7 +2,9 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Get,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { z, ZodError } from 'zod';
@@ -14,11 +16,14 @@ import {
   SeoActionAppliedInputSchema,
   type SeoActionAppliedResult,
 } from '../services/seo-action-attribution.service';
+import { SeoActionOutcomeService } from '../services/seo-action-outcome.service';
 
 /**
  * PR-1 — Endpoint admin « seed manuel » de l'attribution SEO (boucle OBSERVE).
  *
- *   POST /api/admin/seo/action/applied
+ *   POST /api/admin/seo/action/applied      — seed attribution (PR-1)
+ *   POST /api/admin/seo/action/materialize  — matérialise les outcomes (PR-2)
+ *   GET  /api/admin/seo/action/outcomes     — lecture des outcomes (PR-2)
  *
  * Déclaration owner-asserted : « action X appliquée à la page P à T0 ». Garde-fous :
  *  - admin-only (`AuthenticatedGuard` + `IsAdminGuard`) — jamais public ;
@@ -29,7 +34,10 @@ import {
 @Controller('api/admin/seo/action')
 @UseGuards(AuthenticatedGuard, IsAdminGuard)
 export class SeoActionAttributionController {
-  constructor(private readonly attribution: SeoActionAttributionService) {}
+  constructor(
+    private readonly attribution: SeoActionAttributionService,
+    private readonly outcomes: SeoActionOutcomeService,
+  ) {}
 
   @Post('applied')
   async recordApplied(
@@ -49,4 +57,33 @@ export class SeoActionAttributionController {
     }
     return this.attribution.recordActionApplied(parsed, actorEmail ?? 'admin');
   }
+
+  /**
+   * Matérialise les outcomes (delta baseline vs fenêtre 7/14/28 j). Idempotent.
+   * On-demand en V1 (pas de cron — évite un cron silencieux ; à greffer plus tard).
+   */
+  @Post('materialize')
+  async materialize(
+    @Query('lookback_days') lookbackDays?: string,
+  ): Promise<Record<string, unknown>> {
+    return this.outcomes.materialize(parsePositiveInt(lookbackDays, 90));
+  }
+
+  /** Lecture des outcomes matérialisés (enveloppe honnête observationnelle). */
+  @Get('outcomes')
+  async getOutcomes(
+    @Query('lookback_days') lookbackDays?: string,
+    @Query('limit') limit?: string,
+  ): Promise<Record<string, unknown>> {
+    return this.outcomes.getOutcomes(
+      parsePositiveInt(lookbackDays, 90),
+      parsePositiveInt(limit, 100),
+    );
+  }
+}
+
+/** Parse un entier positif de query string, sinon défaut. */
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  const n = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : fallback;
 }

--- a/backend/src/modules/seo-monitoring/controllers/seo-action-attribution.controller.ts
+++ b/backend/src/modules/seo-monitoring/controllers/seo-action-attribution.controller.ts
@@ -1,0 +1,52 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { z, ZodError } from 'zod';
+import { AuthenticatedGuard } from '@auth/authenticated.guard';
+import { IsAdminGuard } from '@auth/is-admin.guard';
+import { User } from '../../../common/decorators/user.decorator';
+import {
+  SeoActionAttributionService,
+  SeoActionAppliedInputSchema,
+  type SeoActionAppliedResult,
+} from '../services/seo-action-attribution.service';
+
+/**
+ * PR-1 — Endpoint admin « seed manuel » de l'attribution SEO (boucle OBSERVE).
+ *
+ *   POST /api/admin/seo/action/applied
+ *
+ * Déclaration owner-asserted : « action X appliquée à la page P à T0 ». Garde-fous :
+ *  - admin-only (`AuthenticatedGuard` + `IsAdminGuard`) — jamais public ;
+ *  - corps validé Zod strict (namespace `seo_action_applied` uniquement) → 400 si invalide ;
+ *  - respecte READ_ONLY via le service (`{recorded:false, reason:'read_only'}`) ;
+ *  - aucune mutation runtime/contenu/URL — écrit seulement une ligne d'audit (observe pur).
+ */
+@Controller('api/admin/seo/action')
+@UseGuards(AuthenticatedGuard, IsAdminGuard)
+export class SeoActionAttributionController {
+  constructor(private readonly attribution: SeoActionAttributionService) {}
+
+  @Post('applied')
+  async recordApplied(
+    @Body() body: unknown,
+    @User('email') actorEmail?: string,
+  ): Promise<SeoActionAppliedResult> {
+    let parsed: z.infer<typeof SeoActionAppliedInputSchema>;
+    try {
+      parsed = SeoActionAppliedInputSchema.parse(body);
+    } catch (e) {
+      if (e instanceof ZodError) {
+        throw new BadRequestException(
+          `Requête invalide : ${e.issues.map((i) => i.message).join(', ')}`,
+        );
+      }
+      throw e;
+    }
+    return this.attribution.recordActionApplied(parsed, actorEmail ?? 'admin');
+  }
+}

--- a/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
+++ b/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
@@ -31,6 +31,7 @@ import { CwvAggregationService } from './services/cwv-aggregation.service';
 import { RuntimeEventsService } from './services/runtime-events.service';
 import { CwvDashboardService } from './services/cwv-dashboard.service';
 import { SeoActionAttributionService } from './services/seo-action-attribution.service';
+import { SeoActionOutcomeService } from './services/seo-action-outcome.service';
 import { SeoMonitoringController } from './controllers/seo-monitoring.controller';
 import { QualityHistoryController } from './controllers/quality-history.controller';
 import { FunnelEventsController } from './controllers/funnel-events.controller';
@@ -62,6 +63,7 @@ import { SeoActionAttributionController } from './controllers/seo-action-attribu
     RuntimeEventsService, // CWV bloc 5 — wrapper __seo_event_log pour 4 runtime events
     CwvDashboardService, // CWV bloc 6 — wraps STABLE RPCs get_cwv_dashboard/funnel_correlation + health
     SeoActionAttributionService, // PR-1 boucle OBSERVE — attribution seo_action_applied (ledger __admin_audit_log)
+    SeoActionOutcomeService, // PR-2 boucle OBSERVE — materialize + read outcomes (__seo_action_outcome)
     // CwvAggregationSchedulerService + CwvAggregationProcessor : wired in workers/worker.module.ts
     // (queue 'seo-monitor' registered there ; pattern mirror SeoDailyFetchProcessor)
   ],

--- a/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
+++ b/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
@@ -30,12 +30,14 @@ import { CwvBeaconService } from './services/cwv-beacon.service';
 import { CwvAggregationService } from './services/cwv-aggregation.service';
 import { RuntimeEventsService } from './services/runtime-events.service';
 import { CwvDashboardService } from './services/cwv-dashboard.service';
+import { SeoActionAttributionService } from './services/seo-action-attribution.service';
 import { SeoMonitoringController } from './controllers/seo-monitoring.controller';
 import { QualityHistoryController } from './controllers/quality-history.controller';
 import { FunnelEventsController } from './controllers/funnel-events.controller';
 import { CwvBeaconController } from './controllers/cwv-beacon.controller';
 import { RuntimeEventsController } from './controllers/runtime-events.controller';
 import { CwvDashboardController } from './controllers/cwv-dashboard.controller';
+import { SeoActionAttributionController } from './controllers/seo-action-attribution.controller';
 
 @Module({
   imports: [ConfigModule],
@@ -59,6 +61,7 @@ import { CwvDashboardController } from './controllers/cwv-dashboard.controller';
     CwvAggregationService, // CWV bloc 4 — RPCs aggregate_cwv_hourly/daily_rum
     RuntimeEventsService, // CWV bloc 5 — wrapper __seo_event_log pour 4 runtime events
     CwvDashboardService, // CWV bloc 6 — wraps STABLE RPCs get_cwv_dashboard/funnel_correlation + health
+    SeoActionAttributionService, // PR-1 boucle OBSERVE — attribution seo_action_applied (ledger __admin_audit_log)
     // CwvAggregationSchedulerService + CwvAggregationProcessor : wired in workers/worker.module.ts
     // (queue 'seo-monitor' registered there ; pattern mirror SeoDailyFetchProcessor)
   ],
@@ -69,6 +72,7 @@ import { CwvDashboardController } from './controllers/cwv-dashboard.controller';
     CwvBeaconController, // POST /api/seo/cwv/beacon (public beacon, bloc 3)
     RuntimeEventsController, // POST /api/seo/runtime-event (public beacon, bloc 5)
     CwvDashboardController, // GET /api/seo/cwv/{dashboard,funnel-correlation,health} (admin, bloc 6)
+    SeoActionAttributionController, // POST /api/admin/seo/action/applied (admin, PR-1 boucle OBSERVE)
   ],
   exports: [
     GoogleCredentialsService,

--- a/backend/src/modules/seo-monitoring/services/seo-action-attribution.service.ts
+++ b/backend/src/modules/seo-monitoring/services/seo-action-attribution.service.ts
@@ -1,0 +1,176 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+import { getEffectiveSupabaseKey } from '@common/utils';
+import { getAppConfig } from '../../../config/app.config';
+import { GoogleCredentialsService } from './google-credentials.service';
+import { canonicalizeGscPageKey } from '../util/gsc-page-key';
+
+/**
+ * PR-1 — Attribution « action SEO appliquée » (boucle OBSERVE).
+ *
+ * Écrit une ligne d'attribution dans le ledger admin EXISTANT `__admin_audit_log`
+ * (on ÉTEND le ledger admin_audit — namespace `aal_action='seo_action_applied'`,
+ * comme `cc_orchestration_shadow_plan` d'ADR-087 — JAMAIS de table de ledger parallèle).
+ *
+ * Invariants (plan « fermer la boucle OBSERVE » + CHECK-0 2026-06-18) :
+ *  - READ_ONLY (PREPROD, ADR-028 Option D) → court-circuit surfacé `{recorded:false}` ;
+ *  - clé page canonicalisée vers le format GSC ABSOLU (sinon 0-join silencieux) via la
+ *    MÊME source que le fetcher (`GoogleCredentialsService.getGSCSiteUrl()`) ;
+ *  - `applied_at_utc` en ISO-8601 « Z » (pas d'off-by-one TZ) ;
+ *  - diagnostic non-bloquant `gsc_match_rows` SURFACÉ (no-silent-fallback) : 0 ligne GSC
+ *    pour la clé ⇒ warn explicite, la mesure resterait vide.
+ */
+
+/** Vocabulaire contrôlé des types d'action (anti-dérive ; extensible par revue de code). */
+export const SEO_ACTION_KINDS = [
+  'meta_rewrite',
+  'content_enrich',
+  'internal_link',
+  'regen_artifact',
+  'other',
+] as const;
+
+export const SeoActionAppliedInputSchema = z
+  .object({
+    /** URL absolue OU chemin ; canonicalisée côté serveur vers le format GSC. */
+    page: z.string().min(1),
+    action_kind: z.enum(SEO_ACTION_KINDS),
+    /** ISO-8601 UTC (suffixe « Z »). Absent ⇒ now() serveur. */
+    applied_at: z
+      .string()
+      .datetime()
+      .refine(
+        (s) => s.endsWith('Z'),
+        'applied_at doit être en UTC (suffixe « Z »)',
+      )
+      .optional(),
+    source_action_id: z.string().min(1).nullable().optional(),
+    baseline_window_days: z
+      .number()
+      .int()
+      .min(7)
+      .max(90)
+      .optional()
+      .default(28),
+    notes: z.string().max(2000).optional(),
+  })
+  .strict();
+
+export type SeoActionAppliedInput = z.infer<typeof SeoActionAppliedInputSchema>;
+
+export interface SeoActionAppliedResult {
+  recorded: boolean;
+  /** raison du non-enregistrement (`read_only`, message DB…) si recorded=false. */
+  reason?: string;
+  /** clé page canonicalisée réellement écrite (utile à l'opérateur pour vérifier la jointure). */
+  canonical_page?: string;
+  /** diagnostic : nb de lignes GSC pour cette clé (0 ⇒ la mesure restera vide). undefined si check KO. */
+  gsc_match_rows?: number;
+}
+
+@Injectable()
+export class SeoActionAttributionService {
+  private readonly logger = new Logger(SeoActionAttributionService.name);
+  private readonly supabase: SupabaseClient;
+
+  constructor(
+    private readonly credentials: GoogleCredentialsService,
+    configService: ConfigService,
+  ) {
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback ANON_KEY en mode READ_ONLY (RLS protège les writes).
+    const key = getEffectiveSupabaseKey();
+    if (!url || !key) {
+      this.logger.warn(
+        'SeoActionAttributionService: env Supabase manquant — échec au premier appel',
+      );
+    }
+    this.supabase = createClient(url, key, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+  }
+
+  /** Enregistre « action `action_kind` appliquée à la page à T0 » dans le ledger. */
+  async recordActionApplied(
+    input: SeoActionAppliedInput,
+    actor: string,
+  ): Promise<SeoActionAppliedResult> {
+    // READ_ONLY (PREPROD) : court-circuit canonique, surfacé (pas de write tenté).
+    if (getAppConfig().supabase.readOnly) {
+      this.logger.warn(
+        { metric: 'readonly.skipped', operation: 'seo-action-attribution' },
+        '[READ_ONLY] Skip seed seo_action_applied',
+      );
+      return { recorded: false, reason: 'read_only' };
+    }
+
+    const canonicalPage = canonicalizeGscPageKey(
+      input.page,
+      this.credentials.getGSCSiteUrl(),
+    );
+    const appliedAtUtc = input.applied_at ?? new Date().toISOString();
+
+    const { error } = await this.supabase.from('__admin_audit_log').insert({
+      aal_action: 'seo_action_applied',
+      aal_entity_type: 'seo_page',
+      aal_entity_id: canonicalPage,
+      aal_user_id: actor,
+      aal_new_value: {
+        action_kind: input.action_kind,
+        applied_at_utc: appliedAtUtc,
+        source_action_id: input.source_action_id ?? null,
+        baseline_window_days: input.baseline_window_days,
+        notes: input.notes ?? null,
+      },
+      aal_metadata: { schema: 'seo_action_applied.v1' },
+    });
+
+    if (error) {
+      this.logger.error(
+        `seo_action_applied insert KO (${canonicalPage}): ${error.message}`,
+      );
+      return {
+        recorded: false,
+        reason: error.message,
+        canonical_page: canonicalPage,
+      };
+    }
+
+    // Diagnostic non-bloquant : la clé joint-elle GSC ? (no-silent-fallback : on SURFACE 0).
+    const gscMatchRows = await this.countGscRows(canonicalPage);
+    if (gscMatchRows === 0) {
+      this.logger.warn(
+        `seo_action_applied : 0 ligne GSC pour « ${canonicalPage} » — la mesure restera vide ` +
+          `tant que GSC n'aura pas de données (vérifier la clé page).`,
+      );
+    }
+
+    return {
+      recorded: true,
+      canonical_page: canonicalPage,
+      gsc_match_rows: gscMatchRows,
+    };
+  }
+
+  /** Compte les lignes GSC (grain query, 71 j d'historique — cf. CHECK-0) pour la clé. */
+  private async countGscRows(page: string): Promise<number | undefined> {
+    try {
+      const { count, error } = await this.supabase
+        .from('__seo_gsc_daily')
+        .select('*', { count: 'exact', head: true })
+        .eq('page', page);
+      if (error) {
+        this.logger.warn(`countGscRows KO (${page}): ${error.message}`);
+        return undefined;
+      }
+      return count ?? 0;
+    } catch (e) {
+      this.logger.warn(
+        `countGscRows a levé (${page}): ${(e as Error).message}`,
+      );
+      return undefined;
+    }
+  }
+}

--- a/backend/src/modules/seo-monitoring/services/seo-action-outcome.service.ts
+++ b/backend/src/modules/seo-monitoring/services/seo-action-outcome.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseClient, createClient } from '@supabase/supabase-js';
+import { getEffectiveSupabaseKey } from '@common/utils';
+import { getAppConfig } from '../../../config/app.config';
+
+/**
+ * PR-2 — Mesure de la boucle OBSERVE.
+ *
+ * Deux chemins, strictement séparés (CHECK-0 flag #2) :
+ *  - `materialize()` → RPC VOLATILE `rpc_seo_action_outcomes_materialize_v1` (service_role) :
+ *    calcule les deltas baseline vs fenêtre 7/14/28 j et UPSERT `__seo_action_outcome`.
+ *    Gardé READ_ONLY (PREPROD ne matérialise pas).
+ *  - `getOutcomes()` → RPC STABLE `rpc_seo_action_outcomes_v1` (lecture, anon-safe) :
+ *    enveloppe honnête {rows, complete, pending, last_data_date, disclaimer}.
+ *
+ * No-silent-fallback : une erreur RPC est SURFACÉE (jamais un faux tableau vide « propre »).
+ */
+@Injectable()
+export class SeoActionOutcomeService {
+  private readonly logger = new Logger(SeoActionOutcomeService.name);
+  private readonly supabase: SupabaseClient;
+
+  constructor(configService: ConfigService) {
+    const url = configService.get<string>('SUPABASE_URL') || '';
+    // ADR-028 Option D — fallback ANON_KEY en READ_ONLY (RLS protège les writes).
+    const key = getEffectiveSupabaseKey();
+    if (!url || !key) {
+      this.logger.warn(
+        'SeoActionOutcomeService: env Supabase manquant — échec au premier appel',
+      );
+    }
+    this.supabase = createClient(url, key, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+  }
+
+  /** Matérialise les outcomes (idempotent). READ_ONLY → no-op surfacé. */
+  async materialize(lookbackDays = 90): Promise<Record<string, unknown>> {
+    if (getAppConfig().supabase.readOnly) {
+      this.logger.warn(
+        {
+          metric: 'readonly.skipped',
+          operation: 'seo-action-outcomes-materialize',
+        },
+        '[READ_ONLY] Skip materialize outcomes',
+      );
+      return { status: 'read_only' };
+    }
+    const { data, error } = await this.supabase.rpc(
+      'rpc_seo_action_outcomes_materialize_v1',
+      { p_lookback_days: lookbackDays },
+    );
+    if (error) {
+      this.logger.error(`materialize outcomes KO: ${error.message}`);
+      // SURFACÉ (no-silent-fallback) — le contrôleur transmet l'échec tel quel.
+      return { status: 'error', reason: error.message };
+    }
+    return (data as Record<string, unknown>) ?? { status: 'ok' };
+  }
+
+  /** Lit les outcomes matérialisés (enveloppe honnête). */
+  async getOutcomes(
+    lookbackDays = 90,
+    limit = 100,
+  ): Promise<Record<string, unknown>> {
+    const { data, error } = await this.supabase.rpc(
+      'rpc_seo_action_outcomes_v1',
+      {
+        p_lookback_days: lookbackDays,
+        p_limit: limit,
+      },
+    );
+    if (error) {
+      this.logger.error(`read outcomes KO: ${error.message}`);
+      // SURFACÉ : on expose l'indisponibilité, jamais un faux tableau vide « ok ».
+      return { rows: [], source_unavailable: true, reason: error.message };
+    }
+    return (data as Record<string, unknown>) ?? { rows: [] };
+  }
+}

--- a/backend/src/modules/seo-monitoring/util/gsc-page-key.test.ts
+++ b/backend/src/modules/seo-monitoring/util/gsc-page-key.test.ts
@@ -1,0 +1,79 @@
+import { canonicalizeGscPageKey } from './gsc-page-key';
+
+/**
+ * Tests du landmine #1 (CHECK-0) : la clé attribuée par l'opérateur DOIT matcher
+ * le format `page` stocké par GSC (URL absolue), sinon la mesure renvoie un faux 0.
+ */
+describe('canonicalizeGscPageKey', () => {
+  const SITE = 'https://www.automecanik.com';
+
+  it('préfixe un chemin avec slash initial', () => {
+    expect(
+      canonicalizeGscPageKey(
+        '/blog-pieces-auto/conseils/colonne-de-direction',
+        SITE,
+      ),
+    ).toBe(
+      'https://www.automecanik.com/blog-pieces-auto/conseils/colonne-de-direction',
+    );
+  });
+
+  it('préfixe un chemin SANS slash initial', () => {
+    expect(
+      canonicalizeGscPageKey('blog-pieces-auto/conseils/capteur-abs', SITE),
+    ).toBe('https://www.automecanik.com/blog-pieces-auto/conseils/capteur-abs');
+  });
+
+  it('laisse une URL déjà absolue inchangée (opérateur a collé l’URL GSC)', () => {
+    const url =
+      'https://www.automecanik.com/blog-pieces-auto/conseils/emetteur-d-embrayage';
+    expect(canonicalizeGscPageKey(url, SITE)).toBe(url);
+  });
+
+  it('matche le format produit GSC pour une page produit (.html)', () => {
+    expect(
+      canonicalizeGscPageKey(
+        '/pieces/compresseur-de-climatisation-447/peugeot-128/207-128018/1-6-hdi-33260.html',
+        SITE,
+      ),
+    ).toBe(
+      'https://www.automecanik.com/pieces/compresseur-de-climatisation-447/peugeot-128/207-128018/1-6-hdi-33260.html',
+    );
+  });
+
+  it('retire un slash final parasite (chemin)', () => {
+    expect(
+      canonicalizeGscPageKey('/blog-pieces-auto/conseils/capteur-abs/', SITE),
+    ).toBe('https://www.automecanik.com/blog-pieces-auto/conseils/capteur-abs');
+  });
+
+  it('retire un slash final parasite (URL absolue)', () => {
+    expect(
+      canonicalizeGscPageKey(
+        'https://www.automecanik.com/blog-pieces-auto/conseils/capteur-abs/',
+        SITE,
+      ),
+    ).toBe('https://www.automecanik.com/blog-pieces-auto/conseils/capteur-abs');
+  });
+
+  it('tolère un gscSiteUrl avec slash final (propriété URL-prefix)', () => {
+    expect(canonicalizeGscPageKey('/x', 'https://www.automecanik.com/')).toBe(
+      'https://www.automecanik.com/x',
+    );
+  });
+
+  it('trim les espaces', () => {
+    expect(canonicalizeGscPageKey('  /x  ', SITE)).toBe(
+      'https://www.automecanik.com/x',
+    );
+  });
+
+  it('est idempotente', () => {
+    const once = canonicalizeGscPageKey('/blog/x', SITE);
+    expect(canonicalizeGscPageKey(once, SITE)).toBe(once);
+  });
+
+  it('renvoie une chaîne vide pour une entrée vide', () => {
+    expect(canonicalizeGscPageKey('', SITE)).toBe('');
+  });
+});

--- a/backend/src/modules/seo-monitoring/util/gsc-page-key.ts
+++ b/backend/src/modules/seo-monitoring/util/gsc-page-key.ts
@@ -1,0 +1,41 @@
+/**
+ * Canonicalise une clé « page » pour qu'elle JOIN exactement les lignes GSC
+ * (`__seo_gsc_daily` / `__seo_gsc_daily_pages`), dont la colonne `page` est l'URL
+ * ABSOLUE renvoyée par l'API Search Console (préfixée par la propriété GSC).
+ *
+ * CHECK-0 (2026-06-18) : GSC stocke `https://www.automecanik.com/<path>` (sans slash
+ * final) ; GA4 stocke des chemins (`/<path>`). Une clé mal normalisée = 0 ligne jointe
+ * = faux « aucun effet » (landmine #1 de la boucle OBSERVE).
+ *
+ * Règles déterministes & idempotentes :
+ *  - entrée déjà absolue (`http(s)://…`) → conservée telle quelle (l'opérateur a collé
+ *    l'URL GSC exacte), simplement trim + retrait du/des slash(es) final(aux) hors origine ;
+ *  - entrée = chemin (`/blog-…` ou `blog-…`) → préfixée par `gscSiteUrl` (MÊME source que
+ *    le fetcher GSC : `GoogleCredentialsService.getGSCSiteUrl()`), slash final du préfixe ôté.
+ *
+ * Ne touche AUCUNE URL canonique / route / slug — hygiène de jointure interne en lecture
+ * du format GSC existant (cf. mémoire `feedback_no_url_changes_ever`).
+ */
+export function canonicalizeGscPageKey(
+  input: string,
+  gscSiteUrl: string,
+): string {
+  const raw = (input ?? '').trim();
+  if (!raw) return raw;
+
+  if (/^https?:\/\//i.test(raw)) {
+    return stripTrailingSlash(raw);
+  }
+
+  const base = stripTrailingSlash((gscSiteUrl ?? '').trim());
+  const path = raw.startsWith('/') ? raw : `/${raw}`;
+  return stripTrailingSlash(`${base}${path}`);
+}
+
+/**
+ * Retire le(s) slash(es) final(aux) en gardant au moins 1 caractère significatif
+ * (l'origine `https://host` et la racine `/` restent intactes).
+ */
+function stripTrailingSlash(u: string): string {
+  return u.replace(/(.)\/+$/, '$1');
+}

--- a/backend/supabase/migrations/20260618_seo_action_applied_attribution.sql
+++ b/backend/supabase/migrations/20260618_seo_action_applied_attribution.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- PR-1 — Attribution « seo_action_applied » (boucle OBSERVE : DATA → … → MESURE)
+-- ----------------------------------------------------------------------------
+-- AUCUNE table créée : on ÉTEND le ledger admin EXISTANT __admin_audit_log via un
+-- namespace aal_action, exactement comme cc_orchestration_shadow_plan (ADR-087).
+-- Jamais de table de ledger parallèle.
+--
+-- CHECK-0 (audit/seo-action-outcome-preflight-2026-06-18.md) :
+--   * __admin_audit_log = table SIMPLE (non partitionnée), RLS ON (policy service_role_aal,
+--     anon refusé au row-level) → un index partiel est sûr (zéro complexité partition).
+--   * aal_action = VARCHAR libre (pas d'ENUM/CHECK) → 'seo_action_applied' accepté SANS DDL.
+--   * volume ~0.5 ligne/j → index partiel < 1 Ko/an, zéro write-amplification.
+--
+-- Idempotent (IF NOT EXISTS) + réversible (section DOWN ci-dessous, à exécuter manuellement).
+-- ============================================================================
+
+-- Index partiel : retrouve les actions SEO attribuées par page + applied_at_utc,
+-- pour la matérialisation des outcomes (PR-2).
+CREATE INDEX IF NOT EXISTS idx_aal_seo_action_applied
+  ON public.__admin_audit_log (aal_entity_id, ((aal_new_value ->> 'applied_at_utc')))
+  WHERE aal_action = 'seo_action_applied';
+
+COMMENT ON INDEX public.idx_aal_seo_action_applied IS
+  'PR-1 boucle OBSERVE : lookup des actions SEO attribuées (namespace seo_action_applied) '
+  'par page + applied_at_utc pour la matérialisation des outcomes (PR-2).';
+
+-- ----------------------------------------------------------------------------
+-- Schéma documenté du payload aal_new_value (seo_action_applied.v1) :
+--   {
+--     action_kind:          meta_rewrite | content_enrich | internal_link | regen_artifact | other,
+--     applied_at_utc:       ISO-8601 « Z » (T0, ancre de mesure),
+--     source_action_id:     text | null  (opportunité Command Center source, ou null = manuel),
+--     baseline_window_days: int (défaut 28),
+--     notes:                text | null
+--   }
+--   aal_entity_type = 'seo_page'
+--   aal_entity_id   = URL ABSOLUE canonique (clé de jointure GSC, cf. gsc-page-key.ts)
+--   aal_metadata    = { "schema": "seo_action_applied.v1" }
+-- ----------------------------------------------------------------------------
+
+-- ============================================================================
+-- DOWN (réversibilité — exécuter manuellement pour annuler) :
+--   DROP INDEX IF EXISTS public.idx_aal_seo_action_applied;
+--   -- Les lignes d'attribution restent (ledger append-only) ; pour les retirer :
+--   -- DELETE FROM public.__admin_audit_log WHERE aal_action = 'seo_action_applied';
+-- ============================================================================

--- a/backend/supabase/migrations/20260618_seo_action_applied_attribution.sql
+++ b/backend/supabase/migrations/20260618_seo_action_applied_attribution.sql
@@ -1,3 +1,10 @@
+-- squawk-ignore-file require-concurrent-index-creation
+--   Plain CREATE INDEX (pas CONCURRENTLY) : __admin_audit_log ≈ 34 lignes → aucun bénéfice,
+--   et CONCURRENTLY ne peut pas tourner en transaction (assume_in_transaction). Même
+--   politique que 20260518_seo_control_003_indexes.sql.
+set lock_timeout = '5s';
+set statement_timeout = '60s';
+
 -- ============================================================================
 -- PR-1 — Attribution « seo_action_applied » (boucle OBSERVE : DATA → … → MESURE)
 -- ----------------------------------------------------------------------------

--- a/backend/supabase/migrations/20260618_seo_action_outcome_rpcs.sql
+++ b/backend/supabase/migrations/20260618_seo_action_outcome_rpcs.sql
@@ -1,0 +1,241 @@
+-- ============================================================================
+-- PR-2 — RPCs de la boucle OBSERVE : materialize (write, service_role) + read (anon-safe)
+-- ----------------------------------------------------------------------------
+-- Séparation stricte (CHECK-0 flag #2) :
+--   * rpc_seo_action_outcomes_materialize_v1 : VOLATILE, SECURITY DEFINER, service_role
+--     UNIQUEMENT. Lit __admin_audit_log (attribution) + __seo_gsc_daily (grain query, 71 j)
+--     et UPSERT __seo_action_outcome. C'est le SEUL chemin qui lit le ledger admin.
+--   * rpc_seo_action_outcomes_v1 : STABLE, SECURITY DEFINER (mirror detect_quality_outliers),
+--     lit UNIQUEMENT __seo_action_outcome (table projetée propre). GRANT anon → sûr car
+--     ne touche jamais __admin_audit_log.
+--
+-- Source métrique V1 = __seo_gsc_daily (grain query) : seul à avoir l'historique baseline
+-- (71 j) ; biais d'anonymisation ~constant qui s'annule dans le delta (cf. CHECK-0).
+-- Math honnête : taux PAR JOUR (impr/clics ÷ n jours), CTR = ratio agrégé, position
+-- pondérée impressions ; fenêtre émise complète SEULEMENT si t0+w <= last_data_date.
+-- ============================================================================
+
+set lock_timeout = '5s';
+set statement_timeout = '120s';
+
+-- ----------------------------------------------------------------------------
+-- MATERIALIZE — VOLATILE, service_role only. Idempotent (UPSERT).
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_seo_action_outcomes_materialize_v1(
+    p_now           timestamptz DEFAULT now(),
+    p_lookback_days integer     DEFAULT 90
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  v_last_data_date date;
+  v_data_lag       int;
+  v_complete       int := 0;
+  v_pending        int := 0;
+  v_windows        int[] := ARRAY[7, 14, 28];
+  r                record;
+  w                int;
+  v_base           record;
+  v_obs            record;
+  v_overlap        text[];
+BEGIN
+  SELECT max(date) INTO v_last_data_date FROM public.__seo_gsc_daily;
+  IF v_last_data_date IS NULL THEN
+    RETURN jsonb_build_object('status', 'no_gsc_data', 'complete', 0, 'pending', 0);
+  END IF;
+  v_data_lag := (p_now::date - v_last_data_date);
+
+  FOR r IN
+    SELECT a.aal_id                                          AS action_ref,
+           a.aal_entity_id                                   AS page,
+           a.aal_new_value->>'action_kind'                   AS action_kind,
+           (a.aal_new_value->>'applied_at_utc')::timestamptz AS t0,
+           COALESCE((a.aal_new_value->>'baseline_window_days')::int, 28) AS base_n
+    FROM public.__admin_audit_log a
+    WHERE a.aal_action = 'seo_action_applied'
+      AND (a.aal_new_value->>'applied_at_utc')::timestamptz
+            >= p_now - (p_lookback_days || ' days')::interval
+      AND (a.aal_new_value->>'applied_at_utc')::timestamptz <= p_now
+  LOOP
+    -- Chevauchement : autre action sur la MÊME page, T0 différent, à <= 28 j.
+    SELECT array_agg(DISTINCT b.aal_id::text) INTO v_overlap
+    FROM public.__admin_audit_log b
+    WHERE b.aal_action = 'seo_action_applied'
+      AND b.aal_entity_id = r.page
+      AND b.aal_id <> r.action_ref
+      AND abs(extract(epoch FROM (
+            (b.aal_new_value->>'applied_at_utc')::timestamptz - r.t0)) / 86400) <= 28;
+
+    FOREACH w IN ARRAY v_windows LOOP
+      IF ((r.t0 AT TIME ZONE 'UTC')::date + w) <= v_last_data_date THEN
+        -- baseline [t0 - base_n, t0)
+        SELECT
+          sum(impressions)::float8 / NULLIF(r.base_n, 0)                 AS d_impr,
+          sum(clicks)::float8      / NULLIF(r.base_n, 0)                 AS d_clk,
+          sum(clicks)::float8      / NULLIF(sum(impressions), 0)         AS ctr,
+          sum(position * impressions)::float8 / NULLIF(sum(impressions), 0) AS pos,
+          (count(*) > 0)                                                 AS has_data
+        INTO v_base
+        FROM public.__seo_gsc_daily
+        WHERE page = r.page AND date >= ((r.t0 AT TIME ZONE 'UTC')::date - r.base_n) AND date < (r.t0 AT TIME ZONE 'UTC')::date;
+
+        -- observed [t0, t0+w)
+        SELECT
+          sum(impressions)::float8 / NULLIF(w, 0)                        AS d_impr,
+          sum(clicks)::float8      / NULLIF(w, 0)                        AS d_clk,
+          sum(clicks)::float8      / NULLIF(sum(impressions), 0)         AS ctr,
+          sum(position * impressions)::float8 / NULLIF(sum(impressions), 0) AS pos
+        INTO v_obs
+        FROM public.__seo_gsc_daily
+        WHERE page = r.page AND date >= (r.t0 AT TIME ZONE 'UTC')::date AND date < ((r.t0 AT TIME ZONE 'UTC')::date + w);
+
+        INSERT INTO public.__seo_action_outcome (
+          action_ref, page, action_kind, t0_utc, window_days, is_complete,
+          expected_complete_date, baseline_has_data,
+          baseline_daily_impr, baseline_daily_clicks, baseline_daily_ctr, baseline_daily_pos,
+          observed_daily_impr, observed_daily_clicks, observed_daily_ctr, observed_daily_pos,
+          delta_daily_impr, delta_daily_clicks, delta_ctr, delta_pos,
+          is_overlapped, confounding_actions, data_lag_days, source, causal_claim, measured_at
+        ) VALUES (
+          r.action_ref, r.page, r.action_kind, r.t0, w, true,
+          NULL, COALESCE(v_base.has_data, false),
+          v_base.d_impr, v_base.d_clk, v_base.ctr, v_base.pos,
+          v_obs.d_impr, v_obs.d_clk, v_obs.ctr, v_obs.pos,
+          (COALESCE(v_obs.d_impr, 0) - COALESCE(v_base.d_impr, 0)),
+          (COALESCE(v_obs.d_clk, 0)  - COALESCE(v_base.d_clk, 0)),
+          (COALESCE(v_obs.ctr, 0)    - COALESCE(v_base.ctr, 0)),
+          (COALESCE(v_obs.pos, 0)    - COALESCE(v_base.pos, 0)),
+          (v_overlap IS NOT NULL), COALESCE(v_overlap, '{}'), v_data_lag,
+          'query_grain', 'OBSERVATIONAL', p_now
+        )
+        ON CONFLICT (action_ref, window_days) DO UPDATE SET
+          is_complete = EXCLUDED.is_complete,
+          expected_complete_date = EXCLUDED.expected_complete_date,
+          baseline_has_data = EXCLUDED.baseline_has_data,
+          baseline_daily_impr = EXCLUDED.baseline_daily_impr,
+          baseline_daily_clicks = EXCLUDED.baseline_daily_clicks,
+          baseline_daily_ctr = EXCLUDED.baseline_daily_ctr,
+          baseline_daily_pos = EXCLUDED.baseline_daily_pos,
+          observed_daily_impr = EXCLUDED.observed_daily_impr,
+          observed_daily_clicks = EXCLUDED.observed_daily_clicks,
+          observed_daily_ctr = EXCLUDED.observed_daily_ctr,
+          observed_daily_pos = EXCLUDED.observed_daily_pos,
+          delta_daily_impr = EXCLUDED.delta_daily_impr,
+          delta_daily_clicks = EXCLUDED.delta_daily_clicks,
+          delta_ctr = EXCLUDED.delta_ctr,
+          delta_pos = EXCLUDED.delta_pos,
+          is_overlapped = EXCLUDED.is_overlapped,
+          confounding_actions = EXCLUDED.confounding_actions,
+          data_lag_days = EXCLUDED.data_lag_days,
+          measured_at = EXCLUDED.measured_at;
+        v_complete := v_complete + 1;
+      ELSE
+        -- fenêtre pas encore mûre → ligne PENDING explicite (jamais un faux 0)
+        INSERT INTO public.__seo_action_outcome (
+          action_ref, page, action_kind, t0_utc, window_days, is_complete,
+          expected_complete_date, baseline_has_data, is_overlapped, confounding_actions,
+          data_lag_days, source, causal_claim, measured_at
+        ) VALUES (
+          r.action_ref, r.page, r.action_kind, r.t0, w, false,
+          ((r.t0 AT TIME ZONE 'UTC')::date + w), false, (v_overlap IS NOT NULL), COALESCE(v_overlap, '{}'),
+          v_data_lag, 'query_grain', 'OBSERVATIONAL', p_now
+        )
+        ON CONFLICT (action_ref, window_days) DO UPDATE SET
+          expected_complete_date = EXCLUDED.expected_complete_date,
+          is_overlapped = EXCLUDED.is_overlapped,
+          confounding_actions = EXCLUDED.confounding_actions,
+          data_lag_days = EXCLUDED.data_lag_days,
+          measured_at = EXCLUDED.measured_at
+        WHERE public.__seo_action_outcome.is_complete = false; -- ne jamais écraser un outcome complet
+        v_pending := v_pending + 1;
+      END IF;
+    END LOOP;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'status', 'ok', 'complete', v_complete, 'pending', v_pending,
+    'last_data_date', v_last_data_date, 'data_lag_days', v_data_lag, 'generated_at', p_now
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.rpc_seo_action_outcomes_materialize_v1(timestamptz, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_seo_action_outcomes_materialize_v1(timestamptz, integer) TO service_role;
+
+COMMENT ON FUNCTION public.rpc_seo_action_outcomes_materialize_v1(timestamptz, integer) IS
+  'PR-2 boucle OBSERVE — matérialise les outcomes (delta baseline vs fenêtre 7/14/28 j) depuis '
+  'les attributions seo_action_applied × __seo_gsc_daily. VOLATILE, service_role only (lit le '
+  'ledger admin). Idempotent. Fenêtre émise complète seulement si t0+w <= last_data_date.';
+
+-- ----------------------------------------------------------------------------
+-- READ — STABLE SECURITY DEFINER, anon-safe (lit la table projetée uniquement).
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rpc_seo_action_outcomes_v1(
+    p_now           timestamptz DEFAULT now(),
+    p_lookback_days integer     DEFAULT 90,
+    p_limit         integer     DEFAULT 100
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $function$
+  WITH sel AS (
+    SELECT o.*
+    FROM public.__seo_action_outcome o
+    WHERE o.t0_utc >= p_now - (p_lookback_days || ' days')::interval
+      AND o.t0_utc <= p_now
+    ORDER BY o.t0_utc DESC, o.window_days
+    LIMIT GREATEST(p_limit, 0)
+  )
+  SELECT jsonb_build_object(
+    'rows', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'action_ref', s.action_ref,
+        'page', s.page,
+        'action_kind', s.action_kind,
+        't0_utc', s.t0_utc,
+        'window_days', s.window_days,
+        'is_complete', s.is_complete,
+        'expected_complete_date', s.expected_complete_date,
+        'baseline_has_data', s.baseline_has_data,
+        'baseline_daily', jsonb_build_object(
+          'impressions', s.baseline_daily_impr, 'clicks', s.baseline_daily_clicks,
+          'ctr', s.baseline_daily_ctr, 'avg_position', s.baseline_daily_pos),
+        'observed_daily', jsonb_build_object(
+          'impressions', s.observed_daily_impr, 'clicks', s.observed_daily_clicks,
+          'ctr', s.observed_daily_ctr, 'avg_position', s.observed_daily_pos),
+        'delta', jsonb_build_object(
+          'daily_impressions', s.delta_daily_impr, 'daily_clicks', s.delta_daily_clicks,
+          'ctr', s.delta_ctr, 'avg_position', s.delta_pos),
+        'is_overlapped', s.is_overlapped,
+        'confounding_actions', s.confounding_actions,
+        'data_lag_days', s.data_lag_days,
+        'source', s.source,
+        'causal_claim', s.causal_claim,
+        'measured_at', s.measured_at
+      ) ORDER BY s.t0_utc DESC, s.window_days)
+      FROM sel s
+    ), '[]'::jsonb),
+    'total', (SELECT count(*) FROM sel),
+    'complete', (SELECT count(*) FROM sel WHERE is_complete),
+    'pending', (SELECT count(*) FROM sel WHERE NOT is_complete),
+    'last_data_date', (SELECT max(date) FROM public.__seo_gsc_daily),
+    'metric_source', 'query_grain',
+    'causal_disclaimer',
+      'OBSERVATIONAL — comparaison baseline vs fenêtre, PAS une inférence causale '
+      || '(saisonnalité, concurrence, mises à jour algorithme non contrôlées).',
+    'generated_at', p_now
+  );
+$function$;
+
+REVOKE ALL ON FUNCTION public.rpc_seo_action_outcomes_v1(timestamptz, integer, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rpc_seo_action_outcomes_v1(timestamptz, integer, integer)
+  TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.rpc_seo_action_outcomes_v1(timestamptz, integer, integer) IS
+  'PR-2 boucle OBSERVE — lecture des outcomes SEO matérialisés (enveloppe honnête : rows + '
+  'complete/pending + last_data_date + disclaimer OBSERVATIONNEL). STABLE, lit UNIQUEMENT '
+  '__seo_action_outcome (jamais __admin_audit_log) → anon-safe.';

--- a/backend/supabase/migrations/20260618_seo_action_outcome_rpcs.sql
+++ b/backend/supabase/migrations/20260618_seo_action_outcome_rpcs.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE FUNCTION public.rpc_seo_action_outcomes_materialize_v1(
 RETURNS jsonb
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = ''
 AS $function$
 DECLARE
   v_last_data_date date;
@@ -161,7 +162,10 @@ BEGIN
 END;
 $function$;
 
-REVOKE ALL ON FUNCTION public.rpc_seo_action_outcomes_materialize_v1(timestamptz, integer) FROM PUBLIC;
+-- FROM PUBLIC seul NE SUFFIT PAS : les default privileges Supabase accordent EXECUTE
+-- aux roles anon/authenticated sur toute fonction de public → on les retire explicitement.
+-- materialize = VOLATILE + SECURITY DEFINER (écrit + lit le ledger admin) → service_role ONLY.
+REVOKE ALL ON FUNCTION public.rpc_seo_action_outcomes_materialize_v1(timestamptz, integer) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.rpc_seo_action_outcomes_materialize_v1(timestamptz, integer) TO service_role;
 
 COMMENT ON FUNCTION public.rpc_seo_action_outcomes_materialize_v1(timestamptz, integer) IS
@@ -181,6 +185,7 @@ RETURNS jsonb
 LANGUAGE sql
 STABLE
 SECURITY DEFINER
+SET search_path = ''
 AS $function$
   WITH sel AS (
     SELECT o.*

--- a/backend/supabase/migrations/20260618_seo_action_outcome_table.sql
+++ b/backend/supabase/migrations/20260618_seo_action_outcome_table.sql
@@ -1,0 +1,84 @@
+-- ============================================================================
+-- PR-2 — Table d'outcomes matérialisés (boucle OBSERVE : … → MESURE 7/14/28 j)
+-- ----------------------------------------------------------------------------
+-- Snapshot IMMUABLE des deltas par (action, fenêtre). Pourquoi matérialiser plutôt
+-- que calculer on-read (anti-bricolage) :
+--   * GSC RÉVISE les jours récents → un calcul on-read dériverait ; un snapshot figé
+--     une fois la fenêtre mûre est replay-proof ;
+--   * l'accès anon de lecture lit UNIQUEMENT cette table projetée (jamais __admin_audit_log)
+--     → la non-exposition du ledger admin est STRUCTURELLE (cf. CHECK-0 flag #2).
+--
+-- Pattern table : mirror RLS de __seo_quality_history (20260507) MAIS **NON partitionnée** :
+-- volume = (nb actions attribuées × 3 fenêtres) = faible → la partition + sa rotation
+-- seraient du sur-engineering et un risque de drift (incident snapshot-partition-rotation).
+--
+-- Idempotent (IF NOT EXISTS) + réversible (DOWN en pied).
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.__seo_action_outcome (
+  action_ref     UUID NOT NULL,                 -- = __admin_audit_log.aal_id de l'attribution
+  page           TEXT NOT NULL,                 -- clé GSC absolue (DÉNORMALISÉE depuis la ligne audit)
+  action_kind    TEXT NOT NULL,                 -- dénormalisé
+  t0_utc         TIMESTAMPTZ NOT NULL,          -- ancre de mesure (applied_at_utc)
+  window_days    INT NOT NULL CHECK (window_days IN (7, 14, 28)),
+  is_complete    BOOLEAN NOT NULL,              -- fenêtre entièrement couverte par les données GSC ?
+  expected_complete_date DATE,                  -- si pending : date à laquelle la fenêtre sera mesurable
+
+  baseline_has_data BOOLEAN NOT NULL DEFAULT false,  -- baseline GSC non vide ? (sinon delta non fiable)
+
+  -- métriques en FLOAT8 (supabase-js convertit NUMERIC → string ; FLOAT8 = number)
+  baseline_daily_impr   FLOAT8,
+  baseline_daily_clicks FLOAT8,
+  baseline_daily_ctr    FLOAT8,                  -- ratio agrégé clics/impr sur la baseline
+  baseline_daily_pos    FLOAT8,                  -- position moyenne pondérée impressions
+  observed_daily_impr   FLOAT8,
+  observed_daily_clicks FLOAT8,
+  observed_daily_ctr    FLOAT8,
+  observed_daily_pos    FLOAT8,
+  delta_daily_impr      FLOAT8,                  -- observed - baseline (taux/jour)
+  delta_daily_clicks    FLOAT8,
+  delta_ctr             FLOAT8,
+  delta_pos             FLOAT8,                  -- NÉGATIF = rang amélioré
+
+  is_overlapped       BOOLEAN NOT NULL DEFAULT false,  -- autre action sur la même page chevauche
+  confounding_actions TEXT[] NOT NULL DEFAULT '{}',    -- aal_id des actions chevauchantes
+  data_lag_days       INT,                              -- lag GSC au moment de la mesure
+  source              TEXT NOT NULL DEFAULT 'query_grain',   -- grain métrique (CHECK-0 : query → swap fidèle plus tard)
+  causal_claim        TEXT NOT NULL DEFAULT 'OBSERVATIONAL', -- jamais causal
+  measured_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (action_ref, window_days)          -- clé d'idempotence de l'UPSERT
+);
+
+COMMENT ON TABLE public.__seo_action_outcome IS
+  'PR-2 boucle OBSERVE — outcomes SEO matérialisés (delta baseline vs fenêtre 7/14/28 j) par '
+  'action attribuée. Snapshot immuable des fenêtres complètes + lignes pending. OBSERVATIONNEL, '
+  'jamais causal. Table de lecture du RPC anon rpc_seo_action_outcomes_v1 (dénormalisée, sans '
+  'exposer __admin_audit_log).';
+
+CREATE INDEX IF NOT EXISTS idx_seo_action_outcome_page_t0
+  ON public.__seo_action_outcome (page, t0_utc DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_action_outcome_t0
+  ON public.__seo_action_outcome (t0_utc DESC);
+CREATE INDEX IF NOT EXISTS idx_seo_action_outcome_kind
+  ON public.__seo_action_outcome (action_kind, is_complete);
+
+-- ----------------------------------------------------------------------------
+-- RLS — pattern __seo_quality_history (service_role tout, authenticated lecture).
+-- PAS de policy anon : l'accès anon se fait UNIQUEMENT via le RPC SECURITY DEFINER
+-- rpc_seo_action_outcomes_v1 (projection contrôlée), jamais en SELECT direct.
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.__seo_action_outcome ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS service_role_all ON public.__seo_action_outcome; -- APPROVED: idempotent re-create of RLS policy
+CREATE POLICY service_role_all ON public.__seo_action_outcome
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS authenticated_read ON public.__seo_action_outcome; -- APPROVED: idempotent re-create of RLS policy
+CREATE POLICY authenticated_read ON public.__seo_action_outcome
+  FOR SELECT TO authenticated USING (true);
+
+-- ============================================================================
+-- DOWN (réversibilité — exécuter manuellement) :
+--   DROP TABLE IF EXISTS public.__seo_action_outcome;
+-- ============================================================================

--- a/backend/supabase/migrations/20260618_seo_action_outcome_table.sql
+++ b/backend/supabase/migrations/20260618_seo_action_outcome_table.sql
@@ -1,3 +1,10 @@
+-- squawk-ignore-file require-concurrent-index-creation
+-- squawk-ignore-file prefer-bigint-over-int
+--   Plain CREATE INDEX (table neuve, volume faible ; CONCURRENTLY interdit en transaction).
+--   window_days/data_lag_days = INT bornés (∈ {7,14,28} / jours) — bigint inutile.
+set lock_timeout = '5s';
+set statement_timeout = '60s';
+
 -- ============================================================================
 -- PR-2 — Table d'outcomes matérialisés (boucle OBSERVE : … → MESURE 7/14/28 j)
 -- ----------------------------------------------------------------------------

--- a/log.md
+++ b/log.md
@@ -502,3 +502,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/cc-orchestration-shadow-phase1`
 - **Décision** : feat(command-center): orchestration Phase 1 « shadow » — fondation inerte (ADR-087)
 - **Sortie** : PR #1010 | commits ed3c3be20
+
+## 2026-06-18 — feat/seo-action-outcome-attribution (auto)
+
+- **Branche** : `feat/seo-action-outcome-attribution`
+- **Décision** : feat(seo-observability): PR-2 mesure outcomes 7/14/28j (boucle OBSERVE) (+1 other commit)
+- **Sortie** : PR aucune | commits a1985e0ea 1ce534a2c

--- a/log.md
+++ b/log.md
@@ -514,3 +514,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-action-outcome-attribution`
 - **Décision** : feat(seo-observability): PR-3 restitution Command Center + MCP (boucle OBSERVE) (+3 other commits)
 - **Sortie** : PR aucune | commits 2f4d8592c fb052bb6f a1985e0ea 1ce534a2c
+
+## 2026-06-18 — feat/seo-action-outcome-attribution (auto)
+
+- **Branche** : `feat/seo-action-outcome-attribution`
+- **Décision** : chore(registry): ownership glob D3 pour migrations seo_action_* (boucle OBSERVE) (+5 other commits)
+- **Sortie** : PR #1025 | commits e6c86fa57 3184b0660 2f4d8592c fb052bb6f a1985e0ea 1ce534a2c

--- a/log.md
+++ b/log.md
@@ -526,3 +526,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-action-outcome-attribution`
 - **Décision** : chore(registry): ownership glob D3 pour migrations seo_action_* (boucle OBSERVE) (+5 other commits)
 - **Sortie** : PR #1025 | commits e6c86fa57 3184b0660 2f4d8592c fb052bb6f a1985e0ea 1ce534a2c
+
+## 2026-06-18 — feat/seo-action-outcome-attribution (auto)
+
+- **Branche** : `feat/seo-action-outcome-attribution`
+- **Décision** : Merge remote-tracking branch 'origin/main' into feat/seo-action-outcome-attribution (+7 other commits)
+- **Sortie** : PR #1025 | commits 989ff8809 43c470f02 e6c86fa57 3184b0660 2f4d8592c fb052bb6f a1985e0ea 1ce534a2c

--- a/log.md
+++ b/log.md
@@ -532,3 +532,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-action-outcome-attribution`
 - **Décision** : Merge remote-tracking branch 'origin/main' into feat/seo-action-outcome-attribution (+7 other commits)
 - **Sortie** : PR #1025 | commits 989ff8809 43c470f02 e6c86fa57 3184b0660 2f4d8592c fb052bb6f a1985e0ea 1ce534a2c
+
+## 2026-06-18 — feat/seo-action-outcome-attribution (auto)
+
+- **Branche** : `feat/seo-action-outcome-attribution`
+- **Décision** : fix(ci): squawk timeouts/ignores + RPC-gate allowlist seo-action-outcome (boucle OBSERVE) (+9 other commits)
+- **Sortie** : PR #1025 | commits 8bbde1757 d3e2392c6 989ff8809 43c470f02 e6c86fa57 3184b0660 2f4d8592c fb052bb6f a1985e0ea 1ce534a2c

--- a/log.md
+++ b/log.md
@@ -508,3 +508,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-action-outcome-attribution`
 - **Décision** : feat(seo-observability): PR-2 mesure outcomes 7/14/28j (boucle OBSERVE) (+1 other commit)
 - **Sortie** : PR aucune | commits a1985e0ea 1ce534a2c
+
+## 2026-06-18 — feat/seo-action-outcome-attribution (auto)
+
+- **Branche** : `feat/seo-action-outcome-attribution`
+- **Décision** : feat(seo-observability): PR-3 restitution Command Center + MCP (boucle OBSERVE) (+3 other commits)
+- **Sortie** : PR aucune | commits 2f4d8592c fb052bb6f a1985e0ea 1ce534a2c

--- a/scripts/mcp-server/server.js
+++ b/scripts/mcp-server/server.js
@@ -132,6 +132,29 @@ class SupabaseMCPServer {
             required: ["table"],
           },
         },
+        {
+          name: "seo_outcomes",
+          description: "Outcomes SEO matérialisés (delta baseline vs fenêtre 7/14/28j par action, boucle OBSERVE). Lecture seule via rpc_seo_action_outcomes_v1.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              lookback_days: { type: "number", description: "Fenêtre de recherche des actions en jours (défaut 90)", default: 90 },
+              limit: { type: "number", description: "Nombre max de lignes (défaut 100)", default: 100 }
+            }
+          },
+        },
+        {
+          name: "seo_low_ctr",
+          description: "Opportunités SEO : pages à fortes impressions et ~0 clic (CTR à récupérer). Lecture seule via rpc_seo_low_ctr_v3.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              window_days: { type: "number", description: "Fenêtre GSC en jours (défaut 120)", default: 120 },
+              min_impressions: { type: "number", description: "Seuil d'impressions (défaut 50)", default: 50 },
+              limit: { type: "number", description: "Nombre max de lignes (défaut 50)", default: 50 }
+            }
+          },
+        },
       ],
     }));
 
@@ -243,6 +266,36 @@ class SupabaseMCPServer {
                   }, null, 2),
                 },
               ],
+            };
+          }
+
+          case "seo_outcomes": {
+            const { lookback_days = 90, limit = 100 } = args;
+            const { data, error } = await supabase.rpc('rpc_seo_action_outcomes_v1', {
+              p_lookback_days: lookback_days,
+              p_limit: limit,
+            });
+            if (error) {
+              throw new Error(`Erreur Supabase: ${error.message}`);
+            }
+            return {
+              content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+            };
+          }
+
+          case "seo_low_ctr": {
+            const { window_days = 120, min_impressions = 50, limit = 50 } = args;
+            const { data, error } = await supabase.rpc('rpc_seo_low_ctr_v3', {
+              p_window_days: window_days,
+              p_min_impressions: min_impressions,
+              p_max_ctr: 0.01,
+              p_limit: limit,
+            });
+            if (error) {
+              throw new Error(`Erreur Supabase: ${error.message}`);
+            }
+            return {
+              content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
             };
           }
 


### PR DESCRIPTION
## Boucle OBSERVE SEO — fermer le maillon manquant (DRAFT, owner-gated)

Ferme le seul maillon absent du système SEO (vérifié vs verdict owner « Sorank ») :
`DATA → DIAGNOSTIC → ACTION → **ATTRIBUTION → MESURE 7/14/28 j → RESTITUTION**`.
**Observe pur, flag OFF par défaut, réversible.** Étend le Command Center / les tables `__seo_*` /
le MCP Supabase existant — **aucun control-plane ni plateforme nouvelle**.

### CHECK-0 (preflight LECTURE SEULE, GREEN) — `audit/seo-action-outcome-preflight-2026-06-18.md`
- RLS `__admin_audit_log` **ON + anon-deny** (policy `service_role_aal`) → grant anon sûr.
- Clé `page` = **URL absolue** GSC (helper via `getGSCSiteUrl()`, même source que le fetcher).
- Source métrique V1 = **grain query `__seo_gsc_daily`** (71 j d'historique) — le grain fidèle
  `__seo_gsc_daily_pages` n'a que 5 j (swap à ≥ 56 j, re-matérialisation propre).

### Les 3 commits
1. **Attribution** — `seo_action_applied` dans le ledger EXISTANT `__admin_audit_log` (namespace,
   comme `cc_orchestration_shadow_plan` / ADR-087 — jamais de ledger parallèle) ; helper de
   canonicalisation clé-page (+10 tests unit) ; `POST /api/admin/seo/action/applied` (IsAdminGuard,
   Zod strict) ; diagnostic `gsc_match_rows` surfacé (no silent fallback) ; migration : index partiel.
2. **Mesure** — table `__seo_action_outcome` (**non-partitionnée** : volume faible → évite le risque
   rotation-drift) ; `rpc_seo_action_outcomes_materialize_v1` (VOLATILE service_role, UPSERT
   idempotent, fenêtre émise complète seulement si `t0+w ≤ last_data_date`, taux/jour + position
   pondérée impressions, dates UTC explicites, overlap/confounding) ; `rpc_seo_action_outcomes_v1`
   (STABLE SECURITY DEFINER **anon-safe** — lit la table projetée, **jamais** l'audit-log) ;
   endpoints `POST .../materialize` + `GET .../outcomes` ; allowlist (read RPC).
3. **Restitution** — champ additif `seo_outcomes` au Command Center (flag
   `COMMAND_CENTER_SEO_OUTCOMES` **OFF défaut / PROD forcé OFF**, strippé en light/disabled) ;
   2 tools MCP read-only (`seo_outcomes`, `seo_low_ctr`). Détection/scoring/owner-queue **inchangés**.

### Vérification
- `tsc --noEmit` : **0 erreur** · ESLint : **0** · Jest helper : **10/10**.
- **SQL prouvé end-to-end** via `BEGIN…ROLLBACK` (données GSC réelles, **0 mutation persistée**) :
  materialize `complete:3` sur pilote `emetteur-d-embrayage` (base 98.4 impr/j, deltas cohérents,
  `delta_pos < 0` = rang amélioré) ; read envelope OK (rows/complete/pending/last_data_date).

### Cohérence avec l'écosystème substance (vérifiée)
**Indépendant** de `shadow_score` / ADR-088 (substance pré-publication) — cette couche mesure
l'OUTCOME post-publication. Couture = `source_action_id` + `action_kind` (content_enrich /
regen_artifact). Pas de SoT dupliquée, pas de collision table/RPC. **Merge idéalement après #50**
(wiki `shadow_score.py`) — narratif (substance active → puis mesure), pas une dépendance technique.

### Owner-gated AVANT merge
- [ ] **Appliquer les 3 migrations** à la DB partagée (process revue, axe 4). Sans ça, le champ CC
      et le tool MCP `seo_outcomes` restent vides (`seo_low_ctr` fonctionne déjà).
- [ ] **Gate runtime PRE-PR** : seed une URL pilote sur DEV:3000 → vérifier la ligne +
      `gsc_match_rows > 0`, puis `materialize` / `outcomes`.
- [ ] **Merge** (idéalement après #50, pour activer la composition substance).

### Non-goals (explicites)
Conversions GA4 (clé path à dériver) · cron materialize · auto-tuning des seuils · PostHog ·
backlinks · beacons maillage · **aucune URL / meta / H1 / contenu / noindex touché**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
