### PR TITLE
test(media-factory): couvre le cap de batch + le flag de feature (durcissement P15)

### DIFF
--- a/backend/tests/unit/media-factory-flag.test.ts
+++ b/backend/tests/unit/media-factory-flag.test.ts
@@ -1,0 +1,42 @@
+/**
+ * isMediaFactoryEnabled — governed feature-flag gate (strict `=== 'true'`, OFF by default).
+ *
+ * The revived MediaFactory HTTP module and its BullMQ video-execution processor are only
+ * registered in the DI graph when this returns true, so the default-OFF and strict-match
+ * behaviour is load-bearing: any non-canonical value must keep the module inert (0 prod).
+ *
+ * @see backend/src/modules/media-factory/media-factory.flag.ts
+ */
+
+import { isMediaFactoryEnabled } from '../../src/modules/media-factory/media-factory.flag';
+
+describe('isMediaFactoryEnabled', () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it('is OFF by default when MEDIA_FACTORY_ENABLED is unset', () => {
+    delete process.env.MEDIA_FACTORY_ENABLED;
+    expect(isMediaFactoryEnabled()).toBe(false);
+  });
+
+  it('is ON only for the exact string "true"', () => {
+    process.env.MEDIA_FACTORY_ENABLED = 'true';
+    expect(isMediaFactoryEnabled()).toBe(true);
+  });
+
+  it('is OFF for "false"', () => {
+    process.env.MEDIA_FACTORY_ENABLED = 'false';
+    expect(isMediaFactoryEnabled()).toBe(false);
+  });
+
+  it.each(['TRUE', 'True', '1', 'yes', 'on', ' true', ''])(
+    'is OFF for non-canonical value %p (strict === match, never truthy coercion)',
+    (val) => {
+      process.env.MEDIA_FACTORY_ENABLED = val;
+      expect(isMediaFactoryEnabled()).toBe(false);
+    },
+  );
+});

