### PR TITLE
fix(ci): serialize PREPROD deploy+e2e via concurrency group (kill flaky homepage socket-hang)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
       - dev
   pull_request: {}
 
+# Garde de concurrence — le container PREPROD (49.12.233.2:3200) est PARTAGÉ (un seul).
+# Sans ça, des pushes `main` rapprochés lancent des `docker compose up` (job `deploy`)
+# qui se chevauchent et SIGTERM le container PENDANT le `e2e-smoke` d'un autre run
+# → "socket hang up" sur la homepage = gate rouge intermittent (ExitCode=0 = restart
+# infra, PAS un crash applicatif — diagnostic 2026-06-21). On sérialise par workflow+ref
+# et on annule le run superséded : seul le DERNIER commit se déploie/teste (sémantique
+# du tag flottant `:preprod` = dernier `main`). PROD (deploy-prod.yml) = workflow distinct, non affecté.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: write
   contents: read


### PR DESCRIPTION
## Problème
Le gate **`e2e-smoke` rouge par intermittence** sur la homepage (#1074, #1073, HEAD — échecs identiques), avec `Error: socket hang up` sur `/`. Diagnostic 2026-06-21 :
- **PAS** un crash applicatif : le container sort en **`ExitCode=0`** (SIGTERM gracieux), `RestartCount` monte, puis **revient `healthy`** ; pas de 500, pas de crash-loop.
- **PAS** mon correctif read-path : zéro erreur `catalog_family` (#1067/#1072 intacts).
- **PAS** le code home : `getHomepageFamilies` en `try/catch`, below-fold en `.catch()` → aucun `unhandledRejection`.
- **PAS** #1074 (routes sitemap **mortes**, non testées par l'e2e) ni le watchdog (`prod-watchdog.sh` = observe-only).

## Cause racine
**PREPROD (`49.12.233.2:3200`) est un container PARTAGÉ unique**, et `ci.yml` n'avait **aucun garde de concurrence**. Des pushes `main` rapprochés (fréquents cette session) lancent des **`docker compose up` (job `deploy`) qui se chevauchent** et **SIGTERM le container PENDANT le `e2e-smoke` d'un autre run** → `socket hang up`. Observé en direct : un run `deploy` pour un nouveau commit tournait pendant le re-test e2e d'un commit précédent.

## Correctif
Garde de **concurrence** au niveau workflow :
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
→ on sérialise par workflow+ref ; un nouveau commit `main` annule le run superséded **avant** qu'il puisse stomper → **seul le dernier commit** se déploie/teste (cohérent avec le tag flottant `:preprod` = dernier `main`).

## Sûreté / périmètre
- Fonctionnalité standard GitHub Actions, additive, faible risque.
- `${{ github.workflow }}` / `${{ github.ref }}` = contexte de confiance, dans un **nom de groupe** (pas un `run:`) → aucune injection.
- **PROD non affecté** : `deploy-prod.yml` est un workflow distinct (tag `v*`).

## Vérification
Au merge, le run `main` (avec le garde) doit faire passer **`e2e-smoke` vert** (plus de stomping). C'est la preuve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)