### PR TITLE
fix(catch-all): strip RR8 .data suffix so legacy 301 redirects fire on client navigation

### DIFF
--- a/frontend/app/routes/$.tsx
+++ b/frontend/app/routes/$.tsx
@@ -9,6 +9,7 @@ import { useRouteError, isRouteErrorResponse } from "react-router";
 import { ErrorGeneric } from "~/components/errors/ErrorGeneric";
 import { buildCacheHeaders } from "~/utils/cache-control";
 import { logger } from "~/utils/logger";
+import { stripSingleFetchSuffix } from "~/utils/single-fetch";
 
 export const meta: MetaFunction = () => [
   { title: "Page non trouvée | Automecanik" },
@@ -28,7 +29,12 @@ export const headers = buildCacheHeaders("no-cache");
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
-  const pathname = url.pathname;
+  // 🛡️ RR8 single-fetch (navigation client) garde le suffixe `.data` sur
+  // request.url. Le retirer pour que la détection garbage, les quick-redirects
+  // et les résolveurs redirect/legacy voient le VRAI chemin — sinon les 301
+  // legacy (/blog, /pieces-auto/*) ne se déclenchent pas en navigation client
+  // (404 au lieu du 301). Encodage préservé. Voir incident 2026-06-25.
+  const pathname = stripSingleFetchSuffix(url.pathname);
 
   // 0a. Short-circuit URLs garbage (base64 spam, bots) — évite 3 appels API inutiles
   if (isGarbageUrl(pathname)) {

--- a/frontend/app/utils/single-fetch.ts
+++ b/frontend/app/utils/single-fetch.ts
@@ -1,0 +1,29 @@
+/**
+ * Normalisation React Router v8 « single-fetch ».
+ *
+ * Sur une navigation CLIENT, RR8 requête les données de la route à
+ * `<pathname>.data`. Le framework retire ce suffixe pour le MATCHING de route
+ * (donc `params.*` est toujours propre), mais l'objet `request` passé au loader
+ * conserve le suffixe sur `request.url`. Tout loader qui dérive un pathname de
+ * `request.url` pour le passer à un résolveur interne (substitution, redirects,
+ * migration legacy) DOIT retirer ce suffixe — sinon le résolveur reçoit une URL
+ * inexistante et échoue silencieusement : 404 sur une page valide, ou 301 legacy
+ * qui ne se déclenche pas en navigation client.
+ *
+ * Incident 2026-06-25 :
+ *   - R1 `/pieces/<gamme>-<id>.html` → 404 en navigation client (substitution).
+ *   - catch-all `$.tsx` → 301 legacy (`/blog`, `/pieces-auto/*`) non déclenchés.
+ *
+ * ⚠️ Préserve l'encodage : opère sur le pathname BRUT (encodé), ne décode rien.
+ * Les pipelines qui attendent un pathname encodé (détection garbage base64,
+ * gestion `%20`, `encodeURIComponent` côté appel API) restent intacts — seul le
+ * suffixe `.data` final est retiré.
+ *
+ * NB : ne gère que la forme `<path>.data` (routes non-index). La route index
+ * (`/` → `/_root.data`) n'utilise pas ce helper.
+ */
+const SINGLE_FETCH_SUFFIX = /\.data$/;
+
+export function stripSingleFetchSuffix(pathname: string): string {
+  return pathname.replace(SINGLE_FETCH_SUFFIX, "");
+}

--- a/frontend/tests/unit/catch-all-data-suffix-redirect.test.ts
+++ b/frontend/tests/unit/catch-all-data-suffix-redirect.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { loader } from "~/routes/$";
+
+vi.mock("~/utils/logger", () => ({
+  logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+/**
+ * Régression 2026-06-25 — RR8 single-fetch (navigation client) garde le suffixe
+ * `.data` sur request.url. Le catch-all dérivait son `pathname` de request.url,
+ * donc les quick-redirects de `resolveKnownPattern` (match EXACT, ex.
+ * `pathname === "/blog"`) ne se déclenchaient plus en navigation client → 404 au
+ * lieu du 301. Empirique : /blog → 301 en document, 404 en `.data` (avant fix).
+ *
+ * Ce test prouve, côté loader, que le suffixe est retiré AVANT resolveKnownPattern,
+ * donc que document et single-fetch produisent le MÊME 301.
+ */
+describe("catch-all $.tsx — quick-redirect survit au suffixe single-fetch .data", () => {
+  beforeEach(() => {
+    // resolveKnownPattern court-circuite AVANT tout fetch ; stub par sécurité.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ found: false })))),
+    );
+  });
+
+  const call = (path: string) =>
+    loader({
+      request: new Request(`https://www.automecanik.com${path}`),
+      params: {},
+      context: {},
+    } as never);
+
+  it("document /blog → 301 vers /blog-pieces-auto", async () => {
+    const res = (await call("/blog")) as Response;
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(301);
+    expect(res.headers.get("Location")).toBe("/blog-pieces-auto");
+  });
+
+  it("single-fetch /blog.data → 301 vers /blog-pieces-auto (identique au document)", async () => {
+    const res = (await call("/blog.data")) as Response;
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(301);
+    expect(res.headers.get("Location")).toBe("/blog-pieces-auto");
+  });
+});

--- a/frontend/tests/unit/single-fetch-suffix.test.ts
+++ b/frontend/tests/unit/single-fetch-suffix.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+
+import { stripSingleFetchSuffix } from "~/utils/single-fetch";
+
+describe("stripSingleFetchSuffix — retire le suffixe RR8 single-fetch", () => {
+  it("retire `.data` (navigation client)", () => {
+    expect(stripSingleFetchSuffix("/pieces/filtre-a-huile-7.html.data")).toBe(
+      "/pieces/filtre-a-huile-7.html",
+    );
+    expect(stripSingleFetchSuffix("/blog.data")).toBe("/blog");
+    expect(stripSingleFetchSuffix("/pieces-auto/filtre-a-huile.data")).toBe(
+      "/pieces-auto/filtre-a-huile",
+    );
+  });
+
+  it("ne touche pas un pathname document (F5)", () => {
+    expect(stripSingleFetchSuffix("/blog")).toBe("/blog");
+    expect(stripSingleFetchSuffix("/pieces/filtre-a-huile-7.html")).toBe(
+      "/pieces/filtre-a-huile-7.html",
+    );
+  });
+
+  it("préserve l'encodage (aucun decode)", () => {
+    expect(stripSingleFetchSuffix("/pi%C3%A8ces/test.data")).toBe(
+      "/pi%C3%A8ces/test",
+    );
+    expect(stripSingleFetchSuffix("/blog%20space")).toBe("/blog%20space");
+  });
+
+  it("ne retire que le suffixe FINAL (un `.data` au milieu reste)", () => {
+    expect(stripSingleFetchSuffix("/foo.data/bar")).toBe("/foo.data/bar");
+  });
+});

--- a/log.md
+++ b/log.md
@@ -424,3 +424,9 @@ Une entrée = 3 à 4 lignes. Heading H2 par session = greppable + naviguable.
 - **Branche** : `feat/seo-a1a-observe-placeholder-events`
 - **Décision** : fix(seo): A1a-observe CI gates — prettier format + role-purity skip on aggregator module (+2 other commits)
 - **Sortie** : PR #1146 | commits 4b3d6ffb9 427927bdc d949b723e
+
+## 2026-06-25 — fix/catchall-data-suffix-redirects (auto)
+
+- **Branche** : `fix/catchall-data-suffix-redirects`
+- **Décision** : fix(catch-all): strip RR8 .data suffix so legacy 301 redirects fire on client-nav
+- **Sortie** : PR #1150 | commits 601ee8c43


### PR DESCRIPTION
## What & why

Same root-cause **class** as #1149 (the R1 404), found by an exhaustive sweep of every loader that derives a path from `request.url`. On a **React Router v8 single-fetch** request (client-side navigation), `request.url` keeps the `.data` suffix. The catch-all `$.tsx` built its `pathname` from `request.url`, so on client navigation:

- `resolveKnownPattern` (exact match, e.g. `pathname === "/blog"`) never matched
- `/api/redirects/resolve-legacy` (`/pieces-auto/*`) lookups missed

→ **legacy 301 redirects silently became 404s on internal navigation.**

Empirically proven (localhost:3000, cache-busted):

| URL | document | `.data` (client nav) |
|---|---|---|
| `/blog` | **301** → `/blog-pieces-auto` | **404** |
| `/pieces-auto/filtre-a-huile` | **301** | **404** |

## Fix — one shared, encoding-preserving normalizer

`frontend/app/utils/single-fetch.ts` → `stripSingleFetchSuffix(pathname)`, applied once in `$.tsx` where `pathname` is derived. Garbage-detection, quick-redirects and the redirect/legacy resolvers then all see the real path.

Encoding is **preserved** — the catch-all's base64 garbage regexes, `%20` handling and `encodeURIComponent` on the API calls all expect an *encoded* pathname, so the decoded splat param is deliberately **not** used here (per adversarial verification). R1 (`pieces.$slug`, #1149) uses the clean matched param instead — even more robust there since it never parses `request.url`. The shared helper covers the routes that genuinely need `request.url`.

## Sweep result (26 sites audited)

- ✅ `pieces.$slug` (R1) → `/api/substitution/check` → **#1149** (the reported 404).
- ✅ `$.tsx` (catch-all) → redirects → **this PR**.
- ⚪ `pieces.$.tsx` (vehicle/R8) → assessed, **not affected** (request.url sink is guard-short-circuited; 2 independent verifiers + no observed document/`.data` divergence).
- ⚪ 18 other sites → safe (read `searchParams` or log only; `.data` lives on the pathname, not the query).

## Tests (TDD)

- `single-fetch-suffix.test.ts` — pure helper (strip `.data`, keep document paths, preserve encoding, only final suffix).
- `catch-all-data-suffix-redirect.test.ts` — loader-level: `/blog.data` must 301 like `/blog`. **Verified RED without the fix, GREEN with it.**
- Existing `catch-all-404-noindex.test.ts` still green.

## Relationship

- #1149 = R1 substitution 404 (the user-reported bug).
- This = the catch-all redirect sibling, same class, shared helper.
- Both merge to `main` → PREPROD; PROD via `v*` tag on owner GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
