### PR TITLE
fix(cart): cross-sell gamme image 404 — build proxy URL via getOptimizedPartImageUrl

### DIFF
--- a/frontend/app/components/cart/CartCrossSell.tsx
+++ b/frontend/app/components/cart/CartCrossSell.tsx
@@ -1,5 +1,9 @@
 import { ChevronRight, Package } from "lucide-react";
 import { Link } from "react-router";
+import {
+  getOptimizedPartImageUrl,
+  isValidImagePath,
+} from "~/utils/image-optimizer";
 import { normalizeTypeAlias } from "~/utils/url-builder.utils";
 import { type VehicleCookie } from "~/utils/vehicle-cookie";
 
@@ -54,9 +58,9 @@ export function CartCrossSell({
             className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
           >
             <div className="flex h-36 items-center justify-center rounded-xl bg-slate-50 p-4">
-              {gamme.pg_img ? (
+              {isValidImagePath(gamme.pg_img) ? (
                 <img
-                  src={gamme.pg_img}
+                  src={getOptimizedPartImageUrl(gamme.pg_img)}
                   alt=""
                   className="max-h-full max-w-full object-contain"
                   loading="lazy"


### PR DESCRIPTION
## Problème (pré-existant, indépendant de React 19)

`CartCrossSell` rendait l'image de gamme avec `src={gamme.pg_img}`. Or `pg_img`
est un **nom de fichier brut** issu de `pieces_gamme.pg_img` (ex. `filtre-a-huile.webp`),
sans préfixe. Le navigateur le résout à la **racine du site** → `GET /filtre-a-huile.webp`
→ **404** (les logs `.webp 404` observés sur le panier).

## Correctif

Réutilise le helper neutre déjà existant `getOptimizedPartImageUrl` + le garde
`isValidImagePath`, tous deux exportés par `~/utils/image-optimizer` (module image
canonique, **pas** d'import cross-domaine blog) :

```diff
- {gamme.pg_img ? (
-   <img src={gamme.pg_img} ... />
+ {isValidImagePath(gamme.pg_img) ? (
+   <img src={getOptimizedPartImageUrl(gamme.pg_img)} ... />
  ) : (
    <Package className="h-12 w-12 text-slate-300" />
  )}
```

- Construit le chemin correct `articles/gammes-produits/catalogue/<pg_img>` puis
  passe par **imgproxy** (`/imgproxy/rs:fit:600/q:85/plain/…@webp`) — exactement le
  pipeline d'image déjà utilisé en production pour ce bucket.
- Le garde `isValidImagePath` **préserve le fallback `<Package>`** existant (aucun
  changement de comportement silencieux) et écarte le sentinel `no.webp`.

## Portée

- **1 seul fichier** : `frontend/app/components/cart/CartCrossSell.tsx`.
- **Aucun refactor** des autres rendus de gamme (`PopularGammesSection`,
  `homepage-rpc.mapper`, route constructeurs) — hors scope, laissés tels quels.
- Aucun changement backend / DB / URL / payments.

## Vérifs locales (worktree, vs `origin/main`)

- ✅ ESLint flat config sur le fichier — propre (exit 0).
- ✅ `npm run typecheck` frontend — **0 erreur** (aucune impliquant le changement).
- Le smoke navigateur/PREPROD `e2e-smoke` couvrira le rendu réel post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)