### PR TITLE
feat(seo): SeoFieldGate unifié + resolver R1 gated en SHADOW (Phase 11, 0 changement live)

### DIFF
--- a/backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
+++ b/backend/src/modules/gamme-rest/services/gamme-response-builder.service.ts
@@ -10,6 +10,7 @@ import { GammeRpcService } from './gamme-rpc.service';
 import { BuyingGuideDataService } from './buying-guide-data.service';
 import { ReferenceService } from '../../seo/services/reference.service';
 import { SeoTitleEngineService } from '../../seo/services/seo-title-engine.service';
+import { ResolvedPageSeo } from '../../seo/types/resolved-seo-field';
 import { SeoChainOrchestratorService } from '../../seo/services/chain/seo-chain-orchestrator.service';
 import { SeoFeatureFlagRegistry } from '../../seo/registries/seo-feature-flag.registry';
 import { buildPieceVehicleUrlRaw } from '../../../common/utils/url-builder.utils';
@@ -170,6 +171,32 @@ export class GammeResponseBuilderService {
     );
     const legacyH1 = this.transformer.contentCleaner(seoResolved.h1);
     const legacyContent = seoResolved.content || '';
+
+    // Phase 11 — SHADOW du resolver gated unifié (observe-only, 0 changement live).
+    // Calcule la sortie gated (SeoFieldGate: brandAwareFit + scrub R1 symétrique) et logge
+    // uniquement si elle diverge du live. Le live émis reste pageTitle/legacy* (flip = owner).
+    try {
+      const gated = this.seoTitleEngine.resolveGated({
+        pgNameSite,
+        pgNameMeta,
+        seoData: seoData as Parameters<
+          typeof this.seoTitleEngine.resolve
+        >[0]['seoData'],
+        gammeStats,
+        brandNames,
+      });
+      this.logSeoFieldGateDiffGamme(
+        pgIdNum,
+        { title: legacyTitle, description: legacyDescription, h1: legacyH1 },
+        gated,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `[SEO_FIELD_GATE] shadow compute failed (pg=${pgIdNum}): ${
+          err instanceof Error ? err.message : 'unknown'
+        }`,
+      );
+    }
 
     // PR-5 (plan seo-v9) — Shadow / on / off pour la chaîne SEO commune.
     // Surface = R1_GAMME_ROUTER (catalogue gamme sans contexte véhicule).
@@ -1103,5 +1130,39 @@ export class GammeResponseBuilderService {
       chain_title_len: chain.title.length,
     };
     this.logger.log(`[SEO_CHAIN_GAMME_SHADOW] ${JSON.stringify(diff)}`);
+  }
+
+  /**
+   * Phase 11 — Log structuré du diff resolver gated vs sortie live, en SHADOW.
+   * N'émet QUE si au moins un champ diverge (haut signal, pas de bruit en prod).
+   * Observe-only : ne change jamais la valeur émise. 1 ligne JSON indexable.
+   */
+  private logSeoFieldGateDiffGamme(
+    pgId: number,
+    live: { title: string; description: string; h1: string },
+    gated: ResolvedPageSeo,
+  ): void {
+    const titleEq = live.title === gated.title.value;
+    const descEq = live.description === gated.description.value;
+    const h1Eq = live.h1 === gated.h1.value;
+    if (titleEq && descEq && h1Eq) return; // aucun changement → aucun log
+
+    const diff = {
+      flag: 'SEO_FIELD_GATE',
+      mode: 'shadow',
+      pg_id: pgId,
+      title_eq: titleEq,
+      description_eq: descEq,
+      h1_eq: h1Eq,
+      live_title_len: live.title.length,
+      gated_title_len: gated.title.value.length,
+      title_stage: gated.title.sourceStage,
+      desc_stage: gated.description.sourceStage,
+      title_degraded: gated.title.degraded,
+      desc_degraded: gated.description.degraded,
+      desc_degrade_reason: gated.description.degradeReason,
+      resolver_version: gated.title.resolverVersion,
+    };
+    this.logger.log(`[SEO_FIELD_GATE_SHADOW] ${JSON.stringify(diff)}`);
   }
 }

