### PR TITLE
feat(rr8-prep): A3 — adopt future.v8_trailingSlashAwareDataRequests (RR7.18)

### DIFF
--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -16,6 +16,9 @@ import { type Config } from "@react-router/dev/config";
  * - A2 `v8_passThroughRequests` : passe la requête HTTP brute aux loaders/actions
  *   (la `Request.url`/host est désormais reconstruite côté serveur — à valider
  *   derrière Caddy : X-Forwarded-Host → contrôle d'origine CSRF des actions).
+ * - A3 `v8_trailingSlashAwareDataRequests` : préserve le trailing-slash dans les
+ *   URLs de requête `.data` (fetch single-fetch interne). N'affecte PAS les URLs
+ *   de page canoniques → gate `url-immutability` (147/147) préservé.
  */
 export default {
   ssr: true,
@@ -23,5 +26,6 @@ export default {
   future: {
     v8_viteEnvironmentApi: true,
     v8_passThroughRequests: true,
+    v8_trailingSlashAwareDataRequests: true,
   },
 } satisfies Config;


### PR DESCRIPTION
## Temps A — flag 3/5 (stacké sur A2 #1118)

`future.v8_trailingSlashAwareDataRequests` : préserve le trailing-slash dans les URLs de requête `.data` (single-fetch interne) ; deviendra le défaut en RR8.

**N'affecte PAS les URLs de page canoniques** — seulement les endpoints internes `.data` de fetch client. Le gate `url-immutability` compare la surface canonique des *route files* modifiés ; aucun route file n'est touché ici → non concerné. Le comportement runtime des `.data` (trailing-slash) est confirmé sur le container PREPROD après merge.

### Validation locale (base = main post-#1116)
- typecheck : 0 erreur · build turbo : 8/8 · lint : 0 erreur
- diff = `react-router.config.ts` uniquement

À merger après A2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)