### PR TITLE
feat(seo-cp): self-pace synthetic probe under throttler tiers (PR1/2 — structural fix)

### DIFF
--- a/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.test.ts
+++ b/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.test.ts
@@ -76,8 +76,16 @@ function mockFetch(responses: Map<string, MockResponse>): jest.Mock {
 function makeConfigService(
   overrides: Record<string, string | number> = {},
 ): ConfigService {
+  // Le pacer (probeMinIntervalMs) ralentit volontairement les départs. Par
+  // défaut on le neutralise (intervalle ~0) pour garder les tests existants
+  // rapides ; le test de pacing dédié réinjecte des knobs réalistes.
+  const env: Record<string, string | number> = {
+    SEO_CP_MAX_RPS: 1_000_000,
+    SEO_CP_MAX_RPM: 1_000_000,
+    ...overrides,
+  };
   return {
-    get: (key: string, def?: unknown): unknown => overrides[key] ?? def,
+    get: (key: string, def?: unknown): unknown => env[key] ?? def,
   } as unknown as ConfigService;
 }
 
@@ -328,5 +336,64 @@ describe('SyntheticCrawlerService', () => {
     const urlsA = await runOnce();
     const urlsB = await runOnce();
     expect(urlsA).toEqual(urlsB);
+  });
+
+  it('paces outbound probes via a shared monotonic cursor (no concurrency burst past the rate cap)', async () => {
+    // 10 page URLs + concurrency 10 : SANS pacer, les 10 fetch partent dans le
+    // même tick (span ~0). Le curseur partagé doit les étaler de minIntervalMs.
+    const PAGES = 10;
+    const responses = new Map<string, MockResponse>([
+      [
+        'https://www.automecanik.com/sitemap.xml',
+        {
+          status: 200,
+          body: '<sitemap><loc>https://www.automecanik.com/sitemap-pieces-1.xml</loc></sitemap>',
+          headers: {},
+        },
+      ],
+    ]);
+    let subBody = '';
+    for (let i = 1; i <= PAGES; i++) {
+      const u = `https://www.automecanik.com/pieces/p${i}-${i}.html`;
+      subBody += `<url><loc>${u}</loc></url>`;
+      responses.set(u, { status: 200, body: '<html></html>', headers: {} });
+    }
+    responses.set('https://www.automecanik.com/sitemap-pieces-1.xml', {
+      status: 200,
+      body: subBody,
+      headers: {},
+    });
+
+    const baseMock = mockFetch(responses);
+    const pageDispatchedAt: number[] = [];
+    globalThis.fetch = jest.fn(async (url: string, init?: RequestInit) => {
+      if (/\/pieces\/p\d+-\d+\.html$/.test(url)) {
+        pageDispatchedAt.push(Date.now());
+      }
+      return baseMock(url, init);
+    }) as unknown as typeof globalThis.fetch;
+
+    const insertSpy = jest.fn().mockResolvedValue({ error: null });
+    // minIntervalMs = max(1000/40, 60000/1200) = max(25, 50) = 50 ms
+    const svc = buildSvc(
+      crit,
+      makeConfigService({
+        SEO_CP_SAMPLE_SIZE: 30,
+        SEO_CP_CONCURRENCY: 10,
+        SEO_CP_MAX_RPS: 40,
+        SEO_CP_MAX_RPM: 1200,
+      }),
+      insertSpy,
+    );
+
+    await svc.run({ triggeredBy: 'test' });
+
+    expect(pageDispatchedAt).toHaveLength(PAGES);
+    const sorted = [...pageDispatchedAt].sort((a, b) => a - b);
+    const span = sorted[sorted.length - 1] - sorted[0];
+    // 10 départs à 50 ms d'intervalle partagé → span >= ~450 ms (setTimeout ne
+    // déclenche jamais en avance). Un burst de concurrency aurait span ~0.
+    // Seuil >=300 ms : prouve sans ambiguïté que le pacing a eu lieu.
+    expect(span).toBeGreaterThanOrEqual(300);
   });
 });

--- a/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.ts
+++ b/backend/src/modules/seo-control-plane/collectors/synthetic-crawler/synthetic-crawler.service.ts
@@ -263,7 +263,15 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
     return out;
   }
 
