### PR TITLE
feat(rr8-prep): A2 — adopt future.v8_passThroughRequests (RR7.18)

### DIFF
--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -13,11 +13,15 @@ import { type Config } from "@react-router/dev/config";
  * un flag par PR pour isoler les régressions ; ces flags deviennent le comportement
  * par défaut en RR8 et seront retirés au bump) :
  * - A1 `v8_viteEnvironmentApi` : active la Vite Environment API (requiert Vite 7 ✅).
+ * - A2 `v8_passThroughRequests` : passe la requête HTTP brute aux loaders/actions
+ *   (la `Request.url`/host est désormais reconstruite côté serveur — à valider
+ *   derrière Caddy : X-Forwarded-Host → contrôle d'origine CSRF des actions).
  */
 export default {
   ssr: true,
   serverModuleFormat: "esm",
   future: {
     v8_viteEnvironmentApi: true,
+    v8_passThroughRequests: true,
   },
 } satisfies Config;


### PR DESCRIPTION
## Temps A — flag 2/5 (stacké sur A1 #1111)

`future.v8_passThroughRequests` : passe la requête HTTP brute aux loaders/actions ; deviendra le défaut en RR8. Un flag par PR pour isoler les régressions.

**Base = `main` post-#1116** (Sentry découplé → RR8 débloqué). Stacké sur A1 ; à merger après A1.

### Validation locale
- typecheck (`react-router typegen && tsc`) : 0 erreur
- build via turbo (deps-first) : OK (8/8)
- lint : 0 erreur (180 warnings pré-existants)

### ⚠️ Validation RUNTIME = PREPROD
Le passage de la requête brute change `Request.url`/host reconstruit derrière Caddy (X-Forwarded-Host → contrôle d'origine **CSRF** des actions). Serveur custom NestJS + `@react-router/express` = surface sensible. À vérifier sur le container PREPROD (mutations panier/auth) après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)