### PR TITLE
fix(registry): regenerate dependency-modernization-inventory after #1078 deps resync

### DIFF
--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:4d4c0de0e2911a4c5a9875b76137bca827ec1fd9c0419a796919de14ae3599eb",
+  "artifact_immutability_hash": "sha256:cb4dfa3ce91afb4613888dfb23f0bbbc2d99d4c51b6f15daf846305e6e47d2cf",
   "divergences": [
     {
       "kind": "specifier",
@@ -40,58 +40,42 @@
       ]
     },
     {
-      "kind": "resolved",
-      "name": "@radix-ui/react-slot",
+      "kind": "specifier",
+      "name": "@react-router/express",
       "occurrences": [
         {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^1.2.4",
-          "workspace": "@fafa/frontend"
-        }
-      ],
-      "resolved_versions": [
-        "1.2.3",
-        "1.2.4"
-      ]
-    },
-    {
-      "kind": "resolved",
-      "name": "@remix-run/node",
-      "occurrences": [
+          "declaredIn": "backend/package.json",
+          "specifier": "^7.0.0",
+          "workspace": "@fafa/backend"
+        },
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^2.17.4",
+          "specifier": "^7.15.0",
           "workspace": "@fafa/frontend"
         },
         {
           "declaredIn": "package.json",
-          "specifier": "^2.17.4",
+          "specifier": "^7.15.0",
           "workspace": "nestjs-remix-monorepo"
         }
       ],
       "resolved_versions": [
-        "2.17.4",
-        "2.17.5"
+        "7.18.0"
       ]
     },
     {
       "kind": "resolved",
-      "name": "@remix-run/server-runtime",
+      "name": "@types/eslint",
       "occurrences": [
         {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^2.17.4",
-          "workspace": "@fafa/frontend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^2.17.4",
-          "workspace": "nestjs-remix-monorepo"
+          "declaredIn": "packages/eslint-config/package.json",
+          "specifier": "^8.56.5",
+          "workspace": "@fafa/eslint-config"
         }
       ],
       "resolved_versions": [
-        "2.17.4",
-        "2.17.5"
+        "8.56.12",
+        "9.6.1"
       ]
     },
     {
@@ -195,78 +179,7 @@
       "resolved_versions": [
         "12.20.55",
         "18.19.130",
-        "20.19.41"
-      ]
-    },
-    {
-      "kind": "resolved",
-      "name": "@typescript-eslint/eslint-plugin",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^8.60.1",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^8.60.1",
-          "workspace": "@fafa/eslint-config"
-        },
-        {
-          "declaredIn": "packages/eslint-config/package.json",
-          "specifier": "^8.60.1",
-          "workspace": "@fafa/frontend"
-        }
-      ],
-      "resolved_versions": [
-        "8.60.1",
-        "8.61.1"
-      ]
-    },
-    {
-      "kind": "resolved",
-      "name": "@typescript-eslint/parser",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^8.60.1",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^8.60.1",
-          "workspace": "@fafa/eslint-config"
-        },
-        {
-          "declaredIn": "packages/eslint-config/package.json",
-          "specifier": "^8.60.1",
-          "workspace": "@fafa/frontend"
-        },
-        {
-          "declaredIn": "packages/eslint-plugin-fafa-ports/package.json",
-          "specifier": "^8.60.1",
-          "workspace": "eslint-plugin-fafa-ports"
-        }
-      ],
-      "resolved_versions": [
-        "8.60.0",
-        "8.60.1"
-      ]
-    },
-    {
-      "kind": "resolved",
-      "name": "@typescript-eslint/utils",
-      "occurrences": [
-        {
-          "declaredIn": "packages/eslint-plugin-fafa-ports/package.json",
-          "specifier": "^8.60.1",
-          "workspace": "eslint-plugin-fafa-ports"
-        }
-      ],
-      "resolved_versions": [
-        "8.59.4",
-        "8.60.0",
-        "8.60.1"
+        "20.19.43"
       ]
     },
     {
@@ -281,23 +194,7 @@
       ],
       "resolved_versions": [
         "2.1.9",
-        "4.1.6",
-        "4.1.8"
-      ]
-    },
-    {
-      "kind": "resolved",
-      "name": "@vitest/coverage-v8",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^4.0.2",
-          "workspace": "@fafa/frontend"
-        }
-      ],
-      "resolved_versions": [
-        "4.1.6",
-        "4.1.8"
+        "4.1.9"
       ]
     },
     {
@@ -331,7 +228,7 @@
       ],
       "resolved_versions": [
         "4.11.4",
-        "4.12.0"
+        "4.12.1"
       ]
     },
     {
@@ -346,7 +243,8 @@
       ],
       "resolved_versions": [
         "1.20.4",
-        "1.20.5"
+        "1.20.5",
+        "2.3.0"
       ]
     },
     {
@@ -460,6 +358,71 @@
       ]
     },
     {
+      "kind": "resolved",
+      "name": "globals",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^14.0.0",
+          "workspace": "@fafa/eslint-config"
+        },
+        {
+          "declaredIn": "packages/eslint-config/package.json",
+          "specifier": "^14.0.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "13.24.0",
+        "14.0.0"
+      ]
+    },
+    {
+      "kind": "resolved",
+      "name": "google-auth-library",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^10.6.1",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "10.5.0",
+        "10.7.0"
+      ]
+    },
+    {
+      "kind": "resolved",
+      "name": "ioredis",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^5.8.2",
+          "workspace": "@fafa/backend"
+        }
+      ],
+      "resolved_versions": [
+        "5.10.1",
+        "5.11.1"
+      ]
+    },
+    {
+      "kind": "resolved",
+      "name": "isbot",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^4.1.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "4.4.0",
+        "5.1.43"
+      ]
+    },
+    {
       "kind": "specifier",
       "name": "js-yaml",
       "occurrences": [
@@ -482,7 +445,8 @@
       "resolved_versions": [
         "3.14.2",
         "4.1.0",
-        "4.1.1"
+        "4.1.1",
+        "4.2.0"
       ]
     },
     {
@@ -516,7 +480,7 @@
         }
       ],
       "resolved_versions": [
-        "1.60.0"
+        "1.61.0"
       ]
     },
     {
@@ -535,7 +499,6 @@
         }
       ],
       "resolved_versions": [
-        "8.5.14",
         "8.5.15"
       ]
     },
