### PR TITLE
fix(seo-cp): defense-in-depth egress floor for synthetic-probe rate-limit exemption

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -91,6 +91,13 @@ jobs:
           # rate-limit exemption on PROD (HMAC verifier side). Unset = stays OFF
           # (probes throttled; in-app 429-rate alert fires). PR #1141 / #1142.
           SEO_CP_SYNTHETIC_PROBE_SECRET_OVERRIDE: ${{ secrets.PROD_SEO_CP_SYNTHETIC_PROBE_SECRET }}
+          # Optional defense-in-depth FLOOR (synthetic-probe egress floor, 2026-06-26): comma-separated egress
+          # IP/CIDR(s) of the synthetic probe. cf-connecting-ip is always forwarded
+          # by Cloudflare (unlike the HMAC header, which the CDN can strip — root
+          # cause of the 2026-06-25 self-throttle), so this keeps the exemption
+          # working even if the header never reaches origin. Unset = floor stays
+          # OFF (fail-closed; HMAC path only). Value is a public IP, not a secret.
+          SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE: ${{ secrets.PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS }}
         run: |
           docker pull massdoc/nestjs-remix-monorepo:production
 
@@ -170,6 +177,22 @@ jobs:
             echo "✅ SEO_CP synthetic-probe exemption secret injected + enabled from GitHub Secrets"
           else
             echo "ℹ️ PROD_SEO_CP_SYNTHETIC_PROBE_SECRET unset — synthetic-crawler exemption stays OFF (probes throttled; in-app 429 alert will fire)"
+          fi
+          # Inject the synthetic-probe egress allowlist (defense-in-depth FLOOR,
+          # synthetic-probe egress floor, 2026-06-26). Independent of the HMAC secret above: this floor recognizes
+          # the probe by its anti-spoofed cf-connecting-ip, so the exemption keeps
+          # working even when Cloudflare strips the x-synthetic-probe header (root
+          # cause of the 2026-06-25 self-throttle). Unset = floor OFF (fail-closed;
+          # HMAC path only). `|` sed delimiter is safe — IP/CIDR values use :, /, ,.
+          if [ -n "$SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE" ]; then
+            if grep -q '^SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS=' .env; then
+              sed -i "s|^SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS=.*|SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS=${SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE}|" .env
+            else
+              echo "SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS=${SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE}" >> .env
+            fi
+            echo "✅ SEO_CP synthetic-probe egress floor configured from GitHub Secrets"
+          else
+            echo "ℹ️ PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS unset — egress floor OFF (HMAC path only)"
           fi
 
           docker network create automecanik-prod 2>/dev/null || true