-  /** Probe HTTP+HTML pour chaque URL, pool de concurrency. */
+  /**
+   * Probe HTTP+HTML pour chaque URL. Pool de concurrency (borne les sockets
+   * in-flight) + PACER de débit partagé : un unique curseur monotone réserve le
+   * prochain départ pour TOUS les workers, de sorte que le débit sortant AGRÉGÉ
+   * reste sous les paliers du throttler de l'app (`app.module.ts` : short 15/1s,
+   * medium 100/60s). La sonde se comporte alors comme un client public bien élevé
+   * et ne déclenche JAMAIS de 429 — aucune exemption rate-limit n'est requise
+   * (solution structurelle vs exempter par en-tête HMAC stripable / IP qui tourne).
+   */
   private async probeAll(
     cands: UrlCandidate[],
     runId: string,
@@ -271,18 +279,51 @@ export class SyntheticCrawlerService extends SupabaseBaseService {
   ): Promise<SyntheticSnapshot[]> {
     const concurrency = this.cfg.get<number>('SEO_CP_CONCURRENCY', 10);
     const timeoutMs = this.cfg.get<number>('SEO_CP_TIMEOUT_MS', 15_000);
+    const minIntervalMs = this.probeMinIntervalMs();
     const results: SyntheticSnapshot[] = [];
     let i = 0;
+    // Curseur monotone PARTAGÉ par tous les workers. `acquireSlot()` réserve
+    // ATOMIQUEMENT le prochain créneau (aucun await entre la lecture et l'écriture
+    // de `nextSlotAt` → exécution single-thread JS) puis avance le curseur. Débit
+    // agrégé = 1 départ / minIntervalMs, jamais un burst de `concurrency` à t0.
+    let nextSlotAt = Date.now();
+    const acquireSlot = async (): Promise<void> => {
+      const now = Date.now();
+      const slot = Math.max(now, nextSlotAt);
+      nextSlotAt = slot + minIntervalMs;
+      const wait = slot - now;
+      if (wait > 0) await this.sleep(wait);
+    };
 
     const worker = async (): Promise<void> => {
       while (i < cands.length) {
         const idx = i++;
+        await acquireSlot();
         results[idx] = await this.probe(cands[idx], runId, seed, timeoutMs);
       }
     };
 
     await Promise.all(Array.from({ length: concurrency }, () => worker()));
     return results;
+  }
+
+  /**
+   * Intervalle minimal (ms) entre deux départs de requête, tel que le débit
+   * sortant AGRÉGÉ reste strictement sous les paliers du throttler de l'app
+   * (`app.module.ts` : short 15 req/1s, medium 100 req/60s). Défauts headroomés :
+   * `SEO_CP_MAX_RPS=12` (< 15/s) et `SEO_CP_MAX_RPM=90` (< 100/min) → on retient le
+   * PLUS LENT des deux (ici 60000/90 ≈ 667 ms). Couplage assumé et documenté : si
+   * les paliers publics d'`app.module.ts` sont resserrés, baisser ces 2 knobs.
+   */
+  private probeMinIntervalMs(): number {
+    const maxRps = Math.max(1, this.cfg.get<number>('SEO_CP_MAX_RPS', 12));
+    const maxRpm = Math.max(1, this.cfg.get<number>('SEO_CP_MAX_RPM', 90));
+    return Math.max(1000 / maxRps, 60_000 / maxRpm);
+  }
+
+  /** setTimeout promisifié (pacer). */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   /** Single URL probe — fetch + HTML parse (regex minimal, no full DOM). */


### PR DESCRIPTION
## Quoi

Le crawler synthétique L1 s'auto-throttle ~90% (270/300 → 429). Cause racine : `probeAll()` est une pure pool de concurrence (`SEO_CP_CONCURRENCY=10`) **sans aucune limite de débit** → 10 workers dépassent le palier `short` (15/1s) de l'app.

**Fix structurel (pas de bricolage)** : faire de la sonde un client public **bien élevé** qui ne déclenche jamais de 429 → **aucune exemption nécessaire**. Pacer monotone **partagé** dans `probeAll()` : un curseur `nextSlotAt` réservé atomiquement par tous les workers cape le débit **agrégé** à `1/minIntervalMs`, avec `minIntervalMs = max(1000/SEO_CP_MAX_RPS, 60000/SEO_CP_MAX_RPM)` (défauts 12 rps / 90 rpm, headroomés sous 15/1s et 100/60s — couplage documenté).

## Pourquoi c'est mieux que les exemptions IP/HMAC

Panel de conception indépendant (fiabilité / sécurité / SRE) — **convergence totale, confiance haute** :
- **Zéro surface de bypass** du rate-limiter (intact pour tous).
- **Indépendant de Cloudflare** (en-tête HMAC strippé par CF) **et de l'IP** (egress IPv6 qui tourne) par construction.
- **Fidélité de mesure préservée** : tape toujours l'URL publique via Cloudflare.
- *Fewest moving parts* : supprimera 2 mécanismes au lieu d'en entretenir un.

Coût : run de 500 URL ~5,5 min (négligeable pour un monitor q15min). La pool de concurrence ne borne plus que les sockets in-flight.

## Séquence (2 PR, gated par preuve)

- **PR1 (celle-ci)** : le pacer. **Additif, ne change pas la mesure.** → PREPROD.
- **Vérif (gate)** : 1 run PROD q15min à ~0% 429 via l'alarme `>20%` existante.
- **PR2 (après preuve PROD, owner-gated)** : retirer HMAC + plancher IP (branche `skipIf`, BotGuard step 6b, credential service, env/deploy plumbing).

## Tests

Test du pacer partagé : 10 départs à 50ms d'intervalle → span ≥300ms (un burst de concurrence aurait span ~0). Les tests existants neutralisent le pacing (knobs élevés) pour rester rapides. **6/6 verts**, prettier + eslint OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)