### PR TITLE
feat(seo-provenance): tier 'rag-legacy' honnête au write-edge + vocabulaire unifié

### DIFF
--- a/backend/src/config/source-provenance.constants.ts
+++ b/backend/src/config/source-provenance.constants.ts
@@ -1,0 +1,36 @@
+/**
+ * Provenance-tier vocabulary — single source of truth for the source.type /
+ * sgpg_source_type value WRITTEN by content enrichers, and rendered by the
+ * provenance humanizer (modules/blog/utils/source-provenance.util.ts).
+ *
+ * Canon (ADR-031/046): RAG is a chatbot retrieval consumer, NEVER a content
+ * source. `rag-legacy` explicitly marks editorial still derived from the
+ * decommissioned RAG knowledge docs — the bare historical `rag` value predates
+ * this tiering. `wiki` is the governed TARGET tier (inert until the
+ * wiki→projection writer actually produces wiki content). Migration progress is
+ * observable as the share of rows leaving `rag-legacy` for `wiki`.
+ */
+export const SOURCE_TIER = {
+  /** Editorial parsed from the legacy RAG knowledge doc (decommissioned source). */
+  RAG_LEGACY: 'rag-legacy',
+  /** Supplementary public web reference. */
+  WEB: 'web',
+  /** Governed wiki projection (target tier — inert until wiki content exists). */
+  WIKI: 'wiki',
+  /** Manually authored / route fallback. */
+  MANUAL: 'manual',
+  /** Owned, gatekept DB tables (e.g. R8 loadGammeEditorial). */
+  DB: 'db',
+} as const;
+
+export type SourceTier = (typeof SOURCE_TIER)[keyof typeof SOURCE_TIER];
+
+/**
+ * True for legacy-RAG-sourced provenance — matches BOTH the historical bare
+ * `rag` value (rows written before tiering) AND the explicit `rag-legacy`.
+ * Use this everywhere instead of comparing the literal, so older rows and newly
+ * stamped rows are treated identically.
+ */
+export function isLegacyRagTier(tier?: string | null): boolean {
+  return tier === 'rag' || tier === SOURCE_TIER.RAG_LEGACY;
+}

--- a/backend/src/modules/admin/services/buying-guide/buying-guide-db.service.ts
+++ b/backend/src/modules/admin/services/buying-guide/buying-guide-db.service.ts
@@ -6,6 +6,7 @@ import {
   MIN_QUALITY_SCORE,
   FAMILY_MARKERS,
 } from '../../../../config/buying-guide-quality.constants';
+import { SOURCE_TIER } from '../../../../config/source-provenance.constants';
 import type { SectionValidationResult } from './buying-guide.types';
 import { BuyingGuideSectionExtractor } from './buying-guide-section-extractor.service';
 import { FeatureFlagsService } from '../../../../config/feature-flags.service';
