### PR TITLE
chore(deps): re-baseline PR-9e auth-session-passport overlay + PR-9f.0 errata

### DIFF
--- a/.claude/knowledge/modules/admin.md
+++ b/.claude/knowledge/modules/admin.md
@@ -2,7 +2,7 @@
 module: admin
 sources:
 - backend/src/modules/admin
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/admin/admin.module.ts
 - backend/src/modules/admin/constants/seo-control.constants.ts

--- a/.claude/knowledge/modules/agentic-engine.md
+++ b/.claude/knowledge/modules/agentic-engine.md
@@ -2,7 +2,7 @@
 module: agentic-engine
 sources:
 - backend/src/modules/agentic-engine
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/agentic-engine/agentic-engine.controller.ts
 - backend/src/modules/agentic-engine/agentic-engine.module.ts

--- a/.claude/knowledge/modules/ai-content.md
+++ b/.claude/knowledge/modules/ai-content.md
@@ -2,7 +2,7 @@
 module: ai-content
 sources:
 - backend/src/modules/ai-content
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/ai-content/ai-content-cache.service.ts
 - backend/src/modules/ai-content/ai-content.controller.ts

--- a/.claude/knowledge/modules/analytics.md
+++ b/.claude/knowledge/modules/analytics.md
@@ -2,7 +2,7 @@
 module: analytics
 sources:
 - backend/src/modules/analytics
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/analytics/analytics.module.ts
 - backend/src/modules/analytics/controllers/simple-analytics.controller.ts

--- a/.claude/knowledge/modules/blog.md
+++ b/.claude/knowledge/modules/blog.md
@@ -2,7 +2,7 @@
 module: blog
 sources:
 - backend/src/modules/blog
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/blog/blog.module.ts
 - backend/src/modules/blog/controllers/advice-hierarchy.controller.ts

--- a/.claude/knowledge/modules/bot-guard.md
+++ b/.claude/knowledge/modules/bot-guard.md
@@ -2,7 +2,7 @@
 module: bot-guard
 sources:
 - backend/src/modules/bot-guard
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/bot-guard/bot-guard.controller.ts
 - backend/src/modules/bot-guard/bot-guard.middleware.test.ts

--- a/.claude/knowledge/modules/cart.md
+++ b/.claude/knowledge/modules/cart.md
@@ -2,7 +2,7 @@
 module: cart
 sources:
 - backend/src/modules/cart
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/cart/cart.module.ts
 - backend/src/modules/cart/controllers/cart-analytics.controller.ts

--- a/.claude/knowledge/modules/catalog.md
+++ b/.claude/knowledge/modules/catalog.md
@@ -2,7 +2,7 @@
 module: catalog
 sources:
 - backend/src/modules/catalog
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/catalog/catalog.controller.ts
 - backend/src/modules/catalog/catalog.module.ts

--- a/.claude/knowledge/modules/commercial.md
+++ b/.claude/knowledge/modules/commercial.md
@@ -2,7 +2,7 @@
 module: commercial
 sources:
 - backend/src/modules/commercial
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/commercial/archives/archives.controller.ts
 - backend/src/modules/commercial/archives/archives.service.ts

--- a/.claude/knowledge/modules/config.md
+++ b/.claude/knowledge/modules/config.md
@@ -2,7 +2,7 @@
 module: config
 sources:
 - backend/src/modules/config
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/config/config.module.ts
 - backend/src/modules/config/controllers/simple-database-config.controller.ts

--- a/.claude/knowledge/modules/dashboard.md
+++ b/.claude/knowledge/modules/dashboard.md
@@ -2,7 +2,7 @@
 module: dashboard
 sources:
 - backend/src/modules/dashboard
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/dashboard/dashboard.controller.ts
 - backend/src/modules/dashboard/dashboard.module.ts

--- a/.claude/knowledge/modules/diagnostic-engine.md
+++ b/.claude/knowledge/modules/diagnostic-engine.md
@@ -2,7 +2,7 @@
 module: diagnostic-engine
 sources:
 - backend/src/modules/diagnostic-engine
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/diagnostic-engine/constants/gamme-map.constants.ts
 - backend/src/modules/diagnostic-engine/diagnostic-engine.controller.test.ts

--- a/.claude/knowledge/modules/errors.md
+++ b/.claude/knowledge/modules/errors.md
@@ -2,7 +2,7 @@
 module: errors
 sources:
 - backend/src/modules/errors
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/errors/controllers/error.controller.ts
 - backend/src/modules/errors/controllers/internal-error-log.controller.ts

--- a/.claude/knowledge/modules/gamme-rest.md
+++ b/.claude/knowledge/modules/gamme-rest.md
@@ -2,7 +2,7 @@
 module: gamme-rest
 sources:
 - backend/src/modules/gamme-rest
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/gamme-rest/controllers/admin-gamme-cache.controller.ts
 - backend/src/modules/gamme-rest/controllers/admin-r1-related-blocks-cache.controller.ts

--- a/.claude/knowledge/modules/health.md
+++ b/.claude/knowledge/modules/health.md
@@ -2,7 +2,7 @@
 module: health
 sources:
 - backend/src/modules/health
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/health/health.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/invoices.md
+++ b/.claude/knowledge/modules/invoices.md
@@ -2,7 +2,7 @@
 module: invoices
 sources:
 - backend/src/modules/invoices
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/invoices/invoices.controller.ts
 - backend/src/modules/invoices/invoices.module.ts

--- a/.claude/knowledge/modules/knowledge-graph.md
+++ b/.claude/knowledge/modules/knowledge-graph.md
@@ -2,7 +2,7 @@
 module: knowledge-graph
 sources:
 - backend/src/modules/knowledge-graph
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/knowledge-graph/index.ts
 - backend/src/modules/knowledge-graph/kg-data.service.ts

--- a/.claude/knowledge/modules/layout.md
+++ b/.claude/knowledge/modules/layout.md
@@ -2,7 +2,7 @@
 module: layout
 sources:
 - backend/src/modules/layout
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/layout/controllers/layout.controller.ts
 - backend/src/modules/layout/controllers/section.controller.ts

--- a/.claude/knowledge/modules/maintenance.md
+++ b/.claude/knowledge/modules/maintenance.md
@@ -2,7 +2,7 @@
 module: maintenance
 sources:
 - backend/src/modules/maintenance
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/maintenance/maintenance.module.ts
 depends_on: []

--- a/.claude/knowledge/modules/marketing.md
+++ b/.claude/knowledge/modules/marketing.md
@@ -2,7 +2,7 @@
 module: marketing
 sources:
 - backend/src/modules/marketing
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/marketing/controllers/marketing-backlinks.controller.ts
 - backend/src/modules/marketing/controllers/marketing-briefs.controller.ts

--- a/.claude/knowledge/modules/mcp-validation.md
+++ b/.claude/knowledge/modules/mcp-validation.md
@@ -2,7 +2,7 @@
 module: mcp-validation
 sources:
 - backend/src/modules/mcp-validation
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/mcp-validation/config/mcp-route-map.config.ts
 - backend/src/modules/mcp-validation/decorators/mcp-verify.decorator.ts

