### PR TITLE
feat(rr8-prep): A6 — adopt future.v8_middleware + RouterContextProvider bridge (RR7.18)

### DIFF
--- a/.claude/knowledge/modules/seo-monitoring.md
+++ b/.claude/knowledge/modules/seo-monitoring.md
@@ -11,7 +11,7 @@ primary_files:
 - backend/src/modules/seo-monitoring/controllers/runtime-events.controller.ts
 - backend/src/modules/seo-monitoring/controllers/seo-monitoring.controller.ts
 - backend/src/modules/seo-monitoring/helpers/ai-readiness-detectors.ts
-- backend/src/modules/seo-monitoring/processors/cwv-aggregation.processor.ts
+- backend/src/modules/seo-monitoring/listeners/order-funnel.listener.test.ts
 depends_on:
 - ConfigModule
 ---

--- a/backend/src/remix/remix.controller.test.ts
+++ b/backend/src/remix/remix.controller.test.ts
@@ -1,22 +1,35 @@
 /**
- * Injection gate — the SSR observability reporter MUST be present in the
- * AppLoadContext returned by getLoadContext.
+ * Injection gate — the SSR observability reporter MUST be handed to the
+ * load-context factory by the controller.
  *
- * Production topology is always NestJS → React Router (embedded), so the SSR
- * bridge (entry.server handleError/onError + reportLoaderError) depends on
- * `context.serverObservability` being injected here. Without it the bridge
- * silently no-ops. This locks PRODUCTION_EMBEDDED_SERVER_OBSERVABILITY = REQUIRED.
+ * Production topology is always NestJS → React Router (embedded). Under
+ * `v8_middleware` (A6) the load context is a `RouterContextProvider` built by
+ * the SSR-realm factory `createAppLoadContext`, bridged into NestJS (CJS) via
+ * `@fafa/frontend`'s `getCreateAppLoadContext` (the keys never cross realms —
+ * dual-realm safety, incident #1106). The SSR bridge (entry.server
+ * handleError/onError + reportLoaderError) reads the reporter via
+ * `context.get(serverObservabilityContext)`, so the controller MUST pass a
+ * `serverObservability` reporter INTO that factory. This locks
+ * PRODUCTION_EMBEDDED_SERVER_OBSERVABILITY = REQUIRED at the backend boundary.
  *
- * Anti-vacuity: the handler awaits getServerBuild() (mocked) BEFORE
- * createRequestHandler, inside a try/catch that swallows failures into a 500 —
- * so without the @fafa/frontend mock + the toHaveBeenCalled() check the test
- * could pass without ever reaching getLoadContext. `expect.assertions(2)` guards.
+ * Split of concerns: the provider's key identity / `.get()` round-trip is
+ * covered by the frontend `load-context-identity.test.ts`; here we lock the
+ * BACKEND contract — getLoadContext invokes the factory with a
+ * `serverObservability.captureException`. The factory is mocked as an
+ * identity passthrough so the gate can inspect the values it receives.
+ *
+ * Anti-vacuity: the handler awaits getServerBuild()+getCreateAppLoadContext()
+ * (both mocked) BEFORE createRequestHandler, inside a try/catch that swallows
+ * failures into a 500 — so without the mocks + the toHaveBeenCalled() check the
+ * test could pass without ever reaching getLoadContext. `expect.assertions(2)` guards.
  */
