### PR TITLE
fix(caddy): never CDN-cache /pieces 4xx/5xx error responses (anti-poisoning)

### DIFF
--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -249,13 +249,27 @@ automecanik.com, www.automecanik.com {
         # Default: set only if no conditional matcher above already set Cache-Control
         header ?Cache-Control "public, max-age=120, stale-while-revalidate=240"
         header Vary "Accept-Encoding"
-        
+
         reverse_proxy monorepo_prod:3000 {
             header_up Host {host}
             header_up X-Real-IP {client_ip}
             header_up X-Forwarded-For {client_ip}
             header_up X-Forwarded-Proto {scheme}
             header_up X-Forwarded-Host {host}
+
+            # 🛡️ Anti-cache-poisoning : une réponse d'erreur (4xx/5xx) du backend
+            # NE DOIT PAS hériter du cache CDN long (s-maxage=86400) posé par
+            # @products / @content ci-dessus. Sinon un 404/500 transitoire (boot
+            # container, TypeError SSR ponctuel) est figé jusqu'à 24h par Cloudflare
+            # sur une page qui existe en réalité (incident 2026-06-25 :
+            # /pieces/barre-stabilisatrice-274.html & plaquette-de-frein-402.html).
+            # Même garde que le bloc imgproxy ci-dessus (@upstream_4xx). `no-store`
+            # l'emporte sur une Cache-Control upstream concurrente (RFC 7234 §5.2.2).
+            @up_error status 4xx 5xx
+            handle_response @up_error {
+                header Cache-Control "no-store"
+                copy_response
+            }
         }
     }
     


### PR DESCRIPTION
## Problème (incident 2026-06-25)

`/pieces/barre-stabilisatrice-274.html` puis `/pieces/plaquette-de-frein-402.html` affichaient « Page introuvable / Une erreur inattendue s'est produite » **alors que l'origine renvoie 200** (13/13 sondes cache-bust, 0 flapping).

**Cause racine :** `config/caddy/Caddyfile`, bloc `@public_cached` — `header @products` pose `s-maxage=86400` sur **toute** réponse `/pieces|products|catalog|vehicule`, **statut ignoré**. Une erreur transitoire du backend (boot container, `TypeError` SSR ponctuel — 1 seul en 48 h dans `__error_logs`) → 404/500 → Caddy colle le cache 24 h → **Cloudflare fige l'erreur 24 h** sur une page qui existe. Remix met pourtant `no-store` sur ses 404 (`buildCacheHeaders`), mais Caddy l'écrase. La purge vide l'edge mais pas le cache navigateur (`max-age=7200`).

Le bloc imgproxy juste au-dessus a déjà le bon garde (`@upstream_4xx`) — **il manquait sur `/pieces`**.

## Correctif

Garde `@up_error status 4xx 5xx` + `handle_response` → `Cache-Control: no-store`, calqué exactement sur le précédent imgproxy. **Seul `config/caddy/Caddyfile` change.**

### Preuve comportementale (banc local `caddy:2-alpine`, bloc patché exact)

| Requête `/pieces/*` | AVANT | APRÈS |
|---|---|---|
| 404 | `s-maxage=86400` ❌ | `no-store` ✅ |
| 410 | `s-maxage=86400` ❌ | `no-store` ✅ |
| 500 | `s-maxage=86400` ❌ | `no-store` ✅ |
| **200** | `s-maxage=86400` ✅ | `s-maxage=86400` ✅ (inchangé) |

Statut HTTP + `X-Robots-Tag` préservés. `caddy adapt` valide le fichier complet (warnings `header_up` pré-existants seulement). Variantes « strip → honorer upstream » testées et **rejetées** (le `?Cache-Control` par défaut reprend la main à `max-age=120`).

## Compromis assumé

Les vrais 404/410 (pages réellement absentes/retirées) ne sont plus cachés au CDN (Remix les voulait `max-age=60/600`). Direction sûre (jamais cacher une erreur, règle « no long TTL on error paths » ≤30 s) ; origine protégée par BotGuard + throttler.

## Déploiement ⚠️ owner-gated, hors CI normale

Le Caddyfile est **monté en volume** (`docker-compose.caddy.yml:15`), pas dans l'image `:preprod/:production`. **Merger `main` ne déploie PAS** ce changement. Application = sur la machine PROD : `git pull` du checkout + `caddy reload` (ou restart container Caddy). Action manuelle.

## Remédiation de l'existant (séparé du code)

Entrées déjà empoisonnées : **Cloudflare Purge Everything** une fois (origine saine → re-cache 200) ou expiration ≤24 h ; client `Ctrl+Shift+R`. Script gouverné : `scripts/ops/cloudflare-purge-by-pattern.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)