--- a/.claude/knowledge/modules/merchant-center.md
+++ b/.claude/knowledge/modules/merchant-center.md
@@ -2,7 +2,7 @@
 module: merchant-center
 sources:
 - backend/src/modules/merchant-center
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/merchant-center/controllers/merchant-center.controller.ts
 - backend/src/modules/merchant-center/merchant-center.module.ts

--- a/.claude/knowledge/modules/messages.md
+++ b/.claude/knowledge/modules/messages.md
@@ -2,7 +2,7 @@
 module: messages
 sources:
 - backend/src/modules/messages
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/messages/dto/index.ts
 - backend/src/modules/messages/dto/message.schemas.ts

--- a/.claude/knowledge/modules/metadata.md
+++ b/.claude/knowledge/modules/metadata.md
@@ -2,7 +2,7 @@
 module: metadata
 sources:
 - backend/src/modules/metadata
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/metadata/controllers/breadcrumb-admin.controller.ts
 - backend/src/modules/metadata/controllers/optimized-breadcrumb.controller.ts

--- a/.claude/knowledge/modules/navigation.md
+++ b/.claude/knowledge/modules/navigation.md
@@ -2,7 +2,7 @@
 module: navigation
 sources:
 - backend/src/modules/navigation
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/navigation/navigation.controller.ts
 - backend/src/modules/navigation/navigation.module.ts

--- a/.claude/knowledge/modules/observability.md
+++ b/.claude/knowledge/modules/observability.md
@@ -2,7 +2,7 @@
 module: observability
 sources:
 - backend/src/modules/observability
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.test.ts
 - backend/src/modules/observability/diagnostic-kg-shadow-metrics.listener.ts

--- a/.claude/knowledge/modules/orders.md
+++ b/.claude/knowledge/modules/orders.md
@@ -2,7 +2,7 @@
 module: orders
 sources:
 - backend/src/modules/orders
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/orders/controllers/order-actions.controller.ts
 - backend/src/modules/orders/controllers/order-archive.controller.ts

--- a/.claude/knowledge/modules/payments.md
+++ b/.claude/knowledge/modules/payments.md
@@ -2,7 +2,7 @@
 module: payments
 sources:
 - backend/src/modules/payments
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/payments/controllers/paybox-callback.controller.ts
 - backend/src/modules/payments/controllers/paybox-monitoring.controller.ts

--- a/.claude/knowledge/modules/products.md
+++ b/.claude/knowledge/modules/products.md
@@ -2,7 +2,7 @@
 module: products
 sources:
 - backend/src/modules/products
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/products/controllers/products-admin.controller.ts
 - backend/src/modules/products/controllers/products-catalog.controller.ts

--- a/.claude/knowledge/modules/promo.md
+++ b/.claude/knowledge/modules/promo.md
@@ -2,7 +2,7 @@
 module: promo
 sources:
 - backend/src/modules/promo
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/promo/promo.controller.ts
 - backend/src/modules/promo/promo.module.ts

--- a/.claude/knowledge/modules/rag-knowledge-bootstrap.md
+++ b/.claude/knowledge/modules/rag-knowledge-bootstrap.md
@@ -2,7 +2,7 @@
 module: rag-knowledge-bootstrap
 sources:
 - backend/src/modules/rag-knowledge-bootstrap
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.guard.ts
 - backend/src/modules/rag-knowledge-bootstrap/rag-knowledge-bootstrap.module.ts

--- a/.claude/knowledge/modules/rag-proxy.md
+++ b/.claude/knowledge/modules/rag-proxy.md
@@ -2,7 +2,7 @@
 module: rag-proxy
 sources:
 - backend/src/modules/rag-proxy
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/rag-proxy/dto/chat.dto.ts
 - backend/src/modules/rag-proxy/dto/manual-ingest.dto.ts

--- a/.claude/knowledge/modules/rm.md
+++ b/.claude/knowledge/modules/rm.md
@@ -2,7 +2,7 @@
 module: rm
 sources:
 - backend/src/modules/rm
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/rm/controllers/rm.controller.ts
 - backend/src/modules/rm/dto/alternatives-v2.dto.ts

--- a/.claude/knowledge/modules/search.md
+++ b/.claude/knowledge/modules/search.md
@@ -2,7 +2,7 @@
 module: search
 sources:
 - backend/src/modules/search
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/search/controllers/pieces.controller.ts
 - backend/src/modules/search/controllers/search-debug.controller.ts

--- a/.claude/knowledge/modules/seo-control-plane.md
+++ b/.claude/knowledge/modules/seo-control-plane.md
@@ -2,7 +2,7 @@
 module: seo-control-plane
 sources:
 - backend/src/modules/seo-control-plane
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.processor.ts
 - backend/src/modules/seo-control-plane/collectors/cf-analytics/cf-analytics.scheduler.service.ts

--- a/.claude/knowledge/modules/seo-logs.md
+++ b/.claude/knowledge/modules/seo-logs.md
@@ -2,7 +2,7 @@
 module: seo-logs
 sources:
 - backend/src/modules/seo-logs
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/seo-logs/controllers/crawl-budget-audit.controller.ts
 - backend/src/modules/seo-logs/controllers/crawl-budget-experiment.controller.ts

--- a/.claude/knowledge/modules/seo-monitoring.md
+++ b/.claude/knowledge/modules/seo-monitoring.md
@@ -2,7 +2,7 @@
 module: seo-monitoring
 sources:
 - backend/src/modules/seo-monitoring
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/seo-monitoring/controllers/cwv-beacon.controller.ts
 - backend/src/modules/seo-monitoring/controllers/cwv-dashboard.controller.ts

--- a/.claude/knowledge/modules/seo-shadow-observatory.md
+++ b/.claude/knowledge/modules/seo-shadow-observatory.md
@@ -2,7 +2,7 @@
 module: seo-shadow-observatory
 sources:
 - backend/src/modules/seo-shadow-observatory
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/seo-shadow-observatory/env.schema.ts
 - backend/src/modules/seo-shadow-observatory/seo-shadow-chain-runner.service.ts

--- a/.claude/knowledge/modules/seo.md
+++ b/.claude/knowledge/modules/seo.md
@@ -2,7 +2,7 @@
 module: seo
 sources:
 - backend/src/modules/seo
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
 - backend/src/modules/seo/config/hreflang.config.ts

--- a/.claude/knowledge/modules/shipping.md
+++ b/.claude/knowledge/modules/shipping.md
@@ -2,7 +2,7 @@
 module: shipping
 sources:
 - backend/src/modules/shipping
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/shipping/shipping.controller.ts
 - backend/src/modules/shipping/shipping.module.ts

--- a/.claude/knowledge/modules/staff.md
+++ b/.claude/knowledge/modules/staff.md
@@ -2,7 +2,7 @@
 module: staff
 sources:
 - backend/src/modules/staff
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/staff/dto/staff.dto.ts
 - backend/src/modules/staff/services/staff-data.service.ts

