### PR TITLE
chore(governance): drop 72h staging-soak gate on runtime-frontend-react-router-vite

### DIFF
--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:9745f66e1ff999e7e9bdd7616a74485765f35c7a934a78417284a46682769a0b",
+  "artifact_immutability_hash": "sha256:5ba4ecb332e043295afaae407f04c884664a5a275f0e22f083c60a3c50216f6f",
   "divergences": [
     {
       "kind": "specifier",
@@ -2937,7 +2937,7 @@
       "pr_assignment": "deferred",
       "production_approved": true,
       "requires_perf_baseline": true,
-      "requires_staging_soak": true,
+      "requires_staging_soak": false,
       "rollback_blast_scope": [
         "ssr",
         "cdn"
@@ -2989,7 +2989,6 @@
       ],
       "safe_parallel_window_minutes": 0,
       "source_url": "https://github.com/remix-run/react-router/releases",
-      "staging_soak_hours": 72,
       "state_compatibility_window_minutes": 0,
       "state_reconciliation_strategy": {
         "duplicate_resolution": "n/a"
@@ -4024,7 +4023,7 @@
     "lockfile": "package-lock.json",
     "lockfile_sha": "sha256:48084457985c294b257aa9de38b4eabc834719f529948c524c8cba52d0919146",
     "overlay": "audit/dependencies/family-overlay.yaml",
-    "overlay_sha": "sha256:5125f1f9db2d1c2be0a86a27da41c4d3823f2ebec82a7623466c74696dbe075d"
+    "overlay_sha": "sha256:42597019658ecd86a9df3c4f64505542d2f89192ab1eef12b9ae218ea5df4728"
   },
   "inventoryFormat": "pr-9-modernization-inventory",
   "matrixVersion": "pr9-v1",

--- a/audit/dependencies/dependency-upgrade-matrix.md
+++ b/audit/dependencies/dependency-upgrade-matrix.md
@@ -42,7 +42,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 | queues-bullmq | 48 | >=20 | workers-first, api-second, full-rollout | ✓ |
 | runtime-backend-nest | 72 | >=20 | canary, full-rollout | ✓ |
 | runtime-backend-platform-fastify | 0 | >=20 | n/a | ✗ |
-| runtime-frontend-react-router-vite | 72 | >=24 | n/a | ✓ |
+| runtime-frontend-react-router-vite | 0 | >=24 | n/a | ✓ |
 | tooling-prettier-husky | 0 | >=20 | n/a | ✓ |
 | tooling-typescript-eslint | 0 | >=20 | n/a | ✓ |
 | tooling-typescript-go | 0 | >=20 | n/a | ✗ |

--- a/audit/dependencies/family-overlay.yaml
+++ b/audit/dependencies/family-overlay.yaml
@@ -768,8 +768,11 @@ families:
     source_url: https://github.com/remix-run/react-router/releases
     upgrade_strategy: staged-rollout
     runtime_criticality: critical
-    requires_staging_soak: true
-    staging_soak_hours: 72
+    # PREPROD est CI-only / READ_ONLY / sans trafic réel → un soak figé n'observe
+    # rien (pas d'INP/hydratation/Sentry/CWV réels à accumuler) et `:preprod` est
+    # un tag flottant. Validation pré-PROD = e2e-smoke (hydratation/critical-path)
+    # sur le container :preprod déployé. Décision owner 2026-06-22.
+    requires_staging_soak: false
     node_runtime_requirement: ">=24"
     peer_dependency_cluster:
       - "@react-router/*"


### PR DESCRIPTION
## Why

The `runtime-frontend-react-router-vite` family inherited `requires_staging_soak: true` + `staging_soak_hours: 72` from the old risky Remix-major family. But **PREPROD is CI-only / READ_ONLY / has no real user traffic**, and `:preprod` is a **floating tag** (rewritten on every `main` merge) — a frozen 72h soak observes nothing (no real INP / hydration / Sentry volume / CWV drift to accumulate over time).

The real pre-PROD validation is the post-merge **`e2e-smoke`** gate running hydration + critical-path specs on the deployed `:preprod` container (passed for React 19 in #1098).

Owner decision (2026-06-22), following the React 19 migration (#1098).

## Change
- `requires_staging_soak: true → false` on `runtime-frontend-react-router-vite` (with an inline rationale so it isn't reverted).
- `staging_soak_hours: 72` removed (no longer required by the schema when soak is false).
- `requires_perf_baseline` **unchanged** (LCP/bundle baseline keeps its value).
- Inventory + matrix regenerated (generated artifacts).

## Verification
- Inventory deterministic `sha256:56afc74d6b53`, matrix in sync.
- Schema test 29 pass / 0 fail.
- Scope: 3 files, all under `audit/dependencies/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)