### PR TITLE
fix(observability): triage Sentry post-deploy — 4xx hygiene + search storage guard + chunk-reload + PREPROD bind

### DIFF
--- a/docker-compose.preprod.yml
+++ b/docker-compose.preprod.yml
@@ -38,7 +38,14 @@ services:
     image: massdoc/nestjs-remix-monorepo:preprod
     restart: always
     ports:
-      - "3200:3000"
+      # Bind to loopback only. PREPROD is CI-only (READ_ONLY) and reached
+      # exclusively via http://localhost:3200 by the self-hosted runner (E2E
+      # Smoke / Lighthouse / health polls in ci.yml). Caddy never proxies :3200
+      # (PROD is monorepo_prod:3000), so nothing external needs it. Enforcing the
+      # canonical "3200 localhost only" guarantee at the Docker layer — instead of
+      # relying solely on a host firewall — closes the exposure that let an
+      # external scanner POST /_next straight to the port (Sentry 2026-06-25).
+      - "127.0.0.1:3200:3000"
     volumes:
       # Sitemap output directory — writable, isolated from PROD's /var/www/sitemaps.
       # The path follows the canonical `/dev/volumes/nestjs-remix/preprod/*` pattern

--- a/frontend/app/components/search/SearchBar.tsx
+++ b/frontend/app/components/search/SearchBar.tsx
@@ -22,6 +22,7 @@ import { useState, useEffect, useRef, useCallback, memo } from "react";
 import { Form, useNavigate, useSearchParams } from "react-router";
 
 import { logger } from "~/utils/logger";
