### PR TITLE
chore(seo-batch): demote pipeline-orchestrator to read-only state detector (salvage-first)

### DIFF
--- a/workspaces/seo-batch/.claude/skills/pipeline-orchestrator/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/pipeline-orchestrator/SKILL.md
@@ -1,28 +1,45 @@
 ---
 name: pipeline-orchestrator
-description: "Orchestrateur SEO pipelines. Interroge la DB, detecte l'etat de chaque pipeline (R1/R3/R4/R6/R7), propose le prochain agent a invoquer."
-argument-hint: "[status|next|run R4|run R3|run R6|run R7]"
+description: "Détecteur READ-ONLY d'état des pipelines SEO. Interroge la DB, affiche un dashboard de couverture (R1/R3/R4/R6/R7) et la prochaine action recommandée. Ne génère AUCUN contenu — la doctrine 'comment produire du contenu' = skill seo-content-loop."
+argument-hint: "[status|next]"
 disable-model-invocation: false
 allowed-tools: mcp__claude_ai_Supabase__execute_sql, Read, Glob, Grep
 version: "1.0"
 ---
 
-# Pipeline Orchestrator — SEO Content Pipelines
+# Pipeline Orchestrator — Détecteur READ-ONLY d'état des pipelines SEO
 
-Tu es un orchestrateur leger pour les pipelines SEO d'AutoMecanik. Tu interroges la DB pour determiner l'etat de chaque pipeline et proposes le prochain agent a invoquer.
+> **⚠️ Skill READ-ONLY (détecteur d'état/couverture).** Ce skill **n'orchestre plus**
+> et **ne génère aucun contenu**. Il interroge la DB et affiche un dashboard de
+> couverture (`status`) + la prochaine action recommandée (`next`). Les anciennes
+> sous-commandes `run R3/R4/R6/R7` ont été **retirées** : elles pilotaient des
+> content-batch lisant le RAG comme **source de contenu**, chemin **mort**
+> (**ADR-031 / ADR-046** : RAG = consommateur de retrieval pour le **chatbot
+> uniquement**, jamais source de vérité ni générateur de contenu).
+>
+> **Doctrine canonique « quoi produire ensuite »** = skill **`seo-content-loop`**.
+> Toute génération de contenu DOIT suivre la boucle **SCRAPING → RAW → WIKI →
+> projection (consumer)**, jamais RAG-as-content. Ce skill se limite à **mesurer**
+> l'état ; il **ne déclenche aucune écriture**.
+
+Tu es un détecteur léger d'état pour les pipelines SEO d'AutoMecanik. Tu interroges la DB (lecture seule) pour determiner l'etat de chaque pipeline et afficher la couverture.
 
 **Projet Supabase** : `cxpojprgwgubzjyqzmoq`
 
 ---
 
-## Pipelines declares
+## Pipelines observés (carte de couverture)
+
+Référence des grains mesurés par ce détecteur (les tables KP/contenu suivies par
+pipeline). Ce skill ne pilote aucun de ces agents — la production de contenu suit
+la doctrine `seo-content-loop`.
 
 ```
-R1 : r1-content-batch (lit __seo_r1_keyword_plan)
-R3 : research-agent → keyword-planner → brief-enricher → conseil-batch
-R4 : r4-keyword-planner (optionnel) → r4-content-batch (skip-kp possible)
-R6 : r6-keyword-planner → r6-content-batch
-R7 : r7-keyword-planner → (pas de content-batch R7 pour l'instant)
+R1 : grain transactionnel (__seo_r1_keyword_plan)
+R3 : grain conseils       (__seo_r3_keyword_plan)
+R4 : grain reference      (__seo_r4_keyword_plan)
+R6 : grain guide d'achat  (__seo_r6_keyword_plan)
+R7 : grain constructeurs  (__seo_r7_keyword_plan)
 ```
 
 ## Tables de reference
@@ -105,15 +122,17 @@ FROM __seo_r7_keyword_plan;
 
 ## Sous-commande : `next`
 
-Determiner la prochaine action optimale selon ces priorites :
+Détecter (lecture seule) le plus gros gap de couverture et **recommander** la prochaine
+gamme à traiter. Cette commande **ne lance rien** : elle pointe vers la doctrine
+`seo-content-loop` (boucle SCRAPING → RAW → WIKI → projection). Priorités d'observation :
 
-1. **R4 content-batch skip-kp** — gammes publiees sans keyword plan (le plus gros gap)
-2. **R4 content-batch complet** — gammes avec KP validated mais sans page_pack
-3. **R3 keyword-planner** — gammes sans R3 KP
-4. **R6 keyword-planner** — gammes sans R6 KP
-5. **R7 keyword-planner** — gammes sans R7 KP
+1. **R4 sans keyword plan** — gammes publiées sans KP (le plus gros gap)
+2. **R4 KP validé sans page_pack** — gammes avec KP validated mais sans page_pack
+3. **R3 sans KP** — gammes sans R3 keyword plan
+4. **R6 sans KP** — gammes sans R6 keyword plan
+5. **R7 sans KP** — constructeurs sans R7 keyword plan
 
-Pour chaque priorite, verifier s'il reste des gammes a traiter. Proposer la premiere priorite non-vide.
+Pour chaque priorité, vérifier s'il reste des gammes non couvertes. Recommander (sans lancer) la première priorité non-vide.
 
 **Query pour trouver la prochaine gamme R4 skip-kp** :
 ```sql
@@ -129,91 +148,24 @@ LIMIT 1;
 **Format de sortie** :
 
 ```
-## Prochaine action recommandee
+## Prochaine action recommandee (observation, lecture seule)
 
 **Pipeline** : R4 Reference
-**Mode** : unitaire-skip-kp
-**Gamme** : {{gamme_name}} (pg_id={{pg_id}}, slug={{slug}})
-**Agent** : r4-content-batch
+**Gamme prioritaire** : {{gamme_name}} (pg_id={{pg_id}}, slug={{slug}})
 **Raison** : {{X}} gammes sans keyword plan, {{Y}} sections vides
 
-Pour lancer :
-> Invoquer l'agent `r4-content-batch` en mode unitaire-skip-kp pour pg_id={{pg_id}}
+> Pour produire le contenu : suivre la doctrine canonique **`seo-content-loop`**
+> (SCRAPING → RAW → WIKI → projection). Ce skill ne déclenche aucune génération.
 ```
-
----
-
-## Sous-commande : `run R4`
-
-1. Executer la query `next` pour R4
-2. Detecter le mode :
-   - Si la gamme a un KP validated → mode complet
-   - Sinon → mode skip-kp
-3. Invoquer l'agent `r4-content-batch` via Agent tool :
-
-```
-Agent tool:
-  subagent_type: r4-content-batch
-  prompt: "Mode unitaire-skip-kp pour la gamme {{gamme_name}} (pg_id={{pg_id}}, slug={{slug}}).
-  Suivre le pipeline complet : etapes 0 → 1 → 1-bis (auto-extract) → 2 (audit) → 3 (blueprint) → 4 (improve) → 5 (lint) → 6 (write).
-  Afficher le resultat de chaque etape. Ecrire en DB uniquement si lint PASS (score >= 70)."
-```
-
-4. Apres execution, afficher le rapport de cloture
-
----
-
-## Sous-commande : `run R3`
-
-1. Trouver la prochaine gamme sans R3 KP :
-```sql
-SELECT g.pg_id, g.pg_name, g.pg_alias
-FROM __seo_gamme_purchase_guide gpg
-JOIN pieces_gamme g ON g.pg_id = gpg.sgpg_pg_id
-LEFT JOIN __seo_r3_keyword_plan kp ON kp.skp_pg_id = g.pg_id
-WHERE kp.skp_id IS NULL
-LIMIT 1;
-```
-2. Invoquer `keyword-planner` (stage 1.5) pour cette gamme
-3. Apres validation KP → proposer `conseil-batch`
-
----
-
-## Sous-commande : `run R6`
-
-1. Trouver la prochaine gamme sans R6 KP :
-```sql
-SELECT g.pg_id, g.pg_name, g.pg_alias
-FROM __seo_gamme_purchase_guide gpg
-JOIN pieces_gamme g ON g.pg_id = gpg.sgpg_pg_id
-LEFT JOIN __seo_r6_keyword_plan kp ON kp.r6kp_pg_id = g.pg_id::text
-WHERE kp.r6kp_id IS NULL
-LIMIT 1;
-```
-2. Invoquer `r6-keyword-planner` pour cette gamme
-3. Apres validation → proposer `r6-content-batch`
-
----
-
-## Sous-commande : `run R7`
-
-1. Trouver le prochain constructeur sans R7 KP :
-```sql
-SELECT DISTINCT b.brand_id, b.brand_name
-FROM brands b
-LEFT JOIN __seo_r7_keyword_plan kp ON kp.r7kp_brand_id = b.brand_id
-WHERE kp.r7kp_id IS NULL AND b.brand_name IS NOT NULL
-ORDER BY b.brand_name
-LIMIT 1;
-```
-2. Invoquer `r7-keyword-planner` pour ce constructeur
 
 ---
 
 ## Regles
 
-1. TOUJOURS interroger la DB avant de proposer une action
-2. TOUJOURS afficher l'etat actuel avant de lancer un agent
-3. Mode **unitaire** par defaut (1 gamme a la fois)
-4. JAMAIS lancer un agent sans afficher la gamme cible et demander confirmation
-5. Apres chaque run, proposer `/pipeline-orchestrator next` pour la suite
+1. **Lecture seule** : ce skill interroge la DB et affiche un état ; il ne déclenche
+   **aucune écriture** ni génération de contenu.
+2. TOUJOURS interroger la DB avant d'afficher un dashboard ou une recommandation.
+3. La doctrine « comment produire du contenu » vit dans le skill **`seo-content-loop`**
+   (boucle SCRAPING → RAW → WIKI → projection). Le contenu ne se génère **jamais**
+   depuis le RAG (ADR-031 / ADR-046 : RAG = retrieval chatbot uniquement).
+4. Après `status`, proposer `/pipeline-orchestrator next` pour la prochaine observation.

--- a/workspaces/seo-batch/README.md
+++ b/workspaces/seo-batch/README.md
@@ -38,7 +38,7 @@ cd /opt/automecanik/app && claude
 
 ### Skills SEO inclus
 
-`content-audit`, `content-gen`, `content-quality-gate` (🚨 deprecated 2026-06-12, fusionné dans `v5-guardian`), `keyword-planner`, `kw-classify`, `legacy-recycler`, `pipeline-orchestrator`, `pollution-scanner` (🚨 deprecated 2026-06-12, fusionné dans `v5-guardian`), `r8-diversity-check`, `rag-check` (🚨 deprecated 2026-06-12, successeur = validation exports WIKI), `rag-ops` (⚠️ chatbot-ops only ; ingestion contenu = legacy ADR-031/046), `seo-content-architect`, `seo-gamme-audit`, `seo-vault-verify`, `surgical-cleaner`, `v5-guardian` (survivant renforcé).
+`content-audit`, `content-gen`, `content-quality-gate` (🚨 deprecated 2026-06-12, fusionné dans `v5-guardian`), `keyword-planner`, `kw-classify`, `legacy-recycler`, `pipeline-orchestrator` (🔎 read-only depuis 2026-06-20 — détecteur d'état/couverture ; sous-commandes `run R3/R4/R6/R7` retirées, doctrine contenu = `seo-content-loop`), `pollution-scanner` (🚨 deprecated 2026-06-12, fusionné dans `v5-guardian`), `r8-diversity-check`, `rag-check` (🚨 deprecated 2026-06-12, successeur = validation exports WIKI), `rag-ops` (⚠️ chatbot-ops only ; ingestion contenu = legacy ADR-031/046), `seo-content-architect`, `seo-gamme-audit`, `seo-vault-verify`, `surgical-cleaner`, `v5-guardian` (survivant renforcé).
 
 ### Skills DEV restés en monorepo racine
 

--- a/workspaces/wiki/README.md
+++ b/workspaces/wiki/README.md
@@ -39,7 +39,7 @@ cd /opt/automecanik/app && claude
 ## Contenu
 
 - `.claude/skills/wiki-proposal-writer/` : skill principal — produit un fichier `automecanik-wiki/proposals/<slug>.md` avec frontmatter ADR-033 v2.0.0 strict (mode propose-only, 0-LLM pour structure, Anthropic seul pour rédactionnel).
-- `.claude/agents/` : agents wiki orchestrateurs (Phase 4 ADR-033, vide aujourd'hui — modèle pattern `pipeline-orchestrator` du seo-batch pour migration progressive `entity_data.symptoms[]` → `diagnostic_relations[]` sur 500+ fiches gamme).
+- `.claude/agents/` : agents wiki orchestrateurs (Phase 4 ADR-033, vide aujourd'hui — pour migration progressive `entity_data.symptoms[]` → `diagnostic_relations[]` sur 500+ fiches gamme). Note : le skill `pipeline-orchestrator` du seo-batch est désormais un **détecteur read-only** (couverture/état, sans pilotage de génération) ; il n'est plus un modèle d'orchestration de contenu.
 - `.claude/rules/wiki-batch.md` : règles spécifiques wiki (sas markdown vs sas DB, schema strict, 9 quality gates, 3 anti-patterns figés ADR-033 §D3, convention slug DB).
 - `.claude/canon-mirrors/agent-exit-contract.md` : copie canon distribuée depuis vault (hash SHA-256 vérifié CI).
 - `.claude/settings.json` : hooks PreToolUse / PostToolUse / Stop (mêmes scripts que monorepo, paths absolus).


### PR DESCRIPTION
## What

Demotes the `pipeline-orchestrator` skill (`workspaces/seo-batch/.claude/skills/pipeline-orchestrator/SKILL.md`) to a **READ-ONLY state/coverage detector**. Salvage-first: the unique capability (coverage dashboard SQL) is kept; the dead-RAG content steering is removed.

## Why (verified premise)

The `run R3/R4/R6/R7` subcommands invoked content-batch agents that read `/opt/automecanik/rag/knowledge/` as a **content source** — confirmed by inspecting the dispatched agents:
- `r4-content-batch.md` → `/opt/automecanik/rag/knowledge/` (L1+L2 knowledge)
- `conseil-batch.md` → `Read /opt/automecanik/rag/knowledge/gammes/{pg_alias}.md`
- `r6-content-batch.md`, `r1-content-batch.md` → same RAG knowledge files

This is the **dead RAG-as-content path** (ADR-031 / ADR-046: RAG = chatbot retrieval consumer only, never source of truth nor content generator). They do **not** use the legitimate `seo-content-loop` pipeline (SCRAPING → RAW → WIKI → projection).

## Changes

- **KEEP**: `status` + `next` subcommands and **all** coverage/dashboard SQL (the unique capability).
- **DELETE**: the `run R3/R4/R6/R7` dispatch subcommands (dead-RAG content steering).
- **frontmatter**: `argument-hint` `[status|next|run R4|run R3|run R6|run R7]` → `[status|next]`; `description` reframed read-only.
- **ADD**: top banner — read-only detector; `what to do next` doctrine = `seo-content-loop`; content must follow SCRAPING → RAW → WIKI → projection, never RAG-as-content (ADR-031/046).
- **Repoint LIVE refs**: `workspaces/seo-batch/README.md` (skill annotation) + `workspaces/wiki/README.md` (no longer an orchestration-pattern model).
- **Untouched**: `.claude/settings.local.json` allowlist; `.spec/00-canon/**` (owner-only).

## Verification

- Frontmatter parses cleanly (gray-matter); keys unchanged, only string values changed → schema-valid.
- `skills-canon-gate` validator (`scripts/governance/validate-skills-frontmatter.js`) scans only monorepo-root `.claude/skills/` — does **not** cover workspace skills; no regression possible there.
- Body now contains `status` + `next` subcommands only; remaining `run R` mention is the banner explaining the removal.
- 3 files changed, +49/-97. No backend runtime touched (skill prose).

## Follow-up (not done — owner-gated)

A canonical record of this demotion (e.g. in `.spec/00-canon/ai-registry/agent-operating-map.yaml`) would be ideal but `.spec/00-canon/**` is owner-only airlock — left as a note, not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)