### PR TITLE
fix(ci): condition-based soft-404 warm — deterministic prime of cold heavy-RPC fixture

### DIFF
--- a/scripts/ci/warm-soft-404-fixtures.sh
+++ b/scripts/ci/warm-soft-404-fixtures.sh
@@ -5,53 +5,107 @@
 # WHY ------------------------------------------------------------------------
 # The soft-404 R2 smoke asserts (in assert-soft-404.py) that each /pieces/ R2
 # soft-404 page renders "≥ 1 deep link /pieces/<a>/<b>/<c>.html" (vehicle
-# alternatives). Those alternatives are computed + cached PER URL on first
-# request. On a freshly-deployed (cold) PREPROD container, the very first hit
-# can render WITHOUT them, flaking only assertion #4 — observed on the SAME 2
-# fixtures across deploys #798, #800 and #799, and cleared every time by a
-# plain re-run (warm container). It cost one CI re-run on each of those deploys.
+# alternatives). Those alternatives come from get_soft_404_alternatives and are
+# cached PER URL (Redis, 300s ok / 30s error) on first request. On a freshly
+# deployed (cold) PREPROD container the first page hit fetches them through the
+# SSR loader, which bounds the internal call with AbortSignal.timeout(3000): for
+# a HEAVY vehicle (the BMW E60 alternateur fixture has 800+ siblings) the cold
+# RPC exceeds 3s, the loader aborts, and the page renders WITHOUT alternatives.
+# The backend RPC still completes + caches in the background, so a later (warm)
+# hit passes — which is why this only ever cost a CI re-run on deploys #798/#799/
+# #800, and recently turned the gate deterministically RED on the heaviest
+# fixture once the old fixed 2s settle was shorter than the cold RPC.
 #
 # WHAT THIS DOES (and does NOT do) -------------------------------------------
-# This is a DETERMINISTIC WARM PRE-PASS, run BEFORE the smoke's assertion loop:
-# it fetches each fixture once (output discarded) so the per-URL alternatives
-# cache is populated by the time the smoke asserts.
+# A CONDITION-BASED warm pre-pass, run BEFORE the smoke's assertion loop:
+#   1. Directly primes the backend alternatives cache via GET /api/rm/alternatives
+#      with a GENEROUS timeout (NOT bounded by the loader's 3s) so the cold RPC
+#      finishes + caches deterministically.
+#   2. Then POLLS the page until it actually renders warm — using the smoke's OWN
+#      assert-soft-404.py as the readiness oracle (zero drift) — or a per-fixture
+#      deadline elapses.
 #
-#   - It does NOT assert anything (the smoke remains the single source of truth).
+#   - It does NOT assert as a gate: warming is non-fatal and assert-soft-404.py is
+#     used here ONLY as a readiness probe. The smoke step remains the single
+#     source of truth — if alternatives are GENUINELY absent the warm spins to its
+#     deadline and the smoke still fails (no masking, no blind retry of a failed
+#     assertion).
 #   - It does NOT change the smoke contract, skip the smoke, lower thresholds,
 #     touch fixtures, or modify application runtime.
-#   - It is NOT a blind retry: it never re-runs a failed assertion. If the
-#     alternatives are GENUINELY absent after warming, the smoke still fails.
-#   - Warm failures are non-fatal here on purpose — diagnosing them is the
-#     smoke's job, not this pre-pass's.
-#
-# It reads the SAME fixtures file the smoke reads, so the two never drift.
+#   - It reads the SAME fixtures file the smoke reads, so the two never drift.
 #
 # Usage: warm-soft-404-fixtures.sh <BASE_URL> [FIXTURES_FILE]