--- a/.claude/knowledge/modules/substitution.md
+++ b/.claude/knowledge/modules/substitution.md
@@ -2,7 +2,7 @@
 module: substitution
 sources:
 - backend/src/modules/substitution
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/substitution/controllers/substitution.controller.ts
 - backend/src/modules/substitution/services/intent-extractor.service.ts

--- a/.claude/knowledge/modules/suppliers.md
+++ b/.claude/knowledge/modules/suppliers.md
@@ -2,7 +2,7 @@
 module: suppliers
 sources:
 - backend/src/modules/suppliers
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/suppliers/dto/index.ts
 - backend/src/modules/suppliers/dto/supplier.dto.ts

--- a/.claude/knowledge/modules/support.md
+++ b/.claude/knowledge/modules/support.md
@@ -2,7 +2,7 @@
 module: support
 sources:
 - backend/src/modules/support
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/support/controllers/ai-support.controller.ts
 - backend/src/modules/support/controllers/claim.controller.ts

--- a/.claude/knowledge/modules/system.md
+++ b/.claude/knowledge/modules/system.md
@@ -2,7 +2,7 @@
 module: system
 sources:
 - backend/src/modules/system
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/system/processors/metrics.processor.ts
 - backend/src/modules/system/services/database-monitor.service.ts

--- a/.claude/knowledge/modules/upload.md
+++ b/.claude/knowledge/modules/upload.md
@@ -2,7 +2,7 @@
 module: upload
 sources:
 - backend/src/modules/upload
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/upload/dto/index.ts
 - backend/src/modules/upload/dto/upload.dto.ts

--- a/.claude/knowledge/modules/users.md
+++ b/.claude/knowledge/modules/users.md
@@ -2,7 +2,7 @@
 module: users
 sources:
 - backend/src/modules/users
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/users/controllers/addresses.controller.ts
 - backend/src/modules/users/controllers/password.controller.ts

--- a/.claude/knowledge/modules/vehicle-context.md
+++ b/.claude/knowledge/modules/vehicle-context.md
@@ -2,7 +2,7 @@
 module: vehicle-context
 sources:
 - backend/src/modules/vehicle-context
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/vehicle-context/vehicle-context.middleware.test.ts
 - backend/src/modules/vehicle-context/vehicle-context.middleware.ts

--- a/.claude/knowledge/modules/vehicles.md
+++ b/.claude/knowledge/modules/vehicles.md
@@ -2,7 +2,7 @@
 module: vehicles
 sources:
 - backend/src/modules/vehicles
-last_scan: '2026-06-23'
+last_scan: '2026-06-24'
 primary_files:
 - backend/src/modules/vehicles/brands.controller.ts
 - backend/src/modules/vehicles/controllers/admin-vehicle-cache.controller.ts

--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:f6f46688a4650ed3e87ec2442c1bd10b4ffa35ab6f3e186ddcab5ccc8c7c98d8",
+  "artifact_immutability_hash": "sha256:35667595f44d371e62d268b1554c2f07f5711a0db67f2f9055dc61f989b2ed84",
   "divergences": [
     {
       "kind": "specifier",
@@ -763,38 +763,33 @@
         "p99-regression-20pct"
       ],
       "compatibility_contracts": [
-        "session-cookie-v7",
-        "connect-redis-v7"
+        "session-cookie-v1",
+        "redis-session-key-v1",
+        "redis-session-json-v1"
       ],
-      "data_migration_required": true,
+      "data_migration_required": false,
       "dependency_lineage": {
         "supersedes": []
       },
       "deployment_sequence": [
-        "dual-runtime",
-        "canary",
         "full-rollout"
       ],
-      "estimated_canary_duration_minutes": 120,
+      "estimated_canary_duration_minutes": 0,
       "estimated_recovery_sequence": [
-        "deploy-banner",
-        "disable-canary",
         "rollback-api",
-        "invalidate-new-format-cookies",
-        "verify-session-roundtrip"
+        "verify-v5-reads-v9-sessions",
+        "verify-session-roundtrip",
+        "verify-auth-success-rate"
       ],
       "expected_user_impact": [
-        "forced-signout",
-        "banner-display"
+        "short-api-restart"
       ],
       "failure_domain": [
         "authentication"
       ],
       "family": "auth-session-passport",
       "incident_comm_protocol": [
-        "status-page",
-        "banner",
-        "email-notification"
+        "status-page"
       ],
       "known_incompatible_families": [
         "data-supabase"
@@ -807,15 +802,12 @@
         "express-session",
         "passport",
         "passport-jwt",
-        "passport-local"
+        "passport-local",
+        "redis"
       ],
-      "migration_blockers": [
-        "Node20Required",
-        "ConnectRedisV8RedisClientV4Required",
-        "AuthServiceAbstractionMerged"
-      ],
+      "migration_blockers": [],
       "node_runtime_requirement": ">=20",
-      "notes": "Abstraction layer first (split AuthService from session middleware), then upgrade. connect-redis v7→v8 changes cookie format ⇒ forced sign-out at deploy boundary. PROD banner mandatory. dual-runtime allows old+new session cookies to coexist during the canary window.\n",
+      "notes": "Re-baselined 2026-06-24 (PR-9a follow-up). Baseline is connect-redis@5.2.0 (the \"v7->v8\" framing was stale — the v7 step never landed); express-session already resolves 1.19.0. Target = connect-redis@9 + redis@5.12 (node-redis, sessions only; ioredis kept for cache/Bull/OIDC/write-guard) + express-session@1.19 + passport@0.7. Migration PRESERVES the wire/state format: prefix \"sess:\", default JSON serializer, disableTouch:false (rolling TTL), cookie name connect.sid => NO data migration, NO forced sign-out. Deploy is ATOMIC (no canary): validate DEV/CI/PREPROD (48h soak, connect-redis 9 alone, synthetic login/logout traffic) then atomic PROD swap on tag. Rollback = redeploy previous image; SAFE because the bidirectional test proves v5 reads sessions written by v9 (migration blocked if that test fails). 48h-soak SLA gate before PROD tag: session-roundtrip p99 <= baseline+20pct, auth-error-rate <= baseline+10pct, zero cookie-format errors over 24h, health-endpoint-ok. redis pinned ~5.12 (NOT 6.0: RESP3-default + 5s command-timeout — deferred to a separate PR). Sequencing (roadmap prose, not blockers): PR-9e.1 extracts SessionStoreService (store encapsulated, impl unchanged connect-redis@5+ioredis) then PR-9e.2 swaps the internal implementation. node_runtime_requirement \">=20\" is the upstream family minimum, satisfied by the repo-wide Node 24 baseline.\n",
       "observability_requirements": [
         "sentry",
         "session-roundtrip",
@@ -827,11 +819,11 @@
       },
       "operational_owner": "auth-team",
       "orchestrator_lock_scope": [
-        "sessions-table",
+        "redis-sessions",
         "auth"
       ],
       "orchestrator_policy": {
-        "deploy_mode": "canary-only",
+        "deploy_mode": "atomic",
         "rollback_mode": "manual-only"
       },
       "packages": [
@@ -968,6 +960,7 @@
         "passport-jwt",
         "express-session",
         "connect-redis",
+        "redis",
         "@nestjs/jwt"
       ],
       "peer_dependency_cluster_resolved": [
@@ -977,7 +970,8 @@
         "express-session",
         "passport",
         "passport-jwt",
-        "passport-local"
+        "passport-local",
+        "redis"
       ],
       "perf_baseline_metrics": [],
       "pr_assignment": "pr-9e",
@@ -988,15 +982,13 @@
         "api",
         "sessions"
       ],
