### PR TITLE
feat(rr8-prep): A1 — adopt future.v8_viteEnvironmentApi (RR7.18)

### DIFF
--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -8,8 +8,16 @@ import { type Config } from "@react-router/dev/config";
  * Les anciens flags Remix v2 `future.v3_*` (fetcherPersist, lazyRouteDiscovery,
  * throwAbortReason, relativeSplatPath, singleFetch) sont le COMPORTEMENT PAR DÉFAUT
  * en RR7 — aucun flag à reporter.
+ *
+ * Préparation RR8 (Temps A — adoption incrémentale des `future.v8_*` sous RR7.18,
+ * un flag par PR pour isoler les régressions ; ces flags deviennent le comportement
+ * par défaut en RR8 et seront retirés au bump) :
+ * - A1 `v8_viteEnvironmentApi` : active la Vite Environment API (requiert Vite 7 ✅).
  */
 export default {
   ssr: true,
   serverModuleFormat: "esm",
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;


### PR DESCRIPTION
## Contexte — Migration RR7 → RR8, **Temps A** (préparation sous RR 7.18)

Première PR du chantier RR8. Stratégie **deux temps** : préparer entièrement RR8 sous RR 7.18 (réversible, **un flag `future.v8_*` par PR** pour isoler les régressions), puis basculer la version (Temps B).

> **MàJ post-#1116** : le découplage Sentry (`@sentry/react-router` retiré → `@sentry/react` + `@sentry/nestjs`) a **levé le verrou RR8** — le flip n'est **plus** gated par Sentry. Prérequis (Node 24 / TS 6 / React 19.2.7 / Vite 7.3.5) déjà sur `main`.

**Ici** : `v8_viteEnvironmentApi` (active la Vite Environment API ; deviendra le défaut en RR8, retiré au bump). Aucun autre code.

## Validation locale (worktree sur `origin/main` post-#1116)
- typecheck (`react-router typegen && tsc`) : 0 erreur
- build via turbo (deps-first) : OK — « Using Vite Environment API » engagé
- **DEV middleware loader** (`index.cjs` → `ssrLoadModule('virtual:react-router/server-build')`) sous l'Environment API : OK → **aucune réécriture de l'intégration dev nécessaire**
- lint : 0 erreur

## Suite
A2 `v8_passThroughRequests` → A3 `v8_trailingSlashAwareDataRequests` → A4 `v8_splitRouteModules` (flags) ; **A6** `v8_middleware` + pont `RouterContextProvider` **(+ adaptateur CJS→ESM requis par RR8 ESM-only)** ; **A5** meta `data`→`loaderData`. Le flip RR8 (Temps B) est **débloqué**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)