### PR TITLE
chore(node24): align @types/node to ^24

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/constants/seo-control.constants.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,11 +2,13 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
+- backend/src/modules/bot-guard/bot-guard.middleware.test.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.ts
 - backend/src/modules/bot-guard/bot-guard.module.ts
+- backend/src/modules/bot-guard/bot-guard.service.test.ts
 - backend/src/modules/bot-guard/bot-guard.service.ts
 depends_on: []
 ---

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.test.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts
@@ -16,7 +16,6 @@ depends_on:
 - CatalogModule
 - DatabaseModule
 - SeoModule
-- AdminModule
 ---
 
 # Module Gamme Rest

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/maintenance.md
+++ b/.claude/knowledge/modules/maintenance.md
@@ -2,7 +2,7 @@
 module: maintenance
 sources:
 - backend/src/modules/maintenance
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/maintenance/maintenance.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/merchant-center.md
+++ b/.claude/knowledge/modules/merchant-center.md
@@ -2,7 +2,7 @@
 module: merchant-center
 sources:
 - backend/src/modules/merchant-center
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/merchant-center/controllers/merchant-center.controller.ts
 - backend/src/modules/merchant-center/merchant-center.module.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/observability.md
+++ b/.claude/knowledge/modules/observability.md
@@ -2,7 +2,7 @@
 module: observability
 sources:
 - backend/src/modules/observability
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.test.ts
 - backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-knowledge-bootstrap.md
+++ b/.claude/knowledge/modules/rag-knowledge-bootstrap.md
@@ -2,7 +2,7 @@
 module: rag-knowledge-bootstrap
 sources:
 - backend/src/modules/rag-knowledge-bootstrap
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
 - backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/dto/alternatives-v2.dto.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-control-plane.md
+++ b/.claude/knowledge/modules/seo-control-plane.md
@@ -2,7 +2,7 @@
 module: seo-control-plane
 sources:
 - backend/src/modules/seo-control-plane
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.processor.ts
 - backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.scheduler.service.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo-monitoring.md
+++ b/.claude/knowledge/modules/seo-monitoring.md
@@ -2,16 +2,16 @@
 module: seo-monitoring
 sources:
 - backend/src/modules/seo-monitoring
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
+- backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
+- backend/src/modules/seo-monitoring/controllers/cwv-dashboard.controller.ts
 - backend/src/modules/seo-monitoring/controllers/funnel-events.controller.ts
 - backend/src/modules/seo-monitoring/controllers/quality-history.controller.ts
+- backend/src/modules/seo-monitoring/controllers/runtime-events.controller.ts
 - backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
 - backend/src/modules/seo-monitoring/helpers/ai-readiness-detectors.ts
-- backend/src/modules/seo-monitoring/processors/seo-daily-fetch.processor.ts
-- backend/src/modules/seo-monitoring/seo-monitoring.module.ts
-- backend/src/modules/seo-monitoring/services/audit-findings.service.ts
-- backend/src/modules/seo-monitoring/services/crux-alerter.service.ts
+- backend/src/modules/seo-monitoring/processors/cwv-aggregation.processor.ts
 depends_on:
 - ConfigModule
 ---

--- a/.claude/knowledge/modules/seo-shadow-observatory.md
+++ b/.claude/knowledge/modules/seo-shadow-observatory.md
@@ -2,7 +2,7 @@
 module: seo-shadow-observatory
 sources:
 - backend/src/modules/seo-shadow-observatory
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/seo-shadow-observatory/env.schema.ts
 - backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,9 +2,8 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
-- backend/src/modules/shipping/shipping-new.module.ts
 - backend/src/modules/shipping/shipping.controller.ts
 - backend/src/modules/shipping/shipping.module.ts
 - backend/src/modules/shipping/shipping.service.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,16 +2,16 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts
 - backend/src/modules/support/controllers/contact.controller.ts
 - backend/src/modules/support/controllers/faq.controller.ts
+- backend/src/modules/support/controllers/leads-admin.controller.ts
 - backend/src/modules/support/controllers/legal.controller.ts
 - backend/src/modules/support/controllers/quote.controller.ts
 - backend/src/modules/support/controllers/review.controller.ts
-- backend/src/modules/support/controllers/support-analytics.controller.ts
 depends_on:
 - ConfigModule
 - DatabaseModule

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicle-context.md
+++ b/.claude/knowledge/modules/vehicle-context.md
@@ -2,7 +2,7 @@
 module: vehicle-context
 sources:
 - backend/src/modules/vehicle-context
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/vehicle-context/vehicle-context.middleware.test.ts
 - backend/src/modules/vehicle-context/vehicle-context.middleware.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-05-24'
