### PR TITLE
fix(ops): sync-dev-runtime self-heals on untracked-file collisions

### DIFF
--- a/scripts/ops/sync-dev-runtime.sh
+++ b/scripts/ops/sync-dev-runtime.sh
@@ -124,6 +124,27 @@ if ! git diff --quiet -- log.md 2>/dev/null; then
   git checkout --quiet -- log.md \
     && log "bruit log.md local réinitialisé avant ff (toléré, régénéré par session-log)"
 fi
+# Généralisation de la tolérance log.md (ci-dessus) à TOUTE collision de fichier
+# untracked : `git merge --ff-only` avorte si un fichier AJOUTÉ en amont existe
+# déjà localement en untracked (ex. skill workspace créé hors-git, observé le
+# 2026-06-20 : DEV figé 3j / 34 commits). Sans ça = cron qui avorte en boucle =
+# drift silencieux (même classe que l'incident log.md). On SAUVEGARDE (réversible,
+# zéro perte) puis on continue ; l'alerte (stderr → MAILTO) rend l'éviction
+# observable. Jamais de suppression : seulement un déplacement vers /tmp.
+collisions=$(git diff --name-only --diff-filter=A "$local_sha".."$remote_sha" 2>/dev/null \
+  | while IFS= read -r f; do
+      [ -n "$f" ] && [ -e "$f" ] \
+        && ! git ls-files --error-unmatch "$f" >/dev/null 2>&1 \
+        && printf '%s\n' "$f"
+    done)
+if [ -n "$collisions" ]; then
+  bkdir="/tmp/${LOG_TAG}-untracked-backup-$(date +%Y%m%d-%H%M%S)"
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    mkdir -p "$bkdir/$(dirname "$f")" && mv "$f" "$bkdir/$f"
+  done <<< "$collisions"
+  alert "fichiers untracked en collision avec le ff — sauvegardés dans $bkdir puis écartés : $(printf '%s ' $collisions)"
+fi
 git merge --ff-only origin/main || abort "non fast-forwardable (lignée divergente) — réconcilier main à la main"
 log "synced $local_sha → $remote_sha"
 


### PR DESCRIPTION
## Quoi
Durcit `scripts/ops/sync-dev-runtime.sh` (le resync DEV:3000 ← origin/main) pour qu'il **ne se bloque plus** sur une collision de fichier untracked.

## Pourquoi (cause racine, observée le 2026-06-20)
DEV était **figé 3 jours / 34 commits en retard**. Cause : `git merge --ff-only` **avorte** quand un fichier **ajouté en amont** existe déjà **localement en untracked** (ici un skill workspace créé hors-git). Le script tolérait déjà ce cas **pour `log.md` uniquement** ; toute autre collision faisait avorter le sync **en boucle** → **drift silencieux** (anti-pattern no-silent-fallback).

## Correctif (robuste, réversible, observable)
Généralise la tolérance : avant le ff, détecter les fichiers ajoutés-en-amont présents localement en untracked → les **déplacer** vers un backup `/tmp` horodaté (réversible, **zéro perte**) → continuer. L'éviction est **alertée sur stderr (→ cron MAILTO)** = observable, jamais silencieuse. **Aucun `reset --hard`, aucune suppression** — uniquement un `mv`.

## Vérifié
`bash -n` OK. +21 lignes, 1 fichier. Étend le pattern existant (log.md), zéro nouveau système.

## Suite (hors PR, infra DEV)
Le script ne tournait qu'en **manuel** (dernières exéc. 17/9/8 juin — pas de cron), alors que `deployment.md` dit « cron ~10 min ». Le **brancher au cron** (toutes les 10 min, MAILTO déjà en place) rend la doc vraie — c'est une étape **infra sur la machine DEV**, faite séparément du code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)