### PR TITLE
chore(rag-proxy): retire RagPipelineService + endpoints pipeline (rag-purge B8)

### DIFF
--- a/backend/src/modules/rag-proxy/rag-pipeline.service.ts
+++ b/backend/src/modules/rag-proxy/rag-pipeline.service.ts
@@ -1,3 +1,9 @@
+// ⚠️ DEPRECATED (ADR-031/046 · programme rag-purge B8 2026-06-19) — RAG = retrieval chatbot only,
+// JAMAIS source de contenu/SEO. Ce service orchestrait l'ingestion/reindex RAG « propre »
+// (spawn de scripts → Weaviate) via les endpoints admin/pipeline/* — RETIRÉS (controller + provider).
+// Architecture cible : RAG = consommateur du wiki, pour le chat ; seule entrée d'ingestion =
+// le sync wiki→rag (scripts/rag-sync/sync-wiki-exports-to-rag.py). Plus aucun câblage DI.
+// Conservé pour salvage (non supprimé) — recoverable via git si réactivation gouvernée requise.
 import {
   Injectable,
   Logger,

--- a/backend/src/modules/rag-proxy/rag-proxy.controller.ts
+++ b/backend/src/modules/rag-proxy/rag-proxy.controller.ts
@@ -23,7 +23,6 @@ import type { Response } from 'express';
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
 import { RagProxyService } from './rag-proxy.service';
-import { RagPipelineService } from './rag-pipeline.service';
 import { RagCleanupService } from './services/rag-cleanup.service';
 import { RagWebIngestDbService } from './services/rag-web-ingest-db.service';
 import { RagIngestionService } from './services/rag-ingestion.service';
@@ -57,7 +56,6 @@ import {
   ManualIngestRequestSchema,
   ManualIngestRequestDto,
 } from './dto/manual-ingest.dto';
-import { PipelineLaunchSchema, PipelineLaunchDto } from './dto/pipeline.dto';
 import {
   WebhookIngestionCompleteSchema,
   WebhookIngestionCompleteDto,
@@ -75,7 +73,6 @@ import { RAG_KNOWLEDGE_PATH } from '../../config/rag.config';
 export class RagProxyController {
   constructor(
     private readonly ragProxyService: RagProxyService,
-    private readonly ragPipelineService: RagPipelineService,
     private readonly ragCleanupService: RagCleanupService,
     private readonly ragWebIngestDbService: RagWebIngestDbService,
     private readonly ragIngestionService: RagIngestionService,
@@ -844,77 +841,13 @@ export class RagProxyController {
     return { ...result, filesMatched: files.length };
   }
 
-  // ── Pipeline endpoints (async job orchestration) ──────────
-
-  @Post('admin/pipeline/launch')
-  @HttpCode(HttpStatus.ACCEPTED)
-  @UseGuards(InternalApiKeyGuard)
-  @UsePipes(new ZodValidationPipe(PipelineLaunchSchema))
-  @ApiOperation({
-    summary: 'Launch a pipeline step (audit / enrich / reindex)',
-  })
-  @ApiResponse({
-    status: 202,
-    description: 'Job queued — poll GET /runs/:runId',
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'Invalid payload or scope not found',
-  })
-  @ApiResponse({ status: 409, description: 'Pipeline already running' })
-  async launchPipeline(
-    @Body() dto: PipelineLaunchDto,
-  ): Promise<{ run_id: string; status: string }> {
-    return this.ragPipelineService.launch(dto);
-  }
-
-  @Get('admin/pipeline/status')
-  @UseGuards(InternalApiKeyGuard)
-  @ApiOperation({
-    summary: 'Global pipeline status: lock + last runs + corpus metrics',
-  })
-  @ApiResponse({ status: 200, description: 'Pipeline status' })
-  async getPipelineStatus(): Promise<object> {
-    return this.ragPipelineService.getStatus();
-  }
-
-  @Get('admin/pipeline/runs/:runId')
-  @UseGuards(InternalApiKeyGuard)
-  @ApiOperation({ summary: 'Get a specific pipeline run state' })
-  @ApiResponse({ status: 200, description: 'Pipeline run' })
-  @ApiResponse({ status: 404, description: 'Run not found' })
-  async getPipelineRun(@Param('runId') runId: string) {
-    return this.ragPipelineService.getRunById(runId);
-  }
-
-  @Get('admin/pipeline/runs/:runId/logs')
-  @UseGuards(InternalApiKeyGuard)
-  @ApiOperation({ summary: 'Get pipeline run logs (snapshot, not streamed)' })
-  @ApiResponse({ status: 200, description: 'Log lines snapshot' })
-  @ApiResponse({ status: 404, description: 'Run not found' })
-  async getPipelineRunLogs(
-    @Param('runId') runId: string,
-    @Query('tail') tail?: string,
-  ) {
-    const tailLines = tail
-      ? Math.min(10_000, Math.max(1, parseInt(tail, 10) || 200))
-      : 200;
-    return this.ragPipelineService.getRunLogs(runId, tailLines);
-  }
-
-  @Post('admin/pipeline/runs/:runId/cancel')
-  @HttpCode(HttpStatus.OK)
-  @UseGuards(InternalApiKeyGuard)
-  @ApiOperation({ summary: 'Cancel a running or queued pipeline run' })
-  @ApiResponse({ status: 200, description: 'Run cancelled' })
-  @ApiResponse({
-    status: 400,
-    description: 'Run not cancellable in current status',
-  })
-  @ApiResponse({ status: 404, description: 'Run not found' })
-  async cancelPipelineRun(@Param('runId') runId: string) {
-    return this.ragPipelineService.cancelRun(runId);
-  }
+  // ── Pipeline endpoints RETIRÉS — rag-purge B8 (ADR-031/046) ──────────
+  // Les endpoints admin/pipeline/* (launch/status/runs/logs/cancel) pilotaient
+  // RagPipelineService = ingestion/reindex RAG « propre » (spawn de scripts → Weaviate).
+  // Architecture cible : RAG = consommateur du wiki, pour le chat seulement ; sa seule
+  // entrée d'ingestion = le sync wiki→rag (scripts/rag-sync/sync-wiki-exports-to-rag.py).
+  // L'application ne déclenche plus aucune ingestion RAG. RagPipelineService est conservé
+  // pour salvage (bannerisé, non câblé) — voir rag-pipeline.service.ts.
 
   // ── Phase 2A — Legacy Adapted Shadow Audit ──────────────
 

--- a/backend/src/modules/rag-proxy/rag-proxy.module.ts
+++ b/backend/src/modules/rag-proxy/rag-proxy.module.ts
@@ -3,7 +3,6 @@ import { ConfigModule } from '@nestjs/config';
 import { SupabaseStorageService } from '../upload/services/supabase-storage.service';
 import { RagProxyController } from './rag-proxy.controller';
 import { RagProxyService } from './rag-proxy.service';
-import { RagPipelineService } from './rag-pipeline.service';
 
 // Existing extracted services
 import { FrontmatterValidatorService } from './services/frontmatter-validator.service';
@@ -83,8 +82,8 @@ import { RagPhase2aShadowAuditService } from './services/rag-phase2a-shadow-audi
     RagVideoManagementService,
     // Facade (depends on all above)
     RagProxyService,
-    // Pipeline orchestration (async jobs: audit / enrich / reindex)
-    RagPipelineService,
+    // NB: RagPipelineService (ingestion/reindex RAG) RETIRÉ des providers — rag-purge B8
+    // (ADR-031/046). RAG = consommateur du wiki pour le chat ; entrée = sync wiki→rag.
   ],
   exports: [
     // Backward compat — external modules inject RagProxyService

--- a/backend/tests/unit/rag-proxy.controller.test.ts
+++ b/backend/tests/unit/rag-proxy.controller.test.ts
@@ -25,7 +25,6 @@ import { RagImageManagementService } from '../../src/modules/rag-proxy/services/
 import { RagVideoManagementService } from '../../src/modules/rag-proxy/services/rag-video-management.service';
 import { RagGammeDetectionService } from '../../src/modules/rag-proxy/services/rag-gamme-detection.service';
 import { RagPhase2aShadowAuditService } from '../../src/modules/rag-proxy/services/rag-phase2a-shadow-audit.service';
-import { RagPipelineService } from '../../src/modules/rag-proxy/rag-pipeline.service';
 
 describe('RagProxyController', () => {
   let app: INestApplication;
@@ -48,7 +47,6 @@ describe('RagProxyController', () => {
         { provide: RagVideoManagementService, useValue: {} },
         { provide: RagGammeDetectionService, useValue: {} },
         { provide: RagPhase2aShadowAuditService, useValue: {} },
-        { provide: RagPipelineService, useValue: {} },
         { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('test-internal-api-key') } },
       ],
     }).compile();

--- a/log.md
+++ b/log.md
@@ -508,3 +508,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-content-loop-source-discovery`
 - **Décision** : feat(skill): seo-content-loop — découverte de sources data-driven par gamme/véhicule/diagnostic (+ track)
 - **Sortie** : PR aucune | commits 171a23158
+
+## 2026-06-19 — chore/rag-purge-b8-pipeline-service (auto)
+
+- **Branche** : `chore/rag-purge-b8-pipeline-service`
+- **Décision** : chore(rag-proxy): retire RagPipelineService + endpoints pipeline (rag-purge B8)
+- **Sortie** : PR aucune | commits f5d45041f


### PR DESCRIPTION
## Pourquoi

Architecture cible (rectif owner) : **RAG = consommateur du wiki, pour le chat seulement.**
Le contenu vient de `scraping → raw → wiki → projection → tables live` ; le RAG n'ingère plus rien
par lui-même — sa seule entrée = le sync `wiki→rag` (`scripts/rag-sync/sync-wiki-exports-to-rag.py`).
`rag-pipeline.service.ts` (orchestrateur d'ingestion/reindex « propre » : `spawn` de scripts → Weaviate)
**ne doit plus être utilisé**. Canon : ADR-031 / ADR-046.

Unité **B8** du programme `rag-purge` (complémentaire des branches B5/B5b/B7/B-R7 — périmètre disjoint).

## Quoi

- `rag-proxy.controller` : retrait des **5 endpoints** `admin/pipeline/*` (`launch` / `status` /
  `runs/:id` / `runs/:id/logs` / `runs/:id/cancel`, tous `InternalApiKeyGuard`) + injection
  `RagPipelineService` + imports devenus inutiles (`PipelineLaunchSchema/Dto`).
- `rag-proxy.module` : `RagPipelineService` retiré des providers (non exporté, aucun autre consommateur).
- `rag-pipeline.service.ts` : **bannière `DEPRECATED` salvage-first** — conservé, non supprimé
  (recoverable via git si réactivation gouvernée requise).
- `tests/unit/rag-proxy.controller.test.ts` : mock `RagPipelineService` retiré.

## Sécurité / non-régression

- **0 caller** des endpoints retirés (frontend / script / cron vérifié ; les `api/admin/pipeline/*`
  trouvés appartiennent à un **autre** controller, `AdminPipelineController`).
- Le chatbot ne dépend pas du pipeline → **`chat` / `chat/stream` / `search` / `health` intacts**.
- Sync `wiki→rag` et gating `RAG_ENABLED` inchangés.
- Salvage-first, **zéro hard-delete**.

## Vérification

```
jest tests/unit/rag-proxy.controller.test.ts
PASS  ✓ GET /api/rag/health   ✓ POST /api/rag/chat   ✓ POST /api/rag/search
Tests: 3 passed, 3 total
```

## Hors périmètre (unités suivantes)

La surface d'ingestion plus large (`admin/ingest/pdf|web|manual`, `webhook/ingestion-complete`,
`gamme-detection`, `cleanup`) utilise **d'autres services** + a des couplages admin-UI → décommission
en unités granulaires séparées (repoint UI façon B7). `admin/images|videos` : consommateur à confirmer
avant tout retrait (potentiellement servis au chatbot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
