### PR TITLE
feat(frontend): pr-9h phase A — v3_singleFetch + json/defer→data()

### DIFF
--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -39,7 +39,10 @@ export const handleError = Sentry.wrapHandleErrorWithSentry(
   },
 );
 
-const ABORT_DELAY = 5_000;
+// Single Fetch : `streamTimeout` borne le rejet des promesses différées côté serveur ;
+// l'abort du flux React doit être strictement au-dessus (streamTimeout + 1s).
+export const streamTimeout = 5_000;
+const ABORT_DELAY = streamTimeout + 1_000;
 
 export default function handleRequest(
   request: Request,

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -1,11 +1,10 @@
 import {
   type ActionFunctionArgs,
-  defer,
   type HeadersFunction,
   type LinksFunction,
   type LoaderFunctionArgs,
-  json,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Links,
@@ -130,7 +129,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     return null;
   });
 
-  return defer({
+  return {
     user,
     cart: cartPromise,
     isBot,
@@ -146,7 +145,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
         process.env.NODE_ENV ||
         "development",
     },
-  });
+  };
 };
 
 export const headers: HeadersFunction = () => ({
@@ -155,7 +154,7 @@ export const headers: HeadersFunction = () => ({
 
 // Reject POST requests from bots/crawlers - root route has no forms
 export const action = async (_args: ActionFunctionArgs) => {
-  return json(
+  return data(
     { error: "Method not allowed" },
     { status: 405, headers: { Allow: "GET" } },
   );

--- a/frontend/app/routes/$.tsx
+++ b/frontend/app/routes/$.tsx
@@ -1,9 +1,9 @@
 // app/routes/$.tsx - Catch-all route pour 404 - Version Optimisée
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import { useRouteError, isRouteErrorResponse } from "@remix-run/react";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
@@ -32,7 +32,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   // 0a. Short-circuit URLs garbage (base64 spam, bots) — évite 3 appels API inutiles
   if (isGarbageUrl(pathname)) {
-    throw json(
+    throw data(
       { url: pathname, message: "Contenu supprimé" },
       {
         status: 410,
@@ -156,7 +156,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             logger.log(
               `[SEO] Legacy URL not resolved, returning 410: ${pathname}`,
             );
-            throw json(
+            throw data(
               {
                 url: pathname,
                 message:
@@ -220,7 +220,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     // 5. Vérifier si c'est un ancien lien connu (logique 410)
     if (errorResponseData.isOldLink) {
-      throw json(
+      throw data(
         {
           ...errorResponseData,
           message: "Ce contenu a été définitivement supprimé ou déplacé",
@@ -239,7 +239,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     // X-Robots-Tag obligatoire : sans ce header, SeoHeadersInterceptor.intercept()
     // applique le default `index, follow` pour les paths non-matchés (ex /wp-admin/,
     // /panier inexistant). Canon SEO : un 404 ne s'indexe jamais.
-    throw json(
+    throw data(
       {
         ...errorResponseData,
         message: "Page non trouvée",
@@ -260,7 +260,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     // Pour toute autre erreur, fallback vers 404 basique
     logger.error("Erreur dans catch-all route:", error);
-    throw json(
+    throw data(
       {
         url: pathname,
         message: "Page non trouvée",

--- a/frontend/app/routes/_index.tsx
+++ b/frontend/app/routes/_index.tsx
@@ -1,5 +1,4 @@
 import {
-  defer,
   type HeadersFunction,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -161,20 +160,20 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     const familiesRaw = await remixApi.getHomepageFamilies();
     const families = mapFamiliesFromSplit(familiesRaw);
 
-    return defer({
+    return {
       families,
       belowFold: belowFoldPromise,
       faqs: faqPromise,
-    });
+    };
   } catch (err) {
     logger.error("[homepage-families] Service call failed:", {
       error: err instanceof Error ? err.message : String(err),
     });
-    return defer({
+    return {
       families: [] as SlimFamily[],
       belowFold: belowFoldPromise,
       faqs: faqPromise,
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/_public+/login.tsx
+++ b/frontend/app/routes/_public+/login.tsx
@@ -1,9 +1,9 @@
 import {
-  json,
   redirect,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data as dataResponse,
 } from "@remix-run/node";
 import {
   Form,
@@ -53,9 +53,9 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     if (user.isPro) return redirect("/commercial");
     return redirect("/account/dashboard");
   }
-  return json({
+  return {
     googleClientId: process.env.VITE_GOOGLE_CLIENT_ID || "",
-  });
+  };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -67,7 +67,7 @@ export async function action({ request }: ActionFunctionArgs) {
   });
 
   if (!parsed.success) {
-    return json(
+    return dataResponse(
       { ok: false as const, errors: parsed.error.flatten().fieldErrors },
       { status: 400 },
     );
@@ -96,7 +96,7 @@ export async function action({ request }: ActionFunctionArgs) {
       }),
     });
   } catch {
-    return json(
+    return dataResponse(
       {
         ok: false as const,
         formError: "Erreur de connexion au serveur. Veuillez réessayer.",
@@ -107,7 +107,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   // Gérer les redirects inattendus du backend (Passport)
   if (backendResponse.status >= 300 && backendResponse.status < 400) {
-    return json(
+    return dataResponse(
       {
         ok: false as const,
         formError: "Email ou mot de passe incorrect.",
@@ -118,7 +118,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   if (!backendResponse.ok) {
     const body = await backendResponse.json().catch(() => null);
-    return json(
+    return dataResponse(
       {
         ok: false as const,
         formError: body?.message || "Email ou mot de passe incorrect.",

--- a/frontend/app/routes/_public+/register.tsx
+++ b/frontend/app/routes/_public+/register.tsx
@@ -1,5 +1,4 @@
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
   redirect,
@@ -158,9 +157,9 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     const redirectTo = url.searchParams.get("redirectTo") || "/profile";
     return redirect(redirectTo);
   }
-  return json({
+  return {
     googleClientId: process.env.VITE_GOOGLE_CLIENT_ID || "",
-  });
+  };
 };
 
 // --- Composants internes ---

--- a/frontend/app/routes/account.addresses.tsx
+++ b/frontend/app/routes/account.addresses.tsx
@@ -1,8 +1,8 @@
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -75,24 +75,23 @@ export async function loader({ request }: LoaderFunctionArgs) {
     });
     if (!res.ok) {
       logger.error(`API addresses error: ${res.status}`);
-      return json<LoaderData>({ billing: null, delivery: [], user });
+      return { billing: null, delivery: [], user };
     }
     const data = await res.json();
-    return json<LoaderData>({
+    return {
       billing: data.billing || null,
       delivery: data.delivery || [],
       user,
-    });
+    };
   } catch (error) {
     logger.error("Erreur chargement adresses:", error);
-    return json<LoaderData>({ billing: null, delivery: [], user });
+    return { billing: null, delivery: [], user };
   }
 }
 
 export async function action({ request }: ActionFunctionArgs) {
   const user = await requireAuth(request);
-  if (!user)
-    return json<ActionData>({ error: "Non authentifié" }, { status: 401 });
+  if (!user) return data({ error: "Non authentifié" }, { status: 401 });
 
   const baseUrl = process.env.API_BASE_URL || "http://localhost:3000";
   const cookie = request.headers.get("Cookie") || "";
@@ -123,19 +122,19 @@ export async function action({ request }: ActionFunctionArgs) {
         break;
       }
       default:
-        return json<ActionData>({ error: "Action inconnue" }, { status: 400 });
+        return data({ error: "Action inconnue" }, { status: 400 });
     }
     if (!res.ok) {
       const errorData = await res.json().catch(() => ({}));
-      return json<ActionData>(
+      return data(
         { error: errorData.message || `Erreur ${res.status}` },
         { status: res.status },
       );
     }
-    return json<ActionData>({ success: true });
+    return { success: true };
   } catch (error) {
     logger.error("Erreur action adresses:", error);
-    return json<ActionData>({ error: "Erreur serveur" }, { status: 500 });
+    return data({ error: "Erreur serveur" }, { status: 500 });
   }
 }
 

--- a/frontend/app/routes/account.claims.$claimId.tsx
+++ b/frontend/app/routes/account.claims.$claimId.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -133,7 +129,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       updatedAt: data.updatedAt || data.clm_updated_at || "",
       resolvedAt: data.resolvedAt || data.clm_resolved_at || undefined,
     };
-    return json<LoaderData>({ claim, user });
+    return { claim, user };
   } catch (error) {
     if (error instanceof Response) throw error;
     logger.error("Erreur chargement réclamation:", error);

--- a/frontend/app/routes/account.claims.new.tsx
+++ b/frontend/app/routes/account.claims.new.tsx
@@ -1,9 +1,9 @@
 import {
-  json,
   redirect,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -49,13 +49,12 @@ const claimTypes = [
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await requireAuth(request);
   if (!user) throw new Response("Non authentifié", { status: 401 });
-  return json<LoaderData>({ user });
+  return { user };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
   const user = await requireAuth(request);
-  if (!user)
-    return json<ActionData>({ error: "Non authentifié" }, { status: 401 });
+  if (!user) return data({ error: "Non authentifié" }, { status: 401 });
 
   const formData = await request.formData();
   const type = formData.get("type") as string;
@@ -76,7 +75,7 @@ export async function action({ request }: ActionFunctionArgs) {
       "La résolution attendue doit faire au moins 10 caractères";
 
   if (Object.keys(fieldErrors).length > 0)
-    return json<ActionData>({ fieldErrors }, { status: 400 });
+    return data({ fieldErrors }, { status: 400 });
 
   const baseUrl = process.env.API_BASE_URL || "http://localhost:3000";
   const cookie = request.headers.get("Cookie") || "";
@@ -103,7 +102,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     if (!res.ok) {
       const errorData = await res.json().catch(() => ({}));
-      return json<ActionData>(
+      return data(
         { error: errorData.message || `Erreur ${res.status}` },
         { status: res.status },
       );
@@ -111,7 +110,7 @@ export async function action({ request }: ActionFunctionArgs) {
     return redirect("/account/claims");
   } catch (error) {
     logger.error("Erreur création réclamation:", error);
-    return json<ActionData>({ error: "Erreur serveur" }, { status: 500 });
+    return data({ error: "Erreur serveur" }, { status: 500 });
   }
 }
 

--- a/frontend/app/routes/account.claims.tsx
+++ b/frontend/app/routes/account.claims.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -84,7 +80,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       `${baseUrl}/api/support/claims?customerId=${userId}`,
       { headers: { Accept: "application/json", Cookie: cookie } },
     );
-    if (!res.ok) return json<LoaderData>({ claims: [], user });
+    if (!res.ok) return { claims: [], user };
 
     const data = await res.json();
     const claims = (Array.isArray(data) ? data : data.data || []).map(
@@ -99,10 +95,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         updatedAt: c.updatedAt || c.clm_updated_at || "",
       }),
     );
-    return json<LoaderData>({ claims, user });
+    return { claims, user };
   } catch (error) {
     logger.error("Erreur chargement réclamations:", error);
-    return json<LoaderData>({ claims: [], user });
+    return { claims: [], user };
   }
 }
 

--- a/frontend/app/routes/account.dashboard.tsx
+++ b/frontend/app/routes/account.dashboard.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunction, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunction, type MetaFunction, data } from "@remix-run/node";
 import {
   useLoaderData,
   useRouteError,
@@ -130,7 +130,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     // Auth stricte si demandée
     if (authenticated && !authResult) {
       logger.log("🔒 Strict auth required - redirecting");
-      return json({ authenticated: false }, { status: 401 });
+      return data({ authenticated: false }, { status: 401 });
     }
 
     // API Call - même endpoint que les versions précédentes
@@ -205,7 +205,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     };
 
     logger.log("✅ Dashboard unifié - Data loaded successfully");
-    return json(responseData);
+    return responseData;
   } catch (error) {
     logger.error("❌ Dashboard unifié - Error:", error);
 

--- a/frontend/app/routes/account.messages.$messageId.tsx
+++ b/frontend/app/routes/account.messages.$messageId.tsx
@@ -1,5 +1,4 @@
 import {
-  json,
   redirect,
   type LoaderFunction,
   type MetaFunction,
@@ -96,7 +95,7 @@ export const loader: LoaderFunction = async ({ request, context, params }) => {
       });
     }
 
-    return json({ message, user });
+    return { message, user };
   } catch (error) {
     logger.error("Erreur chargement message:", error);
     throw redirect("/account/messages?error=not_found");

--- a/frontend/app/routes/account.messages._index.tsx
+++ b/frontend/app/routes/account.messages._index.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunction, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunction, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -78,14 +78,14 @@ export const loader: LoaderFunction = async ({ request, context }) => {
       withOrder: messages.filter((msg) => msg.MSG_ORD_ID !== null).length,
     };
 
-    return json({ messages, stats, user });
+    return { messages, stats, user };
   } catch (error) {
     logger.error("Erreur chargement messages:", error);
-    return json({
+    return {
       messages: [],
       stats: { total: 0, unread: 0, withOrder: 0 },
       user,
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/account.messages.compose.tsx
+++ b/frontend/app/routes/account.messages.compose.tsx
@@ -1,9 +1,9 @@
 import {
-  json,
   redirect,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -44,11 +44,11 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
   const orderId = url.searchParams.get("order");
   const parentId = url.searchParams.get("reply");
 
-  return json<LoaderData>({
+  return {
     user,
     orderId: orderId || undefined,
     parentId: parentId || undefined,
-  });
+  };
 };
 
 export const action = async ({ request, context }: ActionFunctionArgs) => {
@@ -90,7 +90,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     }
   } catch (error) {
     logger.error("Erreur envoi message:", error);
-    return json(
+    return data(
       { error: "Erreur lors de l'envoi du message" },
       { status: 500 },
     );

--- a/frontend/app/routes/account.messages.tsx
+++ b/frontend/app/routes/account.messages.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -108,21 +104,21 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       ? await statsResponse.json()
       : { success: false, data: { total: 0, open: 0, closed: 0, unread: 0 } };
 
-    return json<LoaderData>({
+    return {
       messages: messagesResult.success ? messagesResult.data : [],
       stats: statsResult.success
         ? statsResult.data
         : { total: 0, open: 0, closed: 0, unread: 0 },
       user,
-    });
+    };
   } catch (error) {
     logger.error("Erreur API messages:", error);
 
-    return json<LoaderData>({
+    return {
       messages: [],
       stats: { total: 0, open: 0, closed: 0, unread: 0 },
       user,
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/account.orders.tsx
+++ b/frontend/app/routes/account.orders.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -85,12 +81,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
       totalSpent: orders.reduce((sum, order) => sum + order.totalTTC, 0),
     };
 
-    return json({ orders, pagination, user, stats });
+    return { orders, pagination, user, stats };
   } catch (error) {
     logger.error("Error in loader:", error);
 
     // Retour avec des données vides en cas d'erreur
-    return json({
+    return {
       orders: [],
       pagination: {
         currentPage: 1,
@@ -105,7 +101,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         totalSpent: 0,
       },
       error: "Impossible de charger les commandes",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/account.profile.edit.tsx
+++ b/frontend/app/routes/account.profile.edit.tsx
@@ -1,9 +1,9 @@
 import {
-  json,
   redirect,
   type ActionFunction,
   type LoaderFunction,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -70,7 +70,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
       status: "active",
     };
 
-    return json<LoaderData>({ user });
+    return { user };
   } catch (error) {
     logger.error("Erreur chargement profil:", error);
     throw redirect("/account/profile");
@@ -102,7 +102,7 @@ export const action: ActionFunction = async ({ request, context }) => {
   }
 
   if (Object.keys(fieldErrors).length > 0) {
-    return json<ActionData>({ fieldErrors }, { status: 400 });
+    return data({ fieldErrors }, { status: 400 });
   }
 
   try {
@@ -125,7 +125,7 @@ export const action: ActionFunction = async ({ request, context }) => {
 
     if (!response.ok) {
       logger.error(`Update profile API error: ${response.status}`);
-      return json<ActionData>(
+      return data(
         {
           error: "Erreur lors de la mise à jour du profil",
         },
@@ -136,7 +136,7 @@ export const action: ActionFunction = async ({ request, context }) => {
     return redirect("/account/profile?updated=true");
   } catch (error) {
     logger.error("Erreur mise à jour profil:", error);
-    return json<ActionData>(
+    return data(
       {
         error: "Erreur lors de la mise à jour du profil",
       },

--- a/frontend/app/routes/account.profile.tsx
+++ b/frontend/app/routes/account.profile.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunction, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunction, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -85,20 +85,20 @@ export const loader: LoaderFunction = async ({ request }) => {
 
       if (profileResponse.ok) {
         const { data } = await profileResponse.json();
-        return json<LoaderData>({
+        return {
           user: { ...defaultProfile, ...data },
           stats: {},
-        });
+        };
       }
     } catch (apiError) {
       logger.warn("API profile fetch failed, using default:", apiError);
     }
 
     // Retourner le profil par défaut si l'API échoue
-    return json<LoaderData>({
+    return {
       user: defaultProfile,
       stats: {},
-    });
+    };
   } catch (error) {
     // Propager les Response HTTP (404, etc.) telles quelles
     if (error instanceof Response) {

--- a/frontend/app/routes/account.security.tsx
+++ b/frontend/app/routes/account.security.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunction, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunction, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -135,7 +135,7 @@ export const loader: LoaderFunction = async ({ request }) => {
       ],
     };
 
-    return json<LoaderData>({ security, user });
+    return { security, user };
   } catch (error) {
     // Propager les Response HTTP (404, etc.) telles quelles
     if (error instanceof Response) {

--- a/frontend/app/routes/account.settings.tsx
+++ b/frontend/app/routes/account.settings.tsx
@@ -1,9 +1,9 @@
 import {
-  json,
   redirect,
   type ActionFunction,
   type LoaderFunction,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -60,7 +60,7 @@ export const loader: LoaderFunction = async ({ context }) => {
     currency: "EUR",
   };
 
-  return json({ user, preferences });
+  return { user, preferences };
 };
 
 export const action: ActionFunction = async ({ request, context }) => {
@@ -70,25 +70,25 @@ export const action: ActionFunction = async ({ request, context }) => {
 
   if (action === "updatePreferences") {
     // TODO: Implémenter la mise à jour des préférences
-    return json({
+    return {
       success: true,
       message: "Préférences mises à jour avec succès",
-    });
+    };
   }
 
   if (action === "exportData") {
     // TODO: Implémenter l'export des données
-    return json({
+    return {
       success: true,
       message: "Export des données en cours... Vous recevrez un email",
-    });
+    };
   }
 
   if (action === "deleteAccount") {
     // TODO: Implémenter la suppression du compte
     const confirmation = formData.get("confirmation");
     if (confirmation !== "SUPPRIMER") {
-      return json(
+      return data(
         {
           success: false,
           error: "Veuillez taper SUPPRIMER pour confirmer",
@@ -101,7 +101,7 @@ export const action: ActionFunction = async ({ request, context }) => {
     return redirect("/account/deleted");
   }
 
-  return json({ success: false, error: "Action non reconnue" });
+  return { success: false, error: "Action non reconnue" };
 };
 
 export default function AccountSettings() {

--- a/frontend/app/routes/account.tsx
+++ b/frontend/app/routes/account.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunction, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunction, type MetaFunction } from "@remix-run/node";
 import { Outlet, useRouteError, isRouteErrorResponse } from "@remix-run/react";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
@@ -14,7 +14,7 @@ export const meta: MetaFunction = () => createNoIndexMeta("Mon Compte");
 
 export const loader: LoaderFunction = async ({ context }) => {
   const user = await requireUser({ context });
-  return json({ user });
+  return { user };
 };
 
 export default function AccountLayout() {

--- a/frontend/app/routes/account_.orders.$orderId.invoice.tsx
+++ b/frontend/app/routes/account_.orders.$orderId.invoice.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -177,7 +173,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     })),
   };
 
-  return json({ invoice, user });
+  return { invoice, user };
 }
 
 export default function OrderInvoice() {

--- a/frontend/app/routes/account_.orders.$orderId.tsx
+++ b/frontend/app/routes/account_.orders.$orderId.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -71,7 +67,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       throw new Response("Commande introuvable", { status: 404 });
     }
 
-    return json({ order, user });
+    return { order, user };
   } catch (error) {
     // Propager les Response HTTP (404, etc.) telles quelles
     if (error instanceof Response) {

--- a/frontend/app/routes/admin.articles.tsx
+++ b/frontend/app/routes/admin.articles.tsx
@@ -5,7 +5,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
   type ActionFunctionArgs,
@@ -128,12 +127,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const response = await fetch(`${backendUrl}/api/blog/dashboard`);
 
     if (!response.ok) {
-      return json<LoaderData>({
+      return {
         articles: [],
         totalCount: 0,
         isError: true,
         errorMessage: "Erreur lors de la récupération des données",
-      });
+      };
     }
 
     await response.json();
@@ -205,20 +204,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
       startIndex + limit,
     );
 
-    return json<LoaderData>({
+    return {
       articles: paginatedArticles,
       totalCount: filteredArticles.length,
       isError: false,
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors du chargement des articles:", error);
 
-    return json<LoaderData>({
+    return {
       articles: [],
       totalCount: 0,
       isError: true,
       errorMessage: error instanceof Error ? error.message : "Erreur inconnue",
-    });
+    };
   }
 }
 
@@ -231,19 +230,19 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     if (action === "delete") {
       // Simulation de suppression
-      return json({
+      return {
         success: true,
         message: `Article ${articleId} supprimé avec succès`,
-      });
+      };
     }
 
-    return json({ success: false, message: "Action non reconnue" });
+    return { success: false, message: "Action non reconnue" };
   } catch (error) {
-    return json({
+    return {
       success: false,
       message:
         error instanceof Error ? error.message : "Erreur lors de l'action",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.blog-analytics.tsx
+++ b/frontend/app/routes/admin.blog-analytics.tsx
@@ -2,7 +2,7 @@
  * Admin Blog Analytics — /admin/blog-analytics
  * Dashboard avec stats détaillées, top articles, distribution, intent breakdown
  */
-import { type LoaderFunction, json, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunction, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   BarChart3,
@@ -99,25 +99,25 @@ export const loader: LoaderFunction = async ({ request, context }) => {
 
     if (!response.ok) {
       logger.warn(`Blog analytics API returned ${response.status}`);
-      return json<LoaderData>({
+      return {
         analytics: null,
         isError: true,
         errorMessage: `API error: ${response.status}`,
-      });
+      };
     }
 
     const result = await response.json();
-    return json<LoaderData>({
+    return {
       analytics: result.data || null,
       isError: false,
-    });
+    };
   } catch (error) {
     logger.error("Blog analytics loader error:", error);
-    return json<LoaderData>({
+    return {
       analytics: null,
       isError: true,
       errorMessage: error instanceof Error ? error.message : "Erreur inconnue",
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/admin.blog.tsx
+++ b/frontend/app/routes/admin.blog.tsx
@@ -4,11 +4,7 @@
  * @route /admin/blog-simple
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import { useState } from "react";
 import { Alert } from "~/components/ui/alert";
@@ -152,7 +148,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       );
 
       // Données de fallback si API en erreur
-      return json<LoaderData>({
+      return {
         stats: {
           totalArticles: 91, // Valeurs de démonstration
           totalViews: 245680,
@@ -167,7 +163,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
           status: response.status,
           statusText: response.statusText,
         },
-      });
+      };
     }
 
     const data = await response.json();
@@ -189,7 +185,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         overview?.totalGuides || data?.data?.byType?.guide?.total || 0,
     };
 
-    return json<LoaderData>({
+    return {
       stats,
       isError: false,
       apiStatus: "success",
@@ -198,12 +194,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
         status: response.status,
         dataKeys: Object.keys(data),
       },
-    });
+    };
   } catch (error) {
     logger.error("[ADMIN BLOG SIMPLE] Erreur loader:", error);
 
     // Fallback complet en cas d'erreur
-    return json<LoaderData>({
+    return {
       stats: {
         totalArticles: 91,
         totalViews: 245680,
@@ -222,7 +218,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         error: error instanceof Error ? error.message : String(error),
         timestamp: new Date().toISOString(),
       },
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.brands-seo.tsx
+++ b/frontend/app/routes/admin.brands-seo.tsx
@@ -7,7 +7,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -164,19 +163,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
       }
     }
 
-    return json({
+    return {
       brand: brandData.data,
       brands: brandsData.data || [],
       editorial,
-    });
+    };
   } catch (error) {
     logger.error("[Brands SEO Admin] Error:", error);
-    return json({
+    return {
       brand: null,
       brands: [],
       editorial: null,
       error: "Erreur chargement données",
-    });
+    };
   }
 }
 
@@ -186,17 +185,17 @@ export async function action({ request }: ActionFunctionArgs) {
 
   if (action === "update-seo") {
     // TODO: Implémenter API update
-    return json({ success: true, message: "SEO mis à jour" });
+    return { success: true, message: "SEO mis à jour" };
   }
 
   if (action === "update-editorial") {
     const marqueId = Number(formData.get("marque_id"));
     if (!marqueId || marqueId <= 0) {
-      return json({
+      return {
         success: false,
         message: "marque_id invalide",
         action: "editorial",
-      });
+      };
     }
 
     // Parse JSON fields from form (textareas)
@@ -228,11 +227,11 @@ export async function action({ request }: ActionFunctionArgs) {
         curated_by: (formData.get("curated_by") || "admin-ui").toString(),
       };
     } catch (e) {
-      return json({
+      return {
         success: false,
         message: (e as Error).message,
         action: "editorial",
-      });
+      };
     }
 
     try {
@@ -252,31 +251,31 @@ export async function action({ request }: ActionFunctionArgs) {
       );
       const data = await res.json();
       if (!res.ok) {
-        return json({
+        return {
           success: false,
           message: data?.message || "Erreur upsert éditorial",
           issues: data?.issues,
           action: "editorial",
-        });
+        };
       }
-      return json({
+      return {
         success: true,
         message: `Éditorial enregistré — enrichissement R7 : ${data.enrichment?.seoDecision} (score ${data.enrichment?.diversityScore?.toFixed?.(1) || "?"})`,
         enrichment: data.enrichment,
         editorial: data.editorial,
         action: "editorial",
-      });
+      };
     } catch (e) {
       logger.error("[Brands SEO Admin] PUT editorial failed:", e);
-      return json({
+      return {
         success: false,
         message: `Erreur réseau : ${(e as Error).message}`,
         action: "editorial",
-      });
+      };
     }
   }
 
-  return json({ success: false, message: "Action inconnue" });
+  return { success: false, message: "Action inconnue" };
 }
 
 export default function AdminBrandsSeo() {

--- a/frontend/app/routes/admin.claims._index.tsx
+++ b/frontend/app/routes/admin.claims._index.tsx
@@ -1,8 +1,8 @@
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -127,10 +127,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       assignedTo: c.assignedTo || c.clm_assigned_to || undefined,
       createdAt: c.createdAt || c.clm_created_at || "",
     }));
-    return json<LoaderData>({ claims, stats: statsData });
+    return { claims, stats: statsData };
   } catch (error) {
     logger.error("Erreur chargement claims admin:", error);
-    return json<LoaderData>({
+    return {
       claims: [],
       stats: {
         total: 0,
@@ -139,7 +139,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         averageResolutionTime: 0,
         satisfactionRating: 0,
       },
-    });
+    };
   }
 }
 
@@ -163,15 +163,15 @@ export async function action({ request }: ActionFunctionArgs) {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      return json<ActionData>(
+      return data(
         { error: err.message || `Erreur ${res.status}` },
         { status: res.status },
       );
     }
-    return json<ActionData>({ success: true });
+    return { success: true };
   } catch (error) {
     logger.error("Erreur action claim admin:", error);
-    return json<ActionData>({ error: "Erreur serveur" }, { status: 500 });
+    return data({ error: "Erreur serveur" }, { status: 500 });
   }
 }
 

--- a/frontend/app/routes/admin.command-center.tsx
+++ b/frontend/app/routes/admin.command-center.tsx
@@ -14,8 +14,8 @@
 import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
-  json,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import { useActionData, useLoaderData } from "@remix-run/react";
 import { type CommandCenterResponse } from "@repo/registry";
@@ -26,6 +26,16 @@ import {
   FileWarning,
   Workflow,
 } from "lucide-react";
+import { CertBadge } from "~/components/command-center/badges";
+import { GlobalHealthBar } from "~/components/command-center/GlobalHealthBar";
+import { ModuleGrid } from "~/components/command-center/ModuleGrid";
+import {
+  OrchestrationPanel,
+  type OrchestrationActionData,
+  type OrchestrationStatus,
+  type ShadowPlanView,
+} from "~/components/command-center/OrchestrationPanel";
+import { OwnerActionQueue } from "~/components/command-center/OwnerActionQueue";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Badge } from "~/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
@@ -42,16 +52,6 @@ import { getInternalApiUrlFromRequest } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
 import { requireAdmin } from "../auth/unified.server";
-import { GlobalHealthBar } from "~/components/command-center/GlobalHealthBar";
-import { OwnerActionQueue } from "~/components/command-center/OwnerActionQueue";
-import { ModuleGrid } from "~/components/command-center/ModuleGrid";
-import { CertBadge } from "~/components/command-center/badges";
-import {
-  OrchestrationPanel,
-  type OrchestrationActionData,
-  type OrchestrationStatus,
-  type ShadowPlanView,
-} from "~/components/command-center/OrchestrationPanel";
 
 export const meta: MetaFunction = () =>
   createNoIndexMeta("Command Center — Admin");
@@ -133,20 +133,20 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     );
     if (res.status === 404) {
       // COMMAND_CENTER_MODE=disabled (prod-safe default) → endpoint 404s.
-      return json({
+      return {
         cc: degraded(
           "Command Center désactivé dans cet environnement.",
           "disabled",
         ),
         orchestration: null as OrchestrationStatus | null,
-      });
+      };
     }
     if (!res.ok) {
       logger.warn(`[command-center] API ${res.status} — rendering degraded`);
-      return json({
+      return {
         cc: degraded(`backend API ${res.status}`),
         orchestration: null as OrchestrationStatus | null,
-      });
+      };
     }
     const body = (await res.json()) as {
       data?: CommandCenterResponse;
@@ -155,22 +155,17 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     const cc = body.data ?? (body as CommandCenterResponse);
     const orchestration =
       cc.mode === "disabled" ? null : await fetchOrchestration(request);
-    return json({ cc, orchestration });
+    return { cc, orchestration };
   } catch (e) {
     logger.error(`[command-center] fetch failed: ${e}`);
-    return json({
+    return {
       cc: degraded("backend unreachable"),
       orchestration: null as OrchestrationStatus | null,
-    });
+    };
   }
 }
 
-export async function action({
-  request,
-  context,
-}: ActionFunctionArgs): Promise<
-  ReturnType<typeof json<OrchestrationActionData>>
-> {
+export async function action({ request, context }: ActionFunctionArgs) {
   await requireAdmin({ context });
   const form = await request.formData();
   const kind = String(form.get("kind") ?? "");
@@ -199,13 +194,13 @@ export async function action({
       const msg = Array.isArray(body.message)
         ? body.message.join(", ")
         : (body.message ?? `Erreur backend ${res.status}`);
-      return json({ ok: false, error: msg }, { status: res.status });
+      return data({ ok: false, error: msg }, { status: res.status });
     }
     const plan = body.data ?? (body as ShadowPlanView);
-    return json({ ok: true, plan });
+    return { ok: true, plan };
   } catch (e) {
     logger.error(`[command-center] shadow preview failed: ${e}`);
-    return json({ ok: false, error: "Backend injoignable." }, { status: 502 });
+    return data({ ok: false, error: "Backend injoignable." }, { status: 502 });
   }
 }
 

--- a/frontend/app/routes/admin.config._index.tsx
+++ b/frontend/app/routes/admin.config._index.tsx
@@ -3,10 +3,10 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import { useLoaderData, useActionData, Form, Link } from "@remix-run/react";
 import {
@@ -175,20 +175,20 @@ export async function loader({ context }: LoaderFunctionArgs) {
       ),
     };
 
-    return json({
+    return {
       categories: CATEGORIES,
       configs,
       stats,
-    });
+    };
   } catch (error) {
     logger.error("❌ Erreur chargement configurations:", error);
 
-    return json({
+    return {
       categories: CATEGORIES,
       configs: [],
       stats: { totalConfigs: 0, configsByCategory: {} },
       error: "Erreur lors du chargement des configurations",
-    });
+    };
   }
 }
 
@@ -215,7 +215,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           try {
             processedValue = JSON.parse(value);
           } catch {
-            return json(
+            return data(
               {
                 error: "Format JSON invalide",
                 field: key,
@@ -226,28 +226,28 @@ export async function action({ request, context }: ActionFunctionArgs) {
         }
 
         await mockConfigApi.updateConfig(key, processedValue);
-        return json({
+        return {
           success: true,
           message: `Configuration "${key}" mise à jour avec succès`,
           timestamp: new Date().toISOString(),
-        });
+        };
       }
 
       case "backup": {
-        return json({
+        return {
           success: true,
           backupId: "backup-" + Date.now(),
           message: "Sauvegarde créée avec succès",
           timestamp: new Date().toISOString(),
-        });
+        };
       }
 
       default:
-        return json({ error: "Action inconnue" }, { status: 400 });
+        return data({ error: "Action inconnue" }, { status: 400 });
     }
   } catch (error) {
     logger.error(`❌ Erreur action ${action}:`, error);
-    return json(
+    return data(
       {
         error: `Erreur lors de l'action ${action}`,
         timestamp: new Date().toISOString(),

--- a/frontend/app/routes/admin.control-plane.tsx
+++ b/frontend/app/routes/admin.control-plane.tsx
@@ -10,9 +10,8 @@
  * so the WIP section degrades gracefully when the file is absent (e.g. a fresh
  * container) — the repo section (committed canonical.json) always renders.
  */
-import { type LoaderFunctionArgs, json, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import { type ReactNode } from "react";
 import {
   GitPullRequest,
   Skull,
@@ -23,6 +22,7 @@ import {
   ExternalLink,
   AlertTriangle,
 } from "lucide-react";
+import { type ReactNode } from "react";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Badge } from "~/components/ui/badge";
 import {
@@ -76,7 +76,8 @@ interface ControlPlaneSummary {
   };
 }
 
-export const meta: MetaFunction = () => createNoIndexMeta("Control Plane — Admin");
+export const meta: MetaFunction = () =>
+  createNoIndexMeta("Control Plane — Admin");
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
   await requireAdmin({ context });
@@ -96,10 +97,12 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     throw new Response("Control Plane API error", { status: res.status });
   }
 
-  const body = (await res.json()) as { data?: ControlPlaneSummary } & ControlPlaneSummary;
+  const body = (await res.json()) as {
+    data?: ControlPlaneSummary;
+  } & ControlPlaneSummary;
   // AdminResponseInterceptor wraps as { success, data, meta }.
   const summary = body.data ?? (body as ControlPlaneSummary);
-  return json(summary);
+  return summary;
 }
 
 function Stat({
@@ -163,7 +166,11 @@ export default function AdminControlPlane() {
       <section className="space-y-3">
         <h2 className="text-lg font-semibold">WIP (PRs ouvertes)</h2>
         <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-          <Stat icon={<GitPullRequest className="h-4 w-4" />} label="PRs ouvertes" value={wip.prCount} />
+          <Stat
+            icon={<GitPullRequest className="h-4 w-4" />}
+            label="PRs ouvertes"
+            value={wip.prCount}
+          />
           <Stat
             icon={<Skull className="h-4 w-4" />}
             label="Zombies (>14j)"
@@ -187,7 +194,9 @@ export default function AdminControlPlane() {
           <Card>
             <CardHeader>
               <CardTitle className="text-base">Top staleness</CardTitle>
-              <CardDescription>PRs triées par jours sans activité</CardDescription>
+              <CardDescription>
+                PRs triées par jours sans activité
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <Table>
@@ -215,7 +224,9 @@ export default function AdminControlPlane() {
                           <ExternalLink className="h-3 w-3" />
                         </a>
                       </TableCell>
-                      <TableCell className="max-w-md truncate">{pr.title}</TableCell>
+                      <TableCell className="max-w-md truncate">
+                        {pr.title}
+                      </TableCell>
                       <TableCell>
                         <Badge variant="outline">{pr.status}</Badge>
                       </TableCell>
@@ -245,7 +256,11 @@ export default function AdminControlPlane() {
         <h2 className="text-lg font-semibold">Dépôt (canonical.json)</h2>
         {repo ? (
           <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-            <Stat icon={<Boxes className="h-4 w-4" />} label="Domaines" value={repo.domainCount} />
+            <Stat
+              icon={<Boxes className="h-4 w-4" />}
+              label="Domaines"
+              value={repo.domainCount}
+            />
             <Stat
               icon={<ShieldAlert className="h-4 w-4" />}
               label="Ownership gaps"
@@ -253,7 +268,12 @@ export default function AdminControlPlane() {
               tone={repo.ownershipGaps > 0 ? "warn" : "default"}
             />
             {Object.entries(repo.counts).map(([kind, n]) => (
-              <Stat key={kind} icon={<Boxes className="h-4 w-4" />} label={kind} value={n} />
+              <Stat
+                key={kind}
+                icon={<Boxes className="h-4 w-4" />}
+                label={kind}
+                value={n}
+              />
             ))}
           </div>
         ) : (

--- a/frontend/app/routes/admin.couleurs-constructeurs.tsx
+++ b/frontend/app/routes/admin.couleurs-constructeurs.tsx
@@ -1,11 +1,7 @@
 // 🎨 PAGE ADMIN - VISUALISATION DES COULEURS CONSTRUCTEURS
 // Affiche tous les gradients de couleurs par marque automobile
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import { ChevronLeft, Car } from "lucide-react";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
@@ -41,7 +37,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     a.marque_name.localeCompare(b.marque_name),
   );
 
-  return json<LoaderData>({ brands });
+  return { brands };
 }
 
 export default function CouleursConstructeursAdminPage() {

--- a/frontend/app/routes/admin.couleurs-familles.tsx
+++ b/frontend/app/routes/admin.couleurs-familles.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
@@ -21,16 +17,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
     // Charger toutes les familles
     const catalogData = await hierarchyApi.getHomepageData();
 
-    return json({
+    return {
       families: catalogData.families || [],
       success: true,
-    });
+    };
   } catch (error) {
     logger.error("Erreur chargement familles:", error);
-    return json({
+    return {
       families: [],
       success: false,
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.db-governance.tsx
+++ b/frontend/app/routes/admin.db-governance.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   AlertCircle,
@@ -72,28 +68,28 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     }).catch(() => null);
 
     if (!response || !response.ok) {
-      return json({
+      return {
         report: null,
         error: "Impossible de charger les métriques DB Governance",
         timestamp: new Date().toISOString(),
-      });
+      };
     }
 
     const result = await response.json();
     const report: GovernanceReport = result.data || result;
 
-    return json({
+    return {
       report,
       error: null,
       timestamp: new Date().toISOString(),
-    });
+    };
   } catch (error) {
     logger.error("Erreur DB Governance loader:", error);
-    return json({
+    return {
       report: null,
       error: "Erreur lors du chargement",
       timestamp: new Date().toISOString(),
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/admin.debug.tsx
+++ b/frontend/app/routes/admin.debug.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
@@ -13,14 +9,14 @@ export const meta: MetaFunction = () => createNoIndexMeta("Debug - Admin");
 export async function loader({ context }: LoaderFunctionArgs) {
   const user = await getOptionalUser({ context });
 
-  return json({
+  return {
     user: user,
     context: {
       hasUser: !!context.user,
       userType: typeof context.user,
       userKeys: context.user ? Object.keys(context.user) : [],
     },
-  });
+  };
 }
 
 export default function AdminDebug() {

--- a/frontend/app/routes/admin.diagnostic-engine.tsx
+++ b/frontend/app/routes/admin.diagnostic-engine.tsx
@@ -4,7 +4,7 @@
  * Admin dashboard for the Diagnostic Engine.
  * Shows stats, recent sessions, system coverage.
  */
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { type LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   Activity,
@@ -58,7 +58,7 @@ export const loader = async ({ request: _request }: LoaderFunctionArgs) => {
     ? await sessionsRes.json()
     : { sessions: [] };
 
-  return json({ stats, sessions: sessionsData.sessions || [] });
+  return { stats, sessions: sessionsData.sessions || [] };
 };
 
 const SYSTEM_LABELS: Record<string, string> = {

--- a/frontend/app/routes/admin.diagnostic.$id.edit.tsx
+++ b/frontend/app/routes/admin.diagnostic.$id.edit.tsx
@@ -1,5 +1,4 @@
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
@@ -73,7 +72,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
 
     const observable: Observable = await res.json();
 
-    return json({ observable });
+    return { observable };
   } catch (error) {
     logger.error("Loader error:", error);
     throw new Response("Erreur serveur", { status: 500 });
@@ -117,13 +116,13 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     if (!res.ok) {
       const error = await res.text();
-      return json({ success: false, error: `Erreur mise a jour: ${error}` });
+      return { success: false, error: `Erreur mise a jour: ${error}` };
     }
 
     return redirect("/admin/diagnostic?updated=true");
   } catch (error) {
     logger.error("Action error:", error);
-    return json({ success: false, error: "Erreur serveur" });
+    return { success: false, error: "Erreur serveur" };
   }
 }
 

--- a/frontend/app/routes/admin.diagnostic._index.tsx
+++ b/frontend/app/routes/admin.diagnostic._index.tsx
@@ -1,5 +1,4 @@
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
 } from "@remix-run/node";
@@ -158,7 +157,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const totalObservables =
       stats.nodesByType?.Observable || observables.length;
 
-    return json({
+    return {
       observables: filtered,
       stats,
       pagination: {
@@ -168,10 +167,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         totalPages: Math.ceil(totalObservables / limit),
       },
       error: undefined as string | undefined,
-    });
+    };
   } catch (error) {
     logger.error("Loader error:", error);
-    return json({
+    return {
       observables: [],
       stats: {
         totalNodes: 0,
@@ -181,7 +180,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       },
       pagination: { page: 1, limit: 25, total: 0, totalPages: 1 },
       error: "Erreur de chargement",
-    });
+    };
   }
 }
 
@@ -226,9 +225,9 @@ export async function action({ request }: ActionFunctionArgs) {
 
         if (!res.ok) {
           const error = await res.text();
-          return json({ success: false, error: `Erreur creation: ${error}` });
+          return { success: false, error: `Erreur creation: ${error}` };
         }
-        return json({ success: true, message: "Symptome cree avec succes" });
+        return { success: true, message: "Symptome cree avec succes" };
       }
 
       case "delete": {
@@ -237,9 +236,8 @@ export async function action({ request }: ActionFunctionArgs) {
           `http://127.0.0.1:3000/api/knowledge-graph/nodes/${nodeId}`,
           { method: "DELETE" },
         );
-        if (!res.ok)
-          return json({ success: false, error: "Erreur suppression" });
-        return json({ success: true, message: "Symptome supprime" });
+        if (!res.ok) return { success: false, error: "Erreur suppression" };
+        return { success: true, message: "Symptome supprime" };
       }
 
       case "toggle": {
@@ -253,20 +251,19 @@ export async function action({ request }: ActionFunctionArgs) {
             body: JSON.stringify({ is_active: !isActive }),
           },
         );
-        if (!res.ok)
-          return json({ success: false, error: "Erreur modification" });
-        return json({
+        if (!res.ok) return { success: false, error: "Erreur modification" };
+        return {
           success: true,
           message: isActive ? "Symptome desactive" : "Symptome active",
-        });
+        };
       }
 
       default:
-        return json({ success: false, error: "Action inconnue" });
+        return { success: false, error: "Action inconnue" };
     }
   } catch (error) {
     logger.error("Action error:", error);
-    return json({ success: false, error: "Erreur serveur" });
+    return { success: false, error: "Erreur serveur" };
   }
 }
 

--- a/frontend/app/routes/admin.gammes-seo.$pgId.tsx
+++ b/frontend/app/routes/admin.gammes-seo.$pgId.tsx
@@ -12,7 +12,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -160,7 +159,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     ),
   };
 
-  return json({ detail, freshness });
+  return { detail, freshness };
 }
 
 // Action
@@ -191,7 +190,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
         },
       );
 
-      return json(await response.json());
+      return await response.json();
     }
 
     if (intent === "updateSwitch") {
@@ -207,7 +206,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
         },
       );
 
-      return json(await response.json());
+      return await response.json();
     }
 
     if (intent === "updatePurchaseGuide") {
@@ -223,7 +222,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
         },
       );
 
-      return json(await response.json());
+      return await response.json();
     }
 
     // === TOGGLE INDEX/NOINDEX ===
@@ -242,15 +241,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
         },
       );
 
-      return json(await response.json());
+      return await response.json();
     }
 
-    return json({ success: false, message: "Action non reconnue" });
+    return { success: false, message: "Action non reconnue" };
   } catch (error) {
-    return json({
+    return {
       success: false,
       message: error instanceof Error ? error.message : "Erreur",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.gammes-seo._index.tsx
+++ b/frontend/app/routes/admin.gammes-seo._index.tsx
@@ -8,7 +8,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -222,7 +221,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const thresholdsData = thresholdsRes.ok ? await thresholdsRes.json() : null;
     const auditData = auditRes.ok ? await auditRes.json() : null;
 
-    return json({
+    return {
       gammes: gammesData?.data || [],
       total: gammesData?.total || 0,
       page: gammesData?.page || 1,
@@ -246,10 +245,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         sortOrder,
       },
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[Admin Gammes SEO] Error:", error);
-    return json({
+    return {
       gammes: [],
       total: 0,
       page: 1,
@@ -273,7 +272,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         sortOrder: "desc",
       },
       error: "Erreur chargement données",
-    });
+    };
   }
 }
 
@@ -304,7 +303,7 @@ export async function action({ request }: ActionFunctionArgs) {
         );
 
         const result = await response.json();
-        return json({ success: result.success, message: result.message });
+        return { success: result.success, message: result.message };
       }
 
       case "batch-action": {
@@ -324,11 +323,11 @@ export async function action({ request }: ActionFunctionArgs) {
         );
 
         const result = await response.json();
-        return json({
+        return {
           success: result.success,
           message: result.message,
           updated: result.updated,
-        });
+        };
       }
 
       case "regenerate-sitemap": {
@@ -345,26 +344,26 @@ export async function action({ request }: ActionFunctionArgs) {
 
         const result = await response.json();
         if (result.success) {
-          return json({
+          return {
             success: true,
             message: `Sitemap régénéré: ${result.data?.totalUrls || 0} URLs dans ${result.data?.files?.length || 0} fichiers`,
             sitemapData: result.data,
-          });
+          };
         }
-        return json({
+        return {
           success: false,
           message: result.message || "Erreur lors de la régénération",
-        });
+        };
       }
 
       default:
-        return json({ success: false, message: "Action inconnue" });
+        return { success: false, message: "Action inconnue" };
     }
   } catch (error) {
-    return json({
+    return {
       success: false,
       message: error instanceof Error ? error.message : "Erreur",
-    });
+    };
   }
 }
 
@@ -734,9 +733,7 @@ export default function AdminGammesSeo() {
           <Button
             variant="outline"
             onClick={() => setShowThresholdsPanel(!showThresholdsPanel)}
-            className={
-              showThresholdsPanel ? "bg-muted border-indigo-400" : ""
-            }
+            className={showThresholdsPanel ? "bg-muted border-indigo-400" : ""}
           >
             <Settings className="h-4 w-4 mr-2" />
             Seuils
@@ -958,7 +955,7 @@ export default function AdminGammesSeo() {
                         </td>
                         <td className="px-3 py-2">
                           <Badge
-                            className={`text-xs ${ entry.action_type.includes("THRESHOLD") ? "bg-muted text-foreground" : entry.action_type.includes("PROMOTE") ? "bg-green-100 text-green-700" : entry.action_type.includes("DEMOTE") ? "bg-red-100 text-red-700" : entry.action_type.includes("G1") ? "bg-yellow-100 text-yellow-700" : "bg-gray-100 text-green-900" }`}
+                            className={`text-xs ${entry.action_type.includes("THRESHOLD") ? "bg-muted text-foreground" : entry.action_type.includes("PROMOTE") ? "bg-green-100 text-green-700" : entry.action_type.includes("DEMOTE") ? "bg-red-100 text-red-700" : entry.action_type.includes("G1") ? "bg-yellow-100 text-yellow-700" : "bg-gray-100 text-green-900"}`}
                           >
                             {entry.action_type.replace(/_/g, " ")}
                           </Badge>
@@ -1901,7 +1898,7 @@ export default function AdminGammesSeo() {
                       )}
                       {/* Ligne de gamme - Highlighting basé sur Execution status */}
                       <tr
-                        className={`hover:bg-gray-100 transition-colors ${ gamme.pg_top === "1" ? "bg-emerald-50 border-l-emerald-500" : gamme.execution_status === "PASS" ? "bg-green-50 border-l-green-400" : gamme.execution_status === "WARN" ? "bg-amber-50 border-l-amber-400" : gamme.execution_status === "FAIL" ? "bg-red-50 border-l-red-400" : "" }`}
+                        className={`hover:bg-gray-100 transition-colors ${gamme.pg_top === "1" ? "bg-emerald-50 border-l-emerald-500" : gamme.execution_status === "PASS" ? "bg-green-50 border-l-green-400" : gamme.execution_status === "WARN" ? "bg-amber-50 border-l-amber-400" : gamme.execution_status === "FAIL" ? "bg-red-50 border-l-red-400" : ""}`}
                       >
                         <td className="px-2 py-3">
                           <Checkbox

--- a/frontend/app/routes/admin.invoices._index.tsx
+++ b/frontend/app/routes/admin.invoices._index.tsx
@@ -5,11 +5,7 @@
  * Intégration avec le service InvoicesService nouvellement créé
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link, Form, useNavigation } from "@remix-run/react";
 import { Button } from "~/components/ui/button";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
@@ -117,19 +113,19 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       totalItems: invoicesData.total,
     };
 
-    return json({
+    return {
       invoices: invoicesData.invoices,
       stats,
       pagination,
       user,
       selectedStatus: status,
       searchTerm: search,
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors de la récupération des factures:", error);
 
     // Données par défaut en cas d'erreur
-    return json({
+    return {
       invoices: [],
       stats: {
         totalInvoices: 0,
@@ -149,7 +145,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       user,
       selectedStatus: "",
       searchTerm: "",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.keyword-planner.tsx
+++ b/frontend/app/routes/admin.keyword-planner.tsx
@@ -4,7 +4,6 @@
  */
 
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -176,14 +175,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
     /* loader error — empty state */
   }
 
-  return json<LoaderData>({
+  return {
     coverage,
     gammes,
     totalGammes,
     totalKeywords,
     fullyCoveredCount,
     rag,
-  });
+  };
 }
 
 // ── Action ──
@@ -208,9 +207,9 @@ export async function action({ request }: ActionFunctionArgs) {
     try {
       keywords = JSON.parse(cleaned);
       if (!Array.isArray(keywords))
-        return json({ _action: "import", error: "JSON doit etre un array" });
+        return { _action: "import", error: "JSON doit etre un array" };
     } catch (e) {
-      return json({ _action: "import", error: `JSON invalide: ${e}` });
+      return { _action: "import", error: `JSON invalide: ${e}` };
     }
 
     try {
@@ -225,9 +224,9 @@ export async function action({ request }: ActionFunctionArgs) {
           body: JSON.stringify({ pg_id, pg_alias, keywords, dry_run: dryRun }),
         },
       );
-      return json({ _action: "import", ...(await resp.json()) });
+      return { _action: "import", ...(await resp.json()) };
     } catch (e) {
-      return json({ _action: "import", error: String(e) });
+      return { _action: "import", error: String(e) };
     }
   }
 
@@ -248,14 +247,14 @@ export async function action({ request }: ActionFunctionArgs) {
         },
       );
       if (resp.ok) {
-        return json({ _action: "generate_content", ...(await resp.json()) });
+        return { _action: "generate_content", ...(await resp.json()) };
       }
-      return json({
+      return {
         _action: "generate_content",
         error: `Backend ${resp.status}: ${await resp.text()}`,
-      });
+      };
     } catch (e) {
-      return json({ _action: "generate_content", error: String(e) });
+      return { _action: "generate_content", error: String(e) };
     }
   }
 
@@ -279,10 +278,10 @@ export async function action({ request }: ActionFunctionArgs) {
         body: JSON.stringify({ pg_id, roles }),
       },
     );
-    if (resp.ok) return json({ _action: "generate", ...(await resp.json()) });
-    return json({ _action: "generate", error: `Backend ${resp.status}` });
+    if (resp.ok) return { _action: "generate", ...(await resp.json()) };
+    return { _action: "generate", error: `Backend ${resp.status}` };
   } catch (e) {
-    return json({ _action: "generate", error: String(e) });
+    return { _action: "generate", error: String(e) };
   }
 }
 
@@ -1996,10 +1995,7 @@ function GammeAuditRow({
         </TableCell>
         <TableCell className="py-1 px-2 text-right">
           {g.kw_count > 0 ? (
-            <Badge
-              variant="secondary"
-              className="bg-muted text-foreground"
-            >
+            <Badge variant="secondary" className="bg-muted text-foreground">
               {g.kw_count}
             </Badge>
           ) : (

--- a/frontend/app/routes/admin.leads.$id.tsx
+++ b/frontend/app/routes/admin.leads.$id.tsx
@@ -7,11 +7,11 @@
  */
 
 import {
-  json,
   redirect,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -22,12 +22,12 @@ import {
   isRouteErrorResponse,
   Link,
 } from "@remix-run/react";
-import { ArrowLeft, Save } from "lucide-react";
 import {
   LEAD_TRANSITIONS,
   LEAD_STATUSES,
   type LeadStatus,
 } from "@repo/database-types";
+import { ArrowLeft, Save } from "lucide-react";
 
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { logger } from "~/utils/logger";
@@ -95,7 +95,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const cookie = request.headers.get("Cookie") || "";
   const id = params.id;
 
-  if (!id) throw json({ error: "Lead id manquant" }, { status: 400 });
+  if (!id) throw data({ error: "Lead id manquant" }, { status: 400 });
 
   try {
     const res = await fetch(`${baseUrl}/api/admin/leads/${id}`, {
@@ -103,13 +103,13 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     });
 
     if (res.status === 401 || res.status === 403) {
-      throw json(
+      throw data(
         { error: "Authentification admin requise" },
         { status: res.status },
       );
     }
     if (res.status === 404) {
-      throw json(
+      throw data(
         { error: "Lead introuvable ou non-trackable" },
         { status: 404 },
       );
@@ -120,15 +120,15 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
         status: res.status,
         errText,
       });
-      throw json({ error: `API leads failed: ${res.status}` }, { status: 502 });
+      throw data({ error: `API leads failed: ${res.status}` }, { status: 502 });
     }
 
     const lead = (await res.json()) as LeadDetail;
-    return json<LoaderData>({ lead });
+    return { lead };
   } catch (err) {
     if (err instanceof Response) throw err;
     logger.error("admin.leads.$id loader exception", { err });
-    throw json({ error: "API leads unreachable" }, { status: 502 });
+    throw data({ error: "API leads unreachable" }, { status: 502 });
   }
 }
 
@@ -136,7 +136,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const baseUrl = process.env.API_BASE_URL || "http://localhost:3000";
   const cookie = request.headers.get("Cookie") || "";
   const id = params.id;
-  if (!id) return json({ error: "Lead id manquant" }, { status: 400 });
+  if (!id) return data({ error: "Lead id manquant" }, { status: 400 });
 
   const formData = await request.formData();
   const intent = String(formData.get("intent") || "");
@@ -144,7 +144,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   if (intent === "status") {
     const nextStatus = String(formData.get("status") || "") as LeadStatus;
     if (!LEAD_STATUSES.includes(nextStatus)) {
-      return json({ error: "Status invalide" }, { status: 400 });
+      return data({ error: "Status invalide" }, { status: 400 });
     }
     const res = await fetch(`${baseUrl}/api/admin/leads/${id}/status`, {
       method: "PATCH",
@@ -159,7 +159,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       const errBody = await res
         .json()
         .catch(() => ({ message: "Transition échouée" }));
-      return json(
+      return data(
         { error: errBody.message || `Status update failed: ${res.status}` },
         { status: res.status },
       );
@@ -199,7 +199,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       const errBody = await res
         .json()
         .catch(() => ({ message: "Mise à jour échouée" }));
-      return json(
+      return data(
         { error: errBody.message || `Fields update failed: ${res.status}` },
         { status: res.status },
       );
@@ -213,7 +213,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       headers: { Accept: "application/json", Cookie: cookie },
     });
     if (!res.ok) {
-      return json(
+      return data(
         { error: `Clear follow-up failed: ${res.status}` },
         { status: res.status },
       );
@@ -221,7 +221,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return redirect(`/admin/leads/${id}`);
   }
 
-  return json({ error: "Intent inconnu" }, { status: 400 });
+  return data({ error: "Intent inconnu" }, { status: 400 });
 }
 
 export default function AdminLeadDetail() {
@@ -273,12 +273,8 @@ export default function AdminLeadDetail() {
         <CardContent className="space-y-3 text-sm">
           <div>
             <span className="font-medium">Client :</span> {customerName}
-            {lead.customer?.cst_mail && (
-              <> — {lead.customer.cst_mail}</>
-            )}
-            {lead.customer?.cst_phone && (
-              <> — {lead.customer.cst_phone}</>
-            )}
+            {lead.customer?.cst_mail && <> — {lead.customer.cst_mail}</>}
+            {lead.customer?.cst_phone && <> — {lead.customer.cst_phone}</>}
           </div>
           {lead.msg_crm_source_page && (
             <div className="text-muted-foreground">
@@ -385,11 +381,7 @@ export default function AdminLeadDetail() {
               </Button>
               {lead.msg_crm_next_follow_up_at && (
                 <Form method="post">
-                  <input
-                    type="hidden"
-                    name="intent"
-                    value="clear_follow_up"
-                  />
+                  <input type="hidden" name="intent" value="clear_follow_up" />
                   <Button
                     type="submit"
                     variant="ghost"

--- a/frontend/app/routes/admin.leads._index.tsx
+++ b/frontend/app/routes/admin.leads._index.tsx
@@ -6,11 +6,11 @@
  */
 
 import {
-  json,
   redirect,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -21,12 +21,12 @@ import {
   isRouteErrorResponse,
   Link,
 } from "@remix-run/react";
-import { Bell, Filter, ChevronLeft, ChevronRight } from "lucide-react";
 import {
   LEAD_TRANSITIONS,
   isValidLeadTransition,
   type LeadStatus,
 } from "@repo/database-types";
+import { Bell, Filter, ChevronLeft, ChevronRight } from "lucide-react";
 
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { logger } from "~/utils/logger";
@@ -66,7 +66,10 @@ type LoaderData = {
 
 const STATUS_LABEL: Record<
   LeadStatus,
-  { label: string; variant: "default" | "secondary" | "destructive" | "outline" }
+  {
+    label: string;
+    variant: "default" | "secondary" | "destructive" | "outline";
+  }
 > = {
   new: { label: "Nouveau", variant: "default" },
   contacted: { label: "Contacté", variant: "secondary" },
@@ -107,7 +110,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     });
 
     if (res.status === 401 || res.status === 403) {
-      throw json(
+      throw data(
         { error: "Authentification admin requise" },
         { status: res.status },
       );
@@ -115,11 +118,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     if (!res.ok) {
       const errText = await res.text().catch(() => "");
-      logger.error("admin.leads loader failed", { status: res.status, errText });
-      throw json(
-        { error: `API leads failed: ${res.status}` },
-        { status: 502 },
-      );
+      logger.error("admin.leads loader failed", {
+        status: res.status,
+        errText,
+      });
+      throw data({ error: `API leads failed: ${res.status}` }, { status: 502 });
     }
 
     const body = (await res.json()) as {
@@ -129,18 +132,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
       page_size: number;
     };
 
-    return json<LoaderData>({
+    return {
       rows: body.rows,
       total: body.total,
       page: body.page,
       page_size: body.page_size,
       filter_status: status,
       filter_follow_up: followUp || "any",
-    });
+    };
   } catch (err) {
     if (err instanceof Response) throw err;
     logger.error("admin.leads loader exception", { err });
-    throw json({ error: "API leads unreachable" }, { status: 502 });
+    throw data({ error: "API leads unreachable" }, { status: 502 });
   }
 }
 
@@ -154,7 +157,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const intent = String(formData.get("intent") || "");
 
   if (!leadId || intent !== "transition") {
-    return json({ error: "Invalid request" }, { status: 400 });
+    return data({ error: "Invalid request" }, { status: 400 });
   }
 
   const res = await fetch(`${baseUrl}/api/admin/leads/${leadId}/status`, {
@@ -168,8 +171,10 @@ export async function action({ request }: ActionFunctionArgs) {
   });
 
   if (!res.ok) {
-    const errBody = await res.json().catch(() => ({ message: "Unknown error" }));
-    return json(
+    const errBody = await res
+      .json()
+      .catch(() => ({ message: "Unknown error" }));
+    return data(
       { error: errBody.message || `Transition failed: ${res.status}` },
       { status: res.status },
     );
@@ -270,7 +275,8 @@ export default function AdminLeadsIndex() {
                     : "—";
                   const followUpOverdue = isOverdue(followUpDate);
                   const statusInfo = STATUS_LABEL[lead.msg_crm_status];
-                  const allowedTransitions = LEAD_TRANSITIONS[lead.msg_crm_status];
+                  const allowedTransitions =
+                    LEAD_TRANSITIONS[lead.msg_crm_status];
 
                   return (
                     <tr
@@ -316,52 +322,52 @@ export default function AdminLeadsIndex() {
                       </td>
                       <td className="px-4 py-3 text-right">
                         <div className="flex flex-wrap justify-end gap-1">
-                          {(["contacted", "quoted", "won", "lost"] as const).map(
-                            (target) => {
-                              if (
-                                !isValidLeadTransition(
-                                  lead.msg_crm_status,
-                                  target,
-                                ) ||
-                                target === lead.msg_crm_status
-                              ) {
-                                return null;
-                              }
-                              if (!allowedTransitions.includes(target))
-                                return null;
-                              return (
-                                <Form
-                                  method="post"
-                                  key={`${lead.msg_id}-${target}`}
-                                  className="inline"
+                          {(
+                            ["contacted", "quoted", "won", "lost"] as const
+                          ).map((target) => {
+                            if (
+                              !isValidLeadTransition(
+                                lead.msg_crm_status,
+                                target,
+                              ) ||
+                              target === lead.msg_crm_status
+                            ) {
+                              return null;
+                            }
+                            if (!allowedTransitions.includes(target))
+                              return null;
+                            return (
+                              <Form
+                                method="post"
+                                key={`${lead.msg_id}-${target}`}
+                                className="inline"
+                              >
+                                <input
+                                  type="hidden"
+                                  name="intent"
+                                  value="transition"
+                                />
+                                <input
+                                  type="hidden"
+                                  name="lead_id"
+                                  value={lead.msg_id}
+                                />
+                                <input
+                                  type="hidden"
+                                  name="next_status"
+                                  value={target}
+                                />
+                                <Button
+                                  type="submit"
+                                  variant="outline"
+                                  size="sm"
+                                  disabled={isLoading}
                                 >
-                                  <input
-                                    type="hidden"
-                                    name="intent"
-                                    value="transition"
-                                  />
-                                  <input
-                                    type="hidden"
-                                    name="lead_id"
-                                    value={lead.msg_id}
-                                  />
-                                  <input
-                                    type="hidden"
-                                    name="next_status"
-                                    value={target}
-                                  />
-                                  <Button
-                                    type="submit"
-                                    variant="outline"
-                                    size="sm"
-                                    disabled={isLoading}
-                                  >
-                                    → {STATUS_LABEL[target].label}
-                                  </Button>
-                                </Form>
-                              );
-                            },
-                          )}
+                                  → {STATUS_LABEL[target].label}
+                                </Button>
+                              </Form>
+                            );
+                          })}
                         </div>
                       </td>
                     </tr>

--- a/frontend/app/routes/admin.marketing._index.tsx
+++ b/frontend/app/routes/admin.marketing._index.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { type LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { Link2, TrendingUp, FileText, Target } from "lucide-react";
 import { Badge } from "~/components/ui/badge";
@@ -13,11 +13,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
         headers: { Cookie: request.headers.get("Cookie") || "" },
       },
     );
-    if (!res.ok) return json({ dashboard: null, error: "Failed to load" });
+    if (!res.ok) return { dashboard: null, error: "Failed to load" };
     const result = await res.json();
-    return json({ dashboard: result.data, error: null });
+    return { dashboard: result.data, error: null };
   } catch (e: any) {
-    return json({ dashboard: null, error: e.message });
+    return { dashboard: null, error: e.message };
   }
 }
 

--- a/frontend/app/routes/admin.marketing.backlinks.tsx
+++ b/frontend/app/routes/admin.marketing.backlinks.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { type LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData, useSearchParams } from "@remix-run/react";
 import { Link2, ExternalLink, TrendingUp } from "lucide-react";
 import { Badge } from "~/components/ui/badge";
@@ -39,36 +39,36 @@ export async function loader({ request }: LoaderFunctionArgs) {
     ]);
 
     if (!backlinksRes.ok || !statsRes.ok) {
-      return json({
+      return {
         backlinks: [],
         stats: null,
         total: 0,
         page: 1,
         totalPages: 0,
         error: "Failed to load",
-      });
+      };
     }
 
     const backlinksData = await backlinksRes.json();
     const statsData = await statsRes.json();
 
-    return json({
+    return {
       backlinks: backlinksData.data || [],
       stats: statsData.data,
       total: backlinksData.total || 0,
       page: parseInt(page),
       totalPages: backlinksData.totalPages || 0,
       error: null,
-    });
+    };
   } catch (e: any) {
-    return json({
+    return {
       backlinks: [],
       stats: null,
       total: 0,
       page: 1,
       totalPages: 0,
       error: e.message,
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.marketing.briefs.tsx
+++ b/frontend/app/routes/admin.marketing.briefs.tsx
@@ -10,7 +10,7 @@
  * Filtres : `?unit=ECOMMERCE|LOCAL|HYBRID`, `?status=draft|reviewed|...`,
  * `?agent_id=...`. Pagination simple.
  */
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { type LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData, Link, Form, useSubmit } from "@remix-run/react";
 import { Calendar, FileText, MapPin, ShoppingBag, Zap } from "lucide-react";
 import { Badge } from "~/components/ui/badge";
@@ -73,7 +73,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       headers: { Cookie: request.headers.get("Cookie") || "" },
     });
     if (!res.ok) {
-      return json({
+      return {
         items: [] as BriefRow[],
         total: 0,
         page: 1,
@@ -81,10 +81,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         unit,
         status,
         error: `Backend ${res.status}`,
-      });
+      };
     }
     const result = (await res.json()) as BriefsResponse;
-    return json({
+    return {
       items: result.data.items,
       total: result.data.total,
       page: result.data.page,
@@ -92,10 +92,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       unit,
       status,
       error: null,
-    });
+    };
   } catch (e) {
     const message = e instanceof Error ? e.message : "Unknown error";
-    return json({
+    return {
       items: [] as BriefRow[],
       total: 0,
       page: 1,
@@ -103,7 +103,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       unit,
       status,
       error: message,
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.marketing.content-roadmap.tsx
+++ b/frontend/app/routes/admin.marketing.content-roadmap.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { type LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData, useSearchParams } from "@remix-run/react";
 import {
   Map,
@@ -137,7 +137,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       pipelineRes.ok ? pipelineRes.json() : { data: null },
     ]);
 
-    return json({
+    return {
       roadmap: roadmapData.data || [],
       coverage: coverageData.data as CoverageData | null,
       pipeline: pipelineData.data as PipelineData | null,
@@ -146,9 +146,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
       totalPages: roadmapData.totalPages || 0,
       view,
       error: null,
-    });
+    };
   } catch (e: unknown) {
-    return json({
+    return {
       roadmap: [],
       coverage: null,
       pipeline: null,
@@ -157,7 +157,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       totalPages: 0,
       view: "pipeline",
       error: e instanceof Error ? e.message : "Unknown error",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.marketing.social-hub.posts.tsx
+++ b/frontend/app/routes/admin.marketing.social-hub.posts.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useSearchParams } from "@remix-run/react";
 import {
   FileText,
@@ -222,12 +218,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ? await statusRes.value.json()
       : null;
 
-  return json({
+  return {
     posts: (postsData.data || []) as SocialPost[],
     total: postsData.total || 0,
     filters: { week, status },
     pipeline: pipelineData as PipelineStatus | null,
-  });
+  };
 }
 
 // ── Post Actions ──

--- a/frontend/app/routes/admin.menu.tsx
+++ b/frontend/app/routes/admin.menu.tsx
@@ -2,11 +2,7 @@
  * Route Admin Menu - Navigation principale
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import { Button } from "~/components/ui/button";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
@@ -19,7 +15,7 @@ export const meta: MetaFunction = () =>
 export async function loader({ request, context }: LoaderFunctionArgs) {
   const user = await requireAdmin({ context });
 
-  return json({
+  return {
     user,
     menu: {
       title: "Administration",
@@ -62,7 +58,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         },
       ],
     },
-  });
+  };
 }
 
 export default function AdminMenu() {

--- a/frontend/app/routes/admin.messages.tsx
+++ b/frontend/app/routes/admin.messages.tsx
@@ -4,7 +4,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   redirect,
@@ -183,14 +182,14 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 
       logger.log(`✅ ${messagesData.messages?.length || 0} messages récupérés`);
 
-      return json({
+      return {
         messages: messagesData.messages || [],
         total: messagesData.total || 0,
         page: messagesData.page || 1,
         totalPages: messagesData.totalPages || 1,
         stats: statsData || { total: 0, open: 0, closed: 0 },
         fallbackMode: false,
-      } as MessageData);
+      } as MessageData;
     } else {
       logger.error(
         "❌ Erreur API messages:",
@@ -198,7 +197,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         statsResponse.status,
       );
 
-      return json({
+      return {
         messages: [],
         total: 0,
         page: 1,
@@ -206,12 +205,12 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         stats: { total: 0, open: 0, closed: 0 },
         error: `Erreur API (${messagesResponse.status})`,
         fallbackMode: true,
-      } as MessageData);
+      } as MessageData;
     }
   } catch (error: unknown) {
     logger.error("❌ Erreur lors du chargement des messages:", error);
 
-    return json({
+    return {
       messages: [],
       total: 0,
       page: 1,
@@ -219,7 +218,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       stats: { total: 0, open: 0, closed: 0 },
       error: "Erreur de connexion à l'API messages",
       fallbackMode: true,
-    } as MessageData);
+    } as MessageData;
   }
 }
 
@@ -311,7 +310,7 @@ export default function AdminMessages() {
 
       {/* Indicateur de source */}
       <div
-        className={`mb-6 p-4 rounded-lg ${ fallbackMode ? "border-warning bg-warning/10" : "border-success bg-success/10" }`}
+        className={`mb-6 p-4 rounded-lg ${fallbackMode ? "border-warning bg-warning/10" : "border-success bg-success/10"}`}
       >
         <div className="flex items-center gap-2">
           {fallbackMode ? (

--- a/frontend/app/routes/admin.optimization-summary.tsx
+++ b/frontend/app/routes/admin.optimization-summary.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { Badge } from "~/components/ui/badge";
@@ -30,7 +26,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     const response = await fetch("http://127.0.0.1:3000/dashboard/stats");
     const stats: DashboardStats = await response.json();
 
-    return json({
+    return {
       stats,
       timestamp: new Date().toISOString(),
       tests: {
@@ -38,10 +34,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         monitoring: true,
         abTesting: true,
       },
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors du chargement des stats:", error);
-    return json({
+    return {
       stats: null,
       error: "Impossible de charger les statistiques",
       timestamp: new Date().toISOString(),
@@ -50,7 +46,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         monitoring: false,
         abTesting: false,
       },
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/admin.orders.$orderId.tsx
+++ b/frontend/app/routes/admin.orders.$orderId.tsx
@@ -4,9 +4,9 @@
  */
 
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
+  data,
 } from "@remix-run/node";
 import { Link, useFetcher, useLoaderData } from "@remix-run/react";
 import {
@@ -171,7 +171,7 @@ export const loader = async ({
       throw new Response("Commande introuvable", { status: 404 });
     }
 
-    return json<LoaderData>({ order: result.data });
+    return { order: result.data };
   } catch (error) {
     if (error instanceof Response) throw error;
     logger.error("Erreur chargement commande:", error);
@@ -189,7 +189,7 @@ export const action = async ({
 }: ActionFunctionArgs) => {
   const user = await requireUser({ context });
   if (!user || !user.level || user.level < 3) {
-    return json({ error: "Acces refuse" }, { status: 403 });
+    return data({ error: "Acces refuse" }, { status: 403 });
   }
 
   const orderId = params.orderId;
@@ -225,7 +225,7 @@ export const action = async ({
         body = JSON.stringify({ statusId: formData.get("statusId") });
         break;
       default:
-        return json({ error: "Action inconnue" }, { status: 400 });
+        return data({ error: "Action inconnue" }, { status: 400 });
     }
 
     const headers: Record<string, string> = { Cookie: cookie };
@@ -234,12 +234,12 @@ export const action = async ({
     const res = await fetch(apiUrl, { method, headers, body });
     if (!res.ok) {
       const err = await res.json().catch(() => ({ message: "Erreur" }));
-      return json({ error: err.message || "Erreur" }, { status: 500 });
+      return data({ error: err.message || "Erreur" }, { status: 500 });
     }
 
-    return json({ success: true, message: `Action "${intent}" executee` });
+    return { success: true, message: `Action "${intent}" executee` };
   } catch (error) {
-    return json({ error: "Erreur serveur" }, { status: 500 });
+    return data({ error: "Erreur serveur" }, { status: 500 });
   }
 };
 

--- a/frontend/app/routes/admin.orders._index.tsx
+++ b/frontend/app/routes/admin.orders._index.tsx
@@ -18,9 +18,9 @@
  */
 
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
+  data,
 } from "@remix-run/node";
 import {
   useActionData,
@@ -75,7 +75,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
   const user = await requireUser({ context });
   if (!user || !user.level || user.level < 3) {
     logger.error(`🚫 [Action] Accès refusé`);
-    return json<ActionData>({ error: "Accès refusé" }, { status: 403 });
+    return data({ error: "Accès refusé" }, { status: 403 });
   }
 
   const permissions = await loadUserPermissions(
@@ -99,10 +99,7 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     switch (intent) {
       case "markPaid":
         if (!permissions.canMarkPaid) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         const markPaidResponse = await fetch(
           `http://127.0.0.1:3000/api/admin/orders/${orderId}/confirm-payment`,
@@ -113,23 +110,20 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
         if (!markPaidResponse.ok) {
           const error = await markPaidResponse.json();
-          return json<ActionData>(
+          return data(
             { error: error.message || "Erreur lors du paiement" },
             { status: 500 },
           );
         }
         logger.log(`💰 Order #${orderId} marked as paid`);
-        return json<ActionData>({
+        return {
           success: true,
           message: `Commande #${orderId} marquée comme payée`,
-        });
+        };
 
       case "validate":
         if (!permissions.canValidate) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         const validateResponse = await fetch(
           `http://127.0.0.1:3000/api/admin/orders/${orderId}/validate`,
@@ -140,23 +134,20 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
         if (!validateResponse.ok) {
           const error = await validateResponse.json();
-          return json<ActionData>(
+          return data(
             { error: error.message || "Erreur lors de la validation" },
             { status: 500 },
           );
         }
         logger.log(`✅ Order #${orderId} validated`);
-        return json<ActionData>({
+        return {
           success: true,
           message: `Commande #${orderId} validée`,
-        });
+        };
 
       case "startProcessing":
         if (!permissions.canValidate) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         const processingResponse = await fetch(
           `http://127.0.0.1:3000/api/orders/admin/${orderId}/status`,
@@ -171,23 +162,20 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
         if (!processingResponse.ok) {
           const error = await processingResponse.json();
-          return json<ActionData>(
+          return data(
             { error: error.message || "Erreur lors du passage en préparation" },
             { status: 500 },
           );
         }
         logger.log(`📦 Order #${orderId} processing started`);
-        return json<ActionData>({
+        return {
           success: true,
           message: `Commande #${orderId} mise en préparation`,
-        });
+        };
 
       case "markReady":
         if (!permissions.canShip) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         const readyResponse = await fetch(
           `http://127.0.0.1:3000/api/orders/admin/${orderId}/status`,
@@ -202,23 +190,20 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
         if (!readyResponse.ok) {
           const error = await readyResponse.json();
-          return json<ActionData>(
+          return data(
             { error: error.message || "Erreur lors du marquage prête" },
             { status: 500 },
           );
         }
         logger.log(`✅ Order #${orderId} marked as ready`);
-        return json<ActionData>({
+        return {
           success: true,
           message: `Commande #${orderId} prête à expédier`,
-        });
+        };
 
       case "ship":
         if (!permissions.canShip) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         const shipResponse = await fetch(
           `http://127.0.0.1:3000/api/admin/orders/${orderId}/ship`,
@@ -229,23 +214,20 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
         if (!shipResponse.ok) {
           const error = await shipResponse.json();
-          return json<ActionData>(
+          return data(
             { error: error.message || "Erreur lors de l'expédition" },
             { status: 500 },
           );
         }
         logger.log(`🚚 Order #${orderId} shipped`);
-        return json<ActionData>({
+        return {
           success: true,
           message: `Commande #${orderId} expédiée`,
-        });
+        };
 
       case "deliver":
         if (!permissions.canDeliver) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         const deliverResponse = await fetch(
           `http://127.0.0.1:3000/api/admin/orders/${orderId}/deliver`,
@@ -256,23 +238,20 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
         if (!deliverResponse.ok) {
           const error = await deliverResponse.json();
-          return json<ActionData>(
+          return data(
             { error: error.message || "Erreur lors de la livraison" },
             { status: 500 },
           );
         }
         logger.log(`✅ Order #${orderId} delivered`);
-        return json<ActionData>({
+        return {
           success: true,
           message: `Commande #${orderId} livrée`,
-        });
+        };
 
       case "cancel":
         if (!permissions.canCancel) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         const cancelResponse = await fetch(
           `http://127.0.0.1:3000/api/admin/orders/${orderId}/cancel`,
@@ -283,23 +262,20 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
         if (!cancelResponse.ok) {
           const error = await cancelResponse.json();
-          return json<ActionData>(
+          return data(
             { error: error.message || "Erreur lors de l'annulation" },
             { status: 500 },
           );
         }
         logger.log(`❌ Order #${orderId} cancelled`);
-        return json<ActionData>({
+        return {
           success: true,
           message: `Commande #${orderId} annulée`,
-        });
+        };
 
       case "delete":
         if (!permissions.canCancel) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         const deleteResponse = await fetch(
           `http://127.0.0.1:3000/api/admin/orders/${orderId}/cancel`,
@@ -310,23 +286,20 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
         if (!deleteResponse.ok) {
           const error = await deleteResponse.json();
-          return json<ActionData>(
+          return data(
             { error: error.message || "Erreur lors de la suppression" },
             { status: 500 },
           );
         }
         logger.log(`🗑️ Order #${orderId} deleted`);
-        return json<ActionData>({
+        return {
           success: true,
           message: `Commande #${orderId} supprimée`,
-        });
+        };
 
       case "updateOrder":
         if (!permissions.canValidate) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         const orderStatus = formData.get("orderStatus");
         const isPaid = formData.get("isPaid") === "on" ? "1" : "0";
@@ -351,36 +324,33 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         );
         if (!updateResponse.ok) {
           const error = await updateResponse.json();
-          return json<ActionData>(
+          return data(
             { error: error.message || "Erreur lors de la modification" },
             { status: 500 },
           );
         }
         logger.log(`✏️ Order #${orderId} updated`);
-        return json<ActionData>({
+        return {
           success: true,
           message: `Commande #${orderId} modifiée avec succès`,
-        });
+        };
 
       case "export":
         if (!permissions.canExport) {
-          return json<ActionData>(
-            { error: "Permission refusée" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusée" }, { status: 403 });
         }
         logger.log(`📄 Export CSV by ${user.email}`);
-        return json<ActionData>({
+        return {
           success: true,
           message: "Export CSV généré",
-        });
+        };
 
       default:
-        return json<ActionData>({ error: "Action inconnue" }, { status: 400 });
+        return data({ error: "Action inconnue" }, { status: 400 });
     }
   } catch (error) {
     logger.error("❌ Action error:", error);
-    return json<ActionData>(
+    return data(
       {
         error: error instanceof Error ? error.message : "Erreur inconnue",
       },
@@ -501,7 +471,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       `Page ${page}/${totalPages} - ${orders.length}/${totalFromApi} orders`,
     );
 
-    return json<LoaderData>({
+    return {
       orders,
       stats,
       filters: { search, orderStatus, paymentStatus, paymentMethod, dateRange },
@@ -510,10 +480,10 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       totalPages,
       permissions,
       user: { level: user.level || 0, email: user.email, role: userRole },
-    });
+    };
   } catch (error) {
     logger.error("❌ Loader error:", error);
-    return json<LoaderData>({
+    return {
       orders: [],
       stats: {
         totalOrders: 0,
@@ -536,7 +506,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       totalPages: 0,
       permissions,
       user: { level: user.level || 0, email: user.email, role: userRole },
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/admin.page-role.tsx
+++ b/frontend/app/routes/admin.page-role.tsx
@@ -8,11 +8,7 @@
  * - Visualiser la matrice des liens
  */
 
-import {
-  type LoaderFunctionArgs,
-  type MetaFunction,
-  json,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   Shield,
@@ -110,13 +106,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
       : { hierarchy: [] };
     const rules = rulesRes.ok ? await rulesRes.json() : { rules: {} };
 
-    return json({ matrix, hierarchy, rules });
+    return { matrix, hierarchy, rules };
   } catch {
-    return json({
+    return {
       matrix: { matrix: {}, table: {}, roles: [] },
       hierarchy: { hierarchy: [] },
       rules: { rules: {} },
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.payments.$paymentId.tsx
+++ b/frontend/app/routes/admin.payments.$paymentId.tsx
@@ -1,8 +1,8 @@
 import {
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
-  json,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -56,10 +56,10 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
 
   try {
     const payment = await getPaymentById(paymentId);
-    return json<LoaderData>({ payment });
+    return { payment };
   } catch (error) {
     logger.error("❌ Error loading payment:", error);
-    return json<LoaderData>({ payment: null });
+    return { payment: null };
   }
 }
 
@@ -77,13 +77,13 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
       await processRefund(paymentId, amount, reason);
 
-      return json({
+      return {
         success: true,
         message: "Remboursement traité avec succès",
-      });
+      };
     }
 
-    return json(
+    return data(
       {
         success: false,
         message: "Action non reconnue",
@@ -92,7 +92,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
     );
   } catch (error) {
     logger.error("❌ Error processing action:", error);
-    return json(
+    return data(
       {
         success: false,
         message: "Erreur lors du traitement de l'action",

--- a/frontend/app/routes/admin.payments.dashboard.tsx
+++ b/frontend/app/routes/admin.payments.dashboard.tsx
@@ -1,8 +1,4 @@
-import {
-  type LoaderFunctionArgs,
-  json,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useSearchParams, useNavigate } from "@remix-run/react";
 import {
   Clock,
@@ -138,16 +134,16 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       statsRevenue: stats.totalRevenue,
     });
 
-    return json<LoaderData>({
+    return {
       payments: paymentsResult.payments,
       stats,
       pagination: paymentsResult.pagination,
       payboxMonitoring,
       payboxHealth,
-    });
+    };
   } catch (error) {
     logger.error("❌ Error loading admin payments:", error);
-    return json<LoaderData>({
+    return {
       payments: [],
       stats: {
         totalRevenue: 0,
@@ -179,7 +175,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       },
       payboxMonitoring: null,
       payboxHealth: null,
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.payments.tsx
+++ b/frontend/app/routes/admin.payments.tsx
@@ -1,11 +1,7 @@
 // app/routes/admin.payments.tsx
 // Tableau de bord paiements optimisé appliquant "vérifier existant et utiliser le meilleur"
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { Outlet, useLoaderData, NavLink } from "@remix-run/react";
 import {
   CreditCard,
@@ -63,7 +59,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     conversionRate: 94.2,
   };
 
-  return json({ user, paymentStats });
+  return { user, paymentStats };
 }
 
 export default function AdminPaymentsLayout() {

--- a/frontend/app/routes/admin.products.$productId.tsx
+++ b/frontend/app/routes/admin.products.$productId.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import { Alert } from "~/components/ui/alert";
 import { Badge } from "~/components/ui/badge";
@@ -64,7 +60,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
       throw new Response("Produit non trouvé", { status: 404 });
     }
 
-    return json({ product: productData.data });
+    return { product: productData.data };
   } catch (error) {
     // Propager les Response HTTP (404, etc.) telles quelles
     if (error instanceof Response) {

--- a/frontend/app/routes/admin.products._index.tsx
+++ b/frontend/app/routes/admin.products._index.tsx
@@ -31,11 +31,7 @@
  *
  * @meta noindex, nofollow - Admin only
  */
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   useRouteLoaderData,
@@ -109,14 +105,14 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
     logger.log(`✅ Produits chargés: ${productsData.data.length} items`);
 
-    return json({
+    return {
       products: productsData,
       searchQuery: search,
-    });
+    };
   } catch (error) {
     logger.error("❌ Erreur chargement produits:", error);
 
-    return json({
+    return {
       products: {
         success: false,
         data: [],
@@ -125,7 +121,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       },
       searchQuery: "",
       error: String(error),
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/admin.products.gammes.$gammeId.tsx
+++ b/frontend/app/routes/admin.products.gammes.$gammeId.tsx
@@ -11,11 +11,7 @@
  * Route: /admin/products/gammes/:gammeId
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link, Form, useSearchParams } from "@remix-run/react";
 import {
   ArrowLeft,
@@ -180,7 +176,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       ).length,
     };
 
-    return json<AdminGammeData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -202,11 +198,11 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       },
       enhanced,
       stats,
-    });
+    };
   } catch (error) {
     logger.error("❌ Erreur loader admin gamme:", error);
 
-    return json<AdminGammeData>({
+    return {
       user: {
         id: "error",
         name: "Erreur",
@@ -223,7 +219,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
         error instanceof Error
           ? error.message
           : "Impossible de charger la gamme",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.prototype.buying-guide.$pgId.tsx
+++ b/frontend/app/routes/admin.prototype.buying-guide.$pgId.tsx
@@ -4,11 +4,7 @@
  * Admin only, noindex.
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   AlertTriangle,
@@ -68,7 +64,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   }
 
   const data: PreviewData = await response.json();
-  return json(data);
+  return data;
 }
 
 function QualityBadge({

--- a/frontend/app/routes/admin.r1-images.tsx
+++ b/frontend/app/routes/admin.r1-images.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   Image,
@@ -79,7 +75,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     prompts = res.ok ? await res.json() : [];
   }
 
-  return json({ pgAlias, prompts });
+  return { pgAlias, prompts };
 }
 
 function StatusBadge({

--- a/frontend/app/routes/admin.r1-qa.tsx
+++ b/frontend/app/routes/admin.r1-qa.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   Image,
@@ -124,7 +120,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     });
   }
 
-  return json({ gammeData });
+  return { gammeData };
 }
 
 function ScoreBadge({ score }: { score: number }) {

--- a/frontend/app/routes/admin.rag._index.tsx
+++ b/frontend/app/routes/admin.rag._index.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { Link, useFetcher, useLoaderData } from "@remix-run/react";
 import {
   FileText,
@@ -80,7 +76,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ? await intentsRes.value.json()
       : { totalMessages: 0, intents: [] };
 
-  return json({ corpus, intents });
+  return { corpus, intents };
 }
 
 const TRUTH_STATUS: Record<string, StatusType> = {

--- a/frontend/app/routes/admin.rag.documents.$docId.tsx
+++ b/frontend/app/routes/admin.rag.documents.$docId.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import { ArrowLeft, FileText } from "lucide-react";
 import { DashboardShell } from "~/components/admin/patterns/DashboardShell";
@@ -48,7 +44,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const doc: KnowledgeDocFull = await response.json();
 
-  return json({ doc });
+  return { doc };
 }
 
 const TRUTH_STATUS: Record<string, StatusType> = {

--- a/frontend/app/routes/admin.rag.documents.tsx
+++ b/frontend/app/routes/admin.rag.documents.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   Link,
   useLoaderData,
@@ -93,7 +89,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     ? await coverageRes.json()
     : [];
 
-  return json({ documents, coverage });
+  return { documents, coverage };
 }
 
 const TRUTH_STATUS: Record<string, StatusType> = {

--- a/frontend/app/routes/admin.rag.images.tsx
+++ b/frontend/app/routes/admin.rag.images.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   Image,
@@ -68,7 +64,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   );
 
   const images: RagImage[] = res.ok ? await res.json() : [];
-  return json({ images });
+  return { images };
 }
 
 function formatSize(bytes: number): string {

--- a/frontend/app/routes/admin.rag.webhook-monitor.tsx
+++ b/frontend/app/routes/admin.rag.webhook-monitor.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { Zap, RefreshCw, CheckCircle2, Activity, Clock } from "lucide-react";
 import {
@@ -63,7 +59,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const [statsRes, auditRes] = await Promise.allSettled([
     fetch(
-      getInternalApiUrlFromRequest("/api/rag/admin/webhook-stats?days=7", request),
+      getInternalApiUrlFromRequest(
+        "/api/rag/admin/webhook-stats?days=7",
+        request,
+      ),
       { headers },
     ),
     fetch(
@@ -92,7 +91,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ? await auditRes.value.json()
       : { data: [], total: 0 };
 
-  return json({ stats, audit: auditData });
+  return { stats, audit: auditData };
 }
 
 // ── Helpers ──

--- a/frontend/app/routes/admin.reports._index.tsx
+++ b/frontend/app/routes/admin.reports._index.tsx
@@ -2,7 +2,7 @@
  * Page Rapports - Analyses et statistiques détaillées
  */
 
-import { type LoaderFunction, type MetaFunction, json } from "@remix-run/node";
+import { type LoaderFunction, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   BarChart3,
@@ -164,10 +164,10 @@ export const loader: LoaderFunction = async () => {
 
     logger.log("✅ Données des rapports chargées:", reportData);
 
-    return json({ reportData });
+    return { reportData };
   } catch (error) {
     logger.error("❌ Erreur lors du chargement des rapports:", error);
-    return json({
+    return {
       reportData: {
         users: { total: 0, active: 0, professional: 0, verified: 0 },
         orders: {
@@ -185,7 +185,7 @@ export const loader: LoaderFunction = async () => {
         trends: { usersThisMonth: 0, ordersThisMonth: 0, revenueThisMonth: 0 },
       },
       error: "Erreur de connexion aux APIs pour les rapports",
-    });
+    };
   }
 };
 
@@ -326,10 +326,7 @@ export default function AdminReports() {
               </div>
               <div className="flex items-center justify-between">
                 <span>Emails Vérifiés</span>
-                <Badge
-                  variant="default"
-                  className="bg-muted text-foreground"
-                >
+                <Badge variant="default" className="bg-muted text-foreground">
                   {reportData.users.verified}
                 </Badge>
               </div>
@@ -367,10 +364,7 @@ export default function AdminReports() {
               </div>
               <div className="flex items-center justify-between">
                 <span>Chiffre d'Affaires</span>
-                <Badge
-                  variant="default"
-                  className="bg-muted text-foreground"
-                >
+                <Badge variant="default" className="bg-muted text-foreground">
                   {reportData.orders.revenue.toFixed(2)}€
                 </Badge>
               </div>

--- a/frontend/app/routes/admin.reports.tsx
+++ b/frontend/app/routes/admin.reports.tsx
@@ -2,7 +2,7 @@
  * Page Rapports - Analyses et rapports avec Context7
  */
 
-import { type LoaderFunction, json, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunction, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   BarChart3,
@@ -126,14 +126,14 @@ export const loader: LoaderFunction = async ({ request, context }) => {
       scheduledReports: reports.filter((r) => r.status === "scheduled").length,
     };
 
-    return json({
+    return {
       reports,
       analytics,
       context7: {
         servicesAvailable: !!ordersResult?.success,
         fallbackMode: !ordersResult?.success,
       },
-    });
+    };
   } catch (error) {
     logger.error("❌ Erreur lors du chargement des rapports:", error);
 
@@ -152,7 +152,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
       },
     ];
 
-    return json({
+    return {
       reports: fallbackReports,
       analytics: {
         totalReports: 1,
@@ -166,7 +166,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
         fallbackMode: true,
         errorMode: true,
       },
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/admin.seo-content.tsx
+++ b/frontend/app/routes/admin.seo-content.tsx
@@ -1,7 +1,6 @@
 // app/routes/admin.seo-content.tsx
 // Dashboard de validation du contenu SEO R4 (References) et R5 (Diagnostics)
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -100,15 +99,15 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       ? r5Data
       : r5Data.drafts || [];
 
-    return json({
+    return {
       r4Drafts,
       r5Drafts,
       success: true,
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[SEO Content] Erreur:", error);
-    return json({
+    return {
       r4Drafts: [],
       r5Drafts: [],
       error:
@@ -116,7 +115,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
           ? error.message
           : "Erreur de connexion au backend",
       success: false,
-    });
+    };
   }
 }
 
@@ -143,7 +142,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           },
         );
         if (!response.ok) throw new Error(`API Error: ${response.status}`);
-        return json({ success: true, message: `R4 "${slug}" publié` });
+        return { success: true, message: `R4 "${slug}" publié` };
       }
 
       case "publish-r5": {
@@ -159,7 +158,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           },
         );
         if (!response.ok) throw new Error(`API Error: ${response.status}`);
-        return json({ success: true, message: `R5 "${slug}" publié` });
+        return { success: true, message: `R5 "${slug}" publié` };
       }
 
       case "delete-r4": {
@@ -175,7 +174,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           },
         );
         if (!response.ok) throw new Error(`API Error: ${response.status}`);
-        return json({ success: true, message: `R4 "${slug}" supprimé` });
+        return { success: true, message: `R4 "${slug}" supprimé` };
       }
 
       case "delete-r5": {
@@ -191,7 +190,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           },
         );
         if (!response.ok) throw new Error(`API Error: ${response.status}`);
-        return json({ success: true, message: `R5 "${slug}" supprimé` });
+        return { success: true, message: `R5 "${slug}" supprimé` };
       }
 
       case "publish-all-r4": {
@@ -210,7 +209,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           );
           if (response.ok) published++;
         }
-        return json({ success: true, message: `${published} R4 publiés` });
+        return { success: true, message: `${published} R4 publiés` };
       }
 
       case "publish-all-r5": {
@@ -229,18 +228,18 @@ export async function action({ request, context }: ActionFunctionArgs) {
           );
           if (response.ok) published++;
         }
-        return json({ success: true, message: `${published} R5 publiés` });
+        return { success: true, message: `${published} R5 publiés` };
       }
 
       default:
-        return json({ success: false, message: "Action inconnue" });
+        return { success: false, message: "Action inconnue" };
     }
   } catch (error) {
     logger.error("[SEO Content Action] Erreur:", error);
-    return json({
+    return {
       success: false,
       message: error instanceof Error ? error.message : "Erreur",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.seo-control.tsx
+++ b/frontend/app/routes/admin.seo-control.tsx
@@ -25,10 +25,10 @@
  *   - backend/src/modules/admin/controllers/seo-control.controller.ts (endpoint)
  *   - packages/seo-types/src/control-dashboard.ts (Zod contract)
  */
-import { json, type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
-import { ExternalLink } from "lucide-react";
 import { SeoControlSnapshotSchema, RangeSchema } from "@repo/seo-types";
+import { ExternalLink } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import {
   Table,
@@ -69,15 +69,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   // 404 = feature flag OFF or admin not enrolled — show empty state, don't crash
   if (res.status === 404) {
-    return json({ snapshot: null, range, status: 404 });
+    return { snapshot: null, range, status: 404 };
   }
   if (!res.ok) {
-    throw new Response(`snapshot unavailable (${res.status})`, { status: res.status });
+    throw new Response(`snapshot unavailable (${res.status})`, {
+      status: res.status,
+    });
   }
 
   // Fail-loud Zod parse — anti-bricolage
   const snapshot = SeoControlSnapshotSchema.parse(await res.json());
-  return json({ snapshot, range, status: 200 });
+  return { snapshot, range, status: 200 };
 }
 
 // ─── Component (UI minimal Phase A — 2 blocs visibles) ──────────────
@@ -92,7 +94,8 @@ export default function SeoControlDashboard() {
         <h1 className="text-2xl font-bold mb-2">SEO Business Control</h1>
         <p className="text-muted-foreground text-sm">
           Dashboard non activé pour cet utilisateur. Contactez l&apos;admin pour
-          override <code className="font-mono">SEO_CONTROL_DASHBOARD_ENABLED</code>.
+          override{" "}
+          <code className="font-mono">SEO_CONTROL_DASHBOARD_ENABLED</code>.
         </p>
       </main>
     );
@@ -122,9 +125,8 @@ export default function SeoControlDashboard() {
           <p className="text-sm mt-1">
             <strong>Trafic {range}</strong> ·{" "}
             {tw.clicks.toLocaleString("fr-FR")} clics ·{" "}
-            {tw.impressions.toLocaleString("fr-FR")} imp ·{" "}
-            CTR {tw.ctr.toFixed(2)}% ·{" "}
-            pos {tw.avg_position.toFixed(1)} ·{" "}
+            {tw.impressions.toLocaleString("fr-FR")} imp · CTR{" "}
+            {tw.ctr.toFixed(2)}% · pos {tw.avg_position.toFixed(1)} ·{" "}
             <span className={directionColor}>
               Δ clics {tw.delta_vs_previous.clicks_pct ?? "—"}%
             </span>
@@ -170,7 +172,10 @@ export default function SeoControlDashboard() {
           <TableBody>
             {snapshot.topLosers.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={8} className="text-center text-muted-foreground">
+                <TableCell
+                  colSpan={8}
+                  className="text-center text-muted-foreground"
+                >
                   Aucune page en perte cette semaine.
                 </TableCell>
               </TableRow>
@@ -181,15 +186,19 @@ export default function SeoControlDashboard() {
                     <a
                       href={row.page}
                       target="_blank"
-                      rel="noopener nofollow"
+                      rel="noopener nofollow noreferrer"
                       className="text-blue-600 hover:underline inline-flex items-center gap-1"
                     >
                       {row.page}
                       <ExternalLink className="w-3 h-3" />
                     </a>
                   </TableCell>
-                  <TableCell className="font-mono text-xs">{row.surface_key}</TableCell>
-                  <TableCell className="text-right">{row.clicks_current}</TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {row.surface_key}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {row.clicks_current}
+                  </TableCell>
                   <TableCell className="text-right text-red-600">
                     {row.delta_clicks} ({row.delta_pct ?? "—"}%)
                   </TableCell>
@@ -205,7 +214,9 @@ export default function SeoControlDashboard() {
                   <TableCell className="font-mono text-[10px]">
                     {row.decisions.decision_rule_ids.join(", ")}
                   </TableCell>
-                  <TableCell className="text-xs">{row.decisions.role_id}</TableCell>
+                  <TableCell className="text-xs">
+                    {row.decisions.role_id}
+                  </TableCell>
                 </TableRow>
               ))
             )}
@@ -233,7 +244,10 @@ export default function SeoControlDashboard() {
           <TableBody>
             {criticalAlerts.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={7} className="text-center text-muted-foreground">
+                <TableCell
+                  colSpan={7}
+                  className="text-center text-muted-foreground"
+                >
                   Aucune alerte critique active.
                 </TableCell>
               </TableRow>
@@ -241,7 +255,9 @@ export default function SeoControlDashboard() {
               criticalAlerts.map((a, i) => (
                 <TableRow key={`${a.source}-${a.detected_at}-${i}`}>
                   <TableCell>{a.operational_domain}</TableCell>
-                  <TableCell className="font-mono text-xs">{a.alert_type}</TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {a.alert_type}
+                  </TableCell>
                   <TableCell className="font-mono text-xs">
                     {a.entity_url ?? "—"}
                   </TableCell>
@@ -252,7 +268,9 @@ export default function SeoControlDashboard() {
                   <TableCell className="font-mono text-[10px]">
                     {a.decisions.decision_rule_ids.join(", ")}
                   </TableCell>
-                  <TableCell className="text-xs">{a.decisions.role_id}</TableCell>
+                  <TableCell className="text-xs">
+                    {a.decisions.role_id}
+                  </TableCell>
                 </TableRow>
               ))
             )}
@@ -268,9 +286,8 @@ export default function SeoControlDashboard() {
           log.md.
         </p>
         <p>
-          Format trace :{" "}
-          <code>## YYYY-MM-DD — Décision dashboard</code> avec champs Bloc /
-          Signal / Décision / Verdict rule_id / Mesure prévue.
+          Format trace : <code>## YYYY-MM-DD — Décision dashboard</code> avec
+          champs Bloc / Signal / Décision / Verdict rule_id / Mesure prévue.
         </p>
       </footer>
     </main>

--- a/frontend/app/routes/admin.seo-dashboard.tsx
+++ b/frontend/app/routes/admin.seo-dashboard.tsx
@@ -8,11 +8,7 @@
  * - Évolution journalière
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useRevalidator } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
@@ -72,28 +68,28 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     if (!response.ok) {
       // Retourner des données mock si l'API n'est pas disponible
-      return json({
+      return {
         report: getMockReport(startDate, endDate),
         error: null,
         filters: { startDate, endDate },
-      });
+      };
     }
 
     const report: PerformanceReport = await response.json();
 
-    return json({
+    return {
       report,
       error: null,
       filters: { startDate, endDate },
-    });
+    };
   } catch (error) {
     logger.error("Error fetching SEO metrics:", error);
-    return json({
+    return {
       report: getMockReport(startDate, endDate),
       error:
         "Impossible de charger les métriques. Affichage des données de démonstration.",
       filters: { startDate, endDate },
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub._index.tsx
+++ b/frontend/app/routes/admin.seo-hub._index.tsx
@@ -9,7 +9,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -104,18 +103,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const dashboardData = dashboardRes.ok ? await dashboardRes.json() : null;
     const alertsData = alertsRes.ok ? await alertsRes.json() : null;
 
-    return json({
+    return {
       dashboard: dashboardData?.data as DashboardKpis | null,
       alerts: (alertsData?.data || []) as Alert[],
       error: dashboardData?.success === false ? dashboardData.error : null,
-    });
+    };
   } catch (error) {
     logger.error("[SEO Hub Index] Loader error:", error);
-    return json({
+    return {
       dashboard: null,
       alerts: [],
       error: "Erreur connexion backend",
-    });
+    };
   }
 }
 
@@ -135,10 +134,10 @@ export async function action({ request }: ActionFunctionArgs) {
         },
       );
       const result = await res.json();
-      return json({
+      return {
         success: result.success,
         message: result.data?.message || "Risks refreshed",
-      });
+      };
     }
 
     if (intent === "trigger-monitor") {
@@ -150,15 +149,15 @@ export async function action({ request }: ActionFunctionArgs) {
         },
       );
       const result = await res.json();
-      return json({
+      return {
         success: result.success,
         message: result.data?.message || "Monitor triggered",
-      });
+      };
     }
 
-    return json({ success: false, message: "Unknown action" });
+    return { success: false, message: "Unknown action" };
   } catch (error) {
-    return json({ success: false, message: "Erreur réseau" });
+    return { success: false, message: "Erreur réseau" };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.audit.tsx
+++ b/frontend/app/routes/admin.seo-hub.audit.tsx
@@ -8,11 +8,7 @@
  * - Preview validations
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useSearchParams } from "@remix-run/react";
 import {
   Calendar,
@@ -85,18 +81,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const historyData = historyRes.ok ? await historyRes.json() : null;
     const statsData = statsRes.ok ? await statsRes.json() : null;
 
-    return json({
+    return {
       history: (historyData?.data || []) as AuditEntry[],
       stats: statsData?.data as AuditStats | null,
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[SEO Audit] Loader error:", error);
-    return json({
+    return {
       history: [],
       stats: null,
       error: "Erreur connexion backend",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.content._index.tsx
+++ b/frontend/app/routes/admin.seo-hub.content._index.tsx
@@ -7,11 +7,7 @@
  * - Articles Blog
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import {
   BookOpen,
@@ -80,16 +76,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const data = res.ok ? await res.json() : null;
 
-    return json({
+    return {
       stats: data?.data as ContentStats | null,
       error: data?.success === false ? "Erreur chargement stats" : null,
-    });
+    };
   } catch (error) {
     logger.error("[SEO Content] Loader error:", error);
-    return json({
+    return {
       stats: null,
       error: "Erreur connexion backend",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.content.diagnostics.$slug.tsx
+++ b/frontend/app/routes/admin.seo-hub.content.diagnostics.$slug.tsx
@@ -5,7 +5,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -72,9 +71,9 @@ interface LoaderData {
   error: string | null;
 }
 
-// Action data type union (for future use)
-type _ActionData =
-  | { success: true; action: "update" | "publish" }
+type ActionData =
+  | { success: boolean; action: "publish" }
+  | { success: true; action: "update" }
   | { success: false; errors: string[] };
 
 const SAFETY_GATE_COLORS: Record<string, string> = {
@@ -98,28 +97,31 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     });
 
     if (!res.ok) {
-      return json<LoaderData>({
+      return {
         diagnostic: null,
         error: "Diagnostic non trouvé",
-      });
+      };
     }
 
     const diagnostic = await res.json();
 
-    return json<LoaderData>({
+    return {
       diagnostic,
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[R5 Edit] Loader error:", error);
-    return json<LoaderData>({
+    return {
       diagnostic: null,
       error: "Erreur connexion backend",
-    });
+    };
   }
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({
+  request,
+  params,
+}: ActionFunctionArgs): Promise<ActionData> {
   const backendUrl = getInternalApiUrl("");
   const cookieHeader = request.headers.get("Cookie") || "";
   const { slug } = params;
@@ -135,7 +137,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       },
     );
     const data = await res.json();
-    return json({ success: data.success, action: "publish" });
+    return { success: data.success, action: "publish" };
   }
 
   // Update diagnostic
@@ -161,7 +163,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   }
 
   if (errors.length > 0) {
-    return json({ success: false, errors });
+    return { success: false, errors };
   }
 
   // Parse arrays
@@ -203,16 +205,16 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     if (!res.ok) {
       const error = await res.json();
-      return json({
+      return {
         success: false,
         errors: [error.message || "Erreur lors de la mise à jour"],
-      });
+      };
     }
 
-    return json({ success: true, action: "update" });
+    return { success: true, action: "update" };
   } catch (error) {
     logger.error("[R5 Edit] Action error:", error);
-    return json({ success: false, errors: ["Erreur serveur"] });
+    return { success: false, errors: ["Erreur serveur"] };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.content.diagnostics._index.tsx
+++ b/frontend/app/routes/admin.seo-hub.content.diagnostics._index.tsx
@@ -8,7 +8,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -142,14 +141,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
     ]);
 
     if (draftsRes.status === 403) {
-      return json<LoaderData>({
+      return {
         diagnostics: [],
         total: 0,
         clusters: [],
         error:
           "Accès refusé : vous devez être connecté en tant qu'administrateur (niveau 7+) pour accéder aux drafts.",
         authError: true,
-      });
+      };
     }
 
     const featuredData = featuredRes.ok
@@ -175,20 +174,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ...new Set(diagnostics.map((d) => d.clusterId).filter(Boolean)),
     ] as string[];
 
-    return json<LoaderData>({
+    return {
       diagnostics,
       total: published.length + drafts.length,
       clusters,
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[R5 List] Loader error:", error);
-    return json<LoaderData>({
+    return {
       diagnostics: [],
       total: 0,
       clusters: [],
       error: "Erreur connexion backend",
-    });
+    };
   }
 }
 
@@ -209,7 +208,7 @@ export async function action({ request }: ActionFunctionArgs) {
           { method: "PATCH", headers: { Cookie: cookieHeader } },
         );
         const data = await res.json();
-        return json({ success: data.success, action: "publish", slug });
+        return { success: data.success, action: "publish", slug };
       }
       case "delete": {
         const res = await fetch(`${backendUrl}/api/seo/diagnostic/${slug}`, {
@@ -217,14 +216,14 @@ export async function action({ request }: ActionFunctionArgs) {
           headers: { Cookie: cookieHeader },
         });
         const data = await res.json();
-        return json({ success: data.success, action: "delete", slug });
+        return { success: data.success, action: "delete", slug };
       }
       default:
-        return json({ success: false, error: "Action non reconnue" });
+        return { success: false, error: "Action non reconnue" };
     }
   } catch (error) {
     logger.error("[R5 Action] Error:", error);
-    return json({ success: false, error: "Erreur serveur" });
+    return { success: false, error: "Erreur serveur" };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.content.diagnostics.new.tsx
+++ b/frontend/app/routes/admin.seo-hub.content.diagnostics.new.tsx
@@ -5,7 +5,6 @@
  */
 
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
@@ -74,13 +73,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const gammesData = gammesRes.ok ? await gammesRes.json() : { data: [] };
     const r4Data = r4Res.ok ? await r4Res.json() : { references: [] };
 
-    return json<LoaderData>({
+    return {
       gammes: gammesData.data || [],
       r4Slugs: (r4Data.references || []).map((r: { slug: string }) => r.slug),
-    });
+    };
   } catch (error) {
     logger.error("[R5 New] Loader error:", error);
-    return json<LoaderData>({ gammes: [], r4Slugs: [] });
+    return { gammes: [], r4Slugs: [] };
   }
 }
 
@@ -116,7 +115,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   if (errors.length > 0) {
-    return json({ success: false, errors });
+    return { success: false, errors };
   }
 
   // Parse arrays
@@ -160,16 +159,16 @@ export async function action({ request }: ActionFunctionArgs) {
 
     if (!res.ok) {
       const error = await res.json();
-      return json({
+      return {
         success: false,
         errors: [error.message || "Erreur lors de la création"],
-      });
+      };
     }
 
     return redirect(`/admin/seo-hub/content/diagnostics/${slug}`);
   } catch (error) {
     logger.error("[R5 New] Action error:", error);
-    return json({ success: false, errors: ["Erreur serveur"] });
+    return { success: false, errors: ["Erreur serveur"] };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.content.generator.tsx
+++ b/frontend/app/routes/admin.seo-hub.content.generator.tsx
@@ -9,7 +9,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -138,10 +137,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
     );
 
     if (!gammesRes.ok) {
-      return json<LoaderData>({
+      return {
         gammes: [],
         error: "Erreur chargement gammes",
-      });
+      };
     }
 
     const gammesData = await gammesRes.json();
@@ -164,13 +163,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
       }),
     );
 
-    return json<LoaderData>({ gammes, error: null });
+    return { gammes, error: null };
   } catch (error) {
     logger.error("[Generator] Loader error:", error);
-    return json<LoaderData>({
+    return {
       gammes: [],
       error: "Erreur connexion backend",
-    });
+    };
   }
 }
 
@@ -210,13 +209,13 @@ export async function action({ request }: ActionFunctionArgs) {
         },
       ];
 
-      return json({ success: true, ragSources, intent: "fetch_rag" });
+      return { success: true, ragSources, intent: "fetch_rag" };
     } catch (error) {
-      return json({
+      return {
         success: false,
         error: "Erreur lecture RAG",
         intent: "fetch_rag",
-      });
+      };
     }
   }
 
@@ -279,16 +278,16 @@ export async function action({ request }: ActionFunctionArgs) {
           keywordsMatched: ["keyword1", "keyword2"],
         };
 
-        return json({
+        return {
           success: true,
           content: mockContent,
           intent: "generate",
-        });
+        };
       }
 
       const data = await res.json();
       // Extraire les champs pour éviter le doublon de 'success' dans content
-      return json({
+      return {
         success: data.success !== false,
         content: {
           r4: data.r4,
@@ -297,13 +296,13 @@ export async function action({ request }: ActionFunctionArgs) {
           keywordsMatched: data.keywordsMatched || [],
         },
         intent: "generate",
-      });
+      };
     } catch (error) {
-      return json({
+      return {
         success: false,
         error: "Erreur génération",
         intent: "generate",
-      });
+      };
     }
   }
 
@@ -334,20 +333,20 @@ export async function action({ request }: ActionFunctionArgs) {
 
       if (!res.ok) {
         const error = await res.json();
-        return json({
+        return {
           success: false,
           error: error.message || "Erreur sauvegarde R4",
           intent: "save_r4",
-        });
+        };
       }
 
-      return json({ success: true, intent: "save_r4", slug: r4Data.slug });
+      return { success: true, intent: "save_r4", slug: r4Data.slug };
     } catch (error) {
-      return json({
+      return {
         success: false,
         error: "Erreur serveur",
         intent: "save_r4",
-      });
+      };
     }
   }
 
@@ -380,24 +379,24 @@ export async function action({ request }: ActionFunctionArgs) {
 
       if (!res.ok) {
         const error = await res.json();
-        return json({
+        return {
           success: false,
           error: error.message || "Erreur sauvegarde R5",
           intent: "save_r5",
-        });
+        };
       }
 
-      return json({ success: true, intent: "save_r5", slug: r5Data.slug });
+      return { success: true, intent: "save_r5", slug: r5Data.slug };
     } catch (error) {
-      return json({
+      return {
         success: false,
         error: "Erreur serveur",
         intent: "save_r5",
-      });
+      };
     }
   }
 
-  return json({ success: false, error: "Action non reconnue" });
+  return { success: false, error: "Action non reconnue" };
 }
 
 export default function AdminSeoGenerator() {

--- a/frontend/app/routes/admin.seo-hub.content.references.$slug.tsx
+++ b/frontend/app/routes/admin.seo-hub.content.references.$slug.tsx
@@ -5,7 +5,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -75,9 +74,10 @@ interface LoaderData {
   error: string | null;
 }
 
-// Action data type union (for future use)
-type _ActionData =
-  | { success: true; action: "update" | "publish" }
+// Action data type union (discriminates the success/error shapes returned below)
+type ActionData =
+  | { success: boolean; action: "publish" }
+  | { success: true; action: "update" }
   | { success: false; errors: string[] };
 
 export const meta: MetaFunction = () =>
@@ -99,32 +99,35 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     ]);
 
     if (!refRes.ok) {
-      return json<LoaderData>({
+      return {
         reference: null,
         gammes: [],
         error: "Référence non trouvée",
-      });
+      };
     }
 
     const reference = await refRes.json();
     const gammesData = gammesRes.ok ? await gammesRes.json() : { data: [] };
 
-    return json<LoaderData>({
+    return {
       reference,
       gammes: gammesData.data || [],
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[R4 Edit] Loader error:", error);
-    return json<LoaderData>({
+    return {
       reference: null,
       gammes: [],
       error: "Erreur connexion backend",
-    });
+    };
   }
 }
 
-export async function action({ request, params }: ActionFunctionArgs) {
+export async function action({
+  request,
+  params,
+}: ActionFunctionArgs): Promise<ActionData> {
   const backendUrl = getInternalApiUrl("");
   const cookieHeader = request.headers.get("Cookie") || "";
   const { slug } = params;
@@ -137,7 +140,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
       headers: { Cookie: cookieHeader },
     });
     const data = await res.json();
-    return json({ success: data.success, action: "publish" });
+    return { success: data.success, action: "publish" };
   }
 
   // Update reference
@@ -160,7 +163,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   }
 
   if (errors.length > 0) {
-    return json({ success: false, errors });
+    return { success: false, errors };
   }
 
   // Parse arrays
@@ -198,16 +201,16 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
     if (!res.ok) {
       const error = await res.json();
-      return json({
+      return {
         success: false,
         errors: [error.message || "Erreur lors de la mise à jour"],
-      });
+      };
     }
 
-    return json({ success: true, action: "update" });
+    return { success: true, action: "update" };
   } catch (error) {
     logger.error("[R4 Edit] Action error:", error);
-    return json({ success: false, errors: ["Erreur serveur"] });
+    return { success: false, errors: ["Erreur serveur"] };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.content.references._index.tsx
+++ b/frontend/app/routes/admin.seo-hub.content.references._index.tsx
@@ -9,7 +9,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -117,14 +116,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     // Vérifier les erreurs d'autorisation (403)
     if (draftsRes.status === 403) {
-      return json<LoaderData>({
+      return {
         references: [],
         drafts: [],
         total: 0,
         error:
           "Accès refusé : vous devez être connecté en tant qu'administrateur (niveau 7+) pour accéder aux drafts.",
         authError: true,
-      });
+      };
     }
 
     const publishedData = publishedRes.ok
@@ -152,20 +151,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
       references = [...drafts, ...published];
     }
 
-    return json<LoaderData>({
+    return {
       references,
       drafts,
       total: published.length + drafts.length,
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[R4 List] Loader error:", error);
-    return json<LoaderData>({
+    return {
       references: [],
       drafts: [],
       total: 0,
       error: "Erreur connexion backend",
-    });
+    };
   }
 }
 
@@ -187,7 +186,7 @@ export async function action({ request }: ActionFunctionArgs) {
           },
         );
         const data = await res.json();
-        return json({ success: data.success, action: "publish", slug });
+        return { success: data.success, action: "publish", slug };
       }
       case "delete": {
         const res = await fetch(`${backendUrl}/api/seo/reference/${slug}`, {
@@ -195,14 +194,14 @@ export async function action({ request }: ActionFunctionArgs) {
           headers: { Cookie: cookieHeader },
         });
         const data = await res.json();
-        return json({ success: data.success, action: "delete", slug });
+        return { success: data.success, action: "delete", slug };
       }
       default:
-        return json({ success: false, error: "Action non reconnue" });
+        return { success: false, error: "Action non reconnue" };
     }
   } catch (error) {
     logger.error("[R4 Action] Error:", error);
-    return json({ success: false, error: "Erreur serveur" });
+    return { success: false, error: "Erreur serveur" };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.content.references.new.tsx
+++ b/frontend/app/routes/admin.seo-hub.content.references.new.tsx
@@ -5,7 +5,6 @@
  */
 
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
@@ -81,16 +80,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const gammesData = gammesRes.ok ? await gammesRes.json() : { data: [] };
     const r5Data = r5Res.ok ? await r5Res.json() : { data: [] };
 
-    return json<LoaderData>({
+    return {
       gammes: gammesData.data || [],
       r5Slugs: r5Data.data || [],
-    });
+    };
   } catch (error) {
     logger.error("[R4 New] Loader error:", error);
-    return json<LoaderData>({
+    return {
       gammes: [],
       r5Slugs: [],
-    });
+    };
   }
 }
 
@@ -124,7 +123,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   if (errors.length > 0) {
-    return json({ success: false, errors });
+    return { success: false, errors };
   }
 
   // Parse arrays
@@ -166,16 +165,16 @@ export async function action({ request }: ActionFunctionArgs) {
 
     if (!res.ok) {
       const error = await res.json();
-      return json({
+      return {
         success: false,
         errors: [error.message || "Erreur lors de la création"],
-      });
+      };
     }
 
     return redirect(`/admin/seo-hub/content/references/${slug}`);
   } catch (error) {
     logger.error("[R4 New] Action error:", error);
-    return json({ success: false, errors: ["Erreur serveur"] });
+    return { success: false, errors: ["Erreur serveur"] };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.cwv.tsx
+++ b/frontend/app/routes/admin.seo-hub.cwv.tsx
@@ -11,11 +11,7 @@
  *  - Backend : @repo/cwv-taxonomy + cwv-dashboard.controller.ts
  *  - Migrations : 20260526 (raw), 20260527 (agg), 20260528 (runtime), 20260529 (RPCs)
  */
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useSearchParams } from "@remix-run/react";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Badge } from "~/components/ui/badge";
@@ -137,13 +133,13 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     apiError = err instanceof Error ? err.message : "Unknown fetch error";
   }
 
-  return json<LoaderData>({
+  return {
     dashboard,
     funnel,
     health,
     priorityTier,
     apiError,
-  });
+  };
 };
 
 function formatMs(value: number | null, metric: string): string {

--- a/frontend/app/routes/admin.seo-hub.findings.tsx
+++ b/frontend/app/routes/admin.seo-hub.findings.tsx
@@ -20,7 +20,6 @@
  */
 
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -88,7 +87,13 @@ interface FindingRow {
   audit_type: AuditType;
   entity_url: string;
   severity: Severity;
-  payload: Record<string, unknown>;
+  payload: {
+    gap_type?: string;
+    source_table?: string;
+    field?: string;
+    section_type?: string;
+    content_length?: number;
+  };
   detected_at: string;
   resolved_at: string | null;
   fixed_at: string | null;
@@ -115,7 +120,8 @@ export const meta: MetaFunction = () =>
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
-  const auditType = (url.searchParams.get("type") ?? "r_content_gap") as AuditType;
+  const auditType = (url.searchParams.get("type") ??
+    "r_content_gap") as AuditType;
   const limitParam = parseInt(url.searchParams.get("limit") ?? "200", 10);
   const limit = Math.min(Math.max(limitParam, 1), 1000);
 
@@ -140,22 +146,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
       : null;
     const findingsData = findingsRes.ok ? await findingsRes.json() : null;
 
-    return json({
+    return {
       auditType,
       limit,
       summary,
-      findings: ((findingsData?.rows ?? []) as FindingRow[]),
+      findings: (findingsData?.rows ?? []) as FindingRow[],
       error: null as string | null,
-    });
+    };
   } catch (error) {
     logger.error("[SEO Findings] Loader error:", error);
-    return json({
+    return {
       auditType,
       limit,
       summary: null,
       findings: [] as FindingRow[],
       error: "Erreur connexion backend SEO Monitoring",
-    });
+    };
   }
 }
 
@@ -182,23 +188,22 @@ export async function action({ request }: ActionFunctionArgs) {
     );
 
     if (!res.ok) {
-      return json({
+      return {
         ok: false,
         message: `Backend ${res.status}: ${await res.text()}`,
         result: null as RContentRunResult | null,
-      });
+      };
     }
 
     const result: RContentRunResult = await res.json();
-    return json({ ok: true, message: null as string | null, result });
+    return { ok: true, message: null as string | null, result };
   } catch (error) {
     logger.error("[SEO Findings] Action error:", error);
-    return json({
+    return {
       ok: false,
-      message:
-        error instanceof Error ? error.message : "Erreur trigger audit",
+      message: error instanceof Error ? error.message : "Erreur trigger audit",
       result: null as RContentRunResult | null,
-    });
+    };
   }
 }
 
@@ -236,12 +241,18 @@ export default function SeoHubFindings() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="r_content_gap">R-content gap (Phase 2a')</SelectItem>
+              <SelectItem value="r_content_gap">
+                R-content gap (Phase 2a')
+              </SelectItem>
               <SelectItem value="schema_violation">Schema violation</SelectItem>
               <SelectItem value="image_seo">Image SEO</SelectItem>
-              <SelectItem value="canonical_conflict">Canonical conflict</SelectItem>
+              <SelectItem value="canonical_conflict">
+                Canonical conflict
+              </SelectItem>
               <SelectItem value="meta_experiment">Meta experiment</SelectItem>
-              <SelectItem value="internal_link_suggestion">Internal linking</SelectItem>
+              <SelectItem value="internal_link_suggestion">
+                Internal linking
+              </SelectItem>
             </SelectContent>
           </Select>
           <Form method="post">
@@ -273,15 +284,14 @@ export default function SeoHubFindings() {
           <AlertDescription className="space-y-1 text-sm">
             <p>
               <strong>{actionData.result.findingsDetected}</strong> findings
-              détectés ·{" "}
-              <strong>{actionData.result.findingsInserted}</strong> insérés ·{" "}
-              {actionData.result.durationSeconds.toFixed(2)}s
+              détectés · <strong>{actionData.result.findingsInserted}</strong>{" "}
+              insérés · {actionData.result.durationSeconds.toFixed(2)}s
             </p>
             <p className="text-muted-foreground">
-              Sources : conseil={actionData.result.bySource.conseil ?? 0} ·
-              R6={actionData.result.bySource.purchase_guide ?? 0} ·
-              R4={actionData.result.bySource.reference ?? 0} ·
-              R7={actionData.result.bySource.brand_editorial ?? 0}
+              Sources : conseil={actionData.result.bySource.conseil ?? 0} · R6=
+              {actionData.result.bySource.purchase_guide ?? 0} · R4=
+              {actionData.result.bySource.reference ?? 0} · R7=
+              {actionData.result.bySource.brand_editorial ?? 0}
             </p>
           </AlertDescription>
         </Alert>
@@ -356,12 +366,9 @@ export default function SeoHubFindings() {
               </TableHeader>
               <TableBody>
                 {data.findings.map((f) => {
-                  const gapType = (f.payload.gap_type as string) ?? "—";
-                  const source = (f.payload.source_table as string) ?? "—";
-                  const field =
-                    (f.payload.field as string) ??
-                    (f.payload.section_type as string) ??
-                    "";
+                  const gapType = f.payload.gap_type ?? "—";
+                  const source = f.payload.source_table ?? "—";
+                  const field = f.payload.field ?? f.payload.section_type ?? "";
                   const contentLen =
                     typeof f.payload.content_length === "number"
                       ? ` (${f.payload.content_length}c)`

--- a/frontend/app/routes/admin.seo-hub.keyword-clusters.tsx
+++ b/frontend/app/routes/admin.seo-hub.keyword-clusters.tsx
@@ -4,11 +4,7 @@
  * /admin/seo-hub/keyword-clusters
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   AlertTriangle,
@@ -87,17 +83,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const clustersData = clustersRes.ok ? await clustersRes.json() : null;
     const statsData = statsRes.ok ? await statsRes.json() : null;
 
-    return json({
+    return {
       clusters: (clustersData?.data ?? []) as ClusterRow[],
       stats: (statsData?.data ?? null) as ClusterStats | null,
       error: null,
-    });
+    };
   } catch (error) {
-    return json({
+    return {
       clusters: [] as ClusterRow[],
       stats: null as ClusterStats | null,
       error: `Erreur chargement: ${error instanceof Error ? error.message : "inconnu"}`,
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.monitoring.tsx
+++ b/frontend/app/routes/admin.seo-hub.monitoring.tsx
@@ -8,11 +8,7 @@
  * - URLs à risque
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useSearchParams } from "@remix-run/react";
 import {
   Activity,
@@ -104,20 +100,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const indexData = indexRes.ok ? await indexRes.json() : null;
     const atRiskData = atRiskRes.ok ? await atRiskRes.json() : null;
 
-    return json({
+    return {
       crawlActivity: (crawlData?.data || []) as CrawlActivity[],
       indexChanges: (indexData?.data || []) as IndexChange[],
       urlsAtRisk: (atRiskData?.data || []) as UrlAtRisk[],
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[SEO Monitoring] Loader error:", error);
-    return json({
+    return {
       crawlActivity: [],
       indexChanges: [],
       urlsAtRisk: [],
       error: "Erreur connexion backend",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.observability.tsx
+++ b/frontend/app/routes/admin.seo-hub.observability.tsx
@@ -19,11 +19,7 @@
  * - PR #166 : recharts ^2.15.4 ajouté en Phase 0
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData, useSearchParams } from "@remix-run/react";
 import {
   AlertCircle,
@@ -176,27 +172,27 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const cwvData = cwvRes.ok ? await cwvRes.json() : null;
     const runsData = runsRes.ok ? await runsRes.json() : null;
 
-    return json({
+    return {
       health,
-      gscRows: ((gscData?.rows ?? []) as GscRow[]),
+      gscRows: (gscData?.rows ?? []) as GscRow[],
       gscTotals: gscData?.totals ?? {
         clicks: 0,
         impressions: 0,
         ctr: 0,
         avg_position: 0,
       },
-      ga4Rows: ((ga4Data?.rows ?? []) as Ga4Row[]),
+      ga4Rows: (ga4Data?.rows ?? []) as Ga4Row[],
       ga4Totals: ga4Data?.totals ?? { sessions: 0, conversions: 0 },
-      cwvRows: ((cwvData?.rows ?? []) as CwvRow[]),
-      runs: ((runsData?.rows ?? []) as RunRow[]),
+      cwvRows: (cwvData?.rows ?? []) as CwvRow[],
+      runs: (runsData?.rows ?? []) as RunRow[],
       dateFrom,
       dateTo,
       days,
       error: null as string | null,
-    });
+    };
   } catch (error) {
     logger.error("[SEO Observability] Loader error:", error);
-    return json({
+    return {
       health: null,
       gscRows: [] as GscRow[],
       gscTotals: { clicks: 0, impressions: 0, ctr: 0, avg_position: 0 },
@@ -210,7 +206,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       dateTo: new Date().toISOString().slice(0, 10),
       days: 30,
       error: "Erreur connexion backend SEO Monitoring",
-    });
+    };
   }
 }
 
@@ -228,7 +224,10 @@ export default function SeoHubObservability() {
 
   // Aggrégation par jour pour les line charts
   const gscByDay = useMemo(() => aggregateByDate(data.gscRows), [data.gscRows]);
-  const ga4ByDay = useMemo(() => aggregateGa4ByDate(data.ga4Rows), [data.ga4Rows]);
+  const ga4ByDay = useMemo(
+    () => aggregateGa4ByDate(data.ga4Rows),
+    [data.ga4Rows],
+  );
 
   return (
     <div className="container mx-auto p-6 max-w-7xl space-y-6">
@@ -239,8 +238,8 @@ export default function SeoHubObservability() {
             SEO Observability
           </h1>
           <p className="text-muted-foreground mt-1">
-            GSC + GA4 + Core Web Vitals timeseries · {data.days} jours
-            ({data.dateFrom} → {data.dateTo})
+            GSC + GA4 + Core Web Vitals timeseries · {data.days} jours (
+            {data.dateFrom} → {data.dateTo})
           </p>
         </div>
         <Select
@@ -277,8 +276,8 @@ export default function SeoHubObservability() {
           <AlertTitle>Configuration requise</AlertTitle>
           <AlertDescription className="space-y-2">
             <p>
-              Avant que la donnée Google soit ingérée, suivre la procédure
-              setup Service Account dans{" "}
+              Avant que la donnée Google soit ingérée, suivre la procédure setup
+              Service Account dans{" "}
               <code className="text-xs">
                 .spec/runbooks/seo/observability-setup.md
               </code>
@@ -291,7 +290,8 @@ export default function SeoHubObservability() {
                   <span className="text-green-600">✓</span>
                 ) : (
                   <span className="text-amber-600">
-                    ✗ {data.health?.readiness.gsc.reason ?? "credentials missing"}
+                    ✗{" "}
+                    {data.health?.readiness.gsc.reason ?? "credentials missing"}
                   </span>
                 )}
               </li>
@@ -301,7 +301,8 @@ export default function SeoHubObservability() {
                   <span className="text-green-600">✓</span>
                 ) : (
                   <span className="text-amber-600">
-                    ✗ {data.health?.readiness.ga4.reason ?? "credentials missing"}
+                    ✗{" "}
+                    {data.health?.readiness.ga4.reason ?? "credentials missing"}
                   </span>
                 )}
               </li>
@@ -361,9 +362,7 @@ export default function SeoHubObservability() {
           <Card>
             <CardHeader>
               <CardTitle>Position moyenne & CTR (GSC)</CardTitle>
-              <CardDescription>
-                Évolution sur {data.days} jours
-              </CardDescription>
+              <CardDescription>Évolution sur {data.days} jours</CardDescription>
             </CardHeader>
             <CardContent>
               {hasGscData ? (
@@ -399,9 +398,7 @@ export default function SeoHubObservability() {
           <Card>
             <CardHeader>
               <CardTitle>Sessions & conversions (GA4)</CardTitle>
-              <CardDescription>
-                Évolution sur {data.days} jours
-              </CardDescription>
+              <CardDescription>Évolution sur {data.days} jours</CardDescription>
             </CardHeader>
             <CardContent>
               {hasGa4Data ? (
@@ -440,9 +437,7 @@ export default function SeoHubObservability() {
           <Card>
             <CardHeader>
               <CardTitle>Top pages GSC</CardTitle>
-              <CardDescription>
-                Triées par clicks décroissants
-              </CardDescription>
+              <CardDescription>Triées par clicks décroissants</CardDescription>
             </CardHeader>
             <CardContent>
               {hasGscData ? (
@@ -693,7 +688,13 @@ function EmptyState({ message }: { message: string }) {
 
 function aggregateByDate(
   rows: GscRow[],
-): Array<{ date: string; clicks: number; impressions: number; position: number; ctr_pct: number }> {
+): Array<{
+  date: string;
+  clicks: number;
+  impressions: number;
+  position: number;
+  ctr_pct: number;
+}> {
   const m = new Map<
     string,
     { clicks: number; impressions: number; position_sum: number }

--- a/frontend/app/routes/admin.seo-hub.page-briefs.tsx
+++ b/frontend/app/routes/admin.seo-hub.page-briefs.tsx
@@ -8,7 +8,6 @@
  */
 
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -138,31 +137,31 @@ export async function loader({ request }: LoaderFunctionArgs) {
     );
 
     if (!res.ok) {
-      return json({
+      return {
         briefs: [] as BriefRow[],
         stats: null as BriefStats | null,
         total: 0,
         error: `API error: ${res.status}`,
-      });
+      };
     }
 
     const body = await res.json();
     const briefs = (body.data ?? []) as BriefRow[];
     const stats = computeStats(briefs);
 
-    return json({
+    return {
       briefs,
       stats,
       total: body.total ?? briefs.length,
       error: null,
-    });
+    };
   } catch (error) {
-    return json({
+    return {
       briefs: [] as BriefRow[],
       stats: null as BriefStats | null,
       total: 0,
       error: `Erreur chargement: ${error instanceof Error ? error.message : "inconnu"}`,
-    });
+    };
   }
 }
 
@@ -186,14 +185,14 @@ export async function action({ request }: ActionFunctionArgs) {
         body: JSON.stringify({ briefIds: [parseInt(briefId, 10)] }),
       });
       const data = await res.json();
-      return json({
+      return {
         ok: data.validated === true,
         action: "validate",
         briefId,
         message: data.validated
           ? "Brief valide"
           : `Overlap detecte: ${data.overlap?.details?.length ?? 0} conflits`,
-      });
+      };
     }
 
     if (intent === "activate") {
@@ -205,27 +204,27 @@ export async function action({ request }: ActionFunctionArgs) {
         },
       );
       const data = await res.json();
-      return json({
+      return {
         ok: !!data.id,
         action: "activate",
         briefId,
         message: data.id ? "Brief active" : "Erreur activation",
-      });
+      };
     }
 
-    return json({
+    return {
       ok: false,
       action: intent,
       briefId,
       message: "Action inconnue",
-    });
+    };
   } catch (error) {
-    return json({
+    return {
       ok: false,
       action: intent,
       briefId,
       message: `Erreur: ${error instanceof Error ? error.message : "inconnu"}`,
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.seo-hub.tsx
+++ b/frontend/app/routes/admin.seo-hub.tsx
@@ -9,11 +9,7 @@
  * - Audit (Historique unifié)
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { Outlet, Link, useLocation, useLoaderData } from "@remix-run/react";
 import {
   LayoutDashboard,
@@ -104,16 +100,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const summary = summaryRes.ok ? await summaryRes.json() : null;
 
-    return json({
+    return {
       summary: summary?.data || null,
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[SEO Hub] Loader error:", error);
-    return json({
+    return {
       summary: null,
       error: "Erreur chargement summary",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.seo.tsx
+++ b/frontend/app/routes/admin.seo.tsx
@@ -1,6 +1,5 @@
 // app/routes/admin.seo.tsx
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -93,16 +92,16 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     const pagesWithoutSeo =
       pagesRes && pagesRes.ok ? await pagesRes.json().catch(() => null) : null;
 
-    return json({
+    return {
       analytics,
       kpis,
       pagesWithoutSeo,
       success: true,
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("[SEO Admin] Erreur:", error);
-    return json({
+    return {
       analytics: null,
       kpis: null,
       pagesWithoutSeo: null,
@@ -111,7 +110,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
           ? error.message
           : "Erreur de connexion au backend",
       success: false,
-    });
+    };
   }
 }
 
@@ -143,10 +142,10 @@ export async function action({ request, context }: ActionFunctionArgs) {
         });
 
         if (!response.ok) throw new Error(`API Error: ${response.status}`);
-        return json({
+        return {
           success: true,
           message: "Métadonnées mises à jour avec succès",
-        });
+        };
       }
 
       case "regenerate-sitemap": {
@@ -159,11 +158,11 @@ export async function action({ request, context }: ActionFunctionArgs) {
         });
         if (!response.ok) throw new Error(`API Error: ${response.status}`);
         const result = await response.json();
-        return json({
+        return {
           success: true,
           message: "Sitemap regénéré avec succès",
           details: result,
-        });
+        };
       }
 
       case "batch-update": {
@@ -185,21 +184,21 @@ export async function action({ request, context }: ActionFunctionArgs) {
         });
 
         if (!response.ok) throw new Error(`API Error: ${response.status}`);
-        return json({
+        return {
           success: true,
           message: `${selectedPages.length} pages mises à jour en lot`,
-        });
+        };
       }
 
       default:
-        return json({ success: false, error: "Action non reconnue" });
+        return { success: false, error: "Action non reconnue" };
     }
   } catch (error) {
     logger.error("[SEO Admin Action] Erreur:", error);
-    return json({
+    return {
       success: false,
       error: error instanceof Error ? error.message : "Erreur inconnue",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.staff._index.tsx
+++ b/frontend/app/routes/admin.staff._index.tsx
@@ -5,11 +5,7 @@
  * Module admin moderne avec API REST et nouveau StaffService
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link, Form, useNavigation } from "@remix-run/react";
 import { useState } from "react";
 import { Alert } from "~/components/ui/alert";
@@ -158,7 +154,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       ),
     };
 
-    return json({
+    return {
       staff,
       stats,
       pagination: {
@@ -169,12 +165,12 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       },
       fallbackMode: false,
       timestamp: new Date().toISOString(),
-    });
+    };
   } catch (error) {
     logger.error("Erreur loader staff:", error);
 
     // Fallback en cas d'erreur
-    return json({
+    return {
       staff: [],
       stats: {
         total: 0,
@@ -185,7 +181,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       pagination: { page: 1, totalPages: 1, totalItems: 0 },
       error: "Erreur lors du chargement du staff",
       fallbackMode: true,
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.staff.tsx
+++ b/frontend/app/routes/admin.staff.tsx
@@ -3,11 +3,7 @@
  * Utilise les vraies données et inclut la gestion des messages
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import {
   Shield,
@@ -78,13 +74,13 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
           // Les données sont déjà dans le bon format
           const staffMembers = staffData.data;
 
-          return json({
+          return {
             staff: staffMembers,
             total: staffData.total,
             fallbackMode: false,
             messagesEnabled: true,
             apiSource: "test-staff-endpoint",
-          } as StaffData);
+          } as StaffData;
         }
       }
     } catch (staffApiError) {
@@ -129,13 +125,13 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         logger.warn(
           "⚠️ Structure de données inattendue, utilisation mode minimal",
         );
-        return json({
+        return {
           staff: [],
           total: 0,
           fallbackMode: true,
           messagesEnabled: false,
           apiSource: "minimal-fallback",
-        } as StaffData);
+        } as StaffData;
       }
 
       // Filtrer pour ne garder que le staff (niveau >= 7)
@@ -147,29 +143,29 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         `✅ ${staffMembers.length} membres du staff trouvés sur ${allUsers.length} utilisateurs`,
       );
 
-      return json({
+      return {
         staff: staffMembers,
         total: staffMembers.length,
         fallbackMode: true,
         messagesEnabled: false,
         apiSource: "users-api",
-      } as StaffData);
+      } as StaffData;
     } else {
       logger.error("❌ Erreur API:", response.status, response.statusText);
 
-      return json({
+      return {
         staff: [],
         total: 0,
         fallbackMode: true,
         messagesEnabled: false,
         apiSource: "error-fallback",
-      } as StaffData);
+      } as StaffData;
     }
   } catch (error: unknown) {
     logger.error("❌ Erreur lors du chargement du staff:", error);
 
     // Mode fallback d'urgence
-    return json({
+    return {
       staff: [
         {
           id: user.id,
@@ -190,7 +186,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       error: "Erreur de connexion à l'API",
       fallbackMode: true,
       messagesEnabled: false,
-    } as StaffData);
+    } as StaffData;
   }
 }
 
@@ -254,7 +250,7 @@ export default function AdminStaff() {
 
       {/* Indicateur de source */}
       <div
-        className={`mb-6 p-4 rounded-lg ${ fallbackMode ? "border-warning bg-warning/10" : "border-success bg-success/10" }`}
+        className={`mb-6 p-4 rounded-lg ${fallbackMode ? "border-warning bg-warning/10" : "border-success bg-success/10"}`}
       >
         <div className="flex items-center gap-2">
           {fallbackMode ? (

--- a/frontend/app/routes/admin.stock.tsx
+++ b/frontend/app/routes/admin.stock.tsx
@@ -1,5 +1,4 @@
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -123,21 +122,21 @@ export async function loader({ request }: LoaderFunctionArgs) {
       stats: statsData?.data || {},
     };
 
-    return json({
+    return {
       dashboard,
       stockData,
       filters,
       success: true,
-    });
+    };
   } catch (error) {
     logger.error("Erreur chargement stock:", error);
-    return json({
+    return {
       dashboard: null,
       stockData: { items: [], total: 0, stats: {} },
       filters,
       error: "Erreur de chargement des données stock",
       success: false,
-    });
+    };
   }
 }
 
@@ -169,13 +168,13 @@ export async function action({ request }: ActionFunctionArgs) {
         );
 
         if (response.ok) {
-          return json({
+          return {
             success: true,
             message: "Mouvement enregistré avec succès",
-          });
+          };
         } else {
           const error = await response.json();
-          return json({ success: false, error: error.message });
+          return { success: false, error: error.message };
         }
       }
 
@@ -198,22 +197,22 @@ export async function action({ request }: ActionFunctionArgs) {
 
         if (response.ok) {
           const result = await response.json();
-          return json({ success: true, message: result.message });
+          return { success: true, message: result.message };
         } else {
           const error = await response.json();
-          return json({ success: false, error: error.message });
+          return { success: false, error: error.message };
         }
       }
 
       default:
-        return json({ success: false, error: "Action non reconnue" });
+        return { success: false, error: "Action non reconnue" };
     }
   } catch (error) {
     logger.error("Erreur action stock:", error);
-    return json({
+    return {
       success: false,
       error: "Erreur lors de l'exécution de l'action",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/admin.suppliers.$id.tsx
+++ b/frontend/app/routes/admin.suppliers.$id.tsx
@@ -6,10 +6,10 @@
  */
 
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import { useLoaderData, Link, useFetcher } from "@remix-run/react";
 import { toast } from "sonner";
@@ -89,10 +89,10 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
 
     if (!response.ok) {
       if (response.status === 404) {
-        return json<SupplierDetailData>({
+        return {
           supplier: null,
           error: `Fournisseur avec ID ${supplierId} non trouvé`,
-        });
+        };
       }
       throw new Error(`API Error: ${response.status}`);
     }
@@ -126,14 +126,14 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
       links: supplier_raw.links || [],
     };
 
-    return json<SupplierDetailData>({ supplier });
+    return { supplier };
   } catch (error: unknown) {
     logger.error("[SupplierDetail] Erreur:", error);
     const message = error instanceof Error ? error.message : String(error);
-    return json<SupplierDetailData>({
+    return {
       supplier: null,
       error: `Erreur lors de la récupération: ${message || "Erreur inconnue"}`,
-    });
+    };
   }
 }
 
@@ -522,7 +522,7 @@ export async function action({
         throw new Error(`Erreur API: ${response.status}`);
       }
 
-      return json({ success: true });
+      return { success: true };
     }
 
     if (intent === "delete") {
@@ -542,13 +542,10 @@ export async function action({
       return redirect("/admin/suppliers");
     }
 
-    return json({ error: "Action non reconnue" }, { status: 400 });
+    return data({ error: "Action non reconnue" }, { status: 400 });
   } catch (error: unknown) {
     logger.error("[SupplierDetail Action] Erreur:", error);
     const message = error instanceof Error ? error.message : String(error);
-    return json(
-      { error: message || "Erreur inconnue" },
-      { status: 500 },
-    );
+    return data({ error: message || "Erreur inconnue" }, { status: 500 });
   }
 }

--- a/frontend/app/routes/admin.suppliers.tsx
+++ b/frontend/app/routes/admin.suppliers.tsx
@@ -1,11 +1,7 @@
 // app/routes/admin.suppliers.tsx
 // Dashboard fournisseurs avec stats réelles depuis pieces_marque (pm_display breakdown)
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { Outlet, useLoaderData, Link } from "@remix-run/react";
 import {
   Building2,
@@ -110,7 +106,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     apiError = "API supplier-stats indisponible";
   }
 
-  return json({ user, stats, listItems, listTotal, search, display, apiError });
+  return { user, stats, listItems, listTotal, search, display, apiError };
 }
 
 export default function AdminSuppliersLayout() {

--- a/frontend/app/routes/admin.system-config._index.tsx
+++ b/frontend/app/routes/admin.system-config._index.tsx
@@ -10,10 +10,10 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import { useLoaderData, useFetcher } from "@remix-run/react";
 import {
@@ -140,12 +140,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
       }
     }
 
-    return json({
+    return {
       overview: overviewData.data,
       moduleData,
       environment,
       currentModule: _module,
-    });
+    };
   } catch (error) {
     throw new Response("Erreur lors du chargement des configurations", {
       status: 500,
@@ -210,9 +210,9 @@ export async function action({ request }: ActionFunctionArgs) {
     }
 
     const result = await response.json();
-    return json({ success: true, data: result });
+    return { success: true, data: result };
   } catch (error) {
-    return json(
+    return data(
       {
         success: false,
         error: error instanceof Error ? error.message : "Erreur inconnue",
@@ -333,7 +333,7 @@ export default function SystemConfigurationDashboard() {
               {/* Vue d'ensemble */}
               <button
                 onClick={() => setActiveModule("overview")}
-                className={`w-full flex items-center px-3 py-2 text-sm font-medium rounded-md ${ activeModule === "overview" ? "bg-primary/15 text-blue-700 " : "text-gray-600 hover:bg-gray-50 hover:text-gray-900" }`}
+                className={`w-full flex items-center px-3 py-2 text-sm font-medium rounded-md ${activeModule === "overview" ? "bg-primary/15 text-blue-700 " : "text-gray-600 hover:bg-gray-50 hover:text-gray-900"}`}
               >
                 <Activity className="mr-3 h-5 w-5" />
                 Vue d'ensemble
@@ -642,7 +642,7 @@ function OverviewPanel({
               </dt>
               <dd className="mt-1">
                 <span
-                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${ overview.health.overall === "healthy" ? "text-success bg-success/10 " : overview.health.overall === "warning" ? "text-warning bg-warning/10 " : overview.health.overall === "error" ? "text-destructive bg-destructive/10 " : "text-gray-600 bg-gray-50 " }`}
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${overview.health.overall === "healthy" ? "text-success bg-success/10 " : overview.health.overall === "warning" ? "text-warning bg-warning/10 " : overview.health.overall === "error" ? "text-destructive bg-destructive/10 " : "text-gray-600 bg-gray-50 "}`}
                 >
                   {overview.health.overall}
                 </span>

--- a/frontend/app/routes/admin.system-overview.tsx
+++ b/frontend/app/routes/admin.system-overview.tsx
@@ -2,11 +2,7 @@
 // Tableau de bord complet du système optimisé
 // Applique "vérifier existant et utiliser le meilleur"
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import {
   Shield,
@@ -88,7 +84,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     },
   };
 
-  return json({ systemData });
+  return { systemData };
 }
 
 export default function SystemOverview() {

--- a/frontend/app/routes/admin.system.tsx
+++ b/frontend/app/routes/admin.system.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { AlertCircle, CheckCircle } from "lucide-react";
 import { useState, useEffect } from "react";
@@ -45,19 +41,19 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       ? await metricsResponse.json()
       : null;
 
-    return json({
+    return {
       initialHealth: healthData,
       initialMetrics: metricsData,
       timestamp: new Date().toISOString(),
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors du chargement des données système:", error);
-    return json({
+    return {
       initialHealth: null,
       initialMetrics: null,
       error: "Impossible de charger les données système",
       timestamp: new Date().toISOString(),
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/admin.users.$id.edit.tsx
+++ b/frontend/app/routes/admin.users.$id.edit.tsx
@@ -1,5 +1,4 @@
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -63,7 +62,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
     notes: "Client privilégié, excellent historique de commandes.",
   };
 
-  return json<LoaderData>({ user: mockUser });
+  return { user: mockUser };
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
@@ -72,9 +71,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   // Simuler la sauvegarde
   try {
     // En production : await updateUser(userId, formData);
-    return json<ActionData>({ success: true });
+    return { success: true };
   } catch (error) {
-    return json<ActionData>({ error: "Erreur lors de la sauvegarde" });
+    return { error: "Erreur lors de la sauvegarde" };
   }
 };
 

--- a/frontend/app/routes/admin.users.$id.tsx
+++ b/frontend/app/routes/admin.users.$id.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -221,7 +217,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
       );
     }
 
-    return json<LoaderData>({
+    return {
       targetUser: {
         ...user,
         totalOrders: stats.totalOrders,
@@ -229,7 +225,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
       },
       stats,
       recentOrders,
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors du chargement de l'utilisateur:", error);
     throw new Response("Erreur lors du chargement de l'utilisateur", {

--- a/frontend/app/routes/admin.users._index.tsx
+++ b/frontend/app/routes/admin.users._index.tsx
@@ -4,10 +4,10 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -151,7 +151,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
           ) / 100
         : 1;
 
-    return json<LoaderData>({
+    return {
       users: data.data || [],
       total: totalUsers,
       currentPage: page,
@@ -171,10 +171,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         newUsersToday: Math.floor(Math.random() * 50), // Simulé
         averageLevel,
       },
-    });
+    };
   } catch (error) {
     logger.error("❌ Erreur loader admin.users:", error);
-    return json<LoaderData>({
+    return {
       users: [],
       total: 0,
       currentPage: 1,
@@ -195,7 +195,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         newUsersToday: 0,
         averageLevel: 1,
       },
-    });
+    };
   }
 };
 
@@ -235,10 +235,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
           );
         }
 
-        return json({
+        return {
           success: true,
           message: `Utilisateur ${newStatus ? "activé" : "désactivé"} avec succès`,
-        });
+        };
 
       case "delete":
         // Appel API pour supprimer
@@ -256,10 +256,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         if (!deleteResponse.ok)
           throw new Error("Erreur lors de la suppression");
 
-        return json({
+        return {
           success: true,
           message: "Utilisateur supprimé avec succès",
-        });
+        };
 
       case "bulkDelete":
         // Suppression en masse
@@ -278,10 +278,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         const successCount = results.filter(
           (r) => r.status === "fulfilled",
         ).length;
-        return json({
+        return {
           success: true,
           message: `${successCount}/${userIds.length} utilisateurs supprimés`,
-        });
+        };
 
       case "export":
         // Export CSV - récupérer tous les utilisateurs filtrés
@@ -329,12 +329,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         });
 
       default:
-        return json({ error: "Action non reconnue" }, { status: 400 });
+        return data({ error: "Action non reconnue" }, { status: 400 });
     }
   } catch (error: unknown) {
     logger.error("❌ Erreur action admin.users:", error);
     const message = error instanceof Error ? error.message : String(error);
-    return json(
+    return data(
       { error: message || "Une erreur est survenue" },
       { status: 500 },
     );

--- a/frontend/app/routes/admin.v-level-status.tsx
+++ b/frontend/app/routes/admin.v-level-status.tsx
@@ -8,11 +8,7 @@
  * - Validation rules
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useRevalidator } from "@remix-run/react";
 import {
   BarChart3,
@@ -80,24 +76,24 @@ export async function loader({ request }: LoaderFunctionArgs) {
     });
 
     if (!response.ok) {
-      return json({
+      return {
         stats: null,
         error: "Impossible de charger les statistiques V-Level",
-      });
+      };
     }
 
     const data = await response.json();
 
-    return json({
+    return {
       stats: data.data as VLevelStats,
       error: null,
-    });
+    };
   } catch (error) {
     logger.error("Error fetching V-Level stats:", error);
-    return json({
+    return {
       stats: null,
       error: "Erreur de connexion au serveur",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/api.cart.tsx
+++ b/frontend/app/routes/api.cart.tsx
@@ -6,9 +6,9 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
+  data as dataResponse,
 } from "@remix-run/node";
 import { logger } from "~/utils/logger";
 
@@ -40,7 +40,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         response.status,
         response.statusText,
       );
-      return json(
+      return dataResponse(
         {
           items: [],
           subtotal: 0,
@@ -61,15 +61,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
     );
 
     // Le backend retourne data.totals.*, on le transforme en format plat
-    return json({
+    return {
       items: data.items || [],
       subtotal: data.totals?.subtotal || 0,
       itemCount: data.totals?.total_items || 0,
       consigneTotal: data.totals?.consigne_total || 0,
-    });
+    };
   } catch (error) {
     logger.error("[API Cart] Erreur:", error);
-    return json(
+    return dataResponse(
       {
         items: [],
         subtotal: 0,
@@ -118,7 +118,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
       const data = await response.json();
       logger.log("[API Cart] Update response:", data.success ? "OK" : "FAIL");
-      return json(data);
+      return data;
     }
 
     if (intent === "remove") {
@@ -138,7 +138,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
       const data = await response.json();
       logger.log("[API Cart] Remove response:", data.success ? "OK" : "FAIL");
-      return json(data);
+      return data;
     }
 
     if (intent === "clear") {
@@ -156,14 +156,14 @@ export async function action({ request }: ActionFunctionArgs) {
 
       const data = await response.json();
       logger.log("[API Cart] Clear response:", data.success ? "OK" : "FAIL");
-      return json(data);
+      return data;
     }
 
     logger.error("[API Cart] Intent inconnu:", intent);
-    return json({ error: "Intent inconnu", intent }, { status: 400 });
+    return dataResponse({ error: "Intent inconnu", intent }, { status: 400 });
   } catch (error) {
     logger.error("[API Cart Action] Erreur:", error);
-    return json(
+    return dataResponse(
       { error: "Erreur serveur", details: String(error) },
       { status: 500 },
     );

--- a/frontend/app/routes/api.errors.suggestions.tsx
+++ b/frontend/app/routes/api.errors.suggestions.tsx
@@ -1,4 +1,4 @@
-import { type ActionFunctionArgs, json } from "@remix-run/node";
+import { type ActionFunctionArgs, data } from "@remix-run/node";
 import { logger } from "~/utils/logger";
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -51,13 +51,13 @@ export async function action({ request }: ActionFunctionArgs) {
         logger.error("Erreur lors de l'appel API de logging:", apiError);
       }
 
-      return json({ success: true });
+      return { success: true };
     }
 
-    return json({ error: "Action non reconnue" }, { status: 400 });
+    return data({ error: "Action non reconnue" }, { status: 400 });
   } catch (error) {
     logger.error("Erreur dans l'API de rapport d'erreurs:", error);
-    return json({ error: "Erreur interne" }, { status: 500 });
+    return data({ error: "Erreur interne" }, { status: 500 });
   }
 }
 
@@ -67,7 +67,7 @@ export async function loader({ request }: { request: Request }) {
     const errorUrl = url.searchParams.get("url");
 
     if (!errorUrl) {
-      return json({ error: "URL manquante" }, { status: 400 });
+      return data({ error: "URL manquante" }, { status: 400 });
     }
 
     // Récupérer les suggestions via l'API interne
@@ -83,15 +83,15 @@ export async function loader({ request }: { request: Request }) {
 
       if (response.ok) {
         const data = await response.json();
-        return json({ suggestions: data.suggestions || [] });
+        return { suggestions: data.suggestions || [] };
       }
     } catch (apiError) {
       logger.error("Erreur lors de l'appel API suggestions:", apiError);
     }
 
-    return json({ suggestions: [] });
+    return { suggestions: [] };
   } catch (error) {
     logger.error("Erreur lors de la récupération des suggestions:", error);
-    return json({ suggestions: [] });
+    return { suggestions: [] };
   }
 }

--- a/frontend/app/routes/api.notifications.actions.tsx
+++ b/frontend/app/routes/api.notifications.actions.tsx
@@ -2,7 +2,7 @@
  * 🔔 API NOTIFICATIONS ACTIONS - Endpoint pour les actions sur notifications
  */
 
-import { json, type ActionFunctionArgs } from "@remix-run/node";
+import { type ActionFunctionArgs, data } from "@remix-run/node";
 import { logger } from "~/utils/logger";
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -24,58 +24,58 @@ export async function action({ request }: ActionFunctionArgs) {
         "Marking as read:",
         idsString ? JSON.parse(idsString) : [notificationId],
       );
-      return json({
+      return {
         success: true,
         message: "Notifications marquées comme lues",
-      });
+      };
 
     case "mark-unread":
       logger.log(
         "Marking as unread:",
         idsString ? JSON.parse(idsString) : [notificationId],
       );
-      return json({
+      return {
         success: true,
         message: "Notifications marquées comme non lues",
-      });
+      };
 
     case "delete":
       logger.log(
         "Deleting:",
         idsString ? JSON.parse(idsString) : [notificationId],
       );
-      return json({ success: true, message: "Notifications supprimées" });
+      return { success: true, message: "Notifications supprimées" };
 
     case "view-order":
       logger.log("Viewing order for notification:", notificationId);
-      return json({ success: true, redirect: `/orders/${notificationId}` });
+      return { success: true, redirect: `/orders/${notificationId}` };
 
     case "process-order":
       logger.log("Processing order for notification:", notificationId);
-      return json({
+      return {
         success: true,
         message: "Commande en cours de traitement",
-      });
+      };
 
     case "restock":
       logger.log("Restocking product for notification:", notificationId);
-      return json({
+      return {
         success: true,
         message: "Demande de réapprovisionnement envoyée",
-      });
+      };
 
     case "retry-processing":
       logger.log("Retrying processing for notification:", notificationId);
-      return json({ success: true, message: "Nouveau traitement lancé" });
+      return { success: true, message: "Nouveau traitement lancé" };
 
     case "manual-process":
       logger.log("Manual processing for notification:", notificationId);
-      return json({
+      return {
         success: true,
         redirect: `/admin/orders/manual-process/${notificationId}`,
-      });
+      };
 
     default:
-      return json({ error: "Action non reconnue" }, { status: 400 });
+      return data({ error: "Action non reconnue" }, { status: 400 });
   }
 }

--- a/frontend/app/routes/api.notifications.count.tsx
+++ b/frontend/app/routes/api.notifications.count.tsx
@@ -1,12 +1,6 @@
-/**
- * 🔔 API NOTIFICATIONS COUNT - Endpoint pour compter les notifications non lues
- */
-
-import { json } from "@remix-run/node";
-
 export async function loader() {
   // Mock: retourner un nombre de notifications non lues
   const unreadCount = Math.floor(Math.random() * 5) + 1; // Entre 1 et 5
-  
-  return json({ unreadCount });
+
+  return { unreadCount };
 }

--- a/frontend/app/routes/api.notifications.tsx
+++ b/frontend/app/routes/api.notifications.tsx
@@ -2,19 +2,19 @@
  * 🔔 API NOTIFICATIONS - Mock endpoint pour tester NotificationCenter
  */
 
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { type LoaderFunctionArgs } from "@remix-run/node";
 
 interface Notification {
   id: string;
   title: string;
   message: string;
-  type: 'info' | 'success' | 'warning' | 'error';
+  type: "info" | "success" | "warning" | "error";
   isRead: boolean;
   createdAt: string;
   actions?: Array<{
     label: string;
     action: string;
-    variant?: 'primary' | 'secondary' | 'danger';
+    variant?: "primary" | "secondary" | "danger";
   }>;
   metadata?: {
     userId?: string;
@@ -34,9 +34,9 @@ const MOCK_NOTIFICATIONS: Notification[] = [
     createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(), // 10 min ago
     actions: [
       { label: "Voir", action: "view-order", variant: "primary" },
-      { label: "Traiter", action: "process-order", variant: "secondary" }
+      { label: "Traiter", action: "process-order", variant: "secondary" },
     ],
-    metadata: { orderId: "12345", userId: "user-123" }
+    metadata: { orderId: "12345", userId: "user-123" },
   },
   {
     id: "2",
@@ -46,9 +46,9 @@ const MOCK_NOTIFICATIONS: Notification[] = [
     isRead: false,
     createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2h ago
     actions: [
-      { label: "Réapprovisionner", action: "restock", variant: "primary" }
+      { label: "Réapprovisionner", action: "restock", variant: "primary" },
     ],
-    metadata: { productId: "prod-456" }
+    metadata: { productId: "prod-456" },
   },
   {
     id: "3",
@@ -57,7 +57,7 @@ const MOCK_NOTIFICATIONS: Notification[] = [
     type: "success",
     isRead: true,
     createdAt: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(), // 4h ago
-    metadata: { orderId: "12344" }
+    metadata: { orderId: "12344" },
   },
   {
     id: "4",
@@ -68,9 +68,9 @@ const MOCK_NOTIFICATIONS: Notification[] = [
     createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // 1 day ago
     actions: [
       { label: "Retry", action: "retry-processing", variant: "primary" },
-      { label: "Manuel", action: "manual-process", variant: "secondary" }
+      { label: "Manuel", action: "manual-process", variant: "secondary" },
     ],
-    metadata: { orderId: "12343" }
+    metadata: { orderId: "12343" },
   },
   {
     id: "5",
@@ -79,8 +79,8 @@ const MOCK_NOTIFICATIONS: Notification[] = [
     type: "info",
     isRead: true,
     createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(), // 2 days ago
-    metadata: { userId: "user-789" }
-  }
+    metadata: { userId: "user-789" },
+  },
 ];
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -93,16 +93,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   switch (filter) {
     case "unread":
-      filteredNotifications = MOCK_NOTIFICATIONS.filter(n => !n.isRead);
+      filteredNotifications = MOCK_NOTIFICATIONS.filter((n) => !n.isRead);
       break;
     case "read":
-      filteredNotifications = MOCK_NOTIFICATIONS.filter(n => n.isRead);
+      filteredNotifications = MOCK_NOTIFICATIONS.filter((n) => n.isRead);
       break;
     case "info":
     case "success":
     case "warning":
     case "error":
-      filteredNotifications = MOCK_NOTIFICATIONS.filter(n => n.type === filter);
+      filteredNotifications = MOCK_NOTIFICATIONS.filter(
+        (n) => n.type === filter,
+      );
       break;
     default:
       // "all" - pas de filtre
@@ -111,11 +113,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   // Limiter le nombre de résultats
   const notifications = filteredNotifications.slice(0, limit);
-  const unreadCount = MOCK_NOTIFICATIONS.filter(n => !n.isRead).length;
+  const unreadCount = MOCK_NOTIFICATIONS.filter((n) => !n.isRead).length;
 
-  return json({
+  return {
     notifications,
     total: filteredNotifications.length,
-    unreadCount
-  });
+    unreadCount,
+  };
 }

--- a/frontend/app/routes/api.redirects.check.tsx
+++ b/frontend/app/routes/api.redirects.check.tsx
@@ -1,4 +1,4 @@
-import { json } from "@remix-run/node";
+import { data } from "@remix-run/node";
 import { logger } from "~/utils/logger";
 
 export async function loader({ request }: { request: Request }) {
@@ -7,7 +7,7 @@ export async function loader({ request }: { request: Request }) {
     const checkUrl = url.searchParams.get("url");
 
     if (!checkUrl) {
-      return json({ error: "URL manquante" }, { status: 400 });
+      return data({ error: "URL manquante" }, { status: 400 });
     }
 
     // Vérifier les redirections via l'API interne
@@ -23,19 +23,19 @@ export async function loader({ request }: { request: Request }) {
 
       if (response.ok) {
         const data = await response.json();
-        return json({
+        return {
           destination: data.destination || null,
           permanent: data.permanent || false,
           found: !!data.destination,
-        });
+        };
       }
     } catch (apiError) {
       logger.error("Erreur lors de l'appel API redirections:", apiError);
     }
 
-    return json({ destination: null, permanent: false, found: false });
+    return { destination: null, permanent: false, found: false };
   } catch (error) {
     logger.error("Erreur lors de la vérification de redirection:", error);
-    return json({ destination: null, permanent: false, found: false });
+    return { destination: null, permanent: false, found: false };
   }
 }

--- a/frontend/app/routes/api.search.global.tsx
+++ b/frontend/app/routes/api.search.global.tsx
@@ -2,13 +2,13 @@
  * 🔍 API GLOBAL SEARCH - Endpoint pour la recherche globale
  */
 
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { type LoaderFunctionArgs } from "@remix-run/node";
 
 interface SearchResult {
   id: string;
   title: string;
   description?: string;
-  category: 'products' | 'users' | 'orders' | 'pages' | 'settings';
+  category: "products" | "users" | "orders" | "pages" | "settings";
   url: string;
   metadata?: {
     badge?: string;
@@ -27,8 +27,8 @@ const MOCK_RESULTS: SearchResult[] = [
     url: "/admin/products/prod-1",
     metadata: {
       price: "89,99€",
-      badge: "En stock"
-    }
+      badge: "En stock",
+    },
   },
   {
     id: "user-1",
@@ -38,8 +38,8 @@ const MOCK_RESULTS: SearchResult[] = [
     url: "/admin/users/user-1",
     metadata: {
       status: "Actif",
-      badge: "Pro"
-    }
+      badge: "Pro",
+    },
   },
   {
     id: "order-1",
@@ -49,8 +49,8 @@ const MOCK_RESULTS: SearchResult[] = [
     url: "/admin/orders/order-1",
     metadata: {
       status: "En traitement",
-      price: "125,99€"
-    }
+      price: "125,99€",
+    },
   },
   {
     id: "page-1",
@@ -74,8 +74,8 @@ const MOCK_RESULTS: SearchResult[] = [
     url: "/admin/products/prod-2",
     metadata: {
       price: "45,50€",
-      badge: "Stock faible"
-    }
+      badge: "Stock faible",
+    },
   },
   {
     id: "user-2",
@@ -84,9 +84,9 @@ const MOCK_RESULTS: SearchResult[] = [
     category: "users",
     url: "/admin/users/user-2",
     metadata: {
-      status: "Nouveau"
-    }
-  }
+      status: "Nouveau",
+    },
+  },
 ];
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -96,25 +96,28 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const limit = parseInt(url.searchParams.get("limit") || "20");
 
   if (!query.trim()) {
-    return json({ results: [] });
+    return { results: [] };
   }
 
   // Filtrer par recherche textuelle
-  let filteredResults = MOCK_RESULTS.filter(result => 
-    result.title.toLowerCase().includes(query.toLowerCase()) ||
-    result.description?.toLowerCase().includes(query.toLowerCase())
+  let filteredResults = MOCK_RESULTS.filter(
+    (result) =>
+      result.title.toLowerCase().includes(query.toLowerCase()) ||
+      result.description?.toLowerCase().includes(query.toLowerCase()),
   );
 
   // Filtrer par catégorie
   if (category && category !== "all") {
-    filteredResults = filteredResults.filter(result => result.category === category);
+    filteredResults = filteredResults.filter(
+      (result) => result.category === category,
+    );
   }
 
   // Limiter les résultats
   const results = filteredResults.slice(0, limit);
 
   // Simuler un délai de recherche
-  await new Promise(resolve => setTimeout(resolve, 200));
+  await new Promise((resolve) => setTimeout(resolve, 200));
 
-  return json({ results });
+  return { results };
 }

--- a/frontend/app/routes/blog-pieces-auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto._index.tsx
@@ -18,10 +18,10 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
   type ActionFunctionArgs,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -197,7 +197,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     logger.warn({ err: error, url: request.url }, "Blog API error");
   }
 
-  return json(
+  return data(
     { blogData, searchParams },
     {
       headers: {
@@ -216,14 +216,14 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     switch (actionType) {
       case "bookmark":
-        return json({ success: true, message: "Article ajouté aux favoris" });
+        return { success: true, message: "Article ajouté aux favoris" };
       case "share":
-        return json({ success: true, message: "Article partagé" });
+        return { success: true, message: "Article partagé" };
       default:
-        return json({ success: false, error: "Action non reconnue" });
+        return { success: false, error: "Action non reconnue" };
     }
   } catch {
-    return json(
+    return data(
       { success: false, error: "Erreur lors de l'action" },
       { status: 500 },
     );

--- a/frontend/app/routes/blog-pieces-auto.advice._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.advice._index.tsx
@@ -6,11 +6,7 @@
  * Intention : Découvrir des conseils pratiques
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -197,7 +193,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     const endTime = Date.now();
     logger.log(`[PERF] Advice loader completed in ${endTime - startTime}ms`);
 
-    return json({
+    return {
       articles,
       total: data.data?.total || 0,
       page: data.data?.page || 1,
@@ -209,10 +205,10 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       popularTags,
       stats,
       success: true,
-    });
+    };
   } catch (error) {
     logger.error("[ERROR] Advice loader failed:", error);
-    return json({
+    return {
       articles: [],
       total: 0,
       page: 1,
@@ -225,7 +221,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       stats: { totalViews: 0, avgReadingTime: 3, totalArticles: 0 },
       success: false,
       error: error instanceof Error ? error.message : "Unknown error",
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/blog-pieces-auto.article.$slug.tsx
+++ b/frontend/app/routes/blog-pieces-auto.article.$slug.tsx
@@ -1,5 +1,4 @@
 import {
-  defer,
   redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -283,10 +282,10 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       return redirect("/blog-pieces-auto", 301);
     }
 
-    return defer({
+    return {
       article,
       relatedArticles,
-    });
+    };
   } catch (error) {
     clearTimeout(timeoutId);
 

--- a/frontend/app/routes/blog-pieces-auto.auto.$marque.$modele.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto.$marque.$modele.tsx
@@ -1,9 +1,5 @@
 // app/routes/blog-pieces-auto.auto.$marque.$modele.tsx
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   Link,
   useLoaderData,
@@ -124,12 +120,12 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
         ]
       : [];
 
-    return json<LoaderData>({
+    return {
       brand: response.data.brand,
       modelGroup: response.data.model,
       models: models,
       metadata: response.data.metadata || null,
-    });
+    };
   } catch (e) {
     clearTimeout(timeoutId);
 
@@ -550,7 +546,7 @@ export default function BlogPiecesAutoMarqueModele() {
                   <div className="flex flex-wrap gap-1.5">
                     <button
                       onClick={() => setSelectedFuel(null)}
-                      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${ selectedFuel === null ? "bg-primary text-white shadow-md scale-105 border-indigo-700" : "bg-white text-gray-700 hover:bg-gray-50 hover:scale-105 border-gray-300" }`}
+                      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${selectedFuel === null ? "bg-primary text-white shadow-md scale-105 border-indigo-700" : "bg-white text-gray-700 hover:bg-gray-50 hover:scale-105 border-gray-300"}`}
                     >
                       <span>🔍</span>
                       <span>Tous</span>
@@ -623,7 +619,7 @@ export default function BlogPiecesAutoMarqueModele() {
                             selectedPowerRange === range.id ? null : range.id,
                           )
                         }
-                        className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${ selectedPowerRange === range.id ? "bg-gradient-to-r text-white shadow-md shadow-purple-200 scale-105 border-purple-600" : "bg-muted text-foreground border-purple-300 hover:bg-muted hover:scale-105" }`}
+                        className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${selectedPowerRange === range.id ? "bg-gradient-to-r text-white shadow-md shadow-purple-200 scale-105 border-purple-600" : "bg-muted text-foreground border-purple-300 hover:bg-muted hover:scale-105"}`}
                       >
                         <Gauge className="w-3 h-3" />
                         <span>{range.label}</span>

--- a/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
@@ -1,9 +1,5 @@
 // app/routes/blog-pieces-auto.auto.$marque.tsx
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   Link,
   useLoaderData,
@@ -152,11 +148,11 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
         }
       : null;
 
-    return json<LoaderData>({
+    return {
       brand,
       models: mappedModels,
       metadata,
-    });
+    };
   } catch (e) {
     logger.error("Erreur loader marque:", e);
     if (e instanceof Response) throw e;

--- a/frontend/app/routes/blog-pieces-auto.auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto._index.tsx
@@ -1,9 +1,5 @@
 // app/routes/blog-pieces-auto.auto._index.tsx
-import {
-  defer,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   Link,
   useLoaderData,
@@ -130,7 +126,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       }),
     );
 
-    return defer({
+    return {
       brands: mappedBrands,
       popularModels: mappedModels,
       metadata: metadataData?.success ? metadataData.data : null,
@@ -138,14 +134,14 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         totalBrands: mappedBrands.length,
         totalModels: mappedModels.length,
       },
-    });
+    };
   } catch (e) {
     logger.error("Erreur loader auto:", e);
-    return defer({
+    return {
       brands: [],
       popularModels: [],
       stats: { totalBrands: 0, totalModels: 0 },
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/blog-pieces-auto.calendrier-entretien.tsx
+++ b/frontend/app/routes/blog-pieces-auto.calendrier-entretien.tsx
@@ -9,11 +9,7 @@
  * Si pas fournis : calendrier générique (sans personnalisation véhicule).
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import {
   AlertTriangle,
@@ -120,9 +116,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const res = await fetch(apiUrl);
     if (!res.ok) throw new Error(`API ${res.status}`);
     const calendar = (await res.json()) as CalendarPayload;
-    return json({ calendar });
+    return { calendar };
   } catch {
-    return json({
+    return {
       calendar: {
         type_id: null,
         current_km: 0,
@@ -131,7 +127,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         alerts: [],
         controles_mensuels: [],
       } as CalendarPayload,
-    });
+    };
   }
 }
 
@@ -416,10 +412,7 @@ export default function CalendrierEntretienPage() {
               ) : (
                 <div className="space-y-6">
                   {calendar.alerts.map((palier) => (
-                    <div
-                      key={palier.milestone_km}
-                      className="pl-4"
-                    >
+                    <div key={palier.milestone_km} className="pl-4">
                       <h3 className="font-semibold text-lg flex items-center gap-2 mb-2">
                         <Badge className="bg-muted text-foreground text-sm">
                           {palier.milestone_km.toLocaleString("fr-FR")} km

--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -7,11 +7,10 @@
  */
 
 import {
-  defer,
-  json,
   type HeadersFunction,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Await,
@@ -145,7 +144,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const { pg_alias } = params;
 
   if (!pg_alias) {
-    throw json({ message: "Alias manquant" }, { status: 404 });
+    throw data({ message: "Alias manquant" }, { status: 404 });
   }
 
   const controller = new AbortController();
@@ -164,7 +163,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
     if (!response.ok) {
       if (response.status === 404) {
-        throw json(
+        throw data(
           { message: `Guide R3 introuvable: ${pg_alias}` },
           { status: 404 },
         );
@@ -176,7 +175,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     const guide = result?.data as R3GuidePayload | null;
 
     if (!guide) {
-      throw json(
+      throw data(
         { message: `Pas de donnees R3 pour: ${pg_alias}` },
         { status: 404 },
       );
@@ -237,7 +236,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       }
     })();
 
-    return defer(
+    return data(
       { guide, pg_alias, r4Reference: r4ReferencePromise },
       {
         headers: {
@@ -249,7 +248,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     clearTimeout(timeoutId);
     if (error instanceof Response) throw error;
     logger.error(`[R3 Guide] Error loading guide for: ${pg_alias}`, error);
-    throw json(
+    throw data(
       { message: `Erreur chargement guide R3: ${pg_alias}` },
       { status: 404 },
     );

--- a/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
@@ -9,11 +9,7 @@
  *              → Par intention → Securite → FAQ → CTA
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -119,12 +115,12 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
     if (!data?.success || !data.data?.families) {
       logger.error("Format de r\u00e9ponse inattendu:", data);
-      return json<LoaderData>({
+      return {
         groupedArticles: [],
         allArticles: [],
         totalArticles: 0,
         stats: { totalViews: 0, totalCategories: 0 },
-      });
+      };
     }
 
     const allArticles: BlogArticle[] = [];
@@ -158,7 +154,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       0,
     );
 
-    return json<LoaderData>({
+    return {
       groupedArticles,
       allArticles,
       totalArticles,
@@ -166,15 +162,15 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         totalViews,
         totalCategories: groupedArticles.length,
       },
-    });
+    };
   } catch (e) {
     logger.error("Erreur loader conseils:", e);
-    return json<LoaderData>({
+    return {
       groupedArticles: [],
       allArticles: [],
       totalArticles: 0,
       stats: { totalViews: 0, totalCategories: 0 },
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
@@ -6,11 +6,7 @@
  * Intention : Découvrir l'histoire des marques automobiles
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -379,7 +375,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       const paginatedItems = filtered.slice(startIndex, startIndex + limit);
 
       // Enrichir avec les données manquantes
-      return json({
+      return {
         constructeurs: paginatedItems.map((m: any) => ({
           id: m.id,
           title: m.name,
@@ -413,7 +409,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         },
         success: true,
         source: "api",
-      });
+      };
     }
   } catch (error) {
     logger.warn("[API] Error, using fallback data:", error);
@@ -517,7 +513,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     totalModels: DEMO_CONSTRUCTEURS.reduce((sum, c) => sum + c.modelsCount, 0),
   };
 
-  return json({
+  return {
     constructeurs: paginatedConstructeurs,
     total: filteredConstructeurs.length,
     page,
@@ -531,7 +527,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     popularBrands,
     stats,
     success: true,
-  });
+  };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
@@ -11,11 +11,11 @@
  */
 
 import {
-  json,
   redirect,
   type HeadersFunction,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Link,
@@ -138,7 +138,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
   const { pg_alias } = params;
 
   if (!pg_alias) {
-    throw json({ message: "Alias manquant" }, { status: 404 });
+    throw data({ message: "Alias manquant" }, { status: 404 });
   }
 
   try {
@@ -190,7 +190,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
       if (guide && (!guide.intentType || guide.intentType === "R6")) {
         const r4Reference = await fetchR4Reference(guide.page.pg_id, request);
-        return json({ guide, pg_alias, r4Reference });
+        return { guide, pg_alias, r4Reference };
       }
     }
 
@@ -204,7 +204,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     clearTimeout(timeoutId);
 
     if (!blogResponse.ok) {
-      throw json(
+      throw data(
         { message: `Guide "${pg_alias}" non trouve` },
         { status: 404 },
       );
@@ -214,7 +214,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     const blogGuide = blogResult?.data;
 
     if (!blogGuide) {
-      throw json(
+      throw data(
         { message: `Guide "${pg_alias}" non disponible` },
         { status: 404 },
       );
@@ -261,12 +261,12 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     };
 
     const r4Reference = await fetchR4Reference(guide.page.pg_id, request);
-    return json({ guide, pg_alias, r4Reference });
+    return { guide, pg_alias, r4Reference };
   } catch (error) {
     clearTimeout(timeoutId);
     if (error instanceof Response) throw error;
     logger.error(`[R6 Guide] Error loading guide for: ${pg_alias}`, error);
-    throw json(
+    throw data(
       { message: `Erreur chargement guide "${pg_alias}"` },
       { status: 500 },
     );

--- a/frontend/app/routes/blog-pieces-auto.guide-achat._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat._index.tsx
@@ -16,9 +16,9 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Link,
@@ -164,7 +164,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     `Guides: ${guides.length}, Conseils: ${relatedAdvice.length}/${totalAdvice}`,
   );
 
-  return json<LoaderData>(
+  return data(
     { guides, relatedAdvice, totalAdvice },
     {
       headers: {

--- a/frontend/app/routes/brands.$brandId.models.$modelId.types.tsx
+++ b/frontend/app/routes/brands.$brandId.models.$modelId.types.tsx
@@ -5,11 +5,7 @@
  * Route: /brands/$brandId/models/$modelId/types
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link, useParams } from "@remix-run/react";
 import {
   ArrowLeft,
@@ -197,10 +193,10 @@ export async function loader({ params }: LoaderFunctionArgs) {
           : { min: 0, max: 0 },
     };
 
-    return json({ types, model, brand, stats } as LoaderData);
+    return { types, model, brand, stats } as LoaderData;
   } catch (error) {
     logger.error("Erreur chargement types:", error);
-    return json({
+    return {
       types: [],
       model: null,
       brand: null,
@@ -211,7 +207,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
         powerRange: { min: 0, max: 0 },
       },
       error: "Impossible de charger les types",
-    } as LoaderData);
+    } as LoaderData;
   }
 }
 

--- a/frontend/app/routes/brands.$brandId.tsx
+++ b/frontend/app/routes/brands.$brandId.tsx
@@ -8,11 +8,7 @@
  * Intention : Navigation vers modèles d'une marque
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link, useParams } from "@remix-run/react";
 import { ArrowLeft, Car, Calendar, Settings } from "lucide-react";
 
@@ -128,15 +124,15 @@ export async function loader({ params }: LoaderFunctionArgs) {
     // Récupérer quelques types pour affichage (optionnel)
     const types: any[] = [];
 
-    return json({ models, brand, types } as LoaderData);
+    return { models, brand, types } as LoaderData;
   } catch (error) {
     logger.error("Erreur chargement marque:", error);
-    return json({
+    return {
       models: [],
       brand: null,
       types: [],
       error: "Impossible de charger les données",
-    } as LoaderData);
+    } as LoaderData;
   }
 }
 

--- a/frontend/app/routes/brands._index.tsx
+++ b/frontend/app/routes/brands._index.tsx
@@ -10,11 +10,7 @@
  * Intention : Sélection de marque
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import { Search, Car, ArrowRight } from "lucide-react";
 import { useState } from "react";
@@ -174,21 +170,21 @@ export async function loader({ request }: LoaderFunctionArgs) {
       logger.error("Erreur chargement logos:", error);
     }
 
-    return json({
+    return {
       brands: brands.sort((a, b) => a.marque_name.localeCompare(b.marque_name)),
       total: brands.length,
       popularModels,
       brandLogos,
-    } as LoaderData);
+    } as LoaderData;
   } catch (error) {
     logger.error("Erreur chargement marques:", error);
-    return json({
+    return {
       brands: [],
       total: 0,
       popularModels: [],
       brandLogos: [],
       error: "Impossible de charger les marques",
-    } as LoaderData);
+    } as LoaderData;
   }
 }
 

--- a/frontend/app/routes/cart.tsx
+++ b/frontend/app/routes/cart.tsx
@@ -9,10 +9,10 @@
  */
 
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Link,
@@ -158,18 +158,18 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     const effectiveVehicle =
       cartTypeId && vehicle && cartTypeId !== vehicle.type_id ? null : vehicle;
 
-    return json({
+    return {
       cart: cartData,
       vehicle: effectiveVehicle,
       crossSellGammes,
       success: true,
       error: null,
-    });
+    };
   } catch {
     const vehicle = await getVehicleFromCookie(
       request.headers.get("Cookie"),
     ).catch(() => null);
-    return json({
+    return {
       cart: {
         items: [],
         summary: {
@@ -186,7 +186,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
       crossSellGammes: [] as CrossSellGamme[],
       success: false,
       error: "Erreur lors du chargement du panier",
-    });
+    };
   }
 };
 
@@ -195,7 +195,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const parsed = cartActionSchema.safeParse(Object.fromEntries(formData));
 
   if (!parsed.success) {
-    return json(
+    return data(
       {
         success: false,
         error: "Donnees invalides",
@@ -210,17 +210,15 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     switch (input.intent) {
       case "update":
-        return json(
-          await updateQuantity(request, input.productId, input.quantity),
-        );
+        return await updateQuantity(request, input.productId, input.quantity);
       case "remove":
-        return json(await removeFromCart(request, input.productId));
+        return await removeFromCart(request, input.productId);
       case "clear":
-        return json(await clearCart(request));
+        return await clearCart(request);
     }
   } catch (error) {
     logger.error("[Cart Action] Erreur:", error);
-    return json(
+    return data(
       { success: false, error: "Erreur serveur panier" },
       { status: 500 },
     );

--- a/frontend/app/routes/checkout-payment-return.tsx
+++ b/frontend/app/routes/checkout-payment-return.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -113,7 +109,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       }
     }
 
-    return json({
+    return {
       result: {
         status: derivedStatus,
         transactionId: auto,
@@ -122,7 +118,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         date: new Date().toISOString(),
         errorCode: erreur !== "00000" ? erreur : undefined,
       } satisfies PaymentResult,
-    });
+    };
   }
 
   // --- SystemPay / Cyberplus return ---
@@ -137,7 +133,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     logger.warn("[PaymentReturn] Missing transactionId", {
       keys: Array.from(url.searchParams.keys()),
     });
-    return json({
+    return {
       result: {
         status: "ERROR" as const,
         transactionId: "",
@@ -147,7 +143,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         errorMessage:
           "Transaction introuvable. Verifiez votre email de confirmation ou contactez le support.",
       } satisfies PaymentResult,
-    });
+    };
   }
 
   try {
@@ -166,7 +162,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       status: (result as PaymentResult).status,
     });
 
-    return json({ result: result as PaymentResult });
+    return { result: result as PaymentResult };
   } catch (error) {
     if (error instanceof Response) {
       throw error;
@@ -204,7 +200,8 @@ export default function PaymentReturnPage() {
             order_id: String(txId),
             item_count: 1,
             revenue_cents:
-              typeof result.amount === "number" && Number.isFinite(result.amount)
+              typeof result.amount === "number" &&
+              Number.isFinite(result.amount)
                 ? Math.round(result.amount * 100)
                 : null,
             referrer: classifyReferrer(),

--- a/frontend/app/routes/checkout.resume.tsx
+++ b/frontend/app/routes/checkout.resume.tsx
@@ -7,7 +7,6 @@
  */
 
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -56,22 +55,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     // Mode check : afficher l'état sans consommer le token
     if (isCheck) {
-      return json({
+      return {
         mode: "check" as const,
         orderId,
         isPaid: isPaid === "1" || isPaid === true,
         orderStatus,
-      });
+      };
     }
 
     // Si déjà payé, afficher la confirmation
     if (isPaid === "1" || isPaid === true) {
-      return json({
+      return {
         mode: "already_paid" as const,
         orderId,
         isPaid: true,
         orderStatus,
-      });
+      };
     }
 
     // Rediriger vers Paybox (le token sera marqué used_at par le backend)

--- a/frontend/app/routes/checkout.tsx
+++ b/frontend/app/routes/checkout.tsx
@@ -5,11 +5,11 @@
  */
 
 import {
-  json,
   redirect,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -110,10 +110,10 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     const cart = await getCart(request, context);
 
     if (!cart || !cart.items) {
-      return json({
+      return {
         cart: null,
         error: "Erreur de structure du panier. Veuillez recharger.",
-      });
+      };
     }
 
     const itemsCount = Array.isArray(cart.items) ? cart.items.length : 0;
@@ -133,20 +133,20 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 
     const googleClientId = process.env.VITE_GOOGLE_CLIENT_ID || "";
 
-    return json({
+    return {
       cart,
       user,
       userProfile,
       paymentMethods,
       vehicle,
       googleClientId,
-    });
+    };
   } catch (error) {
     logger.error("[Checkout] Erreur chargement:", error);
-    return json({
+    return {
       cart: null,
       error: "Erreur lors du chargement du panier. Veuillez reessayer.",
-    });
+    };
   }
 };
 
@@ -179,7 +179,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
         .map(([k, msgs]) => `${labelMap[k] || k} : ${(msgs as string[])[0]}`)
         .join(" | ");
       logger.warn("[Checkout] Validation failed:", details);
-      return json(
+      return data(
         {
           ok: false,
           error: details || "Veuillez corriger les informations du formulaire.",
@@ -227,7 +227,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
     const cartData = await getCart(request);
 
     if (!cartData.items || cartData.items.length === 0) {
-      return json(
+      return data(
         {
           ok: false,
           error: "Votre panier est vide.",
@@ -282,7 +282,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
       }
       // Handle email conflict
       if (orderResult.emailConflict) {
-        return json(
+        return data(
           {
             ok: false,
             error: orderResult.error,
@@ -293,7 +293,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           { status: orderResult.status },
         );
       }
-      return json(
+      return data(
         {
           ok: false,
           error: orderResult.error,
@@ -310,7 +310,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
     if (!orderDetails) {
       logger.error("[Checkout] getOrderForPayment returned null for:", orderId);
-      return json(
+      return data(
         {
           ok: false,
           error: "Commande creee mais impossible de recuperer les details.",
@@ -325,7 +325,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
     }
 
     if (orderDetails.totalTTC <= 0) {
-      return json(
+      return data(
         {
           ok: false,
           error: "Montant de commande invalide.",
@@ -337,7 +337,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
     const customerEmail = orderDetails.customerEmail || guestEmail || "";
     if (!customerEmail) {
-      return json(
+      return data(
         {
           ok: false,
           error: "Email client manquant sur la commande.",
@@ -362,10 +362,10 @@ export async function action({ request, context }: ActionFunctionArgs) {
     const resumeToken = orderResult.success
       ? orderResult.resumeToken
       : undefined;
-    return json({ ok: true, redirectUrl, orderId, resumeToken });
+    return { ok: true, redirectUrl, orderId, resumeToken };
   } catch (error) {
     logger.error("[Checkout] Action error:", error);
-    return json(
+    return data(
       {
         ok: false,
         error: error instanceof Error ? error.message : "Erreur inconnue",

--- a/frontend/app/routes/client.set-password.tsx
+++ b/frontend/app/routes/client.set-password.tsx
@@ -1,9 +1,9 @@
 import {
-  json,
   type ActionFunction,
   type LoaderFunction,
   type MetaFunction,
   redirect,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -37,7 +37,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     throw new Response("Token manquant", { status: 400 });
   }
 
-  return json({ token });
+  return { token };
 };
 
 export const action: ActionFunction = async ({ request }) => {
@@ -45,7 +45,7 @@ export const action: ActionFunction = async ({ request }) => {
   const token = url.searchParams.get("token");
 
   if (!token) {
-    return json({ error: "Token manquant" }, { status: 400 });
+    return data({ error: "Token manquant" }, { status: 400 });
   }
 
   const formData = await request.formData();
@@ -53,11 +53,11 @@ export const action: ActionFunction = async ({ request }) => {
   const confirmPassword = formData.get("confirmPassword");
 
   if (!password || !confirmPassword) {
-    return json({ error: "Tous les champs sont requis" }, { status: 400 });
+    return data({ error: "Tous les champs sont requis" }, { status: 400 });
   }
 
   if (password !== confirmPassword) {
-    return json(
+    return data(
       { error: "Les mots de passe ne correspondent pas" },
       { status: 400 },
     );
@@ -66,7 +66,7 @@ export const action: ActionFunction = async ({ request }) => {
   const pwd = password.toString();
 
   if (pwd.length < 6) {
-    return json(
+    return data(
       { error: "Le mot de passe doit contenir au moins 6 caracteres" },
       { status: 400 },
     );
@@ -87,12 +87,12 @@ export const action: ActionFunction = async ({ request }) => {
       return redirect("/login?activated=success");
     }
 
-    return json(
+    return data(
       { error: result.message || "Token invalide ou expire" },
       { status: 400 },
     );
   } catch {
-    return json(
+    return data(
       { error: "Une erreur est survenue. Veuillez reessayer." },
       { status: 500 },
     );

--- a/frontend/app/routes/commercial._index.tsx
+++ b/frontend/app/routes/commercial._index.tsx
@@ -5,7 +5,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
   redirect,
@@ -104,18 +103,18 @@ export async function loader({ context }: LoaderFunctionArgs) {
       };
     }
 
-    return json({
+    return {
       dashboardData,
       user: {
         name: `${user.firstName} ${user.lastName}`,
         email: user.email,
         level: user.level,
       },
-    });
+    };
   } catch (error) {
     logger.error("Erreur dashboard commercial:", error);
 
-    return json({
+    return {
       dashboardData: {
         orders: {
           totalOrders: 0,
@@ -130,7 +129,7 @@ export async function loader({ context }: LoaderFunctionArgs) {
         email: user.email,
         level: user.level,
       },
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/commercial.orders.$orderId.tsx
+++ b/frontend/app/routes/commercial.orders.$orderId.tsx
@@ -5,9 +5,9 @@
  */
 
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
+  data,
 } from "@remix-run/node";
 import { Link, useFetcher, useLoaderData } from "@remix-run/react";
 import {
@@ -88,7 +88,7 @@ export const loader = async ({
     if (!result.success || !result.data)
       throw new Response("Commande introuvable", { status: 404 });
 
-    return json({ order: result.data });
+    return { order: result.data };
   } catch (error) {
     if (error instanceof Response) throw error;
     logger.error("Erreur chargement commande:", error);
@@ -104,7 +104,7 @@ export const action = async ({
 }: ActionFunctionArgs) => {
   const user = await getOptionalUser({ context });
   if (!user || !user.level || user.level < 3) {
-    return json({ error: "Acces refuse" }, { status: 403 });
+    return data({ error: "Acces refuse" }, { status: 403 });
   }
 
   const orderId = params.orderId;
@@ -135,7 +135,7 @@ export const action = async ({
         apiUrl = `http://127.0.0.1:3000/api/admin/orders/${orderId}/deliver`;
         break;
       default:
-        return json({ error: "Action inconnue" }, { status: 400 });
+        return data({ error: "Action inconnue" }, { status: 400 });
     }
 
     const headers: Record<string, string> = { Cookie: cookie };
@@ -144,12 +144,12 @@ export const action = async ({
     const res = await fetch(apiUrl, { method, headers, body });
     if (!res.ok) {
       const err = await res.json().catch(() => ({ message: "Erreur" }));
-      return json({ error: err.message || "Erreur" }, { status: 500 });
+      return data({ error: err.message || "Erreur" }, { status: 500 });
     }
 
-    return json({ success: true, message: `Action "${intent}" executee` });
+    return { success: true, message: `Action "${intent}" executee` };
   } catch {
-    return json({ error: "Erreur serveur" }, { status: 500 });
+    return data({ error: "Erreur serveur" }, { status: 500 });
   }
 };
 

--- a/frontend/app/routes/commercial.orders._index.tsx
+++ b/frontend/app/routes/commercial.orders._index.tsx
@@ -5,9 +5,9 @@
  */
 
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
+  data,
 } from "@remix-run/node";
 import {
   useActionData,
@@ -46,7 +46,7 @@ export const meta = () => [
 export const action = async ({ request, context }: ActionFunctionArgs) => {
   const user = await getOptionalUser({ context });
   if (!user || !user.level || user.level < 3) {
-    return json<ActionData>({ error: "Acces refuse" }, { status: 403 });
+    return data({ error: "Acces refuse" }, { status: 403 });
   }
 
   const permissions = await loadUserPermissions(
@@ -66,26 +66,17 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     switch (intent) {
       case "markPaid":
         if (!permissions.canMarkPaid)
-          return json<ActionData>(
-            { error: "Permission refusee" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusee" }, { status: 403 });
         apiUrl = `http://127.0.0.1:3000/api/admin/orders/${orderId}/confirm-payment`;
         break;
       case "validate":
         if (!permissions.canValidate)
-          return json<ActionData>(
-            { error: "Permission refusee" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusee" }, { status: 403 });
         apiUrl = `http://127.0.0.1:3000/api/admin/orders/${orderId}/validate`;
         break;
       case "ship":
         if (!permissions.canShip)
-          return json<ActionData>(
-            { error: "Permission refusee" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusee" }, { status: 403 });
         apiUrl = `http://127.0.0.1:3000/api/admin/orders/${orderId}/ship`;
         body = JSON.stringify({
           trackingNumber: formData.get("trackingNumber"),
@@ -93,23 +84,17 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
         break;
       case "deliver":
         if (!permissions.canDeliver)
-          return json<ActionData>(
-            { error: "Permission refusee" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusee" }, { status: 403 });
         apiUrl = `http://127.0.0.1:3000/api/admin/orders/${orderId}/deliver`;
         break;
       case "cancel":
         if (!permissions.canCancel)
-          return json<ActionData>(
-            { error: "Permission refusee" },
-            { status: 403 },
-          );
+          return data({ error: "Permission refusee" }, { status: 403 });
         apiUrl = `http://127.0.0.1:3000/api/admin/orders/${orderId}/cancel`;
         body = JSON.stringify({ reason: formData.get("reason") });
         break;
       default:
-        return json<ActionData>({ error: "Action inconnue" }, { status: 400 });
+        return data({ error: "Action inconnue" }, { status: 400 });
     }
 
     const headers: Record<string, string> = { Cookie: cookie };
@@ -118,18 +103,15 @@ export const action = async ({ request, context }: ActionFunctionArgs) => {
     const res = await fetch(apiUrl, { method, headers, body });
     if (!res.ok) {
       const err = await res.json().catch(() => ({ message: "Erreur" }));
-      return json<ActionData>(
-        { error: err.message || "Erreur" },
-        { status: 500 },
-      );
+      return data({ error: err.message || "Erreur" }, { status: 500 });
     }
 
-    return json<ActionData>({
+    return {
       success: true,
       message: `Action "${intent}" executee`,
-    });
+    };
   } catch {
-    return json<ActionData>({ error: "Erreur serveur" }, { status: 500 });
+    return data({ error: "Erreur serveur" }, { status: 500 });
   }
 };
 
@@ -227,7 +209,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
 
     const totalPages = Math.ceil(totalFromApi / limit);
 
-    return json<LoaderData>({
+    return {
       orders,
       stats,
       filters: {
@@ -242,10 +224,10 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       totalPages,
       permissions,
       user: { level: user.level, email: user.email, role: userRole },
-    });
+    };
   } catch (error) {
     logger.error("Loader error:", error);
-    return json<LoaderData>({
+    return {
       orders: [],
       stats: {
         totalOrders: 0,
@@ -267,7 +249,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       totalPages: 0,
       permissions,
       user: { level: user.level || 0, email: user.email, role: userRole },
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/commercial.reports._index.tsx
+++ b/frontend/app/routes/commercial.reports._index.tsx
@@ -5,11 +5,7 @@
  * Utilise les APIs existantes dashboard et legacy-orders
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import {
   BarChart3,
@@ -66,7 +62,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
           )
         : "0.00";
 
-    return json({
+    return {
       statistics: {
         totalOrders: dashboardData.totalOrders || 0,
         completedOrders: dashboardData.completedOrders || 0,
@@ -78,10 +74,10 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         averageOrderValue,
       },
       recentOrders: recentOrders.orders || [],
-    });
+    };
   } catch (error) {
     logger.error("Erreur chargement rapports:", error);
-    return json({
+    return {
       statistics: {
         totalOrders: 0,
         completedOrders: 0,
@@ -93,7 +89,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         averageOrderValue: "0.00",
       },
       recentOrders: [],
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/commercial.returns._index.tsx
+++ b/frontend/app/routes/commercial.returns._index.tsx
@@ -9,7 +9,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -342,14 +341,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
     returnRate: 2.1, // Pourcentage de retour par rapport aux commandes
   };
 
-  return json({
+  return {
     returns: filteredReturns,
     stats,
     totalReturns: filteredReturns.length,
     currentPage: page,
     limit,
     filters: { search, status, reason },
-  });
+  };
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -359,21 +358,21 @@ export async function action({ request }: ActionFunctionArgs) {
   switch (action) {
     case "approve":
       // Logique d'approbation du retour
-      return json({ success: true, message: "Retour approuvé avec succès" });
+      return { success: true, message: "Retour approuvé avec succès" };
 
     case "reject":
       // Logique de refus du retour
-      return json({ success: true, message: "Retour refusé" });
+      return { success: true, message: "Retour refusé" };
 
     case "generate_label":
       // Générer l'étiquette de retour
-      return json({
+      return {
         success: true,
         message: "Étiquette générée et envoyée au client",
-      });
+      };
 
     default:
-      return json({ success: false, error: "Action non reconnue" });
+      return { success: false, error: "Action non reconnue" };
   }
 }
 

--- a/frontend/app/routes/commercial.shipping._index.tsx
+++ b/frontend/app/routes/commercial.shipping._index.tsx
@@ -2,11 +2,7 @@
  * 📦 Gestion des expéditions - Interface principale
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link, useSearchParams, Form } from "@remix-run/react";
 import {
   Truck,
@@ -398,7 +394,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       },
     };
 
-    return json({
+    return {
       orders: filteredOrders,
       stats,
       totalOrders: filteredOrders.length,
@@ -410,10 +406,10 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         zone,
         trackingStatus,
       },
-    });
+    };
   } catch (error) {
     logger.error("Erreur chargement expéditions commercial:", error);
-    return json({
+    return {
       orders: [],
       stats: {
         totalShipments: 0,
@@ -434,7 +430,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       currentPage: 1,
       limit: 20,
       filters: { search: "", status: "", zone: "", trackingStatus: "" },
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/commercial.shipping.create._index.tsx
+++ b/frontend/app/routes/commercial.shipping.create._index.tsx
@@ -8,7 +8,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
@@ -222,43 +221,27 @@ export async function loader({ request }: LoaderFunctionArgs) {
           height: 10,
         },
         shippingAddress: {
-          firstName:
-            order.shippingAddress?.firstName ||
-            order.firstName ||
-            "",
-          lastName:
-            order.shippingAddress?.lastName ||
-            order.lastName ||
-            "",
+          firstName: order.shippingAddress?.firstName || order.firstName || "",
+          lastName: order.shippingAddress?.lastName || order.lastName || "",
           company: order.shippingAddress?.company || "",
-          address1:
-            order.shippingAddress?.address1 ||
-            order.address ||
-            "",
+          address1: order.shippingAddress?.address1 || order.address || "",
           address2: order.shippingAddress?.address2 || "",
           postalCode:
-            order.shippingAddress?.postalCode ||
-            order.postalCode ||
-            "",
-          city:
-            order.shippingAddress?.city || order.city || "",
-          country:
-            order.shippingAddress?.country ||
-            order.country ||
-            "France",
-          phone:
-            order.shippingAddress?.phone || order.phone || "",
+            order.shippingAddress?.postalCode || order.postalCode || "",
+          city: order.shippingAddress?.city || order.city || "",
+          country: order.shippingAddress?.country || order.country || "France",
+          phone: order.shippingAddress?.phone || order.phone || "",
         },
         items: [{ name: "Articles de la commande", quantity: 1, weight: 2.5 }],
       };
     }
 
-    return json({
+    return {
       order: transformedOrder,
       orders: allOrders, // Utiliser les vraies commandes récupérées
       carriers,
       shippingRates: [],
-    });
+    };
   } catch (error) {
     // Propager les Response HTTP (404, etc.) telles quelles
     if (error instanceof Response) {
@@ -291,13 +274,13 @@ export async function action({ request }: ActionFunctionArgs) {
       createdAt: new Date().toISOString(),
     };
 
-    return json({
+    return {
       success: true,
       shipment: shipmentData,
       message: "Expédition créée avec succès",
-    });
+    };
   } catch (error) {
-    return json({ success: false, error: "Erreur serveur" });
+    return { success: false, error: "Erreur serveur" };
   }
 }
 
@@ -307,7 +290,9 @@ export default function CreateShipment() {
 
   // États pour le formulaire
   const [selectedCarrier, setSelectedCarrier] = useState<Carrier | null>(null);
-  const [selectedService, setSelectedService] = useState<Carrier["services"][number] | null>(null);
+  const [selectedService, setSelectedService] = useState<
+    Carrier["services"][number] | null
+  >(null);
   const [weight, setWeight] = useState<number>(order?.totalWeight || 2.5);
   const [dimensions, setDimensions] = useState({
     length: order?.dimensions.length || 30,
@@ -389,9 +374,9 @@ export default function CreateShipment() {
                           {orderItem.totalPrice || 0}€
                         </div>
                         <div className="text-sm text-gray-500">
-                          {new Date(orderItem.createdAt ?? "").toLocaleDateString(
-                            "fr-FR",
-                          )}
+                          {new Date(
+                            orderItem.createdAt ?? "",
+                          ).toLocaleDateString("fr-FR")}
                         </div>
                       </div>
                     </div>

--- a/frontend/app/routes/commercial.shipping.tracking._index.tsx
+++ b/frontend/app/routes/commercial.shipping.tracking._index.tsx
@@ -2,11 +2,7 @@
  * 📦 Suivi des expéditions - Interface commerciale
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import {
   Clock,
@@ -297,7 +293,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       exceptions: shipments.filter((s) => s.status === "exception").length,
     };
 
-    return json({ shipments, stats });
+    return { shipments, stats };
   } catch (error) {
     logger.error("❌ Erreur tracking:", error);
 
@@ -311,7 +307,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       exceptions: shipments.filter((s) => s.status === "exception").length,
     };
 
-    return json({ shipments, stats });
+    return { shipments, stats };
   }
 }
 

--- a/frontend/app/routes/commercial.stock._index.tsx
+++ b/frontend/app/routes/commercial.stock._index.tsx
@@ -7,11 +7,7 @@
  * ✅ Données réelles de pieces_price
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useSearchParams, Form, Link } from "@remix-run/react";
 import {
   Package,
@@ -97,7 +93,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const dashboardResponse = await fetch(dashboardUrl.toString());
     const dashboardData = await dashboardResponse.json();
 
-    return json({
+    return {
       stats: statsData.success
         ? statsData.data
         : {
@@ -111,10 +107,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       currentPage: page,
       limit,
       filters: { search, available, minPrice, maxPrice },
-    });
+    };
   } catch (error) {
     logger.error("Erreur chargement stock commercial:", error);
-    return json({
+    return {
       stats: {
         availableItems: 0,
         unavailableItems: 0,
@@ -126,7 +122,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       currentPage: 1,
       limit: 20,
       filters: { search: "", available: "", minPrice: "", maxPrice: "" },
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/commercial.tsx
+++ b/frontend/app/routes/commercial.tsx
@@ -2,7 +2,6 @@ import {
   type LoaderFunctionArgs,
   type MetaFunction,
   redirect,
-  json,
 } from "@remix-run/node";
 import {
   Outlet,
@@ -41,7 +40,7 @@ export async function loader({ context }: LoaderFunctionArgs) {
     logger.log("Erreur récupération stats sidebar commercial:", error);
   }
 
-  return json({ user, stats });
+  return { user, stats };
 }
 
 export default function CommercialLayout() {

--- a/frontend/app/routes/commercial.vehicles._index.tsx
+++ b/frontend/app/routes/commercial.vehicles._index.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
   redirect,
@@ -77,18 +76,18 @@ export async function loader({ context }: LoaderFunctionArgs) {
       error = "Erreur lors du chargement des statistiques";
     }
 
-    return json<LoaderData>({
+    return {
       user,
       stats,
       error,
-    });
+    };
   } catch (err) {
     logger.error("Erreur loader véhicules:", err);
-    return json<LoaderData>({
+    return {
       user,
       stats: null,
       error: "Erreur serveur",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/commercial.vehicles.advanced-search.tsx
+++ b/frontend/app/routes/commercial.vehicles.advanced-search.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useSubmit } from "@remix-run/react";
 import {
   Search,
@@ -170,7 +166,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     compatibleProducts = productVariations.slice(0, numProducts);
   }
 
-  return json<LoaderData>({
+  return {
     compatibleProducts,
     stats,
     searchParams: {
@@ -178,7 +174,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       typeId: typeId || undefined,
       year: year || undefined,
     },
-  });
+  };
 }
 
 export default function AdvancedVehicleSearch() {

--- a/frontend/app/routes/commercial.vehicles.brands.$brandId.models.tsx
+++ b/frontend/app/routes/commercial.vehicles.brands.$brandId.models.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
   redirect,
@@ -101,14 +100,14 @@ export async function loader({ context, params }: LoaderFunctionArgs) {
         null;
     }
 
-    return json({ models, brand } as LoaderData);
+    return { models, brand } as LoaderData;
   } catch (error) {
     logger.error("Erreur chargement modèles:", error);
-    return json({
+    return {
       models: [],
       brand: null,
       error: "Impossible de charger les modèles",
-    } as LoaderData);
+    } as LoaderData;
   }
 }
 

--- a/frontend/app/routes/commercial.vehicles.brands.tsx
+++ b/frontend/app/routes/commercial.vehicles.brands.tsx
@@ -17,7 +17,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
   redirect,
@@ -96,17 +95,17 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     // Trier par nom de marque
     brands.sort((a, b) => a.marque_name.localeCompare(b.marque_name));
 
-    return json({
+    return {
       brands,
       totalBrands: brands.length,
-    } as LoaderData);
+    } as LoaderData;
   } catch (error) {
     logger.error("Erreur chargement marques:", error);
-    return json({
+    return {
       brands: [],
       totalBrands: 0,
       error: "Impossible de charger les marques de véhicules",
-    } as LoaderData);
+    } as LoaderData;
   }
 }
 

--- a/frontend/app/routes/commercial.vehicles.compatibility.tsx
+++ b/frontend/app/routes/commercial.vehicles.compatibility.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -137,21 +136,21 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       }
     }
 
-    return json<CompatibilityData>({
+    return {
       user,
       compatibilityResult,
       partsByVehicle,
       vehicleInfo,
       searchMode,
       error,
-    });
+    };
   } catch (err) {
     logger.error("Erreur loader compatibilité:", err);
-    return json<CompatibilityData>({
+    return {
       user,
       searchMode: null,
       error: "Erreur serveur",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/commercial.vehicles.models.$modelId.types.tsx
+++ b/frontend/app/routes/commercial.vehicles.models.$modelId.types.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
   redirect,
@@ -120,14 +119,14 @@ export async function loader({ context, params }: LoaderFunctionArgs) {
       }
     }
 
-    return json({ types, model } as LoaderData);
+    return { types, model } as LoaderData;
   } catch (error) {
     logger.error("Erreur chargement types:", error);
-    return json({
+    return {
       types: [],
       model: null,
       error: "Impossible de charger les types de véhicule",
-    } as LoaderData);
+    } as LoaderData;
   }
 }
 

--- a/frontend/app/routes/commercial.vehicles.search.tsx
+++ b/frontend/app/routes/commercial.vehicles.search.tsx
@@ -6,7 +6,6 @@
  */
 
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -102,7 +101,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const brandsResponse = await fetch(
       `${baseUrl}/api/catalog/vehicles/brands`,
     );
-    let brands = [];
+    let brands: VehicleSearchData["brands"] = [];
 
     if (brandsResponse.ok) {
       const brandsData = await brandsResponse.json();
@@ -112,7 +111,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     }
 
     // Recherche de véhicules si des critères sont spécifiés
-    let searchResults = [];
+    let searchResults: VehicleSearchData["searchResults"] = [];
     let totalResults = 0;
     let error: string | undefined = undefined;
 
@@ -146,24 +145,24 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       }
     }
 
-    return json<VehicleSearchData>({
+    return {
       user,
       brands,
       searchResults,
       totalResults,
       currentFilters: filters,
       error,
-    });
+    };
   } catch (err) {
     logger.error("Erreur loader recherche véhicules:", err);
-    return json<VehicleSearchData>({
+    return {
       user,
       brands: [],
       searchResults: [],
       totalResults: 0,
       currentFilters: filters,
       error: "Erreur serveur",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/conditions-generales-de-vente[.]html.tsx
+++ b/frontend/app/routes/conditions-generales-de-vente[.]html.tsx
@@ -1,9 +1,5 @@
 // Route: /conditions-generales-de-vente.html -> CGV
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 
 // SEO Page Role (Phase 5 - Quasi-Incopiable)
@@ -50,7 +46,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     if (response.ok) {
       const dbPage = await response.json();
-      return json({
+      return {
         page: {
           key: "cgv",
           title: dbPage.h1 || dbPage.title,
@@ -61,13 +57,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
           indexable: false,
         },
         fromDB: true,
-      });
+      };
     }
   } catch (error) {
     logger.warn("Failed to fetch CGV:", error);
   }
 
-  return json({
+  return {
     page: {
       key: "cgv",
       title: "Conditions Générales de Vente",
@@ -78,7 +74,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       indexable: false,
     },
     fromDB: false,
-  });
+  };
 }
 
 export { default } from "./legal.$pageKey";

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -5,7 +5,6 @@
 // .spec/00-canon/role-matrix.md §R8 et @repo/seo-roles forbidden-overlap.ts.
 
 import {
-  defer,
   redirect,
   type LinksFunction,
   type LoaderFunctionArgs,
@@ -183,7 +182,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   const cached = loaderCache.get(cacheKey);
   if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
     logger.log("✅ [CACHE HIT] Données véhicule en cache:", cacheKey);
-    return defer(cached.data as unknown as Record<string, unknown>);
+    return cached.data as unknown as Record<string, unknown>;
   }
 
   logger.log("🚀 [RPC] Vehicle detail loader avec params:", params);
@@ -287,7 +286,10 @@ export async function loader({ params }: LoaderFunctionArgs) {
     const code = isTimeout
       ? "LOADER_503_RPC_TIMEOUT"
       : "LOADER_503_RPC_FETCH_ERROR";
-    logger.error(`${isTimeout ? "⏱️" : "❌"} [RPC] ${code} type_id=${type_id}:`, error);
+    logger.error(
+      `${isTimeout ? "⏱️" : "❌"} [RPC] ${code} type_id=${type_id}:`,
+      error,
+    );
     await notify503ToErrorLog(
       `/constructeurs/${brand}/${model}/${type}`,
       code,
@@ -384,7 +386,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     parts: loaderData.popularParts.length,
   });
 
-  return defer(loaderData as unknown as Record<string, unknown>);
+  return loaderData as unknown as Record<string, unknown>;
 }
 
 // 🎯 Meta function avec SEO optimisé (logique PHP)
@@ -1194,9 +1196,7 @@ export default function VehicleDetailPage() {
                   </button>
                   {openFaqIndex === index && (
                     <div className="px-5 pb-5 text-gray-600 animate-in slide-in-from-top-2 duration-200">
-                      <div className="pl-4 border-brand">
-                        {item.answer}
-                      </div>
+                      <div className="pl-4 border-brand">{item.answer}</div>
                     </div>
                   )}
                 </div>

--- a/frontend/app/routes/constructeurs.$brand[.]html.tsx
+++ b/frontend/app/routes/constructeurs.$brand[.]html.tsx
@@ -6,7 +6,6 @@
 // Intention : Hub marque constructeur
 
 import {
-  defer,
   type HeadersFunction,
   type LinksFunction,
   type LoaderFunctionArgs,
@@ -353,7 +352,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     // 🏭 R7 enriched content (optional overlay)
     const r7Content = await brandApi.getR7Content(marque_id);
 
-    return defer({ ...bestsellersResponse.data, r7Content });
+    return { ...bestsellersResponse.data, r7Content };
   } catch (error) {
     // Propager les Response HTTP (404, etc.) telles quelles
     if (error instanceof Response) {
@@ -1070,7 +1069,7 @@ function VehicleCard({ vehicle }: { vehicle: PopularVehicle }) {
           {/* Badge carburant */}
           {fuelLabel && (
             <span
-              className={`px-2 py-0.5 rounded-full text-[10px] font-semibold shadow-md ${ fuelLabel === "Diesel" ? "bg-gray-800 text-white" : fuelLabel === "Essence" ? "bg-green-600 text-white" : fuelLabel === "Hybride" ? "bg-blue-500 text-white" : "bg-primary text-white" }`}
+              className={`px-2 py-0.5 rounded-full text-[10px] font-semibold shadow-md ${fuelLabel === "Diesel" ? "bg-gray-800 text-white" : fuelLabel === "Essence" ? "bg-green-600 text-white" : fuelLabel === "Hybride" ? "bg-blue-500 text-white" : "bg-primary text-white"}`}
             >
               {fuelLabel}
             </span>

--- a/frontend/app/routes/contact.tsx
+++ b/frontend/app/routes/contact.tsx
@@ -7,10 +7,10 @@
  */
 
 import {
-  json,
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -141,9 +141,7 @@ interface LoaderData {
   };
 }
 
-export async function loader({
-  request,
-}: LoaderFunctionArgs): Promise<Response> {
+export async function loader({ request }: LoaderFunctionArgs) {
   const session = await getSession(request);
   const userId = session.get("userId");
 
@@ -160,12 +158,28 @@ export async function loader({
     },
   };
 
-  return json(loaderData);
+  return loaderData;
+}
+
+/**
+ * Forme unifiée de la réponse de l'action.
+ * Chaque branche (validation, succès, erreur serveur) ne renseigne qu'un
+ * sous-ensemble des champs ; les consommateurs lisent par présence (`?.`),
+ * exactement comme le runtime le fait déjà.
+ */
+interface ActionData {
+  success: boolean;
+  fieldErrors?: Record<string, string>;
+  error?: string;
+  ticketNumber?: string;
+  ticket?: unknown;
 }
 
 export async function action({
   request,
-}: ActionFunctionArgs): Promise<Response> {
+}: ActionFunctionArgs): Promise<
+  ActionData | ReturnType<typeof data<ActionData>>
+> {
   const formData = await request.formData();
   const session = await getSession(request);
 
@@ -199,7 +213,8 @@ export async function action({
   }
 
   if (Object.keys(fieldErrors).length > 0) {
-    return json({ success: false, fieldErrors }, { status: 400 });
+    const validationData: ActionData = { success: false, fieldErrors };
+    return data(validationData, { status: 400 });
   }
 
   // Préparer les données de contact
@@ -233,23 +248,22 @@ export async function action({
 
   try {
     const result = await createContact(contactData);
-    return json({
+    const successData: ActionData = {
       success: true,
       ticketNumber: result.ticketNumber,
       ticket: result.ticket,
-    });
+    };
+    return successData;
   } catch (error) {
     logger.error("Erreur lors de la création du ticket:", error);
-    return json(
-      {
-        success: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Une erreur est survenue lors de l'envoi du message",
-      },
-      { status: 500 },
-    );
+    const errorData: ActionData = {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Une erreur est survenue lors de l'envoi du message",
+    };
+    return data(errorData, { status: 500 });
   }
 }
 

--- a/frontend/app/routes/diagnostic-auto.$slug.tsx
+++ b/frontend/app/routes/diagnostic-auto.$slug.tsx
@@ -12,7 +12,6 @@
  */
 
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
@@ -255,10 +254,10 @@ export async function loader({ params }: LoaderFunctionArgs) {
     const safetyConfig = (safetyJson?.entity_data ??
       null) as SafetyConfigData | null;
 
-    return json({
+    return {
       diagnostic: data.data as DiagnosticData,
       safetyConfig,
-    });
+    };
   } catch (error) {
     if (error instanceof Response) throw error;
     logger.error("[diagnostic-auto.$slug] Loader error:", error);

--- a/frontend/app/routes/diagnostic-auto._index.tsx
+++ b/frontend/app/routes/diagnostic-auto._index.tsx
@@ -6,11 +6,7 @@
  * Intention : Identifier un symptôme automobile
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   Link,
   useLoaderData,
@@ -39,11 +35,6 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useState, useEffect } from "react";
-import {
-  emitFunnel,
-  getFunnelDevice,
-  getFunnelSessionId,
-} from "~/utils/funnel-beacon";
 
 import { DiagnosticWizard } from "~/components/diagnostic-wizard/DiagnosticWizard";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
@@ -59,6 +50,11 @@ import { Badge } from "~/components/ui/badge";
 import { Input } from "~/components/ui/input";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
 import { Separator } from "~/components/ui/separator";
+import {
+  emitFunnel,
+  getFunnelDevice,
+  getFunnelSessionId,
+} from "~/utils/funnel-beacon";
 import { logger } from "~/utils/logger";
 import { PageRole, createPageRoleMeta } from "~/utils/page-role.types";
 
@@ -270,14 +266,14 @@ export async function loader({ request: _request }: LoaderFunctionArgs) {
       ),
     ]);
 
-  return json({
+  return {
     featured: (featuredJson?.data ?? []) as DiagnosticItem[],
     clusters: vocab?.clusters ?? [],
     perceptionIcons: vocab?.perception_icons ?? {},
     signs: signsData?.signs ?? [],
     faq: faqData?.faq ?? [],
     riskLevels: safetyData?.risk_levels ?? {},
-  });
+  };
 }
 
 export default function DiagnosticAutoIndex() {

--- a/frontend/app/routes/diagnostic.tsx
+++ b/frontend/app/routes/diagnostic.tsx
@@ -1,4 +1,4 @@
-import { json, type ActionFunctionArgs } from "@remix-run/node";
+import { type ActionFunctionArgs } from "@remix-run/node";
 import { useLoaderData, useFetcher } from "@remix-run/react";
 import {
   Search,
@@ -60,16 +60,16 @@ export async function loader() {
       "http://127.0.0.1:3000/api/knowledge-graph/nodes?type=Observable",
     );
     if (!response.ok) {
-      return json({
+      return {
         observables: [],
         error: "Erreur de chargement des symptômes",
-      });
+      };
     }
     const data = await response.json();
-    return json({ observables: data || [], error: null });
+    return { observables: data || [], error: null };
   } catch (error) {
     logger.error("Loader error:", error);
-    return json({ observables: [], error: "Service indisponible" });
+    return { observables: [], error: "Service indisponible" };
   }
 }
 
@@ -79,7 +79,7 @@ export async function action({ request }: ActionFunctionArgs) {
   const symptoms = formData.getAll("symptoms") as string[];
 
   if (symptoms.length === 0) {
-    return json({ error: "Veuillez sélectionner au moins un symptôme" });
+    return { error: "Veuillez sélectionner au moins un symptôme" };
   }
 
   try {
@@ -93,13 +93,13 @@ export async function action({ request }: ActionFunctionArgs) {
     );
 
     if (!response.ok) {
-      return json({ error: "Erreur lors du diagnostic" });
+      return { error: "Erreur lors du diagnostic" };
     }
 
-    return json(await response.json());
+    return await response.json();
   } catch (error) {
     logger.error("Action error:", error);
-    return json({ error: "Service de diagnostic indisponible" });
+    return { error: "Service de diagnostic indisponible" };
   }
 }
 

--- a/frontend/app/routes/enhanced-vehicle-catalog.$brand.$model.$type.tsx
+++ b/frontend/app/routes/enhanced-vehicle-catalog.$brand.$model.$type.tsx
@@ -1,7 +1,7 @@
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   useLoaderData,
@@ -110,15 +110,15 @@ export async function loader({ params: _params }: LoaderFunctionArgs) {
       },
     ];
 
-    return json({
+    return {
       vehicle: vehicleData,
       parts: mockParts,
       success: true,
       timestamp: new Date().toISOString(),
-    });
+    };
   } catch (error) {
     logger.error("Erreur dans le loader:", error);
-    throw json({ error: "Véhicule non trouvé" }, { status: 404 });
+    throw data({ error: "Véhicule non trouvé" }, { status: 404 });
   }
 }
 

--- a/frontend/app/routes/forgot-password.tsx
+++ b/frontend/app/routes/forgot-password.tsx
@@ -1,8 +1,8 @@
 import {
-  json,
   type ActionFunction,
   type MetaFunction,
   redirect,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -36,7 +36,7 @@ export const action: ActionFunction = async ({ request }) => {
   const email = formData.get("email");
 
   if (!email) {
-    return json({ error: "Email is required" }, { status: 400 });
+    return data({ error: "Email is required" }, { status: 400 });
   }
 
   try {
@@ -54,7 +54,7 @@ export const action: ActionFunction = async ({ request }) => {
       return redirect("/forgot-password?status=sent");
     }
 
-    return json(
+    return data(
       { error: result.message || "Une erreur est survenue" },
       { status: response.status },
     );

--- a/frontend/app/routes/legal.$pageKey.tsx
+++ b/frontend/app/routes/legal.$pageKey.tsx
@@ -1,10 +1,6 @@
 // app/routes/legal.$pageKey.tsx - Pages légales dynamiques
 // Fetches from ___META_TAGS_ARIANE via API with fallback to static content
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   Link,
   useLoaderData,
@@ -293,7 +289,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
       if (response.ok) {
         const dbPage: LegalPageFromDB = await response.json();
 
-        return json({
+        return {
           page: {
             key: pageKey,
             title: dbPage.h1 || dbPage.title,
@@ -304,7 +300,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
             indexable: dbPage.indexable,
           },
           fromDB: true,
-        });
+        };
       }
     } catch (error) {
       logger.warn(`Failed to fetch legal page from API for ${pageKey}:`, error);
@@ -317,7 +313,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     throw new Response("Page légale non trouvée", { status: 404 });
   }
 
-  return json({
+  return {
     page: {
       key: staticPage.key,
       title: staticPage.title,
@@ -328,7 +324,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
       indexable: true,
     },
     fromDB: false,
-  });
+  };
 }
 
 export default function LegalPage() {

--- a/frontend/app/routes/mentions-legales.tsx
+++ b/frontend/app/routes/mentions-legales.tsx
@@ -1,9 +1,5 @@
 // Route: /mentions-legales -> Mentions légales
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 
 // SEO Page Role (Phase 5 - Quasi-Incopiable)
@@ -48,7 +44,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     if (response.ok) {
       const dbPage = await response.json();
-      return json({
+      return {
         page: {
           key: "legal-notice",
           title: dbPage.h1 || dbPage.title,
@@ -59,13 +55,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
           indexable: false,
         },
         fromDB: true,
-      });
+      };
     }
   } catch (error) {
     logger.warn("Failed to fetch mentions légales:", error);
   }
 
-  return json({
+  return {
     page: {
       key: "legal-notice",
       title: "Mentions légales",
@@ -76,7 +72,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       indexable: false,
     },
     fromDB: false,
-  });
+  };
 }
 
 export { default } from "./legal.$pageKey";

--- a/frontend/app/routes/orders.$id.tsx
+++ b/frontend/app/routes/orders.$id.tsx
@@ -3,7 +3,7 @@
  * Affiche toutes les informations d'une commande spécifique avec adresses
  */
 
-import { json, type LoaderFunction, type MetaFunction } from "@remix-run/node";
+import { type LoaderFunction, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -119,7 +119,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   const orderId = params.id;
 
   if (!orderId) {
-    return json<LoaderData>({ order: null, error: "ID de commande manquant" });
+    return { order: null, error: "ID de commande manquant" };
   }
 
   logger.log(`🔍 [Frontend] Chargement commande avec ID: ${orderId}`);
@@ -144,10 +144,10 @@ export const loader: LoaderFunction = async ({ params, request }) => {
         errorText,
       );
 
-      return json<LoaderData>({
+      return {
         order: null,
         error: `Commande non trouvée avec l'ID: ${orderId}`,
-      });
+      };
     }
 
     const data = await response.json();
@@ -155,23 +155,23 @@ export const loader: LoaderFunction = async ({ params, request }) => {
 
     if (!order || !order.ord_id) {
       logger.error(`❌ [Frontend] Commande non trouvée ou structure invalide`);
-      return json<LoaderData>({
+      return {
         order: null,
         error: "Commande non trouvée",
-      });
+      };
     }
 
     logger.log(`✅ [Frontend] Commande ${orderId} chargée (format BDD)`);
-    return json<LoaderData>({
+    return {
       order: order,
       error: undefined,
-    });
+    };
   } catch (error) {
     logger.error("❌ [Frontend] Error loading order:", error);
-    return json<LoaderData>({
+    return {
       order: null,
       error: "Erreur lors du chargement de la commande",
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/orders.new.tsx
+++ b/frontend/app/routes/orders.new.tsx
@@ -4,11 +4,11 @@
  */
 
 import {
-  json,
   redirect,
   type ActionFunction,
   type LoaderFunction,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -82,14 +82,14 @@ export const loader: LoaderFunction = async ({ context }) => {
   // const user = await requireUser({ context });
 
   // Ici, vous pourriez charger des données nécessaires comme les produits disponibles
-  return json({
+  return {
     // Ajouter des données de test pour les produits disponibles
     products: [
       { id: "1", name: "Produit A", price: 10.99, sku: "PROD-A" },
       { id: "2", name: "Produit B", price: 15.99, sku: "PROD-B" },
       { id: "3", name: "Produit C", price: 20.99, sku: "PROD-C" },
     ],
-  });
+  };
 };
 
 export const action: ActionFunction = async ({ request, context }) => {
@@ -120,7 +120,7 @@ export const action: ActionFunction = async ({ request, context }) => {
 
     // Validation côté client
     if (!items || items.length === 0) {
-      return json<ActionData>(
+      return data(
         {
           error: "Au moins un article est requis",
         },
@@ -134,7 +134,7 @@ export const action: ActionFunction = async ({ request, context }) => {
       !deliveryAddress.postalCode ||
       !deliveryAddress.country
     ) {
-      return json<ActionData>(
+      return data(
         {
           error: "Tous les champs de l'adresse de livraison sont requis",
         },
@@ -149,7 +149,7 @@ export const action: ActionFunction = async ({ request, context }) => {
     const result = await integration.createOrderForRemix?.(orderData);
 
     if (!result.success) {
-      return json<ActionData>(
+      return data(
         {
           error: result.error || "Erreur lors de la création de la commande",
         },
@@ -160,7 +160,7 @@ export const action: ActionFunction = async ({ request, context }) => {
     return redirect(`/orders/${result.order.id}`);
   } catch (error) {
     logger.error("Error creating order:", error);
-    return json<ActionData>(
+    return data(
       {
         error: "Erreur lors de la création de la commande",
       },

--- a/frontend/app/routes/pieces.$slug.tsx
+++ b/frontend/app/routes/pieces.$slug.tsx
@@ -10,10 +10,10 @@
  */
 
 import {
-  defer,
   redirect,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Await,
@@ -50,11 +50,11 @@ import {
 } from "~/types/gamme-page-contract.types";
 import { type R1ImagesBySlot } from "~/types/r1-images.types";
 import { type R1RelatedBlocksPayload } from "~/types/r1-related.types";
+import { buildCacheHeaders } from "~/utils/cache-control";
 import {
   extractEditorialBlocks,
   mergeFaqBlocks,
 } from "~/utils/editorial-parser";
-import { buildCacheHeaders } from "~/utils/cache-control";
 import { parseGammePageData } from "~/utils/gamme-page-contract.utils";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
@@ -365,7 +365,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
     });
     const r1Sources = buildSourceMapFromPack(sectionPack);
 
-    return defer(
+    return data(
       {
         // === SYNC (above-fold + meta/JSON-LD) — ~5-10KB ===
         _v: pageData._v,
@@ -870,7 +870,10 @@ export default function PiecesDetailPage() {
            H2 #2 — Qualité, prix et marques
            Image PRICE, marques, fiche technique
            ═══════════════════════════════════════════════════════ */}
-      <section id="qualite-prix" className="py-10 px-4 sm:px-6 bg-slate-50 cv-auto">
+      <section
+        id="qualite-prix"
+        className="py-10 px-4 sm:px-6 bg-slate-50 cv-auto"
+      >
         <div className="max-w-[1280px] mx-auto">
           <h2 className="text-2xl font-bold text-slate-900 mb-6">
             Qualité, prix et marques
@@ -993,7 +996,10 @@ export default function PiecesDetailPage() {
            H2 #4 — Trouver la bonne référence
            Compatibilités, motorisations, commande
            ═══════════════════════════════════════════════════════ */}
-      <section id="reference" className="py-10 px-4 sm:px-6 bg-slate-50 cv-auto">
+      <section
+        id="reference"
+        className="py-10 px-4 sm:px-6 bg-slate-50 cv-auto"
+      >
         <div className="max-w-[1280px] mx-auto">
           <h2 className="text-2xl font-bold text-slate-900 mb-6">
             Trouver la bonne référence pour votre véhicule
@@ -1049,7 +1055,10 @@ export default function PiecesDetailPage() {
            H2 #6 — Aller plus loin
            Maillage, famille, guide CTA
            ═══════════════════════════════════════════════════════ */}
-      <section id="aller-plus-loin" className="py-10 px-4 sm:px-6 bg-slate-50 cv-auto">
+      <section
+        id="aller-plus-loin"
+        className="py-10 px-4 sm:px-6 bg-slate-50 cv-auto"
+      >
         <div className="max-w-[1280px] mx-auto">
           <h2 className="text-2xl font-bold text-slate-900 mb-6">
             Aller plus loin

--- a/frontend/app/routes/plan-du-site.tsx
+++ b/frontend/app/routes/plan-du-site.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link } from "@remix-run/react";
 import {
   Home,
@@ -92,13 +88,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
       0,
     );
 
-    return json({ families, brands, totalGammes });
+    return { families, brands, totalGammes };
   } catch {
-    return json({
+    return {
       families: [] as Family[],
       brands: [] as Brand[],
       totalGammes: 0,
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/politique-confidentialite.tsx
+++ b/frontend/app/routes/politique-confidentialite.tsx
@@ -1,9 +1,5 @@
 // Route: /politique-confidentialite -> Confidentialité
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 
 // SEO Page Role (Phase 5 - Quasi-Incopiable)
@@ -49,7 +45,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     if (response.ok) {
       const dbPage = await response.json();
-      return json({
+      return {
         page: {
           key: "privacy",
           title: dbPage.h1 || dbPage.title,
@@ -60,13 +56,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
           indexable: false,
         },
         fromDB: true,
-      });
+      };
     }
   } catch (error) {
     logger.warn("Failed to fetch confidentialité:", error);
   }
 
-  return json({
+  return {
     page: {
       key: "privacy",
       title: "Politique de confidentialité",
@@ -77,7 +73,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       indexable: false,
     },
     fromDB: false,
-  });
+  };
 }
 
 export { default } from "./legal.$pageKey";

--- a/frontend/app/routes/politique-cookies.tsx
+++ b/frontend/app/routes/politique-cookies.tsx
@@ -1,9 +1,5 @@
 // Route: /politique-cookies -> Cookies
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 
 // SEO Page Role (Phase 5 - Quasi-Incopiable)
@@ -51,7 +47,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     if (response.ok) {
       const dbPage = await response.json();
-      return json({
+      return {
         page: {
           key: "cookies",
           title: dbPage.h1 || dbPage.title,
@@ -62,13 +58,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
           indexable: false,
         },
         fromDB: true,
-      });
+      };
     }
   } catch (error) {
     logger.warn("Failed to fetch cookies:", error);
   }
 
-  return json({
+  return {
     page: {
       key: "cookies",
       title: "Politique de cookies",
@@ -79,7 +75,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       indexable: false,
     },
     fromDB: false,
-  });
+  };
 }
 
 export { default } from "./legal.$pageKey";

--- a/frontend/app/routes/products.$category.$subcategory.tsx
+++ b/frontend/app/routes/products.$category.$subcategory.tsx
@@ -1,9 +1,5 @@
 // app/routes/products.$category.$subcategory.tsx - Exemple d'usage optimisé
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   useRouteError,
@@ -38,13 +34,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     },
   ];
 
-  return json({
+  return {
     seoData,
     metaTags, // ✅ Passer les métadonnées créées côté serveur
     products,
     category: category,
     subcategory: subcategory,
-  });
+  };
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/frontend/app/routes/products.$id.tsx
+++ b/frontend/app/routes/products.$id.tsx
@@ -15,11 +15,7 @@
  * - /products/:id?enhanced=true (advanced interface)
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -152,7 +148,11 @@ interface ProductDetailData {
   error?: string;
 }
 
-export async function loader({ params, request, context }: LoaderFunctionArgs) {
+export async function loader({
+  params,
+  request,
+  context,
+}: LoaderFunctionArgs): Promise<ProductDetailData> {
   const user = await requireUser({ context });
 
   // Determine user role and check access
@@ -225,7 +225,7 @@ export async function loader({ params, request, context }: LoaderFunctionArgs) {
         }
       : null;
 
-    return json<ProductDetailData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -234,7 +234,7 @@ export async function loader({ params, request, context }: LoaderFunctionArgs) {
       },
       product,
       enhanced,
-    });
+    };
   } catch (error) {
     logger.error("Product detail loading error:", error);
 
@@ -242,7 +242,7 @@ export async function loader({ params, request, context }: LoaderFunctionArgs) {
       throw error;
     }
 
-    return json<ProductDetailData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -252,7 +252,7 @@ export async function loader({ params, request, context }: LoaderFunctionArgs) {
       product: null,
       enhanced,
       error: "Erreur lors du chargement du produit",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/products.admin.tsx
+++ b/frontend/app/routes/products.admin.tsx
@@ -30,11 +30,7 @@
  * - /products/admin?enhanced=true (interface avancée)
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -158,7 +154,10 @@ interface ProductsData {
   error?: string;
 }
 
-export async function loader({ request, context }: LoaderFunctionArgs) {
+export async function loader({
+  request,
+  context,
+}: LoaderFunctionArgs): Promise<ProductsData> {
   const user = await requireUser({ context });
 
   // Vérifier accès commercial (niveau 3+)
@@ -317,7 +316,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       // Continuer avec tableau vide
     }
 
-    return json<ProductsData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -333,10 +332,10 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         ? (await responses[1].json()).slice(0, 6)
         : [],
       recentBrands: responses[2]?.ok ? await responses[2].json() : [],
-    });
+    };
   } catch (error) {
     logger.error("Products data loading error:", error);
-    return json<ProductsData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -349,7 +348,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       filterLists: { gammes: [], brands: [] },
       enhanced,
       error: "Erreur lors du chargement des données produits",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/products.brands.tsx
+++ b/frontend/app/routes/products.brands.tsx
@@ -15,11 +15,7 @@
  * - /products/brands?enhanced=true (advanced interface)
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -69,13 +65,16 @@ interface BrandsData {
   error?: string;
 }
 
-export async function loader({ request, context }: LoaderFunctionArgs) {
+export async function loader({
+  request,
+  context,
+}: LoaderFunctionArgs): Promise<BrandsData> {
   const user = await requireUser({ context });
 
   // Determine user role and check access
   const userLevel = user.level || 0;
   const userName = user.name || "Utilisateur";
-  const userRole =
+  const userRole: "pro" | "commercial" | null =
     userLevel >= 4 ? "pro" : userLevel >= 3 ? "commercial" : null;
 
   if (!userRole) {
@@ -125,7 +124,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       }),
     };
 
-    return json<BrandsData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -135,10 +134,10 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       brands,
       stats,
       enhanced,
-    });
+    };
   } catch (error) {
     logger.error("Brands loading error:", error);
-    return json<BrandsData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -149,7 +148,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       stats: { total: 0, active: 0 },
       enhanced,
       error: "Erreur lors du chargement des marques",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/products.catalog.tsx
+++ b/frontend/app/routes/products.catalog.tsx
@@ -15,11 +15,7 @@
  * - /products/catalog?enhanced=true (advanced interface)
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -103,7 +99,10 @@ interface CatalogData {
   error?: string;
 }
 
-export async function loader({ request, context }: LoaderFunctionArgs) {
+export async function loader({
+  request,
+  context,
+}: LoaderFunctionArgs): Promise<CatalogData> {
   const user = await requireUser({ context });
 
   // Determine user role and check access
@@ -185,7 +184,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       totalPages: Math.ceil((catalogData.total || products.length) / limit),
     };
 
-    return json<CatalogData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -201,10 +200,10 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         activeOnly,
       },
       enhanced,
-    });
+    };
   } catch (error) {
     logger.error("Catalog loading error:", error);
-    return json<CatalogData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -216,7 +215,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       filters: { searchTerm, activeOnly: false },
       enhanced,
       error: "Erreur lors du chargement du catalogue",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/products.gammes.$gammeId.tsx
+++ b/frontend/app/routes/products.gammes.$gammeId.tsx
@@ -11,11 +11,7 @@
  * Route: /products/gammes/:gammeId
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -181,7 +177,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       logger.error(`❌ API error ${response.status} for gamme ${gammeId}`);
 
       // Au lieu de lancer une erreur, retournons des données par défaut
-      return json<GammeDetailData>({
+      return {
         user: {
           id: user.id,
           name: userName,
@@ -207,7 +203,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
         },
         enhanced,
         error: `Erreur API: ${response.status}`,
-      });
+      };
     }
 
     const apiData = await response.json();
@@ -225,7 +221,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
     // Adapter les données de notre nouvelle API au format attendu
     const gammeData = apiData.success ? apiData.data : null;
 
-    return json<GammeDetailData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -251,11 +247,11 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
         sortOrder: "asc",
       },
       enhanced,
-    });
+    };
   } catch (error) {
     logger.error("❌ Erreur loader gamme detail:", error);
 
-    return json<GammeDetailData>({
+    return {
       user: {
         id: "error",
         name: "Erreur",
@@ -271,7 +267,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
         error instanceof Error
           ? error.message
           : "Impossible de charger la gamme",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/products.ranges.$rangeId.tsx
+++ b/frontend/app/routes/products.ranges.$rangeId.tsx
@@ -8,11 +8,7 @@
  * - Filtres par disponibilité, prix, etc.
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link, useSearchParams, Form } from "@remix-run/react";
 import {
   ArrowLeft,
@@ -240,7 +236,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
 
       const totalPages = Math.ceil(totalFiltered / limit);
 
-      return json<ProductsByRangeData>({
+      return {
         user: {
           id: user.id,
           name: userName,
@@ -273,7 +269,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
           view: viewMode,
         },
         enhanced,
-      });
+      };
     }
 
     throw new Error("Impossible de charger les produits");
@@ -284,7 +280,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       throw error;
     }
 
-    return json<ProductsByRangeData>({
+    return {
       user: { id: "error", name: "Erreur", level: 1, role: "commercial" },
       range: { id: "", name: "Erreur", description: "Erreur de chargement" },
       products: [],
@@ -293,7 +289,7 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       filters: { search: "", status: "all", sort: "name", view: "grid" },
       enhanced: false,
       error: "Impossible de charger les produits de cette gamme",
-    });
+    };
   }
 }
 
@@ -386,9 +382,7 @@ export default function ProductsByRange() {
         )}
 
         {user.role === "pro" && (
-          <Badge className="bg-gradient-to-r to-pink-500">
-            💎 PRO
-          </Badge>
+          <Badge className="bg-gradient-to-r to-pink-500">💎 PRO</Badge>
         )}
       </div>
 

--- a/frontend/app/routes/products.ranges.advanced.tsx
+++ b/frontend/app/routes/products.ranges.advanced.tsx
@@ -9,11 +9,7 @@
  * - Mode Pro avec analytics
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import { useLoaderData, Link, useSearchParams, Form } from "@remix-run/react";
 import {
   ArrowLeft,
@@ -225,7 +221,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
 
     const totalPages = Math.ceil(totalFound / limit);
 
-    return json<RangesAdvancedData>({
+    return {
       user: {
         id: user.id,
         name: userName,
@@ -253,11 +249,11 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         view: viewMode,
       },
       enhanced,
-    });
+    };
   } catch (error) {
     logger.error("❌ Erreur loader products.ranges.advanced:", error);
 
-    return json<RangesAdvancedData>({
+    return {
       user: { id: "error", name: "Erreur", level: 1, role: "commercial" },
       ranges: [],
       stats: { total: 0, active: 0, top: 0, totalProducts: 0, filtered: 0 },
@@ -265,7 +261,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       filters: { search: "", status: "all", sort: "name", view: "grid" },
       enhanced: false,
       error: "Impossible de charger les gammes",
-    });
+    };
   }
 }
 
@@ -365,9 +361,7 @@ export default function ProductsRangesAdvanced() {
         )}
 
         {user.role === "pro" && (
-          <Badge className="bg-gradient-to-r to-pink-500">
-            💎 PRO
-          </Badge>
+          <Badge className="bg-gradient-to-r to-pink-500">💎 PRO</Badge>
         )}
       </div>
 

--- a/frontend/app/routes/products.ranges.tsx
+++ b/frontend/app/routes/products.ranges.tsx
@@ -15,11 +15,7 @@
  * - /products/ranges?enhanced=true (advanced interface)
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -95,7 +91,10 @@ interface ProductsRangesData {
   error?: string;
 }
 
-export async function loader({ request, context }: LoaderFunctionArgs) {
+export async function loader({
+  request,
+  context,
+}: LoaderFunctionArgs): Promise<ProductsRangesData> {
   try {
     // Authentification optionnelle (permet l'accès aux invités)
     const user = await getOptionalUser({ context });
@@ -194,7 +193,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       totalPages: Math.ceil(totalRanges / limit),
     };
 
-    return json<ProductsRangesData>({
+    return {
       user: user
         ? {
             id: user.id,
@@ -217,11 +216,11 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       },
       enhanced,
       pagination,
-    });
+    };
   } catch (error) {
     logger.error("❌ Erreur loader products.ranges:", error);
 
-    return json<ProductsRangesData>({
+    return {
       user: {
         id: "error",
         name: "Erreur",
@@ -232,7 +231,7 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       stats: { total: 0, active: 0, top: 0, totalProducts: 0 },
       enhanced: false,
       error: "Impossible de charger les gammes de produits",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/reference-auto.$slug.tsx
+++ b/frontend/app/routes/reference-auto.$slug.tsx
@@ -10,9 +10,9 @@
  */
 
 import {
-  json,
   type LoaderFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Link,
@@ -361,7 +361,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
       // Silently ignore — related refs are optional
     }
 
-    return json<LoaderData>(
+    return data(
       { reference, relatedRefs },
       {
         headers: {

--- a/frontend/app/routes/reference-auto._index.tsx
+++ b/frontend/app/routes/reference-auto._index.tsx
@@ -6,11 +6,7 @@
  * Intention : Hub des définitions officielles / vérités mécaniques
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   Link,
   useLoaderData,
@@ -126,18 +122,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     if (!res.ok) {
       logger.error("Erreur API référence:", res.status);
-      return json<LoaderData>({ references: [], total: 0 });
+      return { references: [], total: 0 };
     }
 
     const data = await res.json();
 
-    return json<LoaderData>({
+    return {
       references: data.references || [],
       total: data.total || 0,
-    });
+    };
   } catch (error) {
     logger.error("Erreur chargement références:", error);
-    return json<LoaderData>({ references: [], total: 0 });
+    return { references: [], total: 0 };
   }
 }
 
@@ -315,7 +311,7 @@ export default function ReferenceIndexPage() {
                 {/* Chip "Toutes" */}
                 <button
                   onClick={() => setActiveGamme(null)}
-                  className={`shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-colors ${ activeGamme === null ? "bg-primary text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200" }`}
+                  className={`shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-colors ${activeGamme === null ? "bg-primary text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
                 >
                   Toutes ({total})
                 </button>
@@ -327,7 +323,7 @@ export default function ReferenceIndexPage() {
                       onClick={() =>
                         setActiveGamme(activeGamme === name ? null : name)
                       }
-                      className={`shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors ${ activeGamme === name ? "bg-primary text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200" }`}
+                      className={`shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors ${activeGamme === name ? "bg-primary text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200"}`}
                     >
                       <span
                         className={`w-2 h-2 rounded-full ${activeGamme === name ? "bg-white" : color.dot}`}
@@ -376,7 +372,7 @@ export default function ReferenceIndexPage() {
                     key={letter}
                     onClick={() => hasEntries && scrollToLetter(letter)}
                     disabled={!hasEntries}
-                    className={`w-9 h-9 rounded-lg flex items-center justify-center text-sm font-semibold transition-colors ${ hasEntries ? "text-foreground hover:bg-muted cursor-pointer" : "text-gray-300 cursor-default" }`}
+                    className={`w-9 h-9 rounded-lg flex items-center justify-center text-sm font-semibold transition-colors ${hasEntries ? "text-foreground hover:bg-muted cursor-pointer" : "text-gray-300 cursor-default"}`}
                     aria-label={`Aller à la lettre ${letter}`}
                   >
                     {letter}

--- a/frontend/app/routes/reset-password.$token.tsx
+++ b/frontend/app/routes/reset-password.$token.tsx
@@ -1,9 +1,9 @@
 import {
-  json,
   type ActionFunction,
   type LoaderFunction,
   type MetaFunction,
   redirect,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -41,14 +41,14 @@ export const loader: LoaderFunction = async ({ params }) => {
     throw new Response("Token manquant", { status: 400 });
   }
 
-  return json({ token });
+  return { token };
 };
 
 export const action: ActionFunction = async ({ params, request }) => {
   const token = params.token;
 
   if (!token) {
-    return json({ error: "Token manquant" }, { status: 400 });
+    return data({ error: "Token manquant" }, { status: 400 });
   }
 
   const formData = await request.formData();
@@ -56,11 +56,11 @@ export const action: ActionFunction = async ({ params, request }) => {
   const confirmPassword = formData.get("confirmPassword");
 
   if (!password || !confirmPassword) {
-    return json({ error: "Tous les champs sont requis" }, { status: 400 });
+    return data({ error: "Tous les champs sont requis" }, { status: 400 });
   }
 
   if (password !== confirmPassword) {
-    return json(
+    return data(
       { error: "Les mots de passe ne correspondent pas" },
       { status: 400 },
     );
@@ -69,7 +69,7 @@ export const action: ActionFunction = async ({ params, request }) => {
   const pwd = password.toString();
 
   if (pwd.length < 6) {
-    return json(
+    return data(
       { error: "Le mot de passe doit contenir au moins 6 caractères" },
       { status: 400 },
     );
@@ -90,12 +90,12 @@ export const action: ActionFunction = async ({ params, request }) => {
       return redirect("/login?reset=success");
     }
 
-    return json(
+    return data(
       { error: result.message || "Token invalide ou expiré" },
       { status: 400 },
     );
   } catch {
-    return json(
+    return data(
       { error: "Une erreur est survenue. Veuillez réessayer." },
       { status: 500 },
     );

--- a/frontend/app/routes/reviews.$reviewId.tsx
+++ b/frontend/app/routes/reviews.$reviewId.tsx
@@ -3,11 +3,12 @@
  * Affichage complet et modération d'un avis spécifique
  */
 import {
-  json,
   redirect,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
+  type TypedResponse,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -71,49 +72,54 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
   try {
     const review = await getReviewById(Number(reviewId), request);
-    return json<LoaderData>({ review });
+    return { review };
   } catch (error) {
     logger.error("Erreur lors du chargement de l'avis:", error);
     throw new Response("Avis non trouvé", { status: 404 });
   }
 }
 
-export async function action({ params, request }: ActionFunctionArgs) {
+export async function action({
+  params,
+  request,
+}: ActionFunctionArgs): Promise<
+  ActionData | ReturnType<typeof data<ActionData>> | TypedResponse<never>
+> {
   const reviewId = params.reviewId;
   const formData = await request.formData();
   const intent = formData.get("intent");
 
   if (!reviewId) {
-    return json<ActionData>({ error: "ID d'avis manquant" }, { status: 400 });
+    return data<ActionData>({ error: "ID d'avis manquant" }, { status: 400 });
   }
 
   try {
     switch (intent) {
       case "approve":
         await updateReviewStatus(Number(reviewId), "approved", request);
-        return json<ActionData>({ success: true });
+        return { success: true };
 
       case "reject":
         await updateReviewStatus(Number(reviewId), "rejected", request);
-        return json<ActionData>({ success: true });
+        return { success: true };
 
       case "pending":
         await updateReviewStatus(Number(reviewId), "pending", request);
-        return json<ActionData>({ success: true });
+        return { success: true };
 
       case "delete":
         await deleteReview(Number(reviewId), request);
         return redirect("/reviews?deleted=true");
 
       default:
-        return json<ActionData>(
+        return data<ActionData>(
           { error: "Action non reconnue" },
           { status: 400 },
         );
     }
   } catch (error) {
     logger.error("Erreur lors de l'action:", error);
-    return json<ActionData>(
+    return data<ActionData>(
       { error: "Erreur lors de l'action" },
       { status: 500 },
     );

--- a/frontend/app/routes/reviews._index.tsx
+++ b/frontend/app/routes/reviews._index.tsx
@@ -3,10 +3,10 @@
  * Interface complète pour la modération et gestion des avis
  */
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -90,7 +90,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       })),
     ]);
 
-    return json<LoaderData>({
+    return {
       reviews: reviewsData.reviews || [],
       stats,
       pagination:
@@ -104,10 +104,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
                 (reviewsData.total || 0) / (reviewsData.limit || 10),
               ),
             },
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors du chargement des avis:", error);
-    return json<LoaderData>({
+    return {
       reviews: [],
       stats: {
         total: 0,
@@ -118,7 +118,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         ratingDistribution: { "5": 0, "4": 0, "3": 0, "2": 0, "1": 0 },
       },
       pagination: { page: 1, limit: 10, total: 0, totalPages: 0 },
-    });
+    };
   }
 }
 
@@ -137,20 +137,35 @@ export async function action({ request }: ActionFunctionArgs) {
         : "pending";
     try {
       await updateReviewStatus(Number(reviewId), status, request);
-      return json({ success: true });
+      return { success: true };
     } catch (error) {
-      return json(
+      return data(
         { error: "Erreur lors de la mise à jour du statut" },
         { status: 500 },
       );
     }
   }
 
-  return json({ error: "Action non reconnue" }, { status: 400 });
+  return data({ error: "Action non reconnue" }, { status: 400 });
 }
 
 export default function ReviewsPage() {
   const { reviews, stats, pagination } = useLoaderData<typeof loader>();
+  // Le payload runtime de l'endpoint stats est en camelCase (cf. backend
+  // ReviewService.getReviewStats). Le type snake_case `ReviewStats` du service
+  // frontend est obsolète ; on sélectionne ici la forme camelCase réellement
+  // servie — la branche snake_case ne se produit jamais à l'exécution.
+  const statsView =
+    "averageRating" in stats
+      ? stats
+      : {
+          total: stats.total_reviews,
+          pending: stats.pending_reviews,
+          approved: stats.approved_reviews,
+          rejected: stats.rejected_reviews,
+          averageRating: stats.average_rating,
+          ratingDistribution: stats.rating_distribution,
+        };
   const submit = useSubmit();
   const navigation = useNavigation();
   const [selectedReviews, setSelectedReviews] = useState<number[]>([]);
@@ -272,7 +287,7 @@ export default function ReviewsPage() {
             <div className="ml-4">
               <p className="text-sm font-medium text-gray-500">Total</p>
               <p className="text-2xl font-semibold text-gray-900">
-                {stats.total}
+                {statsView.total}
               </p>
             </div>
           </div>
@@ -289,9 +304,9 @@ export default function ReviewsPage() {
               <p className="text-sm font-medium text-gray-500">Moyenne</p>
               <div className="flex items-center">
                 <p className="text-2xl font-semibold text-gray-900 mr-2">
-                  {stats.averageRating.toFixed(1)}
+                  {statsView.averageRating.toFixed(1)}
                 </p>
-                {renderStars(Math.round(stats.averageRating))}
+                {renderStars(Math.round(statsView.averageRating))}
               </div>
             </div>
           </div>
@@ -309,7 +324,7 @@ export default function ReviewsPage() {
             <div className="ml-4">
               <p className="text-sm font-medium text-gray-500">En attente</p>
               <p className="text-2xl font-semibold text-gray-900">
-                {stats.pending}
+                {statsView.pending}
               </p>
             </div>
           </div>
@@ -325,7 +340,7 @@ export default function ReviewsPage() {
             <div className="ml-4">
               <p className="text-sm font-medium text-gray-500">Approuvés</p>
               <p className="text-2xl font-semibold text-gray-900">
-                {stats.approved}
+                {statsView.approved}
               </p>
             </div>
           </div>
@@ -341,7 +356,7 @@ export default function ReviewsPage() {
             <div className="ml-4">
               <p className="text-sm font-medium text-gray-500">Rejetés</p>
               <p className="text-2xl font-semibold text-gray-900">
-                {stats.rejected}
+                {statsView.rejected}
               </p>
             </div>
           </div>

--- a/frontend/app/routes/reviews.analytics.tsx
+++ b/frontend/app/routes/reviews.analytics.tsx
@@ -2,11 +2,7 @@
  * Page Analytics des Avis Clients
  * Tableaux de bord et statistiques avancées
  */
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   useRouteError,
@@ -137,14 +133,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
         stats.total > 0 ? Math.round((item.count / stats.total) * 100) : 0,
     }));
 
-    return json<LoaderData>({
+    return {
       stats,
       trends,
       ratingBreakdown,
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors du chargement des analytics:", error);
-    return json<LoaderData>({
+    return {
       stats: {
         total: 0,
         pending: 0,
@@ -162,7 +158,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         growthRate: 0,
       },
       ratingBreakdown: [],
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/reviews.create.tsx
+++ b/frontend/app/routes/reviews.create.tsx
@@ -3,10 +3,10 @@
  * Formulaire pour soumettre un nouvel avis client
  */
 import {
-  json,
   redirect,
   type ActionFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -85,7 +85,7 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   if (Object.keys(errors).length > 0) {
-    return json<ActionData>({ errors }, { status: 400 });
+    return data({ errors }, { status: 400 });
   }
 
   try {
@@ -93,14 +93,10 @@ export async function action({ request }: ActionFunctionArgs) {
     return redirect(`/reviews?created=true`);
   } catch (error) {
     logger.error("Erreur lors de la création de l'avis:", error);
-    return json<ActionData>(
-      {
-        errors: {
-          general: "Erreur lors de la création de l'avis. Veuillez réessayer.",
-        },
-      },
-      { status: 500 },
-    );
+    const generalError: ActionData["errors"] = {
+      general: "Erreur lors de la création de l'avis. Veuillez réessayer.",
+    };
+    return data({ errors: generalError }, { status: 500 });
   }
 }
 

--- a/frontend/app/routes/search.cnit.tsx
+++ b/frontend/app/routes/search.cnit.tsx
@@ -5,11 +5,7 @@
  * Route: /search/cnit
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Form,
@@ -86,7 +82,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const cnitCode = url.searchParams.get("code")?.trim();
 
   if (!cnitCode) {
-    return json<LoaderData>({ searchTerm: "" });
+    return { searchTerm: "" };
   }
 
   try {
@@ -107,10 +103,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       logger.error("API Error:", response.status, errorText);
 
       if (response.status === 404) {
-        return json<LoaderData>({
+        return {
           searchTerm: cnitCode,
           error: "Aucun véhicule trouvé pour ce code CNIT",
-        });
+        };
       }
 
       throw new Error(`Erreur API: ${response.status}`);
@@ -120,22 +116,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     // La réponse de notre API est un VehicleResponseDto
     if (result.data && result.data.length > 0) {
-      return json<LoaderData>({
+      return {
         vehicle: result.data[0], // Premier résultat
         searchTerm: cnitCode,
-      });
+      };
     } else {
-      return json<LoaderData>({
+      return {
         searchTerm: cnitCode,
         error: "Aucun véhicule trouvé pour ce code CNIT",
-      });
+      };
     }
   } catch (error) {
     logger.error("Search error:", error);
-    return json<LoaderData>({
+    return {
       searchTerm: cnitCode,
       error: "Erreur lors de la recherche. Veuillez réessayer.",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/search.mine.tsx
+++ b/frontend/app/routes/search.mine.tsx
@@ -5,11 +5,7 @@
  * Route: /search/mine
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Form,
@@ -81,7 +77,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const mineCode = url.searchParams.get("code")?.trim();
 
   if (!mineCode) {
-    return json<LoaderData>({ searchTerm: "" });
+    return { searchTerm: "" };
   }
 
   try {
@@ -102,10 +98,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       logger.error("API Error:", response.status, errorText);
 
       if (response.status === 404) {
-        return json<LoaderData>({
+        return {
           searchTerm: mineCode,
           error: "Aucun véhicule trouvé pour ce code mine",
-        });
+        };
       }
 
       throw new Error(`Erreur API: ${response.status}`);
@@ -115,22 +111,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     // La réponse de notre API est un VehicleResponseDto
     if (result.data && result.data.length > 0) {
-      return json<LoaderData>({
+      return {
         vehicle: result.data[0], // Premier résultat
         searchTerm: mineCode,
-      });
+      };
     } else {
-      return json<LoaderData>({
+      return {
         searchTerm: mineCode,
         error: "Aucun véhicule trouvé pour ce code mine",
-      });
+      };
     }
   } catch (error) {
     logger.error("Search error:", error);
-    return json<LoaderData>({
+    return {
       searchTerm: mineCode,
       error: "Erreur lors de la recherche. Veuillez réessayer.",
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/search.results.tsx
+++ b/frontend/app/routes/search.results.tsx
@@ -2,11 +2,7 @@
  * 🔍 SEARCH RESULTS PAGE - Page de résultats de recherche v3.0
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   useNavigation,
@@ -69,14 +65,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const version = (url.searchParams.get("version") as "v7" | "v8") || "v8";
 
   if (!query) {
-    return json<SearchResultsData>({
+    return {
       query: "",
       results: [],
       totalCount: 0,
       searchTime: 0,
       version,
       suggestions: [],
-    });
+    };
   }
 
   // Simulation d'appel API (en réalité, ceci ferait appel au SearchService backend)
@@ -113,7 +109,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       result.description.toLowerCase().includes(query.toLowerCase()),
   );
 
-  return json<SearchResultsData>({
+  return {
     query,
     results: mockResults,
     totalCount: mockResults.length,
@@ -123,7 +119,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       query.length > 2
         ? [`${query} compatible`, `${query} original`, `${query} haute qualité`]
         : [],
-  });
+  };
 }
 
 export default function SearchResults() {

--- a/frontend/app/routes/search.tsx
+++ b/frontend/app/routes/search.tsx
@@ -15,11 +15,7 @@
  * - Mobile-first responsive
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   useSearchParams,
@@ -133,7 +129,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   // Retour rapide si pas de requête
   if (!query) {
-    return json<SearchPageData>({
+    return {
       results: null,
       pieces: [],
       groupedPieces: [],
@@ -141,7 +137,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       filters: {},
       hasError: false,
       performance: { loadTime: Date.now() - startTime },
-    });
+    };
   }
 
   try {
@@ -193,7 +189,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const loadTime = Date.now() - startTime;
 
-    return json<SearchPageData>({
+    return {
       results: {
         ...results,
         page,
@@ -209,11 +205,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
         searchTime: results?.executionTime || 0,
         totalItems: total,
       },
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors de la recherche:", error);
 
-    return json<SearchPageData>({
+    return {
       results: null,
       pieces: [],
       groupedPieces: [],
@@ -222,7 +218,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       hasError: true,
       errorMessage: error instanceof Error ? error.message : "Erreur inconnue",
       performance: { loadTime: Date.now() - startTime },
-    });
+    };
   }
 }
 
@@ -826,7 +822,7 @@ export default function SearchPage() {
                       </button>
                       <button
                         onClick={() => setSortBy("brand")}
-                        className={`w-10 h-10 rounded-lg flex items-center justify-center transition-all ${ sortBy === "brand" ? "bg-primary text-white shadow-md" : "bg-white text-gray-700 hover:bg-gray-50 border border-gray-200" }`}
+                        className={`w-10 h-10 rounded-lg flex items-center justify-center transition-all ${sortBy === "brand" ? "bg-primary text-white shadow-md" : "bg-white text-gray-700 hover:bg-gray-50 border border-gray-200"}`}
                         title="Trier par marque"
                       >
                         <ArrowUpDown className="w-5 h-5" />

--- a/frontend/app/routes/staff._index.tsx
+++ b/frontend/app/routes/staff._index.tsx
@@ -6,11 +6,7 @@
  * Architecture moderne alignée avec orders, users, suppliers
  */
 
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -99,7 +95,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       );
     }
 
-    return json({
+    return {
       staff: staffResult.staff || [],
       statistics: statisticsResult.statistics || {
         total: 0,
@@ -110,11 +106,11 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       pagination: staffResult.pagination,
       success: true,
       timestamp: new Date().toISOString(),
-    });
+    };
   } catch (error) {
     logger.error("Erreur loader staff:", error);
 
-    return json({
+    return {
       staff: [],
       statistics: {
         total: 0,
@@ -126,7 +122,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       success: false,
       error: error instanceof Error ? error.message : "Erreur inconnue",
       timestamp: new Date().toISOString(),
-    });
+    };
   }
 };
 

--- a/frontend/app/routes/support.ai.tsx
+++ b/frontend/app/routes/support.ai.tsx
@@ -1,8 +1,4 @@
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   useLoaderData,
   Link,
@@ -91,7 +87,7 @@ interface _ContactTicket {
 
 export async function loader({ request }: LoaderFunctionArgs) {
   // Version simplifiée pour démo
-  return json({
+  return {
     tickets: [
       {
         msg_id: "demo-1",
@@ -127,7 +123,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         predictive: "ok",
       },
     },
-  });
+  };
 }
 
 // Fonctions utilitaires simplifiées

--- a/frontend/app/routes/support.tsx
+++ b/frontend/app/routes/support.tsx
@@ -2,11 +2,7 @@
  * Dashboard Support - Vue d'ensemble des tickets et statistiques
  * Page principale pour la gestion du support client
  */
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   Link,
   useLoaderData,
@@ -58,14 +54,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
       (ticket) => ticket.priority === "urgent" || ticket.priority === "high",
     );
 
-    return json<LoaderData>({
+    return {
       stats,
       recentTickets: recentTicketsData.tickets,
       urgentTickets: urgentTickets.slice(0, 5),
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors du chargement du dashboard:", error);
-    return json<LoaderData>({
+    return {
       stats: {
         total_tickets: 0,
         open_tickets: 0,
@@ -74,7 +70,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       },
       recentTickets: [],
       urgentTickets: [],
-    });
+    };
   }
 }
 

--- a/frontend/app/routes/tickets.$ticketId.tsx
+++ b/frontend/app/routes/tickets.$ticketId.tsx
@@ -3,10 +3,10 @@
  * Remix Route Component pour voir et modifier un ticket spécifique
  */
 import {
-  json,
   type LoaderFunctionArgs,
   type ActionFunctionArgs,
   type MetaFunction,
+  data,
 } from "@remix-run/node";
 import {
   Form,
@@ -52,7 +52,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
   try {
     const ticket = await getTicket(ticketId, request);
-    return json<LoaderData>({ ticket });
+    return { ticket };
   } catch (error) {
     logger.error("Erreur lors du chargement du ticket:", error);
     throw new Response("Ticket non trouvé", { status: 404 });
@@ -68,10 +68,7 @@ export async function action({ params, request }: ActionFunctionArgs) {
   const ticketId = params.ticketId;
 
   if (!ticketId) {
-    return json<ActionData>(
-      { error: "ID de ticket manquant" },
-      { status: 400 },
-    );
+    return data({ error: "ID de ticket manquant" }, { status: 400 });
   }
 
   try {
@@ -82,18 +79,18 @@ export async function action({ params, request }: ActionFunctionArgs) {
       const newStatus = formData.get("status") as "open" | "closed";
 
       if (!newStatus || !["open", "closed"].includes(newStatus)) {
-        return json<ActionData>({ error: "Statut invalide" }, { status: 400 });
+        return data({ error: "Statut invalide" }, { status: 400 });
       }
 
       await updateTicketStatus(ticketId, newStatus, request);
 
-      return json<ActionData>({ success: true });
+      return { success: true };
     }
 
-    return json<ActionData>({ error: "Action non reconnue" }, { status: 400 });
+    return data({ error: "Action non reconnue" }, { status: 400 });
   } catch (error) {
     logger.error("Erreur lors de l'action:", error);
-    return json<ActionData>(
+    return data(
       {
         error:
           error instanceof Error
@@ -162,13 +159,13 @@ export default function TicketDetailPage() {
       </div>
 
       {/* Messages de retour */}
-      {actionData?.success && (
+      {actionData && "success" in actionData && actionData.success && (
         <Alert intent="success">
           <p>Ticket mis à jour avec succès !</p>
         </Alert>
       )}
 
-      {actionData?.error && (
+      {actionData && "error" in actionData && actionData.error && (
         <Alert intent="error">
           <p>{actionData.error}</p>
         </Alert>

--- a/frontend/app/routes/tickets._index.tsx
+++ b/frontend/app/routes/tickets._index.tsx
@@ -2,11 +2,7 @@
  * Page de gestion des tickets - Liste et recherche
  * Remix Route Component pour la gestion des tickets de support
  */
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type LoaderFunctionArgs, type MetaFunction } from "@remix-run/node";
 import {
   Link,
   useLoaderData,
@@ -69,7 +65,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const stats = await getContactStats(request);
 
-    return json<LoaderData>({
+    return {
       tickets: ticketsData.tickets,
       stats,
       pagination: {
@@ -78,10 +74,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         limit: ticketsData.limit,
         totalPages: Math.ceil(ticketsData.total / ticketsData.limit),
       },
-    });
+    };
   } catch (error) {
     logger.error("Erreur lors du chargement des tickets:", error);
-    return json<LoaderData>({
+    return {
       tickets: [],
       stats: {
         total_tickets: 0,
@@ -90,7 +86,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         tickets_last_24h: 0,
       },
       pagination: { total: 0, page: 1, limit: 10, totalPages: 0 },
-    });
+    };
   }
 }
 

--- a/frontend/app/utils/pieces-vehicle.loader.server.ts
+++ b/frontend/app/utils/pieces-vehicle.loader.server.ts
@@ -5,12 +5,7 @@
  * Extrait de la route pour reduire le fichier principal a un thin orchestrator.
  */
 
-import {
-  defer,
-  json,
-  redirect,
-  type LoaderFunctionArgs,
-} from "@remix-run/node";
+import { redirect, type LoaderFunctionArgs, data } from "@remix-run/node";
 import { enrichTypeNameForHeadings } from "@repo/seo-types";
 import { type NoProductsData } from "~/components/pieces/NoProductsAlternatives";
 import { type FiltersData } from "~/components/pieces/PiecesFilterSidebar";
@@ -266,11 +261,11 @@ export async function piecesVehicleLoader({
     // long-TTL caching of a transient blip (canon: no silent fallback).
     type RmAlternativesResponse = {
       success: boolean;
-      version?: 'v2';
+      version?: "v2";
       etag?: string;
-      alternativeGammes: NoProductsData['alternativeGammes'];
-      alternativeVehicles: NoProductsData['alternativeVehicles'];
-      relatedModels: NoProductsData['relatedModels'];
+      alternativeGammes: NoProductsData["alternativeGammes"];
+      alternativeVehicles: NoProductsData["alternativeVehicles"];
+      relatedModels: NoProductsData["relatedModels"];
     };
     let alternativesData: RmAlternativesResponse | null = null;
     let alternativesFetchOk = false;
@@ -278,7 +273,7 @@ export async function piecesVehicleLoader({
       const altResp = await fetch(
         `http://127.0.0.1:3000/api/rm/alternatives?gamme_id=${gammeId}&type_id=${vehicleIds.typeId}&limit=12`,
         {
-          headers: { Accept: 'application/json' },
+          headers: { Accept: "application/json" },
           signal: AbortSignal.timeout(3000),
         },
       );
@@ -311,19 +306,19 @@ export async function piecesVehicleLoader({
       marqueName: vi?.marqueName ?? _marqueData.alias.replace(/-/g, " "),
       modeleName: vi?.modeleName ?? _modeleData.alias.replace(/-/g, " "),
       typeName: vi?.typeName ?? _typeData.alias.replace(/-/g, " "),
-      typeFuel: vi?.typeFuel ?? '',
-      typePowerPs: vi?.typePowerPs ?? '',
-      yearFrom: vi?.typeYearFrom ?? '',
-      yearTo: vi?.typeYearTo ?? '',
+      typeFuel: vi?.typeFuel ?? "",
+      typePowerPs: vi?.typePowerPs ?? "",
+      yearFrom: vi?.typeYearFrom ?? "",
+      yearTo: vi?.typeYearTo ?? "",
     };
 
     // Beacon télémétrie fire-and-forget (n'attend jamais)
-    void fetch('http://127.0.0.1:3000/api/rm/alternatives/track-soft-404', {
-      method: 'POST',
+    void fetch("http://127.0.0.1:3000/api/rm/alternatives/track-soft-404", {
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'user-agent': request.headers.get('user-agent') ?? '',
-        referer: request.headers.get('referer') ?? '',
+        "Content-Type": "application/json",
+        "user-agent": request.headers.get("user-agent") ?? "",
+        referer: request.headers.get("referer") ?? "",
       },
       body: JSON.stringify({ pg_id: gammeId, type_id: vehicleIds.typeId }),
     }).catch(() => {
@@ -334,7 +329,10 @@ export async function piecesVehicleLoader({
     const alternativeVehicles = alternativesData?.alternativeVehicles ?? [];
     const relatedModels = alternativesData?.relatedModels ?? [];
     const hasAlternatives =
-      alternativeGammes.length + alternativeVehicles.length + relatedModels.length > 0;
+      alternativeGammes.length +
+        alternativeVehicles.length +
+        relatedModels.length >
+      0;
 
     // Canon: cache TTL must reflect payload confidence — no silent fallback,
     // no long-TTL on error paths (feedback_no_long_ttl_cache_on_error_paths).
@@ -347,7 +345,7 @@ export async function piecesVehicleLoader({
         ? "public, max-age=300, s-maxage=3600"
         : "public, max-age=30, s-maxage=30";
 
-    return json(
+    return data(
       {
         noProducts: true as const,
         gammeId,
@@ -516,7 +514,7 @@ export async function piecesVehicleLoader({
     // LCP OPTIMIZATION V6: defer() pour streamer donnees non-critiques
     // Donnees critiques (vehicle, pieces, seo) : retournees immediatement
     // Donnees non-critiques (relatedArticles, blogArticle) : streamees apres le first paint
-    return defer(
+    return data(
       {
         // === DONNEES CRITIQUES (bloquantes, necessaires pour LCP) ===
         canonicalPath,

--- a/frontend/tests/unit/catch-all-404-noindex.test.ts
+++ b/frontend/tests/unit/catch-all-404-noindex.test.ts
@@ -19,7 +19,7 @@ const fetchMock = vi.fn(() =>
  * des 404 (`/wp-admin/`, `/panier`, etc.) ce qui contredit la doctrine SEO.
  *
  * Empirique 2026-05-25 : audit GSC automecanik.com confirme bug sur 3/3 URLs sondées.
- * Fix : tout throw json(..., status 404|410) du catch-all DOIT inclure
+ * Fix : tout throw data(..., { status: 404|410 }) du catch-all DOIT inclure
  * `"X-Robots-Tag": "noindex, follow"` (canon : `noindex` + `follow` pour permettre
  * crawl des liens internes existants tout en empêchant l'indexation).
  */
@@ -35,16 +35,17 @@ describe("catch-all $.tsx — 404/410 X-Robots-Tag noindex,follow", () => {
   it("404 catch-all émet X-Robots-Tag: noindex, follow", async () => {
     const request = new Request("https://www.automecanik.com/wp-admin/");
 
-    let thrown: Response | undefined;
+    let thrown: { init?: { status?: number; headers?: HeadersInit } } | undefined;
     try {
       await loader({ request, params: {}, context: {} } as never);
     } catch (e) {
-      thrown = e as Response;
+      thrown = e as { init?: { status?: number; headers?: HeadersInit } };
     }
 
-    expect(thrown).toBeInstanceOf(Response);
-    expect(thrown?.status).toBe(404);
-    expect(thrown?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+    expect(thrown?.init?.status).toBe(404);
+    expect(new Headers(thrown?.init?.headers).get("X-Robots-Tag")).toBe(
+      "noindex, follow",
+    );
   });
 
   it("410 garbage URL émet X-Robots-Tag: noindex, follow (pas noindex seul)", async () => {
@@ -53,16 +54,17 @@ describe("catch-all $.tsx — 404/410 X-Robots-Tag noindex,follow", () => {
       "https://www.automecanik.com/wl8k5m6HsSkVW3cXi61ZQ==",
     );
 
-    let thrown: Response | undefined;
+    let thrown: { init?: { status?: number; headers?: HeadersInit } } | undefined;
     try {
       await loader({ request, params: {}, context: {} } as never);
     } catch (e) {
-      thrown = e as Response;
+      thrown = e as { init?: { status?: number; headers?: HeadersInit } };
     }
 
-    expect(thrown).toBeInstanceOf(Response);
-    expect(thrown?.status).toBe(410);
-    expect(thrown?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+    expect(thrown?.init?.status).toBe(410);
+    expect(new Headers(thrown?.init?.headers).get("X-Robots-Tag")).toBe(
+      "noindex, follow",
+    );
   });
 
   it("404 de fallback (error path) émet X-Robots-Tag: noindex, follow", async () => {
@@ -74,16 +76,17 @@ describe("catch-all $.tsx — 404/410 X-Robots-Tag noindex,follow", () => {
       "https://www.automecanik.com/this-page-does-not-exist-12345",
     );
 
-    let thrown: Response | undefined;
+    let thrown: { init?: { status?: number; headers?: HeadersInit } } | undefined;
     try {
       await loader({ request, params: {}, context: {} } as never);
     } catch (e) {
-      thrown = e as Response;
+      thrown = e as { init?: { status?: number; headers?: HeadersInit } };
     }
 
-    expect(thrown).toBeInstanceOf(Response);
-    expect(thrown?.status).toBe(404);
-    expect(thrown?.headers.get("X-Robots-Tag")).toBe("noindex, follow");
+    expect(thrown?.init?.status).toBe(404);
+    expect(new Headers(thrown?.init?.headers).get("X-Robots-Tag")).toBe(
+      "noindex, follow",
+    );
   });
 });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,13 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+// Single Fetch (v3_singleFetch) — active les types Single Fetch côté loaders/actions.
+declare module '@remix-run/server-runtime' {
+	interface Future {
+		v3_singleFetch: true;
+	}
+}
+
 const MODE = process.env.NODE_ENV;
 const isProduction = MODE === 'production';
 const isAnalyze = process.env.ANALYZE === 'true';
@@ -120,9 +127,9 @@ export default defineConfig({
 				// use absolute Links only — flag is a no-op for current
 				// code, opt-in for v3 readiness.
 				v3_relativeSplatPath: true,
-				// NOTE: v3_singleFetch deferred to a follow-up PR. Audit
-				// surfaced 18 useFetcher() and 6 headers() exports that
-				// need coordinated review before flipping this flag.
+				// Single Fetch activé (PR-9h Phase A) : json()/defer() migrés vers
+				// data() (status/headers) ou retours bruts ; entry.server passe à streamTimeout.
+				v3_singleFetch: true,
 			},
 
 			// When running locally in development mode, we use the built in remix


### PR DESCRIPTION
## PR-9h Phase A — enable `v3_singleFetch` + migrate `json()`/`defer()` → `data()`/raw

**Première PR du chantier PR-9h** (frontend Remix v2 → React Router v7). Single Fetch est le **prérequis** de RR7 et son flag `v3_singleFetch` était délibérément différé. Le spike a mesuré que la migration `json`/`defer`→`data()` est le **travail dominant** de toute la migration — isolé ici, en amont du core.

### Ce qui change
- **Codemod AST** (ts-morph) — transforme **uniquement** le `json`/`defer` importé de `@remix-run/{node,server-runtime}`, **jamais** `.json()` (Fetch API, ~1000 faux positifs évités) : **669 transforms / 190 fichiers**.
  - `json(x)` → retour brut `x` · `json(x, {status/headers})` → `data(x, {...})` · `defer(x)` → brut.
  - `throw json()` → `throw data()` — **comportement préservé** : le router (`isDataWithResponseInit` → `new Headers(init.headers)` + status) applique `init.status`/`init.headers`. **X-Robots-Tag `noindex,follow` sur 404/410** du catch-all vérifié (test mis à jour pour la sémantique `data()`).
- **entry.server** : `ABORT_DELAY` → `export const streamTimeout = 5000` (+1 s pour l'abort React).
- **vite.config** : `future.v3_singleFetch: true` + augmentation TS `Future { v3_singleFetch: true }`.
- **70 erreurs de type** (Single Fetch rend les unions précises) corrigées **au source** (annoter le retour loader/action, typer les accumulateurs) — **zéro `as any`/`@ts-ignore`**, zéro changement de comportement runtime.

### Vérification locale (Node 22)
- `tsc --noEmit` : **0 erreur** · `turbo build --filter=@fafa/frontend` : **OK** · `eslint` : **0 erreur** (41 warnings import/order non-bloquants) · `vitest` : **270/270**.
- Parité comportement SEO (X-Robots-Tag 404/410) **vérifiée préservée**.
- Aucune dépendance modifiée (`package.json`/lockfile intacts).

### Hors scope (étapes PR-9h suivantes)
ESLint flat-config (retrait `@remix-run/eslint-config`) · migration core RR7 (codemod imports + routes.ts adapter) · Sentry · backend handler · parité URL runtime · TS6.

### Gate runtime
E2E crawler (bot) + navigation client (data) = **smoke PREPROD** (le chantier prévoit soak 72h `runtime-frontend-remix-vite`). **Aucun merge / tag sans GO owner.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
