### PR TITLE
fix(dt-1): CTA action foreground a11y — recolor #FFF→#000 (visual-change)

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -181,7 +181,7 @@ export const Navbar = memo(function Navbar() {
             >
               <ShoppingCart className="w-5 h-5" />
               {summary.total_items > 0 && (
-                <span className="absolute top-1 right-1 w-4 h-4 bg-cta rounded-full text-[9px] font-bold flex items-center justify-center text-white">
+                <span className="absolute top-1 right-1 w-4 h-4 bg-cta rounded-full text-[9px] font-bold flex items-center justify-center text-black">
                   {summary.total_items > 99 ? "99+" : summary.total_items}
                 </span>
               )}
@@ -264,10 +264,10 @@ export const Navbar = memo(function Navbar() {
 
             <Link
               to="/diagnostic-auto"
-              className="no-style no-visited relative px-5 py-2.5 text-sm font-bold text-white rounded-xl bg-gradient-to-r from-cta to-cta-hover ring-1 ring-cta-light/30 shadow-lg shadow-cta/30 hover:shadow-xl hover:shadow-cta/40 hover:-translate-y-0.5 active:translate-y-0 transition-all flex items-center gap-2 overflow-hidden group"
+              className="no-style no-visited relative px-5 py-2.5 text-sm font-bold text-black rounded-xl bg-gradient-to-r from-cta to-cta-hover ring-1 ring-cta-light/30 shadow-lg shadow-cta/30 hover:shadow-xl hover:shadow-cta/40 hover:-translate-y-0.5 active:translate-y-0 transition-all flex items-center gap-2 overflow-hidden group"
             >
               <span className="absolute inset-0 bg-gradient-to-r from-white/0 via-white/15 to-white/0 -translate-x-full group-hover:translate-x-full transition-transform duration-700" />
-              <ScanLine className="w-4 h-4 text-white relative group-hover:scale-110 transition-transform" />
+              <ScanLine className="w-4 h-4 text-black relative group-hover:scale-110 transition-transform" />
               <span className="relative">Diagnostic</span>
               <span className="relative text-[10px] font-bold bg-white/20 px-1.5 py-0.5 rounded-md">
                 GRATUIT
@@ -323,7 +323,7 @@ export const Navbar = memo(function Navbar() {
               {summary.total_items > 0 && (
                 <Badge
                   variant="destructive"
-                  className="min-w-[18px] h-[18px] px-1 flex items-center justify-center text-[10px] font-bold bg-cta text-white shadow-sm"
+                  className="min-w-[18px] h-[18px] px-1 flex items-center justify-center text-[10px] font-bold bg-cta text-black shadow-sm"
                 >
                   {summary.total_items > 99 ? "99+" : summary.total_items}
                 </Badge>
@@ -358,7 +358,7 @@ export const Navbar = memo(function Navbar() {
                 <Link
                   to="/register"
                   rel="nofollow"
-                  className="no-style no-visited flex px-5 py-2.5 text-sm font-bold text-white bg-cta hover:bg-cta-hover rounded-lg transition-all hover:shadow-lg active:scale-95"
+                  className="no-style no-visited flex px-5 py-2.5 text-sm font-bold text-black bg-cta hover:bg-cta-hover rounded-lg transition-all hover:shadow-lg active:scale-95"
                 >
                   Inscription
                 </Link>

--- a/frontend/app/components/cart/CartSummaryBlock.tsx
+++ b/frontend/app/components/cart/CartSummaryBlock.tsx
@@ -145,8 +145,8 @@ export function CartSummaryBlock({
 
         <div className="mt-4 pt-4 border-t-2 border-slate-200">
           <div className="flex justify-between items-center p-5 bg-cta rounded-xl shadow-lg">
-            <span className="font-bold text-lg text-white">Total TTC</span>
-            <span className="font-extrabold text-3xl text-white">
+            <span className="font-bold text-lg text-black">Total TTC</span>
+            <span className="font-extrabold text-3xl text-black">
               {formatPrice(total)}
             </span>
           </div>
@@ -159,10 +159,10 @@ export function CartSummaryBlock({
           aria-disabled={checkoutDisabled}
           className={`w-full py-4 px-6 bg-cta hover:bg-cta-hover rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 flex items-center justify-center gap-3 ${checkoutDisabled ? "pointer-events-none opacity-50" : ""}`}
         >
-          <span className="text-white font-bold text-lg">
+          <span className="text-black font-bold text-lg">
             Continuer vers la livraison
           </span>
-          <ArrowRight className="h-5 w-5 text-white" />
+          <ArrowRight className="h-5 w-5 text-black" />
         </Link>
 
         <div className="grid grid-cols-3 gap-3 pt-2 text-center text-xs text-slate-500">

--- a/frontend/app/components/checkout/CheckoutLivraisonSection.tsx
+++ b/frontend/app/components/checkout/CheckoutLivraisonSection.tsx
@@ -284,7 +284,7 @@ export function CheckoutLivraisonSection({
                   type="button"
                   onClick={handleEmailCheck}
                   disabled={isCheckingEmail || !guestEmail.includes("@")}
-                  className="px-6 py-3 bg-cta text-white rounded-xl font-medium hover:bg-cta-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                  className="px-6 py-3 bg-cta text-black rounded-xl font-medium hover:bg-cta-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
                 >
                   {isCheckingEmail ? "..." : "Continuer"}
                 </button>
@@ -324,7 +324,7 @@ export function CheckoutLivraisonSection({
                     type="button"
                     onClick={handleInlineLogin}
                     disabled={isLoggingIn}
-                    className="px-6 py-3 bg-cta text-white rounded-xl font-medium hover:bg-cta-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-6 py-3 bg-cta text-black rounded-xl font-medium hover:bg-cta-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {isLoggingIn ? "Connexion..." : "Se connecter"}
                   </button>
@@ -655,7 +655,7 @@ export function CheckoutLivraisonSection({
           <button
             type="button"
             onClick={handleContinue}
-            className="w-full py-3 bg-cta hover:bg-cta-hover text-white rounded-xl font-semibold transition-all flex items-center justify-center gap-2"
+            className="w-full py-3 bg-cta hover:bg-cta-hover text-black rounded-xl font-semibold transition-all flex items-center justify-center gap-2"
           >
             <span>Continuer vers le paiement</span>
             <svg

--- a/frontend/app/components/checkout/CheckoutPaiementSection.tsx
+++ b/frontend/app/components/checkout/CheckoutPaiementSection.tsx
@@ -223,7 +223,7 @@ export function CheckoutPaiementSection({
         type="submit"
         disabled={isProcessing}
         size="lg"
-        className={`w-full py-4 px-6 rounded-xl font-semibold shadow-lg transition-all duration-200 ${canSubmit ? "bg-cta hover:bg-cta-hover text-white shadow-cta/30 hover:shadow-xl hover:shadow-cta/40" : "bg-cta/70 text-white shadow-cta/20"}`}
+        className={`w-full py-4 px-6 rounded-xl font-semibold shadow-lg transition-all duration-200 ${canSubmit ? "bg-cta hover:bg-cta-hover text-black shadow-cta/30 hover:shadow-xl hover:shadow-cta/40" : "bg-cta/70 text-black shadow-cta/20"}`}
       >
         {isProcessing ? (
           <>

--- a/frontend/app/components/gamme/GammeHero.tsx
+++ b/frontend/app/components/gamme/GammeHero.tsx
@@ -205,7 +205,7 @@ export default function GammeHero({
                       <Button
                         type="submit"
                         disabled={mineCode.length < 5}
-                        className="h-12 w-full rounded-2xl bg-cta text-[16px] font-semibold text-white shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
+                        className="h-12 w-full rounded-2xl bg-cta text-[16px] font-semibold text-black shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
                       >
                         <Search size={15} className="mr-2" /> Rechercher
                       </Button>
@@ -304,7 +304,7 @@ export default function GammeHero({
                       <Button
                         type="submit"
                         disabled={mineCode.length < 5}
-                        className="h-12 shrink-0 rounded-2xl bg-cta px-8 text-[15px] font-semibold text-white shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
+                        className="h-12 shrink-0 rounded-2xl bg-cta px-8 text-[15px] font-semibold text-black shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
                       >
                         <Search size={15} className="mr-2" /> Rechercher
                       </Button>

--- a/frontend/app/components/home/CatalogueSection.tsx
+++ b/frontend/app/components/home/CatalogueSection.tsx
@@ -69,7 +69,7 @@ const CatalogFamilyCard = memo(function CatalogFamilyCard({
             </span>
           )}
           {pop && (
-            <span className="absolute top-2.5 right-2.5 text-[10px] font-bold uppercase tracking-wide text-white bg-cta/90 px-2 py-0.5 rounded-md shadow-sm z-10">
+            <span className="absolute top-2.5 right-2.5 text-[10px] font-bold uppercase tracking-wide text-black bg-cta/90 px-2 py-0.5 rounded-md shadow-sm z-10">
               Populaire
             </span>
           )}

--- a/frontend/app/components/home/DiagnosticBanner.tsx
+++ b/frontend/app/components/home/DiagnosticBanner.tsx
@@ -45,7 +45,7 @@ export default function DiagnosticBanner() {
 
           <Button
             onClick={() => navigate("/diagnostic-auto")}
-            className="h-12 w-full shrink-0 rounded-2xl bg-cta px-8 text-[15px] font-semibold text-white shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover lg:w-auto"
+            className="h-12 w-full shrink-0 rounded-2xl bg-cta px-8 text-[15px] font-semibold text-black shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover lg:w-auto"
           >
             <ScanLine size={16} className="mr-2" />
             Lancer le diagnostic

--- a/frontend/app/components/home/HeroSection.tsx
+++ b/frontend/app/components/home/HeroSection.tsx
@@ -152,7 +152,7 @@ export default function HeroSection() {
                         <Button
                           type="submit"
                           disabled={mineCode.length < 5}
-                          className="h-12 w-full rounded-2xl bg-cta text-[16px] font-semibold text-white shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
+                          className="h-12 w-full rounded-2xl bg-cta text-[16px] font-semibold text-black shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
                         >
                           <Search size={15} className="mr-2" /> Rechercher
                         </Button>
@@ -186,7 +186,7 @@ export default function HeroSection() {
                         <Button
                           type="submit"
                           disabled={!refQuery.trim()}
-                          className="h-12 w-full rounded-2xl bg-cta text-[16px] font-semibold text-white shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
+                          className="h-12 w-full rounded-2xl bg-cta text-[16px] font-semibold text-black shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
                         >
                           <Search size={15} className="mr-2" /> Rechercher
                         </Button>
@@ -286,7 +286,7 @@ export default function HeroSection() {
                       <Button
                         type="submit"
                         disabled={mineCode.length < 5}
-                        className="h-12 shrink-0 rounded-2xl bg-cta px-8 text-[15px] font-semibold text-white shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
+                        className="h-12 shrink-0 rounded-2xl bg-cta px-8 text-[15px] font-semibold text-black shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
                       >
                         <Search size={15} className="mr-2" /> Rechercher
                       </Button>
@@ -319,7 +319,7 @@ export default function HeroSection() {
                       <Button
                         type="submit"
                         disabled={!refQuery.trim()}
-                        className="h-12 shrink-0 rounded-2xl bg-cta px-8 text-[15px] font-semibold text-white shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
+                        className="h-12 shrink-0 rounded-2xl bg-cta px-8 text-[15px] font-semibold text-black shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover disabled:opacity-50"
                       >
                         <Search size={15} className="mr-2" /> Rechercher
                       </Button>

--- a/frontend/app/components/layout/BottomNav.tsx
+++ b/frontend/app/components/layout/BottomNav.tsx
@@ -95,7 +95,7 @@ export default function BottomNav() {
         <span className="relative">
           <ShoppingCart size={20} strokeWidth={isCartActive ? 2.5 : 1.5} />
           {itemCount > 0 && (
-            <span className="absolute -top-1.5 -right-2.5 min-w-[16px] h-[16px] px-0.5 bg-cta rounded-full text-[9px] font-bold flex items-center justify-center text-white">
+            <span className="absolute -top-1.5 -right-2.5 min-w-[16px] h-[16px] px-0.5 bg-cta rounded-full text-[9px] font-bold flex items-center justify-center text-black">
               {itemCount > 99 ? "99+" : itemCount}
             </span>
           )}

--- a/frontend/app/components/pieces/PiecesVehicleContent.tsx
+++ b/frontend/app/components/pieces/PiecesVehicleContent.tsx
@@ -553,7 +553,7 @@ export function PiecesVehicleContent() {
         <button
           type="button"
           onClick={openCartSidebar}
-          className="relative py-3 px-4 bg-orange-500 hover:bg-orange-600 text-white rounded-xl font-bold flex items-center gap-2 transition-colors"
+          className="relative py-3 px-4 bg-orange-500 hover:bg-orange-600 text-black rounded-xl font-bold flex items-center gap-2 transition-colors"
         >
           <ShoppingCart className="w-5 h-5" />
           Panier

--- a/frontend/app/components/vehicle/VehicleSelector.tsx
+++ b/frontend/app/components/vehicle/VehicleSelector.tsx
@@ -633,7 +633,7 @@ const VehicleSelector = memo(function VehicleSelector({
             if (selectedType) handleTypeSelect(selectedType);
           }}
           disabled={!canSearch}
-          className="w-full h-12 bg-cta rounded-2xl text-white text-[16px] font-semibold shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover active:translate-y-0 disabled:opacity-40 disabled:shadow-none"
+          className="w-full h-12 bg-cta rounded-2xl text-black text-[16px] font-semibold shadow-[0_12px_24px_rgba(249,115,22,0.28)] hover:bg-cta-hover active:translate-y-0 disabled:opacity-40 disabled:shadow-none"
         >
           Rechercher des pièces
         </Button>

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -371,7 +371,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
       <button
         onClick={scrollToTop}
         type="button"
-        className={`fixed bottom-40 right-4 md:bottom-24 md:right-8 z-[9999] w-12 h-12 rounded-full shadow-2xl flex items-center justify-center bg-cta hover:bg-cta-hover text-white transition-all duration-300 hover:scale-110 ${showScrollTop ? "opacity-100 scale-100" : "opacity-0 scale-50 pointer-events-none"}`}
+        className={`fixed bottom-40 right-4 md:bottom-24 md:right-8 z-[9999] w-12 h-12 rounded-full shadow-2xl flex items-center justify-center bg-cta hover:bg-cta-hover text-black transition-all duration-300 hover:scale-110 ${showScrollTop ? "opacity-100 scale-100" : "opacity-0 scale-50 pointer-events-none"}`}
         aria-label="Retour en haut"
       >
         <ChevronUp className="w-6 h-6" />

--- a/frontend/app/routes/404.tsx
+++ b/frontend/app/routes/404.tsx
@@ -71,7 +71,7 @@ export default function NotFound() {
         <div className="space-y-4">
           <Link
             to="/"
-            className="inline-block bg-cta text-white px-6 py-3 rounded-lg hover:bg-cta-hover transition-colors font-medium"
+            className="inline-block bg-cta text-black px-6 py-3 rounded-lg hover:bg-cta-hover transition-colors font-medium"
           >
             Retour à l'accueil
           </Link>

--- a/frontend/app/routes/_public+/login.tsx
+++ b/frontend/app/routes/_public+/login.tsx
@@ -327,7 +327,7 @@ export default function LoginPage() {
                 <Button
                   type="submit"
                   disabled={isLoading}
-                  className="w-full h-14 bg-cta hover:bg-cta-hover text-white font-bold text-base rounded-2xl shadow-[0_12px_30px_rgba(249,115,22,0.28)] transition-colors"
+                  className="w-full h-14 bg-cta hover:bg-cta-hover text-black font-bold text-base rounded-2xl shadow-[0_12px_30px_rgba(249,115,22,0.28)] transition-colors"
                 >
                   {isLoading ? (
                     <span className="flex items-center gap-2">

--- a/frontend/app/routes/_public+/register.tsx
+++ b/frontend/app/routes/_public+/register.tsx
@@ -1067,7 +1067,7 @@ export default function RegisterPage() {
                     <Button
                       type="submit"
                       disabled={isSubmitting}
-                      className="w-full h-14 bg-cta hover:bg-cta-hover text-white font-bold text-base rounded-2xl shadow-[0_12px_30px_rgba(249,115,22,0.28)] transition-colors"
+                      className="w-full h-14 bg-cta hover:bg-cta-hover text-black font-bold text-base rounded-2xl shadow-[0_12px_30px_rgba(249,115,22,0.28)] transition-colors"
                     >
                       {isSubmitting ? (
                         <span className="flex items-center gap-2">

--- a/frontend/app/routes/cart.tsx
+++ b/frontend/app/routes/cart.tsx
@@ -540,12 +540,12 @@ export default function CartPage() {
           aria-disabled={isAnyMutating}
           className={`flex-1 py-3 px-4 bg-cta hover:bg-cta-hover rounded-xl flex items-center justify-center gap-2 touch-target ${isAnyMutating ? "pointer-events-none opacity-50" : ""}`}
         >
-          <span className="text-white font-bold">
+          <span className="text-black font-bold">
             {cart.summary.total_items} article
             {cart.summary.total_items > 1 ? "s" : ""} &middot;{" "}
             {formatPrice(cart.summary.total_price || cart.summary.subtotal)}
           </span>
-          <ArrowRight className="h-5 w-5 text-white" />
+          <ArrowRight className="h-5 w-5 text-black" />
         </Link>
       </MobileBottomBar>
 

--- a/frontend/app/routes/checkout.tsx
+++ b/frontend/app/routes/checkout.tsx
@@ -800,7 +800,7 @@ export default function CheckoutPage() {
             </Link>
             <Link
               to="/#catalogue"
-              className="inline-flex items-center gap-2 px-5 py-3 bg-cta hover:bg-cta-hover text-white font-semibold rounded-xl transition-colors"
+              className="inline-flex items-center gap-2 px-5 py-3 bg-cta hover:bg-cta-hover text-black font-semibold rounded-xl transition-colors"
             >
               Trouver des pièces
             </Link>
@@ -1227,7 +1227,7 @@ export default function CheckoutPage() {
               <div className="flex flex-col gap-2 w-full mt-2">
                 <a
                   href={`/checkout/resume?token=${pendingOrderInfo.resumeToken}`}
-                  className="inline-flex items-center justify-center gap-2 px-4 py-3 bg-cta text-white rounded-lg font-medium hover:bg-cta/90 transition-colors"
+                  className="inline-flex items-center justify-center gap-2 px-4 py-3 bg-cta text-black rounded-lg font-medium hover:bg-cta/90 transition-colors"
                 >
                   Reprendre le paiement
                 </a>
@@ -1274,7 +1274,7 @@ export default function CheckoutPage() {
             form="checkout-form"
             disabled={isLocked}
             size="lg"
-            className={`w-full rounded-xl font-bold touch-target ${canSubmitOrder ? "bg-cta hover:bg-cta-hover text-white" : "bg-cta/70 text-white"}`}
+            className={`w-full rounded-xl font-bold touch-target ${canSubmitOrder ? "bg-cta hover:bg-cta-hover text-black" : "bg-cta/70 text-black"}`}
           >
             {isLocked ? (
               <>

--- a/frontend/app/routes/diagnostic-auto._index.tsx
+++ b/frontend/app/routes/diagnostic-auto._index.tsx
@@ -370,7 +370,7 @@ export default function DiagnosticAutoIndex() {
               />
               <button
                 type="submit"
-                className="h-11 px-5 bg-cta hover:bg-cta-hover text-white font-semibold rounded-xl transition-colors whitespace-nowrap"
+                className="h-11 px-5 bg-cta hover:bg-cta-hover text-black font-semibold rounded-xl transition-colors whitespace-nowrap"
               >
                 Scanner
               </button>
@@ -441,7 +441,7 @@ export default function DiagnosticAutoIndex() {
             {/* Methode 1 */}
             <div className="mb-6">
               <h3 className="text-lg font-bold text-gray-900 mb-2 flex items-center gap-2">
-                <span className="w-7 h-7 rounded-full bg-cta text-white text-sm flex items-center justify-center font-bold shrink-0">
+                <span className="w-7 h-7 rounded-full bg-cta text-black text-sm flex items-center justify-center font-bold shrink-0">
                   1
                 </span>
                 Observer les symptômes sensoriels (sans outil)
@@ -500,7 +500,7 @@ export default function DiagnosticAutoIndex() {
             {/* Methode 2 */}
             <div className="mb-6">
               <h3 className="text-lg font-bold text-gray-900 mb-2 flex items-center gap-2">
-                <span className="w-7 h-7 rounded-full bg-cta text-white text-sm flex items-center justify-center font-bold shrink-0">
+                <span className="w-7 h-7 rounded-full bg-cta text-black text-sm flex items-center justify-center font-bold shrink-0">
                   2
                 </span>
                 Lire les voyants du tableau de bord
@@ -533,7 +533,7 @@ export default function DiagnosticAutoIndex() {
             {/* Methode 3 */}
             <div>
               <h3 className="text-lg font-bold text-gray-900 mb-2 flex items-center gap-2">
-                <span className="w-7 h-7 rounded-full bg-cta text-white text-sm flex items-center justify-center font-bold shrink-0">
+                <span className="w-7 h-7 rounded-full bg-cta text-black text-sm flex items-center justify-center font-bold shrink-0">
                   3
                 </span>
                 Scanner le code OBD (P, C, B, U)
@@ -966,7 +966,7 @@ export default function DiagnosticAutoIndex() {
             />
             <button
               type="submit"
-              className="h-12 px-6 bg-cta hover:bg-cta-hover text-white font-bold rounded-xl transition-colors flex items-center gap-2"
+              className="h-12 px-6 bg-cta hover:bg-cta-hover text-black font-bold rounded-xl transition-colors flex items-center gap-2"
             >
               Scanner
               <ChevronRight className="w-4 h-4" />

--- a/frontend/app/routes/forgot-password.tsx
+++ b/frontend/app/routes/forgot-password.tsx
@@ -112,7 +112,7 @@ export default function ForgotPassword() {
             <Button
               type="submit"
               size="lg"
-              className="w-full bg-cta hover:bg-cta-hover text-white"
+              className="w-full bg-cta hover:bg-cta-hover text-black"
             >
               Envoyer le lien de réinitialisation
             </Button>

--- a/frontend/tests/unit/cta-contrast.test.ts
+++ b/frontend/tests/unit/cta-contrast.test.ts
@@ -1,0 +1,98 @@
+/**
+ * DT-1 — CTA foreground accessibility guard (frontend consumer side).
+ *
+ * The `cta` color block is HARDCODED in `frontend/tailwind.config.cjs` (it is NOT
+ * token-driven — the design-tokens projection only feeds `colors.semantic.*`). The
+ * filled-CTA buttons render `bg-cta` / `bg-cta-hover` / `bg-cta-light`; DT-1 flips
+ * their glyph from `text-white` (≈2.8:1, WCAG fail) to `text-black`.
+ *
+ * This test reads the SHADES STRAIGHT FROM the config (no duplicated literals) and
+ * asserts the recolor is sound: black passes AA on every filled shade, white did not,
+ * and — the negative guard — black would FAIL on the darker `cta.dark` shade, so the
+ * recolor must never be applied blindly to that shade.
+ *
+ * The package-side WCAG math lives in `packages/design-tokens/tests/tokens.test.mjs`
+ * (the `action`/`actionContrast` semantic pair). This file covers the hardcoded
+ * Tailwind `cta` block the token pipeline does not own.
+ */
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+
+// Load the real Tailwind config via Node's native require (a .cjs file that itself
+// requires the @fafa/design-tokens projection — bypass Vite's transform).
+const require = createRequire(import.meta.url);
+const tailwindConfig = require("../../tailwind.config.cjs") as {
+  theme: { extend: { colors: { cta: Record<string, string> } } };
+};
+const cta = tailwindConfig.theme.extend.colors.cta;
+
+const BLACK = "#000000";
+const WHITE = "#FFFFFF";
+const AA_NORMAL = 4.5;
+
+/** sRGB channel → linear (WCAG 2.x relative-luminance step). */
+function channelLuminance(srgb: number): number {
+  const c = srgb / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG 2.x relative luminance of a #rrggbb hex. */
+function relativeLuminance(hex: string): number {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!m) throw new Error(`expected #rrggbb, got ${hex}`);
+  const n = parseInt(m[1], 16);
+  const r = channelLuminance((n >> 16) & 0xff);
+  const g = channelLuminance((n >> 8) & 0xff);
+  const b = channelLuminance(n & 0xff);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG 2.x contrast ratio between two #rrggbb hexes (1..21). */
+function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe("DT-1 — CTA filled-shade foreground contrast (config-sourced)", () => {
+  // The shades actually used as a button FILL background (bg-cta / -hover / -light).
+  const FILLED_SHADES = [
+    ["cta.DEFAULT", cta.DEFAULT],
+    ["cta.hover", cta.hover],
+    ["cta.light", cta.light],
+  ] as const;
+
+  it.each(FILLED_SHADES)(
+    "black text on %s passes WCAG AA (≥4.5)",
+    (_name, shade) => {
+      expect(contrastRatio(shade, BLACK)).toBeGreaterThanOrEqual(AA_NORMAL);
+    },
+  );
+
+  it("white text on cta.DEFAULT would FAIL AA — the defect DT-1 fixes", () => {
+    expect(contrastRatio(cta.DEFAULT, WHITE)).toBeLessThan(AA_NORMAL);
+  });
+
+  it.each(FILLED_SHADES)(
+    "black beats white on %s (recolor strictly improves contrast)",
+    (_name, shade) => {
+      expect(contrastRatio(shade, BLACK)).toBeGreaterThan(
+        contrastRatio(shade, WHITE),
+      );
+    },
+  );
+
+  it("NEGATIVE GUARD: black on the darker cta.dark shade FAILS AA (<4.5)", () => {
+    // cta.dark (#C2410C) is too dark for a black glyph (~4.06:1). DT-1 must never
+    // recolor a bg-cta-dark surface to text-black; that shade keeps a light glyph.
+    expect(contrastRatio(cta.dark, BLACK)).toBeLessThan(AA_NORMAL);
+    expect(contrastRatio(cta.dark, WHITE)).toBeGreaterThanOrEqual(AA_NORMAL);
+  });
+
+  it("config exposes the shades this guard depends on", () => {
+    for (const key of ["DEFAULT", "hover", "light", "dark"]) {
+      expect(cta[key]).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+  });
+});

--- a/packages/design-tokens/src/styles/tokens.css
+++ b/packages/design-tokens/src/styles/tokens.css
@@ -97,8 +97,8 @@
   --color-neutral-black-contrast: #ffffff;
   --color-semantic-action: #F97316;
   --color-semantic-action-contrast: #000000;
-  --color-semantic-actionContrast: #FFFFFF;
-  --color-semantic-actionContrast-contrast: #000000;
+  --color-semantic-actionContrast: #000000;
+  --color-semantic-actionContrast-contrast: #ffffff;
   --color-semantic-info: #0F4C81;
   --color-semantic-info-contrast: #ffffff;
   --color-semantic-infoContrast: #FFFFFF;

--- a/packages/design-tokens/src/tailwind-tokens.cjs
+++ b/packages/design-tokens/src/tailwind-tokens.cjs
@@ -57,7 +57,7 @@ module.exports = {
     },
     "semantic": {
       "action": "#F97316",
-      "actionContrast": "#FFFFFF",
+      "actionContrast": "#000000",
       "info": "#0F4C81",
       "infoContrast": "#FFFFFF",
       "success": "#1E8449",

--- a/packages/design-tokens/src/tokens.json
+++ b/packages/design-tokens/src/tokens.json
@@ -190,7 +190,7 @@
         "$type": "color"
       },
       "actionContrast": {
-        "$value": "#FFFFFF",
+        "$value": "#000000",
         "$type": "color"
       },
       "info": {

--- a/packages/design-tokens/src/tokens/generated.ts
+++ b/packages/design-tokens/src/tokens/generated.ts
@@ -60,7 +60,7 @@ export const designTokens = {
     },
     "semantic": {
       "action": "#F97316",
-      "actionContrast": "#FFFFFF",
+      "actionContrast": "#000000",
       "info": "#0F4C81",
       "infoContrast": "#FFFFFF",
       "success": "#1E8449",

--- a/packages/design-tokens/tests/tokens.test.mjs
+++ b/packages/design-tokens/tests/tokens.test.mjs
@@ -12,7 +12,15 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { createRequire } from "node:module";
 import { validateTokens } from "../scripts/tokens-schema.mjs";
-import { getContrastColor, hexToHSL } from "../scripts/color-utils.mjs";
+import { getContrastColor, hexToHSL, calculateLuminance } from "../scripts/color-utils.mjs";
+
+/** WCAG 2.x contrast ratio between two #rrggbb hexes. */
+const contrastRatio = (a, b) => {
+  const la = calculateLuminance(a);
+  const lb = calculateLuminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+};
 
 const PKG = dirname(dirname(fileURLToPath(import.meta.url)));
 const source = JSON.parse(readFileSync(join(PKG, "src/tokens.json"), "utf8"));
@@ -77,6 +85,33 @@ describe("color math (v3-oracle verified)", () => {
     const hsl = hexToHSL(source.color.primary["500"].$value);
     expect(source.shadcn.primary.$value).toBe(hsl);
     expect(source.shadcn.ring.$value).toBe(hsl);
+  });
+});
+
+describe("DT-1 — CTA action foreground a11y (#FFF→#000)", () => {
+  it("light semantic.actionContrast is #000000 (was #FFFFFF, WCAG ~2.8:1 fail)", () => {
+    expect(source.color.semantic.actionContrast.$value).toBe("#000000");
+  });
+
+  it("the light action surface + actionContrast pair passes WCAG AA (≥4.5)", () => {
+    const surface = source.color.semantic.action.$value; // #F97316
+    const fg = source.color.semantic.actionContrast.$value; // #000000
+    expect(contrastRatio(surface, fg)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("white-on-action would FAIL AA (the defect this fixes)", () => {
+    expect(contrastRatio(source.color.semantic.action.$value, "#FFFFFF")).toBeLessThan(4.5);
+  });
+
+  it("the DARK action block is untouched (descoped — stays as-is)", () => {
+    // dark.semantic.actionContrast must remain #FFFFFF (no runtime .dark activation; byte-identical)
+    expect(source.dark.semantic.actionContrast.$value).toBe("#FFFFFF");
+    expect(projection.dark.semantic.actionContrast).toBe("#FFFFFF");
+  });
+
+  it("the auto luminance-contrast var for action stays #000000 (single source of truth)", () => {
+    // getContrastColor(#F97316) must agree with the explicit actionContrast now (both #000)
+    expect(getContrastColor(source.color.semantic.action.$value)).toBe("#000000");
   });
 });
 


### PR DESCRIPTION
## DT-1 — CTA action foreground accessibility (`#FFF` → `#000`)

Second step of the *fiabiliser design-tokens → Tailwind 4* chantier (after GATE-0 #1170, DT-0 #1163). **Dark descoped.** This is an **intentional visual change** (CTA glyph white→black).

### Defect
The filled-CTA glyph rendered **white on orange** — `#FFF` on `#F97316` ≈ **2.8:1**, below WCAG AA (4.5:1). Black on the same shade ≈ **7.5:1**.

### Fix — two truth sources
**1. Token double-truth** (`packages/design-tokens`)
- `src/tokens.json`: `color.semantic.actionContrast` `#FFFFFF`→`#000000` (**LIGHT only**). The auto luminance-derived `--…-contrast` var already computed `#000`; the explicit token was the WCAG-wrong half → now a single source of truth.
- `dark.semantic.actionContrast` left `#FFFFFF` — **DARK descoped** (no runtime `.dark` activation; byte-identical; deferred to a separate dark chantier with its own activation + baselines).
- Regenerated `tokens.css` / `tailwind-tokens.cjs` / `tokens/generated.ts` via the Style Dictionary pipeline. `build:check` byte-identity **green**; dark block untouched.

**2. Frontend consumer** — 40 className edits across 19 files
- The `cta` color block is **hardcoded** in `tailwind.config.cjs` (not token-driven); filled CTAs use `bg-cta` + literal `text-white`.
- Swapped `text-white`→`text-black` **only** where the computed style is `bg #F97316` + `color #FFF` (default-shade fills). **Residual `bg-cta`+`text-white` = 0.** No global `text-white` replacement; chips/badges/non-CTA surfaces untouched.

### WCAG guards (both layers)
- `packages/design-tokens/tests/tokens.test.mjs` — action/actionContrast AA pair, white-on-action fails, dark untouched, auto-contrast agreement (**17/17**).
- `frontend/tests/unit/cta-contrast.test.ts` — black passes AA on every filled shade (default/hover/light), white failed, **+ NEGATIVE GUARD**: black FAILS on the darker `cta.dark` shade (~4.06:1) so the recolor is never applied there (**9/9**).

### Validation
| Check | Result |
|---|---|
| frontend `tsc --noEmit` | **0** |
| design-tokens `build:check` (byte-identity) | **0** — proper regen, no hand-edit |
| design-tokens vitest | **17/17** |
| frontend cta-contrast vitest | **9/9** |
| frontend full unit suite | **324/324 assertions** (3 files fail at import on `@repo/registry`/`@repo/database-types` — worktree workspaces-not-built, pre-existing infra, CI builds them) |

### Visual gate — post-merge re-baseline required ⚠️
The visual gate (`visual-gate.yml`) is **`workflow_dispatch`-only** right now (the `workflow_run` PR trigger is intentionally not flipped yet), so it does **not** auto-compare this PR. This change deliberately shifts pixels (CTA glyph white→black on all 9 gate pages — via Navbar Inscription/Diagnostic CTAs + page-specific). **After merge**, the gate baselines must be refreshed against `:preprod`-with-DT-1: run `visual-gate.yml` with `capture_baselines=true` (captures in gate env PREPROD:3200, uploads artifact). Until then the existing v3 baselines are stale-by-design for the CTA glyph.

### Scope
No URL / route / slug / canonical / meta / H1 / payments touched. Backwards-compatible. Merge → PREPROD only (no PROD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)