### PR TITLE
chore(registry): catch-up deps-derived projections (zero version change)

### DIFF
--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:5ba4ecb332e043295afaae407f04c884664a5a275f0e22f083c60a3c50216f6f",
+  "artifact_immutability_hash": "sha256:a104242b3564070503f287ea2c6484bb9f142b66a49bb0c287f980c9bc23bc22",
   "divergences": [
     {
       "kind": "specifier",
@@ -119,65 +119,6 @@
       ],
       "resolved_versions": [
         "4.0.10"
-      ]
-    },
-    {
-      "kind": "specifier",
-      "name": "@types/node",
-      "occurrences": [
-        {
-          "declaredIn": "backend/package.json",
-          "specifier": "^20.19.24",
-          "workspace": "@fafa/backend"
-        },
-        {
-          "declaredIn": "packages/design-tokens/package.json",
-          "specifier": "^20.17.6",
-          "workspace": "@fafa/design-tokens"
-        },
-        {
-          "declaredIn": "packages/cwv-taxonomy/package.json",
-          "specifier": "^20.0.0",
-          "workspace": "@repo/cwv-taxonomy"
-        },
-        {
-          "declaredIn": "packages/database-types/package.json",
-          "specifier": "^20.0.0",
-          "workspace": "@repo/database-types"
-        },
-        {
-          "declaredIn": "packages/domain-commerce/package.json",
-          "specifier": "^20.0.0",
-          "workspace": "@repo/domain-commerce"
-        },
-        {
-          "declaredIn": "packages/registry/package.json",
-          "specifier": "^20.0.0",
-          "workspace": "@repo/registry"
-        },
-        {
-          "declaredIn": "packages/seo-role-contracts/package.json",
-          "specifier": "^20.0.0",
-          "workspace": "@repo/seo-role-contracts"
-        },
-        {
-          "declaredIn": "packages/seo-roles/package.json",
-          "specifier": "^20.0.0",
-          "workspace": "@repo/seo-roles"
-        },
-        {
-          "declaredIn": "packages/seo-types/package.json",
-          "specifier": "^20.0.0",
-          "workspace": "@repo/seo-types"
-        },
-        {
-          "declaredIn": "packages/seo-url-contract/package.json",
-          "specifier": "^20.0.0",
-          "workspace": "@repo/seo-url-contract"
-        }
-      ],
-      "resolved_versions": [
-        "24.13.2"
       ]
     },
     {
@@ -507,44 +448,6 @@
     },
     {
       "kind": "specifier",
-      "name": "react",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "18.3.1",
-          "workspace": "@fafa/frontend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^18.3.1",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "19.2.7"
-      ]
-    },
-    {
-      "kind": "specifier",
-      "name": "react-dom",
-      "occurrences": [
-        {
-          "declaredIn": "frontend/package.json",
-          "specifier": "18.3.1",
-          "workspace": "@fafa/frontend"
-        },
-        {
-          "declaredIn": "package.json",
-          "specifier": "^18.3.1",
-          "workspace": "nestjs-remix-monorepo"
-        }
-      ],
-      "resolved_versions": [
-        "19.2.7"
-      ]
-    },
-    {
-      "kind": "specifier",
       "name": "react-router",
       "occurrences": [
         {
@@ -692,72 +595,72 @@
       ]
     },
     {
-      "kind": "resolved",
+      "kind": "specifier",
       "name": "typescript",
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
-          "specifier": "^5.9.3",
+          "specifier": "~6.0.3",
           "workspace": "@fafa/backend"
         },
         {
           "declaredIn": "frontend/package.json",
-          "specifier": "^5.9.3",
+          "specifier": "~6.0.3",
           "workspace": "@fafa/design-tokens"
         },
         {
-          "declaredIn": "package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/cwv-taxonomy/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@fafa/eslint-config"
         },
         {
-          "declaredIn": "packages/cwv-taxonomy/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/database-types/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@fafa/frontend"
         },
         {
-          "declaredIn": "packages/database-types/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/design-tokens/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@repo/cwv-taxonomy"
         },
         {
-          "declaredIn": "packages/design-tokens/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/domain-commerce/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@repo/database-types"
         },
         {
-          "declaredIn": "packages/domain-commerce/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/eslint-config/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@repo/domain-commerce"
         },
         {
-          "declaredIn": "packages/eslint-config/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/registry/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@repo/registry"
         },
         {
-          "declaredIn": "packages/registry/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/seo-role-contracts/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@repo/seo-role-contracts"
         },
         {
-          "declaredIn": "packages/seo-role-contracts/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/seo-roles/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@repo/seo-roles"
         },
         {
-          "declaredIn": "packages/seo-roles/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/seo-types/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@repo/seo-types"
         },
         {
-          "declaredIn": "packages/seo-types/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "packages/seo-url-contract/package.json",
+          "specifier": "~6.0.3",
           "workspace": "@repo/seo-url-contract"
         },
         {
-          "declaredIn": "packages/seo-url-contract/package.json",
-          "specifier": "^5.9.3",
+          "declaredIn": "package.json",
+          "specifier": "6.0.3",
           "workspace": "nestjs-remix-monorepo"
         }
       ],
