### PR TITLE
fix(r1): stop RR8 .data-suffix leak into substitution → intermittent 404 on valid R1 pages

### DIFF
--- a/frontend/app/routes/pieces.$slug.tsx
+++ b/frontend/app/routes/pieces.$slug.tsx
@@ -194,14 +194,19 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 
     // 🚀 Fetch en parallèle : données gamme + substitution (LCP optimization)
     const API_URL = getInternalApiUrl("");
-    const currentUrl = new URL(request.url);
-    const pathname = currentUrl.pathname;
+    // 🛡️ Chemin substitution bâti depuis le param de route `slug` (toujours
+    // propre) et NON depuis `request.url` : ce dernier conserve le suffixe
+    // `.data` des requêtes React Router v8 single-fetch (navigation client),
+    // ce qui faisait résoudre la substitution en `unknown_slug` → httpStatus
+    // 404 → 404 sur une page R1 valide (incident 2026-06-25, figé 2 h par le CDN
+    // en PROD). `slug` est nettoyé par RR avant le matching de route.
+    const substitutionPath = `/pieces/${slug}`;
 
     const [apiData, substitutionResponse] = await Promise.all([
       fetchGammePageData(gammeId, { signal: controller.signal }),
       // 🔄 Substitution API pour données enrichies (412/410 handling)
       fetch(
-        `${API_URL}/api/substitution/check?url=${encodeURIComponent(pathname)}`,
+        `${API_URL}/api/substitution/check?url=${encodeURIComponent(substitutionPath)}`,
         {
           signal: subController.signal,
         },

--- a/frontend/tests/unit/pieces-substitution-data-suffix.test.ts
+++ b/frontend/tests/unit/pieces-substitution-data-suffix.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { loader } from "~/routes/pieces.$slug";
+
 /**
  * Régression R1 404 (2026-06-25) — fuite du suffixe `.data` (React Router v8
  * single-fetch) dans l'URL envoyée au moteur de substitution.
@@ -16,6 +18,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
  * avant le matching). Le correctif : bâtir l'URL substitution depuis `slug`.
  */
 
+// vi.mock est hoisté par Vitest avant les imports au runtime — déclaré après les
+// imports pour satisfaire `import/first` tout en gardant les mocks effectifs.
 vi.mock("~/utils/logger", () => ({
   logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
 }));
@@ -35,8 +39,6 @@ vi.mock("~/services/api/gamme-api.service", () => ({
     meta: {},
   })),
 }));