-      "rollback_complexity": "dangerous",
+      "rollback_complexity": "moderate",
       "rollback_confidence_level": "theoretical",
-      "rollback_data_loss_risk": "partial-loss",
+      "rollback_data_loss_risk": "none",
       "rollback_drill_commit": null,
       "rollback_observability_grace_period_minutes": 30,
       "rollback_preconditions": [
-        "banner-deployed",
-        "dual-runtime-active",
-        "canary-disabled"
+        "previous-image-available"
       ],
       "rollback_requires_human_approval": true,
       "rollback_rto_minutes": 30,
@@ -1009,8 +1001,7 @@
       ],
       "runtime_budget_constraints": {},
       "runtime_capabilities": [
-        "supports-canary",
-        "supports-dual-write"
+        "none"
       ],
       "runtime_contract_expiry": "2026-12-31",
       "runtime_criticality": "critical",
@@ -1033,21 +1024,21 @@
         "redis",
         "cookies"
       ],
-      "safe_parallel_window_minutes": 1440,
+      "safe_parallel_window_minutes": 0,
       "source_url": "https://github.com/jaredhanson/passport/releases",
       "staging_soak_hours": 48,
-      "state_compatibility_window_minutes": 1440,
+      "state_compatibility_window_minutes": 120,
       "state_reconciliation_strategy": {
-        "duplicate_resolution": "latest-write-wins"
+        "duplicate_resolution": "n/a"
       },
-      "state_schema_version": "session-v7",
-      "state_transition_strategy": "dual-write",
+      "state_schema_version": "redis-session-json-v1",
+      "state_transition_strategy": "none",
       "stateful_surface": [
         "redis-sessions",
         "cookies"
       ],
-      "supports_dual_runtime": "full",
-      "target_major": "see source_url",
+      "supports_dual_runtime": "none",
+      "target_major": "connect-redis@9 + redis@5.12 + express-session@1.19 + passport@0.7",
       "total_occurrences": 9,
       "upgrade_cost_estimate": {
         "estimated_engineer_days": 14,
@@ -3894,7 +3885,7 @@
     "lockfile": "package-lock.json",
     "lockfile_sha": "sha256:7b0b689e4b6c0a70b3bbe92dee8777fbdb6b8cf3f30b3a47674386b8a3ef778e",
     "overlay": "audit/dependencies/family-overlay.yaml",
-    "overlay_sha": "sha256:42597019658ecd86a9df3c4f64505542d2f89192ab1eef12b9ae218ea5df4728"
+    "overlay_sha": "sha256:27fd355bd68ab7e56f4adbf67edf8e704100487d3f744b76f95b9a11aba10fe6"
   },
   "inventoryFormat": "pr-9-modernization-inventory",
   "matrixVersion": "pr9-v1",

--- a/audit/dependencies/dependency-upgrade-matrix.md
+++ b/audit/dependencies/dependency-upgrade-matrix.md
@@ -16,7 +16,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:upgrade-plan START -->
 | Family | Blast radius | Target major | PR | Upgrade strategy | Runtime criticality |
 | --- | --- | --- | --- | --- | --- |
-| auth-session-passport | auth | see source_url | pr-9e | abstraction-first | critical |
+| auth-session-passport | auth | connect-redis@9 + redis@5.12 + express-session@1.19 + passport@0.7 | pr-9e | abstraction-first | critical |
 | data-supabase | data | see source_url | deferred | staged-rollout | critical |
 | internal-workspace | internal | workspace | deferred | in-place | medium |
 | observability-otel | observability | see source_url | deferred | in-place | medium |
@@ -35,7 +35,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:execution START -->
 | Family | Soak (h) | Node | Deployment sequence | Production approved |
 | --- | --- | --- | --- | --- |
-| auth-session-passport | 48 | >=20 | dual-runtime, canary, full-rollout | ✓ |
+| auth-session-passport | 48 | >=20 | full-rollout | ✓ |
 | data-supabase | 72 | >=20 | canary, full-rollout | ✓ |
 | internal-workspace | 0 | >=20 | n/a | ✓ |
 | observability-otel | 0 | >=20 | n/a | ✓ |
@@ -54,7 +54,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:governance START -->
 | Family | Rollback complexity | Migration blockers | Observability requirements |
 | --- | --- | --- | --- |
-| auth-session-passport | dangerous | Node20Required, ConnectRedisV8RedisClientV4Required, AuthServiceAbstractionMerged | sentry, session-roundtrip, structured-logs |
+| auth-session-passport | moderate | [] | sentry, session-roundtrip, structured-logs |
 | data-supabase | dangerous | Node20Required, SupabaseRealtimeV2Compatible | sentry, structured-logs, health-endpoint |
 | internal-workspace | moderate | [] | structured-logs |
 | observability-otel | moderate | Node20Required | structured-logs, traces |
@@ -78,7 +78,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:operational START -->
 | Family | Data migration | Dual runtime | RTO (min) | Owner domain | Perf baseline |
 | --- | --- | --- | --- | --- | --- |
-| auth-session-passport | yes | full | 30 | auth, backend-runtime | no |
+| auth-session-passport | no | none | 30 | auth, backend-runtime | no |
 | data-supabase | yes | partial | 30 | data, backend-runtime | no |
 | internal-workspace | no | none | 15 | platform-tooling | no |
 | observability-otel | no | full | 15 | observability | no |
@@ -104,7 +104,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:control-plane START -->
 | Family | Runbook required | User impact | Perf metrics | Recovery sequence |
 | --- | --- | --- | --- | --- |
-| auth-session-passport | true | forced-signout, banner-display | [] | deploy-banner, disable-canary, rollback-api, invalidate-new-format-cookies, verify-session-roundtrip |
+| auth-session-passport | true | short-api-restart | [] | rollback-api, verify-v5-reads-v9-sessions, verify-session-roundtrip, verify-auth-success-rate |
 | data-supabase | true | short-api-restart | [] | disable-canary, rollback-api, supabase-realtime-channel-rollback, verify-health-endpoint |
 | internal-workspace | false | none | [] | changeset-rollback, rebuild |
 | observability-otel | false | none | [] | revert-pr, verify-log-format |
@@ -129,7 +129,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:state-canary START -->
 | Family | Stateful surface | Rollback validation checks | Canary abort conditions | Runtime state coupling | Safe parallel window (min) |
 | --- | --- | --- | --- | --- | --- |