+last_scan: '2026-06-21'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:cb4dfa3ce91afb4613888dfb23f0bbbc2d99d4c51b6f15daf846305e6e47d2cf",
+  "artifact_immutability_hash": "sha256:e4cb97fe6ffc5ad883bda4367713ceff7eed2f55216b21d1f314f0e35ca3cb91",
   "divergences": [
     {
       "kind": "specifier",
@@ -177,9 +177,7 @@
         }
       ],
       "resolved_versions": [
-        "12.20.55",
-        "18.19.130",
-        "20.19.43"
+        "24.13.2"
       ]
     },
     {
@@ -3799,7 +3797,7 @@
     "deps_registry": "audit/registry/deps.json",
     "deps_registry_sha": "sha256:20a1be4e31fee1e65206581c2cea743ca9f11712edf6d8586dce988c5959a811",
     "lockfile": "package-lock.json",
-    "lockfile_sha": "sha256:c149f19ccbab0f134760ba9f3b84a8f0e029a0c7db0e0225bde0c32f0129df96",
+    "lockfile_sha": "sha256:3b4460fb4270d41652f4988dcca5feb5abf2680171cbf2db4c3010e32c85efe1",
     "overlay": "audit/dependencies/family-overlay.yaml",
     "overlay_sha": "sha256:4067a5535b22d0d6c98fa6f3c980189b2a68f9837edd7f7caf1e7b1e10c44746"
   },
