### PR TITLE
feat(seo): A1b — SeoVariables additive fields + fail-closed safeParse at V4 chain entry

### DIFF
--- a/backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
+++ b/backend/src/modules/seo/__tests__/dynamic-seo-v4-via-chain.test.ts
@@ -1,3 +1,5 @@
+import { BadRequestException } from '@nestjs/common';
+
 import { DynamicSeoV4UltimateService } from '../dynamic-seo-v4-ultimate.service';
 import { SeoSurfaceRegistry } from '../registries/seo-surface.registry';
 import { SeoVariantFamilyRegistry } from '../registries/seo-variant-family.registry';
@@ -196,5 +198,42 @@ describe('DynamicSeoV4UltimateService → chain delegation (PR-2d E2E)', () => {
     const r2 = await v4.generateCompleteSeo(1, 1, baseVars);
 
     expect(r2.metadata.cacheHit).toBe(false);
+  });
+
+  // ── A1b : SeoVariables additif + safeParse fail-CLOSED ──────────────────────
+
+  it('contrat additif : powerKw + gammeId optionnels acceptés (zéro breakage)', async () => {
+    const v4 = buildV4({
+      templateRow: { sgc_id: 5, sgc_title: '#Gamme#' },
+    });
+
+    // Les champs A1b sont optionnels : présents → validés, absents → OK.
+    const result = await v4.generateCompleteSeo(5, 5, {
+      ...baseVars,
+      powerKw: 66,
+      gammeId: 124,
+    });
+
+    expect(result.title).toContain('Plaquettes');
+  });
+
+  it('fail-CLOSED : variables invalides → BadRequestException et generateDefaultSeo JAMAIS appelé', async () => {
+    const v4 = buildV4({
+      templateRow: { sgc_id: 1, sgc_title: '#Gamme#' },
+    });
+    // Le fallback ne doit JAMAIS produire de page depuis des variables invalides
+    // (le throw safeParse est levé AVANT le try/catch fail-open).
+    const defaultSpy = jest.spyOn(
+      v4 as unknown as { generateDefaultSeo: (...a: unknown[]) => unknown },
+      'generateDefaultSeo',
+    );
+
+    // nbCh est requis (number positif) ; on passe une valeur non-numérique.
+    const invalidVars = { ...baseVars, nbCh: 'quatre-vingt-dix' } as never;
+
+    await expect(
+      v4.generateCompleteSeo(1, 1, invalidVars),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(defaultSpy).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/seo/dynamic-seo-v4-ultimate.service.ts
+++ b/backend/src/modules/seo/dynamic-seo-v4-ultimate.service.ts
@@ -24,7 +24,7 @@
  * @version 4.1.0 (refactor seo-v9 PR-2c)
  */
 
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 
 import { SupabaseBaseService } from '@database/services/supabase-base.service';
 import { SeoChainOrchestratorService } from './services/chain/seo-chain-orchestrator.service';
@@ -89,7 +89,23 @@ export class DynamicSeoV4UltimateService extends SupabaseBaseService {
     variables: SeoVariables,
   ): Promise<CompleteSeoResult> {
     const startTime = Date.now();
-    const validatedVars = SeoVariablesSchema.parse(variables);
+
+    // Fail-CLOSED à l'entrée chaîne (A1b) : `safeParse` plutôt que `.parse()`.
+    // Variables invalides → 400 explicite/observable, levé AVANT le `try` plus
+    // bas — donc le throw échappe au `catch` fail-open (qui retournerait
+    // `generateDefaultSeo`) : on ne compose JAMAIS une page depuis des variables
+    // invalides. Inputs valides → `parsed.data` identique à l'ancien `.parse()`
+    // (sortie inchangée). Seuls appelants = les 4 endpoints debug V4.
+    const parsed = SeoVariablesSchema.safeParse(variables);
+    if (!parsed.success) {
+      this.logger.error(
+        `❌ [SEO V4→chain] SeoVariables invalides (pgId=${pgId}, typeId=${typeId}) : ${JSON.stringify(
+          parsed.error.flatten(),
+        )}`,
+      );
+      throw new BadRequestException(parsed.error.flatten());
+    }
+    const validatedVars = parsed.data;
 
     this.logger.log(
       `🎯 [SEO V4→chain] Génération complète : pgId=${pgId}, typeId=${typeId}`,

--- a/backend/src/modules/seo/seo-v4.types.ts
+++ b/backend/src/modules/seo/seo-v4.types.ts
@@ -26,6 +26,7 @@ export const SeoVariablesSchema = z.object({
   // Variables techniques
   annee: z.string(),
   nbCh: z.number().positive(),
+  powerKw: z.number().positive().optional(), // puissance kW (pendant de nbCh ; cf colonne DB type_power_kw)
   carosserie: z.string(),
   fuel: z.string(),
   codeMoteur: z.string(),
@@ -38,6 +39,7 @@ export const SeoVariablesSchema = z.object({
   familyName: z.string().optional(),
 
   // Métadonnées contextuelles (nouvelles)
+  gammeId: z.number().int().positive().optional(), // pg_id (convention r2-composition.schema)
   articlesCount: z.number().int().nonnegative().default(0),
   gammeLevel: z.number().int().min(1).max(3).default(1),
   isTopGamme: z.boolean().default(false),


### PR DESCRIPTION
## A1b — SeoVariables additif + safeParse fail-closed (Phase 3, `SEO_RUNTIME_FOUNDATION_PASS`)

Première slice de la fondation runtime SEO du pipeline R\* anti-duplicate. **Périmètre minimal, additif, zéro changement de texte visible.**

### Ce que ça fait
1. **`SeoVariablesSchema`** : ajoute `powerKw` (puissance kW, pendant de `nbCh`) et `gammeId` (= `pg_id`) — **optionnels** ⇒ contrat additif, zéro breakage. Noms **camelCase gouvernés** (verify-before-invent : `powerKw` cf col DB `type_power_kw` + `vehicles-forms-simple`, `gammeId` cf `r2-composition.schema`), **pas** `puissance_kW`/`gamme_id` (qui inventeraient une convention).
2. **`generateCompleteSeo`** : `.parse()` → `.safeParse()`, **maintenu HORS du `try`/`catch`**. Variables invalides ⇒ **400 explicite + observable** (`BadRequestException` + `error.flatten()` loggé) au lieu d'un 500 opaque, et **ne peuvent JAMAIS** atteindre le fallback fail-open `generateDefaultSeo`. Inputs valides ⇒ `parsed.data` **identique** à l'ancien `.parse()` (sortie byte-identique).

### Pourquoi cette forme (corrections du red-team adversarial)
- Le `catch` (`generateCompleteSeo`) retourne `generateDefaultSeo` = fail-OPEN canonique. Le `safeParse` reste **avant** le `try` pour que le throw l'échappe ⇒ **fail-CLOSED réel**.
- Test dédié asserte `generateDefaultSeo` **jamais appelé** sur input invalide (pas seulement « ça throw »).

### Périmètre & sécurité
- Touche **uniquement** l'entrée de l'adaptateur V4 debug (4 endpoints `/api/seo-dynamic-v4/*`). Le chemin gamme R1 prod (stateless `SeoTitleEngine`) n'est pas concerné.
- **0 changement** texte meta visible · URL · canonical · robots · cache · queues · payments.
- Réversible : revert flip + drop 2 champs optionnels (aucune migration data).

### Vérification (PRE-PR)
- `jest dynamic-seo-v4-via-chain.test.ts` : **6/6 pass** (4 pré-existants = non-régression + 2 nouveaux).
- `tsc --noEmit -p tsconfig.json` : **exit 0, 0 erreur**.

### Hors-scope (slices séparées, suite Phase 3)
- **A1a** (observe-only) : rendre observable le silent-strip pré-existant de `cleanContent()` (efface `#markers` sans log). **A1c** : descopé (chemin gamme déjà Redis+versionné+mono-process). **A1d** : HTML-escape re-scopé per-sink consumer (pas producteur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
