### PR TITLE
chore(remotion): migrate to TypeScript 6.0.3

### DIFF
--- a/services/remotion-renderer/package-lock.json
+++ b/services/remotion-renderer/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^24",
         "@types/react": "^18.3.0",
         "tsx": "^4.19.0",
-        "typescript": "^5.9.3"
+        "typescript": "~6.0.3"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -5716,9 +5716,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/services/remotion-renderer/package.json
+++ b/services/remotion-renderer/package.json
@@ -25,6 +25,6 @@
     "@types/node": "^24",
     "@types/react": "^18.3.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.9.3"
+    "typescript": "~6.0.3"
   }
 }

--- a/services/remotion-renderer/tsconfig.json
+++ b/services/remotion-renderer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "types": ["node"],
     "module": "commonjs",
     "lib": ["ES2022"],
     "outDir": "dist",


### PR DESCRIPTION
## Quoi
`services/remotion-renderer` (hors workspace) était le **dernier sous-projet en typescript@5.9.3**. Bump → `~6.0.3`.

## TS6
- `tsconfig` : ajout `types:["node"]` (défaut TS6 `types:[]` — remotion utilise les globals Node).
- Pas de déprécation node10 déclenchée (`module:commonjs` sans `moduleResolution` explicite) → pas d'`ignoreDeprecations` nécessaire.
- `@types/node` déjà `^24` (#1089).

## Mesure (worktree depuis origin/main)
- `npm run build` (tsc) = **0 erreur** ✅
- Lockfile régénéré avec npm@10.8.2 (diff propre, typescript@6.0.3).

Clôt l'alignement TypeScript 6 sur **tout** le repo (workspace #1096 + remotion ici).

🤖 Generated with [Claude Code](https://claude.com/claude-code)