### PR TITLE
fix(agents): seo-content AGENTS.md — contenu via WIKI (pas RAG) + garde anti-RAG-source

### DIFF
--- a/agents/seo-content/AGENTS.md
+++ b/agents/seo-content/AGENTS.md
@@ -95,7 +95,7 @@ Si `kw_missing_count > 50` (gap batch) — **1 seul ticket global** (pas de tick
 229+ gammes sans données Google Ads dans __seo_keywords.
 
 **Informatif uniquement — non bloquant.**
-Le pipeline /content-gen fonctionne normalement depuis le RAG.
+Le contenu est produit par le pipeline WIKI gouverné (RAW → WIKI → projection, ADR-031/059) ; les données Google Ads sont un signal non bloquant, jamais une source.
 
 Action DEV requise :
 1. Créer scripts/seo/import-gads-kp-to-db.py
@@ -127,7 +127,7 @@ Pour chaque gap P2 (max 3 tickets par heartbeat) :
 Contenu R3 manquant pour "<pg_nom>" (<pg_alias>). KP validé ✅.
 
 **Action DEV requise :**
-cd /opt/automecanik/app && claude --print "/content-gen <pg_alias> --r3"
+cd /opt/automecanik/app && claude --print "/seo-content-loop <pg_alias>"
 
 Priorité : P2
 Gamme : <pg_alias>
@@ -158,23 +158,29 @@ Format :
 
 ## Types de tickets (référence)
 
+> **Provenance du contenu (canon)** : le contenu R* est produit par le pipeline **WIKI gouverné**
+> (RAW → WIKI → projection → DB ; ADR-031 / ADR-059 / ADR-083), méthode opératoire `/seo-content-loop`.
+> Le **RAG n'est jamais source de contenu** (RAG = chatbot only, ADR-046) ; le mode RAG-source
+> `/content-gen` est **legacy/abandonné pour le contenu** (cf. `workspaces/seo-batch/README.md`).
+> Les données Google Ads (`__seo_keywords`) sont un **signal non bloquant**, jamais une source.
+
 ### KP_GAMME — Keyword plan manquant
 Action DEV : `claude --print "/kp <alias> --r3"` dans `/opt/automecanik/app`
 
 ### CONTENT_R3 — Contenu R3 manquant (KP ok)
-Action DEV : `claude --print "/content-gen <alias> --r3"` dans `/opt/automecanik/app`
+Action DEV : `claude --print "/seo-content-loop <alias>"` dans `/opt/automecanik/app` (cible : sections conseil R3)
 
 ### CONTENT_R6 — Guide d'achat R6 manquant
-Action DEV : `claude --print "/content-gen <alias> --r6"` dans `/opt/automecanik/app`
+Action DEV : `claude --print "/seo-content-loop <alias>"` dans `/opt/automecanik/app` (cible : guide d'achat R6)
 
 ### KW_BATCH_IMPORT — Import batch Google Ads manquant (informatif, P3)
 Créer si `kw_missing_count > 50`. **1 seul ticket global** — pas de ticket par gamme.
 Action DEV : créer `scripts/seo/import-gads-kp-to-db.py` + fournir CSV Google Ads.
-**Non bloquant** — le pipeline génère depuis le RAG même sans cette donnée.
+**Non bloquant** — le contenu vient du pipeline WIKI gouverné (RAW → WIKI → projection, ADR-031/059), pas de cette donnée KW.
 
 ### KW_MANQUANT — Données Google Ads absentes pour une gamme (informatif, low)
 Créer si `kw_missing_count <= 50`. Max 3 tickets/heartbeat.
-**Non bloquant** — le pipeline génère depuis le RAG même sans cette donnée.
+**Non bloquant** — le contenu vient du pipeline WIKI gouverné (RAW → WIKI → projection, ADR-031/059), pas de cette donnée KW.
 
 ### AUDIT_SEO — Audit qualité d'une gamme
 Action DEV : `claude --print "/seo-gamme-audit <alias>"` dans `/opt/automecanik/app`

--- a/scripts/agents/validate-agents-md.sh
+++ b/scripts/agents/validate-agents-md.sh
@@ -35,6 +35,14 @@ RE_STATE_FIGE='\b(ABSENTE|PRÉSENTE|PRESENTE|DOWN)\b'
 # WARN regexes
 RE_URL_OTHER='https?://'
 RE_STATE_FLOU='\b(UP|OFF|ON)\b'
+# WARN — dérive doctrine contenu : RAG présenté comme source de CONTENU (canon : contenu = WIKI,
+# RAG = chatbot only, ADR-031/046 ; pendant prose de la garde code-only seo-no-rag-as-content-source).
+# Patterns volontairement précis pour NE PAS flagger la prose corrective ("/content-gen abandonné",
+# "RAG = chatbot only") : on exige un verbe de production suivi de "depuis le RAG", ou l'invocation
+# `--print … /content-gen` (proposer d'exécuter le générateur RAG-source legacy).
+RE_RAG_AS_CONTENT='(g[ée]n[èe]r|produi|fonctionne|pipeline|source).*depuis le RAG'
+# NB : démarre par une classe [-] (et non `--`) sinon grep interprète le motif comme une option.
+RE_CONTENT_GEN_INVOKE='[-]-print.*/content-gen'
 
 BLOCKS=0
 WARNS=0
@@ -147,6 +155,21 @@ check_antipattern_lines() {
       emit_warn "$label" "$f" "$lineno" "mot d'état flou (UP/OFF/ON)"
     fi
   done < <(printf '%s\n' "$content" | grep -nE "$RE_URL_OTHER|$RE_STATE_FLOU" 2>/dev/null || true)
+
+  # WARN — dérive doctrine contenu (RAG-comme-source / invocation du générateur RAG-source legacy)
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    local lineno
+    lineno=$(printf '%s\n' "$line" | sed 's/:.*//')
+    local body
+    body=$(printf '%s\n' "$line" | sed 's/^[0-9]*://')
+    if echo "$body" | grep -Eiq "$RE_RAG_AS_CONTENT"; then
+      emit_warn "$label" "$f" "$lineno" "RAG comme source de contenu — canon : contenu = WIKI (RAW→WIKI→projection), RAG = chatbot only (ADR-031/046)"
+    fi
+    if echo "$body" | grep -Eq "$RE_CONTENT_GEN_INVOKE"; then
+      emit_warn "$label" "$f" "$lineno" "invocation du générateur RAG-source /content-gen (legacy) — préférer le pipeline WIKI / seo-content-loop"
+    fi
+  done < <(printf '%s\n' "$content" | grep -niE "$RE_RAG_AS_CONTENT|$RE_CONTENT_GEN_INVOKE" 2>/dev/null || true)
 }
 
 # ─── Modes d'invocation ───────────────────────────────────────────────────────
@@ -284,8 +307,43 @@ EOF
   bash "$0" --file "$tmp/fr-down.md" >/dev/null 2>&1
   test_case "PASS — 'down' lowercase (FR normal, pas assertion)" 0 $?
 
+  # 10. WARN — dérive doctrine contenu : "génère … depuis le RAG" = WARN (non bloquant, exit 0)
+  local out10 ec10
+  printf 'Le pipeline genere le contenu depuis le RAG.\n' > "$tmp/rag-content.md"
+  out10=$(bash "$0" --file "$tmp/rag-content.md" 2>&1); ec10=$?
+  if [ "$ec10" = "0" ] && printf '%s' "$out10" | grep -q "RAG comme source de contenu"; then
+    printf '  ✓ %s\n' "WARN RAG-comme-source-de-contenu (non bloquant)"
+  else
+    printf '  ✗ %s (exit=%s, WARN attendu)\n' "WARN RAG-comme-source-de-contenu" "$ec10"
+    failed=$((failed + 1))
+  fi
+
+  # 11. WARN — invocation du générateur RAG-source legacy `--print … /content-gen` (le motif démarre
+  #     par `--`, piège grep-option → vérifie la classe [-] du regex).
+  local out11 ec11
+  printf 'cd /opt/automecanik/app && claude --print "/content-gen <alias> --r3"\n' > "$tmp/rag-invoke.md"
+  out11=$(bash "$0" --file "$tmp/rag-invoke.md" 2>&1); ec11=$?
+  if [ "$ec11" = "0" ] && printf '%s' "$out11" | grep -q "générateur RAG-source /content-gen"; then
+    printf '  ✓ %s\n' "WARN invocation /content-gen legacy (non bloquant)"
+  else
+    printf '  ✗ %s (exit=%s, WARN attendu)\n' "WARN invocation /content-gen legacy" "$ec11"
+    failed=$((failed + 1))
+  fi
+
+  # 12. PASS — non-régression : la prose CORRECTIVE ("/content-gen abandonné", "RAG = chatbot only")
+  #     ne doit PAS déclencher le WARN (pas de faux positif sur la doctrine elle-même).
+  local out12
+  printf 'Le mode RAG-source /content-gen est abandonne ; contenu = WIKI (RAG = chatbot only).\n' > "$tmp/rag-corrective.md"
+  out12=$(bash "$0" --file "$tmp/rag-corrective.md" 2>&1)
+  if printf '%s' "$out12" | grep -qE "RAG comme source de contenu|générateur RAG-source"; then
+    printf '  ✗ %s (faux positif sur prose corrective)\n' "PASS prose-corrective-non-flaggée"
+    failed=$((failed + 1))
+  else
+    printf '  ✓ %s\n' "PASS prose-corrective-non-flaggée"
+  fi
+
   if [ $failed -eq 0 ]; then
-    echo "✅ all 9 self-tests passed"
+    echo "✅ all 12 self-tests passed"
     exit 0
   else
     echo "❌ $failed self-test(s) failed"


### PR DESCRIPTION
## Problème

`agents/seo-content/AGENTS.md` (agent runtime IA-SEO Master, créateur de tickets) affirmait encore le modèle **RAG-source-de-contenu**, abandonné par le canon (ADR-031 / ADR-046, RAG = chatbot only) :

- 3× « le pipeline **génère depuis le RAG** » (lignes 98, 173, 177)
- 3× tickets DEV proposant `/content-gen <gamme> --rX` (lignes 130, 165, 168), le générateur RAG-source legacy

C'est l'incohérence signalée : le contenu vient désormais du **pipeline WIKI** (RAW → WIKI → projection), pas du RAG.

## Correction (contenu)

- Les 3 assertions « depuis le RAG » → **pipeline WIKI gouverné** (RAW → WIKI → projection, ADR-031/059) ; les données Google Ads sont reformulées en **signal non bloquant**, jamais une source.
- Les 3 tickets `/content-gen --rX` → repointés vers **`/seo-content-loop`** (méthode contenu canonique, R1–R8), rôle conservé dans le texte du ticket.
- Ajout d'une **note de provenance canon** sous *Types de tickets* (ADR-031/046/059/083 + `seo-content-loop`). `/content-gen` n'apparaît plus qu'une fois, étiqueté *legacy/abandonné*.

## Prévention structurelle (no-bricolage)

La garde canonique `seo-no-rag-as-content-source` (rag-purge B9, déjà sur `main`) est **`severity: warning`** mais **code-only** : `files: backend/src/modules/{admin,seo}/services/**/*.ts`, pattern `RAG_KNOWLEDGE_PATH`. **La prose des `AGENTS.md` était un angle mort** — rien n'empêchait la dérive que cette PR corrige.

Plutôt que créer un système parallèle, j'**étends la garde existante** `scripts/agents/validate-agents-md.sh` (déjà le gate pre-commit + CI des AGENTS.md/CLAUDE.md) avec **2 WARN advisory** (sévérité alignée sur la garde code) :

- `(génère|pipeline|…) … depuis le RAG` → RAG-comme-source-de-contenu
- `--print … /content-gen` → invocation du générateur RAG-source legacy

Patterns volontairement **précis** : ils ne flaggent **pas** la prose corrective (« /content-gen abandonné », « RAG = chatbot only »). WARN (exit 0) = non bloquant, comme la garde code — n'impacte que les **lignes ajoutées** des futurs commits (aucun effet rétroactif).

## Vérification

- `validate-agents-md.sh --self-test` : **12/12** (ajout des tests 10/11/12).
- La garde étendue **catch les 6 lignes de dérive d'origine** (98/130/165/168/173/177) et **0 faux positif** sur le fichier corrigé.
- `--staged` (gate CI) : **blocks = 0** (l'unique WARN « ## Format recommandée » est structurel pré-existant, non bloquant).

## Gouvernance

Les deux chemins sont **CODEOWNERS `@ak125`** (`/agents/`, `/scripts/agents/`) → merge bloqué jusqu'à approbation owner. C'est voulu : revue owner avant merge.

## Hors-scope (signalé, non touché)

- `workspaces/seo-batch/AGENTS.md` liste encore `/content-gen --r1` comme *remplacement* d'un script déviant (table de dépréciation 2026-06-07) — formulation plus douce, dans le programme owner « ne pas réécrire réactivement ». La nouvelle garde ne la flagge pas (forme non égregieuse).
- Le `cwd` des tickets (`/opt/automecanik/app`) est uniformément inexact pour les skills seo-batch (incl. `/kp`) — angle mort latent laissé tel quel par discipline de périmètre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
