### PR TITLE
feat(pricing-ops): câble la rotation des partitions pricing/supplier/pieces_price (finding runtime-truth-p0)

### DIFF
--- a/backend/supabase/migrations/20260621_pricing_partition_rotation_cron.down.sql
+++ b/backend/supabase/migrations/20260621_pricing_partition_rotation_cron.down.sql
@@ -3,9 +3,8 @@
 -- Retire les 3 crons + la fonction de maintenance créée. N'efface AUCUNE
 -- partition (les CREATE TABLE IF NOT EXISTS sont des données — non détruites).
 -- maintain_pricing/supplier_* préexistantes : conservées (créées ailleurs).
+-- assume_in_transaction (squawk) : PAS de BEGIN/COMMIT explicite.
 -- ============================================================================
-
-BEGIN;
 
 SELECT cron.unschedule('pieces-price-history-partition-rotation')
   WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pieces-price-history-partition-rotation');
@@ -15,5 +14,3 @@ SELECT cron.unschedule('supplier-offer-snapshot-partition-rotation')
   WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'supplier-offer-snapshot-partition-rotation');
 
 DROP FUNCTION IF EXISTS public.maintain_pieces_price_history_partitions();
-
-COMMIT;

--- a/backend/supabase/migrations/20260621_pricing_partition_rotation_cron.down.sql
+++ b/backend/supabase/migrations/20260621_pricing_partition_rotation_cron.down.sql
@@ -1,0 +1,19 @@
+-- ============================================================================
+-- Rollback de 20260621_pricing_partition_rotation_cron.sql
+-- Retire les 3 crons + la fonction de maintenance créée. N'efface AUCUNE
+-- partition (les CREATE TABLE IF NOT EXISTS sont des données — non détruites).
+-- maintain_pricing/supplier_* préexistantes : conservées (créées ailleurs).
+-- ============================================================================
+
+BEGIN;
+
+SELECT cron.unschedule('pieces-price-history-partition-rotation')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pieces-price-history-partition-rotation');
+SELECT cron.unschedule('pricing-decision-snapshot-partition-rotation')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pricing-decision-snapshot-partition-rotation');
+SELECT cron.unschedule('supplier-offer-snapshot-partition-rotation')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'supplier-offer-snapshot-partition-rotation');
+
+DROP FUNCTION IF EXISTS public.maintain_pieces_price_history_partitions();
+
+COMMIT;

--- a/backend/supabase/migrations/20260621_pricing_partition_rotation_cron.sql
+++ b/backend/supabase/migrations/20260621_pricing_partition_rotation_cron.sql
@@ -15,10 +15,12 @@
 -- Pattern aligné sur 20260522_seo_snapshot_partition_rotation.sql (cron quotidien
 -- idempotent `cron.schedule(...) WHERE NOT EXISTS`) + maintain_*_partitions +1 mois.
 -- Additive, idempotente, reversible (cf. .down.sql). search_path pinné (advisor).
+-- assume_in_transaction (squawk) : PAS de BEGIN/COMMIT explicite.
 -- Rollback : 20260621_pricing_partition_rotation_cron.down.sql
 -- ============================================================================
 
-BEGIN;
+SET lock_timeout = '5s';
+SET statement_timeout = '15s';
 
 -- ----------------------------------------------------------------------------
 -- 1) Fonction de maintenance manquante pour pieces_price_history
@@ -83,8 +85,6 @@ SELECT cron.schedule(
 ) WHERE NOT EXISTS (
   SELECT 1 FROM cron.job WHERE jobname = 'supplier-offer-snapshot-partition-rotation'
 );
-
-COMMIT;
 
 -- ----------------------------------------------------------------------------
 -- Vérification post-apply (manuelle) :