@@ -2799,7 +2702,7 @@
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^18.2.20",
+              "specifier": "19.2.17",
               "workspace": "@fafa/frontend"
             }
           ],
@@ -2814,7 +2717,7 @@
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^18.2.7",
+              "specifier": "19.2.3",
               "workspace": "@fafa/frontend"
             }
           ],
@@ -2824,17 +2727,17 @@
         },
         {
           "divergent_resolved": false,
-          "divergent_specifiers": true,
+          "divergent_specifiers": false,
           "name": "react",
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "18.3.1",
+              "specifier": "19.2.7",
               "workspace": "@fafa/frontend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^18.3.1",
+              "specifier": "19.2.7",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -2844,17 +2747,17 @@
         },
         {
           "divergent_resolved": false,
-          "divergent_specifiers": true,
+          "divergent_specifiers": false,
           "name": "react-dom",
           "occurrences": [
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "18.3.1",
+              "specifier": "19.2.7",
               "workspace": "@fafa/frontend"
             },
             {
               "declaredIn": "package.json",
-              "specifier": "^18.3.1",
+              "specifier": "19.2.7",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -3527,72 +3430,72 @@
         },
         {
           "divergent_resolved": true,
-          "divergent_specifiers": false,
+          "divergent_specifiers": true,
           "name": "typescript",
           "occurrences": [
             {
               "declaredIn": "backend/package.json",
-              "specifier": "^5.9.3",
+              "specifier": "~6.0.3",
               "workspace": "@fafa/backend"
             },
             {
               "declaredIn": "frontend/package.json",
-              "specifier": "^5.9.3",
+              "specifier": "~6.0.3",
               "workspace": "@fafa/design-tokens"
             },
             {
-              "declaredIn": "package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/cwv-taxonomy/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@fafa/eslint-config"
             },
             {
-              "declaredIn": "packages/cwv-taxonomy/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/database-types/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@fafa/frontend"
             },
             {
-              "declaredIn": "packages/database-types/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/design-tokens/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@repo/cwv-taxonomy"
             },
             {
-              "declaredIn": "packages/design-tokens/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/domain-commerce/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@repo/database-types"
             },
             {
-              "declaredIn": "packages/domain-commerce/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/eslint-config/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@repo/domain-commerce"
             },
             {
-              "declaredIn": "packages/eslint-config/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/registry/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@repo/registry"
             },
             {
-              "declaredIn": "packages/registry/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/seo-role-contracts/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@repo/seo-role-contracts"
             },
             {
-              "declaredIn": "packages/seo-role-contracts/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/seo-roles/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@repo/seo-roles"
             },
             {
-              "declaredIn": "packages/seo-roles/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/seo-types/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@repo/seo-types"
             },
             {
-              "declaredIn": "packages/seo-types/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "packages/seo-url-contract/package.json",
+              "specifier": "~6.0.3",
               "workspace": "@repo/seo-url-contract"
             },
             {
-              "declaredIn": "packages/seo-url-contract/package.json",
-              "specifier": "^5.9.3",
+              "declaredIn": "package.json",
+              "specifier": "6.0.3",
               "workspace": "nestjs-remix-monorepo"
             }
           ],
@@ -4019,7 +3922,7 @@
   ],
   "generatedFrom": {
     "deps_registry": "audit/registry/deps.json",
-    "deps_registry_sha": "sha256:20a1be4e31fee1e65206581c2cea743ca9f11712edf6d8586dce988c5959a811",
+    "deps_registry_sha": "sha256:6fd309862d50cc07affebfe1a5d441e2745a7a9fb2d40a3f98789bfb91b8b394",
     "lockfile": "package-lock.json",
     "lockfile_sha": "sha256:48084457985c294b257aa9de38b4eabc834719f529948c524c8cba52d0919146",
     "overlay": "audit/dependencies/family-overlay.yaml",
@@ -4050,7 +3953,7 @@
       "pr-9f": 17,
       "pr-9g": 0
     },
-    "divergent_packages_count": 39,
+    "divergent_packages_count": 36,
     "families_count": 12,
     "total_occurrences": 339,
     "total_packages": 231,
@@ -4079,7 +3982,7 @@
       "occurrences": [
         {
           "declaredIn": "package.json",
-          "specifier": "0.43.0",
+          "specifier": "0.44.0",
           "workspace": "nestjs-remix-monorepo"
         }
       ],
@@ -5100,57 +5003,57 @@
     },
     {
       "divergent_resolved": false,
-      "divergent_specifiers": true,
+      "divergent_specifiers": false,
       "name": "@types/node",
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
-          "specifier": "^20.19.24",
+          "specifier": "^24",
           "workspace": "@fafa/backend"
         },
         {
-          "declaredIn": "packages/design-tokens/package.json",
-          "specifier": "^20.17.6",
+          "declaredIn": "packages/cwv-taxonomy/package.json",
+          "specifier": "^24",
           "workspace": "@fafa/design-tokens"
         },
         {
-          "declaredIn": "packages/cwv-taxonomy/package.json",
-          "specifier": "^20.0.0",
+          "declaredIn": "packages/database-types/package.json",
+          "specifier": "^24",
           "workspace": "@repo/cwv-taxonomy"
         },
         {
-          "declaredIn": "packages/database-types/package.json",
-          "specifier": "^20.0.0",
+          "declaredIn": "packages/design-tokens/package.json",
+          "specifier": "^24",
           "workspace": "@repo/database-types"
         },
         {
           "declaredIn": "packages/domain-commerce/package.json",
-          "specifier": "^20.0.0",
+          "specifier": "^24",
           "workspace": "@repo/domain-commerce"
         },
         {
           "declaredIn": "packages/registry/package.json",
-          "specifier": "^20.0.0",
+          "specifier": "^24",
           "workspace": "@repo/registry"
         },
         {
           "declaredIn": "packages/seo-role-contracts/package.json",
-          "specifier": "^20.0.0",
+          "specifier": "^24",
           "workspace": "@repo/seo-role-contracts"
         },
         {
           "declaredIn": "packages/seo-roles/package.json",
-          "specifier": "^20.0.0",
+          "specifier": "^24",
           "workspace": "@repo/seo-roles"
         },
         {
           "declaredIn": "packages/seo-types/package.json",
-          "specifier": "^20.0.0",
+          "specifier": "^24",
           "workspace": "@repo/seo-types"
         },
         {
           "declaredIn": "packages/seo-url-contract/package.json",
-          "specifier": "^20.0.0",
+          "specifier": "^24",
           "workspace": "@repo/seo-url-contract"
         }
       ],