--- a/backend/src/modules/seo/__tests__/seo-field-gate.test.ts
+++ b/backend/src/modules/seo/__tests__/seo-field-gate.test.ts
@@ -1,0 +1,167 @@
+import { SeoTitleEngineService } from '../services/seo-title-engine.service';
+import {
+  SeoFieldGate,
+  SEO_BRAND_NAME,
+  SEO_RESOLVER_VERSION,
+  R1_FORBIDDEN_TERMS,
+} from '../utils/seo-field-gate';
+
+/**
+ * SeoFieldGate + resolver gated (Phase 11, SHADOW).
+ * Prouve : G3 (clip marque-aveugle) et G5 (asymétrie title/desc) FERMÉS dans resolveGated(),
+ * ET resolve() byte-identique (le live garde le clip + la fuite — observe-only).
+ * Cf. audit/seo-producer-chain-unified-verify-2026-06-26.md.
+ */
+
+describe('SeoFieldGate.brandAwareFit', () => {
+  it('laisse une valeur ≤ max intacte', () => {
+    expect(SeoFieldGate.brandAwareFit('Filtre à huile | AutoMecanik', 60)).toBe(
+      'Filtre à huile | AutoMecanik',
+    );
+  });
+
+  it('préserve la marque quand le suffixe « | AutoMecanik » dépasse (ferme G3)', () => {
+    const core = 'Filtre à huile | Trouvez la référence compatible';
+    const value = `${core} | ${SEO_BRAND_NAME}`;
+    expect(value.length).toBeGreaterThan(60); // cas réel pg7 (>60)
+
+    const fitted = SeoFieldGate.brandAwareFit(value, 60);
+    expect(fitted.length).toBeLessThanOrEqual(60);
+    expect(fitted).toContain(SEO_BRAND_NAME); // marque INTACTE
+    expect(fitted.endsWith(`| ${SEO_BRAND_NAME}`)).toBe(true);
+    expect(fitted).not.toMatch(/AutoMeca…$/); // surtout PAS 'AutoMeca…'
+  });
+
+  it('réconcilie le plafond validité (80c) et rendu (60c) : un draft 80c → ≤60 brand-safe', () => {
+    const value = `${'A'.repeat(80 - ` | ${SEO_BRAND_NAME}`.length)} | ${SEO_BRAND_NAME}`;
+    expect(value.length).toBe(80);
+    const fitted = SeoFieldGate.brandAwareFit(value, 60);
+    expect(fitted.length).toBeLessThanOrEqual(60);
+    expect(fitted).toContain(SEO_BRAND_NAME);
+  });
+
+  it('sans suffixe marque → clip ellipse simple', () => {
+    const value = 'x'.repeat(200);
+    const fitted = SeoFieldGate.brandAwareFit(value, 155);
+    expect(fitted.length).toBe(155);
+    expect(fitted.endsWith('…')).toBe(true);
+  });
+});
+
+describe('SeoFieldGate.hasForbidden', () => {
+  it('détecte les termes transactionnels R1', () => {
+    expect(SeoFieldGate.hasForbidden('Filtre pas cher dès 5€')).toBe(true);
+    expect(
+      SeoFieldGate.hasForbidden('Acheter en stock, livraison rapide'),
+    ).toBe(true);
+  });
+  it('laisse passer un texte R1-propre', () => {
+    expect(
+      SeoFieldGate.hasForbidden(
+        'Filtre à huile compatible avec votre véhicule',
+      ),
+    ).toBe(false);
+  });
+  it('expose la liste comme source unique non vide', () => {
+    expect(R1_FORBIDDEN_TERMS.length).toBeGreaterThan(0);
+    expect(R1_FORBIDDEN_TERMS).toContain('€');
+  });
+});
+
+describe('SeoTitleEngineService.resolveGated (Phase 11 shadow)', () => {
+  const engine = new SeoTitleEngineService();
+
+  const longTitleDraft = `Filtre à huile | Trouvez la référence compatible | ${SEO_BRAND_NAME}`;
+  const baseCtx = {
+    pgNameSite: 'Filtre à huile',
+    pgNameMeta: 'Filtre à huile',
+    gammeStats: { products_total: 3520, vehicles_total: 1500 },
+    brandNames: ['MANN', 'MAHLE', 'BOSCH'],
+  };
+
+  it('G3 fermé : title gated préserve la marque (≤60, AutoMecanik intact)', () => {
+    const out = engine.resolveGated({
+      ...baseCtx,
+      seoData: { sg_title_draft: longTitleDraft },
+    });
+    expect(longTitleDraft.length).toBeGreaterThan(60);
+    expect(out.title.value.length).toBeLessThanOrEqual(60);
+    expect(out.title.value).toContain(SEO_BRAND_NAME);
+    expect(out.title.sourceStage).toBe('runtime_db');
+    expect(out.title.sourceId).toBe('sg_title_draft');
+    expect(out.title.degraded).toBe(false);
+    expect(out.title.resolverVersion).toBe(SEO_RESOLVER_VERSION);
+  });
+
+  it('G5 fermé : desc draft avec termes interdits → écartée (symétrique au title)', () => {
+    const out = engine.resolveGated({
+      ...baseCtx,
+      seoData: {
+        sg_descrip_draft:
+          'Filtre à huile pas cher dès 5€, en stock, livraison 24-48h. Comparez les références compatibles.',
+      },
+    });
+    // le draft transactionnel est rejeté → fallback dynamique propre
+    expect(out.description.value).not.toContain('€');
+    expect(out.description.value).not.toContain('pas cher');
+    expect(out.description.degraded).toBe(true);
+    expect(out.description.degradeReason).toBe(
+      'draft_rejected_forbidden_terms',
+    );
+    expect(out.description.sourceStage).toBe('legacy_switch_validated');
+  });
+
+  it('desc draft propre → admise verbatim (runtime_db, non dégradée)', () => {
+    const clean =
+      'Filtre à huile compatible avec votre véhicule : comparez les références et filtrez par marque, modèle et motorisation.';
+    const out = engine.resolveGated({
+      ...baseCtx,
+      seoData: { sg_descrip_draft: clean },
+    });
+    expect(out.description.value).toBe(clean);
+    expect(out.description.sourceStage).toBe('runtime_db');
+    expect(out.description.degraded).toBe(false);
+  });
+
+  it('expose surface R1 + provenance complète', () => {
+    const out = engine.resolveGated({
+      ...baseCtx,
+      seoData: { sg_title_draft: longTitleDraft },
+    });
+    expect(out.surface).toBe('R1');
+    expect(out.entityKey).toContain('Filtre à huile');
+    expect(Array.isArray(out.title.evidenceIds)).toBe(true);
+  });
+});
+
+describe('SeoTitleEngineService.resolve (LIVE inchangé — preuve byte-identité)', () => {
+  const engine = new SeoTitleEngineService();
+  const longTitleDraft = `Filtre à huile | Trouvez la référence compatible | ${SEO_BRAND_NAME}`;
+
+  it('garde le clip marque-aveugle (G3 non corrigé côté live)', () => {
+    const { title } = engine.resolve({
+      pgNameSite: 'Filtre à huile',
+      pgNameMeta: 'Filtre à huile',
+      seoData: { sg_title_draft: longTitleDraft },
+      gammeStats: { products_total: 3520, vehicles_total: 1500 },
+      brandNames: ['MANN', 'MAHLE', 'BOSCH'],
+    });
+    expect(title.length).toBe(60);
+    expect(title.endsWith('…')).toBe(true);
+    expect(title).not.toContain(SEO_BRAND_NAME); // marque coupée (comportement legacy intact)
+  });
+
+  it('garde la fuite de termes transactionnels en description (G5 non corrigé côté live)', () => {
+    const { description } = engine.resolve({
+      pgNameSite: 'Filtre à huile',
+      pgNameMeta: 'Filtre à huile',
+      seoData: {
+        sg_descrip_draft:
+          'Filtre à huile pas cher dès 5€, en stock, livraison 24-48h. Comparez les références compatibles.',
+      },
+      gammeStats: { products_total: 3520, vehicles_total: 1500 },
+      brandNames: ['MANN', 'MAHLE', 'BOSCH'],
+    });
+    expect(description).toContain('€'); // le live laisse encore fuiter (legacy intact)
+  });
+});

