### PR TITLE
fix(seo-control-plane): exempt internal synthetic crawler from rate-limit (scoped HMAC credential)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -187,6 +187,16 @@ SEO_CP_CONCURRENCY=10
 SEO_CP_TIMEOUT_MS=15000
 SEO_CP_PROD_BASE=https://www.automecanik.com
 
+# Exemption rate-limit du crawler synthétique (incident 2026-06-25). Le crawler
+# sonde ses pages publiques via Cloudflare ; sans exemption il est 429 par le
+# throttler (mono-IP en rafale) → 89,7 % de sondes throttlées, monitoring L1
+# aveugle. Le crawler signe un HMAC (header x-synthetic-probe) vérifié par
+# BotGuardMiddleware ; l'exemption est scopée GET + catalogue public (least-priv).
+# DÉFAUT = OFF. Provisionner via SOPS en PROD uniquement ; laisser vide en DEV/PREPROD.
+#   secret : openssl rand -hex 32  (≠ INTERNAL_API_KEY — compartimenté)
+SEO_CP_SYNTHETIC_PROBE_ENABLED=
+SEO_CP_SYNTHETIC_PROBE_SECRET=
+
 # PR-2A-2 — L1 Cloudflare Analytics Collector (q5min GraphQL ingest)
 # Réutilise CLOUDFLARE_API_TOKEN + CLOUDFLARE_ZONE_ID déjà câblés pour
 # scripts/ops/cloudflare-purge-by-pattern.sh. Si l'un manque, le collector

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,6 +16,8 @@ import { FeatureFlagsModule } from './config/feature-flags.module'; // 🎛️ N
 import { WriteGuardModule } from './config/write-guard.module'; // 🛡️ P1.5 - Write Ownership & Collision Guard
 import { RpcGateModule } from './security/rpc-gate/rpc-gate.module'; // 🛡️ NOUVEAU - RPC Safety Gate pour gouvernance Supabase !
 import { BotGuardModule } from './modules/bot-guard/bot-guard.module'; // 🛡️ Bot protection (geo-block, IP block, behavioral scoring)
+import { SyntheticProbeCredentialModule } from './modules/seo-control-plane/synthetic-probe-credential.module'; // 🛡️ HMAC credential du crawler synthétique (exemption rate-limit scopée)
+import { isSyntheticExemptPath } from './modules/seo-control-plane/types';
 import { DatabaseModule } from './database/database.module';
 import { OrdersModule } from './modules/orders/orders.module';
 import { HealthModule } from './modules/health/health.module';
@@ -135,6 +137,20 @@ import { TrendSignalsModule } from './modules/trend-signals/trend-signals.module
           return true;
         }
 
