### PR TITLE
ci(e2e): capture PREPROD container diagnostics on E2E Smoke failure (RR7 regression root-cause)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1083,6 +1083,33 @@ jobs:
           CI: true
           PLAYWRIGHT_BASE_URL: http://localhost:3200
 
+      # Diagnostic root-cause sur échec E2E. Le runner self-hosted EST l'hôte
+      # PREPROD (49.12.233.2) : on capture l'état exact du container + la mémoire
+      # hôte au moment de l'échec. Sert à distinguer OOM-kill (capacité) vs crash
+      # applicatif vs prioritisation kernel — sans deviner. Tout best-effort
+      # (`|| true`), n'altère pas le verdict du job (déjà en échec). Observabilité
+      # pure (canon : prefer observability ; no silent fallback).
+      - name: 🩺 Capture PREPROD container diagnostics (root-cause)
+        if: failure()
+        run: |
+          C=nestjs-remix-monorepo-preprod
+          echo "::group::container state"
+          docker ps -a --filter "name=preprod" --format '{{.Names}}\t{{.Status}}\t{{.RunningFor}}' || true
+          docker inspect "$C" --format 'OOMKilled={{.State.OOMKilled}} ExitCode={{.State.ExitCode}} Status={{.State.Status}} RestartCount={{.RestartCount}} StartedAt={{.State.StartedAt}} FinishedAt={{.State.FinishedAt}}' || true
+          echo "::endgroup::"
+          echo "::group::host memory (free -m)"
+          free -m || true
+          echo "::endgroup::"
+          echo "::group::per-container memory (docker stats)"
+          docker stats --no-stream --format '{{.Name}}\t{{.MemUsage}}\t{{.MemPerc}}' || true
+          echo "::endgroup::"
+          echo "::group::container logs (tail 150)"
+          docker logs --tail 150 "$C" 2>&1 | tail -150 || true
+          echo "::endgroup::"
+          echo "::group::kernel OOM (dmesg, best-effort)"
+          (dmesg 2>/dev/null | grep -iE 'oom|killed process|out of memory' | tail -25) || echo "dmesg unavailable (no perm)"
+          echo "::endgroup::"
+
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Contexte
Le gate **E2E Smoke** a régressé exactement à RR7 : deploys pré-RR7 (#1054/#1046/#1055/#1057) **verts**, deploys RR7 (#1052/#1058) **rouges**, mode identique.

## Diagnostic structurel (sans deviner)
- Job **Deploy PREPROD** sert des pages RR7 réelles (health 200, R1 `plaquette-de-frein-402.html`, R2 product, admin-guard 403) → **RR7 SSR fonctionne**.
- Step **"Wait for PREPROD healthy"** PASSE (`PREPROD healthy`), puis le container devient injoignable (`ERR_CONNECTION_REFUSED`/`socket hang up`) **à l'instant où le chromium des tests démarre** — y compris sur `/health` (backend pur, 0 RR7).
- Suite déjà **single-worker** (`workers: CI?1`) → pas la parallélisation.
- ⇒ container PREPROD **tué quand le chromium E2E s'ajoute** à l'empreinte plus lourde de RR7 sur la machine 16GB partagée (PROD + PREPROD + runner). `restart: always`, **aucune limite mémoire**.

## Ce que fait cette PR
Le runner self-hosted **EST** l'hôte PREPROD. Ce step `if: failure()` capture l'état exact au moment de l'échec : `docker inspect .State.OOMKilled/ExitCode/RestartCount`, `free -m`, `docker stats` par container, `docker logs`, `dmesg` OOM. → confirme **OOM-kill (capacité)** vs **crash applicatif** vs **prioritisation kernel**, pour dimensionner le fix de fond **précisément** (anti-bricolage).

Observabilité pure (best-effort, n'altère pas le verdict). Le fix structurel suit, basé sur l'évidence capturée au prochain deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)