### PR TITLE
fix(seo-conseil): source gamme term from authoritative pg_name, not the slug

### DIFF
--- a/backend/src/modules/admin/services/conseil-enricher.naming.test.ts
+++ b/backend/src/modules/admin/services/conseil-enricher.naming.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests — authoritative gamme display-name resolution (conseil R3 enrichment).
+ *
+ * Regression guard for the "pb caractère" incident: section headings such as
+ * "Quand changer les temoin d usure" were built from the SLUG
+ * (`pgAlias.replace(/-/g, ' ')`), which is ASCII — accents stripped and the
+ * apostrophe collapsed to a space. The fix sources the display term from the
+ * authoritative `pieces_gamme.pg_name` ("Témoin d'usure"), which carries both
+ * the accents AND the apostrophe.
+ *
+ * The DB fetch lives in the service; the pure formatting is `formatGammeDisplayName`.
+ */
+
+import { formatGammeDisplayName } from './conseil-enricher.service';
+
+describe('formatGammeDisplayName — authoritative term, mid-sentence casing', () => {
+  // Identity fallback so we can assert the fallback path was taken.
+  const idRestore = (s: string) => s;
+
+  it('uses pg_name and restores the apostrophe (the slug had lost it)', () => {
+    expect(
+      formatGammeDisplayName("Témoin d'usure", 'temoin-d-usure', idRestore),
+    ).toBe("témoin d'usure");
+    expect(
+      formatGammeDisplayName(
+        "Courroie d'accessoire",
+        'courroie-d-accessoire',
+        idRestore,
+      ),
+    ).toBe("courroie d'accessoire");
+  });
+
+  it('keeps the accents the slug had stripped', () => {
+    expect(formatGammeDisplayName('Démarreur', 'demarreur', idRestore)).toBe(
+      'démarreur',
+    );
+    expect(
+      formatGammeDisplayName('Filtre à huile', 'filtre-a-huile', idRestore),
+    ).toBe('filtre à huile');
+  });
+
+  it('lower-cases the first letter for mid-sentence interpolation ("les ${name}")', () => {
+    // Title template is "Quand changer les {name} :" — {name} is never sentence-initial.
+    expect(
+      formatGammeDisplayName(
+        'Plaquette de frein',
+        'plaquette-de-frein',
+        idRestore,
+      ),
+    ).toBe('plaquette de frein');
+  });
+
+  it('lower-cases a leading accented capital that is NOT an acronym (Étrier → étrier)', () => {
+    // Load-bearing: the ^[A-ZÀ-Ý]{2,} guard must NOT treat "Ét" as an acronym.
+    expect(
+      formatGammeDisplayName('Étrier de frein', 'etrier-de-frein', idRestore),
+    ).toBe('étrier de frein');
+    expect(formatGammeDisplayName('É', 'e', idRestore)).toBe('é');
+    expect(formatGammeDisplayName('A', 'a', idRestore)).toBe('a');
+  });
+
+  it('preserves acronym / all-caps initial tokens (ABS, FAP, ÉTRIER, ABS capteur)', () => {
+    expect(formatGammeDisplayName('ABS', 'abs', idRestore)).toBe('ABS');
+    expect(
+      formatGammeDisplayName('FAP catalysé', 'fap-catalyse', idRestore),
+    ).toBe('FAP catalysé');
+    expect(
+      formatGammeDisplayName('ABS capteur', 'abs-capteur', idRestore),
+    ).toBe('ABS capteur');
+    expect(formatGammeDisplayName('ÉTRIER', 'etrier', idRestore)).toBe(
+      'ÉTRIER',
+    );
+  });
+
+  it('passes an already-lower-cased name through unchanged', () => {
+    expect(
+      formatGammeDisplayName('filtre à huile', 'filtre-a-huile', idRestore),
+    ).toBe('filtre à huile');
+  });
+
+  it('falls back to restoreAccents(slug) when pg_name is missing — never the raw slug', () => {
+    const spy = jest.fn((s: string) => s.replace('temoin', 'témoin'));
+    expect(formatGammeDisplayName(null, 'temoin-d-usure', spy)).toBe(
+      'témoin d usure',
+    );
+    expect(spy).toHaveBeenCalledWith('temoin d usure');
+
+    expect(formatGammeDisplayName(undefined, 'demarreur', idRestore)).toBe(
+      'demarreur',
+    );
+    expect(formatGammeDisplayName('   ', 'demarreur', idRestore)).toBe(
+      'demarreur',
+    );
+    expect(formatGammeDisplayName('', '', idRestore)).toBe('');
+  });
+
+  it('applies mid-sentence casing on the FALLBACK path too (contract consistency)', () => {
+    // Even if restoreAccents yields a capitalized token, the determiner-position
+    // contract holds: first char is lower-cased (acronyms still preserved).
+    expect(
+      formatGammeDisplayName(null, 'demarreur', (s) => `D${s.slice(1)}`),
+    ).toBe('demarreur');
+    expect(formatGammeDisplayName(null, 'abs', () => 'ABS')).toBe('ABS');
+  });
+});

