### PR TITLE
chore(pr-9f): record rollback drill evidence (rollback_tested_at)

### DIFF
--- a/audit/dependencies/dependency-modernization-inventory.json
+++ b/audit/dependencies/dependency-modernization-inventory.json
@@ -1,5 +1,5 @@
 {
-  "artifact_immutability_hash": "sha256:1298ed690ab93c58ca052c8b0ef6fc6ce90bb2b890a4996d987d13a405ce1a84",
+  "artifact_immutability_hash": "sha256:ce39e866fe6fbb25ba6ba768b82a73b5df8dbaa4fd64347f386a93f1fdac8e74",
   "divergences": [
     {
       "kind": "specifier",
@@ -2275,7 +2275,7 @@
       "rollback_complexity": "dangerous",
       "rollback_confidence_level": "theoretical",
       "rollback_data_loss_risk": "none",
-      "rollback_drill_commit": null,
+      "rollback_drill_commit": "ab8f572f90979d4e7426c667d2411c84834a6e97",
       "rollback_observability_grace_period_minutes": 20,
       "rollback_preconditions": [
         "canary-disabled",
@@ -2285,7 +2285,7 @@
       "rollback_requires_human_approval": true,
       "rollback_rto_minutes": 60,
       "rollback_runbook_required": true,
-      "rollback_tested_at": null,
+      "rollback_tested_at": "2026-06-26T09:57:36Z",
       "rollback_validation_checks": [
         "health-endpoint-ok",
         "traces-continuity",
@@ -3862,7 +3862,7 @@
     "lockfile": "package-lock.json",
     "lockfile_sha": "sha256:fe31bd6c846ad80cf19f429468e03677b3aff0f8faf320d8d20cb167c65ae49a",
     "overlay": "audit/dependencies/family-overlay.yaml",
-    "overlay_sha": "sha256:4788b9a5e54718e4556d2eeb5a7bf991ea33ce12a6303b69773589dc3ba06ee4"
+    "overlay_sha": "sha256:f5b19e7c0c73a75b55e4c0a620e0d01c6665dfcfffe8b00a77d5c8928bb05117"
   },
   "inventoryFormat": "pr-9-modernization-inventory",
   "matrixVersion": "pr9-v1",

--- a/audit/dependencies/family-overlay.yaml
+++ b/audit/dependencies/family-overlay.yaml
@@ -571,8 +571,13 @@ families:
     operational_owner: backend-runtime-team
     estimated_canary_duration_minutes: 0
     rollback_requires_human_approval: true
-    rollback_tested_at: null
-    rollback_drill_commit: null
+    # PR-9f rollback drill (2026-06-26): atomic `git revert` of #1152 (squash
+    # 19e4d6402) is conflict-free and byte-identical to 74da962dc (#1151) — the
+    # last state built + E2E-Smoke + Lighthouse green on the PREPROD container.
+    # PROD image rollback target massdoc/nestjs-remix-monorepo:sha-74da962dc…
+    # present on DockerHub. Drill artifact: draft PR #1156 (rollback-drill/pr9f-nestjs11).
+    rollback_tested_at: "2026-06-26T09:57:36Z"
+    rollback_drill_commit: "ab8f572f90979d4e7426c667d2411c84834a6e97"
     known_incompatible_families:
       - runtime-backend-platform-fastify
       - queues-bullmq


### PR DESCRIPTION
## Record PR-9f rollback drill evidence

Fills `runtime-backend-nest.rollback_tested_at` + `rollback_drill_commit` in the
`family-overlay.yaml` SoT (L2) — the governance precondition the plan set for any
PR-9f **PROD tag** (`AVANT tag`). NestJS 11 / Express 5 / path-to-regexp 8 (#1152).

### Drill performed (non-destructive — no churn of protected `main`)
Since the PREPROD container only redeploys on `main` push and **Nest 10 was green
on PREPROD the day before** (as #1151 `74da962dc`), re-deploying a revert to the
live container would add ~zero evidence at the cost of 2 protected-main commits.
Instead the drill proves the revert is an atomic, clean rollback to a *known-green*
state:

| Check | Result |
|---|---|
| `git revert 19e4d6402` (atomic squash revert) | **0 conflicts** |
| Reverted tree vs `74da962dc` (last PREPROD-green) | **byte-identical** (`git diff` empty, excl. `log.md`) |
| Versions restored | `@nestjs/* ^10`, `@nestjs/bull ^10.2.3`, `@nestjs/swagger 7.4.2`, `path-to-regexp 3.3.0` |
| PROD image rollback target | `massdoc/nestjs-remix-monorepo:sha-74da962dc…` present on DockerHub (SHA-immutable) |
| Runner-side build of rollback target | draft PR #1156 CI (build + tests) |

### Artifacts
- **Drill commit**: `ab8f572f9` (recorded as `rollback_drill_commit`).
- **Ready rollback artifact**: draft PR #1156 `[ROLLBACK DRILL — DO NOT MERGE]`, kept
  open for one-click rollback should a Nest 11 incident require it.

### Rollback procedures (both validated as available)
- **PROD (fast)**: `docker pull massdoc/nestjs-remix-monorepo:sha-74da962dc…` + redeploy
  (`docker-compose.prod.yml`), per `.claude/rules/deployment.md`.
- **main/PREPROD**: mark #1156 ready → squash-merge → `main` push redeploys PREPROD on Nest 10.

Modernization inventory regenerated; `lockfile_sha` unchanged → **no dependency drift**
(pure governance metadata). PROD tag remains owner-gated — this PR only records evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
