### PR TITLE
fix(preprod): restore anon EXECUTE on 3 page-render RPCs (e2e-smoke drift fix)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -698,6 +698,11 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: medium
+  - glob: backend/supabase/migrations/20260621_grant_anon_execute_page_render_rpcs.sql
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/supabase/migrations/*seo_admin_job*
     domain: D3
     owner: '@ak125/seo-team'

--- a/backend/supabase/migrations/20260621_grant_anon_execute_page_render_rpcs.sql
+++ b/backend/supabase/migrations/20260621_grant_anon_execute_page_render_rpcs.sql
@@ -1,0 +1,39 @@
+-- =====================================================
+-- Restaure l'EXECUTE `anon` sur 3 fonctions SECURITY DEFINER de rendu de page
+-- Date: 2026-06-21
+-- =====================================================
+--
+-- POURQUOI
+-- En READ_ONLY (container PREPROD, ADR-028 Option D) le backend bascule TOUT son
+-- client Supabase sur le rôle `anon` — donc chaque `.rpc()` du read-path s'exécute
+-- en `anon`. La doctrine vague-5 (PR #1012, docs/security/vague5-rls-drift-tail-20260616.md)
+-- classe ces fonctions de rendu de page parmi les "~114 fonctions référencées par le
+-- backend qui DOIVENT rester anon-exécutables". Le gros REVOKE FROM PUBLIC (migration #5)
+-- avait d'ailleurs été ABANDONNÉ précisément pour ne pas les casser.
+--
+-- DÉRIVE CONSTATÉE (2026-06-21, MCP read-only sur le projet partagé)
+-- Ces 3 fonctions ont perdu l'EXECUTE `anon` (révocation du grant PUBLIC, hors de toute
+-- migration versionnée) → gate requis `e2e-smoke` ROUGE à chaque merge (cold cache PREPROD
+-- → 1ʳᵉ requête anon → `permission denied for function`). `authenticated` les exécute encore.
+-- PROD non affecté (service_role). Cette migration RÉTABLIT la conformité repo↔DB.
+--
+-- SÛRETÉ (vérifiée — revue adversariale lecture-seule, 2026-06-21)
+-- Les 3 fonctions ne renvoient QUE des données publiques : catalogue, SEO, et (pour
+-- rm_get_page_complete_v2) des prix de VENTE déjà affichés sur le site. AUCUN prix d'achat /
+-- marge, AUCUNE donnée client (___xtr_customer/order/invoice), AUCUN secret, AUCUNE écriture.
+-- Elles sont SECURITY DEFINER : la fonction tourne en owner et contrôle sa sortie ; redonner
+-- l'EXECUTE à anon n'élargit pas ce qu'anon peut atteindre au-delà de ce que la fonction renvoie.
+--
+-- FORME
+-- Grant EXPLICITE au rôle `anon` (pas via PUBLIC) — pour résister à un futur REVOKE … FROM
+-- PUBLIC (même pattern que get_soft_404_alternatives). Idempotent (GRANT) · réversible
+-- (REVOKE EXECUTE … FROM anon). `authenticated` a déjà l'EXECUTE → inchangé.
+
+GRANT EXECUTE ON FUNCTION public.get_homepage_data_optimized()                                                     TO anon;
+GRANT EXECUTE ON FUNCTION public.get_brand_page_data_optimized(p_marque_id integer)                                TO anon;
+GRANT EXECUTE ON FUNCTION public.rm_get_page_complete_v2(p_gamme_id integer, p_vehicle_id bigint, p_limit integer) TO anon;
+
+-- ROLLBACK (manuel si besoin) :
+--   REVOKE EXECUTE ON FUNCTION public.get_homepage_data_optimized()                                                     FROM anon;
+--   REVOKE EXECUTE ON FUNCTION public.get_brand_page_data_optimized(p_marque_id integer)                                FROM anon;
+--   REVOKE EXECUTE ON FUNCTION public.rm_get_page_complete_v2(p_gamme_id integer, p_vehicle_id bigint, p_limit integer) FROM anon;


### PR DESCRIPTION
## Problème
Le gate requis **`e2e-smoke` est rouge à chaque merge sur `main`**. Le container PREPROD tourne le backend en rôle Supabase **`anon`** (READ_ONLY, ADR-028 Option D), donc chaque `.rpc()` du read-path s'exécute en `anon`. Trois fonctions `SECURITY DEFINER` de rendu de page ne sont plus exécutables par `anon` → `permission denied for function` au cold-cache PREPROD → smoke rouge.

## Cause racine = dérive (pas une décision)
Ces 3 fonctions font partie des **~114 fonctions read-path qui DOIVENT rester anon-exécutables** (doctrine vague-5, PR #1012, `docs/security/vague5-rls-drift-tail-20260616.md`). Le gros `REVOKE … FROM PUBLIC` avait même été **abandonné** pour ne pas les casser. Pourtant la **base partagée a dérivé** : l'EXECUTE `anon` a été retiré (révocation du grant `PUBLIC`) **hors de toute migration versionnée**. `authenticated` les exécute encore ; **PROD non affecté** (service_role).

| Fonction | anon avant | anon après |
|---|---|---|
| `get_homepage_data_optimized()` | ❌ | ✅ |
| `get_brand_page_data_optimized(integer)` | ❌ | ✅ |
| `rm_get_page_complete_v2(integer,bigint,integer)` | ❌ | ✅ |

## Sûreté (revue adversariale lecture-seule, 2026-06-21)
Les 3 fonctions ne renvoient **que des données publiques** : catalogue, SEO, et (pour `rm_get_page_complete_v2`) des **prix de VENTE déjà affichés sur le site**. **Aucun** prix d'achat/marge, **aucune** donnée client (`___xtr_customer`/order/invoice), **aucun** secret, **aucune** écriture. `SECURITY DEFINER` → la fonction tourne en owner et contrôle sa sortie ; redonner l'EXECUTE à `anon` n'élargit rien au-delà de ce qu'elle renvoie déjà.

## Correctif
`GRANT EXECUTE … TO anon` **explicite** (pas via `PUBLIC`, pour résister à un futur `REVOKE … FROM PUBLIC` — même pattern que `get_soft_404_alternatives`). Idempotent · réversible (rollback en commentaire dans la migration).

**Déjà appliqué à la base partagée le 2026-06-21** (migrations non auto-appliquées, cf. `.claude/rules/deployment.md`) ; cette PR **versionne** le correctif pour rétablir la conformité repo↔DB.

## Vérification
- DB : `has_function_privilege('anon', …, 'EXECUTE')` = `true` sur les 3 (vérifié).
- CI : `e2e-smoke` doit passer vert au merge.
- Négatif : `anon` reste sans accès aux tables/fonctions internes/PII (inchangé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)