### PR TITLE
fix(substitution): fail-OPEN on RPC error — stop intermittent 404 on valid R1 pages

### DIFF
--- a/.spec/00-canon/repository-registry/ownership.yaml
+++ b/.spec/00-canon/repository-registry/ownership.yaml
@@ -108,6 +108,13 @@ entries:
     owner: '@ak125/seo-team'
     sourceConfidence: high
     risk: low
+  # Fix get_substitution_data GROUP BY (chemin slug inconnu) — CREATE OR REPLACE d'une fonction
+  # (additif, réversible, non auto-appliqué). Débloque le fail-OPEN R1 404. Owner GO 2026-07-15. Glob exact.
+  - glob: backend/supabase/migrations/20260625_fix_get_substitution_data_group_by_unknown_slug.sql
+    domain: D14
+    owner: '@ak125/seo-team'
+    sourceConfidence: high
+    risk: low
   # ADR-059 PR-6 — SEO projection write-side schema (7 tables + 2 MV). Owner GO session 2026-06-19.
   # Glob exact volontaire — les migrations ne sont PAS auto-couvertes (review ownership à chaque fois).
   - glob: backend/supabase/migrations/20260619_adr059_pr6_seo_projection_schema.sql

--- a/backend/src/modules/substitution/services/substitution.service.ts
+++ b/backend/src/modules/substitution/services/substitution.service.ts
@@ -123,26 +123,35 @@ export class SubstitutionService extends SupabaseBaseService {
       );
 
       if (error) {
-        this.logger.error(`RPC error: ${error.message}`);
+        // FAIL-OPEN observable (cf. determineSubstitution) : une erreur RPC est
+        // une panne d'infra, PAS une "gamme non trouvée" → `rpc_error: true` pour
+        // ne pas 404 une page valide. Log conservé = visibilité de la panne.
+        this.logger.error(
+          `RPC error → fail-open (substitution skipped, page renders on primary data): ${error.message}`,
+        );
         return {
           _meta: {
             gamme_found: false,
             resolved_by: 'none',
             products_count: 0,
             vehicle_found: false,
+            rpc_error: true,
           },
         };
       }
 
       return data as SubstitutionDataResponse;
     } catch (error) {
-      this.logger.error(`RPC exception: ${getErrorMessage(error)}`);
+      this.logger.error(
+        `RPC exception → fail-open (substitution skipped, page renders on primary data): ${getErrorMessage(error)}`,
+      );
       return {
         _meta: {
           gamme_found: false,
           resolved_by: 'none',
           products_count: 0,
           vehicle_found: false,
+          rpc_error: true,
         },
       };
     }
