### PR TITLE
fix(seo-control-plane): activate synthetic-crawler exemption — governed PROD secret + authoritative kill-switch

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -87,6 +87,10 @@ jobs:
           # Optional override. If unset, the value already present in the PROD
           # .env is used (REQUIRED_VARS below guarantees it exists).
           JWT_SECRET_OVERRIDE: ${{ secrets.PROD_JWT_SECRET }}
+          # Optional. When set, activates the seo-control-plane synthetic-crawler
+          # rate-limit exemption on PROD (HMAC verifier side). Unset = stays OFF
+          # (probes throttled; in-app 429-rate alert fires). PR #1141 / #1142.
+          SEO_CP_SYNTHETIC_PROBE_SECRET_OVERRIDE: ${{ secrets.PROD_SEO_CP_SYNTHETIC_PROBE_SECRET }}
         run: |
           docker pull massdoc/nestjs-remix-monorepo:production
 
@@ -142,6 +146,30 @@ jobs:
               echo "JWT_SECRET=${JWT_SECRET_OVERRIDE}" >> .env
             fi
             echo "✅ JWT_SECRET updated from GitHub Secrets"
+          fi
+          # Inject the seo-control-plane synthetic-crawler probe HMAC secret and
+          # ATOMICALLY enable its rate-limit exemption (BotGuardMiddleware is the
+          # verifier — PR #1141). The enable flag is flipped to true ONLY when the
+          # secret is actually provided, so a half-config ("enabled but no secret")
+          # never reaches PROD; the app would fail-closed + log loudly anyway, but
+          # we avoid the state entirely. When PROD_SEO_CP_SYNTHETIC_PROBE_SECRET is
+          # unset the exemption stays OFF: probes get throttled and the in-app
+          # 429-rate alert fires (no silent degradation). Mirrors the JWT pattern.
+          # `|` sed delimiter is safe — the value is hex (openssl rand -hex 32).
+          if [ -n "$SEO_CP_SYNTHETIC_PROBE_SECRET_OVERRIDE" ]; then
+            if grep -q '^SEO_CP_SYNTHETIC_PROBE_SECRET=' .env; then
+              sed -i "s|^SEO_CP_SYNTHETIC_PROBE_SECRET=.*|SEO_CP_SYNTHETIC_PROBE_SECRET=${SEO_CP_SYNTHETIC_PROBE_SECRET_OVERRIDE}|" .env
+            else
+              echo "SEO_CP_SYNTHETIC_PROBE_SECRET=${SEO_CP_SYNTHETIC_PROBE_SECRET_OVERRIDE}" >> .env
+            fi
+            if grep -q '^SEO_CP_SYNTHETIC_PROBE_ENABLED=' .env; then
+              sed -i "s|^SEO_CP_SYNTHETIC_PROBE_ENABLED=.*|SEO_CP_SYNTHETIC_PROBE_ENABLED=true|" .env
+            else
+              echo "SEO_CP_SYNTHETIC_PROBE_ENABLED=true" >> .env
+            fi
+            echo "✅ SEO_CP synthetic-probe exemption secret injected + enabled from GitHub Secrets"
+          else
+            echo "ℹ️ PROD_SEO_CP_SYNTHETIC_PROBE_SECRET unset — synthetic-crawler exemption stays OFF (probes throttled; in-app 429 alert will fire)"
           fi
 
           docker network create automecanik-prod 2>/dev/null || true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -192,8 +192,15 @@ SEO_CP_PROD_BASE=https://www.automecanik.com
 # throttler (mono-IP en rafale) → 89,7 % de sondes throttlées, monitoring L1
 # aveugle. Le crawler signe un HMAC (header x-synthetic-probe) vérifié par
 # BotGuardMiddleware ; l'exemption est scopée GET + catalogue public (least-priv).
-# DÉFAUT = OFF. Provisionner via SOPS en PROD uniquement ; laisser vide en DEV/PREPROD.
-#   secret : openssl rand -hex 32  (≠ INTERNAL_API_KEY — compartimenté)
+# DÉFAUT = OFF.
+#
+# Provisioning PROD (gouverné — parité JWT_SECRET) : créer le GitHub Actions secret
+# `PROD_SEO_CP_SYNTHETIC_PROBE_SECRET` (valeur `openssl rand -hex 32`, ≠ INTERNAL_API_KEY,
+# compartimenté). deploy-prod.yml l'injecte dans le .env PROD et passe ENABLED=true
+# atomiquement. Ne JAMAIS coller le secret ici ni dans le .env PROD à la main.
+#   - PREPROD : non requis (READ_ONLY → le processor skip la sonde, ne sonde jamais).
+#   - DEV     : laisser vide ; le crawler y est désactivé (SEO_CP_SYNTHETIC_ENABLED=false)
+#               pour ne pas sonder PROD depuis le poste DEV.
 SEO_CP_SYNTHETIC_PROBE_ENABLED=
 SEO_CP_SYNTHETIC_PROBE_SECRET=
 