--- a/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.test.ts
@@ -5,6 +5,7 @@ type ServiceMock = Record<string, jest.Mock | (() => boolean)>;
 function makeMiddleware(
   overrides: ServiceMock = {},
   probeVerify: () => boolean = () => false,
+  probeEgress: (ip?: string) => boolean = () => false,
 ) {
   const service = {
     isEnabled: () => true,
@@ -16,9 +17,12 @@ function makeMiddleware(
     trackAllowed: jest.fn(async () => undefined),
     ...overrides,
   };
-  // Synthetic-probe credential: par défaut verify=false (chemin synthétique
-  // jamais pris → comportement existant inchangé).
-  const syntheticProbe = { verify: jest.fn(probeVerify) };
+  // Synthetic-probe credential: par défaut verify=false ET egress=false (chemin
+  // synthétique jamais pris → comportement existant inchangé).
+  const syntheticProbe = {
+    verify: jest.fn(probeVerify),
+    isExemptEgressIp: jest.fn(probeEgress),
+  };
   const middleware = new BotGuardMiddleware(
     service as never,
     syntheticProbe as never,
@@ -114,6 +118,36 @@ describe('BotGuardMiddleware ordering', () => {
     expect(
       (req as { isVerifiedSyntheticProbe?: boolean }).isVerifiedSyntheticProbe,
     ).toBeUndefined();
+  });
+
+  it('recognizes the synthetic probe by its egress IP when the HMAC header is absent (defense-in-depth floor)', async () => {
+    // verify=false (en-tête HMAC retiré par le CDN) MAIS isExemptEgressIp=true
+    // (cf-connecting-ip de la sonde dans l'allowlist) → exemption maintenue.
+    const { middleware, service, syntheticProbe } = makeMiddleware(
+      {
+        isCountryBlocked: jest.fn(async () => true), // would block if consulted
+        calculateSuspicionScore: jest.fn(() => 100), // would block if consulted
+      },
+      () => false, // HMAC absent / stripped
+      () => true, // egress IP recognized
+    );
+    const { req, res, next } = makeReqRes({
+      'cf-ipcountry': 'DE',
+      'cf-connecting-ip': '203.0.113.7',
+    });
+
+    await middleware.use(req, res, next);
+
+    expect(syntheticProbe.verify).toHaveBeenCalledTimes(1);
+    // getClientIp's anti-spoofed IP is passed to the egress check
+    expect(syntheticProbe.isExemptEgressIp).toHaveBeenCalledWith('203.0.113.7');
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(
+      (req as { isVerifiedSyntheticProbe?: boolean }).isVerifiedSyntheticProbe,
+    ).toBe(true);
+    expect((req as { isVerifiedBot?: boolean }).isVerifiedBot).toBeUndefined();
+    expect(service.isCountryBlocked).not.toHaveBeenCalled();
+    expect(service.calculateSuspicionScore).not.toHaveBeenCalled();
   });
 
   it('still honors an explicit operator IP block even for a would-be verified crawler (ip_block wins, no DNS work)', async () => {

--- a/backend/src/modules/bot-guard/bot-guard.middleware.ts
+++ b/backend/src/modules/bot-guard/bot-guard.middleware.ts
@@ -69,12 +69,20 @@ export class BotGuardMiddleware implements NestMiddleware {
       }
 
       // 6b. Verified internal synthetic probe (seo-control-plane L1). Identity is
-      // an HMAC credential header — NEVER the User-Agent. Like a verified crawler
-      // it bypasses geo + behavioral (its mono-IP burst would otherwise score as
-      // suspicious and 403), while the rate-limit exemption is further scoped to
-      // public-catalogue GETs in app.module.ts skipIf. The explicit IP blocklist
-      // above still wins. Fail-closed: verify() returns false on any error.
-      if (this.syntheticProbe.verify(req)) {
+      // proven by EITHER an HMAC credential header (primary) OR the probe's own
+      // egress IP (defense-in-depth floor) — NEVER the User-Agent. The HMAC header
+      // can be stripped in transit by the CDN (Cloudflare did not forward
+      // x-synthetic-probe → probe self-throttled ~90%); cf-connecting-ip is always
+      // forwarded and anti-spoofed in getClientIp, so the egress floor keeps the
+      // exemption working regardless. Like a verified crawler it bypasses geo +
+      // behavioral; the rate-limit exemption is further scoped to public-catalogue
+      // GETs in app.module.ts skipIf. The explicit IP blocklist above still wins.
+      // Both paths fail-closed (verify() false on any error; egress allowlist empty
+      // → false). `ip` is the anti-spoofed client IP from getClientIp (line 32).
+      if (
+        this.syntheticProbe.verify(req) ||
+        this.syntheticProbe.isExemptEgressIp(ip)
+      ) {
         (
           req as Request & { isVerifiedSyntheticProbe?: boolean }
         ).isVerifiedSyntheticProbe = true;

--- a/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.test.ts
+++ b/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.test.ts
@@ -8,6 +8,7 @@ import {
   SYNTHETIC_PROBE_SECRET_KEY,
   SYNTHETIC_PROBE_ENABLED_KEY,
   SYNTHETIC_PROBE_WINDOW_MS,
+  SYNTHETIC_PROBE_EGRESS_IPS_KEY,
   isSyntheticExemptPath,
 } from './types';
 
@@ -117,6 +118,79 @@ describe('SyntheticProbeCredentialService', () => {
     expect(
       makeService({ [SYNTHETIC_PROBE_SECRET_KEY]: SECRET }).isActive(),
     ).toBe(false);
+  });
+});
+
+describe('SyntheticProbeCredentialService.isExemptEgressIp (plancher défense-en-profondeur)', () => {
+  // IP d'egress observée de la sonde PROD (incident 2026-06-25). Fixture de test.
+  const PROBE_V6 = '2a01:4f8:1c1b:5e4e::1';
+
+  it('exempte une IPv6 exacte présente dans l’allowlist', () => {
+    const s = makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: PROBE_V6 });
+    expect(s.isExemptEgressIp(PROBE_V6)).toBe(true);
+  });
+
+  it('exempte via un CIDR IPv6', () => {
+    const s = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '2a01:4f8:1c1b:5e4e::/64',
+    });
+    expect(s.isExemptEgressIp(PROBE_V6)).toBe(true);
+    expect(s.isExemptEgressIp('2a01:4f8:1c1b:5e4e:abcd::9')).toBe(true);
+  });
+
+  it('exempte une IPv4 exacte et via CIDR', () => {
+    const s = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '203.0.113.7, 198.51.100.0/24',
+    });
+    expect(s.isExemptEgressIp('203.0.113.7')).toBe(true);
+    expect(s.isExemptEgressIp('198.51.100.42')).toBe(true);
+  });
+
+  it('normalise un IPv4-mapped IPv6 (::ffff:) vers IPv4', () => {
+    const s = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '203.0.113.0/24',
+    });
+    expect(s.isExemptEgressIp('::ffff:203.0.113.7')).toBe(true);
+  });
+
+  it('REFUSE une IP hors allowlist', () => {
+    const s = makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: PROBE_V6 });
+    expect(s.isExemptEgressIp('8.8.8.8')).toBe(false);
+    expect(s.isExemptEgressIp('2a01:4f8:1c1b:5e4f::1')).toBe(false);
+  });
+
+  it('fail-closed : allowlist vide → toujours false', () => {
+    expect(makeService({}).isExemptEgressIp(PROBE_V6)).toBe(false);
+    expect(
+      makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '' }).isExemptEgressIp(
+        PROBE_V6,
+      ),
+    ).toBe(false);
+  });
+
+  it('REFUSE une IP absente/illisible (fail-closed, pas de crash)', () => {
+    const s = makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: PROBE_V6 });
+    expect(s.isExemptEgressIp(undefined)).toBe(false);
+    expect(s.isExemptEgressIp('')).toBe(false);
+    expect(s.isExemptEgressIp('pas-une-ip')).toBe(false);
+    expect(s.isExemptEgressIp('unknown')).toBe(false);
+  });
+
+  it('ignore les entrées invalides mais garde les valides (parse résilient)', () => {
+    const s = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: `garbage, ${PROBE_V6}, 999.999.0.0/8`,
+    });
+    expect(s.isExemptEgressIp(PROBE_V6)).toBe(true);
+    expect(s.isExemptEgressIp('8.8.8.8')).toBe(false);
+  });
+
+  it('ne confond pas les familles (IPv4 vs plage IPv6 et inversement)', () => {
+    const v6only = makeService({ [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: PROBE_V6 });
+    expect(v6only.isExemptEgressIp('203.0.113.7')).toBe(false);
+    const v4only = makeService({
+      [SYNTHETIC_PROBE_EGRESS_IPS_KEY]: '203.0.113.0/24',
+    });
+    expect(v4only.isExemptEgressIp(PROBE_V6)).toBe(false);
   });
 });
 