@@ -556,7 +519,7 @@
       ],
       "resolved_versions": [
         "2.8.8",
-        "3.8.3"
+        "3.8.4"
       ]
     },
     {
@@ -595,6 +558,30 @@
       ],
       "resolved_versions": [
         "18.3.1"
+      ]
+    },
+    {
+      "kind": "specifier",
+      "name": "react-router",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^7.0.0",
+          "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^7.15.0",
+          "workspace": "@fafa/frontend"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^7.15.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "7.18.0"
       ]
     },
     {
@@ -723,77 +710,6 @@
     },
     {
       "kind": "resolved",
-      "name": "tsx",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "^4.22.4",
-          "workspace": "@fafa/frontend"
-        },
-        {
-          "declaredIn": "packages/cwv-taxonomy/package.json",
-          "specifier": "^4.22.4",
-          "workspace": "@repo/cwv-taxonomy"
-        },
-        {
-          "declaredIn": "packages/database-types/package.json",
-          "specifier": "^4.22.4",
-          "workspace": "@repo/database-types"
-        },
-        {
-          "declaredIn": "packages/domain-commerce/package.json",
-          "specifier": "^4.22.4",
-          "workspace": "@repo/domain-commerce"
-        },
-        {
-          "declaredIn": "packages/registry/package.json",
-          "specifier": "^4.22.4",
-          "workspace": "@repo/registry"
-        },
-        {
-          "declaredIn": "packages/seo-role-contracts/package.json",
-          "specifier": "^4.22.4",
-          "workspace": "@repo/seo-role-contracts"
-        },
-        {
-          "declaredIn": "packages/seo-roles/package.json",
-          "specifier": "^4.22.4",
-          "workspace": "@repo/seo-roles"
-        },
-        {
-          "declaredIn": "packages/seo-types/package.json",
-          "specifier": "^4.22.4",
-          "workspace": "@repo/seo-types"
-        },
-        {
-          "declaredIn": "packages/seo-url-contract/package.json",
-          "specifier": "^4.22.4",
-          "workspace": "@repo/seo-url-contract"
-        }
-      ],
-      "resolved_versions": [
-        "4.22.2",
-        "4.22.4"
-      ]
-    },
-    {
-      "kind": "resolved",
-      "name": "undici",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^7.13.0",
-          "workspace": "@fafa/backend"
-        }
-      ],
-      "resolved_versions": [
-        "6.25.0",
-        "6.26.0",
-        "7.25.0"
-      ]
-    },
-    {
-      "kind": "resolved",
       "name": "vite",
       "occurrences": [
         {
@@ -809,7 +725,6 @@
       ],
       "resolved_versions": [
         "5.4.21",
-        "8.0.13",
         "8.0.16"
       ]
     },
@@ -830,8 +745,7 @@
       ],
       "resolved_versions": [
         "2.1.9",
-        "4.1.6",
-        "4.1.8"
+        "4.1.9"
       ]
     },
     {
@@ -1298,7 +1212,7 @@
             }
           ],
           "resolved_versions": [
-            "2.106.0"
+            "2.108.2"
           ]
         }
       ],