--- a/backend/supabase/migrations/20260621_pricing_partition_rotation_cron.sql
+++ b/backend/supabase/migrations/20260621_pricing_partition_rotation_cron.sql
@@ -1,0 +1,97 @@
+-- ============================================================================
+-- 20260621_pricing_partition_rotation_cron.sql
+--
+-- OPS migration différée (cf. 20260523_pricing_decision_snapshot_and_offers.sql
+-- ligne 116 : « Called by pg_cron (governed in a separate ops migration once
+-- cron is scheduled) »). Câble la ROTATION manquante des 3 tables mensuelles du
+-- Pricing Control Plane.
+--
+-- Finding runtime-truth-p0 (audit 2026-06-21) :
+--   pricing_decision_snapshot + supplier_offer_snapshot ont une fonction
+--   maintain_* MAIS aucun cron ; pieces_price_history n'a NI fonction NI cron.
+--   Partitions s'arrêtent au 2026-08-01 → falaise « no partition found for row »
+--   si l'écriture démarre (tables actuellement n_tup_ins=0, donc préventif).
+--
+-- Pattern aligné sur 20260522_seo_snapshot_partition_rotation.sql (cron quotidien
+-- idempotent `cron.schedule(...) WHERE NOT EXISTS`) + maintain_*_partitions +1 mois.
+-- Additive, idempotente, reversible (cf. .down.sql). search_path pinné (advisor).
+-- Rollback : 20260621_pricing_partition_rotation_cron.down.sql
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1) Fonction de maintenance manquante pour pieces_price_history
+--    (modèle identique à maintain_pricing_decision_snapshot_partitions, sans GIN
+--     car pieces_price_history n'a pas de colonne jsonb). PARTITION BY RANGE(created_at).
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.maintain_pieces_price_history_partitions()
+RETURNS TEXT
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  v_next_month DATE := date_trunc('month', now() + INTERVAL '1 month')::date;
+  v_after      DATE := date_trunc('month', now() + INTERVAL '2 month')::date;
+  v_part_name  TEXT := 'pieces_price_history_' || to_char(v_next_month, 'YYYY_MM');
+BEGIN
+  EXECUTE format(
+    'CREATE TABLE IF NOT EXISTS %I PARTITION OF pieces_price_history FOR VALUES FROM (%L) TO (%L);',
+    v_part_name, v_next_month, v_after
+  );
+  RETURN format('ensured %s', v_part_name);
+END $$;
+
+COMMENT ON FUNCTION public.maintain_pieces_price_history_partitions IS
+  'Idempotently pre-creates the next monthly partition of pieces_price_history. Scheduled daily via pg_cron (cf. 20260621_pricing_partition_rotation_cron.sql).';
+
+GRANT EXECUTE ON FUNCTION public.maintain_pieces_price_history_partitions() TO service_role;
+
+-- ----------------------------------------------------------------------------
+-- 2) Backfill immédiat (idempotent : CREATE TABLE IF NOT EXISTS) — crée la
+--    partition du mois prochain pour les 3 tables dès l'application.
+-- ----------------------------------------------------------------------------
+SELECT public.maintain_pieces_price_history_partitions();
+SELECT public.maintain_pricing_decision_snapshot_partitions();
+SELECT public.maintain_supplier_offer_snapshot_partitions();
+
+-- ----------------------------------------------------------------------------
+-- 3) Crons quotidiens idempotents (pattern snapshot-partition-rotation @ 02:20).
+--    Staggered 02:25/02:30/02:35 UTC. `WHERE NOT EXISTS` préserve toute
+--    modification manuelle ultérieure.
+-- ----------------------------------------------------------------------------
+SELECT cron.schedule(
+  'pieces-price-history-partition-rotation',
+  '25 2 * * *',
+  $cron$SELECT public.maintain_pieces_price_history_partitions();$cron$
+) WHERE NOT EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'pieces-price-history-partition-rotation'
+);
+
+SELECT cron.schedule(
+  'pricing-decision-snapshot-partition-rotation',
+  '30 2 * * *',
+  $cron$SELECT public.maintain_pricing_decision_snapshot_partitions();$cron$
+) WHERE NOT EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'pricing-decision-snapshot-partition-rotation'
+);
+
+SELECT cron.schedule(
+  'supplier-offer-snapshot-partition-rotation',
+  '35 2 * * *',
+  $cron$SELECT public.maintain_supplier_offer_snapshot_partitions();$cron$
+) WHERE NOT EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'supplier-offer-snapshot-partition-rotation'
+);
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Vérification post-apply (manuelle) :
+--   SELECT jobname, schedule, active FROM cron.job
+--     WHERE jobname LIKE '%-partition-rotation' ORDER BY jobname;
+--   -- attendu : 3 nouveaux jobs actifs (+ snapshot-partition-rotation préexistant)
+--   SELECT inhrelid::regclass FROM pg_inherits
+--     WHERE inhparent = 'pieces_price_history'::regclass ORDER BY 1;
+--   -- attendu : la partition du mois prochain présente
+-- ----------------------------------------------------------------------------


### PR DESCRIPTION
## Improvement Check (Full — DB)

- **Problem:** 3 tables mensuelles du Pricing Control Plane (`pricing_decision_snapshot`, `supplier_offer_snapshot`, `pieces_price_history`) **sans cron de rotation** → partitions s'arrêtent au **2026-08-01** → falaise `no partition found for row` dès la 1ʳᵉ écriture.
- **Evidence before:** audit runtime-truth-p0 (2026-06-21, [rapport](../blob/main/audit/runtime-truth-p0-audit-2026-06-21.md)) : `cron.job` ne nomme aucune des 3 ; `maintain_pricing/supplier_*` existent mais non schédulées (différées par 20260523 l.116) ; `pieces_price_history` n'a aucune fonction. `n_tup_ins=0` partout → **préventif, 0 impact actuel**.
- **Expected gain:** rotation auto +1 mois/jour ⇒ la partition du mois suivant existe toujours avant la frontière. Ferme la falaise du 2026-08-01.
- **Risk:** bas. Additive uniquement (1 fonction + 3 crons + backfill idempotent). search_path pinné (advisor). **Reversible** : `.down.sql` (unschedule ×3 + drop fn) — **0 partition détruite**. Tables dormantes (n_tup_ins=0) → même en cas d'erreur, aucune donnée live affectée.
- **Test:** modelé exactement sur `20260522_seo_snapshot_partition_rotation.sql` (cron quotidien idempotent) + `maintain_pricing_*` (CREATE TABLE IF NOT EXISTS +1 mois). Vérif post-apply incluse en commentaire (cron.job + pg_inherits).
- **Evidence after:** post-apply (manuel) : 3 jobs `*-partition-rotation` actifs + partition mois prochain présente.
- **Verdict:** `GO` (après revue gate Migration Safety).
- **Next action:** merge → **apply manuel** (discipline : migrations non auto-appliquées à la DB partagée ; autorisation owner reçue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)