--- a/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.ts
+++ b/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import * as ipaddr from 'ipaddr.js';
+import { BlockList, isIP } from 'node:net';
 import {
   SYNTHETIC_PROBE_HEADER,
   SYNTHETIC_PROBE_SECRET_KEY,
@@ -9,9 +9,6 @@ import {
   SYNTHETIC_PROBE_WINDOW_MS,
   SYNTHETIC_PROBE_EGRESS_IPS_KEY,
 } from './types';
-
-/** Entrée allowlist normalisée : adresse de base + longueur de préfixe. */
-type EgressCidr = [ipaddr.IPv4 | ipaddr.IPv6, number];
 
 /** Requête minimale lisible par {@link SyntheticProbeCredentialService.verify}. */
 export interface SyntheticVerifiableRequest {
@@ -60,8 +57,10 @@ export class SyntheticProbeCredentialService {
   private readonly logger = new Logger(SyntheticProbeCredentialService.name);
   private readonly secret: string;
   private readonly enabled: boolean;
-  /** Plancher défense-en-profondeur : CIDRs d'egress de la sonde (cf. types). */
-  private readonly egressAllowlist: EgressCidr[];
+  /** Plancher défense-en-profondeur : allowlist d'egress de la sonde (cf. types). */
+  private readonly egressAllowlist: BlockList;
+  /** Nombre de règles d'egress chargées (0 → plancher inactif, fail-closed). */
+  private readonly egressRuleCount: number;
   private warnedSecretMissing = false;
 
   constructor(private readonly config: ConfigService) {
@@ -76,34 +75,64 @@ export class SyntheticProbeCredentialService {
       );
     }
 
-    this.egressAllowlist = this.config
-      .get<string>(SYNTHETIC_PROBE_EGRESS_IPS_KEY, '')
-      .split(',')
-      .map((entry) => this.parseEgressEntry(entry))
-      .filter((cidr): cidr is EgressCidr => cidr !== null);
-    if (this.egressAllowlist.length > 0) {
+    const egress = this.buildEgressAllowlist(
+      this.config.get<string>(SYNTHETIC_PROBE_EGRESS_IPS_KEY, ''),
+    );
+    this.egressAllowlist = egress.list;
+    this.egressRuleCount = egress.count;
+    if (this.egressRuleCount > 0) {
       this.logger.log(
-        `Plancher egress sonde synthétique actif (${this.egressAllowlist.length} entrée(s) ${SYNTHETIC_PROBE_EGRESS_IPS_KEY}).`,
+        `Plancher egress sonde synthétique actif (${this.egressRuleCount} entrée(s) ${SYNTHETIC_PROBE_EGRESS_IPS_KEY}).`,
       );
     }
   }
 
   /**
-   * Parse une entrée d'allowlist (IP simple ou CIDR, v4/v6) → [adresse, préfixe].
-   * Entrée vide ou invalide → `null` (ignorée + warn, pas de fail-open silencieux).
+   * Construit l'allowlist d'egress (IP simples ou CIDR, v4/v6) depuis une liste
+   * séparée par des virgules, via `net.BlockList` (primitive stdlib Node : aucune
+   * dépendance tierce, et `check()` normalise nativement les IPv4-mapped-IPv6).
+   * Chaque entrée invalide est ignorée + warn (no silent fail-open). `count` =
+   * nombre d'entrées valides chargées (0 → plancher OFF / fail-closed).
    */
-  private parseEgressEntry(entry: string): EgressCidr | null {
-    const trimmed = entry.trim();
-    if (!trimmed) return null;
+  private buildEgressAllowlist(raw: string): {
+    list: BlockList;
+    count: number;
+  } {
+    const list = new BlockList();
+    let count = 0;
+    for (const entry of raw.split(',')) {
+      const trimmed = entry.trim();
+      if (trimmed && this.addEgressEntry(list, trimmed)) count += 1;
+    }
+    return { list, count };
+  }
+
+  /**
+   * Ajoute une entrée (IP simple ou CIDR, v4/v6) à la BlockList. Retourne `false`
+   * si l'entrée est invalide (ignorée + warn) — `isIP` rejette une IP malformée et
+   * `addSubnet`/`addAddress` lèvent sur un préfixe hors-domaine, capté ici.
+   */
+  private addEgressEntry(list: BlockList, entry: string): boolean {
     try {
-      if (trimmed.includes('/')) return ipaddr.parseCIDR(trimmed);
-      const addr = ipaddr.parse(trimmed);
-      return [addr, addr.kind() === 'ipv6' ? 128 : 32];
+      if (entry.includes('/')) {
+        const [net, prefixRaw] = entry.split('/');
+        const family = isIP(net);
+        const prefix = Number(prefixRaw);
+        if (family === 0 || !Number.isInteger(prefix)) {
+          throw new Error('CIDR invalide');
+        }
+        list.addSubnet(net, prefix, family === 6 ? 'ipv6' : 'ipv4');
+        return true;
+      }
+      const family = isIP(entry);
+      if (family === 0) throw new Error('IP invalide');
+      list.addAddress(entry, family === 6 ? 'ipv6' : 'ipv4');
+      return true;
     } catch {
       this.logger.warn(
-        `Entrée ${SYNTHETIC_PROBE_EGRESS_IPS_KEY} invalide ignorée: "${trimmed}".`,
+        `Entrée ${SYNTHETIC_PROBE_EGRESS_IPS_KEY} invalide ignorée: "${entry}".`,
       );
-      return null;
+      return false;
     }
   }
 
@@ -115,25 +144,16 @@ export class SyntheticProbeCredentialService {
    * en aval dans `skipIf` — cette méthode ne décide QUE de l'identité, pas du scope.
    */
   isExemptEgressIp(ip: string | undefined): boolean {
-    if (this.egressAllowlist.length === 0 || !ip) return false;
-    let parsed: ipaddr.IPv4 | ipaddr.IPv6;
+    if (this.egressRuleCount === 0 || !ip) return false;
+    const family = isIP(ip);
+    if (family === 0) return false; // IP illisible → fail-closed
     try {
-      // `process` normalise un IPv4-mapped IPv6 (`::ffff:1.2.3.4`) → IPv4.
-      parsed = ipaddr.process(ip);
+      // `BlockList.check` normalise un IPv4-mapped IPv6 (`::ffff:1.2.3.4`) et
+      // n'inter-matche jamais deux familles distinctes (enforce family equality).
+      return this.egressAllowlist.check(ip, family === 6 ? 'ipv6' : 'ipv4');
     } catch {
       return false;
     }
-    // `instanceof` narrows BOTH operands to the same family so `.match` is
-    // callable (the IPv4|IPv6 union method isn't) — and enforces family equality.
-    return this.egressAllowlist.some(([range, prefix]) => {
-      if (parsed instanceof ipaddr.IPv6 && range instanceof ipaddr.IPv6) {
-        return parsed.match(range, prefix);
-      }
-      if (parsed instanceof ipaddr.IPv4 && range instanceof ipaddr.IPv4) {
-        return parsed.match(range, prefix);
-      }
-      return false;
-    });
   }
 
   /** Le credential est-il opérationnel (flag ON + secret présent) ? */

--- a/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.ts
+++ b/backend/src/modules/seo-control-plane/synthetic-probe-credential.service.ts
@@ -1,12 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import * as ipaddr from 'ipaddr.js';
 import {
   SYNTHETIC_PROBE_HEADER,
   SYNTHETIC_PROBE_SECRET_KEY,
   SYNTHETIC_PROBE_ENABLED_KEY,
   SYNTHETIC_PROBE_WINDOW_MS,
+  SYNTHETIC_PROBE_EGRESS_IPS_KEY,
 } from './types';
+
+/** Entrée allowlist normalisée : adresse de base + longueur de préfixe. */
+type EgressCidr = [ipaddr.IPv4 | ipaddr.IPv6, number];
 
 /** Requête minimale lisible par {@link SyntheticProbeCredentialService.verify}. */
 export interface SyntheticVerifiableRequest {
@@ -40,6 +45,12 @@ export interface SyntheticVerifiableRequest {
  *     throttler normal. JAMAIS de fail-open vers « vérifié ».
  *   - Le least-privilege (scope GET + catalogue) est appliqué dans `skipIf`, pas ici.
  *
+ * Défense en profondeur ({@link isExemptEgressIp}, ajout 2026-06-26) : le HMAC
+ * voyage dans un en-tête custom qu'un CDN peut retirer en transit (Cloudflare ne
+ * l'a PAS transmis → sonde auto-throttlée). Un PLANCHER par IP d'egress
+ * (`cf-connecting-ip`, toujours transmis + anti-spoofé) rend l'exemption robuste
+ * indépendamment du CDN. Même scope least-privilege, env-gated, fail-closed.
+ *
  * Stateless. Dépend uniquement de ConfigService. Fourni par un module @Global pour
  * être injecté à la fois par BotGuardMiddleware (verify) et SyntheticCrawlerService
  * (sign) sans dépendance circulaire.
@@ -49,6 +60,8 @@ export class SyntheticProbeCredentialService {
   private readonly logger = new Logger(SyntheticProbeCredentialService.name);
   private readonly secret: string;
   private readonly enabled: boolean;
+  /** Plancher défense-en-profondeur : CIDRs d'egress de la sonde (cf. types). */
+  private readonly egressAllowlist: EgressCidr[];
   private warnedSecretMissing = false;
 
   constructor(private readonly config: ConfigService) {
@@ -62,6 +75,65 @@ export class SyntheticProbeCredentialService {
           'exemption synthétique DÉSACTIVÉE (fail-closed).',
       );
     }
+
+    this.egressAllowlist = this.config
+      .get<string>(SYNTHETIC_PROBE_EGRESS_IPS_KEY, '')
+      .split(',')
+      .map((entry) => this.parseEgressEntry(entry))
+      .filter((cidr): cidr is EgressCidr => cidr !== null);
+    if (this.egressAllowlist.length > 0) {
+      this.logger.log(
+        `Plancher egress sonde synthétique actif (${this.egressAllowlist.length} entrée(s) ${SYNTHETIC_PROBE_EGRESS_IPS_KEY}).`,
+      );
+    }
+  }
+
+  /**
+   * Parse une entrée d'allowlist (IP simple ou CIDR, v4/v6) → [adresse, préfixe].
+   * Entrée vide ou invalide → `null` (ignorée + warn, pas de fail-open silencieux).
+   */
+  private parseEgressEntry(entry: string): EgressCidr | null {
+    const trimmed = entry.trim();
+    if (!trimmed) return null;
+    try {
+      if (trimmed.includes('/')) return ipaddr.parseCIDR(trimmed);
+      const addr = ipaddr.parse(trimmed);
+      return [addr, addr.kind() === 'ipv6' ? 128 : 32];
+    } catch {
+      this.logger.warn(
+        `Entrée ${SYNTHETIC_PROBE_EGRESS_IPS_KEY} invalide ignorée: "${trimmed}".`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Plancher défense-en-profondeur : `true` si l'IP cliente (déjà anti-spoofée par
+   * BotGuard.getClientIp = `cf-connecting-ip` cru uniquement derrière le proxy
+   * interne) appartient à l'allowlist d'egress de la sonde. Allowlist vide → `false`
+   * (fail-closed). Le scope least-privilege (GET + catalogue public) reste appliqué
+   * en aval dans `skipIf` — cette méthode ne décide QUE de l'identité, pas du scope.
+   */
+  isExemptEgressIp(ip: string | undefined): boolean {
+    if (this.egressAllowlist.length === 0 || !ip) return false;
+    let parsed: ipaddr.IPv4 | ipaddr.IPv6;
+    try {
+      // `process` normalise un IPv4-mapped IPv6 (`::ffff:1.2.3.4`) → IPv4.
+      parsed = ipaddr.process(ip);
+    } catch {
+      return false;
+    }
+    // `instanceof` narrows BOTH operands to the same family so `.match` is
+    // callable (the IPv4|IPv6 union method isn't) — and enforces family equality.
+    return this.egressAllowlist.some(([range, prefix]) => {
+      if (parsed instanceof ipaddr.IPv6 && range instanceof ipaddr.IPv6) {
+        return parsed.match(range, prefix);
+      }
+      if (parsed instanceof ipaddr.IPv4 && range instanceof ipaddr.IPv4) {
+        return parsed.match(range, prefix);
+      }
+      return false;
+    });
   }
 
   /** Le credential est-il opérationnel (flag ON + secret présent) ? */

--- a/backend/src/modules/seo-control-plane/types.ts
+++ b/backend/src/modules/seo-control-plane/types.ts
@@ -31,6 +31,26 @@ export const SYNTHETIC_PROBE_ENABLED_KEY = 'SEO_CP_SYNTHETIC_PROBE_ENABLED';
 export const SYNTHETIC_PROBE_WINDOW_MS = 60_000;
 
 /**
+ * Allowlist d'IP/CIDR d'egress de la sonde synthétique — PLANCHER de défense en
+ * profondeur du rate-limit, EN PLUS du HMAC. Liste séparée par virgules d'IP ou
+ * CIDR (IPv4 ou IPv6).
+ *
+ * Pourquoi (incident 2026-06-25) : le HMAC voyage dans un en-tête custom
+ * (`x-synthetic-probe`) que le CDN peut retirer en transit (Cloudflare ne l'a PAS
+ * transmis à l'origine → sonde auto-throttlée ~90 %, monitoring L1 aveugle). Or
+ * `cf-connecting-ip` est TOUJOURS transmis par Cloudflare et anti-spoofé à
+ * l'origine (cf. BotGuard.getClientIp : la valeur n'est crue QUE si le pair TCP
+ * est le reverse-proxy interne). Reconnaître l'IP d'egress de NOTRE propre sonde
+ * rend l'exemption robuste, que l'en-tête survive ou non au CDN.
+ *
+ * Vide = plancher OFF (fail-closed) → seule la voie HMAC s'applique. Le même
+ * périmètre least-privilege (GET + catalogue public, {@link isSyntheticExemptPath})
+ * est appliqué en aval dans `skipIf` : même blast-radius que la voie HMAC.
+ */
+export const SYNTHETIC_PROBE_EGRESS_IPS_KEY =
+  'SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS';
+
+/**
  * Préfixes de chemins PUBLICS en lecture sur lesquels l'exemption rate-limit du
  * crawler synthétique peut s'appliquer (least-privilege). Aligné sur la surface
  * publique cacheable (Caddyfile @products/@content). Une fuite éventuelle du


### PR DESCRIPTION
## Point 1 — la sonde synthétique s'auto-throttle (~90 %) car Cloudflare retire l'en-tête HMAC

### Cause racine (confirmée le 2026-06-25)
L'exemption HMAC (#1141) est correcte et **déployée** (secret + `ENABLED=true` vérifiés dans le log de déploiement 17:34 UTC). Mais elle voyage dans un **en-tête custom `x-synthetic-probe` que Cloudflare ne transmet pas à l'origine**. Preuve : un en-tête **correctement signé**, envoyé via Cloudflare en rafale → **`15 200 / 15 429`** (le throttler est pleinement actif = l'en-tête est absent à l'origine). La sonde *live* (en-tête valide via `sign()`) → ~90 % de 429. Dépendre d'un **seul** en-tête transmis par un CDN = le maillon fragile.

### La solution la plus robuste = défense en profondeur
On ajoute un **PLANCHER** indépendant du CDN, keyé sur l'**IP d'egress** de la sonde via `cf-connecting-ip` — le **seul** signal que Cloudflare transmet **toujours** (le throttler s'en sert déjà) et que `getClientIp()` **anti-spoofe** (cru uniquement derrière le reverse-proxy interne). L'exemption fonctionne désormais **que l'en-tête survive ou non** au CDN.

| Couche | Signal | Robustesse |
|---|---|---|
| Primaire | HMAC (`x-synthetic-probe`) | crypto, mais dépend du CDN |
| **Plancher (ce PR)** | IP egress (`cf-connecting-ip`) | toujours transmis + anti-spoof |

### Changements
- **`types.ts`** : nouvelle clé env `SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS` (IP/CIDR séparés par virgules, v4/v6). Vide = plancher **OFF** (fail-closed).
- **`SyntheticProbeCredentialService.isExemptEgressIp()`** : matching robuste via **`net.BlockList`** (primitive stdlib Node — zéro dépendance ; CIDR, IPv4, IPv6, normalisation native `::ffff:`) ; parse résilient (entrées invalides → warn + ignorées, jamais de fail-open).
- **`BotGuardMiddleware`** : reconnaît la sonde par `verify()` HMAC **OU** IP d'egress. **Même périmètre least-privilege** (GET + catalogue public, appliqué en aval dans `skipIf`) → **blast-radius identique** à la voie HMAC.
- **`deploy-prod.yml`** : injecte l'allowlist depuis `secrets.PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS` (calqué sur l'injection du secret HMAC). Non posé = plancher OFF.

### Runtime-awareness
- **Rollout** : env-gated, **défaut OFF** (fail-closed) → inerte tant que l'owner ne pose pas le secret. Réversible (vider le secret + redéployer).
- **Sécurité** : `cf-connecting-ip` non spoofable de l'extérieur (CF le pose, origine joignable seulement via Caddy) ; scope GET + pages publiques déjà cacheables → aucune surface nouvelle vs #1141.
- **Cache/queues** : aucun impact (l'exemption ne fait que sauter le rate-limit).
- **Observabilité** : log au boot si le plancher est actif ; l'alerte 429-rate existante de la sonde reste le filet.

### Tests (TDD) — 32 verts
`synthetic-probe-credential.service.test.ts` (+9 `isExemptEgressIp` : exact/CIDR v4+v6, `::ffff:`, hors-liste, **fail-closed allowlist vide**, IP illisible, parse résilient, **non-confusion des familles**) + `bot-guard.middleware.test.ts` (+1 : reconnaissance par IP d'egress quand l'en-tête HMAC est absent). Les 18 tests HMAC/scope/middleware existants restent **inchangés**.

### Activation (owner, après merge)
1. **Correctif racine Cloudflare** (idéal) : faire transmettre `x-synthetic-probe` à l'origine (vérifier les Transform/Cache Rules qui le retirent).
2. **Plancher (ce PR)** : poser le secret GitHub `PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS` = IP d'egress observée de la sonde (`2a01:4f8:1c1b:5e4e::1`, voir `__seo_snapshot_synthetic`), puis re-déployer PROD (tag `v*`). Plancher actif immédiatement, indépendant de Cloudflare.
3. **Purger** ensuite les 429 déjà cachés par Cloudflare (vu `429` sur `cf_cache_status=HIT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
