### PR TITLE
fix(ci): make E2E smoke gate resilient to transient PREPROD restarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1075,21 +1075,63 @@ jobs:
       - name: Install Playwright browsers
         run: cd frontend && npx playwright install chromium --with-deps
 
-      - name: Wait for PREPROD to be healthy
+      - name: Wait for PREPROD to be stably healthy
         run: |
-          for i in {1..12}; do
+          # Require CONSECUTIVE healthy polls, not first-hit. The shared PREPROD
+          # container can briefly restart (host-side: ExitCode=0 + restart:always,
+          # diagnostic 2026-06-21) — a single healthy poll can land in a momentary
+          # window just before a restart. Wait until it is STABLE before starting
+          # Playwright. Bounded; resets on any blip (no silent fallback).
+          need=4; stable=0
+          for i in $(seq 1 40); do
             if curl -sf http://localhost:3200/health > /dev/null 2>&1; then
-              echo "PREPROD healthy"
-              exit 0
+              stable=$((stable + 1))
+              echo "healthy ${stable}/${need} (poll ${i})"
+              if [ "$stable" -ge "$need" ]; then
+                echo "✅ PREPROD stably healthy"
+                exit 0
+              fi
+            else
+              if [ "$stable" -gt 0 ]; then echo "⚠️ health blip at poll ${i} — resetting stability counter"; fi
+              stable=0
             fi
-            echo "Attempt $i/12 — waiting 10s..."
-            sleep 10
+            sleep 5
           done
-          echo "PREPROD not available on port 3200"
+          echo "::error::PREPROD never reached ${need} consecutive healthy polls on :3200"
           exit 1
 
-      - name: 🎭 Run critical E2E tests
-        run: cd frontend && npx playwright test tests/e2e/critical-path.spec.ts tests/e2e/url-validation.spec.ts --project=chromium --reporter=github,list
+      - name: 🎭 Run critical E2E tests (resilient to transient PREPROD restart)
+        run: |
+          cd frontend
+          run_e2e() {
+            npx playwright test tests/e2e/critical-path.spec.ts tests/e2e/url-validation.spec.ts \
+              --project=chromium --reporter=github,list
+          }
+          # First pass.
+          if run_e2e; then exit 0; fi
+          # First pass failed. The shared PREPROD container can restart MID-SUITE
+          # (host-side, ~20s blind window) → connection-refused on an otherwise
+          # healthy app (diagnostic 2026-06-21: ExitCode=0, no OOM, no crash).
+          # Distinguish that from a REAL failure: wait until PREPROD is STABLY
+          # healthy again, then re-run the suite ONCE. If it never re-stabilizes,
+          # or the re-run also fails, it is a genuine failure (no silent fallback).
+          echo "::warning::E2E first pass failed — checking for a transient PREPROD restart…"
+          need=4; stable=0
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3200/health > /dev/null 2>&1; then
+              stable=$((stable + 1))
+              if [ "$stable" -ge "$need" ]; then break; fi
+            else
+              stable=0
+            fi
+            sleep 3
+          done
+          if [ "$stable" -lt "$need" ]; then
+            echo "::error::PREPROD did not re-stabilize after the failure — real failure, not a transient restart"
+            exit 1
+          fi
+          echo "PREPROD stably healthy again — re-running the critical E2E suite once"
+          run_e2e
         env:
           CI: true
           PLAYWRIGHT_BASE_URL: http://localhost:3200


### PR DESCRIPTION
## Problem
The `🎭 E2E Smoke` gate flakes intermittently (`ERR_CONNECTION_REFUSED` / `socket hang up` on :3200). It was red on the Node 24 flip merge (#1083) **and on Node 22 before it** — pre-existing.

## Root cause (diagnosed, not guessed)
On the failing job, the `🩺 Capture PREPROD diagnostics` step shows: **`OOMKilled=false ExitCode=0 RestartCount=1`**, host memory fine → the **shared PREPROD container restarts cleanly** (`restart: always`) **during** the run (~20s blind window). It's an **infra restart, not an app crash, not OOM, not Node 24**. The failure pattern is intermittent (some :3200 requests pass, the ones in the restart window fail in 18-31 ms).

The repo already serializes main deploys (`concurrency: cancel-in-progress`) and added diagnostics (#1059/#1060). The residual trigger is **host-side** (no concurrent deploy in the failing run — verified) and not preventable from the repo.

## Fix — robust to a transient restart, without masking real failures
- **`Wait for PREPROD`** now requires **4 consecutive healthy polls** (not first-hit), resetting on any blip → Playwright never starts in a pre-restart window.
- **Test step** re-runs the suite **once**, but only after PREPROD is **stably healthy again**. If it never re-stabilizes, or the re-run also fails → **gate fails** (no silent fallback; real regressions still go red).

## Not done (deliberate)
- **No concurrency change.** `cancel-in-progress: true` is kept (floating `:preprod` = "last main wins"). Switching to queue would deploy stale commits and doesn't address the observed failure.
- The host-side restart trigger needs runner access to eliminate fully (separate from this repo fix).

## Verification
Bash logic dry-run (set -eo pipefail): transient-restart → pass after re-run; never-stabilizes / persistent-fail → exit 1; mid-blip wait-gate → resets then passes. (`e2e-smoke` is main-only, so it exercises on merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)