### PR TITLE
docs(knowledge): codify the governed measured-improvement loop (§8)

### DIFF
--- a/.claude/knowledge/agent-method-patterns.md
+++ b/.claude/knowledge/agent-method-patterns.md
@@ -87,6 +87,37 @@ cassé ? `DONE` sur-déclaré alors que `PARTIAL` ?
 mémoire externe comme canon · browser agent mutant sans garde-fou · continuous checkpoint push
 (le push est une action gouvernée).
 
+## 8. Boucle d'amélioration mesurée (keep/revert gouverné)
+
+Pour une amélioration **pilotée par une métrique** (taille de bundle, temps de build/typecheck,
+vitesse des tests). **PAS** un runner autonome, **PAS** un nouveau gate, **PAS** de `score-runner`
+maison — réutilise l'existant. Décision = [continuous-improvement-global](../skills/continuous-improvement-global/SKILL.md) (§DECIDE).
+
+| Étape | Mécanisme (déjà là) |
+|---|---|
+| Cible + métrique | 1 surface où la mesure est **rapide + déterministe + difficile à tricher** ; sinon → *advisory* |
+| Juge = gate existant | [.size-limit.json](../../frontend/.size-limit.json) · `tsc` · ratchets [audit-compare-baseline.js](../../scripts/cleanup/audit-compare-baseline.js) / `*-ratchet.yml` |
+| Isolation | worktree dédié ([deployment.md](../rules/deployment.md)) — jamais éditer `main` ni un chemin servi par DEV:3000 |
+| Mesure | baseline → change → re-mesure (métrique bruitée → médiane de N + delta minimum) |
+| Verdict | [improvement-report.schema.json](../../.spec/00-canon/improvement-report.schema.json) + [agent-exit-contract.md](../canon-mirrors/agent-exit-contract.md) |
+| Promotion | **PR owner-gated** (branch protection §2) — **jamais d'auto-merge d'une boucle** |
+
+**Garde-fou n°1 — anti-faux-vert : holdout LARGE + contrôle baseline.** Un test étroit vert ne
+prouve RIEN. Rejouer l'ensemble pertinent **et** comparer à un run *baseline* (avant-change) sur le
+**même** ensemble ; ne garder que si métrique↑ **ET** 0 régression vs baseline. *(2026-06-20 : un
+holdout 8-fichiers vert aurait livré 73 tests cassés — détail dans `audit/karpathy-loop-pilot-*.verdict.json`.)*
+
+**Règle d'autonomie (par qualité de métrique) :**
+
+- **Auto** uniquement si métrique rapide + déterministe + intriquable : perf / build / typecheck / tests.
+- **Advisory** (propose, ne publie jamais) : contenu R2/R8, SEO — métrique lente/triable → surapprentissage
+  → contenu générique (interdit par CLAUDE.md « filler SEO générique » + invariant rank #1).
+- **Owner GO** obligatoire : prix · panier/commande/paiement · auth/RLS · migration · publication/indexation
+  SEO · promotion WIKI canon (cf. danger-zone §2).
+
+> La boucle **garde** le gain réel et sûr, **rejette** le reste : améliorer le chiffre en cassant
+> autre chose (SEO, tests, DI) = surapprentissage, refusé. Le « keep » exige score↑ **et** holdout vert.
+
 ---
 
 _Non-canon. Pour toute règle qui fait foi, voir la source pointée (vault · `.spec/00-canon/` ·


### PR DESCRIPTION
## Quoi
Ajoute **§8 « Boucle d'amélioration mesurée (keep/revert gouverné) »** au fichier de méthodes d'agent existant `.claude/knowledge/agent-method-patterns.md`. **Pointer-only, non-canon, zéro autorité** — pas de nouveau framework, pas de nouveau gate, pas de `score-runner` maison. Pure extension (1 fichier existant, +31 lignes).

## Pourquoi
On a utilisé cette boucle 3× cette session (verdicts dans `audit/karpathy-loop-pilot-*.verdict.json`). La méthode vivait « dans la tête » — surtout la **leçon clé du 2026-06-20** : un holdout étroit (8 fichiers) était **vert** et aurait livré **73 tests cassés** ; seul le **holdout large + comparaison baseline** l'a attrapé. Cette règle est maintenant **écrite et imposée**.

## Contenu (résumé)
- **Garde-fou n°1 (anti-faux-vert)** : holdout LARGE + contrôle baseline → garder seulement si métrique↑ **ET** 0 régression vs baseline.
- **Juge = un gate qui existe déjà** (`.size-limit.json` / `tsc` / ratchets), jamais un score-runner neuf.
- **Isolation worktree**, **PR owner-gated**, **jamais d'auto-merge d'une boucle**.
- **Règle d'autonomie par qualité de métrique** : auto = perf/build/tests · advisory = contenu/SEO · owner GO = prix/paiement/auth/RLS/publication SEO/WIKI.

## Sûreté / périmètre
- 1 fichier existant modifié (pas de fichier neuf → pas de `block-new`).
- Vérifié : 0 vocabulaire DEV/PREPROD interdit (lint `check-preprod-vocabulary.sh` = 0 violation / 625 fichiers), 0 lien vers mémoire privée, 6/6 liens valides.
- Réversible (revert d'un seul fichier de doc).

Aligné CLAUDE.md « Prefer extension over creation » + « NEVER invent architecture already governed elsewhere ». Le fichier reste explicitement *non-canon, advisory, pointer-only*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)