### PR TITLE
ci(e2e): capture pre-restart shutdown window (E2E root-cause, mémoire RÉFUTÉE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1103,8 +1103,19 @@ jobs:
           echo "::group::per-container memory (docker stats)"
           docker stats --no-stream --format '{{.Name}}\t{{.MemUsage}}\t{{.MemPerc}}' || true
           echo "::endgroup::"
-          echo "::group::container logs (tail 150)"
-          docker logs --tail 150 "$C" 2>&1 | tail -150 || true
+          # FinishedAt = horodatage d'arrêt du run PRÉCÉDENT (avant le restart auto).
+          # On capture les logs JUSTE AVANT cet instant = la raison de l'arrêt (exit 0
+          # observé = sortie propre/SIGTERM, pas un OOM). Sans ça, `--tail` ne montre
+          # que le bruit post-restart (requêtes) et masque la cause.
+          FIN=$(docker inspect "$C" --format '{{.State.FinishedAt}}' 2>/dev/null || true)
+          echo "::group::logs JUSTE AVANT le dernier restart (raison de l'arrêt) [until=$FIN]"
+          docker logs --until "$FIN" --tail 80 "$C" 2>&1 | tail -80 || true
+          echo "::endgroup::"
+          echo "::group::lifecycle markers (tail 800 filtré)"
+          docker logs --tail 800 "$C" 2>&1 | grep -iE 'Nest application|SIGTERM|SIGINT|signal|shutdown|closed|bootstrap|Démarrage|Starting Nest|listening|FATAL|uncaught|unhandledRejection|heap out of memory|Killed|process exit|beforeExit|enableShutdownHooks' | tail -60 || echo "(aucun marqueur lifecycle)"
+          echo "::endgroup::"
+          echo "::group::container logs (tail 120, post-restart)"
+          docker logs --tail 120 "$C" 2>&1 | tail -120 || true
           echo "::endgroup::"
           echo "::group::kernel OOM (dmesg, best-effort)"
           (dmesg 2>/dev/null | grep -iE 'oom|killed process|out of memory' | tail -25) || echo "dmesg unavailable (no perm)"


### PR DESCRIPTION
Suite à #1059. **L'évidence capturée RÉFUTE l'hypothèse mémoire** : `OOMKilled=false ExitCode=0 RestartCount=1`, hôte **10.7 GB libres**, container **413 MB**. Le container PREPROD fait **UN restart propre (sortie 0)** au milieu de la suite E2E (homepage [android]/[iphone] passent → restart 21:21:45 → reste échoue pendant le reboot ~10s). Pas mémoire, pas un bug de page.

Le `--tail` ne montrait que le post-restart (bruit 404 images). Ce patch capture la **fenêtre pré-restart** (`docker logs --until $FinishedAt`) + grep lifecycle (Nest closing / SIGTERM / uncaught / bootstrap) → révèle **pourquoi** le process sort en 0. Observabilité pure. Fix de fond suit l'évidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)