-#   WARM_SETTLE_SECONDS (env, default 2): brief settle after warming so any
-#   async cache-fill completes before assertions. Set 0 to disable.
+#   WARM_MAX_SECONDS    (env, default 30): per-fixture condition-based deadline.
+#   WARM_POLL_SECONDS   (env, default 2):  gap between readiness polls.
+#   WARM_SETTLE_SECONDS (env, default 0):  residual settle after warming (legacy;
+#                                          superseded by the condition-based poll).
 # ----------------------------------------------------------------------------
 set -uo pipefail
 
 BASE="${1:?usage: warm-soft-404-fixtures.sh <BASE_URL> [fixtures_file]}"
 FIXTURES="${2:-scripts/ci/soft-404-fixtures.txt}"
-SETTLE_SECONDS="${WARM_SETTLE_SECONDS:-2}"
+ASSERT="${SOFT_404_ASSERT:-scripts/ci/assert-soft-404.py}"
+WARM_MAX_SECONDS="${WARM_MAX_SECONDS:-30}"
+WARM_POLL_SECONDS="${WARM_POLL_SECONDS:-2}"
+SETTLE_SECONDS="${WARM_SETTLE_SECONDS:-0}"
 
 if [ ! -f "$FIXTURES" ]; then
   echo "🔥 warm: fixtures file not found: $FIXTURES" >&2
   exit 1
 fi
+if [ ! -f "$ASSERT" ]; then
+  echo "🔥 warm: readiness oracle not found: $ASSERT" >&2
+  exit 1
+fi
 
-echo "🔥 Warming soft-404 R2 fixtures (cache pre-pass — no assertions) against $BASE"
+# Prime the backend alternatives cache directly for one fixture URL. Best-effort:
+# parses gamme_id (trailing -<id> of the first /pieces/ segment) + type_id
+# (trailing -<id> before .html) and hits GET /api/rm/alternatives?...&limit=12
+# (the EXACT call the SSR loader makes) with a generous timeout, so the cold RPC
+# completes + caches even though the page loader would abort it at 3s. A parse
+# miss or unreachable endpoint just falls through to the page-readiness poll.
+prime_backend() {
+  local url="$1" gamme_id type_id
+  gamme_id="$(printf '%s' "$url" | sed -nE 's#^/pieces/[^/]*-([0-9]+)/.*#\1#p')"
+  type_id="$(printf '%s' "$url" | sed -nE 's#.*-([0-9]+)\.html$#\1#p')"
+  if [ -n "$gamme_id" ] && [ -n "$type_id" ]; then
+    curl -s -o /dev/null --max-time 25 \
+      "$BASE/api/rm/alternatives?gamme_id=${gamme_id}&type_id=${type_id}&limit=12" || true
+  fi
+}
+
+echo "🔥 Warming soft-404 R2 fixtures (condition-based cache pre-pass) against $BASE"
 warmed=0
+ready=0
 while IFS= read -r url || [ -n "$url" ]; do
   # Same skip rules as the smoke loop: blank lines + comments.
   [[ -z "${url// }" ]] && continue
   case "$url" in \#*) continue ;; esac
-  # Same --max-time as the smoke (15s) — no per-request timeout increase.
-  curl -s -o /dev/null --max-time 15 "$BASE$url" || true
   warmed=$((warmed + 1))
-  echo "  warmed: $url"
+
+  prime_backend "$url"
+
+  deadline=$(( $(date +%s) + WARM_MAX_SECONDS ))
+  hits=0
+  while :; do
+    hits=$((hits + 1))
+    # Same request shape as the smoke (curl -s -i, 15s).
+    http_out="$(curl -s -i --max-time 15 "$BASE$url" || true)"
+    if [ -n "$http_out" ] && printf '%s' "$http_out" | python3 "$ASSERT" >/dev/null 2>&1; then
+      ready=$((ready + 1))
+      echo "  ✅ warm-ready: $url (after ${hits} page hit(s))"
+      break
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "  ⏳ warm deadline ${WARM_MAX_SECONDS}s reached: $url (still cold or genuinely empty — the smoke assertion will decide)"
+      break
+    fi
+    sleep "$WARM_POLL_SECONDS"
+  done
 done < "$FIXTURES"
 