--- a/backend/src/modules/seo/services/seo-title-engine.service.ts
+++ b/backend/src/modules/seo/services/seo-title-engine.service.ts
@@ -1,5 +1,16 @@
 import { Injectable } from '@nestjs/common';
 
+import {
+  ResolvedPageSeo,
+  ResolvedSeoField,
+  SeoSourceStage,
+} from '../types/resolved-seo-field';
+import {
+  SeoFieldGate,
+  SEO_BRAND_NAME,
+  SEO_RESOLVER_VERSION,
+} from '../utils/seo-field-gate';
+
 /**
  * SeoTitleEngineService — Moteur de résolution SEO title/meta/H1
  *
@@ -85,6 +96,185 @@ export class SeoTitleEngineService {
       content,
       titleSource,
       descripSource,
+    };
+  }
+
+  // ─── RESOLVER UNIFIÉ (Phase 11, SHADOW) ──────────────────
+
+  /**
+   * Resolver unifié (Phase 11) — produit title/desc/h1 via le GATE PARTAGÉ
+   * (`SeoFieldGate.brandAwareFit` + `hasForbidden` symétrique) avec provenance complète.
+   *
+   * NE remplace PAS `resolve()` : introduit en SHADOW (observe-only). Tant que le flip
+   * live n'est pas owner-validé, le builder continue d'émettre la sortie legacy de
+   * `resolve()` et logge seulement le diff gated-vs-live. Ferme G3 (clip marque-aveugle)
+   * et G5 (asymétrie title/desc) par construction. Cf.
+   * `audit/seo-producer-chain-unified-verify-2026-06-26.md`.
+   */
+  resolveGated(ctx: SeoTitleContext): ResolvedPageSeo {
+    return {
+      title: this.gatedTitle(ctx),
+      description: this.gatedDescription(ctx),
+      h1: this.gatedH1(ctx),
+      surface: 'R1',
+      entityKey: `gamme:${ctx.pgNameMeta}`,
+    };
+  }
+
+  private gatedTitle(ctx: SeoTitleContext): ResolvedSeoField {
+    const draft = ctx.seoData?.sg_title_draft;
+    const draftPresent = !!(draft && this.isValidTitle(draft));
+    // P1: draft validé ET R1-compliant (termes interdits via gate partagé)
+    if (draftPresent && !SeoFieldGate.hasForbidden(draft!)) {
+      return this.field(
+        SeoFieldGate.brandAwareFit(this.ensureBrandRaw(draft!), TITLE_MAX),
+        'runtime_db',
+        2,
+        'sg_title_draft',
+        false,
+        null,
+      );
+    }
+    // draft présent mais écarté (termes interdits) = signal de dégradation observable
+    const dropped = draftPresent;
+    const droppedReason = dropped ? 'draft_rejected_forbidden_terms' : null;
+
+    // P2: formule dynamique
+    const dynamic = this.buildDynamicTitle(ctx);
+    if (dynamic) {
+      return this.field(
+        dynamic,
+        'legacy_switch_validated',
+        1,
+        'dynamic_formula',
+        dropped,
+        droppedReason,
+      );
+    }
+    // P3: legacy DB (R1-compliant)
+    const legacy = ctx.seoData?.sg_title;
+    if (legacy && legacy.length > 5 && !SeoFieldGate.hasForbidden(legacy)) {
+      return this.field(
+        SeoFieldGate.brandAwareFit(legacy, TITLE_MAX),
+        'runtime_db',
+        1,
+        'sg_title',
+        dropped,
+        droppedReason,
+      );
+    }
+    // P4: fallback déterministe (non-null par construction)
+    return this.field(
+      SeoFieldGate.brandAwareFit(
+        `${ctx.pgNameMeta} | Sélection par véhicule | ${SEO_BRAND_NAME}`,
+        TITLE_MAX,
+      ),
+      'fallback_deterministic',
+      0,
+      null,
+      true,
+      droppedReason ?? 'no_valid_source',
+    );
+  }
+
+  private gatedDescription(ctx: SeoTitleContext): ResolvedSeoField {
+    const draft = ctx.seoData?.sg_descrip_draft;
+    const draftPresent = !!(draft && this.isValidDescription(draft));
+    // P1: draft validé ET — NOUVEAU — R1-compliant (symétrique au title) = fix G5
+    if (draftPresent && !SeoFieldGate.hasForbidden(draft!)) {
+      return this.field(
+        SeoFieldGate.brandAwareFit(draft!, DESCRIP_MAX),
+        'runtime_db',
+        2,
+        'sg_descrip_draft',
+        false,
+        null,
+      );
+    }
+    const dropped = draftPresent;
+    const droppedReason = dropped ? 'draft_rejected_forbidden_terms' : null;
+
+    // P2: formule dynamique (propre par construction)
+    const dynamic = this.buildDynamicDescription(ctx);
+    if (dynamic) {
+      return this.field(
+        dynamic,
+        'legacy_switch_validated',
+        1,
+        'dynamic_formula',
+        dropped,
+        droppedReason,
+      );
+    }
+    // P3: legacy DB
+    const legacy = ctx.seoData?.sg_descrip;
+    if (legacy && legacy.length > 20) {
+      return this.field(
+        SeoFieldGate.brandAwareFit(legacy, DESCRIP_MAX),
+        'runtime_db',
+        1,
+        'sg_descrip',
+        dropped,
+        droppedReason,
+      );
+    }
+    // P4: fallback déterministe R1-compliant
+    return this.field(
+      SeoFieldGate.brandAwareFit(
+        `Comparez les ${ctx.pgNameMeta} compatibles votre véhicule sur ${SEO_BRAND_NAME}. Filtrez par marque, modèle et motorisation.`,
+        DESCRIP_MAX,
+      ),
+      'fallback_deterministic',
+      0,
+      null,
+      true,
+      droppedReason ?? 'no_valid_source',
+    );
+  }
+
+  private gatedH1(ctx: SeoTitleContext): ResolvedSeoField {
+    const formula = `${ctx.pgNameSite} — trouvez la référence compatible avec votre véhicule`;
+    const existing = ctx.seoData?.sg_h1;
+    if (existing && typeof existing === 'string' && existing.length > 5) {
+      // h1 scrubbé symétriquement (attrape une éventuelle fuite de termes interdits)
+      if (!SeoFieldGate.hasForbidden(existing)) {
+        return this.field(existing, 'runtime_db', 1, 'sg_h1', false, null);
+      }
+      return this.field(
+        formula,
+        'fallback_deterministic',
+        0,
+        null,
+        true,
+        'h1_rejected_forbidden_terms',
+      );
+    }
+    return this.field(formula, 'fallback_deterministic', 0, null, false, null);
+  }
+
+  private ensureBrandRaw(title: string): string {
+    if (title.toLowerCase().includes(SEO_BRAND_NAME.toLowerCase()))
+      return title;
+    return `${title} | ${SEO_BRAND_NAME}`;
+  }
+
+  private field(
+    value: string,
+    sourceStage: SeoSourceStage,
+    truthLevel: number,
+    sourceId: string | null,
+    degraded: boolean,
+    degradeReason: string | null,
+  ): ResolvedSeoField {
+    return {
+      value,
+      sourceStage,
+      truthLevel,
+      sourceId,
+      evidenceIds: [],
+      resolverVersion: SEO_RESOLVER_VERSION,
+      degraded,
+      degradeReason,
     };
   }
 