@@ -1460,6 +1374,11 @@
             },
             {
               "declaredIn": "frontend/package.json",
+              "specifier": "*",
+              "workspace": "@fafa/design-tokens"
+            },
+            {
+              "declaredIn": "packages/design-tokens/package.json",
               "specifier": "*",
               "workspace": "@fafa/frontend"
             }
@@ -1626,7 +1545,7 @@
       ],
       "supports_dual_runtime": "none",
       "target_major": "workspace",
-      "total_occurrences": 14,
+      "total_occurrences": 15,
       "upgrade_cost_estimate": {
         "estimated_engineer_days": 1,
         "estimated_review_load": "low"
@@ -1916,11 +1835,11 @@
             }
           ],
           "resolved_versions": [
-            "5.76.10"
+            "5.79.0"
           ]
         },
         {
-          "divergent_resolved": false,
+          "divergent_resolved": true,
           "divergent_specifiers": false,
           "name": "ioredis",
           "occurrences": [
@@ -1931,7 +1850,8 @@
             }
           ],
           "resolved_versions": [
-            "5.10.1"
+            "5.10.1",
+            "5.11.1"
           ]
         }
       ],
@@ -2354,7 +2274,8 @@
           ],
           "resolved_versions": [
             "1.20.4",
-            "1.20.5"
+            "1.20.5",
+            "2.3.0"
           ]
         },
         {
@@ -2715,153 +2636,6 @@
       "packages": [
         {
           "divergent_resolved": false,
-          "divergent_specifiers": false,
-          "name": "@remix-run/dev",
-          "occurrences": [
-            {
-              "declaredIn": "frontend/package.json",
-              "specifier": "^2.17.5",
-              "workspace": "@fafa/frontend"
-            },
-            {
-              "declaredIn": "package.json",
-              "specifier": "^2.17.5",
-              "workspace": "nestjs-remix-monorepo"
-            }
-          ],
-          "resolved_versions": [
-            "2.17.5"
-          ]
-        },
-        {
-          "divergent_resolved": false,
-          "divergent_specifiers": false,
-          "name": "@remix-run/eslint-config",
-          "occurrences": [
-            {
-              "declaredIn": "frontend/package.json",
-              "specifier": "^2.17.5",
-              "workspace": "@fafa/eslint-config"
-            },
-            {
-              "declaredIn": "packages/eslint-config/package.json",
-              "specifier": "^2.17.5",
-              "workspace": "@fafa/frontend"
-            }
-          ],
-          "resolved_versions": [
-            "<unresolved>"
-          ]
-        },
-        {
-          "divergent_resolved": false,
-          "divergent_specifiers": false,
-          "name": "@remix-run/express",
-          "occurrences": [
-            {
-              "declaredIn": "backend/package.json",
-              "specifier": "^2.17.4",
-              "workspace": "@fafa/backend"
-            },
-            {
-              "declaredIn": "frontend/package.json",
-              "specifier": "^2.17.4",
-              "workspace": "@fafa/frontend"
-            },
-            {
-              "declaredIn": "package.json",
-              "specifier": "^2.17.4",
-              "workspace": "nestjs-remix-monorepo"
-            }
-          ],
-          "resolved_versions": [
-            "2.17.4"
-          ]
-        },
-        {
-          "divergent_resolved": true,
-          "divergent_specifiers": false,
-          "name": "@remix-run/node",
-          "occurrences": [
-            {
-              "declaredIn": "frontend/package.json",
-              "specifier": "^2.17.4",
-              "workspace": "@fafa/frontend"
-            },
-            {
-              "declaredIn": "package.json",
-              "specifier": "^2.17.4",
-              "workspace": "nestjs-remix-monorepo"
-            }
-          ],
-          "resolved_versions": [
-            "2.17.4",
-            "2.17.5"
-          ]
-        },
-        {
-          "divergent_resolved": false,
-          "divergent_specifiers": false,
-          "name": "@remix-run/react",
-          "occurrences": [
-            {
-              "declaredIn": "frontend/package.json",
-              "specifier": "^2.17.4",
-              "workspace": "@fafa/frontend"
-            },
-            {
-              "declaredIn": "package.json",
-              "specifier": "^2.17.4",
-              "workspace": "nestjs-remix-monorepo"
-            }
-          ],
-          "resolved_versions": [
-            "2.17.4"
-          ]
-        },
-        {
-          "divergent_resolved": false,
-          "divergent_specifiers": false,
-          "name": "@remix-run/serve",
-          "occurrences": [
-            {
-              "declaredIn": "frontend/package.json",
-              "specifier": "^2.17.4",
-              "workspace": "@fafa/frontend"
-            },
-            {
-              "declaredIn": "package.json",
-              "specifier": "^2.17.4",
-              "workspace": "nestjs-remix-monorepo"
-            }
-          ],
-          "resolved_versions": [
-            "2.17.4"
-          ]
-        },
-        {
-          "divergent_resolved": true,
-          "divergent_specifiers": false,
-          "name": "@remix-run/server-runtime",
-          "occurrences": [
-            {
-              "declaredIn": "frontend/package.json",
-              "specifier": "^2.17.4",
-              "workspace": "@fafa/frontend"
-            },
-            {
-              "declaredIn": "package.json",
-              "specifier": "^2.17.4",
-              "workspace": "nestjs-remix-monorepo"
-            }
-          ],
-          "resolved_versions": [
-            "2.17.4",
-            "2.17.5"
-          ]
-        },
-        {
-          "divergent_resolved": false,
           "divergent_specifiers": true,
           "name": "react",
           "occurrences": [
@@ -2918,7 +2692,6 @@
           ],
           "resolved_versions": [
             "5.4.21",
-            "8.0.13",
             "8.0.16"
           ]
         }
@@ -2930,13 +2703,6 @@
         "vite"
       ],
       "peer_dependency_cluster_resolved": [
-        "@remix-run/dev",
-        "@remix-run/eslint-config",
-        "@remix-run/express",
-        "@remix-run/node",
-        "@remix-run/react",
-        "@remix-run/serve",
-        "@remix-run/server-runtime",
         "react",
         "react-dom",
         "vite"
@@ -3013,7 +2779,7 @@
       ],
       "supports_dual_runtime": "none",
       "target_major": "see source_url",
-      "total_occurrences": 21,
+      "total_occurrences": 6,
       "upgrade_cost_estimate": {
         "estimated_engineer_days": 21,
         "estimated_review_load": "extreme"
@@ -3120,7 +2886,7 @@
           ],
           "resolved_versions": [
             "2.8.8",
-            "3.8.3"
+            "3.8.4"
           ]
         },
         {
@@ -3139,7 +2905,7 @@
           ]
         },
         {
-          "divergent_resolved": true,
+          "divergent_resolved": false,
           "divergent_specifiers": false,
           "name": "tsx",
           "occurrences": [
@@ -3190,7 +2956,6 @@
             }
           ],
           "resolved_versions": [
-            "4.22.2",
             "4.22.4"
           ]
         }