@@ -5937,7 +5840,7 @@
       "occurrences": [
         {
           "declaredIn": "package.json",
-          "specifier": "6.16.1",
+          "specifier": "6.17.1",
           "workspace": "nestjs-remix-monorepo"
         }
       ],
@@ -6375,7 +6278,7 @@
       "occurrences": [
         {
           "declaredIn": "package.json",
-          "specifier": "2.57.0",
+          "specifier": "2.58.0",
           "workspace": "nestjs-remix-monorepo"
         }
       ],
@@ -6511,7 +6414,7 @@
       "occurrences": [
         {
           "declaredIn": "backend/package.json",
-          "specifier": "^9.6.0",
+          "specifier": "^9.6.2",
           "workspace": "@fafa/backend"
         }
       ],

--- a/audit/registry/canonical.json
+++ b/audit/registry/canonical.json
@@ -22835,14 +22835,14 @@
       "declaredIn": [
         "package.json"
       ],
-      "id": "npm:@ast-grep/cli@0.43.0",
+      "id": "npm:@ast-grep/cli@0.44.0",
       "name": "@ast-grep/cli",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "workspaces": [
         "nestjs-remix-monorepo"
       ]
@@ -24301,8 +24301,10 @@
     },
     {
       "declaredIn": [
+        "backend/package.json",
         "packages/cwv-taxonomy/package.json",
         "packages/database-types/package.json",
+        "packages/design-tokens/package.json",
         "packages/domain-commerce/package.json",
         "packages/registry/package.json",
         "packages/seo-role-contracts/package.json",
@@ -24310,15 +24312,17 @@
         "packages/seo-types/package.json",
         "packages/seo-url-contract/package.json"
       ],
-      "id": "npm:@types/node@^20.0.0",
+      "id": "npm:@types/node@^24",
       "name": "@types/node",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^20.0.0",
+      "version": "^24",
       "workspaces": [
+        "@fafa/backend",
+        "@fafa/design-tokens",
         "@repo/cwv-taxonomy",
         "@repo/database-types",
         "@repo/domain-commerce",
@@ -24327,38 +24331,6 @@
         "@repo/seo-roles",
         "@repo/seo-types",
         "@repo/seo-url-contract"
-      ]
-    },
-    {
-      "declaredIn": [
-        "packages/design-tokens/package.json"
-      ],
-      "id": "npm:@types/node@^20.17.6",
-      "name": "@types/node",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^20.17.6",
-      "workspaces": [
-        "@fafa/design-tokens"
-      ]
-    },
-    {
-      "declaredIn": [
-        "backend/package.json"
-      ],
-      "id": "npm:@types/node@^20.19.24",
-      "name": "@types/node",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^20.19.24",
-      "workspaces": [
-        "@fafa/backend"
       ]
     },
     {
@@ -24429,14 +24401,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@types/react-dom@^18.2.7",
+      "id": "npm:@types/react-dom@19.2.3",
       "name": "@types/react-dom",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^18.2.7",
+      "version": "19.2.3",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -24445,14 +24417,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@types/react@^18.2.20",
+      "id": "npm:@types/react@19.2.17",
       "name": "@types/react",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^18.2.20",
+      "version": "19.2.17",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -25533,14 +25505,14 @@
       "declaredIn": [
         "package.json"
       ],
-      "id": "npm:knip@6.16.1",
+      "id": "npm:knip@6.17.1",
       "name": "knip",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "6.16.1",
+      "version": "6.17.1",
       "workspaces": [
         "nestjs-remix-monorepo"
       ]
@@ -25955,33 +25927,19 @@
     },
     {
       "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:react-dom@18.3.1",
-      "name": "react-dom",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "18.3.1",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
+        "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:react-dom@^18.3.1",
+      "id": "npm:react-dom@19.2.7",
       "name": "react-dom",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^18.3.1",
+      "version": "19.2.7",
       "workspaces": [
+        "@fafa/frontend",
         "nestjs-remix-monorepo"
       ]
     },