+        // Skip the internal synthetic crawler (seo-control-plane L1) — but ONLY
+        // for public-catalogue GETs (least-privilege). The flag is set upstream
+        // by BotGuardMiddleware after verifying an HMAC credential (NOT the UA),
+        // and isSyntheticExemptPath() blocks /api, /auth, /cart, /checkout,
+        // /admin and every non-GET, so even a leaked credential cannot relax
+        // rate-limiting beyond already-public, already-CDN-cached reads.
+        // Incident 2026-06-25 (crawler 89.7% 429 → L1 monitoring blind).
+        if (
+          request.isVerifiedSyntheticProbe === true &&
+          isSyntheticExemptPath(request.method, request.path || '')
+        ) {
+          return true;
+        }
+
         // Skip for admin users (level >= 7)
         if (user?.isAdmin === true || parseInt(user?.level) >= 7) {
           return true;
@@ -173,6 +189,11 @@ import { TrendSignalsModule } from './modules/trend-signals/trend-signals.module
 
     // 🛡️ Bot protection - geo-block, IP block, behavioral scoring (must be before other modules)
     BotGuardModule,
+
+    // 🛡️ Credential HMAC du crawler synthétique (@Global) — injecté par
+    // BotGuardMiddleware (verify) + SyntheticCrawlerService (sign). Posé avant les
+    // modules consommateurs pour disponibilité DI app-wide. Incident 2026-06-25.
+    SyntheticProbeCredentialModule,
 
     // 🎛️ Feature flags centralisés (Global)
     FeatureFlagsModule,

--- a/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
@@ -2,7 +2,10 @@ import { BotGuardMiddleware } from './bot-guard.middleware';
 
 type ServiceMock = Record<string, jest.Mock | (() => boolean)>;
 
-function makeMiddleware(overrides: ServiceMock = {}) {
+function makeMiddleware(
+  overrides: ServiceMock = {},
+  probeVerify: () => boolean = () => false,
+) {
   const service = {
     isEnabled: () => true,
     isIpBlocked: jest.fn(async () => false),
@@ -13,8 +16,14 @@ function makeMiddleware(overrides: ServiceMock = {}) {
     trackAllowed: jest.fn(async () => undefined),
     ...overrides,
   };
-  const middleware = new BotGuardMiddleware(service as never);
-  return { middleware, service };
+  // Synthetic-probe credential: par défaut verify=false (chemin synthétique
+  // jamais pris → comportement existant inchangé).
+  const syntheticProbe = { verify: jest.fn(probeVerify) };
+  const middleware = new BotGuardMiddleware(
+    service as never,
+    syntheticProbe as never,
+  );
+  return { middleware, service, syntheticProbe };
 }
 
 function makeReqRes(
@@ -61,6 +70,50 @@ describe('BotGuardMiddleware ordering', () => {
     expect((res as { statusCode: number }).statusCode).toBe(200);
     // geo never consulted because the verified bypass returned first
     expect(service.isCountryBlocked).not.toHaveBeenCalled();
+  });
+
+  it('lets a verified synthetic probe through (dedicated flag) and bypasses geo + behavioral', async () => {
+    const { middleware, service, syntheticProbe } = makeMiddleware(
+      {
+        isVerifiedSearchEngine: jest.fn(async () => false), // NOT a search engine
+        isCountryBlocked: jest.fn(async () => true), // would block if consulted
+        calculateSuspicionScore: jest.fn(() => 100), // would block if consulted
+      },
+      () => true, // valid HMAC credential
+    );
+    const { req, res, next } = makeReqRes({
+      'cf-ipcountry': 'DE',
+      'cf-connecting-ip': '203.0.113.7', // public client IP → reaches the probe check
+    });
+
+    await middleware.use(req, res, next);
+
+    expect(syntheticProbe.verify).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(
+      (req as { isVerifiedSyntheticProbe?: boolean }).isVerifiedSyntheticProbe,
+    ).toBe(true);
+    // distinct from the search-engine flag (least-privilege; skipIf scopes it)
+    expect((req as { isVerifiedBot?: boolean }).isVerifiedBot).toBeUndefined();
+    expect((res as { statusCode: number }).statusCode).toBe(200);
+    expect(service.isCountryBlocked).not.toHaveBeenCalled();
+    expect(service.calculateSuspicionScore).not.toHaveBeenCalled();
+  });
+
+  it('does NOT set the synthetic flag without a valid credential (verify=false → normal flow)', async () => {
+    const { middleware, syntheticProbe } = makeMiddleware(); // default verify=false
+    const { req, res, next } = makeReqRes({
+      'cf-ipcountry': 'DE',
+      'cf-connecting-ip': '203.0.113.7',
+    });
+
+    await middleware.use(req, res, next);
+
+    expect(syntheticProbe.verify).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(
+      (req as { isVerifiedSyntheticProbe?: boolean }).isVerifiedSyntheticProbe,
+    ).toBeUndefined();
   });
 
   it('still honors an explicit operator IP block even for a would-be verified crawler (ip_block wins, no DNS work)', async () => {

--- a/backend/src/modules/bot-guard/bot-guard.middleware.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.ts
@@ -1,12 +1,16 @@
 import { HttpStatus, Injectable, Logger, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { BotGuardService } from './bot-guard.service';
+import { SyntheticProbeCredentialService } from '../seo-control-plane/synthetic-probe-credential.service';
 
 @Injectable()
 export class BotGuardMiddleware implements NestMiddleware {
   private readonly logger = new Logger(BotGuardMiddleware.name);
 
-  constructor(private readonly botGuardService: BotGuardService) {}
+  constructor(
+    private readonly botGuardService: BotGuardService,
+    private readonly syntheticProbe: SyntheticProbeCredentialService,
+  ) {}
 
   async use(req: Request, res: Response, next: NextFunction) {
     // 1. Skip health checks and static assets
@@ -60,6 +64,20 @@ export class BotGuardMiddleware implements NestMiddleware {
       // identity is proven by forward-confirmed reverse DNS.
       if (await this.botGuardService.isVerifiedSearchEngine(ip, userAgent)) {
         (req as Request & { isVerifiedBot?: boolean }).isVerifiedBot = true;
+        this.botGuardService.trackAllowed(country).catch(() => {});
+        return next();
+      }
+
+      // 6b. Verified internal synthetic probe (seo-control-plane L1). Identity is
+      // an HMAC credential header — NEVER the User-Agent. Like a verified crawler
+      // it bypasses geo + behavioral (its mono-IP burst would otherwise score as
+      // suspicious and 403), while the rate-limit exemption is further scoped to
+      // public-catalogue GETs in app.module.ts skipIf. The explicit IP blocklist
+      // above still wins. Fail-closed: verify() returns false on any error.
+      if (this.syntheticProbe.verify(req)) {
+        (
+          req as Request & { isVerifiedSyntheticProbe?: boolean }
+        ).isVerifiedSyntheticProbe = true;
         this.botGuardService.trackAllowed(country).catch(() => {});
         return next();
       }

--- a/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.test.ts
+++ b/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.test.ts
@@ -100,6 +100,9 @@ function buildSvc(
     logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
     criticality: crit,
     cfg,
+    // Exemption inactive en test → buildProbeHeaders n'ajoute que l'UA (comportement
+    // identique à l'existant ; pas de header HMAC).
+    probeCredential: { isActive: () => false, sign: jest.fn() },
     supabase: {
       from: (_table: string) => ({ insert: spyInsert }),
     },

--- a/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.ts
+++ b/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.ts
@@ -30,8 +30,11 @@ import { randomUUID } from 'node:crypto';
 import type { TierId } from '@repo/registry';
 import { SupabaseBaseService } from '../../../../database/services/supabase-base.service';
 import { CriticalityLoaderService } from '../../services/criticality-loader.service';
+import { SyntheticProbeCredentialService } from '../../synthetic-probe-credential.service';
 import {
   SYNTHETIC_USER_AGENT,
+  SYNTHETIC_PROBE_HEADER,
+  SYNTHETIC_PROBE_ENABLED_KEY,
   type SyntheticCrawlJobData,
   type SyntheticRunResult,
   type SyntheticSnapshot,
@@ -57,9 +60,34 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
   constructor(
     private readonly criticality: CriticalityLoaderService,
     configService: ConfigService,
+    private readonly probeCredential: SyntheticProbeCredentialService,
   ) {
     super(configService);
     this.cfg = configService;
+  }
+
+  /**
+   * En-têtes de sonde : UA identifiable + (si le credential est actif) un HMAC
+   * `x-synthetic-probe` signé sur (GET|pathname|fenêtre) pour être exempté du
+   * rate-limiter sans usurper d'UA. Si l'exemption est OFF/non provisionnée, le
+   * header est omis (la sonde sera throttlée — surfacé par l'alerte 429 du run).
+   */
+  private buildProbeHeaders(url: string): Record<string, string> {
+    const headers: Record<string, string> = {
+      'User-Agent': SYNTHETIC_USER_AGENT,
+    };
+    if (this.probeCredential.isActive()) {
+      try {
+        const { pathname } = new URL(url);
+        headers[SYNTHETIC_PROBE_HEADER] = this.probeCredential.sign(
+          'GET',
+          pathname,
+        );
+      } catch {
+        // URL malformée — pas de header ; la sonde sera throttlée (observable).
+      }
+    }
+    return headers;
   }
 
   /**
@@ -124,15 +152,34 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
       tier1: { probed: 0, fail_5xx: 0 },
       tier2: { probed: 0, fail_5xx: 0 },
     };
+    let http429 = 0;
     for (const s of snapshots) {
       if (s.error_kind != null || s.http_code === 0) result.totals.error++;
       else if (s.http_code >= 500) result.totals.http_5xx++;
       else if (s.http_code >= 400) result.totals.http_4xx++;
       else if (s.http_code >= 300) result.totals.http_3xx++;
       else if (s.http_code >= 200) result.totals.http_2xx++;
+      if (s.http_code === 429) http429++;
       const t = tierCounts[s.tier];
       t.probed++;
       if (s.http_code >= 500) t.fail_5xx++;
+    }
+
+    // 🚨 Observabilité anti silent-fallback : si une part anormale des sondes est
+    // throttlée (429), l'exemption rate-limit est probablement inactive (flag OFF,
+    // secret non provisionné) ou a dérivé → le monitoring L1 redevient AVEUGLE.
+    // On le rend BRUYANT (log.error, visible Sentry) plutôt que de dégrader en
+    // silence (incident 2026-06-25 : 89,7 % de 429 jamais alertés).
+    if (snapshots.length > 0) {
+      const rate429 = http429 / snapshots.length;
+      if (rate429 > 0.2) {
+        this.logger.error(
+          `🚨 synthetic-crawler: ${(rate429 * 100).toFixed(1)}% des sondes throttlées ` +
+            `(${http429}/${snapshots.length} en 429). L'exemption rate-limit est ` +
+            `probablement inactive (${SYNTHETIC_PROBE_ENABLED_KEY}/secret) ou a dérivé — ` +
+            `monitoring L1 dégradé.`,
+        );
+      }
     }
     for (const tier of ['tier0', 'tier1', 'tier2'] as TierId[]) {
       const t = tierCounts[tier];
@@ -251,7 +298,7 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
     try {
       const res = await fetch(cand.url, {
         signal: ctrl.signal,
-        headers: { 'User-Agent': SYNTHETIC_USER_AGENT },
+        headers: this.buildProbeHeaders(cand.url),
         redirect: 'manual',
       });
       const ttfb = Date.now() - t0;
@@ -361,7 +408,7 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
     try {
       const res = await fetch(url, {
         signal: ctrl.signal,
-        headers: { 'User-Agent': SYNTHETIC_USER_AGENT },
+        headers: this.buildProbeHeaders(url),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status} on ${url}`);
       return await res.text();

--- a/backend/src/modules/seo-control-plane/synthetic-probe-credential.module.ts
+++ b/backend/src/modules/seo-control-plane/synthetic-probe-credential.module.ts
@@ -1,0 +1,17 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { SyntheticProbeCredentialService } from './synthetic-probe-credential.service';
+
+/**
+ * @Global — le credential synthétique est injecté par DEUX modules distincts :
+ * BotGuardModule (verify, côté origine) et SeoControlPlaneModule (sign, côté
+ * crawler). Le rendre global évite une dépendance circulaire
+ * bot-guard ↔ seo-control-plane et ne duplique aucun provider.
+ */
+@Global()
+@Module({
+  imports: [ConfigModule],
+  providers: [SyntheticProbeCredentialService],
+  exports: [SyntheticProbeCredentialService],
+})
+export class SyntheticProbeCredentialModule {}

--- a/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.test.ts
+++ b/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.test.ts
@@ -1,0 +1,158 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  SyntheticProbeCredentialService,
+  type SyntheticVerifiableRequest,
+} from './synthetic-probe-credential.service';
+import {
+  SYNTHETIC_PROBE_HEADER,
+  SYNTHETIC_PROBE_SECRET_KEY,
+  SYNTHETIC_PROBE_ENABLED_KEY,
+  SYNTHETIC_PROBE_WINDOW_MS,
+  isSyntheticExemptPath,
+} from './types';
+
+/** Secret fixture — JAMAIS une vraie valeur. */
+const SECRET = 'a'.repeat(64);
+const OTHER_SECRET = 'b'.repeat(64);
+const ENABLED: Record<string, string> = {
+  [SYNTHETIC_PROBE_ENABLED_KEY]: 'true',
+  [SYNTHETIC_PROBE_SECRET_KEY]: SECRET,
+};
+
+function makeService(
+  env: Record<string, string | undefined>,
+): SyntheticProbeCredentialService {
+  const config = {
+    get: (k: string, d?: string) => env[k] ?? d ?? '',
+  } as unknown as ConfigService;
+  return new SyntheticProbeCredentialService(config);
+}
+
+function reqWith(
+  mac: string | undefined,
+  method = 'GET',
+  path = '/pieces/x.html',
+): SyntheticVerifiableRequest {
+  return {
+    method,
+    path,
+    headers: mac === undefined ? {} : { [SYNTHETIC_PROBE_HEADER]: mac },
+  };
+}
+
+describe('SyntheticProbeCredentialService', () => {
+  const T0 = 1_700_000_000_000; // epoch ms fixe
+  let nowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(T0);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('signe et vérifie dans la même fenêtre', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/x.html');
+    expect(s.verify(reqWith(mac))).toBe(true);
+  });
+
+  it('accepte la fenêtre précédente (t-1, tolérance de skew)', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/x.html');
+    nowSpy.mockReturnValue(T0 + SYNTHETIC_PROBE_WINDOW_MS);
+    expect(s.verify(reqWith(mac))).toBe(true);
+  });
+
+  it('rejette une signature expirée (> 2 fenêtres)', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/x.html');
+    nowSpy.mockReturnValue(T0 + 2 * SYNTHETIC_PROBE_WINDOW_MS + 1000);
+    expect(s.verify(reqWith(mac))).toBe(false);
+  });
+
+  it('rejette une signature faite avec un autre secret', () => {
+    const signer = makeService(ENABLED);
+    const verifier = makeService({
+      ...ENABLED,
+      [SYNTHETIC_PROBE_SECRET_KEY]: OTHER_SECRET,
+    });
+    const mac = signer.sign('GET', '/pieces/x.html');
+    expect(verifier.verify(reqWith(mac))).toBe(false);
+  });
+
+  it('rejette le rejeu sur un autre chemin (binding chemin)', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/a.html');
+    expect(s.verify(reqWith(mac, 'GET', '/pieces/b.html'))).toBe(false);
+  });
+
+  it('rejette le rejeu avec une autre méthode (binding méthode)', () => {
+    const s = makeService(ENABLED);
+    const mac = s.sign('GET', '/pieces/x.html');
+    expect(s.verify(reqWith(mac, 'POST', '/pieces/x.html'))).toBe(false);
+  });
+
+  it('rejette quand le header est absent (spoof UA-seul = sans effet)', () => {
+    const s = makeService(ENABLED);
+    expect(s.verify(reqWith(undefined))).toBe(false);
+  });
+
+  it('rejette (fail-closed) quand le kill-switch est OFF', () => {
+    const off = makeService({ [SYNTHETIC_PROBE_SECRET_KEY]: SECRET }); // enabled non posé
+    const mac = makeService(ENABLED).sign('GET', '/pieces/x.html');
+    expect(off.isActive()).toBe(false);
+    expect(off.verify(reqWith(mac))).toBe(false);
+  });
+
+  it('rejette (fail-closed) quand activé mais secret absent', () => {
+    const noSecret = makeService({ [SYNTHETIC_PROBE_ENABLED_KEY]: 'true' });
+    expect(noSecret.isActive()).toBe(false);
+    expect(noSecret.verify(reqWith('anything'))).toBe(false);
+  });
+
+  it('isActive() = vrai seulement si activé ET secret présent', () => {
+    expect(makeService(ENABLED).isActive()).toBe(true);
+    expect(
+      makeService({ [SYNTHETIC_PROBE_ENABLED_KEY]: 'true' }).isActive(),
+    ).toBe(false);
+    expect(
+      makeService({ [SYNTHETIC_PROBE_SECRET_KEY]: SECRET }).isActive(),
+    ).toBe(false);
+  });
+});
+
+describe('isSyntheticExemptPath (least-privilege scope)', () => {
+  it('exempte les GET catalogue publics + accueil', () => {
+    expect(isSyntheticExemptPath('GET', '/')).toBe(true);
+    expect(isSyntheticExemptPath('GET', '/pieces/barre-274.html')).toBe(true);
+    expect(isSyntheticExemptPath('GET', '/pieces')).toBe(true);
+    expect(
+      isSyntheticExemptPath('GET', '/constructeurs/audi/a4/2-0.html'),
+    ).toBe(true);
+    expect(isSyntheticExemptPath('GET', '/blog/guide')).toBe(true);
+  });
+
+  it('ne couvre PAS les sitemaps (servis statiquement par Caddy, hors throttler)', () => {
+    expect(isSyntheticExemptPath('GET', '/sitemap-pieces-1.xml')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/sitemap.xml')).toBe(false);
+  });
+
+  it('REFUSE toute méthode non-GET (même chemin public)', () => {
+    expect(isSyntheticExemptPath('POST', '/pieces/x.html')).toBe(false);
+    expect(isSyntheticExemptPath('HEAD', '/pieces/x.html')).toBe(false);
+    expect(isSyntheticExemptPath('PUT', '/')).toBe(false);
+  });
+
+  it('REFUSE les chemins sensibles/non-publics (blast radius borné)', () => {
+    expect(isSyntheticExemptPath('GET', '/api/auth/login')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/cart')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/checkout')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/admin')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/account/orders')).toBe(false);
+  });
+
+  it('ne matche pas un préfixe partiel trompeur', () => {
+    // '/piecesXYZ' ne doit PAS matcher le préfixe '/pieces'
+    expect(isSyntheticExemptPath('GET', '/pieces-fake/x')).toBe(false);
+    expect(isSyntheticExemptPath('GET', '/blogger')).toBe(false);
+  });
+});

--- a/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.ts
+++ b/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.ts
@@ -1,0 +1,122 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import {
+  SYNTHETIC_PROBE_HEADER,
+  SYNTHETIC_PROBE_SECRET_KEY,
+  SYNTHETIC_PROBE_ENABLED_KEY,
+  SYNTHETIC_PROBE_WINDOW_MS,
+} from './types';
+
+/** Requête minimale lisible par {@link SyntheticProbeCredentialService.verify}. */
+export interface SyntheticVerifiableRequest {
+  method?: string;
+  path?: string;
+  headers?: Record<string, unknown>;
+}
+
+/**
+ * SyntheticProbeCredentialService — credential vérifiable (HMAC) prouvant qu'une
+ * requête provient du crawler synthétique interne (seo-control-plane L1), SANS
+ * faire confiance à l'User-Agent (spoofable).
+ *
+ * Pourquoi (incident 2026-06-25) : le crawler L1 sonde ses propres pages publiques
+ * via Cloudflare pour mesurer la santé edge+page, mais le ThrottlerGuard global
+ * (clé par IP) le 429 à 89,7 % car c'est une source mono-IP en rafale → le
+ * monitoring L1 devient AVEUGLE. Ce credential permet à BotGuardMiddleware de poser
+ * `req.isVerifiedSyntheticProbe`, lu par une branche `skipIf` SCOPÉE (GET + préfixes
+ * catalogue publics uniquement, cf. {@link isSyntheticExemptPath}) dans app.module.
+ *
+ * Sécurité (issue d'un panel de conception adverse, 2026-06-25) :
+ *   - HMAC-SHA256(`${method}|${pathname}|${windowCounter}`) avec un secret DÉDIÉ
+ *     (≠ INTERNAL_API_KEY : compartimentation — une fuite ne touche pas les
+ *     endpoints internes admin). Le SECRET ne transite JAMAIS sur le fil ; seule
+ *     une signature (liée méthode+chemin+fenêtre 60 s) circule.
+ *   - `timingSafeEqual` length-guardé (même primitive qu'InternalApiKeyGuard).
+ *   - Fenêtre 60 s + acceptation `t` et `t-1` (skew d'horloge ; crawler et origine
+ *     co-localisés sur la même machine PROD → skew ~0).
+ *   - FAIL-CLOSED : kill-switch OFF, secret absent, header absent, parse error,
+ *     signature invalide ou fenêtre expirée → `false` → la requête retombe sur le
+ *     throttler normal. JAMAIS de fail-open vers « vérifié ».
+ *   - Le least-privilege (scope GET + catalogue) est appliqué dans `skipIf`, pas ici.
+ *
+ * Stateless. Dépend uniquement de ConfigService. Fourni par un module @Global pour
+ * être injecté à la fois par BotGuardMiddleware (verify) et SyntheticCrawlerService
+ * (sign) sans dépendance circulaire.
+ */
+@Injectable()
+export class SyntheticProbeCredentialService {
+  private readonly logger = new Logger(SyntheticProbeCredentialService.name);
+  private readonly secret: string;
+  private readonly enabled: boolean;
+  private warnedSecretMissing = false;
+
+  constructor(private readonly config: ConfigService) {
+    this.secret = this.config.get<string>(SYNTHETIC_PROBE_SECRET_KEY, '');
+    this.enabled =
+      this.config.get<string>(SYNTHETIC_PROBE_ENABLED_KEY, '') === 'true';
+    if (this.enabled && !this.secret) {
+      // Erreur de config explicite (no silent enable) : flag ON mais secret absent.
+      this.logger.error(
+        `${SYNTHETIC_PROBE_ENABLED_KEY}=true mais ${SYNTHETIC_PROBE_SECRET_KEY} absent — ` +
+          'exemption synthétique DÉSACTIVÉE (fail-closed).',
+      );
+    }
+  }
+
+  /** Le credential est-il opérationnel (flag ON + secret présent) ? */
+  isActive(): boolean {
+    return this.enabled && this.secret.length > 0;
+  }
+
+  /** Signe une requête sortante du crawler (côté émetteur). */
+  sign(method: string, pathname: string): string {
+    return this.computeMac(method, pathname, this.windowCounter());
+  }
+
+  /**
+   * Vérifie l'en-tête `x-synthetic-probe` d'une requête entrante (côté origine).
+   * Retourne `true` SEULEMENT si la signature est valide pour la fenêtre courante
+   * ou précédente. Fail-closed sur toute condition d'erreur.
+   */
+  verify(req: SyntheticVerifiableRequest): boolean {
+    if (!this.enabled) return false;
+    if (!this.secret) {
+      if (!this.warnedSecretMissing) {
+        this.warnedSecretMissing = true;
+        this.logger.warn(
+          `${SYNTHETIC_PROBE_SECRET_KEY} absent — exemption synthétique inactive (fail-closed).`,
+        );
+      }
+      return false;
+    }
+
+    const provided = req.headers?.[SYNTHETIC_PROBE_HEADER];
+    if (typeof provided !== 'string' || provided.length === 0) return false;
+
+    const method = (req.method ?? '').toUpperCase();
+    const pathname = req.path ?? '';
+    const w = this.windowCounter();
+    // Accepte la fenêtre courante ET la précédente (tolérance de skew d'horloge).
+    return (
+      this.safeEqual(provided, this.computeMac(method, pathname, w)) ||
+      this.safeEqual(provided, this.computeMac(method, pathname, w - 1))
+    );
+  }
+
+  private windowCounter(): number {
+    return Math.floor(Date.now() / SYNTHETIC_PROBE_WINDOW_MS);
+  }
+
+  private computeMac(method: string, pathname: string, window: number): string {
+    return createHmac('sha256', this.secret)
+      .update(`${method.toUpperCase()}|${pathname}|${window}`)
+      .digest('hex');
+  }
+
+  private safeEqual(a: string, b: string): boolean {
+    const bufA = Buffer.from(a, 'utf8');
+    const bufB = Buffer.from(b, 'utf8');
+    return bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
+  }
+}

--- a/backend/src/modules/seo-control-plane/types.ts
+++ b/backend/src/modules/seo-control-plane/types.ts
@@ -17,6 +17,57 @@ export type SyntheticRunTrigger = 'scheduler' | 'manual' | 'test';
 export const SYNTHETIC_USER_AGENT =
   'AutoMecanikSyntheticBot/1.0 (+https://www.automecanik.com/bots/synthetic)';
 
+/**
+ * Identité du crawler synthétique vis-à-vis du rate-limiter (incident 2026-06-25).
+ *
+ * En-tête CUSTOM (PAS `Authorization` — vérifié empiriquement : n'entre pas dans la
+ * cache-key Cloudflare, préserve donc `cf_cache_status`) portant un HMAC signé par
+ * le crawler et vérifié par BotGuardMiddleware. On n'expose ici que les NOMS d'env
+ * et le nom du header — AUCUNE valeur (IP/secret) en dur.
+ */
+export const SYNTHETIC_PROBE_HEADER = 'x-synthetic-probe';
+export const SYNTHETIC_PROBE_SECRET_KEY = 'SEO_CP_SYNTHETIC_PROBE_SECRET';
+export const SYNTHETIC_PROBE_ENABLED_KEY = 'SEO_CP_SYNTHETIC_PROBE_ENABLED';
+export const SYNTHETIC_PROBE_WINDOW_MS = 60_000;
+
+/**
+ * Préfixes de chemins PUBLICS en lecture sur lesquels l'exemption rate-limit du
+ * crawler synthétique peut s'appliquer (least-privilege). Aligné sur la surface
+ * publique cacheable (Caddyfile @products/@content). Une fuite éventuelle du
+ * credential ne peut donc relâcher le rate-limit QUE sur des GET de pages
+ * publiques déjà CDN-cachées — jamais /api, /auth, /cart, /checkout, /admin, ni
+ * aucune méthode non-GET.
+ *
+ * NB : les sitemaps (`/sitemap*.xml`) ne figurent PAS ici — Caddy les sert en
+ * statique (`@sitemaps → file_server`), ils n'atteignent jamais le throttler NestJS.
+ */
+export const SYNTHETIC_PROBE_PUBLIC_PREFIXES = [
+  '/pieces',
+  '/products',
+  '/catalog',
+  '/vehicule',
+  '/constructeurs',
+  '/blog',
+  '/blog-pieces-auto',
+] as const;
+
+/**
+ * Scope (pur, testable) de l'exemption rate-limit synthétique : `true` uniquement
+ * pour un GET vers la page d'accueil ou un préfixe catalogue public. Toute autre
+ * méthode ou chemin (API/auth/panier/admin/…) renvoie `false` même avec un flag
+ * `isVerifiedSyntheticProbe` vrai — borne le rayon d'explosion d'un secret fuité.
+ */
+export function isSyntheticExemptPath(method: string, path: string): boolean {
+  if (method !== 'GET') return false;
+  if (path === '/') return true;
+  return SYNTHETIC_PROBE_PUBLIC_PREFIXES.some(
+    (prefix) =>
+      path === prefix ||
+      path.startsWith(`${prefix}/`) ||
+      path.startsWith(`${prefix}.`),
+  );
+}
+
 /** Payload du job BullMQ `seo-cp-synthetic-crawl`. */
 export interface SyntheticCrawlJobData {
   triggeredBy: SyntheticRunTrigger;


### PR DESCRIPTION
## Pourquoi

**Incident 2026-06-25.** Le crawler synthétique L1 (`seo-control-plane`, ADR-064) sonde ses propres pages publiques via Cloudflare pour mesurer la santé edge+page. Il est mono-IP en rafale → le **ThrottlerGuard global (clé par IP) le 429 à 89,7 %** → le monitoring L1 devient **aveugle** (il ne mesure plus que ses propres throttles, pas l'état réel des pages).

Sujet distinct du fix Caddy #1140 (cache d'erreurs) — ici c'est le rate-limiter applicatif qui étrangle une source interne légitime.

## Approche (no-bricolage — credential vérifiable, pas de trust UA)

| Pièce | Rôle |
|---|---|
| `SyntheticProbeCredentialService` (`@Global`) | HMAC-SHA256 sur `method\|pathname\|window` (fenêtre 60 s, accepte `t`/`t-1` pour le skew), `timingSafeEqual` length-guardé. Secret **dédié** (≠ `INTERNAL_API_KEY`, compartimenté), **jamais sur le fil**. **Fail-closed** sur toute erreur. |
| `BotGuardMiddleware` | Pose `req.isVerifiedSyntheticProbe` **après vérif HMAC** (jamais l'User-Agent, spoofable). Placé **après** la blocklist IP opérateur (qui gagne toujours) et le FCrDNS ; bypasse geo + behavioral comme un crawler vérifié. |
| `ThrottlerGuard.skipIf` | Exemption **scopée** `isSyntheticExemptPath()` (least-privilege) — **GET + catalogue public uniquement**. `/api`, `/auth`, `/cart`, `/checkout`, `/admin` et tout non-GET restent throttlés. |
| En-tête `x-synthetic-probe` | **Custom** (pas `Authorization`) : vérifié empiriquement qu'il **n'entre pas dans la cache-key Cloudflare** → préserve `cf_cache_status`, ne pollue pas la mesure edge. |
| `SyntheticCrawlerService` | Signe ses sondes si le credential est actif ; sinon header omis (throttlée, observable). **Anti silent-fallback** : `log.error` bruyant si > 20 % des sondes en 429. |

### Blast radius d'un secret fuité
Borné par construction : une fuite ne peut relâcher le rate-limit **que** sur des **GET de pages déjà publiques et déjà CDN-cachées**. Jamais d'écriture, jamais d'endpoint sensible, jamais de bypass de la blocklist IP opérateur.

## Sécurité
- `timingSafeEqual` (même primitive qu'`InternalApiKeyGuard`), pas de `===`.
- Secret jamais hardcodé : noms d'env seulement (`SEO_CP_SYNTHETIC_PROBE_SECRET` / `_ENABLED`), valeurs via SOPS en PROD.
- Fail-closed exhaustif : kill-switch OFF / secret absent / header absent / parse error / signature invalide / fenêtre expirée → `false` → throttler normal.
- Pas de fail-open vers « vérifié » (le `catch` fail-open existant du middleware est inchangé et ne touche pas ce chemin).

## Déploiement (default OFF — owner-gated)
1. `SEO_CP_SYNTHETIC_PROBE_ENABLED` et `SEO_CP_SYNTHETIC_PROBE_SECRET` sont **vides par défaut** → comportement inchangé (crawler toujours throttlé tant que non activé).
2. Activation PROD = provisionner le secret via **SOPS** (`openssl rand -hex 32`) + `SEO_CP_SYNTHETIC_PROBE_ENABLED=true`, **côté crawler ET côté origine** (même secret, sinon fail-closed).
3. Vérif post-activation : un run synthétique doit faire chuter le taux de 429 ; l'alerte `log.error` > 20 % doit disparaître.

> ⚠️ Merge `main` = déploiement **container PREPROD CI** uniquement. Le flip du flag + tag PROD `v*` sont **owner-gated** (non inclus ici).

## Vérification
- `npx tsc --noEmit` ✅ · `eslint` ✅ · `npm run build` (`tsc --build` + `tsc-alias`) ✅
- Jest **27 verts** : 15 credential (sign/verify, t-1, expiration, mauvais secret, binding méthode+chemin, header absent, kill-switch OFF, fail-closed, `isSyntheticExemptPath` scope) + bot-guard middleware ordering (probe vérifié → flag posé + bypass geo/behavioral ; sans credential → flux normal) + crawler header wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)