### PR TITLE
fix(seo-control): skip SWR refresh job in READ_ONLY (PREPROD) — stops crash-loop

### DIFF
--- a/backend/src/modules/admin/processors/seo-control-refresh.processor.test.ts
+++ b/backend/src/modules/admin/processors/seo-control-refresh.processor.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression test for SeoControlRefreshProcessor READ_ONLY guard.
+ *
+ * Guards a PREPROD crash-loop: without the guard, the scheduled SWR refresh job
+ * calls SeoControlService.refreshBlock() → rpc_seo_alerts_v1, which reads
+ * RLS-protected tables (e.g. __seo_audit_findings) the anon role cannot access
+ * in READ_ONLY mode (ADR-028 Option D). The job failed, retried in a storm, and
+ * the rejection crashed the process (exit 1) ~5 min after every boot — a
+ * restart-loop that intermittently broke the E2E Smoke gate (container
+ * unreachable on :3200). The fix skips the job in READ_ONLY, like the sibling
+ * collectors (cf-analytics / cf-rum / runtime-logs / synthetic-crawler).
+ */
+import { getAppConfig } from '../../../config/app.config';
+import { SeoControlRefreshProcessor } from './seo-control-refresh.processor';
+import type { SeoControlService } from '../services/seo-control.service';
+import type { SeoControlRefreshJobData } from '../services/seo-control-refresher.service';
+import type { Job } from 'bull';
+
+jest.mock('../../../config/app.config');
+
+const mockedGetAppConfig = getAppConfig as jest.MockedFunction<
+  typeof getAppConfig
+>;
+
+function makeJob(): Job<SeoControlRefreshJobData> {
+  return {
+    id: 'job-1',
+    data: { block: 'alerts', range: '7d' },
+  } as unknown as Job<SeoControlRefreshJobData>;
+}
+
+function makeService(): { refreshBlock: jest.Mock } {
+  return { refreshBlock: jest.fn().mockResolvedValue(undefined) };
+}
+
+describe('SeoControlRefreshProcessor — READ_ONLY guard', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('skips refreshBlock in READ_ONLY (PREPROD anon) — prevents the RLS crash-loop', async () => {
+    mockedGetAppConfig.mockReturnValue({
+      supabase: { readOnly: true },
+    } as ReturnType<typeof getAppConfig>);
+    const svc = makeService();
+    const proc = new SeoControlRefreshProcessor(
+      svc as unknown as SeoControlService,
+    );
+
+    await expect(proc.handleRefresh(makeJob())).resolves.toBeUndefined();
+    expect(svc.refreshBlock).not.toHaveBeenCalled();
+  });
+
+  it('runs refreshBlock when not READ_ONLY (PROD / service_role)', async () => {
+    mockedGetAppConfig.mockReturnValue({
+      supabase: { readOnly: false },
+    } as ReturnType<typeof getAppConfig>);
+    const svc = makeService();
+    const proc = new SeoControlRefreshProcessor(
+      svc as unknown as SeoControlService,
+    );
+
+    await proc.handleRefresh(makeJob());
+    expect(svc.refreshBlock).toHaveBeenCalledWith('alerts', '7d');
+  });
+});

--- a/backend/src/modules/admin/processors/seo-control-refresh.processor.ts
+++ b/backend/src/modules/admin/processors/seo-control-refresh.processor.ts
@@ -16,19 +16,35 @@ import {
 } from '../constants/seo-control.constants';
 import { type SeoControlRefreshJobData } from '../services/seo-control-refresher.service';
 import { SeoControlService } from '../services/seo-control.service';
+import { getAppConfig } from '../../../config/app.config';
 
 @Processor(SEO_CONTROL_REFRESH_QUEUE)
 export class SeoControlRefreshProcessor {
   private readonly logger = new Logger(SeoControlRefreshProcessor.name);
+  private readonly readOnly: boolean;
 
   // NB: SeoControlRefresherService is a singleton provider in AdminModule, so
   // Nest eagerly instantiates it and runs its onModuleInit scheduling on its
   // own — the processor does not need to inject it. See its *.test.ts.
-  constructor(private readonly seoControlService: SeoControlService) {}
+  constructor(private readonly seoControlService: SeoControlService) {
+    this.readOnly = getAppConfig().supabase.readOnly;
+  }
 
   @Process(SEO_CONTROL_REFRESH_JOB)
   async handleRefresh(job: Job<SeoControlRefreshJobData>): Promise<void> {
     const { block, range } = job.data;
+    // READ_ONLY (PREPROD, anon key — ADR-028 Option D): refreshBlock() calls
+    // rpc_seo_alerts_v1 which reads RLS-protected tables (e.g. __seo_audit_findings)
+    // the anon role cannot access → the job fails, retries storm, and the rejection
+    // crashes the process (exit 1 → restart-loop ~5 min, breaking E2E Smoke). Skip
+    // like the sibling collectors (cf-analytics / cf-rum / runtime-logs /
+    // synthetic-crawler) already do — there is nothing to refresh in PREPROD.
+    if (this.readOnly) {
+      this.logger.log(
+        `[READ_ONLY] Skipping seo-control refresh ${block}/${range}`,
+      );
+      return;
+    }
     const start = Date.now();
     try {
       await this.seoControlService.refreshBlock(block, range);


### PR DESCRIPTION
## Root cause (confirmed via host `docker logs` + `docker events`)
The PREPROD container `die exitCode=1` **every ~5 min**, then `restart: always` relaunched it — a restart-loop that intermittently broke the E2E Smoke gate (`:3200` unreachable mid-suite → `ERR_CONNECTION_REFUSED` / `socket hang up`).

The trigger: the **seo-control SWR refresh** BullMQ job had **no READ_ONLY guard** — unlike its 4 sibling collectors (`cf-analytics` / `cf-rum` / `runtime-logs` / `synthetic-crawler`, which all `[READ_ONLY] Skipping`). In PREPROD (`READ_ONLY=true` → **anon key**, ADR-028 Option D) it calls `rpc_seo_alerts_v1`, which reads RLS-protected tables the anon role cannot access:
```
query would be affected by row-level security policy for table "__seo_audit_findings"
```
→ job fails, retry storm (~3×/20s), the rejection crashes the process (`exit 1`) at the first round-minute after boot (~5 min). **Confirmed on Node 22 AND Node 24 → pre-existing, NOT Node-24-related.**

## Fix
Add the same READ_ONLY skip the sibling collectors already have. Nothing to refresh in PREPROD (READ_ONLY, CI-only, no dashboard viewers). **PROD unaffected** — service_role bypasses RLS, so the job runs normally there. **No DB change** (a service_role RLS policy would not help PREPROD, which runs as anon).

- `seo-control-refresh.processor.ts`: `if (this.readOnly) { skip }` guard (pattern-identical to siblings).
- `+ regression test` pinning the skip.

## Relation to #1086
Complementary: #1086 made the E2E gate **resilient** to a transient restart (defense-in-depth); this PR removes the **root cause** of the restarts. Together the loop is gone *and* the gate tolerates any residual blip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)