### PR TITLE
feat(rr8-prep): A5 — meta() MetaArgs.data → loaderData (RR7.18, forward-compat)

### DIFF
--- a/frontend/app/routes/account.claims.$claimId.tsx
+++ b/frontend/app/routes/account.claims.$claimId.tsx
@@ -22,7 +22,7 @@ import {
 } from "../components/ui/card";
 import { PublicBreadcrumb } from "../components/ui/PublicBreadcrumb";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => [
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => [
   {
     title: data?.claim?.title
       ? `${data.claim.title} | Réclamation`

--- a/frontend/app/routes/account_.orders.$orderId.tsx
+++ b/frontend/app/routes/account_.orders.$orderId.tsx
@@ -35,7 +35,7 @@ import {
 import { PublicBreadcrumb } from "../components/ui/PublicBreadcrumb";
 import { getOrderDetails } from "../services/orders.server";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) =>
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) =>
   createNoIndexMeta(
     data?.order?.orderNumber
       ? `Commande #${data.order.orderNumber}`

--- a/frontend/app/routes/admin.gammes-seo.$pgId.tsx
+++ b/frontend/app/routes/admin.gammes-seo.$pgId.tsx
@@ -80,7 +80,7 @@ import { Textarea } from "~/components/ui/textarea";
 import { getInternalApiUrl } from "~/utils/internal-api.server";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) =>
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) =>
   createNoIndexMeta(
     data?.detail?.gamme?.pg_name
       ? `${data.detail.gamme.pg_name} - Admin`

--- a/frontend/app/routes/admin.payments.$paymentId.tsx
+++ b/frontend/app/routes/admin.payments.$paymentId.tsx
@@ -33,7 +33,7 @@ import {
 } from "../services/payment-admin.server";
 import { type Payment, PaymentStatus } from "../types/payment";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) =>
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) =>
   createNoIndexMeta(
     data?.payment?.id
       ? `Paiement #${data.payment.id.slice(0, 8)} - Admin`

--- a/frontend/app/routes/admin.products.$productId.tsx
+++ b/frontend/app/routes/admin.products.$productId.tsx
@@ -9,7 +9,7 @@ import { Badge } from "~/components/ui/badge";
 import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) =>
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) =>
   createNoIndexMeta(
     data?.product?.piece_name
       ? `${data.product.piece_name} - Admin`

--- a/frontend/app/routes/admin.rag.documents.$docId.tsx
+++ b/frontend/app/routes/admin.rag.documents.$docId.tsx
@@ -16,7 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { getInternalApiUrlFromRequest } from "~/utils/internal-api.server";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) =>
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) =>
   createNoIndexMeta(data?.doc?.id ? `Doc: ${data.doc.id}` : "Document RAG");
 
 interface KnowledgeDocFull {

--- a/frontend/app/routes/admin.suppliers.$id.tsx
+++ b/frontend/app/routes/admin.suppliers.$id.tsx
@@ -21,7 +21,7 @@ import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
 import { requireUser } from "../auth/unified.server";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const supplierName = data?.supplier?.name;
   return createNoIndexMeta(
     supplierName

--- a/frontend/app/routes/admin.users.$id.edit.tsx
+++ b/frontend/app/routes/admin.users.$id.edit.tsx
@@ -12,7 +12,7 @@ import { Alert } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const user = data?.user;
   const userName =
     user?.firstName && user?.lastName

--- a/frontend/app/routes/admin.users.$id.tsx
+++ b/frontend/app/routes/admin.users.$id.tsx
@@ -30,7 +30,7 @@ import { Badge } from "~/components/ui/badge";
 import { logger } from "~/utils/logger";
 import { createNoIndexMeta } from "~/utils/meta-helpers";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const user = data?.targetUser;
   const userName =
     user?.firstName && user?.lastName

--- a/frontend/app/routes/blog-pieces-auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto._index.tsx
@@ -85,7 +85,7 @@ interface LoaderData {
 }
 
 // Métadonnées SEO — robots conditionnel pour éviter cannibalisation des filtres
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const title = "Blog Automecanik - Conseils et Guides Auto Experts";
   const description =
     "Diagnostiquer une panne, comprendre une pièce, réussir un montage, choisir la bonne référence. Plus de 500 articles pratiques pour l'entretien de votre véhicule.";

--- a/frontend/app/routes/blog-pieces-auto.advice._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.advice._index.tsx
@@ -85,7 +85,7 @@ interface LoaderData {
   error?: string;
 }
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const search = data?.search || "";
   const total = data?.total || 0;
 

--- a/frontend/app/routes/blog-pieces-auto.article.$slug.tsx
+++ b/frontend/app/routes/blog-pieces-auto.article.$slug.tsx
@@ -83,7 +83,7 @@ interface LoaderData {
 }
 
 // Meta SEO
-export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
   if (!data?.article) {
     return [
       { title: "Article non trouvé - Blog Automecanik" },

--- a/frontend/app/routes/blog-pieces-auto.auto.$marque.$modele.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto.$marque.$modele.tsx
@@ -151,7 +151,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 /* ===========================
    Meta
 =========================== */
-export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
   const metadata = data?.metadata;
   const brand = data?.brand;
   const modelGroup = data?.modelGroup;

--- a/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
@@ -166,7 +166,7 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
 /* ===========================
    Meta
 =========================== */
-export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
   const metadata = data?.metadata;
   const brand = data?.brand;
   const modelsCount = data?.models?.length ?? 0;

--- a/frontend/app/routes/blog-pieces-auto.auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto._index.tsx
@@ -149,7 +149,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 /* ===========================
    Meta
 =========================== */
-export const meta: MetaFunction<typeof loader> = ({ data: rawData }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: rawData }) => {
   const data = rawData as LoaderData | undefined;
   const metadata = data?.metadata;
   const count = data?.stats?.totalBrands ?? 0;

--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -270,7 +270,7 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 
 // ── Meta ─────────────────────────────────────────────────
 
-export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
   if (!data) {
     return [
       { title: "Article non trouvé" },

--- a/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
@@ -177,7 +177,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
 // ── Meta ────────────────────────────────────────────────
 
-export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
   const count = data?.totalArticles ?? 0;
   const hasFilters = location?.search && location.search.length > 1;
 

--- a/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
@@ -531,7 +531,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   };
 }
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const title = data?.search
     ? `Constructeurs Automobiles - Recherche: ${data.search}`
     : data?.letter

--- a/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
@@ -288,7 +288,7 @@ export const shouldRevalidate: ShouldRevalidateFunction = ({
 
 // ── Meta (noindex if no data) ───────────────────────────
 
-export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
   if (!data) {
     return [
       { title: "Guide non trouve" },

--- a/frontend/app/routes/blog-pieces-auto.guide-achat._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat._index.tsx
@@ -182,7 +182,7 @@ export const headers = buildCacheHeaders(
 /* ===========================
    Meta + Structured Data
 =========================== */
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const count = data?.guides?.length ?? 0;
   const canonicalUrl =
     "https://www.automecanik.com/blog-pieces-auto/guide-achat";

--- a/frontend/app/routes/brands.$brandId.models.$modelId.types.tsx
+++ b/frontend/app/routes/brands.$brandId.models.$modelId.types.tsx
@@ -48,7 +48,7 @@ export const handle = {
   }),
 };
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data?.brand || !data?.model) {
     return [
       { title: "Motorisations | Automecanik" },

--- a/frontend/app/routes/brands.$brandId.tsx
+++ b/frontend/app/routes/brands.$brandId.tsx
@@ -40,7 +40,7 @@ export const handle = {
 /**
  * 🔍 SEO Meta Tags
  */
-export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
   const brandName = data?.brand?.marque_name || "Marque";
   const modelsCount = data?.models?.length || 0;
   const canonicalUrl = `https://www.automecanik.com${location.pathname}`;

--- a/frontend/app/routes/brands._index.tsx
+++ b/frontend/app/routes/brands._index.tsx
@@ -46,7 +46,7 @@ export const handle = {
 /**
  * 🔍 SEO Meta Tags
  */
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const total = data?.total || 0;
   const title = `Toutes les Marques Automobiles (${total}) | Pièces Détachées Auto`;
   const description = `Découvrez notre catalogue complet de ${total} marques automobiles. Trouvez les pièces détachées pour BMW, Mercedes, Audi, Volkswagen, Renault, Peugeot et toutes les autres marques.`;

--- a/frontend/app/routes/conditions-generales-de-vente[.]html.tsx
+++ b/frontend/app/routes/conditions-generales-de-vente[.]html.tsx
@@ -18,7 +18,7 @@ export const handle = {
 
 const API_URL = getInternalApiUrl("");
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data) {
     return [{ title: "CGV - Automecanik" }];
   }

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -388,7 +388,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
 }
 
 // 🎯 Meta function avec SEO optimisé (logique PHP)
-export const meta: MetaFunction<typeof loader> = ({ data: rawData }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: rawData }) => {
   const data = rawData as LoaderData | undefined;
   if (!data) {
     return [

--- a/frontend/app/routes/constructeurs.$brand[.]html.tsx
+++ b/frontend/app/routes/constructeurs.$brand[.]html.tsx
@@ -93,7 +93,7 @@ export const headers: HeadersFunction = () => ({
 // 🔄 META
 // ==========================================
 
-export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) => {
   if (!data || !data.seo) {
     return [{ title: "Pièces Auto" }];
   }

--- a/frontend/app/routes/diagnostic-auto.$slug.tsx
+++ b/frontend/app/routes/diagnostic-auto.$slug.tsx
@@ -167,7 +167,7 @@ const SAFETY_GATE_FALLBACK: SafetyGateEntry = {
   label: "",
 };
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data?.diagnostic) {
     return [{ title: "Diagnostic non trouvé | AutoMekanik" }];
   }

--- a/frontend/app/routes/diagnostic-auto._index.tsx
+++ b/frontend/app/routes/diagnostic-auto._index.tsx
@@ -118,7 +118,7 @@ const ICON_MAP: Record<string, LucideIcon> = {
   Wrench,
 };
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const canonicalUrl = "https://www.automecanik.com/diagnostic-auto";
 
   // Unified FAQPage: wiki FAQ entries + dynamic featured items

--- a/frontend/app/routes/enhanced-vehicle-catalog.$brand.$model.$type.tsx
+++ b/frontend/app/routes/enhanced-vehicle-catalog.$brand.$model.$type.tsx
@@ -123,7 +123,7 @@ export async function loader({ params: _params }: LoaderFunctionArgs) {
 // ========================================
 // 🎯 META FUNCTION
 // ========================================
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data || !data.vehicle) {
     return [
       { title: "Véhicule non trouvé" },

--- a/frontend/app/routes/legal.$pageKey.tsx
+++ b/frontend/app/routes/legal.$pageKey.tsx
@@ -172,7 +172,7 @@ const _availablePages = [...legalPages, ...helpPages, ...infoPages];
 // Pages qui ne doivent PAS être indexées (contenu juridique standard)
 const noIndexPages = ["cgv", "privacy", "terms", "cookies", "legal-notice"];
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data || "error" in data) {
     return [
       { title: "Page non trouvée - Automecanik" },

--- a/frontend/app/routes/mentions-legales.tsx
+++ b/frontend/app/routes/mentions-legales.tsx
@@ -17,7 +17,7 @@ export const handle = {
 
 const API_URL = getInternalApiUrl("");
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data) {
     return [{ title: "Mentions légales - Automecanik" }];
   }

--- a/frontend/app/routes/orders.$id.tsx
+++ b/frontend/app/routes/orders.$id.tsx
@@ -111,7 +111,7 @@ interface LoaderData {
   error?: string;
 }
 
-export const meta: MetaFunction<typeof loader> = ({ data }) =>
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) =>
   createNoIndexMeta(
     data?.order?.ord_id ? `Commande #${data.order.ord_id}` : "Commande",
   );

--- a/frontend/app/routes/pieces.$gamme.$marque.$modele.$type[.]html.tsx
+++ b/frontend/app/routes/pieces.$gamme.$marque.$modele.$type[.]html.tsx
@@ -61,7 +61,7 @@ export const headers = buildCacheHeaders(
 // META - SEO (Schema.org genere par composant Breadcrumbs)
 // ========================================
 
-export const meta: MetaFunction<typeof loader> = ({ data, location }) =>
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data, location }) =>
   buildPiecesVehicleMeta(data, location);
 
 // ========================================

--- a/frontend/app/routes/pieces.$slug.tsx
+++ b/frontend/app/routes/pieces.$slug.tsx
@@ -411,7 +411,7 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 }
 
 export const meta: MetaFunction<typeof loader> = ({
-  data: rawData,
+  loaderData: rawData,
   location,
 }) => {
   const data = rawData as PiecesPageSyncData | undefined;

--- a/frontend/app/routes/politique-confidentialite.tsx
+++ b/frontend/app/routes/politique-confidentialite.tsx
@@ -17,7 +17,7 @@ export const handle = {
 
 const API_URL = getInternalApiUrl("");
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data) {
     return [{ title: "Politique de confidentialité - Automecanik" }];
   }

--- a/frontend/app/routes/politique-cookies.tsx
+++ b/frontend/app/routes/politique-cookies.tsx
@@ -17,7 +17,7 @@ export const handle = {
 
 const API_URL = getInternalApiUrl("");
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data) {
     return [{ title: "Politique de cookies - Automecanik" }];
   }

--- a/frontend/app/routes/products.$category.$subcategory.tsx
+++ b/frontend/app/routes/products.$category.$subcategory.tsx
@@ -43,7 +43,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   };
 }
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data?.metaTags) {
     return [{ title: "Erreur | Automecanik" }];
   }

--- a/frontend/app/routes/products.$id.tsx
+++ b/frontend/app/routes/products.$id.tsx
@@ -62,7 +62,7 @@ export const handle = {
 /**
  * 🔍 SEO Meta Tags - Page produit individuel
  */
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data?.product) {
     return [
       { title: "Produit non trouvé" },

--- a/frontend/app/routes/products.catalog.tsx
+++ b/frontend/app/routes/products.catalog.tsx
@@ -50,7 +50,7 @@ import { PublicBreadcrumb } from "../components/ui/PublicBreadcrumb";
 /**
  * 🔍 SEO Meta Tags - Catalogue produits (accès restreint)
  */
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const total = data?.pagination?.total || 0;
   return [
     { title: `Catalogue Produits (${total.toLocaleString()}) | Espace Pro` },

--- a/frontend/app/routes/reference-auto.$slug.tsx
+++ b/frontend/app/routes/reference-auto.$slug.tsx
@@ -256,7 +256,7 @@ function shouldUseHeroRole(
 /* ===========================
    Meta
 =========================== */
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   if (!data?.reference) {
     return [
       { title: "Référence non trouvée - Pièces Auto" },

--- a/frontend/app/routes/reviews.$reviewId.tsx
+++ b/frontend/app/routes/reviews.$reviewId.tsx
@@ -40,7 +40,7 @@ import {
   deleteReview,
 } from "../services/api/review.api";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   return [
     {
       title: data

--- a/frontend/app/routes/search.results.tsx
+++ b/frontend/app/routes/search.results.tsx
@@ -20,7 +20,7 @@ import { PublicBreadcrumb } from "../components/ui/PublicBreadcrumb";
 /**
  * 🔍 SEO Meta Tags - noindex pour pages de recherche
  */
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const query = data?.query || "";
   const total = data?.totalCount || 0;
 

--- a/frontend/app/routes/search.tsx
+++ b/frontend/app/routes/search.tsx
@@ -227,7 +227,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 // META SEO
 // ===============================
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   const query = data?.query || "";
   const total = data?.performance.totalItems || 0;
 

--- a/frontend/app/routes/tickets.$ticketId.tsx
+++ b/frontend/app/routes/tickets.$ticketId.tsx
@@ -28,7 +28,7 @@ import {
   type ContactTicket,
 } from "../services/api/contact.api";
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: MetaFunction<typeof loader> = ({ loaderData: data }) => {
   return [
     {
       title: data


### PR DESCRIPTION
## Temps A · A5 — meta API forward-migration (RR7.18, reversible, surface-safe)

React Router 8 removes the `@deprecated` `MetaArgs.data` in favour of `MetaArgs.loaderData`. Both already exist in RR 7.18 with **identical types** (verified in `node_modules/react-router/dist/development/data-*.d.ts`), so migrating now is forward-compatible and reversible under the current pinned version.

### What changed
Each route `meta` function's loader-data param is migrated to the RR8 property via the **alias form** — `({ data }) → ({ loaderData: data })` (and `{ data: x } → { loaderData: x }`) — applied by a scope-aware **TS-compiler-API codemod** (no `ts-morph`; throwaway script, not committed). **44 route files, param-only (44 +/44 −).**

### Why the alias form (not `{ loaderData }` + body rename)
- The meta **body** — and therefore the `meta` **return** expression — stays **byte-for-byte unchanged**. The R-SEO-09 canonical-surface guard serializes **only the meta return** (`scripts/seo/lib/canonical-surface-extractor.mjs`), so the protected SEO surface stays deep-equal and the guard **passes with no owner override**.
- A clean `{ loaderData }` rename would alpha-rename identifiers *inside* the return (same runtime output, different surface AST) → R-SEO-09 hard-block.
- Strongest **no-touch-meta** compliance: the meta-generating code is literally unchanged.

### Verification
- ✅ **R-SEO-09 canonical-surface guard — PASS** locally (`OK: no canonical surface touched vs origin/main`)
- ✅ `turbo typecheck` (frontend) — 0 errors
- ✅ `turbo build` (frontend) — clean
- ✅ `turbo lint` (frontend) — 0 errors
- ✅ Diff is param-only — every changed line is the destructuring pattern; no body/return edits
- ✅ No test invokes `meta()` with the old `{ data }` shape

### Scope discipline
One named change (meta API). No version bump, no flag change, no behaviour change, no SEO-surface change. Part of the **Temps A** RR8 preparation sequence (A1–A4 + A6 merged; A5 here). Temps B = the `react-router@8` version flip, owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)