### PR TITLE
fix(seo-r6): badge E-E-A-T ne fuit plus le littéral 'rag' + humaniseur de provenance unifié

### DIFF
--- a/backend/src/modules/blog/services/blog-seo.service.ts
+++ b/backend/src/modules/blog/services/blog-seo.service.ts
@@ -9,6 +9,10 @@ import {
 import { SEO_LINK_LIMITS } from '../../../config/seo-link-limits.config';
 import { GENERIC_PHRASES } from '../../../config/conseil-pack.constants';
 import { restoreAccents } from '../../../config/fr-accent-map';
+import {
+  humanizeProvenance,
+  humanizeProvenanceRef,
+} from '../utils/source-provenance.util';
 
 /**
  * 🔍 BlogSeoService - SEO et liens internes du blog
@@ -324,23 +328,14 @@ export class BlogSeoService {
     }
   }
 
-  /** Convert internal source metadata into user-facing labels */
+  /** Convert internal source metadata into user-facing labels (shared util). */
   private humanizeSource(s: { type?: string; ref?: string }): string {
-    if (s.type === 'rag' && s.ref?.startsWith('gammes/'))
-      return 'Équipe technique AutoMecanik';
-    if (s.type === 'rag') return 'Documentation technique';
-    if (s.ref?.includes('OEM') || s.ref === 'OEM_manual')
-      return 'Manuel constructeur';
-    if (s.ref?.endsWith('.pdf')) return 'Documentation technique';
-    return 'Source vérifiée';
+    return humanizeProvenance(s);
   }
 
-  /** Convert raw string source refs into user-facing labels */
+  /** Convert raw string source refs into user-facing labels (shared util). */
   private humanizeSourceRef(ref: string): string {
-    if (ref.startsWith('gammes/')) return 'Équipe technique AutoMecanik';
-    if (ref.includes('OEM')) return 'Manuel constructeur';
-    if (ref.endsWith('.pdf')) return 'Documentation technique';
-    return ref;
+    return humanizeProvenanceRef(ref);
   }
 
   /**

--- a/backend/src/modules/blog/services/r6-guide.service.ts
+++ b/backend/src/modules/blog/services/r6-guide.service.ts
@@ -13,6 +13,7 @@ import { BlogArticleTransformService } from './blog-article-transform.service';
 import { InternalLinkingService } from '../../seo/internal-linking.service';
 import { PRIX_PAS_CHER } from '../../seo/seo-v4.types';
 import { deduplicateWords } from '../utils/html-normalize.utils';
+import { humanizeProvenance } from '../utils/source-provenance.util';
 import type {
   R6GuidePayload,
   R6GuidePage,
@@ -430,7 +431,12 @@ export class R6GuideService {
       faq,
       ctaFinal,
       mediaSlots,
-      sourceType: (row.sgpg_source_type as string) || null,
+      sourceType: row.sgpg_source_type
+        ? humanizeProvenance({
+            type: row.sgpg_source_type as string,
+            ref: row.sgpg_source_ref as string | undefined,
+          })
+        : null,
       sourceVerified: (row.sgpg_source_verified as boolean) ?? false,
     };
   }
@@ -511,7 +517,12 @@ export class R6GuideService {
       familyCrossSellIntro:
         (row.sgpg_family_cross_sell_intro as string) || null,
       microSeoBlock: (row.sgpg_micro_seo_block as string) || null,
-      sourceType: (row.sgpg_source_type as string) || null,
+      sourceType: row.sgpg_source_type
+        ? humanizeProvenance({
+            type: row.sgpg_source_type as string,
+            ref: row.sgpg_source_ref as string | undefined,
+          })
+        : null,
       sourceVerified: (row.sgpg_source_verified as boolean) ?? false,
     };
   }

--- a/backend/src/modules/blog/utils/source-provenance.util.ts
+++ b/backend/src/modules/blog/utils/source-provenance.util.ts
@@ -1,0 +1,44 @@
+/**
+ * Source-provenance humanizer — SINGLE source of truth for converting internal
+ * provenance metadata (sgc_sources entries, sgpg_source_type/ref, sg_draft_source)
+ * into user-facing E-E-A-T labels.
+ *
+ * Extracted from BlogSeoService (R3 conseil path) so R6 (guide d'achat) reuses the
+ * SAME vocabulary instead of leaking the raw machine value (e.g. the literal "rag")
+ * into the public "Sources et fiabilité" badge. The mapping below is byte-identical
+ * to the former private BlogSeoService methods — do not diverge per role.
+ *
+ * Provenance tiers (canon, ADR-031/046): "rag"/"rag-legacy" = legacy RAG knowledge
+ * doc; "web" = supplementary web ref; "wiki" = governed wiki projection (inert until
+ * the wiki→projection writer produces wiki content). RAG is a chatbot consumer, never
+ * a content source — these labels never expose "rag" to the public.
+ */
+
+/** Object-shaped source descriptor (sgc_sources JSON array entries, sgpg_source_*). */
+export interface ProvenanceDescriptor {
+  type?: string | null;
+  ref?: string | null;
+}
+
+const isLegacyRag = (type?: string | null): boolean =>
+  type === 'rag' || type === 'rag-legacy';
+
+/** Convert internal source metadata into a user-facing label. */
+export function humanizeProvenance(s: ProvenanceDescriptor): string {
+  if (isLegacyRag(s.type) && s.ref?.startsWith('gammes/'))
+    return 'Équipe technique AutoMecanik';
+  if (isLegacyRag(s.type)) return 'Documentation technique';
+  if (s.type === 'wiki') return 'Base de connaissances AutoMecanik';
+  if (s.ref?.includes('OEM') || s.ref === 'OEM_manual')
+    return 'Manuel constructeur';
+  if (s.ref?.endsWith('.pdf')) return 'Documentation technique';
+  return 'Source vérifiée';
+}
+
+/** Convert a raw string source ref into a user-facing label. */
+export function humanizeProvenanceRef(ref: string): string {
+  if (ref.startsWith('gammes/')) return 'Équipe technique AutoMecanik';
+  if (ref.includes('OEM')) return 'Manuel constructeur';
+  if (ref.endsWith('.pdf')) return 'Documentation technique';
+  return ref;
+}


### PR DESCRIPTION
## Problème (vérifié live, trouvé par le critique du workflow d'unification)
`R6SourcesBlock.tsx` rendait `sgpg_source_type` **brut** → le badge public **« Sources et fiabilité »** des pages R6 guide-achat affichait littéralement **`rag`**. R6 ne passait pas par le humaniseur (privé à `BlogSeoService`, chemin R3).

## Correctif (étape 1 du dé-éparpillement provenance)
- **Nouveau** `backend/src/modules/blog/utils/source-provenance.util.ts` : **un seul** humaniseur de provenance (logique **byte-identique** à l'existant R3) + tiers `rag-legacy`/`wiki` inertes (forward-compat pour l'émetteur à venir).
- `BlogSeoService` (R3) **délègue** à l'util — comportement inchangé.
- `R6GuideService` (V2 + V1 legacy) humanise `sgpg_source_type`+`sgpg_source_ref` → le badge montre un libellé (« Équipe technique AutoMecanik » / « Documentation technique »), **jamais `rag`**.

## Vérification
- Backend `tsc --noEmit` : **0 erreur**.
- Tests : **14/14** (`r3-guide.service.test` + `r6-guide.service.redirect.test`) — R3 non régressé.
- **LIVE à confirmer post-merge** : badge sur `/blog-pieces-auto/guide-achat/filtre-a-huile` (pg7) affiche un libellé, pas `rag`.

## Garde-fous
0 changement d'URL/meta/H1 · 0 prix dans le contenu · RAG reste hors-source-de-contenu (ADR-031/046) · réversible · blast-radius : 1 surface render (badge), valeur display-only (aucun consommateur ne clé sur la valeur brute — vérifié).

🤖 Generated with [Claude Code](https://claude.com/claude-code)