### PR TITLE
fix(analytics): env-gate GA4 tag to stop CI/headless pollution

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,6 +59,11 @@ services:
       - VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      # Google Analytics 4 — measurement ID (public, non-secret). Fourni UNIQUEMENT
+      # ici (compose PROD) : DEV (`npm run dev`) et PREPROD (docker-compose.preprod.yml)
+      # ne l'ont pas → le tag gtag n'est pas injecté → fin de la pollution GA4 par les
+      # navigateurs headless E2E/Lighthouse de la CI. Override possible via host env.
+      - VITE_GA_MEASUREMENT_ID=${VITE_GA_MEASUREMENT_ID:-G-ZVG6K5R740}
       # 🚨 Sentry — values inherited from `sops exec-env secrets/sentry.prod.sops.env`
       # wrapping the deploy command (see deploy-prod.yml). Bare names = "inherit
       # from host process env"; missing values keep the SDK in no-op mode.

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -142,6 +142,12 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
         process.env.APP_ENV ||
         process.env.NODE_ENV ||
         "development",
+      // GA4 measurement ID — provisionné par environnement (docker-compose.prod.yml
+      // uniquement). Vide en DEV (`npm run dev`) et PREPROD (CI) → le tag gtag n'est
+      // PAS injecté, ce qui évite que les navigateurs headless E2E/Lighthouse polluent
+      // la propriété GA4 de PROD (hostname=localhost, géo datacenter). Config-driven,
+      // pas de measurement ID en dur dans le bundle client.
+      VITE_GA_MEASUREMENT_ID: process.env.VITE_GA_MEASUREMENT_ID || "",
     },
   };
 };
@@ -393,6 +399,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
   const data = useRouteLoaderData<typeof loader>("root");
   const nonce = data?.cspNonce || "";
   const isBot = data?.isBot ?? false;
+  // GA4 mesure uniquement quand l'ID est provisionné (PROD). Vide en DEV/PREPROD
+  // → pas de tag → pas de pollution CI/headless. Cf. loader ENV ci-dessus.
+  const gaMeasurementId = data?.ENV?.VITE_GA_MEASUREMENT_ID ?? "";
 
   return (
     <html lang="fr" className="h-full" suppressHydrationWarning>
@@ -430,8 +439,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <link rel="stylesheet" href={animationsStylesheet} />
         </noscript>
         {/* Google Analytics 4 - Optimisé avec requestIdleCallback + Consent Mode v2 (RGPD) */}
-        {/* 🤖 Bot filter: ne pas charger gtag pour les bots (évite pollution GA4) */}
-        {!isBot && (
+        {/* Double garde anti-pollution GA4 :
+            1. !isBot         → exclut les crawlers (UA serveur)
+            2. gaMeasurementId → l'ID n'est provisionné qu'en PROD (docker-compose.prod.yml),
+               donc pas de tag en DEV/PREPROD (stoppe la pollution headless E2E/Lighthouse). */}
+        {!isBot && gaMeasurementId !== "" && (
           <script
             nonce={nonce}
             suppressHydrationWarning
@@ -461,11 +473,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
                 var loadScript = function() {
                   var script = document.createElement('script');
-                  script.src = 'https://www.googletagmanager.com/gtag/js?id=G-ZVG6K5R740';
+                  script.src = 'https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}';
                   script.async = true;
                   script.onload = function() {
                     gtag('js', new Date());
-                    gtag('config', 'G-ZVG6K5R740', {
+                    gtag('config', '${gaMeasurementId}', {
                       page_title: document.title,
                       page_location: window.location.href,
                       send_page_view: false


### PR DESCRIPTION
## Problème (mesuré)

Audit GA4 live 2026-06-23 (property \`311870207\`), suite à une suspicion bot de l'owner sur la hausse du trafic hors-France.

- **Hors-France = 85 % du trafic mesuré**, dont **~46 % de TOUT le trafic provient du hostname \`localhost\`** géolocalisé « Germany ».
- Signature : landing \`(not set)\`, engagement ~0,4 %, device \`desktop/Windows\` (E2E Smoke) + \`mobile/Android\` (Lighthouse mobile).
- « Germany » = la machine Hetzner Nuremberg (\`nbg1\` = 49.12.233.2) qui héberge les containers PREPROD/PROD et le runner CI. → ce sont les **navigateurs headless de la CI** (E2E Smoke + Lighthouse) qui exécutent le JS client et **déclenchent le tag GA4 de PROD à chaque merge sur \`main\`**. La machine DEV (\`npm run dev\`) polluait aussi.

### Cause racine

Le measurement ID \`G-ZVG6K5R740\` était **codé en dur** dans \`frontend/app/root.tsx\` et injecté dans **tous** les environnements, gardé uniquement par un filtre UA serveur \`!isBot\` (qui laisse passer Lighthouse/Playwright). \`__loadGTM\` s'auto-déclenche sans interaction (\`requestIdleCallback\` + \`setTimeout(3000)\`) → un navigateur headless qui idle 3 s suffit.

## Fix (structurel, config-driven, zéro magic constant)

1. Le measurement ID passe par le pattern **\`window.ENV\`** déjà gouverné (comme \`VITE_SENTRY_DSN\`), exposé au request-time depuis le loader root.
2. Le tag n'est injecté que si l'ID est présent : **double garde \`!isBot && gaMeasurementId !== ""\`**.
3. L'ID (public, non-secret) est provisionné **uniquement** par \`docker-compose.prod.yml\` → DEV (\`npm run dev\`) et PREPROD (\`docker-compose.preprod.yml\`) ne l'ont pas → **plus de tag, plus de pollution**. Défaut \`:-G-ZVG6K5R740\` → **aucune perte d'analytics PROD**.

## Hors scope (volontaire)

- **Module \`payments/\` NON touché** : le Measurement Protocol server-side (\`paybox-callback.controller.ts\`) ne se déclenche que sur achat réel, n'est pas une source de pollution, et est sous règle de protection.
- **Mirror \`__seo_ga4_daily\`** : hérite aussi de la pollution (aucun filtre hostname/pays) → suivi séparé proposé.
- **Filtre GA4 Admin** (exclure hostName ≠ www.automecanik.com) : action console, complémentaire, à faire côté GA4.

## Vérification

- \`react-router typegen && tsc\` : **exit 0, 0 erreur** (aucune sur root.tsx).
- \`eslint app/root.tsx\` : **exit 0**.
- \`docker-compose.prod.yml\` : YAML valide.
- Plus aucun measurement ID en dur dans \`root.tsx\`.

## Rollout / rollback

- Merge \`main\` → redéploie **PREPROD** (CI), où le tag sera **absent** (effet voulu : la CI cesse de polluer GA4).
- PROD via tag \`v*\` (décision owner) → le tag reste actif (ID fourni par le compose PROD).
- Rollback = revert de la PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)