### PR TITLE
feat(content-factory): PR-0 block adapter + D1 WIKI brief generator + IA-SEO doc reconciliation (all dark)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -102,6 +102,12 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: low
+  # D1 brief-from-wiki — colonnes audit provenance __seo_page_brief (additif, non auto-appliqué). Owner GO 2026-06-20. Glob exact.
+  - glob: backend/supabase/migrations/20260620_d1_brief_from_wiki_evidence_columns.sql
+    domain: D14
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: low
   # ADR-059 PR-6 — SEO projection write-side schema (7 tables + 2 MV). Owner GO session 2026-06-19.
   # Glob exact volontaire — les migrations ne sont PAS auto-couvertes (review ownership à chaque fois).
   - glob: backend/supabase/migrations/20260619_adr059_pr6_seo_projection_schema.sql

--- a/agents/seo-content/AGENTS.md
+++ b/agents/seo-content/AGENTS.md
@@ -11,29 +11,46 @@ Tu es le SEO Lead d'AutoMecanik. Tu **audites** la couverture SEO et **crées de
 
 **Mode heartbeat (automatique)** :
 - Appeler l'endpoint d'audit SEO sur DEV
-- Créer des tickets pour les gaps P1 (KP manquant) et P2 (contenu manquant)
+- Créer des tickets pour les gaps de **preuve** (P1) et de **contenu** (P2)
 - Poster rapport de couverture
 
 **Mode ticket (à la demande)** :
-- Audit couverture KP d'une gamme spécifique
-- Rapport top N gammes sans contenu
-- Vérifier statut d'une gamme
+- Audit couverture preuve/contenu d'une gamme ou d'un véhicule
+- Rapport top N entités sans contenu sourcé
+- Vérifier statut d'une entité
+
+## Doctrine contenu — la BOUCLE (non négociable)
+
+Le contenu suit **toujours** : `SCRAPING sourcé → RAW → WIKI (validé) → CONSUMER R1/R2/R3/R8 → mesure SCORE → itérer`.
+Méthode opératoire canonique : skill **`seo-content-loop`** (workspace seo-batch). Canon au vault :
+ADR-031 (raw/wiki/rag/seo) · ADR-046 (RAG = chatbot only) · ADR-059 (projection runtime) ·
+ADR-083 (promotion tiered) · ADR-086 (content excellence).
+
+- ❌ **RAG ≠ source de contenu/SEO** (ADR-046). Le RAG est une couche **chatbot**, jamais une source de vérité contenu.
+  Aucun ticket ne doit demander de « générer depuis le RAG ».
+- ❌ **Keyword brut `__seo_keywords` = signal de comptage uniquement** (mapping contaminé) — jamais un terme produit,
+  jamais le gate. Le gate est **source → WIKI accepté → score rank-#1 capable**.
+- ✅ La vérité documentaire est `RAW → WIKI → exports → consommateurs`. Le contenu ne crée jamais l'information ;
+  il structure ce qui est **sourcé et vérifié**.
 
 ## Hiérarchie
 
