### PR TITLE
docs(seo-content-loop): état réel du scoring (shadow_score existe, non câblé)

### DIFF
--- a/workspaces/seo-batch/.claude/skills/seo-content-loop/SKILL.md
+++ b/workspaces/seo-batch/.claude/skills/seo-content-loop/SKILL.md
@@ -62,11 +62,16 @@ SCRAPING LARGE (RUN_TARGETED_RAW_TO_WIKI) → RAW → WIKI → CONSUMER (R1/R2/R
      - **Diagnostic** : sources symptômes→causes (codes OBD/VAG, constructeur, forums techniques) — à découvrir de même.
      - **Dédup + refresh** : chaque cible scrapée **une seule fois** (manifest type `app/audit/scrape-targets-*.md`) ;
        rafraîchir périodiquement. Sortie toujours **`.md`** par `target_wiki_field` (cf. ci-dessus).
-   - **Mesure de la substance produite (complète l'étape 5)** : scorer **réel** =
-     `automecanik-wiki/_scripts/compute-confidence-score.py` (4 composantes) + promotion `promote.py`
-     (TIER A/B, ADR-083 ; seuil auto NO-OP par défaut → revue humaine). Le scorer **6-dimensions à planchers**
-     (`claim`/`applies_to`/`evidence`/`related_gammes` par engineBlock) est la **cible ADR-088** —
-     **pas encore bâti** (`shadow_score.py` n'existe pas) → re-scraper jusqu'au TIER A.
+   - **Mesure de la substance produite (complète l'étape 5) — ⚠️ SCORING EN TRANSITION, ne pas traiter le score scalaire comme fiable** :
+     - **Câblé aujourd'hui (autoritaire)** : `automecanik-wiki/_scripts/compute-confidence-score.py` (4 composantes) + `promote.py`
+       (TIER A/B, ADR-083 ; seuil auto **NO-OP** par défaut → revue humaine). ⚠️ **Ce scorer déflate l'OE** (défaut
+       `medium`=0.6 ; ex. `disque-de-frein` OE = 0.36 malgré 64 sources OE) — connu, à remplacer.
+     - **Cible ratifiée (ADR-091)** : `shadow_score.py` **EXISTE** (6-dim à planchers `claim`/`applies_to`/`evidence`/`related_gammes`,
+       ADR-088, + `test_shadow_score.py`) — derrière flag `PROMOTE_GATE_ENGINE`, **PAS encore câblé** comme scorer autoritaire
+       (câblage + baseline-resync de tout le corpus = **Phase B**, atomique).
+     - **Gate de régression** `compare-proposal-versions.py` (#60, mergé) utilise **encore** `compute-confidence-score` (celui qui déflate).
+     - **Conséquence** : « itérer jusqu'au SCORE » n'est fiable qu'**après** câblage ADR-091. Tant que non câblé : **revue humaine décide** ;
+       ne jamais conclure « TIER A / fait » sur le score scalaire seul. (Détail + plan : `app/audit/content-loop-method-confusion-and-hardening-2026-06-22.md`.)
 2. **RAW** (`automecanik-raw/`) — normaliser/recycler le scrape en fiches sourcées (frontmatter contrat
    `_schemas/recycled-frontmatter.schema.json`), `verification_status` `to_verify`→`verified` (humain).
    `recycled/` n'est **jamais** canon (canon RAW `CLAUDE.md`).


### PR DESCRIPTION
## P0 — clarté de la méthode (demande owner : « confusion dans la méthode, durcir avant »)

Le skill canonique `seo-content-loop` (§étape 1) disait **« `shadow_score.py` n'existe pas »** — **faux**.

### Réalité (vérifiée, wiki main)
- `shadow_score.py` **existe** (6-dim à planchers, ADR-088, + `test_shadow_score.py`), derrière flag `PROMOTE_GATE_ENGINE` — mais **PAS câblé** comme scorer autoritaire (ADR-091 ratifié, câblage = Phase B).
- Le scorer **câblé** (`compute-confidence-score`, 4-comp) **déflate l'OE** (disque OE = 0.36 malgré 64 sources) ; le gate #60 l'utilise encore.

### Ce que corrige cette PR (doc only)
Remplace l'affirmation périmée par l'**état réel honnête** : *scoring en transition, le score scalaire n'est pas fiable tant qu'ADR-091 n'est pas câblé → revue humaine décide ; ne pas conclure « TIER A / fait » sur le scalaire seul.* Pointe ADR-088/091 + l'audit (`audit/content-loop-method-confusion-and-hardening-2026-06-22.md`), ne duplique pas le canon.

**Aucun code touché.** 10 insertions / 5 suppressions, 1 fichier doc. Rétro-compatible.

> P1 (le vrai durcissement : câbler ADR-091 partout + bâtir le gate rank-#1) = gouvernance / Phase B, owner-gated — hors scope de cette PR de clarté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)