### PR TITLE
fix(rr7): résoudre flatRoutes appDir depuis le fichier, pas le cwd (DEV:3000 crash post-#1052)

### DIFF
--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -1,3 +1,6 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { remixRoutesOptionAdapter } from "@react-router/remix-routes-option-adapter";
 import { flatRoutes } from "remix-flat-routes";
 import { type RouteConfig } from "@react-router/dev/routes";
@@ -7,15 +10,23 @@ import { type RouteConfig } from "@react-router/dev/routes";
  *
  * Routing SAFE-FIRST : `@react-router/remix-routes-option-adapter` enveloppe
  * `remix-flat-routes` (l'option `routes` de Remix v2 migrée 1:1). Parité URL prouvée
- * 139/139 vs Remix v2 ; `@react-router/fs-routes` casse 7 URLs (/aide /catalogue /home
+ * 147/147 vs Remix v2 ; `@react-router/fs-routes` casse 7 URLs (/aide /catalogue /home
  * /login /marques /register + index mangle) → NO-GO. Les `ignoredRouteFiles` sont
  * préservés à l'identique de l'ancien `vite.config.ts` (exclusion admin/ui-kit/design-system
  * en production uniquement).
  */
 const isProduction = process.env.NODE_ENV === "production";
 
+// `flatRoutes` résout son `appDir` (défaut "app") relativement à `process.cwd()`.
+// Le build tourne depuis `frontend/` (cwd OK) mais le serveur dev NestJS démarre
+// depuis la RACINE du monorepo → scandir 'app/routes' échoue (ENOENT, crash boot).
+// Ancrer `appDir` sur l'emplacement de CE fichier (= `frontend/app`) rend la
+// résolution déterministe quel que soit le cwd (build, dev, comparateur de parité).
+const appDir = dirname(fileURLToPath(import.meta.url));
+
 export default remixRoutesOptionAdapter((defineRoutes) =>
   flatRoutes("routes", defineRoutes, {
+    appDir,
     ignoredRouteFiles: [
       ".*",
       "**/*.css",


### PR DESCRIPTION
## Problème
Après merge de #1052 (RR7 core), le **serveur dev NestJS (DEV:3000) crashe au boot** :
```
Error: Route config in "routes.ts" is invalid.
Error: ENOENT: no such file or directory, scandir 'app/routes'
  at frontend/app/routes.ts:18
```

## Cause
`routes.ts` appelle `flatRoutes("routes", ...)` sans `appDir`. Le défaut `"app"` de
remix-flat-routes est résolu relativement à **`process.cwd()`**. Le build tourne depuis
`frontend/` (cwd OK → `frontend/app/routes`), mais le **dev server démarre depuis la racine
du monorepo** → `scandir 'app/routes'` cherche `/opt/automecanik/app/app/routes` → ENOENT.
Build-time non affecté (c'est pourquoi la CI de #1052 et le build PREPROD passent) ; **runtime dev uniquement**.

## Fix
Ancrer `appDir` sur l'emplacement du fichier : `dirname(fileURLToPath(import.meta.url))` = `frontend/app`.
Résolution déterministe quel que soit le cwd (build, dev, comparateur de parité).

## Vérification (reproduit + corrigé)
- **Repro** : `react-router build frontend` depuis la racine → ENOENT (identique au crash).
- **Après fix** : même commande → build vert (2781 modules transformés, exit 0).
- typecheck `0` · parité URL **147/147 IDENTIQUE** (route set inchangé) · 1 fichier, +12/-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)