@@ -157,6 +166,21 @@ export class SubstitutionService extends SupabaseBaseService {
     data: SubstitutionDataResponse,
     includeVehicleOptions: boolean = true,
   ): SubstitutionResult {
+    // FAIL-OPEN (gouverné + observable — l'erreur RPC est loggée dans
+    // fetchSubstitutionData) : une panne d'INFRA RPC n'est PAS un "gamme non
+    // trouvée". La transformer en 404 tuait des pages R1 VALIDES de façon
+    // intermittente (incident 2026-06-25 : get_substitution_data GROUP BY).
+    // → On rend 200 'none' : la page se rend sur sa data principale, la
+    // substitution est juste absente. Un vrai slug inconnu (RPC OK,
+    // gamme_found:false) reste un 404 ci-dessous (CASE 1), inchangé.
+    if (data._meta?.rpc_error) {
+      return this.buildResult(
+        'none',
+        200,
+        'Substitution temporairement indisponible',
+      );
+    }
+
     // CASE 1: Gamme non trouvée → 404
     if (!data._meta?.gamme_found) {
       return this.buildResult('unknown_slug', 404, 'Gamme non reconnue', {

--- a/backend/src/modules/substitution/types/substitution.types.ts
+++ b/backend/src/modules/substitution/types/substitution.types.ts
@@ -290,5 +290,12 @@ export interface SubstitutionDataResponse {
     vehicle_found: boolean;
     products_count: number;
     resolved_by: 'exact' | 'similarity' | 'none';
+    /**
+     * True quand l'appel RPC `get_substitution_data` a ÉCHOUÉ (erreur infra/SQL),
+     * par opposition à un vrai "gamme non trouvée". Distingue les deux pour que
+     * `determineSubstitution` fasse fail-OPEN (200) au lieu de fail-CLOSE (404)
+     * sur une page valide. Voir incident 2026-06-25.
+     */
+    rpc_error?: boolean;
   };
 }

--- a/backend/supabase/migrations/20260625_fix_get_substitution_data_group_by_unknown_slug.sql
+++ b/backend/supabase/migrations/20260625_fix_get_substitution_data_group_by_unknown_slug.sql
@@ -41,6 +41,11 @@
 -- Date: 2026-06-25
 -- ============================================================================
 
+-- Garde-fous d'exécution (squawk require-timeout-settings) : borne l'attente de
+-- lock et le temps d'exécution de ce CREATE OR REPLACE (DDL métadonnée rapide).
+set statement_timeout = '5s';
+set lock_timeout = '1s';
+
 CREATE OR REPLACE FUNCTION public.get_substitution_data(
   p_gamme_alias text,
   p_marque_alias text DEFAULT NULL::text,

--- a/backend/supabase/migrations/20260625_fix_get_substitution_data_group_by_unknown_slug.sql
+++ b/backend/supabase/migrations/20260625_fix_get_substitution_data_group_by_unknown_slug.sql
@@ -1,0 +1,203 @@
+-- ============================================================================
+-- FIX: get_substitution_data — erreur GROUP BY (chemin slug inconnu)
+-- ============================================================================
+-- Symptôme (confirmé live 2026-06-25, ligne 47 de la fonction) :
+--   ERROR 42803: column "pieces_gamme.pg_name" must appear in the GROUP BY
+--   clause or be used in an aggregate function
+--
+-- Déclencheur :
+--   Branche `IF v_gamme_id IS NULL` (gamme non résolue). Le bloc `suggestions`
+--   applique `ORDER BY pg_name` AU NIVEAU REQUÊTE sur un SELECT agrégé
+--   (jsonb_agg). Postgres exige alors pg_name dans GROUP BY → la fonction lève
+--   42803. Le service substitution catch l'erreur et renvoie gamme_found:false
+--   → httpStatus 404. Conséquence :
+--     • toute page R1 dont l'intent substitution échoue à résoudre v_gamme_id
+--       renvoie un 404 sur une gamme pourtant valide (404 intermittent observé
+--       sur /pieces/filtre-a-huile-7.html) ;
+--     • tout slug réellement inconnu lève aussi l'erreur → ses « suggestions »
+--       (bloc d'aide sur la page 404) ne sont jamais rendues.
+--
+-- Historique :
+--   Le correctif d'origine (20260213_fix_get_substitution_data_group_by.sql)
+--   triait/limitait en sous-requête AVANT jsonb_agg. Il a été PERDU lors de la
+--   réécriture du 2026-03-15 (migrations unify_cross_gamme_car_new /
+--   drop_cross_gamme_car_deprecated) qui a basculé la fonction sur
+--   `__cross_gamme_car_new` en réintroduisant la forme buggée des suggestions.
+--
+-- Correctif (chirurgical) :
+--   Réordonner/limiter dans une sous-requête `s`, puis agréger — exactement
+--   comme les autres blocs sains. Le reste de la fonction (table
+--   `__cross_gamme_car_new`, `SET search_path TO 'public'`, SECURITY DEFINER)
+--   est préservé VERBATIM depuis la définition live.
+--
+-- Réversibilité : pur CREATE OR REPLACE d'une fonction (aucune donnée touchée,
+--   aucun DDL de schéma). Rollback = ré-appliquer la définition précédente.
+--
+-- NB (hors scope, latent non-bloquant) : plusieurs LIMIT (related_parts 6,
+--   compatible_motors 20, compatible_gammes 50) sont placés APRÈS jsonb_agg
+--   donc inopérants (n'érigent aucune erreur). À corriger séparément si besoin
+--   de borner la taille du payload — non requis pour lever le 404.
+--
+-- Date: 2026-06-25
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_substitution_data(
+  p_gamme_alias text,
+  p_marque_alias text DEFAULT NULL::text,
+  p_modele_alias text DEFAULT NULL::text,
+  p_type_alias text DEFAULT NULL::text,
+  p_gamme_id integer DEFAULT NULL::integer
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_gamme_id INTEGER;
+  v_gamme_name TEXT;
+  v_gamme_alias TEXT;
+  v_mf_id TEXT;
+  v_mf_name TEXT;
+  v_resolved_by TEXT := 'none';
+  v_products_count INTEGER := 0;
+  v_first_type_id INTEGER;
+  v_result JSONB;
+BEGIN
+  IF p_gamme_id IS NOT NULL THEN
+    SELECT pg.pg_id, pg.pg_name, pg.pg_alias, cg.mc_mf_id
+    INTO v_gamme_id, v_gamme_name, v_gamme_alias, v_mf_id
+    FROM pieces_gamme pg
+    LEFT JOIN catalog_gamme cg ON cg.mc_pg_id = pg.pg_id::TEXT
+    WHERE pg.pg_id = p_gamme_id LIMIT 1;
+    IF v_gamme_id IS NOT NULL THEN v_resolved_by := 'exact'; END IF;
+  END IF;
+
+  IF v_gamme_id IS NULL AND p_gamme_alias IS NOT NULL THEN
+    SELECT pg.pg_id, pg.pg_name, pg.pg_alias, cg.mc_mf_id
+    INTO v_gamme_id, v_gamme_name, v_gamme_alias, v_mf_id
+    FROM pieces_gamme pg
+    LEFT JOIN catalog_gamme cg ON cg.mc_pg_id = pg.pg_id::TEXT
+    WHERE pg.pg_alias = LOWER(p_gamme_alias) LIMIT 1;
+    IF v_gamme_id IS NOT NULL THEN v_resolved_by := 'exact'; END IF;
+  END IF;
+
+  IF v_mf_id IS NOT NULL THEN
+    SELECT mf_name INTO v_mf_name FROM catalog_family WHERE mf_id = v_mf_id;
+  END IF;
+
+  IF v_gamme_id IS NOT NULL THEN
+    SELECT COUNT(*)::INTEGER INTO v_products_count FROM pieces WHERE piece_pg_id = v_gamme_id;
+  END IF;
+
+  v_result := jsonb_build_object('_meta', jsonb_build_object(
+    'gamme_found', v_gamme_id IS NOT NULL,
+    'resolved_by', v_resolved_by,
+    'products_count', v_products_count,
+    'vehicle_found', false
+  ));
+
+  IF v_gamme_id IS NULL THEN
+    -- FIX 42803 : trier/limiter en sous-requête, PUIS agréger.
+    v_result := v_result || jsonb_build_object('suggestions', (
+      SELECT COALESCE(
+        jsonb_agg(
+          jsonb_build_object(
+            'pg_id', s.pg_id,
+            'pg_name', s.pg_name,
+            'pg_alias', s.pg_alias,
+            'reason', 'popular'
+          )
+          ORDER BY s.pg_name
+        ),
+        '[]'::jsonb
+      )
+      FROM (
+        SELECT pg_id, pg_name, pg_alias
+        FROM pieces_gamme
+        WHERE pg_level = '1'
+        ORDER BY pg_name
+        LIMIT 5
+      ) s
+    ));
+    RETURN v_result;
+  END IF;
+
+  v_result := v_result || jsonb_build_object('gamme', jsonb_build_object(
+    'pg_id', v_gamme_id, 'pg_name', v_gamme_name, 'pg_alias', v_gamme_alias, 'mf_id', v_mf_id, 'mf_name', v_mf_name
+  ));
+
+  v_result := v_result || jsonb_build_object('substitute', (
+    SELECT jsonb_build_object('piece_id', p.piece_id, 'piece_name', p.piece_name, 'piece_ref', COALESCE(p.piece_ref, ''), 'pm_name', COALESCE(pm.pm_name, ''))
+    FROM pieces p LEFT JOIN pieces_marque pm ON pm.pm_id = p.piece_pm_id::INTEGER
+    WHERE p.piece_pg_id = v_gamme_id AND p.piece_display = '1'
+    ORDER BY p.piece_qty_sale::INTEGER DESC NULLS LAST, p.piece_sort ASC NULLS LAST LIMIT 1
+  ));
+
+  v_result := v_result || jsonb_build_object('related_parts', (
+    SELECT COALESCE(jsonb_agg(jsonb_build_object('pg_id', pg.pg_id, 'pg_name', pg.pg_name, 'pg_alias', pg.pg_alias)), '[]'::jsonb)
+    FROM pieces_gamme pg JOIN catalog_gamme cg ON cg.mc_pg_id = pg.pg_id::TEXT
+    WHERE cg.mc_mf_id = v_mf_id AND pg.pg_id != v_gamme_id LIMIT 6
+  ));
+
+  v_result := v_result || jsonb_build_object('compatible_motors', (
+    SELECT COALESCE(jsonb_agg(DISTINCT jsonb_build_object(
+      'type_id', t.type_id::INTEGER,
+      'type_name', t.type_name,
+      'type_alias', t.type_alias,
+      'type_fuel', t.type_fuel,
+      'type_power_ps', t.type_power_ps,
+      'type_year_from', t.type_year_from,
+      'type_year_to', t.type_year_to,
+      'type_body', t.type_body
+    )), '[]'::jsonb)
+    FROM __cross_gamme_car_new cgc
+    JOIN auto_type t ON t.type_id = cgc.cgc_type_id
+    WHERE cgc.cgc_pg_id = v_gamme_id::TEXT
+      AND cgc.cgc_level IN ('1', '2', '3')
+    LIMIT 20
+  ));
+
+  SELECT (t.type_id)::INTEGER INTO v_first_type_id
+  FROM __cross_gamme_car_new cgc
+  JOIN auto_type t ON t.type_id = cgc.cgc_type_id
+  WHERE cgc.cgc_pg_id = v_gamme_id::TEXT
+    AND cgc.cgc_level IN ('1', '2', '3')
+  LIMIT 1;
+
+  IF v_first_type_id IS NOT NULL THEN
+    v_result := v_result || jsonb_build_object('compatible_gammes', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'pg_id', pg.pg_id,
+        'pg_name', pg.pg_name,
+        'pg_alias', pg.pg_alias,
+        'pg_pic', pg.pg_pic,
+        'total_pieces', sub.total_pieces
+      ) ORDER BY sub.total_pieces DESC), '[]'::jsonb)
+      FROM (
+        SELECT
+          prt.rtp_pg_id::INTEGER AS pg_id,
+          COUNT(DISTINCT prt.rtp_piece_id)::BIGINT AS total_pieces
+        FROM pieces_relation_type prt
+        INNER JOIN pieces p ON prt.rtp_piece_id = p.piece_id
+        INNER JOIN pieces_gamme pg ON p.piece_pg_id = pg.pg_id
+        WHERE
+          prt.rtp_type_id = v_first_type_id
+          AND p.piece_display = true
+          AND pg.pg_display = '1'
+          AND pg.pg_level IN ('1', '2')
+        GROUP BY prt.rtp_pg_id
+      ) sub
+      JOIN pieces_gamme pg ON pg.pg_id = sub.pg_id
+      LIMIT 50
+    ));
+  ELSE
+    v_result := v_result || jsonb_build_object('compatible_gammes', '[]'::jsonb);
+  END IF;
+
+  RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.get_substitution_data IS
+  'V5 - 2026-06-25: re-fix GROUP BY pg_name (chemin slug inconnu, ligne suggestions). Régression introduite par la réécriture cross_gamme_car_new du 2026-03-15. Sur __cross_gamme_car_new + search_path pinné.';

--- a/backend/tests/unit/substitution-fail-open.test.ts
+++ b/backend/tests/unit/substitution-fail-open.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SubstitutionService — fail-OPEN on RPC infrastructure error
+ *
+ * Incident 2026-06-25: `get_substitution_data` RPC errored in SQL
+ * (`column "pieces_gamme.pg_name" must appear in the GROUP BY clause`). The
+ * service fail-CLOSED — an RPC *error* was returned as `gamme_found:false`,
+ * which `determineSubstitution` maps to httpStatus 404. The R1 loader then
+ * threw a 404 on a VALID page (gamme 7, whose primary data loaded fine) →
+ * intermittent 404 on real R1 pages.
+ *
+ * Contract: an RPC INFRASTRUCTURE error is NOT "gamme not found". It must
+ * fail-OPEN to httpStatus 200 'none' (substitution enrichment absent, page
+ * renders normally), while a genuine not-found (RPC ok, gamme_found:false)
+ * still yields 404. The RPC error remains logged → observable, not silent.
+ *
+ * @see backend/src/modules/substitution/services/substitution.service.ts
+ */
+import { SubstitutionService } from '@modules/substitution/services/substitution.service';
+
+function makeService(callRpc: jest.Mock): SubstitutionService {
+  const configService = {
+    get: jest.fn((k: string) => (/URL/i.test(k) ? 'http://localhost:54321' : 'test-key')),
+  };
+  const intentExtractor = {
+    isSuspiciousBot: jest.fn(() => false),
+    extractFromPathname: jest.fn(() => ({
+      gammeAlias: 'filtre-a-huile',
+      gammeId: 7,
+    })),
+  };
+  const substitutionLogger = { logAsync: jest.fn() };
+  const rpcGate = {};
+  const svc = new SubstitutionService(
+    configService as any,
+    intentExtractor as any,
+    substitutionLogger as any,
+    rpcGate as any,
+  );
+  // callRpc is the only DB seam — override it so no real Supabase call happens.
+  (svc as any).callRpc = callRpc;
+  return svc;
+}
+
+describe('SubstitutionService — fail-open on RPC error', () => {
+  it('RPC error → 200 (fail-open), NOT 404 — valid page survives a broken RPC', async () => {
+    const callRpc = jest.fn().mockResolvedValue({
+      data: null,
+      error: {
+        message:
+          'column "pieces_gamme.pg_name" must appear in the GROUP BY clause',
+      },
+    });
+    const svc = makeService(callRpc);
+
+    const res = await svc.checkSubstitution(
+      '/pieces/filtre-a-huile-7.html',
+      'Mozilla/5.0',
+    );
+
+    expect(res.httpStatus).toBe(200);
+    expect(res.type).toBe('none');
+  });
+
+  it('RPC exception (throw) → 200 (fail-open), NOT 404', async () => {
+    const callRpc = jest.fn().mockRejectedValue(new Error('connection reset'));
+    const svc = makeService(callRpc);
+
+    const res = await svc.checkSubstitution(
+      '/pieces/filtre-a-huile-7.html',
+      'Mozilla/5.0',
+    );
+
+    expect(res.httpStatus).toBe(200);
+  });
+
+  it('genuine not-found (RPC ok, gamme_found:false) → still 404 (preserved)', async () => {
+    const callRpc = jest.fn().mockResolvedValue({
+      data: {
+        _meta: {
+          gamme_found: false,
+          vehicle_found: false,
+          products_count: 0,
+          resolved_by: 'none',
+        },
+      },
+      error: null,
+    });
+    const svc = makeService(callRpc);
+
+    const res = await svc.checkSubstitution(
+      '/pieces/zzz-inexistant-999.html',
+      'Mozilla/5.0',
+    );
+
+    expect(res.httpStatus).toBe(404);
+    expect(res.type).toBe('unknown_slug');
+  });
+
+  it('valid gamme (RPC ok, products>0) → 200', async () => {
+    const callRpc = jest.fn().mockResolvedValue({
+      data: {
+        _meta: {
+          gamme_found: true,
+          vehicle_found: false,
+          products_count: 12,
+          resolved_by: 'exact',
+        },
+        gamme: { pg_id: 7, pg_name: 'Filtre à huile', pg_alias: 'filtre-a-huile' },
+      },
+      error: null,
+    });
+    const svc = makeService(callRpc);
+
+    const res = await svc.checkSubstitution(
+      '/pieces/filtre-a-huile-7.html',
+      'Mozilla/5.0',
+    );
+
+    expect(res.httpStatus).toBe(200);
+  });
+});

--- a/log.md
+++ b/log.md
@@ -549,3 +549,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/attribution-beacon-cache-cutover-prA`
 - **Décision** : feat(analytics): déplace l'attribution first-touch GET→POST beacon (cutover cache HTML, PR A)
 - **Sortie** : PR #1271 | commits 7f288d9da
+
+## 2026-07-15 — fix/substitution-fail-open-on-rpc-error (auto)
+
+- **Branche** : `fix/substitution-fail-open-on-rpc-error`
+- **Décision** : fix(migration): add statement_timeout + lock_timeout guards (squawk migration-safety) (+2 other commits)
+- **Sortie** : PR #1148 | commits d04a1b2e8 68b87e00b 9044444c4


### PR DESCRIPTION
## Root cause (the recurring R1 404)

`/pieces/<gamme>-<id>.html` intermittently returned **404** on pages that return **200 at origin**. Traced live (owner DEV logs):

```
✅ RPC V2 SUCCESS pour gamme 7        ← primary data loads fine
ERROR: RPC ERROR: get_substitution_data
   error: column "pieces_gamme.pg_name" must appear in the GROUP BY clause
DEBUG: Substitution resolved → unknown_slug (404)
🔄 Substitution: httpStatus=404
```

Chain: `get_substitution_data` RPC errors (SQL) → `fetchSubstitutionData` **fail-CLOSED** (`gamme_found:false`) → `determineSubstitution` → httpStatus **404** → R1 loader `pieces.$slug.tsx:268` throws **404** — on a **valid** gamme whose primary data already loaded. Intermittent (single-fetch `.data` calls hit it) → the 404 Caddy was caching (the original incident; #1140 stopped the *caching*, not the *source*).

## Fix — fail-OPEN (governed + observable)

An RPC **infrastructure** error is **not** "gamme not found":
- `_meta.rpc_error: true` set on RPC error/exception (error still **logged** → observable, not silent).
- `determineSubstitution` fail-OPENs on `rpc_error` → **httpStatus 200 'none'**: the page renders on its primary data; substitution enrichment simply absent (same shape as a normal valid page).
- A **genuine** not-found (RPC ok, `gamme_found:false`) → **still 404** (CASE 1 unchanged).

This is the structural fix for the recurring R1 404. Pre-existing (not caused by any recent deploy — `substitution.service.ts` untouched since #190).

## Scope / governance

- ✅ Resolves a **silent-fallback violation** (the old fail-CLOSE silently turned an RPC error into a 404).
- ✅ No URL/route/canonical change. Genuine 404/410 paths preserved.
- ✅ First unit suite for `SubstitutionService` (4 tests, TDD red→green).
- 🔜 **Follow-up (separate, owner-gated)**: fix the `get_substitution_data` SQL (`pg_name` GROUP BY) so substitution actually runs — DB migration applied to the shared DB is owner-gated (deployment axis 4).

## Verify

- `npx jest substitution-fail-open` → 4/4 green.
- Post-merge: DEV:3000 resync / PREPROD E2E — `curl /pieces/filtre-a-huile-7.html.data` → **200** (was 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