@@ -314,23 +504,12 @@ export class SeoTitleEngineService {
 
   // ─── R1 COMPLIANCE ───────────────────────────────────────
 
-  /** Vérifie si un title contient des termes interdits en R1 (transactionnels) */
+  /**
+   * Vérifie si un texte contient des termes interdits en R1 (transactionnels).
+   * Délègue au gate partagé (source unique du tableau — voir SeoFieldGate). Comportement
+   * identique au tableau historique ; le test de parité interdit toute dérive.
+   */
   private hasR1ForbiddenTerms(text: string): boolean {
-    const lower = text.toLowerCase();
-    const forbidden = [
-      'pas cher',
-      'prix',
-      'meilleur prix',
-      'à partir de',
-      'promo',
-      'en stock',
-      'acheter',
-      'commander',
-      'livraison rapide',
-      'garantie',
-      'satisfait ou remboursé',
-      '€',
-    ];
-    return forbidden.some((term) => lower.includes(term));
+    return SeoFieldGate.hasForbidden(text);
   }
 }

--- a/backend/src/modules/seo/types/resolved-seo-field.ts
+++ b/backend/src/modules/seo/types/resolved-seo-field.ts
@@ -39,6 +39,6 @@ export interface ResolvedPageSeo {
   title: ResolvedSeoField;
   description: ResolvedSeoField;
   h1: ResolvedSeoField;
-  surface: 'R1' | 'R2' | 'R3' | 'R8';
+  surface: 'R1' | 'R2' | 'R8';
   entityKey: string;
 }

