### PR TITLE
feat(rr8-prep): A4 — adopt future.v8_splitRouteModules: true (RR7.18)

### DIFF
--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -19,6 +19,9 @@ import { type Config } from "@react-router/dev/config";
  * - A3 `v8_trailingSlashAwareDataRequests` : préserve le trailing-slash dans les
  *   URLs de requête `.data` (fetch single-fetch interne). N'affecte PAS les URLs
  *   de page canoniques → gate `url-immutability` (147/147) préservé.
+ * - A4 `v8_splitRouteModules: true` (PAS `"enforce"`) : découpe automatiquement
+ *   les exports de route en chunks séparés quand c'est possible. `true` (et non
+ *   `"enforce"`) pour ne pas faire échouer le build sur une route non-séparable.
  */
 export default {
   ssr: true,
@@ -27,5 +30,6 @@ export default {
     v8_viteEnvironmentApi: true,
     v8_passThroughRequests: true,
     v8_trailingSlashAwareDataRequests: true,
+    v8_splitRouteModules: true,
   },
 } satisfies Config;


### PR DESCRIPTION
## Temps A — flag 4/5 (stacké sur A3 #1120)

`future.v8_splitRouteModules: true` : découpe automatiquement les exports de route (`clientLoader`/`clientAction`/`clientMiddleware`/`HydrateFallback`) en chunks séparés ; deviendra le défaut en RR8. **`true` et NON `"enforce"`** (qui ferait échouer le build sur une route non-séparable — réservé à un audit ultérieur).

### Validation locale (build forcé, non caché — change le graphe de chunks)
- typecheck : 0 · build turbo : 8/8
- ✅ chunk **`sentry-vendor-*.js` toujours produit** → le strip `modulepreload` de `vite.config.ts` (qui en dépend, lignes 40-64) reste fonctionnel
- 191 chunks client → découpage des modules de route effectif

À merger après A3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)