### PR TITLE
chore(deploy): synthetic-probe egress floor via GitHub variable (not secret)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -96,8 +96,11 @@ jobs:
           # by Cloudflare (unlike the HMAC header, which the CDN can strip — root
           # cause of the 2026-06-25 self-throttle), so this keeps the exemption
           # working even if the header never reaches origin. Unset = floor stays
-          # OFF (fail-closed; HMAC path only). Value is a public IP, not a secret.
-          SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE: ${{ secrets.PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS }}
+          # OFF (fail-closed; HMAC path only). The value is a public egress IP, NOT a
+          # credential — so it lives as a GitHub Actions *variable* (vars), which is
+          # readable/verifiable (`gh variable list`), unlike the write-only HMAC secret
+          # above. cf-connecting-ip is anti-spoofed at origin, so exposing the IP is safe.
+          SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE: ${{ vars.PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS }}
         run: |
           docker pull massdoc/nestjs-remix-monorepo:production
 
@@ -190,7 +193,7 @@ jobs:
             else
               echo "SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS=${SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS_OVERRIDE}" >> .env
             fi
-            echo "✅ SEO_CP synthetic-probe egress floor configured from GitHub Secrets"
+            echo "✅ SEO_CP synthetic-probe egress floor configured from GitHub Variables"
           else
             echo "ℹ️ PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS unset — egress floor OFF (HMAC path only)"
           fi


### PR DESCRIPTION
## Quoi

Bascule `PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS` de `secrets.*` → `vars.*` dans `deploy-prod.yml` (1 hunk + commentaire/echo).

## Pourquoi

La valeur du plancher egress est une **IP publique d'egress, pas un credential**. La lire depuis `secrets.*` la rendait **write-only / non-vérifiable**. En `vars.*` (GitHub Actions Variable), elle est **lisible** (`gh variable list`) — le bon primitive pour de la config non-sensible, et ça permet de **vérifier la valeur** après pose.

Le secret HMAC (`PROD_SEO_CP_SYNTHETIC_PROBE_SECRET`) **reste un `secrets.*`** (vrai credential).

## Sûreté

- Comportement inchangé : même var injectée dans le `.env` PROD, même branche `else` fail-closed si non posée.
- `cf-connecting-ip` est anti-spoofé à l'origine (cru uniquement derrière le proxy interne) → exposer l'IP ne crée aucun risque de spoof.
- **Aucun deploy déclenché par ce merge** : `deploy-prod.yml` ne tourne que sur tag `v*` / `workflow_dispatch`.

## Après merge (owner)

Poser la **Variable** (pas un secret) :
```bash
gh variable set PROD_SEO_CP_SYNTHETIC_PROBE_EGRESS_IPS \
  --repo ak125/nestjs-remix-monorepo \
  --body '2a01:4f8:1c1b:5e4e::1'
```
Puis tag `v*` → le plancher s'active en PROD (log boot : `Plancher egress sonde synthétique actif (1 entrée(s))`).

Follow-up de #1158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)