### PR TITLE
docs(runtime-truth): durcis le check rpc-registry-drift (triage callRpc + anti sur-classement)

### DIFF
--- a/.claude/skills/runtime-truth-audit/checks/rpc-registry-drift.md
+++ b/.claude/skills/runtime-truth-audit/checks/rpc-registry-drift.md
@@ -80,6 +80,27 @@ applicable aux RPC Postgres.
 - Extensions Postgres (pg_cron, pg_net) ajoutent des fonctions
   pas dans la spec. Mitigation : filtrer par `pronamespace = 'public'` et
   ignorer schémas d'extensions.
+- `spec_only` brut est **dominé par le bruit** : triggers (`trg_*`,
+  `*_updated_at`), fns jamais appelées. Le diff seul n'a pas de sévérité.
+
+## Triage de sévérité post-diff (appris 2026-06-21, runtime-truth-p0)
+
+Le `spec_only` brut ne suffit pas — il faut **2 croisements** avant de classer :
+
+1. **`spec_only ∩ appelé-en-code` = le sous-ensemble RÉEL.** Croiser chaque nom
+   absent contre `backend/src` + `frontend/app` **par nom-en-littéral**, en
+   incluant le wrapper interne `this.callRpc('<name>', …)` — **PAS seulement
+   `\.rpc\(['"]<name>`**. Le 2026-06-21, 9 RPC absentes appelées via `callRpc`
+   ont été **ratées par le regex `.rpc(`** (faux négatif) — trouvées seulement
+   par grep nom-littéral. Sans ce croisement, le check passe à côté.
+2. **Confirmer par vérif live AVANT de classer HIGH** (anti sur-classement). Le
+   même jour, `sitemap-v10` (bucket `temperature`, `throw` sur RPC absente)
+   semblait « dégradation SEO active » — mais `www.automecanik.com/sitemap.xml`
+   = 11 enfants **frais** → bucket non load-bearing → **MEDIUM**, pas HIGH.
+   Code-seul ⇒ déduction ; live ⇒ preuve. Cf. `feedback_no_deduction_verify_the_proof`.
+
+(Ce triage = guidance d'interprétation du diff existant, **pas** un nouveau check
+ni un mega-analyzer — cf. garde anti-AST-universe du SKILL.)
 
 ## Limites
 


### PR DESCRIPTION
## Improvement Check

- **Problem:** le check `rpc-registry-drift` produisait `spec_only` brut (~55) sans triage — dominé par le bruit (triggers, fns jamais appelées). Pire : la détection d'appel par `.rpc('<name>')` est un **faux négatif** (les services appellent via le wrapper `this.callRpc(...)`).
- **Evidence before:** audit runtime-truth-p0 2026-06-21 — 9 RPC absentes **appelées via callRpc** ratées par le regex `.rpc(`, trouvées seulement par grep nom-littéral. Et `sitemap-v10` a failli être sur-classé HIGH (« dégradation SEO ») alors que la vérif live (`sitemap.xml` = 11 enfants frais) montrait MEDIUM.
- **Expected gain:** les prochains audits trient `spec_only` par `∩ appelé-en-code` (incl. wrapper) et confirment par vérif live avant de classer HIGH → moins de bruit, moins de faux négatifs ET de sur-classement.
- **Risk:** nul — note d'interprétation dans un `checks/*.md` (DEV skill, réversible). **Pas** un nouveau check ni un mega-analyzer (respecte la garde anti-AST-universe du SKILL).
- **Test:** relecture cohérence ; +21 lignes doc, 0 logique.
- **Verdict:** `GO`
- **Next action:** mergé → appliqué au prochain run runtime-truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)