### PR TITLE
fix(runtime): survive background unhandledRejection — stop PREPROD crash-loop

### DIFF
--- a/backend/src/instrument.test.ts
+++ b/backend/src/instrument.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression guard for the process-level error handlers registered as an
+ * import side-effect in instrument.ts.
+ *
+ * The `unhandledRejection` handler is the structural fix for the PREPROD
+ * ~5-min crash-loop: a background async rejection (e.g. an RLS-blocked write in
+ * READ_ONLY PREPROD, or a transient RPC error) must NOT take down the whole
+ * server via Node's default `--unhandled-rejections=throw`. This test pins that
+ * contract: the handler stays registered, logs, and never calls `process.exit`.
+ *
+ * SENTRY_DSN is unset in the unit-test env, so `Sentry.init` is skipped on
+ * import (no network), and `Sentry.captureException` inside the handler is a
+ * safe no-op.
+ */
+describe('instrument.ts — process-level error handlers', () => {
+  it('registers a non-fatal unhandledRejection handler (logs, never exits)', () => {
+    const before = new Set(process.listeners('unhandledRejection'));
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('./instrument');
+    });
+
+    const added = process
+      .listeners('unhandledRejection')
+      .filter((h) => !before.has(h));
+    expect(added.length).toBeGreaterThanOrEqual(1);
+
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const errSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const handler = added[added.length - 1] as (reason: unknown) => void;
+    handler(new Error('simulated background rejection'));
+
+    // The fix: a background rejection is logged but the process survives.
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalled();
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+
+    // Avoid leaking the freshly-registered listener into other suites.
+    process.removeListener(
+      'unhandledRejection',
+      handler as (reason: unknown, promise: Promise<unknown>) => void,
+    );
+  });
+});

--- a/backend/src/instrument.ts
+++ b/backend/src/instrument.ts
@@ -73,3 +73,47 @@ if (dsn) {
     beforeSend: sanitizeSentryEvent,
   });
 }
+
+// Defense-in-depth — a single unhandled promise rejection must NOT take down the
+// whole server. Several background paths fire-and-forget async work (cache warms,
+// scheduled refreshes, web-vitals beacons). When one rejects — e.g. an RLS-blocked
+// write in READ_ONLY PREPROD (anon key, ADR-028 Option D), or a transient RPC error
+// — Node's default (`--unhandled-rejections=throw`) exits the process with code 1.
+// On the PREPROD container's `restart: always` that became a ~5-min crash-loop that
+// intermittently broke the E2E Smoke gate (:3200 unreachable mid-suite →
+// ERR_CONNECTION_REFUSED / socket hang up). Log + report to Sentry and keep serving:
+// the failing operation still fails, the server survives. NOT a silent fallback —
+// every rejection is surfaced (stderr + Sentry), which also reveals the culprit path
+// for a follow-up source fix. Registered here (instrument.ts is imported first, before
+// bootstrap) so it covers rejections from the very start. uncaughtException is left to
+// Node's default — a sync uncaught error genuinely leaves the process in an undefined
+// state and should still terminate.
+process.on('unhandledRejection', (reason: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error('[unhandledRejection] non-fatal — logged + reported:', reason);
+  try {
+    Sentry.captureException(reason);
+  } catch {
+    // Sentry not initialised (no DSN) — the stderr line above is the record.
+  }
+});
+
+// uncaughtException is genuinely fatal — a synchronous error left the process in an
+// undefined state, so we keep Node's "exit" semantics (NOT a silent fallback). But we
+// first capture + flush to Sentry so the crash is finally observable: until now these
+// exits produced no recognisable marker in the container logs, which is exactly why the
+// ~5-min restart cause stayed invisible. Log → report → best-effort flush → exit(1).
+process.on('uncaughtException', (err: Error) => {
+  // eslint-disable-next-line no-console
+  console.error('[uncaughtException] fatal — logged + reported, exiting:', err);
+  try {
+    Sentry.captureException(err);
+    // Give Sentry up to 2s to ship the event, then exit regardless.
+    void Sentry.close(2000).then(
+      () => process.exit(1),
+      () => process.exit(1),
+    );
+  } catch {
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
## Problème (root cause)

Le container PREPROD (`nestjs-remix-monorepo-preprod`, `:3200`, `READ_ONLY=true`, clé anon ADR-028 Option D) **sortait avec exit code 1 toutes les ~5 min** (`restart: always` → crash-loop). Pendant un run E2E Smoke, `:3200` devenait injoignable en plein milieu de la suite → gate **rouge intermittent**.

`#1091` a éteint **une** tête : `SeoControlRefreshProcessor` écrivait dans une table RLS en READ_ONLY → rejet → exit. Confirmé déployé + actif (20× `Skipping seo-control` sur le runner). Mais le container **continuait** de sortir exit-1 sans marqueur de crash reconnaissable dans les logs — d'où une cause restée invisible.

Diagnostic :
- `exitCode=1` (pas `137`=OOM/SIGKILL, pas `143`=SIGTERM) → exit Node sur erreur, **pas** un OOM.
- Aucun marqueur sync (`FATAL ERROR` / `heap out of memory` / `Killed`) dans les logs.
- Plusieurs chemins background font du fire-and-forget async (warms de cache, refreshs planifiés, beacons web-vitals) ; en READ_ONLY un seul écrit RLS-bloqué → **rejet de promesse non géré** → Node `--unhandled-rejections=throw` → `exit(1)`.
- Node n'imprime pas le littéral « unhandledRejection » → les greps précédents le rataient.

## Correctif (structurel + observable)

Handlers process-level dans `instrument.ts` (importé en premier, avant bootstrap) :

- **`unhandledRejection`** → log stderr + Sentry, **on garde le serveur vivant**. L'opération qui échoue échoue toujours ; le serveur survit. **C'est le fix.**
- **`uncaughtException`** → log + Sentry + flush best-effort, **puis `exit(1)`** (une erreur sync non rattrapée laisse le process dans un état indéfini → on conserve la sémantique de crash). **Ajoute l'observabilité** : ces sorties ne laissaient aucun marqueur — c'est précisément pourquoi la cause restait invisible.

**Pas un silent fallback** (CLAUDE.md) : chaque rejet/exception est **surfacé** (stderr + Sentry), ce qui **révèle aussi le chemin coupable** pour un fix source de suivi.

Complète `#1091` : celui-ci durcit le serveur contre **tout** rejet background restant ou futur, au lieu de jouer au whack-a-mole writer par writer.

## Vérification

- ✅ Typecheck ciblé `instrument.ts` : 0 erreur.
- ✅ ESLint : exit 0.
- ✅ Test de régression `instrument.test.ts` (PASS) : le handler `unhandledRejection` reste enregistré et **n'appelle jamais `process.exit`**.
- ⏳ **POST-MERGE LIVE** (à valider sur le runner 49.12.233.2) : `docker inspect` RestartCount stable + apparition de `[unhandledRejection] …` dans `docker logs` (le coupable enfin visible) → puis E2E Smoke vert.

## Runtime-awareness

- Rollout : `main` → tag `:preprod` → container PREPROD. **Pas de PROD** (owner-gated via tag `v*`).
- Observabilité : réutilise Sentry existant (`instrument.ts`), aucun canary externe.
- Rollback : revert PR + push main.
- Changement de sémantique de crash limité au rejet async (le sync continue d'exit). Réversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)