@@ -3310,7 +3075,7 @@
       },
       "packages": [
         {
-          "divergent_resolved": true,
+          "divergent_resolved": false,
           "divergent_specifiers": false,
           "name": "@typescript-eslint/eslint-plugin",
           "occurrences": [
@@ -3331,12 +3096,11 @@
             }
           ],
           "resolved_versions": [
-            "8.60.1",
             "8.61.1"
           ]
         },
         {
-          "divergent_resolved": true,
+          "divergent_resolved": false,
           "divergent_specifiers": false,
           "name": "@typescript-eslint/parser",
           "occurrences": [
@@ -3362,8 +3126,7 @@
             }
           ],
           "resolved_versions": [
-            "8.60.0",
-            "8.60.1"
+            "8.61.1"
           ]
         },
         {
@@ -3469,6 +3232,11 @@
             {
               "declaredIn": "frontend/package.json",
               "specifier": "^6.10.2",
+              "workspace": "@fafa/eslint-config"
+            },
+            {
+              "declaredIn": "packages/eslint-config/package.json",
+              "specifier": "^6.10.2",
               "workspace": "@fafa/frontend"
             }
           ],
@@ -3504,6 +3272,11 @@
             {
               "declaredIn": "frontend/package.json",
               "specifier": "^7.37.5",
+              "workspace": "@fafa/eslint-config"
+            },
+            {
+              "declaredIn": "packages/eslint-config/package.json",
+              "specifier": "^7.37.5",
               "workspace": "@fafa/frontend"
             }
           ],
