### PR TITLE
feat(cwv): pg_cron orchestration for RUM aggregation (raw→hourly→daily_rum)

### DIFF
--- a/backend/supabase/migrations/20260626_seo_cwv_aggregation_coverage_alert_tune.down.sql
+++ b/backend/supabase/migrations/20260626_seo_cwv_aggregation_coverage_alert_tune.down.sql
@@ -1,0 +1,115 @@
+-- Rollback du tuning : restaure l'état #811 (20260601) du détecteur de couverture.
+--  (1) Fonction → version #811 (sans auto-résolution, hint d'origine).
+--  (2) Job 'cwv-aggregation-coverage-check' → schedule '35 3 * * *' (#811).
+-- Ne supprime PAS le job (il appartient à #811). Fail-closed sur owner homonyme.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+-- (1) Restaurer la fonction #811 (identique à 20260601_seo_cwv_aggregation_coverage_alert.sql)
+CREATE OR REPLACE FUNCTION public.detect_cwv_aggregation_coverage_gap(
+  p_window_hours INT DEFAULT 48,
+  p_grace_hours  INT DEFAULT 2,
+  p_min_missing  INT DEFAULT 2
+)
+RETURNS TABLE(alerts_inserted INT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count         INT := 0;
+  v_missing_hours INT := 0;
+  v_oldest        TIMESTAMPTZ;
+  v_newest        TIMESTAMPTZ;
+  v_rows_at_risk  BIGINT := 0;
+BEGIN
+  WITH raw_hours AS (
+    SELECT date_trunc('hour', received_at) AS hr, count(*)::BIGINT AS n
+    FROM __seo_cwv_raw
+    WHERE received_at >= now() - make_interval(hours => p_window_hours)
+      AND ua_class = 'human'
+      AND date_trunc('hour', received_at)
+            < date_trunc('hour', now()) - make_interval(hours => p_grace_hours)
+    GROUP BY 1
+  ),
+  missing AS (
+    SELECT rh.hr, rh.n
+    FROM raw_hours rh
+    WHERE NOT EXISTS (
+      SELECT 1 FROM __seo_cwv_hourly h WHERE h.hour = rh.hr
+    )
+  )
+  SELECT count(*), min(hr), max(hr), COALESCE(sum(n), 0)
+  INTO v_missing_hours, v_oldest, v_newest, v_rows_at_risk
+  FROM missing;
+
+  IF v_missing_hours < p_min_missing THEN
+    alerts_inserted := 0;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM __seo_event_log e
+    WHERE e.event_type = 'anomaly_detected'
+      AND e.resolved_at IS NULL
+      AND e.created_at >= now() - INTERVAL '7 days'
+      AND e.payload->>'alert_kind' = 'cwv_aggregation_coverage_gap'
+  ) THEN
+    alerts_inserted := 0;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  INSERT INTO __seo_event_log (event_type, entity_url, severity, payload)
+  VALUES (
+    'anomaly_detected'::seo_event_type,
+    NULL,
+    'high'::seo_severity,
+    jsonb_build_object(
+      'alert_kind',          'cwv_aggregation_coverage_gap',
+      'missing_hours',       v_missing_hours,
+      'oldest_missing_hour', v_oldest,
+      'newest_missing_hour', v_newest,
+      'raw_rows_at_risk',    v_rows_at_risk,
+      'window_hours',        p_window_hours,
+      'grace_hours',         p_grace_hours,
+      'hint',                'raw humain présent dans __seo_cwv_raw mais non agrégé dans __seo_cwv_hourly. Backfill OWNER : aggregate_cwv_hourly(<hour>) puis aggregate_cwv_daily_rum(<date>) AVANT purge raw (TTL ~48h). Vérifier SEO_CWV_AGGREGATION_ENABLED + worker BullMQ.'
+    )
+  );
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  alerts_inserted := v_count;
+  RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.detect_cwv_aggregation_coverage_gap(INT, INT, INT) IS
+  'Bloc 4 follow-up (#3) — READ-ONLY/ALERTING. Détecte des heures raw humaines (TTL ~48h) non agrégées dans __seo_cwv_hourly et émet anomaly_detected (payload.alert_kind=cwv_aggregation_coverage_gap) dans __seo_event_log, dédupliqué sur événements ouverts. Ne backfille pas / ne mute pas raw / ne touche pas le scheduler. Mirror de detect_cwv_trend_divergence.';
+
+GRANT EXECUTE ON FUNCTION public.detect_cwv_aggregation_coverage_gap(INT, INT, INT) TO service_role;
+
+-- (2) Job → schedule #811 '35 3 * * *' (transition inverse, fail-closed, jamais delete)
+DO $$
+DECLARE
+  v_job cron.job%ROWTYPE;
+  v_expected_cmd text := 'SELECT public.detect_cwv_aggregation_coverage_gap();';
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'cwv-aggregation-coverage-check' AND username <> current_user) THEN
+    RAISE EXCEPTION 'cwv-aggregation-coverage-check exists under another owner — refusing to alter';
+  END IF;
+
+  SELECT * INTO v_job FROM cron.job WHERE jobname = 'cwv-aggregation-coverage-check' AND username = current_user;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'cwv-aggregation-coverage-check not found — nothing to revert';
+  ELSIF v_job.schedule = '35 3 * * *' AND btrim(v_job.command) = btrim(v_expected_cmd) THEN
+    NULL;  -- already at #811 schedule = no-op
+  ELSIF v_job.schedule = '35 * * * *' AND btrim(v_job.command) = btrim(v_expected_cmd) THEN
+    PERFORM cron.alter_job(v_job.jobid, schedule := '35 3 * * *');
+  ELSE
+    RAISE EXCEPTION 'cwv-aggregation-coverage-check has an unexpected definition (schedule=%) — refusing to alter', v_job.schedule;
+  END IF;
+END;
+$$;

--- a/backend/supabase/migrations/20260626_seo_cwv_aggregation_coverage_alert_tune.sql
+++ b/backend/supabase/migrations/20260626_seo_cwv_aggregation_coverage_alert_tune.sql
@@ -1,0 +1,149 @@
+-- Migration : tuning du détecteur de couverture CWV (suite #811 / 20260601).
+--
+-- Pré-requis : 20260601_seo_cwv_aggregation_coverage_alert.sql (#811) DOIT être
+-- appliquée AVANT (elle crée la fonction + le job @ '35 3 * * *'). Cette migration
+-- de tuning ne remplace PAS l'application de #811 — elle la fait évoluer.
+--
+-- Deux changements :
+--  (1) detect_cwv_aggregation_coverage_gap() → CREATE OR REPLACE pour AJOUTER
+--      l'AUTO-RÉSOLUTION (couverture rétablie ⇒ resolved_at sur les alertes
+--      ouvertes) + corriger le hint (orchestration = pg_cron, pas BullMQ).
+--      Aligne le RUM sur la doctrine CWV OPEN → STILL_OPEN → RESOLVED (ADR-063).
+--  (2) job pg_cron 'cwv-aggregation-coverage-check' : transition CONTRÔLÉE
+--      '35 3 * * *' (#811) → '35 * * * *' (horaire) via cron.alter_job — détection
+--      en quelques heures (grâce 2 h + seuil 2 h) au lieu de jusqu'à 24 h.
+--
+-- Convergence fail-closed : le job de couverture est le SEUL hand-off délibéré
+-- (créé par #811, modifié ici). On vérifie l'état EXACT attendu de #811 avant
+-- d'altérer ; toute autre définition → RAISE EXCEPTION. Garde homonyme (autre owner).
+-- Ne crée ni ne supprime le job (il appartient à #811).
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+-- =============================================================================
+-- (1) Fonction : auto-résolution + hint corrigé (reste identique à #811)
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.detect_cwv_aggregation_coverage_gap(
+  p_window_hours INT DEFAULT 48,   -- borne = TTL raw + fenêtre auto-heal pg_cron
+  p_grace_hours  INT DEFAULT 2,    -- heures récentes pas encore agrégées (job @ :05 + retries)
+  p_min_missing  INT DEFAULT 2     -- seuil anti-flapping : 1 heure isolée = transient toléré
+)
+RETURNS TABLE(alerts_inserted INT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count         INT := 0;
+  v_missing_hours INT := 0;
+  v_oldest        TIMESTAMPTZ;
+  v_newest        TIMESTAMPTZ;
+  v_rows_at_risk  BIGINT := 0;
+BEGIN
+  WITH raw_hours AS (
+    SELECT date_trunc('hour', received_at) AS hr, count(*)::BIGINT AS n
+    FROM __seo_cwv_raw
+    WHERE received_at >= now() - make_interval(hours => p_window_hours)
+      AND ua_class = 'human'
+      AND date_trunc('hour', received_at)
+            < date_trunc('hour', now()) - make_interval(hours => p_grace_hours)
+    GROUP BY 1
+  ),
+  missing AS (
+    SELECT rh.hr, rh.n
+    FROM raw_hours rh
+    WHERE NOT EXISTS (
+      SELECT 1 FROM __seo_cwv_hourly h WHERE h.hour = rh.hr
+    )
+  )
+  SELECT count(*), min(hr), max(hr), COALESCE(sum(n), 0)
+  INTO v_missing_hours, v_oldest, v_newest, v_rows_at_risk
+  FROM missing;
+
+  -- Sous le seuil → couverture saine. AUTO-RÉSOLUTION des alertes ouvertes
+  -- (le détecteur tourne désormais à l'heure ; sans ça une alerte resterait
+  -- ouverte après récupération et le gate « 0 alerte ouverte » échouerait).
+  IF v_missing_hours < p_min_missing THEN
+    UPDATE public.__seo_event_log
+    SET resolved_at = now(),
+        payload = payload || jsonb_build_object(
+          'resolution_kind', 'coverage_restored',
+          'resolved_by',     'detect_cwv_aggregation_coverage_gap',
+          'resolved_at',     now()
+        )
+    WHERE event_type = 'anomaly_detected'
+      AND resolved_at IS NULL
+      AND payload->>'alert_kind' = 'cwv_aggregation_coverage_gap';
+
+    alerts_inserted := 0;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  -- Dédup : ne pas ré-alerter si une alerte de couverture est déjà OUVERTE (7j).
+  IF EXISTS (
+    SELECT 1 FROM __seo_event_log e
+    WHERE e.event_type = 'anomaly_detected'
+      AND e.resolved_at IS NULL
+      AND e.created_at >= now() - INTERVAL '7 days'
+      AND e.payload->>'alert_kind' = 'cwv_aggregation_coverage_gap'
+  ) THEN
+    alerts_inserted := 0;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  INSERT INTO __seo_event_log (event_type, entity_url, severity, payload)
+  VALUES (
+    'anomaly_detected'::seo_event_type,
+    NULL,
+    'high'::seo_severity,
+    jsonb_build_object(
+      'alert_kind',          'cwv_aggregation_coverage_gap',
+      'missing_hours',       v_missing_hours,
+      'oldest_missing_hour', v_oldest,
+      'newest_missing_hour', v_newest,
+      'raw_rows_at_risk',    v_rows_at_risk,
+      'window_hours',        p_window_hours,
+      'grace_hours',         p_grace_hours,
+      'hint',                'raw humain présent dans __seo_cwv_raw mais non agrégé dans __seo_cwv_hourly. Orchestration = pg_cron (jobs cwv-hourly-aggregation @ :05 / cwv-daily-rum-aggregation @ 00:15 UTC, ADR-045). Vérifier cron.job_run_details (dernier statut) + cron.log_run=on. Backfill OWNER si besoin : aggregate_cwv_hourly(<hour>) puis aggregate_cwv_daily_rum(<date>) AVANT purge raw (TTL ~48h).'
+    )
+  );
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  alerts_inserted := v_count;
+  RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION public.detect_cwv_aggregation_coverage_gap(INT, INT, INT) IS
+  'Bloc 4 follow-up (#811 + tune 20260626) — READ-ONLY/ALERTING + AUTO-RESOLVE. Détecte des heures raw humaines (TTL ~48h) non agrégées dans __seo_cwv_hourly → anomaly_detected (alert_kind=cwv_aggregation_coverage_gap) dans __seo_event_log, dédupliqué ; résout automatiquement les alertes ouvertes quand la couverture est rétablie (OPEN→RESOLVED). Orchestration pg_cron (ADR-045). Ne backfille pas / ne mute pas raw.';
+
+GRANT EXECUTE ON FUNCTION public.detect_cwv_aggregation_coverage_gap(INT, INT, INT) TO service_role;
+
+-- =============================================================================
+-- (2) Transition contrôlée du job de couverture : #811 '35 3 * * *' → '35 * * * *'
+-- =============================================================================
+DO $$
+DECLARE
+  v_job cron.job%ROWTYPE;
+  v_expected_cmd text := 'SELECT public.detect_cwv_aggregation_coverage_gap();';
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'cwv-aggregation-coverage-check' AND username <> current_user) THEN
+    RAISE EXCEPTION 'cwv-aggregation-coverage-check exists under another owner — refusing to alter';
+  END IF;
+
+  SELECT * INTO v_job FROM cron.job WHERE jobname = 'cwv-aggregation-coverage-check' AND username = current_user;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'cwv-aggregation-coverage-check not found — apply #811 (20260601_seo_cwv_aggregation_coverage_alert.sql) FIRST';
+  ELSIF v_job.schedule = '35 * * * *' AND btrim(v_job.command) = btrim(v_expected_cmd) THEN
+    NULL;  -- already tuned (re-apply) = no-op
+  ELSIF v_job.schedule = '35 3 * * *' AND btrim(v_job.command) = btrim(v_expected_cmd) THEN
+    PERFORM cron.alter_job(v_job.jobid, schedule := '35 * * * *');  -- #811 → hourly
+  ELSE
+    RAISE EXCEPTION 'cwv-aggregation-coverage-check has an unexpected definition (schedule=%) — refusing to alter', v_job.schedule;
+  END IF;
+END;
+$$;

--- a/backend/supabase/migrations/20260626_seo_cwv_aggregation_cron.down.sql
+++ b/backend/supabase/migrations/20260626_seo_cwv_aggregation_cron.down.sql
@@ -1,0 +1,23 @@
+-- Rollback : retire les 2 cron d'agrégation CWV RUM (20260626_seo_cwv_aggregation_cron).
+--
+-- Ne supprime QUE les jobs possédés par CETTE migration (jobname + owner +
+-- marqueur de provenance dans la command) → jamais un job homonyme créé à la
+-- main ni un job d'un autre owner. N'affecte PAS les RPC aggregate_cwv_* (20260527)
+-- ni les cron de rotation de partitions.
+
+DO $$
+DECLARE
+  v_jobname text;
+BEGIN
+  FOREACH v_jobname IN ARRAY ARRAY['cwv-hourly-aggregation', 'cwv-daily-rum-aggregation'] LOOP
+    IF EXISTS (
+      SELECT 1 FROM cron.job
+      WHERE jobname = v_jobname
+        AND username = current_user
+        AND command LIKE '%migration:20260626_seo_cwv_aggregation_cron%'
+    ) THEN
+      PERFORM cron.unschedule(v_jobname);
+    END IF;
+  END LOOP;
+END;
+$$;

--- a/backend/supabase/migrations/20260626_seo_cwv_aggregation_cron.sql
+++ b/backend/supabase/migrations/20260626_seo_cwv_aggregation_cron.sql
@@ -1,0 +1,110 @@
+-- Migration : pg_cron pour l'agrégation CWV RUM (raw → hourly → daily_rum).
+--
+-- PROBLÈME (mesuré 2026-06-26, audit runtime-truth) :
+--   __seo_cwv_raw afflue en continu (beacon PROD), mais __seo_cwv_hourly était
+--   VIDE et __seo_cwv_daily_rum FIGÉ depuis 2026-06-03 → 20 j de données déjà
+--   perdues (raw TTL ~48 h) et la collecte courante à risque de purge.
+--
+-- CAUSE RACINE (architecturale, pas une valeur de flag) :
+--   L'agrégation était un repeatable **Bull v4** (`@nestjs/bull` + `bull@4`,
+--   CwvAggregationSchedulerService, queue `seo-monitor`) gardé par
+--   SEO_CWV_AGGREGATION_ENABLED, sur un worker DEV mort. DEV = poste opérateur,
+--   pas un host runtime (deployment.md). Une chaîne de données PROD ne doit pas
+--   dépendre du poste DEV. Le bloc 20260527 avait mis les ROTATIONS de
+--   partitions sous pg_cron mais PAS l'agrégation elle-même — ce trou est comblé ici.
+--
+-- SOLUTION (robuste, découplée de l'app) :
+--   Planifier les RPC VOLATILE existantes aggregate_cwv_hourly(timestamptz) /
+--   aggregate_cwv_daily_rum(date) directement via pg_cron, là où vit la donnée.
+--   Toujours-actif, survit aux restarts/déploiements, zéro dépendance Bull/flag/DEV.
+--   Bull v4 sera retiré dans une PR de clôture séparée (D1) — pg_cron devient le
+--   SEUL orchestrateur. ADR-045 (amendement 2026-06-26) gouverne ce placement.
+--
+-- AUTO-HEAL = 48 h : l'hourly réagrège les 48 dernières heures complètes (pas
+--   juste la précédente). UPSERT idempotent → réagréger une heure faite est un
+--   no-op sûr ; une panne de plusieurs heures (cron/DB/maintenance) se rattrape
+--   seule au tick suivant tant que le raw (TTL ~48 h) n'est pas purgé. La fenêtre
+--   d'auto-heal (48 h) = la fenêtre du détecteur de couverture (#811) = le TTL raw.
+--
+-- CONVERGENCE (exact-match / fail-closed — pas d'écrasement aveugle) :
+--   Pour CHAQUE job : absent → créer ; présent à la définition EXACTE attendue
+--   (schedule + command + active, marqueur de provenance inclus) → no-op ; présent
+--   avec toute autre définition → RAISE EXCEPTION (jamais d'alter_job d'un état
+--   inconnu : le .down ne saurait pas le restaurer). Garde aussi contre un job
+--   HOMONYME appartenant à un autre owner.
+--
+-- PROVENANCE : chaque command porte le marqueur stable
+--   /* migration:20260626_seo_cwv_aggregation_cron */ → réapplication idempotente,
+--   et le .down ne supprime QUE le job possédé par cette migration.
+--
+-- SÉCURITÉ / SCOPE :
+--   - Additif pur. Aucune table, aucune RPC modifiée. Réutilise les RPC (20260527)
+--     + pg_cron déjà actif. 100 % réversible (down = cron.unschedule ciblé).
+--   - Horaires sans chevauchement des rotations (cwv-*-rotation @ 02:55/03:00/03:10) :
+--     agrégation hourly @ :05, daily @ 00:15 UTC.
+--   - daily @ 00:15 : la dernière heure de J-1 (23:00) a été agrégée à 00:05 par
+--     l'hourly → J-1 est complet en hourly avant le rollup. (Le choix n'est PAS
+--     justifié par « après les rotations » — 00:15 leur est antérieur.)
+--
+-- Anti-régression PR #697 : blocs ATOMIQUES, idempotents.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+
+-- =============================================================================
+-- 1. Cron agrégation HORAIRE : toutes les heures à HH:05 UTC.
+--    Réagrège les 48 dernières heures complètes (UTC-explicite, auto-heal 48 h).
+-- =============================================================================
+DO $$
+DECLARE
+  v_job cron.job%ROWTYPE;
+  v_expected_command text := $cmd$/* migration:20260626_seo_cwv_aggregation_cron */
+SELECT public.aggregate_cwv_hourly(
+  date_trunc('hour', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' - make_interval(hours => h)
+)
+FROM generate_series(1, 48) AS gs(h);
+$cmd$;
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'cwv-hourly-aggregation' AND username <> current_user) THEN
+    RAISE EXCEPTION 'cwv-hourly-aggregation already exists under another owner — refusing to create a duplicate';
+  END IF;
+
+  SELECT * INTO v_job FROM cron.job WHERE jobname = 'cwv-hourly-aggregation' AND username = current_user;
+
+  IF NOT FOUND THEN
+    PERFORM cron.schedule('cwv-hourly-aggregation', '5 * * * *', v_expected_command);
+  ELSIF v_job.schedule <> '5 * * * *'
+     OR btrim(v_job.command) <> btrim(v_expected_command)
+     OR v_job.active IS NOT TRUE THEN
+    RAISE EXCEPTION 'Unexpected existing definition for cwv-hourly-aggregation (drift / missing provenance marker) — refusing to overwrite';
+  END IF;  -- exact match (provenance marker included) = no-op
+END;
+$$;
+
+-- =============================================================================
+-- 2. Cron agrégation JOURNALIÈRE : tous les jours à 00:15 UTC.
+--    Réagrège hier + avant-hier (UTC-explicite, auto-heal). Idempotent (UPSERT).
+-- =============================================================================
+DO $$
+DECLARE
+  v_job cron.job%ROWTYPE;
+  v_expected_command text := $cmd$/* migration:20260626_seo_cwv_aggregation_cron */
+SELECT public.aggregate_cwv_daily_rum(((now() AT TIME ZONE 'UTC')::date - d))
+FROM generate_series(1, 2) AS gs(d);
+$cmd$;
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'cwv-daily-rum-aggregation' AND username <> current_user) THEN
+    RAISE EXCEPTION 'cwv-daily-rum-aggregation already exists under another owner — refusing to create a duplicate';
+  END IF;
+
+  SELECT * INTO v_job FROM cron.job WHERE jobname = 'cwv-daily-rum-aggregation' AND username = current_user;
+
+  IF NOT FOUND THEN
+    PERFORM cron.schedule('cwv-daily-rum-aggregation', '15 0 * * *', v_expected_command);
+  ELSIF v_job.schedule <> '15 0 * * *'
+     OR btrim(v_job.command) <> btrim(v_expected_command)
+     OR v_job.active IS NOT TRUE THEN
+    RAISE EXCEPTION 'Unexpected existing definition for cwv-daily-rum-aggregation (drift / missing provenance marker) — refusing to overwrite';
+  END IF;  -- exact match (provenance marker included) = no-op
+END;
+$$;


### PR DESCRIPTION
## Why
CWV RUM aggregation was orchestrated by a **dead DEV-only Bull v4 worker** gated by `SEO_CWV_AGGREGATION_ENABLED` — a PROD data chain depending on the DEV box (`deployment.md` anti-pattern). Result: `__seo_cwv_raw` kept filling (beacon on PROD) but `__seo_cwv_hourly` went empty and `__seo_cwv_daily_rum` froze at **2026-06-03** (incident `web-vitals-attribution-unstable`; priority `web-vitals-attribution-ingestion`; commerce-loop-v1 Step 7).

**Salvage already done** (owner-authorized, pre-PR): the 6,784 currently-collected human samples were aggregated into `hourly` (1,282 rows / 63h) + `daily_rum` (06-24, 06-25); `missing_complete_hours = 0`. Permanent loss bounded to **2026-06-04 → 2026-06-23** (raw TTL already purged — unrecoverable, logged).

## What
Move orchestration **DB-side via pg_cron** over the existing `aggregate_cwv_*()` RPCs (always-on, survives restarts, zero Bull/flag/DEV dependency). Governed by ADR-045 amendment (Bull/BullMQ for external-I/O work vs pg_cron for DB-local idempotent SQL — vault).

**`20260626_seo_cwv_aggregation_cron.sql`** — `cwv-hourly-aggregation` (@`:05`, **48h UTC auto-heal**) + `cwv-daily-rum-aggregation` (@`00:15`, J-1/J-2).
- **Exact-match / fail-closed** convergence: absent→create, exact expected def (schedule+command+provenance marker)→no-op, any drift→`RAISE EXCEPTION` (never `alter_job` an unknown state the `.down` can't restore).
- **Provenance marker** `/* migration:20260626_seo_cwv_aggregation_cron */` in each command + **cross-owner homonym guard**; `.down` unschedules **only** this migration's jobs.

**`20260626_seo_cwv_aggregation_coverage_alert_tune.sql`** (apply **after** #811 `20260601`) — `CREATE OR REPLACE detect_cwv_aggregation_coverage_gap()` adding **auto-resolution** (OPEN→RESOLVED when coverage restored) + pg_cron-correct hint; **controlled `cron.alter_job`** transition `35 3 * * *` → `35 * * * *` (hourly detection), fail-closed on any non-#811 pre-state, never creates/deletes #811's job.

## Apply order (owner-gated — migrations are not auto-applied, deployment.md axe 4)
1. (done) salvage
2. apply `20260626_seo_cwv_aggregation_cron` → record `migration_applied_at`
3. **prove**: a `succeeded` run in `cron.job_run_details` after apply; `missing_complete_hours = 0`; `max(daily_rum.date) = yesterday UTC`
4. apply `20260601` (#811) → verify function + job `cwv-aggregation-coverage-check` @ `35 3 * * *`
5. apply `20260626_..._tune` → verify hourly schedule
6. **C3 deterministic test** (`BEGIN…ROLLBACK`): insert a fake open `cwv_aggregation_coverage_gap` alert → run detector on healthy coverage → assert `alerts_inserted=0` AND the row `resolved_at IS NOT NULL` AND `payload->>'resolution_kind'='coverage_restored'`

## Verified pre-PR (read-only)
- RPC internals: `aggregate_cwv_hourly` buckets raw `[h,h+1h)` `ua_class='human'`; `aggregate_cwv_daily_rum` reads `hourly` (human-only, sample-weighted) → A1-before-A2 holds.
- `cron.alter_job` present; `TimeZone=UTC`, `cron.timezone=GMT`.
- D0: Bull `seo-monitor` has **0** `cwv-aggregation-*` repeatables, flag unset, no worker → no dual-orchestrator (probe `scripts/audit/runtime-truth/bull-repeatable-drift.ts`, separate PR).

## Follow-ups (separate PRs)
- Bull v4 retirement (worker scheduler/processor + delete `SEO_CWV_AGGREGATION_ENABLED`).
- Skills (`web-vitals-audit`, `db-migration`, `runtime-truth-audit` + Bull probe) + registry.
- Vault: ADR-045 amendment, ADR-063 RUM note, RUM recovery runbook.
- `automation-reality.yaml` `cwv-rum-aggregation` ACTIVE (after first proven run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)