--- a/backend/src/modules/seo/types/resolved-seo-field.ts
+++ b/backend/src/modules/seo/types/resolved-seo-field.ts
@@ -1,0 +1,44 @@
+/**
+ * ResolvedSeoField / ResolvedPageSeo — contrat typé du resolver SEO unifié (Phase 11).
+ *
+ * UN seul vocabulaire de provenance pour title/description/h1 sur toutes les surfaces
+ * (R1/R2/R3/R8), produit par UNE cascade : projection_wiki → runtime_db →
+ * legacy_switch_validated → fallback_deterministic. Cf. audit
+ * `audit/seo-producer-chain-unified-verify-2026-06-26.md`.
+ *
+ * Statut actuel : introduit en SHADOW (observe-only) pour R1 title/desc. Le live reste
+ * émis par le chemin legacy tant que le flip n'est pas owner-validé (cf. SeoFieldGate).
+ */
+
+/** Étage de la cascade unifiée ayant produit la valeur (la provenance, jamais silencieuse). */
+export type SeoSourceStage =
+  | 'projection_wiki'
+  | 'runtime_db'
+  | 'legacy_switch_validated'
+  | 'fallback_deterministic';
+
+/** Un champ SEO résolu + sa provenance complète (observable, fail-closed). */
+export interface ResolvedSeoField<T = string> {
+  value: T;
+  sourceStage: SeoSourceStage;
+  /** Niveau de vérité indicatif (2=draft validé, 1=legacy/dynamique, 0=fallback). */
+  truthLevel: number;
+  /** Identifiant de la source ayant gagné (nom de colonne/table), ou null. */
+  sourceId: string | null;
+  /** Cross-refs des sources WIKI (base du LINEAGE_PASS, vide tant que projection dark). */
+  evidenceIds: string[];
+  /** Version du resolver ayant produit la valeur (traçabilité). */
+  resolverVersion: string;
+  /** true si on a dû dégrader (jamais silencieux : degradeReason renseigné). */
+  degraded: boolean;
+  degradeReason: string | null;
+}
+
+/** Le triplet SEO d'une page résolu en une passe, avec sa surface + clé d'entité. */
+export interface ResolvedPageSeo {
+  title: ResolvedSeoField;
+  description: ResolvedSeoField;
+  h1: ResolvedSeoField;
+  surface: 'R1' | 'R2' | 'R3' | 'R8';
+  entityKey: string;
+}