@@ -3518,6 +3291,11 @@
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
+              "specifier": "^4.6.2",
+              "workspace": "@fafa/eslint-config"
+            },
+            {
+              "declaredIn": "packages/eslint-config/package.json",
               "specifier": "^4.6.2",
               "workspace": "@fafa/frontend"
             }
@@ -3618,11 +3396,14 @@
         "eslint-config-prettier",
         "eslint-plugin-fafa-ports",
         "eslint-plugin-import",
+        "eslint-plugin-jest",
+        "eslint-plugin-jest-dom",
         "eslint-plugin-jsx-a11y",
         "eslint-plugin-prettier",
         "eslint-plugin-react",
         "eslint-plugin-react-hooks",
         "eslint-plugin-storybook",
+        "eslint-plugin-testing-library",
         "typescript"
       ],
       "perf_baseline_metrics": [],
@@ -3676,7 +3457,7 @@
       ],
       "supports_dual_runtime": "none",
       "target_major": "locked-at-execution",
-      "total_occurrences": 38,
+      "total_occurrences": 41,
       "upgrade_cost_estimate": {
         "estimated_engineer_days": 5,
         "estimated_review_load": "medium"
@@ -4016,9 +3797,9 @@
   ],
   "generatedFrom": {
     "deps_registry": "audit/registry/deps.json",
-    "deps_registry_sha": "sha256:a6b9e71676d3a16c8689b62bfd8c01f355ba811b1eae3e80e1f64264702f4438",
+    "deps_registry_sha": "sha256:20a1be4e31fee1e65206581c2cea743ca9f11712edf6d8586dce988c5959a811",
     "lockfile": "package-lock.json",
-    "lockfile_sha": "sha256:017b31ebce3d0b6e8c9d9530e56ba1efd0c786083eb89221e8e31770694d951b",
+    "lockfile_sha": "sha256:c149f19ccbab0f134760ba9f3b84a8f0e029a0c7db0e0225bde0c32f0129df96",
     "overlay": "audit/dependencies/family-overlay.yaml",
     "overlay_sha": "sha256:4067a5535b22d0d6c98fa6f3c980189b2a68f9837edd7f7caf1e7b1e10c44746"
   },
@@ -4033,13 +3814,13 @@
       "observability": 2,
       "queues": 5,
       "runtime-backend": 17,
-      "runtime-frontend": 10,
+      "runtime-frontend": 3,
       "tooling": 15,
-      "unassigned": 160,
+      "unassigned": 171,
       "validation": 2
     },
     "by_pr_assignment": {
-      "deferred": 25,
+      "deferred": 18,
       "pr-9b": 10,
       "pr-9c": 2,
       "pr-9d": 5,
@@ -4047,11 +3828,11 @@
       "pr-9f": 17,
       "pr-9g": 0
     },
-    "divergent_packages_count": 41,
+    "divergent_packages_count": 39,
     "families_count": 12,
