### PR TITLE
fix(preprod): homepage families via SECURITY DEFINER RPC (unbreak e2e-smoke under anon)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -703,6 +703,11 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: medium
+  - glob: backend/supabase/migrations/20260621_get_homepage_families_definer_rpc.sql
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/supabase/migrations/*seo_admin_job*
     domain: D3
     owner: '@ak125/seo-team'

--- a/backend/governance/rpc/rpc_allowlist.json
+++ b/backend/governance/rpc/rpc_allowlist.json
@@ -390,6 +390,11 @@
       "reason": "Read-only optimization (migrated from P2)"
     },
     {
+      "name": "get_homepage_families",
+      "volatility": "STABLE",
+      "reason": "Homepage families read-path (SECURITY DEFINER) — replaces direct catalog_family/.from() reads broken under anon (ADR-028, DB row_security=off)"
+    },
+    {
       "name": "get_listing_products_extended",
       "volatility": "STABLE",
       "reason": "SELECT only"

--- a/backend/src/modules/catalog/services/homepage-rpc.service.ts
+++ b/backend/src/modules/catalog/services/homepage-rpc.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { TABLES } from '@repo/database-types';
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { CacheService } from '@cache/cache.service';
 import { RpcGateService } from '@security/rpc-gate/rpc-gate.service';
@@ -163,11 +162,17 @@ export class HomepageRpcService extends SupabaseBaseService {
 
   /**
    * ⚡ Families-only pour above-fold SSR (Phase 1 perf: split RPC)
-   * Requête Supabase directe — plus rapide que le RPC complet (~50ms vs ~150ms)
+   *
+   * Lecture via la fonction SECURITY DEFINER `get_homepage_families()` — et non plus
+   * via des `.from()` directs sur catalog_family/catalog_gamme/pieces_gamme. Raison :
+   * en READ_ONLY (container PREPROD, ADR-028 Option D) le backend tourne en rôle `anon`,
+   * qui ne peut PAS lire les tables RLS en direct (réglage base `row_security=off` →
+   * erreur 42501). La fonction DEFINER bypasse la RLS, comme tout le reste du read-path
+   * catalogue. La forme de sortie ({ success, catalog: { families } }) est inchangée.
    */
   async getHomepageFamilies() {
     const startTime = performance.now();
-    const cacheKey = 'homepage:families:v1';
+    const cacheKey = 'homepage:families:v2';
 
     const cached = await this.cacheService.get<unknown>(cacheKey);
     if (cached) {
@@ -177,64 +182,28 @@ export class HomepageRpcService extends SupabaseBaseService {
       return cached;
     }
 
-    this.logger.debug('❌ CACHE MISS families, requête Supabase...');
+    this.logger.debug(
+      '❌ CACHE MISS families, appel RPC get_homepage_families...',
+    );
 
-    // Parallel: fetch families + catalog_gamme mapping
-    const [familiesRes, catalogGammesRes] = await Promise.all([
-      this.supabase
-        .from(TABLES.catalog_family)
-        .select('mf_id, mf_name, mf_pic, mf_description, mf_sort')
-        .eq('mf_display', '1'),
-      this.supabase
-        .from(TABLES.catalog_gamme)
-        .select('mc_pg_id, mc_mf_prime, mc_sort'),
-    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await this.callRpc<any>(
+      'get_homepage_families',
+      {},
+      {
+        source: 'api',
+        role: 'service_role',
+      },
+    );
 
-    if (familiesRes.error) {
+    if (error || !data?.success) {
       throw new DatabaseException({
         code: ErrorCodes.CATALOG.RPC_FAILED,
-        message: `Families query failed: ${familiesRes.error.message}`,
+        message: `Families RPC failed: ${error?.message ?? 'invalid data'}`,
       });
     }
 
-    // Get gamme IDs from catalog_gamme mapping
-    const gammeIds = (catalogGammesRes.data || []).map((cg) => cg.mc_pg_id);
-
-    const { data: gammes, error: gammesError } = await this.supabase
-      .from(TABLES.pieces_gamme)
-      .select('pg_id, pg_name, pg_alias, pg_img')
-      .in('pg_id', gammeIds);
-
-    if (gammesError) {
-      this.logger.warn('⚠️ Gammes query failed, continuing without gammes');
-    }
-
-    // Build gamme lookup map (String keys to handle type mismatches from Supabase)
-    const gammeMap = new Map((gammes || []).map((g) => [String(g.pg_id), g]));
-
-    // Build families with gammes hierarchy (sort numerically — mf_sort is TEXT in DB)
-    const families = (familiesRes.data || [])
-      .sort((a, b) => Number(a.mf_sort || 0) - Number(b.mf_sort || 0))
-      .map((family) => {
-        const familyGammeLinks = (catalogGammesRes.data || [])
-          .filter((cg) => String(cg.mc_mf_prime) === String(family.mf_id))
-          .sort((a, b) => Number(a.mc_sort || 0) - Number(b.mc_sort || 0));
-
-        const familyGammes = familyGammeLinks
-          .map((cg) => gammeMap.get(String(cg.mc_pg_id)))
-          .filter(Boolean);
-
-        return {
-          mf_id: family.mf_id,
-          mf_name: family.mf_name,
-          mf_pic: family.mf_pic,
-          mf_description: family.mf_description,
-          gammes: familyGammes,
-          gammes_count: familyGammes.length,
-        };
-      });
-
-    const result = { success: true, catalog: { families } };
+    const result = data;
 
     // Cache asynchronously
     this.cacheService
@@ -242,7 +211,7 @@ export class HomepageRpcService extends SupabaseBaseService {
       .catch((err) => this.logger.error('Erreur cache families:', err));
 
     this.logger.log(
-      `✅ Families query en ${(performance.now() - startTime).toFixed(1)}ms (${families.length} familles)`,
+      `✅ Families RPC en ${(performance.now() - startTime).toFixed(1)}ms (${result?.catalog?.families?.length ?? 0} familles)`,
     );
     return result;
   }

--- a/backend/supabase/migrations/20260621_get_homepage_families_definer_rpc.sql
+++ b/backend/supabase/migrations/20260621_get_homepage_families_definer_rpc.sql
@@ -1,0 +1,72 @@
+-- =====================================================
+-- get_homepage_families() — fonction SECURITY DEFINER pour le menu "familles" de la home
+-- Date: 2026-06-21
+-- =====================================================
+--
+-- POURQUOI
+-- Le menu "familles" de la page d'accueil (above-fold, `await` → bloque le SSR) lisait
+-- catalog_family + catalog_gamme + pieces_gamme **en direct** (`.from()`). En READ_ONLY
+-- (container PREPROD, ADR-028 Option D) le backend tourne en rôle `anon`, qui ne peut PAS
+-- lire une table RLS en direct : le réglage base `row_security=off` fait que Postgres lève
+-- `42501 query would be affected by row-level security policy` (au lieu de filtrer). La home
+-- plantait donc sous anon → gate `e2e-smoke` rouge. (Les autres pages passent car elles
+-- lisent le catalogue via des fonctions SECURITY DEFINER, qui bypassent la RLS.)
+--
+-- CORRECTIF
+-- Une fonction SECURITY DEFINER (tourne en owner → RLS bypassée) qui fait ces 3 lectures et
+-- renvoie EXACTEMENT la même forme JSON qu'avant ({ success, catalog: { families: [...] } }).
+-- Le service `getHomepageFamilies()` appelle cette fonction au lieu des `.from()` directs.
+--
+-- SÛRETÉ : ne renvoie que des données publiques (taxonomie catalogue + gammes), aucune
+-- écriture. EXECUTE accordé à anon/authenticated/service_role. Idempotent · réversible (DROP).
+--
+-- assume_in_transaction (squawk) : pas de BEGIN/COMMIT explicite. Timeouts requis
+-- (squawk require-timeout-settings) avant l'opération CREATE FUNCTION.
+SET lock_timeout = '5s';
+SET statement_timeout = '30s';
+
+CREATE OR REPLACE FUNCTION public.get_homepage_families()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'success', true,
+    'catalog', jsonb_build_object(
+      'families', COALESCE(jsonb_agg(f_obj ORDER BY f_sort, f_id), '[]'::jsonb)
+    )
+  )
+  FROM (
+    SELECT
+      CASE WHEN f.mf_sort ~ '^[0-9]+(\.[0-9]+)?$' THEN f.mf_sort::numeric ELSE 0 END AS f_sort,
+      f.mf_id::text AS f_id,
+      jsonb_build_object(
+        'mf_id', f.mf_id,
+        'mf_name', f.mf_name,
+        'mf_pic', f.mf_pic,
+        'mf_description', f.mf_description,
+        'gammes', COALESCE(gg.gammes, '[]'::jsonb),
+        'gammes_count', COALESCE(gg.cnt, 0)
+      ) AS f_obj
+    FROM catalog_family f
+    LEFT JOIN LATERAL (
+      SELECT
+        jsonb_agg(
+          jsonb_build_object('pg_id', pg.pg_id, 'pg_name', pg.pg_name, 'pg_alias', pg.pg_alias, 'pg_img', pg.pg_img)
+          ORDER BY CASE WHEN cg.mc_sort ~ '^[0-9]+(\.[0-9]+)?$' THEN cg.mc_sort::numeric ELSE 0 END
+        ) AS gammes,
+        count(*) AS cnt
+      FROM catalog_gamme cg
+      JOIN pieces_gamme pg ON pg.pg_id::text = cg.mc_pg_id::text
+      WHERE cg.mc_mf_prime::text = f.mf_id::text
+    ) gg ON true
+    WHERE f.mf_display = '1'
+  ) sub;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_homepage_families() TO anon, authenticated, service_role;
+
+-- ROLLBACK (manuel) :
+--   DROP FUNCTION IF EXISTS public.get_homepage_families();


### PR DESCRIPTION
## Problème (suite de #1067)
Après #1067 (qui a réouvert l'EXECUTE anon sur 3 fonctions de page), le gate **`e2e-smoke` restait rouge** : la **page d'accueil** plante sous le rôle `anon` (PREPROD, READ_ONLY).

## Cause racine (vérifiée live)
La base a le réglage **`row_security=off`** (defaut DB). Conséquence : un rôle sans BYPASSRLS (**`anon`**) **ne peut PAS lire une table RLS-activée en direct** — Postgres lève `42501 query would be affected by row-level security policy` **au lieu de filtrer**. Tout le catalogue a la RLS activée ; les pages passent car elles lisent **via des fonctions `SECURITY DEFINER`** (qui bypassent la RLS).

**L'exception** : `getHomepageFamilies()` (menu familles, above-fold, `await` → **bloque le SSR**) lisait `catalog_family` + `catalog_gamme` + `pieces_gamme` **en direct** (`.from()`) → `42501` sous anon → home en erreur → `e2e-smoke` rouge.

## Correctif
Nouvelle fonction **`SECURITY DEFINER` `get_homepage_families()`** (tourne en owner → RLS bypassée) qui renvoie **exactement la même forme JSON** (`{ success, catalog: { families: [...] } }`). Le service `getHomepageFamilies()` l'appelle via `callRpc` au lieu des 3 lectures directes. Cohérent avec le reste du read-path catalogue.

**Vérifié** : appel en tant qu'`anon` (clé publishable) → `HTTP 200`, 19 familles. Fonction **déjà appliquée à la base** le 2026-06-21 ; cette migration la versionne.

## Sûreté / périmètre
- La fonction ne renvoie que des **données publiques** (taxonomie catalogue + gammes), **aucune écriture**.
- `import { TABLES }` retiré (devenu inutilisé). Cache key bumpée `v1`→`v2`.
- Ownership déclaré (`D3/seo-team`, comme les migrations sœurs).
- **Below-fold** (marques/blog) fait aussi des lectures directes mais est en **`defer()` (non-bloquant)** → n'empêche pas le gate ; suivi séparé.

## Vérif post-merge
Run `main` → `e2e-smoke` doit passer **vert** (Deploy PREPROD + E2E Smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)