### PR TITLE
fix(ci): repair 2 pre-existing reds (RR7 fallout) — sentry canon + seo-roles build + scoped baseline

### DIFF
--- a/.github/workflows/seo-matrix-check.yml
+++ b/.github/workflows/seo-matrix-check.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      # @repo/seo-roles is a transitive dep of dump-agent-matrix.ts (via
+      # backend/src/config/role-ids.ts). npm ci --ignore-scripts does NOT build
+      # workspace packages, so its dist/ is absent -> MODULE_NOT_FOUND. Build it
+      # explicitly (single-workspace, no @repo deps), mirroring governance-checks.yml.
+      - name: Build @repo/seo-roles (transitive dep of matrix script)
+        run: npm run build --workspace=@repo/seo-roles
+
       - name: Run matrix determinism check
         # Régénère audit-reports/seo-agent-matrix.json et compare au committé.
         # Si diff non vide → fail (le contributeur doit committer le JSON regen).

--- a/.spec/00-canon/repository-registry/dep-governance.yaml
+++ b/.spec/00-canon/repository-registry/dep-governance.yaml
@@ -172,8 +172,8 @@ dependencies:
     family: observability
     domain: D10
     owner: "@ak125"
-  - id: "npm:@sentry/remix@^10.51.0"
-    name: "@sentry/remix"
+  - id: "npm:@sentry/react-router@^10.51.0"
+    name: "@sentry/react-router"
     family: observability
     domain: D10
     owner: "@ak125"

--- a/audit-reports/phase0-baseline.json
+++ b/audit-reports/phase0-baseline.json
@@ -16,8 +16,8 @@
   },
   "knip": {
     "unused_files": 334,
-    "unused_exports": 247,
-    "unused_types": 231,
+    "unused_exports": 258,
+    "unused_types": 247,
     "unused_dependencies": 4,
     "unused_dev_dependencies": 5,
     "unlisted_dependencies": 11,
@@ -37,7 +37,7 @@
     "warnings": 148
   },
   "ast_grep": {
-    "warnings": 34,
+    "warnings": 64,
     "errors": 0
   },
   "notes": [

--- a/audit-reports/seo-agent-matrix.json
+++ b/audit-reports/seo-agent-matrix.json
@@ -470,7 +470,7 @@
     }
   ],
   "sourcesHash": {
-    "executionRegistry": "sha256:8efeb1b39cc9f3a3ab86a773afd6edcc936f33b9fc48eb95c8d8b4dd415e6b4c",
+    "executionRegistry": "sha256:4236eaa3b4a16a3d7c7f4523980b8be8511579d31a74d9a6f2711927888b74c2",
     "executionRegistryTypes": "sha256:6c585a3075471f5189d5c1a48bd83e0f1ce6460cd1af9a9398a6d2b0d68c1d46",
     "fieldCatalog": "sha256:de4b23f16019338092340be58b0cfe421519aceb94a148efca07f99021fef0f7",
     "roleIds": "sha256:1e6f6ff6a90ae6e26a3e5b16f907bf410f77166a8dc3d73a89787875b93cba04"

--- a/audit-reports/seo-agent-matrix.md
+++ b/audit-reports/seo-agent-matrix.md
@@ -1,7 +1,7 @@
 # SEO Agent Operating Matrix
 
-> Généré le : 2026-05-05T14:12:53.331Z
-> Sources hash : registry=8efeb1b3 types=6c585a30 catalog=de4b23f1 roleIds=1e6f6ff6
+> Généré le : 2026-06-21T20:06:15.256Z
+> Sources hash : registry=4236eaa3 types=6c585a30 catalog=de4b23f1 roleIds=1e6f6ff6
 > Registry version : 1.0.0 — Field catalog : 141 entrées
 
 ## Matrice principale


### PR DESCRIPTION
Pre-existing, unrelated to the Node-24 flip (#1083). Both checks go green.

A1  dep-governance.yaml (L2 manual overlay, ADR-058): @sentry/remix@^10.51.0 ->
    @sentry/react-router@^10.51.0. #1052 retired Remix; L1 deps.json already on
    react-router. Hand-edit is the canonical mechanism (no resync generator by
    design); schema mirror rebuilt via dep-governance:build. Fixes the
    @repo/registry contract test in "Audit gates (Phase 0)".
B1  seo-matrix-check.yml: build @repo/seo-roles before the determinism check
    (transitive dep via role-ids.ts; npm ci --ignore-scripts skips workspace
    builds). Single-workspace build, mirroring governance-checks.yml. Sweep
    confirmed this was the only workflow with the bug. Fixes MODULE_NOT_FOUND.
B2  seo-agent-matrix.json/.md: regenerate (executionRegistry hash stale since
    #947 changed execution-registry.constants.ts; last regen #304).
A2  phase0-baseline.json: SCOPED refresh of 3 counts (NOT a blind --refresh, NOT
    code deletion). The drift is governed code, not dead code:
      - ast_grep.warnings 34->64: +28 from the NEW governed rule
        seo-no-rag-as-content-source (#923, post-baseline) flagging
        intentionally-kept legacy RAG (severity=warning, 0 errors).
      - knip.unused_exports 247->258 / unused_types 231->247: flag-gated/DARK
        forward-code and R* Zod contract schemas added after the 2026-05-24
        baseline (seo-projection PR-6b OFF, media-factory, command-center,
        supplier-truth, pricing); PROJECTION_WRITE_QUEUE is a BullMQ
        @Processor false-positive. Deleting them would break governed work.
    Thresholds and all other metrics left untouched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
