### PR TITLE
refactor(tw-1): canonicalize Tailwind-v4 hard-removed utilities (dual-compat, zero-visual)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,13 @@ jobs:
       - name: 🛡️ Reserved-namespace-zero (frontend app CSS)
         run: bash scripts/lint/check-frontend-css-am-namespace.sh
 
+      # TW-1 (Tailwind-4 chantier): block utilities Tailwind v4 HARD-REMOVES
+      # (flex-shrink/grow, *-opacity-N, overflow-ellipsis, decoration-slice/clone).
+      # They still work under v3, so nothing else stops a regression before the
+      # engine swap (TW-2). Pre-normalized to the v3+v4 canonical form here.
+      - name: 🛡️ No Tailwind-v4 hard-removed utilities
+        run: bash scripts/lint/check-tailwind-v4-removed-utilities.sh
+
   typecheck:
     name: ʦ TypeScript
     runs-on: ubuntu-latest

--- a/frontend/app/components/AdminSidebar.tsx
+++ b/frontend/app/components/AdminSidebar.tsx
@@ -561,7 +561,7 @@ export const AdminSidebar = memo(function AdminSidebar({
                       }
                     }}
                   >
-                    <Icon className="h-5 w-5 flex-shrink-0" />
+                    <Icon className="h-5 w-5 shrink-0" />
                     <div className="flex-1 min-w-0">
                       <div className="font-medium flex items-center justify-between">
                         <span>{item.name}</span>