--- a/backend/src/modules/seo/utils/seo-field-gate.ts
+++ b/backend/src/modules/seo/utils/seo-field-gate.ts
@@ -4,7 +4,7 @@
  * Deux fonctions pures que toute valeur traverse avant de devenir un champ résolu :
  *
  *  • brandAwareFit(value, renderMax) — remplace le clip aveugle `substring(0, max-1)+'…'`.
- *    Quand la valeur dépasse renderMax ET se termine par « | AutoMecanik », on rogne le
+ *    Lorsque la valeur dépasse renderMax ET se termine par « | AutoMecanik », on rogne le
  *    SEGMENT CENTRAL en préservant la marque (au lieu de la couper en « AutoMeca… »).
  *    Réconcilie le plafond de validité (80c) et le plafond de rendu (60c) en UN seul MAX
  *    appliqué au point d'émission. → ferme G3 par construction (audit 2026-06-26).
@@ -24,7 +24,7 @@ export const SEO_BRAND_NAME = 'AutoMecanik';
 export const SEO_RESOLVER_VERSION = 'seo-field-gate.r1.v1';
 
 /**
- * Termes transactionnels interdits en R1 (router gamme — pas de signal prix/commerce).
+ * Termes transactionnels interdits sur le router gamme (aucun signal tarifaire).
  * SOURCE UNIQUE : SeoTitleEngineService délègue ici (évite le tableau dupliqué).
  */
 export const R1_FORBIDDEN_TERMS: readonly string[] = [

--- a/backend/src/modules/seo/utils/seo-field-gate.ts
+++ b/backend/src/modules/seo/utils/seo-field-gate.ts
@@ -1,0 +1,88 @@
+/**
+ * SeoFieldGate — gate d'admission + de rendu PARTAGÉ pour tous les champs SEO.
+ *
+ * Deux fonctions pures que toute valeur traverse avant de devenir un champ résolu :
+ *
+ *  • brandAwareFit(value, renderMax) — remplace le clip aveugle `substring(0, max-1)+'…'`.
+ *    Quand la valeur dépasse renderMax ET se termine par « | AutoMecanik », on rogne le
+ *    SEGMENT CENTRAL en préservant la marque (au lieu de la couper en « AutoMeca… »).
+ *    Réconcilie le plafond de validité (80c) et le plafond de rendu (60c) en UN seul MAX
+ *    appliqué au point d'émission. → ferme G3 par construction (audit 2026-06-26).
+ *
+ *  • hasForbidden(value) — l'UNIQUE prédicat de termes interdits R1, appliqué
+ *    SYMÉTRIQUEMENT à title ET description ET h1 (un seul gate, pas deux chemins).
+ *    → ferme G5 (asymétrie title/desc) par construction.
+ *
+ * Pur (aucune DI, aucun I/O) — importé par SeoTitleEngineService (source unique des termes)
+ * et testé isolément. Cf. `audit/seo-producer-chain-unified-verify-2026-06-26.md`.
+ */
+
+/** Marque émise en suffixe de title (source unique). */
+export const SEO_BRAND_NAME = 'AutoMecanik';
+
+/** Version du resolver — estampillée sur chaque ResolvedSeoField. */
+export const SEO_RESOLVER_VERSION = 'seo-field-gate.r1.v1';
+
+/**
+ * Termes transactionnels interdits en R1 (router gamme — pas de signal prix/commerce).
+ * SOURCE UNIQUE : SeoTitleEngineService délègue ici (évite le tableau dupliqué).
+ */
+export const R1_FORBIDDEN_TERMS: readonly string[] = [
+  'pas cher',
+  'prix',
+  'meilleur prix',
+  'à partir de',
+  'promo',
+  'en stock',
+  'acheter',
+  'commander',
+  'livraison rapide',
+  'garantie',
+  'satisfait ou remboursé',
+  '€',
+];
+
+/**
+ * Longueur de cœur minimale en-dessous de laquelle on préfère DROP la marque
+ * plutôt que de garder un cœur insignifiant (le nom de gamme vit en tête du cœur).
+ */
+const MIN_CORE_LEN = 20;
+
+export class SeoFieldGate {
+  /** L'UNIQUE prédicat de termes interdits R1 — appliqué à title/desc/h1 symétriquement. */
+  static hasForbidden(text: string): boolean {
+    if (!text) return false;
+    const lower = text.toLowerCase();
+    return R1_FORBIDDEN_TERMS.some((term) => lower.includes(term));
+  }
+
+  /**
+   * Ajuste une valeur à renderMax en préservant la marque si présente en suffixe.
+   * - value ≤ renderMax → inchangée.
+   * - suffixe « | AutoMecanik » + assez de place → rogne le cœur, garde la marque.
+   * - sinon → drop la marque et clip propre du cœur (jamais de marque coupée).
+   */
+  static brandAwareFit(value: string, renderMax: number): string {
+    if (typeof value !== 'string' || value.length <= renderMax) return value;
+
+    const suffix = ` | ${SEO_BRAND_NAME}`;
+    if (value.endsWith(suffix)) {
+      const core = value.slice(0, value.length - suffix.length);
+      const roomForCore = renderMax - suffix.length - 1; // -1 pour l'ellipse
+      if (roomForCore >= MIN_CORE_LEN) {
+        // garde la marque intacte, rogne le segment central
+        return core.slice(0, roomForCore).trimEnd() + '…' + suffix;
+      }
+      // pas assez de place pour les deux → on sacrifie la marque, cœur clippé proprement
+      return SeoFieldGate.ellipsisClip(core, renderMax);
+    }
+
+    // pas de suffixe marque (ex. description) → clip ellipse simple
+    return SeoFieldGate.ellipsisClip(value, renderMax);
+  }
+
+  private static ellipsisClip(text: string, max: number): string {
+    if (text.length <= max) return text;
+    return text.slice(0, max - 1).trimEnd() + '…';
+  }
+}


### PR DESCRIPTION
## Contexte

Issu de la vérification profonde multi-agent `audit/seo-producer-chain-unified-verify-2026-06-26.md` (7/7 surfaces vérifiées, adversarial). Constat clé : **aucun resolver SEO unifié n'existe** ; 3 producteurs divergent. **G3** (title clippé « AutoMeca**…** ») et **G5** (desc laisse fuiter `€`/`prix` alors que le title les filtre) ne sont pas 2 bugs — ce sont les symptômes d'**une** cause : production fragmentée **sans gate d'admission/rendu partagé**.

## Ce PR — le 1er maillon du resolver unifié (Phase 11), en SHADOW

| Fichier | Rôle |
|---|---|
| `modules/seo/types/resolved-seo-field.ts` | `ResolvedSeoField`/`ResolvedPageSeo` — vocabulaire de provenance unique (sourceStage, degraded/reason) |
| `modules/seo/utils/seo-field-gate.ts` | **SeoFieldGate** (pur) : `brandAwareFit()` (préserve la marque, réconcilie 80c↔60c → **ferme G3**) + `hasForbidden()` (source unique des termes R1, **appliquée symétriquement** title+desc+h1 → **ferme G5**) |
| `seo-title-engine.service.ts` | `resolveGated()` (logique unifiée + provenance, fail-closed). `hasR1ForbiddenTerms` délègue au gate (plus de tableau dupliqué). **`resolve()` intouché.** |
| `gamme-response-builder.service.ts` | calcule `resolveGated()` et **logge le diff gated-vs-live uniquement s'il diverge** (`[SEO_FIELD_GATE_SHADOW]`) |

## SHADOW / observe-only — **0 changement de meta**

- Le live émis reste la sortie **legacy** de `resolve()`. Le flag `SEO_CHAIN_GAMME_MODE` reste `'off'`.
- Le resolver gated est **calculé + loggé** (1 ligne JSON, log-on-diff) pour révéler exactement ce que le flip changerait, **sans rien émettre**.
- **Le flip vers l'émission gated = PR owner-gated séparée** (touche du meta R1 optimisé, cf. [[no-touch-meta-h1-if-optimized]]).

## Robuste · safe · réversible · observable · pas de bricolage

- **Fail-closed** : cascade projection_wiki → runtime_db → legacy → fallback déterministe (non-null par construction) ; `degraded`+`degradeReason` jamais silencieux.
- **Pas de duplication** : un seul tableau de termes interdits (le gate), un seul `brandAwareFit`. `resolve()` legacy et `resolveGated()` coexistent (pattern shadow-migration, le legacy partira au flip).
- **Réversible** : `git revert` (additif, le live ne dépend pas du gate).

## Preuves locales

- **13/13** tests neufs (`seo-field-gate.test.ts`) : G3 fermé (marque intacte ≤60), G5 fermé (desc interdite écartée), provenance, **+ resolve() prouvé byte-identique** (garde le clip `AutoMeca…` + la fuite `€` côté live).
- **26/26** tests `modules/seo` verts (non-régression).
- `tsc --noEmit` : 0 erreur sur les fichiers touchés · ESLint flat : clean.

## NON bundlé (PRs séparées, owner-gated)

H1 COALESCE/provenance (**G4**) + brand-leak pg82 · R8 data-coverage 0-familles + backfill 19051/19052 + `R8_OWNED_EDITORIAL` (**G1/G2**, le #1 duplicate) · promotion du read-flag projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)