-
-import { loader } from "~/routes/pieces.$slug";
 
 describe("pieces.$slug loader — pas de fuite du suffixe .data vers la substitution", () => {
   let capturedSubUrl: string | undefined;

--- a/frontend/tests/unit/pieces-substitution-data-suffix.test.ts
+++ b/frontend/tests/unit/pieces-substitution-data-suffix.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Régression R1 404 (2026-06-25) — fuite du suffixe `.data` (React Router v8
+ * single-fetch) dans l'URL envoyée au moteur de substitution.
+ *
+ * Sur une navigation client, RR8 requête `<url>.data`. Le loader construisait
+ * l'URL de substitution depuis `new URL(request.url).pathname`, qui CONSERVE le
+ * suffixe `.data` (`/pieces/filtre-a-huile-7.html.data`). Le parser substitution
+ * (`-(\d+)\.html$`) ne reconnaît alors plus la gamme → `unknown_slug` →
+ * httpStatus 404 → le loader throw 404 sur une page POURTANT valide.
+ * En F5/document (`request.url` sans `.data`) → 200. D'où un 404 qui n'apparaît
+ * qu'en navigation client (et figé 2h par le CDN en PROD).
+ *
+ * Le param de route `params.slug` est, lui, TOUJOURS propre (RR retire `.data`
+ * avant le matching). Le correctif : bâtir l'URL substitution depuis `slug`.
+ */
+
+vi.mock("~/utils/logger", () => ({
+  logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("~/utils/internal-api.server", () => ({
+  getInternalApiUrl: () => "http://internal-api",
+}));
+
+// apiData minimal mais suffisant pour franchir le guard "gamme existe".
+vi.mock("~/services/api/gamme-api.service", () => ({
+  fetchGammePageData: vi.fn(async () => ({
+    hero: {
+      pg_name: "Filtre à huile",
+      pg_alias: "filtre-a-huile",
+      h1: "Filtre à huile",
+    },
+    meta: {},
+  })),
+}));
+
+import { loader } from "~/routes/pieces.$slug";
+
+describe("pieces.$slug loader — pas de fuite du suffixe .data vers la substitution", () => {
+  let capturedSubUrl: string | undefined;
+
+  beforeEach(() => {
+    capturedSubUrl = undefined;
+    // Simule le vrai backend "200 Always" : httpStatus dans le body.
+    // Renvoie 404 SI (et seulement si) l'URL reçue contient `.data` —
+    // exactement le comportement observé en live.
+    global.fetch = vi.fn(async (input: unknown) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : (input as Request).url ?? String(input);
+      if (url.includes("/api/substitution/check")) {
+        capturedSubUrl = url;
+        const dirty = decodeURIComponent(url).includes(".data");
+        return new Response(
+          JSON.stringify({
+            httpStatus: dirty ? 404 : 200,
+            type: dirty ? "unknown_slug" : "none",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+  });
+
+  it("requête single-fetch (.data) → substitution appelée avec /pieces/<slug> propre, jamais 404", async () => {
+    let thrown: unknown;
+    try {
+      await loader({
+        params: { slug: "filtre-a-huile-7.html" },
+        request: new Request(
+          "https://www.automecanik.com/pieces/filtre-a-huile-7.html.data",
+        ),
+        context: {},
+      } as never);
+    } catch (e) {
+      thrown = e;
+    }
+
+    // Cœur du correctif : l'URL substitution ne doit PAS porter le suffixe .data.
+    expect(capturedSubUrl).toBeDefined();
+    const decoded = decodeURIComponent(capturedSubUrl as string);
+    expect(decoded).toContain("/pieces/filtre-a-huile-7.html");
+    expect(decoded).not.toContain(".data");
+
+    // Garantie utilisateur : une page valide ne doit jamais ressortir en 404.
+    if (thrown instanceof Response) {
+      expect(thrown.status).not.toBe(404);
+    }
+  });
+});


### PR DESCRIPTION
## The bug you reported

`/pieces/<gamme>-<id>.html` **reloads fine (200)** but **404s when you click a link to it**. On PROD the 404 then sticks for ~2h.

## Root cause (empirically proven)

The `pieces.$slug` loader built the substitution URL from `new URL(request.url).pathname`. On a **React Router v8 single-fetch** request (what a client-side navigation issues), `request.url` **keeps the `.data` suffix**:

```
document (F5):       /pieces/filtre-a-huile-7.html        → substitution 200 ✅
client nav (.data):  /pieces/filtre-a-huile-7.html.data   → substitution 404 ❌
```

The substitution parser (`-(\d+)\.html$`) can't read the gamme id from `…html.data` → resolves `unknown_slug` → `httpStatus 404` → the loader throws **404 on a valid page**.

| | document | `.data` |
|---|---|---|
| localhost:3000 (cache-busted, 3/3) | 200 | **404** |
| PROD origin (cache-bust, MISS) | 200 | **404** |
| PROD via Cloudflare | 200 | **404 — `cf-cache-status: HIT`, `age 3571`, `max-age=7200`** |

That last row is why it looked **PROD-only and persistent**: the `.data` 404 gets cached at the edge for 2h. On localhost there's no CDN, and reload-testing (F5) only ever hits the 200 document path.

## The fix (1 value)

Build the substitution path from the matched route param `slug` (which RR **strips `.data` from** before matching) instead of `request.url`:

```diff
- const currentUrl = new URL(request.url);
- const pathname = currentUrl.pathname;
+ const substitutionPath = `/pieces/${slug}`;
  ...
- fetch(`${API_URL}/api/substitution/check?url=${encodeURIComponent(pathname)}`,
+ fetch(`${API_URL}/api/substitution/check?url=${encodeURIComponent(substitutionPath)}`,
```

No change for document requests (same value). The **3-layer error system was working as designed** — it faithfully served a genuine loader-thrown 404; the defect was upstream (wrong URL handed to substitution). No error-handling layer is touched.

## Tests

`tests/unit/pieces-substitution-data-suffix.test.ts` (TDD red→green): asserts the substitution URL carries **no `.data`** and that a valid page never 404s on a `.data` request. Existing pieces unit tests still green.

## Relationship to #1148 & the CDN

- This PR is the **actual root-cause fix** for the reported 404.
- #1148 (substitution fail-open guard + RPC GROUP BY migration) is **independent hardening**, not required for this fix. ⚠️ Do **not** apply the #1148 RPC migration alone before this lands — it would turn the masked `.data` path into a *deterministic* 404. Order: this PR first.
- The already-cached poisoned `.data` 404s on PROD still need #1140 (Caddy `no-store` on `/pieces` errors) **deployed** + a one-time Cloudflare purge to clear the 2h window.

## Follow-up (separate)

The catch-all `$.tsx` (redirect/error-suggestion APIs) has the same `request.url`→internal-API pattern at lower severity (legacy redirects may not fire on client nav). Sweeping siblings separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