-echo "🔥 Warmed ${warmed} fixture(s); settling ${SETTLE_SECONDS}s before assertions."
-sleep "$SETTLE_SECONDS"
+echo "🔥 Warmed ${warmed} fixture(s); ${ready} reached warm-ready before assertions."
+if [ "$SETTLE_SECONDS" -gt 0 ]; then
+  sleep "$SETTLE_SECONDS"
+fi
+exit 0


### PR DESCRIPTION
## Contexte — la 2ᵉ tête de la rouge

Vérification (4 sondes parallèles) sur la gate E2E rouge : **deux causes indépendantes**, pas une.

1. **Crash/restart du container PREPROD mid-run** — visé par #1091 (seo-control READ_ONLY) + #1092 (handler `unhandledRejection`). #1092 a tenu au déploiement (boot sain, pid stable, zéro restart in-window).
2. **Soft-404 alternatives vides** — *cette* PR. C'est elle qui a fait rougir le run de #1092 (`Deploy PREPROD` ✅, mais step `🩹 Soft-404 R2 smoke` ❌ sur 1 URL).

## Cause racine (vérifiée contre la DB live `cxpojprgwgubzjyqzmoq`)

L'URL `/pieces/alternateur-4/bmw-33/serie-5-e60-33052/530-i-phase-2-16023.html` (BMW E60, **800+ véhicules siblings**) est un **vrai soft-404 légitime** (0 produit alternateur). Et la data alternatives **EXISTE** : `get_soft_404_alternatives(16023,4,12)` renvoie **6 véhicules + 4 modèles**, `anon` a bien le droit `EXECUTE` (pas de souci RLS ici).

Le bloc rend vide uniquement **à froid** : le loader SSR [pieces-vehicle.loader.server.ts:272-294](frontend/app/utils/pieces-vehicle.loader.server.ts#L272-L294) borne le fetch interne `/api/rm/alternatives` par `AbortSignal.timeout(3000)`. Sur container fraîchement déployé, le RPC froid de ce véhicule lourd **dépasse 3s** → abort → bloc vide. Le warm de déploiement existant hit chaque page une fois puis **dormait 2s fixes** — trop court pour que le RPC froid finisse + cache avant l'assert. Déterministe sur la fixture la plus lourde.

## Fix — warm CONDITIONNEL (pattern condition-based-waiting), CI-only

[scripts/ci/warm-soft-404-fixtures.sh](scripts/ci/warm-soft-404-fixtures.sh) :

1. **Prime le cache backend en direct** via `GET /api/rm/alternatives?...&limit=12` (l'appel exact du loader) avec timeout **généreux 25s** — non borné par les 3s du loader → le RPC froid finit + cache **déterministiquement**.
2. **Poll la page** jusqu'à rendu réellement chaud, en réutilisant `assert-soft-404.py` (l'oracle du smoke lui-même → zéro drift), borné par deadline/fixture (`WARM_MAX_SECONDS`=30).

**Le smoke reste la seule source de vérité** : le warm est non-fatal, l'oracle n'est qu'une sonde de readiness. Si les alternatives sont **réellement** absentes → le warm tourne jusqu'à sa deadline et **le smoke échoue quand même** (pas de masquage, pas de blind-retry d'une assertion ratée).

**Zéro changement runtime / R2 / CWV** — outillage CI uniquement. Signature d'invocation `bash warm-soft-404-fixtures.sh "$BASE"` préservée (ci.yml:877).

## Ownership

Sonde dédiée : **aucune PR ouverte ni branche/worktree active** sur soft-404 alternatives (les 8 branches sont mergées/closes il y a 1 mois). Pas de duplication.

## Vérification

- ✅ `shellcheck` : 0 finding · `bash -n` : OK.
- ✅ Run réel contre le runtime DEV (chaud) : **5/5 fixtures warm-ready en 1 hit** (dont l'alternateur/BMW-E60).
- ⏳ POST-MERGE : le run main (cold deploy) doit voir le step Soft-404 passer → E2E Smoke enfin atteint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)