### PR TITLE
fix(governance): role-purity — word-boundary match + exempt admin operator dashboards

### DIFF
--- a/scripts/governance/__tests__/check-role-purity.test.ts
+++ b/scripts/governance/__tests__/check-role-purity.test.ts
@@ -11,7 +11,7 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-import { checkSource } from "../check-role-purity";
+import { checkSource, isSkipped } from "../check-role-purity";
 
 describe("check-role-purity — comment contamination detection", () => {
   test("detects R3_CONSEILS comment containing R2 transactional vocab", () => {
@@ -161,5 +161,95 @@ describe("check-role-purity — comment contamination detection", () => {
     const violations = checkSource("synthetic.ts", source);
     assert.equal(violations.length, 1);
     assert.equal(violations[0].role, "R4_REFERENCE");
+  });
+
+  test("WORD BOUNDARY: 'use' (R5 wear vocab) does NOT match inside 'carousel'", () => {
+    // Regression: brands._index.tsx header — "carousel modèles populaires" was
+    // flagged because the short term 'use' (usé/usure) matched as a substring of
+    // 'car-ouse-l'. Forbidden terms must match at a word boundary, not mid-word.
+    const source = [
+      "/**",
+      " * 🏷️ LISTE DES MARQUES — Rôle SEO : R1 - ROUTER",
+      " * VERSION avec carousel modèles populaires",
+      " */",
+      "export const brands = 1;",
+    ].join("\n");
+    const violations = checkSource(
+      "frontend/app/routes/brands._index.tsx",
+      source,
+    );
+    assert.equal(
+      violations.length,
+      0,
+      "'use' must not match as a substring of 'carousel'",
+    );
+  });
+
+  test("WORD BOUNDARY: forbidden term still matches an inflected (plural) form", () => {
+    // Left-anchored matching must PRESERVE detection of inflections: a single-role
+    // R4 comment that drifts into 'diagnostics' (plural of R5 'diagnostic') is
+    // still a real contamination and must be flagged.
+    const source = [
+      "// R4_REFERENCE — explique les diagnostics moteur en détail",
+      "export const x = 1;",
+    ].join("\n");
+    const violations = checkSource("synthetic.ts", source);
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].term, "diagnostic");
+  });
+
+  test("WORD BOUNDARY: multi-word forbidden phrase still matches", () => {
+    // 'ajouter au panier' is R2 transactional vocab, forbidden for R4.
+    const source = [
+      "// R4_REFERENCE — cliquer pour ajouter au panier rapidement",
+      "export const x = 1;",
+    ].join("\n");
+    const violations = checkSource("synthetic.ts", source);
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].term, "ajouter au panier");
+  });
+
+  test("ADMIN exemption: operator dashboards are skipped (multi-role by design)", () => {
+    // admin.* routes are back-office operator tooling that orchestrate/observe
+    // MULTIPLE R-roles (SEO HUB, content cockpits). No public role-bound SEO
+    // surface → cross-role vocabulary in their comments is legitimate.
+    assert.equal(isSkipped("frontend/app/routes/admin.seo-hub.tsx"), true);
+    assert.equal(isSkipped("frontend/app/routes/admin.seo-content.tsx"), true);
+    assert.equal(
+      isSkipped("frontend/app/routes/admin.seo-hub.content._index.tsx"),
+      true,
+    );
+  });
+
+  test("ADMIN exemption: public role-bound routes are still scanned", () => {
+    assert.equal(isSkipped("frontend/app/routes/brands._index.tsx"), false);
+    assert.equal(isSkipped("frontend/app/routes/pieces.$gamme.tsx"), false);
+  });
+
+  test("ADMIN exemption anchor is tight (no 'admin'-prefix leak)", () => {
+    // The trailing `\.` in the pattern must keep the exemption from leaking onto
+    // non-admin routes that merely START with the string 'admin'. Locks the
+    // anchor against a future loosening of the skip rule.
+    assert.equal(
+      isSkipped("frontend/app/routes/administration.public.tsx"),
+      false,
+    );
+    assert.equal(isSkipped("frontend/app/routes/adminPanel.tsx"), false);
+    assert.equal(isSkipped("frontend/app/components/admin.widget.tsx"), false);
+  });
+
+  test("real contamination in a 2-role comment is still flagged (no over-exemption)", () => {
+    // Guard: naming R4 + R8 (2 roles) while using R2 transactional vocab
+    // ('acheter', owned by the UNNAMED R2) is still a contamination. Neither
+    // fix may silence this.
+    const source = [
+      "// R4_REFERENCE + R8_VEHICLE — bon endroit pour acheter la pièce",
+      "export const x = 1;",
+    ].join("\n");
+    const violations = checkSource("synthetic.ts", source);
+    assert.ok(
+      violations.some((v) => v.term === "acheter"),
+      "transactional vocab from an unnamed role must still flag",
+    );
   });
 });