-| auth-session-passport | redis-sessions, cookies | session-roundtrip, no-sentry-spike, health-endpoint-ok | sentry-error-rate-spike, session-roundtrip-fail, p99-regression-20pct | redis, cookies | 1440 |
+| auth-session-passport | redis-sessions, cookies | session-roundtrip, no-sentry-spike, health-endpoint-ok | sentry-error-rate-spike, session-roundtrip-fail, p99-regression-20pct | redis, cookies | 0 |
 | data-supabase | realtime-channels | health-endpoint-ok, no-sentry-spike | sentry-error-rate-spike, p99-regression-20pct, health-endpoint-fail | realtime-channels | 120 |
 | internal-workspace | none | none | [] | none | 0 |
 | observability-otel | none | traces-continuity | [] | none | 1440 |
@@ -155,7 +155,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:orchestration START -->
 | Family | Data loss risk | Runtime entrypoints | Operational owner | Canary duration (min) | Human approval |
 | --- | --- | --- | --- | --- | --- |
-| auth-session-passport | partial-loss | api, ssr | auth-team | 120 | true |
+| auth-session-passport | none | api, ssr | auth-team | 0 | true |
 | data-supabase | partial-loss | api, workers | data-team | 60 | true |
 | internal-workspace | none | build-only | platform-tooling-team | 0 | false |
 | observability-otel | none | api, workers | observability-team | 0 | false |
@@ -206,7 +206,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:runtime-dag START -->
 | Family | depends_on_runtime | Rollback preconditions | SLI queries (count) | State schema version | Rollback blast scope |
 | --- | --- | --- | --- | --- | --- |
-| auth-session-passport | [] | banner-deployed, dual-runtime-active, canary-disabled | 2 | session-v7 | api, sessions |
+| auth-session-passport | [] | previous-image-available | 2 | redis-session-json-v1 | api, sessions |
 | data-supabase | auth-session-passport | no-realtime-active, canary-disabled | 2 | supabase-v2 | api, workers, realtime |
 | internal-workspace | [] | [] | 0 | n/a | none |
 | observability-otel | [] | [] | 0 | n/a | none |
@@ -232,7 +232,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:platform-engineering START -->
 | Family | Runtime capabilities | Failure domain | Rollback confidence | State transition strategy | Incident comm protocol |
 | --- | --- | --- | --- | --- | --- |
-| auth-session-passport | supports-canary, supports-dual-write | authentication | theoretical | dual-write | status-page, banner, email-notification |
+| auth-session-passport | none | authentication | theoretical | none | status-page |
 | data-supabase | supports-canary | data-layer | theoretical | lazy-migration | status-page |
 | internal-workspace | supports-feature-flag | tooling | theoretical | none | none |
 | observability-otel | none | observability | theoretical | none | none |
@@ -258,7 +258,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:contract-orchestration START -->
 | Family | Compatibility contracts | Freeze window | Orchestrator policy | Lineage supersedes | State compat window (min) |
 | --- | --- | --- | --- | --- | --- |
-| auth-session-passport | session-cookie-v7, connect-redis-v7 | 22:00→06:00 | {manual-only, canary-only} | [] | 1440 |
+| auth-session-passport | session-cookie-v1, redis-session-key-v1, redis-session-json-v1 | 22:00→06:00 | {manual-only, atomic} | [] | 120 |
 | data-supabase | supabase-v2 | 22:00→06:00 | {manual-only, staged} | [] | 120 |
 | internal-workspace | [] | null | {auto-allowed, staged} | [] | 0 |
 | observability-otel | pino-v8 | null | {auto-allowed, staged} | [] | 1440 |
@@ -284,7 +284,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:budget-reconciliation START -->
 | Family | Runtime budget constraints | Duplicate resolution | Lock scope | Grace period (min) | Contract expiry |
 | --- | --- | --- | --- | --- | --- |
-| auth-session-passport | {} | latest-write-wins | sessions-table, auth | 30 | 2026-12-31 |
+| auth-session-passport | {} | n/a | redis-sessions, auth | 30 | 2026-12-31 |
 | data-supabase | {} | latest-write-wins | realtime-channels, data-layer | 30 | 2027-06-30 |
 | internal-workspace | {} | n/a | [] | 0 | null |
 | observability-otel | {} | n/a | [] | 5 | null |
@@ -314,7 +314,7 @@ Prose surrounding the tables (reading guides, callouts) is human-edited.
 <!-- AUTO-TABLE:peer-clusters START -->
 | Family | Overlay patterns | Resolved members (frozen) |
 | --- | --- | --- |
-| auth-session-passport | passport, @nestjs/passport, passport-local, passport-jwt, express-session, connect-redis, @nestjs/jwt | @nestjs/jwt, @nestjs/passport, connect-redis, express-session, passport, passport-jwt, passport-local |
+| auth-session-passport | passport, @nestjs/passport, passport-local, passport-jwt, express-session, connect-redis, redis, @nestjs/jwt | @nestjs/jwt, @nestjs/passport, connect-redis, express-session, passport, passport-jwt, passport-local, redis |
 | data-supabase | @supabase/supabase-js | @supabase/supabase-js |
 | observability-otel | pino, pino-pretty | pino, pino-pretty |
 | queues-bullmq | bullmq, @nestjs/bullmq, @nestjs/bull, bull, ioredis | @nestjs/bull, @nestjs/bullmq, bull, bullmq, ioredis |

--- a/audit/dependencies/family-overlay.yaml
+++ b/audit/dependencies/family-overlay.yaml
@@ -362,7 +362,7 @@ families:
 
   - family: auth-session-passport
     blast_radius: auth
-    target_major: "see source_url"
+    target_major: "connect-redis@9 + redis@5.12 + express-session@1.19 + passport@0.7"
     pr_assignment: pr-9e
     source_url: https://github.com/jaredhanson/passport/releases
     upgrade_strategy: abstraction-first
@@ -377,23 +377,19 @@ families:
       - passport-jwt
       - express-session
       - connect-redis
+      - redis
       - "@nestjs/jwt"
     deployment_sequence:
-      - dual-runtime
-      - canary
       - full-rollout
     production_approved: true
-    rollback_complexity: dangerous
-    migration_blockers:
-      - Node20Required
-      - ConnectRedisV8RedisClientV4Required
-      - AuthServiceAbstractionMerged
+    rollback_complexity: moderate
+    migration_blockers: []
     observability_requirements:
       - sentry
       - session-roundtrip
       - structured-logs
-    data_migration_required: true
-    supports_dual_runtime: full
+    data_migration_required: false
+    supports_dual_runtime: none
     rollback_rto_minutes: 30
     upgrade_owner_domain:
       - auth
@@ -401,15 +397,13 @@ families:
     requires_perf_baseline: false
     rollback_runbook_required: true
     expected_user_impact:
-      - forced-signout
-      - banner-display
+      - short-api-restart
     perf_baseline_metrics: []
     estimated_recovery_sequence:
-      - deploy-banner
-      - disable-canary
       - rollback-api
-      - invalidate-new-format-cookies
+      - verify-v5-reads-v9-sessions
       - verify-session-roundtrip
+      - verify-auth-success-rate
     stateful_surface:
       - redis-sessions
       - cookies
@@ -424,13 +418,13 @@ families:
     runtime_state_coupling:
       - redis
       - cookies
