### PR TITLE
fix(errors): status-aware HTML for generic errors (429/5xx) to browsers, preserve HTTP status

### DIFF
--- a/backend/src/modules/errors/filters/global-error.filter.ts
+++ b/backend/src/modules/errors/filters/global-error.filter.ts
@@ -12,6 +12,35 @@ import { ErrorService } from '../services/error.service';
 import { DomainException } from '@common/exceptions';
 import { RedirectException } from '../../../auth/redirected-error.exception';
 
+/**
+ * Libellés FR par code HTTP pour la page d'erreur générique servie aux
+ * navigateurs/crawlers (429, 5xx et autres 4xx non spécialisés). Miroir
+ * volontairement minimal de `getStatusDescription()` côté frontend
+ * (`frontend/app/components/errors/ErrorGeneric.tsx`) — le rendu Remix reste la
+ * surface riche ; ceci est le repli serveur lorsqu'un throttler (429) ou une
+ * 5xx court-circuite avant que Remix ne rende. 404/410/412/451 sont traités
+ * en amont (handlers dédiés) et n'atteignent jamais ce chemin.
+ */
+const GENERIC_ERROR_LABELS_FR: Record<number, string> = {
+  400: 'Requête incorrecte',
+  401: 'Non autorisé',
+  403: 'Accès interdit',
+  405: 'Méthode non autorisée',
+  408: "Délai d'attente dépassé",
+  422: 'Entité non traitable',
+  429: 'Trop de requêtes',
+  500: 'Erreur serveur interne',
+  502: 'Passerelle incorrecte',
+  503: 'Service indisponible',
+  504: "Délai d'attente de la passerelle",
+};
+
+/** Retry-After (secondes) pour les statuts où il a un sens sémantique. */
+const RETRY_AFTER_SECONDS: Record<number, number> = {
+  429: 60, // throttler: fenêtre `medium` = 60s (app.module.ts)
+  503: 120,
+};
+
 @Catch()
 export class GlobalErrorFilter implements ExceptionFilter {
   private readonly logger = new Logger(GlobalErrorFilter.name);
@@ -365,21 +394,95 @@ export class GlobalErrorFilter implements ExceptionFilter {
       exception instanceof Error ? exception.stack : undefined,
     );
 
-    // Réponse d'erreur
-    const errorResponse = {
-      statusCode: status,
-      timestamp: new Date().toISOString(),
-      path: request.url,
-      method: request.method,
-      message,
-      error: code,
-    };
-
+    // Réponse d'erreur — content negotiation (même pattern isApiRequest que
+    // handle404/410/412/451) : navigateur/crawler → page HTML status-aware
+    // (code HTTP préservé, jamais de 302, noindex) ; client API → JSON inchangé.
+    // NB : 429/5xx sont rendus en HTML INLINE (et non via une route Remix comme
+    // /404) car le throttler (APP_GUARD) et les erreurs serveur court-circuitent
+    // AVANT que Remix ne rende ; un 302 vers une route Remix perdrait le code
+    // HTTP (un 429/503 doit rester 429/503 pour les crawlers).
     try {
-      response.status(status).json(errorResponse);
+      if (this.isApiRequest(request)) {
+        response.status(status).json({
+          statusCode: status,
+          timestamp: new Date().toISOString(),
+          path: request.url,
+          method: request.method,
+          message,
+          error: code,
+        });
+      } else {
+        this.sendErrorHtml(request, response, status);
+      }
     } catch (err) {
       this.logger.error('Failed to send error response:', err);
     }
+  }
+
+  /**
+   * Sert une page d'erreur HTML status-aware au navigateur/crawler.
+   * Code HTTP PRÉSERVÉ (jamais de 302), `X-Robots-Tag: noindex, follow`,
+   * `Retry-After` sur 429/503. Aucune donnée dynamique/interne n'est reflétée
+   * dans le HTML (pas de fuite d'info ni de surface XSS).
+   */
+  private sendErrorHtml(
+    request: Request,
+    response: Response,
+    status: number,
+  ): void {
+    if (response.headersSent) return;
+
+    response.setHeader('Content-Type', 'text/html; charset=utf-8');
+    response.setHeader('X-Robots-Tag', 'noindex, follow');
+
+    const retryAfter = RETRY_AFTER_SECONDS[status];
+    if (retryAfter) response.setHeader('Retry-After', String(retryAfter));
+
+    response.status(status).send(this.renderErrorPageHtml(status));
+  }
+
+  /**
+   * Page d'erreur autonome (aucune dépendance, mobile-first, accessible).
+   * Ne rend QUE le code HTTP (entier contrôlé) + un libellé FR statique —
+   * aucune chaîne dynamique reflétée.
+   */
+  private renderErrorPageHtml(status: number): string {
+    const label = GENERIC_ERROR_LABELS_FR[status] ?? 'Erreur';
+    const isServerError = status >= 500;
+    const accent = isServerError ? '#dc2626' : '#ea580c'; // red-600 / orange-600
+    const help = isServerError
+      ? 'Un problème technique est survenu de notre côté. Nos équipes ont été notifiées.'
+      : 'Veuillez réessayer dans quelques instants.';
+
+    return `<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, follow">
+<title>${status} — ${label} | Automecanik</title>
+<style>
+  *{box-sizing:border-box}
+  body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;
+    background:#f3f4f6;color:#111827;padding:24px;
+    font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+  main{max-width:32rem;text-align:center}
+  .code{font-size:4rem;font-weight:800;line-height:1;color:${accent};margin:0}
+  h1{font-size:1.5rem;font-weight:700;margin:.5rem 0 0}
+  p{color:#6b7280;margin:.75rem 0 0}
+  a{display:inline-block;margin-top:1.5rem;padding:.625rem 1.25rem;border-radius:.5rem;
+    background:${accent};color:#fff;text-decoration:none;font-weight:600}
+</style>
+</head>
+<body>
+<main>
+  <p class="code">${status}</p>
+  <h1>${label}</h1>
+  <p>${help}</p>
+  <a href="/">Retour à l'accueil</a>
+</main>
+</body>
+</html>`;
   }
 
   /**

--- a/backend/tests/unit/global-error-filter.test.ts
+++ b/backend/tests/unit/global-error-filter.test.ts
@@ -1,0 +1,190 @@
+/**
+ * GlobalErrorFilter — handleGenericError content-negotiation tests
+ *
+ * Covers the structural gap surfaced 2026-06-25: generic errors (429, 5xx and
+ * other non-special 4xx) were always returned as raw JSON, even to a browser /
+ * crawler. The fix makes `handleGenericError` content-negotiated, mirroring the
+ * existing `isApiRequest()` pattern used by handle404/410/412/451:
+ *   - browser request (Accept: text/html, non-/api) → status-aware HTML page,
+ *     HTTP status PRESERVED (429 stays 429), `X-Robots-Tag: noindex, follow`.
+ *   - API request (/api/* or Accept: application/json) → JSON (unchanged).
+ *
+ * @see backend/src/modules/errors/filters/global-error.filter.ts
+ */
+import { GlobalErrorFilter } from '@modules/errors/filters/global-error.filter';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function createErrorServiceMock() {
+  return {
+    logError: jest.fn().mockResolvedValue(undefined),
+    handle404: jest.fn(),
+    handle410: jest.fn(),
+  };
+}
+
+function createResponseMock() {
+  const res: Record<string, jest.Mock | unknown> = {
+    headersSent: false,
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+    redirect: jest.fn().mockReturnThis(),
+  };
+  return res as any;
+}
+
+function createRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    url: '/pieces/alternateur-4.html',
+    path: '/pieces/alternateur-4.html',
+    method: 'GET',
+    headers: { accept: 'text/html' },
+    ...overrides,
+  } as any;
+}
+
+// handleGenericError is private; we exercise it directly (decorator-free,
+// deterministic) — the public `catch()` routes 429/5xx here via its switch.
+function callGeneric(
+  filter: GlobalErrorFilter,
+  req: unknown,
+  res: unknown,
+  status: number,
+  message = 'Erreur',
+  code = 'Error',
+) {
+  return (filter as any).handleGenericError(
+    req,
+    res,
+    status,
+    message,
+    code,
+    new Error(message),
+  );
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('GlobalErrorFilter.handleGenericError — content negotiation', () => {
+  let filter: GlobalErrorFilter;
+  let errorService: ReturnType<typeof createErrorServiceMock>;
+
+  beforeEach(() => {
+    errorService = createErrorServiceMock();
+    filter = new GlobalErrorFilter(errorService as any);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('browser request (Accept: text/html)', () => {
+    it('429 → status-aware HTML with status code PRESERVED (not 302, not JSON)', () => {
+      const res = createResponseMock();
+      callGeneric(filter, createRequest(), res, 429, 'Too many requests');
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(res.send).toHaveBeenCalledTimes(1);
+      expect(res.json).not.toHaveBeenCalled();
+      expect(res.redirect).not.toHaveBeenCalled();
+
+      const html = String(res.send.mock.calls[0][0]);
+      expect(html).toContain('429');
+      expect(html).toContain('Trop de requêtes'); // FR label, status-aware
+      expect(html.toLowerCase()).toContain('<!doctype html');
+    });
+
+    it('emits X-Robots-Tag: noindex, follow (server-side, SEO-safe)', () => {
+      const res = createResponseMock();
+      callGeneric(filter, createRequest(), res, 503, 'Service unavailable');
+
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'X-Robots-Tag',
+        expect.stringContaining('noindex'),
+      );
+      const html = String(res.send.mock.calls[0][0]);
+      expect(html).toContain('503');
+      expect(html).toContain('Service indisponible');
+    });
+
+    it('sends Retry-After on 429 and 503', () => {
+      const res429 = createResponseMock();
+      callGeneric(filter, createRequest(), res429, 429);
+      expect(res429.setHeader).toHaveBeenCalledWith(
+        'Retry-After',
+        expect.anything(),
+      );
+
+      const res503 = createResponseMock();
+      callGeneric(filter, createRequest(), res503, 503);
+      expect(res503.setHeader).toHaveBeenCalledWith(
+        'Retry-After',
+        expect.anything(),
+      );
+    });
+
+    it('does NOT send Retry-After on a 500', () => {
+      const res = createResponseMock();
+      callGeneric(filter, createRequest(), res, 500);
+      const retryCalls = res.setHeader.mock.calls.filter(
+        (c: unknown[]) => c[0] === 'Retry-After',
+      );
+      expect(retryCalls).toHaveLength(0);
+    });
+
+    it('does NOT reflect the raw internal message into public HTML (no info-leak, no injection)', () => {
+      const res = createResponseMock();
+      callGeneric(
+        filter,
+        createRequest(),
+        res,
+        500,
+        '<script>alert(1)</script> dsn=postgres://secret',
+      );
+      const html = String(res.send.mock.calls[0][0]);
+      // The internal message is never echoed into the public page.
+      expect(html).not.toContain('alert(1)');
+      expect(html).not.toContain('secret');
+      expect(html).not.toContain('<script>alert(1)</script>');
+      // Still status-aware (controlled, static label + integer status).
+      expect(html).toContain('500');
+      expect(html).toContain('Erreur serveur interne');
+    });
+  });
+
+  describe('API request (unchanged → JSON)', () => {
+    it('/api/* path → JSON, never HTML', () => {
+      const res = createResponseMock();
+      const req = createRequest({
+        url: '/api/foo',
+        path: '/api/foo',
+        headers: { accept: 'application/json' },
+      });
+      callGeneric(filter, req, res, 429, 'Too many requests');
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(res.json).toHaveBeenCalledTimes(1);
+      expect(res.send).not.toHaveBeenCalled();
+
+      const payload = res.json.mock.calls[0][0];
+      expect(payload).toMatchObject({ statusCode: 429 });
+    });
+
+    it('Accept: application/json (non-/api) → JSON', () => {
+      const res = createResponseMock();
+      const req = createRequest({ headers: { accept: 'application/json' } });
+      callGeneric(filter, req, res, 500);
+
+      expect(res.json).toHaveBeenCalledTimes(1);
+      expect(res.send).not.toHaveBeenCalled();
+    });
+  });
+
+  it('respects headersSent guard (no double-send)', () => {
+    const res = createResponseMock();
+    res.headersSent = true;
+    callGeneric(filter, createRequest(), res, 429);
+    expect(res.send).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problème

`GlobalErrorFilter.handleGenericError()` renvoyait **toujours du JSON brut** — y compris aux navigateurs/crawlers — pour **429** (throttler), **5xx** et autres 4xx non spécialisés. Un visiteur throttlé ou tombant sur une 5xx voyait `{"statusCode":429,...}` au lieu d'une page, alors que **404/410 rendaient déjà du HTML**. Cette incohérence est exactement ce qui a fait confondre, lors d'un audit externe, un **429** avec l'écran « 404 — Page introuvable ».

## Correctif

Étend la content-negotiation **déjà existante** (`isApiRequest()`, même pattern que `handle404/410/412/451`) à `handleGenericError` :

- **navigateur/crawler** → page HTML **status-aware**, **code HTTP préservé** (jamais de 302), `X-Robots-Tag: noindex, follow`, `Retry-After` sur 429/503.
- **client API** (`/api/*` ou `Accept: application/json`) → **JSON inchangé (byte-identique)**.

Le HTML ne reflète **que** l'entier `status` + un libellé FR statique (miroir de `ErrorGeneric.tsx`) — le `message` interne n'est **jamais** rendu → pas de fuite d'info ni de surface XSS. Les 429/5xx sont rendus **inline** (et non via une route Remix) car le throttler/5xx court-circuitent avant Remix, et un 302 perdrait le code HTTP.

## Périmètre / garde-fous

- ✅ Aucun changement d'**URL / route / canonical**. Les chemins gouvernés **404/410/412/451** ne sont **pas touchés**.
- ✅ Statut HTTP **préservé** (R-SEO : pas de 302 sur erreur), `noindex, follow` (R-SEO-08).
- ✅ Contrat JSON API inchangé.
- ✅ Premier test unitaire du module `errors` (**8 tests**, module non testé jusqu'ici).
- 🚫 **Pas de tag PROD** — ce PR cible `main` (déploiement PREPROD CI). La mise en service PROD reste une décision owner-gated séparée.

## Vérification

- `npx jest global-error-filter` → **8/8 vert** (TDD red→green).
- `tsc --noEmit` → 0 erreur sur le fichier ; ESLint `src` clean.
- **Revue adverse** (3 lentilles indépendantes) : Regression **PASS**, Security **PASS** (pas de XSS/leak), SEO/governance **CONCERN** non-bloquant (findings low/medium seulement).

## Caveat opérationnel (pas de changement code requis)

Si le throttling 429 persiste, GSC peut afficher du bruit « Crawl Anomaly » (réponses 429 `noindex`). Comportement **correct** ; à **monitorer** post-deploy. La config throttler n'est pas modifiée ici.

## Hors-scope (pré-existant, signalé pour suivi — non corrigé ici)

- `frontend/app/routes/admin.optimization-summary.tsx:29` fetch `/dashboard/stats` (sans `/api/`) — typo d'URL pré-existant.
- `global-error.filter.ts:72` `RedirectException` interpole `message` dans une URL sans encodage — info de sécurité pré-existante.
- Le JSON API expose toujours `message` (inchangé, pré-existant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