@@ -26037,33 +25995,19 @@
     },
     {
       "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:react@18.3.1",
-      "name": "react",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "18.3.1",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
+        "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:react@^18.3.1",
+      "id": "npm:react@19.2.7",
       "name": "react",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^18.3.1",
+      "version": "19.2.7",
       "workspaces": [
+        "@fafa/frontend",
         "nestjs-remix-monorepo"
       ]
     },
@@ -26269,14 +26213,14 @@
       "declaredIn": [
         "package.json"
       ],
-      "id": "npm:squawk-cli@2.57.0",
+      "id": "npm:squawk-cli@2.58.0",
       "name": "squawk-cli",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "2.57.0",
+      "version": "2.58.0",
       "workspaces": [
         "nestjs-remix-monorepo"
       ]
@@ -26431,14 +26375,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:ts-loader@^9.6.0",
+      "id": "npm:ts-loader@^9.6.2",
       "name": "ts-loader",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^9.6.0",
+      "version": "^9.6.2",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -26573,9 +26517,24 @@
     },
     {
       "declaredIn": [
+        "package.json"
+      ],
+      "id": "npm:typescript@6.0.3",
+      "name": "typescript",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "6.0.3",
+      "workspaces": [
+        "nestjs-remix-monorepo"
+      ]
+    },
+    {
+      "declaredIn": [
         "backend/package.json",
         "frontend/package.json",
-        "package.json",
         "packages/cwv-taxonomy/package.json",
         "packages/database-types/package.json",
         "packages/design-tokens/package.json",
@@ -26587,14 +26546,14 @@
         "packages/seo-types/package.json",
         "packages/seo-url-contract/package.json"
       ],
-      "id": "npm:typescript@^5.9.3",
+      "id": "npm:typescript@~6.0.3",
       "name": "typescript",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^5.9.3",
+      "version": "~6.0.3",
       "workspaces": [
         "@fafa/backend",
         "@fafa/design-tokens",
@@ -26607,8 +26566,7 @@
         "@repo/seo-role-contracts",
         "@repo/seo-roles",
         "@repo/seo-types",
-        "@repo/seo-url-contract",
-        "nestjs-remix-monorepo"
+        "@repo/seo-url-contract"
       ]
     },
     {
@@ -95212,12 +95170,12 @@
       ".spec/00-canon/repository-registry/ownership.yaml": "9c243c28ac174f5470f9d054359bafd8d95a2c08a14981069fa3c23d2eebf94e",
       ".spec/00-canon/repository-registry/status-overrides.yaml": "6acccd32de6d9c15b47621ab22d9f2d3e34861ea8b6b1a3cd559f68a9fa32e02",
       "audit/registry/db.json": "4221fce2a80e5a9dbee75d87424bf08d18cc97cfdb120d655ad4c6ddf2e9e3b5",
-      "audit/registry/deps.json": "20a1be4e31fee1e65206581c2cea743ca9f11712edf6d8586dce988c5959a811",
+      "audit/registry/deps.json": "6fd309862d50cc07affebfe1a5d441e2745a7a9fb2d40a3f98789bfb91b8b394",
       "audit/registry/files.json": "72d2f47cfd5a3fcbae7f4a9435f323d953faca1c5329a5d9a7d69affe1736be1",
       "audit/registry/rpc.json": "6e5c182566d80733d4186f734032a1b52a0816ed932c20dba8c82900b34084e5",
       "audit/registry/runtime.json": "43e79a9fb7feb07c2bb0519da2f18b46f0263f176441a88e4e304982ea119660"
     },