+import { getCreateAppLoadContext } from '@fafa/frontend';
 import { createRequestHandler } from '@react-router/express';
 import { RemixController } from './remix.controller';
 
 jest.mock('@fafa/frontend', () => ({
   getServerBuild: jest.fn().mockResolvedValue({}),
+  getCreateAppLoadContext: jest.fn(),
 }));
 jest.mock('@sentry/nestjs', () => ({
   withScope: jest.fn(),
@@ -31,6 +44,15 @@ jest.mock('./remix-api.service', () => ({ RemixApiService: class {} }));
 describe('RemixController — serverObservability injection gate', () => {
   it('injects serverObservability into getLoadContext (embedded prod)', async () => {
     expect.assertions(2);
+
+    // A6 factory bridge: getCreateAppLoadContext resolves the SSR-realm factory.
+    // Mock it as an identity passthrough so the gate inspects the exact values
+    // the controller hands in (the real factory wraps them in a
+    // RouterContextProvider — its key round-trip is the frontend identity test).
+    jest
+      .mocked(getCreateAppLoadContext)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockResolvedValue(((values: any) => values) as any);
 
     jest.mocked(createRequestHandler).mockImplementation(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/backend/src/remix/remix.controller.ts
+++ b/backend/src/remix/remix.controller.ts
@@ -1,4 +1,4 @@
-import { getServerBuild } from '@fafa/frontend';
+import { getServerBuild, getCreateAppLoadContext } from '@fafa/frontend';
 import {
   All,
   Controller,
@@ -76,17 +76,25 @@ export class RemixController {
     }
 
     try {
-      const build = await getServerBuild();
+      // v8_middleware: `getLoadContext` must return a `RouterContextProvider`.
+      // The factory is sourced from the SSR build's `entry.module` via the
+      // façade bridge (`getCreateAppLoadContext`), so NestJS (CJS) never imports
+      // the identity-keyed `createContext()` keys — dual-realm safety (#1106).
+      // `parsedBody` dropped (DEAD).
+      const [build, createAppLoadContext] = await Promise.all([
+        getServerBuild(),
+        getCreateAppLoadContext(),
+      ]);
       return createRequestHandler({
         build,
-        getLoadContext: () => ({
-          user: request.user,
-          remixService: this.remixService,
-          remixIntegration: this.remixApiService,
-          parsedBody: request.body,
-          cspNonce: response.locals.cspNonce,
-          serverObservability,
-        }),
+        getLoadContext: () =>
+          createAppLoadContext({
+            user: request.user,
+            remixService: this.remixService,
+            remixIntegration: this.remixApiService,
+            cspNonce: response.locals.cspNonce ?? '',
+            serverObservability,
+          }),
       })(request, response, next);
     } catch (error) {
       // L'échec de chargement du build SSR survient AVANT que entry.server.tsx prenne

--- a/backend/src/remix/remix.controller.ts
+++ b/backend/src/remix/remix.controller.ts
@@ -14,6 +14,21 @@ import { NextFunction, Request, Response } from 'express';
 import { RemixService } from './remix.service';
 import { RemixApiService } from './remix-api.service';
 
+// v8_middleware (A6): the frontend enables `future.v8_middleware`; `react-router
+// typegen` augments `Future` for the FRONTEND project only. This backend project
+// (separate tsconfig) does not see that augmentation, so without this declaration
+// `MiddlewareEnabled` resolves to `false` here and `@react-router/express`'s
+// `getLoadContext` would be typed to return `AppLoadContext` ({ [k]: unknown }) —
+// which a `RouterContextProvider` is NOT assignable to (no index signature). This
+// ambient augmentation aligns the backend's type view with the runtime truth (the
+// same Node process serves the middleware-enabled SSR build), so `getLoadContext`
+// correctly expects the `RouterContextProvider` produced by the façade factory.
+declare module 'react-router' {
+  interface Future {
+    v8_middleware: true;
+  }
+}
+
 /**
  * Pont d'observabilité serveur — UNIQUE client Sentry = `@sentry/nestjs` (init dans
  * `backend/src/instrument.ts`). Le bundle SSR React Router ne charge AUCUN SDK serveur

--- a/frontend/app/auth/unified.server.ts
+++ b/frontend/app/auth/unified.server.ts
@@ -1,5 +1,6 @@
-import { redirect, type AppLoadContext } from "react-router";
+import { redirect, type RouterContextProvider } from "react-router";
 import { z } from "zod";
+import { userContext } from "~/server/load-context";
 import { logger } from "~/utils/logger";
 import { getProxyHeaders } from "~/utils/proxy-headers.server";
 
@@ -60,18 +61,19 @@ const authenticatedUserSchema = z.object({
 export const getOptionalUser = async ({
   context,
 }: {
-  context: AppLoadContext;
+  context: Readonly<RouterContextProvider>;
 }): Promise<AuthUser | null> => {
   try {
-    if (context.user && typeof context.user === "object") {
-      const rawUser = context.user as RawContextUser;
+    const ctxUser = context.get(userContext);
+    if (ctxUser && typeof ctxUser === "object") {
+      const rawUser = ctxUser as RawContextUser;
       if (rawUser.error) {
         return null;
       }
       const user = authenticatedUserSchema
         .optional()
         .nullable()
-        .parse(context.user);
+        .parse(ctxUser);
       if (user) {
         return {
           id: rawUser.id ?? "",
@@ -192,7 +194,7 @@ export const requireUser = async ({
   context,
   request,
 }: {
-  context: AppLoadContext;
+  context: Readonly<RouterContextProvider>;
   request?: Request;
 }): Promise<AuthUser> => {
   const user = await getOptionalUser({ context });
@@ -216,7 +218,7 @@ export const requireUser = async ({
 export const requireAuth = async (
   requestOrOptions:
     | Request
-    | { request: Request; context?: AppLoadContext; redirectTo?: string },
+    | { request: Request; context?: Readonly<RouterContextProvider>; redirectTo?: string },
 ): Promise<AuthUser> => {
   let request: Request;
   let redirectTo = "/login";
@@ -249,7 +251,7 @@ export const requireUserWithRedirect = async ({
   context,
 }: {
   request: Request;
-  context: AppLoadContext;
+  context: Readonly<RouterContextProvider>;
 }): Promise<AuthUser> => {
   const user = await getOptionalUser({ context });
   if (!user) {
@@ -270,7 +272,7 @@ export const requireUserWithRedirect = async ({
 export const requireAdmin = async ({
   context,
 }: {
-  context: AppLoadContext;
+  context: Readonly<RouterContextProvider>;
 }): Promise<AuthUser> => {
   const user = await getOptionalUser({ context });
 
@@ -303,7 +305,7 @@ export const requireAdmin = async ({
 export const redirectIfAuthenticated = async ({
   context,
 }: {
-  context: AppLoadContext;
+  context: Readonly<RouterContextProvider>;
 }) => {
   const user = await getOptionalUser({ context });
   if (user) {

--- a/frontend/app/auth/unified.server.ts
+++ b/frontend/app/auth/unified.server.ts
@@ -1,6 +1,6 @@
 import { redirect, type RouterContextProvider } from "react-router";
 import { z } from "zod";
-import { userContext } from "~/server/load-context";
+import { userContext } from "~/utils/load-context";
 import { logger } from "~/utils/logger";
 import { getProxyHeaders } from "~/utils/proxy-headers.server";
 

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -17,7 +17,7 @@ import {
 import {
   cspNonceContext,
   serverObservabilityContext,
-} from "~/server/load-context";
+} from "~/utils/load-context";
 import { logger } from "~/utils/logger";
 import  { type ServerObservability } from "~/utils/observability-contract";
 
@@ -25,7 +25,7 @@ import  { type ServerObservability } from "~/utils/observability-contract";
 // `build.entry.module` for the NestJS façade bridge (`getCreateAppLoadContext`).
 // This is the CJS→ESM pont: NestJS calls the factory without ever importing the
 // identity-keyed `createContext()` keys (dual-realm safety, incident #1106).
-export { createAppLoadContext } from "~/server/load-context";
+export { createAppLoadContext } from "~/utils/load-context";
 
 // ⚠️ NO server-side Sentry SDK in this SSR bundle — DO NOT add `Sentry.init()` /
 // import `@sentry/node` / `@sentry/react-router` here. `@sentry/nestjs`

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -10,12 +10,22 @@ import { isbot } from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
 import {
   ServerRouter,
-  type AppLoadContext,
   type EntryContext,
   type HandleErrorFunction,
+  type RouterContextProvider,
 } from "react-router";
-import type { ServerObservability } from "~/utils/observability-contract";
+import {
+  cspNonceContext,
+  serverObservabilityContext,
+} from "~/server/load-context";
 import { logger } from "~/utils/logger";
+import  { type ServerObservability } from "~/utils/observability-contract";
+
+// Re-export the load-context factory so the SSR build exposes it on
+// `build.entry.module` for the NestJS façade bridge (`getCreateAppLoadContext`).
+// This is the CJS→ESM pont: NestJS calls the factory without ever importing the
+// identity-keyed `createContext()` keys (dual-realm safety, incident #1106).
+export { createAppLoadContext } from "~/server/load-context";
 
 // ⚠️ NO server-side Sentry SDK in this SSR bundle — DO NOT add `Sentry.init()` /
 // import `@sentry/node` / `@sentry/react-router` here. `@sentry/nestjs`
@@ -32,16 +42,15 @@ export const handleError: HandleErrorFunction = (
   error,
   { request, context },
 ): void => {
-  // `context` is `any` in RR7 (DefaultContext, no v8_middleware). RR8 CHECKPOINT:
-  // enabling `v8_middleware` makes it `RouterContextProvider` (no .serverObservability)
-  // → this access becomes a TS error and the pont must move to `context.get(...)`.
-  const ctx = context as AppLoadContext;
+  // v8_middleware: `context` is a Readonly<RouterContextProvider>. Read the
+  // NestJS-owned reporter via the typed key (nullable default → never throws).
+  const observability = context.get(serverObservabilityContext);
   // Skip aborted requests (client gone) — equivalent to @sentry/react-router's
   // createSentryHandleError abort guard. `flushIfServerless` deliberately NOT
   // reproduced: persistent NestJS process, not serverless (and RR doesn't await
   // handleError anyway).
   if (!request.signal.aborted) {
-    ctx.serverObservability?.captureException(error, {
+    observability?.captureException(error, {
       mechanism: { type: "react-router", handled: false },
       tags: { observability_channel: "react-router-handle-error" },
       extra: { method: request.method, pathname: new URL(request.url).pathname },
@@ -62,12 +71,12 @@ export default function handleRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
-  loadContext: AppLoadContext,
+  loadContext: RouterContextProvider,
 ) {
-  const nonce = loadContext.cspNonce || "";
+  const nonce = loadContext.get(cspNonceContext) || "";
   // Pass the reporter OBJECT (not a detached method) down so the streaming
   // onError callbacks can forward render errors to the NestJS-owned Sentry client.
-  const observability = loadContext.serverObservability;
+  const observability = loadContext.get(serverObservabilityContext) ?? undefined;
 
   return isbot(request.headers.get("user-agent") || "")
     ? handleBotRequest(

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -29,7 +29,7 @@ import {
   useNavigation,
 } from "react-router";
 
-import { cspNonceContext } from "~/server/load-context";
+import { cspNonceContext } from "~/utils/load-context";
 import { logger } from "~/utils/logger";
 import { getOptionalUser } from "./auth/unified.server";
 import { ErrorGeneric } from "./components/errors";

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -29,7 +29,7 @@ import {
   useNavigation,
 } from "react-router";
 
-import type { ServerObservability } from "~/utils/observability-contract";
+import { cspNonceContext } from "~/server/load-context";
 import { logger } from "~/utils/logger";
 import { getOptionalUser } from "./auth/unified.server";
 import { ErrorGeneric } from "./components/errors";
@@ -132,7 +132,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
     user,
     cart: cartPromise,
     isBot,
-    cspNonce: context.cspNonce || "",
+    cspNonce: context.get(cspNonceContext) || "",
     // Public runtime env exposed to the browser via `window.ENV` (see <script>
     // injection below). Same image runs in DEV/PROD with different values, so
     // these MUST be read at request time, not inlined at build time.
@@ -167,17 +167,6 @@ export const action = async (_args: ActionFunctionArgs) => {
 
 // Re-exports depuis module neutre pour éviter la dépendance circulaire root ↔ Navbar
 export { useOptionalUser, useRootCart } from "./hooks/useRootData";
-
-declare module "react-router" {
-  interface AppLoadContext {
-    remixService: any;
-    remixIntegration?: any; // injection côté Nest: RemixApiService
-    parsedBody?: any;
-    user: unknown;
-    cspNonce?: string; // injecté par le handler NestJS (response.locals.cspNonce)
-    serverObservability?: ServerObservability; // pont SSR → client Sentry NestJS (remix.controller.ts)
-  }
-}
 
 /** Error boundary that silently catches ChatWidget crashes without affecting the app. */
 class ChatWidgetErrorBoundary extends Component<

--- a/frontend/app/routes/admin.debug.tsx
+++ b/frontend/app/routes/admin.debug.tsx
@@ -4,6 +4,7 @@ import {
   useLoaderData,
 } from "react-router";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
+import { userContext } from "~/server/load-context";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
 import { getOptionalUser } from "../auth/unified.server";
 
@@ -11,13 +12,17 @@ export const meta: MetaFunction = () => createNoIndexMeta("Debug - Admin");
 
 export async function loader({ context }: LoaderFunctionArgs) {
   const user = await getOptionalUser({ context });
+  const ctxUser = context.get(userContext);
 
   return {
     user: user,
     context: {
-      hasUser: !!context.user,
-      userType: typeof context.user,
-      userKeys: context.user ? Object.keys(context.user) : [],
+      hasUser: !!ctxUser,
+      userType: typeof ctxUser,
+      userKeys:
+        ctxUser && typeof ctxUser === "object"
+          ? Object.keys(ctxUser as object)
+          : [],
     },
   };
 }

--- a/frontend/app/routes/admin.debug.tsx
+++ b/frontend/app/routes/admin.debug.tsx
@@ -4,7 +4,7 @@ import {
   useLoaderData,
 } from "react-router";
 import { PublicBreadcrumb } from "~/components/ui/PublicBreadcrumb";
-import { userContext } from "~/server/load-context";
+import { userContext } from "~/utils/load-context";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
 import { getOptionalUser } from "../auth/unified.server";
 

--- a/frontend/app/routes/admin.tsx
+++ b/frontend/app/routes/admin.tsx
@@ -14,6 +14,7 @@ import {
   isRouteErrorResponse,
 } from "react-router";
 import { ErrorGeneric } from "~/components/errors";
+import { userContext } from "~/server/load-context";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { getOptionalUser, getAuthUser } from "../auth/unified.server";
@@ -39,7 +40,7 @@ export const meta: MetaFunction = () => {
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
   // Auth unifiée : context d'abord, puis fallback request (JWT)
-  let user = context?.user ? await getOptionalUser({ context }) : null;
+  let user = context.get(userContext) ? await getOptionalUser({ context }) : null;
   if (!user) {
     user = await getAuthUser(request);
   }

--- a/frontend/app/routes/admin.tsx
+++ b/frontend/app/routes/admin.tsx
@@ -14,7 +14,7 @@ import {
   isRouteErrorResponse,
 } from "react-router";
 import { ErrorGeneric } from "~/components/errors";
-import { userContext } from "~/server/load-context";
+import { userContext } from "~/utils/load-context";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { logger } from "~/utils/logger";
 import { getOptionalUser, getAuthUser } from "../auth/unified.server";

--- a/frontend/app/routes/cart.tsx
+++ b/frontend/app/routes/cart.tsx
@@ -56,6 +56,7 @@ import {
   type CartItem as CartItemType,
   type CartSummary as CartSummaryType,
 } from "~/schemas/cart.schemas";
+import { serverObservabilityContext } from "~/server/load-context";
 import { trackViewCart } from "~/utils/analytics";
 import { logger } from "~/utils/logger";
 import { reportLoaderError } from "~/utils/observability.server";
@@ -168,10 +169,15 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
   } catch (err) {
     // Observabilité : un getCart en échec est rattrapé ici (dégradation
     // gracieuse) → invisible pour Sentry sans remontée explicite.
-    reportLoaderError(context.serverObservability, "cart_load_failed", err, {
-      method: request.method,
-      pathname: new URL(request.url).pathname,
-    });
+    reportLoaderError(
+      context.get(serverObservabilityContext) ?? undefined,
+      "cart_load_failed",
+      err,
+      {
+        method: request.method,
+        pathname: new URL(request.url).pathname,
+      },
+    );
     const vehicle = await getVehicleFromCookie(
       request.headers.get("Cookie"),
     ).catch(() => null);

--- a/frontend/app/routes/cart.tsx
+++ b/frontend/app/routes/cart.tsx
@@ -56,7 +56,7 @@ import {
   type CartItem as CartItemType,
   type CartSummary as CartSummaryType,
 } from "~/schemas/cart.schemas";
-import { serverObservabilityContext } from "~/server/load-context";
+import { serverObservabilityContext } from "~/utils/load-context";
 import { trackViewCart } from "~/utils/analytics";
 import { logger } from "~/utils/logger";
 import { reportLoaderError } from "~/utils/observability.server";

--- a/frontend/app/routes/checkout.tsx
+++ b/frontend/app/routes/checkout.tsx
@@ -56,6 +56,7 @@ import {
   parseCheckoutFormData,
   validateCheckoutClient,
 } from "~/schemas/checkout.schemas";
+import { serverObservabilityContext } from "~/server/load-context";
 import {
   buildOrderLines,
   buildPayboxRedirectUrl,
@@ -143,7 +144,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
   } catch (error) {
     logger.error("[Checkout] Erreur chargement:", error);
     reportLoaderError(
-      context.serverObservability,
+      context.get(serverObservabilityContext) ?? undefined,
       "checkout_cart_load_failed",
       error,
       { method: request.method, pathname: new URL(request.url).pathname },

--- a/frontend/app/routes/checkout.tsx
+++ b/frontend/app/routes/checkout.tsx
@@ -56,7 +56,7 @@ import {
   parseCheckoutFormData,
   validateCheckoutClient,
 } from "~/schemas/checkout.schemas";
-import { serverObservabilityContext } from "~/server/load-context";
+import { serverObservabilityContext } from "~/utils/load-context";
 import {
   buildOrderLines,
   buildPayboxRedirectUrl,

--- a/frontend/app/server/remix-api.server.ts
+++ b/frontend/app/server/remix-api.server.ts
@@ -9,7 +9,7 @@ import {
   remixIntegrationContext,
   remixServiceContext,
   userContext,
-} from "~/server/load-context";
+} from "~/utils/load-context";
 import { logger } from "~/utils/logger";
 
 /**

--- a/frontend/app/server/remix-api.server.ts
+++ b/frontend/app/server/remix-api.server.ts
@@ -4,7 +4,12 @@
  * Remplacement ultra-allégé de remix-integration.server.ts
  */
 // import "reflect-metadata"; // Désactivé - géré par le backend
-import { type AppLoadContext } from "react-router";
+import { type RouterContextProvider } from "react-router";
+import {
+  remixIntegrationContext,
+  remixServiceContext,
+  userContext,
+} from "~/server/load-context";
 import { logger } from "~/utils/logger";
 
 /**
@@ -12,41 +17,29 @@ import { logger } from "~/utils/logger";
  * Gère le bootstrap de l'application NestJS si nécessaire.
  */
 export async function getRemixApiService(
-  context: AppLoadContext,
+  context: Readonly<RouterContextProvider>,
 ): Promise<any> {
-  // Si le backend Nest a déjà injecté le service dans le contexte, on l'utilise directement
-  const ctx: any = context as any;
+  // Si le backend Nest a déjà injecté le service dans le contexte, on l'utilise
+  // directement. v8_middleware : les valeurs sont lues via les clés typées
+  // (`.get`), pas en accès propriété — un RouterContextProvider n'expose aucune
+  // clé énumérable (l'ancien `Object.keys(ctx)` retournerait toujours `[]`).
+  const remixIntegration = context.get(remixIntegrationContext);
+  const remixService = context.get(remixServiceContext);
 
-  logger.log("[getRemixApiService] Context keys:", Object.keys(ctx));
   logger.log(
     "[getRemixApiService] remixIntegration available:",
-    !!ctx.remixIntegration,
+    !!remixIntegration,
   );
-  logger.log(
-    "[getRemixApiService] remixService available:",
-    !!ctx.remixService,
-  );
+  logger.log("[getRemixApiService] remixService available:", !!remixService);
 
-  if (ctx.remixIntegration) {
-    logger.log(
-      "[getRemixApiService] Using remixIntegration:",
-      Object.keys(ctx.remixIntegration),
-    );
-    return ctx.remixIntegration;
+  if (remixIntegration) {
+    return remixIntegration;
   }
-  if (ctx.remixService?.integration) {
-    logger.log(
-      "[getRemixApiService] Using remixService.integration:",
-      Object.keys(ctx.remixService.integration),
-    );
-    return ctx.remixService.integration;
+  if (remixService?.integration) {
+    return remixService.integration;
   }
-  if (ctx.remixService) {
-    logger.log(
-      "[getRemixApiService] Using remixService directly:",
-      Object.keys(ctx.remixService),
-    );
-    return ctx.remixService;
+  if (remixService) {
+    return remixService;
   }
 
   logger.log("[getRemixApiService] Creating fallback API service");
@@ -67,15 +60,21 @@ export async function getRemixApiService(
     };
 
     // Transmettre les informations d'authentification du contexte
-    if (ctx.user) {
-      headers["X-User-Id"] = String(ctx.user.id || ctx.user.usr_id);
-      headers["X-User-Email"] = String(ctx.user.email || ctx.user.usr_email);
-      headers["X-User-Level"] = String(
-        ctx.user.level || ctx.user.usr_level || 1,
-      );
+    const user = context.get(userContext) as {
+      id?: unknown;
+      usr_id?: unknown;
+      email?: unknown;
+      usr_email?: unknown;
+      level?: unknown;
+      usr_level?: unknown;
+    } | null;
+    if (user) {
+      headers["X-User-Id"] = String(user.id || user.usr_id);
+      headers["X-User-Email"] = String(user.email || user.usr_email);
+      headers["X-User-Level"] = String(user.level || user.usr_level || 1);
       logger.log(
         "[makeApiCall] Auth headers ajoutés pour utilisateur:",
-        ctx.user.email,
+        String(user.email),
       );
     }
 

--- a/frontend/app/server/remix-integration.server.ts
+++ b/frontend/app/server/remix-integration.server.ts
@@ -3,18 +3,24 @@
  * Ce fichier ne doit être importé que dans les loaders et actions de Remix.
  */
 // import "reflect-metadata"; // Désactivé - géré par le backend
-import { type AppLoadContext } from "react-router";
+import { type RouterContextProvider } from "react-router";
+import {
+  remixIntegrationContext,
+  remixServiceContext,
+} from "~/server/load-context";
 
 /**
  * Récupère une instance du service d'intégration Remix.
  * Gère le bootstrap de l'application NestJS si nécessaire.
  */
 export async function getRemixIntegrationService(
-  context: AppLoadContext,
+  context: Readonly<RouterContextProvider>,
 ): Promise<any> {
-  const ctx: any = context as any;
-  if (ctx.remixIntegration) return ctx.remixIntegration;
-  if (ctx.remixService?.integration) return ctx.remixService.integration;
+  // v8_middleware : lecture via clés typées (pas d'accès propriété sur le provider).
+  const remixIntegration = context.get(remixIntegrationContext);
+  if (remixIntegration) return remixIntegration;
+  const remixService = context.get(remixServiceContext);
+  if (remixService?.integration) return remixService.integration;
   // Fallback sur le helper API
   const { getRemixApiService } = await import("./remix-api.server");
   return getRemixApiService(context);

--- a/frontend/app/server/remix-integration.server.ts
+++ b/frontend/app/server/remix-integration.server.ts
@@ -7,7 +7,7 @@ import { type RouterContextProvider } from "react-router";
 import {
   remixIntegrationContext,
   remixServiceContext,
-} from "~/server/load-context";
+} from "~/utils/load-context";
 
 /**
  * Récupère une instance du service d'intégration Remix.

--- a/frontend/app/services/cart.server.ts
+++ b/frontend/app/services/cart.server.ts
@@ -5,7 +5,7 @@
  * Compatible avec l'architecture existante RemixApiService
  */
 
-import { type AppLoadContext } from "react-router";
+import { type RouterContextProvider } from "react-router";
 import { logger } from "~/utils/logger";
 import {
   type CartItem,
@@ -46,7 +46,7 @@ class CartServerService {
   /**
    * Obtenir le panier complet
    */
-  async getCart(request: Request, context?: AppLoadContext): Promise<CartData> {
+  async getCart(request: Request, context?: Readonly<RouterContextProvider>): Promise<CartData> {
     const backendUrl = process.env.BACKEND_URL || "http://localhost:3000";
     const cookie = request.headers.get("Cookie") || "";
 
@@ -358,7 +358,7 @@ class CartServerService {
    */
   async validateCart(
     request: Request,
-    context?: AppLoadContext,
+    context?: Readonly<RouterContextProvider>,
   ): Promise<CartActionResult> {
     try {
       const cart = await this.getCart(request, context);
@@ -518,7 +518,7 @@ class CartServerService {
    */
   private async getCartAsLegacyFormat(
     request: Request,
-    context?: AppLoadContext,
+    context?: Readonly<RouterContextProvider>,
   ): Promise<Cart> {
     const cartData = await this.getCart(request, context);
 
@@ -561,7 +561,7 @@ export const cartServerService = new CartServerService();
 /**
  * 🎯 Fonctions utilitaires pour l'export
  */
-export const getCart = (request: Request, context?: AppLoadContext) =>
+export const getCart = (request: Request, context?: Readonly<RouterContextProvider>) =>
   cartServerService.getCart(request, context);
 
 export const addItem = (
@@ -582,7 +582,7 @@ export const removeFromCart = (request: Request, itemId: string) =>
 export const clearCart = (request: Request) =>
   cartServerService.clearCart(request);
 
-export const validateCart = (request: Request, context?: AppLoadContext) =>
+export const validateCart = (request: Request, context?: Readonly<RouterContextProvider>) =>
   cartServerService.validateCart(request, context);
 
 /**

--- a/frontend/app/utils/api.ts
+++ b/frontend/app/utils/api.ts
@@ -4,7 +4,7 @@
  */
 
 import { type RouterContextProvider } from "react-router";
-import { remixServiceContext } from "~/server/load-context";
+import { remixServiceContext } from "~/utils/load-context";
 import { logger } from "~/utils/logger";
 
 // Configuration de l'API backend

--- a/frontend/app/utils/api.ts
+++ b/frontend/app/utils/api.ts
@@ -3,6 +3,8 @@
  * Utilise les variables d'environnement ou des valeurs par défaut
  */
 
+import { type RouterContextProvider } from "react-router";
+import { remixServiceContext } from "~/server/load-context";
 import { logger } from "~/utils/logger";
 
 // Configuration de l'API backend
@@ -87,15 +89,20 @@ export interface PaymentStats {
  * Récupère les statistiques des paiements
  * Utilise le service direct ou fallback HTTP
  */
-export async function getPaymentStats(context?: any): Promise<PaymentStats> {
+export async function getPaymentStats(
+  context?: Readonly<RouterContextProvider>,
+): Promise<PaymentStats> {
   try {
     // Utilisation directe du service NestJS via le contexte (comme pour orders)
-    if (context?.remixService?.integration) {
+    // v8_middleware : service lu via clé typée (`.get`), pas en accès propriété.
+    const integration = context?.get(remixServiceContext)?.integration;
+    if (integration) {
       logger.log("✅ Utilisation du service de paiements direct");
       // Note: il faudra ajouter getPaymentStatsForRemix au service d'intégration
-      const result =
-        await context.remixService.integration.getPaymentStatsForRemix?.();
-      if (result?.success) {
+      const result = (await integration.getPaymentStatsForRemix?.()) as
+        | { success?: boolean; stats?: PaymentStats }
+        | undefined;
+      if (result?.success && result.stats) {
         return result.stats;
       }
     }
@@ -130,15 +137,18 @@ export async function getPaymentStats(context?: any): Promise<PaymentStats> {
  */
 export async function createPayment(
   payment: CreateLegacyPaymentRequest,
-  context?: any,
+  context?: Readonly<RouterContextProvider>,
 ): Promise<LegacyPayment> {
   try {
     // Utilisation directe du service NestJS via le contexte
-    if (context?.remixService?.integration) {
+    // v8_middleware : service lu via clé typée (`.get`), pas en accès propriété.
+    const integration = context?.get(remixServiceContext)?.integration;
+    if (integration) {
       logger.log("✅ Utilisation du service de paiements direct");
-      const result =
-        await context.remixService.integration.createPaymentForRemix?.(payment);
-      if (result?.success) {
+      const result = (await integration.createPaymentForRemix?.(payment)) as
+        | { success?: boolean; payment?: LegacyPayment }
+        | undefined;
+      if (result?.success && result.payment) {
         return result.payment;
       }
     }
@@ -170,17 +180,18 @@ export async function createPayment(
  */
 export async function getPaymentStatus(
   orderId: string | number,
-  context?: any,
+  context?: Readonly<RouterContextProvider>,
 ): Promise<LegacyPayment> {
   try {
     // Utilisation directe du service NestJS via le contexte
-    if (context?.remixService?.integration) {
+    // v8_middleware : service lu via clé typée (`.get`), pas en accès propriété.
+    const integration = context?.get(remixServiceContext)?.integration;
+    if (integration) {
       logger.log("✅ Utilisation du service de paiements direct");
-      const result =
-        await context.remixService.integration.getPaymentStatusForRemix?.(
-          orderId,
-        );
-      if (result?.success) {
+      const result = (await integration.getPaymentStatusForRemix?.(
+        orderId,
+      )) as { success?: boolean; payment?: LegacyPayment } | undefined;
+      if (result?.success && result.payment) {
         return result.payment;
       }
     }

--- a/frontend/app/utils/load-context.ts
+++ b/frontend/app/utils/load-context.ts
@@ -1,0 +1,76 @@
+/**
+ * SINGLE app-context token module (RR8 `v8_middleware`, A6).
+ *
+ * REALM INVARIANT: this module lives ONLY in the SSR/ESM server build realm.
+ * `createContext()` returns IDENTITY-KEYED objects — they must be a single
+ * instance per process. They reach NestJS (CJS) EXCLUSIVELY via the
+ * `@fafa/frontend` façade FACTORY (`getCreateAppLoadContext` →
+ * `build.entry.module.createAppLoadContext`), NEVER by NestJS importing this
+ * file directly. A second key instance in the CJS realm would make `.set()` and
+ * `.get()` operate on different identities → silent context loss (the dual-realm
+ * class of PROD incident #1106 / getsentry#21696).
+ *
+ * Every key carries a NULLABLE / non-`undefined` default so `context.get(key)`
+ * returns the default instead of throwing when a value was never set
+ * (`RouterContextProvider.get` throws only when no `defaultValue` was provided).
+ *
+ * Ports are STRUCTURAL interfaces (no NestJS class is imported into frontend).
+ */
+import { createContext, RouterContextProvider } from "react-router";
+import { type ServerObservability } from "~/utils/observability-contract";
+
+/* ── Structural ports (no NestJS class import) ───────────────────────────── */
+
+/** Raw user as deposited by Passport/NestJS session (shape validated downstream). */
+export type ContextUser = unknown;
+
+/** Integration surface (NestJS `RemixApiService`) — only the methods read here. */
+export interface RemixIntegrationPort {
+  getPaymentStatsForRemix?: (...args: unknown[]) => Promise<unknown>;
+  createPaymentForRemix?: (...args: unknown[]) => Promise<unknown>;
+  getPaymentStatusForRemix?: (...args: unknown[]) => Promise<unknown>;
+  [key: string]: unknown;
+}
+
+/** NestJS `RemixService` — only `.integration` is read by consumers. */
+export interface RemixServicePort {
+  integration?: RemixIntegrationPort;
+  [key: string]: unknown;
+}
+
+/* ── Context keys (identity-keyed; nullable defaults → .get never throws) ──── */
+
+export const userContext = createContext<ContextUser>(null);
+export const remixServiceContext = createContext<RemixServicePort | null>(null);
+/** LIVE (kept). Injected by NestJS as `RemixApiService`. Nullable. */
+export const remixIntegrationContext =
+  createContext<RemixIntegrationPort | null>(null);
+export const cspNonceContext = createContext<string>("");
+export const serverObservabilityContext =
+  createContext<ServerObservability | null>(null);
+
+/* ── Factory: plain values → RouterContextProvider ───────────────────────── */
+
+export interface AppLoadContextValues {
+  user: ContextUser;
+  remixService: RemixServicePort | null;
+  remixIntegration: RemixIntegrationPort | null;
+  cspNonce: string;
+  serverObservability: ServerObservability | null;
+}
+
+/**
+ * Build the per-request `RouterContextProvider`. Called inside the SSR realm via
+ * the façade bridge. `parsedBody` is intentionally absent (DEAD — dropped in A6).
+ */
+export function createAppLoadContext(
+  values: AppLoadContextValues,
+): RouterContextProvider {
+  const provider = new RouterContextProvider();
+  provider.set(userContext, values.user);
+  provider.set(remixServiceContext, values.remixService);
+  provider.set(remixIntegrationContext, values.remixIntegration);
+  provider.set(cspNonceContext, values.cspNonce);
+  provider.set(serverObservabilityContext, values.serverObservability);
+  return provider;
+}

--- a/frontend/index.cjs
+++ b/frontend/index.cjs
@@ -16,6 +16,23 @@ module.exports.getServerBuild = async function getServerBuild() {
 	return ssrModule;
 };
 
+/**
+ * CJS→ESM bridge for the RR8 `v8_middleware` load context (A6).
+ *
+ * NestJS (CJS) must NEVER import `app/server/load-context.ts` directly — the
+ * `createContext()` keys are identity-keyed and a second instance in the CJS
+ * realm would silently break `.set()`/`.get()` (dual-realm hazard, incident
+ * #1106). Instead we hand back the `createAppLoadContext` factory that the SSR
+ * build itself re-exports from `entry.server` (`build.entry.module`), so it
+ * rides the EXACT same module graph as the loaders/actions → single key
+ * identity, guaranteed. Works for both realms because `getServerBuild()`
+ * already resolves DEV (Vite SSR graph) vs PROD (built ESM bundle).
+ */
+module.exports.getCreateAppLoadContext = async function getCreateAppLoadContext() {
+	const build = await module.exports.getServerBuild();
+	return build.entry.module.createAppLoadContext;
+};
+
 module.exports.startDevServer = async function startDevServer(app) {
 	if (process.env.NODE_ENV === 'production') return;
 

--- a/frontend/index.cjs
+++ b/frontend/index.cjs
@@ -19,7 +19,7 @@ module.exports.getServerBuild = async function getServerBuild() {
 /**
  * CJS→ESM bridge for the RR8 `v8_middleware` load context (A6).
  *
- * NestJS (CJS) must NEVER import `app/server/load-context.ts` directly — the
+ * NestJS (CJS) must NEVER import `app/utils/load-context.ts` directly — the
  * `createContext()` keys are identity-keyed and a second instance in the CJS
  * realm would silently break `.set()`/`.get()` (dual-realm hazard, incident
  * #1106). Instead we hand back the `createAppLoadContext` factory that the SSR

--- a/frontend/index.d.cts
+++ b/frontend/index.d.cts
@@ -2,4 +2,18 @@ declare module '@fafa/frontend' {
 	export function getPublicDir(): string;
 	export function getServerBuild(): Promise<any>;
 	export function startDevServer(app: any): Promise<void>;
+	/**
+	 * RR8 `v8_middleware` bridge (A6): returns the SSR-realm factory that builds a
+	 * `RouterContextProvider` from plain values. The factory is sourced from the
+	 * server build's `entry.module`, so NestJS never imports the context keys.
+	 */
+	export function getCreateAppLoadContext(): Promise<
+		(values: {
+			user: unknown;
+			remixService: unknown;
+			remixIntegration: unknown;
+			cspNonce: string;
+			serverObservability: unknown;
+		}) => import('react-router').RouterContextProvider
+	>;
 }

--- a/frontend/react-router.config.ts
+++ b/frontend/react-router.config.ts
@@ -22,6 +22,13 @@ import { type Config } from "@react-router/dev/config";
  * - A4 `v8_splitRouteModules: true` (PAS `"enforce"`) : découpe automatiquement
  *   les exports de route en chunks séparés quand c'est possible. `true` (et non
  *   `"enforce"`) pour ne pas faire échouer le build sur une route non-séparable.
+ * - A6 `v8_middleware` : le contexte des loaders/actions devient un
+ *   `RouterContextProvider` (lecture via `context.get(key)`), `getLoadContext`
+ *   renvoie ce provider. Le pont CJS→ESM (NestJS → SSR) passe par la fabrique
+ *   `createAppLoadContext` réexposée sur `build.entry.module` via la façade
+ *   `@fafa/frontend` — NestJS n'importe jamais les clés `createContext`
+ *   (sécurité dual-realm, incident #1106). `typegen` régénère les types pour
+ *   que `MiddlewareEnabled = true` (clés typées, accès propriété interdit).
  */
 export default {
   ssr: true,
@@ -31,5 +38,6 @@ export default {
     v8_passThroughRequests: true,
     v8_trailingSlashAwareDataRequests: true,
     v8_splitRouteModules: true,
+    v8_middleware: true,
   },
 } satisfies Config;

--- a/frontend/tests/unit/load-context-identity.test.ts
+++ b/frontend/tests/unit/load-context-identity.test.ts
@@ -7,7 +7,7 @@ import {
   remixServiceContext,
   remixIntegrationContext,
   serverObservabilityContext,
-} from "~/server/load-context";
+} from "~/utils/load-context";
 
 /**
  * RR8 `v8_middleware` context-identity guard (A6).

--- a/frontend/tests/unit/load-context-identity.test.ts
+++ b/frontend/tests/unit/load-context-identity.test.ts
@@ -1,0 +1,72 @@
+import { createStaticHandler, RouterContextProvider } from "react-router";
+import { describe, it, expect } from "vitest";
+import {
+  createAppLoadContext,
+  userContext,
+  cspNonceContext,
+  remixServiceContext,
+  remixIntegrationContext,
+  serverObservabilityContext,
+} from "~/server/load-context";
+
+/**
+ * RR8 `v8_middleware` context-identity guard (A6).
+ *
+ * The CJS→ESM bridge (NestJS → SSR build) hands NestJS a FACTORY
+ * (`createAppLoadContext`) rather than the identity-keyed `createContext()` keys,
+ * precisely so the keys are never duplicated across realms (dual-realm hazard,
+ * incident #1106). This test proves, at the unit level, that a value SET through
+ * the factory is observable via the SAME key when read inside a REAL loader run
+ * (`createStaticHandler().query`) — not a same-line set/get, which would prove
+ * nothing about key identity. If the factory and the loader ever resolved two
+ * distinct key instances, `context.get` would return the nullable DEFAULT and
+ * the assertion would fail.
+ */
+describe("load-context identity (RR8 v8_middleware bridge)", () => {
+  it("a value set by createAppLoadContext is read back via the SAME key inside a real loader run", async () => {
+    const SENTINEL_USER = { id: "sentinel-123", email: "s@a.z" };
+    const provider = createAppLoadContext({
+      user: SENTINEL_USER,
+      remixService: null,
+      remixIntegration: null,
+      cspNonce: "nonce-xyz",
+      serverObservability: null,
+    });
+
+    const handler = createStaticHandler([
+      {
+        id: "root",
+        path: "/",
+        loader({ context }) {
+          // Read exactly as app loaders do — via the typed keys imported from
+          // the same module the factory uses.
+          return {
+            user: context.get(userContext),
+            nonce: context.get(cspNonceContext),
+          };
+        },
+      },
+    ]);
+
+    const result = await handler.query(new Request("http://identity.test/"), {
+      requestContext: provider,
+    });
+
+    if (result instanceof Response) {
+      throw new Error("expected StaticHandlerContext, got a Response");
+    }
+
+    // Same OBJECT identity (toBe), not merely structural — proves single-instance keys.
+    expect(result.loaderData.root.user).toBe(SENTINEL_USER);
+    expect(result.loaderData.root.nonce).toBe("nonce-xyz");
+  });
+
+  it("unset keys return their nullable default — context.get never throws", () => {
+    const empty = new RouterContextProvider();
+    expect(empty.get(userContext)).toBeNull();
+    expect(empty.get(cspNonceContext)).toBe("");
+    expect(empty.get(remixServiceContext)).toBeNull();
+    expect(empty.get(remixIntegrationContext)).toBeNull();
+    expect(empty.get(serverObservabilityContext)).toBeNull();
+  });
+});

--- a/log.md
+++ b/log.md
@@ -592,3 +592,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/rr8-prep-sentry-decouple`
 - **Décision** : chore(canon): align dep-governance Sentry ids (owner) (+2 other commits)
 - **Sortie** : PR #1116 | commits 5233664db c583c9cfa 33a3c6a44
+
+## 2026-06-23 — feat/rr8-prep-a6-middleware (auto)
+
+- **Branche** : `feat/rr8-prep-a6-middleware`
+- **Décision** : feat(rr8-prep): A6 — adopt future.v8_middleware + RouterContextProvider bridge (RR7.18)
+- **Sortie** : PR #1124 | commits 75dfb7275


### PR DESCRIPTION
## Temps A — A6 (the architecturally load-bearing step)

Enables `future.v8_middleware` under RR7.18. Loader/action `context` becomes a `RouterContextProvider` (read via `context.get(key)`); `getLoadContext` returns that provider. This is the **CJS→ESM pont** between NestJS (CommonJS) and the React Router SSR build (ESM) — same dual-realm risk class as PROD incident **#1106** (Sentry recursion). **No version bump** — `react-router@8` flip stays deferred (Temps B). Fully reversible (one `future` flag).

### Realm-safe design
- **New single app-context token** `frontend/app/utils/load-context.ts` (governed `utils/**` path, isomorphic-safe): typed `createContext()` keys with **nullable defaults** (so `.get` never throws) + a `createAppLoadContext()` factory → `RouterContextProvider`. Ports are **structural interfaces** (no NestJS class imported into frontend).
- The `createContext()` keys are **identity-keyed**; NestJS **never imports them**. The factory is re-exported from `entry.server` and reached via **`build.entry.module.createAppLoadContext`** through the `@fafa/frontend` façade (`getCreateAppLoadContext`) — same module graph as the loaders ⇒ **single key identity guaranteed** (no second CJS instance).
- `parsedBody` dropped (DEAD); `remixIntegration` kept (LIVE, nullable).
- `remix.controller.ts` carries an ambient `Future.v8_middleware = true` augmentation so the **backend** tsc (separate project, blind to frontend typegen) types `getLoadContext` to return `RouterContextProvider` — truthful, since the same Node process serves the middleware-enabled SSR build.

### Migrations (`context.X` → `context.get(key)`)
Helpers receiving loader context type it `Readonly<RouterContextProvider>`. Files: `entry.server.tsx`, `root.tsx` (drops the `AppLoadContext` augmentation + `parsedBody`), `auth/unified.server.ts`, `server/remix-api.server.ts` (removes an `as any` escape hatch + `Object.keys` logging that returned `[]` on a provider), `server/remix-integration.server.ts`, `services/cart.server.ts` (forwards-only), `routes/admin.tsx`, `routes/admin.debug.tsx`, `routes/cart.tsx`, `routes/checkout.tsx`, `utils/api.ts`.

### Verification (local)
- `react-router typegen` regenerated (`MiddlewareEnabled = true`).
- **Frontend + backend typecheck: 0 errors.** Full FE suite: **298 tests pass**.
- New **context-identity test** (`tests/unit/load-context-identity.test.ts`): a value set via the factory is read back through the **same key inside a real `createStaticHandler().query` loader run** (proves single-key identity, not a same-line set/get); unset keys return defaults without throwing.
- Prod build OK; empirically confirmed `build.entry.module.createAppLoadContext` is reachable and produces a working provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)