-- **Reporte à** : IA-CMO (`811668e1-991a-4c87-bdc0-4648f7520131`)
-- **Coordonne avec** : RAG Lead (`c6762b10`) pour la couverture documentaire
+- **Reporte à** : IA-CMO (UUID dans le registre Paperclip — SoT mapping, jamais en dur ici)
+- **Coordonne avec** : RAG Lead (couverture documentaire chatbot)
 - **Périmètre strict** : SEO uniquement — ne pas toucher au pipeline RAG (c'est RAG Lead)
 
 ## Infrastructure
 
-**Accès disponible depuis AI-COS :**
-- NestJS DEV API : `http://46.224.118.55:3000` (HTTP uniquement)
-- Paperclip API : `http://178.104.1.118:3100` (gestion tickets)
+**Accès disponibles depuis AI-COS** (HTTP/MCP, lecture seule — endpoints sans IP en dur, voir `.claude/rules/deployment.md`) :
+- NestJS **DEV API** (poste opérateur DEV) — audit SEO interne
+- **Paperclip API** — gestion tickets
 
-**Accès NON disponible depuis AI-COS :**
+**Accès NON disponibles depuis AI-COS :**
 - `mcp__supabase__execute_sql` — utiliser l'endpoint NestJS à la place
-- `claude --print "/skill"` — les skills ne sont pas chargés sur AI-COS
+- skills Claude Code — non chargés sur AI-COS
+
+> Hôtes, ports, IP et UUID : jamais en dur dans ce fichier (garde `scripts/agents/validate-agents-md.sh`).
+> Topologie DEV/PREPROD/PROD : `.claude/rules/deployment.md`. UUID agents : registre Paperclip.
 
 ## Protocole heartbeat
 
@@ -41,98 +58,69 @@ Tu es le SEO Lead d'AutoMecanik. Tu **audites** la couverture SEO et **crées de
 
 ### 1. Récupérer l'audit de couverture SEO
 
-```bash
-curl -s -H "X-Internal-Key: $INTERNAL_API_KEY" \
-  http://46.224.118.55:3000/api/internal/seo/audit/coverage
-```
+Appeler (clé interne en en-tête) l'endpoint DEV : `/api/internal/seo/audit/coverage` (base URL DEV — voir `.claude/rules/deployment.md`).
 
 Réponse JSON :
 ```json
 {
   "timestamp": "...",
-  "gammes_total": 241,
-  "kp_r3_missing": [{"pg_alias": "...", "pg_name": "..."}],
-  "kp_r3_missing_count": N,
-  "kp_r6_missing": [...],
-  "kp_r6_missing_count": N,
-  "content_r3_missing": [...],
-  "content_r3_missing_count": N,
-  "p1_count": N,
-  "p2_count": N
+  "entities_total": "N",
+  "wiki_missing": [{ "slug": "...", "name": "...", "kind": "gamme|vehicle" }],
+  "wiki_missing_count": "N",
+  "content_missing": ["..."],
+  "content_missing_count": "N",
+  "p1_count": "N",
+  "p2_count": "N"
 }
 ```
 
 ### 2. Analyser les gaps
 
-- **P1** (bloquant) : `kp_r3_missing_count > 0` → KP manquant, impossible de générer du contenu
-- **P2** (important) : gammes dans `content_r3_missing` mais présentes dans `kp_r3_missing` est vide → KP ok mais pas de contenu
-- **KW** (informatif) : `kw_missing_count > 0` → gammes sans données Google Ads dans `__seo_keywords` — non bloquant, pipeline continue normalement
-- Priorité aux gammes avec forte valeur trafic (alphabétique si pas de signal trafic)
+- **P1** (bloquant) : entité à valeur trafic **sans WIKI sourcé** (`wiki_missing`) → impossible de produire du contenu prouvé.
+- **P2** (important) : WIKI accepté présent mais **contenu R non composé** (`content_missing`).
+- **KW** (informatif) : absence de données Google Ads — **non bloquant**, simple signal de demande (comptage), jamais un gate.
+- Priorité aux entités à forte valeur trafic (alphabétique si pas de signal).
 
 ### 3. Créer des tickets d'action DEV
 
-Pour chaque gap P1 (max 5 tickets par heartbeat) :
+Pour chaque gap P1 (max 5 tickets / heartbeat) :
 
-**Titre** : `[KP_GAMME] <pg_alias>`  
+**Titre** : `[WIKI_SOURCED] <slug>`
 **Description** :
 ```
-KP R3 manquant pour la gamme "<pg_nom>" (<pg_alias>).
+Pas de WIKI sourcé pour "<nom>" (<slug>). Le contenu ne peut pas être produit sans preuve.
 
-**Action DEV requise :**
-cd /opt/automecanik/app && claude --print "/kp <pg_alias> --r3"
+**Action DEV requise (BOUCLE seo-content-loop) :**
+1. Scraper sourcé (sources primaires/OE) -> automecanik-raw/sources/web-research/<slug>/
+2. Revue humaine -> proposal WIKI -> score rank-#1 capable -> promotion TIER A
 
-Priorité : P1
-Gamme : <pg_alias>
-Détecté le : <timestamp>
+Priorité : P1 — Entité : <slug> — Détecté le : <timestamp>
 ```
 **Assigné à** : IA-CMO ou board humain pour validation
 
-Si `kw_missing_count > 50` (gap batch) — **1 seul ticket global** (pas de ticket par gamme) :
+Pour chaque gap P2 (max 3 tickets / heartbeat) :
 
-**Titre** : `[KW_BATCH_IMPORT]`  
+**Titre** : `[CONTENT_R] <slug>`
 **Description** :
 ```
-229+ gammes sans données Google Ads dans __seo_keywords.
+WIKI accepté ✅ mais contenu R non composé pour "<nom>" (<slug>).
 
-**Informatif uniquement — non bloquant.**
-Le contenu est produit par le pipeline WIKI gouverné (RAW → WIKI → projection, ADR-031/059) ; les données Google Ads sont un signal non bloquant, jamais une source.
+**Action DEV requise :** composer R1/R3/R8 depuis la projection WIKI (consumer, flags OFF + preview),
+jamais depuis le RAG. Voir skill seo-content-loop.
 
-Action DEV requise :
-1. Créer scripts/seo/import-gads-kp-to-db.py
-2. Fournir CSV Google Ads (alias,keyword,volume,cpc) pour les gammes manquantes
-3. Lancer l'import batch
-
-Priorité : P3 (low)
-kw_missing_count : <N>
-Détecté le : <timestamp>
+Priorité : P2 — Entité : <slug> — Détecté le : <timestamp>
 ```
-⚠️ Ne pas recréer ce ticket si un ticket [KW_BATCH_IMPORT] ouvert existe déjà (idempotence).
 
-Si `kw_missing_count <= 50` (gap résiduel) — tickets individuels (max 3/heartbeat, priorité low) :
+Signal KW (informatif, max 1 ticket global, idempotent) :
 
-**Titre** : `[KW_MANQUANT] <pg_alias>`  
+**Titre** : `[KW_DEMAND_SIGNAL]`
 **Description** :
 ```
-Données Google Ads absentes pour "<pg_alias>" dans __seo_keywords.
-Informatif uniquement — non bloquant.
-Action optionnelle : importer les keywords Google Ads pour cette gamme.
-Priorité : low — Détecté le : <timestamp>
+N entités sans données Google Ads dans __seo_keywords.
+**Informatif uniquement — non bloquant.** Le KW est un signal de demande (comptage), pas une source de contenu.
+Priorité : P3 (low) — Détecté le : <timestamp>
 ```
-
-Pour chaque gap P2 (max 3 tickets par heartbeat) :
-
-**Titre** : `[CONTENT_R3] <pg_alias>`  
-**Description** :
-```
-Contenu R3 manquant pour "<pg_nom>" (<pg_alias>). KP validé ✅.
-
-**Action DEV requise :**
-cd /opt/automecanik/app && claude --print "/seo-content-loop <pg_alias>"
-
-Priorité : P2
-Gamme : <pg_alias>
-Détecté le : <timestamp>
-```
+⚠️ Ne pas recréer si un ticket ouvert du même titre existe (idempotence).
 
 ### 4. Poster rapport heartbeat
 
@@ -141,14 +129,14 @@ Format :
 ## Rapport SEO — [DATE]
 
 **Audit couverture :**
-- Gammes totales : N
-- KP R3 manquant (P1) : N gammes
-- Contenu R3 manquant (P2) : N gammes
+- Entités totales : N
+- WIKI sourcé manquant (P1) : N
+- Contenu R non composé (P2) : N
 
 **Tickets créés ce heartbeat :**
-- [KP_GAMME] alias-1, alias-2, ...
-- [CONTENT_R3] alias-3, ...
-- [KW_BATCH_IMPORT] (si kw_missing > 50) ou [KW_MANQUANT] alias-4, ... (si ≤ 50)
+- [WIKI_SOURCED] slug-1, slug-2, ...
+- [CONTENT_R] slug-3, ...
+- [KW_DEMAND_SIGNAL] (si applicable)
 
 **Actions en attente de DEV :**
 [liste ou "RAS"]
@@ -158,48 +146,33 @@ Format :
 
 ## Types de tickets (référence)
 
-> **Provenance du contenu (canon)** : le contenu R* est produit par le pipeline **WIKI gouverné**
-> (RAW → WIKI → projection → DB ; ADR-031 / ADR-059 / ADR-083), méthode opératoire `/seo-content-loop`.
-> Le **RAG n'est jamais source de contenu** (RAG = chatbot only, ADR-046) ; le mode RAG-source
-> `/content-gen` est **legacy/abandonné pour le contenu** (cf. `workspaces/seo-batch/README.md`).
-> Les données Google Ads (`__seo_keywords`) sont un **signal non bloquant**, jamais une source.
+### WIKI_SOURCED — Pas de WIKI sourcé (bloque la production de contenu prouvé)
+Action DEV : BOUCLE `seo-content-loop` (scrape sourcé → RAW → proposal WIKI → score → promotion TIER A).
 
-### KP_GAMME — Keyword plan manquant
-Action DEV : `claude --print "/kp <alias> --r3"` dans `/opt/automecanik/app`
+### CONTENT_R — WIKI accepté, contenu R non composé
+Action DEV : composer R1/R3/R8 depuis la **projection WIKI** (consumer, flags OFF + preview). Jamais depuis le RAG.
 
-### CONTENT_R3 — Contenu R3 manquant (KP ok)
-Action DEV : `claude --print "/seo-content-loop <alias>"` dans `/opt/automecanik/app` (cible : sections conseil R3)
+### KW_DEMAND_SIGNAL — Données Google Ads absentes (informatif, P3)
+Signal de demande (comptage) uniquement. **Non bloquant** — n'est jamais une source de contenu.
 
-### CONTENT_R6 — Guide d'achat R6 manquant
-Action DEV : `claude --print "/seo-content-loop <alias>"` dans `/opt/automecanik/app` (cible : guide d'achat R6)
-
-### KW_BATCH_IMPORT — Import batch Google Ads manquant (informatif, P3)
-Créer si `kw_missing_count > 50`. **1 seul ticket global** — pas de ticket par gamme.
-Action DEV : créer `scripts/seo/import-gads-kp-to-db.py` + fournir CSV Google Ads.
-**Non bloquant** — le contenu vient du pipeline WIKI gouverné (RAW → WIKI → projection, ADR-031/059), pas de cette donnée KW.
-
-### KW_MANQUANT — Données Google Ads absentes pour une gamme (informatif, low)
-Créer si `kw_missing_count <= 50`. Max 3 tickets/heartbeat.
-**Non bloquant** — le contenu vient du pipeline WIKI gouverné (RAW → WIKI → projection, ADR-031/059), pas de cette donnée KW.
-
-### AUDIT_SEO — Audit qualité d'une gamme
-Action DEV : `claude --print "/seo-gamme-audit <alias>"` dans `/opt/automecanik/app`
+### AUDIT_SEO — Audit qualité d'une entité
+Action DEV : audit gamme/véhicule (skill `seo-gamme-audit`).
 
 ## Règles de comportement
 
-1. **Jamais d'exécution directe** — créer des tickets, ne pas lancer de commands bash/skills.
-2. **Jamais de `mcp__supabase__execute_sql`** — utiliser l'endpoint HTTP `/api/internal/seo/audit/coverage`.
-3. **Idempotence** : avant de créer un ticket, vérifier si un ticket ouvert avec le même titre existe déjà.
-4. **Max 11 tickets par heartbeat** (5 P1 + 3 P2 + 3 KW low) — éviter le flooding.
+1. **Jamais d'exécution directe** — créer des tickets, ne pas lancer de commandes/skills.
+2. **Jamais de `mcp__supabase__execute_sql`** — utiliser l'endpoint HTTP d'audit SEO interne.
+3. **Idempotence** : avant de créer un ticket, vérifier si un ticket ouvert du même titre existe.
+4. **Max 9 tickets / heartbeat** (5 P1 + 3 P2 + 1 KW signal) — éviter le flooding.
 5. **Budget tokens** : rester concis. Pas d'analyse narrative longue.
 6. **Retry policy** : 0 retry sur 4xx/5xx. 1 retry sur timeout réseau.
 7. **Escalade** : tout P1 SEO → IA-CMO, tout P1 technique → IA-CTO.
 
 ## Définitions des priorités
 
-- **P1** : KP manquant → bloque la génération de contenu
-- **P2** : KP présent mais contenu absent → génération possible, non déclenchée
-- **P3** : refresh, amélioration scores qualité, optimisation
+- **P1** : pas de WIKI sourcé → bloque la production de contenu prouvé
+- **P2** : WIKI accepté mais contenu R non composé → composition possible, non déclenchée
+- **P3** : refresh, amélioration scores qualité, signal de demande
 
 ## Recherche documentaire (avant analyse)
 

--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "generated_at": "2026-02-03T14:00:00Z",
   "description": "RPC READ_SAFE - Autorisees pour tous les roles",
-  "total": 181,
+  "total": 183,
   "functions": [
     {
       "name": "__gov_m1_table_sizes",
@@ -408,6 +408,11 @@
       "name": "get_merchant_center_feed_v1",
       "volatility": "STABLE",
       "reason": "PR commerce-loop V1 step 5B — Google Shopping XML feed rows. STABLE pure SELECT joins pieces × price × gamme × marque × media_img. Called by MerchantCenterFeedService.fetchPage (pagination). GRANT EXECUTE service_role only."
+    },
+    {
+      "name": "get_active_seo_projection",
+      "volatility": "STABLE",
+      "reason": "ADR-059/090 D1 — SEO projection read (facts+blocks envelope, role-filtered). STABLE SECURITY DEFINER pure SELECT over mv_seo_entity_facts_current × mv_seo_content_blocks_current. Backend-proxied (no anon GRANT), called by SeoBriefService.composeBrief. EXECUTE service_role only."
     },
     {
       "name": "get_missing_v4_type_ids",

--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -70,6 +70,15 @@ export class FeatureFlagsService {
     return this.bool('BRIEF_AWARE_ENABLED', false);
   }
 
+  /**
+   * Gate le générateur de briefs **evidence-driven** (D1, SeoBriefService) : ON → le brief est composé
+   * depuis la projection WIKI (get_active_seo_projection) au lieu du chemin keyword-first. OFF (défaut) →
+   * comportement keyword-first inchangé. Dégrade observable (wiki_available=false) si projection absente.
+   */
+  get seoBriefWikiEnabled(): boolean {
+    return this.bool('SEO_BRIEF_WIKI_ENABLED', false);
+  }
+
   // ── Phase 2 Orchestration flags ──
 
   get executionRegistryEnabled(): boolean {
@@ -330,6 +339,7 @@ export class FeatureFlagsService {
     'R8_OWNED_EDITORIAL_ENABLED',
     'BRIEF_GATES_ENABLED',
     'BRIEF_GATES_OBSERVE_ONLY',
+    'SEO_BRIEF_WIKI_ENABLED',
     'RAG_CATCHUP_ENABLED',
     'RAG_MERGE_DRY_RUN',
     'RAG_MERGE_ALLOWED_ROLES',

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -78,6 +78,7 @@ import {
 import { ConseilEnricherService } from './services/conseil-enricher.service'; // 🔄 R3 Conseils enricher
 import { CanonObservabilityService } from './services/canon-observability.service'; // 🛡️ Canon violation Sentry emitter
 import { PageBriefService } from './services/page-brief.service'; // 📋 Page Briefs CRUD + overlap
+import { SeoBriefService } from './services/seo-brief.service'; // 🧱 D1 — WIKI-driven evidence brief (ADR-059/090)
 import { BriefGatesService } from './services/brief-gates.service'; // 🚦 Pre-publish gates anti-cannibalisation
 import { HardGatesService } from './services/hard-gates.service'; // 🚦 Hard gates (attribution, no_guess, scope, contradiction, seo)
 import { KeywordDensityGateService } from './services/keyword-density-gate.service'; // 🚦 Gate F: keyword density check
@@ -271,6 +272,7 @@ import { SeoControlRefreshProcessor } from './processors/seo-control-refresh.pro
     ConseilEnricherService, // 🔄 R3 Conseils S1-S8 enricher
     CanonObservabilityService, // 🛡️ Canon violation Sentry emitter (R3 PR-E)
     PageBriefService, // 📋 Page Briefs CRUD + overlap detection
+    SeoBriefService, // 🧱 D1 — WIKI-driven evidence brief generator (flag SEO_BRIEF_WIKI_ENABLED, OFF)
     BriefGatesService, // 🚦 Pre-publish gates anti-cannibalisation
     HardGatesService, // 🚦 Hard gates (attribution, no_guess, scope, contradiction, seo)
     KeywordDensityGateService, // 🚦 Gate F: keyword density (feature flag KEYWORD_DENSITY_GATE_ENABLED)

--- a/backend/src/modules/admin/services/brief-template.d1.test.ts
+++ b/backend/src/modules/admin/services/brief-template.d1.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests D1 — helpers PURES d'intégration brief-template (toBriefRole + wikiOverridesFromBundle).
+ * Le câblage DB (bulkGenerateFromTemplate) n'est pas testé ici (I/O) ; on couvre la logique déterministe.
+ */
+import { toBriefRole, wikiOverridesFromBundle } from './brief-template.service';
+import { type BriefEvidenceBundle } from './seo-brief.service';
+
+describe('toBriefRole', () => {
+  it('mappe les rôles composables WIKI', () => {
+    expect(toBriefRole('R3')).toBe('R3_CONSEILS');
+    expect(toBriefRole('r3_conseils')).toBe('R3_CONSEILS');
+    expect(toBriefRole('R6')).toBe('R3_GUIDE');
+    expect(toBriefRole('R6_GUIDE_ACHAT')).toBe('R3_GUIDE');
+    expect(toBriefRole('R8')).toBe('R8_VEHICLE');
+    expect(toBriefRole('R8_VEHICLE')).toBe('R8_VEHICLE');
+  });
+
+  it('retourne null pour R2 et rôles non composés (→ keyword-first conservé)', () => {
+    expect(toBriefRole('R2')).toBeNull();
+    expect(toBriefRole('R2_PRODUCT')).toBeNull();
+    expect(toBriefRole('R1')).toBeNull();
+    expect(toBriefRole('')).toBeNull();
+  });
+});
+
+describe('wikiOverridesFromBundle', () => {
+  it('mappe les champs du bundle vers BriefOverrides (preuves = source_ids, jamais de texte inventé)', () => {
+    const bundle: BriefEvidenceBundle = {
+      entity_id: 'gamme:filtre-a-air',
+      page_role: 'R3_CONSEILS',
+      wiki_available: true,
+      proprietary_count: 5,
+      substance_gate: { pass: true, count: 5, floor: 5, reasons: [] },
+      brief_source: 'wiki_evidence',
+      brief_fields: {
+        angles_obligatoires: ['diagnostic', 'symptomes'],
+        preuves: ['oem:bosch-1', 'web:vroomly-2'],
+        termes_techniques: ['debitmetre'],
+      },
+      substance_elements: [],
+      evidence_source_mix: {
+        db_owned: 1,
+        sourced: 4,
+        inferred: 0,
+        editorial: 0,
+      },
+      demand_signal: {},
+    };
+    const ov = wikiOverridesFromBundle(bundle);
+    expect(ov.angles_obligatoires).toEqual(['diagnostic', 'symptomes']);
+    expect(ov.preuves).toEqual(['oem:bosch-1', 'web:vroomly-2']);
+    expect(ov.termes_techniques).toEqual(['debitmetre']);
+  });
+});

--- a/backend/src/modules/admin/services/brief-template.service.ts
+++ b/backend/src/modules/admin/services/brief-template.service.ts
@@ -1,7 +1,18 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  Optional,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHash } from 'node:crypto';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { FeatureFlagsService } from '@config/feature-flags.service';
+import {
+  SeoBriefService,
+  type BriefRole,
+  type BriefEvidenceBundle,
+} from './seo-brief.service';
 
 // ── Types ──
 
@@ -35,14 +46,81 @@ export interface CloneDetectionResult {
   isClone: boolean;
 }
 
+// ── D1 — helpers PURES (evidence-driven brief, ADR-059/086) ──
+
+/**
+ * Map un `page_role` de brief (string DB) vers un `BriefRole` composable WIKI. Retourne `null` pour
+ * R2 et tout rôle non couvert par la fabrique evidence-driven → le chemin keyword-first est conservé.
+ */
+export function toBriefRole(pageRole: string): BriefRole | null {
+  const r = (pageRole ?? '').toUpperCase();
+  if (r === 'R3' || r === 'R3_CONSEILS') return 'R3_CONSEILS';
+  if (r === 'R6' || r === 'R3_GUIDE' || r === 'R6_GUIDE_ACHAT')
+    return 'R3_GUIDE';
+  if (r === 'R8' || r === 'R8_VEHICLE') return 'R8_VEHICLE';
+  return null; // R2 + autres → jamais via WIKI ici (page transactionnelle = chemin strict dédié)
+}
+
+/** Construit des `BriefOverrides` depuis un bundle WIKI (preuves citables, jamais de texte inventé). PURE. */
+export function wikiOverridesFromBundle(
+  bundle: BriefEvidenceBundle,
+): BriefOverrides {
+  return {
+    angles_obligatoires: bundle.brief_fields.angles_obligatoires,
+    preuves: bundle.brief_fields.preuves,
+    termes_techniques: bundle.brief_fields.termes_techniques,
+  };
+}
+
 // ── Service ──
 
 @Injectable()
 export class BriefTemplateService extends SupabaseBaseService {
   protected override readonly logger = new Logger(BriefTemplateService.name);
 
-  constructor(configService: ConfigService) {
+  constructor(
+    configService: ConfigService,
+    @Optional() private readonly featureFlags?: FeatureFlagsService,
+    @Optional() private readonly seoBrief?: SeoBriefService,
+  ) {
     super(configService);
+  }
+
+  /**
+   * D1 — tente un brief evidence-driven depuis la projection WIKI. Retourne `null` (→ keyword-first)
+   * si flag OFF / rôle non composable / projection indisponible / gate substance FAIL. **Observable**
+   * (chaque dégradation est loguée, jamais de fallback silencieux).
+   */
+  private async tryComposeWikiBrief(
+    pgId: number,
+    pgAlias: string,
+    pageRole: string,
+  ): Promise<BriefEvidenceBundle | null> {
+    if (!this.featureFlags?.seoBriefWikiEnabled || !this.seoBrief) return null;
+    const role = toBriefRole(pageRole);
+    if (!role) return null;
+
+    const bundle = await this.seoBrief.composeBrief({
+      pgId,
+      pgAlias,
+      pageRole: role,
+    });
+    if (!bundle.wiki_available) {
+      this.logger.log(
+        `[D1] ${pgAlias}/${pageRole}: WIKI indisponible (${bundle.substance_gate.reasons[0] ?? 'n/a'}) → keyword-first`,
+      );
+      return null;
+    }
+    if (!bundle.substance_gate.pass) {
+      this.logger.warn(
+        `[D1] ${pgAlias}/${pageRole}: substance gate FAIL (${bundle.substance_gate.reasons.join('; ')}) → keyword-first`,
+      );
+      return null;
+    }
+    this.logger.log(
+      `[D1] ${pgAlias}/${pageRole}: brief WIKI (${bundle.proprietary_count} preuves propriétaires)`,
+    );
+    return bundle;
   }
 
   // ── Template CRUD ──
@@ -348,12 +426,22 @@ export class BriefTemplateService extends SupabaseBaseService {
       }
 
       try {
-        // Build overrides from gamme-specific data
-        const overrides = await this.buildGammeOverrides(
+        // D1 — chemin evidence-driven (flag-gated). Dégrade observable vers keyword-first si indispo/gate FAIL.
+        const wikiBundle = await this.tryComposeWikiBrief(
           gamme.pg_id,
           gamme.pg_alias,
-          gamme.pg_name,
+          pageRole,
         );
+        const useWiki = wikiBundle != null;
+
+        // Overrides : WIKI (preuves citables) si dispo + gate OK, sinon keyword-first (chemin existant inchangé).
+        const overrides = useWiki
+          ? wikiOverridesFromBundle(wikiBundle)
+          : await this.buildGammeOverrides(
+              gamme.pg_id,
+              gamme.pg_alias,
+              gamme.pg_name,
+            );
 
         const overridesHash = this.computeOverridesHash(overrides);
 
@@ -392,6 +480,17 @@ export class BriefTemplateService extends SupabaseBaseService {
             coverage_score: this.computeCoverageScore(merged),
             version: 1,
             status: 'draft',
+            // D1 provenance — colonnes additives écrites SEULEMENT en chemin wiki_evidence (flag ON +
+            // migration 20260620_d1_brief_from_wiki_evidence_columns appliquée). Chemin keyword = byte-identique.
+            ...(useWiki
+              ? {
+                  brief_source: 'wiki_evidence',
+                  substance_count: wikiBundle.proprietary_count,
+                  substance_elements: wikiBundle.substance_elements,
+                  evidence_source_mix: wikiBundle.evidence_source_mix,
+                  demand_signal: wikiBundle.demand_signal,
+                }
+              : {}),
           });
         }
 

--- a/backend/src/modules/admin/services/seo-brief.service.test.ts
+++ b/backend/src/modules/admin/services/seo-brief.service.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests du gate de substance déterministe (D1, ADR-086) — fonctions PURES, sans I/O.
+ * On vérifie : extraction depuis block.content (forme PR-0), comptage propriétaire (db_owned|sourced + source_id),
+ * SOURCE_MIX (pas 100% éditorial), SUBSTANCE_FLOOR par rôle, EVIDENCE_BOUND (orphelins non comptés), exclusion R2.
+ */
+import {
+  extractSubstanceElements,
+  countProprietary,
+  sourceMix,
+  evaluateSubstanceGate,
+  SUBSTANCE_FLOOR_BY_ROLE,
+  type BriefRole,
+  type BlockTruthLevel,
+} from './seo-brief.service';
+
+const block = (
+  truth_level: BlockTruthLevel,
+  source_ids: string[],
+  role = 'R3_CONSEILS',
+  section = 'diagnostic',
+) => ({
+  role,
+  block_kind: section,
+  content: { content_md: 'x'.repeat(80), source_ids, truth_level, section },
+});
+
+describe('extractSubstanceElements', () => {
+  it('lit truth_level/source_ids DANS block.content (forme réglée par PR-0), filtre par rôle', () => {
+    const blocks = [
+      block('sourced', ['oem:bosch-1'], 'R3_CONSEILS', 's1'),
+      block('db_owned', ['db:pieces'], 'R8_VEHICLE', 's2'), // autre rôle → exclu
+    ];
+    const els = extractSubstanceElements(blocks, 'R3_CONSEILS');
+    expect(els).toHaveLength(1);
+    expect(els[0]).toMatchObject({
+      truth_level: 'sourced',
+      source_id: 'oem:bosch-1',
+      field: 's1',
+    });
+  });
+
+  it('ignore les blocs sans truth_level (pas de fabrication)', () => {
+    const els = extractSubstanceElements(
+      [{ role: 'R3_CONSEILS', content: { content_md: 'y' } }],
+      'R3_CONSEILS',
+    );
+    expect(els).toHaveLength(0);
+  });
+});
+
+describe('countProprietary', () => {
+  it('compte seulement db_owned|sourced AVEC source_id', () => {
+    const els = extractSubstanceElements(
+      [
+        block('db_owned', ['db:x']),
+        block('sourced', ['web:y']),
+        block('sourced', []), // pas de source_id → non compté (EVIDENCE_BOUND)
+        block('editorial', ['web:z']), // editorial → non propriétaire
+        block('inferred', ['raw:w']), // inferred → non propriétaire
+      ],
+      'R3_CONSEILS',
+    );
+    expect(countProprietary(els)).toBe(2);
+  });
+});
+
+describe('sourceMix', () => {
+  it('répartit par truth_level', () => {
+    const els = extractSubstanceElements(
+      [
+        block('db_owned', ['db:a']),
+        block('editorial', []),
+        block('editorial', []),
+      ],
+      'R3_CONSEILS',
+    );
+    expect(sourceMix(els)).toEqual({
+      db_owned: 1,
+      sourced: 0,
+      inferred: 0,
+      editorial: 2,
+    });
+  });
+});
+
+describe('evaluateSubstanceGate', () => {
+  const fiveProprietary = (role: BriefRole) =>
+    extractSubstanceElements(
+      Array.from({ length: 5 }, (_, i) =>
+        block(
+          'sourced',
+          [`oem:s${i}`],
+          role === 'R8_VEHICLE' ? 'R8_VEHICLE' : 'R3_CONSEILS',
+          `sec${i}`,
+        ),
+      ),
+      role === 'R8_VEHICLE' ? 'R8_VEHICLE' : 'R3_CONSEILS',
+    );
+
+  it('PASS quand le plancher du rôle est atteint avec preuves', () => {
+    const r = evaluateSubstanceGate(
+      fiveProprietary('R3_CONSEILS'),
+      'R3_CONSEILS',
+    );
+    expect(r.pass).toBe(true);
+    expect(r.count).toBe(5);
+    expect(r.floor).toBe(SUBSTANCE_FLOOR_BY_ROLE.R3_CONSEILS);
+    expect(r.reasons).toHaveLength(0);
+  });
+
+  it('R8 a un plancher plus bas (3) — 3 preuves suffisent', () => {
+    const els = extractSubstanceElements(
+      Array.from({ length: 3 }, (_, i) =>
+        block('db_owned', [`db:${i}`], 'R8_VEHICLE', `s${i}`),
+      ),
+      'R8_VEHICLE',
+    );
+    const r = evaluateSubstanceGate(els, 'R8_VEHICLE');
+    expect(r.pass).toBe(true);
+    expect(r.floor).toBe(3);
+  });
+
+  it('FAIL SUBSTANCE_FLOOR : contenu trop maigre', () => {
+    const els = extractSubstanceElements(
+      [block('sourced', ['web:1'])],
+      'R3_CONSEILS',
+    );
+    const r = evaluateSubstanceGate(els, 'R3_CONSEILS');
+    expect(r.pass).toBe(false);
+    expect(r.reasons.some((x) => x.includes('SUBSTANCE_FLOOR'))).toBe(true);
+  });
+
+  it('FAIL SOURCE_MIX : 100% éditorial (générique, anti-IA)', () => {
+    const els = extractSubstanceElements(
+      Array.from({ length: 6 }, (_, i) =>
+        block('editorial', [], 'R3_CONSEILS', `s${i}`),
+      ),
+      'R3_CONSEILS',
+    );
+    const r = evaluateSubstanceGate(els, 'R3_CONSEILS');
+    expect(r.pass).toBe(false);
+    expect(r.count).toBe(0);
+    expect(r.reasons.some((x) => x.includes('SOURCE_MIX'))).toBe(true);
+  });
+
+  it('EVIDENCE_BOUND : un bloc propriétaire sans source_id est signalé + non compté', () => {
+    const els = extractSubstanceElements(
+      [
+        ...Array.from({ length: 5 }, (_, i) =>
+          block('sourced', [`oem:${i}`], 'R3_CONSEILS', `s${i}`),
+        ),
+        block('db_owned', [], 'R3_CONSEILS', 'orphan'),
+      ],
+      'R3_CONSEILS',
+    );
+    const r = evaluateSubstanceGate(els, 'R3_CONSEILS');
+    expect(r.count).toBe(5); // l'orphelin db_owned sans source_id n'est pas compté
+    expect(r.reasons.some((x) => x.includes('EVIDENCE_BOUND'))).toBe(true);
+  });
+
+  it('R2 est exclu au niveau type (BriefRole) — pas de plancher R2 défini', () => {
+    // @ts-expect-error R2 n'est pas un BriefRole — la page transactionnelle a un chemin dédié strict.
+    const floor = SUBSTANCE_FLOOR_BY_ROLE.R2_PRODUCT;
+    expect(floor).toBeUndefined();
+  });
+});

--- a/backend/src/modules/admin/services/seo-brief.service.ts
+++ b/backend/src/modules/admin/services/seo-brief.service.ts
@@ -1,0 +1,307 @@
+/**
+ * SeoBriefService — générateur de briefs SEO **evidence-driven** (ADR-059/086/090, D1).
+ *
+ * Compose un brief par surface (R3/R8) à partir de la PROJECTION WIKI (get_active_seo_projection,
+ * forme réglée par PR-0 : blocs `content.{content_md, source_ids, truth_level, …}`), JAMAIS depuis le RAG
+ * ni le top-kw brut contaminé. Le contenu vient de la vérité métier (WIKI sourcée), il n'est jamais inventé.
+ *
+ * Gate de substance **déterministe** (le LLM n'est jamais le juge) :
+ *   - SUBSTANCE_FLOOR : ≥ N éléments propriétaires par rôle ;
+ *   - EVIDENCE_BOUND  : tout élément propriétaire porte un source_id ;
+ *   - SOURCE_MIX      : jamais 100 % éditorial/inféré (au moins une preuve db_owned|sourced).
+ *
+ * Dégradation **observable** (jamais de fallback silencieux, CLAUDE.md) : projection absente / RPC en erreur /
+ * flag OFF → `wiki_available=false` + log → l'appelant retombe sur le chemin keyword-first existant.
+ * R2 est **exclu au niveau type** (BriefRole) — la page transactionnelle reste la plus stricte, traitée en dernier.
+ */
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
+import { FeatureFlagsService } from '@config/feature-flags.service';
+
+/** Rôles composables par cette fabrique. **R2 exclu structurellement** (transactionnel = chemin dédié strict). */
+export type BriefRole = 'R3_CONSEILS' | 'R3_GUIDE' | 'R8_VEHICLE';
+
+export type BlockTruthLevel = 'db_owned' | 'sourced' | 'inferred' | 'editorial';
+
+export interface SubstanceElement {
+  /** Extrait court (PAS le contenu complet — audit/traçabilité, pas une recopie). */
+  text: string;
+  source_id: string | null;
+  truth_level: BlockTruthLevel;
+  /** Champ d'origine (section/usefulness_target/block_kind). */
+  field: string;
+}
+
+export interface SubstanceGateResult {
+  pass: boolean;
+  /** Nombre d'éléments propriétaires (db_owned|sourced AVEC source_id). */
+  count: number;
+  floor: number;
+  reasons: string[];
+}
+
+export interface BriefEvidenceBundle {
+  entity_id: string;
+  page_role: BriefRole;
+  wiki_available: boolean;
+  proprietary_count: number;
+  substance_gate: SubstanceGateResult;
+  brief_source: 'keyword' | 'wiki_evidence';
+  brief_fields: {
+    angles_obligatoires: string[];
+    preuves: string[];
+    termes_techniques: string[];
+  };
+  substance_elements: SubstanceElement[];
+  evidence_source_mix: Record<BlockTruthLevel, number>;
+  /** Signal de demande GSC (WARN-only, JAMAIS un gate). Additif ultérieur ; jamais fabriqué. */
+  demand_signal: Record<string, unknown>;
+}
+
+/** Planchers par rôle (constantes nommées — pas de magic number). Calibrables avant passage en BLOCKING. */
+export const SUBSTANCE_FLOOR_BY_ROLE: Record<BriefRole, number> = {
+  R3_CONSEILS: 5,
+  R3_GUIDE: 5,
+  R8_VEHICLE: 3,
+};
+
+const PROPRIETARY_TRUTH_LEVELS: ReadonlySet<BlockTruthLevel> =
+  new Set<BlockTruthLevel>(['db_owned', 'sourced']);
+
+interface ProjectionBlock {
+  role?: string;
+  block_kind?: string;
+  content?: {
+    content_md?: string;
+    source_ids?: string[];
+    truth_level?: BlockTruthLevel;
+    section?: string;
+    usefulness_target?: string;
+  } | null;
+}
+
+interface ProjectionEnvelope {
+  entity_id: string;
+  entity_type: string;
+  slug: string;
+  facts: unknown[];
+  blocks: ProjectionBlock[];
+}
+
+// ── Fonctions PURES (déterministes, sans I/O — le cœur testable du gate, partagé avec D2) ──
+
+/**
+ * Extrait les éléments d'une liste de blocs projetés (filtre par rôle). PURE.
+ * Lit `block.content.truth_level` / `content.source_ids` (forme réglée par PR-0 — DANS content, pas top-level).
+ */
+export function extractSubstanceElements(
+  blocks: ProjectionBlock[],
+  role: string,
+): SubstanceElement[] {
+  const out: SubstanceElement[] = [];
+  for (const b of blocks ?? []) {
+    if (b.role && b.role !== role) continue;
+    const c = b.content ?? {};
+    const tl = c.truth_level;
+    if (!tl) continue;
+    const sids = Array.isArray(c.source_ids)
+      ? c.source_ids.filter((s) => typeof s === 'string' && s.length > 0)
+      : [];
+    out.push({
+      text: (c.content_md ?? '').slice(0, 200),
+      source_id: sids[0] ?? null,
+      truth_level: tl,
+      field: c.section ?? c.usefulness_target ?? b.block_kind ?? 'block',
+    });
+  }
+  return out;
+}
+
+/** Compte propriétaire = truth_level ∈ {db_owned, sourced} ET ≥1 source_id réel. PURE. */
+export function countProprietary(elements: SubstanceElement[]): number {
+  return elements.filter(
+    (e) => PROPRIETARY_TRUTH_LEVELS.has(e.truth_level) && !!e.source_id,
+  ).length;
+}
+
+/** Répartition par truth_level. PURE. */
+export function sourceMix(
+  elements: SubstanceElement[],
+): Record<BlockTruthLevel, number> {
+  const mix: Record<BlockTruthLevel, number> = {
+    db_owned: 0,
+    sourced: 0,
+    inferred: 0,
+    editorial: 0,
+  };
+  for (const e of elements) mix[e.truth_level] += 1;
+  return mix;
+}
+
+/**
+ * Gate de substance déterministe (PURE). FLOOR + EVIDENCE_BOUND + SOURCE_MIX.
+ * Aucune décision LLM. Renvoie des raisons observables (jamais de pass/fail silencieux).
+ */
+export function evaluateSubstanceGate(
+  elements: SubstanceElement[],
+  role: BriefRole,
+): SubstanceGateResult {
+  const floor = SUBSTANCE_FLOOR_BY_ROLE[role];
+  const count = countProprietary(elements);
+  const mix = sourceMix(elements);
+  const reasons: string[] = [];
+
+  if (mix.db_owned + mix.sourced === 0) {
+    reasons.push(
+      'SOURCE_MIX: 100% éditorial/inféré — aucune preuve propriétaire (db_owned|sourced)',
+    );
+  }
+  const orphan = elements.filter(
+    (e) => PROPRIETARY_TRUTH_LEVELS.has(e.truth_level) && !e.source_id,
+  ).length;
+  if (orphan > 0) {
+    reasons.push(
+      `EVIDENCE_BOUND: ${orphan} élément(s) propriétaire(s) sans source_id (non comptés)`,
+    );
+  }
+  if (count < floor) {
+    reasons.push(
+      `SUBSTANCE_FLOOR: ${count}/${floor} éléments propriétaires (contenu trop générique)`,
+    );
+  }
+  return { pass: reasons.length === 0, count, floor, reasons };
+}
+
+@Injectable()
+export class SeoBriefService extends SupabaseBaseService {
+  protected override readonly logger = new Logger(SeoBriefService.name);
+
+  constructor(
+    configService: ConfigService,
+    @Optional() rpcGate?: RpcGateService,
+    @Optional() private readonly featureFlags?: FeatureFlagsService,
+  ) {
+    super(configService);
+    if (rpcGate) this.rpcGate = rpcGate;
+  }
+
+  /**
+   * Compose un brief evidence-driven depuis la projection WIKI. Dégrade **observable** (wiki_available=false)
+   * si flag OFF / projection absente / RPC en erreur → l'appelant retombe sur keyword-first. Ne fabrique jamais.
+   */
+  async composeBrief(params: {
+    pgId?: number;
+    pgAlias?: string;
+    vehicleSlug?: string;
+    pageRole: BriefRole;
+  }): Promise<BriefEvidenceBundle> {
+    const { pgAlias, vehicleSlug, pageRole } = params;
+    const entityId = vehicleSlug
+      ? `vehicle:${vehicleSlug}`
+      : `gamme:${pgAlias}`;
+    const projRole = this.projectionRole(pageRole);
+
+    if (this.featureFlags && !this.featureFlags.seoBriefWikiEnabled) {
+      return this.degraded(entityId, pageRole, 'SEO_BRIEF_WIKI_ENABLED=false');
+    }
+
+    let env: ProjectionEnvelope | null = null;
+    try {
+      const { data, error } = await this.callRpc<ProjectionEnvelope | null>(
+        'get_active_seo_projection',
+        { p_entity_id: entityId, p_role: projRole },
+        { source: 'api' },
+      );
+      if (error) {
+        this.logger.warn(
+          `projection RPC error ${entityId}: ${error.message} → keyword-first (observable)`,
+        );
+        return this.degraded(entityId, pageRole, `RPC error: ${error.message}`);
+      }
+      env = (data as ProjectionEnvelope | null) ?? null;
+    } catch (e) {
+      this.logger.warn(
+        `projection RPC exception ${entityId}: ${String(e)} → keyword-first (observable)`,
+      );
+      return this.degraded(entityId, pageRole, 'RPC exception');
+    }
+
+    if (!env) {
+      this.logger.log(
+        `projection vide ${entityId} (non projetée) → keyword-first (observable)`,
+      );
+      return this.degraded(entityId, pageRole, 'projection absente');
+    }
+
+    const elements = extractSubstanceElements(env.blocks ?? [], projRole);
+    const gate = evaluateSubstanceGate(elements, pageRole);
+
+    return {
+      entity_id: entityId,
+      page_role: pageRole,
+      wiki_available: true,
+      proprietary_count: gate.count,
+      substance_gate: gate,
+      brief_source: 'wiki_evidence',
+      brief_fields: {
+        angles_obligatoires: [
+          ...new Set(elements.map((e) => e.field).filter(Boolean)),
+        ],
+        preuves: elements
+          .map((e) => e.source_id)
+          .filter((s): s is string => !!s),
+        termes_techniques: [
+          ...new Set(
+            elements
+              .filter((e) => e.truth_level === 'db_owned')
+              .map((e) => e.field),
+          ),
+        ],
+      },
+      substance_elements: elements,
+      evidence_source_mix: sourceMix(elements),
+      demand_signal: {},
+    };
+  }
+
+  /** Rôle de bloc projeté correspondant (R3_CONSEILS/R3_GUIDE partagent les blocs R3_CONSEILS). */
+  private projectionRole(role: BriefRole): string {
+    return role === 'R8_VEHICLE' ? 'R8_VEHICLE' : 'R3_CONSEILS';
+  }
+
+  /** Bundle dégradé observable (wiki indisponible) → l'appelant garde le chemin keyword-first. */
+  private degraded(
+    entityId: string,
+    pageRole: BriefRole,
+    reason: string,
+  ): BriefEvidenceBundle {
+    return {
+      entity_id: entityId,
+      page_role: pageRole,
+      wiki_available: false,
+      proprietary_count: 0,
+      substance_gate: {
+        pass: false,
+        count: 0,
+        floor: SUBSTANCE_FLOOR_BY_ROLE[pageRole],
+        reasons: [reason],
+      },
+      brief_source: 'keyword',
+      brief_fields: {
+        angles_obligatoires: [],
+        preuves: [],
+        termes_techniques: [],
+      },
+      substance_elements: [],
+      evidence_source_mix: {
+        db_owned: 0,
+        sourced: 0,
+        inferred: 0,
+        editorial: 0,
+      },
+      demand_signal: {},
+    };
+  }
+}

--- a/backend/src/modules/seo-projection/seo-projection-gate.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-gate.test.ts
@@ -16,7 +16,15 @@ const validExport = (): SeoProjectionExport => ({
   generated_at: '2026-06-19T00:00:00Z',
   facts: [{ k: 'v' }],
   sources: [{ url: 'https://x' }],
-  blocks: [{ role: 'R1', block_kind: 'quality_tiers', content: { md: 'x' } }],
+  blocks: [
+    {
+      role: 'R1',
+      content_md: 'x',
+      source_ids: [],
+      truth_level: 'editorial',
+      section: 'quality_tiers',
+    },
+  ],
   roles_allowed: ['R1'],
   consumers_allowed: ['seo'],
 });
@@ -38,7 +46,10 @@ describe('SeoProjectionGateService', () => {
 
   it('CanonGate KO si un block a un rôle hors roles_allowed (impureté)', () => {
     const exp = validExport();
-    exp.blocks = [{ role: 'R8', block_kind: 'k', content: {} }]; // R8 absent de roles_allowed=[R1]
+    // R8 absent de roles_allowed=[R1] (bloc FLAT valide ; le gate ne lit que role).
+    exp.blocks = [
+      { role: 'R8', content_md: 'k', source_ids: [], truth_level: 'editorial' },
+    ];
     const v = gate.canonGate(exp);
     expect(v.ok).toBe(false);
     expect(v.reasons.some((r) => r.includes('R8'))).toBe(true);

--- a/backend/src/modules/seo-projection/seo-projection-writer.service.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.service.ts
@@ -20,6 +20,7 @@ import { getAppConfig } from '../../config/app.config';
 import { SeoProjectionGateService } from './seo-projection-gate.service';
 import {
   type EntityWriteOutcome,
+  type ProjectedBlockRow,
   type ProjectionRunMeta,
   type ProjectionRunResult,
   type ProjectionTriggeredBy,
@@ -27,6 +28,65 @@ import {
   type SeoProjectionExport,
   WRITER_CONTRACT_VERSION,
 } from './seo-projection.types';
+
+/** Slug déterministe (kebab, ascii) pour dériver block_kind depuis `section`. */
+function slugifyKind(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+/**
+ * Adapte un bloc d'export **FLAT** (`role`/`content_md`/`source_ids`/`truth_level` + `section`/
+ * `usefulness_target` + provenance D3 optionnelle) vers la forme **DB** versionnée
+ * (`block_kind` + `content` jsonb, tous deux NOT NULL). Déterministe, **sans perte, sans enrichissement** :
+ * toute la provenance est copiée verbatim dans `content`. `block_kind = slug(section)` ; fallback
+ * positionnel `b<index>` si `section` absente (jamais de collision, jamais de silent-fallback — l'appelant
+ * logue `kindFallback`). `content_hash` recalculé sur le `content` réel → no-op detection correcte par bloc.
+ */
+export function mapExportBlockToDbBlock(
+  entityId: string,
+  b: SeoProjectionBlock,
+  index: number,
+): ProjectedBlockRow {
+  const sectionSlug = slugifyKind((b.section ?? '').trim());
+  const kindFallback = sectionSlug === '';
+  const blockKind =
+    b.block_kind?.trim() || (kindFallback ? `b${index}` : sectionSlug);
+  const blockId = b.block_id ?? `${entityId}#${b.role}#${blockKind}`;
+
+  // content jsonb = contenu citable verbatim (zéro enrichissement, ordre de clés déterministe pour le hash).
+  const content: Record<string, unknown> = {
+    content_md: b.content_md,
+    source_ids: b.source_ids ?? [],
+    truth_level: b.truth_level,
+  };
+  if (b.section != null) content.section = b.section;
+  if (b.usefulness_target != null)
+    content.usefulness_target = b.usefulness_target;
+  if (b.evidence_type != null) content.evidence_type = b.evidence_type;
+  if (b.applies_to != null) content.applies_to = b.applies_to;
+  if (b.last_verified_at != null) content.last_verified_at = b.last_verified_at;
+  if (b.consumer_pages != null) content.consumer_pages = b.consumer_pages;
+
+  const contentHash =
+    b.content_hash ??
+    createHash('md5').update(JSON.stringify(content)).digest('hex');
+
+  return {
+    blockId,
+    blockKind,
+    content,
+    contentHash,
+    sourceType: b.truth_level ?? null,
+    confidenceBase:
+      typeof b.confidence_base === 'number' ? b.confidence_base : null,
+    kindFallback,
+  };
+}
 
 @Injectable()
 export class SeoProjectionWriterService extends SupabaseBaseService {
@@ -214,15 +274,22 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
   ): Promise<{ written: number; regressed: number }> {
     let written = 0;
     let regressed = 0;
-    for (const b of exp.blocks ?? []) {
-      const blockId =
-        b.block_id ?? `${exp.entity_id}#${b.role}#${b.block_kind}`;
+    const blocks = exp.blocks ?? [];
+    for (let index = 0; index < blocks.length; index += 1) {
+      const b = blocks[index];
+      // Adapte le bloc FLAT (builder) → forme DB (block_kind + content jsonb NOT NULL). Sans perte.
+      const row = mapExportBlockToDbBlock(exp.entity_id, b, index);
+      if (row.kindFallback) {
+        this.log.warn(
+          `bloc sans 'section' (${exp.entity_id} role=${b.role} #${index}) → block_kind positionnel '${row.blockKind}' (observable, pas de fallback silencieux)`,
+        );
+      }
       await this.supabase.from('__seo_content_blocks').upsert(
         {
-          block_id: blockId,
+          block_id: row.blockId,
           entity_id: exp.entity_id,
           role: b.role,
-          block_kind: b.block_kind,
+          block_kind: row.blockKind,
           updated_at: new Date().toISOString(),
         },
         { onConflict: 'block_id' },
@@ -231,44 +298,44 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       const { data: active } = await this.supabase
         .from('__seo_content_block_versions')
         .select('content_hash, confidence_base')
-        .eq('block_id', blockId)
+        .eq('block_id', row.blockId)
         .eq('status', 'active')
         .maybeSingle();
 
-      const newHash = b.content_hash ?? this.hashBlock(b);
-      if (active?.content_hash === newHash) continue; // no-op
+      if (active?.content_hash === row.contentHash) continue; // no-op
 
       // no-rétro-régression : si une version active existe avec une confiance strictement supérieure, on
       // insère la nouvelle en draft (jamais active) + conflit observable.
       const wouldRegress =
         active != null &&
         typeof active.confidence_base === 'number' &&
-        typeof b.confidence_base === 'number' &&
-        b.confidence_base < active.confidence_base;
+        row.confidenceBase != null &&
+        row.confidenceBase < active.confidence_base;
 
       const { data: ins, error } = await this.supabase
         .from('__seo_content_block_versions')
         .insert({
-          block_id: blockId,
+          block_id: row.blockId,
           status: wouldRegress ? 'draft' : 'active',
-          content_hash: newHash,
-          confidence_base: b.confidence_base ?? null,
-          content: b.content,
+          content_hash: row.contentHash,
+          confidence_base: row.confidenceBase,
+          source_type: row.sourceType,
+          content: row.content,
           run_id: runId,
         })
         .select('version_id')
         .single();
       if (error || !ins)
         throw new Error(
-          `insert block_version ${blockId}: ${error?.message ?? 'no row'}`,
+          `insert block_version ${row.blockId}: ${error?.message ?? 'no row'}`,
         );
 
       if (wouldRegress) {
         await this.recordConflict(
           exp.entity_id,
-          blockId,
+          row.blockId,
           'would_regress',
-          { newHash, kept_active: true },
+          { newHash: row.contentHash, kept_active: true },
           runId,
         );
         regressed += 1;
@@ -277,7 +344,7 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       await this.supabase
         .from('__seo_content_block_versions')
         .update({ status: 'deprecated', valid_to: new Date().toISOString() })
-        .eq('block_id', blockId)
+        .eq('block_id', row.blockId)
         .eq('status', 'active')
         .neq('version_id', ins.version_id);
       await this.supabase
@@ -286,7 +353,7 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
           active_version_id: ins.version_id,
           updated_at: new Date().toISOString(),
         })
-        .eq('block_id', blockId);
+        .eq('block_id', row.blockId);
       written += 1;
     }
     return { written, regressed };
@@ -358,12 +425,5 @@ export class SeoProjectionWriterService extends SupabaseBaseService {
       detail,
       run_id: runId,
     });
-  }
-
-  private hashBlock(b: SeoProjectionBlock): string {
-    // hash déterministe minimal (le content_hash autoritaire vient du builder wiki ; fallback ici).
-    return createHash('md5')
-      .update(JSON.stringify(b.content ?? {}))
-      .digest('hex');
   }
 }

--- a/backend/src/modules/seo-projection/seo-projection-writer.test.ts
+++ b/backend/src/modules/seo-projection/seo-projection-writer.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests de `mapExportBlockToDbBlock` (PR-0, ADR-059/090) — l'adaptateur FLAT (builder wiki) → DB.
+ * Fonction pure, déterministe, sans I/O : on vérifie l'absence de perte, l'unicité de block_kind,
+ * la copie verbatim de la provenance (truth_level/source_ids + D3) et la stabilité du content_hash.
+ */
+import { mapExportBlockToDbBlock } from './seo-projection-writer.service';
+import { type SeoProjectionBlock } from './seo-projection.types';
+
+const baseBlock = (
+  over: Partial<SeoProjectionBlock> = {},
+): SeoProjectionBlock => ({
+  role: 'R3_CONSEILS',
+  content_md: 'Sur Golf 5 1.9 TDI BXE, vérifier le filtre avant remplacement.',
+  source_ids: ['oem:bosch-123', 'web:evidence-7'],
+  truth_level: 'sourced',
+  section: 'Diagnostic',
+  ...over,
+});
+
+describe('mapExportBlockToDbBlock', () => {
+  it('mappe un bloc FLAT vers la forme DB sans perte de provenance', () => {
+    const row = mapExportBlockToDbBlock('gamme:filtre-a-air', baseBlock(), 0);
+
+    expect(row.blockKind).toBe('diagnostic');
+    expect(row.blockId).toBe('gamme:filtre-a-air#R3_CONSEILS#diagnostic');
+    expect(row.kindFallback).toBe(false);
+    expect(row.sourceType).toBe('sourced');
+    expect(row.content).toMatchObject({
+      content_md: baseBlock().content_md,
+      source_ids: ['oem:bosch-123', 'web:evidence-7'],
+      truth_level: 'sourced',
+      section: 'Diagnostic',
+    });
+    // content jsonb NOT NULL : jamais vide (le bug PR-0 stockait {}).
+    expect(Object.keys(row.content).length).toBeGreaterThan(0);
+  });
+
+  it('dérive un block_kind positionnel observable quand section absente (jamais de collision)', () => {
+    const a = mapExportBlockToDbBlock(
+      'gamme:x',
+      baseBlock({ section: null }),
+      0,
+    );
+    const b = mapExportBlockToDbBlock(
+      'gamme:x',
+      baseBlock({ section: undefined }),
+      1,
+    );
+
+    expect(a.kindFallback).toBe(true);
+    expect(a.blockKind).toBe('b0');
+    expect(b.blockKind).toBe('b1');
+    expect(a.blockId).not.toBe(b.blockId);
+  });
+
+  it('deux blocs même rôle / sections distinctes → block_id distincts (pas de collision)', () => {
+    const a = mapExportBlockToDbBlock(
+      'gamme:x',
+      baseBlock({ section: 'Symptômes' }),
+      0,
+    );
+    const b = mapExportBlockToDbBlock(
+      'gamme:x',
+      baseBlock({ section: 'Compatibilité' }),
+      1,
+    );
+
+    expect(a.blockId).toBe('gamme:x#R3_CONSEILS#symptomes');
+    expect(b.blockId).toBe('gamme:x#R3_CONSEILS#compatibilite');
+    expect(a.blockId).not.toBe(b.blockId);
+  });
+
+  it('copie la provenance citable D3 verbatim si présente, l’omet sinon (jamais fabriquée)', () => {
+    const withD3 = mapExportBlockToDbBlock(
+      'vehicle:golf-5-1-9-tdi',
+      baseBlock({
+        evidence_type: 'oem',
+        applies_to: { scope: 'motorization', key: 'engine:BXE' },
+        last_verified_at: '2026-06-20T00:00:00Z',
+        consumer_pages: ['R8_VEHICLE', 'R3_CONSEILS'],
+      }),
+      0,
+    );
+    expect(withD3.content.evidence_type).toBe('oem');
+    expect(withD3.content.applies_to).toEqual({
+      scope: 'motorization',
+      key: 'engine:BXE',
+    });
+    expect(withD3.content.consumer_pages).toEqual([
+      'R8_VEHICLE',
+      'R3_CONSEILS',
+    ]);
+
+    const withoutD3 = mapExportBlockToDbBlock('vehicle:x', baseBlock(), 0);
+    expect(withoutD3.content).not.toHaveProperty('evidence_type');
+    expect(withoutD3.content).not.toHaveProperty('applies_to');
+    expect(withoutD3.content).not.toHaveProperty('consumer_pages');
+  });
+
+  it('content_hash : stable pour un contenu identique, distinct sinon (no-op detection par bloc)', () => {
+    const h1 = mapExportBlockToDbBlock('gamme:x', baseBlock(), 0).contentHash;
+    const h2 = mapExportBlockToDbBlock('gamme:x', baseBlock(), 0).contentHash;
+    const h3 = mapExportBlockToDbBlock(
+      'gamme:x',
+      baseBlock({ content_md: 'texte différent' }),
+      0,
+    ).contentHash;
+
+    expect(h1).toBe(h2);
+    expect(h1).not.toBe(h3);
+    expect(h1).toHaveLength(32); // md5 hex
+  });
+
+  it('respecte un content_hash autoritaire fourni par le builder', () => {
+    const row = mapExportBlockToDbBlock(
+      'gamme:x',
+      baseBlock({ content_hash: 'authoritative-hash' }),
+      0,
+    );
+    expect(row.contentHash).toBe('authoritative-hash');
+  });
+
+  it('passe confidence_base si numérique, sinon null', () => {
+    expect(
+      mapExportBlockToDbBlock('e', baseBlock({ confidence_base: 0.84 }), 0)
+        .confidenceBase,
+    ).toBe(0.84);
+    expect(
+      mapExportBlockToDbBlock('e', baseBlock(), 0).confidenceBase,
+    ).toBeNull();
+  });
+});

--- a/backend/src/modules/seo-projection/seo-projection.types.ts
+++ b/backend/src/modules/seo-projection/seo-projection.types.ts
@@ -78,13 +78,44 @@ export interface SeoProjectionExport {
   consumers_allowed: string[];
 }
 
+/** Niveau de vérité d'un bloc (ADR-086). Porte la provenance lue par D1/D2 (sépare DB-owned de sourced). */
+export type BlockTruthLevel = 'db_owned' | 'sourced' | 'inferred' | 'editorial';
+
+/**
+ * Bloc tel qu'émis par le builder wiki — forme **FLAT**, miroir de `exports-seo.schema.json`
+ * (`role`, `content_md`, `source_ids`, `truth_level` requis ; `section`/`usefulness_target` optionnels ;
+ * provenance citable D3 optionnelle). Le writer l'**adapte** vers la forme DB (`block_kind` + `content`
+ * jsonb, tous deux NOT NULL) via `mapExportBlockToDbBlock` — voir writer. Aucun enrichissement.
+ */
 export interface SeoProjectionBlock {
-  block_id?: string;
   role: string;
-  block_kind: string;
+  content_md: string;
+  source_ids: string[];
+  truth_level: BlockTruthLevel;
+  section?: string | null;
+  usefulness_target?: string | null;
+  // Provenance citable optionnelle (D3 ADR-086) — copiée verbatim dans content si présente, jamais fabriquée.
+  evidence_type?: string;
+  applies_to?: { scope: string; key: string } | null;
+  last_verified_at?: string | null;
+  consumer_pages?: string[];
+  // Optionnels hérités : si le builder les fournit on les respecte, sinon le writer les dérive.
+  block_id?: string;
+  block_kind?: string;
   content_hash?: string;
   confidence_base?: number | null;
+}
+
+/** Forme DB d'un bloc projeté (cible de l'adaptation `mapExportBlockToDbBlock`). */
+export interface ProjectedBlockRow {
+  blockId: string;
+  blockKind: string;
   content: Record<string, unknown>;
+  contentHash: string;
+  sourceType: string | null;
+  confidenceBase: number | null;
+  /** true si block_kind a dû retomber sur un index positionnel (section absente) — à loguer (observable). */
+  kindFallback: boolean;
 }
 
 /** Verdict d'une porte (CanonGate / QualityGate). Fail-closed : `ok=false` → conflit observable, pas d'écriture. */

--- a/backend/supabase/migrations/20260620_d1_brief_from_wiki_evidence_columns.sql
+++ b/backend/supabase/migrations/20260620_d1_brief_from_wiki_evidence_columns.sql
@@ -1,0 +1,35 @@
+-- ADR-059/086/090 D1 — colonnes audit provenance pour le brief WIKI-driven (SeoBriefService).
+--
+-- Additif, idempotent, NON auto-appliqué (deployment.md axe 4 : owner-reviewed `apply_migration`).
+-- Aucune contrainte NOT NULL stricte (DEFAULT only → lignes existantes lisent le défaut, pas de rewrite),
+-- aucun backfill, aucun lock long, aucun DROP/TRUNCATE. Réversible (bloc rollback en pied).
+--
+-- Ces colonnes ne sont écrites QUE par le chemin `brief_source='wiki_evidence'` (flag SEO_BRIEF_WIKI_ENABLED ON,
+-- qui requiert cette migration appliquée au préalable). Chemin keyword-first inchangé → comportement actuel intact.
+
+ALTER TABLE public.__seo_page_brief
+  ADD COLUMN IF NOT EXISTS brief_source varchar(20) DEFAULT 'keyword',
+  ADD COLUMN IF NOT EXISTS substance_count integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS substance_elements jsonb DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS evidence_source_mix jsonb DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS demand_signal jsonb DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN public.__seo_page_brief.brief_source IS
+  'keyword (legacy keyword-first) | wiki_evidence (D1 SeoBriefService, projection WIKI). Audit de provenance du brief.';
+COMMENT ON COLUMN public.__seo_page_brief.substance_count IS
+  'Nombre d''éléments propriétaires (truth_level db_owned|sourced AVEC source_id) — gate substance D1 (FLOOR).';
+COMMENT ON COLUMN public.__seo_page_brief.substance_elements IS
+  'Audit [{text,source_id,truth_level,field}] : chaque élément du brief WIKI mappé à sa preuve (EVIDENCE_BOUND).';
+COMMENT ON COLUMN public.__seo_page_brief.evidence_source_mix IS
+  'Répartition par truth_level {db_owned,sourced,inferred,editorial} (SOURCE_MIX : jamais 100% éditorial).';
+COMMENT ON COLUMN public.__seo_page_brief.demand_signal IS
+  'Signal de demande GSC (WARN-only, JAMAIS un gate ; sous-capture ~4x). {bucket, ...} ou {}.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Rollback (manuel) :
+-- ALTER TABLE public.__seo_page_brief
+--   DROP COLUMN IF EXISTS brief_source,
+--   DROP COLUMN IF EXISTS substance_count,
+--   DROP COLUMN IF EXISTS substance_elements,
+--   DROP COLUMN IF EXISTS evidence_source_mix,
+--   DROP COLUMN IF EXISTS demand_signal;

--- a/backend/supabase/migrations/20260620_d1_brief_from_wiki_evidence_columns.sql
+++ b/backend/supabase/migrations/20260620_d1_brief_from_wiki_evidence_columns.sql
@@ -7,9 +7,14 @@
 -- Ces colonnes ne sont écrites QUE par le chemin `brief_source='wiki_evidence'` (flag SEO_BRIEF_WIKI_ENABLED ON,
 -- qui requiert cette migration appliquée au préalable). Chemin keyword-first inchangé → comportement actuel intact.
 
+-- Timeouts bornés (squawk require-timeout-settings ; convention migrations récentes).
+SET lock_timeout = '5s';
+SET statement_timeout = '15s';
+
+-- Types : text / bigint (squawk prefer-text-field + prefer-bigint-over-int — best practice PG17).
 ALTER TABLE public.__seo_page_brief
-  ADD COLUMN IF NOT EXISTS brief_source varchar(20) DEFAULT 'keyword',
-  ADD COLUMN IF NOT EXISTS substance_count integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS brief_source text DEFAULT 'keyword',
+  ADD COLUMN IF NOT EXISTS substance_count bigint DEFAULT 0,
   ADD COLUMN IF NOT EXISTS substance_elements jsonb DEFAULT '[]'::jsonb,
   ADD COLUMN IF NOT EXISTS evidence_source_mix jsonb DEFAULT '{}'::jsonb,
   ADD COLUMN IF NOT EXISTS demand_signal jsonb DEFAULT '{}'::jsonb;

--- a/log.md
+++ b/log.md
@@ -532,3 +532,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-projection-block-content-adapter`
 - **Décision** : feat(seo-brief): D1 — WIKI evidence-driven brief generator core (SeoBriefService, dark) (+2 other commits)
 - **Sortie** : PR aucune | commits b4a226f6a 4961b59fa a8b79cd87
+
+## 2026-06-20 — feat/seo-projection-block-content-adapter (auto)
+
+- **Branche** : `feat/seo-projection-block-content-adapter`
+- **Décision** : feat(seo-brief): D1 wiring — brief-template uses WIKI evidence brief when flag ON (dark) (+4 other commits)
+- **Sortie** : PR aucune | commits 6350b71ff 1d8c45715 b4a226f6a 4961b59fa a8b79cd87

--- a/log.md
+++ b/log.md
@@ -526,3 +526,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-projection-block-content-adapter`
 - **Décision** : fix(seo-projection): PR-0 — adapt flat wiki export blocks to DB content shape
 - **Sortie** : PR aucune | commits a8b79cd87
+
+## 2026-06-20 — feat/seo-projection-block-content-adapter (auto)
+
+- **Branche** : `feat/seo-projection-block-content-adapter`
+- **Décision** : feat(seo-brief): D1 — WIKI evidence-driven brief generator core (SeoBriefService, dark) (+2 other commits)
+- **Sortie** : PR aucune | commits b4a226f6a 4961b59fa a8b79cd87

--- a/log.md
+++ b/log.md
@@ -520,3 +520,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/adr059-pr6-seo-projection-schema`
 - **Décision** : feat(db): ADR-059 PR-6 — SEO projection schema (7 tables + 2 MV, kg_v3 pattern)
 - **Sortie** : PR aucune | commits 3771252c1
+
+## 2026-06-20 — feat/seo-projection-block-content-adapter (auto)
+
+- **Branche** : `feat/seo-projection-block-content-adapter`
+- **Décision** : fix(seo-projection): PR-0 — adapt flat wiki export blocks to DB content shape
+- **Sortie** : PR aucune | commits a8b79cd87

--- a/log.md
+++ b/log.md
@@ -538,3 +538,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-projection-block-content-adapter`
 - **Décision** : feat(seo-brief): D1 wiring — brief-template uses WIKI evidence brief when flag ON (dark) (+4 other commits)
 - **Sortie** : PR aucune | commits 6350b71ff 1d8c45715 b4a226f6a 4961b59fa a8b79cd87
+
+## 2026-06-20 — feat/seo-projection-block-content-adapter (auto)
+
+- **Branche** : `feat/seo-projection-block-content-adapter`
+- **Décision** : fix(migration): D1 columns — squawk gate (timeouts + text/bigint) (+7 other commits)
+- **Sortie** : PR #1045 | commits cec9dca92 e4df62251 1e61e0792 6350b71ff 1d8c45715 b4a226f6a 4961b59fa a8b79cd87

--- a/workspaces/seo-batch/.claude/skills/seo-content-loop/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/seo-content-loop/SKILL.md
@@ -62,9 +62,11 @@ SCRAPING LARGE (RUN_TARGETED_RAW_TO_WIKI) → RAW → WIKI → CONSUMER (R1/R2/R
      - **Diagnostic** : sources symptômes→causes (codes OBD/VAG, constructeur, forums techniques) — à découvrir de même.
      - **Dédup + refresh** : chaque cible scrapée **une seule fois** (manifest type `app/audit/scrape-targets-*.md`) ;
        rafraîchir périodiquement. Sortie toujours **`.md`** par `target_wiki_field` (cf. ci-dessus).
-   - **Mesure de la substance produite (complète l'étape 5)** : le **scorer shadow ADR-088**
-     (`automecanik-wiki/_scripts/shadow_score.py`, 6 dimensions à **planchers entity-type-aware**) note
-     `claim`/`applies_to`/`evidence`/`related_gammes` par engineBlock → re-scraper jusqu'au TIER A.
+   - **Mesure de la substance produite (complète l'étape 5)** : scorer **réel** =
+     `automecanik-wiki/_scripts/compute-confidence-score.py` (4 composantes) + promotion `promote.py`
+     (TIER A/B, ADR-083 ; seuil auto NO-OP par défaut → revue humaine). Le scorer **6-dimensions à planchers**
+     (`claim`/`applies_to`/`evidence`/`related_gammes` par engineBlock) est la **cible ADR-088** —
+     **pas encore bâti** (`shadow_score.py` n'existe pas) → re-scraper jusqu'au TIER A.
 2. **RAW** (`automecanik-raw/`) — normaliser/recycler le scrape en fiches sourcées (frontmatter contrat
    `_schemas/recycled-frontmatter.schema.json`), `verification_status` `to_verify`→`verified` (humain).
    `recycled/` n'est **jamais** canon (canon RAW `CLAUDE.md`).


### PR DESCRIPTION
## Résumé

Fondations de la **content factory** AutoMecanik — tout **additif, flags OFF, en sommeil** (0 changement runtime tant que rien n'est activé). 4 tranches vérifiées (tsc 0 · jest · eslint · ast-grep · governance gate).

### 1. PR-0 — adaptateur bloc export FLAT → DB (`seo-projection-writer`)
Bug réel corrigé : le writer lisait `b.block_kind`/`b.content` alors que le contrat export + builder émettent des blocs **FLAT** (`role/content_md/source_ids/truth_level/section`). Les 2 colonnes DB sont **NOT NULL** → chaque insert de bloc **jetait** ; `hashBlock` hachait `{}` → empreinte identique pour tous (no-op detection cassée). `mapExportBlockToDbBlock` (pure, 7 tests) mappe sans perte + recalcule `content_hash`. Dark (projection non alimentée).

### 2. D1 — générateur de briefs evidence-driven (`SeoBriefService`)
Compose un brief par surface (R3/R8) depuis la **projection WIKI** (`get_active_seo_projection`, forme réglée par PR-0), **jamais** depuis le RAG ni le top-kw contaminé. **Gate de substance déterministe** (fonctions pures, 10 tests, partagées avec D2) : `SUBSTANCE_FLOOR` + `EVIDENCE_BOUND` (chaque preuve a un `source_id`) + `SOURCE_MIX` (jamais 100% éditorial). **R2 exclu au niveau type**. Flag gouverné `SEO_BRIEF_WIKI_ENABLED` (OFF) + entrée `rpc_allowlist`. Câblé dans `brief-template.bulkGenerate` (flag-gated) : chemin keyword-first **byte-identique** ; dégradation **observable** (jamais silencieuse). Migration **additive** `__seo_page_brief` (DEFAULTs, non auto-appliquée).

### 3. Doc — réconciliation IA-SEO Master ↔ BOUCLE
`agents/seo-content/AGENTS.md` réécrit (BOUCLE evidence-first ; RAG-as-source retiré ; IP/UUID en dur retirés → passe `validate-agents-md.sh`). `seo-content-loop` : réf `shadow_score.py` corrigée (inexistant ; réel = `compute-confidence-score.py` + `promote.py`).

## ⏳ Action owner requise (Block-new)
La migration neuve `backend/supabase/migrations/20260620_d1_brief_from_wiki_evidence_columns.sql` n'est pas auto-couverte → ajouter 1 entrée ownership (`.spec/00-canon/repository-registry/ownership.yaml`, owner-only), domain D14.

## Reste (hors cette PR)
- **D2** (miroir substance dans QualityScoringEngine) — délicat (bump version → resync baseline impeccable) → tranche dédiée **observe-first**.
- **Verrou réel** : la **matière côté wiki** (fiches avec blocs de preuves structurés). Le contrat de bloc wiki est non réglé (builder/schéma/proposals incohérents) → la factory est prête mais **inerte** sans contenu structuré (boucle contenu wiki, repo séparé).

## Activation (owner-gated, séquencée — rien ne s'active seul)
ownership line → merge → appliquer migration → `SEO_BRIEF_WIKI_ENABLED=ON` (après contenu wiki réel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)