-    "sotFingerprint": "70c12838d747"
+    "sotFingerprint": "c011d7a7d55d"
   },
   "runtime": [
     {

--- a/audit/registry/deps.json
+++ b/audit/registry/deps.json
@@ -20,14 +20,14 @@
       "declaredIn": [
         "package.json"
       ],
-      "id": "npm:@ast-grep/cli@0.43.0",
+      "id": "npm:@ast-grep/cli@0.44.0",
       "name": "@ast-grep/cli",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "workspaces": [
         "nestjs-remix-monorepo"
       ]
@@ -1486,8 +1486,10 @@
     },
     {
       "declaredIn": [
+        "backend/package.json",
         "packages/cwv-taxonomy/package.json",
         "packages/database-types/package.json",
+        "packages/design-tokens/package.json",
         "packages/domain-commerce/package.json",
         "packages/registry/package.json",
         "packages/seo-role-contracts/package.json",
@@ -1495,15 +1497,17 @@
         "packages/seo-types/package.json",
         "packages/seo-url-contract/package.json"
       ],
-      "id": "npm:@types/node@^20.0.0",
+      "id": "npm:@types/node@^24",
       "name": "@types/node",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^20.0.0",
+      "version": "^24",
       "workspaces": [
+        "@fafa/backend",
+        "@fafa/design-tokens",
         "@repo/cwv-taxonomy",
         "@repo/database-types",
         "@repo/domain-commerce",
@@ -1512,38 +1516,6 @@
         "@repo/seo-roles",
         "@repo/seo-types",
         "@repo/seo-url-contract"
-      ]
-    },
-    {
-      "declaredIn": [
-        "packages/design-tokens/package.json"
-      ],
-      "id": "npm:@types/node@^20.17.6",
-      "name": "@types/node",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^20.17.6",
-      "workspaces": [
-        "@fafa/design-tokens"
-      ]
-    },
-    {
-      "declaredIn": [
-        "backend/package.json"
-      ],
-      "id": "npm:@types/node@^20.19.24",
-      "name": "@types/node",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "^20.19.24",
-      "workspaces": [
-        "@fafa/backend"
       ]
     },
     {
@@ -1614,14 +1586,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@types/react-dom@^18.2.7",
+      "id": "npm:@types/react-dom@19.2.3",
       "name": "@types/react-dom",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^18.2.7",
+      "version": "19.2.3",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -1630,14 +1602,14 @@
       "declaredIn": [
         "frontend/package.json"
       ],
-      "id": "npm:@types/react@^18.2.20",
+      "id": "npm:@types/react@19.2.17",
       "name": "@types/react",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^18.2.20",
+      "version": "19.2.17",
       "workspaces": [
         "@fafa/frontend"
       ]
@@ -2718,14 +2690,14 @@
       "declaredIn": [
         "package.json"
       ],
-      "id": "npm:knip@6.16.1",
+      "id": "npm:knip@6.17.1",
       "name": "knip",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "6.16.1",
+      "version": "6.17.1",
       "workspaces": [
         "nestjs-remix-monorepo"
       ]
@@ -3140,33 +3112,19 @@
     },
     {
       "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:react-dom@18.3.1",
-      "name": "react-dom",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "18.3.1",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
+        "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:react-dom@^18.3.1",
+      "id": "npm:react-dom@19.2.7",
       "name": "react-dom",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^18.3.1",
+      "version": "19.2.7",
       "workspaces": [
+        "@fafa/frontend",
         "nestjs-remix-monorepo"
       ]
     },
@@ -3222,33 +3180,19 @@
     },
     {
       "declaredIn": [
-        "frontend/package.json"
-      ],
-      "id": "npm:react@18.3.1",
-      "name": "react",
-      "owner": "__unassigned__",
-      "schemaVersion": "1.0.0",
-      "source": "npm",
-      "sourceConfidence": "high",
-      "status": "LIVE",
-      "version": "18.3.1",
-      "workspaces": [
-        "@fafa/frontend"
-      ]
-    },
-    {
-      "declaredIn": [
+        "frontend/package.json",
         "package.json"
       ],
-      "id": "npm:react@^18.3.1",
+      "id": "npm:react@19.2.7",
       "name": "react",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^18.3.1",
+      "version": "19.2.7",
       "workspaces": [
+        "@fafa/frontend",
         "nestjs-remix-monorepo"
       ]
     },
