### PR TITLE
fix(remotion): align @types/node to ^24 + fix pre-existing build (composition props)

### DIFF
--- a/log.md
+++ b/log.md
@@ -568,3 +568,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `fix/sitemap-children-dev-parity`
 - **Décision** : Merge remote-tracking branch 'origin/main' into fix/sitemap-children-dev-parity (+3 other commits)
 - **Sortie** : PR #1068 | commits e0bd733a0 77a4a82ca 59b7e510f 05ca12857
+
+## 2026-06-21 — chore/node24-remotion-types-node-24 (auto)
+
+- **Branche** : `chore/node24-remotion-types-node-24`
+- **Décision** : fix(remotion): align @types/node to ^24 + make composition props optional
+- **Sortie** : PR #1089 | commits 6348dac8d

--- a/services/remotion-renderer/package-lock.json
+++ b/services/remotion-renderer/package-lock.json
@@ -20,10 +20,10 @@
         "zod": "^3.24.0"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^24",
         "@types/react": "^18.3.0",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2977,12 +2977,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
-      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -5730,9 +5730,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/services/remotion-renderer/package.json
+++ b/services/remotion-renderer/package.json
@@ -22,7 +22,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^24",
     "@types/react": "^18.3.0",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3"

--- a/services/remotion-renderer/src/compositions/NeChangePasTropVite.tsx
+++ b/services/remotion-renderer/src/compositions/NeChangePasTropVite.tsx
@@ -34,12 +34,12 @@ interface NeChangePasTropViteProps {
   briefId?: string;
   videoType?: string;
   vertical?: string;
-  hook: string;
-  symptom: string;
-  pieceWrong: string;
-  causes: Cause[];
-  advice: string;
-  cta: string;
+  hook?: string;
+  symptom?: string;
+  pieceWrong?: string;
+  causes?: Cause[];
+  advice?: string;
+  cta?: string;
   disclaimer?: string;
   audioUrl?: string;
   brandName?: string;

--- a/services/remotion-renderer/src/compositions/PieceExpliquee.tsx
+++ b/services/remotion-renderer/src/compositions/PieceExpliquee.tsx
@@ -33,12 +33,12 @@ interface PieceExpliqueeProps {
   briefId?: string;
   videoType?: string;
   vertical?: string;
-  piece: string;
-  pieceFunction: string;
-  location: string;
-  wearSigns: WearSign[];
-  whenToChange: string;
-  cta: string;
+  piece?: string;
+  pieceFunction?: string;
+  location?: string;
+  wearSigns?: WearSign[];
+  whenToChange?: string;
+  cta?: string;
   disclaimer?: string;
   audioUrl?: string;
   brandName?: string;

--- a/services/remotion-renderer/src/compositions/ShortBrakingFact.tsx
+++ b/services/remotion-renderer/src/compositions/ShortBrakingFact.tsx
@@ -25,10 +25,10 @@ interface ShortBrakingFactProps {
   briefId?: string;
   videoType?: string;
   vertical?: string;
-  factText: string;
-  factValue: string;
-  factUnit: string;
-  sourceRef: string;
+  factText?: string;
+  factValue?: string;
+  factUnit?: string;
+  sourceRef?: string;
   schemaSvgId?: 'full' | 'caliper' | 'disc' | 'fluid';
   audioUrl?: string;
   brandName?: string;

--- a/services/remotion-renderer/src/compositions/SymptomeTroisCauses.tsx
+++ b/services/remotion-renderer/src/compositions/SymptomeTroisCauses.tsx
@@ -34,9 +34,9 @@ interface SymptomeTroisCausesProps {
   briefId?: string;
   videoType?: string;
   vertical?: string;
-  symptom: string;
-  causes: CauseDetail[];
-  cta: string;
+  symptom?: string;
+  causes?: CauseDetail[];
+  cta?: string;
   disclaimer?: string;
   audioUrl?: string;
   brandName?: string;


### PR DESCRIPTION
## Quoi
1. `@types/node` `^22 → ^24` (remotion = dernier sous-projet non aligné ; son Dockerfile est en node:24 via #1083).
2. **Fix d'un build `tsc` pré-existant cassé** (4× TS2322, indépendant de Node).

## Le build remotion était déjà rouge sur main
4 composants (`ShortBrakingFact`, `NeChangePasTropVite`, `SymptomeTroisCauses`, `PieceExpliquee`) sont typés `React.FC<Props>` avec des props **requises** → non assignables à `LooseComponentType<Record<string, unknown>>` dans `<Composition component={…}>` (remotion est **hors du `turbo typecheck`** du workspace, donc ce rouge passait inaperçu).

**Fix structurel** : marquer ces props **optionnelles** dans les interfaces top-level — elles ont **déjà des defaults au destructuring**, ce qui aligne sur la convention all-optional des 2 composants qui passaient (`TestCard`, `ShortProductHighlight`). **Zéro cast, zéro changement de comportement.**

## Mesure (worktree depuis `origin/main`)
| | build `tsc` |
|---|---|
| baseline @22 (origin/main) | **❌ 4 erreurs** |
| @24 + fix interfaces | **✅ 0 erreur** |

- Lockfile remotion régénéré avec npm@10.8.2 → diff minimal (18 l).
- Smoke (`bash test/smoke.sh`) non lançable ici (FFmpeg/S3 absents) → tourne en CI/Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)