-    safe_parallel_window_minutes: 1440
-    rollback_data_loss_risk: partial-loss
+    safe_parallel_window_minutes: 0
+    rollback_data_loss_risk: none
     runtime_entrypoints:
       - api
       - ssr
     operational_owner: auth-team
-    estimated_canary_duration_minutes: 120
+    estimated_canary_duration_minutes: 0
     rollback_requires_human_approval: true
     rollback_tested_at: null
     rollback_drill_commit: null
@@ -445,52 +439,61 @@ families:
     runtime_dependency_edges:
       depends_on_runtime: []
     rollback_preconditions:
-      - banner-deployed
-      - dual-runtime-active
-      - canary-disabled
+      - previous-image-available
     observability_sli_queries:
       auth-success-rate: "sum(rate(auth_login_success_total[5m])) / sum(rate(auth_login_attempt_total[5m]))"
       api-p99: "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))"
-    state_schema_version: session-v7
+    state_schema_version: redis-session-json-v1
     rollback_blast_scope:
       - api
       - sessions
     runtime_capabilities:
-      - supports-canary
-      - supports-dual-write
+      - none
     failure_domain:
       - authentication
     rollback_confidence_level: theoretical
-    state_transition_strategy: dual-write
+    state_transition_strategy: none
     incident_comm_protocol:
       - status-page
-      - banner
-      - email-notification
     compatibility_contracts:
-      - session-cookie-v7
-      - connect-redis-v7
+      - session-cookie-v1
+      - redis-session-key-v1
+      - redis-session-json-v1
     runtime_freeze_window:
       start: "22:00"
       end: "06:00"
     orchestrator_policy:
       rollback_mode: manual-only
-      deploy_mode: canary-only
+      deploy_mode: atomic
     dependency_lineage:
       supersedes: []
-    state_compatibility_window_minutes: 1440
+    state_compatibility_window_minutes: 120
     runtime_budget_constraints: {}
     state_reconciliation_strategy:
-      duplicate_resolution: latest-write-wins
+      duplicate_resolution: n/a
     orchestrator_lock_scope:
-      - sessions-table
+      - redis-sessions
       - auth
     rollback_observability_grace_period_minutes: 30
     runtime_contract_expiry: "2026-12-31"
     notes: >
-      Abstraction layer first (split AuthService from session middleware),
-      then upgrade. connect-redis v7→v8 changes cookie format ⇒ forced sign-out
-      at deploy boundary. PROD banner mandatory. dual-runtime allows
-      old+new session cookies to coexist during the canary window.
+      Re-baselined 2026-06-24 (PR-9a follow-up). Baseline is connect-redis@5.2.0 (the
+      "v7->v8" framing was stale — the v7 step never landed); express-session already
+      resolves 1.19.0. Target = connect-redis@9 + redis@5.12 (node-redis, sessions only;
+      ioredis kept for cache/Bull/OIDC/write-guard) + express-session@1.19 + passport@0.7.
+      Migration PRESERVES the wire/state format: prefix "sess:", default JSON serializer,
+      disableTouch:false (rolling TTL), cookie name connect.sid => NO data migration, NO
+      forced sign-out. Deploy is ATOMIC (no canary): validate DEV/CI/PREPROD (48h soak,
+      connect-redis 9 alone, synthetic login/logout traffic) then atomic PROD swap on tag.
+      Rollback = redeploy previous image; SAFE because the bidirectional test proves v5
+      reads sessions written by v9 (migration blocked if that test fails). 48h-soak SLA
+      gate before PROD tag: session-roundtrip p99 <= baseline+20pct, auth-error-rate <=
+      baseline+10pct, zero cookie-format errors over 24h, health-endpoint-ok. redis pinned
+      ~5.12 (NOT 6.0: RESP3-default + 5s command-timeout — deferred to a separate PR).
+      Sequencing (roadmap prose, not blockers): PR-9e.1 extracts SessionStoreService
+      (store encapsulated, impl unchanged connect-redis@5+ioredis) then PR-9e.2 swaps the
+      internal implementation. node_runtime_requirement ">=20" is the upstream family
+      minimum, satisfied by the repo-wide Node 24 baseline.
     members:
       - passport
       - "@nestjs/passport"
@@ -498,6 +501,7 @@ families:
       - passport-jwt
       - express-session
       - connect-redis
+      - redis
       - bcrypt
       - "@nestjs/jwt"
 

--- a/audit/dependencies/pr-9-modernization-roadmap.md
+++ b/audit/dependencies/pr-9-modernization-roadmap.md
@@ -137,28 +137,30 @@
 - **Rollback runbook (mandatory in PR body):** (1) revert PR, (2) drain v5 repeatable jobs, (3) re-emit in v4 Job-ID format, (4) verify workers consuming, (5) `queue-metrics` back to baseline.
 - **Runtime risk:** queues stop processing if Worker registration drifts. **Workers MUST deploy before API.**
 
-## PR-9e — Auth abstraction
+## PR-9e — Auth/session modernization (PR-9e.1 abstraction → PR-9e.2 impl swap)
+
+> **Re-baselined 2026-06-24** (PR-9a follow-up). Original entry was stale (pre-React-Router-migration, pre-Node-24): it framed the bump as `connect-redis v7→v8` with `data_migration: YES` / `dual-write` / forced-signout. **Reality verified against the lockfile:** baseline is `connect-redis@5.2.0` (the v7 step never landed), `express-session` already resolves `1.19.0`, the official `redis` client is absent. connect-redis@9 **preserves** the v5 wire/state format (prefix `sess:`, default JSON serializer, `disableTouch:false`) ⇒ **no data migration, no forced sign-out**, deploy is **atomic** (the repo has no canary).
 
 - **Family:** `auth-session-passport`