@@ -3454,14 +3398,14 @@
       "declaredIn": [
         "package.json"
       ],
-      "id": "npm:squawk-cli@2.57.0",
+      "id": "npm:squawk-cli@2.58.0",
       "name": "squawk-cli",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "2.57.0",
+      "version": "2.58.0",
       "workspaces": [
         "nestjs-remix-monorepo"
       ]
@@ -3616,14 +3560,14 @@
       "declaredIn": [
         "backend/package.json"
       ],
-      "id": "npm:ts-loader@^9.6.0",
+      "id": "npm:ts-loader@^9.6.2",
       "name": "ts-loader",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^9.6.0",
+      "version": "^9.6.2",
       "workspaces": [
         "@fafa/backend"
       ]
@@ -3758,9 +3702,24 @@
     },
     {
       "declaredIn": [
+        "package.json"
+      ],
+      "id": "npm:typescript@6.0.3",
+      "name": "typescript",
+      "owner": "__unassigned__",
+      "schemaVersion": "1.0.0",
+      "source": "npm",
+      "sourceConfidence": "high",
+      "status": "LIVE",
+      "version": "6.0.3",
+      "workspaces": [
+        "nestjs-remix-monorepo"
+      ]
+    },
+    {
+      "declaredIn": [
         "backend/package.json",
         "frontend/package.json",
-        "package.json",
         "packages/cwv-taxonomy/package.json",
         "packages/database-types/package.json",
         "packages/design-tokens/package.json",
@@ -3772,14 +3731,14 @@
         "packages/seo-types/package.json",
         "packages/seo-url-contract/package.json"
       ],
-      "id": "npm:typescript@^5.9.3",
+      "id": "npm:typescript@~6.0.3",
       "name": "typescript",
       "owner": "__unassigned__",
       "schemaVersion": "1.0.0",
       "source": "npm",
       "sourceConfidence": "high",
       "status": "LIVE",
-      "version": "^5.9.3",
+      "version": "~6.0.3",
       "workspaces": [
         "@fafa/backend",
         "@fafa/design-tokens",
@@ -3792,8 +3751,7 @@
         "@repo/seo-role-contracts",
         "@repo/seo-roles",
         "@repo/seo-types",
-        "@repo/seo-url-contract",
-        "nestjs-remix-monorepo"
+        "@repo/seo-url-contract"
       ]
     },
     {


### PR DESCRIPTION
## Quoi
Régénération pure des projections `deps`-dérivées qui avaient dérivé sur `main` :
- `audit/registry/deps.json`
- `audit/registry/canonical.json` (projection)
- `audit/dependencies/dependency-modernization-inventory.json`

## Pourquoi
Ces projections n'avaient pas été régénérées après les merges récents de manifestes
(TS6 #1096, React 19 #1098, `@types/node ^24`, `@ast-grep/cli 0.44.0`, dev-deps #1100).
`registry-fresh` étant non-bloquant, le drift s'est accumulé. Un `registry:build:deps`
sur `main` intact produit déjà un gros diff de rattrapage — vérifié.

## Comment
Régénération via les builders sanctionnés uniquement (jamais d'édition à la main) :
```
registry:build:deps → registry:build:canonical → audit:pr-9-modernization-inventory
```
**Zéro changement de manifeste / version** (`git diff --name-only -- '**/package.json'` = vide).
Gates re-validées localement : `modernization-inventory:check` ✓, `registry:validate:zod` ✓.

## Pourquoi maintenant
Prérequis d'attribution pour la PR isolée **Vite 7** à venir : sans ce rattrapage, la
régénération deps post-bump emporterait ce drift et casserait l'attribution « Vite-only ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)