@@ -4977,7 +4975,7 @@
       ]
     },
     {
-      "divergent_resolved": true,
+      "divergent_resolved": false,
       "divergent_specifiers": true,
       "name": "@types/node",
       "occurrences": [
@@ -5033,9 +5031,7 @@
         }
       ],
       "resolved_versions": [
-        "12.20.55",
-        "18.19.130",
-        "20.19.43"
+        "24.13.2"
       ]
     },
     {

--- a/backend/package.json
+++ b/backend/package.json
@@ -129,7 +129,7 @@
     "@types/express-session": "^1.19.0",
     "@types/jest": "^29.5.2",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20.19.24",
+    "@types/node": "^24",
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",
     "@types/supertest": "^6.0.0",

--- a/log.md
+++ b/log.md
@@ -574,3 +574,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `chore/node24-align-types-node-24`
 - **Décision** : chore(node24): align @types/node to ^24
 - **Sortie** : PR aucune | commits 915dd3b05
+
+## 2026-06-21 — chore/node24-align-types-node-24 (auto)
+
+- **Branche** : `chore/node24-align-types-node-24`
+- **Décision** : chore(node24): regenerate dependency-modernization-inventory after @types/node@24 (+2 other commits)
+- **Sortie** : PR #1087 | commits 6ae2d6336 29a9c49e8 915dd3b05

--- a/log.md
+++ b/log.md
@@ -568,3 +568,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/sitemap-children-dev-parity`
 - **Décision** : Merge remote-tracking branch 'origin/main' into fix/sitemap-children-dev-parity (+3 other commits)
 - **Sortie** : PR #1068 | commits e0bd733a0 77a4a82ca 59b7e510f 05ca12857
+
+## 2026-06-21 — chore/node24-align-types-node-24 (auto)
+
+- **Branche** : `chore/node24-align-types-node-24`
+- **Décision** : chore(node24): align @types/node to ^24
+- **Sortie** : PR aucune | commits 915dd3b05

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
       }
     },
     "backend": {
@@ -176,7 +176,7 @@
         "@types/express-session": "^1.19.0",
         "@types/jest": "^29.5.2",
         "@types/js-yaml": "^4.0.9",
-        "@types/node": "^20.19.24",
+        "@types/node": "^24",
         "@types/passport-jwt": "^4.0.1",
         "@types/passport-local": "^1.0.38",
         "@types/supertest": "^6.0.0",
@@ -203,7 +203,7 @@
         "zod-to-json-schema": "^3.25.2"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
       }
     },
     "backend/node_modules/reflect-metadata": {
@@ -337,7 +337,7 @@
         "vitest": "^4.0.2"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
       }
     },
     "frontend/node_modules/isbot": {
@@ -4472,13 +4472,6 @@
         "find-up": "^4.1.0",
         "fs-extra": "^8.1.0"
       }
-    },
-    "node_modules/@manypkg/find-root/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -11387,12 +11380,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -25770,15 +25763,6 @@
         }
       }
     },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "node_modules/openai/node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -25803,12 +25787,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
     "node_modules/openai/node_modules/webidl-conversions": {
@@ -32758,9 +32736,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -35042,7 +35020,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^24",
         "tsx": "^4.22.4",
         "typescript": "^5.9.3"
       }
@@ -35054,7 +35032,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^24",
         "tsx": "^4.22.4",
         "typescript": "^5.9.3"
       }
@@ -35069,14 +35047,14 @@
       "devDependencies": {
         "@fafa/eslint-config": "*",
         "@fafa/typescript-config": "*",
-        "@types/node": "^20.17.6",
+        "@types/node": "^24",
         "eslint": "^8.57.1",
         "tsup": "^8.3.5",
         "typescript": "^5.9.3",
         "vitest": "^2.1.8"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.0.0"
       }
     },
     "packages/design-tokens/node_modules/@vitest/browser": {
@@ -35407,7 +35385,7 @@
       "name": "@repo/domain-commerce",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^24",
         "tsx": "^4.22.4",
         "typescript": "^5.9.3"
       }
@@ -35469,7 +35447,7 @@
       "devDependencies": {
         "@types/js-yaml": "4.0.9",
         "@types/micromatch": "^4.0.9",
-        "@types/node": "^20.0.0",
+        "@types/node": "^24",
         "tsx": "^4.22.4",
         "typescript": "^5.9.3"
       }
@@ -35503,7 +35481,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^24",
         "tsx": "^4.22.4",
         "typescript": "^5.9.3"
       }
@@ -35515,7 +35493,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^24",
         "tsx": "^4.22.4",
         "typescript": "^5.9.3"
       }
@@ -35527,7 +35505,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^24",
         "tsx": "^4.22.4",
         "typescript": "^5.9.3"
       }
@@ -35536,7 +35514,7 @@
       "name": "@repo/seo-url-contract",
       "version": "0.1.0",
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^24",
         "tsx": "^4.22.4",
         "typescript": "^5.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "zod": "^3.25.76"
   },
   "overrides": {
+    "@types/node": "^24",
     "path-to-regexp": "3.3.0",
     "zod": "^3.25.76",
     "typescript": "^5.9.3",

--- a/packages/cwv-taxonomy/package.json
+++ b/packages/cwv-taxonomy/package.json
@@ -22,7 +22,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^24",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   }

--- a/packages/database-types/package.json
+++ b/packages/database-types/package.json
@@ -39,7 +39,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^24",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   }

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@fafa/eslint-config": "*",
     "@fafa/typescript-config": "*",
-    "@types/node": "^20.17.6",
+    "@types/node": "^24",
     "eslint": "^8.57.1",
     "tsup": "^8.3.5",
     "typescript": "^5.9.3",

--- a/packages/domain-commerce/package.json
+++ b/packages/domain-commerce/package.json
@@ -19,7 +19,7 @@
     "test": "tsx --test src/**/*.test.ts"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^24",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   }

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/js-yaml": "4.0.9",
     "@types/micromatch": "^4.0.9",
-    "@types/node": "^20.0.0",
+    "@types/node": "^24",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   }

--- a/packages/seo-role-contracts/package.json
+++ b/packages/seo-role-contracts/package.json
@@ -23,7 +23,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^24",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   }

--- a/packages/seo-roles/package.json
+++ b/packages/seo-roles/package.json
@@ -22,7 +22,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^24",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   }

--- a/packages/seo-types/package.json
+++ b/packages/seo-types/package.json
@@ -73,7 +73,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^24",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   }

--- a/packages/seo-url-contract/package.json
+++ b/packages/seo-url-contract/package.json
@@ -19,7 +19,7 @@
     "test": "tsx --test src/**/*.test.ts"
   },
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^24",
     "tsx": "^4.22.4",
     "typescript": "^5.9.3"
   }


### PR DESCRIPTION
## Quoi
Aligne `@types/node` → `^24` sur tout le workspace (10 packages) + **override racine** pour une version hoïstée unique.

## Pourquoi
**#1083** a déjà passé runtime / `engines` / Dockerfiles / CI à **Node 24** ; seuls les `@types` décrivaient encore Node 20. C'est le **dernier item code-side du chantier Node 24**, **découplé de TS6** (faisable sous TS5.9).

## Mesure (worktree jetable depuis `origin/main` e3b91f433)
| | typecheck |
|---|---|
| Baseline `@types/node@20` | **0 erreur, 21/21 tâches** (main propre) |
| Après `@types/node@24.13.2` (`--force`) | **0 erreur, 21/21** |

→ **delta blast-radius = 0** sous TS5.9.

## Notes
- Lockfile régénéré avec **npm@10.8.2** (le `packageManager` du repo) → diff minimal `@types/node`-only.
- `services/remotion-renderer` (hors workspace) = follow-up séparé (lockfile + build + smoke).
- **PROD en Node 24** = tag `v*` **owner-gated**, hors scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)