--- a/backend/src/modules/admin/services/conseil-enricher.service.ts
+++ b/backend/src/modules/admin/services/conseil-enricher.service.ts
@@ -223,6 +223,38 @@ interface SupplementaryClassification {
   specs: string[];
 }
 
+/**
+ * Resolve the authoritative, character-faithful gamme display term for use INSIDE
+ * a sentence ("Quand changer les {term} :", "Pièces … avec les {term} :").
+ *
+ * Source of truth = `pieces_gamme.pg_name` ("Témoin d'usure") — it carries the
+ * accents AND the apostrophe. The slug (pg_alias) must NEVER be used as the term:
+ * it is ASCII, so accents are stripped and the apostrophe is collapsed to '-'/' ',
+ * which produced the de-accented "temoin d usure" headings (pb caractère incident).
+ *
+ * Casing (applied uniformly to BOTH the pg_name and the fallback paths): every
+ * template embeds the term after a determiner, so the first letter is lower-cased —
+ * except when the leading token is an acronym / all-caps run (2+ leading uppercase:
+ * ABS, FAP, ÉTRIER…), which is preserved verbatim.
+ *
+ * When pg_name is unavailable, fall back (observably — the caller logs) to
+ * restoreAccents() on the slug: it recovers accents from the FR lexicon, the best
+ * achievable without the canonical name (it cannot recover apostrophes).
+ */
+export function formatGammeDisplayName(
+  pgName: string | null | undefined,
+  slug: string,
+  restoreAccents: (s: string) => string,
+): string {
+  const raw = (
+    pgName?.trim() || restoreAccents(slug.replace(/-/g, ' '))
+  ).trim();
+  if (/^[A-ZÀ-Ý]{2,}/.test(raw)) {
+    return raw;
+  }
+  return raw.charAt(0).toLowerCase() + raw.slice(1);
+}
+
 @Injectable()
 export class ConseilEnricherService extends SupabaseBaseService {
   protected override readonly logger = new Logger(ConseilEnricherService.name);
@@ -249,6 +281,32 @@ export class ConseilEnricherService extends SupabaseBaseService {
 
   /** LLM polish disabled — skills Claude Code (/content-gen) replace Groq for quality polish */
   private readonly llmPolishEnabled = false;
+
+  /**
+   * Authoritative gamme display term from `pieces_gamme.pg_name` (canonical product
+   * name) — resolved once per enrichment and threaded to every section builder.
+   * NEVER derive the term from the slug; see {@link formatGammeDisplayName}.
+   */
+  private async resolveGammeDisplayName(
+    pgId: string,
+    pgAlias: string,
+  ): Promise<string> {
+    const { data, error } = await this.client
+      .from('pieces_gamme')
+      .select('pg_name')
+      .eq('pg_id', parseInt(pgId, 10))
+      .maybeSingle();
+    const pgName = (data as { pg_name?: string } | null)?.pg_name;
+    if (error || !pgName) {
+      this.logger.warn(
+        `resolveGammeDisplayName: no authoritative pg_name for pgId=${pgId} ` +
+          `(${pgAlias}) — falling back to restoreAccents(slug)`,
+      );
+    }
+    return formatGammeDisplayName(pgName, pgAlias, (s) =>
+      this.textUtils.restoreAccents(s),
+    );
+  }
 
   /**
    * Enrich a single gamme's R3 Conseils sections using RAG knowledge.
@@ -279,6 +337,10 @@ export class ConseilEnricherService extends SupabaseBaseService {
         };
       }
     }
+
+    // Authoritative gamme display term (accents + apostrophe) — resolved once,
+    // threaded to every section builder. NEVER derive the term from the slug.
+    const gammeName = await this.resolveGammeDisplayName(pgId, pgAlias);
 
     // 1. Load RAG knowledge doc (API first, disk fallback)
     let ragContent: string;
@@ -314,12 +376,13 @@ export class ConseilEnricherService extends SupabaseBaseService {
             `No primary RAG doc for ${pgAlias}, building contract from ${supplementaryFiles.length} supplementary files`,
           );
           const contract: PageContract = {};
-          this.mergeSupplementaryIntoContract(contract, classified, pgAlias);
+          this.mergeSupplementaryIntoContract(contract, classified, gammeName);
           // Jump to step 3 below with this contract (always supplementary-enriched)
           return this.executeEnrichment(
             pgId,
             pgAlias,
             contract,
+            gammeName,
             true,
             conservativeMode,
           );
@@ -358,11 +421,12 @@ export class ConseilEnricherService extends SupabaseBaseService {
             `No page_contract for ${pgAlias}, building from ${supplementaryFiles.length} supplementary files`,
           );
           contract = {};
-          this.mergeSupplementaryIntoContract(contract, classified, pgAlias);
+          this.mergeSupplementaryIntoContract(contract, classified, gammeName);
           return this.executeEnrichment(
             pgId,
             pgAlias,
             contract,
+            gammeName,
             true,
             conservativeMode,
           );
@@ -392,7 +456,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
       supplementaryEnriched = this.mergeSupplementaryIntoContract(
         contract,
         classified,
-        pgAlias,
+        gammeName,
       );
       this.logger.log(
         `Merged supplementary content for ${pgAlias} (modified=${supplementaryEnriched}): ` +
@@ -538,6 +602,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
       pgId,
       pgAlias,
       contract,
+      gammeName,
       supplementaryEnriched,
       conservativeMode,
       force || ragChanged,
@@ -622,6 +687,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
     pgId: string,
     pgAlias: string,
     contract: PageContract,
+    gammeName: string,
     hasSupplementary = false,
     conservativeMode = false,
     force = false,
@@ -635,7 +701,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
     const actions = this.planActions(
       existing,
       contract,
-      pgAlias,
+      gammeName,
       hasSupplementary || force,
     );
 
@@ -647,6 +713,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
       const observableFallback = await this.buildS2DiagFromObservable(
         pgId,
         pgAlias,
+        gammeName,
         existing,
       );
       if (observableFallback) {
@@ -724,6 +791,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
         pgId,
         contract,
         pgAlias,
+        gammeName,
         conservativeMode,
       );
 
@@ -1265,6 +1333,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
   private async buildS2DiagFromObservable(
     pgId: string,
     pgAlias: string,
+    gammeName: string,
     existing: Map<string, { sgc_id: string; sgc_content: string }>,
   ): Promise<SectionAction | null> {
     const existingS2D = existing.get(SECTION_TYPES.S2_DIAG);
@@ -1290,7 +1359,6 @@ export class ConseilEnricherService extends SupabaseBaseService {
 
       if (error || !data || data.length < 2) return null;
 
-      const gammeName = pgAlias.replace(/-/g, ' ');
       const rows = (
         data as Array<{
           symptom: string;
@@ -1358,11 +1426,10 @@ export class ConseilEnricherService extends SupabaseBaseService {
       }
     >,
     contract: PageContract,
-    pgAlias: string,
+    gammeName: string,
     hasSupplementary = false,
   ): SectionAction[] {
     const actions: SectionAction[] = [];
-    const gammeName = pgAlias.replace(/-/g, ' ');
     const hp = contract.headingPlan || {};
 
     /**
@@ -1400,7 +1467,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
         const syncParts = contract.intro.syncParts || [];
         const syncHtml =
           syncParts.length > 0
-            ? `<br>Pièces liées : ${syncParts.map((p) => `<b>${p.replace(/-/g, ' ')}</b>`).join(', ')}.`
+            ? `<br>Pièces liées : ${syncParts.map((p) => `<b>${this.textUtils.restoreAccents(p.replace(/-/g, ' '))}</b>`).join(', ')}.`
             : '';
         const s1Content = `${contract.intro.role}${syncHtml}`;
         if (!wouldRegress(existingS1?.sgc_content, s1Content)) {
@@ -2421,9 +2488,8 @@ export class ConseilEnricherService extends SupabaseBaseService {
   private mergeSupplementaryIntoContract(
     contract: PageContract,
     supplementary: SupplementaryClassification,
-    pgAlias: string,
+    gammeName: string,
   ): boolean {
-    const gammeName = pgAlias.replace(/-/g, ' ');
     let modified = false;
 
     // S1 (definitions) → enrich intro.role (filter marketing content)
@@ -2557,6 +2623,7 @@ export class ConseilEnricherService extends SupabaseBaseService {
     pgId: string,
     contract: PageContract,
     pgAlias: string,
+    gammeName: string,
     conservativeMode = false,
   ): Promise<void> {
     const templateDescrip = this.composeSeoDescrip(contract, pgAlias);
@@ -2576,7 +2643,6 @@ export class ConseilEnricherService extends SupabaseBaseService {
             )
           : null;
 
-        const gammeLabelName = pgAlias.replace(/-/g, ' ');
         const result = await this.aiContentService.generateContent({
           type: brief ? 'seo_descrip_R3' : 'seo_descrip_polish',
           prompt: `Polish meta description for ${pgAlias}`,
@@ -2585,8 +2651,8 @@ export class ConseilEnricherService extends SupabaseBaseService {
           maxLength: 200,
           temperature: 0.3,
           context: brief
-            ? { draft: templateDescrip, gammeName: gammeLabelName, brief }
-            : { draft: templateDescrip, gammeName: gammeLabelName },
+            ? { draft: templateDescrip, gammeName, brief }
+            : { draft: templateDescrip, gammeName },
           useCache: true,
         });
         const polished = result.content.trim();


### PR DESCRIPTION
## Problème ("pb caractère")

Sur les articles blog R3 (ex. `/blog-pieces-auto/article/comment-changer-un-temoin-d-usure`), des titres H2 affichaient le terme **désaccentué et sans apostrophe** : `temoin d usure` au lieu de `témoin d'usure`, `demarreur` au lieu de `démarreur`, `courroie d accessoire` au lieu de `courroie d'accessoire`.

## Cause racine

`conseil-enricher.service.ts` dérivait le terme affiché **du slug** :

```ts
const gammeName = pgAlias.replace(/-/g, ' ');   // "temoin-d-usure" → "temoin d usure"
```

Le slug est ASCII : accents supprimés, apostrophe écrasée. Les sections sans override `heading_plan` curé tombaient sur ce fallback → titres désaccentués. Le nom autoritaire `pieces_gamme.pg_name` (« Témoin d'usure », avec accents **et** apostrophe) n'était jamais chargé.

## Fix (structurel, source unique)

- **`formatGammeDisplayName()`** — helper pur (exporté, testé) : `pg_name` → terme mid-sentence (1ʳᵉ lettre minuscule sauf acronymes ABS/FAP ; accents + apostrophe préservés). Fallback **observable** `restoreAccents(slug)` si `pg_name` absent (loggé — pas de silent fallback).
- **`resolveGammeDisplayName()`** — résout `pg_name` une fois par enrichment.
- `gammeName` threadé `enrichSingle → executeEnrichment → planActions / buildS2DiagFromObservable / mergeSupplementaryIntoContract / writeSeoDescripDraft`. **Toutes** les dérivations slug→terme supprimées.
- Labels « Pièces liées » (S1 syncParts) passent désormais par `restoreAccents()`, comme le chemin S7 existant.

**Garde-fous** : aucune URL/slug/canonical touché ; overrides `heading_plan` curés préservés ; changement strictement limité à la fidélité accent/apostrophe.

## Tests & vérification

- `conseil-enricher.naming.test.ts` — 8 cas (apostrophe, accents, casing mid-sentence, Étrier vs acronyme ABS/ÉTRIER, fallback, contrat de casing fallback).
- Typecheck backend : 0 erreur.
- Revue adverse multi-lens (3 lentilles) : `safe-to-merge` (0 blocker) ; must-fix « casing fallback » appliqué.

## Backfill données (DB partagée, déjà appliqué)

Le code corrige la **génération future** ; les lignes déjà stockées dans `__seo_gamme_conseil` ont été corrigées par un UPDATE **guard-validé accent/ponctuation-only** (`unaccent` normalisé : on n'applique que si le nouveau == l'ancien une fois accents+ponctuation neutralisés) :

- **350 titres / 87 gammes** + **25 lignes de contenu** corrigés.
- Backup réversible : table `zz_bak_conseil_accents_20260627` (379 lignes candidates) — supprimable après validation.
- Vérifié live : page témoin → 9 H2 accentués, 0 occurrence `temoin d usure`.

## Exclus (follow-up séparé — NON touchés)

Le guard a écarté **37 lignes / 6 gammes** qui ne sont **pas** des bugs d'accent :

- **`Contacteur feu de recul`** (alias `contacteur-de-feu-de-recul`) : divergence de mot (alias a un « de » en trop), pas d'accent.
- **`Boîtier papillon`** (alias `corps-papillon`) : « corps papillon » est un **synonyme valide** utilisé dans le contenu ; remplacer renommerait, casserait « (ou corps papillon) » et des ancres de liens.
- **4 titres `META`** désaccentués (`Gicleur détendeur`, `Mécatronique boîte automatique`, `Commande correcteur de portée`, `Ampoule feu arrière`) : produits par un **autre chemin** (génération META), pas par `planActions` — à traiter séparément.

## Runtime-awareness

Chemin enrichment **offline/batch** (admin R3), pas de hot path. Note non-bloquante de la revue : `resolveGammeDisplayName` ajoute un SELECT PK indexé sur `pieces_gamme` ; threader `pg_name` depuis `execution-router` traverserait l'interface hétérogène des enrichers (R1/R2/R3/R4/R7/R8) → reporté (blast radius).
