### PR TITLE
fix(spec-validation): valider réellement les specs OpenAPI (fin du no-op silencieux)

### DIFF
--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -136,8 +136,18 @@ jobs:
         run: |
           echo "Validating OpenAPI specifications..."
           
-          # Find all OpenAPI spec files
-          API_SPECS=$(find .spec/api -name "*.yaml" -o -name "*.yml" || true)
+          # OpenAPI 3.x specs: per-domain contracts under .spec/apis/ plus the
+          # aggregate root .spec/openapi.yaml. (.spec/asyncapi.yaml is AsyncAPI —
+          # a different schema — and is intentionally NOT fed to
+          # openapi-spec-validator.) The previous glob pointed at .spec/api
+          # (singular), a non-existent directory, so this step silently
+          # validated nothing while 3 real specs drifted unchecked.
+          API_SPECS=$(
+            {
+              find .spec/apis \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null
+              [ -f .spec/openapi.yaml ] && echo .spec/openapi.yaml
+            } || true
+          )
           
           if [ -z "$API_SPECS" ]; then
             echo "ℹ️ No OpenAPI specs found yet"
@@ -245,7 +255,7 @@ jobs:
           # `set -e` crashes the whole step otherwise (observed on .spec/api).
           FEATURE_COUNT=$(find .spec/features -name "*.md" 2>/dev/null | wc -l)
           ARCH_COUNT=$(find .spec/architecture -name "*.md" 2>/dev/null | wc -l)
-          API_COUNT=$(find .spec/api \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null | wc -l)
+          API_COUNT=$( { find .spec/apis \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null; [ -f .spec/openapi.yaml ] && echo x; } | wc -l)
           TYPE_COUNT=$(find .spec/types -name "*.ts" 2>/dev/null | wc -l)
           WORKFLOW_COUNT=$(find .spec/workflows -name "*.md" 2>/dev/null | wc -l)
           

--- a/.spec/openapi.yaml
+++ b/.spec/openapi.yaml
@@ -435,7 +435,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: Stock insuffisant (disponible: 1)
+                    example: "Stock insuffisant (disponible: 1)"
 
   /api/cart/items/{productId}:
     delete:


### PR DESCRIPTION
## Problème (suivi de #1070)

L'étape **Validate OpenAPI specs** de [spec-validation.yml](.github/workflows/spec-validation.yml) globait `find .spec/api` (**singulier**) — un dossier **inexistant**. Résultat : `ℹ️ No OpenAPI specs found yet` → `exit 0`. Elle **validait silencieusement rien** pendant que **3 vraies specs OpenAPI 3.x** dérivaient sans contrôle. → violation directe du canon `[CRITICAL]` **"No silent fallback"**.

(Avant #1070, le job échouait de toute façon en amont sur `specify check` ; une fois ce gate retiré, ce no-op silencieux est devenu visible.)

## Ce que ça corrige (1 préoccupation atomique)

1. **Path** → découverte des vraies specs : `.spec/apis/*.{yaml,yml}` (`order-api`, `payment-api`) + l'agrégat racine `.spec/openapi.yaml`. `.spec/asyncapi.yaml` (AsyncAPI ≠ OpenAPI) est **volontairement exclu** d'`openapi-spec-validator`. Le compteur du coverage-report utilise le même ensemble.
2. **Erreur YAML exposée** : dé-silencier la validation a révélé un vrai bug que le no-op masquait — `.spec/openapi.yaml` ligne 438, scalaire non quoté avec un `: ` interne (`example: Stock insuffisant (disponible: 1)`) que YAML lit comme un mapping. **Quoté.**

➡️ Les deux changements sont **indissociables** : corriger le path sans corriger l'erreur exposée shipperait un workflow **rouge**. C'est pourquoi ils sont dans la même PR (une seule préoccupation : *« la validation OpenAPI doit valider pour de vrai »*).

## Vérification (local, outil identique à la CI — `openapi-spec-validator 0.9.0`)

| Spec | Résultat |
|---|---|
| `.spec/apis/order-api.yaml` | ✅ valide |
| `.spec/apis/payment-api.yaml` | ✅ valide |
| `.spec/openapi.yaml` (après fix L438) | ✅ valide |
| `.spec/asyncapi.yaml` | exclu (AsyncAPI) |

`ERRORS=0`, `API_COUNT=3`, YAML du workflow re-parsé (10 steps). Cette PR touche `.spec/**` → le check **Validate Specifications** tourne dessus et doit être **vert** (preuve CI directe au niveau PR).

## Portée / sûreté

- 2 fichiers, +14/−4. `.spec/openapi.yaml` = hand-authored (pas généré, hors `00-canon`). Le fix = quoter une string (valeur sémantiquement identique, YAML désormais parseable).
- Aucune modification du module `payments/` (on valide un fichier de doc `payment-api.yaml`, on ne touche pas le code paiement).
- `.github/workflows/` → merge `main` = **PREPROD** seulement, réversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)