### PR TITLE
chore(registry): map backend/src/common/guards/** ownership (D13) — follow-up #1097

### DIFF
--- a/.claude/knowledge/REPO_MAP.md
+++ b/.claude/knowledge/REPO_MAP.md
@@ -3,7 +3,7 @@ title: Repository Map
 kind: registry-index
 generated_at: "1970-01-01T00:00:00.000Z"
 source: audit/registry/canonical.json
-source_sha256: 41543127f6b855214be49d87f0b54e45a1557378708b0afb840a70b7acb6804c
+source_sha256: 020751de36e8891921f0990d6da79d1e15be0b9bbceb158d182c84d268ed48c5
 schema_version: "1.0.0"
 do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-058 PR-F)
 ---
@@ -24,7 +24,7 @@ do_not_edit: true   # généré par scripts/registry/build-llm-repo-map.js (ADR-
 | Dependencies (Layer 1) | 252 |
 | Runtime entrypoints (Layer 1) | 507 |
 
-Source sotFingerprint: `d0ff78f48b28`.
+Source sotFingerprint: `70c12838d747`.
 
 ## Comment l'utiliser
 

--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -390,6 +390,11 @@ entries:
     owner: '@ak125'
     sourceConfidence: high
     risk: medium
+  - glob: backend/src/common/guards/**
+    domain: D13
+    owner: '@ak125'
+    sourceConfidence: high
+    risk: medium
   - glob: backend/src/config/**
     domain: D13
     owner: '@ak125'

--- a/audit/registry/canonical.json
+++ b/audit/registry/canonical.json
@@ -95209,7 +95209,7 @@
       ".spec/00-canon/repository-registry/automation-reality.yaml": "351240bac221fed13bbf87f4ffb050a4f72dbbb25120c8bb50f1b9303b4fd2fe",
       ".spec/00-canon/repository-registry/delete-policy.yaml": "2e698ddddc3d11c244c710271a02e376ce471812c53290439a55220bf6c7aff6",
       ".spec/00-canon/repository-registry/domains.yaml": "670a81abb20bf96ded77ca329883305243207680f9c05aa66190502dd4f8d2a2",
-      ".spec/00-canon/repository-registry/ownership.yaml": "469ffbb4a23f28d8d9c085a8d50a5d832883288d05edf61b5ac1049c5da08149",
+      ".spec/00-canon/repository-registry/ownership.yaml": "9c243c28ac174f5470f9d054359bafd8d95a2c08a14981069fa3c23d2eebf94e",
       ".spec/00-canon/repository-registry/status-overrides.yaml": "6acccd32de6d9c15b47621ab22d9f2d3e34861ea8b6b1a3cd559f68a9fa32e02",
       "audit/registry/db.json": "4221fce2a80e5a9dbee75d87424bf08d18cc97cfdb120d655ad4c6ddf2e9e3b5",
       "audit/registry/deps.json": "20a1be4e31fee1e65206581c2cea743ca9f11712edf6d8586dce988c5959a811",
@@ -95217,7 +95217,7 @@
       "audit/registry/rpc.json": "6e5c182566d80733d4186f734032a1b52a0816ed932c20dba8c82900b34084e5",
       "audit/registry/runtime.json": "43e79a9fb7feb07c2bb0519da2f18b46f0263f176441a88e4e304982ea119660"
     },
-    "sotFingerprint": "d0ff78f48b28"
+    "sotFingerprint": "70c12838d747"
   },
   "runtime": [
     {


### PR DESCRIPTION
## Contexte
[#1097](https://github.com/ak125/nestjs-remix-monorepo/pull/1097) a mergé le `CloudflareThrottlerGuard` (`backend/src/common/guards/`) **avant** que le glob d'ownership n'embarque — l'auto-merge a tiré sur les checks requis (block-new = gate **non-requis**) pendant que je préparais le mapping. Résultat : les fichiers `guards/` sont sur `main` sans entrée d'ownership (domaine UNKNOWN dans le registry).

## Changement
- `ownership.yaml` (L2, owner-authorized @ak125) : glob `backend/src/common/guards/** → D13` (« Config & System », identique à `common/pipes`, `common/schemas`, `config/**`).
- Régénération **déterministe** des projections L3 (`registry:build:canonical` + `registry:build:llm-map`) — `canonical.json` + `REPO_MAP.md`. Rebuild idempotent vérifié (sha256:020751de36e8 stable, Node 24).

## Vérif
- `registry:validate` ✓ (203 entrées, 16 domaines).
- `check-new-files` ✓ (0 fichier non mappé).
- Diff = 3 fichiers (ownership +5 lignes, canonical/REPO_MAP = refs sotFp).

Pas de changement de code/runtime — pur registry hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)