@@ -588,7 +588,7 @@ export const AdminSidebar = memo(function AdminSidebar({
                     )}
                     {/* Indicateur d'expansion pour menus avec sous-items */}
                     {(item as any).subItems && (
-                      <div className="ml-2 flex-shrink-0">
+                      <div className="ml-2 shrink-0">
                         <div
                           className={cn(
                             "transition-transform duration-200",
@@ -619,7 +619,7 @@ export const AdminSidebar = memo(function AdminSidebar({
                                 : "text-slate-400 hover:text-slate-200",
                             )}
                           >
-                            <SubIcon className="h-3 w-3 flex-shrink-0" />
+                            <SubIcon className="h-3 w-3 shrink-0" />
                             <div className="flex-1 min-w-0">
                               <div className="font-medium">{subItem.name}</div>
                               <div className="text-xs opacity-75 truncate">
@@ -691,7 +691,7 @@ export const AdminSidebar = memo(function AdminSidebar({
       </div>
 
       {/* Spacer pour le contenu principal sur desktop */}
-      <div className="hidden lg:block w-64 flex-shrink-0" />
+      <div className="hidden lg:block w-64 shrink-0" />
     </>
   );
 });

--- a/frontend/app/components/CommercialSidebar.tsx
+++ b/frontend/app/components/CommercialSidebar.tsx
@@ -110,7 +110,7 @@ export const CommercialSidebar = memo(function CommercialSidebar({
       {/* Sidebar overlay for mobile */}
       {isOpen && (
         <div
-          className="lg:hidden fixed inset-0 z-40 bg-neutral-900 bg-opacity-50"
+          className="lg:hidden fixed inset-0 z-40 bg-neutral-900/50"
           onClick={() => setIsOpen(false)}
         />
       )}
@@ -206,7 +206,7 @@ export const CommercialSidebar = memo(function CommercialSidebar({
                   <div className="flex items-center">
                     <Icon
                       className={cn(
-                        "mr-3 h-5 w-5 flex-shrink-0",
+                        "mr-3 h-5 w-5 shrink-0",
                         active
                           ? "text-blue-600"
                           : "text-gray-400 group-hover:text-gray-600",

--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -219,7 +219,7 @@ export const Navbar = memo(function Navbar() {
           <Link
             to="/"
             prefetch="intent"
-            className="no-style no-visited flex-shrink-0 group hidden lg:block"
+            className="no-style no-visited shrink-0 group hidden lg:block"
             aria-label="Retour à l'accueil"
           >
             <span
@@ -233,7 +233,7 @@ export const Navbar = memo(function Navbar() {
           </Link>
 
           {/* DESKTOP NAV LINKS */}
-          <div className="hidden lg:flex items-center gap-1 min-w-0 flex-shrink">
+          <div className="hidden lg:flex items-center gap-1 min-w-0 shrink">
             <Link
               to="/#catalogue"
               onClick={(e) => scrollToSection(e, "catalogue")}
@@ -310,7 +310,7 @@ export const Navbar = memo(function Navbar() {
           </form>
 
           {/* DESKTOP: User actions */}
-          <div className="hidden lg:flex items-center gap-1 flex-shrink-0">
+          <div className="hidden lg:flex items-center gap-1 shrink-0">
             {/* Cart */}
             <button
               onClick={toggleCart}

--- a/frontend/app/components/account/AccountMenuSections.tsx
+++ b/frontend/app/components/account/AccountMenuSections.tsx
@@ -105,7 +105,7 @@ export function AccountMenuSections({ isPro }: AccountMenuSectionsProps) {
 
         {isPro && (
           <div className="bg-gradient-to-r from-slate-800 to-slate-900 rounded-2xl p-4 flex items-center gap-3.5 mb-4 border border-slate-700">
-            <div className="w-11 h-11 rounded-xl bg-amber-500 flex items-center justify-center shadow-md shadow-amber-500/20 flex-shrink-0">
+            <div className="w-11 h-11 rounded-xl bg-amber-500 flex items-center justify-center shadow-md shadow-amber-500/20 shrink-0">
               <Award size={20} className="text-white" />
             </div>
             <div className="flex-1">

--- a/frontend/app/components/account/AccountNavigation.tsx
+++ b/frontend/app/components/account/AccountNavigation.tsx
@@ -118,7 +118,7 @@ export function SideNavigation({ user, stats }: SideNavigationProps) {
           >
             <item.icon
               className={cn(
-                "w-5 h-5 flex-shrink-0",
+                "w-5 h-5 shrink-0",
                 isActive(item.href)
                   ? "text-blue-600"
                   : "text-gray-400 group-hover:text-gray-500",
@@ -144,7 +144,7 @@ export function SideNavigation({ user, stats }: SideNavigationProps) {
             </div>
             <ChevronRight
               className={cn(
-                "w-4 h-4 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity",
+                "w-4 h-4 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity",
                 isActive(item.href) && "opacity-100",
               )}
             />

--- a/frontend/app/components/account/AccountOrdersSection.tsx
+++ b/frontend/app/components/account/AccountOrdersSection.tsx
@@ -96,7 +96,7 @@ export function AccountOrdersSection({
                   onClick={() => setExpandedOrderId(isOpen ? null : o.id)}
                   className="w-full p-4 text-left flex items-center gap-3 bg-transparent border-none cursor-pointer font-[inherit]"
                 >
-                  <div className="w-10 h-10 rounded-xl bg-slate-100 flex items-center justify-center flex-shrink-0">
+                  <div className="w-10 h-10 rounded-xl bg-slate-100 flex items-center justify-center shrink-0">
                     <Package size={18} className="text-slate-400" />
                   </div>
                   <div className="flex-1 min-w-0">
@@ -114,7 +114,7 @@ export function AccountOrdersSection({
                       {o.info || "Commande"} &middot; {formatDate(o.date)}
                     </div>
                   </div>
-                  <div className="text-right flex-shrink-0">
+                  <div className="text-right shrink-0">
                     <div className="text-[13px] font-bold text-slate-800">
                       {formatPrice(o.totalTtc)}
                     </div>

--- a/frontend/app/components/account/AccountProfileCard.tsx
+++ b/frontend/app/components/account/AccountProfileCard.tsx
@@ -42,7 +42,7 @@ export function AccountProfileCard({ user, stats }: AccountProfileCardProps) {
     <section className="bg-gradient-to-b from-[var(--navy)] to-[var(--navy-light)]">
       <div className="px-5 pt-5 pb-6">
         <div className="flex items-center gap-4">
-          <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shadow-lg shadow-blue-500/20 flex-shrink-0">
+          <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shadow-lg shadow-blue-500/20 shrink-0">
             <span className="text-[24px] font-extrabold text-white font-heading">
               {initials}
             </span>

--- a/frontend/app/components/admin/GammeActionBar.tsx
+++ b/frontend/app/components/admin/GammeActionBar.tsx
@@ -178,7 +178,7 @@ export function GammeActionBar({
           <Button
             size="sm"
             variant="outline"
-            className="gap-1.5 h-7 text-xs flex-shrink-0"
+            className="gap-1.5 h-7 text-xs shrink-0"
             onClick={() => handleCopy(contentResult.command!)}
           >
             <ClipboardCopy className="h-3 w-3" />

--- a/frontend/app/components/admin/OrderLineActions.tsx
+++ b/frontend/app/components/admin/OrderLineActions.tsx
@@ -282,7 +282,7 @@ export function OrderLineActions({
 
       {/* Modal de confirmation */}
       {showModal && (
-        <div className="fixed inset-0 bg-neutral-900 bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-neutral-900/50 flex items-center justify-center z-50">
           <div className="bg-white p-6 rounded-lg max-w-md w-full">
             <h3 className="text-lg font-bold mb-4">Confirmer l'action</h3>
 

--- a/frontend/app/components/admin/gamme-seo/VLevelTab.tsx
+++ b/frontend/app/components/admin/gamme-seo/VLevelTab.tsx
@@ -143,7 +143,7 @@ export const VLevelTab = memo(function VLevelTab({
       {/* V2 violation warning */}
       {(v2Violations.diesel.length > 0 || v2Violations.essence.length > 0) && (
         <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-red-800 flex items-center gap-3">
-          <AlertCircle className="h-5 w-5 flex-shrink-0" />
+          <AlertCircle className="h-5 w-5 shrink-0" />
           <div>
             <p className="font-medium">Violation regle V2</p>
             <p className="text-sm">

--- a/frontend/app/components/admin/patterns/FilterBar.tsx
+++ b/frontend/app/components/admin/patterns/FilterBar.tsx
@@ -85,7 +85,7 @@ export function FilterBar({
             </Button>
           </SheetTrigger>
           <SheetContent side="bottom" className="h-[80vh] flex flex-col">
-            <SheetHeader className="flex-shrink-0">
+            <SheetHeader className="shrink-0">
               <SheetTitle className="flex items-center justify-between">
                 <span className="flex items-center gap-2">
                   <Filter className="h-5 w-5" />
@@ -111,7 +111,7 @@ export function FilterBar({
             </div>
 
             {/* Footer avec actions */}
-            <SheetFooter className="flex-shrink-0 pt-4 border-t">
+            <SheetFooter className="shrink-0 pt-4 border-t">
               <div className="flex gap-3 w-full">
                 <Button
                   variant="outline"

--- a/frontend/app/components/admin/patterns/ResponsiveDataTable.tsx
+++ b/frontend/app/components/admin/patterns/ResponsiveDataTable.tsx
@@ -196,7 +196,7 @@ export function ResponsiveDataTable<T extends Record<string, unknown>>({
                     </div>
                   ))}
                 </div>
-                <ChevronRight className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+                <ChevronRight className="h-5 w-5 text-muted-foreground shrink-0" />
               </div>
             </CardContent>
           </Card>

--- a/frontend/app/components/blog/BlogFAQ.tsx
+++ b/frontend/app/components/blog/BlogFAQ.tsx
@@ -84,7 +84,7 @@ export function BlogFAQ() {
                     {item.question}
                   </span>
                   <ChevronDown
-                    className={`w-5 h-5 text-gray-400 flex-shrink-0 transition-transform ${
+                    className={`w-5 h-5 text-gray-400 shrink-0 transition-transform ${
                       openIndex === index ? "rotate-180" : ""
                     }`}
                   />

--- a/frontend/app/components/blog/CTAButton.tsx
+++ b/frontend/app/components/blog/CTAButton.tsx
@@ -19,7 +19,7 @@ export default function CTAButton({ anchor, link, className = "" }: CTAButtonPro
         >
           <div className="flex items-center justify-between gap-4">
             <div className="flex items-center gap-4">
-              <div className="flex-shrink-0 w-14 h-14 bg-gradient-to-br from-blue-600 rounded-xl flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
+              <div className="shrink-0 w-14 h-14 bg-gradient-to-br from-blue-600 rounded-xl flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
                 <ShoppingCart className="w-7 h-7 text-white" />
               </div>
               <div className="flex-1">
@@ -37,7 +37,7 @@ export default function CTAButton({ anchor, link, className = "" }: CTAButtonPro
                 </p>
               </div>
             </div>
-            <div className="flex-shrink-0 w-10 h-10 bg-primary rounded-full flex items-center justify-center group-hover:bg-primary/90 transition-colors shadow-lg">
+            <div className="shrink-0 w-10 h-10 bg-primary rounded-full flex items-center justify-center group-hover:bg-primary/90 transition-colors shadow-lg">
               <ArrowRight className="w-5 h-5 text-white group-hover:translate-x-1 transition-transform" />
             </div>
           </div>

--- a/frontend/app/components/blog/CompactBlogHeader.tsx
+++ b/frontend/app/components/blog/CompactBlogHeader.tsx
@@ -113,7 +113,7 @@ export function CompactBlogHeader({
             <div className="flex-1 flex items-center gap-3 md:gap-4">
               {/* Logo */}
               {logo && (
-                <div className="flex-shrink-0">
+                <div className="shrink-0">
                   <div className="w-20 h-20 md:w-24 md:h-24 bg-white rounded-2xl shadow-xl p-1.5 md:p-2 flex items-center justify-center hover:scale-105 hover:rotate-2 transition-all duration-300">
                     <img
                       src={logo}
@@ -122,7 +122,7 @@ export function CompactBlogHeader({
                       onError={(e) => {
                         // Masquer le conteneur si le logo 404
                         const container =
-                          e.currentTarget.closest("div.flex-shrink-0");
+                          e.currentTarget.closest("div.shrink-0");
                         if (container instanceof HTMLElement) {
                           container.style.display = "none";
                         }

--- a/frontend/app/components/blog/DiagnosticSection.tsx
+++ b/frontend/app/components/blog/DiagnosticSection.tsx
@@ -72,7 +72,7 @@ export function DiagnosticSection({ articles }: DiagnosticSectionProps) {
                 <Card className="h-full border border-orange-200 hover:border-orange-400 hover:shadow-lg transition-all bg-white">
                   <CardContent className="p-4">
                     <div className="flex items-start justify-between gap-2 mb-2">
-                      <Badge className="bg-orange-100 text-orange-700 text-xs flex-shrink-0">
+                      <Badge className="bg-orange-100 text-orange-700 text-xs shrink-0">
                         Diagnostic
                       </Badge>
                       <span className="text-xs text-gray-400 flex items-center gap-1">

--- a/frontend/app/components/blog/IntentHero.tsx
+++ b/frontend/app/components/blog/IntentHero.tsx
@@ -165,7 +165,7 @@ export function IntentHero({ stats }: IntentHeroProps) {
                     {lane.bullets.map((bullet) => (
                       <li key={bullet} className="flex items-start gap-1.5">
                         <span
-                          className={`mt-1 w-1.5 h-1.5 rounded-full bg-gradient-to-br ${lane.color} flex-shrink-0`}
+                          className={`mt-1 w-1.5 h-1.5 rounded-full bg-gradient-to-br ${lane.color} shrink-0`}
                         />
                         {bullet}
                       </li>

--- a/frontend/app/components/blog/QuickChecklist.tsx
+++ b/frontend/app/components/blog/QuickChecklist.tsx
@@ -30,7 +30,7 @@ export function QuickChecklist() {
           <ol className="space-y-3">
             {CHECKS.map((check, i) => (
               <li key={i} className="flex items-start gap-3">
-                <div className="flex-shrink-0 w-6 h-6 rounded-full bg-green-100 flex items-center justify-center mt-0.5">
+                <div className="shrink-0 w-6 h-6 rounded-full bg-green-100 flex items-center justify-center mt-0.5">
                   <CheckCircle2 className="w-4 h-4 text-green-600" />
                 </div>
                 <span className="text-sm text-gray-700">{check}</span>

--- a/frontend/app/components/blog/RelatedArticlesSidebar.tsx
+++ b/frontend/app/components/blog/RelatedArticlesSidebar.tsx
@@ -51,7 +51,7 @@ export function RelatedArticlesSidebar({
                     <img
                       src={related.featuredImage}
                       alt={related.title}
-                      className="w-20 h-16 object-cover rounded-md flex-shrink-0 border-2 border-gray-200 group-hover:scale-105 transition-transform"
+                      className="w-20 h-16 object-cover rounded-md shrink-0 border-2 border-gray-200 group-hover:scale-105 transition-transform"
                       loading="lazy"
                       width="80"
                       height="64"
@@ -60,13 +60,13 @@ export function RelatedArticlesSidebar({
                     <img
                       src={`/upload/blog/guide/mini/${related.wall}`}
                       alt={related.title}
-                      className="w-20 h-16 object-cover rounded-md flex-shrink-0 border-2 border-gray-200 group-hover:scale-105 transition-transform"
+                      className="w-20 h-16 object-cover rounded-md shrink-0 border-2 border-gray-200 group-hover:scale-105 transition-transform"
                       loading="lazy"
                       width="80"
                       height="64"
                     />
                   ) : (
-                    <div className="w-20 h-16 bg-gradient-to-br from-blue-100 to-blue-200 rounded-md flex-shrink-0 flex items-center justify-center border-2 border-gray-200">
+                    <div className="w-20 h-16 bg-gradient-to-br from-blue-100 to-blue-200 rounded-md shrink-0 flex items-center justify-center border-2 border-gray-200">
                       <span className="text-xl text-blue-400">
                         <Eye className="w-5 h-5" />
                       </span>

--- a/frontend/app/components/blog/TableOfContents.tsx
+++ b/frontend/app/components/blog/TableOfContents.tsx
@@ -92,7 +92,7 @@ export function TableOfContents({
               >
                 <span className="flex items-center gap-2">
                   {isActive && (
-                    <ChevronRight className="w-4 h-4 flex-shrink-0" />
+                    <ChevronRight className="w-4 h-4 shrink-0" />
                   )}
                   <span className="line-clamp-2">{section.title}</span>
                 </span>

--- a/frontend/app/components/blog/conseil/SourcesDisclaimer.tsx
+++ b/frontend/app/components/blog/conseil/SourcesDisclaimer.tsx
@@ -9,7 +9,7 @@ export function SourcesDisclaimer() {
   return (
     <div className="mt-8 pt-6 border-t border-gray-200">
       <div className="flex items-start gap-2 text-xs text-gray-400">
-        <FileText className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+        <FileText className="w-3.5 h-3.5 shrink-0 mt-0.5" />
         <p>
           Les valeurs de couple et intervalles de remplacement indiqués sont
           donnés à titre indicatif et correspondent aux recommandations

--- a/frontend/app/components/blog/conseil/SummarySnippet.tsx
+++ b/frontend/app/components/blog/conseil/SummarySnippet.tsx
@@ -26,7 +26,7 @@ export function SummarySnippet({ conseil }: SummarySnippetProps) {
       <ol className="px-5 py-4 space-y-3">
         {points.map((point, i) => (
           <li key={i} className="flex items-start gap-3">
-            <span className="flex-shrink-0 w-7 h-7 rounded-full bg-blue-600 text-white text-sm font-bold flex items-center justify-center mt-0.5">
+            <span className="shrink-0 w-7 h-7 rounded-full bg-blue-600 text-white text-sm font-bold flex items-center justify-center mt-0.5">
               {i + 1}
             </span>
             <div>

--- a/frontend/app/components/blog/guide-achat/R6BrandsGuide.tsx
+++ b/frontend/app/components/blog/guide-achat/R6BrandsGuide.tsx
@@ -77,7 +77,7 @@ export function R6BrandsGuide({ brandsGuide, gammeName }: Props) {
                 <ul className="space-y-1 text-sm text-gray-600">
                   {tier.quality_signals.map((signal, j) => (
                     <li key={j} className="flex items-start gap-2">
-                      <Shield className="w-3.5 h-3.5 text-emerald-500 mt-0.5 flex-shrink-0" />
+                      <Shield className="w-3.5 h-3.5 text-emerald-500 mt-0.5 shrink-0" />
                       <span>{signal}</span>
                     </li>
                   ))}

--- a/frontend/app/components/blog/guide-achat/R6CompatibilityChecklist.tsx
+++ b/frontend/app/components/blog/guide-achat/R6CompatibilityChecklist.tsx
@@ -26,7 +26,7 @@ export function R6CompatibilityChecklist({ axes, gammeName }: Props) {
             className="rounded-lg border border-indigo-200 bg-muted/50 p-4"
           >
             <div className="flex items-start gap-3">
-              <div className="p-1.5 bg-muted rounded-lg flex-shrink-0 mt-0.5">
+              <div className="p-1.5 bg-muted rounded-lg shrink-0 mt-0.5">
                 <Search className="w-4 h-4 text-foreground" />
               </div>
               <div className="flex-1">

--- a/frontend/app/components/blog/guide-achat/R6HeroDecisionSection.tsx
+++ b/frontend/app/components/blog/guide-achat/R6HeroDecisionSection.tsx
@@ -35,7 +35,7 @@ export function R6HeroDecisionSection({
             <ul className="space-y-2 mb-4">
               {heroDecision.bullets.map((bullet, i) => (
                 <li key={i} className="flex items-start gap-2">
-                  <CheckCircle2 className="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" />
+                  <CheckCircle2 className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
                   <span className="text-sm text-gray-700">{bullet}</span>
                 </li>
               ))}

--- a/frontend/app/components/blog/guide-achat/R6PriceGuide.tsx
+++ b/frontend/app/components/blog/guide-achat/R6PriceGuide.tsx
@@ -62,7 +62,7 @@ export function R6PriceGuide({ priceGuide, gammeName }: Props) {
                 key={i}
                 className="flex items-center gap-2 text-sm text-gray-700"
               >
-                <div className="w-1.5 h-1.5 bg-green-500 rounded-full flex-shrink-0" />
+                <div className="w-1.5 h-1.5 bg-green-500 rounded-full shrink-0" />
                 {factor}
               </li>
             ))}
@@ -71,7 +71,7 @@ export function R6PriceGuide({ priceGuide, gammeName }: Props) {
       )}
 
       <div className="flex items-start gap-2 text-xs text-gray-500 bg-gray-50 rounded-lg p-3">
-        <Info className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+        <Info className="w-3.5 h-3.5 mt-0.5 shrink-0" />
         <span>{priceGuide.disclaimer}</span>
       </div>
     </section>

--- a/frontend/app/components/blog/guide-achat/R6WhenPro.tsx
+++ b/frontend/app/components/blog/guide-achat/R6WhenPro.tsx
@@ -25,7 +25,7 @@ export function R6WhenPro({ cases, gammeName: _gammeName }: Props) {
           <Card key={i} className="border-orange-200">
             <CardContent className="p-4">
               <div className="flex items-start gap-3">
-                <div className="p-1.5 bg-orange-100 rounded-lg flex-shrink-0 mt-0.5">
+                <div className="p-1.5 bg-orange-100 rounded-lg shrink-0 mt-0.5">
                   <Wrench className="w-4 h-4 text-orange-600" />
                 </div>
                 <div>

--- a/frontend/app/components/cart/CartIcon.tsx
+++ b/frontend/app/components/cart/CartIcon.tsx
@@ -28,7 +28,7 @@ export const CartIcon = memo(function CartIcon({
       className={`hover:text-blue-200 transition-colors relative inline-flex items-center ${className}`}
       aria-label="Panier"
     >
-      <ShoppingCart className="flex-shrink-0" size={20} />
+      <ShoppingCart className="shrink-0" size={20} />
       {itemCount > 0 && (
         <Badge
           data-cart-badge

--- a/frontend/app/components/cart/CartItem.tsx
+++ b/frontend/app/components/cart/CartItem.tsx
@@ -84,7 +84,7 @@ export const CartItem = memo(function CartItem({
       <CardContent className="p-4">
         <div className="flex items-center gap-4">
           {/* Image produit */}
-          <div className="w-20 h-20 bg-gray-100 rounded-md overflow-hidden flex-shrink-0">
+          <div className="w-20 h-20 bg-gray-100 rounded-md overflow-hidden shrink-0">
             <img
               src={productImage}
               alt={productName}

--- a/frontend/app/components/cart/CartItemRow.tsx
+++ b/frontend/app/components/cart/CartItemRow.tsx
@@ -118,7 +118,7 @@ export function CartItemRow({ item }: { item: CartItemType }) {
     >
       <div className="p-4 sm:p-5">
         <div className="flex items-start gap-3 mb-4">
-          <div className="w-20 h-20 flex-shrink-0 bg-slate-100 rounded-lg overflow-hidden">
+          <div className="w-20 h-20 shrink-0 bg-slate-100 rounded-lg overflow-hidden">
             {item.product_image &&
             item.product_image !== "/images/categories/default.svg" ? (
               <img

--- a/frontend/app/components/cart/EmptyCart.tsx
+++ b/frontend/app/components/cart/EmptyCart.tsx
@@ -137,7 +137,7 @@ export function EmptyCart({ vehicle }: EmptyCartProps) {
               to={`/pieces/${gamme.alias}-${gamme.id}.html`}
               className="flex items-center gap-3 min-h-[44px] px-4 py-3 bg-white rounded-xl border border-slate-200 hover:border-cta hover:shadow-md transition-all group"
             >
-              <gamme.Icon className="h-5 w-5 text-slate-400 group-hover:text-cta flex-shrink-0 transition-colors" />
+              <gamme.Icon className="h-5 w-5 text-slate-400 group-hover:text-cta shrink-0 transition-colors" />
               <span className="text-sm font-medium text-slate-700 group-hover:text-slate-900 transition-colors">
                 {gamme.name}
               </span>

--- a/frontend/app/components/catalog/PiecesCatalogGrid.tsx
+++ b/frontend/app/components/catalog/PiecesCatalogGrid.tsx
@@ -327,21 +327,21 @@ export default function PiecesCatalogGrid({
         </div>
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <div className="bg-white bg-opacity-20 rounded-lg p-3 text-center">
+          <div className="bg-white/20 rounded-lg p-3 text-center">
             <div className="text-2xl font-bold">{categories.length}</div>
             <div className="text-xs opacity-90">Catégories</div>
           </div>
-          <div className="bg-white bg-opacity-20 rounded-lg p-3 text-center">
+          <div className="bg-white/20 rounded-lg p-3 text-center">
             <div className="text-2xl font-bold">
               {stats.categories_with_pieces}
             </div>
             <div className="text-xs opacity-90">Catégories actives</div>
           </div>
-          <div className="bg-white bg-opacity-20 rounded-lg p-3 text-center">
+          <div className="bg-white/20 rounded-lg p-3 text-center">
             <div className="text-2xl font-bold">{stats.total_brands}</div>
             <div className="text-xs opacity-90">Marques</div>
           </div>
-          <div className="bg-white bg-opacity-20 rounded-lg p-3 text-center">
+          <div className="bg-white/20 rounded-lg p-3 text-center">
             <div className="text-2xl font-bold">
               {stats.total_pieces > 0
                 ? Math.round(stats.total_pieces / stats.categories_with_pieces)
@@ -378,12 +378,12 @@ export default function PiecesCatalogGrid({
                   </div>
 
                   <div className="flex justify-between items-center">
-                    <span className="bg-white bg-opacity-30 rounded-full px-3 py-1 text-sm font-bold">
+                    <span className="bg-white/30 rounded-full px-3 py-1 text-sm font-bold">
                       {category.piecesCount.toLocaleString()} pièces
                     </span>
                     <button
                       onClick={() => toggleCategory(category.id)}
-                      className="bg-white bg-opacity-20 hover:bg-opacity-30 rounded-full p-2 transition-colors"
+                      className="bg-white/20 hover:bg-white/30 rounded-full p-2 transition-colors"
                     >
                       <svg
                         className={`w-4 h-4 transform transition-transform ${isExpanded ? "rotate-180" : ""}`}

--- a/frontend/app/components/catalog/ProductCatalog.tsx
+++ b/frontend/app/components/catalog/ProductCatalog.tsx
@@ -370,7 +370,7 @@ export function ProductCatalog({
                     >
                       <div className="flex items-center space-x-4">
                         {/* Image miniature */}
-                        <div className="w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0 overflow-hidden">
+                        <div className="w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center shrink-0 overflow-hidden">
                           {product.piece_image ? (
                             <img
                               src={product.piece_image}

--- a/frontend/app/components/catalog/PurchaseGuide.tsx
+++ b/frontend/app/components/catalog/PurchaseGuide.tsx
@@ -75,7 +75,7 @@ export function PurchaseGuide({
             <div className="relative p-6 md:p-8">
               <div className="flex items-start gap-4 md:gap-6">
                 {/* Badge numéro avec animation pulse */}
-                <div className="flex-shrink-0">
+                <div className="shrink-0">
                   <div className="relative">
                     <div className="absolute inset-0 bg-blue-500 rounded-full blur-xl opacity-30 animate-pulse"></div>
                     <div className="relative w-16 h-16 md:w-20 md:h-20 bg-gradient-to-br from-blue-500 to-blue-700 text-white rounded-full flex items-center justify-center shadow-xl">
@@ -95,7 +95,7 @@ export function PurchaseGuide({
                   {/* Highlight box avec icône */}
                   <div className="bg-gradient-to-r from-blue-100 to-blue-50 p-4 rounded-r-lg mb-5 shadow-sm">
                     <div className="flex items-center gap-3">
-                      <Shield className="w-6 h-6 text-blue-600 flex-shrink-0" />
+                      <Shield className="w-6 h-6 text-blue-600 shrink-0" />
                       <p className="text-sm md:text-base font-semibold text-blue-900">
                         {categoryData.step1.highlight}
                       </p>
@@ -109,7 +109,7 @@ export function PurchaseGuide({
                         key={idx}
                         className="flex items-start gap-3 text-gray-700 group"
                       >
-                        <div className="flex-shrink-0 w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center mt-0.5 shadow-md group-hover:scale-110 transition-transform">
+                        <div className="shrink-0 w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center mt-0.5 shadow-md group-hover:scale-110 transition-transform">
                           <CheckCircle2 className="w-4 h-4 text-white" />
                         </div>
                         <span className="text-base leading-relaxed">
@@ -131,7 +131,7 @@ export function PurchaseGuide({
               {/* Header de l'étape */}
               <div className="mb-3">
                 <div className="flex items-start gap-4 md:gap-6">
-                  <div className="flex-shrink-0">
+                  <div className="shrink-0">
                     <div className="relative">
                       <div className="absolute inset-0 bg-green-500 rounded-full blur-xl opacity-30 animate-pulse"></div>
                       <div className="relative w-16 h-16 md:w-20 md:h-20 bg-gradient-to-br from-green-500 to-green-700 text-white rounded-full flex items-center justify-center shadow-xl">
@@ -155,7 +155,7 @@ export function PurchaseGuide({
                     {/* Highlight box avec icône */}
                     <div className="bg-gradient-to-r from-green-100 to-green-50 p-4 rounded-r-lg shadow-sm">
                       <div className="flex items-center gap-3">
-                        <CheckCircle2 className="w-6 h-6 text-green-600 flex-shrink-0" />
+                        <CheckCircle2 className="w-6 h-6 text-green-600 shrink-0" />
                         <p className="text-sm md:text-base font-semibold text-green-900">
                           Toutes nos gammes sont certifiées et garantissent
                           votre sécurité
@@ -343,7 +343,7 @@ export function PurchaseGuide({
                     style={{ animationDelay: "100ms" }}
                   >
                     <div
-                      className={`w-12 h-12 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full flex items-center justify-center shadow-lg flex-shrink-0 ${
+                      className={`w-12 h-12 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full flex items-center justify-center shadow-lg shrink-0 ${
                         selectedRange === "economique"
                           ? "bg-gradient-to-br from-gray-100 to-gray-200"
                           : selectedRange === "qualite_plus"
@@ -408,7 +408,7 @@ export function PurchaseGuide({
                             className="flex items-start gap-3 p-3 bg-white rounded-lg border border-gray-100 hover:border-green-200 hover:shadow-sm transition-all animate-in fade-in slide-in-from-left-2 duration-300 fill-mode-both"
                             style={{ animationDelay: `${350 + idx * 50}ms` }}
                           >
-                            <div className="flex-shrink-0 w-2 h-2 bg-green-500 rounded-full mt-2"></div>
+                            <div className="shrink-0 w-2 h-2 bg-green-500 rounded-full mt-2"></div>
                             <span className="text-sm text-gray-700 leading-relaxed">
                               {spec}
                             </span>
@@ -443,7 +443,7 @@ export function PurchaseGuide({
           <div className="relative bg-gradient-to-br from-red-50 via-white to-red-50/50 rounded-2xl shadow-lg border border-red-200/50 overflow-hidden">
             <div className="relative p-6 md:p-8">
               <div className="flex items-start gap-4 md:gap-6">
-                <div className="flex-shrink-0">
+                <div className="shrink-0">
                   <div className="relative">
                     <div className="absolute inset-0 bg-red-500 rounded-full blur-xl opacity-30 animate-pulse"></div>
                     <div className="relative w-16 h-16 md:w-20 md:h-20 bg-gradient-to-br from-red-500 to-red-700 text-white rounded-full flex items-center justify-center shadow-xl">
@@ -485,7 +485,7 @@ export function PurchaseGuide({
                           <div className="flex items-start gap-3">
                             {/* Icône avec gradient de la famille */}
                             <div
-                              className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center shadow-md bg-gradient-to-br ${familleColor}`}
+                              className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center shadow-md bg-gradient-to-br ${familleColor}`}
                             >
                               {alert.type === "danger" ? (
                                 <AlertTriangle className="w-5 h-5 text-white" />

--- a/frontend/app/components/checkout/CheckoutOrderSummary.tsx
+++ b/frontend/app/components/checkout/CheckoutOrderSummary.tsx
@@ -61,7 +61,7 @@ export function CheckoutOrderSummary({
       {/* Vehicle context */}
       {vehicleLabel && (
         <div className="flex items-center gap-2.5 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3">
-          <Car className="h-4 w-4 text-emerald-600 flex-shrink-0" />
+          <Car className="h-4 w-4 text-emerald-600 shrink-0" />
           <div className="min-w-0">
             <p className="text-sm font-medium text-slate-800 truncate">
               {vehicleLabel}
@@ -78,7 +78,7 @@ export function CheckoutOrderSummary({
 
       {/* Delivery ETA */}
       <div className="flex items-start gap-2.5 rounded-xl border border-blue-100 bg-blue-50 px-4 py-3">
-        <Truck className="h-4 w-4 text-blue-600 flex-shrink-0 mt-0.5" />
+        <Truck className="h-4 w-4 text-blue-600 shrink-0 mt-0.5" />
         <div className="text-sm">
           <p className="font-medium text-slate-800">
             Livraison estimee {deliveryETA.formattedRange}
@@ -141,14 +141,14 @@ export function CheckoutOrderSummary({
           {/* Contextual reassurance messages */}
           <div className="mt-2 space-y-1">
             <p className="flex items-center gap-1.5 text-xs text-emerald-600">
-              <Package className="h-3 w-3 flex-shrink-0" />
+              <Package className="h-3 w-3 shrink-0" />
               {cart.items.length} article{cart.items.length > 1 ? "s" : ""} pret
               {cart.items.length > 1 ? "s" : ""} a etre expedie
               {cart.items.length > 1 ? "s" : ""}
             </p>
             {vehicleLabel && (
               <p className="flex items-center gap-1.5 text-xs text-emerald-600">
-                <CheckCircle className="h-3 w-3 flex-shrink-0" />
+                <CheckCircle className="h-3 w-3 shrink-0" />
                 Pieces compatibles avec votre vehicule
               </p>
             )}
@@ -177,7 +177,7 @@ export function CheckoutOrderSummary({
           {cart.items.map((item: CartItemType) => (
             <div key={item.id} className="flex items-start gap-3">
               {/* Product thumbnail */}
-              <div className="w-10 h-10 rounded-lg border border-slate-200 bg-slate-50 flex-shrink-0 overflow-hidden">
+              <div className="w-10 h-10 rounded-lg border border-slate-200 bg-slate-50 shrink-0 overflow-hidden">
                 {item.product_image ? (
                   <img
                     src={item.product_image}
@@ -223,7 +223,7 @@ export function CheckoutOrderSummary({
                   Qte {item.quantity}
                 </p>
               </div>
-              <span className="text-sm font-medium text-slate-900 flex-shrink-0">
+              <span className="text-sm font-medium text-slate-900 shrink-0">
                 {formatPrice(item.price * item.quantity)}
               </span>
             </div>
@@ -257,19 +257,19 @@ export function CheckoutOrderSummary({
       {/* Trust badges — 4 columns */}
       <div className="mt-4 rounded-xl border p-3 grid grid-cols-2 gap-2 text-xs text-gray-600">
         <span className="flex items-center gap-1.5">
-          <Truck className="h-4 w-4 text-blue-600 flex-shrink-0" />
+          <Truck className="h-4 w-4 text-blue-600 shrink-0" />
           Expedition 24-48h
         </span>
         <span className="flex items-center gap-1.5">
-          <Shield className="h-4 w-4 text-green-600 flex-shrink-0" />
+          <Shield className="h-4 w-4 text-green-600 shrink-0" />
           Paiement securise
         </span>
         <span className="flex items-center gap-1.5">
-          <CreditCard className="h-4 w-4 text-foreground flex-shrink-0" />
+          <CreditCard className="h-4 w-4 text-foreground shrink-0" />
           3D Secure
         </span>
         <span className="flex items-center gap-1.5">
-          <RotateCcw className="h-4 w-4 text-orange-500 flex-shrink-0" />
+          <RotateCcw className="h-4 w-4 text-orange-500 shrink-0" />
           Retours 30 jours
         </span>
       </div>

--- a/frontend/app/components/checkout/CheckoutPaiementSection.tsx
+++ b/frontend/app/components/checkout/CheckoutPaiementSection.tsx
@@ -143,7 +143,7 @@ export function CheckoutPaiementSection({
       <div className="bg-gradient-to-br from-emerald-50 to-teal-50 border border-emerald-200 rounded-xl p-4">
         <div className="flex items-center gap-3">
           <svg
-            className="h-5 w-5 text-emerald-600 flex-shrink-0"
+            className="h-5 w-5 text-emerald-600 shrink-0"
             fill="currentColor"
             viewBox="0 0 20 20"
           >
@@ -169,7 +169,7 @@ export function CheckoutPaiementSection({
       {vehicleLabel && (
         <div className="flex items-center gap-2 rounded-lg bg-emerald-50 border border-emerald-100 px-3 py-2">
           <svg
-            className="h-4 w-4 text-emerald-600 flex-shrink-0"
+            className="h-4 w-4 text-emerald-600 shrink-0"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"

--- a/frontend/app/components/checkout/FreeShippingBar.tsx
+++ b/frontend/app/components/checkout/FreeShippingBar.tsx
@@ -26,7 +26,7 @@ export function FreeShippingBar({
     return (
       <div className="rounded-xl p-3 bg-gradient-to-r from-emerald-500 via-emerald-600 to-teal-500 text-white shadow-sm">
         <div className="flex items-center gap-2">
-          <Truck className="h-4 w-4 flex-shrink-0" />
+          <Truck className="h-4 w-4 shrink-0" />
           <p className="font-bold text-sm flex-1">Livraison OFFERTE</p>
           <span className="text-xs bg-white/20 px-2 py-0.5 rounded-full">
             0,00&nbsp;&euro;
@@ -45,7 +45,7 @@ export function FreeShippingBar({
   return (
     <div className="rounded-xl p-3 bg-white border border-slate-200">
       <div className="flex items-center gap-2 mb-2">
-        <Truck className="h-4 w-4 text-cta flex-shrink-0" />
+        <Truck className="h-4 w-4 text-cta shrink-0" />
         <p className="text-xs text-slate-700 flex-1">
           Plus que{" "}
           <strong className="text-cta">{formatPrice(remaining)}</strong> pour la

--- a/frontend/app/components/constructeurs/BrandPartsSection.tsx
+++ b/frontend/app/components/constructeurs/BrandPartsSection.tsx
@@ -40,7 +40,7 @@ export default function BrandPartsSection({
 
         <div className="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <div className="flex-shrink-0 w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center backdrop-blur-sm shadow-lg">
+            <div className="shrink-0 w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center backdrop-blur-sm shadow-lg">
               <Package className="w-7 h-7 text-white" />
             </div>
             <div>

--- a/frontend/app/components/constructeurs/PopularGammesSection.tsx
+++ b/frontend/app/components/constructeurs/PopularGammesSection.tsx
@@ -159,7 +159,7 @@ export function PopularGammesSection({
                 >
                   {/* Image ou icône */}
                   <div
-                    className="flex-shrink-0 w-14 h-14 md:w-16 md:h-16 mr-3 md:mr-4 
+                    className="shrink-0 w-14 h-14 md:w-16 md:h-16 mr-3 md:mr-4 
                                 rounded-lg bg-gray-100 flex items-center justify-center overflow-hidden"
                   >
                     {imageUrl ? (

--- a/frontend/app/components/constructeurs/VehicleCard.tsx
+++ b/frontend/app/components/constructeurs/VehicleCard.tsx
@@ -160,14 +160,14 @@ const VehicleCard: React.FC<VehicleCardProps> = ({
           <div className="grid grid-cols-2 gap-3 text-sm">
             {/* 🗓️ Période */}
             <div className="flex items-center space-x-2 text-gray-600">
-              <Calendar className="w-4 h-4 flex-shrink-0" />
+              <Calendar className="w-4 h-4 shrink-0" />
               <span className="truncate">{dateRange}</span>
             </div>
 
             {/* ⛽ Carburant */}
             {vehicle.type_fuel && (
               <div className="flex items-center space-x-2 text-gray-600">
-                <Fuel className="w-4 h-4 flex-shrink-0" />
+                <Fuel className="w-4 h-4 shrink-0" />
                 <span className="truncate">{vehicle.type_fuel}</span>
               </div>
             )}
@@ -175,7 +175,7 @@ const VehicleCard: React.FC<VehicleCardProps> = ({
             {/* 🔧 Cylindrée */}
             {vehicle.type_liter && (
               <div className="flex items-center space-x-2 text-gray-600">
-                <Car className="w-4 h-4 flex-shrink-0" />
+                <Car className="w-4 h-4 shrink-0" />
                 <span className="truncate">{vehicle.type_liter}L</span>
               </div>
             )}
@@ -183,7 +183,7 @@ const VehicleCard: React.FC<VehicleCardProps> = ({
             {/* ⚡ Puissance (si pas déjà affichée en badge) */}
             {vehicle.type_power_ps && (
               <div className="flex items-center space-x-2 text-gray-600">
-                <Zap className="w-4 h-4 flex-shrink-0" />
+                <Zap className="w-4 h-4 shrink-0" />
                 <span className="truncate">{vehicle.type_power_ps} PS</span>
               </div>
             )}

--- a/frontend/app/components/diagnostic-wizard/results/ActionCard.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/ActionCard.tsx
@@ -89,7 +89,7 @@ export function ActionCard({
           : "border"
       }`}
     >
-      <Icon className="h-6 w-6 flex-shrink-0 text-primary" aria-hidden />
+      <Icon className="h-6 w-6 shrink-0 text-primary" aria-hidden />
       <div className="flex-1">
         <p className="font-medium">{label}</p>
         <p className="text-xs text-muted-foreground">

--- a/frontend/app/components/diagnostic-wizard/results/HumanEscalationCard.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/HumanEscalationCard.tsx
@@ -59,12 +59,12 @@ export function HumanEscalationCard({
     >
       {escalation.priority_boost ? (
         <AlertCircle
-          className="h-6 w-6 flex-shrink-0 text-amber-600"
+          className="h-6 w-6 shrink-0 text-amber-600"
           aria-hidden
         />
       ) : (
         <UserRound
-          className="h-6 w-6 flex-shrink-0 text-muted-foreground"
+          className="h-6 w-6 shrink-0 text-muted-foreground"
           aria-hidden
         />
       )}

--- a/frontend/app/components/diagnostic-wizard/results/ResultCatalog.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/ResultCatalog.tsx
@@ -101,7 +101,7 @@ export function ResultCatalog({ catalogGuard }: Props) {
                       {g.confidence}
                     </Badge>
                   </div>
-                  <ExternalLink className="w-4 h-4 text-gray-400 group-hover:text-blue-500 flex-shrink-0" />
+                  <ExternalLink className="w-4 h-4 text-gray-400 group-hover:text-blue-500 shrink-0" />
                 </a>
               ))}
             </div>

--- a/frontend/app/components/diagnostic-wizard/results/ResultHypotheses.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/ResultHypotheses.tsx
@@ -72,7 +72,7 @@ export function ResultHypotheses({ hypotheses }: Props) {
               >
                 {/* Rank */}
                 <span
-                  className={`flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold flex-shrink-0 ${
+                  className={`flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold shrink-0 ${
                     isTop
                       ? "bg-blue-600 text-white"
                       : "bg-gray-100 text-white border border-gray-200"
@@ -181,7 +181,7 @@ export function ResultHypotheses({ hypotheses }: Props) {
                   {/* Verification method */}
                   {h.verification_method && (
                     <div className="flex items-start gap-2 p-2 rounded bg-amber-50 border border-amber-100">
-                      <Wrench className="w-3.5 h-3.5 mt-0.5 text-amber-600 flex-shrink-0" />
+                      <Wrench className="w-3.5 h-3.5 mt-0.5 text-amber-600 shrink-0" />
                       <div>
                         <p className="text-xs font-medium text-amber-800">
                           Vérification recommandée

--- a/frontend/app/components/diagnostic-wizard/results/ResultSafety.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/ResultSafety.tsx
@@ -49,7 +49,7 @@ export function ResultSafety({ riskLevel, riskFlags, safetyAlert }: Props) {
       role="alert"
     >
       <div className="flex items-start gap-3">
-        <ShieldAlert className={`w-6 h-6 flex-shrink-0 mt-0.5 ${style.icon}`} />
+        <ShieldAlert className={`w-6 h-6 shrink-0 mt-0.5 ${style.icon}`} />
         <div className="space-y-1">
           <h3 className={`font-semibold text-sm ${style.text}`}>
             {riskLevel === "critical"
@@ -68,7 +68,7 @@ export function ResultSafety({ riskLevel, riskFlags, safetyAlert }: Props) {
         {riskFlags.map((flag, i) => (
           <li key={i} className="flex items-start gap-2 text-sm">
             <AlertTriangle
-              className={`w-3.5 h-3.5 mt-0.5 flex-shrink-0 ${style.icon}`}
+              className={`w-3.5 h-3.5 mt-0.5 shrink-0 ${style.icon}`}
             />
             <span className={style.text}>{flag}</span>
           </li>

--- a/frontend/app/components/diagnostic-wizard/results/ResultSummary.tsx
+++ b/frontend/app/components/diagnostic-wizard/results/ResultSummary.tsx
@@ -60,7 +60,7 @@ export function ResultSummary({
                 key={i}
                 className="flex items-start gap-2 text-sm text-gray-700"
               >
-                <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 text-green-500 flex-shrink-0" />
+                <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 text-green-500 shrink-0" />
                 {fact}
               </li>
             ))}

--- a/frontend/app/components/diagnostic-wizard/steps/StepSymptom.tsx
+++ b/frontend/app/components/diagnostic-wizard/steps/StepSymptom.tsx
@@ -164,7 +164,7 @@ export function StepSymptom({ state, dispatch }: Props) {
                 }`}
               >
                 <Cog
-                  className={`w-5 h-5 mt-0.5 flex-shrink-0 ${
+                  className={`w-5 h-5 mt-0.5 shrink-0 ${
                     active ? "text-blue-600" : "text-gray-400"
                   }`}
                 />
@@ -295,7 +295,7 @@ export function StepSymptom({ state, dispatch }: Props) {
                     }`}
                   >
                     <div
-                      className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center flex-shrink-0 ${
+                      className={`mt-0.5 w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 ${
                         selected
                           ? "border-blue-500 bg-blue-500"
                           : "border-gray-300"

--- a/frontend/app/components/ecommerce/ConversionButton.tsx
+++ b/frontend/app/components/ecommerce/ConversionButton.tsx
@@ -222,9 +222,9 @@ export function ConversionButton({
       </>
     ) : (
       <>
-        {iconLeft && <span className="flex-shrink-0">{iconLeft}</span>}
+        {iconLeft && <span className="shrink-0">{iconLeft}</span>}
         <span>{children}</span>
-        {iconRight && <span className="flex-shrink-0">{iconRight}</span>}
+        {iconRight && <span className="shrink-0">{iconRight}</span>}
       </>
     );
 

--- a/frontend/app/components/ecommerce/TechnicalReference.tsx
+++ b/frontend/app/components/ecommerce/TechnicalReference.tsx
@@ -198,7 +198,7 @@ export function TechnicalSpec({
       className={`flex items-center justify-between px-4 py-3 rounded-lg ${importanceColors[importance]}`}
     >
       <div className="flex items-center gap-3">
-        {icon && <div className="text-xl flex-shrink-0">{icon}</div>}
+        {icon && <div className="text-xl shrink-0">{icon}</div>}
 
         <div>
           <p className="text-sm font-sans font-medium text-gray-500">{label}</p>
@@ -476,7 +476,7 @@ export function SimplifiedExplanation({
 }: SimplifiedExplanationProps) {
   return (
     <div className="flex gap-3 p-4 bg-blue-50 border-secondary-500 rounded-lg">
-      <div className="flex-shrink-0 text-2xl">{icon}</div>
+      <div className="shrink-0 text-2xl">{icon}</div>
 
       <div className="flex-1">
         <p className="text-sm font-sans font-semibold text-secondary-500 mb-1">

--- a/frontend/app/components/ecommerce/TrustPage.tsx
+++ b/frontend/app/components/ecommerce/TrustPage.tsx
@@ -397,7 +397,7 @@ const CustomerReviewCard: React.FC<{ review: CustomerReview }> = ({ review }) =>
       {/* Header: Avatar + Nom + Date */}
       <div className="flex items-start gap-sm mb-md">
         {/* Avatar */}
-        <div className="w-12 h-12 rounded-full bg-neutral-200 flex items-center justify-center flex-shrink-0 overflow-hidden">
+        <div className="w-12 h-12 rounded-full bg-neutral-200 flex items-center justify-center shrink-0 overflow-hidden">
           {review.customerPhoto ? (
             <img
               src={review.customerPhoto}

--- a/frontend/app/components/ecommerce/VehicleCompatibilityBanner.tsx
+++ b/frontend/app/components/ecommerce/VehicleCompatibilityBanner.tsx
@@ -94,7 +94,7 @@ export const VehicleCompatibilityBanner: React.FC<VehicleCompatibilityBannerProp
           {/* Message principal */}
           <div className="flex items-center gap-sm flex-1 min-w-0">
             {/* Icône */}
-            <span className="text-2xl flex-shrink-0" aria-hidden="true">
+            <span className="text-2xl shrink-0" aria-hidden="true">
               {iconEmoji}
             </span>
 
@@ -129,7 +129,7 @@ export const VehicleCompatibilityBanner: React.FC<VehicleCompatibilityBannerProp
                 font-heading text-sm
                 px-md py-sm rounded-md
                 transition-colors duration-200
-                flex-shrink-0
+                shrink-0
                 border border-transparent hover:border-neutral-300
               "
               aria-label="Changer de véhicule"

--- a/frontend/app/components/errors/ErrorGeneric.tsx
+++ b/frontend/app/components/errors/ErrorGeneric.tsx
@@ -120,7 +120,7 @@ export const ErrorGeneric = memo(function ErrorGeneric({
                   className={`mt-4 p-4 ${colorMap[color].bg} border ${colorMap[color].border} rounded-md`}
                 >
                   <div className="flex">
-                    <div className="flex-shrink-0">
+                    <div className="shrink-0">
                       <svg
                         className={`h-5 w-5 ${colorMap[color].icon}`}
                         viewBox="0 0 20 20"

--- a/frontend/app/components/errors/PopularCategories.tsx
+++ b/frontend/app/components/errors/PopularCategories.tsx
@@ -106,7 +106,7 @@ export const PopularCategories = memo(function PopularCategories({
               to={category.href}
               className="group flex items-center gap-3 p-4 bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-md hover:border-primary/30 hover:bg-primary/5 transition-all duration-200"
             >
-              <div className="flex-shrink-0 w-10 h-10 flex items-center justify-center bg-primary/10 text-primary rounded-lg group-hover:bg-primary group-hover:text-white transition-colors duration-200">
+              <div className="shrink-0 w-10 h-10 flex items-center justify-center bg-primary/10 text-primary rounded-lg group-hover:bg-primary group-hover:text-white transition-colors duration-200">
                 <Icon className="w-5 h-5" />
               </div>
               <div className="min-w-0">

--- a/frontend/app/components/expert/CompatibilityBadgeV2.tsx
+++ b/frontend/app/components/expert/CompatibilityBadgeV2.tsx
@@ -114,7 +114,7 @@ function VehicleDisplay({ vehicle }: { vehicle: VehicleInfoV2 }) {
 
   return (
     <div className="flex items-center gap-1.5 text-sm">
-      <Car className="h-3.5 w-3.5 flex-shrink-0" />
+      <Car className="h-3.5 w-3.5 shrink-0" />
       <span className="truncate max-w-[180px] sm:max-w-[250px]">
         {displayText}
       </span>

--- a/frontend/app/components/expert/CompatibilityResolverModal.tsx
+++ b/frontend/app/components/expert/CompatibilityResolverModal.tsx
@@ -84,7 +84,7 @@ function HelpCard({
   return (
     <div className="bg-slate-50 rounded-lg p-3 border border-slate-200">
       <div className="flex items-start gap-2">
-        <Info className="h-4 w-4 text-slate-400 mt-0.5 flex-shrink-0" />
+        <Info className="h-4 w-4 text-slate-400 mt-0.5 shrink-0" />
         <div>
           <div className="text-xs font-medium text-slate-700">{title}</div>
           <div className="text-xs text-slate-500 mt-0.5">{description}</div>

--- a/frontend/app/components/expert/CompatibilitySheetV2.tsx
+++ b/frontend/app/components/expert/CompatibilitySheetV2.tsx
@@ -285,7 +285,7 @@ function VehicleCardV2({
         <div className="mt-3 pt-3 border-t border-slate-100 space-y-1">
           {vehicle.cnit && (
             <div className="flex items-center justify-between text-xs gap-2">
-              <span className="text-slate-400 flex-shrink-0">CNIT</span>
+              <span className="text-slate-400 shrink-0">CNIT</span>
               <code
                 className="text-slate-600 bg-slate-50 px-1.5 py-0.5 rounded break-all text-right"
                 style={{ fontFamily: "'JetBrains Mono', monospace" }}
@@ -296,7 +296,7 @@ function VehicleCardV2({
           )}
           {vehicle.typeMine && (
             <div className="flex items-center justify-between text-xs gap-2">
-              <span className="text-slate-400 flex-shrink-0">Type Mine</span>
+              <span className="text-slate-400 shrink-0">Type Mine</span>
               <code
                 className="text-slate-600 bg-slate-50 px-1.5 py-0.5 rounded break-all text-right"
                 style={{ fontFamily: "'JetBrains Mono', monospace" }}

--- a/frontend/app/components/expert/TrustRowV2.tsx
+++ b/frontend/app/components/expert/TrustRowV2.tsx
@@ -195,7 +195,7 @@ function TrustBadgeV2Component({
       {/* Icon with pulse effect on highlight */}
       <div
         className={cn(
-          "flex-shrink-0 transition-transform duration-200",
+          "shrink-0 transition-transform duration-200",
           isHovered && "scale-110",
         )}
         style={{ color: colors.icon }}

--- a/frontend/app/components/gamme/GammeChecklist.tsx
+++ b/frontend/app/components/gamme/GammeChecklist.tsx
@@ -107,7 +107,7 @@ export default function GammeChecklist({
                 )}
                 <div className="flex items-center gap-2.5">
                   <div
-                    className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 transition-all ${
+                    className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 transition-all ${
                       ok
                         ? "bg-emerald-500 shadow-md shadow-emerald-200"
                         : "bg-blue-50"
@@ -139,7 +139,7 @@ export default function GammeChecklist({
 
       {checked.length === total && (
         <div className="mt-4 p-3.5 bg-emerald-50 border border-emerald-200 rounded-xl flex items-center gap-2.5 animate-subtle-fade-in">
-          <CheckCircle size={16} className="text-emerald-500 flex-shrink-0" />
+          <CheckCircle size={16} className="text-emerald-500 shrink-0" />
           <span className="text-[12px] font-semibold text-emerald-700">
             Tout validé — commandez en confiance.
           </span>

--- a/frontend/app/components/gamme/GammeContent.tsx
+++ b/frontend/app/components/gamme/GammeContent.tsx
@@ -106,11 +106,11 @@ export default function GammeContent({
             }`}
           >
             {tip.type === "info" ? (
-              <Info size={15} className="text-blue-500 mt-0.5 flex-shrink-0" />
+              <Info size={15} className="text-blue-500 mt-0.5 shrink-0" />
             ) : (
               <AlertTriangle
                 size={15}
-                className="text-amber-500 mt-0.5 flex-shrink-0"
+                className="text-amber-500 mt-0.5 shrink-0"
               />
             )}
             <p

--- a/frontend/app/components/gamme/GammeContent.tsx
+++ b/frontend/app/components/gamme/GammeContent.tsx
@@ -52,7 +52,7 @@ const FAMILY_TIPS: Record<string, { type: "info" | "warning"; text: string }> =
  *
  * NE gère PAS :
  * - Images R1 (gérées par la section dédiée dans pieces.$slug.tsx)
- * - "Pourquoi nous choisir" (déplacé vers R1TrustStrip)
+ * - Bloc de réassurance « nous choisir » (déplacé vers R1TrustStrip)
  * - Resource cards (déplacées vers GammeGuideCTA ou section séparée)
  */
 export default function GammeContent({

--- a/frontend/app/components/gamme/GammeDiagnosticCTA.tsx
+++ b/frontend/app/components/gamme/GammeDiagnosticCTA.tsx
@@ -9,7 +9,7 @@ export default function GammeDiagnosticCTA() {
       <div className="bg-white rounded-[24px] shadow-[0_14px_34px_rgba(15,23,42,0.08)] border border-orange-100 overflow-hidden">
         <div className="px-5 pt-4 pb-2 flex items-center justify-between">
           <div className="flex items-center gap-2.5">
-            <div className="w-9 h-9 lg:w-10 lg:h-10 rounded-lg bg-gradient-to-br from-orange-500 to-orange-600 flex items-center justify-center shadow-md shadow-orange-200 flex-shrink-0">
+            <div className="w-9 h-9 lg:w-10 lg:h-10 rounded-lg bg-gradient-to-br from-orange-500 to-orange-600 flex items-center justify-center shadow-md shadow-orange-200 shrink-0">
               <SearchCheck
                 size={17}
                 className="text-white animate-subtle-float"

--- a/frontend/app/components/gamme/GammeEquipementiers.tsx
+++ b/frontend/app/components/gamme/GammeEquipementiers.tsx
@@ -42,7 +42,7 @@ export default function GammeEquipementiers({
           <Reveal key={e.name} delay={i * 60}>
             <div className="bg-white/[0.05] border border-white/[0.08] rounded-[22px] p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] backdrop-blur-sm hover:bg-white/[0.08] hover:border-white/[0.15] transition-all group">
               <div className="flex items-center gap-3 mb-2.5">
-                <div className="w-11 h-11 lg:w-12 lg:h-12 rounded-xl bg-white/[0.08] flex items-center justify-center flex-shrink-0 group-hover:text-white group-hover:bg-white/[0.12] transition-all overflow-hidden">
+                <div className="w-11 h-11 lg:w-12 lg:h-12 rounded-xl bg-white/[0.08] flex items-center justify-center shrink-0 group-hover:text-white group-hover:bg-white/[0.12] transition-all overflow-hidden">
                   {e.logo ? (
                     <img
                       src={e.logo}

--- a/frontend/app/components/gamme/GammeErrors.tsx
+++ b/frontend/app/components/gamme/GammeErrors.tsx
@@ -38,7 +38,7 @@ export default function GammeErrors({
         {items.map((e, i) => (
           <Reveal key={i} delay={i * 60}>
             <div className="flex items-center gap-3 bg-white border border-red-100 rounded-[18px] px-4 py-3.5 shadow-[0_6px_18px_rgba(15,23,42,0.05)] hover:border-red-200 hover:shadow-lg transition-all group">
-              <div className="w-8 h-8 rounded-lg bg-red-50 flex items-center justify-center flex-shrink-0 group-hover:bg-red-500 transition-colors">
+              <div className="w-8 h-8 rounded-lg bg-red-50 flex items-center justify-center shrink-0 group-hover:bg-red-500 transition-colors">
                 <X
                   size={14}
                   className="text-red-500 group-hover:text-white transition-colors"

--- a/frontend/app/components/gamme/GammeFaq.tsx
+++ b/frontend/app/components/gamme/GammeFaq.tsx
@@ -45,7 +45,7 @@ export default function GammeFaq({ items, h2Override }: GammeFaqProps) {
                   className="w-full p-4 text-left flex items-center gap-3 text-[13px] font-semibold text-slate-800"
                 >
                   <div
-                    className={`w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 transition-colors ${
+                    className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 transition-colors ${
                       isOpen
                         ? "bg-blue-100 text-blue-600"
                         : "bg-slate-100 text-blue-900"
@@ -58,7 +58,7 @@ export default function GammeFaq({ items, h2Override }: GammeFaqProps) {
                   </span>
                   <Plus
                     size={16}
-                    className={`flex-shrink-0 transition-transform duration-300 ${
+                    className={`shrink-0 transition-transform duration-300 ${
                       isOpen ? "rotate-45 text-blue-500" : "text-slate-400"
                     }`}
                   />

--- a/frontend/app/components/gamme/GammeGuideCTA.tsx
+++ b/frontend/app/components/gamme/GammeGuideCTA.tsx
@@ -19,7 +19,7 @@ export default function GammeGuideCTA({
         to={`/blog-pieces-auto/conseils/${pgAlias}`}
         className="flex items-center gap-3.5 bg-slate-50 border border-slate-200 rounded-[22px] p-4 lg:p-5 shadow-[0_6px_18px_rgba(15,23,42,0.05)] hover:border-blue-200 hover:shadow-lg hover:-translate-y-0.5 transition-all group"
       >
-        <div className="w-11 h-11 lg:w-12 lg:h-12 rounded-xl bg-blue-50 border border-blue-100 flex items-center justify-center flex-shrink-0 group-hover:bg-blue-100 group-hover:scale-105 transition-all">
+        <div className="w-11 h-11 lg:w-12 lg:h-12 rounded-xl bg-blue-50 border border-blue-100 flex items-center justify-center shrink-0 group-hover:bg-blue-100 group-hover:scale-105 transition-all">
           <BookOpen size={20} className="text-blue-600" />
         </div>
         <div className="flex-1">
@@ -32,7 +32,7 @@ export default function GammeGuideCTA({
         </div>
         <ArrowRight
           size={14}
-          className="text-slate-300 group-hover:text-blue-500 group-hover:translate-x-0.5 transition-all flex-shrink-0"
+          className="text-slate-300 group-hover:text-blue-500 group-hover:translate-x-0.5 transition-all shrink-0"
         />
       </Link>
     </Section>

--- a/frontend/app/components/gamme/GammeHero.tsx
+++ b/frontend/app/components/gamme/GammeHero.tsx
@@ -75,7 +75,7 @@ export default function GammeHero({
       <div className="max-w-7xl mx-auto px-page pb-5 lg:pb-8">
         <div className="flex flex-col lg:flex-row lg:items-stretch lg:gap-8">
           {/* Product image */}
-          <div className="lg:w-[280px] lg:flex-shrink-0 flex">
+          <div className="lg:w-[280px] lg:shrink-0 flex">
             <div className="mx-0 mb-4 lg:mb-0 w-full max-h-[280px] bg-gradient-to-br from-white/[0.08] to-white/[0.03] border border-white/[0.12] rounded-2xl overflow-hidden flex items-center justify-center backdrop-blur-sm">
               {r1HeroPath || pgPic ? (
                 (() => {

--- a/frontend/app/components/guide/GuideParts.tsx
+++ b/frontend/app/components/guide/GuideParts.tsx
@@ -59,7 +59,7 @@ export function GuideParts({ section, pgAlias, pgId }: GuidePartsProps) {
               prefetch="intent"
               className="group flex items-center gap-3 px-4 py-3 bg-white rounded-lg border border-green-100 hover:border-green-300 hover:shadow-sm transition-all"
             >
-              <div className="flex-shrink-0 p-1.5 bg-green-100 rounded-md group-hover:bg-green-200 transition-colors">
+              <div className="shrink-0 p-1.5 bg-green-100 rounded-md group-hover:bg-green-200 transition-colors">
                 <Package className="w-4 h-4 text-green-700" />
               </div>
               <span className="flex-1 text-sm font-medium text-gray-800 group-hover:text-green-800 capitalize">

--- a/frontend/app/components/heroes/HeroDiagnostic.tsx
+++ b/frontend/app/components/heroes/HeroDiagnostic.tsx
@@ -60,7 +60,7 @@ export function HeroDiagnostic({
       <div className="container mx-auto px-4">
         <div className="max-w-4xl flex items-start gap-4">
           <div
-            className={`flex-shrink-0 p-3 rounded-xl ${styles.accentBg} border ${styles.border}`}
+            className={`shrink-0 p-3 rounded-xl ${styles.accentBg} border ${styles.border}`}
           >
             <Icon className={`w-6 h-6 md:w-7 md:h-7 ${styles.accent}`} />
           </div>

--- a/frontend/app/components/heroes/HeroRole.tsx
+++ b/frontend/app/components/heroes/HeroRole.tsx
@@ -61,7 +61,7 @@ export function HeroRole({
       <div className="relative container mx-auto px-4">
         <div className="max-w-4xl flex items-start gap-6">
           {/* Illustration ou icone */}
-          <div className="flex-shrink-0">
+          <div className="shrink-0">
             {illustration ? (
               <img
                 src={illustration.src}

--- a/frontend/app/components/home/BlogCarousel.tsx
+++ b/frontend/app/components/home/BlogCarousel.tsx
@@ -71,7 +71,7 @@ function CompactCard({ b }: { b: BlogArticle }) {
     <Link to={b.link || "#"} className="no-style no-visited lg:hidden group">
       <Card className="rounded-[20px] border overflow-hidden shadow-[0_6px_18px_rgba(15,23,42,0.05)] hover:shadow-lg transition-all duration-200 flex flex-row h-24">
         <div
-          className={`w-24 h-full flex-shrink-0 overflow-hidden ${b.img ? "bg-slate-100" : `bg-gradient-to-br ${gradient}`}`}
+          className={`w-24 h-full shrink-0 overflow-hidden ${b.img ? "bg-slate-100" : `bg-gradient-to-br ${gradient}`}`}
         >
           {b.img ? (
             <img

--- a/frontend/app/components/home/BrandsGrid.tsx
+++ b/frontend/app/components/home/BrandsGrid.tsx
@@ -88,7 +88,7 @@ export default function BrandsGrid({
               {[...equipList, ...equipList].map((e, i) => (
                 <div
                   key={`${e.name}-${i}`}
-                  className="flex-shrink-0 h-10 sm:h-12"
+                  className="shrink-0 h-10 sm:h-12"
                 >
                   <img
                     src={e.logo}

--- a/frontend/app/components/home/CatalogueSection.tsx
+++ b/frontend/app/components/home/CatalogueSection.tsx
@@ -247,7 +247,7 @@ export default function CatalogueSection({
                     value={domain.label}
                     className="group text-xs sm:text-[13px] px-3 sm:px-4 py-2.5 sm:py-2.5 rounded-lg whitespace-nowrap font-semibold flex items-center gap-1.5 min-h-[44px] text-slate-500 hover:text-slate-700 hover:bg-white/60 data-[state=active]:bg-white data-[state=active]:text-slate-900 data-[state=active]:shadow-sm data-[state=active]:ring-1 data-[state=active]:ring-slate-200"
                   >
-                    <DomainIcon className="w-3.5 h-3.5 flex-shrink-0 group-data-[state=active]:text-cta" />
+                    <DomainIcon className="w-3.5 h-3.5 shrink-0 group-data-[state=active]:text-cta" />
                     <span className="hidden sm:inline">{domain.label}</span>
                     <span className="sm:hidden">
                       {domain.label.split(" ")[0]}

--- a/frontend/app/components/home/FaqSection.tsx
+++ b/frontend/app/components/home/FaqSection.tsx
@@ -24,7 +24,7 @@ function FaqCards({ items }: { items: Array<{ q: string; a: string }> }) {
             className="rounded-[24px] border border-slate-200 bg-white p-5 shadow-[0_6px_18px_rgba(15,23,42,0.05)] transition-all duration-200 hover:border-slate-300 hover:shadow-lg"
           >
             <div className="flex items-start gap-4">
-              <div className="h-14 w-14 rounded-2xl bg-slate-50 flex items-center justify-center flex-shrink-0">
+              <div className="h-14 w-14 rounded-2xl bg-slate-50 flex items-center justify-center shrink-0">
                 <FaqIcon size={22} className="text-slate-500" />
               </div>
               <div className="flex-1 min-w-0">

--- a/frontend/app/components/home/Footer.tsx
+++ b/frontend/app/components/home/Footer.tsx
@@ -109,7 +109,7 @@ export default function Footer() {
               </h3>
               <ul className="space-y-3">
                 <li className="flex items-start gap-2.5">
-                  <MapPin size={16} className="text-cta flex-shrink-0 mt-0.5" />
+                  <MapPin size={16} className="text-cta shrink-0 mt-0.5" />
                   <span className="text-[13px] text-white/60">
                     184 avenue Aristide Briand
                     <br />
@@ -117,7 +117,7 @@ export default function Footer() {
                   </span>
                 </li>
                 <li className="flex items-center gap-2.5">
-                  <Phone size={16} className="text-cta flex-shrink-0" />
+                  <Phone size={16} className="text-cta shrink-0" />
                   <a
                     href={`tel:${SITE_CONFIG.contact.phone.raw}`}
                     className="text-[13px] text-white/60 hover:text-white transition-colors"
@@ -126,7 +126,7 @@ export default function Footer() {
                   </a>
                 </li>
                 <li className="flex items-center gap-2.5">
-                  <Mail size={16} className="text-cta flex-shrink-0" />
+                  <Mail size={16} className="text-cta shrink-0" />
                   <a
                     href={`mailto:${SITE_CONFIG.contact.email}`}
                     className="text-[13px] text-white/60 hover:text-white transition-colors"

--- a/frontend/app/components/home/QuickAccessGrid.tsx
+++ b/frontend/app/components/home/QuickAccessGrid.tsx
@@ -110,7 +110,7 @@ function ShortcutItem({
   );
 
   const cls = compact
-    ? "flex flex-shrink-0 items-center gap-2.5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 transition-colors hover:border-cta/30 hover:bg-orange-50 active:scale-[0.98] cursor-pointer"
+    ? "flex shrink-0 items-center gap-2.5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 transition-colors hover:border-cta/30 hover:bg-orange-50 active:scale-[0.98] cursor-pointer"
     : "group flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3.5 transition-all hover:border-cta/30 hover:bg-orange-50/50 hover:shadow-sm cursor-pointer";
 
   // Route link → <Link>

--- a/frontend/app/components/layout/GlobalSearch.tsx
+++ b/frontend/app/components/layout/GlobalSearch.tsx
@@ -501,7 +501,7 @@ export const GlobalSearch = memo(function GlobalSearch({
                           >
                             <div className="flex items-center space-x-3 flex-1 min-w-0">
                               <Icon
-                                className={`w-5 h-5 flex-shrink-0 ${
+                                className={`w-5 h-5 shrink-0 ${
                                   selectedIndex === globalIndex
                                     ? "text-blue-600"
                                     : "text-gray-400"

--- a/frontend/app/components/layout/NotificationCenter.tsx
+++ b/frontend/app/components/layout/NotificationCenter.tsx
@@ -382,7 +382,7 @@ export const NotificationCenter = memo(function NotificationCenter({
 
                         {/* Icône du type */}
                         <div
-                          className={`flex-shrink-0 mt-0.5 p-1 rounded-full bg-${typeColor}-100`}
+                          className={`shrink-0 mt-0.5 p-1 rounded-full bg-${typeColor}-100`}
                         >
                           <TypeIcon
                             className={`w-4 h-4 text-${typeColor}-600`}

--- a/frontend/app/components/layout/SectionHeader.tsx
+++ b/frontend/app/components/layout/SectionHeader.tsx
@@ -47,7 +47,7 @@ export default function SectionHeader({
       {linkText && linkHref && (
         <Link
           to={linkHref}
-          className="flex items-center gap-1 text-sm font-semibold text-cta whitespace-nowrap flex-shrink-0"
+          className="flex items-center gap-1 text-sm font-semibold text-cta whitespace-nowrap shrink-0"
         >
           {linkText} <ArrowRight className="w-3.5 h-3.5" />
         </Link>

--- a/frontend/app/components/layout/templates/Gallery.tsx
+++ b/frontend/app/components/layout/templates/Gallery.tsx
@@ -59,7 +59,7 @@ export const Gallery: React.FC<GalleryProps> = memo(function Gallery({
 
                 {/* Overlay avec caption */}
                 {image.caption && (
-                  <div className="absolute inset-0 bg-neutral-900 bg-opacity-0 group-hover:bg-opacity-60 transition-all duration-300 flex items-end">
+                  <div className="absolute inset-0 bg-neutral-900/0 group-hover:bg-neutral-900/60 transition-all duration-300 flex items-end">
                     <p className="text-white p-4 transform translate-y-full group-hover:translate-y-0 transition-transform duration-300">
                       {image.caption}
                     </p>

--- a/frontend/app/components/model/ModelContentV1Display.tsx
+++ b/frontend/app/components/model/ModelContentV1Display.tsx
@@ -106,7 +106,7 @@ export const ModelContentV1Display = memo(function ModelContentV1Display({
       >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="flex-shrink-0 w-10 h-10 bg-white/20 rounded-lg flex items-center justify-center backdrop-blur-sm">
+            <div className="shrink-0 w-10 h-10 bg-white/20 rounded-lg flex items-center justify-center backdrop-blur-sm">
               <Book className="w-5 h-5 text-white" />
             </div>
             <div>

--- a/frontend/app/components/pieces/CatalogueSection.tsx
+++ b/frontend/app/components/pieces/CatalogueSection.tsx
@@ -210,7 +210,7 @@ const CatalogueSection = memo(function CatalogueSection({
               >
                 <div className="flex flex-col h-full">
                   <div className="flex items-start gap-3 mb-2">
-                    <div className="relative flex-shrink-0">
+                    <div className="relative shrink-0">
                       <img
                         src={item.image}
                         alt={`${item.name} — ${catalogueMameFamille.title}`}
@@ -234,7 +234,7 @@ const CatalogueSection = memo(function CatalogueSection({
                           const badge = getUrgencyBadge(item.name);
                           return badge ? (
                             <span
-                              className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full whitespace-nowrap flex-shrink-0 ${badge.color}`}
+                              className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full whitespace-nowrap shrink-0 ${badge.color}`}
                             >
                               {badge.label}
                             </span>

--- a/frontend/app/components/pieces/CompatibilityConfirmationBlock.tsx
+++ b/frontend/app/components/pieces/CompatibilityConfirmationBlock.tsx
@@ -81,7 +81,7 @@ export const CompatibilityConfirmationBlock = memo(
     if (!selectedVehicle) {
       return (
         <div className="flex items-start gap-4 rounded-xl border border-blue-200 bg-blue-50 p-5">
-          <Car className="mt-0.5 h-6 w-6 flex-shrink-0 text-blue-600" />
+          <Car className="mt-0.5 h-6 w-6 shrink-0 text-blue-600" />
           <div className="flex-1">
             <p className="font-semibold text-blue-900">
               Sélectionnez votre véhicule pour vérifier la compatibilité
@@ -115,7 +115,7 @@ export const CompatibilityConfirmationBlock = memo(
 
       return (
         <div className="flex items-start gap-4 rounded-xl border border-emerald-200 bg-emerald-50 p-5">
-          <ShieldCheck className="mt-0.5 h-6 w-6 flex-shrink-0 text-emerald-600" />
+          <ShieldCheck className="mt-0.5 h-6 w-6 shrink-0 text-emerald-600" />
           <div className="flex-1">
             <p className="font-semibold text-emerald-900">
               Compatibilité garantie pour votre {vehicleName}
@@ -126,7 +126,7 @@ export const CompatibilityConfirmationBlock = memo(
                   key={proof}
                   className="flex items-start gap-2 text-sm text-emerald-800"
                 >
-                  <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-500" />
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
                   <span>{proof}</span>
                 </li>
               ))}
@@ -157,7 +157,7 @@ export const CompatibilityConfirmationBlock = memo(
     // ── État 2 : Non confirmé (ambre) ──
     return (
       <div className="flex items-start gap-4 rounded-xl border border-amber-200 bg-amber-50 p-5">
-        <ShieldQuestion className="mt-0.5 h-6 w-6 flex-shrink-0 text-amber-600" />
+        <ShieldQuestion className="mt-0.5 h-6 w-6 shrink-0 text-amber-600" />
         <div className="flex-1">
           <p className="font-semibold text-amber-900">
             Votre {vehicleName} n&apos;apparaît pas dans les motorisations

--- a/frontend/app/components/pieces/ConseilsSection.tsx
+++ b/frontend/app/components/pieces/ConseilsSection.tsx
@@ -197,7 +197,7 @@ function ConseilCard({
     <div className="border border-gray-200 rounded-lg overflow-hidden hover:border-green-300 transition-colors">
       <div className="p-4">
         <h3 className="font-semibold text-gray-900 mb-3 flex items-center gap-2">
-          <span className="flex-shrink-0 w-7 h-7 rounded-full bg-green-100 text-green-700 flex items-center justify-center text-sm font-bold">
+          <span className="shrink-0 w-7 h-7 rounded-full bg-green-100 text-green-700 flex items-center justify-center text-sm font-bold">
             {conseil.id}
           </span>
           {conseil.title}

--- a/frontend/app/components/pieces/ContentGuidePills.tsx
+++ b/frontend/app/components/pieces/ContentGuidePills.tsx
@@ -38,7 +38,7 @@ export const ContentGuidePills = memo(function ContentGuidePills({
     >
       {/* Phrase universelle — 18 mots */}
       <div className="flex items-center gap-2 mb-3">
-        <HelpCircle className="w-4 h-4 text-gray-400 flex-shrink-0" />
+        <HelpCircle className="w-4 h-4 text-gray-400 shrink-0" />
         <p className="text-sm text-gray-600">
           Sélectionnez votre véhicule ci-dessus pour afficher uniquement les{" "}
           {lowerName} compatibles avec votre motorisation.

--- a/frontend/app/components/pieces/DecisionGridSection.tsx
+++ b/frontend/app/components/pieces/DecisionGridSection.tsx
@@ -148,7 +148,7 @@ export const DecisionGridSection = memo(function DecisionGridSection({
                   <div key={node.id} className="relative">
                     {/* Question */}
                     <div className="flex items-start gap-3 mb-2">
-                      <span className="flex-shrink-0 w-7 h-7 rounded-full bg-slate-700 text-white flex items-center justify-center text-xs font-bold mt-0.5">
+                      <span className="shrink-0 w-7 h-7 rounded-full bg-slate-700 text-white flex items-center justify-center text-xs font-bold mt-0.5">
                         {nodeIdx + 1}
                       </span>
                       <p className="font-medium text-slate-900 text-base leading-relaxed">
@@ -170,7 +170,7 @@ export const DecisionGridSection = memo(function DecisionGridSection({
                             key={optIdx}
                             className="flex items-start gap-2 text-sm"
                           >
-                            <ArrowRight className="w-4 h-4 text-slate-400 mt-0.5 flex-shrink-0" />
+                            <ArrowRight className="w-4 h-4 text-slate-400 mt-0.5 shrink-0" />
                             <div className="flex flex-wrap items-center gap-2">
                               <span className="font-medium text-slate-800">
                                 {opt.label}

--- a/frontend/app/components/pieces/EquipementiersSection.tsx
+++ b/frontend/app/components/pieces/EquipementiersSection.tsx
@@ -79,7 +79,7 @@ const EquipementiersSection = memo(function EquipementiersSection({
               className="group border border-gray-200 rounded-lg p-5 hover:border-orange-300 hover:shadow-md transition-all duration-200 block"
             >
               <div className="flex items-start space-x-4">
-                <div className="flex-shrink-0">
+                <div className="shrink-0">
                   <img
                     src={equipementier.pm_logo || equipementier.image}
                     alt={`Logo ${equipementier.pm_name}`}

--- a/frontend/app/components/pieces/GuideLinkCard.tsx
+++ b/frontend/app/components/pieces/GuideLinkCard.tsx
@@ -19,7 +19,7 @@ export function GuideLinkCard({ pgAlias, pgName }: GuideLinkCardProps) {
         prefetch="intent"
         className="group flex items-center gap-4 px-6 py-5 bg-white rounded-xl border border-violet-200 hover:border-violet-400 shadow-sm hover:shadow-md transition-all"
       >
-        <div className="flex-shrink-0 p-3 bg-muted rounded-lg group-hover:bg-muted transition-colors">
+        <div className="shrink-0 p-3 bg-muted rounded-lg group-hover:bg-muted transition-colors">
           <BookOpen className="w-6 h-6 text-foreground" />
         </div>
         <div className="flex-1 min-w-0">
@@ -30,7 +30,7 @@ export function GuideLinkCard({ pgAlias, pgName }: GuideLinkCardProps) {
             Symptômes, remplacement étape par étape, erreurs à éviter et FAQ
           </p>
         </div>
-        <ArrowRight className="w-5 h-5 text-gray-300 group-hover:text-foreground transition-colors flex-shrink-0" />
+        <ArrowRight className="w-5 h-5 text-gray-300 group-hover:text-foreground transition-colors shrink-0" />
       </Link>
     </div>
   );

--- a/frontend/app/components/pieces/InformationsSection.tsx
+++ b/frontend/app/components/pieces/InformationsSection.tsx
@@ -449,7 +449,7 @@ const InformationsSection = memo(function InformationsSection({
             des {pluralGammeName || "pièces"}
           </p>
           <p className="text-sm text-green-600 ml-10 mb-4 flex items-center gap-2">
-            <CheckCircle className="w-4 h-4 flex-shrink-0" />
+            <CheckCircle className="w-4 h-4 shrink-0" />
             <span>
               Nous filtrons selon votre véhicule et votre essieu (avant/arrière)
               pour éviter toute erreur de compatibilité.
@@ -458,7 +458,7 @@ const InformationsSection = memo(function InformationsSection({
           <div className="space-y-3 ml-10">
             {essentials.map((infoHtml, index) => (
               <div key={index} className="flex items-start gap-3">
-                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-green-500 text-white flex items-center justify-center text-sm font-bold shadow-sm">
+                <span className="shrink-0 w-6 h-6 rounded-full bg-green-500 text-white flex items-center justify-center text-sm font-bold shadow-sm">
                   {index + 1}
                 </span>
                 <HtmlContent

--- a/frontend/app/components/pieces/MotorisationsSection.tsx
+++ b/frontend/app/components/pieces/MotorisationsSection.tsx
@@ -99,7 +99,7 @@ const MotorisationsSection = memo(function MotorisationsSection({
         <div className="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             {/* Icône animée */}
-            <div className="flex-shrink-0 w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center backdrop-blur-sm shadow-lg">
+            <div className="shrink-0 w-12 h-12 bg-white/20 rounded-xl flex items-center justify-center backdrop-blur-sm shadow-lg">
               <Car className="w-7 h-7 text-white" />
             </div>
 
@@ -169,7 +169,7 @@ const MotorisationsSection = memo(function MotorisationsSection({
               <div className="relative p-5 md:p-6">
                 <div className="flex items-start gap-4">
                   {/* Image agrandie avec effet hover */}
-                  <div className="flex-shrink-0">
+                  <div className="shrink-0">
                     <div className="relative">
                       <div
                         className={`absolute inset-0 bg-gradient-to-br ${familleColor} rounded-xl opacity-0 group-hover:opacity-20 blur-xl transition-all duration-300`}

--- a/frontend/app/components/pieces/NoProductsAlternatives.tsx
+++ b/frontend/app/components/pieces/NoProductsAlternatives.tsx
@@ -164,7 +164,7 @@ export const NoProductsAlternatives = memo(function NoProductsAlternatives({
                         {v.type_name} · {v.type_power_ps}ch · {v.type_fuel}
                       </span>
                     </div>
-                    <ArrowRight className="w-4 h-4 text-gray-400 group-hover:text-blue-600 flex-shrink-0" />
+                    <ArrowRight className="w-4 h-4 text-gray-400 group-hover:text-blue-600 shrink-0" />
                   </Link>
                 ))}
               </div>
@@ -192,7 +192,7 @@ export const NoProductsAlternatives = memo(function NoProductsAlternatives({
                       <img
                         src={`https://img.automecanik.com/gamme/${g.pg_pic}`}
                         alt={g.pg_name}
-                        className="w-10 h-10 object-contain flex-shrink-0"
+                        className="w-10 h-10 object-contain shrink-0"
                         loading="lazy"
                         width={40}
                         height={40}
@@ -228,7 +228,7 @@ export const NoProductsAlternatives = memo(function NoProductsAlternatives({
                     <span className="text-sm font-medium text-gray-800 group-hover:text-foreground">
                       {m.marque_name} {m.modele_name}
                     </span>
-                    <ArrowRight className="w-4 h-4 text-gray-400 group-hover:text-foreground flex-shrink-0" />
+                    <ArrowRight className="w-4 h-4 text-gray-400 group-hover:text-foreground shrink-0" />
                   </Link>
                 ))}
               </div>

--- a/frontend/app/components/pieces/PieceDetailModal.tsx
+++ b/frontend/app/components/pieces/PieceDetailModal.tsx
@@ -358,7 +358,7 @@ export const PieceDetailModal = memo(function PieceDetailModal({
                                       className="bg-white rounded-lg px-4 py-3 border border-gray-200"
                                     >
                                       <div className="flex justify-between items-start gap-3">
-                                        <span className="text-sm font-semibold text-gray-700 flex-shrink-0">
+                                        <span className="text-sm font-semibold text-gray-700 shrink-0">
                                           {critere.name}
                                         </span>
                                         <span className="text-sm text-gray-900 font-medium text-right">
@@ -396,7 +396,7 @@ export const PieceDetailModal = memo(function PieceDetailModal({
                                 className="bg-white rounded-lg px-4 py-3 hover:shadow-md transition-shadow border border-gray-200"
                               >
                                 <div className="flex justify-between items-start gap-3">
-                                  <span className="text-sm font-semibold text-gray-700 flex-shrink-0">
+                                  <span className="text-sm font-semibold text-gray-700 shrink-0">
                                     {critere.name}
                                   </span>
                                   <span className="text-sm text-gray-900 font-medium text-right">

--- a/frontend/app/components/pieces/PiecesBuyingGuide.tsx
+++ b/frontend/app/components/pieces/PiecesBuyingGuide.tsx
@@ -154,7 +154,7 @@ export const PiecesBuyingGuide = memo(function PiecesBuyingGuide({
                     key={index}
                     className="flex items-start gap-3 bg-white/80 backdrop-blur-sm rounded-xl p-4 border border-amber-200/50"
                   >
-                    <span className="flex-shrink-0 w-6 h-6 bg-amber-100 rounded-full flex items-center justify-center">
+                    <span className="shrink-0 w-6 h-6 bg-amber-100 rounded-full flex items-center justify-center">
                       <svg
                         className="w-4 h-4 text-amber-600"
                         fill="currentColor"

--- a/frontend/app/components/pieces/PiecesCompatibilityInfo.tsx
+++ b/frontend/app/components/pieces/PiecesCompatibilityInfo.tsx
@@ -64,7 +64,7 @@ export const PiecesCompatibilityInfo = memo(function PiecesCompatibilityInfo({
 
         {/* Années de production */}
         <div className="flex items-start gap-4">
-          <div className="flex-shrink-0 w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
+          <div className="shrink-0 w-12 h-12 bg-muted rounded-lg flex items-center justify-center">
             <svg
               className="w-6 h-6 text-foreground"
               fill="none"
@@ -92,7 +92,7 @@ export const PiecesCompatibilityInfo = memo(function PiecesCompatibilityInfo({
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {motorCodesFormatted && (
               <div className="flex items-start gap-4 bg-gradient-to-br from-gray-50 to-slate-50 rounded-lg p-4 border border-gray-200">
-                <div className="flex-shrink-0 w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
+                <div className="shrink-0 w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
                   <svg
                     className="w-5 h-5 text-blue-600"
                     fill="none"
@@ -125,7 +125,7 @@ export const PiecesCompatibilityInfo = memo(function PiecesCompatibilityInfo({
             )}
             {mineCodesFormatted && (
               <div className="flex items-start gap-4 bg-gradient-to-br from-gray-50 to-slate-50 rounded-lg p-4 border border-gray-200">
-                <div className="flex-shrink-0 w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
+                <div className="shrink-0 w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
                   <svg
                     className="w-5 h-5 text-green-600"
                     fill="none"
@@ -200,7 +200,7 @@ export const PiecesCompatibilityInfo = memo(function PiecesCompatibilityInfo({
           <Alert className="rounded-lg p-5" variant="warning">
             <div className="flex items-start gap-3">
               <svg
-                className="w-5 h-5 text-yellow-600 mt-0.5 flex-shrink-0"
+                className="w-5 h-5 text-yellow-600 mt-0.5 shrink-0"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -244,7 +244,7 @@ export const PiecesCompatibilityInfo = memo(function PiecesCompatibilityInfo({
                 véhicule
               </p>
             </div>
-            <button className="flex-shrink-0 bg-white text-foreground px-4 py-2 rounded-lg font-medium hover:bg-info/20 transition-colors shadow-lg">
+            <button className="shrink-0 bg-white text-foreground px-4 py-2 rounded-lg font-medium hover:bg-info/20 transition-colors shadow-lg">
               Vérifier
             </button>
           </div>

--- a/frontend/app/components/pieces/PiecesCrossSelling.tsx
+++ b/frontend/app/components/pieces/PiecesCrossSelling.tsx
@@ -188,7 +188,7 @@ export const PiecesCrossSelling = memo(function PiecesCrossSelling({
         <div className="mt-6 p-4 bg-teal-50 rounded-lg border border-teal-200">
           <p className="text-xs text-teal-800 flex items-start gap-2">
             <svg
-              className="w-4 h-4 mt-0.5 flex-shrink-0"
+              className="w-4 h-4 mt-0.5 shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -260,7 +260,7 @@ export const PiecesCrossSellingCompact = memo(
                 to={url}
                 className="flex items-center gap-3 p-2 rounded-lg hover:bg-teal-50 transition-colors group"
               >
-                <div className="w-10 h-10 bg-gradient-to-br from-teal-100 to-cyan-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                <div className="w-10 h-10 bg-gradient-to-br from-teal-100 to-cyan-100 rounded-lg flex items-center justify-center shrink-0">
                   {gamme.PG_IMAGE ? (
                     <img
                       src={gamme.PG_IMAGE}

--- a/frontend/app/components/pieces/PiecesGridView.tsx
+++ b/frontend/app/components/pieces/PiecesGridView.tsx
@@ -284,10 +284,10 @@ const PieceCard = memo(function PieceCard({
       {/* Footer: Marque + Référence + Prix + Bouton */}
       <div className="p-2.5 pt-2 border-t border-slate-100 bg-gradient-to-b from-white to-slate-50/50">
         <div className="flex items-center gap-1.5 mb-2 min-w-0">
-          <span className="text-xs sm:text-sm font-bold text-slate-600 uppercase tracking-wide flex-shrink-0">
+          <span className="text-xs sm:text-sm font-bold text-slate-600 uppercase tracking-wide shrink-0">
             {piece.brand}
           </span>
-          <span className="text-slate-300 flex-shrink-0">|</span>
+          <span className="text-slate-300 shrink-0">|</span>
           <code className="text-sm sm:text-base font-mono font-bold text-foreground truncate">
             {piece.reference}
           </code>
@@ -501,7 +501,7 @@ export function PiecesGridView({
           <div className="inline-flex flex-col gap-2 text-sm text-left bg-card rounded-xl p-4 shadow-sm border border-border">
             <div className="flex items-start gap-2">
               <svg
-                className="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0"
+                className="w-4 h-4 text-blue-500 mt-0.5 shrink-0"
                 fill="currentColor"
                 viewBox="0 0 20 20"
               >
@@ -517,7 +517,7 @@ export function PiecesGridView({
             </div>
             <div className="flex items-start gap-2">
               <svg
-                className="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
+                className="w-4 h-4 text-primary mt-0.5 shrink-0"
                 fill="currentColor"
                 viewBox="0 0 20 20"
               >
@@ -533,7 +533,7 @@ export function PiecesGridView({
             </div>
             <div className="flex items-start gap-2">
               <svg
-                className="w-4 h-4 text-primary mt-0.5 flex-shrink-0"
+                className="w-4 h-4 text-primary mt-0.5 shrink-0"
                 fill="currentColor"
                 viewBox="0 0 20 20"
               >

--- a/frontend/app/components/pieces/PiecesListView.tsx
+++ b/frontend/app/components/pieces/PiecesListView.tsx
@@ -169,7 +169,7 @@ export const PiecesListView = React.memo(
                           ? `Désélectionner ${piece.name}`
                           : `Sélectionner ${piece.name}`
                       }
-                      className={`w-5 h-5 rounded-md border-2 flex-shrink-0 flex items-center justify-center transition-all mt-1 ${
+                      className={`w-5 h-5 rounded-md border-2 shrink-0 flex items-center justify-center transition-all mt-1 ${
                         isSelected
                           ? "bg-blue-600 border-blue-600 shadow-sm"
                           : "border-slate-300 hover:border-blue-400 hover:bg-blue-50"
@@ -192,7 +192,7 @@ export const PiecesListView = React.memo(
                   )}
 
                   {/* Image produit - responsive */}
-                  <div className="w-24 h-24 sm:w-32 sm:h-32 flex-shrink-0 bg-gradient-to-br from-slate-50 to-white rounded-xl overflow-hidden border border-slate-100 relative shadow-sm">
+                  <div className="w-24 h-24 sm:w-32 sm:h-32 shrink-0 bg-gradient-to-br from-slate-50 to-white rounded-xl overflow-hidden border border-slate-100 relative shadow-sm">
                     {piece.image &&
                     piece.image !== "/images/pieces/default.png" ? (
                       <img
@@ -309,7 +309,7 @@ export const PiecesListView = React.memo(
 
                   {/* Bouton panier - plus grand sur mobile */}
                   <button
-                    className={`w-12 h-12 sm:w-10 sm:h-10 rounded-xl sm:rounded-lg flex-shrink-0 flex items-center justify-center transition-all duration-200 ${ hasStock && !loadingItems.has(piece.id) ? "bg-gradient-to-r from-blue-600 hover:from-blue-700 hover: text-white shadow-md hover:shadow-lg hover:scale-110" : "bg-slate-100 text-slate-400 cursor-not-allowed" }`}
+                    className={`w-12 h-12 sm:w-10 sm:h-10 rounded-xl sm:rounded-lg shrink-0 flex items-center justify-center transition-all duration-200 ${ hasStock && !loadingItems.has(piece.id) ? "bg-gradient-to-r from-blue-600 hover:from-blue-700 hover: text-white shadow-md hover:shadow-lg hover:scale-110" : "bg-slate-100 text-slate-400 cursor-not-allowed" }`}
                     disabled={!hasStock || loadingItems.has(piece.id)}
                     onClick={() => hasStock && handleAddToCart(piece.id)}
                     title={hasStock ? "Ajouter au panier" : "Indisponible"}

--- a/frontend/app/components/pieces/PiecesOemSection.tsx
+++ b/frontend/app/components/pieces/PiecesOemSection.tsx
@@ -161,7 +161,7 @@ export const PiecesOemSection = memo(function PiecesOemSection({
                   {/* Titre H3 OEM avec préfixe et modèle */}
                   <h3 className="text-sm font-semibold text-gray-900 mb-2 flex items-center gap-2">
                     <svg
-                      className={`w-4 h-4 flex-shrink-0 ${
+                      className={`w-4 h-4 shrink-0 ${
                         isAvant ? "text-blue-600" : "text-orange-600"
                       }`}
                       fill="none"

--- a/frontend/app/components/pieces/PiecesSEOSection.tsx
+++ b/frontend/app/components/pieces/PiecesSEOSection.tsx
@@ -92,7 +92,7 @@ export const PiecesSEOSection = memo(function PiecesSEOSection({
                   className="flex items-start gap-2 text-sm text-gray-700"
                 >
                   <svg
-                    className="w-4 h-4 text-blue-600 mt-0.5 flex-shrink-0"
+                    className="w-4 h-4 text-blue-600 mt-0.5 shrink-0"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >

--- a/frontend/app/components/pieces/PiecesVehicleContent.tsx
+++ b/frontend/app/components/pieces/PiecesVehicleContent.tsx
@@ -300,7 +300,7 @@ export function PiecesVehicleContent() {
         <div className="flex flex-col lg:flex-row gap-8">
           {/* Sidebar filtres et catalogue — hidden on mobile, toggle via MobileBottomBar */}
           <aside
-            className={`lg:w-80 flex-shrink-0 space-y-6 animate-in fade-in slide-in-from-left duration-700 ${showFilters ? "block" : "hidden lg:block"}`}
+            className={`lg:w-80 shrink-0 space-y-6 animate-in fade-in slide-in-from-left duration-700 ${showFilters ? "block" : "hidden lg:block"}`}
           >
             {/* Filtres */}
             <div className="sticky top-24">
@@ -385,7 +385,7 @@ export function PiecesVehicleContent() {
                 </p>
                 <a
                   href="#compatibilite"
-                  className="flex-shrink-0 text-sm font-semibold text-amber-700 hover:text-amber-900 bg-amber-100 hover:bg-amber-200 px-3 py-1.5 rounded-md transition-colors"
+                  className="shrink-0 text-sm font-semibold text-amber-700 hover:text-amber-900 bg-amber-100 hover:bg-amber-200 px-3 py-1.5 rounded-md transition-colors"
                 >
                   Vérifier
                 </a>

--- a/frontend/app/components/pieces/ProductGallery.tsx
+++ b/frontend/app/components/pieces/ProductGallery.tsx
@@ -265,7 +265,7 @@ export const ProductGallery = memo(function ProductGallery({
               setCurrentImage(img.url);
             }}
             onMouseEnter={() => setCurrentImage(img.url)}
-            className={`w-12 h-12 flex-shrink-0 rounded border-2 ${currentImage === img.url ? "border-blue-400 ring-2 ring-blue-400 scale-110" : "border-white/50 hover:border-white"} overflow-hidden transition-all bg-white shadow-lg`}
+            className={`w-12 h-12 shrink-0 rounded border-2 ${currentImage === img.url ? "border-blue-400 ring-2 ring-blue-400 scale-110" : "border-white/50 hover:border-white"} overflow-hidden transition-all bg-white shadow-lg`}
           >
             <img
               src={img.url}
@@ -279,7 +279,7 @@ export const ProductGallery = memo(function ProductGallery({
           </button>
         ))}
         {allImages.length > 5 && (
-          <div className="w-12 h-12 flex-shrink-0 rounded border-2 border-white/50 bg-neutral-900/50 flex items-center justify-center text-white text-xs font-bold shadow-lg">
+          <div className="w-12 h-12 shrink-0 rounded border-2 border-white/50 bg-neutral-900/50 flex items-center justify-center text-white text-xs font-bold shadow-lg">
             +{allImages.length - 5}
           </div>
         )}

--- a/frontend/app/components/pieces/PurchaseNarrativeSection.tsx
+++ b/frontend/app/components/pieces/PurchaseNarrativeSection.tsx
@@ -50,7 +50,7 @@ export const PurchaseNarrativeSection = memo(function PurchaseNarrativeSection({
       <CardHeader className="pb-3">
         <h2 className="text-xl sm:text-2xl md:text-[28px] font-bold tracking-tight text-slate-900 flex items-center gap-3">
           <span
-            className="flex-shrink-0 w-10 h-10 rounded-full bg-navy text-white flex items-center justify-center"
+            className="shrink-0 w-10 h-10 rounded-full bg-navy text-white flex items-center justify-center"
             aria-hidden="true"
           >
             <Info className="w-5 h-5" />
@@ -62,7 +62,7 @@ export const PurchaseNarrativeSection = memo(function PurchaseNarrativeSection({
         {/* Bloc 1: Role + pieces liees */}
         <div className="flex gap-4 p-4 bg-white rounded-lg border border-slate-200">
           <div
-            className="flex-shrink-0 w-10 h-10 rounded-full bg-navy/10 text-navy flex items-center justify-center font-bold"
+            className="shrink-0 w-10 h-10 rounded-full bg-navy/10 text-navy flex items-center justify-center font-bold"
             aria-hidden="true"
           >
             1
@@ -91,7 +91,7 @@ export const PurchaseNarrativeSection = memo(function PurchaseNarrativeSection({
         {/* Bloc 2: Risques + cout */}
         <div className="flex gap-4 p-4 bg-white rounded-lg border border-red-200">
           <div
-            className="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 text-red-700 flex items-center justify-center font-bold"
+            className="shrink-0 w-10 h-10 rounded-full bg-red-100 text-red-700 flex items-center justify-center font-bold"
             aria-hidden="true"
           >
             <AlertTriangle className="w-5 h-5" />
@@ -132,7 +132,7 @@ export const PurchaseNarrativeSection = memo(function PurchaseNarrativeSection({
         {/* Bloc 3: Timing */}
         <div className="flex gap-4 p-4 bg-white rounded-lg border border-slate-200">
           <div
-            className="flex-shrink-0 w-10 h-10 rounded-full bg-cta/10 text-cta flex items-center justify-center font-bold"
+            className="shrink-0 w-10 h-10 rounded-full bg-cta/10 text-cta flex items-center justify-center font-bold"
             aria-hidden="true"
           >
             <Clock className="w-5 h-5" />
@@ -188,7 +188,7 @@ export const PurchaseNarrativeSection = memo(function PurchaseNarrativeSection({
               {steps.map((step, i) => (
                 <div key={i} className="flex items-center gap-1.5">
                   <span
-                    className="flex-shrink-0 w-6 h-6 rounded-full bg-navy text-white flex items-center justify-center text-xs font-bold"
+                    className="shrink-0 w-6 h-6 rounded-full bg-navy text-white flex items-center justify-center text-xs font-bold"
                     aria-hidden="true"
                   >
                     {i + 1}

--- a/frontend/app/components/pieces/QuickGuideSection.tsx
+++ b/frontend/app/components/pieces/QuickGuideSection.tsx
@@ -82,7 +82,7 @@ function GuideCardComponent({ card }: { card: GuideCard }) {
       <CardContent className="p-4">
         <div className="flex items-start gap-3">
           <div
-            className={`${colors.icon} w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0`}
+            className={`${colors.icon} w-10 h-10 rounded-lg flex items-center justify-center shrink-0`}
           >
             {card.icon}
           </div>

--- a/frontend/app/components/pieces/R1KpiCoverage.tsx
+++ b/frontend/app/components/pieces/R1KpiCoverage.tsx
@@ -80,7 +80,7 @@ export const R1KpiCoverage = memo(function R1KpiCoverage({
           key={i}
           className="flex items-center gap-3 rounded-xl border border-gray-100 bg-white p-3 sm:p-4"
         >
-          <div className="flex-shrink-0">{item.icon}</div>
+          <div className="shrink-0">{item.icon}</div>
           <div className="min-w-0">
             <p className="text-sm font-bold text-gray-900 leading-tight">
               {item.value}

--- a/frontend/app/components/pieces/R1ReusableContent.tsx
+++ b/frontend/app/components/pieces/R1ReusableContent.tsx
@@ -114,7 +114,7 @@ export const R1ReusableContent = memo(function R1ReusableContent({
               key={i}
               className="flex items-start gap-2 text-sm text-gray-700"
             >
-              <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
+              <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0 mt-0.5" />
               <span>{bullet}</span>
             </li>
           ))}
@@ -122,7 +122,7 @@ export const R1ReusableContent = memo(function R1ReusableContent({
 
         {/* Carte grise tip — toujours affiché */}
         <div className="flex items-start gap-2 p-3 rounded-lg bg-blue-50 border border-blue-100 mb-3">
-          <Info className="w-4 h-4 text-blue-600 flex-shrink-0 mt-0.5" />
+          <Info className="w-4 h-4 text-blue-600 shrink-0 mt-0.5" />
           <p className="text-xs text-blue-800 leading-relaxed">
             <strong>Astuce carte grise :</strong> {block.carteGriseTip}
           </p>
@@ -130,7 +130,7 @@ export const R1ReusableContent = memo(function R1ReusableContent({
 
         {/* Alerte sécurité — toujours affiché */}
         <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-50 border border-amber-100">
-          <Shield className="w-4 h-4 text-amber-600 flex-shrink-0 mt-0.5" />
+          <Shield className="w-4 h-4 text-amber-600 shrink-0 mt-0.5" />
           <p className="text-xs text-amber-800 leading-relaxed">
             <strong>Important :</strong> {block.safetyAlert}
           </p>
@@ -147,7 +147,7 @@ export const R1ReusableContent = memo(function R1ReusableContent({
                 className={`${style.bg} transition-all hover:shadow-md h-full`}
               >
                 <CardContent className="p-4 flex items-start gap-3">
-                  <div className="flex-shrink-0 mt-0.5">{style.icon}</div>
+                  <div className="shrink-0 mt-0.5">{style.icon}</div>
                   <div className="flex-1 min-w-0">
                     <h3 className={`${style.text} font-semibold text-sm mb-1`}>
                       {card.label}

--- a/frontend/app/components/pieces/R1TrustStrip.tsx
+++ b/frontend/app/components/pieces/R1TrustStrip.tsx
@@ -10,7 +10,7 @@ export const R1TrustStrip = memo(function R1TrustStrip() {
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
       {/* 1. Compatibilité vérifiée */}
       <div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-green-50 p-3 sm:p-4">
-        <ShieldCheck className="w-6 h-6 text-green-600 flex-shrink-0" />
+        <ShieldCheck className="w-6 h-6 text-green-600 shrink-0" />
         <div className="min-w-0">
           <p className="text-sm font-semibold text-gray-900 leading-tight">
             Compatibilité vérifiée
@@ -23,7 +23,7 @@ export const R1TrustStrip = memo(function R1TrustStrip() {
 
       {/* 2. Livraison */}
       <div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-blue-50 p-3 sm:p-4">
-        <Truck className="w-6 h-6 text-blue-600 flex-shrink-0" />
+        <Truck className="w-6 h-6 text-blue-600 shrink-0" />
         <div className="min-w-0">
           <p className="text-sm font-semibold text-gray-900 leading-tight">
             Livraison 24–48h
@@ -36,7 +36,7 @@ export const R1TrustStrip = memo(function R1TrustStrip() {
 
       {/* 3. Retours */}
       <div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-amber-50 p-3 sm:p-4">
-        <RotateCcw className="w-6 h-6 text-amber-600 flex-shrink-0" />
+        <RotateCcw className="w-6 h-6 text-amber-600 shrink-0" />
         <div className="min-w-0">
           <p className="text-sm font-semibold text-gray-900 leading-tight">
             Retours 30 jours
@@ -49,7 +49,7 @@ export const R1TrustStrip = memo(function R1TrustStrip() {
 
       {/* 4. Paiement sécurisé */}
       <div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-muted p-3 sm:p-4">
-        <Lock className="w-6 h-6 text-foreground flex-shrink-0" />
+        <Lock className="w-6 h-6 text-foreground shrink-0" />
         <div className="min-w-0">
           <p className="text-sm font-semibold text-gray-900 leading-tight">
             Paiement sécurisé

--- a/frontend/app/components/pieces/R2TransactionGuide.tsx
+++ b/frontend/app/components/pieces/R2TransactionGuide.tsx
@@ -79,7 +79,7 @@ export const R2TransactionGuide = memo(function R2TransactionGuide({
                   key={c.key}
                   className="flex items-start gap-2 text-sm text-gray-700"
                 >
-                  <ShieldCheck className="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" />
+                  <ShieldCheck className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
                   <span>
                     <span className="font-medium text-gray-900">{c.label}</span>{" "}
                     — {c.guidance}
@@ -91,7 +91,7 @@ export const R2TransactionGuide = memo(function R2TransactionGuide({
                   key={`rule-${i}`}
                   className="flex items-start gap-2 text-sm text-gray-700"
                 >
-                  <ShieldCheck className="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" />
+                  <ShieldCheck className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
                   <span>{rule}</span>
                 </li>
               ))}
@@ -127,7 +127,7 @@ export const R2TransactionGuide = memo(function R2TransactionGuide({
                   key={i}
                   className="flex items-start gap-2 text-sm text-gray-700"
                 >
-                  <PackageCheck className="w-4 h-4 text-amber-500 mt-0.5 flex-shrink-0" />
+                  <PackageCheck className="w-4 h-4 text-amber-500 mt-0.5 shrink-0" />
                   <span>{item}</span>
                 </li>
               ))}
@@ -154,7 +154,7 @@ export const R2TransactionGuide = memo(function R2TransactionGuide({
                   key={i}
                   className="flex items-start gap-2 text-sm text-gray-700"
                 >
-                  <AlertTriangle className="w-4 h-4 text-rose-500 mt-0.5 flex-shrink-0" />
+                  <AlertTriangle className="w-4 h-4 text-rose-500 mt-0.5 shrink-0" />
                   <span>{item}</span>
                 </li>
               ))}

--- a/frontend/app/components/pieces/ReferenceEncartSection.tsx
+++ b/frontend/app/components/pieces/ReferenceEncartSection.tsx
@@ -24,7 +24,7 @@ export const ReferenceEncartSection = memo(function ReferenceEncartSection({
         <Card className="border-indigo-200 shadow-sm hover:shadow-md transition-shadow">
           <CardContent className="p-6 md:p-8">
             <div className="flex items-start gap-4">
-              <div className="flex-shrink-0 w-12 h-12 rounded-xl bg-muted flex items-center justify-center">
+              <div className="shrink-0 w-12 h-12 rounded-xl bg-muted flex items-center justify-center">
                 <BookOpen className="w-6 h-6 text-foreground" />
               </div>
               <div className="flex-1 min-w-0">

--- a/frontend/app/components/pieces/SafeCompatTable.tsx
+++ b/frontend/app/components/pieces/SafeCompatTable.tsx
@@ -63,7 +63,7 @@ const SafeCompatTable = memo(function SafeCompatTable({
           return (
             <div key={i} className="flex items-start gap-3 px-4 py-3 text-sm">
               <Icon
-                className="w-4 h-4 text-blue-600 mt-0.5 flex-shrink-0"
+                className="w-4 h-4 text-blue-600 mt-0.5 shrink-0"
                 aria-hidden="true"
               />
               <div className="flex-1 min-w-0">

--- a/frontend/app/components/pieces/VehicleHeader.tsx
+++ b/frontend/app/components/pieces/VehicleHeader.tsx
@@ -73,7 +73,7 @@ export const VehicleHeader = memo(function VehicleHeader({
             <div className="flex items-center gap-4 mb-4">
               {/* Image gamme si disponible */}
               {gamme.image && (
-                <div className="w-16 h-16 bg-gray-100 rounded-lg overflow-hidden flex-shrink-0">
+                <div className="w-16 h-16 bg-gray-100 rounded-lg overflow-hidden shrink-0">
                   <img
                     src={gamme.image}
                     alt={gamme.name}
@@ -148,7 +148,7 @@ export const VehicleHeader = memo(function VehicleHeader({
           </div>
 
           {/* Actions */}
-          <div className="flex-shrink-0 ml-6">
+          <div className="shrink-0 ml-6">
             <div className="flex flex-col gap-3">
               <Button
                 className="px-6 py-3 rounded-lg   flex items-center gap-2"

--- a/frontend/app/components/profile/ActivityTimeline.tsx
+++ b/frontend/app/components/profile/ActivityTimeline.tsx
@@ -123,7 +123,7 @@ export const ActivityTimeline = memo(function ActivityTimeline({
 
                 {/* Icône */}
                 <div
-                  className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${getActivityColor(activity.type)} relative z-10`}
+                  className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${getActivityColor(activity.type)} relative z-10`}
                 >
                   {getActivityIcon(activity.type)}
                 </div>
@@ -137,7 +137,7 @@ export const ActivityTimeline = memo(function ActivityTimeline({
                         {activity.description}
                       </p>
                     </div>
-                    <Badge variant="outline" className="flex-shrink-0 text-xs">
+                    <Badge variant="outline" className="shrink-0 text-xs">
                       {getActivityLabel(activity.type)}
                     </Badge>
                   </div>
@@ -174,7 +174,7 @@ export const ActivityTimelineCompact = memo(function ActivityTimelineCompact({
           className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors"
         >
           <div
-            className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${getActivityColor(activity.type)}`}
+            className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${getActivityColor(activity.type)}`}
           >
             {getActivityIcon(activity.type)}
           </div>

--- a/frontend/app/components/rag/ChatInput.tsx
+++ b/frontend/app/components/rag/ChatInput.tsx
@@ -65,7 +65,7 @@ const ChatInput = memo(function ChatInput({
       <button
         onClick={handleSubmit}
         disabled={!message.trim() || isLoading}
-        className="flex-shrink-0 w-10 h-10 flex items-center justify-center bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-xl hover:shadow-lg transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="shrink-0 w-10 h-10 flex items-center justify-center bg-gradient-to-r from-orange-500 to-amber-500 text-white rounded-xl hover:shadow-lg transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
         aria-label="Envoyer"
       >
         {isLoading ? (

--- a/frontend/app/components/rag/ChatMessage.tsx
+++ b/frontend/app/components/rag/ChatMessage.tsx
@@ -46,7 +46,7 @@ const ChatMessage = memo(function ChatMessage({ message }: ChatMessageProps) {
     <div className={`flex gap-3 ${isUser ? "flex-row-reverse" : "flex-row"}`}>
       {/* Avatar */}
       <div
-        className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+        className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
           isUser
             ? "bg-gradient-to-r from-orange-500 to-amber-500"
             : "bg-gray-200"

--- a/frontend/app/components/search/ProductSearch.tsx
+++ b/frontend/app/components/search/ProductSearch.tsx
@@ -151,7 +151,7 @@ export const ProductSearch = memo(function ProductSearch({
                         className="w-full p-4 hover:bg-info/20 transition-colors flex items-center gap-4 text-left"
                       >
                         {/* Image responsive */}
-                        <div className="flex-shrink-0 w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center overflow-hidden">
+                        <div className="shrink-0 w-16 h-16 bg-gray-100 rounded-lg flex items-center justify-center overflow-hidden">
                           {result.image_url ? (
                             <PartImage
                               src={result.image_url}
@@ -182,7 +182,7 @@ export const ProductSearch = memo(function ProductSearch({
                         </div>
 
                         {/* Price & Stock */}
-                        <div className="text-right flex-shrink-0">
+                        <div className="text-right shrink-0">
                           {result.price_ttc && (
                             <p className="font-bold text-blue-600">
                               {result.price_ttc.toFixed(2)} €

--- a/frontend/app/components/search/SearchBar.tsx
+++ b/frontend/app/components/search/SearchBar.tsx
@@ -484,7 +484,7 @@ export const SearchBar = memo(function SearchBar({
                   "border-b border-gray-100 last:border-b-0",
                 )}
               >
-                <div className="flex-shrink-0 mr-3">{suggestion.icon}</div>
+                <div className="shrink-0 mr-3">{suggestion.icon}</div>
 
                 <div className="flex-1 min-w-0">
                   <div className="font-medium text-gray-900 truncate">

--- a/frontend/app/components/search/SearchBarEnhancedHomepage.tsx
+++ b/frontend/app/components/search/SearchBarEnhancedHomepage.tsx
@@ -416,7 +416,7 @@ export const SearchBarEnhancedHomepage = memo(
                             : "hover:bg-gray-50",
                         )}
                       >
-                        <Tag className="w-4 h-4 text-foreground flex-shrink-0" />
+                        <Tag className="w-4 h-4 text-foreground shrink-0" />
                         <span className="text-gray-900 font-medium">
                           {suggestion}
                         </span>

--- a/frontend/app/components/search/SearchResultsEnhanced.tsx
+++ b/frontend/app/components/search/SearchResultsEnhanced.tsx
@@ -280,7 +280,7 @@ export const SearchResultsEnhanced = memo(function SearchResultsEnhanced({
             <CardContent className="p-4">
               <div className="flex gap-4">
                 {/* Image - ✅ OPTIMISÉE WEBP */}
-                <div className="flex-shrink-0 w-32 h-32 bg-gradient-to-br from-gray-100 to-gray-200 rounded-lg overflow-hidden flex items-center justify-center group-hover:from-gray-200 group-hover:to-gray-300 transition-colors">
+                <div className="shrink-0 w-32 h-32 bg-gradient-to-br from-gray-100 to-gray-200 rounded-lg overflow-hidden flex items-center justify-center group-hover:from-gray-200 group-hover:to-gray-300 transition-colors">
                   {item.image ? (
                     <img
                       src={optimizeImageUrl(item.image, 300)}

--- a/frontend/app/components/seo/AntiMistakesSection.tsx
+++ b/frontend/app/components/seo/AntiMistakesSection.tsx
@@ -49,7 +49,7 @@ export const AntiMistakesSection = memo(function AntiMistakesSection({
                   key={index}
                   className="flex items-start gap-3 p-3 bg-white rounded-lg border border-rose-200"
                 >
-                  <span className="flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-rose-100 text-rose-700 text-sm font-bold">
+                  <span className="shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-rose-100 text-rose-700 text-sm font-bold">
                     !
                   </span>
                   <span className="text-gray-700">{item}</span>

--- a/frontend/app/components/seo/SymptomsSection.tsx
+++ b/frontend/app/components/seo/SymptomsSection.tsx
@@ -51,7 +51,7 @@ export const SymptomsSection = memo(function SymptomsSection({
                   key={index}
                   className="flex items-start gap-3 p-3 bg-white rounded-lg border border-orange-200"
                 >
-                  <span className="flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-orange-100 text-orange-600 text-sm font-bold">
+                  <span className="shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-orange-100 text-orange-600 text-sm font-bold">
                     {index + 1}
                   </span>
                   <span className="text-gray-700">{symptom}</span>

--- a/frontend/app/components/trust/FrictionReducer.tsx
+++ b/frontend/app/components/trust/FrictionReducer.tsx
@@ -62,7 +62,7 @@ export const FrictionReducer = memo(function FrictionReducer({
   if (variant === "compact") {
     return (
       <div className={cn("flex items-center gap-2 text-sm", className)}>
-        <Icon className={cn("w-4 h-4 flex-shrink-0", config.color)} />
+        <Icon className={cn("w-4 h-4 shrink-0", config.color)} />
         <span className="font-medium text-gray-700">{config.title}</span>
       </div>
     );

--- a/frontend/app/components/ui/BrandLogo.tsx
+++ b/frontend/app/components/ui/BrandLogo.tsx
@@ -92,7 +92,7 @@ export function BrandLogo({
     <Avatar
       className={cn(
         sizeClass,
-        "flex-shrink-0",
+        "shrink-0",
         typeof size === "number" &&
           "w-[var(--brand-size)] h-[var(--brand-size)]",
         className,

--- a/frontend/app/components/ui/DynamicMenu.tsx
+++ b/frontend/app/components/ui/DynamicMenu.tsx
@@ -126,7 +126,7 @@ export function DynamicMenu({ module, className = "" }: DynamicMenuProps) {
           >
             <div className="flex items-center space-x-3 flex-1 min-w-0">
               {item.icon && (
-                <span className="flex-shrink-0 w-4 h-4 text-current">
+                <span className="shrink-0 w-4 h-4 text-current">
                   {item.icon}
                 </span>
               )}
@@ -156,7 +156,7 @@ export function DynamicMenu({ module, className = "" }: DynamicMenuProps) {
             </div>
 
             {hasChildren && (
-              <div className="flex-shrink-0 ml-2">
+              <div className="shrink-0 ml-2">
                 {isExpanded ? (
                   <ChevronDown className="w-4 h-4 text-gray-500" />
                 ) : (

--- a/frontend/app/components/ui/LoadingSpinner.tsx
+++ b/frontend/app/components/ui/LoadingSpinner.tsx
@@ -63,7 +63,7 @@ export function LoadingSpinner({
 
   if (fullScreen) {
     return (
-      <div className="fixed inset-0 bg-white bg-opacity-75 flex items-center justify-center z-50">
+      <div className="fixed inset-0 bg-white/75 flex items-center justify-center z-50">
         {spinner}
       </div>
     );

--- a/frontend/app/components/ui/MultiCarousel.tsx
+++ b/frontend/app/components/ui/MultiCarousel.tsx
@@ -170,7 +170,7 @@ const MultiCarousel: React.FC<MultiCarouselProps> = ({
           {childrenArray.map((child, index) => (
             <div
               key={index}
-              className="flex-shrink-0"
+              className="shrink-0"
               style={{ width: itemWidth }}
               role="listitem"
               aria-hidden={index < currentIndex || index >= currentIndex + itemsPerView}

--- a/frontend/app/components/ui/alert.tsx
+++ b/frontend/app/components/ui/alert.tsx
@@ -55,7 +55,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
         {...props}
       >
         {icon && (
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 flex-shrink-0">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 shrink-0">
             {icon}
           </span>
         )}

--- a/frontend/app/components/ui/badge.tsx
+++ b/frontend/app/components/ui/badge.tsx
@@ -38,7 +38,7 @@ function Badge({ className = "", variant = "default", size = "sm", icon, childre
       className={`${baseClasses} ${sizeClasses[size]} ${variantClasses[variant]} ${className}`}
       {...props}
     >
-      {icon && <span className="flex-shrink-0">{icon}</span>}
+      {icon && <span className="shrink-0">{icon}</span>}
       {children}
     </div>
   );

--- a/frontend/app/components/ui/filter-section.tsx
+++ b/frontend/app/components/ui/filter-section.tsx
@@ -73,7 +73,7 @@ const FilterSection = React.forwardRef<HTMLDivElement, FilterSectionProps>(
             "mb-3",
           )}
         >
-          {icon && <span className="flex-shrink-0">{icon}</span>}
+          {icon && <span className="shrink-0">{icon}</span>}
           <h3 className="text-xs font-semibold">{title}</h3>
           {badge && <span className="ml-auto">{badge}</span>}
         </div>

--- a/frontend/app/components/ui/input.tsx
+++ b/frontend/app/components/ui/input.tsx
@@ -55,7 +55,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         
         {error && (
           <p id={errorId} className="text-sm text-red-600 flex items-center gap-1.5">
-            <AlertCircle className="w-4 h-4 flex-shrink-0" />
+            <AlertCircle className="w-4 h-4 shrink-0" />
             <span>{error}</span>
           </p>
         )}

--- a/frontend/app/components/ui/skeleton.tsx
+++ b/frontend/app/components/ui/skeleton.tsx
@@ -54,7 +54,7 @@ function CartItemSkeleton() {
   return (
     <div className="flex gap-3 p-4 bg-white rounded-lg border animate-fade-in">
       {/* Image */}
-      <Skeleton className="w-20 h-20 rounded-lg flex-shrink-0" />
+      <Skeleton className="w-20 h-20 rounded-lg shrink-0" />
       
       {/* Content */}
       <div className="flex-1 space-y-2">

--- a/frontend/app/components/ui/textarea.tsx
+++ b/frontend/app/components/ui/textarea.tsx
@@ -55,7 +55,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             id={errorId}
             className="text-sm text-red-600 flex items-center gap-1.5"
           >
-            <AlertCircle className="w-4 h-4 flex-shrink-0" />
+            <AlertCircle className="w-4 h-4 shrink-0" />
             <span>{error}</span>
           </p>
         )}

--- a/frontend/app/components/vehicle/VehicleSelector.tsx
+++ b/frontend/app/components/vehicle/VehicleSelector.tsx
@@ -386,7 +386,7 @@ const VehicleSelector = memo(function VehicleSelector({
         data-nosnippet
         data-noindex
       >
-        <Car className="hidden sm:block w-5 h-5 text-cta flex-shrink-0" />
+        <Car className="hidden sm:block w-5 h-5 text-cta shrink-0" />
 
         {/* Marque */}
         <select
@@ -871,7 +871,7 @@ const VehicleSelector = memo(function VehicleSelector({
               {/* Aide */}
               <div className="bg-muted border border-purple-200 rounded-lg p-4">
                 <div className="flex items-start gap-3">
-                  <FileText className="w-5 h-5 text-foreground mt-0.5 flex-shrink-0" />
+                  <FileText className="w-5 h-5 text-foreground mt-0.5 shrink-0" />
                   <div className="text-sm text-foreground">
                     <p className="font-medium mb-1">
                       Le Type Mine se trouve sur votre carte grise

--- a/frontend/app/components/vehicle/r8/sections/AntiErrorsSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/AntiErrorsSection.tsx
@@ -15,7 +15,7 @@ export function AntiErrorsSection({ vehicle }: Props) {
         <div className="flex items-start gap-3 mb-4">
           <AlertTriangle
             size={24}
-            className="text-amber-600 flex-shrink-0 mt-0.5"
+            className="text-amber-600 shrink-0 mt-0.5"
           />
           <h2 className="text-xl font-bold text-gray-900">
             Erreurs fréquentes à éviter
@@ -23,7 +23,7 @@ export function AntiErrorsSection({ vehicle }: Props) {
         </div>
         <ul className="space-y-3 ml-9">
           <li className="flex items-start gap-2 text-gray-700">
-            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 shrink-0" />
             <span>
               Vérifier l'année exacte ({vehicle.type_year_from}–
               {vehicle.type_year_to || "aujourd'hui"}) : les pièces peuvent
@@ -31,7 +31,7 @@ export function AntiErrorsSection({ vehicle }: Props) {
             </span>
           </li>
           <li className="flex items-start gap-2 text-gray-700">
-            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 shrink-0" />
             <span>
               Puissance proche ≠ moteur identique : confirmez avec le CNIT ou le
               code moteur
@@ -41,7 +41,7 @@ export function AntiErrorsSection({ vehicle }: Props) {
             </span>
           </li>
           <li className="flex items-start gap-2 text-gray-700">
-            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+            <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 shrink-0" />
             <span>
               En cas de doute entre deux motorisations, utilisez le VIN (17
               caractères, carte grise case E)
@@ -49,7 +49,7 @@ export function AntiErrorsSection({ vehicle }: Props) {
           </li>
           {vehicle.type_body && vehicle.type_body.includes("/") && (
             <li className="flex items-start gap-2 text-gray-700">
-              <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 flex-shrink-0" />
+              <span className="w-1.5 h-1.5 bg-amber-500 rounded-full mt-2 shrink-0" />
               <span>
                 Attention à la carrosserie ({vehicle.type_body}) : les pièces
                 peuvent varier selon la version

--- a/frontend/app/components/vehicle/r8/sections/HowtoSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/HowtoSection.tsx
@@ -15,7 +15,7 @@ export function HowtoSection({ vehicle }: Props) {
         <div className="flex items-start gap-3 mb-4">
           <ListChecks
             size={24}
-            className="text-blue-600 flex-shrink-0 mt-0.5"
+            className="text-blue-600 shrink-0 mt-0.5"
           />
           <h2 className="text-xl font-bold text-gray-900">
             Comment choisir sans se tromper

--- a/frontend/app/components/vehicle/r8/sections/R8EnrichedSection.tsx
+++ b/frontend/app/components/vehicle/r8/sections/R8EnrichedSection.tsx
@@ -28,11 +28,11 @@ export function R8EnrichedSection({ r8Content }: Props) {
         >
           <div className="flex items-start gap-3 mb-3">
             {block.type === "variant_difference" ? (
-              <Car size={24} className="text-foreground flex-shrink-0 mt-0.5" />
+              <Car size={24} className="text-foreground shrink-0 mt-0.5" />
             ) : (
               <Wrench
                 size={24}
-                className="text-blue-600 flex-shrink-0 mt-0.5"
+                className="text-blue-600 shrink-0 mt-0.5"
               />
             )}
             <h2 className="text-xl font-bold text-gray-900">{block.title}</h2>

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -354,8 +354,8 @@ function AppShell({ children }: { children: React.ReactNode }) {
       {...pageRoleAttrs}
     >
       {!hideGlobalNavbar && <Navbar />}
-      <main className="flex-grow flex flex-col">
-        <div className="flex-grow">{children}</div>
+      <main className="grow flex flex-col">
+        <div className="grow">{children}</div>
       </main>
       {!hideGlobalFooter && (
         <Suspense fallback={null}>

--- a/frontend/app/routes/_public+/_layout.tsx
+++ b/frontend/app/routes/_public+/_layout.tsx
@@ -58,7 +58,7 @@ export default function AuthLayout() {
       </header>
 
       {/* Contenu */}
-      <main className="flex-grow">
+      <main className="grow">
         <Outlet />
       </main>
 

--- a/frontend/app/routes/_public+/register.tsx
+++ b/frontend/app/routes/_public+/register.tsx
@@ -649,7 +649,7 @@ export default function RegisterPage() {
                         role="alert"
                       >
                         <svg
-                          className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5"
+                          className="w-5 h-5 text-red-500 shrink-0 mt-0.5"
                           fill="none"
                           stroke="currentColor"
                           viewBox="0 0 24 24"

--- a/frontend/app/routes/account.messages._index.tsx
+++ b/frontend/app/routes/account.messages._index.tsx
@@ -194,9 +194,9 @@ export default function MessagesList() {
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 mb-1">
                         {message.MSG_OPEN === 0 ? (
-                          <Mail className="h-4 w-4 text-blue-500 flex-shrink-0" />
+                          <Mail className="h-4 w-4 text-blue-500 shrink-0" />
                         ) : (
-                          <MailOpen className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                          <MailOpen className="h-4 w-4 text-gray-400 shrink-0" />
                         )}
                         <span className="font-medium text-sm">
                           {message.MSG_ORD_ID

--- a/frontend/app/routes/admin.ai-content.tsx
+++ b/frontend/app/routes/admin.ai-content.tsx
@@ -97,7 +97,7 @@ export default function AiContentDashboard() {
         {/* Info Banner */}
         <div className="mb-6 rounded-lg bg-blue-50 p-4 border border-blue-200">
           <div className="flex">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <svg
                 className="h-5 w-5 text-blue-400"
                 viewBox="0 0 20 20"
@@ -344,7 +344,7 @@ function InfoCard({
   return (
     <div className="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
       <div className="flex items-center">
-        <div className="flex-shrink-0">
+        <div className="shrink-0">
           <span className="text-3xl">{icon}</span>
         </div>
         <div className="ml-5 w-0 flex-1">
@@ -382,7 +382,7 @@ function SetupStep({
 
   return (
     <div className="flex items-start">
-      <div className="flex-shrink-0">
+      <div className="shrink-0">
         <span className="flex h-8 w-8 items-center justify-center rounded-full bg-yellow-200 text-sm font-semibold text-yellow-900">
           {number}
         </span>

--- a/frontend/app/routes/admin.blog.tsx
+++ b/frontend/app/routes/admin.blog.tsx
@@ -349,7 +349,7 @@ export default function AdminBlogSimplePage() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <DocumentTextIcon className="h-8 w-8 text-blue-600" />
               </div>
               <div className="ml-5 w-0 flex-1">
@@ -367,7 +367,7 @@ export default function AdminBlogSimplePage() {
 
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <EyeIcon className="h-8 w-8 text-green-600" />
               </div>
               <div className="ml-5 w-0 flex-1">
@@ -385,7 +385,7 @@ export default function AdminBlogSimplePage() {
 
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <ChartBarIcon className="h-8 w-8 text-foreground" />
               </div>
               <div className="ml-5 w-0 flex-1">
@@ -403,7 +403,7 @@ export default function AdminBlogSimplePage() {
 
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <UserGroupIcon className="h-8 w-8 text-orange-600" />
               </div>
               <div className="ml-5 w-0 flex-1">

--- a/frontend/app/routes/admin.messages.tsx
+++ b/frontend/app/routes/admin.messages.tsx
@@ -627,7 +627,7 @@ export default function AdminMessages() {
 
       {/* Modal de détail du message */}
       {selectedMessage && (
-        <div className="fixed inset-0 bg-neutral-900 bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-neutral-900/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold text-gray-900">

--- a/frontend/app/routes/admin.orders._index.tsx
+++ b/frontend/app/routes/admin.orders._index.tsx
@@ -1067,7 +1067,7 @@ export default function OrdersRoute() {
 
       {/* Modal Expédition avec numéro de suivi */}
       {shipModalOpen && (
-        <div className="fixed inset-0 bg-neutral-900 bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-neutral-900/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">
               📦 Expédier la commande #{actionOrderId}
@@ -1117,7 +1117,7 @@ export default function OrdersRoute() {
 
       {/* Modal Annulation avec raison */}
       {cancelModalOpen && (
-        <div className="fixed inset-0 bg-neutral-900 bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-neutral-900/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">
               ❌ Annuler la commande #{actionOrderId}

--- a/frontend/app/routes/admin.payments.$paymentId.tsx
+++ b/frontend/app/routes/admin.payments.$paymentId.tsx
@@ -465,7 +465,7 @@ export default function AdminPaymentDetail() {
 
       {/* Modal de remboursement */}
       {showRefundModal && (
-        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+        <div className="fixed inset-0 bg-gray-600/50 overflow-y-auto h-full w-full z-50">
           <div className="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
             <div className="mt-3 text-center">
               <h3 className="text-lg font-medium text-gray-900 mb-4">

--- a/frontend/app/routes/admin.payments.dashboard.tsx
+++ b/frontend/app/routes/admin.payments.dashboard.tsx
@@ -573,7 +573,7 @@ export default function AdminPaymentsDashboard() {
         {/* Bannière informative */}
         <div className="bg-primary/5 p-4 mb-6 rounded-r-lg">
           <div className="flex">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <AlertTriangle className="h-5 w-5 text-blue-400" />
             </div>
             <div className="ml-3">
@@ -590,7 +590,7 @@ export default function AdminPaymentsDashboard() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
           <div className="bg-white rounded-lg shadow p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <DollarSign className="h-8 w-8 text-green-600" />
               </div>
               <div className="ml-4">
@@ -606,7 +606,7 @@ export default function AdminPaymentsDashboard() {
 
           <div className="bg-white rounded-lg shadow p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <CheckCircle className="h-8 w-8 text-blue-600" />
               </div>
               <div className="ml-4">
@@ -622,7 +622,7 @@ export default function AdminPaymentsDashboard() {
 
           <div className="bg-white rounded-lg shadow p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <Clock className="h-8 w-8 text-yellow-600" />
               </div>
               <div className="ml-4">
@@ -638,7 +638,7 @@ export default function AdminPaymentsDashboard() {
 
           <div className="bg-white rounded-lg shadow p-6">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <AlertTriangle className="h-8 w-8 text-red-600" />
               </div>
               <div className="ml-4">

--- a/frontend/app/routes/admin.products._index.tsx
+++ b/frontend/app/routes/admin.products._index.tsx
@@ -348,7 +348,7 @@ export default function AdminProducts() {
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
                         <div className="flex items-center">
-                          <div className="flex-shrink-0 h-8 w-8">
+                          <div className="shrink-0 h-8 w-8">
                             <div className="h-8 w-8 rounded-md bg-gray-200 flex items-center justify-center">
                               <span className="text-xs">📦</span>
                             </div>

--- a/frontend/app/routes/admin.staff._index.tsx
+++ b/frontend/app/routes/admin.staff._index.tsx
@@ -453,7 +453,7 @@ export default function AdminStaff() {
                   <tr key={staff.cnfa_id} className="hover:bg-gray-50">
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="flex items-center">
-                        <div className="flex-shrink-0 h-10 w-10">
+                        <div className="shrink-0 h-10 w-10">
                           <div className="h-10 w-10 rounded-full bg-primary/15 flex items-center justify-center">
                             <span className="text-blue-600 font-bold text-sm">
                               {staff.cnfa_fname.charAt(0).toUpperCase()}

--- a/frontend/app/routes/admin.staff.tsx
+++ b/frontend/app/routes/admin.staff.tsx
@@ -380,7 +380,7 @@ export default function AdminStaff() {
                 <tr key={member.id} className="hover:bg-gray-50">
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center">
-                      <div className="h-10 w-10 flex-shrink-0">
+                      <div className="h-10 w-10 shrink-0">
                         <div className="h-10 w-10 rounded-full bg-primary/15 flex items-center justify-center">
                           <span className="text-sm font-medium text-blue-600">
                             {member.firstName?.[0]}

--- a/frontend/app/routes/admin.stock.tsx
+++ b/frontend/app/routes/admin.stock.tsx
@@ -529,7 +529,7 @@ export default function AdminStock() {
 
       {/* Modal Mouvement */}
       {showMovementModal && selectedProduct && (
-        <div className="fixed inset-0 bg-neutral-900 bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-neutral-900/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 w-full max-w-md">
             <h3 className="text-lg font-semibold mb-4">
               Enregistrer un mouvement
@@ -626,7 +626,7 @@ export default function AdminStock() {
 
       {/* Modal Ajustement */}
       {showAdjustModal && selectedProduct && (
-        <div className="fixed inset-0 bg-neutral-900 bg-opacity-50 flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-neutral-900/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 w-full max-w-md">
             <h3 className="text-lg font-semibold mb-4">
               Ajustement d'inventaire

--- a/frontend/app/routes/admin.suppliers.tsx
+++ b/frontend/app/routes/admin.suppliers.tsx
@@ -201,7 +201,7 @@ export default function AdminSuppliersLayout() {
 
       {apiError && (
         <div className="bg-amber-50 border border-amber-200 text-amber-800 rounded-lg p-3 mb-6 text-sm flex items-center gap-2">
-          <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+          <AlertTriangle className="h-4 w-4 shrink-0" />
           {apiError}
         </div>
       )}

--- a/frontend/app/routes/admin.system-config._index.tsx
+++ b/frontend/app/routes/admin.system-config._index.tsx
@@ -449,7 +449,7 @@ function OverviewPanel({
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <div className="bg-white rounded-lg shadow p-6">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <Database className="h-8 w-8 text-blue-600" />
             </div>
             <div className="ml-4">
@@ -468,7 +468,7 @@ function OverviewPanel({
 
         <div className="bg-white rounded-lg shadow p-6">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <BarChart3 className="h-8 w-8 text-green-600" />
             </div>
             <div className="ml-4">
@@ -483,7 +483,7 @@ function OverviewPanel({
 
         <div className="bg-white rounded-lg shadow p-6">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <Mail className="h-8 w-8 text-foreground" />
             </div>
             <div className="ml-4">
@@ -498,7 +498,7 @@ function OverviewPanel({
 
         <div className="bg-white rounded-lg shadow p-6">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <Shield className="h-8 w-8 text-red-600" />
             </div>
             <div className="ml-4">

--- a/frontend/app/routes/admin.users.$id.tsx
+++ b/frontend/app/routes/admin.users.$id.tsx
@@ -695,7 +695,7 @@ export default function UserDetails() {
                 >
                   <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
                     {/* Gauche: ID et Date */}
-                    <div className="flex-shrink-0">
+                    <div className="shrink-0">
                       <div className="flex items-center gap-3 mb-2">
                         <span className="font-mono text-sm font-semibold text-gray-900 bg-gray-100 px-3 py-1 rounded-md">
                           #{order.id}
@@ -749,7 +749,7 @@ export default function UserDetails() {
                     )}
 
                     {/* Droite: Montant et Actions */}
-                    <div className="flex-shrink-0 flex flex-col items-end gap-3">
+                    <div className="shrink-0 flex flex-col items-end gap-3">
                       <div className="text-right">
                         <div className="text-xs text-gray-500 uppercase font-semibold mb-1">
                           Montant

--- a/frontend/app/routes/admin.video-hub._index.tsx
+++ b/frontend/app/routes/admin.video-hub._index.tsx
@@ -696,7 +696,7 @@ export default function VideoHubDashboard() {
                     </p>
                   </div>
                   {i < 4 && (
-                    <ChevronRight className="h-4 w-4 text-gray-300 mt-4 hidden md:block flex-shrink-0" />
+                    <ChevronRight className="h-4 w-4 text-gray-300 mt-4 hidden md:block shrink-0" />
                   )}
                 </div>
               );

--- a/frontend/app/routes/blog-pieces-auto.auto.$marque.$modele.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto.$marque.$modele.tsx
@@ -444,7 +444,7 @@ export default function BlogPiecesAutoMarqueModele() {
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
                       {/* Années de production */}
                       <div className="flex items-start gap-2 bg-primary/5 rounded-lg p-3 border border-blue-200">
-                        <Calendar className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" />
+                        <Calendar className="w-5 h-5 text-blue-600 mt-0.5 shrink-0" />
                         <div>
                           <div className="text-xs text-blue-600 font-semibold mb-0.5">
                             Années de production
@@ -458,7 +458,7 @@ export default function BlogPiecesAutoMarqueModele() {
 
                       {/* Motorisations */}
                       <div className="flex items-start gap-2 bg-muted rounded-lg p-3 border border-purple-200">
-                        <Gauge className="w-5 h-5 text-foreground mt-0.5 flex-shrink-0" />
+                        <Gauge className="w-5 h-5 text-foreground mt-0.5 shrink-0" />
                         <div className="flex-1 min-w-0">
                           <div className="text-xs text-foreground font-semibold mb-0.5">
                             Motorisations
@@ -497,7 +497,7 @@ export default function BlogPiecesAutoMarqueModele() {
                     {/* Carrosseries */}
                     {modelGroup.body && (
                       <div className="flex items-start gap-2 bg-muted rounded-lg p-3 border border-indigo-200">
-                        <Car className="w-5 h-5 text-foreground mt-0.5 flex-shrink-0" />
+                        <Car className="w-5 h-5 text-foreground mt-0.5 shrink-0" />
                         <div>
                           <div className="text-xs text-foreground font-semibold mb-0.5">
                             Carrosseries

--- a/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto.$marque.index.tsx
@@ -608,7 +608,7 @@ export default function BlogPiecesAutoMarque() {
 
                         {/* Période + Badge nouveau */}
                         <div className="flex items-center gap-2 text-sm text-muted-foreground mb-3">
-                          <Calendar className="w-4 h-4 flex-shrink-0" />
+                          <Calendar className="w-4 h-4 shrink-0" />
                           <span className="font-semibold">
                             ({model.yearFrom} - {model.yearTo || "aujourd'hui"})
                           </span>

--- a/frontend/app/routes/blog-pieces-auto.auto._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.auto._index.tsx
@@ -709,7 +709,7 @@ export default function BlogPiecesAutoIndex() {
                         className="flex items-start gap-3 p-4 rounded-xl"
                         variant="success"
                       >
-                        <div className="w-6 h-6 rounded-full bg-success flex items-center justify-center flex-shrink-0 mt-0.5">
+                        <div className="w-6 h-6 rounded-full bg-success flex items-center justify-center shrink-0 mt-0.5">
                           <svg
                             className="w-3 h-3 text-white"
                             fill="currentColor"
@@ -736,7 +736,7 @@ export default function BlogPiecesAutoIndex() {
                         className="flex items-start gap-3 p-4 rounded-xl"
                         variant="info"
                       >
-                        <div className="w-6 h-6 rounded-full bg-primary flex items-center justify-center flex-shrink-0 mt-0.5">
+                        <div className="w-6 h-6 rounded-full bg-primary flex items-center justify-center shrink-0 mt-0.5">
                           <svg
                             className="w-3 h-3 text-white"
                             fill="currentColor"
@@ -763,7 +763,7 @@ export default function BlogPiecesAutoIndex() {
                         className="flex items-start gap-3 p-4 rounded-xl"
                         variant="default"
                       >
-                        <div className="w-6 h-6 rounded-full bg-primary flex items-center justify-center flex-shrink-0 mt-0.5">
+                        <div className="w-6 h-6 rounded-full bg-primary flex items-center justify-center shrink-0 mt-0.5">
                           <svg
                             className="w-3 h-3 text-white"
                             fill="currentColor"

--- a/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils.$pg_alias.tsx
@@ -606,7 +606,7 @@ export default function R3GuidePage() {
                   {sourceType === "conseil" && page.cta_link && (
                     <div className="my-6 rounded-lg border border-emerald-200 bg-emerald-50/50 p-4">
                       <div className="flex items-center gap-3">
-                        <Tag className="w-5 h-5 text-emerald-600 flex-shrink-0" />
+                        <Tag className="w-5 h-5 text-emerald-600 shrink-0" />
                         <p className="text-sm text-gray-700">
                           Trouvez votre{" "}
                           <Link
@@ -633,7 +633,7 @@ export default function R3GuidePage() {
                   {/* Cross-link R6 guide d'achat */}
                   <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-4 mb-8">
                     <div className="flex items-center gap-2">
-                      <ExternalLink className="w-4 h-4 text-emerald-600 flex-shrink-0" />
+                      <ExternalLink className="w-4 h-4 text-emerald-600 shrink-0" />
                       <p className="text-sm text-gray-700">
                         Choisir la bonne piece ?{" "}
                         <Link

--- a/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.conseils._index.tsx
@@ -533,7 +533,7 @@ export default function BlogConseilsIndex() {
                             to={getArticleUrl(article)}
                             className="text-sm text-gray-700 hover:text-primary hover:underline flex items-start gap-1.5"
                           >
-                            <ArrowRight className="h-3.5 w-3.5 mt-0.5 flex-shrink-0 text-gray-400" />
+                            <ArrowRight className="h-3.5 w-3.5 mt-0.5 shrink-0 text-gray-400" />
                             <span className="line-clamp-1">
                               {article.title}
                             </span>
@@ -797,7 +797,7 @@ export default function BlogConseilsIndex() {
                   key={i}
                   className="flex items-start gap-3 rounded-lg bg-white p-4 border border-amber-200/60"
                 >
-                  <div className="w-6 h-6 rounded-full bg-amber-100 text-amber-800 flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">
+                  <div className="w-6 h-6 rounded-full bg-amber-100 text-amber-800 flex items-center justify-center text-xs font-bold shrink-0 mt-0.5">
                     {i + 1}
                   </div>
                   <p className="text-sm text-gray-700 leading-relaxed">

--- a/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.constructeurs._index.tsx
@@ -919,7 +919,7 @@ export default function ConstructeursHomePage() {
 
       <div className="container mx-auto px-4 py-8 lg:flex lg:gap-8">
         {/* Sidebar avec toutes les marques */}
-        <aside className="hidden lg:block lg:w-64 flex-shrink-0">
+        <aside className="hidden lg:block lg:w-64 shrink-0">
           <div className="bg-white rounded-lg shadow-sm p-6 sticky top-4">
             <h3 className="font-bold text-lg mb-4 uppercase">
               Marques des constructeurs
@@ -962,7 +962,7 @@ export default function ConstructeursHomePage() {
               </div>
 
               {/* Filtre par lettre */}
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <select
                   value={letter}
                   onChange={(e) => handleFilterChange("letter", e.target.value)}
@@ -978,7 +978,7 @@ export default function ConstructeursHomePage() {
               </div>
 
               {/* Filtre par marque */}
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <select
                   value={brand}
                   onChange={(e) => handleFilterChange("brand", e.target.value)}
@@ -994,7 +994,7 @@ export default function ConstructeursHomePage() {
               </div>
 
               {/* Tri */}
-              <div className="flex-shrink-0">
+              <div className="shrink-0">
                 <select
                   value={sortBy}
                   onChange={(e) => handleFilterChange("sortBy", e.target.value)}

--- a/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat.$pg_alias.tsx
@@ -552,7 +552,7 @@ export default function R6GuidePage() {
                   {/* Cross-link R3 encadre */}
                   <div className="rounded-lg border border-blue-200 bg-blue-50/50 p-4 mb-8">
                     <div className="flex items-center gap-2">
-                      <ExternalLink className="w-4 h-4 text-blue-600 flex-shrink-0" />
+                      <ExternalLink className="w-4 h-4 text-blue-600 shrink-0" />
                       <p className="text-sm text-gray-700">
                         Procedure de remplacement ?{" "}
                         <Link
@@ -1003,7 +1003,7 @@ function V1Sections({
               <ul className="space-y-2">
                 {guide.symptoms.map((s, i) => (
                   <li key={i} className="flex items-start gap-2">
-                    <CheckCircle2 className="w-4 h-4 text-orange-500 mt-0.5 flex-shrink-0" />
+                    <CheckCircle2 className="w-4 h-4 text-orange-500 mt-0.5 shrink-0" />
                     <span className="text-sm text-gray-700">{s}</span>
                   </li>
                 ))}

--- a/frontend/app/routes/blog-pieces-auto.guide-achat._index.tsx
+++ b/frontend/app/routes/blog-pieces-auto.guide-achat._index.tsx
@@ -573,7 +573,7 @@ function FaqSection() {
                     {item.q}
                   </span>
                   <ChevronDown
-                    className={`w-4 h-4 text-gray-400 flex-shrink-0 transition-transform ${openIndex === idx ? "rotate-180" : ""}`}
+                    className={`w-4 h-4 text-gray-400 shrink-0 transition-transform ${openIndex === idx ? "rotate-180" : ""}`}
                   />
                 </button>
                 {openIndex === idx && (
@@ -811,7 +811,7 @@ export default function BlogGuidesIndex() {
                       <CardContent className="p-4">
                         <div className="flex items-start gap-3">
                           <div
-                            className={`w-10 h-10 rounded-lg bg-gradient-to-br ${item.color} flex items-center justify-center flex-shrink-0`}
+                            className={`w-10 h-10 rounded-lg bg-gradient-to-br ${item.color} flex items-center justify-center shrink-0`}
                           >
                             <Icon className="w-5 h-5 text-white" />
                           </div>
@@ -923,7 +923,7 @@ export default function BlogGuidesIndex() {
                 <Card className="overflow-hidden border-2 border-gray-100 hover:border-green-300 hover:shadow-2xl hover:shadow-green-100/50 transition-all duration-300 group-hover:-translate-y-1">
                   <div className="flex flex-col md:flex-row">
                     {/* Image */}
-                    <div className="relative md:w-80 h-48 md:h-auto flex-shrink-0 overflow-hidden">
+                    <div className="relative md:w-80 h-48 md:h-auto shrink-0 overflow-hidden">
                       {featuredGuide.featuredImage ? (
                         <ResponsiveImage
                           src={featuredGuide.featuredImage}
@@ -1022,7 +1022,7 @@ export default function BlogGuidesIndex() {
                   >
                     <Card className="h-full hover:shadow-xl hover:shadow-blue-100/50 transition-all duration-300 border border-blue-200 hover:border-blue-400 group-hover:-translate-y-0.5 bg-white overflow-hidden">
                       <div className="flex flex-row h-full">
-                        <div className="relative w-28 flex-shrink-0 overflow-hidden">
+                        <div className="relative w-28 shrink-0 overflow-hidden">
                           <img
                             src="/images/og/outil.webp"
                             alt=""
@@ -1178,7 +1178,7 @@ export default function BlogGuidesIndex() {
                     >
                       <Card className="h-full hover:shadow-xl hover:shadow-green-100/50 transition-all duration-300 border border-gray-100 hover:border-green-300 group-hover:-translate-y-0.5">
                         <div className="flex flex-row h-full">
-                          <div className="relative w-36 flex-shrink-0 overflow-hidden">
+                          <div className="relative w-36 shrink-0 overflow-hidden">
                             {guide.featuredImage ? (
                               <ResponsiveImage
                                 src={guide.featuredImage}
@@ -1624,7 +1624,7 @@ export default function BlogGuidesIndex() {
               to="/blog-pieces-auto/conseils"
               className="group flex items-center gap-4 rounded-lg p-3 hover:bg-blue-100/60 transition-colors"
             >
-              <div className="relative w-20 h-20 rounded-lg overflow-hidden flex-shrink-0">
+              <div className="relative w-20 h-20 rounded-lg overflow-hidden shrink-0">
                 <img
                   src="/images/og/blog-conseil.webp"
                   alt="Conseils pratiques auto"
@@ -1645,7 +1645,7 @@ export default function BlogGuidesIndex() {
                   </span>
                 </p>
               </div>
-              <ArrowRight className="w-4 h-4 text-blue-400 group-hover:text-blue-600 flex-shrink-0 ml-auto" />
+              <ArrowRight className="w-4 h-4 text-blue-400 group-hover:text-blue-600 shrink-0 ml-auto" />
             </Link>
           </div>
         </div>

--- a/frontend/app/routes/checkout.tsx
+++ b/frontend/app/routes/checkout.tsx
@@ -970,7 +970,7 @@ export default function CheckoutPage() {
           <div className="mb-6 rounded-xl border border-red-200 bg-red-50 p-4 shadow-sm">
             <div className="flex items-start gap-3">
               <svg
-                className="h-5 w-5 flex-shrink-0 text-red-600"
+                className="h-5 w-5 shrink-0 text-red-600"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"

--- a/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
+++ b/frontend/app/routes/constructeurs.$brand.$model.$type.tsx
@@ -539,7 +539,7 @@ export default function VehicleDetailPage() {
         <div className="container mx-auto px-4 max-w-7xl py-6">
           <div className="flex flex-col md:flex-row gap-6 items-start">
             {/* Vehicle image */}
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-48 h-32 md:w-56 md:h-36 rounded-xl overflow-hidden border border-gray-200 bg-gray-50">
                 {!imageError && isValidImagePath(vehicle.modele_pic) ? (
                   <img
@@ -1178,7 +1178,7 @@ export default function VehicleDetailPage() {
                       {item.question}
                     </span>
                     <div
-                      className={`flex-shrink-0 p-1 rounded-full ${openFaqIndex === index ? "bg-brand" : "bg-gray-200"}`}
+                      className={`shrink-0 p-1 rounded-full ${openFaqIndex === index ? "bg-brand" : "bg-gray-200"}`}
                     >
                       {openFaqIndex === index ? (
                         <ChevronUp size={18} className="text-white" />
@@ -1226,7 +1226,7 @@ export default function VehicleDetailPage() {
         <div className="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-200 shadow-sm py-2 px-4 animate-in slide-in-from-top duration-300">
           <div className="max-w-7xl mx-auto flex items-center justify-between gap-4">
             <div className="flex items-center gap-3 min-w-0">
-              <Car size={20} className="text-brand flex-shrink-0" />
+              <Car size={20} className="text-brand shrink-0" />
               <div className="min-w-0">
                 <div className="font-bold text-gray-900 text-sm truncate">
                   {vehicle.marque_name} {vehicle.modele_name}{" "}
@@ -1238,7 +1238,7 @@ export default function VehicleDetailPage() {
                 </div>
               </div>
             </div>
-            <div className="flex items-center gap-2 flex-shrink-0">
+            <div className="flex items-center gap-2 shrink-0">
               <a
                 href="#catalogue"
                 className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-semibold text-white bg-brand hover:brightness-110 transition-all"

--- a/frontend/app/routes/constructeurs.$brand[.]html.tsx
+++ b/frontend/app/routes/constructeurs.$brand[.]html.tsx
@@ -502,7 +502,7 @@ export default function BrandCatalogPage() {
               {/* Layout horizontal : Logo + VehicleSelector côte à côte */}
               <div className="flex flex-col lg:flex-row items-center gap-6 lg:gap-8">
                 {/* Logo constructeur à gauche */}
-                <div className="flex-shrink-0 w-full lg:w-64">
+                <div className="shrink-0 w-full lg:w-64">
                   <div className="relative group">
                     {/* Cercle décoratif arrière-plan */}
                     <div className="absolute inset-0 -z-10">
@@ -561,25 +561,25 @@ export default function BrandCatalogPage() {
           {/* Trust badges premium - Grid responsive pour mobile */}
           <div className="grid grid-cols-2 md:flex md:flex-wrap justify-center gap-3 md:gap-4 max-w-3xl mx-auto animate-in fade-in duration-700 delay-400">
             <div className="group flex items-center gap-2 px-3 md:px-4 py-2.5 bg-gradient-to-br from-white/15 to-white/10 rounded-xl border border-white/30 hover:border-white/50 hover:from-white/20 hover:to-white/15 transition-all shadow-lg hover:shadow-xl hover:scale-105 cursor-default justify-center">
-              <Car className="w-4 h-4 text-green-300 flex-shrink-0 group-hover:scale-110 transition-transform" />
+              <Car className="w-4 h-4 text-green-300 shrink-0 group-hover:scale-110 transition-transform" />
               <span className="text-white text-sm md:text-base font-semibold whitespace-nowrap">
                 400 000+ pièces
               </span>
             </div>
             <div className="group flex items-center gap-2 px-3 md:px-4 py-2.5 bg-gradient-to-br from-white/15 to-white/10 rounded-xl border border-white/30 hover:border-white/50 hover:from-white/20 hover:to-white/15 transition-all shadow-lg hover:shadow-xl hover:scale-105 cursor-default justify-center">
-              <Settings className="w-4 h-4 text-blue-300 flex-shrink-0 group-hover:scale-110 transition-transform" />
+              <Settings className="w-4 h-4 text-blue-300 shrink-0 group-hover:scale-110 transition-transform" />
               <span className="text-white text-sm md:text-base font-semibold whitespace-nowrap">
                 Livraison 24-48h
               </span>
             </div>
             <div className="group flex items-center gap-2 px-3 md:px-4 py-2.5 bg-gradient-to-br from-white/15 to-white/10 rounded-xl border border-white/30 hover:border-white/50 hover:from-white/20 hover:to-white/15 transition-all shadow-lg hover:shadow-xl hover:scale-105 cursor-default justify-center">
-              <Wrench className="w-4 h-4 text-foreground flex-shrink-0 group-hover:scale-110 transition-transform" />
+              <Wrench className="w-4 h-4 text-foreground shrink-0 group-hover:scale-110 transition-transform" />
               <span className="text-white text-sm md:text-base font-semibold whitespace-nowrap">
                 Paiement sécurisé
               </span>
             </div>
             <div className="group flex items-center gap-2 px-3 md:px-4 py-2.5 bg-gradient-to-br from-white/15 to-white/10 rounded-xl border border-white/30 hover:border-white/50 hover:from-white/20 hover:to-white/15 transition-all shadow-lg hover:shadow-xl hover:scale-105 cursor-default justify-center">
-              <Zap className="w-4 h-4 text-orange-300 flex-shrink-0 group-hover:scale-110 transition-transform" />
+              <Zap className="w-4 h-4 text-orange-300 shrink-0 group-hover:scale-110 transition-transform" />
               <span className="text-white text-sm md:text-base font-semibold whitespace-nowrap">
                 Experts gratuits
               </span>
@@ -773,7 +773,7 @@ export default function BrandCatalogPage() {
                         className="flex items-center justify-between gap-2 px-4 py-3 bg-white border border-gray-200 hover:border-blue-400 hover:bg-blue-50 rounded-lg shadow-sm hover:shadow-md transition-all text-sm font-medium text-blue-900 hover:text-blue-700"
                       >
                         <span className="truncate">{m[1]}</span>
-                        <ChevronRight className="w-4 h-4 flex-shrink-0 opacity-60" />
+                        <ChevronRight className="w-4 h-4 shrink-0 opacity-60" />
                       </Link>
                     ))}
                 </div>
@@ -804,7 +804,7 @@ export default function BrandCatalogPage() {
                           className="bg-white rounded-xl p-6 shadow-sm border border-gray-200"
                         >
                           <div className="flex items-center gap-3 mb-3">
-                            <span className="flex-shrink-0 w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold text-lg">
+                            <span className="shrink-0 w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold text-lg">
                               {idx + 1}
                             </span>
                             <h3 className="font-semibold text-gray-900">

--- a/frontend/app/routes/contact.tsx
+++ b/frontend/app/routes/contact.tsx
@@ -438,7 +438,7 @@ export default function ContactPage() {
               <div className="space-y-4">
                 <div className="flex items-start">
                   <svg
-                    className="w-5 h-5 text-gray-400 mt-1 mr-3 flex-shrink-0"
+                    className="w-5 h-5 text-gray-400 mt-1 mr-3 shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -465,7 +465,7 @@ export default function ContactPage() {
 
                 <div className="flex items-start">
                   <svg
-                    className="w-5 h-5 text-gray-400 mt-1 mr-3 flex-shrink-0"
+                    className="w-5 h-5 text-gray-400 mt-1 mr-3 shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -487,7 +487,7 @@ export default function ContactPage() {
 
                 <div className="flex items-start">
                   <svg
-                    className="w-5 h-5 text-gray-400 mt-1 mr-3 flex-shrink-0"
+                    className="w-5 h-5 text-gray-400 mt-1 mr-3 shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -544,7 +544,7 @@ export default function ContactPage() {
                   >
                     <div className="flex">
                       <svg
-                        className="w-5 h-5 text-red-400 mr-2 flex-shrink-0"
+                        className="w-5 h-5 text-red-400 mr-2 shrink-0"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"

--- a/frontend/app/routes/diagnostic-auto.$slug.tsx
+++ b/frontend/app/routes/diagnostic-auto.$slug.tsx
@@ -901,7 +901,7 @@ export default function DiagnosticAutoDetail() {
             <Card className="bg-gray-100">
               <CardContent className="py-4">
                 <div className="flex items-start gap-3">
-                  <Shield className="h-5 w-5 text-gray-600 flex-shrink-0 mt-0.5" />
+                  <Shield className="h-5 w-5 text-gray-600 shrink-0 mt-0.5" />
                   <div className="text-sm text-gray-600">
                     <p className="font-medium mb-1">Avis professionnel</p>
                     <p>

--- a/frontend/app/routes/orders.$id.tsx
+++ b/frontend/app/routes/orders.$id.tsx
@@ -340,7 +340,7 @@ export default function OrderDetailsReal() {
                   </div>
                   <div className="space-y-3">
                     <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
-                      <Mail className="w-5 h-5 text-gray-500 flex-shrink-0" />
+                      <Mail className="w-5 h-5 text-gray-500 shrink-0" />
                       <a
                         href={`mailto:${order.customer.cst_mail}`}
                         className="text-gray-700 hover:text-blue-600 hover:underline font-medium"
@@ -350,7 +350,7 @@ export default function OrderDetailsReal() {
                     </div>
                     {order.customer.cst_tel && (
                       <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
-                        <Phone className="w-5 h-5 text-gray-500 flex-shrink-0" />
+                        <Phone className="w-5 h-5 text-gray-500 shrink-0" />
                         <a
                           href={`tel:${order.customer.cst_tel}`}
                           className="text-gray-700 hover:text-blue-600 font-medium"
@@ -361,7 +361,7 @@ export default function OrderDetailsReal() {
                     )}
                     {order.customer.cst_gsm && (
                       <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
-                        <Phone className="w-5 h-5 text-green-500 flex-shrink-0" />
+                        <Phone className="w-5 h-5 text-green-500 shrink-0" />
                         <a
                           href={`tel:${order.customer.cst_gsm}`}
                           className="text-gray-700 hover:text-blue-600 font-medium"
@@ -610,7 +610,7 @@ export default function OrderDetailsReal() {
                           </Badge>
                         )}
                       </div>
-                      <div className="flex-shrink-0 text-right space-y-1">
+                      <div className="shrink-0 text-right space-y-1">
                         <p className="text-gray-600 text-sm">
                           <span className="font-semibold text-gray-900">
                             {line.orl_art_quantity}

--- a/frontend/app/routes/reference-auto.$slug.tsx
+++ b/frontend/app/routes/reference-auto.$slug.tsx
@@ -833,7 +833,7 @@ export default function ReferenceDetailPage() {
                 <ul className="space-y-2">
                   {reference.composition.map((item, index) => (
                     <li key={item} className="flex items-start gap-3">
-                      <span className="w-6 h-6 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center text-sm font-medium flex-shrink-0">
+                      <span className="w-6 h-6 rounded-full bg-blue-100 text-blue-600 flex items-center justify-center text-sm font-medium shrink-0">
                         {index + 1}
                       </span>
                       <span className="text-gray-700">{item}</span>
@@ -987,7 +987,7 @@ export default function ReferenceDetailPage() {
                         key={point}
                         className="flex items-start gap-3 p-3 bg-red-50 rounded-lg"
                       >
-                        <XCircle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+                        <XCircle className="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
                         <span className="text-gray-700">
                           {point.trim().replace(/\.$/, "")}
                         </span>
@@ -1014,7 +1014,7 @@ export default function ReferenceDetailPage() {
                       key={rule}
                       className="flex items-start gap-3 p-3 bg-muted rounded-lg"
                     >
-                      <span className="w-6 h-6 rounded-full bg-muted text-foreground flex items-center justify-center text-sm font-medium flex-shrink-0">
+                      <span className="w-6 h-6 rounded-full bg-muted text-foreground flex items-center justify-center text-sm font-medium shrink-0">
                         {index + 1}
                       </span>
                       <span className="text-gray-700">{rule}</span>
@@ -1111,7 +1111,7 @@ export default function ReferenceDetailPage() {
                         >
                           <Badge
                             variant="outline"
-                            className="text-xs text-green-600 border-green-200 flex-shrink-0"
+                            className="text-xs text-green-600 border-green-200 shrink-0"
                           >
                             Guide
                           </Badge>
@@ -1148,7 +1148,7 @@ export default function ReferenceDetailPage() {
                           >
                             <Badge
                               variant="outline"
-                              className="text-xs text-orange-600 border-orange-200 flex-shrink-0"
+                              className="text-xs text-orange-600 border-orange-200 shrink-0"
                             >
                               Diagnostic
                             </Badge>
@@ -1184,7 +1184,7 @@ export default function ReferenceDetailPage() {
                         >
                           <Badge
                             variant="outline"
-                            className="text-xs text-foreground border-indigo-200 flex-shrink-0"
+                            className="text-xs text-foreground border-indigo-200 shrink-0"
                           >
                             Réf.
                           </Badge>

--- a/frontend/app/routes/reviews._index.tsx
+++ b/frontend/app/routes/reviews._index.tsx
@@ -277,7 +277,7 @@ export default function ReviewsPage() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6 mb-8">
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-8 h-8 bg-muted rounded-md flex items-center justify-center">
                 <MessageSquare className="w-5 h-5 text-blue-600" />
               </div>
@@ -293,7 +293,7 @@ export default function ReviewsPage() {
 
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-8 h-8 bg-warning/10 rounded-md flex items-center justify-center">
                 <Star className="w-5 h-5 text-yellow-600" />
               </div>
@@ -312,7 +312,7 @@ export default function ReviewsPage() {
 
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-8 h-8 bg-warning/10 rounded-md flex items-center justify-center">
                 <span className="text-sm font-semibold text-yellow-600">
                   ⏳
@@ -330,7 +330,7 @@ export default function ReviewsPage() {
 
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-8 h-8 bg-success/10 rounded-md flex items-center justify-center">
                 <Check className="w-5 h-5 text-green-600" />
               </div>
@@ -346,7 +346,7 @@ export default function ReviewsPage() {
 
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-8 h-8 bg-destructive/10 rounded-md flex items-center justify-center">
                 <X className="w-5 h-5 text-red-600" />
               </div>

--- a/frontend/app/routes/search.cnit.tsx
+++ b/frontend/app/routes/search.cnit.tsx
@@ -187,7 +187,7 @@ export default function SearchCnitPage() {
               </Button>
             </div>
             <div className="flex items-start gap-2 text-sm text-primary bg-primary/10 p-3 rounded-lg">
-              <Info className="h-4 w-4 mt-0.5 flex-shrink-0" />
+              <Info className="h-4 w-4 mt-0.5 shrink-0" />
               <p>
                 Le code CNIT se trouve sur la carte grise du véhicule dans la
                 case K. Il est composé de lettres et de chiffres (généralement 8

--- a/frontend/app/routes/staff._index.tsx
+++ b/frontend/app/routes/staff._index.tsx
@@ -290,7 +290,7 @@ export default function StaffIndex() {
                 >
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center">
-                      <div className="h-10 w-10 flex-shrink-0">
+                      <div className="h-10 w-10 shrink-0">
                         <div className="h-10 w-10 rounded-full bg-primary/15 flex items-center justify-center">
                           <span className="text-sm font-medium text-blue-600">
                             {member.firstName?.[0]}

--- a/frontend/app/routes/support.tsx
+++ b/frontend/app/routes/support.tsx
@@ -130,7 +130,7 @@ export default function SupportDashboard() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-8 h-8 bg-muted rounded-md flex items-center justify-center">
                 <svg
                   className="w-5 h-5 text-blue-600"
@@ -158,7 +158,7 @@ export default function SupportDashboard() {
 
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-8 h-8 bg-success/10 rounded-md flex items-center justify-center">
                 <svg
                   className="w-5 h-5 text-green-600"
@@ -188,7 +188,7 @@ export default function SupportDashboard() {
 
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-8 h-8 bg-muted rounded-md flex items-center justify-center">
                 <svg
                   className="w-5 h-5 text-orange-600"
@@ -216,7 +216,7 @@ export default function SupportDashboard() {
 
         <div className="bg-white p-6 rounded-lg shadow">
           <div className="flex items-center">
-            <div className="flex-shrink-0">
+            <div className="shrink-0">
               <div className="w-8 h-8 bg-muted rounded-md flex items-center justify-center">
                 <svg
                   className="w-5 h-5 text-foreground"

--- a/scripts/lint/check-tailwind-v4-removed-utilities.sh
+++ b/scripts/lint/check-tailwind-v4-removed-utilities.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Block Tailwind-v4 HARD-REMOVED utilities in frontend app code.
+#
+# Why: TW-1 (Tailwind-4 chantier) pre-normalized the deprecated utilities that v4
+# DELETES outright — so a later engine swap (TW-2) is a no-op, not a silent
+# breakage. These utilities still "work" under v3, so nothing else stops a
+# regression from creeping back in before the swap. This gate does.
+#
+# Canonical replacements (all valid under BOTH v3 and v4):
+#   flex-shrink-*  → shrink-*          flex-grow-*  → grow-*
+#   bg-opacity-N   → bg-<color>/N      text-opacity-N → text-<color>/N   (etc.)
+#   overflow-ellipsis → text-ellipsis  decoration-slice/clone → box-decoration-*
+#
+# EXEMPT: dynamic bg-opacity where the color is interpolated
+# (`${expr} bg-opacity-N`) — the /N modifier on a runtime-built class is not
+# JIT-scannable, so it can't be converted here; refactor at TW-2. The 2 known
+# sites are admin.config._index.tsx (category.color). The exemption is by
+# pattern (interpolation immediately before bg-opacity), not by line number.
+#
+# Used by: CI lint job. Read-only; exits 1 on any violation.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCAN_DIR="${1:-$ROOT/frontend/app}"
+
+if [ ! -d "$SCAN_DIR" ]; then
+  echo "check-tailwind-v4-removed-utilities: scan dir not found: $SCAN_DIR" >&2
+  exit 2
+fi
+
+INCLUDES=(--include='*.tsx' --include='*.ts' --include='*.jsx' --include='*.css')
+
+# Class-form patterns. Leading delimiter allows `:` (Tailwind variants like
+# `md:flex-shrink-0`); trailing delimiter EXCLUDES `:` so raw CSS properties
+# (`flex-shrink: 0`, `flex-grow: 1`) are NOT matched — only class tokens are.
+NON_OPACITY='[:"'"'"'`( ]((flex-(shrink|grow))(-[0-9]+)?|overflow-ellipsis|decoration-(slice|clone))["'"'"'`) ]'
+violations=""
+
+non_op="$(grep -rnoE "$NON_OPACITY" "${INCLUDES[@]}" "$SCAN_DIR" 2>/dev/null || true)"
+[ -n "$non_op" ] && violations+="$non_op"$'\n'
+
+# Opacity utilities: flag bg/text/border/divide/ring/placeholder-opacity-N, but
+# DROP lines where a `${...}` interpolation sits immediately before `bg-opacity`
+# (un-convertible dynamic case, exempt until TW-2).
+op="$(grep -rnoE "(bg|text|border|divide|ring|placeholder)-opacity-[0-9]+" "${INCLUDES[@]}" "$SCAN_DIR" 2>/dev/null || true)"
+if [ -n "$op" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    file="${line%%:*}"; rest="${line#*:}"; lineno="${rest%%:*}"
+    # Re-read the source line to test for the dynamic-interpolation exemption.
+    src="$(sed -n "${lineno}p" "$file" 2>/dev/null || true)"
+    if printf '%s' "$src" | grep -qE '\$\{[^}]*\}[^"'"'"'`]*bg-opacity-[0-9]'; then
+      continue # exempt: dynamic interpolated color + bg-opacity
+    fi
+    violations+="$line"$'\n'
+  done <<< "$op"
+fi
+
+violations="$(printf '%s' "$violations" | sed '/^$/d')"
+if [ -n "$violations" ]; then
+  echo "❌ Tailwind-v4 hard-removed utility/utilities found (use the v3+v4 canonical form):" >&2
+  printf '%s\n' "$violations" | sed 's/^/   /' >&2
+  echo "" >&2
+  echo "   flex-shrink-*→shrink-* · flex-grow-*→grow-* · *-opacity-N→/N modifier ·" >&2
+  echo "   overflow-ellipsis→text-ellipsis · decoration-slice/clone→box-decoration-*" >&2
+  exit 1
+fi
+
+echo "✅ no Tailwind-v4 hard-removed utilities in $SCAN_DIR (dynamic bg-opacity exempt)."


### PR DESCRIPTION
## TW-1 — canonicalize the utilities Tailwind v4 hard-removes (dual-compatible)

Next step of the *Tailwind 3 → 4* chantier (after the design-tokens foundation: DT-0 #1163, DT-1 #1171, DT-2a #1173, DT-2b #1175). Pre-normalizes the deprecated utilities v4 **deletes outright**, *while still on v3*, so the eventual engine swap (TW-2) is a **no-op instead of a silent breakage**. Every replacement is valid under **both** v3 and v4 → zero rendered change today.

### Transforms (frontend/app, className contexts only)
- **`flex-shrink-*` → `shrink-*` / `flex-grow-*` → `grow-*`** — 161 files, 316 occurrences. Compile-verified identical: `.shrink-0` and `.flex-shrink-0` both emit `flex-shrink: 0`. *(global.css raw CSS properties `flex-shrink: 0` are NOT touched — the gate's class-form pattern excludes the `:` property form.)*
- **`bg-opacity-N` → the `/N` color modifier** on the paired `bg-<color>` — 18 static occ / 9 files: `bg-neutral-900 bg-opacity-50` → `bg-neutral-900/50`. Variant forms repeat the color: `bg-opacity-0 group-hover:bg-opacity-60` → `bg-neutral-900/0 group-hover:bg-neutral-900/60`. Computed color identical (`rgb(… / 0.5)` == `--tw-bg-opacity: .5`).
- **EXEMPT** — the 2 dynamic cases `${category.color} bg-opacity-10` (`admin.config._index.tsx`): the `/N` modifier on a runtime-interpolated class is **not JIT-scannable**, so it can't be converted here. Deferred to TW-2 (manual refactor).

### Regression gate (new)
`scripts/lint/check-tailwind-v4-removed-utilities.sh` — blocks any v4-hard-removed utility (`flex-shrink/grow`, `*-opacity-N`, `overflow-ellipsis`, `decoration-slice/clone`) from creeping back before the swap. Exempts dynamic bg-opacity **by interpolation pattern** (not line number). Wired into the CI lint job. Negative test: flags static `flex-shrink-0`/`bg-opacity-50`, leaves dynamic bg-opacity + raw CSS properties. The other hard-removed families have **0 occurrences** today.

*Deferred to TW-2 (not dual-compatible): `bg-gradient-to-*` → `bg-linear-to-*`.*

### Validation
| Check | Result |
|---|---|
| compile-parity (shrink/grow/opacity) | declarations **identical / computed-equivalent** |
| frontend `tsc` · build | **0 · exit 0** |
| Total CSS gzip | **42.81 KB** (<60) |
| v4-removed-utilities gate | green + negative test correct |

### Scope
171 files (169 className-only tsx edits + ci.yml gate + 1 new gate script). **No URL / route / meta / H1 / payments.** Zero visual change (compile-proven). Merge → PREPROD only.

TW-1 of the Tailwind-4 chantier. **Next: BROWSER-GATE (owner decision) → TW-2 (v4 engine swap).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)