-    "total_occurrences": 331,
-    "total_packages": 227,
-    "unassigned_count": 160
+    "total_occurrences": 339,
+    "total_packages": 231,
+    "unassigned_count": 171
   },
   "unassigned_packages": [
     {
@@ -4186,7 +3967,7 @@
         }
       ],
       "resolved_versions": [
-        "5.2.2"
+        "5.4.0"
       ]
     },
     {
@@ -4246,7 +4027,7 @@
         }
       ],
       "resolved_versions": [
-        "1.60.0"
+        "1.61.0"
       ]
     },
     {
@@ -4261,7 +4042,7 @@
         }
       ],
       "resolved_versions": [
-        "1.2.12"
+        "1.2.14"
       ]
     },
     {
@@ -4276,7 +4057,7 @@
         }
       ],
       "resolved_versions": [
-        "1.1.11"
+        "1.2.0"
       ]
     },
     {
@@ -4291,7 +4072,7 @@
         }
       ],
       "resolved_versions": [
-        "1.1.12"
+        "1.1.14"
       ]
     },
     {
@@ -4306,7 +4087,7 @@
         }
       ],
       "resolved_versions": [
-        "1.1.15"
+        "1.1.17"
       ]
     },
     {
@@ -4321,7 +4102,7 @@
         }
       ],
       "resolved_versions": [
-        "2.1.16"
+        "2.1.18"
       ]
     },
     {
@@ -4336,7 +4117,7 @@
         }
       ],
       "resolved_versions": [
-        "1.1.15"
+        "1.1.17"
       ]
     },
     {
@@ -4351,7 +4132,7 @@
         }
       ],
       "resolved_versions": [
-        "1.2.14"
+        "1.2.16"
       ]
     },
     {
@@ -4366,7 +4147,7 @@
         }
       ],
       "resolved_versions": [
-        "1.1.15"
+        "1.1.17"
       ]
     },
     {
@@ -4381,7 +4162,7 @@
         }
       ],
       "resolved_versions": [
-        "1.2.10"
+        "1.2.12"
       ]
     },
     {
@@ -4396,7 +4177,7 @@
         }
       ],
       "resolved_versions": [
-        "1.1.8"
+        "1.1.10"
       ]
     },
     {
@@ -4411,11 +4192,11 @@
         }
       ],
       "resolved_versions": [
-        "1.3.6"
+        "1.4.1"
       ]
     },
     {
-      "divergent_resolved": true,
+      "divergent_resolved": false,
       "divergent_specifiers": false,
       "name": "@radix-ui/react-slot",
       "occurrences": [
@@ -4426,8 +4207,7 @@
         }
       ],
       "resolved_versions": [
-        "1.2.3",
-        "1.2.4"
+        "1.3.0"
       ]
     },
     {
@@ -4442,7 +4222,7 @@
         }
       ],
       "resolved_versions": [
-        "1.2.6"
+        "1.3.1"
       ]
     },
     {
@@ -4457,7 +4237,7 @@
         }
       ],
       "resolved_versions": [
-        "1.1.13"
+        "1.1.15"
       ]
     },
     {
@@ -4472,7 +4252,107 @@
         }
       ],
       "resolved_versions": [
-        "1.2.8"
+        "1.2.10"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "@react-router/dev",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^7.15.0",
+          "workspace": "@fafa/frontend"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^7.15.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "7.18.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": true,
+      "name": "@react-router/express",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^7.0.0",
+          "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^7.15.0",
+          "workspace": "@fafa/frontend"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^7.15.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "7.18.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "@react-router/node",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^7.15.0",
+          "workspace": "@fafa/frontend"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^7.15.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "7.18.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "@react-router/remix-routes-option-adapter",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^7.15.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "7.18.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "@react-router/serve",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^7.15.0",
+          "workspace": "@fafa/frontend"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^7.15.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "7.18.0"
       ]
     },
     {
@@ -4582,13 +4462,13 @@
         }
       ],
       "resolved_versions": [
-        "10.53.1"
+        "10.59.0"
       ]
     },
     {
       "divergent_resolved": false,
       "divergent_specifiers": false,
-      "name": "@sentry/remix",
+      "name": "@sentry/react-router",
       "occurrences": [
         {
           "declaredIn": "frontend/package.json",
@@ -4597,7 +4477,7 @@
         }
       ],
       "resolved_versions": [
-        "10.53.1"
+        "10.59.0"
       ]
     },
     {
@@ -4702,7 +4582,7 @@
         }
       ],
       "resolved_versions": [
-        "5.100.10"
+        "5.101.0"
       ]
     },
     {
@@ -4747,7 +4627,7 @@
         }
       ],
       "resolved_versions": [
-        "3.26.1"
+        "3.27.1"
       ]
     },
     {
@@ -4762,7 +4642,7 @@
         }
       ],
       "resolved_versions": [
-        "3.26.1"
+        "3.27.1"
       ]
     },
     {
@@ -4777,7 +4657,7 @@
         }
       ],
       "resolved_versions": [
-        "3.26.1"
+        "3.27.1"
       ]
     },
     {
@@ -4792,7 +4672,7 @@
         }
       ],
       "resolved_versions": [
-        "3.26.1"
+        "3.27.1"
       ]
     },
     {
@@ -4807,7 +4687,7 @@
         }
       ],
       "resolved_versions": [
-        "3.26.1"
+        "3.27.1"
       ]
     },
     {
@@ -4946,7 +4826,7 @@
       ]
     },
     {
-      "divergent_resolved": false,
+      "divergent_resolved": true,
       "divergent_specifiers": false,
       "name": "@types/eslint",
       "occurrences": [
@@ -4957,7 +4837,8 @@
         }
       ],
       "resolved_versions": [
-        "8.56.12"
+        "8.56.12",
+        "9.6.1"
       ]
     },
     {
@@ -5154,7 +5035,7 @@
       "resolved_versions": [
         "12.20.55",
         "18.19.130",
-        "20.19.41"
+        "20.19.43"
       ]
     },
     {
@@ -5169,7 +5050,7 @@
         }
       ],
       "resolved_versions": [
-        "7.0.11"
+        "7.0.12"
       ]
     },
     {
@@ -5229,7 +5110,7 @@
         }
       ],
       "resolved_versions": [
-        "18.3.28"
+        "18.3.31"
       ]
     },
     {
@@ -5319,11 +5200,11 @@
         }
       ],
       "resolved_versions": [
-        "8.60.0"
+        "8.61.1"
       ]
     },
     {
-      "divergent_resolved": true,
+      "divergent_resolved": false,
       "divergent_specifiers": false,
       "name": "@typescript-eslint/utils",
       "occurrences": [
@@ -5334,9 +5215,7 @@
         }
       ],
       "resolved_versions": [
-        "8.59.4",
-        "8.60.0",
-        "8.60.1"
+        "8.61.1"
       ]
     },
     {
@@ -5352,12 +5231,11 @@
       ],
       "resolved_versions": [
         "2.1.9",
-        "4.1.6",
-        "4.1.8"
+        "4.1.9"
       ]
     },
     {
-      "divergent_resolved": true,
+      "divergent_resolved": false,
       "divergent_specifiers": false,
       "name": "@vitest/coverage-v8",
       "occurrences": [
@@ -5368,8 +5246,7 @@
         }
       ],
       "resolved_versions": [
-        "4.1.6",
-        "4.1.8"
+        "4.1.9"
       ]
     },
     {
@@ -5420,7 +5297,7 @@
       ],
       "resolved_versions": [
         "4.11.4",
-        "4.12.0"
+        "4.12.1"
       ]
     },
     {
@@ -5635,6 +5512,36 @@
     {
       "divergent_resolved": false,
       "divergent_specifiers": false,
+      "name": "eslint-plugin-jest",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^28.14.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "28.14.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "eslint-plugin-jest-dom",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^5.5.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "5.5.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
       "name": "eslint-plugin-storybook",
       "occurrences": [
         {
@@ -5645,6 +5552,21 @@
       ],
       "resolved_versions": [
         "9.1.20"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "eslint-plugin-testing-library",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^7.16.2",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "7.16.2"
       ]
     },
     {
@@ -5699,7 +5621,28 @@
       ]
     },
     {
-      "divergent_resolved": false,
+      "divergent_resolved": true,
+      "divergent_specifiers": false,
+      "name": "globals",
+      "occurrences": [
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^14.0.0",
+          "workspace": "@fafa/eslint-config"
+        },
+        {
+          "declaredIn": "packages/eslint-config/package.json",
+          "specifier": "^14.0.0",
+          "workspace": "@fafa/frontend"
+        }
+      ],
+      "resolved_versions": [
+        "13.24.0",
+        "14.0.0"
+      ]
+    },
+    {
+      "divergent_resolved": true,
       "divergent_specifiers": false,
       "name": "google-auth-library",
       "occurrences": [
@@ -5710,7 +5653,8 @@
         }
       ],
       "resolved_versions": [
-        "10.6.2"
+        "10.5.0",
+        "10.7.0"
       ]
     },
     {
@@ -5755,7 +5699,7 @@
         }
       ],
       "resolved_versions": [
-        "8.1.0"
+        "8.2.0"
       ]
     },
     {
@@ -5804,7 +5748,7 @@
       ]
     },
     {
-      "divergent_resolved": false,
+      "divergent_resolved": true,
       "divergent_specifiers": false,
       "name": "isbot",
       "occurrences": [
@@ -5815,7 +5759,8 @@
         }
       ],
       "resolved_versions": [
-        "4.4.0"
+        "4.4.0",
+        "5.1.43"
       ]
     },
     {
@@ -5892,7 +5837,8 @@
       "resolved_versions": [
         "3.14.2",
         "4.1.0",
-        "4.1.1"
+        "4.1.1",
+        "4.2.0"
       ]
     },
     {
@@ -6038,7 +5984,7 @@
         }
       ],
       "resolved_versions": [
-        "8.0.7"
+        "8.0.11"
       ]
     },
     {
@@ -6118,11 +6064,11 @@
         }
       ],
       "resolved_versions": [
-        "1.60.0"
+        "1.61.0"
       ]
     },
     {
-      "divergent_resolved": true,
+      "divergent_resolved": false,
       "divergent_specifiers": true,
       "name": "postcss",
       "occurrences": [
@@ -6138,7 +6084,6 @@
         }
       ],
       "resolved_versions": [
-        "8.5.14",
         "8.5.15"
       ]
     },
