### PR TITLE
feat(registry): allow Node 24 in the 5 contract builders (determinism-verified)

### DIFF
--- a/.dependency-cruiser.generated.cjs
+++ b/.dependency-cruiser.generated.cjs
@@ -5,7 +5,7 @@
  * Source SHA-256:              096d0bdd137e677d8a5cbefa7db1c8b1e9bb68724a59c067368911cd08a30588
  * Generated format version:    1
  * Generated module format:     cjs
- * Generated with Node:         v22.x
+ * Generated with Node:         v22|v24.x
  * Targets depcruise:           16.x
  * Ownership:                   @repo/registry (PR review required for any change to the generator)
  * Generator:                   @repo/registry bin "build-architecture-artifacts"

--- a/packages/registry/src/bin/build-architecture-artifacts.ts
+++ b/packages/registry/src/bin/build-architecture-artifacts.ts
@@ -46,7 +46,7 @@ const GENERATED_MODULE_FORMAT: 'cjs' | 'mjs' = 'cjs';
 
 // Supported Node majors. util.inspect()'s output is NOT stable across untested majors.
 // Extend after re-running determinism tests.
-const SUPPORTED_NODE_MAJORS = ['22'];
+const SUPPORTED_NODE_MAJORS = ['22', '24'];
 
 {
   const currentMajor = process.versions.node.split('.')[0];

--- a/packages/registry/src/bin/build-db-contract-artifacts.ts
+++ b/packages/registry/src/bin/build-db-contract-artifacts.ts
@@ -35,7 +35,7 @@ function fail(msg: string): never {
 // over zodToJsonSchema()'s deterministic output — no util.inspect() dependency,
 // so output is byte-identical across 20.x and 22.x. Extend after re-running
 // determinism on any new major (Node 24+ should be re-verified).
-const SUPPORTED_NODE_MAJORS = ['20', '22'];
+const SUPPORTED_NODE_MAJORS = ['20', '22', '24'];
 
 {
   const currentMajor = process.versions.node.split('.')[0];

--- a/packages/registry/src/bin/build-dep-governance-artifacts.ts
+++ b/packages/registry/src/bin/build-dep-governance-artifacts.ts
@@ -30,7 +30,7 @@ function fail(msg: string): never {
   throw new DepGovernanceBuildError(msg);
 }
 
-const SUPPORTED_NODE_MAJORS = ["20", "22"];
+const SUPPORTED_NODE_MAJORS = ["20", "22", "24"];
 
 {
   const currentMajor = process.versions.node.split(".")[0];

--- a/packages/registry/src/bin/build-rpc-contract-artifacts.ts
+++ b/packages/registry/src/bin/build-rpc-contract-artifacts.ts
@@ -30,7 +30,7 @@ function fail(msg: string): never {
   throw new RpcContractBuildError(msg);
 }
 
-const SUPPORTED_NODE_MAJORS = ["20", "22"];
+const SUPPORTED_NODE_MAJORS = ["20", "22", "24"];
 
 {
   const currentMajor = process.versions.node.split(".")[0];

--- a/packages/registry/src/bin/build-runtime-contract-artifacts.ts
+++ b/packages/registry/src/bin/build-runtime-contract-artifacts.ts
@@ -35,7 +35,7 @@ function fail(msg: string): never {
 // deterministic output — byte-identical across 20.x and 22.x. Empirically
 // verified by PR-W4 #513 on db-contract (same pattern); re-verify on new
 // majors before extending.
-const SUPPORTED_NODE_MAJORS = ["20", "22"];
+const SUPPORTED_NODE_MAJORS = ["20", "22", "24"];
 
 {
   const currentMajor = process.versions.node.split(".")[0];


### PR DESCRIPTION
## What

Extends `SUPPORTED_NODE_MAJORS` to include `'24'` in the 5 registry artifact builders so they stop `process.exit(2)`-ing under Node 24, and regenerates the one tracked artifact whose header embeds the supported-major list.

- `build-architecture-artifacts.ts`: `['22']` → `['22','24']`
- `build-{db,runtime,rpc,dep-governance}-contract-artifacts.ts`: `['20','22']` → `['20','22','24']`
- `.dependency-cruiser.generated.cjs`: regenerated (header `v22.x` → `v22|v24.x` — **body byte-identical**)

## Why

The architecture builder serializes `.dependency-cruiser.generated.cjs` via `util.inspect()`, whose output is *not guaranteed stable across Node majors* — that's why a guard refuses untested majors. This PR is the safe unblock: determinism was **empirically re-verified on DEV (2026-06-21)** — Node **22.22.2** and Node **24.17.0** produce **byte-identical** output for all 5 builders (architecture via `util.inspect` + the 4 JSON builders, identical SHA-256).

## Not in scope (no runtime change)

This only lets the builders / pre-commit run on a Node 24 dev machine. **`.nvmrc`, Dockerfiles, package `engines`, and CI Node pins are untouched** — that's a separate PR-2 (runtime flip). CI's determinism job still runs on Node 22; its freshness gate passes because it regenerates the same header from the extended list. The `[22,24]` CI matrix is a deliberate follow-up (the determinism job currently carries pre-existing ast-grep/baseline drift unrelated to this PR).

## Verification (on DEV)

- Regen with current `['22']` == committed artifact (proves the artifact was fresh + regen faithful).
- Regen with `['22','24']` diffs the committed artifact in **exactly one line** (the header).
- Determinism: architecture `util.inspect` output + the 4 JSON contract artifacts are byte-identical Node 22 ↔ 24 (same SHA-256).
- Contract tests assert build-twice-idempotency, not a fixed `nodeMajor` value → unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)