### PR TITLE
refactor(admin/gates): extract shared QualityGate penalty reducer

### DIFF
--- a/backend/src/config/keyword-plan.constants.ts
+++ b/backend/src/config/keyword-plan.constants.ts
@@ -46,6 +46,48 @@ export interface GateDefinition {
   penalty: number;
 }
 
+// ── Shared QualityGate penalty reducer (pure arithmetic) ──
+//
+// Single source of truth for the start-100 / subtract-penalty / clamp
+// arithmetic shared by KeywordPlanGatesService (R3, tri-state) and
+// R4LintGatesService (R4, binary). Role-private config (gate definitions,
+// penalty inventories, thresholds, verdict cut-offs) stays in each role's
+// own constants — this util only does the score math, never the verdict.
+//
+// Semantics (preserves the exact pre-extraction behavior of both callers):
+//   - status 'fail'  → subtract the full penalty
+//   - status 'warn'  → subtract Math.floor(penalty / 2)
+//   - status 'pass'  → subtract nothing
+//   - final score clamped to >= 0
+// Binary callers (R4) only ever pass 'pass' | 'fail', so the warn branch is
+// inert for them and the output stays byte-identical.
+
+export type GatePenaltyStatus = 'pass' | 'warn' | 'fail';
+
+export interface GatePenaltyItem {
+  status: GatePenaltyStatus;
+  /** Penalty points for this gate (full on fail, half on warn). */
+  penalty: number;
+}
+
+/**
+ * Reduce a list of gate outcomes to a quality score in [0, 100].
+ *
+ * @param items per-gate { status, penalty }
+ * @returns Math.max(0, 100 - Σ penalties)
+ */
+export function reduceQualityGateScore(items: GatePenaltyItem[]): number {
+  let score = 100;
+  for (const item of items) {
+    if (item.status === 'fail') {
+      score -= item.penalty;
+    } else if (item.status === 'warn') {
+      score -= Math.floor(item.penalty / 2);
+    }
+  }
+  return Math.max(0, score);
+}
+
 export const GATE_DEFINITIONS: Record<string, GateDefinition> = {
   G1_INTENT_ALIGNMENT: {
     description: 'Primary intent matches R3 role (informational/how-to)',

--- a/backend/src/modules/admin/services/keyword-plan-gates.service.ts
+++ b/backend/src/modules/admin/services/keyword-plan-gates.service.ts
@@ -25,6 +25,7 @@ import {
   MEDIA_BUDGET,
   R3_ALLOWED_INTENTS,
   VALID_ANCHOR_PREFIXES,
+  reduceQualityGateScore,
 } from '../../../config/keyword-plan.constants';
 import { R3PageContractSchema } from '../../../config/page-contract-r3.schema';
 import {
@@ -455,18 +456,15 @@ export class KeywordPlanGatesService {
       gateReport[r.gate] = r;
     }
 
-    // Compute quality score (100 - sum of penalties for failed gates)
-    let qualityScore = 100;
-    for (const r of results) {
-      if (r.status === 'fail') {
-        const def = GATE_DEFINITIONS[r.gate];
-        qualityScore -= def?.penalty ?? 0;
-      } else if (r.status === 'warn') {
-        const def = GATE_DEFINITIONS[r.gate];
-        qualityScore -= Math.floor((def?.penalty ?? 0) / 2);
-      }
-    }
-    qualityScore = Math.max(0, qualityScore);
+    // Compute quality score (100 - sum of penalties for failed/warn gates).
+    // Penalties stay role-private (GATE_DEFINITIONS); the start-100/subtract/
+    // clamp arithmetic is the shared reducer.
+    const qualityScore = reduceQualityGateScore(
+      results.map((r) => ({
+        status: r.status,
+        penalty: GATE_DEFINITIONS[r.gate]?.penalty ?? 0,
+      })),
+    );
 
     // Compute sub-scores
     const duplicationScore = this.computeDuplicationScore(plan);

--- a/backend/src/modules/admin/services/quality-gate-reducer.characterization.test.ts
+++ b/backend/src/modules/admin/services/quality-gate-reducer.characterization.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Characterization test for the shared QualityGate penalty reducer.
+ *
+ * Pins the EXACT qualityScore / lint score produced by:
+ *   - KeywordPlanGatesService.runAllGates (R3, tri-state fail/warn/pass)
+ *   - R4LintGatesService.validate          (R4, binary fail/pass)
+ *
+ * Purpose: prove the start-100 / subtract-penalty / clamp arithmetic is
+ * byte-identical BEFORE and AFTER extraction into a shared pure util.
+ * These expected numbers are the golden values captured from the
+ * pre-refactor implementations.
+ */
+import { R4LintGatesService, R4LintInput } from './r4-lint-gates.service';
+import { KeywordPlanGatesService, SkpRow } from './keyword-plan-gates.service';
+
+describe('QualityGate reducer characterization (byte-identical guard)', () => {
+  // ── R4LintGatesService ──────────────────────────────────
+
+  describe('R4LintGatesService.validate score', () => {
+    let service: R4LintGatesService;
+    beforeEach(() => {
+      service = new R4LintGatesService();
+    });
+
+    const clean: R4LintInput = {
+      definition:
+        'Le disque de frein est un composant rotatif du système de freinage automobile à friction.',
+      takeaways: [
+        'Convertit énergie cinétique en chaleur par friction',
+        'Fonctionne par paire sur un essieu',
+        'Épaisseur minimale à respecter selon constructeur',
+      ],
+      role_mecanique:
+        'Le disque de frein assure la décélération du véhicule par friction avec les plaquettes. Il dissipe la chaleur générée lors du freinage et maintient la stabilité directionnelle.',
+      composition: [
+        'Fonte grise GG25 — surface de friction',
+        'Moyeu central — fixation au porte-fusée',
+      ],
+      key_specs: [
+        { label: 'Diamètre', value: '256-380 mm', note: 'selon véhicule' },
+      ],
+      common_questions: [
+        {
+          question: 'Peut-on rectifier un disque ?',
+          answer:
+            'La rectification est possible si le disque reste au-dessus de son épaisseur minimale.',
+        },
+      ],
+      regles_metier: [
+        'Toujours intervenir par paire sur un essieu complet',
+        'Ne jamais réutiliser un disque sous épaisseur minimale',
+      ],
+      scope_limites:
+        'Concerne uniquement le disque de frein en tant que pièce de rechange.',
+      targetKeywords: ['disque de frein', 'frein', 'freinage'],
+    };
+
+    it('clean input → score 100, pass true', () => {
+      const r = service.validate(clean);
+      expect(r.score).toBe(100);
+      expect(r.pass).toBe(true);
+    });
+
+    it('LG1 (30) + LG4 (10) fail → score 60', () => {
+      const r = service.validate({
+        ...clean,
+        definition: 'Le prix pas cher avec livraison rapide.',
+        regles_metier: ['freiner', 'supporter'],
+      });
+      // LG1 forbidden=-30, LG4 rules=-10 → 60
+      expect(r.score).toBe(60);
+      expect(r.pass).toBe(false);
+    });
+
+    it('many fails clamp to 0', () => {
+      const r = service.validate({
+        ...clean,
+        definition:
+          'Étape 1 : acheter pas cher en promo livraison. Ce symptome de panne joue un rôle essentiel. Guide achat budget.',
+        role_mecanique:
+          'Étape 1 : acheter pas cher en promo livraison. Ce symptome de panne joue un rôle essentiel. Guide achat budget.',
+        regles_metier: ['freiner', 'supporter'],
+        key_specs: [{ label: 'test', value: '1' }],
+        common_questions: [
+          { question: 'Q?', answer: Array(70).fill('mot').join(' ') },
+        ],
+        targetKeywords: ['inexistant'],
+      });
+      expect(r.score).toBe(0);
+      expect(r.pass).toBe(false);
+    });
+  });
+
+  // ── KeywordPlanGatesService ─────────────────────────────
+
+  describe('KeywordPlanGatesService.runAllGates qualityScore', () => {
+    let service: KeywordPlanGatesService;
+    beforeEach(() => {
+      service = new KeywordPlanGatesService();
+    });
+
+    // All gates pass: valid intent, no pricing terms, mapped cluster.
+    const cleanRow: SkpRow = {
+      skp_pg_id: 1,
+      skp_pg_alias: 'disque-de-frein',
+      skp_primary_intent: 'informational',
+      skp_secondary_intents: [],
+      skp_boundaries: {},
+      skp_heading_plan: { h1: 'Quand changer un disque de frein' },
+      skp_query_clusters: {
+        c1: [{ head: ['quand changer disque'], section_target: 'S2' }],
+      },
+      skp_section_terms: {
+        S2: { include_terms: ['usure', 'intervalle'] },
+      },
+      skp_seo_brief: { recommended_anchors: ['/pieces/disque-de-frein'] },
+    };
+
+    it('clean row → qualityScore 100', () => {
+      const r = service.runAllGates(cleanRow);
+      expect(r.qualityScore).toBe(100);
+    });
+
+    // G1 fail (missing intent) = -30 ; everything else pass.
+    it('G1 fail (missing intent) → qualityScore 70', () => {
+      const r = service.runAllGates({ ...cleanRow, skp_primary_intent: null });
+      expect(r.qualityScore).toBe(70);
+    });
+
+    // G5 full fail (>2 FAQ dup) = -10.
+    it('G5 fail (FAQ dup >2) → qualityScore 90', () => {
+      const row: SkpRow = {
+        ...cleanRow,
+        skp_query_clusters: {
+          c1: [
+            {
+              head: ['quand changer disque'],
+              section_target: 'S2',
+              paa_questions: [
+                'quand changer disque',
+                'prix disque',
+                'usure disque',
+              ],
+            } as never,
+          ],
+        },
+        skp_section_terms: {
+          S2: {
+            include_terms: ['usure'],
+            faq_questions: [
+              'quand changer disque',
+              'prix disque',
+              'usure disque',
+            ],
+          },
+        },
+      };
+      const r = service.runAllGates(row);
+      expect(r.qualityScore).toBe(90);
+    });
+
+    // G4 warn path: 7 sections (21 pairs), exactly 1 overlapping pair so
+    // duplicationScore = 1/21 ≈ 0.048 <= maxDuplicationScore(0.15) → 'warn'.
+    // warn penalty = floor(15/2) = 7 → 100 - 7 = 93.
+    it('G4 warn (half penalty) → qualityScore 93', () => {
+      const terms: Record<string, { include_terms?: string[] }> = {
+        S1: { include_terms: ['shared', 'a1'] },
+        S2: { include_terms: ['shared', 'b1'] },
+        S3: { include_terms: ['c1', 'c2'] },
+        S4: { include_terms: ['d1', 'd2'] },
+        S5: { include_terms: ['e1', 'e2'] },
+        S6: { include_terms: ['f1', 'f2'] },
+        S7: { include_terms: ['g1', 'g2'] },
+      };
+      const row: SkpRow = { ...cleanRow, skp_section_terms: terms };
+      const r = service.runAllGates(row);
+      expect(r.qualityScore).toBe(93);
+    });
+  });
+});

--- a/backend/src/modules/admin/services/r4-lint-gates.service.ts
+++ b/backend/src/modules/admin/services/r4-lint-gates.service.ts
@@ -7,7 +7,10 @@
  * Imports forbidden terms and thresholds from r4-keyword-plan.constants.ts (single source of truth).
  */
 import { Injectable } from '@nestjs/common';
-import type { GateResult } from '../../../config/keyword-plan.constants';
+import {
+  type GateResult,
+  reduceQualityGateScore,
+} from '../../../config/keyword-plan.constants';
 import {
   R4_FORBIDDEN_FROM_R1,
   R4_FORBIDDEN_FROM_R3,
@@ -129,12 +132,15 @@ export class R4LintGatesService {
     gates['LG8_DUPLICATES'] = lg8;
     if (!lg8.pass && lg8.details) violations.push(lg8.details);
 
-    // Compute score: 100 - sum of penalties for failed gates
-    const totalPenalty = Object.values(gates)
-      .filter((g) => !g.pass)
-      .reduce((sum, g) => sum + g.penalty, 0);
-
-    const score = Math.max(0, 100 - totalPenalty);
+    // Compute score: 100 - sum of penalties for failed gates.
+    // R4 is binary (pass/fail); the start-100/subtract/clamp arithmetic is the
+    // shared reducer. The verdict threshold (minLintScore) stays role-private.
+    const score = reduceQualityGateScore(
+      Object.values(gates).map((g) => ({
+        status: g.pass ? ('pass' as const) : ('fail' as const),
+        penalty: g.penalty,
+      })),
+    );
     const pass = score >= R4_CONTENT_THRESHOLDS.minLintScore;
 
     return { score, pass, gates, violations };


### PR DESCRIPTION
## What

Both `R4LintGatesService.validate` and `KeywordPlanGatesService.runAllGates` computed a quality score with the **same** start-100 / subtract-penalty / clamp-to-0 arithmetic, inlined separately. This PR extracts **only that arithmetic** into one pure function `reduceQualityGateScore()` in `backend/src/config/keyword-plan.constants.ts`, next to the existing `GateResult` interface.

## Shape verification (premise confirmed before mutating)

| | base | per-fail | per-warn | clamp | penalty source | verdict in reducer |
|---|---|---|---|---|---|---|
| KP (R3) `runAllGates` | 100 | full | `floor(penalty/2)` | `>=0` | `GATE_DEFINITIONS[gate]` | no |
| R4 `validate` | 100 | full | n/a (binary) | `>=0` | per-gate result | no |

Same core arithmetic. The reducer handles the union: `fail` → full, `warn` → `floor(penalty/2)`, `pass` → 0, then `Math.max(0, ...)`. R4 only emits `pass`/`fail`, so the warn branch is inert for it → byte-identical.

## Kept role-private (NOT coupled)

- `GATE_DEFINITIONS` penalties (G1-G7) and LG penalty inventory stay in each role's own code.
- Verdict cut-offs stay role-private: R4 `R4_CONTENT_THRESHOLDS.minLintScore`; KP has no verdict, only a score. The reducer does **score math only**, never the verdict.
- Forbidden vocab, thresholds, gate definitions untouched.

## Excluded by design (different shapes)

`conseil-quality-scorer`, `buying-guide-quality-gates`, `r1-enricher` inline — not part of this cut.

## Byte-identical proof

Added `quality-gate-reducer.characterization.test.ts` pinning exact scores of both services. Golden values captured **before** the cut and re-run **after**:

- R4: `100` (clean), `60` (LG1+LG4), `0` (clamp)
- KP: `100` (clean), `70` (G1 fail), `90` (G5 fail), `93` (G4 warn = `100 - floor(15/2)`)

All identical after refactor. The pre-existing `r4-lint-gates.service.test.ts` (which asserts exact scores 100/60/0) passes unchanged.

## Verification

- `tsc --noEmit` — 0 errors in changed files
- jest: 29/29 pass (22 r4-lint + 7 characterization)
- eslint: 0 errors on the 4 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)