--- a/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.scheduler.service.test.ts
+++ b/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.scheduler.service.test.ts
@@ -1,0 +1,82 @@
+import type { ConfigService } from '@nestjs/config';
+import type { Queue } from 'bull';
+import { SyntheticCrawlerSchedulerService } from './synthetic-crawler.scheduler.service';
+import { SYNTHETIC_CRAWL_JOB_NAME } from '../../types';
+
+/** Laisse les fire-and-forget (`void this.…()`) de onModuleInit se résoudre. */
+const flushAsync = () => new Promise((r) => setImmediate(r));
+
+function makeQueue(repeatables: Array<{ name: string; key: string }> = []) {
+  return {
+    getRepeatableJobs: jest.fn(async () => repeatables),
+    removeRepeatableByKey: jest.fn(async () => undefined),
+    add: jest.fn(async () => undefined),
+  } as unknown as jest.Mocked<Queue> & {
+    getRepeatableJobs: jest.Mock;
+    removeRepeatableByKey: jest.Mock;
+    add: jest.Mock;
+  };
+}
+
+function makeConfig(env: Record<string, string | undefined>): ConfigService {
+  return {
+    get: (k: string, d?: string) => env[k] ?? d,
+  } as unknown as ConfigService;
+}
+
+describe('SyntheticCrawlerSchedulerService — authoritative kill-switch', () => {
+  it('SEO_CP_SYNTHETIC_ENABLED=false REMOVES the stale repeatable (toggle off is not a no-op)', async () => {
+    const queue = makeQueue([
+      { name: SYNTHETIC_CRAWL_JOB_NAME, key: 'repeat:synthetic:1' },
+      { name: 'seo-cp-cf-analytics-fetch', key: 'repeat:other:1' }, // must NOT be touched
+    ]);
+    const svc = new SyntheticCrawlerSchedulerService(
+      queue,
+      makeConfig({ SEO_CP_SYNTHETIC_ENABLED: 'false' }),
+    );
+
+    svc.onModuleInit();
+    await flushAsync();
+
+    expect(queue.getRepeatableJobs).toHaveBeenCalledTimes(1);
+    expect(queue.removeRepeatableByKey).toHaveBeenCalledTimes(1);
+    expect(queue.removeRepeatableByKey).toHaveBeenCalledWith(
+      'repeat:synthetic:1',
+    );
+    // never schedules, and never touches a sibling collector's repeatable
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('enabled by default (flag unset) → schedules the q15min repeatable', async () => {
+    const queue = makeQueue([]);
+    const svc = new SyntheticCrawlerSchedulerService(queue, makeConfig({}));
+
+    svc.onModuleInit();
+    await flushAsync();
+
+    expect(queue.add).toHaveBeenCalledTimes(1);
+    const [name, , opts] = queue.add.mock.calls[0];
+    expect(name).toBe(SYNTHETIC_CRAWL_JOB_NAME);
+    expect((opts as { repeat?: { cron: string } }).repeat?.cron).toBe(
+      '*/15 * * * *',
+    );
+  });
+
+  it('SEO_CP_SYNTHETIC_ENABLED=0 is also treated as disabled', async () => {
+    const queue = makeQueue([
+      { name: SYNTHETIC_CRAWL_JOB_NAME, key: 'repeat:synthetic:9' },
+    ]);
+    const svc = new SyntheticCrawlerSchedulerService(
+      queue,
+      makeConfig({ SEO_CP_SYNTHETIC_ENABLED: '0' }),
+    );
+
+    svc.onModuleInit();
+    await flushAsync();
+
+    expect(queue.removeRepeatableByKey).toHaveBeenCalledWith(
+      'repeat:synthetic:9',
+    );
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.scheduler.service.ts
+++ b/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.scheduler.service.ts
@@ -40,9 +40,17 @@ export class SyntheticCrawlerSchedulerService implements OnModuleInit {
 
   onModuleInit(): void {
     if (!this.isEnabled()) {
+      // Kill-switch AUTORITAIRE : ne pas seulement éviter de (re)programmer, mais
+      // RETIRER tout repeatable déjà persisté en Redis. Sinon un job ajouté lors
+      // d'un boot précédent (flag absent = default true) SURVIT et continue de
+      // tourner → le toggle off est un no-op silencieux (« feature flag non
+      // gouverné »). Incident 2026-06-25 : le crawler du poste DEV restait throttlé
+      // à 90 % et polluait la table partagée car le repeatable survivait au flag.
+      // Fire-and-forget (discipline backend.md § Non-blocking onModuleInit).
       this.logger.log(
-        'SEO_CP_SYNTHETIC_ENABLED=false — synthetic-crawler scheduler skipped',
+        'SEO_CP_SYNTHETIC_ENABLED=false — synthetic-crawler scheduler disabled; removing any stale repeatable',
       );
+      void this.removeStaleRepeatableJob();
       return;
     }
     void this.configureRepeatableJob();


### PR DESCRIPTION
Suite d'activation de **#1141** (exemption rate-limit du crawler synthétique L1). Le code est mergé mais **inerte**, et l'alerte in-app le confirme en live (`90.0% des sondes throttlées… exemption probablement inactive`). Deux changements **cohérents** pour le même incident 2026-06-25, chacun gouverné, zéro bricolage.

## 1) Activation PROD via secret GitHub Actions gouverné (`deploy-prod.yml`)

Le vérifieur HMAC, c'est le **container PROD**. Plutôt qu'un `echo >> ~/production/.env` en SSH (non versionné, non reproductible, perdu au rebuild, secret recopié à la main), on **étend le pattern déjà en place pour `JWT_SECRET`** :

| Étape | Mécanisme |
|---|---|
| Secret | Nouveau **GitHub Actions secret** `PROD_SEO_CP_SYNTHETIC_PROBE_SECRET` (chiffré, hors repo) |
| Binding | `env: …_OVERRIDE: ${{ secrets.… }}` → `$VAR` dans `run:` (**safe anti-injection**, identique JWT) |
| Injection | `deploy-prod.yml` `sed`/`echo` dans le `.env` PROD (délimiteur `\|`, sûr car secret hex) |
| Atomicité | `SEO_CP_SYNTHETIC_PROBE_ENABLED=true` basculé **uniquement si le secret est fourni** → jamais d'état « enabled sans secret » en PROD |
| Secret absent | Exemption **OFF** : sondes throttlées + alerte 429 in-app (**no silent fallback**) ; déploiement non bloqué |

Reproductible (survit aux redeploys/rebuild), auditable, zéro secret en clair dans le repo, zéro SSH manuel.

## 2) Kill-switch `SEO_CP_SYNTHETIC_ENABLED` rendu autoritaire (scheduler)

Bug latent découvert pendant l'incident : `SEO_CP_SYNTHETIC_ENABLED=false` n'était **pas gouverné** — le scheduler évitait de (re)programmer mais **ne retirait pas** un repeatable BullMQ déjà persisté en Redis. Un job d'un boot précédent (flag absent = default true) **survivait** → toggle off = no-op silencieux (« feature flag non gouverné »).

Fix minimal : le chemin désactivé appelle `removeStaleRepeatableJob()` (déjà existant, ciblé par `name`, ne touche pas cf-analytics/runtime-logs), fire-and-forget (discipline `onModuleInit` non-bloquant). Le flag redevient autoritaire — **off ⇒ le crawler s'arrête vraiment au prochain boot, sans manipulation Redis manuelle**.

C'est ce qui permet de **désactiver proprement le crawler du poste DEV** (`SEO_CP_SYNTHETIC_ENABLED=false` dans le `.env` local) : DEV sonde aussi PROD (défaut `SEO_CP_PROD_BASE`) et écrit dans la table partagée `__seo_snapshot_synthetic` (pas de colonne runtime) → sans gate, ses 429 polluent le monitoring même après activation PROD.

## Périmètre

- **PROD** : vérifieur → secret + flag injectés (changement 1).
- **DEV** : crawler désactivé via `.env` local (non versionné, hors PR) — rendu effectif par le changement 2.
- **PREPROD** : non concerné — `READ_ONLY` → le processor *skip* la sonde.

## Vérification

- `yaml.safe_load` ✅ · `bash -n` du run block ✅ · `sed |` sûr (secret hex).
- `tsc --noEmit` ✅ · eslint ✅ · **3 tests scheduler** verts (off ⇒ remove ciblé + jamais add ; default ⇒ schedule q15min ; '0' ⇒ off).

## Activation (owner-gated)

```bash
gh secret set PROD_SEO_CP_SYNTHETIC_PROBE_SECRET \
  --repo ak125/nestjs-remix-monorepo --body "$(openssl rand -hex 32)"
# puis merge + tag v* → deploy PROD
```

Au prochain run q15min : taux de 429 en chute, alerte `>20%` disparue, snapshots propres.

> ⚠️ Merge `main` = **PREPROD** seulement (et DEV se resync ~10 min → crawler DEV s'arrête proprement). Tag `v*` PROD = décision owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)