--- a/backend/tests/unit/video-execution.controller.test.ts
+++ b/backend/tests/unit/video-execution.controller.test.ts
@@ -11,9 +11,20 @@ import { VideoExecutionController } from '../../src/modules/media-factory/contro
 
 function createMockJobService() {
   return {
-    submitExecution: jest.fn().mockResolvedValue({ executionLogId: 1, bullmqJobId: 'bull-1' }),
-    getCanaryStats: jest.fn().mockResolvedValue({ engineName: 'stub', dailyUsageCount: 0 }),
-    getExecutionStats: jest.fn().mockResolvedValue({ total: 10, byStatus: { completed: 8 } }),
+    submitExecution: jest
+      .fn()
+      .mockResolvedValue({ executionLogId: 1, bullmqJobId: 'bull-1' }),
+    submitBatchExecution: jest.fn().mockResolvedValue({
+      batchId: 'batch-001',
+      submitted: [{ briefId: 'b1', executionLogId: 1 }],
+      skipped: [],
+    }),
+    getCanaryStats: jest
+      .fn()
+      .mockResolvedValue({ engineName: 'stub', dailyUsageCount: 0 }),
+    getExecutionStats: jest
+      .fn()
+      .mockResolvedValue({ total: 10, byStatus: { completed: 8 } }),
     listExecutions: jest.fn().mockResolvedValue([{ id: 1 }, { id: 2 }]),
     getExecutionStatus: jest.fn().mockResolvedValue({
       id: 1,
@@ -21,7 +32,9 @@ function createMockJobService() {
       status: 'completed',
       renderOutputPath: null,
     }),
-    retryExecution: jest.fn().mockResolvedValue({ newExecutionLogId: 2, bullmqJobId: 'bull-2' }),
+    retryExecution: jest
+      .fn()
+      .mockResolvedValue({ newExecutionLogId: 2, bullmqJobId: 'bull-2' }),
   };
 }
 
@@ -46,7 +59,10 @@ describe('VideoExecutionController', () => {
 
   it('executeProduction should delegate briefId with api trigger', async () => {
     const result = await controller.executeProduction('brief-001');
-    expect(mockJobService.submitExecution).toHaveBeenCalledWith('brief-001', 'api');
+    expect(mockJobService.submitExecution).toHaveBeenCalledWith(
+      'brief-001',
+      'api',
+    );
     expect(result.success).toBe(true);
     expect(result.message).toContain('brief-001');
     expect(result.data.executionLogId).toBe(1);
@@ -57,6 +73,35 @@ describe('VideoExecutionController', () => {
     expect(mockJobService.getCanaryStats).toHaveBeenCalled();
     expect(result.success).toBe(true);
     expect(result.data.engineName).toBe('stub');
+  });
+
+  describe('batchExecute (P15) — input validation + size cap', () => {
+    it('rejects an empty briefIds array without calling the service', async () => {
+      const result = await controller.batchExecute({ briefIds: [] });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/must not be empty/);
+      expect(mockJobService.submitBatchExecution).not.toHaveBeenCalled();
+    });
+
+    it('rejects a batch above VIDEO_MAX_BATCH_SIZE without calling the service', async () => {
+      process.env.VIDEO_MAX_BATCH_SIZE = '2';
+      const result = await controller.batchExecute({
+        briefIds: ['a', 'b', 'c'],
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/exceeds maximum \(2\)/);
+      expect(mockJobService.submitBatchExecution).not.toHaveBeenCalled();
+    });
+
+    it('delegates a within-cap batch to the service with the api trigger', async () => {
+      const result = await controller.batchExecute({ briefIds: ['a', 'b'] });
+      expect(mockJobService.submitBatchExecution).toHaveBeenCalledWith(
+        ['a', 'b'],
+        'api',
+      );
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('batch-001');
+    });
   });
 
   describe('getExecutionStats', () => {
@@ -119,7 +164,8 @@ describe('VideoExecutionController', () => {
     it('should return success=false when VIDEO_RENDER_BASE_URL missing', async () => {
       mockJobService.getExecutionStatus.mockResolvedValue({
         id: 1,
-        renderOutputPath: 's3://automecanik-renders/renders/brief-001/1/output.mp4',
+        renderOutputPath:
+          's3://automecanik-renders/renders/brief-001/1/output.mp4',
       });
       const result = await controller.getPresignedUrl(1);
       expect(result.success).toBe(false);

--- a/backend/tests/unit/video-job-batch.test.ts
+++ b/backend/tests/unit/video-job-batch.test.ts
@@ -1,0 +1,116 @@
+/**
+ * VideoJobService.submitBatchExecution (P15) — feature-flag gate + batch-size cap.
+ *
+ * Covers the loop-bound-injection hardening (CodeQL js/loop-bound-injection, alert #64):
+ * `briefIds` comes from the admin request body (user-controlled), so the per-item loop
+ * must be bounded by VIDEO_MAX_BATCH_SIZE *before* iterating, rejecting an oversized batch
+ * explicitly — never truncating silently (canon: no silent fallback).
+ *
+ * Strategy: construct VideoJobService bypassing DI (same pattern as
+ * video-job-retry-guard.test.ts), mock VideoDataService + BullMQ Queue + ConfigService.
+ * The flag/cap guards short-circuit before any DB access, so no Supabase chain is needed
+ * for the rejection paths.
+ */
+
+import { BadRequestException } from '@nestjs/common';
+import { VideoJobService } from '../../src/modules/media-factory/services/video-job.service';
+
+function createMocks() {
+  return {
+    mockQueue: { add: jest.fn().mockResolvedValue({ id: 'bull-job-1' }) },
+    mockDataService: { getProduction: jest.fn() },
+    mockRenderAdapter: { getCanaryStats: jest.fn() },
+    mockConfigService: {
+      get: jest.fn().mockImplementation((key: string) => {
+        const map: Record<string, string> = {
+          SUPABASE_URL: 'https://test.supabase.co',
+          SUPABASE_SERVICE_ROLE_KEY: 'test-service-role-key-placeholder',
+        };
+        return map[key] ?? 'mock-value';
+      }),
+      getOrThrow: jest.fn().mockReturnValue('mock-value'),
+    },
+  };
+}
+
+function buildService(mocks: ReturnType<typeof createMocks>): VideoJobService {
+  // Construct via constructor (bypass DI) — identical pattern to
+  // video-job-retry-guard.test.ts. The base SupabaseBaseService ctor reads the
+  // mocked ConfigService, so `this.logger` is a real Logger (no need to stub it).
+  return new (VideoJobService as any)(
+    mocks.mockConfigService,
+    mocks.mockQueue,
+    mocks.mockDataService,
+    mocks.mockRenderAdapter,
+  );
+}
+
+describe('VideoJobService.submitBatchExecution (P15) — flag gate + batch cap', () => {
+  const savedEnv = { ...process.env };
+  let mocks: ReturnType<typeof createMocks>;
+  let service: VideoJobService;
+
+  beforeEach(() => {
+    mocks = createMocks();
+    service = buildService(mocks);
+  });
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    jest.restoreAllMocks();
+  });
+
+  it('throws BadRequestException when VIDEO_PIPELINE_ENABLED is not "true"', async () => {
+    delete process.env.VIDEO_PIPELINE_ENABLED;
+    await expect(service.submitBatchExecution(['b1'])).rejects.toThrow(
+      BadRequestException,
+    );
+    await expect(service.submitBatchExecution(['b1'])).rejects.toThrow(
+      /disabled/,
+    );
+    expect(mocks.mockDataService.getProduction).not.toHaveBeenCalled();
+  });
+
+  it('rejects a batch larger than the default cap (100) before iterating', async () => {
+    process.env.VIDEO_PIPELINE_ENABLED = 'true';
+    delete process.env.VIDEO_MAX_BATCH_SIZE;
+    const oversized = Array.from({ length: 101 }, (_, i) => `b${i}`);
+
+    await expect(service.submitBatchExecution(oversized)).rejects.toThrow(
+      BadRequestException,
+    );
+    await expect(service.submitBatchExecution(oversized)).rejects.toThrow(
+      /exceeds maximum \(100\)/,
+    );
+    // The loop never ran: no per-item production lookups happened.
+    expect(mocks.mockDataService.getProduction).not.toHaveBeenCalled();
+  });
+
+  it('honours a custom VIDEO_MAX_BATCH_SIZE cap', async () => {
+    process.env.VIDEO_PIPELINE_ENABLED = 'true';
+    process.env.VIDEO_MAX_BATCH_SIZE = '2';
+
+    await expect(
+      service.submitBatchExecution(['b1', 'b2', 'b3']),
+    ).rejects.toThrow(/exceeds maximum \(2\)/);
+    expect(mocks.mockDataService.getProduction).not.toHaveBeenCalled();
+  });
+
+  it('accepts a batch at the cap limit and processes every item (no silent truncation)', async () => {
+    process.env.VIDEO_PIPELINE_ENABLED = 'true';
+    process.env.VIDEO_MAX_BATCH_SIZE = '3';
+    // getProduction rejects → each item is caught and recorded as `skipped`.
+    // Asserting all 3 were processed proves the loop ran the full length, i.e.
+    // the cap allowed the at-limit batch through without dropping any item.
+    mocks.mockDataService.getProduction.mockRejectedValue(
+      new Error('no production'),
+    );
+
+    const result = await service.submitBatchExecution(['b1', 'b2', 'b3']);
+
+    expect(result.batchId).toMatch(/^batch-/);
+    expect(result.submitted).toHaveLength(0);
+    expect(result.skipped).toHaveLength(3);
+    expect(mocks.mockDataService.getProduction).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Quoi

Tests unitaires pour le **durcissement loop-bound-injection** livré dans #1043 et pour le **flag gouverné MediaFactory**. Ces chemins n'avaient aucune couverture (le reste du module en a déjà : `video-job-retry-guard`, `video-job-stats`, `video-execution.controller`, `render-adapter`, gates…).

## Pourquoi

#1043 a corrigé une finding CodeQL `js/loop-bound-injection` (alert #64) : `submitBatchExecution` itérait sur `briefIds.length` (corps de requête admin, user-controlled) sans plafond. Le fix ajoute un cap validé (`VIDEO_MAX_BATCH_SIZE`, défaut 100) avec rejet explicite. Ce PR **verrouille** ce comportement par des tests.

## Tests ajoutés

**`tests/unit/video-job-batch.test.ts`** (nouveau) — `submitBatchExecution` :
- rejette (`BadRequestException`) quand `VIDEO_PIPELINE_ENABLED ≠ "true"` ;
- rejette un batch > cap par défaut (100) **avant d'itérer** (0 lookup DB) ;
- honore un `VIDEO_MAX_BATCH_SIZE` custom ;
- à la limite du cap, traite **chaque** item (preuve : pas de troncature silencieuse).

**`tests/unit/media-factory-flag.test.ts`** (nouveau) — `isMediaFactoryEnabled` :
- OFF par défaut (env absente) ; ON **uniquement** pour `"true"` ; OFF pour `"false"` et toute valeur non-canonique (`TRUE`, `1`, `yes`, …) → match strict `===`.

**`tests/unit/video-execution.controller.test.ts`** (étendu) — `batchExecute` :
- `briefIds` vide rejeté sans déléguer ; batch > cap rejeté sans déléguer ; within-cap délègue au service avec le trigger `api`.

## Discipline

- Suit le **pattern maison** (`tests/unit/*.test.ts`, bypass DI par constructeur casté comme `video-job-retry-guard.test.ts`). Aucun harnais inventé.
- L'invariant **dé-RAG** (`__seo_*` jamais `__rag_knowledge`) est **déjà** couvert par la règle ast-grep `seo-no-rag-as-content-source` → **non dupliqué** ici (extension > duplication).
- **Source non touchée** (PR tests-only, scope propre). Module reste flag-OFF / 0 prod.

## Vérification

- `npx jest tests/unit/video tests/unit/render tests/unit/template-registry tests/unit/media-factory-flag` → **14 suites / 196 tests verts**, 0 régression.
- Anti-vacuité : sous cap désactivé, les tests cap échouent comme attendu (établi par raisonnement ; la preuve empirique par mutation a été bloquée par la contention de la machine partagée DEV, pas par le code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
