### PR TITLE
feat(rr8-prep): A2 — adopt future.v8_passThroughRequests (RR7.18)

### DIFF
--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -13,11 +13,15 @@ import { type Config } from "@react-router/dev/config";
  * un flag par PR pour isoler les régressions ; ces flags deviennent le comportement
  * par défaut en RR8 et seront retirés au bump) :
  * - A1 `v8_viteEnvironmentApi` : active la Vite Environment API (requiert Vite 7 ✅).
+ * - A2 `v8_passThroughRequests` : passe la requête HTTP brute aux loaders/actions
+ *   (la `Request.url`/host est désormais reconstruite côté serveur — à valider
+ *   derrière Caddy : X-Forwarded-Host → contrôle d'origine CSRF des actions).
  */
 export default {
   ssr: true,
   serverModuleFormat: "esm",
   future: {
     v8_viteEnvironmentApi: true,
+    v8_passThroughRequests: true,
   },
 } satisfies Config;


### PR DESCRIPTION
## Temps A — flag 2/5 (rebasé sur `main` après merge de A1 #1111)

`future.v8_passThroughRequests` : passe la requête HTTP brute aux loaders/actions ; deviendra le défaut en RR8. Un flag par PR pour isoler les régressions. (Remplace #1118, fermé mécaniquement par la suppression de la branche de base A1.)

### Validation locale
- typecheck : 0 · build turbo (deps-first) : 8/8 · lint : 0 erreur

### 🔐 Finding sécurité (CSRF / host-spoof) — vérifié, mitigé
Revue auto (MEDIUM) : risque de bypass d'origine CSRF par `X-Forwarded-Host` spoofé. **Vecteur déjà fermé au niveau edge** :
- `config/caddy/Caddyfile` **écrase** `X-Forwarded-Host` avec `{host}` validé par Caddy sur chaque bloc reverse-proxy (lignes 188/200/247/263/286) → valeur client remplacée, non propagée.
- `trusted_proxies static <CIDRs Cloudflare>` (ligne 12) → seul Cloudflare est un proxy de confiance.
- NestJS `trust proxy = 1` ; cookies session `SameSite: lax`.

### ⚠️ Gate PREPROD obligatoire après merge (preuve runtime, pas juste config)
Tester POST panier · POST checkout **non payant** · auth/login · action espace client. Pour chaque : origine `https://www.automecanik.com` **acceptée** ; `Origin` externe **refusée** ; `X-Forwarded-Host` frauduleux client → **ne modifie pas `Request.url`** ; session/cookie conservés ; `Request.url` reste HTTPS + domaine canonique. **Pas de vrai paiement.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)