@@ -6184,7 +6129,32 @@
         }
       ],
       "resolved_versions": [
-        "7.76.0"
+        "7.80.0"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": true,
+      "name": "react-router",
+      "occurrences": [
+        {
+          "declaredIn": "backend/package.json",
+          "specifier": "^7.0.0",
+          "workspace": "@fafa/backend"
+        },
+        {
+          "declaredIn": "frontend/package.json",
+          "specifier": "^7.15.0",
+          "workspace": "@fafa/frontend"
+        },
+        {
+          "declaredIn": "package.json",
+          "specifier": "^7.15.0",
+          "workspace": "nestjs-remix-monorepo"
+        }
+      ],
+      "resolved_versions": [
+        "7.18.0"
       ]
     },
     {
@@ -6467,7 +6437,7 @@
         }
       ],
       "resolved_versions": [
-        "29.4.10"
+        "29.4.11"
       ]
     },
     {
@@ -6482,7 +6452,7 @@
         }
       ],
       "resolved_versions": [
-        "9.6.0"
+        "9.6.1"
       ]
     },
     {
@@ -6543,7 +6513,22 @@
         }
       ],
       "resolved_versions": [
-        "2.9.16"
+        "2.9.18"
+      ]
+    },
+    {
+      "divergent_resolved": false,
+      "divergent_specifiers": false,
+      "name": "typescript-eslint",
+      "occurrences": [
+        {
+          "declaredIn": "packages/eslint-config/package.json",
+          "specifier": "^8.61.1",
+          "workspace": "@fafa/eslint-config"
+        }
+      ],
+      "resolved_versions": [
+        "8.61.1"
       ]
     },
     {
@@ -6562,7 +6547,7 @@
       ]
     },
     {
-      "divergent_resolved": true,
+      "divergent_resolved": false,
       "divergent_specifiers": false,
       "name": "undici",
       "occurrences": [
@@ -6573,9 +6558,7 @@
         }
       ],
       "resolved_versions": [
-        "6.25.0",
-        "6.26.0",
-        "7.25.0"
+        "7.28.0"
       ]
     },
     {
@@ -6626,8 +6609,7 @@
       ],
       "resolved_versions": [
         "2.1.9",
-        "4.1.6",
-        "4.1.8"
+        "4.1.9"
       ]
     },
     {
@@ -6642,7 +6624,7 @@
         }
       ],
       "resolved_versions": [
-        "5.2.0"
+        "5.3.0"
       ]
     }
   ]


### PR DESCRIPTION
Suite à #1078 (resync registry) : `audit/registry/deps.json` a été régénéré mais pas son artefact **dérivé** `audit/dependencies/dependency-modernization-inventory.json` → dérive déterministe.

Check **"Dependency Modernization Inventory determinism (BLOCKING)"** rouge sur `main` (committed `96fa98102608` ≠ regenerated `9bba73d2de91`).

**Fix** : régénère l'inventaire (1 fichier). 231 packages, 12 familles, 39 divergents. Déterministe (hash stable sur 2 runs, Node 24), `--check` vert.

Complète la chaîne registry (cf. `feedback_verify_pr_checks` : régénérer la FULL chain, pas seulement `audit/registry/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)