### PR TITLE
chore(ci): harden contract gates so L2<->L1 / matrix drift can't reach main silently

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,12 +20,12 @@ on:
       - "knip.json"
       - ".dependency-cruiser.cjs"
       - "sgconfig.yml"
-      - "package.json"
+      - "**/package.json"   # root + backend/ + frontend/ + all workspaces (was root-only -> #1052 skip)
       - "package-lock.json"
       - "audit-reports/phase0-baseline.json"
       - ".github/workflows/audit.yml"
-      - ".spec/00-canon/repository-registry/architecture.yaml"
-      - ".spec/00-canon/repository-registry/db.yaml"
+      - ".spec/00-canon/repository-registry/**"   # ALL L2 overlays the contract suite reads (was architecture+db only)
+      - "audit/registry/**"                        # L1 projections the contract tests assert against
       - ".dependency-cruiser.generated.cjs"
 
 permissions:

--- a/.github/workflows/contract-gate.yml
+++ b/.github/workflows/contract-gate.yml
@@ -1,0 +1,55 @@
+name: 🛡️ Contract Gate (deterministic)
+
+# Always-run, blocking-capable gate for the DETERMINISTIC control-plane invariants:
+#   - @repo/registry L1<->L2 contracts (incl. the dep-governance subset test that
+#     #1052 silently drifted past — @sentry/remix vs react-router)
+#   - SEO agent-matrix determinism (the executionRegistry hash #947 left stale)
+#
+# WHY a dedicated workflow (not audit.yml): audit.yml is path-filtered (Phase-0
+# advisory) and also runs heuristic knip/madge/ast-grep that legitimately drift, so
+# it must stay non-required. This gate runs ONLY deterministic checks (green on main)
+# on EVERY PR with NO path filter — so it can be a REQUIRED status check WITHOUT the
+# path-filter skip-bypass (a path-filtered required check that does not trigger is
+# treated by GitHub as absent — the exact hole #1052 used).
+#
+# To make it blocking: add the context "🛡️ Contract Gate" to main's required status
+# checks (owner, branch protection). Until then it runs advisory like any other check.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: contract-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-gate:
+    name: 🛡️ Contract Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # Transitive dep of BOTH the registry contract suite and dump-agent-matrix.ts
+      # (via backend/src/config/role-ids.ts). --ignore-scripts skips workspace builds.
+      - name: Build @repo/seo-roles
+        run: npm run build --workspace=@repo/seo-roles
+
+      - name: 📋 Registry contracts — L1 vs L2 (incl. dep-governance subset)
+        run: npm -w @repo/registry test
+
+      - name: 🛡️ SEO agent-matrix determinism
+        run: npm run audit:seo-matrix:check


### PR DESCRIPTION
Follow-up to #1085 (which fixed the 2 pre-existing reds). Closes the root cause: the
gate that catches dep-governance drift was both path-skippable and non-blocking.

Part 1 — audit.yml trigger completeness. #1052 changed backend/package.json only, but
audit.yml triggered on "package.json" (root) + architecture.yaml + db.yaml only, so the
@repo/registry contract gate (reads ALL 8 repository-registry overlays + 5 audit/registry
L1 projections) never fired. Now triggers on:
  - "**/package.json" (root + backend + frontend + workspaces)
  - ".spec/00-canon/repository-registry/**" (all L2 overlays)
  - "audit/registry/**" (L1 projections)

Part 2 — new contract-gate.yml: an always-run (no path filter) gate running ONLY the
DETERMINISTIC invariants — @repo/registry L1<->L2 contracts (incl. dep-governance) and
SEO matrix determinism (both green on main). Heuristic knip/madge/ast-grep stay advisory
in audit.yml per the repo's Phase-0 posture. Because it has no path filter, it can be made
a REQUIRED check without the skip-bypass (a path-filtered required check that doesn't
trigger is treated as absent — the hole #1052 used).

OWNER follow-up to make it blocking (branch protection, after it runs once):
  gh api -X POST repos/ak125/nestjs-remix-monorepo/branches/main/protection/required_status_checks/contexts \
    -f 'contexts[]=🛡️ Contract Gate'

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
