### PR TITLE
ci(spec-validation): retire les steps morts specify-cli/uv (fix root-cause break upstream)

### DIFF
--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -37,19 +37,16 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Install specify-cli
-        run: |
-          uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
-
-      - name: Check specify installation
-        run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          specify check
+      # NOTE: `specify check` (spec-kit CLI) was removed here. It validated the
+      # *developer's local tool environment* (git, agent CLIs), never our specs,
+      # so it added zero value in CI. It was installed unpinned from
+      # `git+https://github.com/github/spec-kit.git` (git HEAD) and, on
+      # 2026-06-19, an upstream packaging regression
+      # (`ModuleNotFoundError: No module named 'specify_cli.bundler.lib'`)
+      # made `specify check` exit 1 under `bash -e`, which fast-failed the job
+      # and blocked every real validation step below from ever running.
+      # The actual spec validation (structure / metadata / OpenAPI / ADR /
+      # TypeScript schemas) is self-contained and needs neither uv nor specify.
 
       - name: Validate spec structure
         run: |


### PR DESCRIPTION
## Problème

Le check **📋 Validate Specifications** ([spec-validation.yml](.github/workflows/spec-validation.yml)) est **rouge sur tous les runs depuis le 2026-06-19** (38 échecs / 2 succès sur les 40 derniers runs ; les 2 verts sont les plus anciens, ~18:07–18:20 le 06-19).

**Cause racine — preuve directe** (traceback identique sur tous les runs, étape `Check specify installation`) :
```
ModuleNotFoundError: No module named 'specify_cli.bundler.lib'
  .../specify_cli/commands/bundle/__init__.py:18
    from ...bundler.lib.project import (...)
```
C'est une **régression de packaging upstream** de `github/spec-kit` : le package `specify_cli` importe son propre sous-module `bundler.lib`, absent de la distribution. Le workflow installait `specify-cli` **non-pinné depuis git HEAD** (`uv tool install specify-cli --from git+https://github.com/github/spec-kit.git`), donc la même config est passée verte → rouge sans aucun changement de notre côté.

Comme `specify check` tourne sous `bash -e` et fait `exit 1`, il **fast-failait le job** et empêchait **toutes les vraies étapes de validation** de tourner.

## Décision (solution structurelle, pas de masquage)

`specify check` valide **l'environnement d'outils du développeur** (git, CLI agents) — **jamais nos specs**. Il n'avait aucune valeur en CI ; sa présence était le bricolage d'origine.

➡️ **Retrait** des 3 steps morts : `Install uv` + `Install specify-cli` + `Check specify installation`.
- Élimine le couplage supply-chain à un `git HEAD` upstream non-pinné **à la racine**.
- ✗ Pas de pin d'une version (= patcher un step inutile).
- ✗ Pas de `continue-on-error` (= violation "No silent fallback").
- ✅ Restaure la vraie validation, qui ne tournait plus.

## Vérification (local, contre l'arbre `.spec/` actuel)

Toutes les étapes restantes simulées **vertes** :

| Étape | Résultat |
|---|---|
| Validate spec structure | ✅ 6 dirs requis présents (`apis` pluriel) |
| Validate spec metadata | ✅ 54 fichiers, 0 erreur |
| Validate OpenAPI specs | ✅ exit 0 |
| Validate ADR metadata | ✅ 0 erreur |
| Validate TypeScript schemas | ✅ `cart.schema.ts` + `payment.schema.ts` tsc-clean |

Donc le retrait **ne déplace pas le rouge** — il rend la validation réellement verte.

## Portée / sûreté

- 1 fichier, −13/+10 (3 steps supprimés + commentaire explicatif). YAML re-parsé OK, 8 steps de validation intacts.
- `specify`/`uv` ne sont utilisés **nulle part ailleurs** (grep confirmé).
- Check **non-bloquant** (absent des required contexts de branch-protection `main` + rulesets vides) → aucun impact merge.
- `.github/workflows/**` est hors du `paths:` filter du workflow → ce PR ne re-déclenche pas le check ; vérification post-merge via `workflow_dispatch` (`gh workflow run spec-validation.yml --ref main`).

## Hors scope (signalé, non corrigé ici)

L'étape OpenAPI fait `find .spec/api` (**singulier**) alors que le dossier réel est `.spec/apis` (**pluriel**) → validation OpenAPI **silencieusement no-op**. Bug latent orthogonal (ne cause pas l'échec actuel ; le corriger changerait le comportement et pourrait surfacer de nouveaux échecs). À traiter en suivi dédié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)