### PR TITLE
feat(seo-projection): PR-6b forward-writer workers (2-gate + wouldRegress, BullMQ)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -377,6 +377,12 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: medium
+  # ADR-059 PR-6b — SEO projection forward-writer module (workers BullMQ, NON wiré AppModule). Owner GO 2026-06-19.
+  - glob: backend/src/modules/seo-projection/**
+    domain: D14
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/src/modules/admin/**
     domain: D8
     owner: '@ak125/admin-team'

--- a/backend/src/modules/seo-projection/seo-projection-gate.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-gate.service.ts
@@ -58,14 +58,19 @@ export class SeoProjectionGateService {
     if (!Array.isArray(exp.roles_allowed) || exp.roles_allowed.length === 0) {
       reasons.push('roles_allowed vide (aucun rôle autorisé)');
     }
-    if (!Array.isArray(exp.consumers_allowed) || exp.consumers_allowed.length === 0) {
+    if (
+      !Array.isArray(exp.consumers_allowed) ||
+      exp.consumers_allowed.length === 0
+    ) {
       reasons.push('consumers_allowed vide');
     }
     // Pureté : tout rôle d'un block doit être déclaré dans roles_allowed.
     const allowed = new Set(exp.roles_allowed ?? []);
     for (const b of exp.blocks ?? []) {
       if (b?.role && !allowed.has(b.role)) {
-        reasons.push(`block role '${b.role}' absent de roles_allowed (impureté de rôle)`);
+        reasons.push(
+          `block role '${b.role}' absent de roles_allowed (impureté de rôle)`,
+        );
       }
     }
     return { gate: 'canon', ok: reasons.length === 0, reasons };
@@ -76,11 +81,18 @@ export class SeoProjectionGateService {
     const reasons: string[] = [];
     for (const f of REQUIRED_EXPORT_FIELDS) {
       const v = exp[f];
-      if (v === undefined || v === null || (typeof v === 'string' && v.trim() === '')) {
+      if (
+        v === undefined ||
+        v === null ||
+        (typeof v === 'string' && v.trim() === '')
+      ) {
         reasons.push(`champ requis absent: ${String(f)}`);
       }
     }
-    if (typeof exp.content_hash === 'string' && exp.content_hash.trim() === '') {
+    if (
+      typeof exp.content_hash === 'string' &&
+      exp.content_hash.trim() === ''
+    ) {
       reasons.push('content_hash vide (no-op detection impossible)');
     }
     // Un export sans aucun bloc projetable n'est pas une régression mais n'apporte rien : noop aval, pas un fail.

--- a/backend/src/modules/seo-projection/seo-projection-gate.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-gate.service.ts
@@ -1,0 +1,95 @@
+/**
+ * SeoProjectionGateService — les 2 portes du forward-writer (ADR-090 §C4).
+ *
+ * Le scoring de substance 6-dim (ADR-088) + coverage-map (ADR-089) sont DÉJÀ appliqués côté wiki
+ * AVANT la promotion → l'export/seo n'existe que pour des fiches TIER A vérifiées. Ici, les portes
+ * NE re-scorent PAS : elles valident l'INTÉGRITÉ DU CONTRAT d'export avant projection DB (zéro
+ * couplage cross-repo au scorer wiki).
+ *
+ *   - CanonGate   : pureté des rôles (roles_allowed/consumers_allowed non vides, blocks ⊆ roles_allowed),
+ *                   entity_type canon, identité présente.
+ *   - QualityGate : champs requis du contrat exports-seo présents + content_hash (no-op detection aval).
+ *
+ * Fail-closed : la moindre violation → verdict ok=false → l'entité N'EST PAS projetée, un conflit
+ * observable est tracé (jamais de fallback silencieux, ADR-059 §Interdictions).
+ */
+import { Injectable } from '@nestjs/common';
+import {
+  type GateVerdict,
+  type ProjectionEntityType,
+  type SeoProjectionExport,
+} from './seo-projection.types';
+
+const CANON_ENTITY_TYPES: ReadonlySet<ProjectionEntityType> = new Set([
+  'gamme',
+  'vehicle',
+  'constructeur',
+  'diagnostic',
+]);
+
+const REQUIRED_EXPORT_FIELDS: ReadonlyArray<keyof SeoProjectionExport> = [
+  'entity_id',
+  'entity_type',
+  'schema_version',
+  'projection_contract_version',
+  'source_wiki_commit',
+  'wiki_path',
+  'content_hash',
+  'generated_at',
+  'facts',
+  'sources',
+  'blocks',
+  'roles_allowed',
+  'consumers_allowed',
+];
+
+@Injectable()
+export class SeoProjectionGateService {
+  /** CanonGate — pureté des rôles + identité canon. */
+  canonGate(exp: SeoProjectionExport): GateVerdict {
+    const reasons: string[] = [];
+
+    if (!exp.entity_id || typeof exp.entity_id !== 'string') {
+      reasons.push('entity_id manquant/invalide');
+    }
+    if (!CANON_ENTITY_TYPES.has(exp.entity_type)) {
+      reasons.push(`entity_type hors canon: ${String(exp.entity_type)}`);
+    }
+    if (!Array.isArray(exp.roles_allowed) || exp.roles_allowed.length === 0) {
+      reasons.push('roles_allowed vide (aucun rôle autorisé)');
+    }
+    if (!Array.isArray(exp.consumers_allowed) || exp.consumers_allowed.length === 0) {
+      reasons.push('consumers_allowed vide');
+    }
+    // Pureté : tout rôle d'un block doit être déclaré dans roles_allowed.
+    const allowed = new Set(exp.roles_allowed ?? []);
+    for (const b of exp.blocks ?? []) {
+      if (b?.role && !allowed.has(b.role)) {
+        reasons.push(`block role '${b.role}' absent de roles_allowed (impureté de rôle)`);
+      }
+    }
+    return { gate: 'canon', ok: reasons.length === 0, reasons };
+  }
+
+  /** QualityGate — intégrité du contrat exports-seo (champs requis + content_hash). */
+  qualityGate(exp: SeoProjectionExport): GateVerdict {
+    const reasons: string[] = [];
+    for (const f of REQUIRED_EXPORT_FIELDS) {
+      const v = exp[f];
+      if (v === undefined || v === null || (typeof v === 'string' && v.trim() === '')) {
+        reasons.push(`champ requis absent: ${String(f)}`);
+      }
+    }
+    if (typeof exp.content_hash === 'string' && exp.content_hash.trim() === '') {
+      reasons.push('content_hash vide (no-op detection impossible)');
+    }
+    // Un export sans aucun bloc projetable n'est pas une régression mais n'apporte rien : noop aval, pas un fail.
+    return { gate: 'quality', ok: reasons.length === 0, reasons };
+  }
+
+  /** Exécute les 2 portes ; ok ssi les deux passent (fail-closed). */
+  evaluate(exp: SeoProjectionExport): { ok: boolean; verdicts: GateVerdict[] } {
+    const verdicts = [this.canonGate(exp), this.qualityGate(exp)];
+    return { ok: verdicts.every((v) => v.ok), verdicts };
+  }
+}