-- **Family meta:** `upgrade_strategy: abstraction-first`, `runtime_criticality: critical`, `requires_staging_soak: true`, `staging_soak_hours: 48`, `node_runtime_requirement: ">=20"`, `production_approved: true`
-- **Rollback complexity:** **`dangerous`** — mid-flight session invalidation.
-- **Migration blockers:** `Node20Required`, `ConnectRedisV8RedisClientV4Required`, `AuthServiceAbstractionMerged` (Step A merged before Step B opens).
+- **Family meta:** `upgrade_strategy: abstraction-first`, `runtime_criticality: critical`, `requires_staging_soak: true`, `staging_soak_hours: 48`, `node_runtime_requirement: ">=20"` (upstream family minimum — satisfied by the repo-wide Node 24 baseline), `production_approved: true`
+- **Rollback complexity:** **`moderate`** — code revert via image redeploy; no irreversible state change (format preserved).
+- **Migration blockers:** **none.** (`Node20Required` satisfied by Node 24; `ConnectRedisV8RedisClientV4Required` resolved by the explicit target; the `SessionStoreService` extraction is **the first step of PR-9e.1, not an external precondition** — rule #7. Ordering lives in prose below, not as a blocker.)
 - **Observability requirements:** `sentry`, `session-roundtrip`, `structured-logs`.
-- **Data migration:** **YES** — session cookie v7→v8 + Redis key shape. **Dual runtime:** `full`. **RTO:** 30 min. **Owner:** `auth`, `backend-runtime`. **Perf baseline:** not required.
-- **Control plane:** `rollback_runbook_required: true`. **User impact:** `[forced-signout, banner-display]` — release notes + banner template mandatory. **Perf metrics:** `[]`. **Recovery sequence:** `deploy-banner → disable-canary → rollback-api → invalidate-new-format-cookies → verify-session-roundtrip`.
-- **State + canary:** `stateful_surface: [redis-sessions, cookies]` ⚠️ live user state. `rollback_validation_checks: [session-roundtrip, no-sentry-spike, health-endpoint-ok]`. `canary_abort_conditions: [sentry-error-rate-spike, session-roundtrip-fail, p99-regression-20pct]`. `runtime_state_coupling: [redis, cookies]`. `safe_parallel_window_minutes: 1440` (24h dual-cookie acceptance).
-- **Orchestration:** `rollback_data_loss_risk: partial-loss`. `runtime_entrypoints: [api, ssr]`. `operational_owner: auth-team`. `estimated_canary_duration_minutes: 120`. **`rollback_requires_human_approval: true`**.
-- **Lifecycle:** drill banner + cookie cleanup during 48h soak. `known_incompatible_families: [data-supabase]`. Cost: **14 engineer-days, review_load: extreme**. SLO: `[auth-success-rate, api-p99]`.
-- **Runtime DAG:** `depends_on_runtime: []`. `rollback_preconditions: [banner-deployed, dual-runtime-active, canary-disabled]`. `observability_sli_queries: {auth-success-rate, api-p99}`. `state_schema_version: session-v7`. `rollback_blast_scope: [api, sessions]`.
-- **Platform:** `runtime_capabilities: [supports-canary, supports-dual-write]`. `failure_domain: [authentication]`. `rollback_confidence_level: theoretical → drilled at PR-9e (mandatory)`. **`state_transition_strategy: dual-write`**. `incident_comm_protocol: [status-page, banner, email-notification]`.
-- **Peer cluster:** `passport`, `@nestjs/passport`, `passport-local`, `passport-jwt`, `express-session`, `connect-redis`, `@nestjs/jwt`.
-- **Deployment sequence:** `dual-runtime` → `canary` → `full-rollout`
-- **Preconditions:** PR-9d merged.
-- **Scope:** Step A (`PR-9e.1`) — introduce `AuthService` abstraction. Step B (`PR-9e.2`) — bump cluster including `connect-redis` v7 → v8.
-- **CI proof:** login/logout E2E pass; admin/* smoke pass; session round-trip sample.
-- **PREPROD soak:** 48h on the PREPROD container with synthetic login/logout traffic.
-- **Rollback runbook (mandatory in PR body):** (1) deploy PROD banner, (2) revert PR, (3) verify connect-redis v7 cookie format accepted, (4) clear new-format cookies, (5) `session-roundtrip` synthetic green.
-- **Runtime risk:** session format change ⇒ forced sign-out at deploy boundary. Banner mandatory.
+- **Data migration:** **NO** — wire/state format preserved across v5↔v9. **Dual runtime:** `none` (atomic deploy). **RTO:** 30 min. **Owner:** `auth`, `backend-runtime`. **Perf baseline:** not required.
+- **Control plane:** `rollback_runbook_required: true`. **User impact:** `[short-api-restart]` (atomic swap = brief restart; **no** nominal forced sign-out). **Perf metrics:** `[]`. **Recovery sequence:** `rollback-api → verify-v5-reads-v9-sessions → verify-session-roundtrip → verify-auth-success-rate`.
+- **State:** `stateful_surface: [redis-sessions, cookies]`. `rollback_validation_checks: [session-roundtrip, no-sentry-spike, health-endpoint-ok]` (SLA thresholds in overlay `notes`). `runtime_state_coupling: [redis, cookies]`. `safe_parallel_window_minutes: 0` (atomic, no parallel window). `state_compatibility_window_minutes: 120` documents v5↔v9 session interop **for a rollback to the previous image** (not a canary).
+- **Orchestration:** `rollback_data_loss_risk: none`. `runtime_entrypoints: [api, ssr]`. `operational_owner: auth-team`. `estimated_canary_duration_minutes: 0`. **`rollback_requires_human_approval: true`**. `orchestrator_policy.deploy_mode: atomic`.
+- **Lifecycle:** `known_incompatible_families: [data-supabase]`. Cost: **14 engineer-days, review_load: extreme**. SLO: `[auth-success-rate, api-p99]`.
+- **Runtime DAG:** `depends_on_runtime: []`. `rollback_preconditions: [previous-image-available]`. `state_schema_version: redis-session-json-v1`. `rollback_blast_scope: [api, sessions]`.
+- **Platform:** `runtime_capabilities: [none]`. `failure_domain: [authentication]`. **`state_transition_strategy: none`**. `incident_comm_protocol: [status-page]` (banner = contingency only if the compat test fails).
+- **Peer cluster:** `passport`, `@nestjs/passport`, `passport-local`, `passport-jwt`, `express-session`, `connect-redis`, `redis`, `@nestjs/jwt`.
+- **Deployment sequence:** `full-rollout` (atomic — validate DEV/CI/PREPROD, then atomic PROD swap on tag).
+- **Preconditions:** PR-9d **de-facto satisfied** (`bullmq@5.79.1` already live); Node 24 baseline live.
+- **Scope (ordering — rule #7: not blockers):** **PR-9e.1** extracts `SessionStoreService` (store **encapsulated**, exposes `createSessionMiddleware()` + `isOpen()`/`healthCheck()`; impl **unchanged** = connect-redis@5 factory + ioredis; **boot behavior unchanged**) + splits health (`/health` liveness, `/health/ready`, `/health/session-store`). **PR-9e.2** (opens only after 9e.1 merges) swaps the internal impl to `connect-redis@9` + `redis@~5.12` (node-redis, sessions only; ioredis kept for cache/Bull/OIDC/write-guard), adds `OnApplicationBootstrap` connect + fail-fast, `OnApplicationShutdown` ordered close. redis pinned `~5.12` (**not 6.0**: RESP3-default + 5s command-timeout deferred).
+- **CI proof:** **bidirectional v5↔v9 session read/write on REAL Redis** (proves rollback safety incl. `cookie.expires`), contract/fail-fast/resilience/touch-TTL/sessionVersion tests, login/logout E2E, admin/* smoke. Requires a Redis service in CI (currently absent).
+- **PREPROD soak:** 48h, connect-redis 9 **alone**, with a **synthetic login/logout generator** (PREPROD has no real traffic) — SLA gate: `session-roundtrip p99 ≤ baseline+20%`, `auth-error-rate ≤ baseline+10%`, zero cookie-format errors / 24h, `health-endpoint-ok`.
+- **Rollback runbook (mandatory in PR body):** redeploy the previous versioned image. **Safe because the bidirectional test proves v5 reads sessions written by v9** — migration is blocked if that test fails. Banner/forced-signout = secondary contingency only if the compat test regresses.
+- **Runtime risk:** format preserved ⇒ **no nominal forced sign-out**; the residual risk is a brief restart at the atomic swap.
 
 ## PR-9f.0 — Express 5 compatibility audit (audit-only, blocks PR-9f)
 
@@ -179,6 +181,10 @@
 - **CI proof:** existing CI green.
 - **Output verdict (mandatory):** `PASS` or `BLOCKING-FOR-PR9F: <list>`.
 - **Why before PR-9f:** the `Express5CompatibilityAuditPassed` migration_blocker on `runtime-backend-nest` cannot be resolved without this audit.
+
+> **ERRATA 2026-06-24 — original blocking verdict is now stale.** The audit (`pr-9f.0-express-5-compatibility-audit.md`, #723) blocked on `@remix-run/express@2.17.4` (peer `express@^4.20.0`). The **React Router v7→v8 migration** retired Remix v2 (PR #1052 and follow-ups) — `@remix-run/express` is **removed**; SSR now runs through `@react-router/express`, which accepts `express ^4 || ^5`. The upstream blocker is **lifted**. Re-audit verdict ⇒ **PASS, with required (non-blocking) Express-5 migrations identified for PR-9f**, not "PASS with no source change":
+> 1. **Wildcard/regex routes** (path-to-regexp v0→v8): `@All(':path*')` [`backend/src/remix/remix.controller.ts:60`] and `:param(.*)` [`optimized-metadata.controller.ts:40/70/104`, `optimized-breadcrumb.controller.ts:40/117/152/194`, `seo.controller.ts:52/115`] → migrate to named wildcards `{*path}` (`{*path}` also matches the root).
+> 2. **Query parser:** no explicit `query parser` in `main.ts` ⇒ Express 5 flips the default `extended`→`simple` (nested/array params change shape). Prove no controller depends on it, or set `expressApp.set('query parser', 'extended')`.
 
 ## PR-9f — NestJS 11
 

--- a/audit/dependencies/pr-9f.0-express-5-compatibility-audit.md
+++ b/audit/dependencies/pr-9f.0-express-5-compatibility-audit.md
@@ -180,3 +180,20 @@ Single blocker. Application code (handlers, middleware, decorators) is **100% Ex
 ---
 
 *Audit produced 2026-05-24. Audit-only PR per PR-9 roadmap § PR-9f.0. No runtime code modified.*
+
+---
+
+## ERRATA — 2026-06-24 (re-evaluation after the React Router v7→v8 migration)
+
+> The 2026-05-24 verdict above is **preserved for history**. This errata supersedes it. Two findings: the blocker is lifted, **and** the original "100% Express 5-compatible application code" claim was incomplete (its 13 scans did not check route-path syntax).
+
+**Verdict update: `BLOCKING-FOR-PR9F` is LIFTED ⇒ `PASS` with required (non-blocking) Express-5 migrations for PR-9f.**
+
+- **Blocker lifted.** `@remix-run/express@2.17.4` (the sole blocker, peer `express@^4.20.0`) is **gone**: the React Router v7→v8 migration retired Remix v2 (PR #1052 + follow-ups #1041/#1046/#1058/#1126). SSR now runs through `@react-router/express`, whose peer accepts `express ^4 || ^5`. The leftover nested `express@4` under `@react-router/serve` is a CLI not used at runtime, and `@nestjs/platform-express@10` bundles its own `express@4` until NestJS 11.
+- **Correction to the original "0 deprecated patterns" claim.** The 13 scans checked handler/middleware/decorator patterns (`req.param()`, `res.json(status,…)`, etc.) but **not route-path syntax**. Express 5 ships path-to-regexp v8, which breaks the v0 wildcard/regex route forms still present:
+  - `@All(':path*')` — `backend/src/remix/remix.controller.ts:60`
+  - `:param(.*)` regex routes — `backend/src/modules/metadata/controllers/optimized-metadata.controller.ts:40/70/104`, `optimized-breadcrumb.controller.ts:40/117/152/194`, `backend/src/modules/seo/controllers/seo.controller.ts:52/115`
+  - → migrate to named wildcards `{*path}` (which also matches the root path).
+- **Query parser.** `main.ts` sets no explicit `query parser`; Express 5 flips the default `extended`→`simple` (nested/array query params change shape). PR-9f must prove no controller depends on it **or** set `expressApp.set('query parser', 'extended')`.
+
+**Net:** PR-9f is **openable** (no upstream peer-dep wall) with these two migrations as mandatory in-scope work, not "no source change". Re-run a full scan during PR-9f.


### PR DESCRIPTION
## Why
The **PR-9e** entry (`auth-session-passport` family) in the dependency-modernization control plane was **stale** — written before the React Router migration and the Node 24 baseline. Verified against the lockfile:

- baseline is **`connect-redis@5.2.0`** (the roadmap's "v7→v8" step never landed)
- `express-session` already resolves **1.19.0**
- the official `redis` (node-redis) client is **absent**
- `bullmq@5.79.1` is live (the stated PR-9d precondition is de-facto satisfied)
- Node 24 is the repo-wide baseline

connect-redis@9 **preserves** the v5 wire/state format (prefix `sess:`, default JSON serializer, `disableTouch:false`) ⇒ **no data migration, no forced sign-out**. The repo deploys **atomically** (no canary).

## What changed (doc-only — PR-9a follow-up, no runtime code)
**Overlay `audit/dependencies/family-overlay.yaml` (`auth-session-passport`):**
- `data_migration_required: false`, `supports_dual_runtime: none`, `deploy_mode: atomic`, `deployment_sequence: [full-rollout]`, `rollback_complexity: moderate`, `expected_user_impact: [short-api-restart]`, `rollback_data_loss_risk: none`
- `migration_blockers: []` — rule #7: the `SessionStoreService` extraction is PR-9e.1's first step, not an external precondition; `Node20Required` satisfied by Node 24
- `target_major` made explicit (`connect-redis@9 + redis@5.12 + express-session@1.19 + passport@0.7`); `redis` added to members + peer cluster
- `compatibility_contracts` / `state_schema_version` now describe the **preserved** format
- `node_runtime_requirement` kept `">=20"` (upstream family minimum, satisfied by the Node 24 baseline)
- every value validated against the Zod schema + all cross-field refinements

**Regenerated:** L3 `dependency-modernization-inventory.json` + L4 `dependency-upgrade-matrix.md` (both `:check` green).

**Roadmap prose:** PR-9e rewritten (PR-9e.1 abstraction → PR-9e.2 swap ordering, in prose not blockers).

**PR-9f.0 errata (dated):** the `@remix-run/express` Express-5 blocker is **lifted** by the React Router v8 migration ⇒ **PASS**, with required (non-blocking) Express-5 migrations identified for PR-9f: route wildcards `:path*`/`:param(.*)` → `{*path}` and the `extended`→`simple` query-parser default.

## Verification
- `npm run audit:pr-9-modernization-inventory:check` → ✅ deterministic
- `tsx scripts/audit/render-dependency-modernization-matrix.ts --check` → ✅ in sync
- diff ⊆ `audit/dependencies/*` (the daily knowledge `last_scan` refresh is an isolated separate commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)