@@ -86,7 +87,9 @@ export class BuyingGuideDbService extends SupabaseBaseService {
     qualityScore: number,
   ): Record<string, unknown> {
     const payload: Record<string, unknown> = {
-      sgpg_source_type: 'rag',
+      // Honest provenance tier: parsed from the legacy RAG knowledge doc
+      // (decommissioned source), not bare 'rag'. See ADR-031/046.
+      sgpg_source_type: SOURCE_TIER.RAG_LEGACY,
       sgpg_source_uri: sourceUri,
       sgpg_source_ref: sourceRef,
       sgpg_source_verified:

--- a/backend/src/modules/admin/services/conseil-enricher.service.ts
+++ b/backend/src/modules/admin/services/conseil-enricher.service.ts
@@ -11,6 +11,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import * as yaml from 'js-yaml';
 import { RAG_KNOWLEDGE_PATH } from '../../../config/rag.config';
+import { SOURCE_TIER } from '../../../config/source-provenance.constants';
 import {
   GENERIC_PHRASES as SHARED_GENERIC_PHRASES,
   MIN_R3_SECTION_LENGTH,
@@ -2053,13 +2054,15 @@ export class ConseilEnricherService extends SupabaseBaseService {
       const existingRow = existing.get(action.type);
       const sources: Array<{ type: string; ref: string; field: string }> = [
         {
-          type: 'rag',
+          // Honest provenance tier: this descriptor is parsed from the legacy RAG
+          // knowledge doc (decommissioned source) — not bare 'rag'. See ADR-031/046.
+          type: SOURCE_TIER.RAG_LEGACY,
           ref: `gammes/${pgAlias}.md`,
           field:
             action.ragField ?? SECTION_RAG_FIELD_MAP[action.type] ?? 'general',
         },
         ...supplementaryRefs.map((ref) => ({
-          type: 'web',
+          type: SOURCE_TIER.WEB,
           ref,
           field: 'supplementary',
         })),

--- a/backend/src/modules/blog/utils/source-provenance.util.ts
+++ b/backend/src/modules/blog/utils/source-provenance.util.ts
@@ -13,6 +13,7 @@
  * the wiki→projection writer produces wiki content). RAG is a chatbot consumer, never
  * a content source — these labels never expose "rag" to the public.
  */
+import { isLegacyRagTier } from '../../../config/source-provenance.constants';
 
 /** Object-shaped source descriptor (sgc_sources JSON array entries, sgpg_source_*). */
 export interface ProvenanceDescriptor {
@@ -20,8 +21,8 @@ export interface ProvenanceDescriptor {
   ref?: string | null;
 }
 
-const isLegacyRag = (type?: string | null): boolean =>
-  type === 'rag' || type === 'rag-legacy';
+/** Legacy-RAG predicate — sourced from the single provenance vocabulary. */
+const isLegacyRag = isLegacyRagTier;
 
 /** Convert internal source metadata into a user-facing label. */
 export function humanizeProvenance(s: ProvenanceDescriptor): string {


### PR DESCRIPTION
## Quoi
Étape 2 du dé-éparpillement provenance (suite #1034). Les 2 émetteurs d'éditorial SEO stampaient un littéral **`rag`** indistinct. On stampe désormais la provenance **honnête** au write-edge via un vocabulaire de tiers unique.

- **Nouveau** `config/source-provenance.constants.ts` : `SOURCE_TIER` (rag-legacy/web/wiki/manual/db) + `isLegacyRagTier()` (matche `rag` ancien **et** `rag-legacy` nouveau).
- `conseil-enricher` (`sgc_sources`) : `'rag'`→`rag-legacy`, `'web'`→`SOURCE_TIER.WEB`.
- `buying-guide-db` (`sgpg_source_type`) : `'rag'`→`rag-legacy`.
- Humaniseur (#1034) **câblé sur `isLegacyRagTier`** → rend `rag` (anciennes lignes) ET `rag-legacy` (nouvelles) **identiquement** : 0 régression badge.

## Pourquoi (no bricolage)
Rend la **dette provenance mesurable** : la part de lignes quittant `rag-legacy` pour `wiki` = progrès de migration. Prépare le tier `wiki` (déclaré, **inerte** jusqu'à l'existence de contenu wiki — pas de branche morte).

## Sûreté (vérifié)
- **Aucun `UPDATE` SQL en masse** : les 2 439 lignes `rag` existantes restent ; seules les nouvelles ré-enrichies passent `rag-legacy`.
- **Aucun consommateur ne clé sur `'rag'`** : `conseil-quality-scorer` teste la *présence* de sources, pas la valeur (vérifié). Le seul lecteur de label = le humaniseur, qui gère les deux.
- Pas de branche `wiki` émise. RAG reste hors-source-de-contenu (ADR-031/046).
- `tsc` **0 erreur** · **22/22 tests** (conseil-quality + buying-guide + r3 + r6).

Réversible · 0 URL/meta/prix · blast admin-write only (0 impact render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)