### PR TITLE
fix(seo-monitoring): filter GA4 mirror on PROD hostname — clean __seo_ga4_daily

### DIFF
--- a/backend/src/config/site.constants.ts
+++ b/backend/src/config/site.constants.ts
@@ -6,3 +6,10 @@
  * d'import circulaire dans les tests Jest.
  */
 export const SITE_ORIGIN = 'https://www.automecanik.com';
+
+/**
+ * Hostname canonique nu (sans schema) — derive de SITE_ORIGIN.
+ * Pour les APIs qui filtrent par host brut (ex. dimension GA4 `hostName`).
+ * Permet d'exclure le trafic non-PROD (localhost = CI headless / DEV).
+ */
+export const SITE_HOSTNAME = new URL(SITE_ORIGIN).hostname;

--- a/backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.service.ts
+++ b/backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.service.ts
@@ -16,6 +16,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SupabaseClient, createClient } from '@supabase/supabase-js';
 import { getEffectiveSupabaseKey } from '@common/utils';
+import { SITE_HOSTNAME } from '@config/site.constants';
 import { GoogleCredentialsService } from './google-credentials.service';
 import { SeoMonitoringRunsService } from './seo-monitoring-runs.service';
 
@@ -106,8 +107,41 @@ export class Ga4DailyFetcherService {
     let keyEventsFallback = false;
 
     try {
+      // Garde anti-pollution : ne compter que le trafic du hostname de PROD.
+      // GA4 reçoit aussi des hits hostname=localhost (navigateurs headless E2E/
+      // Lighthouse de la CI, géo datacenter) qui faussaient sessions/bounce.
+      // Cf. mémoire ga4_prod_tag_not_env_gated_ci_localhost_pollution + PR #1115.
+      const hostNameFilter = {
+        filter: {
+          fieldName: 'hostName',
+          stringFilter: {
+            matchType: 'EXACT' as const,
+            value: SITE_HOSTNAME,
+          },
+        },
+      };
+
       for (const pattern of segments) {
         result.apiCalls += 1;
+        // Combine le filtre hostname (toujours) avec le filtre pagePath (si segment).
+        const dimensionFilter = pattern
+          ? {
+              andGroup: {
+                expressions: [
+                  hostNameFilter,
+                  {
+                    filter: {
+                      fieldName: 'pagePath',
+                      stringFilter: {
+                        matchType: 'CONTAINS' as const,
+                        value: pattern,
+                      },
+                    },
+                  },
+                ],
+              },
+            }
+          : hostNameFilter;
         const mkReq = (metric: string) => ({
           property,
           dateRanges: [{ startDate: options.date, endDate: options.date }],
@@ -121,17 +155,7 @@ export class Ga4DailyFetcherService {
             { name: 'bounceRate' },
             { name: 'averageSessionDuration' },
           ],
-          dimensionFilter: pattern
-            ? {
-                filter: {
-                  fieldName: 'pagePath',
-                  stringFilter: {
-                    matchType: 'CONTAINS' as const,
-                    value: pattern,
-                  },
-                },
-              }
-            : undefined,
+          dimensionFilter,
           limit: rowLimit,
         });
 

--- a/backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.test.ts
+++ b/backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for Ga4DailyFetcherService — hostName anti-pollution guard.
+ *
+ * Garantit que les requêtes GA4 filtrent sur le hostname de PROD
+ * (SITE_HOSTNAME) pour exclure le trafic localhost (CI headless E2E/Lighthouse).
+ * Cf. mémoire ga4_prod_tag_not_env_gated_ci_localhost_pollution + PR #1115.
+ */
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { SITE_HOSTNAME } from '@config/site.constants';
+import { Ga4DailyFetcherService } from './ga4-daily-fetcher.service';
+import { GoogleCredentialsService } from './google-credentials.service';
+import { SeoMonitoringRunsService } from './seo-monitoring-runs.service';
+
+// Isole le client Supabase externe (le constructeur réel exige une clé valide).
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ from: jest.fn() })),
+}));
+
+function buildService() {
+  const runReport = jest.fn().mockResolvedValue([{ rows: [] }]);
+
+  const credentialsMock = {
+    isMonitoringEnabled: jest.fn().mockReturnValue(true),
+    getGA4Client: jest.fn().mockReturnValue({ runReport }),
+    getGA4PropertyName: jest.fn().mockReturnValue('properties/311870207'),
+  } as unknown as GoogleCredentialsService;
+
+  const runsServiceMock = {
+    logStarted: jest.fn().mockResolvedValue('test-run-id'),
+    logCompleted: jest.fn().mockResolvedValue(undefined),
+    logFailed: jest.fn().mockResolvedValue(undefined),
+  };
+
+  return Test.createTestingModule({
+    providers: [
+      Ga4DailyFetcherService,
+      { provide: GoogleCredentialsService, useValue: credentialsMock },
+      { provide: SeoMonitoringRunsService, useValue: runsServiceMock },
+      {
+        provide: ConfigService,
+        useValue: {
+          get: (k: string) =>
+            k === 'SUPABASE_URL' ? 'https://mock.supabase.co' : undefined,
+        },
+      },
+    ],
+  })
+    .compile()
+    .then((moduleRef) => {
+      const service = moduleRef.get(Ga4DailyFetcherService);
+      return { service, runReport };
+    });
+}
+
+describe('Ga4DailyFetcherService — hostName anti-pollution guard', () => {
+  it('SITE_HOSTNAME dérive bien le host nu de PROD', () => {
+    expect(SITE_HOSTNAME).toBe('www.automecanik.com');
+  });
+
+  it('sans segment pagePath → filtre hostName EXACT seul', async () => {
+    const { service, runReport } = await buildService();
+
+    await service.fetchAndPersist({ date: '2026-06-22', dryRun: true });
+
+    expect(runReport).toHaveBeenCalledTimes(1);
+    const req = runReport.mock.calls[0][0];
+    expect(req.dimensionFilter).toEqual({
+      filter: {
+        fieldName: 'hostName',
+        stringFilter: { matchType: 'EXACT', value: SITE_HOSTNAME },
+      },
+    });
+  });
+
+  it('avec segment pagePath → andGroup [hostName, pagePath]', async () => {
+    const { service, runReport } = await buildService();
+
+    await service.fetchAndPersist({
+      date: '2026-06-22',
+      pagePathPatterns: ['/pieces'],
+      dryRun: true,
+    });
+
+    expect(runReport).toHaveBeenCalledTimes(1);
+    const req = runReport.mock.calls[0][0];
+    expect(req.dimensionFilter.andGroup.expressions).toHaveLength(2);
+    expect(req.dimensionFilter.andGroup.expressions[0]).toEqual({
+      filter: {
+        fieldName: 'hostName',
+        stringFilter: { matchType: 'EXACT', value: SITE_HOSTNAME },
+      },
+    });
+    expect(req.dimensionFilter.andGroup.expressions[1]).toEqual({
+      filter: {
+        fieldName: 'pagePath',
+        stringFilter: { matchType: 'CONTAINS', value: '/pieces' },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Problème

Suite de #1115. Le tag client est désormais env-gaté (plus de pollution future à la source), mais le **fetcher qui alimente la table interne `__seo_ga4_daily`** interroge GA4 **sans filtre de hostname** ([ga4-daily-fetcher.service.ts](backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.service.ts)) → il agrège encore :

- le trafic `hostname=localhost` (navigateurs headless E2E Smoke + Lighthouse CI, géo datacenter),
- les scrapers externes,

ce qui **fausse sessions / bounce / durée** dans les dashboards SEO internes qui lisent cette table.

## Fix (config-driven, réutilise le canon, zéro magic constant)

1. **`SITE_HOSTNAME`** ajouté à [`@config/site.constants`](backend/src/config/site.constants.ts) — dérivé de `SITE_ORIGIN` via `new URL().hostname`. C'est le fichier canonique « domaine du site, utiliser partout » → pas de littéral dupliqué.
2. Le fetcher GA4 filtre désormais sur **`hostName == SITE_HOSTNAME`**, combiné en `andGroup` avec le filtre `pagePath` existant quand un segment est fourni (sinon le filtre hostname seul).
3. **Test unitaire** ([ga4-daily-fetcher.test.ts](backend/src/modules/seo-monitoring/services/ga4-daily-fetcher.test.ts)) : vérifie que la requête GA4 porte bien le filtre hostName — seul, et en `andGroup` avec pagePath.

## ⚠️ Non-rétroactif

Seuls les **fetches futurs** sont propres. Les lignes **historiques** déjà polluées de `__seo_ga4_daily` restent en place. Un backfill (re-run du fetcher sur les dates passées, qui re-tire des données filtrées et upsert par `onConflict: date,page,channel`) les nettoierait — **étape opérationnelle séparée, owner-gated** (pas dans cette PR).

## Vérification

- `jest ga4-daily-fetcher.test.ts` : **3/3 pass** ✓
- `tsc --noEmit` : **exit 0, 0 erreur** ✓
- `eslint` (3 fichiers) : **exit 0** ✓

## Rollout / rollback

- Mutation backend (fetcher cron ~02:00 UTC). Aucun impact runtime utilisateur, aucune queue, aucun cache.
- Rollback = revert de la PR (le fetcher revient au comportement précédent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)