+import { safeLocalStorage } from "~/utils/safe-storage";
 import {
   useEnhancedSearchWithDebounce,
   useEnhancedAutocomplete,
@@ -112,7 +113,7 @@ export const SearchBar = memo(function SearchBar({
   // Charger l'historique au montage
   useEffect(() => {
     if (typeof window !== "undefined" && showHistory) {
-      const stored = localStorage.getItem("search-history");
+      const stored = safeLocalStorage.getItem("search-history");
       if (stored) {
         try {
           setSearchHistory(JSON.parse(stored).slice(0, 5));
@@ -281,7 +282,7 @@ export const SearchBar = memo(function SearchBar({
       ].slice(0, 5);
 
       setSearchHistory(newHistory);
-      localStorage.setItem("search-history", JSON.stringify(newHistory));
+      safeLocalStorage.setItem("search-history", JSON.stringify(newHistory));
     },
     [showHistory, searchHistory],
   );
@@ -290,7 +291,7 @@ export const SearchBar = memo(function SearchBar({
   const clearHistory = useCallback(() => {
     setSearchHistory([]);
     if (typeof window !== "undefined") {
-      localStorage.removeItem("search-history");
+      safeLocalStorage.removeItem("search-history");
     }
   }, []);
 

--- a/frontend/app/components/search/SearchBarEnhancedHomepage.tsx
+++ b/frontend/app/components/search/SearchBarEnhancedHomepage.tsx
@@ -26,6 +26,7 @@ import { useState, useEffect, useRef, memo } from "react";
 import { Form, useNavigate } from "react-router";
 
 import { logger } from "~/utils/logger";
+import { safeLocalStorage } from "~/utils/safe-storage";
 import {
   useEnhancedSearchWithDebounce,
   useEnhancedAutocomplete,
@@ -80,7 +81,7 @@ export const SearchBarEnhancedHomepage = memo(
 
     // Charger les recherches récentes depuis localStorage
     useEffect(() => {
-      const stored = localStorage.getItem("recentSearches");
+      const stored = safeLocalStorage.getItem("recentSearches");
       if (stored) {
         try {
           setRecentSearches(JSON.parse(stored).slice(0, 3));
@@ -103,7 +104,7 @@ export const SearchBarEnhancedHomepage = memo(
 
       // Différer l'écriture localStorage au temps idle
       scheduleIdleCallback(() => {
-        localStorage.setItem("recentSearches", JSON.stringify(updated));
+        safeLocalStorage.setItem("recentSearches", JSON.stringify(updated));
       });
     };
 

--- a/frontend/app/components/search/SearchFilters.tsx
+++ b/frontend/app/components/search/SearchFilters.tsx
@@ -18,6 +18,7 @@ import { Badge } from "~/components/ui/badge";
 import { FilterSection } from "~/components/ui/filter-section";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { logger } from "~/utils/logger";
+import { safeLocalStorage } from "~/utils/safe-storage";
 
 export interface FilterFacet {
   field: string;
@@ -67,7 +68,7 @@ export const SearchFilters = memo(function SearchFilters({
     loadPresets();
     // Restaurer les derniers filtres si aucun filtre actif
     if (Object.keys(currentFilters).length === 0) {
-      const lastFilters = localStorage.getItem(LAST_FILTERS_KEY);
+      const lastFilters = safeLocalStorage.getItem(LAST_FILTERS_KEY);
       if (lastFilters) {
         try {
           JSON.parse(lastFilters);
@@ -82,14 +83,14 @@ export const SearchFilters = memo(function SearchFilters({
   // 💾 Sauvegarder les filtres actuels dans localStorage
   useEffect(() => {
     if (Object.keys(currentFilters).length > 0) {
-      localStorage.setItem(LAST_FILTERS_KEY, JSON.stringify(currentFilters));
+      safeLocalStorage.setItem(LAST_FILTERS_KEY, JSON.stringify(currentFilters));
     }
   }, [currentFilters]);
 
   // 📥 Charger les presets depuis localStorage
   const loadPresets = () => {
     try {
-      const stored = localStorage.getItem(PRESET_STORAGE_KEY);
+      const stored = safeLocalStorage.getItem(PRESET_STORAGE_KEY);
       if (stored) {
         const presets = JSON.parse(stored);
         setSavedPresets(presets);
@@ -121,7 +122,7 @@ export const SearchFilters = memo(function SearchFilters({
 
     const updatedPresets = [...savedPresets, newPreset];
     setSavedPresets(updatedPresets);
-    localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(updatedPresets));
+    safeLocalStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(updatedPresets));
 
     setPresetName("");
     setShowPresetModal(false);
@@ -133,7 +134,7 @@ export const SearchFilters = memo(function SearchFilters({
 
     const updatedPresets = savedPresets.filter((p) => p.id !== presetId);
     setSavedPresets(updatedPresets);
-    localStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(updatedPresets));
+    safeLocalStorage.setItem(PRESET_STORAGE_KEY, JSON.stringify(updatedPresets));
   };
 
   // 🔄 Charger un preset

--- a/frontend/app/entry.client.tsx
+++ b/frontend/app/entry.client.tsx
@@ -13,6 +13,7 @@ import "~/utils/array-at-polyfill.client";
 import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
+import { installChunkReloadGuard } from "~/utils/chunk-reload.client";
 import { logger } from "~/utils/logger";
 import {
   captureReactErrorToSentry,
@@ -37,6 +38,11 @@ if ("serviceWorker" in navigator) {
     }
   });
 }
+
+// Chunk-load recovery — one-shot reload when a deploy rewrote asset hashes while
+// this client still holds stale HTML (`vite:preloadError`). Sync, no Sentry dep,
+// anti-loop guarded. See ~/utils/chunk-reload.client.
+installChunkReloadGuard();
 
 // Early error buffer — captures errors fired between hydration and the lazy
 // Sentry init below. Replayed once Sentry is loaded so no error is lost during

--- a/frontend/app/entry.server.tsx
+++ b/frontend/app/entry.server.tsx
@@ -10,6 +10,7 @@ import { isbot } from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
 import {
   ServerRouter,
+  isRouteErrorResponse,
   type EntryContext,
   type HandleErrorFunction,
   type RouterContextProvider,
@@ -42,6 +43,16 @@ export const handleError: HandleErrorFunction = (
   error,
   { request, context },
 ): void => {
+  // Deterministic client-side routing errors (4xx) are NOT application
+  // incidents and must not reach Sentry: e.g. a scanner probing `POST /_next`
+  // matches the splat route `routes/$` (which has no `action`) → React Router
+  // throws a 405 `ErrorResponse`. Capturing those floods the project with bot
+  // noise. Only 5xx (real server faults) and non-Response throws deserve an
+  // event. The HTTP response sent to the client is unchanged — this gates
+  // observability only, at the single point every RR routing error flows through.
+  if (isRouteErrorResponse(error) && error.status < 500) return;
+  if (error instanceof Response && error.status < 500) return;
+
   // v8_middleware: `context` is a Readonly<RouterContextProvider>. RR's server
   // runtime can invoke handleError BEFORE the load context is resolved (its
   // `loadContext` is still undefined when it rejects an invalid context value),

--- a/frontend/app/utils/chunk-reload.client.ts
+++ b/frontend/app/utils/chunk-reload.client.ts
@@ -1,0 +1,70 @@
+/**
+ * Chunk-load recovery — `vite:preloadError`.
+ *
+ * Vite's build output is content-hashed (`/assets/<name>-<hash>.js`). When a
+ * deploy rewrites those hashes, a client still holding the *pre-deploy* HTML
+ * requests route chunks at URLs that no longer exist at the origin → the dynamic
+ * `import()` fails ("Importing a module script failed" / "Failed to fetch
+ * dynamically imported module", seen especially on iOS Safari). Vite surfaces
+ * this via a `vite:preloadError` window event. A single hard reload fetches the
+ * fresh HTML + chunk graph and the navigation succeeds.
+ *
+ * Scope: RECOVERY only. Observability of the same class stays in
+ * `runtime-errors.client.ts` (`captureChunkLoadErrors`, the SEO beacon). The two
+ * are decoupled so a reload here never suppresses the beacon there.
+ *
+ * Anti-loop: a reload can itself land on stale HTML (e.g. a CDN still serving the
+ * old document inside its `s-maxage` window). We must never reload in a tight
+ * loop. A short-lived timestamp persisted via `safeSessionStorage` (which never
+ * throws under the WebView / private-mode `SecurityError` we already guard
+ * elsewhere) bounds reloads to at most one per `RELOAD_WINDOW_MS`; a genuinely
+ * later deploy still recovers once the window elapses.
+ */
+
+import { safeSessionStorage } from "~/utils/safe-storage";
+
+export const CHUNK_RELOAD_TS_KEY = "vite:preloadError:lastReloadAt";
+export const RELOAD_WINDOW_MS = 10_000;
+
+/**
+ * Pure decision: should we hard-reload now, given the last reload timestamp?
+ *
+ * Reload only when we have not reloaded within the last `windowMs`. A missing
+ * (`null`) or corrupt (non-finite) timestamp is treated as "never reloaded" so
+ * the first failure always recovers. The boundary is strict (`>`), so two
+ * failures exactly `windowMs` apart do NOT double-reload.
+ */
+export function shouldReloadOnPreloadError(
+  now: number,
+  lastReloadAt: number | null,
+  windowMs: number = RELOAD_WINDOW_MS,
+): boolean {
+  if (lastReloadAt === null || !Number.isFinite(lastReloadAt)) return true;
+  return now - lastReloadAt > windowMs;
+}
+
+/**
+ * Install the `vite:preloadError` recovery guard. Call once from
+ * `entry.client.tsx`. No-op under SSR (`window` undefined).
+ */
+export function installChunkReloadGuard(): void {
+  if (typeof window === "undefined") return;
+
+  window.addEventListener("vite:preloadError", (event: Event) => {
+    const now = Date.now();
+    const raw = safeSessionStorage.getItem(CHUNK_RELOAD_TS_KEY);
+    const lastReloadAt = raw === null ? null : Number(raw);
+
+    if (!shouldReloadOnPreloadError(now, lastReloadAt)) {
+      // Reloaded very recently → don't loop. Let the error propagate to the
+      // existing observability path (runtime-errors.client.ts beacon).
+      return;
+    }
+
+    // Handle it ourselves: stop Vite from throwing the unhandled preload error,
+    // record the attempt, then fetch fresh HTML + chunk graph.
+    event.preventDefault();
+    safeSessionStorage.setItem(CHUNK_RELOAD_TS_KEY, String(now));
+    window.location.reload();
+  });
+}

--- a/frontend/tests/unit/chunk-reload.test.ts
+++ b/frontend/tests/unit/chunk-reload.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests unitaires — `shouldReloadOnPreloadError`
+ * (`frontend/app/utils/chunk-reload.client.ts`).
+ *
+ * Garde anti-boucle du recovery `vite:preloadError` : un reload ne doit JAMAIS
+ * se déclencher en boucle serrée (CDN servant encore le HTML périmé dans sa
+ * fenêtre `s-maxage`), tout en récupérant sur un déploiement réellement plus
+ * récent une fois la fenêtre écoulée.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  RELOAD_WINDOW_MS,
+  shouldReloadOnPreloadError,
+} from '~/utils/chunk-reload.client';
+
+describe('shouldReloadOnPreloadError', () => {
+  it('reloads on the first failure (no prior timestamp)', () => {
+    expect(shouldReloadOnPreloadError(1_000_000, null)).toBe(true);
+  });
+
+  it('reloads when last reload is older than the window', () => {
+    const now = 1_000_000;
+    const last = now - RELOAD_WINDOW_MS - 1;
+    expect(shouldReloadOnPreloadError(now, last)).toBe(true);
+  });
+
+  it('does NOT reload within the window (anti-loop)', () => {
+    const now = 1_000_000;
+    const last = now - 1_000; // 1s ago, well inside 10s window
+    expect(shouldReloadOnPreloadError(now, last)).toBe(false);
+  });
+
+  it('does NOT reload exactly at the window boundary (strict >)', () => {
+    const now = 1_000_000;
+    const last = now - RELOAD_WINDOW_MS;
+    expect(shouldReloadOnPreloadError(now, last)).toBe(false);
+  });
+
+  it('reloads when the persisted timestamp is corrupt (NaN)', () => {
+    expect(shouldReloadOnPreloadError(1_000_000, Number.NaN)).toBe(true);
+  });
+
+  it('reloads when the persisted timestamp is non-finite (Infinity)', () => {
+    expect(shouldReloadOnPreloadError(1_000_000, Number.POSITIVE_INFINITY)).toBe(
+      true,
+    );
+  });
+
+  it('honours a custom window argument', () => {
+    const now = 1_000_000;
+    expect(shouldReloadOnPreloadError(now, now - 500, 1_000)).toBe(false);
+    expect(shouldReloadOnPreloadError(now, now - 1_500, 1_000)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Contexte

Triage de 4 alertes Sentry remontées le lendemain du déploiement PROD Vite 8 + React-Router 8 (tag du 2026-06-24). Chaque signal classé en lecture seule (preuves dans le code), puis corrigé avec la solution structurelle — **zéro bricolage**, réutilisation du canon existant.

| # | Signal Sentry | Verdict | Fix |
|---|---------------|---------|-----|
| **A** | `getInternalRouterError` — `POST /_next` 405 | bruit d'alerte | filtre 4xx dans `handleError` |
| **B** | `SecurityError localStorage` `/search` | vrai bug (latent) | `safeLocalStorage` sur la surface search |
| **C** | `Importing a module script failed` `/pieces/*` | transitoire post-deploy | guard `vite:preloadError` reload-once |
| **D** | PREPROD `:3200` joignable de l'externe | misconfiguration | bind `127.0.0.1` |

## Détail

### A — Hygiène alerte Sentry · `frontend/app/entry.server.tsx`
`handleError` forwardait **toute** erreur à Sentry. Un scanner sondant `POST /_next` tombe sur la route splat `routes/$` (sans `action`) → RR8 lève une `ErrorResponse` 405 → pollution du projet par du bruit de bot. On filtre les erreurs client (`isRouteErrorResponse` / `Response`, `status < 500`) ; les **5xx restent capturées**. La réponse HTTP au client est inchangée — on ne touche QUE la décision d'émettre un event.

### B — `SecurityError: localStorage` sur `/search` · 3 composants search
`SearchBar` / `SearchBarEnhancedHomepage` / `SearchFilters` lisaient `window.localStorage` en brut → `DOMException` SecurityError en WebView / navigation privée (Chrome Mobile / Android). Migrés vers le wrapper canon **déjà existant et testé** `safeLocalStorage` (déjà utilisé par `funnel-beacon` / `GlobalSearch`). Pas de nouvelle abstraction.

> **Périmètre** : seule la surface `/search` (qui a planté) est corrigée. ~15 autres fichiers (checkout, cart, vehicle, diagnostic…) ont le même accès brut latent — **follow-up séparé documenté**, pas bundlé dans ce hotfix post-deploy (blast radius).

### C — `Importing a module script failed` · `utils/chunk-reload.client.ts` (+ wire `entry.client.tsx`)
Stale-chunk classique post-deploy : les hash d'assets réécrits par Vite 8 + le `s-maxage` CDN servent du HTML périmé → anciens chunks 404 (surtout iOS Safari). Ajout d'un guard sur l'event dédié **`vite:preloadError`** → un reload one-shot, borné par un timestamp `sessionStorage` (**anti-loop**, via `safeSessionStorage` qui ne throw jamais). L'observabilité de la classe reste dans `runtime-errors.client.ts` (découplé). La décision pure est **testée unitairement** (`tests/unit/chunk-reload.test.ts`).

### D — Exposition port PREPROD · `docker-compose.preprod.yml`
`3200:3000` bindait `0.0.0.0` malgré le canon « 3200 localhost only ». La CI atteint le container **uniquement via `localhost:3200`** (E2E Smoke / Lighthouse / health — vérifié dans `ci.yml`) et Caddy ne proxie jamais `:3200`. Bind sur `127.0.0.1` → ferme l'exposition qui a permis à un scanner externe de `POST /_next` directement sur le port. Aligne la compose sur le canon au niveau Docker (défense en profondeur vs firewall hôte seul).

## Vérification

- ✅ `vitest` : **22/22** (7 nouveaux tests anti-loop + 15 safe-storage)
- ✅ `eslint` : **0 erreur** (2 warnings `shellRendered` pré-existants, non liés)
- ✅ `tsc` (typecheck) : **exit 0**
- ✅ `vite build` (Vite 8, client + SSR) : **exit 0**

## Déploiement

- Merge `main` → rebuild container **PREPROD** (E2E Smoke + Lighthouse couvrent le SSR + `/search`).
- **PROD = promotion via tag `v*` = décision owner** (non incluse ici).

## Follow-ups owner (hors-code, ne bloquent pas ce PR)

Signal D a aussi 2 points à vérifier **sur la PROD-box `49.12.233.2`** (non inspectables depuis DEV) :
1. Exposition réelle de 3200 : `ss -ltnp | grep 3200` · `curl http://49.12.233.2:3200/health` (depuis l'externe) · `docker ps --filter publish=3200`. Le bind `127.0.0.1` prendra effet au prochain redeploy PREPROD ; vérifier ensuite que 3200 n'est plus joignable de l'externe.
2. Event Sentry `environment=developer` : **aucun chemin de code n'émet cette valeur** (possibles : `dev`/`preprod`/`production`). Identifier `release`/`server_name`/SHA de l'event dans Sentry — probablement une image PREPROD périmée ou un container lancé hors-CI.

Suivi séparé : migration des ~15 autres accès `localStorage` bruts vers `safeLocalStorage` (même classe que B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)