### PR TITLE
feat(commerce-loop): server-side r2_order_placed funnel emission (PR-A, flag OFF)

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -718,6 +718,13 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: medium
+  # Commerce-Loop V1 PR-A — idempotency index for server-side r2_order_placed
+  # emission into __seo_event_log (funnel family, même domaine que *seo_event_funnel*).
+  - glob: backend/supabase/migrations/*seo_event_log*
+    domain: D3
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: low
   - glob: backend/supabase/migrations/*seo_cwv*
     domain: D3
     owner: '@ak125/seo-team'

--- a/backend/src/config/feature-flags.service.ts
+++ b/backend/src/config/feature-flags.service.ts
@@ -235,6 +235,23 @@ export class FeatureFlagsService {
     return this.bool('ABANDONED_CART_EMAIL_ENABLED', false);
   }
 
+  // ── Commerce-Loop V1 — server-side funnel emission (PR-A) ──
+
+  /**
+   * Gates the guaranteed SERVER-side emission of conversion funnel events
+   * (r2_order_placed via OrderFunnelListener @OnEvent(ORDER_EVENTS.PAID)),
+   * replacing the lossy client beacon on the payment-return page.
+   * Default: false (inert — the listener is a no-op, nothing is written).
+   * PROD-only by construction: emission is additionally skipped when the
+   * backend runs READ_ONLY (PREPROD anon, ADR-028) since __seo_event_log
+   * grants INSERT to service_role only — see OrderFunnelListener.
+   * Activation order: apply the idempotency-index migration → land the
+   * payments emit(ORDER_EVENTS.PAID) → flip this flag (shadow then on).
+   */
+  get funnelServerEmitEnabled(): boolean {
+    return this.bool('FUNNEL_SERVER_EMIT_ENABLED', false);
+  }
+
   // ── SEO Business Control Dashboard flag (PR-SBD-1 Task 7) ──
 
   /**
@@ -361,6 +378,7 @@ export class FeatureFlagsService {
     'QA_DECISION_ENABLED',
     'BEST_VERSION_PROTECTION_ENABLED',
     'ABANDONED_CART_EMAIL_ENABLED',
+    'FUNNEL_SERVER_EMIT_ENABLED',
     'WRITE_GUARD_ENABLED',
     'WRITE_GUARD_MODE',
     'WRITE_GUARD_CANARY_ROLES',

--- a/backend/src/modules/seo-monitoring/listeners/order-funnel.listener.test.ts
+++ b/backend/src/modules/seo-monitoring/listeners/order-funnel.listener.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests — OrderFunnelListener (Commerce-Loop V1 PR-A).
+ *
+ * The listener extends SupabaseBaseService whose constructor calls createClient
+ * and requires SUPABASE_URL; to keep these tests hermetic (no env / no network)
+ * we build instances via Object.create and inject the collaborators directly.
+ */
+import { OrderFunnelListener } from './order-funnel.listener';
+import type { OrderPaidEvent } from '../../orders/events/order.events';
+
+type LoggerStub = {
+  warn: jest.Mock;
+  error: jest.Mock;
+  debug: jest.Mock;
+  log: jest.Mock;
+};
+
+interface Harness {
+  flags?: { funnelServerEmitEnabled: boolean };
+  funnelEvents?: { recordOnce: jest.Mock };
+  isReadOnlyMode?: boolean;
+  supabase?: unknown;
+}
+
+function makeListener(over: Harness = {}) {
+  const logger: LoggerStub = {
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    log: jest.fn(),
+  };
+  const funnelEvents = over.funnelEvents ?? {
+    recordOnce: jest.fn().mockResolvedValue({ ok: true, deduped: false }),
+  };
+  const listener = Object.create(
+    OrderFunnelListener.prototype,
+  ) as OrderFunnelListener;
+  Object.assign(listener, {
+    logger,
+    flags: over.flags ?? { funnelServerEmitEnabled: true },
+    funnelEvents,
+    isReadOnlyMode: over.isReadOnlyMode ?? false,
+    supabase: over.supabase ?? {},
+  });
+  return { listener, logger, funnelEvents };
+}
+
+const PAID_EVENT: OrderPaidEvent = {
+  orderId: 'ORD-123',
+  customerId: 'CUST-1',
+  amount: 49.9,
+  paymentRef: 'PBX-REF',
+  gateway: 'paybox',
+  timestamp: '2026-06-23T10:00:00.000Z',
+};
+
+/** supabase mock returning a given line count + order total. */
+function supabaseWith(opts: {
+  count?: number | null;
+  countError?: { message: string } | null;
+  total?: unknown;
+  orderError?: { message: string } | null;
+}) {
+  return {
+    from: jest.fn((table: string) => {
+      if (table === '___xtr_order_line') {
+        return {
+          select: jest.fn(() => ({
+            eq: jest.fn(() =>
+              Promise.resolve({
+                count: opts.count ?? 0,
+                error: opts.countError ?? null,
+              }),
+            ),
+          })),
+        };
+      }
+      // ___xtr_order
+      return {
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            maybeSingle: jest.fn(() =>
+              Promise.resolve({
+                data:
+                  opts.total === undefined
+                    ? null
+                    : { ord_total_ttc: opts.total },
+                error: opts.orderError ?? null,
+              }),
+            ),
+          })),
+        })),
+      };
+    }),
+  };
+}
+
+describe('OrderFunnelListener.onOrderPaid', () => {
+  it('is inert when the flag is OFF (no fetch, no emit)', async () => {
+    const { listener, funnelEvents } = makeListener({
+      flags: { funnelServerEmitEnabled: false },
+    });
+    const fetchSpy = jest.spyOn(listener as never, 'fetchOrderFacts');
+    await listener.onOrderPaid(PAID_EVENT);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(funnelEvents.recordOnce).not.toHaveBeenCalled();
+  });
+
+  it('skips emission under READ_ONLY (PROD-only)', async () => {
+    const { listener, funnelEvents } = makeListener({ isReadOnlyMode: true });
+    const fetchSpy = jest.spyOn(listener as never, 'fetchOrderFacts');
+    await listener.onOrderPaid(PAID_EVENT);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(funnelEvents.recordOnce).not.toHaveBeenCalled();
+  });
+
+  it('records r2_order_placed with the correct payload on the happy path', async () => {
+    const { listener, funnelEvents } = makeListener();
+    jest
+      .spyOn(listener as never, 'fetchOrderFacts')
+      .mockResolvedValue({ itemCount: 2, revenueCents: 4990 } as never);
+
+    await listener.onOrderPaid(PAID_EVENT);
+
+    expect(funnelEvents.recordOnce).toHaveBeenCalledTimes(1);
+    expect(funnelEvents.recordOnce).toHaveBeenCalledWith({
+      event_type: 'r2_order_placed',
+      entity_url: null,
+      payload: {
+        session_id: null,
+        order_id: 'ORD-123',
+        item_count: 2,
+        revenue_cents: 4990,
+        referrer: null,
+      },
+    });
+  });
+
+  it('skips (no bogus row) and warns when the order has no readable lines', async () => {
+    const { listener, logger, funnelEvents } = makeListener();
+    jest
+      .spyOn(listener as never, 'fetchOrderFacts')
+      .mockResolvedValue({ itemCount: 0, revenueCents: null } as never);
+
+    await listener.onOrderPaid(PAID_EVENT);
+
+    expect(funnelEvents.recordOnce).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a real insert failure at error (no silent fallback)', async () => {
+    const recordOnce = jest
+      .fn()
+      .mockResolvedValue({ ok: false, deduped: false });
+    const { listener, logger } = makeListener({ funnelEvents: { recordOnce } });
+    jest
+      .spyOn(listener as never, 'fetchOrderFacts')
+      .mockResolvedValue({ itemCount: 1, revenueCents: 1000 } as never);
+
+    await listener.onOrderPaid(PAID_EVENT);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an idempotent dedup as benign (debug, not error)', async () => {
+    const recordOnce = jest.fn().mockResolvedValue({ ok: true, deduped: true });
+    const { listener, logger } = makeListener({ funnelEvents: { recordOnce } });
+    jest
+      .spyOn(listener as never, 'fetchOrderFacts')
+      .mockResolvedValue({ itemCount: 1, revenueCents: 1000 } as never);
+
+    await listener.onOrderPaid(PAID_EVENT);
+
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('never throws when fetching facts fails (non-blocking)', async () => {
+    const { listener, logger, funnelEvents } = makeListener();
+    jest
+      .spyOn(listener as never, 'fetchOrderFacts')
+      .mockRejectedValue(new Error('boom') as never);
+
+    await expect(listener.onOrderPaid(PAID_EVENT)).resolves.toBeUndefined();
+    expect(funnelEvents.recordOnce).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('OrderFunnelListener.fetchOrderFacts (supabase chain)', () => {
+  it('reads line count + parses the order total into cents', async () => {
+    const { listener } = makeListener({
+      supabase: supabaseWith({ count: 3, total: '49.90' }),
+    });
+    const facts = await (
+      listener as unknown as {
+        fetchOrderFacts: (id: string) => Promise<unknown>;
+      }
+    ).fetchOrderFacts('ORD-123');
+    expect(facts).toEqual({ itemCount: 3, revenueCents: 4990 });
+  });
+
+  it('returns null when the line-count read errors', async () => {
+    const { listener } = makeListener({
+      supabase: supabaseWith({
+        count: null,
+        countError: { message: 'db down' },
+      }),
+    });
+    const facts = await (
+      listener as unknown as {
+        fetchOrderFacts: (id: string) => Promise<unknown>;
+      }
+    ).fetchOrderFacts('ORD-123');
+    expect(facts).toBeNull();
+  });
+
+  it('yields null revenue when the total is absent/unparseable', async () => {
+    const { listener } = makeListener({
+      supabase: supabaseWith({ count: 1, total: 'n/a' }),
+    });
+    const facts = await (
+      listener as unknown as {
+        fetchOrderFacts: (
+          id: string,
+        ) => Promise<{ revenueCents: number | null }>;
+      }
+    ).fetchOrderFacts('ORD-123');
+    expect(facts.revenueCents).toBeNull();
+  });
+});
+
+describe('OrderFunnelListener.toCents', () => {
+  const cents = (v: unknown) =>
+    (
+      makeListener().listener as unknown as {
+        toCents: (v: unknown) => number | null;
+      }
+    ).toCents(v);
+
+  it.each([
+    ['49.90', 4990],
+    ['10', 1000],
+    ['0', 0],
+  ])('parses %s → %s cents', (input, expected) => {
+    expect(cents(input)).toBe(expected);
+  });
+
+  it.each([[null], [undefined], ['abc'], ['-5']])(
+    'returns null for %s',
+    (input) => {
+      expect(cents(input)).toBeNull();
+    },
+  );
+});

--- a/backend/src/modules/seo-monitoring/listeners/order-funnel.listener.ts
+++ b/backend/src/modules/seo-monitoring/listeners/order-funnel.listener.ts
@@ -1,0 +1,149 @@
+/**
+ * OrderFunnelListener — Commerce-Loop V1 (PR-A), server-side funnel emission.
+ *
+ * Records the conversion funnel event `r2_order_placed` into `__seo_event_log`
+ * from a GUARANTEED server-side signal (`ORDER_EVENTS.PAID`) instead of the lossy
+ * client beacon on the payment-return page (which captured 0 of every paid order:
+ * post-Paybox-redirect the tab is usually gone before `sendBeacon` fires).
+ *
+ * Why a listener (no payments/ touch): the paid transition itself lives in
+ * payments/ (NEVER-MODIFY without explicit nominative owner request). The single
+ * `emit(ORDER_EVENTS.PAID)` line in payments is a SEPARATE, owner-nominative
+ * change (PR-A′). This listener — and everything in PR-A — is built OUTSIDE
+ * payments and is fully inert until BOTH the flag is on AND that emit lands.
+ *
+ * Guarantees:
+ *  - Flag-gated (`FUNNEL_SERVER_EMIT_ENABLED`, default OFF) → inert by default.
+ *  - PROD-only: skipped under READ_ONLY (PREPROD anon cannot INSERT into
+ *    `__seo_event_log` — grants are service_role-only, ADR-028 Option D). Skipping
+ *    keeps PREPROD E2E green and keeps real PROD insert failures observable.
+ *  - Idempotent: `mark_order_paid_atomic.wasPaid` makes ORDER_EVENTS.PAID fire
+ *    once per order; `FunnelEventsService.recordOnce` + the partial unique index
+ *    `uq_seo_event_log_r2_order_placed_order_id` are defense-in-depth.
+ *  - Non-blocking & no silent fallback: never throws; a true insert failure is
+ *    logged at `error` (observable); a benign dedup is logged at `debug`.
+ *
+ * Authoritative facts (item_count, revenue) are read from the order SoT by
+ * orderId so the payments emit stays a literal one-liner carrying only the event.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { OnEvent } from '@nestjs/event-emitter';
+import { SupabaseBaseService } from '@database/services/supabase-base.service';
+import { FeatureFlagsService } from '@config/feature-flags.service';
+import type { FunnelEventInput } from '@repo/seo-types';
+import {
+  ORDER_EVENTS,
+  type OrderPaidEvent,
+} from '../../orders/events/order.events';
+import { FunnelEventsService } from '../services/funnel-events.service';
+
+@Injectable()
+export class OrderFunnelListener extends SupabaseBaseService {
+  protected readonly logger = new Logger(OrderFunnelListener.name);
+
+  constructor(
+    configService: ConfigService,
+    private readonly funnelEvents: FunnelEventsService,
+    private readonly flags: FeatureFlagsService,
+  ) {
+    super(configService);
+  }
+
+  @OnEvent(ORDER_EVENTS.PAID)
+  async onOrderPaid(event: OrderPaidEvent): Promise<void> {
+    // Inert by default — the whole PR-A scaffolding is a no-op until flipped on.
+    if (!this.flags.funnelServerEmitEnabled) return;
+    // PROD-only: PREPROD runs anon (ADR-028) and cannot INSERT here. Skip cleanly
+    // rather than fail-soft, so real PROD insert failures remain the only errors.
+    if (this.isReadOnlyMode) return;
+
+    try {
+      const facts = await this.fetchOrderFacts(event.orderId);
+      if (!facts || facts.itemCount < 1) {
+        // A paid order with no readable line is anomalous — surface it, never
+        // write a bogus event (item_count must be a positive int per contract).
+        this.logger.warn(
+          `r2_order_placed skipped for order ${event.orderId}: no readable order lines (itemCount=${facts?.itemCount ?? 'n/a'})`,
+        );
+        return;
+      }
+
+      const input: FunnelEventInput = {
+        event_type: 'r2_order_placed',
+        entity_url: null,
+        payload: {
+          // session_id/referrer are not persisted server-side today → null.
+          // Funnel stitching by session_id is a separate additive change (PR-A2):
+          // capture+persist the funnel session_id at order creation.
+          session_id: null,
+          order_id: event.orderId,
+          item_count: facts.itemCount,
+          revenue_cents: facts.revenueCents,
+          referrer: null,
+        },
+      };
+
+      const res = await this.funnelEvents.recordOnce(input);
+      if (!res.ok) {
+        this.logger.error(
+          `r2_order_placed emission failed for order ${event.orderId} (insert error)`,
+        );
+      } else if (res.deduped) {
+        this.logger.debug(
+          `r2_order_placed already recorded for order ${event.orderId} (idempotent skip)`,
+        );
+      }
+    } catch (error) {
+      // Never break the event pipeline — emission is measurement, not a sale path.
+      this.logger.warn(
+        `r2_order_placed listener failed for order ${event.orderId} (non-blocking): ${error}`,
+      );
+    }
+  }
+
+  /**
+   * Authoritative order facts read from the legacy order tables by orderId.
+   * Returns null when the line count cannot be read (caller skips emission).
+   * revenue_cents is best-effort: null when the total is absent/unparseable
+   * (the contract allows a null revenue, but never a null/invalid item_count).
+   */
+  private async fetchOrderFacts(
+    orderId: string,
+  ): Promise<{ itemCount: number; revenueCents: number | null } | null> {
+    const { count, error: countError } = await this.supabase
+      .from('___xtr_order_line')
+      .select('*', { count: 'exact', head: true })
+      .eq('ordl_ord_id', orderId);
+    if (countError) {
+      this.logger.error(
+        `r2_order_placed: order line count read failed for ${orderId}: ${countError.message}`,
+      );
+      return null;
+    }
+
+    const { data: order, error: orderError } = await this.supabase
+      .from('___xtr_order')
+      .select('ord_total_ttc')
+      .eq('ord_id', orderId)
+      .maybeSingle();
+    if (orderError) {
+      this.logger.warn(
+        `r2_order_placed: order total read failed for ${orderId} (revenue→null): ${orderError.message}`,
+      );
+    }
+
+    return {
+      itemCount: count ?? 0,
+      revenueCents: this.toCents(order?.ord_total_ttc),
+    };
+  }
+
+  /** ord_total_ttc is TEXT euros (e.g. "49.90") → integer cents, or null. */
+  private toCents(rawTotal: unknown): number | null {
+    if (rawTotal === null || rawTotal === undefined) return null;
+    const value = Number.parseFloat(String(rawTotal));
+    if (!Number.isFinite(value) || value < 0) return null;
+    return Math.round(value * 100);
+  }
+}

--- a/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
+++ b/backend/src/modules/seo-monitoring/seo-monitoring.module.ts
@@ -26,6 +26,7 @@ import { RContentAuditorService } from './services/r-content-auditor.service';
 import { QualityHistorySnapshotService } from './services/quality-history-snapshot.service';
 import { RagMirrorFreshnessService } from './services/rag-mirror-freshness.service';
 import { FunnelEventsService } from './services/funnel-events.service';
+import { OrderFunnelListener } from './listeners/order-funnel.listener';
 import { CwvBeaconService } from './services/cwv-beacon.service';
 import { CwvAggregationService } from './services/cwv-aggregation.service';
 import { RuntimeEventsService } from './services/runtime-events.service';
@@ -55,6 +56,7 @@ import { CwvDashboardController } from './controllers/cwv-dashboard.controller';
     QualityHistorySnapshotService, // ADR-050 Phase 0 baseline
     RagMirrorFreshnessService, // ADR-046 § L3 RAG MIRROR read-only — PR-E.2
     FunnelEventsService, // Commerce-Loop V1 étape 4-A — funnel outil diagnostic
+    OrderFunnelListener, // Commerce-Loop V1 PR-A — server-side r2_order_placed @OnEvent(order.paid), flag OFF + READ_ONLY-skip
     CwvBeaconService, // CWV Runtime Observability bloc 3 — landing beacons web-vitals
     CwvAggregationService, // CWV bloc 4 — RPCs aggregate_cwv_hourly/daily_rum
     RuntimeEventsService, // CWV bloc 5 — wrapper __seo_event_log pour 4 runtime events

--- a/backend/src/modules/seo-monitoring/services/funnel-events.service.ts
+++ b/backend/src/modules/seo-monitoring/services/funnel-events.service.ts
@@ -43,4 +43,38 @@ export class FunnelEventsService extends SupabaseBaseService {
     }
     return { ok: true };
   }
+
+  /**
+   * Idempotent variant for GUARANTEED server-side emission (Commerce-Loop V1 PR-A).
+   *
+   * Same insert as `record()`, but a `23505` unique_violation (raised by the
+   * partial unique index `uq_seo_event_log_r2_order_placed_order_id`) is treated
+   * as a BENIGN idempotent skip (`deduped: true`) — the event already exists for
+   * this natural key, no duplicate sale is written. Any OTHER error is a real
+   * failure: logged at `error` (observable, never silent — CLAUDE.md) and
+   * returned as `{ ok: false }` so the caller can surface it.
+   *
+   * Used by server-side emitters (e.g. OrderFunnelListener) where a duplicate is
+   * expected-and-harmless but a true write failure must not be swallowed.
+   */
+  async recordOnce(
+    input: FunnelEventInput,
+  ): Promise<{ ok: boolean; deduped: boolean }> {
+    const { error } = await this.supabase.from('__seo_event_log').insert({
+      event_type: input.event_type,
+      entity_url: input.entity_url ?? null,
+      severity: 'info',
+      payload: input.payload,
+    });
+    if (error) {
+      if (error.code === '23505') {
+        return { ok: true, deduped: true };
+      }
+      this.logger.error(
+        `funnel event insert failed (${input.event_type}): ${error.message}`,
+      );
+      return { ok: false, deduped: false };
+    }
+    return { ok: true, deduped: false };
+  }
 }

--- a/backend/supabase/migrations/20260623_seo_event_log_r2_order_placed_idempotency.down.sql
+++ b/backend/supabase/migrations/20260623_seo_event_log_r2_order_placed_idempotency.down.sql
@@ -1,0 +1,4 @@
+-- Rollback: idempotency guard for server-side r2_order_placed funnel emission.
+-- Additive index → fully reversible, no data loss.
+
+DROP INDEX IF EXISTS public.uq_seo_event_log_r2_order_placed_order_id;

--- a/backend/supabase/migrations/20260623_seo_event_log_r2_order_placed_idempotency.sql
+++ b/backend/supabase/migrations/20260623_seo_event_log_r2_order_placed_idempotency.sql
@@ -14,13 +14,20 @@
 --   - EXPRESSION key = payload->>'order_id' (the natural idempotency key).
 --   - NULL order_id is treated as distinct (default) — never blocks; the listener
 --     always sets order_id, malformed rows are not silently merged.
---   - Plain (non-CONCURRENTLY) build: the constrained subset has 0 rows today, so
---     the index builds in milliseconds; no meaningful write-lock window.
 --   - Additive + reversible (see .down.sql). Forward-only, no data rewrite.
 --
 -- The application layer (FunnelEventsService.recordOnce) treats the 23505
 -- unique_violation raised by this index as a benign idempotent skip, NOT a
 -- silent failure (real insert errors still surface) — CLAUDE.md no-silent-fallback.
+-- ⚠️ NON auto-appliquée à la DB partagée (deployment.md axe 4) : revue owner + apply_migration manuel.
+
+-- squawk-ignore-file require-concurrent-index-creation
+--   assume_in_transaction=true (.squawk.toml) → CONCURRENTLY interdit en transaction ; le sous-ensemble
+--   partiel (event_type = 'r2_order_placed') compte 0 ligne aujourd'hui → build en millisecondes,
+--   fenêtre de write-lock négligeable. Pattern identique à 20260619_adr059_pr6_seo_projection_schema.sql.
+-- Transaction gérée par l'outil de migration (assume_in_transaction=true). Timeouts requis (require-timeout-settings) :
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_seo_event_log_r2_order_placed_order_id
   ON public.__seo_event_log ((payload ->> 'order_id'))

--- a/backend/supabase/migrations/20260623_seo_event_log_r2_order_placed_idempotency.sql
+++ b/backend/supabase/migrations/20260623_seo_event_log_r2_order_placed_idempotency.sql
@@ -1,0 +1,30 @@
+-- Migration: idempotency guard for server-side r2_order_placed funnel emission
+-- Commerce-Loop V1 — PR-A (server-side funnel emission).
+--
+-- Context: __seo_event_log has NO unique constraint (only PK on id). When
+-- r2_order_placed moves from the lossy client beacon to a guaranteed SERVER-side
+-- emission (OrderFunnelListener @OnEvent(ORDER_EVENTS.PAID)), the source already
+-- gives exactly-once semantics via mark_order_paid_atomic.wasPaid. This index is
+-- DEFENSE-IN-DEPTH: it makes a double-emit (event redelivery, retried callback)
+-- a benign no-op instead of a duplicated sale.
+--
+-- Design:
+--   - PARTIAL: only r2_order_placed rows are constrained (other event_types and
+--     the existing 6k+ rows are untouched — zero behavior change for them).
+--   - EXPRESSION key = payload->>'order_id' (the natural idempotency key).
+--   - NULL order_id is treated as distinct (default) — never blocks; the listener
+--     always sets order_id, malformed rows are not silently merged.
+--   - Plain (non-CONCURRENTLY) build: the constrained subset has 0 rows today, so
+--     the index builds in milliseconds; no meaningful write-lock window.
+--   - Additive + reversible (see .down.sql). Forward-only, no data rewrite.
+--
+-- The application layer (FunnelEventsService.recordOnce) treats the 23505
+-- unique_violation raised by this index as a benign idempotent skip, NOT a
+-- silent failure (real insert errors still surface) — CLAUDE.md no-silent-fallback.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_seo_event_log_r2_order_placed_order_id
+  ON public.__seo_event_log ((payload ->> 'order_id'))
+  WHERE event_type = 'r2_order_placed';
+
+COMMENT ON INDEX public.uq_seo_event_log_r2_order_placed_order_id IS
+  'Idempotency for server-side r2_order_placed emission (Commerce-Loop V1 PR-A): one funnel event per order_id. Defense-in-depth behind mark_order_paid_atomic.wasPaid exactly-once.';


### PR DESCRIPTION
## Pourquoi

`r2_order_placed` (l'event de **conversion** du funnel) était émis **côté client uniquement**, depuis un `useEffect` sur la page de retour Paybox → il a capturé **0 commande payée** (onglet fermé avant `sendBeacon`). D'où `r2_order_placed`=0 et `can_sell` non mesurable dans la scorecard 2026-06-23.

PR-A câble une **émission serveur garantie**, **inerte jusqu'à activation**, avec **zéro modification de `payments/`**.

## Ce qui atterrit (tout HORS `payments/`)

- **`OrderFunnelListener`** `@OnEvent(ORDER_EVENTS.PAID)` → enregistre `r2_order_placed` dans `__seo_event_log` via le `FunnelEventsService` canonique. Lit `item_count` + `revenue` **autoritatifs** depuis la SoT commande par `orderId`, pour que l'émission côté paiement reste une **ligne unique**.
- **`FeatureFlagsService.funnelServerEmitEnabled`** (`FUNNEL_SERVER_EMIT_ENABLED`, **défaut OFF**, ajouté à `ALLOWED_KEYS`) — flag gouverné, rollback-able.
- **`FunnelEventsService.recordOnce()`** — insert idempotent : `23505` (unique_violation) = dédup bénigne ; toute autre erreur est **remontée en `error`** (no silent fallback).
- **Migration additive** : index unique partiel `uq_seo_event_log_r2_order_placed_order_id` (+ `.down.sql`) — défense-en-profondeur derrière `mark_order_paid_atomic.wasPaid`.
- **17 tests unitaires** (flag-off inerte, skip READ_ONLY, payload, no-bogus-row, échec observable, dédup idempotente, non-bloquant, chaîne supabase, toCents).

## Garde-fous (runtime-awareness)

- **Flag-gated défaut OFF** → inerte par défaut.
- **PROD-only** : émission skippée sous `READ_ONLY` (PREPROD = anon, et `__seo_event_log` n'accorde `INSERT` qu'à `service_role`, ADR-028) → PREPROD E2E reste vert, et seuls les vrais échecs PROD remontent.
- **Idempotent** (`wasPaid` exactly-once + index unique partiel).
- **Non-bloquant** : le listener ne jette jamais (la mesure ne casse pas le flux).
- **Observabilité interne** réutilisée (`__seo_event_log`) — pas de canary externe.

## Inerte jusqu'à (séquence d'activation, owner-gated)

1. **Appliquer la migration** (index idempotence) — convention axe-4 : appliquée à la main, pas auto.
2. **PR-A′** : la ligne unique `emit(ORDER_EVENTS.PAID, …)` dans `payments/` — **NOMINATIVE-GATED** (modif `payments/` = GO nominatif explicite requis ; `payments/` émet déjà `ORDER_EVENTS.REFUNDED`, dépendance existante).
3. **Flip** `FUNNEL_SERVER_EMIT_ENABLED` (shadow → on) en PROD.

## Caveat honnête

0 commande payée / 30j → même parfaitement instrumenté, la métrique lira **~0**. PR-A rend la mesure **fiable**, elle ne crée pas de ventes. Le tunnel paiement quasi-mort est un problème **commerce réel**, séparé.

## Vérification locale

- `jest order-funnel.listener.test.ts` → **17/17 PASS**
- `eslint` 5 fichiers → clean · `tsc --noEmit` → clean sur les fichiers touchés · ast-grep onModuleInit guard → ok

## Note CI — block-new gate

Les **2 fichiers de migration** ne sont pas couverts par un glob `ownership.yaml` (les migrations n'ont que des globs spécifiques). Le listener (`seo-monitoring/**`) + le test (`*.test.ts`) passent. Glob à ajouter (airlock owner-only) :
```yaml
  - glob: backend/supabase/migrations/*seo_event_log*
    domain: D3
    owner: '@ak125/seo-team'
    sourceConfidence: high
    risk: low
```

Plan complet : `~/.claude/plans/commerce-funnel-instrumentation-v1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)