--- a/backend/src/modules/seo-projection/seo-projection-gate.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-gate.test.ts
@@ -41,17 +41,23 @@ describe('SeoProjectionGateService', () => {
     exp.blocks = [{ role: 'R8', block_kind: 'k', content: {} }]; // R8 absent de roles_allowed=[R1]
     const v = gate.canonGate(exp);
     expect(v.ok).toBe(false);
-    expect(v.reasons.some((r) => r.includes("R8"))).toBe(true);
+    expect(v.reasons.some((r) => r.includes('R8'))).toBe(true);
   });
 
   it('CanonGate KO si entity_type hors canon', () => {
-    const v = gate.canonGate({ ...validExport(), entity_type: 'bogus' as never });
+    const v = gate.canonGate({
+      ...validExport(),
+      entity_type: 'bogus' as never,
+    });
     expect(v.ok).toBe(false);
   });
 
   it('QualityGate KO si un champ requis du contrat manque', () => {
     // content_hash absent du contrat → qualityGate doit lever "champ requis absent" (fail-closed).
-    const broken = { ...validExport(), content_hash: undefined } as unknown as SeoProjectionExport;
+    const broken = {
+      ...validExport(),
+      content_hash: undefined,
+    } as unknown as SeoProjectionExport;
     const v = gate.qualityGate(broken);
     expect(v.ok).toBe(false);
     expect(v.reasons.some((r) => r.includes('content_hash'))).toBe(true);

--- a/backend/src/modules/seo-projection/seo-projection-gate.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-gate.test.ts
@@ -50,10 +50,9 @@ describe('SeoProjectionGateService', () => {
   });
 
   it('QualityGate KO si un champ requis du contrat manque', () => {
-    const exp = validExport();
-    // @ts-expect-error suppression volontaire d'un champ requis
-    delete exp.content_hash;
-    const v = gate.qualityGate(exp);
+    // content_hash absent du contrat → qualityGate doit lever "champ requis absent" (fail-closed).
+    const broken = { ...validExport(), content_hash: undefined } as unknown as SeoProjectionExport;
+    const v = gate.qualityGate(broken);
     expect(v.ok).toBe(false);
     expect(v.reasons.some((r) => r.includes('content_hash'))).toBe(true);
   });

--- a/backend/src/modules/seo-projection/seo-projection-gate.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-gate.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests SeoProjectionGateService — les 2 portes fail-closed (ADR-090 §C4).
+ * Pures (aucune DI / DB) : on instancie le service directement.
+ */
+import { SeoProjectionGateService } from './seo-projection-gate.service';
+import type { SeoProjectionExport } from './seo-projection.types';
+
+const validExport = (): SeoProjectionExport => ({
+  entity_id: 'gamme:plaquette-de-frein',
+  entity_type: 'gamme',
+  schema_version: '2.0.0',
+  projection_contract_version: '1.0.0',
+  source_wiki_commit: 'abc1234',
+  wiki_path: 'wiki/gamme/plaquette-de-frein.md',
+  content_hash: 'deadbeef',
+  generated_at: '2026-06-19T00:00:00Z',
+  facts: [{ k: 'v' }],
+  sources: [{ url: 'https://x' }],
+  blocks: [{ role: 'R1', block_kind: 'quality_tiers', content: { md: 'x' } }],
+  roles_allowed: ['R1'],
+  consumers_allowed: ['seo'],
+});
+
+describe('SeoProjectionGateService', () => {
+  const gate = new SeoProjectionGateService();
+
+  it('passe les 2 portes sur un export valide', () => {
+    const r = gate.evaluate(validExport());
+    expect(r.ok).toBe(true);
+    expect(r.verdicts.every((v) => v.ok)).toBe(true);
+  });
+
+  it('CanonGate KO si roles_allowed vide (fail-closed)', () => {
+    const v = gate.canonGate({ ...validExport(), roles_allowed: [] });
+    expect(v.ok).toBe(false);
+    expect(v.reasons.some((r) => r.includes('roles_allowed'))).toBe(true);
+  });
+
+  it('CanonGate KO si un block a un rôle hors roles_allowed (impureté)', () => {
+    const exp = validExport();
+    exp.blocks = [{ role: 'R8', block_kind: 'k', content: {} }]; // R8 absent de roles_allowed=[R1]
+    const v = gate.canonGate(exp);
+    expect(v.ok).toBe(false);
+    expect(v.reasons.some((r) => r.includes("R8"))).toBe(true);
+  });
+
+  it('CanonGate KO si entity_type hors canon', () => {
+    const v = gate.canonGate({ ...validExport(), entity_type: 'bogus' as never });
+    expect(v.ok).toBe(false);
+  });
+
+  it('QualityGate KO si un champ requis du contrat manque', () => {
+    const exp = validExport();
+    // @ts-expect-error suppression volontaire d'un champ requis
+    delete exp.content_hash;
+    const v = gate.qualityGate(exp);
+    expect(v.ok).toBe(false);
+    expect(v.reasons.some((r) => r.includes('content_hash'))).toBe(true);
+  });
+
+  it('evaluate() est fail-closed : KO si une seule porte échoue', () => {
+    const exp = validExport();
+    exp.consumers_allowed = [];
+    expect(gate.evaluate(exp).ok).toBe(false);
+  });
+});

--- a/backend/src/modules/seo-projection/seo-projection-refresh.processor.ts
+++ b/backend/src/modules/seo-projection/seo-projection-refresh.processor.ts
@@ -1,0 +1,40 @@
+/**
+ * SeoProjectionRefreshProcessor — consumer BullMQ de `projection-refresh-queue` (ADR-059 §Découplage).
+ *
+ * `REFRESH MATERIALIZED VIEW CONCURRENTLY` HORS de la transaction runner (lock-free). Concurrency=1 +
+ * jobId singleton côté write-processor = single-flight. Fail-closed : erreur loguée, jamais de throw fatal.
+ *
+ * NB : la RPC `refresh_seo_projection_mvs` est livrée en PR-6c ; tant qu'absente, refreshViews fail-close
+ * proprement (log + retour {refreshed:false}), sans casser la file ni le runtime.
+ */
+import { OnQueueFailed, Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { SeoProjectionWriterService } from './seo-projection-writer.service';
+import {
+  PROJECTION_REFRESH_JOB,
+  PROJECTION_REFRESH_QUEUE,
+  type ProjectionRefreshJobData,
+} from './seo-projection.types';
+
+@Processor(PROJECTION_REFRESH_QUEUE)
+export class SeoProjectionRefreshProcessor {
+  private readonly logger = new Logger(SeoProjectionRefreshProcessor.name);
+
+  constructor(private readonly writer: SeoProjectionWriterService) {}
+
+  @Process(PROJECTION_REFRESH_JOB)
+  async handle(job: Job<ProjectionRefreshJobData>): Promise<{ refreshed: boolean; error?: string }> {
+    const res = await this.writer.refreshViews();
+    this.logger.log(
+      `projection refresh (run=${job?.data?.runId ?? 'n/a'}) → refreshed=${res.refreshed}` +
+        (res.error ? ` (${res.error})` : ''),
+    );
+    return res;
+  }
+
+  @OnQueueFailed()
+  onFailed(job: Job, err: Error): void {
+    this.logger.error(`projection-refresh job ${job?.id} failed: ${err?.message}`);
+  }
+}

--- a/backend/src/modules/seo-projection/seo-projection-refresh.processor.ts
+++ b/backend/src/modules/seo-projection/seo-projection-refresh.processor.ts
@@ -24,7 +24,9 @@ export class SeoProjectionRefreshProcessor {
   constructor(private readonly writer: SeoProjectionWriterService) {}
 
   @Process(PROJECTION_REFRESH_JOB)
-  async handle(job: Job<ProjectionRefreshJobData>): Promise<{ refreshed: boolean; error?: string }> {
+  async handle(
+    job: Job<ProjectionRefreshJobData>,
+  ): Promise<{ refreshed: boolean; error?: string }> {
     const res = await this.writer.refreshViews();
     this.logger.log(
       `projection refresh (run=${job?.data?.runId ?? 'n/a'}) → refreshed=${res.refreshed}` +
@@ -35,6 +37,8 @@ export class SeoProjectionRefreshProcessor {
 
   @OnQueueFailed()
   onFailed(job: Job, err: Error): void {
-    this.logger.error(`projection-refresh job ${job?.id} failed: ${err?.message}`);
+    this.logger.error(
+      `projection-refresh job ${job?.id} failed: ${err?.message}`,
+    );
   }
 }

--- a/backend/src/modules/seo-projection/seo-projection-write.processor.ts
+++ b/backend/src/modules/seo-projection/seo-projection-write.processor.ts
@@ -30,15 +30,28 @@ export class SeoProjectionWriteProcessor {
 
   @Process(PROJECTION_WRITE_JOB)
   async handle(job: Job<ProjectionWriteJobData>): Promise<ProjectionRunResult> {
-    const { exportPaths = [], triggeredBy = 'manual', runMeta = {} } = job.data ?? ({} as ProjectionWriteJobData);
-    const result = await this.writer.projectExports(exportPaths, triggeredBy, runMeta);
+    const {
+      exportPaths = [],
+      triggeredBy = 'manual',
+      runMeta = {},
+    } = job.data ?? ({} as ProjectionWriteJobData);
+    const result = await this.writer.projectExports(
+      exportPaths,
+      triggeredBy,
+      runMeta,
+    );
 
     if (!result.readOnlySkipped && result.entitiesWritten > 0) {
       // Coalescing : jobId fixe → un seul refresh en attente à la fois (single-flight, debounce 5s).
       await this.refreshQueue.add(
         PROJECTION_REFRESH_JOB,
         { triggeredBy, runId: result.runId },
-        { jobId: 'projection-refresh-singleton', delay: REFRESH_DEBOUNCE_MS, removeOnComplete: true, removeOnFail: true },
+        {
+          jobId: 'projection-refresh-singleton',
+          delay: REFRESH_DEBOUNCE_MS,
+          removeOnComplete: true,
+          removeOnFail: true,
+        },
       );
       result.refreshEnqueued = true;
     }
@@ -51,6 +64,8 @@ export class SeoProjectionWriteProcessor {
 
   @OnQueueFailed()
   onFailed(job: Job, err: Error): void {
-    this.logger.error(`projection-write job ${job?.id} failed: ${err?.message}`);
+    this.logger.error(
+      `projection-write job ${job?.id} failed: ${err?.message}`,
+    );
   }
 }

--- a/backend/src/modules/seo-projection/seo-projection-write.processor.ts
+++ b/backend/src/modules/seo-projection/seo-projection-write.processor.ts
@@ -1,0 +1,56 @@
+/**
+ * SeoProjectionWriteProcessor — consumer BullMQ de `projection-write-queue` (ADR-059 §Découplage).
+ *
+ * Délègue au writer (2-gate + INSERT-new-version + wouldRegress), puis enqueue UN refresh débounce-é
+ * (jobId singleton → coalescing : N writes pendant la fenêtre = 1 seul refresh, ADR-059). READ_ONLY géré
+ * dans le writer (skip observable). Transaction d'écriture courte (< 100ms cible).
+ */
+import { InjectQueue, OnQueueFailed, Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job, Queue } from 'bull';
+import { SeoProjectionWriterService } from './seo-projection-writer.service';
+import {
+  PROJECTION_REFRESH_JOB,
+  PROJECTION_REFRESH_QUEUE,
+  PROJECTION_WRITE_JOB,
+  PROJECTION_WRITE_QUEUE,
+  REFRESH_DEBOUNCE_MS,
+  type ProjectionRunResult,
+  type ProjectionWriteJobData,
+} from './seo-projection.types';
+
+@Processor(PROJECTION_WRITE_QUEUE)
+export class SeoProjectionWriteProcessor {
+  private readonly logger = new Logger(SeoProjectionWriteProcessor.name);
+
+  constructor(
+    private readonly writer: SeoProjectionWriterService,
+    @InjectQueue(PROJECTION_REFRESH_QUEUE) private readonly refreshQueue: Queue,
+  ) {}
+
+  @Process(PROJECTION_WRITE_JOB)
+  async handle(job: Job<ProjectionWriteJobData>): Promise<ProjectionRunResult> {
+    const { exportPaths = [], triggeredBy = 'manual', runMeta = {} } = job.data ?? ({} as ProjectionWriteJobData);
+    const result = await this.writer.projectExports(exportPaths, triggeredBy, runMeta);
+
+    if (!result.readOnlySkipped && result.entitiesWritten > 0) {
+      // Coalescing : jobId fixe → un seul refresh en attente à la fois (single-flight, debounce 5s).
+      await this.refreshQueue.add(
+        PROJECTION_REFRESH_JOB,
+        { triggeredBy, runId: result.runId },
+        { jobId: 'projection-refresh-singleton', delay: REFRESH_DEBOUNCE_MS, removeOnComplete: true, removeOnFail: true },
+      );
+      result.refreshEnqueued = true;
+    }
+    this.logger.log(
+      `projection write run=${result.runId ?? 'none'} written=${result.entitiesWritten} refresh=${result.refreshEnqueued}` +
+        (result.readOnlySkipped ? ' [READ_ONLY skipped]' : ''),
+    );
+    return result;
+  }
+
+  @OnQueueFailed()
+  onFailed(job: Job, err: Error): void {
+    this.logger.error(`projection-write job ${job?.id} failed: ${err?.message}`);
+  }
+}

--- a/backend/src/modules/seo-projection/seo-projection-writer.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.service.ts
@@ -47,8 +47,17 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
     runMeta: Partial<ProjectionRunMeta> = {},
   ): Promise<ProjectionRunResult> {
     if (this.readOnly) {
-      this.log.log(`[READ_ONLY] projection write skipped (${exportPaths.length} exports, ${triggeredBy})`);
-      return { runId: null, triggeredBy, entitiesWritten: 0, outcomes: [], refreshEnqueued: false, readOnlySkipped: true };
+      this.log.log(
+        `[READ_ONLY] projection write skipped (${exportPaths.length} exports, ${triggeredBy})`,
+      );
+      return {
+        runId: null,
+        triggeredBy,
+        entitiesWritten: 0,
+        outcomes: [],
+        refreshEnqueued: false,
+        readOnlySkipped: true,
+      };
     }
 
     const runId = await this.openRun(triggeredBy, runMeta);
@@ -61,44 +70,90 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       if (outcome.status === 'written') written += 1;
     }
 
-    await this.closeRun(runId, written, outcomes.some((o) => o.status === 'blocked'));
-    return { runId, triggeredBy, entitiesWritten: written, outcomes, refreshEnqueued: false };
+    await this.closeRun(
+      runId,
+      written,
+      outcomes.some((o) => o.status === 'blocked'),
+    );
+    return {
+      runId,
+      triggeredBy,
+      entitiesWritten: written,
+      outcomes,
+      refreshEnqueued: false,
+    };
   }
 
   /** Projette un export. Fail-closed : erreur → conflit + outcome blocked, jamais de throw. */
-  private async projectOne(path: string, runId: string | null): Promise<EntityWriteOutcome> {
+  private async projectOne(
+    path: string,
+    runId: string | null,
+  ): Promise<EntityWriteOutcome> {
     let exp: SeoProjectionExport;
     try {
       exp = JSON.parse(await fs.readFile(path, 'utf-8')) as SeoProjectionExport;
     } catch (e) {
-      await this.recordConflict('?', null, 'export_unreadable', { path, error: String(e) }, runId);
-      return { entity_id: path, status: 'blocked', reasons: [`export illisible: ${String(e)}`] };
+      await this.recordConflict(
+        '?',
+        null,
+        'export_unreadable',
+        { path, error: String(e) },
+        runId,
+      );
+      return {
+        entity_id: path,
+        status: 'blocked',
+        reasons: [`export illisible: ${String(e)}`],
+      };
     }
 
     const { ok, verdicts } = this.gate.evaluate(exp);
     if (!ok) {
       const reasons = verdicts.flatMap((v) => v.reasons);
-      await this.recordConflict(exp.entity_id, null, 'gate_blocked', { verdicts }, runId);
+      await this.recordConflict(
+        exp.entity_id,
+        null,
+        'gate_blocked',
+        { verdicts },
+        runId,
+      );
       return { entity_id: exp.entity_id, status: 'blocked', reasons };
     }
 
     try {
       return await this.writeEntity(exp, runId);
     } catch (e) {
-      await this.recordConflict(exp.entity_id, null, 'write_error', { error: String(e) }, runId);
-      return { entity_id: exp.entity_id, status: 'blocked', reasons: [`écriture: ${String(e)}`] };
+      await this.recordConflict(
+        exp.entity_id,
+        null,
+        'write_error',
+        { error: String(e) },
+        runId,
+      );
+      return {
+        entity_id: exp.entity_id,
+        status: 'blocked',
+        reasons: [`écriture: ${String(e)}`],
+      };
     }
   }
 
   /** INSERT-new-version (facts) + flip active_version_id ; no-op si content_hash identique. */
-  private async writeEntity(exp: SeoProjectionExport, runId: string | null): Promise<EntityWriteOutcome> {
+  private async writeEntity(
+    exp: SeoProjectionExport,
+    runId: string | null,
+  ): Promise<EntityWriteOutcome> {
     // Upsert la ligne entity (idempotent ; ne touche pas active_version_id ici).
-    await this.supabase
-      .from('__seo_entity_facts')
-      .upsert(
-        { entity_id: exp.entity_id, entity_type: exp.entity_type, slug: exp.wiki_path.split('/').pop()?.replace(/\.md$/, '') ?? exp.entity_id, updated_at: new Date().toISOString() },
-        { onConflict: 'entity_id' },
-      );
+    await this.supabase.from('__seo_entity_facts').upsert(
+      {
+        entity_id: exp.entity_id,
+        entity_type: exp.entity_type,
+        slug:
+          exp.wiki_path.split('/').pop()?.replace(/\.md$/, '') ?? exp.entity_id,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'entity_id' },
+    );
 
     // no-op detection : la version active a-t-elle déjà ce content_hash ?
     const { data: active } = await this.supabase
@@ -124,7 +179,8 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       })
       .select('version_id')
       .single();
-    if (error || !ins) throw new Error(`insert fact_version: ${error?.message ?? 'no row'}`);
+    if (error || !ins)
+      throw new Error(`insert fact_version: ${error?.message ?? 'no row'}`);
 
     // Déprécier l'ancienne active + flip le pointeur (audit trail préservé, jamais DELETE).
     await this.supabase
@@ -135,22 +191,42 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       .neq('version_id', ins.version_id);
     await this.supabase
       .from('__seo_entity_facts')
-      .update({ active_version_id: ins.version_id, updated_at: new Date().toISOString() })
+      .update({
+        active_version_id: ins.version_id,
+        updated_at: new Date().toISOString(),
+      })
       .eq('entity_id', exp.entity_id);
 
     const blocksWritten = await this.writeBlocks(exp, runId);
-    return { entity_id: exp.entity_id, status: 'written', factsVersionId: ins.version_id, blocksWritten: blocksWritten.written, conflicts: blocksWritten.regressed };
+    return {
+      entity_id: exp.entity_id,
+      status: 'written',
+      factsVersionId: ins.version_id,
+      blocksWritten: blocksWritten.written,
+      conflicts: blocksWritten.regressed,
+    };
   }
 
   /** Écrit les blocks rôle-aware ; no-rétro-régression PAR BLOC (version "pire" → draft, pas active). */
-  private async writeBlocks(exp: SeoProjectionExport, runId: string | null): Promise<{ written: number; regressed: number }> {
+  private async writeBlocks(
+    exp: SeoProjectionExport,
+    runId: string | null,
+  ): Promise<{ written: number; regressed: number }> {
     let written = 0;
     let regressed = 0;
     for (const b of exp.blocks ?? []) {
-      const blockId = b.block_id ?? `${exp.entity_id}#${b.role}#${b.block_kind}`;
-      await this.supabase
-        .from('__seo_content_blocks')
-        .upsert({ block_id: blockId, entity_id: exp.entity_id, role: b.role, block_kind: b.block_kind, updated_at: new Date().toISOString() }, { onConflict: 'block_id' });
+      const blockId =
+        b.block_id ?? `${exp.entity_id}#${b.role}#${b.block_kind}`;
+      await this.supabase.from('__seo_content_blocks').upsert(
+        {
+          block_id: blockId,
+          entity_id: exp.entity_id,
+          role: b.role,
+          block_kind: b.block_kind,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'block_id' },
+      );
 
       const { data: active } = await this.supabase
         .from('__seo_content_block_versions')
@@ -172,13 +248,29 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
 
       const { data: ins, error } = await this.supabase
         .from('__seo_content_block_versions')
-        .insert({ block_id: blockId, status: wouldRegress ? 'draft' : 'active', content_hash: newHash, confidence_base: b.confidence_base ?? null, content: b.content, run_id: runId })
+        .insert({
+          block_id: blockId,
+          status: wouldRegress ? 'draft' : 'active',
+          content_hash: newHash,
+          confidence_base: b.confidence_base ?? null,
+          content: b.content,
+          run_id: runId,
+        })
         .select('version_id')
         .single();
-      if (error || !ins) throw new Error(`insert block_version ${blockId}: ${error?.message ?? 'no row'}`);
+      if (error || !ins)
+        throw new Error(
+          `insert block_version ${blockId}: ${error?.message ?? 'no row'}`,
+        );
 
       if (wouldRegress) {
-        await this.recordConflict(exp.entity_id, blockId, 'would_regress', { newHash, kept_active: true }, runId);
+        await this.recordConflict(
+          exp.entity_id,
+          blockId,
+          'would_regress',
+          { newHash, kept_active: true },
+          runId,
+        );
         regressed += 1;
         continue; // ne flippe PAS l'active : le contenu meilleur est conservé
       }
@@ -190,7 +282,10 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
         .neq('version_id', ins.version_id);
       await this.supabase
         .from('__seo_content_blocks')
-        .update({ active_version_id: ins.version_id, updated_at: new Date().toISOString() })
+        .update({
+          active_version_id: ins.version_id,
+          updated_at: new Date().toISOString(),
+        })
         .eq('block_id', blockId);
       written += 1;
     }
@@ -205,14 +300,24 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
    */
   async refreshViews(): Promise<{ refreshed: boolean; error?: string }> {
     if (this.readOnly) return { refreshed: false, error: 'READ_ONLY' };
-    this.log.log('refreshViews: RPC refresh_seo_projection_mvs livrée en PR-6c — refresh différé (no-op).');
+    this.log.log(
+      'refreshViews: RPC refresh_seo_projection_mvs livrée en PR-6c — refresh différé (no-op).',
+    );
     return { refreshed: false, error: 'refresh RPC pending PR-6c' };
   }
 
-  private async openRun(triggeredBy: ProjectionTriggeredBy, meta: Partial<ProjectionRunMeta>): Promise<string | null> {
+  private async openRun(
+    triggeredBy: ProjectionTriggeredBy,
+    meta: Partial<ProjectionRunMeta>,
+  ): Promise<string | null> {
     const { data, error } = await this.supabase
       .from('__seo_projection_runs')
-      .insert({ trigger_kind: triggeredBy === 'test' ? 'manual' : triggeredBy, status: 'running', writer_contract_version: WRITER_CONTRACT_VERSION, ...meta })
+      .insert({
+        trigger_kind: triggeredBy === 'test' ? 'manual' : triggeredBy,
+        status: 'running',
+        writer_contract_version: WRITER_CONTRACT_VERSION,
+        ...meta,
+      })
       .select('run_id')
       .single();
     if (error) {
@@ -222,22 +327,43 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
     return data?.run_id ?? null;
   }
 
-  private async closeRun(runId: string | null, written: number, hadBlocked: boolean): Promise<void> {
+  private async closeRun(
+    runId: string | null,
+    written: number,
+    hadBlocked: boolean,
+  ): Promise<void> {
     if (!runId) return;
     await this.supabase
       .from('__seo_projection_runs')
-      .update({ status: hadBlocked ? 'failed' : 'succeeded', entities_written: written, finished_at: new Date().toISOString() })
+      .update({
+        status: hadBlocked ? 'failed' : 'succeeded',
+        entities_written: written,
+        finished_at: new Date().toISOString(),
+      })
       .eq('run_id', runId);
   }
 
-  private async recordConflict(entityId: string, blockId: string | null, kind: string, detail: Record<string, unknown>, runId: string | null): Promise<void> {
-    await this.supabase
-      .from('__seo_projection_conflicts')
-      .insert({ entity_id: entityId, block_id: blockId, conflict_kind: kind, resolution: 'pending', detail, run_id: runId });
+  private async recordConflict(
+    entityId: string,
+    blockId: string | null,
+    kind: string,
+    detail: Record<string, unknown>,
+    runId: string | null,
+  ): Promise<void> {
+    await this.supabase.from('__seo_projection_conflicts').insert({
+      entity_id: entityId,
+      block_id: blockId,
+      conflict_kind: kind,
+      resolution: 'pending',
+      detail,
+      run_id: runId,
+    });
   }
 
   private hashBlock(b: SeoProjectionBlock): string {
     // hash déterministe minimal (le content_hash autoritaire vient du builder wiki ; fallback ici).
-    return createHash('md5').update(JSON.stringify(b.content ?? {})).digest('hex');
+    return createHash('md5')
+      .update(JSON.stringify(b.content ?? {}))
+      .digest('hex');
   }
 }

--- a/backend/src/modules/seo-projection/seo-projection-writer.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.service.ts
@@ -1,0 +1,242 @@
+/**
+ * SeoProjectionWriterService — cœur du forward-writer (ADR-059 PR-6b / ADR-090 §C4).
+ *
+ * Projette des exports/seo/*.json (déjà TIER A côté wiki) dans la DB versionnée :
+ *   1. ouvre un run (__seo_projection_runs, status=running) ;
+ *   2. par entité : 2 portes (CanonGate→QualityGate) → si KO, conflit observable (jamais d'écriture) ;
+ *   3. si OK : INSERT-new-version (facts + blocks) puis flip active_version_id (JAMAIS UPDATE en place) ;
+ *      no-op si content_hash identique ; no-rétro-régression par bloc (version "pire" insérée en draft) ;
+ *   4. ferme le run (succeeded/failed) ; enqueue un refresh (débounce, hors-tx).
+ *
+ * Fail-closed partout : toute erreur trace un conflit + marque le run failed, jamais de fallback silencieux.
+ * READ_ONLY (PREPROD, ADR-028) → aucune écriture (skip observable). service_role uniquement (RLS write).
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { SupabaseBaseService } from '../../database/services/supabase-base.service';
+import { getAppConfig } from '../../config/app.config';
+import { SeoProjectionGateService } from './seo-projection-gate.service';
+import {
+  type EntityWriteOutcome,
+  type ProjectionRunMeta,
+  type ProjectionRunResult,
+  type ProjectionTriggeredBy,
+  type SeoProjectionBlock,
+  type SeoProjectionExport,
+  WRITER_CONTRACT_VERSION,
+} from './seo-projection.types';
+
+@Injectable()
+export class SeoProjectionWriterService extends SupabaseBaseService {
+  private readonly log = new Logger(SeoProjectionWriterService.name);
+  private readonly readOnly = getAppConfig().supabase.readOnly;
+
+  constructor(
+    configService: ConfigService,
+    private readonly gate: SeoProjectionGateService,
+  ) {
+    super(configService);
+  }
+
+  /** Projette une liste d'exports. Retourne un résultat observable (jamais d'exception non tracée). */
+  async projectExports(
+    exportPaths: string[],
+    triggeredBy: ProjectionTriggeredBy = 'manual',
+    runMeta: Partial<ProjectionRunMeta> = {},
+  ): Promise<ProjectionRunResult> {
+    if (this.readOnly) {
+      this.log.log(`[READ_ONLY] projection write skipped (${exportPaths.length} exports, ${triggeredBy})`);
+      return { runId: null, triggeredBy, entitiesWritten: 0, outcomes: [], refreshEnqueued: false, readOnlySkipped: true };
+    }
+
+    const runId = await this.openRun(triggeredBy, runMeta);
+    const outcomes: EntityWriteOutcome[] = [];
+    let written = 0;
+
+    for (const path of exportPaths) {
+      const outcome = await this.projectOne(path, runId);
+      outcomes.push(outcome);
+      if (outcome.status === 'written') written += 1;
+    }
+
+    await this.closeRun(runId, written, outcomes.some((o) => o.status === 'blocked'));
+    return { runId, triggeredBy, entitiesWritten: written, outcomes, refreshEnqueued: false };
+  }
+
+  /** Projette un export. Fail-closed : erreur → conflit + outcome blocked, jamais de throw. */
+  private async projectOne(path: string, runId: string | null): Promise<EntityWriteOutcome> {
+    let exp: SeoProjectionExport;
+    try {
+      exp = JSON.parse(await fs.readFile(path, 'utf-8')) as SeoProjectionExport;
+    } catch (e) {
+      await this.recordConflict('?', null, 'export_unreadable', { path, error: String(e) }, runId);
+      return { entity_id: path, status: 'blocked', reasons: [`export illisible: ${String(e)}`] };
+    }
+
+    const { ok, verdicts } = this.gate.evaluate(exp);
+    if (!ok) {
+      const reasons = verdicts.flatMap((v) => v.reasons);
+      await this.recordConflict(exp.entity_id, null, 'gate_blocked', { verdicts }, runId);
+      return { entity_id: exp.entity_id, status: 'blocked', reasons };
+    }
+
+    try {
+      return await this.writeEntity(exp, runId);
+    } catch (e) {
+      await this.recordConflict(exp.entity_id, null, 'write_error', { error: String(e) }, runId);
+      return { entity_id: exp.entity_id, status: 'blocked', reasons: [`écriture: ${String(e)}`] };
+    }
+  }
+
+  /** INSERT-new-version (facts) + flip active_version_id ; no-op si content_hash identique. */
+  private async writeEntity(exp: SeoProjectionExport, runId: string | null): Promise<EntityWriteOutcome> {
+    // Upsert la ligne entity (idempotent ; ne touche pas active_version_id ici).
+    await this.supabase
+      .from('__seo_entity_facts')
+      .upsert(
+        { entity_id: exp.entity_id, entity_type: exp.entity_type, slug: exp.wiki_path.split('/').pop()?.replace(/\.md$/, '') ?? exp.entity_id, updated_at: new Date().toISOString() },
+        { onConflict: 'entity_id' },
+      );
+
+    // no-op detection : la version active a-t-elle déjà ce content_hash ?
+    const { data: active } = await this.supabase
+      .from('__seo_entity_fact_versions')
+      .select('content_hash')
+      .eq('entity_id', exp.entity_id)
+      .eq('status', 'active')
+      .maybeSingle();
+
+    if (active?.content_hash === exp.content_hash) {
+      return { entity_id: exp.entity_id, status: 'noop' };
+    }
+
+    // INSERT new version (active) — JAMAIS d'UPDATE d'une version existante.
+    const { data: ins, error } = await this.supabase
+      .from('__seo_entity_fact_versions')
+      .insert({
+        entity_id: exp.entity_id,
+        status: 'active',
+        content_hash: exp.content_hash,
+        facts: exp.facts,
+        run_id: runId,
+      })
+      .select('version_id')
+      .single();
+    if (error || !ins) throw new Error(`insert fact_version: ${error?.message ?? 'no row'}`);
+
+    // Déprécier l'ancienne active + flip le pointeur (audit trail préservé, jamais DELETE).
+    await this.supabase
+      .from('__seo_entity_fact_versions')
+      .update({ status: 'deprecated', valid_to: new Date().toISOString() })
+      .eq('entity_id', exp.entity_id)
+      .eq('status', 'active')
+      .neq('version_id', ins.version_id);
+    await this.supabase
+      .from('__seo_entity_facts')
+      .update({ active_version_id: ins.version_id, updated_at: new Date().toISOString() })
+      .eq('entity_id', exp.entity_id);
+
+    const blocksWritten = await this.writeBlocks(exp, runId);
+    return { entity_id: exp.entity_id, status: 'written', factsVersionId: ins.version_id, blocksWritten: blocksWritten.written, conflicts: blocksWritten.regressed };
+  }
+
+  /** Écrit les blocks rôle-aware ; no-rétro-régression PAR BLOC (version "pire" → draft, pas active). */
+  private async writeBlocks(exp: SeoProjectionExport, runId: string | null): Promise<{ written: number; regressed: number }> {
+    let written = 0;
+    let regressed = 0;
+    for (const b of exp.blocks ?? []) {
+      const blockId = b.block_id ?? `${exp.entity_id}#${b.role}#${b.block_kind}`;
+      await this.supabase
+        .from('__seo_content_blocks')
+        .upsert({ block_id: blockId, entity_id: exp.entity_id, role: b.role, block_kind: b.block_kind, updated_at: new Date().toISOString() }, { onConflict: 'block_id' });
+
+      const { data: active } = await this.supabase
+        .from('__seo_content_block_versions')
+        .select('content_hash, confidence_base')
+        .eq('block_id', blockId)
+        .eq('status', 'active')
+        .maybeSingle();
+
+      const newHash = b.content_hash ?? this.hashBlock(b);
+      if (active?.content_hash === newHash) continue; // no-op
+
+      // no-rétro-régression : si une version active existe avec une confiance strictement supérieure, on
+      // insère la nouvelle en draft (jamais active) + conflit observable.
+      const wouldRegress =
+        active != null &&
+        typeof active.confidence_base === 'number' &&
+        typeof b.confidence_base === 'number' &&
+        b.confidence_base < active.confidence_base;
+
+      const { data: ins, error } = await this.supabase
+        .from('__seo_content_block_versions')
+        .insert({ block_id: blockId, status: wouldRegress ? 'draft' : 'active', content_hash: newHash, confidence_base: b.confidence_base ?? null, content: b.content, run_id: runId })
+        .select('version_id')
+        .single();
+      if (error || !ins) throw new Error(`insert block_version ${blockId}: ${error?.message ?? 'no row'}`);
+
+      if (wouldRegress) {
+        await this.recordConflict(exp.entity_id, blockId, 'would_regress', { newHash, kept_active: true }, runId);
+        regressed += 1;
+        continue; // ne flippe PAS l'active : le contenu meilleur est conservé
+      }
+      await this.supabase
+        .from('__seo_content_block_versions')
+        .update({ status: 'deprecated', valid_to: new Date().toISOString() })
+        .eq('block_id', blockId)
+        .eq('status', 'active')
+        .neq('version_id', ins.version_id);
+      await this.supabase
+        .from('__seo_content_blocks')
+        .update({ active_version_id: ins.version_id, updated_at: new Date().toISOString() })
+        .eq('block_id', blockId);
+      written += 1;
+    }
+    return { written, regressed };
+  }
+
+  /** REFRESH MATERIALIZED VIEW CONCURRENTLY (hors-tx) via RPC service_role. Fail-closed. */
+  async refreshViews(): Promise<{ refreshed: boolean; error?: string }> {
+    if (this.readOnly) return { refreshed: false, error: 'READ_ONLY' };
+    const { error } = await this.supabase.rpc('refresh_seo_projection_mvs');
+    if (error) {
+      this.log.error(`refresh MVs failed: ${error.message}`);
+      return { refreshed: false, error: error.message };
+    }
+    return { refreshed: true };
+  }
+
+  private async openRun(triggeredBy: ProjectionTriggeredBy, meta: Partial<ProjectionRunMeta>): Promise<string | null> {
+    const { data, error } = await this.supabase
+      .from('__seo_projection_runs')
+      .insert({ trigger_kind: triggeredBy === 'test' ? 'manual' : triggeredBy, status: 'running', writer_contract_version: WRITER_CONTRACT_VERSION, ...meta })
+      .select('run_id')
+      .single();
+    if (error) {
+      this.log.error(`openRun failed: ${error.message}`);
+      return null;
+    }
+    return data?.run_id ?? null;
+  }
+
+  private async closeRun(runId: string | null, written: number, hadBlocked: boolean): Promise<void> {
+    if (!runId) return;
+    await this.supabase
+      .from('__seo_projection_runs')
+      .update({ status: hadBlocked ? 'failed' : 'succeeded', entities_written: written, finished_at: new Date().toISOString() })
+      .eq('run_id', runId);
+  }
+
+  private async recordConflict(entityId: string, blockId: string | null, kind: string, detail: Record<string, unknown>, runId: string | null): Promise<void> {
+    await this.supabase
+      .from('__seo_projection_conflicts')
+      .insert({ entity_id: entityId, block_id: blockId, conflict_kind: kind, resolution: 'pending', detail, run_id: runId });
+  }
+
+  private hashBlock(b: SeoProjectionBlock): string {
+    // hash déterministe minimal (le content_hash autoritaire vient du builder wiki ; fallback ici).
+    return createHash('md5').update(JSON.stringify(b.content ?? {})).digest('hex');
+  }
+}

--- a/backend/src/modules/seo-projection/seo-projection-writer.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.service.ts
@@ -200,7 +200,7 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
   /**
    * REFRESH MATERIALIZED VIEW CONCURRENTLY (hors-tx). La RPC gouvernée `refresh_seo_projection_mvs`
    * (SECURITY DEFINER, service_role) + son appel via `callRpc()` sont livrés en PR-6c. Tant qu'absente,
-   * on N'APPELLE RIEN (fail-close propre) — pas de `.rpc()` direct (RPC Safety Gate), pas d'appel à une RPC
+   * on N'APPELLE RIEN (fail-close propre) — aucun appel RPC direct (RPC Safety Gate), pas d'appel à une RPC
    * inexistante. Le worker refresh reste donc dormant (no-op observable) jusqu'à PR-6c.
    */
   async refreshViews(): Promise<{ refreshed: boolean; error?: string }> {

--- a/backend/src/modules/seo-projection/seo-projection-writer.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.service.ts
@@ -197,15 +197,16 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
     return { written, regressed };
   }
 
-  /** REFRESH MATERIALIZED VIEW CONCURRENTLY (hors-tx) via RPC service_role. Fail-closed. */
+  /**
+   * REFRESH MATERIALIZED VIEW CONCURRENTLY (hors-tx). La RPC gouvernée `refresh_seo_projection_mvs`
+   * (SECURITY DEFINER, service_role) + son appel via `callRpc()` sont livrés en PR-6c. Tant qu'absente,
+   * on N'APPELLE RIEN (fail-close propre) — pas de `.rpc()` direct (RPC Safety Gate), pas d'appel à une RPC
+   * inexistante. Le worker refresh reste donc dormant (no-op observable) jusqu'à PR-6c.
+   */
   async refreshViews(): Promise<{ refreshed: boolean; error?: string }> {
     if (this.readOnly) return { refreshed: false, error: 'READ_ONLY' };
-    const { error } = await this.supabase.rpc('refresh_seo_projection_mvs');
-    if (error) {
-      this.log.error(`refresh MVs failed: ${error.message}`);
-      return { refreshed: false, error: error.message };
-    }
-    return { refreshed: true };
+    this.log.log('refreshViews: RPC refresh_seo_projection_mvs livrée en PR-6c — refresh différé (no-op).');
+    return { refreshed: false, error: 'refresh RPC pending PR-6c' };
   }
 
   private async openRun(triggeredBy: ProjectionTriggeredBy, meta: Partial<ProjectionRunMeta>): Promise<string | null> {

--- a/backend/src/modules/seo-projection/seo-projection.module.ts
+++ b/backend/src/modules/seo-projection/seo-projection.module.ts
@@ -1,0 +1,32 @@
+/**
+ * SeoProjectionModule — forward-writer ADR-059 PR-6b (exports/seo → DB versionnée).
+ *
+ * 2 queues découplées (write courte / refresh hors-tx). Réutilise DatabaseModule (SupabaseBaseService,
+ * service_role) + @nestjs/bull. AUCUNE nouvelle infra : tables/MV créées par la migration PR-6.
+ * Read-path (RPC get_active_seo_projection + GRANT anon) = PR-7 ; flag seo_projection_read_v1 OFF.
+ */
+import { BullModule } from '@nestjs/bull';
+import { ConfigModule } from '@nestjs/config';
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { SeoProjectionGateService } from './seo-projection-gate.service';
+import { SeoProjectionWriterService } from './seo-projection-writer.service';
+import { SeoProjectionWriteProcessor } from './seo-projection-write.processor';
+import { SeoProjectionRefreshProcessor } from './seo-projection-refresh.processor';
+import { PROJECTION_REFRESH_QUEUE, PROJECTION_WRITE_QUEUE } from './seo-projection.types';
+
+@Module({
+  imports: [
+    ConfigModule,
+    DatabaseModule,
+    BullModule.registerQueue({ name: PROJECTION_WRITE_QUEUE }, { name: PROJECTION_REFRESH_QUEUE }),
+  ],
+  providers: [
+    SeoProjectionGateService,
+    SeoProjectionWriterService,
+    SeoProjectionWriteProcessor,
+    SeoProjectionRefreshProcessor,
+  ],
+  exports: [SeoProjectionWriterService, SeoProjectionGateService],
+})
+export class SeoProjectionModule {}

--- a/backend/src/modules/seo-projection/seo-projection.module.ts
+++ b/backend/src/modules/seo-projection/seo-projection.module.ts
@@ -13,13 +13,19 @@ import { SeoProjectionGateService } from './seo-projection-gate.service';
 import { SeoProjectionWriterService } from './seo-projection-writer.service';
 import { SeoProjectionWriteProcessor } from './seo-projection-write.processor';
 import { SeoProjectionRefreshProcessor } from './seo-projection-refresh.processor';
-import { PROJECTION_REFRESH_QUEUE, PROJECTION_WRITE_QUEUE } from './seo-projection.types';
+import {
+  PROJECTION_REFRESH_QUEUE,
+  PROJECTION_WRITE_QUEUE,
+} from './seo-projection.types';
 
 @Module({
   imports: [
     ConfigModule,
     DatabaseModule,
-    BullModule.registerQueue({ name: PROJECTION_WRITE_QUEUE }, { name: PROJECTION_REFRESH_QUEUE }),
+    BullModule.registerQueue(
+      { name: PROJECTION_WRITE_QUEUE },
+      { name: PROJECTION_REFRESH_QUEUE },
+    ),
   ],
   providers: [
     SeoProjectionGateService,

--- a/backend/src/modules/seo-projection/seo-projection.types.ts
+++ b/backend/src/modules/seo-projection/seo-projection.types.ts
@@ -28,7 +28,11 @@ export const WRITER_CONTRACT_VERSION = '1.0.0';
 export const REFRESH_DEBOUNCE_MS = 5_000;
 
 export type ProjectionTriggeredBy = 'cron' | 'manual' | 'replay' | 'test';
-export type ProjectionEntityType = 'gamme' | 'vehicle' | 'constructeur' | 'diagnostic';
+export type ProjectionEntityType =
+  | 'gamme'
+  | 'vehicle'
+  | 'constructeur'
+  | 'diagnostic';
 
 /** Données du job write : la liste des chemins d'exports à projeter pour ce run. */
 export interface ProjectionWriteJobData {

--- a/backend/src/modules/seo-projection/seo-projection.types.ts
+++ b/backend/src/modules/seo-projection/seo-projection.types.ts
@@ -1,0 +1,110 @@
+/**
+ * SEO Projection forward-writer — types & constants (ADR-059 PR-6b / ADR-090 §C1-C4).
+ *
+ * Le writer CONSOMME des exports/seo/*.json DÉJÀ vérifiés côté wiki (promotion TIER A,
+ * gates ADR-088/089) et les projette dans la DB versionnée (__seo_entity_facts/_versions,
+ * __seo_content_blocks/_versions) créée par la migration PR-6.
+ *
+ * Invariants (ADR-059 §Interdictions + ADR-090 §C4) :
+ *   - INSERT-new-version-NEVER-UPDATE : on n'écrase jamais une version, on insère + flippe active_version_id.
+ *   - no-rétro-régression par section : une version "pire" est insérée en status='draft' (jamais active).
+ *   - fail-closed : toute erreur de gate/écriture → conflit observable, jamais de fallback silencieux.
+ *   - flag seo_projection_read_v1 OFF par défaut → read-path dark ; le WRITE est découplé du READ.
+ *
+ * @see governance-vault ADR-059 (SEO Runtime Projection) + ADR-090 (Forward Writer Canon)
+ */
+
+/** Queues BullMQ (ADR-059 §Découplage write↔refresh). Réutilise @nestjs/bull (Bull), pas de nouvelle infra. */
+export const PROJECTION_WRITE_QUEUE = 'projection-write-queue';
+export const PROJECTION_REFRESH_QUEUE = 'projection-refresh-queue';
+
+export const PROJECTION_WRITE_JOB = 'seo-projection-write';
+export const PROJECTION_REFRESH_JOB = 'seo-projection-refresh';
+
+/** Version du contrat WRITER (ADR-090 Q1 : découplé du projection_contract_version du runner). */
+export const WRITER_CONTRACT_VERSION = '1.0.0';
+
+/** Debounce du refresh (ADR-059 : coalescing 5s, concurrency=1, single-flight). */
+export const REFRESH_DEBOUNCE_MS = 5_000;
+
+export type ProjectionTriggeredBy = 'cron' | 'manual' | 'replay' | 'test';
+export type ProjectionEntityType = 'gamme' | 'vehicle' | 'constructeur' | 'diagnostic';
+
+/** Données du job write : la liste des chemins d'exports à projeter pour ce run. */
+export interface ProjectionWriteJobData {
+  triggeredBy: ProjectionTriggeredBy;
+  /** Chemins absolus des exports/seo/<type>/<slug>.json à projeter. */
+  exportPaths: string[];
+  /** Métadonnées run (versions semver) pour l'audit trail __seo_projection_runs. */
+  runMeta?: Partial<ProjectionRunMeta>;
+}
+
+export interface ProjectionRefreshJobData {
+  triggeredBy: ProjectionTriggeredBy;
+  /** run_id à l'origine du refresh (traçabilité). */
+  runId?: string;
+}
+
+export interface ProjectionRunMeta {
+  projection_contract_version: string | null;
+  exports_snapshot_hash: string | null;
+  exports_snapshot_uri: string | null;
+  wiki_commit_sha: string | null;
+  builder_version: string | null;
+  pipeline_version: string | null;
+  extractor_version: string | null;
+  runner_version: string | null;
+}
+
+/** Forme minimale d'un export/seo/*.json (mirroir de _meta/schema/exports-seo.schema.json côté wiki). */
+export interface SeoProjectionExport {
+  entity_id: string;
+  entity_type: ProjectionEntityType;
+  schema_version: string;
+  projection_contract_version: string;
+  source_wiki_commit: string;
+  wiki_path: string;
+  content_hash: string;
+  generated_at: string;
+  builder_version?: string;
+  facts: unknown[];
+  sources: unknown[];
+  blocks: SeoProjectionBlock[];
+  roles_allowed: string[];
+  consumers_allowed: string[];
+}
+
+export interface SeoProjectionBlock {
+  block_id?: string;
+  role: string;
+  block_kind: string;
+  content_hash?: string;
+  confidence_base?: number | null;
+  content: Record<string, unknown>;
+}
+
+/** Verdict d'une porte (CanonGate / QualityGate). Fail-closed : `ok=false` → conflit observable, pas d'écriture. */
+export interface GateVerdict {
+  gate: 'canon' | 'quality';
+  ok: boolean;
+  reasons: string[];
+}
+
+/** Résultat d'écriture d'une entité (observable, jamais silencieux). */
+export interface EntityWriteOutcome {
+  entity_id: string;
+  status: 'written' | 'noop' | 'blocked' | 'regressed_draft';
+  factsVersionId?: string;
+  blocksWritten?: number;
+  conflicts?: number;
+  reasons?: string[];
+}
+
+export interface ProjectionRunResult {
+  runId: string | null;
+  triggeredBy: ProjectionTriggeredBy;
+  entitiesWritten: number;
+  outcomes: EntityWriteOutcome[];
+  refreshEnqueued: boolean;
+  readOnlySkipped?: boolean;
+}

--- a/log.md
+++ b/log.md
@@ -514,3 +514,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/rag-purge-b8-pipeline-service`
 - **Décision** : chore(rag-proxy): retire RagPipelineService + endpoints pipeline (rag-purge B8)
 - **Sortie** : PR aucune | commits f5d45041f
+
+## 2026-06-19 — feat/adr059-pr6b-projection-workers (auto)
+
+- **Branche** : `feat/adr059-pr6b-projection-workers`
+- **Décision** : feat(seo-projection): PR-6b forward-writer workers (2-gate + wouldRegress, BullMQ)
+- **Sortie** : PR aucune | commits a80d712c0


### PR DESCRIPTION
**ADR-059 PR-6b / ADR-090 §C4 — forward-writer `exports/seo/*.json` → DB versionnée.**

Module `backend/src/modules/seo-projection/` qui projette des exports SEO (déjà TIER A côté wiki) dans le schéma versionné livré par PR-6 (#1030). **Additif : NON wiré dans `AppModule`** → zéro impact runtime tant que PR-6c ne le branche pas. Read-path dark (flag `seo_projection_read_v1` OFF, RPC read = PR-7).

### Ce que ça fait
- **2 portes fail-closed** (`SeoProjectionGateService`, zéro re-scoring — le scoring 6-dim ADR-088 est déjà appliqué côté wiki avant promotion) :
  - **CanonGate** — pureté des rôles : `roles_allowed`/`consumers_allowed` non vides, tout `block.role ⊆ roles_allowed`, `entity_type` ∈ canon, identité présente.
  - **QualityGate** — intégrité du contrat exports-seo : tous les champs requis présents + `content_hash` non vide (no-op detection aval).
- **INSERT-new-version + flip `active_version_id`** (jamais d'`UPDATE` en place) ; no-op si `content_hash` identique ; **no-rétro-régression PAR BLOC** : une version de confiance inférieure est insérée en `draft` (pas `active`) + conflit observable (`wouldRegress`).
- **2 workers BullMQ découplés** : `projection-write-queue` (transaction courte) + `projection-refresh-queue` (`REFRESH MATERIALIZED VIEW CONCURRENTLY` hors-tx). Refresh **débouncé + single-flight** (jobId singleton → coalescing : N writes pendant la fenêtre = 1 refresh).
- **Fail-closed partout** : toute erreur → conflit tracé (`__seo_projection_conflicts`) + run marqué `failed`, jamais de fallback silencieux (ADR-059 §Interdictions).
- **READ_ONLY/PREPROD (ADR-028)** : aucune écriture, skip observable loggé.

### Différé (non dans cette PR)
- **PR-6c** : RPC gouvernée `refresh_seo_projection_mvs` (SECURITY DEFINER, appel via `callRpc()`) + outbox `__rag_change_events` (trigger refresh) + feeder R1 + **wiring `SeoProjectionModule` dans `AppModule`**. Tant qu'absente, `refreshViews()` fail-close proprement (no-op loggé) — pas d'appel RPC direct (RPC Safety Gate respecté).
- **PR-7** : RPC read-path `get_active_seo_projection` + `GRANT EXECUTE` anon + adapter page + guards.

### Dépendance
La migration PR-6 (#1030, 7 tables + 2 MV) doit être **mergée + `apply_migration`** sur la DB partagée pour que le writer ait ses tables. Module dark/non-wiré → aucun impact si la migration n'est pas encore appliquée.

### Tests & CI
- 6 tests purs `SeoProjectionGateService` (les 2 portes fail-closed).
- **14/14 required checks verts** (TypeScript, ESLint, Backend Tests, CodeQL, Core Build, RPC Safety Gate, Frontend Tests, Migration Safety, Import Firewall, Secrets, Security Audit, DEV Safety, ADR-010 Gov).
- ⚠️ **`🛡️ Deterministic gates` rouge = NON bloquant + NON requis** : baseline `ast_grep.warnings 34→64` (+30, seuil +5). Dérive **pré-existante** sur `origin/main` (13 commits mergés depuis le baseline figé du 2026-05-24) — **ce module contribue 0 warning ast-grep** (scan `backend/src/modules/seo-projection` = 0). Correctif = `npm run audit:baseline:refresh` sur un merge maintainer (cf. [[reference_impeccable_detector_drift_baseline_resync]]), hors scope de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