--- a/scripts/governance/check-role-purity.ts
+++ b/scripts/governance/check-role-purity.ts
@@ -65,6 +65,17 @@ const SKIP_PATTERNS: readonly RegExp[] = [
   /^scripts\/governance\/check-role-purity\.ts$/,
 ];
 
+// Admin operator dashboards (back-office) orchestrate / observe MULTIPLE R-roles
+// by design — e.g. the SEO HUB layout and content-validation cockpits whose
+// headers legitimately legend "R4 References et R5 Diagnostics". They render no
+// public, role-bound SEO surface, so cross-role vocabulary in their comments is
+// documentation, not contamination. Exempt them (the rule protects public
+// content surfaces; `admin.*` routes are never one). Same intent as the existing
+// SKIP_PATTERNS — kept as a distinct, named constant for review clarity.
+const CROSS_ROLE_OPERATOR_SURFACES: readonly RegExp[] = [
+  /^frontend\/app\/routes\/admin\./,
+];
+
 const OPT_OUT_DIRECTIVE = /\/\/\s*@role-purity-skip\b/;
 
 interface Violation {
@@ -76,9 +87,40 @@ interface Violation {
   readonly commentSnippet: string;
 }
 
-function isSkipped(relPath: string): boolean {
+export function isSkipped(relPath: string): boolean {
   const normalized = relPath.replace(/\\/g, "/");
-  return SKIP_PATTERNS.some((p) => p.test(normalized));
+  return (
+    SKIP_PATTERNS.some((p) => p.test(normalized)) ||
+    CROSS_ROLE_OPERATOR_SURFACES.some((p) => p.test(normalized))
+  );
+}
+
+// Escape a string for safe interpolation into a RegExp source.
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Match a forbidden term at a WORD START (left boundary) instead of as a raw
+// substring. `normalizePhrase` yields lowercased, accent-stripped,
+// space-separated tokens, so the left edge of a token is `^` or whitespace.
+// This prevents a short term being matched mid-word — e.g. "use" (usé/usure,
+// R5 wear vocab) inside "car·ouse·l" or "be·cause" — while leaving the right
+// edge unanchored so inflections still match ("diagnostic" in "diagnostics")
+// and multi-word phrases ("guide d achat") match as before.
+const TERM_REGEX_CACHE = new Map<string, RegExp>();
+
+function commentContainsTerm(
+  normalizedComment: string,
+  normalizedTerm: string,
+): boolean {
+  if (normalizedTerm.length === 0) return false;
+  let re = TERM_REGEX_CACHE.get(normalizedTerm);
+  if (!re) {
+    // Non-global → stateless `.test()`, safe to memoize and reuse.
+    re = new RegExp(`(?:^|\\s)${escapeRegExp(normalizedTerm)}`);
+    TERM_REGEX_CACHE.set(normalizedTerm, re);
+  }
+  return re.test(normalizedComment);
 }
 
 function collectFilesRecursive(dir: string, out: string[]): void {
@@ -240,7 +282,7 @@ export function checkSource(filePath: string, source: string): Violation[] {
       for (const term of forbidden) {
         const normalizedTerm = normalizePhrase(term);
         if (normalizedTerm.length === 0) continue;
-        if (normalizedComment.includes(normalizedTerm)) {
+        if (commentContainsTerm(normalizedComment, normalizedTerm)) {
           const { line, column } = lineColumnFromPos(source, comment.pos);
           violations.push({
             file: filePath,


### PR DESCRIPTION
## Problème

Le check advisory `check-role-purity.ts` (governance-checks, **non-required**) signalait 6 « contaminations » qui sont des **faux positifs pré-existants** — déclenchés simplement parce qu'une PR touche un dashboard admin ou un fichier contenant le mot « carousel », sans aucune vraie contamination de vocabulaire de rôle. Deux mécanismes distincts :

1. **Match en sous-chaîne** : le terme R1-interdit `use` (usé/usure, vocab d'usure R5) matchait **au milieu** de `car·ouse·l` → `brands._index.tsx` faussement flaggé.
2. **Dashboards admin multi-rôles** : les en-têtes des cockpits SEO admin légendent légitimement plusieurs rôles (« R4 References et R5 Diagnostics ») → 4 fichiers `admin.seo-*` faussement flaggés (5 violations).

(Constaté sur PR #1041 — migration Single Fetch — qui ne touche que `frontend/app/routes/*` mais hérite de ces FP via `--changed-since`.)

## Correctif (racine, 2 changements minimaux)

1. **Match au début de mot** (`commentContainsTerm`) au lieu de `.includes` substring. `normalizePhrase` produit des tokens séparés par espace → on ancre le bord **gauche** (`(?:^|\s)`). Le bord droit reste libre, donc les inflexions (`diagnostic`→`diagnostics`) et les phrases multi-mots (`ajouter au panier`) matchent toujours. **Supprime strictement** les matches en milieu de mot — aucun vrai positif perdu.
2. **Exemption des dashboards admin** (`CROSS_ROLE_OPERATOR_SURFACES` = `admin.*`). Outillage back-office, multi-rôle par design, **aucune surface SEO publique** ; le check ne scanne que les **commentaires**, jamais le JSX rendu. Même intention que `SKIP_PATTERNS` existant.

## Ce qui est préservé
- **Aucun canon touché** : `forbidden-overlap.ts` / `role-matrix.md` inchangés.
- Heuristique « 3+ rôles = doc multi-rôle » et contrat « 2 rôles restent in-scope » **conservés**.
- Le terme `use`/`acheter`/etc. continue de flagger une vraie contamination (test garde : `R4 + R8 ... acheter` toujours flaggé, R2 non-nommé).

## Tests (19/19 verts)
Word-boundary (`carousel` non flaggé), inflexion plurielle préservée (`diagnostics`), phrase multi-mots préservée (`ajouter au panier`), exemption admin (3 formes de path), route publique toujours scannée, ancre `admin\.` verrouillée contre fuite (`administration.*`/`adminPanel.tsx`), vraie contamination 2-rôles toujours flaggée.

**Vérif A/B sur les 5 fichiers réels** : 6 faux positifs → **0** (4 admin skippés, brands scanné propre, exit 0).

## Hors-scope (suivi)
- FP résiduels en **bord droit** (`panne`⊂`panneau`, EN `use`⊂`user`) — **pré-existants** (l'ancien substring les matchait aussi), non régressés ici. Un correctif futur pourrait ajouter un bord droit admettant les inflexions FR connues.

## Impact
Débloque le gate advisory role-purity sur les PRs touchant des dashboards admin (dont #1041) et tout fichier contenant un mot englobant un terme court. **Correctif racine, pas un contournement de gate** (le gate n'est pas required ; aucune suppression, aucun `@role-purity-skip` scatter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)